### PR TITLE
docs(simulation): document the parameters that carry an enforced domain but no Args: entry

### DIFF
--- a/changelog.d/2054-simulation-args-docstring-completeness.md
+++ b/changelog.d/2054-simulation-args-docstring-completeness.md
@@ -1,0 +1,18 @@
+### Docs: document the simulation parameters that carry an enforced domain but no `Args:` entry
+
+Six public simulation surfaces accepted parameters their docstring never
+mentioned, so a caller could be *refused for a parameter they could not look
+up*: `MuJoCoSimEngine.__init__`'s `ros2_domain` raises unless it is an `int` in
+`[0, 232]`, `add_object`'s `material` is refused for any key outside
+`MATERIAL_KEYS`, and `PolicyRunner.run` / `.evaluate`'s `control_substeps`
+raises unless it is a positive integer - each reported a name with no entry to
+read. `SimEngine.get_observation`'s `skip_images` was documented on the Newton
+backend that implements the method but not on the ABC that declares it.
+
+Every entry is now written from the authoritative source (`_init_ros_bridge`
+for the ROS 2 knobs, `spec_builder.MATERIAL_KEYS` for the material vocabulary,
+`_control_substeps` for the substep contract), and a new guard compares every
+public simulation method's signature against its own `Args:` block in both
+directions, so a parameter can no longer be added - or removed - without the
+docs following. The guard honours combined entry labels (`width/height:`,
+`width, height:`), which two recorder entry points already rely on.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1031,6 +1031,19 @@ class SimEngine(ABC):
         Args:
             robot_name: Which robot to observe. If ``None`` and exactly one
                 robot exists, that robot is used; otherwise returns ``{}``.
+            skip_images: Skip camera rendering and return joint state only.
+                Rendering dominates the per-step cost, so every consumer that
+                reads joint values alone passes ``True`` - the predicate /
+                reward DSL (:mod:`~strands_robots.simulation.predicates`), the
+                LIBERO adapter's state reads, and the ROS 2 bridge when it
+                publishes ``joint_states`` without ``image_raw``. Camera keys
+                are then absent from the result rather than present and empty,
+                so a caller must not read a missing frame as a render failure.
+                A backend overrides a ``True`` here while a dataset recording is
+                active - the recorded frames must carry the camera images the
+                schema declared - so this is a hint, not a guarantee that
+                nothing renders. Defaults to False (render every attached
+                camera).
 
         Returns:
             Observation dict per schema above. Returns ``{}`` if the world
@@ -2169,6 +2182,36 @@ class SimEngine(ABC):
                 dataset recording), backends plug into
                 ``PolicyRunner.run``'s ``on_frame`` hook via
                 :meth:`_make_run_policy_hook`.
+            policy_object: Already-constructed
+                :class:`~strands_robots.policies.Policy` to drive the rollout,
+                bypassing ``create_policy`` entirely (``policy_provider`` /
+                ``policy_config`` are then unused). Reuse one instance across
+                calls so the checkpoint is not reloaded per rollout - the
+                ``policy_load_cache_hit`` field below reports when a caller
+                rebuilt it instead. ``None`` (default) builds the policy from
+                ``policy_provider`` / ``policy_config``.
+            n_steps: Exact control-step horizon. When given it REPLACES
+                ``duration``, which is recomputed as
+                ``n_steps / control_frequency``, and it bypasses the lossy
+                ``int(duration * control_frequency)`` conversion so the rollout
+                executes exactly this many control steps. Must be a positive
+                integer; ``0``, a negative value, a bool, or a fractional or
+                non-numeric value is reported as a structured caller error
+                rather than truncated to a horizon the caller never asked for.
+                ``None`` (default) falls back to ``max_steps``, then to
+                ``duration``.
+            max_steps: Legacy alias for ``n_steps``, kept for callers written
+                against the older name. Consulted only when ``n_steps`` is
+                ``None`` - ``n_steps`` wins when both are passed - and refused
+                under its own name on the same domain.
+            max_onframe_failures: Maximum *consecutive* ``on_frame``-hook
+                exceptions tolerated before the rollout aborts the episode. That
+                hook is where a backend attaches dataset recording and video
+                capture, so a broken recorder otherwise fills an empty dataset
+                behind a successful-looking rollout. ``None`` (default) uses the
+                runner's own limit (currently ``5``); non-consecutive failures
+                reset the counter. Forwarded verbatim to
+                :meth:`~strands_robots.simulation.policy_runner.PolicyRunner.run`.
             seed: Optional master RNG seed for a reproducible single rollout.
                 When set, reseeds Python / NumPy / torch / cuDNN and forwards
                 ``policy.reset(seed=...)`` so a stochastic policy (VLA action-

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -289,6 +289,18 @@ class MuJoCoSimEngine(
             peer_id: Stable identifier the mesh transport uses to
                 address this Simulation. Opaque to MuJoCo itself; only
                 consulted when ``mesh`` is truthy.
+            ros2_bridge: When True, publish per-robot ``joint_states`` and
+                camera ``image_raw`` on a ROS 2 domain every ``step``, so
+                external ROS 2 nodes can subscribe to the running simulation.
+                Requires ``rclpy`` (system ROS 2 / the official docker image);
+                an :class:`ImportError` is raised here if it is missing.
+                Defaults to False - the sim never touches ROS 2.
+            ros2_domain: ROS 2 domain id (``ROS_DOMAIN_ID``) to publish on.
+                Only an ``int`` in ``[0, 232]`` names a domain - the RTPS port
+                map has no room above that - and a value outside it is refused
+                with a :class:`ValueError` during construction whether or not
+                ``ros2_bridge`` is set, so a backend that only publishes later
+                still rejects it up front. Defaults to ``0``.
             **kwargs: Accepted and ignored, for cross-backend forward
                 compatibility. The shared ``create_simulation`` / ``Robot``
                 factory forwards one superset of keyword arguments to whichever
@@ -2666,6 +2678,20 @@ class MuJoCoSimEngine(
                 True; other shapes default to dynamic.
             mesh_path: Mesh asset path; required and only used when
                 ``shape="mesh"``.
+            material: Optional MuJoCo material for the object's geom, given as
+                a mapping of material attribute to value. The accepted keys are
+                ``builtin``, ``reflectance``, ``rgb1``, ``rgb2``, ``shininess``,
+                ``specular``, ``texdim``, ``texrepeat`` and ``texture``
+                (:data:`~strands_robots.simulation.mujoco.spec_builder.MATERIAL_KEYS`
+                is the single source of truth). A key outside that vocabulary is
+                refused - with a "did you mean" suggestion and the accepted list
+                - rather than dropped, and so is ``material={}``, which would
+                otherwise report success having compiled the default material.
+                ``rgb1`` / ``rgb2`` / ``texdim`` only colour or size a
+                procedural texture, so passing one without ``builtin`` is
+                refused too: the texture they configure would never be
+                generated. ``None`` (default) leaves the geom on the flat
+                ``color`` rgba.
 
         Returns:
             Agent-tool status dict. ``{"status": "success", ...}`` on success;

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1026,6 +1026,18 @@ class PolicyRunner:
                 broken recording hook otherwise silently produces empty
                 datasets - see GH #117. Non-consecutive failures reset the
                 counter.
+            control_substeps: Physics steps advanced per applied action. ``None``
+                (default) derives the count from ``control_frequency`` and the
+                backend's physics timestep, so a position-servo arm integrates
+                over the full control period instead of a single physics ``dt``.
+                An explicit value must be a positive integer: ``0``, a negative
+                value, a bool or a float raises :class:`ValueError` rather than
+                being clamped, because a clamped ``0`` reinstates the exact
+                under-integration the derivation exists to prevent - the arm
+                then covers a fraction of the way to each target before the next
+                action overwrites it, and the rollout looks like a no-op. The
+                public entry points refuse such a value with a structured error
+                before it reaches the runner.
             seed: Optional master RNG seed for a reproducible single rollout.
                 When set, ``set_eval_seed`` reseeds Python / NumPy / torch /
                 cuDNN and ``policy.reset(seed=...)`` is forwarded so the
@@ -2216,6 +2228,9 @@ class PolicyRunner:
             seed: Master RNG seed. Each episode derives a child RNG from it,
                 so evaluations are reproducible within a process. Only used
                 when ``spec`` is provided.
+            action_horizon: Max actions consumed per policy call before
+                requerying the observation, as in :meth:`run`. Clamped up to the
+                policy's own chunk length when it emits more.
             on_frame: Optional ``(step, observation, action) -> None`` hook
                 fired per applied control step on the eval thread, after
                 ``sim.send_action``. Forwarded on BOTH the ``spec=`` and the
@@ -2230,6 +2245,18 @@ class PolicyRunner:
                 from the script main (e.g. Strands ``Agent`` tool dispatch
                 under asyncio) - see #191 and
                 :meth:`~strands_robots.simulation.mujoco.simulation.Simulation.start_cameras_recording_synchronous`.
+            control_frequency: Target Hz for ``policy.get_actions`` calls, as in
+                :meth:`run`. Also sets the wall-clock period each applied action
+                is integrated over, via the ``control_substeps`` derivation
+                below, so an eval steps physics for the same period per action
+                that :meth:`run` does.
+            control_substeps: Physics steps advanced per applied action, with
+                the same contract as :meth:`run`: ``None`` (default) derives the
+                count from ``control_frequency`` and the backend's physics
+                timestep, and an explicit value must be a positive integer or
+                :class:`ValueError` is raised rather than the value being
+                clamped. Passing ``1`` here is what made eval rollouts look
+                like a policy no-op before the derivation existed.
             async_rtc: Opt-in overlap of policy inference with action-chunk
                 execution on the legacy ``success_fn`` path, mirroring
                 :meth:`run`. Defaults to ``False`` (synchronous): the world is

--- a/tests/simulation/test_args_docstring_completeness.py
+++ b/tests/simulation/test_args_docstring_completeness.py
@@ -1,0 +1,300 @@
+"""A documented parameter is the only discovery surface a caller has.
+
+Several simulation parameters carry a real, enforced domain: ``ros2_domain``
+must be an ``int`` in ``[0, 232]`` or construction raises, ``control_substeps``
+must be a positive integer or the runner raises, and ``add_object``'s
+``material`` mapping is refused for any key outside
+:data:`~strands_robots.simulation.mujoco.spec_builder.MATERIAL_KEYS`. When such
+a parameter has no ``Args:`` entry, a caller can be *refused for a parameter the
+docstring never mentions* - the guard reports a name the reader cannot look up,
+so the remedy is to read the source. That is the same shape as a knob whose
+accepted domain is undiscoverable, and it went unnoticed on six surfaces at once
+because nothing compared a signature against its own ``Args:`` block.
+
+These tests pin the comparison for every public method of every public class in
+:mod:`strands_robots.simulation` (backend subpackages included) whose docstring
+*already* has an ``Args:`` section: adding a parameter without documenting it -
+or documenting one the signature no longer takes - fails here. A docstring with
+no ``Args:`` section at all is out of scope: this guard checks a block that
+exists for completeness rather than demanding one, which is
+``test_public_member_docstrings.py``'s job for the docstring itself.
+
+Combined entry labels are honoured deliberately. Google style is used loosely in
+this package for parameters that share one description, so
+``start_cameras_recording`` documents ``width/height:`` (slash-joined) and
+``start_cameras_recording_synchronous`` documents ``width, height:``
+(comma-joined). Both are genuinely documented, and a parser that compared the
+raw label would demand entries that already exist - so labels are split on
+``/``, ``,`` and ``or`` before comparing. :class:`TestCombinedEntryLabelsCount`
+pins that calibration against the two real surfaces that rely on it.
+
+The scan walks modules by AST, so it needs none of the optional simulation
+backends installed, and :class:`TestTheScanIsNonVacuous` fails if a mis-rooted
+scan reports a clean sweep over nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+import strands_robots.simulation as simulation_pkg
+
+# Derived from an imported symbol rather than a path literal, so a moved package
+# cannot leave this scanning an empty tree while reporting success.
+_PACKAGE_ROOT = Path(inspect.getfile(simulation_pkg)).parent
+
+_SECTION_HEADERS = ("Args:", "Arguments:", "Parameters:")
+
+# ``name (type):`` / ``name:`` / ``**kwargs:`` / ``width, height:`` / ``a/b:``
+_ENTRY = re.compile(r"^\s*(\*{0,2}[A-Za-z_][\w ,/]*?)\s*(\([^)]*\))?\s*:")
+
+# One entry label may name several parameters that share a description.
+_LABEL_SPLIT = re.compile(r"\s*(?:/|,|\bor\b)\s*")
+
+
+def documented_parameters(doc: str) -> tuple[frozenset[str], bool]:
+    """Names documented in ``doc``'s ``Args:`` section, and whether it has one.
+
+    Args:
+        doc: A dedented docstring (as :func:`ast.get_docstring` returns).
+
+    Returns:
+        ``(names, has_section)``. ``names`` is empty when there is no ``Args:``
+        section, so callers must consult ``has_section`` to tell "documents
+        nothing" from "has no block to check". Combined labels are split, and a
+        leading ``*`` / ``**`` is stripped so ``**kwargs:`` documents ``kwargs``.
+    """
+    lines = doc.splitlines()
+    header_indent = None
+    body: list[str] = []
+    for index, line in enumerate(lines):
+        if line.strip() in _SECTION_HEADERS:
+            header_indent = len(line) - len(line.lstrip())
+            body = lines[index + 1 :]
+            break
+    if header_indent is None:
+        return frozenset(), False
+
+    names: set[str] = set()
+    entry_indent = None
+    for line in body:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= header_indent:
+            break  # section ended (next header or a dedented paragraph)
+        if entry_indent is None:
+            entry_indent = indent
+        if indent != entry_indent:
+            continue  # continuation line of the entry above
+        match = _ENTRY.match(line)
+        if not match:
+            continue
+        for part in _LABEL_SPLIT.split(match.group(1)):
+            cleaned = part.strip().lstrip("*")
+            if cleaned:
+                names.add(cleaned)
+    return frozenset(names), True
+
+
+def signature_parameters(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Parameter names of ``fn`` in declaration order, minus ``self`` / ``cls``."""
+    args = fn.args
+    names = [p.arg for p in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    if args.vararg:
+        names.append(args.vararg.arg)
+    if args.kwarg:
+        names.append(args.kwarg.arg)
+    return [name for name in names if name not in ("self", "cls")]
+
+
+def documented_surfaces(root: Path) -> list[tuple[str, list[str], frozenset[str]]]:
+    """Every public method of a public class under ``root`` that has an ``Args:`` block.
+
+    Args:
+        root: Package directory to walk. Every ``*.py`` beneath it is parsed by
+            AST, so no optional backend needs to be importable.
+
+    Returns:
+        ``(surface_id, signature_parameters, documented_parameters)`` triples,
+        where ``surface_id`` is ``"<relative path>::<Class>.<method>"``.
+    """
+    surfaces = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            if cls.name.startswith("_"):
+                continue
+            for fn in cls.body:
+                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                if fn.name.startswith("_") and fn.name != "__init__":
+                    continue
+                doc = ast.get_docstring(fn)
+                if not doc:
+                    continue
+                documented, has_section = documented_parameters(doc)
+                if not has_section:
+                    continue
+                rel = path.relative_to(root.parent)
+                surfaces.append((f"{rel}::{cls.name}.{fn.name}", signature_parameters(fn), documented))
+    return surfaces
+
+
+_SURFACES = documented_surfaces(_PACKAGE_ROOT)
+
+
+@pytest.mark.parametrize(
+    ("surface", "params", "documented"),
+    _SURFACES,
+    ids=[surface for surface, _, _ in _SURFACES],
+)
+def test_every_parameter_has_an_args_entry(surface: str, params: list[str], documented: frozenset[str]) -> None:
+    """A parameter with no entry is undiscoverable, even where a guard enforces it."""
+    missing = [name for name in params if name not in documented]
+    assert not missing, f"{surface} accepts {missing} with no Args: entry"
+
+
+@pytest.mark.parametrize(
+    ("surface", "params", "documented"),
+    _SURFACES,
+    ids=[surface for surface, _, _ in _SURFACES],
+)
+def test_no_args_entry_names_a_parameter_the_signature_lacks(
+    surface: str, params: list[str], documented: frozenset[str]
+) -> None:
+    """The other direction: an entry for a removed parameter is a false promise."""
+    phantom = sorted(name for name in documented if name not in params)
+    assert not phantom, f"{surface} documents {phantom}, which it does not accept"
+
+
+class TestTheScanIsNonVacuous:
+    """A mis-rooted or over-filtered scan must fail rather than sweep nothing."""
+
+    def test_the_scan_root_is_the_simulation_package(self) -> None:
+        assert _PACKAGE_ROOT.name == "simulation"
+        assert (_PACKAGE_ROOT / "base.py").is_file()
+
+    def test_enough_surfaces_are_scanned_to_be_meaningful(self) -> None:
+        assert len(_SURFACES) >= 70, f"only {len(_SURFACES)} surfaces scanned"
+
+    @pytest.mark.parametrize(
+        "expected",
+        [
+            "simulation/base.py::SimEngine.get_observation",
+            "simulation/base.py::SimEngine.run_policy",
+            "simulation/policy_runner.py::PolicyRunner.run",
+            "simulation/policy_runner.py::PolicyRunner.evaluate",
+            "simulation/mujoco/simulation.py::MuJoCoSimEngine.__init__",
+            "simulation/mujoco/simulation.py::MuJoCoSimEngine.add_object",
+        ],
+        ids=lambda expected: expected.rsplit("::", 1)[-1],
+    )
+    def test_a_known_surface_is_in_scope(self, expected: str) -> None:
+        """The six surfaces this guard was written for must actually be walked."""
+        assert any(surface == expected for surface, _, _ in _SURFACES), expected
+
+
+class TestCombinedEntryLabelsCount:
+    """One entry may name several parameters, and both spellings are in use here."""
+
+    @pytest.mark.parametrize(
+        ("label", "expected"),
+        [
+            ("width/height", {"width", "height"}),
+            ("width, height", {"width", "height"}),
+            ("host or port", {"host", "port"}),
+            ("fps (int)", {"fps"}),
+            ("**kwargs", {"kwargs"}),
+        ],
+        ids=["slash", "comma", "or", "typed", "var_keyword"],
+    )
+    def test_a_combined_label_documents_every_name_it_lists(self, label: str, expected: set[str]) -> None:
+        doc = f"Summary.\n\nArgs:\n    {label}: Shared description.\n"
+        documented, has_section = documented_parameters(doc)
+        assert has_section
+        assert documented == frozenset(expected)
+
+    def test_the_real_surfaces_relying_on_combined_labels_are_clean(self) -> None:
+        """Both recorder entry points document width/height as one combined entry.
+
+        They are the reason the split exists: comparing the raw label would
+        report them as missing entries that are plainly present.
+        """
+        relying = [
+            (surface, params, documented)
+            for surface, params, documented in _SURFACES
+            if surface.endswith(("start_cameras_recording", "start_cameras_recording_synchronous"))
+        ]
+        assert len(relying) >= 2, [surface for surface, _, _ in _SURFACES if "cameras_recording" in surface]
+        for surface, params, documented in relying:
+            assert {"width", "height"} <= documented, surface
+            assert not [name for name in params if name not in documented], surface
+
+
+class TestTheScannerDetectsAPlantedDefect:
+    """An empty result must mean clean sources, not a scanner that matches nothing."""
+
+    def _scan(self, tmp_path: Path, source: str) -> list[tuple[str, list[str], frozenset[str]]]:
+        pkg = tmp_path / "simulation"
+        pkg.mkdir()
+        (pkg / "planted.py").write_text(source, encoding="utf-8")
+        return documented_surfaces(pkg)
+
+    def test_a_missing_entry_is_reported(self, tmp_path: Path) -> None:
+        surfaces = self._scan(
+            tmp_path,
+            "class Engine:\n"
+            "    def go(self, kept, dropped):\n"
+            '        """Summary.\n\n        Args:\n            kept: Documented.\n        """\n',
+        )
+        assert len(surfaces) == 1
+        _, params, documented = surfaces[0]
+        assert [name for name in params if name not in documented] == ["dropped"]
+
+    def test_a_phantom_entry_is_reported(self, tmp_path: Path) -> None:
+        surfaces = self._scan(
+            tmp_path,
+            "class Engine:\n"
+            "    def go(self, kept):\n"
+            '        """Summary.\n\n        Args:\n'
+            '            kept: Documented.\n            removed: Gone from the signature.\n        """\n',
+        )
+        assert len(surfaces) == 1
+        _, params, documented = surfaces[0]
+        assert sorted(name for name in documented if name not in params) == ["removed"]
+
+    def test_a_docstring_without_an_args_section_is_out_of_scope(self, tmp_path: Path) -> None:
+        surfaces = self._scan(
+            tmp_path,
+            'class Engine:\n    def go(self, undocumented):\n        """Summary only."""\n',
+        )
+        assert surfaces == []
+
+    def test_a_continuation_line_is_not_read_as_an_entry(self, tmp_path: Path) -> None:
+        """A wrapped description often contains a colon; it must not invent a name."""
+        surfaces = self._scan(
+            tmp_path,
+            "class Engine:\n"
+            "    def go(self, only):\n"
+            '        """Summary.\n\n        Args:\n'
+            '            only: First line.\n                note: this wraps and has a colon.\n        """\n',
+        )
+        assert len(surfaces) == 1
+        _, params, documented = surfaces[0]
+        assert documented == frozenset({"only"})
+        assert not [name for name in params if name not in documented]
+
+    def test_a_private_class_is_out_of_scope(self, tmp_path: Path) -> None:
+        surfaces = self._scan(
+            tmp_path,
+            "class _Internal:\n"
+            "    def go(self, dropped):\n"
+            '        """Summary.\n\n        Args:\n            other: Documented.\n        """\n',
+        )
+        assert surfaces == []


### PR DESCRIPTION
Closes #2054.

## Problem

Six public surfaces in `strands_robots/simulation/` accept parameters that have no `Args:` entry. Three of those parameters carry a **real, enforced domain**, so a caller can be *refused for a parameter the docstring never mentions* — the error names a knob with no entry to look up, and the only remedy is to read the source:

| surface | undocumented | enforced? |
|---|---|---|
| `MuJoCoSimEngine.__init__` | `ros2_bridge`, `ros2_domain` | `ros2_domain` must be an `int` in `[0, 232]` or `__init__` raises `ValueError` — **whether or not `ros2_bridge` is set** |
| `MuJoCoSimEngine.add_object` | `material` | any key outside `MATERIAL_KEYS` is refused, and so is `material={}` |
| `PolicyRunner.run` | `control_substeps` | must be a positive integer or `_control_substeps` raises `ValueError` |
| `PolicyRunner.evaluate` | `action_horizon`, `control_frequency`, `control_substeps` | same `control_substeps` contract |
| `SimEngine.get_observation` | `skip_images` | — |

`skip_images` is the sharpest case: the **Newton backend that implements** `get_observation` documents it, while the **ABC that declares** it does not.

Measured on `2980368a`, the shape is exactly this and nothing more — 82 public functions in the package carry an `Args:` section, 6 have a parameter missing from it, and **zero** document a parameter the signature lacks. (#2054's table says "ten entries"; re-measured it is eight across five surfaces, plus the sixth row which is a false positive of an uncalibrated parser — see below.)

## Change

Every entry is written from the **authoritative source that already exists**, so these are mirror-and-attribute edits rather than new prose:

- `_init_ros_bridge` for both ROS 2 knobs (including the fact the domain is refused at construction even with the bridge off)
- `spec_builder.MATERIAL_KEYS` for the material vocabulary, plus the `builtin` dependency: `rgb1` / `rgb2` / `texdim` only colour or size a procedural texture, so passing one without `builtin` is refused
- `_control_substeps` for the substep contract, including *why* it raises instead of clamping — a clamped `0` reinstates the exact under-integration the derivation exists to prevent

And a guard, `tests/simulation/test_args_docstring_completeness.py`, compares every public method's signature against its own `Args:` block **in both directions**, so a parameter can no longer be added — or removed — without the docs following.

### The guard honours combined entry labels, deliberately

Google style is used loosely here for parameters sharing one description: `start_cameras_recording` documents them as `width/height:` and `start_cameras_recording_synchronous` as `width, height:`. Both are genuinely documented, so a parser comparing the raw label would demand entries that already exist. Labels are split on `/`, `,` and `or`, and `TestCombinedEntryLabelsCount` pins that against the two real surfaces relying on it — not just synthetic strings.

Scope is the whole package including the backend subpackages, with **zero exemptions**: the sweep is clean there too, and an exemption list is where the next gap hides.

## Deliberate overlap with #2053

`run_policy`'s four entries are the block #2053 adds, **carried byte-identically** (extracted from that PR's diff, not retyped). Without them this guard cannot pass on today's `main`, which would make the PR depend on merge order. Verified with `git merge-tree` that the two compose in **either** order:

```
merge-tree(#2053, this) -> rc=0 CLEAN  tree=d742b66e9111
merge-tree(this, #2053) -> rc=0 CLEAN  tree=d742b66e9111   (identical tree)
```

The merged tree carries both changes and no duplicated entry (`policy_object:` count is 2 in `base.py` on `main`, on #2053, on this branch **and** on the merge — `main` already had one in `evaluate_benchmark`), and the completeness sweep is clean over it. If #2053 lands first, this side of the merge is a no-op.

## Verification (Python 3.13, MuJoCo 3.11, `MUJOCO_GL=egl`)

**Pre-fix proof** — source reverted to `upstream/main`, the new guard kept: **6 failed / 177 passed**, each failure naming the surface and the exact parameters:

```
FAILED ...[simulation/base.py::SimEngine.get_observation]
  AssertionError: ... accepts ['skip_images'] with no Args: entry
FAILED ...[simulation/mujoco/simulation.py::MuJoCoSimEngine.__init__]
  AssertionError: ... accepts ['ros2_bridge', 'ros2_domain'] with no Args: entry
FAILED ...[simulation/policy_runner.py::PolicyRunner.evaluate]
  AssertionError: ... accepts ['action_horizon', 'control_frequency', 'control_substeps'] with no Args: entry
```

Post-fix: **183 passed in 0.9s** (no MuJoCo, no optional backend — the scan is pure AST).

**Full suite:** `24930 passed, 257 skipped, 0 failed` in 587s. Zero existing-test churn.
**Lint:** `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` all clean (1126 files formatted, 1123 source files type-checked).
**Changelog:** `scripts/assemble_changelog.py --check` OK.

## No visual artifact, and a proof instead

This change alters **no executable line**. Rather than assert that, it is measured: stripping every docstring and hashing the resulting AST gives an identical digest per file across `main` and this branch —

| file | `main` | branch |
|---|---|---|
| `simulation/base.py` | `5e0291dc67b16a5b` | `5e0291dc67b16a5b` |
| `simulation/policy_runner.py` | `51b7e027be409947` | `51b7e027be409947` |
| `simulation/mujoco/simulation.py` | `484b7e83d615472e` | `484b7e83d615472e` |

The diff is `+414 / -0` across 5 files, so no simulation, policy, rendering, recording or asset behaviour changes and a rollout render would show nothing.
