### PR TITLE
test(zmq): end the block-forever wait by answering it, not by abandoning a thread in the socket

### DIFF
--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -120,13 +120,25 @@ class _Sidecar:
     transport cannot show it.
     """
 
-    def __init__(self, encode: Any) -> None:
+    def __init__(self, encode: Any, port: int | None = None) -> None:
+        """Start answering on ``port``, or on a free port of its own choosing.
+
+        Args:
+            encode: Serialiser for the reply payload.
+            port: Bind to this port instead of an arbitrary free one. For a
+                test that first needs the endpoint to be *unreachable* and
+                only then answering, which a random port cannot express.
+        """
         self._encode = encode
         self._stop = threading.Event()
         self._ctx = zmq.Context()
         self._sock = self._ctx.socket(zmq.REP)
         self._sock.setsockopt(zmq.LINGER, 0)
-        self.port = self._sock.bind_to_random_port("tcp://127.0.0.1")
+        if port is None:
+            self.port = self._sock.bind_to_random_port("tcp://127.0.0.1")
+        else:
+            self._sock.bind(f"tcp://127.0.0.1:{port}")
+            self.port = port
         self._thread = threading.Thread(target=self._serve, daemon=True)
         self._thread.start()
 
@@ -143,6 +155,25 @@ class _Sidecar:
         self._thread.join(timeout=5)
         self._sock.close()
         self._ctx.term()
+
+
+def _free_port() -> int:
+    """A port with nothing bound on it, found by binding and releasing one.
+
+    Discovered through ZMQ rather than the stdlib ``socket`` module, which is
+    the name of the fixture below - and which this file otherwise never needs.
+
+    Returns:
+        A loopback port that is unbound on return, so a request sent to it
+        cannot be answered until something binds it.
+    """
+    context = zmq.Context()
+    sock = context.socket(zmq.REP)
+    try:
+        return sock.bind_to_random_port("tcp://127.0.0.1")
+    finally:
+        sock.close()
+        context.term()
 
 
 def _encoder_for(cls: type) -> Any:
@@ -431,12 +462,20 @@ class TestZmqStillTreatsTheseValuesAsMeasured:
         reinstates on the request path the unbounded hang that ``LINGER = 0``
         exists to prevent on teardown - and ``ping()``, whose contract is to
         answer ``True`` or ``False``, could then never answer.
+
+        The wait is ended by answering the request rather than by leaving the
+        thread parked in ``recv``. A ZMQ socket may be used by one thread only,
+        so the fixture's ``close`` ran on a socket a second thread was still
+        inside, which is undefined and aborted the interpreter. Answering also
+        measures strictly more than abandoning does: the recv completes, so it
+        was blocked for want of a reply rather than for being unusable.
         """
         socket.setsockopt(zmq.RCVTIMEO, -1)
         assert socket.getsockopt(zmq.RCVTIMEO) == -1
 
-        # Nothing is bound on this port, so a blocking recv cannot complete.
-        socket.connect("tcp://127.0.0.1:1")
+        # Nothing is bound here yet, so the request cannot be answered.
+        port = _free_port()
+        socket.connect(f"tcp://127.0.0.1:{port}")
         socket.send(b"ping")
         returned = threading.Event()
 
@@ -447,8 +486,20 @@ class TestZmqStillTreatsTheseValuesAsMeasured:
                 pass
             returned.set()
 
-        threading.Thread(target=blocking_recv, daemon=True).start()
+        recv_thread = threading.Thread(target=blocking_recv, daemon=True)
+        recv_thread.start()
+        # A finite budget would have raised zmq.Again well inside this window.
         assert not returned.wait(timeout=1.5), "a -1 timeout is expected to block"
+
+        # REQ redelivers the queued request as soon as a peer appears, so the
+        # recv that was blocking completes and the thread leaves the socket.
+        server = _Sidecar(lambda payload: msgpack.packb(payload, use_bin_type=True), port=port)
+        try:
+            assert returned.wait(timeout=30), "the blocked recv did not complete once answered"
+        finally:
+            server.close()
+        recv_thread.join(timeout=5)
+        assert not recv_thread.is_alive(), "no thread may outlive the socket it is using"
 
     def test_below_minus_one_is_an_invalid_argument(self, socket: Any) -> None:
         """So it never reached a verdict; it raised ``ZMQError`` naming nothing."""


### PR DESCRIPTION
Closes #2051

`main` is **intermittently** red on `call-test-lint / Test and Lint` with **exit code 134** and no test reporting `FAILED`. This removes the cause.

## The defect

`test_minus_one_is_still_the_block_forever_spelling` proves `RCVTIMEO = -1` blocks by parking a daemon thread in `socket.recv()` and asserting it does not return:

```python
threading.Thread(target=blocking_recv, daemon=True).start()
assert not returned.wait(timeout=1.5), "a -1 timeout is expected to block"
```

The test ends there, with the thread still inside `recv`, and the class fixture closes the socket under it (`sock.close(); context.term()`). A ZMQ socket may be used by one thread only, so that close is undefined; on the CI host libzmq took the `abort()` branch:

```
Fatal Python error: Aborted

Current thread 0x00007ff284ffa6c0 (most recent call first):
  File ".../tests/test_zmq_timeout_ms_domain.py", line 445 in blocking_recv
```

The faulthandler dump names `blocking_recv` as the *current* thread - the signal was raised inside the abandoned recv, not in any test body.

## Why this was hard to see

| property | consequence |
|---|---|
| the abort surfaces while the *next* test is on the console | blamed on `test_below_minus_one_is_an_invalid_argument`, a four-line test that touches no thread |
| the leaking test still prints `PASSED` | the leak is not part of what it asserts |
| undefined behaviour resolves on load | class passes 3/3 and the file 5/5 in isolation; the CI dump shows ~8 live threads, including `concurrent.futures` pool workers left by earlier tests |

So the same tree was green or red at random, and the output pointed away from the cause.

## Evidence

The abort is timing-dependent; the leak that permits it is not. Counting threads still inside `blocking_recv` at teardown, same probe on both trees:

```
before  (b72190b)  test_minus_one...: LEAKED (1 in recv)
after   (this PR)  test_minus_one...: clean  (0 in recv)
```

### A green `main` is not a counterexample

`main` is green as of `2980368`, with the leaking test still present. Over the last 30 merges to `main`, `call-test-lint / Test and Lint` reported:

| outcome | count | commits |
|---|---|---|
| SUCCESS | 26 | - |
| FAILURE | 1 | `b72190b` - the abort quoted above |
| CANCELLED | 3 | `80a2ec4`, `509a9da`, `b387ec8` - superseded by a newer push, not a test outcome |

One genuine abort in 30, and two green runs after it on a tree that still abandons the thread. A green `main` does not show the defect is absent; it shows the undefined behaviour resolved the other way. That is precisely the property being removed here, and it is why the fix is pinned by `assert not recv_thread.is_alive()` - a deterministic assertion on the leak - rather than by waiting for the abort to reproduce.

## The change

End the wait by **answering** the request instead of abandoning it:

1. `_free_port()` binds a loopback port and releases it, so the request has nowhere to go and the recv blocks.
2. The 1.5 s assertion is unchanged - a finite budget would have raised `zmq.Again` well inside that window, which is what makes `-1` distinguishable.
3. A `_Sidecar` then binds that same port. ZMQ redelivers the queued request once a peer appears, so the *same* blocked recv completes, and the thread is joined before the fixture runs.

`_Sidecar` grew an optional `port` argument, because an endpoint that must be unreachable now and answering later cannot be expressed by `bind_to_random_port`.

The premise is stronger, not merely safer: a recv that completes was blocked for want of a reply rather than because the socket was unusable - which is the claim this premise class exists to record. `assert not recv_thread.is_alive()` pins the leak so it cannot return silently.

## Scope

This is the only test in the repository with that shape. The two sibling tests that also park a thread on a ZMQ client (`tests/policies/groot/test_client.py`, `tests/policies/moveit2/test_policy.py`) assert `done.wait(...)` is **true**, so their threads have returned before teardown; `test_a_usable_budget_still_times_out_against_a_slow_sidecar` in this same file already joins its server thread before closing. Only the block-forever premise asserted that a thread did *not* return and then tore the socket down anyway.

Test-only, no production line changes, so no changelog fragment (fragments are for behavioural changes).

## Verification

```
tests/test_zmq_timeout_ms_domain.py     130 passed   x5 consecutive runs
tests/test_no_vacuous_comparisons.py
tests/test_no_host_paths.py               6 passed
ruff 0.15.22 check                      All checks passed
ruff 0.15.22 format --check             1 file already formatted
```

## Changelog

**Author correction, before first review** - description only, no code change (head is unchanged at `d662fa8`):

- The opening claimed `main` **is** red. `main` went green at `a2a71d3` and `2980368` after this branch was cut, so that present-tense claim no longer held and a reviewer checking it would have found `SUCCESS`. Reworded to **intermittently** red.
- Added *A green `main` is not a counterexample* with the measured rate (1 genuine `FAILURE` in the last 30 merges; 3 `CANCELLED` runs distinguished from failures, since a superseded run is not a test outcome). The diagnosis is unaffected - a green `main` is the same nondeterminism this PR removes - but the PR now says so explicitly instead of resting on a state that has since changed.
