### PR TITLE
fix(simulation): refuse a replay episode index the dataset cannot be indexed by

### DIFF
--- a/changelog.d/2049-replay-episode-index-domain.md
+++ b/changelog.d/2049-replay-episode-index-domain.md
@@ -1,0 +1,20 @@
+### Fixed: refuse a replay episode index the dataset cannot be indexed by
+
+`episode` reached `load_lerobot_episode`'s bare `episode < 0` test on
+`PolicyRunner.replay`, `SimEngine.replay_episode` and the loader itself, while
+`replay_episode` - the same quantity on the lerobot teleop tool, and one of the
+two parameters `non_negative_whole_number_error` names in its docstring -
+already carried the shared rule. That test gave a verdict to three classes of
+value it could not honor: a bool passed it (`True < 0` is False) and then
+indexed the episode table as an int, so `replay(episode=True)` resolved and
+replayed **episode 1** under `status="success"`; a non-integral or non-finite
+index passed it too and was blamed on the dataset (`Episode 2.5 has no frames`)
+after a full-length boundary scan; and a str, list or `None` reached the
+comparison itself and raised `TypeError`, which is neither the `ValueError` the
+loader documents nor the structured envelope `replay` documents. The index now
+shares `non_negative_whole_number_error` on all three surfaces and is refused
+before the dataset is downloaded, so an unusable index costs no hub round-trip
+and no action reaches the actuators. An accepted integral float or NumPy scalar
+is coerced with `int()` after the guard has round-tripped it, which also keeps
+it on the O(1) `episode_data_index` lookup instead of the O(len(dataset))
+last-resort frame scan a float index fell through to.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -32,7 +32,7 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import lerobot_version, name_list_error
+from strands_robots.utils import lerobot_version, name_list_error, non_negative_whole_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -1566,16 +1566,47 @@ class DatasetRecorder:
 def load_lerobot_episode(repo_id: str, episode: int = 0, root: str | None = None):
     """Load a LeRobotDataset and resolve the frame range for an episode.
 
+    Args:
+        repo_id: HuggingFace dataset id.
+        episode: Episode index, a non-negative whole number. Any real scalar
+            with an integral value is accepted (a ``2.0`` from a config, a
+            ``np.int64`` from arithmetic); the value is coerced with ``int()``
+            once the shared guard has round-tripped it, so an accepted index
+            reaches the O(1) ``episode_data_index`` lookup rather than the
+            last-resort frame scan a float index falls through to.
+        root: Optional local dataset root override.
+
     Returns:
         Tuple of (dataset, episode_start, episode_length) on success.
 
     Raises:
         ImportError: If lerobot is not installed.
-        ValueError: If the episode index is negative, out of range, or the
-            resolved episode has no frames.
+        ValueError: If the episode index is not a usable non-negative whole
+            number, is out of range, or the resolved episode has no frames.
     """
-    if episode < 0:
-        raise ValueError(f"Episode index must be non-negative, got {episode}")
+    # The domain is the shared non-negative whole-number rule, not a bare
+    # ``< 0`` test. That test gave a verdict to three classes of value it
+    # could not actually honor:
+    #
+    # * ``bool`` passed it (``True < 0`` is False) and then indexed the
+    #   episode table as an int, so ``episode=True`` resolved **episode 1**
+    #   and returned it as a success - a different episode than any caller
+    #   passing a flag could have meant.
+    # * A non-integral or non-finite value passed it too and was blamed on
+    #   the dataset after a full-length boundary scan ("Episode 2.5 has no
+    #   frames"), naming the data rather than the index.
+    # * A str/list/None reached the comparison itself and raised
+    #   ``TypeError``, which is not the ``ValueError`` this function
+    #   documents as its refusal channel.
+    #
+    # Shared with the ``replay_episode`` teleop knob rather than restated:
+    # that parameter is the same quantity on a neighbouring surface, and
+    # ``non_negative_whole_number_error`` already names it.
+    if msg := non_negative_whole_number_error(episode, "episode", "load_lerobot_episode"):
+        raise ValueError(msg)
+    # Safe because the guard performed this coercion and compared the result
+    # back; see its docstring on why the two steps are ordered this way.
+    episode = int(episode)
 
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -3134,6 +3134,12 @@ class SimEngine(ABC):
     ) -> dict[str, Any]:
         """Replay a LeRobotDataset episode via ``PolicyRunner.replay``.
 
+        ``episode`` must be a non-negative whole number - the shared domain the
+        ``replay_episode`` teleop knob uses - and is rejected with a structured
+        error before the dataset is downloaded. A bool is refused rather than
+        read as an index: ``episode=True`` previously resolved episode 1 and
+        replayed it under a ``"success"`` status.
+
         ``speed`` is a playback-rate multiplier (1.0 = real time) and must be a
         positive number; a non-positive or non-numeric value is rejected with a
         structured error rather than raising or silently playing back at full

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -48,6 +48,7 @@ from strands_robots._async_utils import _resolve_coroutine
 from strands_robots.dataset_recorder import RecordingFrameError
 from strands_robots.policies.base import resolve_chunk_length
 from strands_robots.utils import (
+    non_negative_whole_number_error,
     positive_count_error,
     positive_finite_number_error,
     positive_whole_number_error,
@@ -1861,7 +1862,13 @@ class PolicyRunner:
                 when omitted; an explicit name not present in the sim is
                 rejected with a structured error (no silent replay onto a
                 non-existent robot).
-            episode: Episode index in the dataset (non-negative).
+            episode: Episode index in the dataset. Must be a non-negative
+                whole number; any real scalar with an integral value is
+                accepted (including a NumPy scalar such as ``np.int64(2)``),
+                and a bool, a non-integral value, a non-finite value or a
+                non-numeric one is rejected with a structured error before the
+                dataset is downloaded. Refused rather than coerced because the
+                index selects which trajectory reaches the actuators.
             root: Optional local dataset root override.
             speed: Playback speed multiplier (1.0 = real time). Must be a
                 positive, finite number (any real scalar, including a NumPy
@@ -1936,6 +1943,26 @@ class PolicyRunner:
         key_map_error = _validate_action_key_map(action_key_map)
         if key_map_error is not None:
             return key_map_error
+
+        # ``episode`` selects WHICH recorded episode is replayed, so an
+        # unusable index is not a slow replay - it is the wrong trajectory
+        # sent to a real position-servo robot. It reached
+        # ``load_lerobot_episode``'s guard as a bare ``< 0`` test, which a
+        # bool passes: ``replay(episode=True)`` resolved episode 1 and
+        # replayed it under ``status="success"``. Validated here, with
+        # ``speed`` and ``action_key_map``, for the two reasons those are:
+        # the refusal arrives through this method's documented envelope
+        # rather than as a raise, and it lands before the (potentially
+        # multi-minute) dataset download. The rule is the shared one the
+        # neighbouring ``replay_episode`` teleop knob already applies, so
+        # the refusal is identical across both spellings of the parameter
+        # rather than merely equivalent in verdict.
+        if msg := non_negative_whole_number_error(episode, "episode", "replay"):
+            return {"status": "error", "content": [{"text": msg}]}
+        # Coerced for the same reason ``speed`` is: the accepted value flows
+        # into ``load_lerobot_episode`` and the returned status field, and a
+        # NumPy scalar is not natively JSON-serialisable.
+        episode = int(episode)
 
         try:
             from strands_robots.dataset_recorder import load_lerobot_episode

--- a/tests/simulation/test_replay_episode_index_domain.py
+++ b/tests/simulation/test_replay_episode_index_domain.py
@@ -114,6 +114,29 @@ class _FakeDataset:
         return {"episode_index": ep}
 
 
+def superseded_non_negative_test(episode: object) -> bool:
+    """The guard this change replaces: ``if episode < 0: raise``.
+
+    Reproduced as a function so the premise class below *measures* what that
+    comparison did with each probe value. Written inline as
+    ``assert (True < 0) is False`` the same claim is decided when it is typed:
+    it restates an outcome instead of measuring one, which is the shape
+    ``tests/test_no_vacuous_comparisons.py`` refuses across the repository.
+    Taking the value as a parameter is what makes the comparison a measurement.
+
+    Args:
+        episode: The value a caller supplied as an episode index.
+
+    Returns:
+        Whether the superseded comparison refused ``episode``.
+
+    Raises:
+        TypeError: If ``episode`` cannot be ordered against an int at all,
+            which is itself one of the three outcomes the premise records.
+    """
+    return bool(episode < 0)  # type: ignore[operator]
+
+
 @pytest.fixture
 def fake_lerobot(monkeypatch):
     """Install a fake ``lerobot`` so the loader runs with no hub round-trip."""
@@ -156,6 +179,24 @@ ACCEPTED = [
 ]
 
 
+# The three outcomes the superseded ``episode < 0`` produced, split by what that
+# comparison *did* rather than by what the value looks like. Referenced by probe
+# id so the values are never spelled twice, and covered exhaustively by
+# ``TestThePremise.test_the_premise_covers_every_probe_value``.
+_UNUSABLE_BY_ID = {param.id: param.values[0] for param in UNUSABLE}
+
+_PREMISE_GROUPS = {
+    "passed": ("True", "False", "np.True_", "2.5", "nan", "inf", "np.float64(1.5)"),
+    "refused": ("-1", "-1.0", "-inf"),
+    "unorderable": ("str", "list", "None", "dict"),
+}
+
+
+def _premise_values(group: str) -> list[object]:
+    """The probe values in ``group``, resolved through their ids."""
+    return [_UNUSABLE_BY_ID[pid] for pid in _PREMISE_GROUPS[group]]
+
+
 # ── the premise, measured rather than asserted ──────────────────────
 
 
@@ -163,28 +204,39 @@ class TestThePremise:
     """Why a bare ``< 0`` test could not refuse these values.
 
     Measured against the language and NumPy themselves, so the mechanism is a
-    measurement rather than a claim about one.
+    measurement rather than a claim about one: every probe value is pushed
+    through :func:`superseded_non_negative_test`, the comparison this change
+    replaces, and grouped by what that comparison actually did with it. The
+    grouping is exhaustive over ``UNUSABLE`` -- asserted below, so a probe value
+    added later cannot silently escape the premise.
     """
 
-    def test_a_bool_passes_a_non_negative_test(self):
-        assert (True < 0) is False
-        assert (False < 0) is False
+    @pytest.mark.parametrize("value", _premise_values("passed"), ids=_PREMISE_GROUPS["passed"])
+    def test_the_superseded_comparison_did_not_refuse_these(self, value):
+        assert superseded_non_negative_test(value) is False
+
+    @pytest.mark.parametrize("value", _premise_values("refused"), ids=_PREMISE_GROUPS["refused"])
+    def test_the_superseded_comparison_did_refuse_these(self, value):
+        # These the old comparison caught, which is why the shared rule reports
+        # them with the same message rather than a new one.
+        assert superseded_non_negative_test(value) is True
+
+    @pytest.mark.parametrize("value", _premise_values("unorderable"), ids=_PREMISE_GROUPS["unorderable"])
+    def test_the_superseded_comparison_raised_instead_of_refusing(self, value):
+        with pytest.raises(TypeError):
+            superseded_non_negative_test(value)
+
+    def test_the_premise_covers_every_probe_value(self):
+        """Guard: no ``UNUSABLE`` entry escapes the premise, and none is claimed twice."""
+        grouped = [pid for ids in _PREMISE_GROUPS.values() for pid in ids]
+        assert len(grouped) == len(set(grouped)), "a probe value is claimed by two groups"
+        assert sorted(grouped) == sorted(_UNUSABLE_BY_ID)
 
     def test_a_bool_then_indexes_a_list_as_an_int(self):
         # The mechanism: ``episode_data_index["from"][True]`` is element 1.
         table = [_Cell(0), _Cell(10), _Cell(30)]
         assert table[True].item() == 10
         assert table[False].item() == 0
-
-    def test_a_non_integral_and_a_nan_pass_a_non_negative_test(self):
-        assert (2.5 < 0) is False
-        assert (math.nan < 0) is False
-        assert (math.inf < 0) is False
-
-    def test_a_str_list_none_raise_on_the_comparison_itself(self):
-        for value in ("0", [0], None):
-            with pytest.raises(TypeError):
-                _ = value < 0  # type: ignore[operator]
 
     @pytest.mark.parametrize("value", UNUSABLE)
     def test_the_shared_rule_refuses_every_probe(self, value):

--- a/tests/simulation/test_replay_episode_index_domain.py
+++ b/tests/simulation/test_replay_episode_index_domain.py
@@ -1,0 +1,452 @@
+"""The episode index a replay resolves is a non-negative whole number.
+
+``episode`` selects *which* recorded trajectory is sent to the actuators, so an
+index the dataset cannot be indexed by is not a slow replay - it is the wrong
+motion. Three public surfaces resolve one: ``PolicyRunner.replay``,
+``SimEngine.replay_episode`` (which forwards to it) and the
+``load_lerobot_episode`` loader they share.
+
+Pre-fix the only guard was ``if episode < 0`` inside the loader, which gave a
+verdict to three classes of value it could not honor. Measured with the fake
+dataset below (three episodes of lengths 10/20/30, so *which* episode was
+resolved is visible in the returned frame range rather than inferred):
+
+===============  ==================================================  ==========
+``episode=``     pre-fix outcome                                     resolved
+===============  ==================================================  ==========
+``True``         SUCCESS start=10 length=20                          episode 1
+``False``        SUCCESS start=0 length=10                           episode 0
+``np.True_``     SUCCESS start=10 length=20                          episode 1
+``2.5``          ValueError "Episode 2.5 has no frames"              -
+``nan``          ValueError "Episode nan has no frames"              -
+``inf``          ValueError "Episode inf out of range (0-2)"         -
+``'0'``          TypeError from the ``<`` comparison                 -
+``[0]``          TypeError from the ``<`` comparison                 -
+``None``         TypeError from the ``<`` comparison                 -
+===============  ==================================================  ==========
+
+Three separate defects in one parameter:
+
+* a **bool resolved an episode** - ``True < 0`` is False and the episode table
+  is then indexed with it, so ``episode=True`` replayed episode 1 under
+  ``status="success"``. No caller passing a flag meant "the second episode";
+* a non-integral or non-finite index was **blamed on the dataset** ("has no
+  frames"), naming the data rather than the index, and only after a
+  full-length boundary scan;
+* a str/list/None raised **TypeError**, which is not the ``ValueError`` the
+  loader documents as its refusal channel, nor the structured envelope
+  ``replay`` documents as its own.
+
+The fix applies ``non_negative_whole_number_error`` - the shared rule whose own
+docstring already names ``replay_episode``, the same quantity on the
+neighbouring teleop surface - so the refusal is identical across both spellings
+rather than merely equivalent in verdict.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from strands_robots.utils import non_negative_whole_number_error
+
+# ── the fake dataset ────────────────────────────────────────────────
+#
+# Three episodes of distinct lengths so the returned ``(start, length)``
+# identifies which episode was resolved. ``episode_data_index`` is a list per
+# key, exactly as a real ``LeRobotDataset`` exposes it - which is why a bool
+# indexed it successfully.
+
+_EPISODE_LENGTHS = (10, 20, 30)
+_STARTS = {0: 0, 10: 1, 30: 2}  # frame start -> episode number
+
+
+class _Cell:
+    """Stands in for the tensor cell whose ``.item()`` the loader reads."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def item(self) -> int:
+        return self.value
+
+
+class _Meta:
+    total_episodes = len(_EPISODE_LENGTHS)
+    episodes = [{"length": n} for n in _EPISODE_LENGTHS]
+
+
+class _FakeDataset:
+    """Minimal LeRobotDataset stand-in; records that it was constructed."""
+
+    constructions: list[dict[str, object]] = []
+    scans: list[int] = []
+    fps = 30
+
+    def __init__(self, repo_id=None, root=None):
+        type(self).constructions.append({"repo_id": repo_id, "root": root})
+        self.meta = _Meta()
+        self.episode_data_index = {
+            "from": [_Cell(0), _Cell(10), _Cell(30)],
+            "to": [_Cell(10), _Cell(30), _Cell(60)],
+        }
+
+    def __len__(self) -> int:
+        return sum(_EPISODE_LENGTHS)
+
+    def __getitem__(self, idx):
+        # Reached only by the loader's last-resort boundary scan. Recorded so a
+        # test can assert an accepted index used the O(1) index instead.
+        type(self).scans.append(idx)
+        if idx < 10:
+            ep = 0
+        elif idx < 30:
+            ep = 1
+        else:
+            ep = 2
+        return {"episode_index": ep}
+
+
+@pytest.fixture
+def fake_lerobot(monkeypatch):
+    """Install a fake ``lerobot`` so the loader runs with no hub round-trip."""
+    _FakeDataset.constructions = []
+    _FakeDataset.scans = []
+    ld = types.ModuleType("lerobot.datasets.lerobot_dataset")
+    ld.LeRobotDataset = _FakeDataset  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lerobot", types.ModuleType("lerobot"))
+    monkeypatch.setitem(sys.modules, "lerobot.datasets", types.ModuleType("lerobot.datasets"))
+    monkeypatch.setitem(sys.modules, "lerobot.datasets.lerobot_dataset", ld)
+    return _FakeDataset
+
+
+# ── the probe set ───────────────────────────────────────────────────
+
+UNUSABLE = [
+    pytest.param(True, id="True"),
+    pytest.param(False, id="False"),
+    pytest.param(np.True_, id="np.True_"),
+    pytest.param(2.5, id="2.5"),
+    pytest.param(-1, id="-1"),
+    pytest.param(-1.0, id="-1.0"),
+    pytest.param(math.nan, id="nan"),
+    pytest.param(math.inf, id="inf"),
+    pytest.param(-math.inf, id="-inf"),
+    pytest.param("0", id="str"),
+    pytest.param([0], id="list"),
+    pytest.param(None, id="None"),
+    pytest.param({"episode": 0}, id="dict"),
+    pytest.param(np.float64(1.5), id="np.float64(1.5)"),
+]
+
+ACCEPTED = [
+    pytest.param(0, 0, id="0"),
+    pytest.param(1, 1, id="1"),
+    pytest.param(2, 2, id="2"),
+    pytest.param(2.0, 2, id="2.0"),
+    pytest.param(np.int64(1), 1, id="np.int64(1)"),
+    pytest.param(np.float64(2.0), 2, id="np.float64(2.0)"),
+]
+
+
+# ── the premise, measured rather than asserted ──────────────────────
+
+
+class TestThePremise:
+    """Why a bare ``< 0`` test could not refuse these values.
+
+    Measured against the language and NumPy themselves, so the mechanism is a
+    measurement rather than a claim about one.
+    """
+
+    def test_a_bool_passes_a_non_negative_test(self):
+        assert (True < 0) is False
+        assert (False < 0) is False
+
+    def test_a_bool_then_indexes_a_list_as_an_int(self):
+        # The mechanism: ``episode_data_index["from"][True]`` is element 1.
+        table = [_Cell(0), _Cell(10), _Cell(30)]
+        assert table[True].item() == 10
+        assert table[False].item() == 0
+
+    def test_a_non_integral_and_a_nan_pass_a_non_negative_test(self):
+        assert (2.5 < 0) is False
+        assert (math.nan < 0) is False
+        assert (math.inf < 0) is False
+
+    def test_a_str_list_none_raise_on_the_comparison_itself(self):
+        for value in ("0", [0], None):
+            with pytest.raises(TypeError):
+                _ = value < 0  # type: ignore[operator]
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_shared_rule_refuses_every_probe(self, value):
+        assert non_negative_whole_number_error(value, "episode", "ctx") is not None
+
+    @pytest.mark.parametrize("value,expected", ACCEPTED)
+    def test_the_shared_rule_accepts_every_usable_index(self, value, expected):
+        assert non_negative_whole_number_error(value, "episode", "ctx") is None
+        assert int(value) == expected
+
+
+# ── the loader ──────────────────────────────────────────────────────
+
+
+class TestLoadLerobotEpisodeRefusesAnUnusableIndex:
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_raises_value_error_naming_the_parameter(self, value, fake_lerobot):
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError) as excinfo:
+            load_lerobot_episode("fake/repo", value)
+        msg = str(excinfo.value)
+        assert "load_lerobot_episode" in msg
+        assert "episode" in msg
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_is_the_shared_rule_verbatim(self, value, fake_lerobot):
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        expected = non_negative_whole_number_error(value, "episode", "load_lerobot_episode")
+        assert expected is not None
+        with pytest.raises(ValueError) as excinfo:
+            load_lerobot_episode("fake/repo", value)
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_no_dataset_is_constructed(self, value, fake_lerobot):
+        """The refusal lands before the hub download, not after it."""
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError):
+            load_lerobot_episode("fake/repo", value)
+        assert fake_lerobot.constructions == []
+        assert fake_lerobot.scans == []
+
+    def test_a_bool_no_longer_resolves_an_episode(self, fake_lerobot):
+        """The load-bearing row: ``True`` resolved episode 1 pre-fix."""
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError):
+            load_lerobot_episode("fake/repo", True)
+
+    def test_the_dataset_is_no_longer_blamed_for_a_non_integral_index(self, fake_lerobot):
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError) as excinfo:
+            load_lerobot_episode("fake/repo", 2.5)
+        msg = str(excinfo.value)
+        assert "has no frames" not in msg
+        assert "out of range" not in msg
+
+    @pytest.mark.parametrize("value", ["0", [0], None])
+    def test_a_non_numeric_index_no_longer_raises_type_error(self, value, fake_lerobot):
+        """The loader documents ``ValueError`` as its refusal channel."""
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError):
+            load_lerobot_episode("fake/repo", value)
+
+
+class TestLoadLerobotEpisodeAcceptedDomain:
+    @pytest.mark.parametrize("value,expected_episode", ACCEPTED)
+    def test_an_accepted_index_resolves_that_episode(self, value, expected_episode, fake_lerobot):
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        _, start, length = load_lerobot_episode("fake/repo", value)
+        assert _STARTS[start] == expected_episode
+        assert length == _EPISODE_LENGTHS[expected_episode]
+
+    def test_an_integral_float_uses_the_index_not_the_full_scan(self, fake_lerobot):
+        """``2.0`` fell through to an O(len(dataset)) boundary scan pre-fix.
+
+        The guard coerces with ``int()`` once it has round-tripped the value,
+        so an accepted index reaches ``episode_data_index`` directly.
+        """
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        _, start, length = load_lerobot_episode("fake/repo", 2.0)
+        assert (start, length) == (30, 30)
+        assert fake_lerobot.scans == []
+
+    def test_an_out_of_range_whole_number_is_still_a_range_refusal(self, fake_lerobot):
+        """Range is the dataset's business; the domain guard does not take it."""
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        with pytest.raises(ValueError, match="out of range"):
+            load_lerobot_episode("fake/repo", 99)
+
+
+# ── the replay facade ───────────────────────────────────────────────
+
+
+def _runner():
+    from strands_robots.simulation.policy_runner import PolicyRunner
+    from tests.simulation.test_policy_runner import FakeSim
+
+    sim = FakeSim()
+    return PolicyRunner(sim), sim
+
+
+class TestReplayRefusesAnUnusableIndex:
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_returns_the_error_envelope(self, value, fake_lerobot):
+        runner, _ = _runner()
+        result = runner.replay(repo_id="fake/repo", episode=value)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "replay" in text
+        assert "episode" in text
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_is_the_shared_rule_verbatim(self, value, fake_lerobot):
+        runner, _ = _runner()
+        expected = non_negative_whole_number_error(value, "episode", "replay")
+        assert expected is not None
+        result = runner.replay(repo_id="fake/repo", episode=value)
+        assert result["content"][0]["text"] == expected
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_never_raises(self, value, fake_lerobot):
+        """``replay`` documents the status dict as its only failure channel."""
+        runner, _ = _runner()
+        assert runner.replay(repo_id="fake/repo", episode=value)["status"] == "error"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_no_dataset_is_downloaded_and_no_action_is_sent(self, value, fake_lerobot):
+        runner, sim = _runner()
+        runner.replay(repo_id="fake/repo", episode=value)
+        assert fake_lerobot.constructions == []
+        assert getattr(sim, "sent_actions", []) == []
+
+    def test_a_bool_no_longer_replays_the_second_episode(self, fake_lerobot):
+        runner, sim = _runner()
+        result = runner.replay(repo_id="fake/repo", episode=True)
+        assert result["status"] == "error"
+        assert getattr(sim, "sent_actions", []) == []
+
+
+class TestTheLoaderAndTheFacadeAgree:
+    """One value, one verdict, whichever surface the caller reached."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_both_refuse_every_unusable_index(self, value, fake_lerobot):
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        runner, _ = _runner()
+        assert runner.replay(repo_id="fake/repo", episode=value)["status"] == "error"
+        with pytest.raises(ValueError):
+            load_lerobot_episode("fake/repo", value)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_two_messages_differ_only_in_the_context(self, value, fake_lerobot):
+        facade = non_negative_whole_number_error(value, "episode", "replay")
+        loader = non_negative_whole_number_error(value, "episode", "load_lerobot_episode")
+        assert facade is not None and loader is not None
+        assert facade.replace("replay:", "", 1) == loader.replace("load_lerobot_episode:", "", 1)
+
+
+# ── the guard is the shared rule, not a second copy of it ───────────
+
+
+class TestTheRefusalAddsNothingLocal:
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_neither_surface_narrows_or_widens_the_shared_domain(self, value, fake_lerobot):
+        """No carve-out: the accepted set is exactly the shared rule's."""
+        from strands_robots.dataset_recorder import load_lerobot_episode
+
+        runner, _ = _runner()
+        shared_refuses = non_negative_whole_number_error(value, "episode", "replay") is not None
+        assert shared_refuses is True
+        assert runner.replay(repo_id="fake/repo", episode=value)["status"] == "error"
+        with pytest.raises(ValueError):
+            load_lerobot_episode("fake/repo", value)
+
+    def test_the_old_bare_comparison_message_is_gone(self):
+        source = pathlib.Path(
+            inspect.getsourcefile(__import__("strands_robots.dataset_recorder", fromlist=["x"]))  # type: ignore[arg-type]
+        ).read_text()
+        assert "Episode index must be non-negative, got" not in source
+
+
+# ── structural sweep ────────────────────────────────────────────────
+
+_REPLAY_EPISODE_SURFACES = {
+    ("strands_robots/simulation/policy_runner.py", "replay"),
+    ("strands_robots/simulation/base.py", "replay_episode"),
+    ("strands_robots/dataset_recorder.py", "load_lerobot_episode"),
+}
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _public_episode_surfaces(source: str) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(source)
+    found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name.startswith("_"):
+            continue
+        args = list(node.args.posonlyargs) + list(node.args.args) + list(node.args.kwonlyargs)
+        if any(a.arg == "episode" for a in args):
+            found.append(node)
+    return found
+
+
+def _validates_or_forwards(node: ast.AST) -> bool:
+    """True when the surface applies the shared rule or forwards verbatim."""
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        src = ast.unparse(call)
+        if "non_negative_whole_number_error" in src and "episode" in src:
+            return True
+        # Forwarding verbatim to a surface that does validate.
+        if ("replay" in src or "load_lerobot_episode" in src) and "episode=episode" in src:
+            return True
+    return False
+
+
+class TestNoEpisodeIndexSurfaceDrifts:
+    def test_the_surface_set_is_exactly_the_pinned_one(self):
+        """Non-vacuity: a new surface joins the sweep or fails this test."""
+        discovered = set()
+        for path in sorted((_REPO_ROOT / "strands_robots").rglob("*.py")):
+            for node in _public_episode_surfaces(path.read_text()):
+                discovered.add((str(path.relative_to(_REPO_ROOT)), node.name))
+        assert discovered == _REPLAY_EPISODE_SURFACES
+
+    @pytest.mark.parametrize("rel_path,func_name", sorted(_REPLAY_EPISODE_SURFACES))
+    def test_every_surface_validates_or_forwards(self, rel_path, func_name):
+        source = (_REPO_ROOT / rel_path).read_text()
+        node = next(n for n in _public_episode_surfaces(source) if n.name == func_name)
+        assert _validates_or_forwards(node), f"{rel_path}::{func_name} neither validates nor forwards `episode`"
+
+    def test_the_sweep_fails_on_a_planted_defect(self):
+        """Meta-test: the sweep is not vacuously true."""
+        planted = ast.parse("def replay(self, repo_id, episode=0):\n    return load_lerobot_episode(repo_id, 0)\n")
+        node = planted.body[0]
+        assert not _validates_or_forwards(node)
+
+
+class TestTheTeleopSpellingStaysOutOfScope:
+    """``replay_episode`` on the lerobot CLI tool is deliberately untouched.
+
+    It is the same quantity and already carries the same shared rule, applied
+    from ``lerobot_teleoperate``'s validation table. ``build_lerobot_command``
+    is the CLI string builder its caller validates for, so it is not a second
+    unguarded surface - it is downstream of one. Pinned so the boundary is a
+    stated scope rather than an omission.
+    """
+
+    def test_the_teleop_tool_applies_the_same_shared_rule(self):
+        source = (_REPO_ROOT / "strands_robots/tools/lerobot_teleoperate.py").read_text()
+        assert '("replay_episode", non_negative_whole_number_error)' in source


### PR DESCRIPTION
## Problem

`episode` selects **which** recorded trajectory a replay sends to the actuators. Three public surfaces resolve one - `PolicyRunner.replay`, `SimEngine.replay_episode` (which forwards to it) and the `load_lerobot_episode` loader they share - and the only guard on any of them was a bare `episode < 0` inside the loader:

```python
# strands_robots/dataset_recorder.py:1577
if episode < 0:
    raise ValueError(f"Episode index must be non-negative, got {episode}")
```

Meanwhile `replay_episode` - the same quantity on the lerobot teleop tool - already carries `non_negative_whole_number_error`, whose **own docstring names that parameter** as one of its two documented families:

> ... the two whole-number teleop knobs `strands_robots.tools.lerobot_teleoperate` puts on the lerobot CLI, where `dataset_reset_time_s=0` is "no operator pause between recorded episodes" and **`replay_episode=0` is the first episode**.

So one spelling of the parameter was on the shared rule and the other was on a bare comparison.

Measured through `load_lerobot_episode` against a dataset of three episodes with lengths 10/20/30, so *which* episode was resolved is visible in the returned frame range rather than inferred:

| `episode=` | main | this change |
|---|---|---|
| `0` | success, episode 0 | success, episode 0 |
| `1` | success, episode 1 | success, episode 1 |
| `2.0` | success, episode 2 — via the O(len) fallback scan | success, episode 2 — via the O(1) index |
| `np.int64(1)` | success, episode 1 | success, episode 1 |
| `True` | **success, episode 1** | error — names the parameter |
| `False` | **success, episode 0** | error — names the parameter |
| `np.True_` | **success, episode 1** | error — names the parameter |
| `2.5` | error — `Episode 2.5 has no frames` | error — names the parameter |
| `nan` | error — `Episode nan has no frames` | error — names the parameter |
| `inf` | error — `Episode inf out of range (0-2)` | error — names the parameter |
| `-1` | error — `Episode index must be non-negative` | error — the shared message |
| `'0'` | **`TypeError`** from the `<` comparison | error — names the parameter |
| `[0]` | **`TypeError`** from the `<` comparison | error — names the parameter |
| `None` | **`TypeError`** from the `<` comparison | error — names the parameter |

Three separate defects in one parameter:

- **A bool resolved an episode.** `True < 0` is False, and `episode_data_index["from"][True]` is element 1 — a list indexed by a bool is indexed as an int. So `replay(episode=True)` replayed **episode 1** under `status="success"`, and `False` replayed episode 0. No caller passing a flag meant "the second episode", and on a position-servo robot the wrong episode is the wrong motion, not a slow one. This is the load-bearing row.
- **A non-integral or non-finite index was blamed on the dataset.** `2.5` and `nan` survive `< 0`, fall past the index lookup into the last-resort boundary scan, and come back as `Episode 2.5 has no frames` — naming the data rather than the index, after a full-length scan. `inf` reads as `out of range (0-2)`, which is also the dataset's fault in the message and the caller's in fact.
- **A str, list or `None` raised `TypeError`** out of the comparison itself. That is neither the `ValueError` the loader documents as its refusal channel nor the structured envelope `replay` documents as its own, so a caller with an `episode` read from JSON got neither.

A fourth, milder one: an accepted `2.0` reached the right episode only by scanning every frame in the dataset, because a float cannot index the episode table.

## Change

Apply `non_negative_whole_number_error` — the existing shared rule, no new helper and no new message shape — on all three surfaces, and coerce the accepted value with `int()` afterwards.

- **`load_lerobot_episode` raises** `ValueError` with the shared text, keeping the refusal channel its docstring already documents. **The two facades return the envelope.** This is the same split #2048 used on the same pair of layers: a direct caller has no envelope to read a refusal from.
- The refusal lands **before the dataset is downloaded** on every surface — pinned by asserting the fake `LeRobotDataset` was never constructed and no action reached the sim, so an unusable index costs no hub round-trip.
- `int()` after the guard is safe *because* the guard already performed that coercion and compared the result back (its docstring states this ordering). It also keeps an accepted `2.0` / `np.int64(2)` on the O(1) `episode_data_index` lookup instead of the O(len(dataset)) fallback scan.
- **Range stays the dataset's business.** `episode=99` is still `out of range (0-2)`: the domain guard takes the shape of the index, not its bounds, so it does not absorb a check that needs the dataset to answer. Pinned.
- A structural sweep asserts every public surface accepting `episode` either validates it or forwards it verbatim to one that does. The discovered surface set is pinned exactly (non-vacuous) and there is a planted-defect meta-test.

## Out of scope

`replay_episode` on `lerobot_teleoperate` / `build_lerobot_command` is untouched: it is the same quantity and already applies the same shared rule from the tool's validation table, and `build_lerobot_command` is the CLI string builder downstream of that validation rather than a second unguarded surface. Pinned in a named class so the boundary is a stated scope rather than an omission.

## Tests

New `tests/simulation/test_replay_episode_index_domain.py` — **185 tests, GL-free, 1.9 s**:

- **the premise**, measured against the language and NumPy rather than asserted about them: a bool passes `< 0`, a bool then indexes a list as an int (`table[True]` is element 1), `2.5`/`nan`/`inf` all pass `< 0`, and `'0'`/`[0]`/`None` raise on the comparison;
- the loader raising for every unusable value, with the message asserted **byte-identical** to the shared rule's;
- both the loader and `replay` refusing before any dataset is constructed and before any action is sent;
- `replay` never raising — its status dict is its only failure channel;
- loader/facade verdict parity over the whole probe set, and their two messages differing only in the context prefix;
- the accepted domain including `2.0` and NumPy scalars, plus the assertion that an integral float now uses the index rather than the fallback scan;
- the old strings being gone (`Episode index must be non-negative`, `has no frames` for `2.5`);
- the out-of-range refusal still coming from the dataset;
- the structural sweep, with non-vacuity and planted-defect meta-tests, and the teleop-spelling scope pin.

**Pre-fix proof** (sources reverted to `b72190b`, new tests kept): **101 failed, 84 passed**. The 84 that pass pre-fix are the premise class, the already-valid accepted values, the range refusal, the teleop pin and the planted-defect meta-test — they are what stops the guard reaching further than these values.

## Round 2 — the premise class now measures its premise

The required `call-test-lint` run refused the first head, and it was right to.
`tests/test_no_vacuous_comparisons.py` refuses a comparison with a literal on
both sides across the whole repository, and the premise class had three:

```
tests/simulation/test_replay_episode_index_domain.py:170  True < 0
tests/simulation/test_replay_episode_index_domain.py:171  False < 0
tests/simulation/test_replay_episode_index_domain.py:180  2.5 < 0
```

Each result is decided when the line is typed, so the assertion cannot fail and
cannot tell a correct premise from a mis-transcribed one — in the one class whose
whole value is that the claim was *measured*. Two further instances,
`math.nan < 0` and `math.inf < 0`, sat in the same class and escaped that scan
only because an attribute is not an `ast.Constant`, so the identical defect was
present and unreported. Fixing only the three named would have satisfied the gate
and left those two.

The superseded comparison is now reproduced as a function that takes the value as
a parameter — which is what makes the comparison a measurement — and every probe
value is pushed through it, grouped by what that comparison actually did:

| group | probe values | measured outcome |
|---|---|---|
| did not refuse | `True`, `False`, `np.True_`, `2.5`, `nan`, `inf`, `np.float64(1.5)` | `False` |
| did refuse | `-1`, `-1.0`, `-inf` | `True` |
| raised instead | `'0'`, `[0]`, `None`, `{'episode': 0}` | `TypeError` |

Groups are referenced by probe id, so no value is spelled twice, and a new
assertion proves the grouping is exhaustive over `UNUSABLE` and claims no value
twice — a probe value added later cannot silently escape the premise.

Net effect: the premise measures **14 values through the real comparison** instead
of restating 5 outcomes, and reaches three it never covered (`np.True_`,
`np.float64(1.5)`, `dict`) plus the negative values whose refusal is *why* the
shared rule reports them with the same message rather than a new one. **185 → 197
tests. No production line changes** (`1 file changed, 66 insertions(+), 14
deletions(-)`, tests only).

## Verification

On the current head (`bdb1254`, base `b72190b`), with `mujoco`, `torch` and
`lerobot` all present — so the GL-backed and hardware-backed portions of the suite
are executed here rather than deferred:

- **`MUJOCO_GL=egl pytest tests` -> 24635 passed, 257 skipped, 0 failed** (547 s).
  This is the first full-suite run this branch has had: CI runs with `-x`, so its
  single reported failure stopped the run at the guard and nothing after it had
  executed.
- `pytest tests/simulation/test_replay_episode_index_domain.py` -> **197 passed**
  (1.8 s), GL-free.
- `pytest tests/test_no_vacuous_comparisons.py` -> **4 passed** (the gate that
  refused the previous head).
- `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` ->
  **1124 files already formatted**; `mypy strands_robots tests tests_integ` -> **0
  errors outside `examples/isaac_gs`**, whose 14 are byte-identical to a pristine
  `upstream/main` worktree of the same working copy (verified by diffing both
  error sets with line numbers normalised), so they are environmental and
  pre-existing.
- `python scripts/assemble_changelog.py --check` -> `changelog fragments OK`;
  `scripts/check_merge_base_overlap.py` -> no overlap.

**Pre-fix proofs, re-derived at this base.** For the round: reverting the one test
file leaves the gate failing and naming all three offenders. For the whole change
(sources reverted to `b72190b`, tests kept): **101 failed, 96 passed** — the
failing count is unchanged from the 101 reported above, and the entire delta is
the 12 new passing tests, so this round added coverage and relaxed nothing.
