### PR TITLE
fix(simulation): refuse an on_frame failure tolerance the watchdog cannot count against

### DIFF
--- a/changelog.d/2060-onframe-failure-limit-domain.md
+++ b/changelog.d/2060-onframe-failure-limit-domain.md
@@ -1,0 +1,23 @@
+### Fixed: refuse an `on_frame` failure tolerance the watchdog cannot count against
+
+`run_policy(max_onframe_failures=...)` and `PolicyRunner.run(...)` read the
+consecutive-failure ceiling straight into `consecutive_onframe_failures >= limit`
+with no domain, so a value outside it did not resize the tolerance - it silenced
+the mechanism whose own abort text reads "aborting episode to avoid silent
+dataset corruption". Measured on a 100-step rollout whose `on_frame` hook raises
+on every step, `nan` and `inf` made that comparison false for every counter
+value: 100 of 100 frames lost, `status="success"`, and the abort never fired.
+Both values also broke the per-failure warning that would otherwise have
+reported the hook - it interpolates the limit with `%d`, so `logging` emitted its
+own error instead and the operator was told nothing at all. `0` aborted on the
+first failure exactly as `1` does while reporting "failed 0 times in a row";
+`2.7` tolerated two failures and aborted on the third while reporting "failed
+2.7 times in a row"; a string or a list leaked
+`TypeError: '>=' not supported between instances of 'int' and 'str'` from inside
+the hook's own exception handler, and only once the hook first failed.
+
+The limit is now a positive integer or `None` - the same domain `n_steps`,
+`max_steps` and `n_episodes` already carry on the same signature - reported
+through the envelope on the facade and raised on `PolicyRunner`, which is
+drivable directly. The refusal precedes any policy construction, so a bad limit
+costs no weight download and no frame.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1982,6 +1982,59 @@ class SimEngine(ABC):
             return {"status": "error", "content": [{"text": error}]}
         return None
 
+    @staticmethod
+    def _validate_onframe_failure_limit(max_onframe_failures: Any, method: str) -> dict[str, Any] | None:
+        """Reject an ``on_frame`` failure tolerance the watchdog cannot count against.
+
+        ``max_onframe_failures`` is the consecutive-failure ceiling that stops a
+        broken ``on_frame`` hook from producing an empty capture behind a
+        successful-looking rollout (GH #117). The runner counts failures into a
+        plain ``int`` and compares ``consecutive_onframe_failures >= limit``, so a
+        value outside the accepted domain does not merely mis-size the tolerance -
+        it silences the mechanism whose own abort text reads "aborting episode to
+        avoid silent dataset corruption":
+
+        * ``nan`` and ``inf`` make that comparison false for every counter value,
+          so the abort never fires. Measured on a 100-step rollout whose hook
+          raises on every step: 100 of 100 frames lost and
+          ``status="success"``. Both values also break the per-failure warning
+          that would otherwise report the hook - it interpolates the limit with
+          ``%d``, and ``"%d" % nan`` raises ``ValueError`` while ``"%d" % inf``
+          raises ``OverflowError``, so ``logging`` emits its own error instead of
+          the warning and the operator is told nothing at all.
+        * ``0`` is a duplicate spelling of ``1`` carrying a false message. The
+          counter is incremented before the comparison, so a limit of ``1``
+          already aborts on the first failure; ``0`` aborts on the same failure
+          and reports "failed 0 times in a row" when one failure occurred.
+          Refusing it costs no capability, and ``-5`` is the same abort with a
+          message that names a negative count.
+        * ``2.7`` tolerates two failures and aborts on the third while reporting
+          "failed 2.7 times in a row" - a tolerance the caller never asked for.
+          ``True`` is an ``int`` subclass and reports "failed True times in a row".
+        * A string or a list reaches the same comparison and leaks
+          ``TypeError: '>=' not supported between instances of 'int' and 'str'``
+          from inside the hook's own exception handler - and only once the hook
+          first fails, so the value is accepted and inert until then.
+
+        The accepted domain is :meth:`_validate_positive_int`
+        (:func:`~strands_robots.utils.positive_count_error`) - the same rule this
+        method already applies to ``n_steps``, ``max_steps`` and ``n_episodes``,
+        the other step counts of the same signature - plus ``None``, which this
+        parameter documents as "use the runner's own limit" and which is its
+        default.
+
+        Args:
+            max_onframe_failures: The caller-supplied value to validate.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            An error dict naming the offending parameter, or ``None`` when the
+            value is valid (including when it is ``None``).
+        """
+        if max_onframe_failures is None:
+            return None
+        return SimEngine._validate_positive_int(max_onframe_failures, "max_onframe_failures", method)
+
     def _validate_recording_rate(self, control_frequency: float, method: str) -> dict[str, Any] | None:
         """Reject a rollout whose rate the active dataset recording cannot describe.
 
@@ -2221,7 +2274,16 @@ class SimEngine(ABC):
                 capture, so a broken recorder otherwise fills an empty dataset
                 behind a successful-looking rollout. ``None`` (default) uses the
                 runner's own limit (currently ``5``); non-consecutive failures
-                reset the counter. Forwarded verbatim to
+                reset the counter. Must otherwise be a positive integer - the
+                same domain as ``n_steps`` and ``n_episodes`` above, since the
+                runner compares it against a plain integer counter. ``nan`` and
+                ``inf`` make that comparison false forever and so disable the
+                abort entirely; ``0`` aborts on the first failure exactly as
+                ``1`` does while reporting a count of zero. Both are reported as
+                a structured caller error rather than silencing the watchdog -
+                see
+                :meth:`~strands_robots.simulation.base.SimEngine._validate_onframe_failure_limit`.
+                Forwarded verbatim to
                 :meth:`~strands_robots.simulation.policy_runner.PolicyRunner.run`.
             seed: Optional master RNG seed for a reproducible single rollout.
                 When set, reseeds Python / NumPy / torch / cuDNN and forwards
@@ -2455,6 +2517,8 @@ class SimEngine(ABC):
         if err := self._validate_control_substeps(control_substeps, "run_policy"):
             return err
         if err := self._validate_rtc_inference_timeout(rtc_inference_timeout_s, "run_policy"):
+            return err
+        if err := self._validate_onframe_failure_limit(max_onframe_failures, "run_policy"):
             return err
         # Both rates are known only here: the dataset rate was fixed by
         # start_recording one call earlier. Checked before any policy is

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -1025,7 +1025,11 @@ class PolicyRunner:
                 ``_MAX_CONSECUTIVE_ONFRAME_FAILURES`` (currently ``5``). A
                 broken recording hook otherwise silently produces empty
                 datasets - see GH #117. Non-consecutive failures reset the
-                counter.
+                counter. Must otherwise be a positive integer
+                (:func:`~strands_robots.utils.positive_count_error`), raised
+                rather than returned because raising is this layer's contract:
+                a value the counter cannot be compared against would disable
+                the abort above instead of resizing it.
             control_substeps: Physics steps advanced per applied action. ``None``
                 (default) derives the count from ``control_frequency`` and the
                 backend's physics timestep, so a position-servo arm integrates
@@ -1183,6 +1187,14 @@ class PolicyRunner:
             )
         ):
             raise ValueError(timeout_error)
+        # Same shared domain, raised for the same reason: a limit outside it
+        # silences the consecutive-failure abort this runner owns, and the
+        # warning that would report the hook - see
+        # SimEngine._validate_onframe_failure_limit for the measured failure modes.
+        if max_onframe_failures is not None and (
+            limit_error := positive_count_error(max_onframe_failures, "max_onframe_failures", "PolicyRunner.run")
+        ):
+            raise ValueError(limit_error)
         if seed is not None:
             set_eval_seed(seed)
             try:

--- a/tests/simulation/test_onframe_failure_limit_domain.py
+++ b/tests/simulation/test_onframe_failure_limit_domain.py
@@ -1,0 +1,450 @@
+"""``max_onframe_failures`` must be a limit the failure watchdog can count against.
+
+``on_frame`` is where a backend attaches dataset recording and video capture, so
+the runner counts consecutive hook exceptions and aborts the episode after
+``max_onframe_failures`` of them - the abort text reads "aborting episode to
+avoid silent dataset corruption" (GH #117).
+
+The limit was read straight into ``consecutive_onframe_failures >= limit`` with
+no domain, so a value outside it did not resize the tolerance, it silenced the
+mechanism. Measured on a 100-step rollout whose hook raises on every step:
+
+    limit      status     hook calls   aborted   warnings emitted
+    3          error      3            yes       3
+    None (5)   error      5            yes       5
+    nan        success    100          NO        0   <- 100 frames lost
+    inf        success    100          NO        0   <- 100 frames lost
+    0          error      1            yes       "failed 0 times in a row"
+    2.7        error      3            yes       "failed 2.7 times in a row"
+    '5'        error      1            NO        bare TypeError from '>='
+
+``nan``/``inf`` lose the abort *and* the warning: the per-failure warning
+interpolates the limit with ``%d``, and ``"%d" % nan`` raises ``ValueError``
+while ``"%d" % inf`` raises ``OverflowError``, so ``logging`` emits its own
+error and the operator is told nothing at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import math
+import pathlib
+import re
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation import base as base_mod
+from strands_robots.simulation import policy_runner as runner_mod
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+from strands_robots.utils import positive_count_error
+
+# Values no integer failure counter can be compared against. ``None`` is
+# excluded deliberately: it is this parameter's documented "use the runner's own
+# limit" spelling and its default.
+UNUSABLE: list[Any] = [0, -5, True, False, 2.7, math.nan, math.inf, -math.inf, "5", [5], {}]
+USABLE: list[Any] = [1, 3, 5, 100]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="onframe_domain", mesh=False)
+    s.create_world()
+    s.add_robot(name="alice", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _policy(sim):
+    p = MockPolicy()
+    p.set_robot_state_keys(sim.robot_joint_names("alice"))
+    return p
+
+
+class _AlwaysFails:
+    """An ``on_frame`` hook that raises every call and records its call count."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, step: int, observation: dict, action: dict) -> None:
+        self.calls += 1
+        raise ValueError(f"boom-{step}")
+
+
+def _text(result: dict) -> str:
+    return result["content"][0]["text"] if result.get("content") else ""
+
+
+class TestTheFacadeRefusesALimitTheWatchdogCannotCountAgainst:
+    """``SimEngine.run_policy`` reports the refusal through its documented envelope."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_unusable_limit_is_refused(self, sim, value):
+        result = sim.run_policy("alice", policy_provider="mock", n_steps=2, fast_mode=True, max_onframe_failures=value)
+        assert result["status"] == "error", result
+        assert "max_onframe_failures" in _text(result)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_names_the_parameter_the_domain_and_the_value(self, sim, value):
+        result = sim.run_policy("alice", policy_provider="mock", n_steps=2, fast_mode=True, max_onframe_failures=value)
+        text = _text(result)
+        assert "run_policy: max_onframe_failures must be a positive integer" in text, text
+        assert repr(value) in text, text
+
+    def test_the_refusal_costs_no_inference(self, sim):
+        # Guard placement: a refused limit must not query the policy, so it costs
+        # no weight download, no recorded frame and no step. (The hook half is
+        # asserted against PolicyRunner, which is the layer that takes on_frame.)
+        policy = _policy(sim)
+        queried = {"n": 0}
+        real = policy.get_actions
+
+        async def counting(*args: Any, **kwargs: Any) -> Any:
+            queried["n"] += 1
+            return await real(*args, **kwargs)
+
+        policy.get_actions = counting  # type: ignore[method-assign]
+        result = sim.run_policy(
+            "alice", policy_object=policy, n_steps=50, fast_mode=True, max_onframe_failures=math.nan
+        )
+        assert result["status"] == "error", result
+        assert queried["n"] == 0, "a refused limit must not query the policy"
+
+
+class TestTheRunnerRefusesTheSameDomain:
+    """``PolicyRunner`` is drivable directly, so it raises rather than returning."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_unusable_limit_raises(self, sim, value):
+        policy = _policy(sim)
+        with pytest.raises(ValueError, match="max_onframe_failures must be a positive integer"):
+            PolicyRunner(sim).run(
+                "alice", policy, duration=0.1, control_frequency=50, fast_mode=True, max_onframe_failures=value
+            )
+
+    def test_the_raise_names_the_layer_the_caller_called(self, sim):
+        policy = _policy(sim)
+        with pytest.raises(ValueError) as excinfo:
+            PolicyRunner(sim).run(
+                "alice", policy, duration=0.1, control_frequency=50, fast_mode=True, max_onframe_failures=math.inf
+            )
+        assert "PolicyRunner.run:" in str(excinfo.value), str(excinfo.value)
+
+    def test_the_raise_precedes_the_first_hook_call(self, sim):
+        hook = _AlwaysFails()
+        policy = _policy(sim)
+        with pytest.raises(ValueError):
+            PolicyRunner(sim).run(
+                "alice",
+                policy,
+                duration=2.0,
+                control_frequency=50,
+                fast_mode=True,
+                on_frame=hook,
+                max_onframe_failures=math.nan,
+            )
+        assert hook.calls == 0
+
+
+class TestUsableLimitsStillWork:
+    """The change is additive: every limit the counter can honor is unaffected."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_usable_limit_is_accepted(self, sim, value):
+        result = sim.run_policy("alice", policy_provider="mock", n_steps=2, fast_mode=True, max_onframe_failures=value)
+        assert result["status"] == "success", result
+
+    def test_none_is_accepted_and_uses_the_runners_own_limit(self, sim):
+        hook = _AlwaysFails()
+        policy = _policy(sim)
+        result = PolicyRunner(sim).run(
+            "alice",
+            policy,
+            duration=5.0,
+            control_frequency=50,
+            fast_mode=True,
+            on_frame=hook,
+            max_onframe_failures=None,
+        )
+        assert result["status"] == "error", result
+        assert f"failed {runner_mod._MAX_CONSECUTIVE_ONFRAME_FAILURES} times in a row" in _text(result)
+        assert hook.calls == runner_mod._MAX_CONSECUTIVE_ONFRAME_FAILURES
+
+    @pytest.mark.parametrize("limit", [1, 3])
+    def test_a_usable_limit_aborts_after_exactly_that_many_failures(self, sim, limit):
+        hook = _AlwaysFails()
+        policy = _policy(sim)
+        result = PolicyRunner(sim).run(
+            "alice",
+            policy,
+            duration=5.0,
+            control_frequency=50,
+            fast_mode=True,
+            on_frame=hook,
+            max_onframe_failures=limit,
+        )
+        assert result["status"] == "error", result
+        # The abort message quotes the real number of consecutive failures.
+        assert f"failed {limit} times in a row" in _text(result)
+        assert hook.calls == limit
+
+
+class TestZeroIsADuplicateSpellingOfOne:
+    """Refusing ``0`` costs no capability - it aborted where ``1`` aborts.
+
+    The counter is incremented before the comparison, so a limit of ``1``
+    already aborts on the first failure. ``0`` aborted on that same failure and
+    reported "failed 0 times in a row" when one failure had occurred, so it was
+    a duplicate of ``1`` carrying a false count rather than a distinct
+    tolerance.
+    """
+
+    def test_one_already_aborts_on_the_first_failure_with_a_true_count(self, sim):
+        hook = _AlwaysFails()
+        policy = _policy(sim)
+        result = PolicyRunner(sim).run(
+            "alice", policy, duration=5.0, control_frequency=50, fast_mode=True, on_frame=hook, max_onframe_failures=1
+        )
+        assert hook.calls == 1, "limit=1 aborts on the first failure"
+        assert "failed 1 times in a row" in _text(result)
+
+    def test_zero_is_refused_rather_than_reporting_a_count_of_zero(self, sim):
+        policy = _policy(sim)
+        with pytest.raises(ValueError, match="max_onframe_failures must be a positive integer"):
+            PolicyRunner(sim).run(
+                "alice", policy, duration=0.1, control_frequency=50, fast_mode=True, max_onframe_failures=0
+            )
+
+
+class TestWhyANonFiniteLimitSilencedTheWatchdogEntirely:
+    """Executable premise for the failure the domain removes.
+
+    Both halves of the mechanism read the limit, and both are lost for a
+    non-finite value: the abort compares against it, and the warning
+    interpolates it with ``%d``.
+    """
+
+    @pytest.mark.parametrize("limit", [math.nan, math.inf])
+    @pytest.mark.parametrize("consecutive", [1, 5, 100, 10**9])
+    def test_the_abort_comparison_is_false_for_every_counter_value(self, limit, consecutive):
+        assert not (consecutive >= limit), "a counter can never reach this limit"
+
+    @pytest.mark.parametrize(("limit", "expected"), [(math.nan, ValueError), (math.inf, OverflowError)])
+    def test_the_warning_cannot_be_formatted_against_a_non_finite_limit(self, limit, expected):
+        # Exactly the operation logging performs on the warning: a LogRecord
+        # interpolates ``msg % args``, and the limit is interpolated with %d.
+        record = logging.LogRecord(
+            name="probe",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=0,
+            msg="on_frame hook failed (%d/%d consecutive): %s",
+            args=(1, limit, "boom"),
+            exc_info=None,
+        )
+        with pytest.raises(expected):
+            record.getMessage()
+
+    def test_logging_drops_the_warning_rather_than_emitting_it(self):
+        # So a non-finite limit lost the abort AND the only report of the hook.
+        # propagate=False so the record never reaches pytest's own capture
+        # handler, which re-raises a format failure instead of swallowing it.
+        records: list[str] = []
+
+        class _Collect(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                try:
+                    records.append(record.getMessage())
+                except (ValueError, OverflowError):
+                    pass  # exactly what logging reports as "--- Logging error ---"
+
+        handler = _Collect()
+        logger = logging.getLogger("strands_robots.test_onframe_premise")
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)
+        logger.propagate = False
+        try:
+            logger.warning("on_frame hook failed (%d/%d consecutive): %s", 1, math.nan, "boom")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = True
+        assert records == [], "the warning is never emitted for a non-finite limit"
+
+    def test_a_usable_limit_does_emit_the_warning(self):
+        # Non-vacuity for the assertion above: the same call with a usable limit
+        # produces the warning, so its absence is the format failure and not a
+        # property of the harness.
+        records: list[str] = []
+
+        class _Collect(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record.getMessage())
+
+        handler = _Collect()
+        logger = logging.getLogger("strands_robots.test_onframe_premise_ok")
+        logger.addHandler(handler)
+        logger.setLevel(logging.WARNING)
+        logger.propagate = False
+        try:
+            logger.warning("on_frame hook failed (%d/%d consecutive): %s", 1, 5, "boom")
+        finally:
+            logger.removeHandler(handler)
+            logger.propagate = True
+        assert records == ["on_frame hook failed (1/5 consecutive): boom"]
+
+
+class TestTheTwoSurfacesAgree:
+    """Neither layer may accept what the other refuses."""
+
+    @pytest.mark.parametrize("value", [*UNUSABLE, *USABLE, None])
+    def test_the_facade_and_the_runner_reach_the_same_verdict(self, sim, value):
+        facade = sim.run_policy("alice", policy_provider="mock", n_steps=2, fast_mode=True, max_onframe_failures=value)
+        facade_refused = facade["status"] == "error" and "max_onframe_failures" in _text(facade)
+
+        policy = _policy(sim)
+        try:
+            PolicyRunner(sim).run(
+                "alice", policy, duration=0.05, control_frequency=50, fast_mode=True, max_onframe_failures=value
+            )
+            runner_refused = False
+        except ValueError as e:
+            runner_refused = "max_onframe_failures" in str(e)
+
+        assert facade_refused == runner_refused, f"verdicts differ for max_onframe_failures={value!r}"
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_both_report_the_shared_domain_message(self, sim, value):
+        assert positive_count_error(value, "max_onframe_failures", "run_policy") is not None
+        assert _text(
+            sim.run_policy("alice", policy_provider="mock", n_steps=2, fast_mode=True, max_onframe_failures=value)
+        ) == positive_count_error(value, "max_onframe_failures", "run_policy")
+
+
+# --------------------------------------------------------------------------- #
+# Structural guard: a new surface taking the parameter cannot skip the domain.
+# --------------------------------------------------------------------------- #
+
+_PARAM = "max_onframe_failures"
+_DOMAIN_CALLS = {"_validate_onframe_failure_limit", "positive_count_error"}
+
+
+def _scan_root() -> pathlib.Path:
+    # Derived from a symbol rather than a path literal, so a scan rooted
+    # elsewhere fails the non-vacuity assertion below instead of passing.
+    return pathlib.Path(inspect.getfile(SimEngine)).parent
+
+
+def _calls_a_domain_helper(fn: ast.AST) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            f = node.func
+            name = f.attr if isinstance(f, ast.Attribute) else (f.id if isinstance(f, ast.Name) else "")
+            if name in _DOMAIN_CALLS:
+                return True
+    return False
+
+
+def _forwards_the_parameter(fn: ast.AST) -> bool:
+    """A wrapper that hands the value on by keyword inherits the callee's domain."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == _PARAM and isinstance(kw.value, ast.Name) and kw.value.id == _PARAM:
+                    return True
+    return False
+
+
+def _public_surfaces() -> list[tuple[str, str, ast.AST]]:
+    found: list[tuple[str, str, ast.AST]] = []
+    for path in sorted(_scan_root().rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover - the package parses
+            continue
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            if cls.name.startswith("_"):
+                continue
+            for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
+                if fn.name.startswith("_"):
+                    continue
+                args = [a.arg for a in fn.args.args + fn.args.kwonlyargs]
+                if _PARAM in args:
+                    found.append((f"{path.name}::{cls.name}.{fn.name}", path.name, fn))
+    return found
+
+
+class TestNoOnframeFailureLimitSurfaceDrifts:
+    """Every public method taking the parameter validates or forwards it."""
+
+    def test_the_known_surfaces_are_the_ones_found(self):
+        # Non-vacuity: if the scan resolves nothing (or something else), the
+        # negative assertion below could pass by matching nothing.
+        names = {name for name, _mod, _fn in _public_surfaces()}
+        assert names == {
+            "base.py::SimEngine.run_policy",
+            "policy_runner.py::PolicyRunner.run",
+            "simulation.py::MuJoCoSimEngine.run_policy",
+        }, names
+
+    def test_every_public_surface_validates_or_forwards(self):
+        adrift = [
+            name
+            for name, _mod, fn in _public_surfaces()
+            if not (_calls_a_domain_helper(fn) or _forwards_the_parameter(fn))
+        ]
+        assert adrift == [], f"{adrift} read {_PARAM} without a domain and without forwarding it"
+
+    def test_the_scanner_detects_a_planted_surface(self):
+        planted = ast.parse(
+            "class Engine:\n    def run_policy(self, max_onframe_failures=None):\n        return max_onframe_failures\n"
+        )
+        fn = planted.body[0].body[0]  # type: ignore[attr-defined]
+        assert not _calls_a_domain_helper(fn)
+        assert not _forwards_the_parameter(fn)
+
+    def test_the_scanner_accepts_a_planted_forwarder(self):
+        planted = ast.parse(
+            "class Engine:\n"
+            "    def run_policy(self, max_onframe_failures=None):\n"
+            "        return super().run_policy(max_onframe_failures=max_onframe_failures)\n"
+        )
+        fn = planted.body[0].body[0]  # type: ignore[attr-defined]
+        assert _forwards_the_parameter(fn)
+
+
+class TestTheDomainIsDiscoverable:
+    """A refused value must name a parameter whose documented domain says so."""
+
+    @pytest.mark.parametrize(
+        ("method", "owner"),
+        [(SimEngine.run_policy, "run_policy"), (PolicyRunner.run, "PolicyRunner.run")],
+    )
+    def test_the_args_entry_states_the_domain(self, method, owner):
+        doc = inspect.getdoc(method) or ""
+        entry_start = doc.find(f"\n    {_PARAM}:")
+        assert entry_start != -1, f"{owner} has no Args: entry for {_PARAM}"
+        # Bound the slice at the next entry so the claim is "in this entry".
+        rest = doc[entry_start + 1 :]
+        following = re.search(r"\n    (?=\S)", rest[1:])
+        end = 1 + following.start() if following else len(rest)
+        entry = " ".join(rest[:end].split())
+        assert "positive integer" in entry, entry
+
+    def test_the_validator_records_why_a_non_finite_limit_is_refused(self):
+        doc = inspect.getdoc(SimEngine._validate_onframe_failure_limit) or ""
+        collapsed = " ".join(doc.split())
+        assert "the abort never fires" in collapsed, collapsed
+        assert "duplicate spelling of ``1``" in collapsed, collapsed
+
+    def test_the_module_docstring_convention_is_unchanged(self):
+        # base.py owns the envelope-returning guards; policy_runner.py raises.
+        assert "_validate_onframe_failure_limit" in pathlib.Path(inspect.getfile(base_mod)).read_text()
+        assert "positive_count_error" in pathlib.Path(inspect.getfile(runner_mod)).read_text()


### PR DESCRIPTION
## Problem

`max_onframe_failures` is the consecutive-failure ceiling that stops a broken `on_frame` hook from capturing nothing behind a successful-looking rollout. The runner's own abort text says what it is for:

```
on_frame hook failed 5 times in a row; aborting episode to avoid silent dataset corruption.
```

The limit was read straight into `consecutive_onframe_failures >= limit` with no domain, so a value outside it did not resize the tolerance — **it silenced the mechanism**. Measured on a 100-step rollout (so100, 2.0 s at 50 Hz) whose hook raises on every step:

| `max_onframe_failures` | status | steps run | frames captured | warnings emitted | abort fired |
|---|---|---|---|---|---|
| `3` | `error` | 3 | 0 | 3 | yes — "failed 3 times in a row" |
| `None` → 5 | `error` | 5 | 0 | 5 | yes — "failed 5 times in a row" |
| **`nan`** | **`success`** | **100** | **0 of 100** | **0** | **NO** |
| **`inf`** | **`success`** | **100** | **0 of 100** | **0** | **NO** |
| `0` | `error` | 1 | 0 | 1 | yes — "failed **0** times in a row" |
| `-5` | `error` | 1 | 0 | 1 | yes — "failed **-5** times in a row" |
| `True` | `error` | 1 | 0 | 1 | yes — "failed **True** times in a row" |
| `2.7` | `error` | 3 | 0 | 3 | yes — "failed **2.7** times in a row" |
| `'5'` / `[5]` | `error` | 1 | 0 | 0 | no — bare `TypeError` from `'>='` |

Three distinct failures:

1. **`nan` and `inf` disable the watchdog completely.** Every comparison against them is false, so the abort never fires — 100 consecutive hook failures, `status="success"`. They also break the *only other* report of the hook: the per-failure warning interpolates the limit with `%d`, and `"%d" % nan` raises `ValueError` while `"%d" % inf` raises `OverflowError`, so `logging` emits its own error instead. Measured, the warning is never emitted at all. The operator gets neither the warning nor the abort.

2. **`0` is a duplicate spelling of `1` carrying a false message.** The counter is incremented before the comparison, so `1` already aborts on the first failure. Measured, `0` and `1` both abort after exactly one hook call — but `1` reports "failed 1 times in a row" (true) and `0` reports "failed 0 times in a row" (false). `-5` and `True` are the same abort with a message naming a count nobody supplied; `2.7` tolerates two failures and aborts on the third while reporting `2.7`.

3. **A string or a list leaks a bare `TypeError`** from inside the hook's own exception handler, and only once the hook first fails — so the value is accepted and inert until then.

## Change

`max_onframe_failures` is now a positive integer or `None`, delegated to `SimEngine._validate_positive_int` / `positive_count_error` — the same domain `n_steps`, `max_steps` and `n_episodes` already carry **on the same signature**, since the runner compares the limit against a plain integer counter.

Two layers, matching the pattern the sibling rollout knobs already use:

* `SimEngine.run_policy` returns the refusal through its documented envelope (`MuJoCoSimEngine.run_policy` inherits it — it forwards via `super()`).
* `PolicyRunner.run` raises, because raising is that layer's contract: it is drivable directly and a direct caller has no envelope to read a refusal from.

The guard precedes policy construction, so a bad limit costs no weight download and no frame — asserted, not assumed (`policy.get_actions` is never called; the hook never fires).

`None` stays valid and unchanged: it is this parameter's documented "use the runner's own limit" spelling and its default.

### Out of scope, deliberately

The default `_MAX_CONSECUTIVE_ONFRAME_FAILURES = 5` is untouched, and `RecordingFrameError` remains excluded from the tolerance entirely — a lost dataset frame is data loss rather than telemetry, which is a separate decision this change does not revisit.

## Measurement

![max_onframe_failures domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/onframe-failure-limit/onframe-failure-limit-domain.png)

MuJoCo headless (`MUJOCO_GL=egl`), so100, 2.0 s at 50 Hz. The hook renders one frame per step; in the two right-hand runs it raises every call.

* **A** — a working capture hook: 100 of 100 frames, `status="success"`. That frame is **byte-identical on both trees** (max delta `1/255`), so the honored path is untouched.
* **B** — `main` with `max_onframe_failures=nan`: 100 steps ran, 100 hook failures, **0 frames captured**, `status="success"`, **0 warnings emitted**. The arm moved through the full rollout and nothing was captured.
* **C** — this change: refused before step 1, arm still at its start pose.

The middle panel is the point: the hook fails identically in B and in the `limit=3` run, and only the limit differs. Panels B and C differ on 8.31% of pixels; the renders are grounding, and the step chart plus the fact table carry the argument.

Both `facts_*.json` dumps and the generating scripts are published alongside the figure — `compose.py` asserts every number it renders (including that the two dumps came from different trees) before saving.

## Verification

Rebased onto `66a16f0c`; `scripts/check_merge_base_overlap.py` reports no overlap, and the diff is exactly the four files this PR owns.

* Pre-fix proof — source reverted to the base, tests kept: **53 failed / 39 passed**, identical at both bases the branch has had, so the contract is preserved across the rebase. The 39 that pass pre-fix are the additive controls (every usable limit), the executable premise (properties of Python's `>=` and `%d`, not of this change), the planted-defect meta-tests and the structural non-vacuity assertion.
* `MUJOCO_GL=egl python -m pytest tests` on the rebased head: **25485 passed / 257 skipped / 0 failed** (548 s). Zero existing-test churn.
* `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1130 files).
* `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`, **0 outside**. That error set is byte-identical to a pristine `upstream/main` worktree of the same working copy (line numbers normalised, then diffed), so it is environmental and not from this change.
* Root guards (46 tests) and `scripts/assemble_changelog.py --check` pass.
* `tests/simulation/test_onframe_failure_limit_domain.py` alone: 92 tests in 9.4 s.

One flake was seen in the first full run — `test_rollout_seed_is_applied_or_refused.py::…::test_the_seeded_eval_matches_its_sibling_run_policy_contract`, a seeded float-stream equality outside the changed path. It passes alone (1 passed), its whole file passes alone (124 passed), and it passes with this PR's new file immediately ahead of it (216 passed), so the new file provably does not perturb it; two subsequent full runs were clean.

## Tests

`tests/simulation/test_onframe_failure_limit_domain.py` — 92 tests:

* the facade refuses each unusable value through the envelope, naming the parameter, the domain and the value;
* the refusal costs no inference and no frame (`get_actions` never called, hook never fired);
* `PolicyRunner.run` raises the same domain and names the layer the caller called;
* every usable limit still aborts after exactly that many failures with a message quoting the real count, and `None` still uses the runner's own limit;
* `1` already aborts on the first failure with a *true* count — the measured reason refusing `0` costs no capability;
* an executable premise for why a non-finite limit silenced both halves: the comparison is false for every counter value, a real `LogRecord` cannot format it, and `logging` drops the warning (with a non-vacuity test that a usable limit *does* emit it);
* cross-surface parity — neither layer may accept what the other refuses, and both report the shared domain message verbatim;
* a structural guard that every public surface taking the parameter validates or forwards it, with an exact expected-surface set (non-vacuity) plus planted-defect and planted-forwarder meta-tests;
* the `Args:` entry on both surfaces states the domain, asserted against a slice bounded at the next entry.
