### PR TITLE
fix(policies/lerobot_local): refuse an instruction token budget the tokenizer cannot slice by

### DIFF
--- a/changelog.d/2050-tokenizer-max-length-domain.md
+++ b/changelog.d/2050-tokenizer-max-length-domain.md
@@ -1,0 +1,22 @@
+### Fixed: an instruction token budget the tokenizer cannot slice by is refused where it is named
+
+`LerobotLocalPolicy` hands `tokenizer_max_length` to a HuggingFace tokenizer as
+`max_length` alongside `truncation=True`, so the tokenizer reads it as a slice
+bound over the encoded instruction. It was the one count in that constructor
+stored verbatim: `actions_per_step` and `rtc_execution_horizon` are already
+refused on arrival for exactly this reason, and `image_keys` and
+`robot_state_keys` for the shape equivalent.
+
+Measured against a real tokenizer on an 11-token instruction, `0` (and `False`)
+produced a zero-width prompt - a language-conditioned VLA asked to act with its
+whole task specification removed, with nothing reported on any path; `True` kept
+only the first token; `None` fell back to the tokenizer's own 262144-token
+ceiling for every inference step. The remaining values reached the tokenizer's
+binding and surfaced as an `OverflowError` or `TypeError` naming neither the
+parameter nor the policy, and only once inference had begun.
+
+The count is now checked on the two surfaces its siblings already guard - the
+constructor, before any checkpoint is fetched, and `preflight`, so the rollout
+entry point reports it as a structured error - against the shared
+`positive_count_error` domain, whose strict-`int` rule is what the tokenizer's
+binding accepts.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -47,6 +47,13 @@ LerobotLocalPolicy(
 )
 ```
 
+`tokenizer_max_length` is the instruction's token budget and must be a positive
+`int`. The tokenizer takes it as a slice bound over the encoded instruction, so a
+count below one truncates the instruction away and the policy acts on an empty
+prompt; an unusable value is refused when the policy is constructed (and by
+`preflight`, before the weights are fetched) rather than at the first inference.
+
+
 ### Pinning a Hub revision
 
 Pass `revision=` to pin a checkpoint to a reproducible Hub version - a

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 import torch
 
-from ...utils import name_list_error
+from ...utils import name_list_error, positive_count_error
 from .. import Policy, align_action_values, chunk_count_error
 from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys, state_key_remedy
 from .processor import ProcessorBridge
@@ -395,6 +395,12 @@ class LerobotLocalPolicy(Policy):
         use_processor: Whether to load the model's processor pipeline.
         processor_overrides: Dict of overrides for processor pipeline steps.
         tokenizer_max_length: Max token length for VLA language tokenization.
+            Must be a positive ``int``. The tokenizer takes it as a slice bound
+            over the encoded instruction (with ``truncation=True``), so a count
+            below one truncates the instruction away entirely and the policy is
+            asked to act on an empty prompt - which for a language-conditioned
+            VLA discards the whole task specification. It is refused here, where
+            the caller names it, rather than at the first inference.
         tokenizer_padding_side: Padding side for VLA tokenizer ("left" or "right").
         rtc_enabled: Enable Real-Time Chunking for flow-matching policies.
             Auto-detected from model config if None.
@@ -563,6 +569,18 @@ class LerobotLocalPolicy(Policy):
         # features, so the bridge was discarded (see _load_processor_bridge).
         self._embodiment_config_failed = False
         self._tokenizer: Any = None
+        # Refused where the caller's value arrives, and before any checkpoint is
+        # downloaded: the tokenizer reads this as a slice bound over the encoded
+        # instruction, so ``0`` (or ``False``) hands a language-conditioned VLA
+        # an empty prompt, ``True`` keeps only its first token, and ``None``
+        # falls back to the tokenizer's own ``model_max_length`` - none of which
+        # is reported anywhere. The remaining values reach the tokenizer's C
+        # binding and surface as an ``OverflowError`` / ``TypeError`` naming
+        # neither this parameter nor the policy, mid-rollout.
+        if (
+            token_length_error := positive_count_error(tokenizer_max_length, "tokenizer_max_length", "lerobot_local")
+        ) is not None:
+            raise ValueError(token_length_error)
         self._tokenizer_max_length: int = tokenizer_max_length
         self._tokenizer_padding_side: str = tokenizer_padding_side
 
@@ -1482,6 +1500,15 @@ class LerobotLocalPolicy(Policy):
         # supplied value only - ``None`` asks for the checkpoint's own horizon.
         if policy_config.get("rtc_execution_horizon") is not None:
             error = chunk_count_error(policy_config["rtc_execution_horizon"], "rtc_execution_horizon", "lerobot_local")
+            if error:
+                raise ValueError(error)
+
+        # The instruction's token budget, on the same reasoning: it is honored
+        # for every configuration that tokenizes at all, so it cannot be scoped
+        # to an embodiment either, and checking it here refuses it before the
+        # weight download rather than at the first inference.
+        if "tokenizer_max_length" in policy_config:
+            error = positive_count_error(policy_config["tokenizer_max_length"], "tokenizer_max_length", "lerobot_local")
             if error:
                 raise ValueError(error)
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1019,7 +1019,7 @@ def step_aborted_msg(completed: int, requested: int, *, context: str = "step") -
 def positive_count_error(value: Any, param: str, context: str) -> str | None:
     """Error text when ``value`` is not a usable positive integer count.
 
-    Shared domain for two families of discrete quantity:
+    Shared domain for three families of discrete quantity:
 
     * The knobs that count iterations of a control or rollout loop - the
       simulation's ``n_episodes`` / ``max_steps`` / ``control_substeps`` /
@@ -1032,6 +1032,11 @@ def positive_count_error(value: Any, param: str, context: str) -> str | None:
       buffer), but the floor itself must not differ between them: the same
       camera configuration cannot be refused on one backend and accepted on
       another.
+    * A bound on a slice of a token sequence - the ``tokenizer_max_length`` a
+      VLA provider hands a HuggingFace tokenizer as ``max_length`` alongside
+      ``truncation=True``. The tokenizer takes it as a slice bound over the
+      encoded instruction, so a count below one silently produces an EMPTY
+      prompt rather than an error.
 
     It lives here rather than beside one of its callers because those callers
     sit in different layers (:mod:`strands_robots.hardware_robot` must not

--- a/tests/policies/lerobot_local/test_tokenizer_max_length_domain.py
+++ b/tests/policies/lerobot_local/test_tokenizer_max_length_domain.py
@@ -1,0 +1,257 @@
+"""The instruction token budget must be a count the tokenizer can slice by.
+
+``LerobotLocalPolicy`` hands ``tokenizer_max_length`` to a HuggingFace tokenizer
+as ``max_length`` alongside ``truncation=True`` and ``padding="max_length"``, so
+the tokenizer reads it as a slice bound over the encoded instruction. Four
+sibling parameters of the same constructor are already refused on arrival
+(``actions_per_step`` and ``rtc_execution_horizon`` through ``chunk_count_error``,
+``image_keys`` and ``robot_state_keys`` through ``name_list_error``), and the
+docstring of ``rtc_execution_horizon`` states the reason: it bounds a slice, so
+only a positive ``int`` can be honored and anything else is refused where the
+caller names it.
+
+The token budget was the one count in that signature stored verbatim, and it is
+the one whose out-of-domain values are hardest to notice. Measured against a real
+HuggingFace tokenizer, an 11-token instruction encodes as:
+
+* ``48`` (the default) - 48 wide, 11 attended, the full instruction.
+* ``0`` and ``False`` - shape ``(1, 0)``, zero attended tokens, the decoded
+  prompt is ``''``. A language-conditioned VLA is asked to act with its entire
+  task specification removed, and nothing on any path reports it.
+* ``True`` - one token: the instruction's first word only.
+* ``None`` - the tokenizer's own ``model_max_length``, a 262144-wide tensor per
+  inference step instead of 48.
+* ``-5`` - ``OverflowError``; ``2.7`` / ``nan`` / ``inf`` / ``"48"`` / ``[48]`` -
+  ``TypeError`` out of the tokenizer's binding, naming neither this parameter nor
+  the policy, and only once inference has begun.
+
+These tests pin the domain at both surfaces the siblings guard, that the refusal
+precedes the checkpoint download, that the two surfaces cannot diverge, and -
+with a tokenizer that models the slice-bound contract this provider relies on -
+that the refused counts are exactly the ones that lose the instruction.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.utils import positive_count_error
+
+#: Counts a tokenizer can slice an instruction by.
+USABLE: list[Any] = [1, 8, 48, 512]
+
+#: Values no tokenizer can take as a slice bound over the instruction. ``0`` and
+#: ``False`` empty the prompt, ``True`` keeps one token, ``None`` falls back to
+#: the tokenizer's ``model_max_length``, and the rest reach its binding as a
+#: type it cannot interpret as an integer.
+UNUSABLE: list[Any] = [0, -5, True, False, 2.7, 48.0, math.nan, math.inf, -math.inf, "48", None, [48]]
+
+
+def _construct(_loads: list[bool] | None = None, **overrides: Any) -> LerobotLocalPolicy:
+    """Build the policy without fetching a checkpoint.
+
+    ``__init__`` calls ``_load_model`` last, so a guard that raises before it
+    provably costs no download. ``_loads`` collects one entry per call, which is
+    what lets a test assert the refusal came first.
+    """
+
+    def _record(_self: LerobotLocalPolicy) -> None:
+        if _loads is not None:
+            _loads.append(True)
+
+    with patch.object(LerobotLocalPolicy, "_load_model", _record):
+        return LerobotLocalPolicy(pretrained_name_or_path="test/model", **overrides)
+
+
+def _construction_refusal(value: Any) -> str | None:
+    """The refusal text ``__init__`` reports for ``value``, or ``None``."""
+    try:
+        _construct(tokenizer_max_length=value)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _preflight_refusal(value: Any) -> str | None:
+    """The refusal text ``preflight`` reports for ``value``, or ``None``.
+
+    ``preflight`` takes the configuration as keywords, so the value is named the
+    way a caller names it rather than wrapped in a dict.
+    """
+    try:
+        LerobotLocalPolicy.preflight(set(), pretrained_name_or_path="test/model", tokenizer_max_length=value)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+class TestAnUnusableTokenBudgetIsRefusedAtConstruction:
+    """The value is refused where the caller names it, before any download."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_construction_refuses_it(self, value: Any) -> None:
+        refusal = _construction_refusal(value)
+        assert refusal is not None, f"tokenizer_max_length={value!r} was accepted"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_names_the_parameter_and_the_provider(self, value: Any) -> None:
+        refusal = _construction_refusal(value)
+        assert refusal is not None
+        assert "tokenizer_max_length" in refusal
+        assert refusal.startswith("lerobot_local:")
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_precedes_the_checkpoint_load(self, value: Any) -> None:
+        """No weights are fetched for a value the provider cannot honor."""
+        loads: list[bool] = []
+        with pytest.raises(ValueError):
+            _construct(loads, tokenizer_max_length=value)
+        assert loads == [], "the refused construction reached the checkpoint load"
+
+    def test_a_usable_budget_does_reach_the_checkpoint_load(self) -> None:
+        """The ordering assertion above is not vacuous: the load is reachable."""
+        loads: list[bool] = []
+        _construct(loads, tokenizer_max_length=48)
+        assert loads == [True]
+
+
+class TestAUsableTokenBudgetIsAccepted:
+    """The guard refuses only what no tokenizer can slice by."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_construction_accepts_it(self, value: Any) -> None:
+        assert _construction_refusal(value) is None
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_the_accepted_value_is_stored_verbatim(self, value: Any) -> None:
+        policy = _construct(tokenizer_max_length=value)
+        assert policy._tokenizer_max_length == value
+
+    def test_the_default_is_accepted(self) -> None:
+        policy = _construct()
+        assert policy._tokenizer_max_length == 48
+
+
+class TestPreflightRefusesTheSameBudgets:
+    """The rollout entry point reports it before the weights are fetched."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_preflight_refuses_it(self, value: Any) -> None:
+        refusal = _preflight_refusal(value)
+        assert refusal is not None, f"preflight accepted tokenizer_max_length={value!r}"
+        assert "tokenizer_max_length" in refusal
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_preflight_accepts_a_usable_budget(self, value: Any) -> None:
+        assert _preflight_refusal(value) is None
+
+    def test_preflight_says_nothing_when_the_key_is_absent(self) -> None:
+        """Omitting it asks for the provider default, which is not a caller value."""
+        LerobotLocalPolicy.preflight(set(), pretrained_name_or_path="test/model")
+
+
+class TestTheTwoSurfacesAgree:
+    """One parameter, one accepted domain, whichever surface receives it."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
+    def test_construction_and_preflight_reach_the_same_verdict(self, value: Any) -> None:
+        assert (_construction_refusal(value) is None) == (_preflight_refusal(value) is None)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_both_surfaces_report_the_same_text(self, value: Any) -> None:
+        assert _construction_refusal(value) == _preflight_refusal(value)
+
+
+class TestTheDomainIsTheSharedOne:
+    """The provider adds nothing to the shared count rule, so it cannot drift."""
+
+    @pytest.mark.parametrize("value", [*USABLE, *UNUSABLE])
+    def test_the_verdict_matches_the_shared_domain(self, value: Any) -> None:
+        shared = positive_count_error(value, "tokenizer_max_length", "lerobot_local")
+        assert _construction_refusal(value) == shared
+
+    def test_an_integral_float_is_refused_because_the_tokenizer_cannot_take_one(self) -> None:
+        """``48.0`` is the boundary case the wider whole-number domain would admit.
+
+        The tokenizer's binding refuses any ``float`` outright ("``'float' object
+        cannot be interpreted as an integer``"), so the strict-``int`` domain is
+        the one that matches the consumer.
+        """
+        assert _construction_refusal(48.0) is not None
+        assert _construction_refusal(48) is None
+
+
+class _SlicingTokenizer:
+    """A tokenizer modelling the slice-bound contract this provider relies on.
+
+    HuggingFace tokenizers take ``max_length`` as a bound on the encoded
+    sequence and, with ``truncation=True``, cut to it. This reproduces that so
+    the consequence of an out-of-domain count is executable without a download;
+    the real behaviour is quoted in the module docstring.
+    """
+
+    model_max_length = 262144
+    padding_side = "right"
+
+    def __init__(self) -> None:
+        self.pad_token_id = 0
+
+    def __call__(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        ids = [hash(word) % 1000 + 1 for word in text.split()]
+        limit = kwargs.get("max_length")
+        if limit is None:
+            limit = self.model_max_length
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise TypeError(f"argument 'max_length': {type(limit).__name__} object cannot be interpreted as an integer")
+        if limit < 0:
+            raise OverflowError("can't convert negative int to unsigned")
+        kept = ids[:limit]
+        mask = [1] * len(kept) + [0] * (limit - len(kept))
+        kept = kept + [self.pad_token_id] * (limit - len(kept))
+        return {"input_ids": torch.tensor([kept]), "attention_mask": torch.tensor([mask])}
+
+
+class TestAnUnusableBudgetLosesTheInstruction:
+    """Why the domain refuses these counts, measured through the real code path."""
+
+    INSTRUCTION = "pick up the red block and place it in the bowl"
+
+    def _tokenize(self, budget: Any) -> tuple[int, int]:
+        """Return ``(width, attended)`` for ``budget`` via ``_tokenize_instruction``."""
+        policy = LerobotLocalPolicy.__new__(LerobotLocalPolicy)
+        policy._tokenizer = _SlicingTokenizer()
+        policy._tokenizer_max_length = budget
+        policy._tokenizer_padding_side = "right"
+        policy._device = torch.device("cpu")
+        policy._policy = None
+        result = policy._tokenize_instruction(self.INSTRUCTION)
+        assert result is not None
+        tokens, mask = result
+        assert mask is not None
+        return tokens.shape[1], int(mask.sum())
+
+    def test_a_usable_budget_keeps_the_whole_instruction(self) -> None:
+        width, attended = self._tokenize(48)
+        assert width == 48
+        assert attended == len(self.INSTRUCTION.split())
+
+    def test_zero_removes_the_instruction_entirely(self) -> None:
+        """The case the guard exists for: an empty prompt, reported nowhere."""
+        assert self._tokenize(0) == (0, 0)
+        assert _construction_refusal(0) is not None
+
+    def test_a_boolean_keeps_only_the_first_token(self) -> None:
+        assert self._tokenize(1) == (1, 1)
+        assert _construction_refusal(True) is not None
+
+    def test_none_falls_back_to_the_tokenizers_own_ceiling(self) -> None:
+        width, attended = self._tokenize(None)
+        assert width == _SlicingTokenizer.model_max_length
+        assert attended == len(self.INSTRUCTION.split())
+        assert _construction_refusal(None) is not None


### PR DESCRIPTION
## Problem

`LerobotLocalPolicy` hands `tokenizer_max_length` to a HuggingFace tokenizer as
`max_length`, alongside `truncation=True` and `padding="max_length"`:

```python
encoded = tokenizer(
    instruction,
    return_tensors="pt",
    padding="max_length",
    max_length=self._tokenizer_max_length,
    truncation=True,
)
```

So the tokenizer reads it as a **slice bound over the encoded instruction**. It was
the one count in that constructor stored verbatim. Four sibling parameters of the
same signature are already refused on arrival — `actions_per_step` and
`rtc_execution_horizon` through `chunk_count_error`, `image_keys` and
`robot_state_keys` through `name_list_error` — and the docstring of
`rtc_execution_horizon` states the reason in exactly these terms: it bounds a
slice, so only a positive `int` can be honored and anything else is refused where
the caller names it.

## Measured

Real `Qwen2Tokenizer`, an 11-token instruction, driven through the production
`_tokenize_instruction`. Every value below is **accepted by both entry points** on
`main`:

| `tokenizer_max_length` | tensor width | attended | prompt the model receives |
| --- | --- | --- | --- |
| `48` (default) | 48 | 11 | `"pick up the red block and place it in the bowl"` |
| `8` | 8 | 8 | `"pick up the red block and place it"` (the caller's own truncation) |
| `0` | 0 | **0** | `""` — **the instruction is gone** |
| `False` | 0 | **0** | `""` — same |
| `True` | 1 | 1 | `"pick"` — only the first word survives |
| `None` | **262144** | 11 | full prompt, in a 262144-wide tensor every inference step |
| `-5` | — | — | `OverflowError: can't convert negative int to unsigned` |
| `2.7` / `nan` / `inf` / `"48"` / `[48]` | — | — | `TypeError: argument 'max_length': ... cannot be interpreted as an integer` |

Two things make this worth refusing rather than leaving to the consumer:

- **`0` and `False` remove the task specification.** A language-conditioned VLA is
  asked to act on an empty prompt, and nothing on any path reports it — the
  construction succeeds, the rollout succeeds, and the policy simply has no
  instruction.
- **The remaining values escape from the wrong place.** They reach the tokenizer's
  binding and surface as an `OverflowError` / `TypeError` naming neither the
  parameter nor the policy, and only once inference has begun — after the
  checkpoint has been downloaded and loaded.

Both surfaces the siblings guard were open:

```python
create_policy("lerobot_local", pretrained_name_or_path=..., tokenizer_max_length=0)  # accepted, stored 0
LerobotLocalPolicy.preflight(set(), pretrained_name_or_path=..., tokenizer_max_length=0)  # accepted
```

## Change

The count is checked where the caller names it, against the shared
`positive_count_error` domain — whose strict-`int` rule is precisely what the
tokenizer's binding accepts, and whose docstring already scopes it to values
"consumed directly as `range()` bounds, slice indices, or an array / framebuffer
dimension, where an integral float raises `TypeError` rather than being coerced".
That third family is now named there.

- `__init__` — before `_load_model`, so a value the provider cannot honor costs no
  download.
- `preflight` — so the rollout entry point reports it as a structured error rather
  than a raise, and before the weights are fetched.

No new helper: the domain already existed and the two siblings in this constructor
use a thin wrapper over it. The guard adds nothing of its own, which a parity test
pins by comparing its verdict against `positive_count_error` over the whole probe
set.

`48.0` is refused, and deliberately: the wider `positive_whole_number_error` domain
would admit it, while the tokenizer's binding refuses any `float` outright. The
strict-`int` domain is the one that matches the consumer.

## Out of scope

A checkpoint may override the budget from its own config
(`getattr(config, "tokenizer_max_length", ...)` in `_load_processor_bridge`). That
is the model's value, not a caller's, and reconciling it is a separate question.

## Visual

Left half: what the policy is actually asked to do on `main`, per value. Right:
whether each surface honors the domain, before and after.

![tokenizer_max_length instruction budget](https://raw.githubusercontent.com/cagataycali/robots/artifacts/tokenizer-max-length/tokenizer_budget.png)

Every cell is read from two JSON dumps produced by one script run in a worktree at
`upstream/main` and on this branch; the generator asserts the two dumps came from
different trees and re-derives every rendered number, including the
`12 of 16 -> 0 of 16` denominator. The dumps are beside the figure on the artifact
branch.

## Verification

Pre-fix proof, source reverted to `upstream/main` with the tests kept:
**64 failed / 48 passed**. With the change: **112 passed**. The 48 that pass pre-fix
are the accepted-value controls, the shared-domain parity rows for usable counts,
and the consequence measurements — they are what stop the guard reaching further
than the values that lose the instruction.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **24550 passed, 257 skipped,
  0 failed** in 537s, with this PR's 112 new tests and **zero existing-test churn**.
- `ruff check strands_robots tests tests_integ` -> clean;
  `ruff format --check` -> 1124 files already formatted.
- `mypy strands_robots tests tests_integ` -> 0 errors outside `examples/isaac_gs`
  (the 14 there are byte-identical to a pristine `upstream/main` worktree of the
  same working copy, so they are environmental).
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` ->
  no overlap; base `b72190b7`.
- `scripts/assemble_changelog.py --check` -> OK; the five repo-wide root guards ->
  42 passed.
