### PR TITLE
fix(training): refuse an on-policy trust-region half-width that cannot be honored

### DIFF
--- a/changelog.d/2047-clip-range-domain.md
+++ b/changelog.d/2047-clip-range-domain.md
@@ -1,0 +1,23 @@
+### Fixed: refuse an on-policy trust-region half-width that cannot be honored
+
+`RLTrainSpec.clip_param` is the half-width of the trust region PPO is named for,
+read twice per mini-batch - once to clip the policy ratio and once to clip the
+value loss - and nothing judged it. `torch.clamp` cannot: it is defined for every
+unusable value, so each produced a finite, successful, deployable run whose
+objective was not the configured one. `nan` was the sharpest: both clipped terms
+become `nan`, so every reported loss reads `nan`, but the gradient of
+`torch.max` flows to the *unclipped* branch because comparisons against `nan` are
+false - the run descended the unclipped objective and its checkpoint came out
+bit-identical to an unclipped one, with PPO's defining mechanism silently off. A
+negative half-width inverted the clamp bounds into a constant and flipped the
+reported surrogate loss's sign, `0` pinned the value clip to `old_values`, and
+`True` was a silent half-width of one.
+
+`PpoTrainer.validate` now reports a half-width that is not a positive real, so an
+unusable value is refused before the environment, the networks or the optimizer
+are built. Positive infinity stays inside the domain - it is the field's only
+spelling of *do not clip*, and `clamp(ratio, -inf, inf)` honors it by returning
+the ratio unchanged. That is the same endpoint, for the same reason, as the
+sibling clip bound `max_grad_norm`, so the two now share one domain helper
+instead of carrying a copy each. The off-policy backend, which clips no policy
+ratio, stays silent about a field it never reads.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -244,6 +244,32 @@ sign, and `validate()` reports it like any other unusable bound instead of
 raising: Python integers are arbitrary-precision, so `10**400` is one request
 away.
 
+`clip_param` must be a positive number too, checked by the same `validate()` on
+the on-policy backend only (`spec.clip_param` appears in `rl/ppo.py` and nowhere
+else). It is the half-width of the trust region PPO is named for, read twice per
+mini-batch - once to clip the policy ratio and once to clip the value loss - and
+`torch.clamp` judges it not at all, so every unusable value produced a finite,
+successful, deployable run whose objective was not the configured one:
+
+- `nan` **silently removes the trust region.** Both clipped terms become `nan`,
+  so `torch.max(surrogate, surrogate_clipped)` returns `nan` - but its gradient
+  flows to the *unclipped* branch, because every comparison against `nan` is
+  false. Measured over a seeded 60-step run, the resulting checkpoint is
+  bit-identical to an unclipped one (parameter sum `140.1735330768706262`) while
+  `surrogate_loss`, `value_loss` and `latest_loss` are all reported as `nan`.
+- A **negative** half-width is not a window: `1 - c` exceeds `1 + c`, so the
+  clamp bounds are inverted and it returns a constant regardless of the ratio,
+  and the reported surrogate loss changes sign. `0` is the same failure at the
+  boundary - the value clip becomes `clamp(-0, 0)`, so `value_clipped` is exactly
+  `old_values` and the critic's clipped branch is a constant.
+- `True` was a silent half-width of one, five times the shipped `0.2`, and
+  `"0.2"`, `None` and a list raised `TypeError` from inside the update loop.
+
+`inf` is inside this field's domain for the same reason as `max_grad_norm`'s -
+`clamp(ratio, -inf, inf)` returns the ratio unchanged, so it is the field's only
+spelling of *do not clip* - and the two bounds share one domain helper rather
+than a copy each.
+
 ## Worked example
 
 `examples/training/train_ppo_reach.py` (on-policy) and `examples/training/train_fastsac_reach.py`

--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -111,6 +111,15 @@ on-policy objective. It is scoped like :func:`gradient_clip_problems` - only the
 on-policy backend composes that objective - and it bounds the *domain* rather than
 the floor: zero and negative are real configurations for both fields, while a
 non-finite or non-numeric weight is a value no reading makes usable.
+
+:func:`clip_range_problems` is the fourteenth, and the second of the two clip
+bounds on that same *optimization* axis: ``clip_param``, the half-width of the
+trust region the on-policy surrogate is clipped to, which also clips the value
+loss. It shares :func:`_clip_bound_error` with :func:`gradient_clip_problems`
+because the two bounds have one domain for one reason - a clip bound is a
+positive width, and positive infinity is each field's only spelling of "do not
+clip". It is scoped like :func:`gae_lambda_problems`: ``spec.clip_param`` is read
+in ``rl/ppo.py`` and nowhere else.
 """
 
 from __future__ import annotations
@@ -576,13 +585,14 @@ def discount_factor_problems(spec: TrainSpec, *, context: str) -> list[str]:
     now have their own gate too, in :func:`loss_weight_problems`, on the domain
     rather than on the endpoint this docstring called undecided: their zero
     readings are still unsettled and still accepted, but a non-finite weight has
-    no reading at all. ``clip_param`` and ``init_noise_std`` remain out of scope
-    in all five, and for measured reasons rather than by omission: ``clip_param``
-    is a clip *bound* whose ``inf`` is coherently honored as "do not clip"
-    (``clamp(ratio, -inf, inf)`` returns ``ratio`` unchanged), so it needs the
-    endpoint decision :func:`gradient_clip_problems` records for the sibling
-    bound; and every non-finite ``init_noise_std`` is refused by ``torch``, which
-    rejects a ``Normal`` of non-positive or non-finite scale.
+    no reading at all. ``clip_param`` now has its own gate too, in
+    :func:`clip_range_problems`: this docstring left it out because it needed the
+    endpoint decision :func:`gradient_clip_problems` records for the sibling clip
+    bound, and that decision is now shared rather than duplicated - both read
+    :func:`_clip_bound_error`. ``init_noise_std`` remains out of scope in all
+    six, for a measured reason rather than by omission: every non-finite value is
+    refused by ``torch``, which rejects a ``Normal`` of non-positive or
+    non-finite scale.
 
     Args:
         spec: The spec to check.
@@ -794,8 +804,13 @@ def temperature_learning_rate_problems(spec: TrainSpec, *, context: str) -> list
     return [error] if error is not None else []
 
 
-def _gradient_clip_error(value: Any, param: str, context: str) -> str | None:
-    """Error text when *value* is not a gradient-norm clip ``clip_grad_norm_`` honors.
+def _clip_bound_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when *value* is not a clip bound its consumer honors.
+
+    Shared by the two on-policy clip bounds, which have the same domain for the
+    same reason: ``max_grad_norm`` (see :func:`gradient_clip_problems`) and
+    ``clip_param`` (see :func:`clip_range_problems`). One rule, one home - a
+    second copy of it would be free to drift from this one.
 
     The whole of this function's own contribution is that positive **infinity is
     also accepted**; every other decision - numeric-ness, ``bool`` rejection,
@@ -803,12 +818,19 @@ def _gradient_clip_error(value: Any, param: str, context: str) -> str | None:
     :func:`~strands_robots.utils.positive_finite_number_error` domain, so those
     refusals read identically to every other positive-scalar field's.
 
-    Infinity is carved out because the consumer honors it. ``clip_grad_norm_``
-    scales a gradient by ``max_norm / total_norm`` only when that ratio is below
-    one, so an infinite bound leaves every gradient untouched - measured on a
-    parameter whose gradient norm is 5, ``inf`` returns it as ``[3.0, 4.0]``
-    unchanged. That is the only spelling of "do not clip" the field has, and a
-    guard that refused a value its own consumer applies coherently would be
+    Infinity is carved out because both consumers honor it, and it is the only
+    spelling of "do not clip" either field has:
+
+    * ``clip_grad_norm_`` scales a gradient by ``max_norm / total_norm`` only
+      when that ratio is below one, so an infinite bound leaves every gradient
+      untouched - measured on a parameter whose gradient norm is 5, ``inf``
+      returns it as ``[3.0, 4.0]`` unchanged.
+    * ``torch.clamp(ratio, 1 - clip_param, 1 + clip_param)`` becomes
+      ``clamp(ratio, -inf, inf)``, which returns ``ratio`` unchanged, so the
+      surrogate and value clips both fall away and the update descends the
+      unclipped objective - a coherent, finite run.
+
+    A guard that refused a value its own consumer applies coherently would be
     narrower than the code it protects.
 
     Nothing raises out of here, for any input. The carve-out asks the
@@ -891,7 +913,7 @@ def gradient_clip_problems(spec: TrainSpec, *, context: str) -> list[str]:
 
     Zero is **not** the "no clipping" spelling, which is the one reading that
     might have made it a contract question rather than a defect: infinity is,
-    and it is accepted (see :func:`_gradient_clip_error`). So the domain is a
+    and it is accepted (see :func:`_clip_bound_error`). So the domain is a
     positive real, finite or infinite, with no undecided endpoint.
 
     Only the on-policy backend clips gradients - ``grep`` finds
@@ -911,7 +933,7 @@ def gradient_clip_problems(spec: TrainSpec, *, context: str) -> list[str]:
         A single-element list when ``max_grad_norm`` cannot be honored; empty
         otherwise.
     """
-    error = _gradient_clip_error(getattr(spec, "max_grad_norm", 1.0), "max_grad_norm", context)
+    error = _clip_bound_error(getattr(spec, "max_grad_norm", 1.0), "max_grad_norm", context)
     return [error] if error is not None else []
 
 
@@ -996,3 +1018,78 @@ def loss_weight_problems(spec: TrainSpec, *, context: str) -> list[str]:
         if error is not None:
             problems.append(error)
     return problems
+
+
+def clip_range_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return trust-region problems for an on-policy RL :class:`TrainSpec`.
+
+    ``clip_param`` is the half-width of the trust region PPO is named for. The
+    on-policy update reads it twice, in the two expressions that clip::
+
+        surrogate_clipped = -adv * torch.clamp(ratio, 1.0 - spec.clip_param, 1.0 + spec.clip_param)
+        value_clipped = old_values + (value - old_values).clamp(-spec.clip_param, spec.clip_param)
+
+    Nothing judged it, and ``torch.clamp`` cannot: it is defined for every value
+    below, and each one produces a *finite, successful, deployable* run whose
+    objective is not the one the caller configured. Measured on this backend over
+    a seeded 60-step run, against a never-trained control whose checkpoint
+    parameter sum is ``139.8929914773252676``:
+
+    ==========================  =====================================================
+    ``clip_param``              Outcome (checkpoint parameter sum)
+    ==========================  =====================================================
+    ``0.2`` (shipped default)   clips; ``140.1741519418580992``
+    ``inf``                     no clip, finite losses; ``140.1735330768706262``
+    ``nan``                     **bit-identical to the unclipped run**, all losses ``nan``
+    ``True``                    silent half-width of one; ``140.1735330768706262``
+    ``-0.2``                    inverted bounds; ``140.1913412402318500``
+    ``0``                       degenerate window; ``140.2282075245283863``
+    ``-inf``                    trains on ``inf`` losses; ``140.0613218537641842``
+    ``"0.2"`` / ``None`` / ``[0.2]``  raise ``TypeError`` mid-update, from ``rl/ppo.py``
+    ==========================  =====================================================
+
+    Three of those rows are why this is a gate rather than a lint:
+
+    * **A ``nan`` half-width silently removes the trust region.** Both clipped
+      terms become ``nan``, so ``torch.max(surrogate, surrogate_clipped)``
+      returns ``nan`` - but its gradient flows to the *unclipped* branch, because
+      every comparison against ``nan`` is false. The run therefore descends the
+      unclipped objective and its checkpoint is bit-identical to the ``inf`` run,
+      while ``surrogate_loss``, ``value_loss`` and ``latest_loss`` are all
+      reported as ``nan``. PPO's defining mechanism is off and the only signal
+      that anything happened is a metric a caller cannot act on.
+    * **A negative half-width is not a window.** ``1 - c`` exceeds ``1 + c``, so
+      the clamp bounds are inverted and it returns a constant regardless of the
+      ratio - measured, ``clamp([0.7, 1.0, 1.4], 1.2, 0.8)`` is
+      ``[0.8, 0.8, 0.8]`` - and the reported surrogate loss changes sign, from
+      ``-0.008662`` to ``+0.081992``. Zero is the same failure at the boundary:
+      the value clip becomes ``clamp(-0, 0)``, so ``value_clipped`` is exactly
+      ``old_values`` and the critic's clipped branch is a constant.
+    * **A ``bool`` is a silently different trust region.** ``bool`` is an ``int``
+      subclass, so ``clip_param=True`` is a half-width of one - five times the
+      shipped ``0.2`` - written by a value that reads as a flag.
+
+    So the domain is a *positive* real, with positive infinity accepted as the
+    field's only spelling of "do not clip". That is the same rule and the same
+    reason as the sibling bound ``max_grad_norm``, so both read
+    :func:`_clip_bound_error` rather than carrying a copy each.
+
+    Only the on-policy backend clips a policy ratio - ``grep`` finds
+    ``spec.clip_param`` in ``rl/ppo.py`` and nowhere else - so this is scoped
+    like :func:`gae_lambda_problems` rather than :func:`learning_rate_problems`:
+    a backend that does not clip MUST NOT call this, because per
+    :class:`TrainSpec` a backend ignores the fields it does not support and
+    reporting on one would be a false rejection.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``clip_param`` cannot be honored; empty
+        otherwise.
+    """
+    error = _clip_bound_error(getattr(spec, "clip_param", 0.2), "clip_param", context)
+    return [error] if error is not None else []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -622,6 +622,50 @@ class Trainer(ABC):
 
         return loss_weight_problems(spec, context=self.provider_name)
 
+    def _clip_range_problems(self, spec: TrainSpec) -> list[str]:
+        """Trust-region preflight for a backend that clips a policy ratio.
+
+        Returns a problem when :attr:`RLTrainSpec.clip_param` is not a positive
+        real number. It is the half-width of the trust region the on-policy
+        surrogate is clipped to, read twice per mini-batch - once for the policy
+        ratio and once for the value loss - and ``torch.clamp`` judges it not at
+        all, so every unusable value below produced a finite, successful,
+        deployable run whose objective was not the configured one. A ``nan``
+        half-width is the sharpest: both clipped terms become ``nan``, the
+        gradient of ``torch.max`` flows to the *unclipped* branch because every
+        comparison against ``nan`` is false, and the resulting checkpoint is
+        bit-identical to an unclipped run while every reported loss is ``nan`` -
+        the trust region silently gone with no signal a caller can act on. A
+        negative half-width inverts the clamp bounds so they return a constant,
+        a ``bool`` is a silent half-width of one, and a string, ``None`` or a
+        list raises ``TypeError`` mid-update.
+
+        Positive infinity is inside the domain: it is the field's only spelling
+        of *do not clip*, and ``clamp(ratio, -inf, inf)`` honors it by returning
+        the ratio unchanged. That is the same endpoint, for the same reason, as
+        the sibling bound :meth:`_gradient_clip_problems`, so the two share one
+        domain helper rather than carrying a copy each.
+
+        Only a backend that clips a policy ratio may call this: like
+        :meth:`_gradient_clip_problems`, and unlike
+        :meth:`_learning_rate_problems`, a backend that does not read the field
+        MUST NOT report on it, because per :class:`TrainSpec` a backend ignores
+        the fields it does not support.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the module import graph one-way.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            A single-element list when ``clip_param`` cannot be honored; empty
+            otherwise.
+        """
+        from strands_robots.training._validate import clip_range_problems
+
+        return clip_range_problems(spec, context=self.provider_name)
+
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.
 

--- a/strands_robots/training/rl/ppo.py
+++ b/strands_robots/training/rl/ppo.py
@@ -168,6 +168,12 @@ class PpoTrainer(BaseRLAlgo):
         # weight poisons every parameter and surfaces as a torch error naming
         # neither field, and a bool lands as a silently different coefficient.
         problems.extend(self._loss_weight_problems(spec))
+        # clip_param is the half-width of the trust region the surrogate is clipped
+        # to, and also clips the value loss. torch.clamp judges it not at all: a
+        # nan half-width routes the gradient to the unclipped branch, so the run
+        # trains bit-identically to an unclipped one while every reported loss is
+        # nan, and a negative half-width inverts the bounds into a constant.
+        problems.extend(self._clip_range_problems(spec))
         if spec.total_timesteps <= 0:
             problems.append(f"total_timesteps must be > 0, got {spec.total_timesteps}")
         if spec.rollout_steps <= 0:

--- a/tests/training/test_clip_range_domain.py
+++ b/tests/training/test_clip_range_domain.py
@@ -1,0 +1,379 @@
+"""The on-policy trust-region half-width is checked against its domain.
+
+``RLTrainSpec.clip_param`` is the half-width of the trust region PPO is named
+for. ``PpoTrainer.update`` reads it twice per mini-batch, in the two expressions
+that clip::
+
+    surrogate_clipped = -adv * torch.clamp(ratio, 1.0 - spec.clip_param, 1.0 + spec.clip_param)
+    value_clipped = old_values + (value - old_values).clamp(-spec.clip_param, spec.clip_param)
+
+Nothing judged the value, and ``torch.clamp`` cannot: it is defined for every
+value below, and each one produced a *finite, successful, deployable* run whose
+objective was not the one the caller configured. Measured on this backend before
+the gate existed, over a seeded 60-step run against a never-trained control whose
+checkpoint parameter sum is ``139.8929914773252676``:
+
+* ``nan`` **silently removed the trust region.** Both clipped terms become
+  ``nan``, so ``torch.max(surrogate, surrogate_clipped)`` returns ``nan`` - but
+  its gradient flows to the *unclipped* branch, because every comparison against
+  ``nan`` is false. The run therefore descended the unclipped objective, and its
+  checkpoint parameter sum was ``140.1735330768706262`` - bit-identical to the
+  ``inf`` run - while ``surrogate_loss``, ``value_loss`` and ``latest_loss`` were
+  all reported as ``nan``. PPO's defining mechanism was off, and the only signal
+  that anything had happened was a metric a caller cannot act on.
+* ``-0.2`` **inverted the clamp bounds.** ``1 - c`` exceeds ``1 + c``, so the
+  clamp returns a constant regardless of the ratio, and the reported surrogate
+  loss changed sign - ``+0.081992`` against the honored run's ``-0.008662``. The
+  checkpoint sum moved to ``140.1913412402318500``.
+* ``0`` is the same failure at the boundary. The value clip becomes
+  ``clamp(-0, 0)``, so ``value_clipped`` is exactly ``old_values`` and the
+  critic's clipped branch is a constant; the checkpoint sum moved to
+  ``140.2282075245283863``.
+* ``-inf`` trained on ``inf`` losses and still reported success
+  (``140.0613218537641842``), and ``True`` was a silent half-width of one - five
+  times the shipped ``0.2`` - written by a value that reads as a flag.
+* ``"0.2"``, ``None`` and ``[0.2]`` raised ``TypeError`` from ``rl/ppo.py``
+  mid-update, after the environment, the networks and a full rollout had been
+  built.
+
+The honored default's sum is ``140.1741519418580992``, so every row above is a
+run that trained *differently* rather than harmlessly.
+
+``inf`` is **inside** the domain: it is the field's only spelling of "do not
+clip", and the consumer honors it - ``clamp(ratio, -inf, inf)`` returns the ratio
+unchanged, which is a coherent unclipped run with finite losses. That is the same
+endpoint, settled the same way, as the sibling clip bound ``max_grad_norm``, so
+the two share one domain helper rather than carrying a copy each.
+
+Scoped to the on-policy backend: ``spec.clip_param`` appears in ``rl/ppo.py`` and
+nowhere else, so a backend that does not clip a policy ratio must not report on a
+field it never reads. Every domain test here reaches the real ``validate`` entry
+point, so it covers the wiring as well as the domain.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.training import create_trainer
+from strands_robots.training._validate import (
+    _clip_bound_error,
+    clip_range_problems,
+    gradient_clip_problems,
+)
+from strands_robots.training.base import Trainer
+from strands_robots.training.rl import RLTrainSpec
+from strands_robots.utils import positive_finite_number_error
+
+# The one backend whose update clips a policy ratio.
+ON_POLICY = "ppo"
+
+# Backends that never clip a ratio - they must stay quiet about the field.
+NO_CLIP_BACKENDS = ("fast_sac", "mock")
+
+# Half-widths the clip can honor.
+USABLE: list[Any] = [0.2, 0.1, 0.5, 1.0, 3, np.float64(0.2), np.int64(2)]
+
+# The only spelling of "do not clip" the field has.
+NO_CLIPPING: list[Any] = [math.inf, float("inf"), np.float64(math.inf)]
+
+# A window of zero width is not a window: the value clip pins ``value_clipped``
+# to ``old_values`` exactly, so the critic's clipped branch is a constant.
+NO_WINDOW: list[Any] = [0, 0.0]
+
+# A negative half-width inverts the clamp bounds, which then return a constant
+# regardless of the ratio.
+INVERTED_WINDOW: list[Any] = [-0.2, -1.0, -100.0]
+
+# Values the half-width cannot mean, or that read as a different width than the
+# caller wrote. ``True`` is a half-width of one.
+NOT_A_WIDTH: list[Any] = [
+    True,
+    False,
+    float("nan"),
+    float("-inf"),
+    "0.2",
+    "inf",
+    None,
+    [0.2],
+    {"clip_param": 0.2},
+    np.bool_(True),
+]
+
+UNUSABLE: list[Any] = [*NO_WINDOW, *INVERTED_WINDOW, *NOT_A_WIDTH]
+
+
+def _spec(**overrides: Any) -> RLTrainSpec:
+    """An otherwise-valid RL spec carrying *overrides*.
+
+    Every value these tests set is deliberately outside its field's annotation -
+    that is the property under test - so the overrides are applied through
+    ``setattr``, and the one suppression the ``env_factory`` placeholder needs
+    lives here rather than at each call site.
+    """
+    spec = RLTrainSpec(output_dir="/tmp/clip_range_domain", env_factory=lambda: None)  # type: ignore[arg-type,return-value]
+    for field, value in overrides.items():
+        setattr(spec, field, value)
+    return spec
+
+
+@pytest.fixture
+def spec() -> RLTrainSpec:
+    """A spec the on-policy preflight otherwise accepts."""
+    return _spec()
+
+
+def _clip_problems(provider: str, spec: RLTrainSpec) -> list[str]:
+    """Every problem the backend's real ``validate`` reports about the width."""
+    return [p for p in create_trainer(provider).validate(spec) if ": clip_param " in p]
+
+
+class TestTheTrustRegionRefusesAWidthItCannotHonor:
+    """A half-width no reading makes usable is reported, not clipped with."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_unusable_width_is_refused(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.clip_param = value
+        assert _clip_problems(ON_POLICY, spec) != [], f"{value!r} was accepted"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_problem_names_the_field_the_domain_and_the_value(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.clip_param = value
+        (problem,) = _clip_problems(ON_POLICY, spec)
+        assert problem.startswith("ppo: clip_param "), problem
+        assert "must be > 0" in problem, problem
+
+    def test_the_message_is_the_shared_domain_verbatim(self, spec: RLTrainSpec) -> None:
+        """The gate adds no wording of its own; it delegates."""
+        spec.clip_param = -0.2
+        (problem,) = _clip_problems(ON_POLICY, spec)
+        assert problem == _clip_bound_error(-0.2, "clip_param", "ppo")
+
+    def test_the_preflight_reports_rather_than_raises(self) -> None:
+        """``validate`` is read-only, so an unusable width never escapes it."""
+        assert isinstance(create_trainer(ON_POLICY).validate(_spec(clip_param=None)), list)
+
+    def test_two_unusable_optimization_fields_report_two_problems(self, spec: RLTrainSpec) -> None:
+        """The clip-range gate is additional to the sibling bound, not a merge."""
+        spec.clip_param = float("nan")
+        spec.max_grad_norm = float("nan")
+        problems = create_trainer(ON_POLICY).validate(spec)
+        assert sum(1 for p in problems if ": clip_param " in p) == 1
+        assert sum(1 for p in problems if ": max_grad_norm " in p) == 1
+
+
+class TestTheUsableDomainIsUntouched:
+    """Every half-width the clip can honor still passes."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *NO_CLIPPING])
+    def test_a_positive_real_is_accepted(self, spec: RLTrainSpec, value: Any) -> None:
+        spec.clip_param = value
+        assert _clip_problems(ON_POLICY, spec) == []
+
+    def test_the_shipped_default_is_inside_the_domain(self, spec: RLTrainSpec) -> None:
+        assert spec.clip_param == 0.2
+        assert _clip_problems(ON_POLICY, spec) == []
+
+    def test_a_spec_without_the_field_is_silent(self) -> None:
+        """A plain ``TrainSpec`` has no ``clip_param``, so there is nothing to judge."""
+        from strands_robots.training.base import TrainSpec
+
+        plain = TrainSpec(output_dir="/tmp/clip_range_domain")
+        assert clip_range_problems(plain, context="ppo") == []
+
+
+class TestTheTwoClipBoundsShareOneDomain:
+    """One rule, one home - the two on-policy clip bounds cannot drift apart."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *NO_CLIPPING, *UNUSABLE])
+    def test_both_bounds_give_the_same_verdict(self, value: Any) -> None:
+        width = _spec(clip_param=value)
+        norm = _spec(max_grad_norm=value)
+        assert bool(clip_range_problems(width, context="ppo")) == bool(gradient_clip_problems(norm, context="ppo")), (
+            f"the two clip bounds disagree on {value!r}"
+        )
+
+    def test_both_gates_read_the_one_shared_helper(self) -> None:
+        """Structural: neither gate carries its own copy of the rule."""
+        for gate in (clip_range_problems, gradient_clip_problems):
+            source = inspect.getsource(gate)
+            called = {
+                node.func.id
+                for node in ast.walk(ast.parse(source))
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            assert "_clip_bound_error" in called, f"{gate.__name__} does not delegate: {called}"
+
+    @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
+    def test_the_domain_is_the_shared_positive_finite_rule(self, value: Any) -> None:
+        mine = clip_range_problems(_spec(clip_param=value), context="ppo")
+        shared = positive_finite_number_error(value, "clip_param", "ppo")
+        assert mine == ([shared] if shared is not None else []), f"diverged on {value!r}"
+
+    @pytest.mark.parametrize("value", NO_CLIPPING)
+    def test_infinity_is_the_one_carve_out(self, value: Any) -> None:
+        assert clip_range_problems(_spec(clip_param=value), context="ppo") == []
+        assert positive_finite_number_error(value, "clip_param", "ppo") is not None
+
+    def test_negative_infinity_is_not_carved_out(self) -> None:
+        assert clip_range_problems(_spec(clip_param=float("-inf")), context="ppo") != []
+
+
+class TestTheBackendsThatDoNotClipStaySilent:
+    """A backend that never reads the field must not report on it."""
+
+    @pytest.mark.parametrize("provider", NO_CLIP_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_non_clipping_backend_says_nothing_about_the_width(
+        self, provider: str, spec: RLTrainSpec, value: Any
+    ) -> None:
+        spec.clip_param = value
+        assert _clip_problems(provider, spec) == []
+
+    @pytest.mark.parametrize("provider", NO_CLIP_BACKENDS)
+    def test_the_silence_is_scoping_rather_than_an_empty_preflight(self, provider: str) -> None:
+        """Non-vacuity: the same backends do refuse a field they *do* read."""
+        spec = _spec(learning_rate=float("nan"))
+        problems = create_trainer(provider).validate(spec)
+        assert any(": learning_rate " in p for p in problems), problems
+
+
+class TestTheConsumerCannotJudgeTheWidth:
+    """The premises the domain rests on, measured against ``torch``."""
+
+    def test_a_nan_width_routes_the_gradient_to_the_unclipped_branch(self) -> None:
+        """The crux: the loss reads ``nan`` while the update descends unclipped.
+
+        ``torch.max`` propagates the ``nan`` forward, so every reported loss is
+        ``nan``; backward, every comparison against ``nan`` is false, so the
+        gradient is the *unclipped* surrogate's. That is why a ``nan`` half-width
+        trains bit-identically to an unclipped run instead of poisoning it.
+        """
+        torch = pytest.importorskip("torch")
+        adv = torch.tensor([0.5, -0.3, 0.9])
+
+        def surrogate_grad(width: float) -> tuple[list[float], bool]:
+            ratio = torch.tensor([0.7, 1.0, 1.4], requires_grad=True)
+            clipped = -adv * torch.clamp(ratio, 1.0 - width, 1.0 + width)
+            loss = torch.max(-adv * ratio, clipped).mean()
+            loss.backward()
+            assert ratio.grad is not None
+            return [round(v, 6) for v in ratio.grad.tolist()], bool(torch.isnan(loss))
+
+        nan_grad, nan_loss_is_nan = surrogate_grad(float("nan"))
+        unclipped_grad, inf_loss_is_nan = surrogate_grad(math.inf)
+        clipped_grad, default_loss_is_nan = surrogate_grad(0.2)
+
+        assert nan_loss_is_nan, "a nan width must show up in the reported loss"
+        assert not inf_loss_is_nan and not default_loss_is_nan
+        assert nan_grad == unclipped_grad, "a nan width must not be the unclipped gradient"
+        assert nan_grad != clipped_grad, "the clipped gradient must differ, or the probe is vacuous"
+
+    def test_a_negative_width_inverts_the_bounds_into_a_constant(self) -> None:
+        torch = pytest.importorskip("torch")
+        ratio = torch.tensor([0.7, 1.0, 1.4])
+        clamped = torch.clamp(ratio, 1.0 - (-0.2), 1.0 + (-0.2)).tolist()
+        assert len(set(clamped)) == 1, f"expected a constant, got {clamped}"
+        assert torch.clamp(ratio, 0.8, 1.2).tolist() != clamped
+
+    def test_a_zero_width_pins_the_value_clip_to_the_old_values(self) -> None:
+        torch = pytest.importorskip("torch")
+        old_values = torch.tensor([0.4, -1.2, 3.0])
+        delta = torch.tensor([-0.9, 0.5, 0.9])
+        assert torch.equal(old_values + delta.clamp(-0.0, 0.0), old_values)
+        assert not torch.equal(old_values + delta.clamp(-0.2, 0.2), old_values)
+
+    def test_infinity_leaves_the_ratio_unchanged(self) -> None:
+        """The measured basis for the carve-out."""
+        torch = pytest.importorskip("torch")
+        ratio = torch.tensor([0.7, 1.0, 1.4])
+        assert torch.equal(torch.clamp(ratio, 1.0 - math.inf, 1.0 + math.inf), ratio)
+
+
+class TestTheRefusalPrecedesTheUpdate:
+    """A refused width reaches no optimizer."""
+
+    def test_the_on_policy_train_fails_closed_before_building_anything(self, tmp_path: Any) -> None:
+        pytest.importorskip("torch")
+        called: list[str] = []
+
+        def env_factory() -> None:
+            called.append("env")
+            raise AssertionError("the refused width reached the environment")
+
+        spec = _spec(env_factory=env_factory, output_dir=str(tmp_path), clip_param=float("nan"))
+        result = create_trainer(ON_POLICY).train(spec)
+        assert result.status == "error"
+        assert "clip_param" in (result.message or ""), result.message
+        assert called == [], "the preflight must precede the environment"
+
+
+# --- one owner for the domain ------------------------------------------------
+
+
+def _training_modules() -> list[pathlib.Path]:
+    """Every training module except the one that owns the gate."""
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(clip_range_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_width(source: str) -> bool:
+    """Does *source* read ``spec.clip_param``?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr == "clip_param" and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_clip_range_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheClipRangeDomain:
+    """No backend may skip the domain, and none may re-implement it.
+
+    The set of backends in scope is derived from the tree rather than listed: a
+    module that *reads* ``spec.clip_param`` must route it through the shared
+    gate, so a second backend that starts clipping with the field fails this
+    test until it does.
+    """
+
+    def test_every_module_that_reads_it_routes_through_the_shared_gate(self) -> None:
+        adrift = [
+            p.name
+            for p in _training_modules()
+            if _reads_the_width(p.read_text()) and not _calls_the_gate(p.read_text())
+        ]
+        assert adrift == [], f"modules read spec.clip_param without the shared gate: {adrift}"
+
+    def test_the_reader_set_is_the_expected_one(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep over nothing."""
+        readers = {p.name for p in _training_modules() if _reads_the_width(p.read_text())}
+        assert readers == {"ppo.py"}, readers
+
+    def test_the_scanner_detects_a_planted_reader(self) -> None:
+        """A module reading the field without the gate is really reported."""
+        planted = "def validate(self, spec):\n    return [] if spec.clip_param else []\n"
+        assert _reads_the_width(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_no_backend_re_implements_the_bound(self) -> None:
+        """A hand-rolled comparison agrees with the shared rule until it drifts."""
+        offenders = [
+            p.name
+            for p in _training_modules()
+            if "clip_param <= 0" in p.read_text() or "clip_param < 0" in p.read_text()
+        ]
+        assert offenders == [], f"modules compare clip_param themselves: {offenders}"

--- a/tests/training/test_gradient_clip_domain.py
+++ b/tests/training/test_gradient_clip_domain.py
@@ -56,7 +56,7 @@ import numpy as np
 import pytest
 
 from strands_robots.training import create_trainer
-from strands_robots.training._validate import _gradient_clip_error, gradient_clip_problems
+from strands_robots.training._validate import _clip_bound_error, gradient_clip_problems
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_finite_number_error
@@ -254,22 +254,22 @@ class TestInfinityIsTheOnlyDifferenceFromTheSharedRule:
 
     @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
     def test_it_agrees_with_the_shared_positive_finite_rule(self, value: Any) -> None:
-        mine = _gradient_clip_error(value, "max_grad_norm", "ppo")
+        mine = _clip_bound_error(value, "max_grad_norm", "ppo")
         shared = positive_finite_number_error(value, "max_grad_norm", "ppo")
         assert mine == shared, f"diverged on {value!r}: {mine!r} vs {shared!r}"
 
     @pytest.mark.parametrize("value", NO_CLIPPING)
     def test_infinity_is_the_carve_out(self, value: Any) -> None:
-        assert _gradient_clip_error(value, "max_grad_norm", "ppo") is None
+        assert _clip_bound_error(value, "max_grad_norm", "ppo") is None
         assert positive_finite_number_error(value, "max_grad_norm", "ppo") is not None
 
     def test_negative_infinity_is_not_carved_out(self) -> None:
-        assert _gradient_clip_error(float("-inf"), "max_grad_norm", "ppo") is not None
+        assert _clip_bound_error(float("-inf"), "max_grad_norm", "ppo") is not None
 
     @pytest.mark.parametrize("value", [*BEYOND_FLOAT_RANGE, *UNREADABLE_REAL])
     def test_the_carve_out_declines_rather_than_raising(self, value: Any) -> None:
         """A value the carve-out cannot read is delegated, never raised on."""
-        assert isinstance(_gradient_clip_error(value, "max_grad_norm", "ppo"), str)
+        assert isinstance(_clip_bound_error(value, "max_grad_norm", "ppo"), str)
 
     def test_the_unreadable_probes_span_the_prescribed_conversion_errors(self) -> None:
         """Non-vacuity for the wrapper, and a guard against the probes drifting.
@@ -290,7 +290,7 @@ class TestInfinityIsTheOnlyDifferenceFromTheSharedRule:
     def test_a_string_spelling_of_infinity_is_not_carved_out(self) -> None:
         """``float("inf")`` is the carve-out's value, so the type test carries it."""
         assert float("inf") == math.inf  # the premise the type test guards
-        assert _gradient_clip_error("inf", "max_grad_norm", "ppo") is not None
+        assert _clip_bound_error("inf", "max_grad_norm", "ppo") is not None
 
 
 class TestTheBackendsThatDoNotClipStaySilent:


### PR DESCRIPTION
## Problem

`RLTrainSpec.clip_param` is the half-width of the trust region PPO is named for. `PpoTrainer.update` reads it twice per mini-batch, in the two expressions that clip:

```python
surrogate_clipped = -adv * torch.clamp(ratio, 1.0 - spec.clip_param, 1.0 + spec.clip_param)
value_clipped = old_values + (value - old_values).clamp(-spec.clip_param, spec.clip_param)
```

Nothing judged the value, and `torch.clamp` cannot: it is defined for every value below, so each one produced a **finite, successful, deployable** run whose objective was not the one the caller configured.

Measured on the on-policy backend over a seeded 60-step SO-100 reach run, against a never-trained control whose checkpoint parameter sum is `139.8929914773252676` and an honored default of `140.1741519418580992`:

| `clip_param` | `validate()` | outcome | checkpoint parameter sum |
|---|---|---|---|
| `0.2` (shipped default) | accepted | clips as configured | `140.1741519418580992` |
| `inf` | accepted | no clip, finite losses | `140.1735330768706262` |
| `nan` | accepted | **bit-identical to the unclipped run**, every loss `nan` | `140.1735330768706262` |
| `True` | accepted | silent half-width of one | `140.1735330768706262` |
| `-0.2` | accepted | clamp bounds inverted to a constant | `140.1913412402318500` |
| `0` | accepted | value clip pinned to `old_values` | `140.2282075245283863` |
| `-inf` | accepted | trains on `inf` losses | `140.0613218537641842` |
| `"0.2"` / `None` / `[0.2]` | accepted | raise `TypeError` at `rl/ppo.py:443` mid-update | -- |

Three rows are why this is a gate rather than a lint.

**A `nan` half-width silently removes the trust region.** Both clipped terms become `nan`, so `torch.max(surrogate, surrogate_clipped)` returns `nan` -- but its *gradient* flows to the **unclipped** branch, because every comparison against `nan` is false. The run therefore descends the unclipped objective, and its checkpoint comes out bit-identical to the `inf` run, while `surrogate_loss`, `value_loss` and `latest_loss` are all reported as `nan`. PPO's defining mechanism is off, and the only signal that anything happened is a metric a caller cannot act on.

**A negative half-width is not a window.** `1 - c` exceeds `1 + c`, so the clamp bounds are inverted and it returns a constant regardless of the ratio -- `clamp([0.7, 1.0, 1.4], 1.2, 0.8)` is `[0.8, 0.8, 0.8]` -- and the reported surrogate loss changes sign, from `-0.008662` to `+0.081992`. `0` is the same failure at the boundary: the value clip becomes `clamp(-0, 0)`, so `value_clipped` is exactly `old_values` and the critic's clipped branch is a constant.

**A `bool` is a silently different trust region.** `bool` is an `int` subclass, so `clip_param=True` is a half-width of one -- five times the shipped `0.2` -- written by a value that reads as a flag.

## Change

`PpoTrainer.validate` now reports a half-width that is not a positive real, so an unusable value is refused before the environment, the networks or the optimizer are built. `train()` fails closed on `validate()`, so the refusal replaces the deep stack trace a read-only preflight exists to prevent.

**Positive infinity stays inside the domain.** It is the field's only spelling of *do not clip*, and the consumer honors it: `clamp(ratio, -inf, inf)` returns the ratio unchanged, which is a coherent unclipped run with finite losses. A guard that refused a value its own consumer applies coherently would be narrower than the code it protects.

**One rule, one home.** That is the same domain, for the same reason, as the sibling clip bound `max_grad_norm`. Rather than add a second copy free to drift from the first, the existing private helper is **renamed in place** (`_gradient_clip_error` -> `_clip_bound_error`) and read by both gates, with its docstring covering both consumers. The rename is mechanical: one production call site, two docstring cross-references, six references in the sibling test module -- symbol names only, no assertion changed.

`clip_range_problems` is scoped like `gae_lambda_problems`: `spec.clip_param` appears in `rl/ppo.py` and nowhere else, so the off-policy backend stays silent about a field it never reads. A structural guard derives the reader set from the tree, so a second backend that starts clipping with the field fails until it routes through the gate.

The `discount_factor_problems` docstring listed `clip_param` as out of scope because it "needs the endpoint decision `gradient_clip_problems` records for the sibling bound". That decision now exists in the tree, so the caveat is corrected in the same change.

## Measured

![On-policy clip-range domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/clip-range-domain/clip_range_domain.png)

Every cell is read from two JSON dumps produced by one script run in a `git worktree` at `main` and on this branch; the generator asserts each rendered number, that the two dumps came from different trees, and that `nan`'s checkpoint sum is byte-equal to `inf`'s before it will save.

Values honored that no reading makes usable: **main 8 of 8 -> this change 0 of 8**, with all 3 usable values still accepted.

**The configured run is untouched, byte for byte.** Trained on both trees with the shipped default, the checkpoint parameter sum is `140.1741519418580992` on both, 40 deterministic steps of the resulting policy leave the SO-100 `Elbow` at `0.199985` rad on both, and the headless MuJoCo render of that pose differs by `max|delta| = 1/255` -- renderer noise. `np.float64(0.2)` is accepted and bit-identical to `0.2`, so a value read from a config array still trains.

## Scope

`init_noise_std` is the one field left out of the six optimization gates, for a measured reason rather than by omission: every non-finite value is already refused by `torch`, which rejects a `Normal` of non-positive or non-finite scale. The `discount_factor_problems` caveat is updated to say so.

## Verification

Run on the branch head `5faf58a`, based on `1610083`:

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **24109 passed, 257 skipped, 0 failed** in 533 s.
- `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` -> 1121 files already formatted; `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/isaac_gs`** (the 14 there are byte-identical to a pristine `main` worktree of the same working copy, so they are environmental).
- `python3 scripts/assemble_changelog.py --check` -> OK (236 pending); `scripts/check_merge_base_overlap.py` -> no overlap.
- **Pre-fix proof.** Reverting only the call sites (`training/base.py`, `training/rl/ppo.py`) to `main` while keeping `_validate.py`, so the test module still imports: **34 failed, 104 passed**. The structural guard's failure names `ppo.py` directly. The 104 that pass are the gate's own direct-call tests, the shared-domain parity and the `torch` premise measurements -- none of which depend on the wiring, which is what makes the 34 the wiring's own proof.
- `tests/training/` -> 2297 passed, 4 skipped. The 138 new tests are additive: the only change to an existing test file is the six renamed references to the shared helper.
