### PR TITLE
fix(simulation): refuse a rollout step horizon that is not a whole number of steps

### DIFF
--- a/changelog.d/2053-rollout-step-horizon-domain.md
+++ b/changelog.d/2053-rollout-step-horizon-domain.md
@@ -1,0 +1,21 @@
+### Fixed: refuse a rollout step horizon that is not a whole number of steps
+
+`run_policy` / `start_policy` / `run_multi_policy` resolved their step-count
+horizon (`n_steps`, or the legacy `max_steps` alias) with a bare `<= 0` test,
+which only sees the sign. `n_steps=2.7` ran two steps and `n_steps=True` ran
+one, each reported as a successful rollout of a horizon the caller never asked
+for, while every sibling count on the same call - `n_episodes`,
+`action_horizon`, `control_substeps` - and the identically-named `eval_policy`
+step budget already refused both. The horizon now goes through the same shared
+positive-count domain, so one parameter name no longer carries two contracts.
+
+A non-positive `max_steps` also reported `n_steps must be > 0`, naming a
+parameter the caller never passed, because the alias was normalized before the
+check; it is now validated under its own name.
+
+`run_policy`'s `n_steps`, `max_steps`, `policy_object` and
+`max_onframe_failures` had no `Args:` entry, so the domain enforced above was
+undiscoverable from the API docs - the `duration` entry told a reader that a
+step count "wins" over it without either count being documented anywhere. All
+four are now documented, and a test pins every `run_policy` parameter as
+documented so a future one cannot slip in undocumented the same way.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1431,15 +1431,25 @@ class SimEngine(ABC):
 
         ``n_steps`` (primary) or the legacy ``max_steps`` alias specify the
         rollout length as a step count; ``duration = n_steps / control_frequency``.
-        ``n_steps`` wins when both are passed. The inputs are validated before
-        the division so a non-positive horizon or frequency is reported as a
-        caller error rather than silently producing a no-op, a negative
-        duration, or a ``ZeroDivisionError``.
+        ``n_steps`` wins when both are passed. The effective horizon is validated
+        before the division against the shared positive-count domain
+        (:func:`~strands_robots.utils.positive_count_error`) - the same domain
+        :meth:`_validate_positive_int` already applies to ``eval_policy``'s
+        ``max_steps`` and to ``n_episodes`` / ``action_horizon`` /
+        ``control_substeps`` - so a horizon that is not a whole number of steps
+        is reported as a caller error rather than silently truncated. A bare
+        ``<= 0`` test only saw the sign: ``n_steps=2.7`` ran two steps and
+        ``n_steps=True`` ran one, both reported as a successful rollout of a
+        horizon the caller never asked for, while the identically-named
+        ``eval_policy`` budget refused both.
 
         Args:
-            n_steps: Primary step-count horizon, or ``None``.
+            n_steps: Primary step-count horizon, or ``None``. Must be a
+                positive integer when given.
             max_steps: Legacy alias, normalized to ``n_steps`` when ``n_steps``
-                is ``None``.
+                is ``None``, and validated under its own name so a caller who
+                wrote ``max_steps`` is not pointed at a parameter they never
+                passed. Same domain as ``n_steps``.
             control_frequency: Target control-loop frequency in Hz.
             duration: Fallback wall-clock duration used when no step horizon
                 is given. Returned unchanged when no horizon is given, so the
@@ -1454,18 +1464,19 @@ class SimEngine(ABC):
             wall-clock duration (recomputed from the horizon when one was
             given) and ``n_steps`` is the normalized step count (or ``None``).
         """
-        if n_steps is None and max_steps is not None:
-            n_steps = int(max_steps)
         if n_steps is not None:
-            if n_steps <= 0:
-                return (
-                    duration,
-                    n_steps,
-                    {
-                        "status": "error",
-                        "content": [{"text": f"{method}: n_steps must be > 0, got {n_steps}."}],
-                    },
-                )
+            if error := positive_count_error(n_steps, "n_steps", method):
+                return duration, n_steps, {"status": "error", "content": [{"text": error}]}
+        elif max_steps is not None:
+            # Validate the alias under its OWN name: the caller wrote
+            # ``max_steps``, so a refusal naming ``n_steps`` points them at a
+            # parameter they never passed. The normalization below is then exact
+            # (an ``int()`` coercion here would be a second, weaker contract
+            # that silently truncated the value the domain just accepted).
+            if error := positive_count_error(max_steps, "max_steps", method):
+                return duration, max_steps, {"status": "error", "content": [{"text": error}]}
+            n_steps = max_steps
+        if n_steps is not None:
             # control_frequency is validated as a positive number at the public
             # entry points (run_policy / start_policy / eval_policy) via
             # _validate_positive_frequency before this helper runs, so the
@@ -2169,6 +2180,36 @@ class SimEngine(ABC):
                 dataset recording), backends plug into
                 ``PolicyRunner.run``'s ``on_frame`` hook via
                 :meth:`_make_run_policy_hook`.
+            policy_object: Already-constructed
+                :class:`~strands_robots.policies.Policy` to drive the rollout,
+                bypassing ``create_policy`` entirely (``policy_provider`` /
+                ``policy_config`` are then unused). Reuse one instance across
+                calls so the checkpoint is not reloaded per rollout - the
+                ``policy_load_cache_hit`` field below reports when a caller
+                rebuilt it instead. ``None`` (default) builds the policy from
+                ``policy_provider`` / ``policy_config``.
+            n_steps: Exact control-step horizon. When given it REPLACES
+                ``duration``, which is recomputed as
+                ``n_steps / control_frequency``, and it bypasses the lossy
+                ``int(duration * control_frequency)`` conversion so the rollout
+                executes exactly this many control steps. Must be a positive
+                integer; ``0``, a negative value, a bool, or a fractional or
+                non-numeric value is reported as a structured caller error
+                rather than truncated to a horizon the caller never asked for.
+                ``None`` (default) falls back to ``max_steps``, then to
+                ``duration``.
+            max_steps: Legacy alias for ``n_steps``, kept for callers written
+                against the older name. Consulted only when ``n_steps`` is
+                ``None`` - ``n_steps`` wins when both are passed - and refused
+                under its own name on the same domain.
+            max_onframe_failures: Maximum *consecutive* ``on_frame``-hook
+                exceptions tolerated before the rollout aborts the episode. That
+                hook is where a backend attaches dataset recording and video
+                capture, so a broken recorder otherwise fills an empty dataset
+                behind a successful-looking rollout. ``None`` (default) uses the
+                runner's own limit (currently ``5``); non-consecutive failures
+                reset the counter. Forwarded verbatim to
+                :meth:`~strands_robots.simulation.policy_runner.PolicyRunner.run`.
             seed: Optional master RNG seed for a reproducible single rollout.
                 When set, reseeds Python / NumPy / torch / cuDNN and forwards
                 ``policy.reset(seed=...)`` so a stochastic policy (VLA action-

--- a/tests/simulation/mujoco/test_agenttool_contract.py
+++ b/tests/simulation/mujoco/test_agenttool_contract.py
@@ -693,7 +693,7 @@ class TestPolicyHorizonUnification:
         # Either n_steps validation fires first, or robot-not-found; both are
         # acceptable error paths - we just want NO silent success.
         text = r["content"][0]["text"]
-        assert ("n_steps" in text and "> 0" in text) or "Robot" in text
+        assert ("n_steps" in text and "positive integer" in text) or "Robot" in text
 
     def test_run_policy_negative_n_steps_errors(self, sim):
         r = sim._dispatch_action("run_policy", {"robot_name": "ghost", "n_steps": -10})

--- a/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/mujoco/test_run_multi_policy_no_recording.py
@@ -186,7 +186,7 @@ def test_run_multi_policy_rejects_nonpositive_horizon_settings(sim_two_robots):
         control_frequency=50.0,
     )
     assert r["status"] == "error"
-    assert "must be > 0" in r["content"][0]["text"]
+    assert "n_steps must be a positive integer" in r["content"][0]["text"]
 
 
 def test_run_multi_policy_requires_world():

--- a/tests/simulation/test_rollout_step_horizon_domain.py
+++ b/tests/simulation/test_rollout_step_horizon_domain.py
@@ -1,0 +1,246 @@
+"""The rollout step horizon must be a whole number of steps.
+
+``run_policy`` / ``start_policy`` / ``run_multi_policy`` take the rollout length
+as a step count -- ``n_steps``, or the legacy ``max_steps`` alias -- and all
+three resolve it through one shared helper,
+``SimEngine._resolve_horizon``, which converts it to a wall-clock duration
+(``duration = n_steps / control_frequency``).
+
+That helper used to test the horizon with a bare ``<= 0``, which only sees the
+sign. ``n_steps=2.7`` therefore ran two steps and ``n_steps=True`` ran one, each
+reported as a successful rollout of a horizon the caller never asked for, while
+every sibling count on the same call -- ``n_episodes``, ``action_horizon``,
+``control_substeps`` -- and the identically-named ``eval_policy`` step budget
+refused both through the shared positive-count domain. One parameter name,
+``max_steps``, had two contracts depending on which method it was passed to.
+
+A non-positive ``max_steps`` also reported ``n_steps must be > 0``, naming a
+parameter the caller never passed, because the alias was normalized before the
+check rather than validated under its own name.
+
+These tests pin the corrected contract: the effective horizon is refused on the
+shared count domain, under the name the caller wrote, on every entry point that
+resolves one -- and every usable horizon is honoured exactly as before.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies import MockPolicy
+from strands_robots.simulation import create_simulation
+from strands_robots.simulation.base import SimEngine
+
+#: Values no step horizon can be built from. ``0``/negative make the rollout a
+#: no-op; ``2.7``/``3.0``/NumPy scalars/``True`` used to be truncated into a
+#: different horizon; the rest never reached the loop bound at all. The NumPy
+#: and integral-float spellings are refused by ``eval_policy``'s ``max_steps``
+#: too, so refusing them here is parity with the sibling budget rather than a
+#: new restriction (pinned by the parity test below).
+UNUSABLE: list[Any] = [
+    pytest.param(0, id="zero"),
+    pytest.param(-1, id="negative"),
+    pytest.param(-50, id="very-negative"),
+    pytest.param(2.7, id="fractional"),
+    pytest.param(3.0, id="integral-float"),
+    pytest.param(True, id="bool-true"),
+    pytest.param(False, id="bool-false"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+    pytest.param("5", id="numeric-string"),
+    pytest.param([5], id="list"),
+    pytest.param(np.int64(3), id="numpy-int"),
+    pytest.param(np.float64(3.0), id="numpy-float"),
+]
+
+#: Horizons the rollout can execute exactly.
+USABLE = [1, 4, 7]
+
+#: The entry points that resolve a step horizon through ``_resolve_horizon``.
+HORIZON_PARAMS = ["n_steps", "max_steps"]
+
+
+@pytest.fixture
+def sim():
+    s = create_simulation()
+    s.create_world()
+    s.add_robot("arm1", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _text(result: dict) -> str:
+    return " ".join(block["text"] for block in result.get("content", []) if "text" in block)
+
+
+def _report(result: dict) -> dict:
+    return next(block["json"] for block in result["content"] if "json" in block)
+
+
+class _CountingPolicy(MockPolicy):
+    """MockPolicy that records how many times the rollout queried it.
+
+    Exercises the ``policy_object`` parameter (also newly documented) and makes
+    "the refused call never started the rollout" a measurement rather than an
+    inference about the status string.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    async def get_actions(self, observation_dict, instruction, **kwargs):  # type: ignore[no-untyped-def]
+        self.calls += 1
+        return await super().get_actions(observation_dict, instruction, **kwargs)
+
+
+class TestTheStepHorizonIsAWholeNumberOfSteps:
+    """An unusable horizon is a caller error, not a truncated rollout."""
+
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    @pytest.mark.parametrize("bad", UNUSABLE)
+    def test_run_policy_refuses_it(self, sim, param, bad):
+        result = sim.run_policy("arm1", policy_provider="mock", **{param: bad})
+        assert result["status"] == "error", result
+        assert f"{param} must be a positive integer" in _text(result)
+
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    @pytest.mark.parametrize("bad", UNUSABLE)
+    def test_the_refusal_quotes_the_offending_value(self, sim, param, bad):
+        text = _text(sim.run_policy("arm1", policy_provider="mock", **{param: bad}))
+        assert repr(bad) in text or str(bad) in text
+
+    @pytest.mark.parametrize("bad", UNUSABLE)
+    def test_the_message_is_ascii(self, sim, bad):
+        _text(sim.run_policy("arm1", policy_provider="mock", n_steps=bad)).encode("ascii")
+
+
+class TestTheRefusalNamesTheParameterTheCallerPassed:
+    """The legacy alias is validated before it is normalized away.
+
+    Pre-fix ``max_steps`` was rewritten to ``n_steps`` first, so the refusal
+    named a parameter the caller had not written.
+    """
+
+    @pytest.mark.parametrize("bad", UNUSABLE)
+    def test_max_steps_is_named_and_n_steps_is_not(self, sim, bad):
+        text = _text(sim.run_policy("arm1", policy_provider="mock", max_steps=bad))
+        assert "max_steps must be a positive integer" in text
+        assert "n_steps" not in text
+
+    @pytest.mark.parametrize("bad", UNUSABLE)
+    def test_n_steps_is_named_when_it_is_the_one_supplied(self, sim, bad):
+        text = _text(sim.run_policy("arm1", policy_provider="mock", n_steps=bad))
+        assert "n_steps must be a positive integer" in text
+        assert "max_steps" not in text
+
+    def test_n_steps_is_the_effective_knob_when_both_are_supplied(self, sim):
+        # n_steps wins, so a bad max_steps alongside a usable n_steps is not
+        # the value the rollout would have used and must not be reported.
+        result = sim.run_policy("arm1", policy_provider="mock", n_steps=3, max_steps=0)
+        assert result["status"] == "success", result
+        assert _report(result)["n_steps"] == 3
+
+
+class TestEveryEntryPointResolvingAHorizonSharesTheDomain:
+    """``_resolve_horizon`` is the one funnel, so all three refuse alike."""
+
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    def test_start_policy_refuses_synchronously(self, sim, param):
+        result = sim.start_policy("arm1", policy_provider="mock", **{param: 2.7})
+        assert result["status"] == "error", result
+        assert f"start_policy: {param} must be a positive integer" in _text(result)
+        # A false "started" would also leave the robot marked as running.
+        assert "arm1" not in sim._policy_threads
+
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    def test_run_multi_policy_refuses(self, sim, param):
+        result = sim.run_multi_policy({"arm1": MockPolicy()}, **{param: 2.7})
+        assert result["status"] == "error", result
+        assert f"run_multi_policy: {param} must be a positive integer" in _text(result)
+
+
+class TestTheHorizonAgreesWithTheEvalStepBudget:
+    """One parameter name must not carry two contracts.
+
+    ``eval_policy``'s ``max_steps`` is the same quantity -- a per-episode step
+    cap -- and already went through the shared positive-count domain. These
+    assertions are what stop the two drifting apart again.
+    """
+
+    @pytest.mark.parametrize("value", [*UNUSABLE, *[pytest.param(v, id=f"usable-{v}") for v in USABLE]])
+    def test_run_policy_refuses_a_horizon_exactly_when_eval_policy_does(self, sim, value):
+        rollout = sim.run_policy("arm1", policy_provider="mock", n_steps=value)
+        budget = sim.eval_policy(robot_name="arm1", policy_provider="mock", n_episodes=1, max_steps=value)
+        assert (rollout["status"] == "error") == (budget["status"] == "error"), (
+            f"run_policy={rollout['status']} eval_policy={budget['status']} for {value!r}"
+        )
+
+    def test_both_surfaces_use_one_wording(self, sim):
+        rollout = _text(sim.run_policy("arm1", policy_provider="mock", max_steps=2.7))
+        budget = _text(sim.eval_policy(robot_name="arm1", policy_provider="mock", n_episodes=1, max_steps=2.7))
+        assert "max_steps must be a positive integer, got 2.7." in rollout
+        assert "max_steps must be a positive integer, got 2.7." in budget
+
+
+class TestUsableHorizonsAreUnchanged:
+    """The guard is additive: every horizon that worked still works."""
+
+    @pytest.mark.parametrize("good", USABLE)
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    def test_the_rollout_executes_exactly_that_many_steps(self, sim, param, good):
+        result = sim.run_policy("arm1", policy_provider="mock", fast_mode=True, **{param: good})
+        assert result["status"] == "success", result
+        assert _report(result)["n_steps"] == good
+
+    def test_the_duration_path_needs_no_horizon(self, sim):
+        # No step horizon given: duration still resolves the rollout length.
+        result = sim.run_policy("arm1", policy_provider="mock", duration=0.1, control_frequency=50.0, fast_mode=True)
+        assert result["status"] == "success", result
+        assert _report(result)["n_steps"] == 5
+
+
+class TestARefusedHorizonNeverRunsTheRollout:
+    """The guard precedes the loop, so no step and no inference happen."""
+
+    @pytest.mark.parametrize("param", HORIZON_PARAMS)
+    def test_the_policy_is_never_queried(self, sim, param):
+        policy = _CountingPolicy()
+        result = sim.run_policy("arm1", policy_object=policy, **{param: 2.7})
+        assert result["status"] == "error", result
+        assert policy.calls == 0
+
+    def test_the_counting_policy_really_would_have_been_queried(self, sim):
+        # Non-vacuity for the assertion above: a usable horizon does query it.
+        policy = _CountingPolicy()
+        result = sim.run_policy("arm1", policy_object=policy, n_steps=3, fast_mode=True)
+        assert result["status"] == "success", result
+        assert policy.calls > 0
+
+
+class TestTheHorizonParametersAreDiscoverable:
+    """A refused value must name a parameter the docstring documents.
+
+    ``n_steps`` / ``max_steps`` carried no ``Args:`` entry at all, so the
+    domain enforced above was undiscoverable from the API docs: the ``duration``
+    entry told a reader that a step count "wins" over it without either count
+    being documented anywhere. ``policy_object`` (recommended by the Returns:
+    section) and ``max_onframe_failures`` were undocumented for the same reason.
+    """
+
+    @pytest.mark.parametrize("param", ["policy_object", "n_steps", "max_steps", "max_onframe_failures"])
+    def test_run_policy_documents_the_parameter(self, param):
+        doc = inspect.getdoc(SimEngine.run_policy) or ""
+        assert f"\n    {param}:" in doc, f"{param} has no Args: entry"
+
+    def test_every_run_policy_parameter_is_documented(self):
+        # The whole signature, so a parameter added later cannot slip in
+        # undocumented the way these four did.
+        doc = inspect.getdoc(SimEngine.run_policy) or ""
+        signature = inspect.signature(SimEngine.run_policy)
+        undocumented = [name for name in signature.parameters if name != "self" and f"\n    {name}:" not in doc]
+        assert undocumented == [], undocumented

--- a/tests/simulation/test_run_policy_horizon_validation.py
+++ b/tests/simulation/test_run_policy_horizon_validation.py
@@ -10,8 +10,8 @@ Per the agent-tool contract every method returns a structured
 ``{"status": ..., "content": [...]}`` dict rather than raising past dispatch,
 so each guard is asserted to return ``status="error"`` with an actionable,
 ASCII-only message naming the offending parameter. The legacy ``max_steps``
-alias is asserted to behave identically to ``n_steps`` (it is normalized to
-``n_steps`` before the guards run).
+alias shares ``n_steps``'s domain but is validated *before* it is normalized
+away, so the refusal names whichever of the two the caller actually wrote.
 """
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ class TestRunPolicyHorizonGuards:
     @pytest.mark.parametrize("bad", [0, -1, -50])
     def test_non_positive_n_steps_errors(self, sim, bad):
         text = _err_text(sim.run_policy("arm1", n_steps=bad))
-        assert "n_steps must be > 0" in text
+        assert "n_steps must be a positive integer" in text
         assert str(bad) in text
 
     @pytest.mark.parametrize("bad_freq", [0, -10.0])
@@ -62,11 +62,15 @@ class TestRunPolicyHorizonGuards:
         text = _err_text(sim.run_policy("arm1", n_steps=5, control_frequency=bad_freq))
         assert "control_frequency must be > 0" in text
 
-    def test_legacy_max_steps_alias_is_validated_like_n_steps(self, sim):
-        # max_steps is normalized to n_steps before the guards, so a
-        # non-positive max_steps surfaces the same n_steps error.
+    def test_legacy_max_steps_alias_is_refused_under_its_own_name(self, sim):
+        # max_steps is normalized to n_steps, but it is validated BEFORE that
+        # normalization so the refusal names the parameter the caller actually
+        # wrote. This assertion used to expect the n_steps message: the alias
+        # was normalized first, so a caller who passed max_steps was pointed at
+        # a parameter they never passed.
         text = _err_text(sim.run_policy("arm1", max_steps=0))
-        assert "n_steps must be > 0" in text
+        assert "max_steps must be a positive integer" in text
+        assert "n_steps" not in text
 
     def test_error_message_is_ascii(self, sim):
         text = _err_text(sim.run_policy("arm1", n_steps=-1))
@@ -77,7 +81,7 @@ class TestRunPolicyHorizonGuards:
         # wrong: the horizon guard short-circuits ahead of the robot lookup,
         # so the caller sees the horizon problem first.
         text = _err_text(sim.run_policy("ghost", n_steps=0))
-        assert "n_steps must be > 0" in text
+        assert "n_steps must be a positive integer" in text
 
 
 class TestStartPolicyHorizonGuards:
@@ -91,7 +95,7 @@ class TestStartPolicyHorizonGuards:
 
     def test_non_positive_n_steps_errors_synchronously(self, sim):
         text = _err_text(sim.start_policy("arm1", n_steps=-1))
-        assert "n_steps must be > 0" in text
+        assert "n_steps must be a positive integer" in text
 
     def test_non_positive_control_frequency_errors_synchronously(self, sim):
         text = _err_text(sim.start_policy("arm1", n_steps=5, control_frequency=0))
@@ -496,7 +500,7 @@ class TestStartPolicyDurationGuard:
 
     def test_horizon_error_names_start_policy(self, sim):
         text = _err_text(sim.start_policy("arm1", n_steps=0))
-        assert "start_policy: n_steps must be > 0" in text
+        assert "start_policy: n_steps must be a positive integer" in text
 
 
 class TestRunMultiPolicyHorizonGuards:
@@ -521,7 +525,7 @@ class TestRunMultiPolicyHorizonGuards:
 
     def test_non_positive_n_steps_errors(self, sim, policies):
         text = _err_text(sim.run_multi_policy(policies, n_steps=0))
-        assert "run_multi_policy: n_steps must be > 0" in text
+        assert "run_multi_policy: n_steps must be a positive integer" in text
 
     def test_non_positive_control_frequency_errors_on_duration_path(self, sim, policies):
         # Pre-fix the frequency was only checked alongside n_steps, so the


### PR DESCRIPTION
## Problem

`run_policy` / `start_policy` / `run_multi_policy` take the rollout length as a step count (`n_steps`, or the legacy `max_steps` alias) and all three resolve it through one shared helper, `SimEngine._resolve_horizon`, which converts it to a wall-clock duration (`duration = n_steps / control_frequency`).

That helper tested the horizon with a bare `<= 0`, which only sees the **sign**. Measured on a 6-DoF SO-100 arm driven by a policy whose commanded pose is indexed by the step count, so travel *is* the honored horizon:

| `run_policy(...)` | main | this change |
|---|---|---|
| `n_steps=120` | success, 120 steps, travel 10.5794 rad | success, 120 steps, travel 10.5794 rad |
| `n_steps=2.7` | **success, 2 steps**, travel 0.7883 rad | `error: n_steps must be a positive integer, got 2.7.` |
| `n_steps=True` | **success, 1 step**, travel 0.3368 rad | `error: n_steps must be a positive integer, got True.` |
| `max_steps=0` | `error: n_steps must be > 0` — names a parameter never passed | `error: max_steps must be a positive integer, got 0.` |
| `eval_policy(max_steps=2.7)` | `error: max_steps must be a positive integer` | unchanged |

Two things fall out of that:

**One parameter name carried two contracts.** Every sibling count on the same call — `n_episodes`, `action_horizon`, `control_substeps` — and the identically-named `eval_policy` step budget already went through the shared positive-count domain, whose own docstring names `max_steps` as part of its family:

> Shared guard for the rollout count knobs that must be `>= 1` - `n_episodes` (how many reset->rollout episodes to run), **`max_steps` (the per-episode step cap)**, `control_substeps` and `action_horizon`.

So `max_steps=2.7` was a validated positive integer on `eval_policy` and a silently truncated float on `run_policy`. `_resolve_horizon`'s own docstring claimed "the inputs are validated before the division" while validating only the sign.

**The refusal named the wrong parameter.** A non-positive `max_steps` reported `n_steps must be > 0` because the alias was normalized (`n_steps = int(max_steps)`) *before* the check, pointing the caller at a parameter they never passed.

**And the domain was undiscoverable.** `n_steps`, `max_steps`, `policy_object` and `max_onframe_failures` had no `Args:` entry on `run_policy`. The `duration` entry told a reader that a step count "wins" over it — *"Used only when no `n_steps` / `max_steps` is given (the step count wins...)"* — while neither count was documented anywhere, and the `Returns:` section recommends "reusing `policy_object=`", also undocumented.

## Change

- `_resolve_horizon` validates the **effective** horizon against `positive_count_error`, the same domain `_validate_positive_int` binds for `eval_policy`'s `max_steps`. One edit covers all three entry points because they share the funnel.
- The alias is validated **under its own name**, before normalization. The `int()` coercion is gone: over a value the domain has accepted it was a second, weaker contract that truncated it.
- The message wording moves from `must be > 0` to `must be a positive integer`, because the old wording is *false* of exactly the values that were slipping through (`2.7` and `True` are both `> 0`). Six assertions in `test_run_policy_horizon_validation.py` and two elsewhere are updated for that reason.
- The four missing `Args:` entries are added, and a test pins **every** `run_policy` parameter as documented so a future one cannot slip in undocumented the same way.

The NumPy and integral-float spellings (`np.int64(3)`, `3.0`) are refused too — measured to be exactly what `eval_policy`'s `max_steps` already refuses, so this is parity with the sibling budget rather than a new restriction. A parity test asserts `run_policy` refuses a horizon **iff** `eval_policy` does, over the whole probe set.

One existing test pinned the old behaviour as intent (`test_legacy_max_steps_alias_is_validated_like_n_steps`, whose comment read "so a non-positive `max_steps` surfaces the same `n_steps` error"). It is renamed to the corrected contract with the reason in place, not shimmed.

## Visual artifact

Panel A is the horizon the caller asked for; B is main accepting a horizon nobody asked for as a success; C is the refusal. Panel A is **bit-identical on both trees** (travel `10.5794` rad on each, renders differing by 1/255), and the refused rollout leaves the arm within 1/255 of its own starting frame.

![rollout step-horizon domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-step-horizon/horizon_domain.png)

Capture and compose scripts: [`capture.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-step-horizon/capture.py), [`compose.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-step-horizon/compose.py); measured facts [`facts_main.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-step-horizon/facts_main.json) / [`facts_branch.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rollout-step-horizon/facts_branch.json). Every number rendered in the figure is asserted against those two dumps by the compose script before it saves.

## Verification

Base `2980368a`, headless MuJoCo (`MUJOCO_GL=egl`).

- **Pre-fix proof** — source reverted to `upstream/main`, both test files kept: **96 failed / 282 passed**, e.g. `assert 'max_steps must be a positive integer' in 'run_policy: n_steps must be > 0, got 0.'`. Post-fix: 378 passed.
- **Full suite**: `24875 passed, 257 skipped, 0 failed` in 532s. Pristine `upstream/main` on the same host is `24747 passed, 257 skipped` — the delta is exactly the 128 new tests, with no other churn.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1126 files).
- `mypy strands_robots tests tests_integ`: **0 errors** outside `examples/isaac_gs`; that directory's 14 errors are byte-identical to a pristine `upstream/main` worktree of the same working copy (an artifact of this checkout, not of the change).
- `scripts/assemble_changelog.py --check`: OK; `scripts/check_merge_base_overlap.py`: no overlap.

## Scope

The horizon domain is the change. Six other public `simulation/` surfaces also have undocumented parameters (`get_observation`'s `skip_images`, `MuJoCoSimEngine.__init__`'s `ros2_bridge`/`ros2_domain`, `add_object`'s `material`, `PolicyRunner.run`/`evaluate`'s `control_substeps`/`action_horizon`/`control_frequency`); those are not touched here — only the parameters whose domain this PR changes, plus the two remaining entries of the same `Args:` block. `PolicyRunner.run`'s own `n_steps` is left as-is: its docstring documents the value as "resolved by the caller", and the caller is the guarded funnel.
