### PR TITLE
fix(hardware): refuse a task step cap the control loop cannot count against

### DIFF
--- a/changelog.d/2059-hardware-step-cap-domain.md
+++ b/changelog.d/2059-hardware-step-cap-domain.md
@@ -1,0 +1,19 @@
+### Fixed: a hardware task step cap the control loop cannot count against is refused
+
+`Robot.run_policy(n_steps=...)` and the `_execute_task_sync` chokepoint now
+validate the optional step cap against the shared positive-count domain, the
+same rule the loop's `action_horizon` and the simulation's `run_policy` step
+horizon already apply. The loop bounds a rollout with
+`n_steps is None or step_count < n_steps`, ANDed with the `duration` budget, and
+the cap beside `duration` in the same signature was read straight into that
+comparison: `0`, a negative, `nan` and `False` made it false on its first
+evaluation, so the task reported `status="success"` and "Policy rollout
+completed: 0 steps" for a rollout that never queried the policy and never
+commanded a servo; `inf` was never false, so the requested cap silently
+vanished and the rollout ran to the `duration` budget instead; `True` read as a
+silent cap of one and `2.7` stopped after three applied actions, a count the
+caller never named; and a non-numeric cap surfaced a bare `TypeError` naming a
+comparison internal rather than the parameter. `None` remains the documented
+"no cap" spelling. The refusal lands before the policy is initialized and before
+the bus is claimed, so a cap that cannot be honored costs no inference and no
+servo write.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -119,6 +119,7 @@ robot.stop_teleop()   # stop all sessions
 | Reset | `reset()` rewinds to t=0 | Holds current pose |
 | Randomization | `randomize(...)` | N/A |
 | Policy execution | `run_policy()` / `start_policy()` | `start_task()` / `execute` action |
+| Rollout horizon | `duration` **or** `n_steps` (`n_steps` supersedes it) | `duration` **and** `n_steps` (ANDed, so `duration` always bounds it) |
 
 ## See also
 

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1369,7 +1369,9 @@ class Robot(TeleopMixin, AgentTool):
         ``duration`` / ``n_steps`` comes first. The two conditions are ANDed,
         so ``duration`` bounds the rollout even with a step cap - it is
         validated at every public entry point rather than only when it is the
-        sole horizon.
+        sole horizon. ``n_steps`` is validated there too: a cap the
+        ``step_count < n_steps`` comparison cannot be made against never
+        reaches this loop.
 
         Either way the policy's per-episode state is reset before the rollout,
         so a task never begins from the state the previous task left behind.
@@ -1586,6 +1588,49 @@ class Robot(TeleopMixin, AgentTool):
             return {"status": "error", "content": [{"text": error}]}
         return None
 
+    @staticmethod
+    def _n_steps_error(n_steps: Any, method: str) -> dict[str, Any] | None:
+        """Reject a task ``n_steps`` cap the control loop cannot count against.
+
+        ``n_steps`` is the optional step cap the loop compares the applied-action
+        count against (``n_steps is None or step_count < n_steps``), ANDed with
+        the wall-clock budget :meth:`_duration_error` bounds. ``None`` is the
+        documented "no cap" spelling and leaves ``duration`` the sole horizon;
+        every other value has to be a count that comparison can be made against.
+
+        A cap ``<= 0`` (and ``nan``, which is never ``<= 0`` but fails every
+        comparison it reaches) makes the condition false on its first
+        evaluation, so the task reported ``status="success"`` and "Policy
+        rollout completed: 0 steps" for a rollout that never queried the policy
+        and never commanded a servo - the same false ``completed`` an unusable
+        ``duration`` used to produce. ``inf`` is never false, so the requested
+        cap silently vanishes and the rollout runs to the ``duration`` budget
+        instead. ``True`` reads as a silent cap of one. A float cap applies a
+        count the caller never named: ``2.7`` stops after three applied
+        actions. A non-numeric cap reached the comparison intact and surfaced a
+        bare ``TypeError`` naming a comparison internal ("'<' not supported
+        between instances of 'int' and 'str'") rather than the parameter.
+
+        The accepted domain is
+        :func:`~strands_robots.utils.positive_count_error`, already shared with
+        this loop's ``action_horizon`` and with the simulation's ``run_policy``
+        step horizon, so the same cap cannot be refused for a digital twin and
+        accepted for the arm it mirrors.
+
+        Args:
+            n_steps: The caller-supplied cap to validate, or ``None`` for no cap.
+            method: Public entry point name, used to prefix the message.
+
+        Returns:
+            A tool-shaped error dict naming ``n_steps``, or ``None`` when the
+            cap can be honored (including when no cap was requested).
+        """
+        if n_steps is None:
+            return None
+        if error := positive_count_error(n_steps, "n_steps", method):
+            return {"status": "error", "content": [{"text": error}]}
+        return None
+
     def _shutdown_error(self, method: str) -> dict[str, Any] | None:
         """Refuse a rollout on a robot whose ``cleanup()`` has already run.
 
@@ -1713,6 +1758,8 @@ class Robot(TeleopMixin, AgentTool):
         if err := self._shutdown_error("execute_task"):
             return err
         if err := self._duration_error(duration, "execute_task"):
+            return err
+        if err := self._n_steps_error(n_steps, "execute_task"):
             return err
         if err := self._claim_task(instruction):
             return err
@@ -1945,7 +1992,13 @@ class Robot(TeleopMixin, AgentTool):
                 commanded nothing.
             n_steps: Optional cap on applied actions (mirrors the sim
                 ``run_policy`` parameter); the loop stops at whichever of
-                ``duration`` / ``n_steps`` comes first.
+                ``duration`` / ``n_steps`` comes first. ``None`` (the
+                default) requests no cap and leaves ``duration`` the sole
+                horizon. Any other value must be a positive integer, the
+                domain the sim horizon and this loop's ``action_horizon``
+                already share: the loop bounds the rollout by
+                ``step_count < n_steps``, so a cap it cannot count against
+                is refused rather than spent on the arm.
 
         Returns:
             Tool-shaped result: a text summary plus a ``{"json": ...}`` block
@@ -1961,6 +2014,8 @@ class Robot(TeleopMixin, AgentTool):
         if err := self._shutdown_error("run_policy"):
             return err
         if err := self._duration_error(duration, "run_policy"):
+            return err
+        if err := self._n_steps_error(n_steps, "run_policy"):
             return err
         if err := self._claim_task(instruction):
             return err

--- a/tests/test_hardware_step_cap_guard.py
+++ b/tests/test_hardware_step_cap_guard.py
@@ -1,0 +1,314 @@
+"""Behavior tests for the accepted ``n_steps`` domain of a hardware task.
+
+``strands_robots.hardware_robot.Robot`` bounds every rollout by two ANDed
+conditions: elapsed wall-clock time against ``duration``, and the applied-action
+count against the optional ``n_steps`` cap
+(``n_steps is None or step_count < n_steps``). ``duration`` has been refused up
+front since it became the effective horizon; the step cap beside it in the same
+signature was read straight into that comparison. These tests pin that a cap the
+loop cannot count against is refused at the public entry point instead of being
+spent on the arm:
+
+    - ``0`` / negative / ``nan`` / ``False`` make the comparison false on its
+      first evaluation, so the task reported ``status="success"`` and "Policy
+      rollout completed: 0 steps" for a rollout that never queried the policy
+      and never commanded a servo - the same false ``completed`` an unusable
+      ``duration`` used to produce;
+    - ``inf`` is never false, so the requested cap silently vanished and the
+      rollout ran to the ``duration`` budget instead;
+    - ``True`` read as a silent cap of one, and a float cap applied a count the
+      caller never named (``2.7`` stopped after three applied actions);
+    - a non-numeric cap reached the comparison intact and surfaced a bare
+      ``TypeError`` naming a comparison internal ("'<' not supported between
+      instances of 'int' and 'str'") rather than the parameter;
+    - the refusal happens before the policy is initialized and before the arm is
+      commanded, so a cap that cannot be honored costs no inference and no write;
+    - ``_execute_task_sync`` refuses too: it is the chokepoint the agent-tool
+      ``execute`` action and the mesh ``execute`` dispatch reach directly, so a
+      peer-supplied cap is bounded by the same rule;
+    - ``None`` stays the documented "no cap" spelling, and every cap that IS
+      accepted still stops the rollout at exactly that many applied actions;
+    - the accepted domain matches the simulation's rollout horizon
+      (``SimEngine._resolve_horizon``), so the same cap cannot be refused for a
+      digital twin and accepted for the arm it mirrors.
+
+No serial/USB hardware is touched: the driver is an in-memory fake and the
+policy is a structural stub.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.simulation.base import SimEngine
+from tests.test_hardware_control_loop_rate_guard import _FakeArm
+
+# Caps the loop cannot count against. ``0`` / negative / ``nan`` / ``False``
+# make ``step_count < n_steps`` false immediately (a task that commands
+# nothing); ``inf`` never makes it false (the cap vanishes); ``True`` is a
+# silent cap of one; a float applies a count nobody named; the rest are not
+# counts the comparison can be made against at all. ``np.int64`` is refused for
+# parity with the simulation horizon, which requires a true ``int``.
+UNUSABLE_STEP_CAPS: list[Any] = [
+    0,
+    -1,
+    -5,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    True,
+    False,
+    2.7,
+    3.0,
+    "10",
+    [4],
+    {},
+    np.int64(3),
+    np.float64(4.0),
+]
+
+# Caps that are honorable: a positive ``int``. ``None`` is the documented
+# "no cap" spelling and is covered by its own test rather than this list.
+USABLE_STEP_CAPS: list[int] = [1, 2, 4, 25]
+
+
+class _CountingPolicy:
+    """Structural stand-in for a policy that records every inference."""
+
+    supports_rtc = False
+    execution_horizon = 1
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def reset(self, seed: int | None = None) -> None:
+        return None
+
+    def set_control_frequency(self, hz: float) -> None:
+        return None
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        return None
+
+    async def get_actions(self, observation: Any, instruction: str) -> list[dict[str, Any]]:
+        self.calls += 1
+        return [{"j0.pos": 0.1}]
+
+
+@pytest.fixture
+def hw() -> Any:
+    """A ``Robot`` wired to an in-memory arm, with the connect path stubbed.
+
+    ``policy_inits`` records every policy initialization so a test can assert a
+    refused cap never got that far, and ``robot.sent_actions`` records every
+    command that reached the arm. The control frequency is high so a rollout
+    bounded by ``duration`` alone finishes many steps inside a short budget.
+    """
+    robot = HwRobot.__new__(HwRobot)
+    robot.tool_name_str = "test_arm"
+    robot.action_horizon = 1
+    robot.data_config = None
+    robot.control_frequency = 200.0
+    robot.action_sleep_time = 1.0 / 200.0
+    robot._task_state = RobotTaskState()
+    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._shutdown_event = threading.Event()
+    robot._stop_requested = threading.Event()
+    robot._task_admission = threading.Lock()
+    robot._task_claimed = False
+    robot.mesh = None
+    robot.peer_id = None
+    robot.robot = _FakeArm()
+    robot.policy_inits = []  # type: ignore[attr-defined]
+
+    async def _connected() -> tuple[bool, str]:
+        return (True, "")
+
+    async def _ready() -> bool:
+        return True
+
+    def _init_policy(policy: Any) -> Any:
+        robot.policy_inits.append(policy)  # type: ignore[attr-defined]
+        return _ready()
+
+    def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+        return None
+
+    robot._connect_robot = _connected  # type: ignore[method-assign]
+    robot._initialize_policy = _init_policy  # type: ignore[method-assign]
+    robot._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+    try:
+        yield robot
+    finally:
+        robot._shutdown_event.set()
+        robot._task_state.status = TaskStatus.STOPPED
+        robot._executor.shutdown(wait=False)
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The text of a tool-shaped result."""
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _sim_refuses(cap: Any) -> bool:
+    """Whether the simulation rollout horizon refuses ``cap``.
+
+    ``SimEngine._resolve_horizon`` is the sim's ``n_steps`` chokepoint; it
+    validates the effective horizon before converting it into a duration.
+    """
+    _duration, _steps, error = SimEngine._resolve_horizon(cap, None, 50.0, 10.0, "run_policy")
+    return error is not None
+
+
+class TestUnusableStepCapRefused:
+    """Every entry point taking a step cap refuses one it cannot count against."""
+
+    @pytest.mark.parametrize("cap", UNUSABLE_STEP_CAPS)
+    def test_run_policy_refuses(self, hw: Any, cap: Any):
+        """``run_policy`` errors naming the parameter, not a comparison."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps=cap)
+
+        assert result["status"] == "error"
+        assert "n_steps" in _text(result)
+        assert "run_policy" in _text(result)
+
+    @pytest.mark.parametrize("cap", UNUSABLE_STEP_CAPS)
+    def test_the_shared_chokepoint_refuses(self, hw: Any, cap: Any):
+        """``_execute_task_sync`` refuses on its own.
+
+        The agent-tool ``execute`` action and the mesh ``execute`` dispatch call
+        it directly rather than through ``run_policy``, so a peer-supplied cap
+        must be bounded here too.
+        """
+        result = hw._execute_task_sync("probe", policy_port=9000, n_steps=cap)
+
+        assert result["status"] == "error"
+        assert "n_steps" in _text(result)
+
+    def test_the_message_never_names_a_comparison_internal(self, hw: Any):
+        """A non-numeric cap is reported as a caller error, not a ``TypeError``."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps="10")
+
+        assert "n_steps must be a positive integer" in _text(result)
+        assert "'<' not supported" not in _text(result)
+
+    def test_a_refused_cap_is_not_reported_as_a_completed_rollout(self, hw: Any):
+        """The false ``completed`` this guard exists to remove."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps=0)
+
+        assert result["status"] == "error"
+        assert "completed" not in _text(result)
+        assert hw._task_state.step_count == 0
+
+
+class TestRefusalPrecedesTheArm:
+    """A cap that cannot be honored costs no inference and no servo write."""
+
+    @pytest.mark.parametrize("cap", UNUSABLE_STEP_CAPS)
+    def test_no_action_reaches_the_arm(self, hw: Any, cap: Any):
+        """The refusal lands before the control loop commands the bus."""
+        hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps=cap)
+
+        assert hw.robot.sent_actions == []
+
+    def test_no_policy_is_initialized_and_no_inference_is_spent(self, hw: Any):
+        """Bring-up is not reached, so the checkpoint is never queried."""
+        policy = _CountingPolicy()
+
+        hw.run_policy(policy_object=policy, instruction="probe", n_steps=-5)
+
+        assert hw.policy_inits == []
+        assert policy.calls == 0
+
+    def test_the_bus_claim_is_released_for_the_next_rollout(self, hw: Any):
+        """A refused cap must not take the single command bus away."""
+        hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps=0)
+
+        accepted = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", n_steps=2)
+
+        assert accepted["status"] == "success"
+
+
+class TestUsableStepCapAccepted:
+    """Every cap that can be counted against still runs, and stops at it."""
+
+    @pytest.mark.parametrize("cap", USABLE_STEP_CAPS)
+    def test_the_rollout_stops_at_exactly_that_many_actions(self, hw: Any, cap: int):
+        """The cap is honored, not merely accepted."""
+        policy = _CountingPolicy()
+
+        result = hw.run_policy(policy_object=policy, instruction="probe", duration=30.0, n_steps=cap)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == cap
+        assert hw._task_state.step_count == cap
+
+    def test_none_requests_no_cap_and_duration_bounds_the_rollout(self, hw: Any):
+        """``None`` is the documented "no cap" spelling and stays accepted."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", duration=0.2, n_steps=None)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) > 1
+
+    def test_the_default_is_no_cap(self, hw: Any):
+        """Omitting the parameter behaves exactly as ``None``."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", duration=0.2)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) > 1
+
+    def test_the_chokepoint_accepts_a_usable_cap(self, hw: Any):
+        """The refusal at ``_execute_task_sync`` is not a blanket rejection."""
+        result = hw._execute_task_sync("probe", policy_object=_CountingPolicy(), n_steps=3)
+
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == 3
+
+
+class TestDomainMatchesSimulation:
+    """The arm and its digital twin agree on every step cap."""
+
+    @pytest.mark.parametrize("cap", [*UNUSABLE_STEP_CAPS, *USABLE_STEP_CAPS])
+    def test_hardware_and_simulation_agree(self, hw: Any, cap: Any):
+        """Neither surface may accept a cap the other refuses."""
+        hardware_refuses = hw._n_steps_error(cap, "run_policy") is not None
+
+        assert hardware_refuses is _sim_refuses(cap)
+
+    def test_both_read_none_as_no_cap(self, hw: Any):
+        """``None`` is a request for no cap on both surfaces, not a bad value."""
+        assert hw._n_steps_error(None, "run_policy") is None
+        assert not _sim_refuses(None)
+
+    def test_the_refusal_wording_is_the_shared_domain(self, hw: Any):
+        """One domain, so the two surfaces report a bad cap identically."""
+        hardware = _text(hw._n_steps_error(0, "run_policy"))
+        _duration, _steps, sim_error = SimEngine._resolve_horizon(0, None, 50.0, 10.0, "run_policy")
+
+        assert sim_error is not None
+        assert hardware == _text(sim_error)
+
+
+class TestTheStepCapGuardIsNotTheDurationGuard:
+    """The two horizon conditions are ANDed, so each is validated on its own."""
+
+    def test_a_usable_cap_with_an_unusable_budget_is_still_refused(self, hw: Any):
+        """``duration`` remains the effective horizon and keeps its own domain."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", duration=0, n_steps=4)
+
+        assert result["status"] == "error"
+        assert "duration" in _text(result)
+
+    def test_a_usable_budget_with_an_unusable_cap_is_refused(self, hw: Any):
+        """A cap is not excused by a budget that could have bounded the rollout."""
+        result = hw.run_policy(policy_object=_CountingPolicy(), instruction="probe", duration=5.0, n_steps=0)
+
+        assert result["status"] == "error"
+        assert "n_steps" in _text(result)


### PR DESCRIPTION
## Problem

`Robot.run_policy` bounds a hardware rollout by two **ANDed** conditions:

```python
while (... and (time.time() - start_time < duration)
           and (n_steps is None or self._task_state.step_count < n_steps)):
```

`duration` is refused up front — `_duration_error` exists precisely because a budget the loop
cannot honor produced a rollout that commanded nothing and still reported `completed`. Its
docstring names the knob beside it in the same signature:

> unlike the simulation's `run_policy` — where an `n_steps` recomputes `duration` and supersedes
> it — the two conditions are ANDed here, so `duration` is the effective horizon **even when a
> step cap is given**.

That step cap was read straight into the comparison with no domain, so on a real arm:

| `n_steps` | outcome on `main` |
|---|---|
| `0` / `-5` / `False` | `status="success"`, **"Policy rollout completed: 0 steps"** — 0 commands, 0 inferences |
| `nan` | `status="success"`, **"completed: 0 steps"** (never `<=` anything, so the comparison is false at once) |
| `inf` | `status="success"` — the requested cap silently vanishes, the rollout runs the `duration` budget |
| `True` | `status="success"` — a silent cap of one |
| `2.7` / `3.0` | `status="success"`, **3 applied actions** — a count the caller never named |
| `'10'` / `[4]` | `error: "'<' not supported between instances of 'int' and 'str'"` — names a comparison internal, not the parameter |
| `None` / `4` | correct (no cap / stops at 4) |

The first five rows are the same false `completed` `_duration_error` was added to remove, reached
through the sibling knob. The same values are all refused by the simulation's `run_policy`, so one
parameter name had two contracts decided by which surface it was passed to.

## Change

`Robot._n_steps_error` validates the cap against
`utils.positive_count_error` — the domain this loop's `action_horizon` and the simulation's
`_resolve_horizon` step horizon already share. `_validate_positive_int` states why that domain lives
in `utils` rather than in either surface:

> the hardware control loop's `action_horizon` must enforce the identical rule and
> `strands_robots.hardware_robot` cannot import `strands_robots.simulation`; sharing one
> implementation is what stops the same count being refused for a digital twin and accepted for the
> arm it mirrors.

`n_steps` is the other count that loop reads. The guard is applied at the two entry points that take
it — `run_policy` and `_execute_task_sync` (the chokepoint the agent-tool `execute` action and the
mesh `execute` dispatch reach directly) — placed immediately after the `duration` guard, so a
refusal precedes policy initialization and the motors-bus claim. `None` remains the documented
"no cap" spelling and is unchanged.

The refusal message is byte-identical to the simulation's for the same value, asserted by a test.

## Measured

so100 replay of exactly what `run_policy` commanded the servo bus. The commanded pose is indexed by
the applied-action count, so how far the arm travels **is** the horizon the loop honored.

![hardware step cap domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/hardware-step-cap/artifact_step_cap.png)

The honored `n_steps=120` rollout is identical on both trees — 120 commands, 120 inferences, every
joint equal to 4 dp (`Rotation 1.2978`, `Elbow 1.9066`), renders within `max|delta| = 1/255` — so
nothing about an honorable cap changes. The two defect panels differ from it on 18.8% and 19.0% of
pixels.

## Tests

`tests/test_hardware_step_cap_guard.py` (79 tests, 1.1 s, no serial/USB hardware — in-memory driver,
structural policy stub):

- every unusable cap refused at `run_policy` **and** at `_execute_task_sync`, naming the parameter;
- the refusal is not reported as a completed rollout, and the message never carries `'<' not supported`;
- **refusal precedes the arm**: no action reaches the driver, no policy is initialized, no inference
  is spent, and the single command bus is released for the next rollout;
- every accepted cap is *honored*, not merely accepted — the rollout stops at exactly that many
  applied actions;
- `None` and the default still request no cap, with `duration` bounding the rollout;
- cross-surface parity against `SimEngine._resolve_horizon` over every probe value, plus a test that
  the refusal wording is the shared domain verbatim;
- the two horizon conditions stay independent: a usable cap with an unusable `duration` is still
  refused for `duration`, and vice versa.

Pre-fix (source reverted to `main`, tests kept): **61 failed / 18 passed**. The 18 that pass are the
accepted-cap cases, the `None`/default cases and the `duration` cross-check — they are what stops the
guard reaching further than the one parameter. That run also took **287 s** versus **1.1 s** after,
because on `main` the unusable caps genuinely reached the loop (`inf` ran the whole `duration`
budget).

Blast radius: zero existing-test changes. Every hardware test already passes a plain positive `int`.

## Gate

Rebased onto `upstream/main` (`2b38ebe5` → current) because a package-wide `Args:`-completeness guard
landed mid-verification and its verdict is base-dependent; the full suite below is the tree that merges.

- `MUJOCO_GL=egl pytest tests -q --no-cov` → **25393 passed, 257 skipped, 0 failed** (607 s)
- `ruff check strands_robots tests tests_integ` → clean; `ruff format --check` → 1129 files formatted
- `mypy strands_robots tests tests_integ` → `Success: no issues found in 1126 source files`
- repo-wide guards (`Args:` completeness, changelog fragments/format, dangling doc refs, internal
  paths, unreachable statements) → 410 passed

## Out of scope

`start_task` takes no `n_steps` (its rollout is bounded by `duration` alone), so it needs no guard;
`_execute_task_async` / `_drive_claimed_task` / `_run_control_loop` are internal and reachable only
through the two guarded entry points.
