### PR TITLE
docs: root the Args:-completeness guard at the package, not the simulation subtree

### DIFF
--- a/changelog.d/2056-args-docstring-completeness-package-wide.md
+++ b/changelog.d/2056-args-docstring-completeness-package-wide.md
@@ -1,0 +1,21 @@
+### Docs: the `Args:`-completeness guard now compares the whole package, and the four surfaces outside the simulation subtree that needed it
+
+The guard that compares a signature against its own `Args:` block was rooted at
+`strands_robots.simulation`, which is the subtree the six surfaces it was written
+for happened to live in - nothing about the drift is simulation-specific. Rooted
+at the package it compares 629 parameters over 172 surfaces instead of 345 over
+82, and it reported four more surfaces accepting a parameter their docstring
+never mentions (and none in the other direction, anywhere in the package).
+
+`DatasetRecorder.create` now documents `camera_dims`, `video_width` and
+`video_height` - the three parameters that decide the shape every camera column
+is declared with, including that `camera_dims` is `(height, width)` while the
+pair it falls back to on the same call is width-then-height. Both
+`Cosmos3Policy.get_actions` and `LerobotLocalPolicy.get_actions` now say what
+they do with `**kwargs`: Cosmos 3 forwards it on the `diffusers` backend and
+drops it on `service`, and the LeRobot-local provider never reads it, honouring
+only the `inference_kwargs` bound at construction. `LiberoAdapter.__init__` now
+documents `state_gripper_joint_names`, whose length is the width of
+`state.gripper` and is not arity-checked - unlike the `state_gripper_signs`
+vector it has to agree with, which is, so a mismatch is warned about and the
+signs silently skipped.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -350,6 +350,20 @@ class LiberoAdapter(BenchmarkProtocol):
                 is ``"finger_joint1"``. The Menagerie Panda's two-finger
                 MJCF equality constraint mirrors the value to the second
                 finger, so reading just one is sufficient.
+            state_gripper_joint_names: Ordered finger joint names read for the
+                LIBERO ``state.gripper`` vector, in the order the trained state
+                vector uses. ``None`` (default) auto-derives
+                ``["<scene_gripper_prefix>finger_joint1",
+                "<scene_gripper_prefix>finger_joint2"]`` - see
+                :attr:`state_gripper_joint_names`, which exposes the resolved
+                list. The number of names is the width of ``state.gripper``:
+                :meth:`_read_gripper_qpos` reads one ``qpos`` per name, so a list
+                that is not 2 long disagrees with ``state_gripper_signs``, which
+                IS arity-checked to 2 at construction. That disagreement is not
+                refused - the signs are skipped with a warning and
+                ``state.gripper`` is recorded unsigned, which is the
+                out-of-distribution state #168 exists to prevent - so keep the
+                two the same length when overriding either.
             state_gripper_signs: Optional 2-element sign/scale vector
                 multiplied elementwise onto the ``state.gripper``
                 2-vector, whatever source produced it. RoboSuite's

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -794,6 +794,21 @@ class DatasetRecorder:
             camera_keys: List of DISTINCT camera names (images become video
                 features). One name per camera, in schema order; a single name
                 still has to be a one-element list.
+            camera_dims: Per-camera declared frame shape as
+                ``{camera_key: (height, width)}``, keyed by the same names
+                ``camera_keys`` declares. Note the order: ``(height, width)``,
+                the reverse of the ``video_width`` / ``video_height`` pair it
+                falls back to on this same call. Every backend that supplies it
+                reads the camera's real render resolution, so a camera present
+                here is declared at its own shape rather than the global one; a
+                camera absent from the mapping (or ``None``, the default) takes
+                ``(video_height, video_width)``.
+            video_width/video_height: Declared frame shape for every camera
+                ``camera_dims`` does not cover. A declaration rather than a
+                resize - the recorder rescales nothing - so a camera streaming
+                another size is declared at a shape it does not have. This is why
+                the backends pass ``camera_dims`` read from the live cameras
+                instead of relying on this pair.
             joint_names: List of DISTINCT joint names (alternative to
                 robot_features for sim). These become the ``observation.state``
                 column names, and add_frame reads each one out of the

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -382,6 +382,16 @@ class Cosmos3Policy(Policy):
             observation_dict: Flat robots observation (joint floats + camera
                 ndarrays), per the ``SimEngine.get_observation`` schema.
             instruction: Natural-language task instruction.
+            **kwargs: Extra inference options, honored on the ``diffusers``
+                backend only - they are forwarded verbatim to the world model's
+                ``infer`` call. The ``service`` backend calls the remote client
+                without them, so the same keyword is silently dropped there; the
+                ABC requires a provider to ignore what it cannot honor rather
+                than raise (:meth:`~strands_robots.policies.base.Policy.get_actions`),
+                and this provider's answer depends on the ``backend`` it was
+                constructed with. None of the well-known keys the ABC lists
+                (``target_pose``, ``target_joints``, ``world_update``) is read by
+                either backend.
 
         Returns:
             ``list[dict]`` - one action dict per predicted timestep.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -2070,6 +2070,15 @@ class LerobotLocalPolicy(Policy):
         Args:
             observation_dict: Robot observation (cameras + state).
             instruction: Natural language instruction.
+            **kwargs: Accepted and not read. This provider's runtime selectors
+                are bound once at construction and forwarded on every step as
+                ``inference_kwargs`` (to ``predict_action_chunk`` on the chunking
+                path, ``select_action`` otherwise), so a per-call keyword is
+                discarded rather than honored - pass it as
+                ``inference_kwargs=`` when creating the policy instead. Ignoring
+                an unknown keyword rather than raising is what the ABC requires
+                (:meth:`~strands_robots.policies.base.Policy.get_actions`), so
+                the parameter stays in the signature.
 
         Returns:
             List of action dicts for robot execution.

--- a/tests/test_args_docstring_completeness.py
+++ b/tests/test_args_docstring_completeness.py
@@ -1,23 +1,30 @@
 """A documented parameter is the only discovery surface a caller has.
 
-Several simulation parameters carry a real, enforced domain: ``ros2_domain``
-must be an ``int`` in ``[0, 232]`` or construction raises, ``control_substeps``
-must be a positive integer or the runner raises, and ``add_object``'s
-``material`` mapping is refused for any key outside
-:data:`~strands_robots.simulation.mujoco.spec_builder.MATERIAL_KEYS`. When such
-a parameter has no ``Args:`` entry, a caller can be *refused for a parameter the
-docstring never mentions* - the guard reports a name the reader cannot look up,
-so the remedy is to read the source. That is the same shape as a knob whose
-accepted domain is undiscoverable, and it went unnoticed on six surfaces at once
-because nothing compared a signature against its own ``Args:`` block.
+Parameters across this package carry real, enforced domains and real
+consequences: ``ros2_domain`` must be an ``int`` in ``[0, 232]`` or construction
+raises, ``control_substeps`` must be a positive integer or the runner raises,
+``add_object``'s ``material`` mapping is refused for any key outside
+:data:`~strands_robots.simulation.mujoco.spec_builder.MATERIAL_KEYS`, and
+``DatasetRecorder.create``'s ``camera_dims`` decides the shape every camera
+column is declared with. When such a parameter has no ``Args:`` entry, a caller
+can be *refused for - or silently governed by - a parameter the docstring never
+mentions*, so the only remedy is to read the source. It went unnoticed on six
+simulation surfaces at once, and on four more outside that subtree, because
+nothing compared a signature against its own ``Args:`` block.
 
 These tests pin the comparison for every public method of every public class in
-:mod:`strands_robots.simulation` (backend subpackages included) whose docstring
-*already* has an ``Args:`` section: adding a parameter without documenting it -
-or documenting one the signature no longer takes - fails here. A docstring with
-no ``Args:`` section at all is out of scope: this guard checks a block that
-exists for completeness rather than demanding one, which is
-``test_public_member_docstrings.py``'s job for the docstring itself.
+:mod:`strands_robots` (backend and provider subpackages included) whose
+docstring *already* has an ``Args:`` section: adding a parameter without
+documenting it - or documenting one the signature no longer takes - fails here.
+A docstring with no ``Args:`` section at all is out of scope: this guard checks a
+block that exists for completeness rather than demanding one, which is the
+``*_public_member_docstrings.py`` guards' job for the docstring itself.
+
+The root is the whole package rather than one subtree because nothing about this
+drift is subtree-specific. Rooted at :mod:`strands_robots.simulation` the scan
+compared 345 parameters over 82 surfaces; rooted here it compares 629 over 172,
+and the four surfaces the widening found (#2056) were undiscoverable in exactly
+the way the original six were.
 
 Combined entry labels are honoured deliberately. Google style is used loosely in
 this package for parameters that share one description, so
@@ -28,9 +35,9 @@ raw label would demand entries that already exist - so labels are split on
 ``/``, ``,`` and ``or`` before comparing. :class:`TestCombinedEntryLabelsCount`
 pins that calibration against the two real surfaces that rely on it.
 
-The scan walks modules by AST, so it needs none of the optional simulation
-backends installed, and :class:`TestTheScanIsNonVacuous` fails if a mis-rooted
-scan reports a clean sweep over nothing.
+The scan walks modules by AST, so it needs none of the optional backends or
+policy providers installed, and :class:`TestTheScanIsNonVacuous` fails if a
+mis-rooted or re-narrowed scan reports a clean sweep over less than the package.
 """
 
 from __future__ import annotations
@@ -42,11 +49,11 @@ from pathlib import Path
 
 import pytest
 
-import strands_robots.simulation as simulation_pkg
+import strands_robots as package
 
 # Derived from an imported symbol rather than a path literal, so a moved package
 # cannot leave this scanning an empty tree while reporting success.
-_PACKAGE_ROOT = Path(inspect.getfile(simulation_pkg)).parent
+_PACKAGE_ROOT = Path(inspect.getfile(package)).parent
 
 _SECTION_HEADERS = ("Args:", "Arguments:", "Parameters:")
 
@@ -176,27 +183,47 @@ def test_no_args_entry_names_a_parameter_the_signature_lacks(
 class TestTheScanIsNonVacuous:
     """A mis-rooted or over-filtered scan must fail rather than sweep nothing."""
 
-    def test_the_scan_root_is_the_simulation_package(self) -> None:
-        assert _PACKAGE_ROOT.name == "simulation"
-        assert (_PACKAGE_ROOT / "base.py").is_file()
+    def test_the_scan_root_is_the_whole_package(self) -> None:
+        """Replaces the simulation-rooted assertion this guard shipped with.
+
+        Kept as an assertion rather than dropped: a root narrowed back to one
+        subtree is the failure mode that reports a clean sweep over half the
+        package, which is what #2056 measured.
+        """
+        assert _PACKAGE_ROOT.name == "strands_robots"
+        assert (_PACKAGE_ROOT / "simulation" / "base.py").is_file()
+        assert (_PACKAGE_ROOT / "dataset_recorder.py").is_file()
 
     def test_enough_surfaces_are_scanned_to_be_meaningful(self) -> None:
-        assert len(_SURFACES) >= 70, f"only {len(_SURFACES)} surfaces scanned"
+        assert len(_SURFACES) >= 150, f"only {len(_SURFACES)} surfaces scanned"
+
+    def test_the_scan_reaches_past_the_simulation_subtree(self) -> None:
+        """A count alone cannot tell a wide root from a large subtree."""
+        outside = [surface for surface, _, _ in _SURFACES if not surface.startswith("strands_robots/simulation/")]
+        assert len(outside) >= 60, f"only {len(outside)} surfaces outside the simulation subtree"
 
     @pytest.mark.parametrize(
         "expected",
         [
-            "simulation/base.py::SimEngine.get_observation",
-            "simulation/base.py::SimEngine.run_policy",
-            "simulation/policy_runner.py::PolicyRunner.run",
-            "simulation/policy_runner.py::PolicyRunner.evaluate",
-            "simulation/mujoco/simulation.py::MuJoCoSimEngine.__init__",
-            "simulation/mujoco/simulation.py::MuJoCoSimEngine.add_object",
+            "strands_robots/simulation/base.py::SimEngine.get_observation",
+            "strands_robots/simulation/base.py::SimEngine.run_policy",
+            "strands_robots/simulation/policy_runner.py::PolicyRunner.run",
+            "strands_robots/simulation/policy_runner.py::PolicyRunner.evaluate",
+            "strands_robots/simulation/mujoco/simulation.py::MuJoCoSimEngine.__init__",
+            "strands_robots/simulation/mujoco/simulation.py::MuJoCoSimEngine.add_object",
+            "strands_robots/dataset_recorder.py::DatasetRecorder.create",
+            "strands_robots/policies/cosmos3/policy.py::Cosmos3Policy.get_actions",
+            "strands_robots/policies/lerobot_local/policy.py::LerobotLocalPolicy.get_actions",
+            "strands_robots/benchmarks/libero/adapter.py::LiberoAdapter.__init__",
         ],
         ids=lambda expected: expected.rsplit("::", 1)[-1],
     )
     def test_a_known_surface_is_in_scope(self, expected: str) -> None:
-        """The six surfaces this guard was written for must actually be walked."""
+        """The ten surfaces this guard was written for must actually be walked.
+
+        Six from the simulation subtree it started in, four from outside it, so
+        a root that loses either half fails here rather than sweeping clean.
+        """
         assert any(surface == expected for surface, _, _ in _SURFACES), expected
 
 
@@ -241,7 +268,7 @@ class TestTheScannerDetectsAPlantedDefect:
     """An empty result must mean clean sources, not a scanner that matches nothing."""
 
     def _scan(self, tmp_path: Path, source: str) -> list[tuple[str, list[str], frozenset[str]]]:
-        pkg = tmp_path / "simulation"
+        pkg = tmp_path / "package"
         pkg.mkdir()
         (pkg / "planted.py").write_text(source, encoding="utf-8")
         return documented_surfaces(pkg)


### PR DESCRIPTION
Closes #2056

The guard added by #2055 compares every public method's signature against its own `Args:` block, in both directions. Its scan root was the **simulation package** - the subtree the six surfaces it was written for happened to live in. Nothing about the drift is simulation-specific, and half the package was outside it.

## What the widening measures

Same scanner, two roots, on `2b38ebe`:

| root | surfaces | parameters compared |
| --- | --- | --- |
| `strands_robots/simulation` (before) | 82 | 345 |
| `strands_robots` (this PR) | 172 | 629 |

Four surfaces outside the old root accept a parameter their docstring never mentions. **Zero** in the other direction anywhere in the package, so widening the root is these four entries rather than a docs rewrite.

## The four entries, each written from the source that decides the behaviour

**`DatasetRecorder.create`** - `camera_dims`, `video_width`, `video_height`. Twenty parameters, seventeen documented at length; the three deciding the shape every camera column is declared with were not among them. `_build_features` is where they meet:

```python
cam_h, cam_w = camera_dims.get(cam_name, (video_height, video_width))
```

So `camera_dims` values are **`(height, width)`** - the reverse of the `video_width` / `video_height` pair they fall back to on the same call. Every internal producer passes it that way and says so in its own docstring (`isaac/recording.py:423`, `newton/recording.py:372`, `simulation/recording.py:998`); the public entry point they all call did not. The entry also states that neither is a resize - the recorder rescales nothing (there is no `resize` / `cv2` / `.shape` read in the module), so a camera streaming another size is declared at a shape it does not have, which is why the backends pass `camera_dims` read from the live cameras instead of relying on the global pair.

**`Cosmos3Policy.get_actions`** - `kwargs`. Forwarded verbatim on one backend and dropped on the other, decided by a constructor argument the reader of this method cannot see:

```python
if self.backend == "diffusers":
    result = self._diffusers.infer(obs, **kwargs)   # forwarded
...
result = self._client.infer(obs)                    # dropped
```

**`LerobotLocalPolicy.get_actions`** - `kwargs`. Accepted and never read: the parameter appears exactly once in the method, in its own signature. The only runtime selectors honoured are the constructor-time `inference_kwargs`, forwarded to `predict_action_chunk` / `select_action`. The entry names that surface as the remedy.

Both `**kwargs` cases are compliant with the ABC, which requires a provider to ignore what it cannot honour rather than raise - so the entries document the behaviour and cite the ABC, and change nothing.

**`LiberoAdapter.__init__`** - `state_gripper_joint_names`. Its two neighbours are documented; the parameter that names the *source* of the vector `state_gripper_signs` multiplies is not. The pair has an asymmetry worth an entry, because only one half is enforced:

- `state_gripper_signs` is arity-checked to exactly 2 at construction (`_validated_float_vector(state_gripper_signs, 2, ...)`).
- `state_gripper_joint_names` is not arity-checked, and its length becomes the width of `state.gripper` (`_read_gripper_qpos` reads one `qpos` per name).

Three names is therefore accepted, and the disagreement surfaces at read time as a `logger.warning` with `state.gripper` recorded **unsigned** (`adapter.py:2096-2103`) - one warning line in a per-control-step path, on the axis #168 exists to keep in distribution.

## The test module moves, and its non-vacuity assertions are replaced rather than deleted

`tests/simulation/test_args_docstring_completeness.py` -> `tests/test_args_docstring_completeness.py`, because it is no longer a simulation test. Per the premise-test guidance in `AGENTS.md`, the boundary assertions narrow rather than go:

- `test_the_scan_root_is_the_simulation_package` -> `test_the_scan_root_is_the_whole_package`. Still an assertion, because a root narrowed back to one subtree is precisely the failure mode that reports a clean sweep over half the package.
- Surface floor 70 -> 150.
- New `test_the_scan_reaches_past_the_simulation_subtree` (>= 60 surfaces outside it): a count alone cannot tell a wide root from a large subtree.
- `test_a_known_surface_is_in_scope` carries ten surfaces - the original six plus the four found here - so a root that loses either half fails rather than sweeping clean.

The scan still walks by AST, so it needs no optional backend or policy provider installed.

## Verification

Docstrings only on the source side. The docstring-stripped AST hashes identically to `main` for all four modified modules, so there are no executable line changes:

```
ee606c51c59cb653  ee606c51c59cb653  SAME  strands_robots/dataset_recorder.py
f82ff04bbea5bbc1  f82ff04bbea5bbc1  SAME  strands_robots/policies/cosmos3/policy.py
9d8e2f38c28e2830  9d8e2f38c28e2830  SAME  strands_robots/policies/lerobot_local/policy.py
91eb241c14fc0b18  91eb241c14fc0b18  SAME  strands_robots/benchmarks/libero/adapter.py
```

The guard is non-vacuous on this branch - reverting only `strands_robots/` reproduces exactly the four claimed failures and nothing else:

```
tests/test_args_docstring_completeness.py                 368 passed   (this branch)
  with strands_robots/ reverted to main                 4 failed / 364 passed
    LiberoAdapter.__init__          accepts ['state_gripper_joint_names']
    DatasetRecorder.create          accepts ['camera_dims', 'video_width', 'video_height']
    Cosmos3Policy.get_actions       accepts ['kwargs']
    LerobotLocalPolicy.get_actions  accepts ['kwargs']

tests/test_doc*.py, tests/benchmarks, tests/policies      3450 passed, 223 skipped
  (29 failures, all ModuleNotFoundError for optional extras absent from this
   env - mujoco, lerobot, huggingface_hub - and identical on main)
tests/test_changelog_fragments.py, test_changelog_format.py  30 passed
ruff 0.15.22 check                                        All checks passed
ruff 0.15.22 format --check                               5 files already formatted
```

## Scope

Deliberately not here, and named in #2056 so they are not lost: whether `state_gripper_joint_names` should be arity-checked the way `state_gripper_signs` is, and whether a provider that drops `**kwargs` should say so at runtime rather than only in prose. Both are behavioural changes and do not belong inside a docs change.
