### PR TITLE
fix(rendering): refuse an encode_clip quality the clip encoder cannot honor

### DIFF
--- a/changelog.d/2058-encode-clip-quality-domain.md
+++ b/changelog.d/2058-encode-clip-quality-domain.md
@@ -1,0 +1,19 @@
+### Fixed: `encode_clip` refuses a `quality` the clip encoder cannot honor
+
+`quality` was the one knob in `strands_robots.rendering.encode_clip`'s signature
+with no domain, and the dependency's own bound is not a substitute for one.
+`imageio-ffmpeg` enforces it with a bare `assert 1 <= quality <= 10`, so the
+refusal was an `AssertionError` outside the documented `Raises:` set - and
+`python -O` strips assertions, leaving no domain at all: `quality=-5` and
+`quality=0` encoded a real but different clip, `nan` and `"8"` leaked raw
+arithmetic errors out of the bitrate computation, and `500` surfaced only as
+"the encoder wrote no clip". The docstring also advertised `0-10` while the
+writer asserts `1 <=`, so `0` was a documented value the code refused, and
+`True` was accepted as a silent quality of `1` - the lowest offered, and the
+same substitution `mjpeg_frames`' quality guard already rejected in the same
+module. A finite number in `[1, 10]` is now required, on both containers, and
+a NumPy real is converted for the writer, whose `isinstance(quality, (float,
+int))` gate refused `np.int64(8)` despite it naming a usable quality. The two
+sibling guards in that module now share the same numeric domain, so an integer
+too large to convert to a float reports instead of raising `OverflowError` out
+of a function whose contract is to return the message.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -391,6 +391,23 @@ the output path still returned. `encode_clip` also raises `RuntimeError` when th
 encoder wrote no clip despite accepting the frames, so a returned path always
 names a clip that exists.
 
+`encode_clip`'s `quality` is a finite number in `[1, 10]` (higher is better), and
+that domain holds for both containers even though only the MP4 writer reads the
+value - so one call does not become valid by changing the output extension. The
+bound is the encoder's own: `0` is refused despite older documentation offering
+`0-10`, and `True` is refused rather than acting as a silent quality of `1`, the
+lowest offered. A NumPy real such as `np.int64(8)` is accepted and converted,
+since the ffmpeg writer only recognises a plain `int`/`float`. The refusal is a
+`ValueError` from `encode_clip` rather than the encoder's own `assert`, so it
+does not disappear when Python runs with `-O`:
+
+```python
+from strands_robots.rendering import encode_clip
+
+encode_clip(frames, "clip.mp4", fps=30, quality=9)   # a usable quality
+encode_clip(frames, "clip.mp4", fps=30, quality=0)   # ValueError: quality must be between 1 and 10
+```
+
 ## Video codec (H.264 default, AV1 opt-in)
 
 `start_recording` (and `DatasetRecorder.create`/`resume`) default to

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import io
 import logging
-import math
-import numbers
 import time
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from pathlib import Path
@@ -21,16 +19,68 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import positive_whole_number_error, require_optional, sequence_length
+from strands_robots.utils import (
+    finite_number_error,
+    positive_whole_number_error,
+    require_optional,
+    sequence_length,
+)
 
 logger = logging.getLogger(__name__)
+
+
+# libx264 quality bounds. ``imageio-ffmpeg`` enforces them with a bare
+# ``assert 1 <= quality <= 10`` in its writer, and ``python -O`` strips
+# assertions: on an optimized interpreter an out-of-range quality is encoded at
+# whatever the arithmetic produces rather than refused, a non-numeric one leaks
+# a raw ``TypeError``/``ValueError`` out of the bitrate computation, and a value
+# above the range surfaces only as "the encoder wrote no clip". The lower bound
+# is 1, not the 0 this module and imageio's own plugin documentation both used
+# to advertise as the lowest quality.
+_MIN_CLIP_QUALITY = 1
+_MAX_CLIP_QUALITY = 10
+
+
+def _clip_quality_error(quality: Any) -> str | None:
+    """Error text when ``quality`` is outside the range the clip encoder honors.
+
+    Only a finite number in ``[_MIN_CLIP_QUALITY, _MAX_CLIP_QUALITY]`` reaches
+    the encoder as the requested quality. ``bool`` is rejected explicitly - an
+    ``int`` subclass whose ``True`` acted as a silent quality of 1, the lowest
+    the encoder offers, which is the same substitution
+    :func:`_jpeg_quality_error` rejects on the streaming side.
+
+    The numeric half is delegated to
+    :func:`~strands_robots.utils.finite_number_error` rather than hand-rolled,
+    so an integer too large to convert to a float reports the shared
+    64-bit-float reason instead of raising ``OverflowError`` out of the
+    ``float()`` this guard would otherwise apply itself. Only the interval is
+    decided here.
+
+    A fractional quality such as ``2.7`` is honorable and accepted: the encoder
+    maps this knob onto a bitrate by arithmetic rather than indexing a table of
+    discrete levels. That is the one way this domain is wider than
+    :func:`_jpeg_quality_error`'s, where Pillow's JPEG quality is a whole-number
+    scale.
+
+    Args:
+        quality: The caller-supplied clip quality.
+
+    Returns:
+        An error message, or ``None`` when the quality is usable.
+    """
+    if text := finite_number_error(quality, "quality", "encode_clip"):
+        return text
+    if not _MIN_CLIP_QUALITY <= float(quality) <= _MAX_CLIP_QUALITY:
+        return f"encode_clip: quality must be between {_MIN_CLIP_QUALITY} and {_MAX_CLIP_QUALITY}, got {quality!r}."
+    return None
 
 
 def encode_clip(
     frames: Iterable[np.ndarray],
     path: str | Path,
     fps: int = 20,
-    quality: int = 8,
+    quality: float = 8,
     macro_block_size: int = 1,
 ) -> Path:
     """Encode RGB frames into a clip at ``path`` (``.mp4`` or ``.gif``).
@@ -48,8 +98,12 @@ def encode_clip(
         fps: playback frame rate, a positive whole number of frames per
             second (the shared media domain - see
             :func:`~strands_robots.utils.positive_whole_number_error`).
-        quality: imageio/ffmpeg quality knob (0-10, higher is better).
-            Ignored for GIF.
+        quality: encoder quality knob, a finite number in ``[1, 10]`` (higher
+            is better - see :func:`_clip_quality_error`). Read only by the MP4
+            writer, since the GIF writer takes a per-frame duration instead,
+            but the domain applies to both containers so that one call does not
+            become valid by changing the output extension. A NumPy real is
+            accepted and converted for the writer.
         macro_block_size: libx264 macro-block rounding; ``1`` preserves the
             exact frame size (the recorders' convention), ``8``/``16`` lets
             ffmpeg pad to codec-friendly sizes. Ignored for GIF.
@@ -60,9 +114,10 @@ def encode_clip(
     Raises:
         ImportError: if ``imageio`` (and, for MP4, ``imageio-ffmpeg``) is not
             installed.
-        ValueError: if ``frames`` is empty, or if ``fps`` is not a positive
-            whole number -- either would silently produce a corrupt or
-            wrongly-timed artifact rather than the requested clip.
+        ValueError: if ``frames`` is empty, if ``fps`` is not a positive whole
+            number, or if ``quality`` is not a finite number in ``[1, 10]`` --
+            each would silently produce a corrupt, wrongly-timed or
+            wrongly-encoded artifact rather than the requested clip.
         RuntimeError: if the encoder wrote no clip despite accepting the
             frames (for example a ``macro_block_size`` that rounds the frame
             size to dimensions libx264 refuses), so the returned path always
@@ -71,6 +126,8 @@ def encode_clip(
     # Guard the caller's parameters before probing the optional encoder, so
     # the same mistake reports identically whether or not imageio is installed.
     if text := positive_whole_number_error(fps, "fps", "encode_clip"):
+        raise ValueError(text)
+    if text := _clip_quality_error(quality):
         raise ValueError(text)
     require_optional(
         "imageio",
@@ -90,7 +147,11 @@ def encode_clip(
         # Pillow's GIF writer takes per-frame duration (ms), not fps.
         imageio.mimsave(str(out), frame_list, duration=1000.0 / int(fps))
     else:
-        writer = imageio.get_writer(str(out), fps=int(fps), quality=quality, macro_block_size=macro_block_size)
+        # ``float(quality)`` is load-bearing rather than cosmetic: the ffmpeg
+        # writer gates the knob on ``isinstance(quality, (float, int))``, which
+        # a NumPy scalar such as ``np.int64(8)`` or ``np.float32(8.0)`` fails
+        # even though it names a quality this function has already accepted.
+        writer = imageio.get_writer(str(out), fps=int(fps), quality=float(quality), macro_block_size=macro_block_size)
         try:
             for frame in frame_list:
                 writer.append_data(frame)
@@ -131,6 +192,12 @@ def _stream_rate_error(fps: Any) -> str | None:
     header stores an integer frame rate, but pacing a live view is just a sleep
     interval, so a fractional rate such as ``12.5`` is honorable here.
 
+    The "is this a number at all" half is delegated to
+    :func:`~strands_robots.utils.finite_number_error`, which every rate and
+    quality guard in this module shares, so an integer too large to convert to a
+    float reports rather than raising ``OverflowError`` out of the ``float()``
+    below - out of a function whose whole contract is to return the message.
+
     Args:
         fps: The caller-supplied frame rate.
 
@@ -138,10 +205,9 @@ def _stream_rate_error(fps: Any) -> str | None:
         An error message, or ``None`` when the rate is usable.
     """
     message = f"mjpeg_frames: fps must be a positive finite number, got {fps!r}."
-    if isinstance(fps, bool) or not isinstance(fps, numbers.Real):
+    if finite_number_error(fps, "fps", "mjpeg_frames"):
         return message
-    numeric = float(fps)
-    if not math.isfinite(numeric) or numeric <= 0:
+    if float(fps) <= 0:
         return message
     return None
 
@@ -155,6 +221,11 @@ def _jpeg_quality_error(quality: Any) -> str | None:
     ``bool`` is rejected explicitly - an ``int`` subclass whose ``True`` would
     act as a silent quality of 1.
 
+    Shares the numeric half with :func:`_stream_rate_error` and
+    :func:`_clip_quality_error` via
+    :func:`~strands_robots.utils.finite_number_error`, so only the whole-number
+    scale and the bounds are decided here.
+
     Args:
         quality: The caller-supplied JPEG quality.
 
@@ -165,10 +236,10 @@ def _jpeg_quality_error(quality: Any) -> str | None:
         f"mjpeg_frames: quality must be a whole number between {_MIN_JPEG_QUALITY} "
         f"and {_MAX_JPEG_QUALITY}, got {quality!r}."
     )
-    if isinstance(quality, bool) or not isinstance(quality, numbers.Real):
+    if finite_number_error(quality, "quality", "mjpeg_frames"):
         return message
     numeric = float(quality)
-    if not math.isfinite(numeric) or numeric != int(numeric):
+    if numeric != int(numeric):
         return message
     if not _MIN_JPEG_QUALITY <= int(numeric) <= _MAX_JPEG_QUALITY:
         return message

--- a/tests/rendering/test_encode_clip_quality_domain.py
+++ b/tests/rendering/test_encode_clip_quality_domain.py
@@ -1,0 +1,216 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``encode_clip`` only accepts a ``quality`` the clip encoder can honor.
+
+``quality`` was the one knob in ``encode_clip``'s signature with no domain, and
+the dependency's own enforcement is not a substitute for one:
+
+* ``imageio-ffmpeg`` bounds the knob with a bare ``assert 1 <= quality <= 10``,
+  so the refusal is an ``AssertionError`` -- absent from the documented
+  ``Raises:`` set -- and ``python -O`` strips it. On an optimized interpreter
+  ``quality=-5`` and ``quality=0`` encoded silently (a real but different clip),
+  ``nan`` and ``"8"`` leaked raw arithmetic errors out of the bitrate
+  computation, and ``500`` surfaced only as "the encoder wrote no clip".
+* The docstring advertised ``0-10`` while the writer asserts ``1 <= quality``,
+  so ``0`` was a documented value the code refused.
+* ``True`` was accepted as a silent quality of ``1`` -- the lowest the encoder
+  offers -- which is the same substitution ``_jpeg_quality_error`` already
+  rejects for the streaming encoder in this module.
+* A NumPy real such as ``np.int64(8)`` was refused by the writer's
+  ``isinstance(quality, (float, int))`` gate even though it names a perfectly
+  usable quality.
+
+These tests pin the domain, its independence from ``-O``, and that a usable
+quality still reaches the encoder unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import encode_clip
+from strands_robots.rendering.video import (
+    _MAX_CLIP_QUALITY,
+    _MAX_JPEG_QUALITY,
+    _MIN_CLIP_QUALITY,
+    _MIN_JPEG_QUALITY,
+    _clip_quality_error,
+    _jpeg_quality_error,
+)
+
+# Values the clip encoder cannot turn into the requested quality: below and
+# above the range it accepts (``0`` is the one the docstring used to advertise),
+# non-finite floats, both bools (``True`` silently acted as a quality of 1), a
+# numeric string, a missing value, a sequence, and an integer too large to
+# convert to a float.
+OUT_OF_RANGE = [0, -5, 11, 500]
+NOT_A_NUMBER = [math.nan, math.inf, -math.inf, True, False, np.True_, "8", None, [8], 10**400]
+UNUSABLE_QUALITY = [*OUT_OF_RANGE, *NOT_A_NUMBER]
+
+# Qualities inside the range, in every spelling the guard accepts: the bounds,
+# a plain int, a fractional value the encoder maps onto a bitrate, an integral
+# float, and NumPy reals that the writer's own type gate would refuse.
+USABLE_QUALITY = [1, 10, 8, 2.7, 8.0, np.int64(8), np.float32(8.0), np.float64(8.0)]
+
+
+def _frames(n: int = 6, w: int = 48, h: int = 32) -> list[np.ndarray]:
+    """``n`` distinct RGB frames of one shape (a gradient, so decode is visible)."""
+    return [np.full((h, w, 3), (i * 20) % 256, dtype=np.uint8) for i in range(n)]
+
+
+@pytest.mark.parametrize("suffix", [".gif", ".mp4"])
+@pytest.mark.parametrize("quality", UNUSABLE_QUALITY)
+def test_unusable_quality_is_refused_before_any_file_is_written(tmp_path, suffix, quality) -> None:
+    """A quality the encoder cannot honor is a ValueError naming the parameter."""
+    out = tmp_path / f"clip{suffix}"
+    with pytest.raises(ValueError, match="quality must be"):
+        encode_clip(_frames(), out, fps=10, quality=quality)
+    assert not out.exists(), f"encode_clip(quality={quality!r}) left a file behind at {out}"
+
+
+def test_the_lower_bound_is_one_not_the_zero_the_docstring_advertised() -> None:
+    """``0`` is refused: the encoder asserts ``1 <= quality``, so 0-10 was wrong."""
+    assert _MIN_CLIP_QUALITY == 1
+    assert _MAX_CLIP_QUALITY == 10
+    assert _clip_quality_error(0) is not None
+    assert _clip_quality_error(_MIN_CLIP_QUALITY) is None
+
+
+@pytest.mark.parametrize("suffix", [".gif", ".mp4"])
+@pytest.mark.parametrize("quality", USABLE_QUALITY)
+def test_a_usable_quality_still_encodes_a_clip(tmp_path, suffix, quality) -> None:
+    """Every accepted spelling encodes, so the guard is not narrower than the encoder."""
+    pytest.importorskip("imageio.v2")
+    out = encode_clip(_frames(), tmp_path / f"clip{suffix}", fps=10, quality=quality)
+    assert out.exists() and out.stat().st_size > 0
+
+
+@pytest.mark.parametrize("quality", [np.int64(8), np.float32(8.0), np.float64(8.0), 8.0])
+def test_a_numpy_real_encodes_identically_to_the_plain_int(tmp_path, quality) -> None:
+    """The ``float()`` at the writer is load-bearing: NumPy reals are honored.
+
+    The ffmpeg writer gates the knob on ``isinstance(quality, (float, int))``,
+    which ``np.int64`` and ``np.float32`` fail. Asserting byte equality with the
+    plain ``int`` pins both halves: the value reaches the encoder, and the
+    conversion does not change the requested quality.
+    """
+    pytest.importorskip("imageio.v2")
+    plain = encode_clip(_frames(), tmp_path / "plain.mp4", fps=10, quality=8)
+    coerced = encode_clip(_frames(), tmp_path / "coerced.mp4", fps=10, quality=quality)
+    assert hashlib.md5(coerced.read_bytes()).digest() == hashlib.md5(plain.read_bytes()).digest()
+
+
+def test_a_fractional_quality_is_honored_rather_than_rounded(tmp_path) -> None:
+    """``2.7`` is a real quality here, unlike Pillow's whole-number JPEG scale."""
+    pytest.importorskip("imageio.v2")
+    fractional = encode_clip(_frames(), tmp_path / "frac.mp4", fps=10, quality=2.7)
+    whole = encode_clip(_frames(), tmp_path / "whole.mp4", fps=10, quality=3)
+    assert fractional.read_bytes() != whole.read_bytes()
+
+
+def test_true_would_have_been_a_silent_quality_of_one(tmp_path) -> None:
+    """``True`` is refused, and the substitution it would have made is not a no-op.
+
+    ``bool`` is an ``int`` subclass, so ``True`` reached the encoder as a quality
+    of ``1`` -- the lowest offered. Encoding at ``1`` and at the default ``8``
+    produces different clips, so the substitution silently changed the artifact
+    rather than being harmless.
+    """
+    pytest.importorskip("imageio.v2")
+    with pytest.raises(ValueError, match="quality must be"):
+        encode_clip(_frames(), tmp_path / "bool.mp4", fps=10, quality=True)
+    lowest = encode_clip(_frames(), tmp_path / "one.mp4", fps=10, quality=1)
+    default = encode_clip(_frames(), tmp_path / "eight.mp4", fps=10, quality=8)
+    assert lowest.read_bytes() != default.read_bytes()
+
+
+@pytest.mark.parametrize("quality", [0, -5, 500, True])
+def test_quality_is_refused_before_the_optional_encoder_is_probed(tmp_path, monkeypatch, quality) -> None:
+    """The same mistake reports identically whether or not imageio is installed."""
+    from strands_robots.rendering import video
+
+    def _no_imageio(*args, **kwargs):
+        raise AssertionError("require_optional must not be reached for a refused quality")
+
+    monkeypatch.setattr(video, "require_optional", _no_imageio)
+    with pytest.raises(ValueError, match="quality must be"):
+        encode_clip(_frames(), tmp_path / "clip.mp4", fps=10, quality=quality)
+
+
+@pytest.mark.parametrize("quality", [0, 500, True, "8"])
+def test_the_domain_does_not_depend_on_the_output_container(tmp_path, quality) -> None:
+    """One signature, one domain: changing the extension cannot make a call valid.
+
+    ``quality`` is read only by the MP4 writer, but it is refused for a ``.gif``
+    target too - otherwise the same call would be valid or invalid depending on
+    a string, and a caller would learn that an out-of-range quality is fine.
+    """
+    messages = []
+    for suffix in (".gif", ".mp4"):
+        with pytest.raises(ValueError, match="quality must be") as excinfo:
+            encode_clip(_frames(), tmp_path / f"clip{suffix}", fps=10, quality=quality)
+        messages.append(str(excinfo.value))
+    assert messages[0] == messages[1], messages
+
+
+def test_the_refusal_does_not_depend_on_assertions_being_enabled(tmp_path) -> None:
+    """``python -O`` strips the encoder's own ``assert``, so the guard must not be one.
+
+    Run in a child interpreter with ``-O``: the dependency's bound disappears
+    there, and pre-fix ``quality=-5`` encoded a clip rather than being refused.
+    """
+    code = (
+        "import numpy as np\n"
+        "from strands_robots.rendering import encode_clip\n"
+        "frames = [np.zeros((32, 48, 3), np.uint8) for _ in range(4)]\n"
+        "for bad in (-5, 0, 500, True):\n"
+        "    try:\n"
+        f"        encode_clip(frames, {str(tmp_path / 'child.mp4')!r}, fps=10, quality=bad)\n"
+        "    except ValueError as exc:\n"
+        "        if 'quality must be' not in str(exc):\n"
+        "            print('WRONG-REASON', bad, exc)\n"
+        "            raise SystemExit(1)\n"
+        "    else:\n"
+        "        print('ACCEPTED', bad)\n"
+        "        raise SystemExit(1)\n"
+        "print('ALL-REFUSED')\n"
+    )
+    proc = subprocess.run([sys.executable, "-O", "-c", code], capture_output=True, text=True, timeout=300, check=False)
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr[-800:]!r}"
+    assert "ALL-REFUSED" in proc.stdout, proc.stdout
+
+
+@pytest.mark.parametrize("quality", NOT_A_NUMBER)
+def test_both_quality_knobs_in_this_module_refuse_the_same_non_numeric_values(quality) -> None:
+    """The clip and JPEG quality guards agree on what is not a quality at all.
+
+    The two encoders accept different ranges, but "is this a number a quality
+    can be read from" is one question, so ``bool``, a numeric string, a
+    non-finite float and a missing value are refused by both.
+    """
+    assert _clip_quality_error(quality) is not None
+    assert _jpeg_quality_error(quality) is not None
+
+
+def test_the_two_quality_ranges_differ_because_the_encoders_do() -> None:
+    """Each range is the one its own encoder honors, so they are not interchangeable.
+
+    Pinned as a deliberate divergence rather than left to convention. libx264
+    takes ``[1, 10]`` and maps the knob onto a bitrate by arithmetic, so ``2.7``
+    is a real quality; Pillow's JPEG quality is a whole-number ``[1, 95]`` scale,
+    so ``11`` is usable there and not for a clip.
+    """
+    assert (_MIN_CLIP_QUALITY, _MAX_CLIP_QUALITY) == (1, 10)
+    assert (_MIN_JPEG_QUALITY, _MAX_JPEG_QUALITY) == (1, 95)
+    # A fractional quality: usable for the clip encoder, not for the JPEG scale.
+    assert _clip_quality_error(2.7) is None
+    assert _jpeg_quality_error(2.7) is not None
+    # A whole number above the clip range but inside the JPEG one.
+    assert _clip_quality_error(11) is not None
+    assert _jpeg_quality_error(11) is None


### PR DESCRIPTION
## Problem

`quality` was the one knob in `strands_robots.rendering.encode_clip`'s signature with no domain. The dependency's own bound is not a substitute for one, and the docstring advertised a value the code refused.

`imageio-ffmpeg` bounds the knob with a bare `assert isinstance(quality, (float, int))` / `assert 1 <= quality <= 10`. That makes the refusal an `AssertionError` — absent from `encode_clip`'s documented `Raises:` set — and **`python -O` strips assertions**, so on an optimized interpreter there was no domain at all.

Measured over 24 real MuJoCo frames (640x480, headless EGL) through the encoder, comparing each decode against its source frame:

| `encode_clip(quality=...)` | main | main, `python -O` | this change |
|---|---|---|---|
| `8` (default) | encoded, 41.89 dB | encoded, 41.89 dB | encoded, 41.89 dB |
| `1` | encoded, 31.91 dB | encoded, 31.91 dB | encoded, 31.91 dB |
| **`True`** | **encoded, 31.91 dB** | encoded, 31.91 dB | refused |
| **`0`** | AssertionError | **encoded, 28.42 dB** | refused |
| **`-5`** | AssertionError | **encoded, 28.42 dB** | refused |
| `500` | AssertionError | **`OSError`** | refused |
| `nan` | AssertionError | **`ValueError` from the bitrate arithmetic** | refused |
| `'8'` | AssertionError | **`TypeError` from the bitrate arithmetic** | refused |
| **`np.int64(8)`** | **AssertionError** | encoded, 41.89 dB | encoded, 41.89 dB |

Four distinct problems in that table:

- **`True` was a silent quality of `1`.** `bool` is an `int` subclass, so it reached the encoder as the lowest quality offered — byte-identically to `quality=1` (md5 `ac2e0a354302` for both), a **9.98 dB** loss on a clip the caller asked to encode at 8, under `status success`. This is the same substitution `_jpeg_quality_error` already rejects for the streaming encoder **in this same module**, whose docstring names it: *"`bool` is rejected explicitly - an `int` subclass whose `True` would act as a silent quality of 1."*
- **The docstring advertised `0-10` while the writer asserts `1 <= quality`.** `0` was a documented value the code refused. (imageio's own plugin documentation carries the same error — *"Highest quality is 10, lowest is 0"* — so ours had propagated it.)
- **Under `-O` the refusals disappear.** `0` and `-5` encoded a real but different clip (28.42 dB), and `nan` / `'8'` leaked raw arithmetic errors out of ffmpeg's bitrate computation rather than naming the parameter.
- **A NumPy real was refused despite naming a usable quality.** The writer gates on `isinstance(quality, (float, int))`, which `np.int64` and `np.float32` fail — a value class the repo's shared numeric domains explicitly honor.

## Change

`encode_clip` now requires a finite number in `[1, 10]`, refused with a `ValueError` naming the parameter and the value, alongside the existing `fps` guard and **before** `require_optional` — so the same mistake reports identically whether or not `imageio` is installed, and no file is written.

`_clip_quality_error` mirrors the module's existing `_jpeg_quality_error` and delegates the "is this a number at all" half to `utils.finite_number_error`, deciding only the interval. Two consequences worth calling out:

- **A fractional quality is accepted.** `2.7` encodes a genuinely distinct clip, because libx264 maps this knob onto a bitrate by arithmetic rather than indexing discrete levels. Refusing it would make the guard narrower than the encoder it protects. That is the one way this domain is wider than the JPEG one, where Pillow's quality is a whole-number `[1, 95]` scale — pinned as a deliberate divergence.
- **`float(quality)` at the writer is load-bearing, not cosmetic.** `np.int64(8)` now encodes byte-identically to the plain `int` (md5 `346dab35d295` for both), which pins that the value reaches the encoder *and* that the conversion does not change the requested quality.

The domain applies to **both containers** even though only the MP4 writer reads the value, so one call does not become valid by changing the output extension. Pinned in its own named test with the reason, so it is not narrowed later.

The two sibling guards in the module now share that same numeric half. That is a strict simplification — it deletes their duplicated hand-rolled `isinstance`/`isfinite` blocks (and with them the module's last uses of `math` and `numbers`) and closes an identical escape my parity test found: `_jpeg_quality_error(10**400)` and `_stream_rate_error(10**400)` each raised `OverflowError` out of their own `float()`, out of functions whose entire contract is to *return* the message. **46 of 46 verdicts across both guards are unchanged**; every pinned message survives byte-for-byte, so no existing test changed.

### Out of scope, measured

`macro_block_size` is the neighbouring knob with the same assert-based enforcement (`0`, `-4` and `None` all silently mean `1`; `2.7` and `'1'` are asserts). It is left alone because its out-of-domain outcome is already documented and implemented — `encode_clip`'s `Raises:` names *"a `macro_block_size` that rounds the frame size to dimensions libx264 refuses"* as the `RuntimeError` case, and it produces exactly that. Unlike `quality`, its documented contract and its behaviour agree.

## Visual artifact

Row 1 is the source render, the clip at the requested quality, and the clip `quality=True` silently produced on main; row 2 is the 3x zoom of the boxed region, where the blocking on the arm edges is what the 9.98 dB is. Row 3 is the measured table above. Every number in the figure is asserted by its generator against the three JSON dumps.

![encode_clip quality domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/encode-clip-quality/encode_clip_quality.png)

The capture and compose scripts, and the raw `facts_main.json` / `facts_main_O.json` / `facts_branch.json` the figure is built from, are on the `artifacts/encode-clip-quality` branch of the fork.

## Tests

`tests/rendering/test_encode_clip_quality_domain.py`, 71 tests:

- every unusable value refused on both containers, with no file left behind;
- the lower bound is `1`, not the `0` the docstring advertised;
- every accepted spelling still encodes, so the guard is not narrower than the encoder;
- a NumPy real encodes **byte-identically** to the plain `int` (the coercion pin);
- a fractional quality is honored rather than rounded;
- `True` is refused, *and* encoding at `1` differs from `8` — so the substitution it would have made was not harmless;
- refused before the optional encoder is probed;
- the domain does not depend on the output container, with identical message text for both;
- **the refusal survives `python -O`**, run in a child interpreter — pre-fix that test fails with `stdout='ACCEPTED -5'`;
- both quality guards in the module refuse the same non-numeric values, and the two ranges differ because the encoders do.

**Pre-fix proof** (source reverted to `upstream/main`, tests kept; the three tests that call the new symbol directly stripped so the rest run rather than failing at collection): **42 failed / 17 passed → 71 passed**. The 17 that pass pre-fix are the accepted-value controls and the JPEG-side pins — they are what stop the guard reaching further than the one parameter.

## Gate

At `2b38ebe5` (`scripts/check_merge_base_overlap.py`: no overlap):

- `MUJOCO_GL=egl pytest tests` — **25129 passed / 257 skipped / 0 failed** in 602.63s, **zero existing-test churn**
- `ruff check` / `ruff format --check strands_robots tests tests_integ` — clean, 1128 files
- `mypy strands_robots tests tests_integ` — **0 errors outside `examples/isaac_gs`**; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy, i.e. environmental
- `tests/rendering/` alone — 273 passed / 2 skipped; `scripts/assemble_changelog.py --check` OK

The gate above ran at `5f779a2`; the pushed head `205816c` differs from it only in the changelog fragment's filename (`2056-` renamed to `2058-` once the PR number was known), which `assemble_changelog.py --check` and `tests/test_changelog_fragments.py` were re-run against.

