### PR TITLE
fix(device_connect): check allow_insecure against its declared type instead of returning it as given

### DIFF
--- a/changelog.d/2061-allow-insecure-argument-checked-not-parsed.md
+++ b/changelog.d/2061-allow-insecure-argument-checked-not-parsed.md
@@ -1,0 +1,23 @@
+### Fixed: `allow_insecure="false"` enabled insecure Device Connect transport instead of refusing it
+
+`resolve_allow_insecure` resolves one security posture from two sources and
+documents the argument as outranking `DEVICE_CONNECT_ALLOW_INSECURE`. The
+environment value was parsed - only `("true", "1", "yes")` opt in - while the
+argument was returned as given. A non-empty string is truthy, so the two sources
+disagreed about the same value: `resolve_allow_insecure("false")` resolved to
+insecure while `DEVICE_CONNECT_ALLOW_INSECURE=false` resolved to secure, and
+every *off* spelling (`"false"`, `"no"`, `"0"`, `"off"`) inverted on the
+higher-precedence path. `init_device_connect(allow_insecure="false")` logged the
+prominent INSECURE-mode warning and handed the string through to the runtime.
+
+Each source is now held to its own declared type: the environment value is still
+parsed, and the argument - declared `bool | None` - is checked, with a non-boolean
+refused before any runtime is constructed. A numpy boolean is accepted and
+normalized, so the declared `bool` return is real for a caller's comparison
+result. A non-string `env_value` is refused too, rather than raising
+`AttributeError` from `.lower()` out of a function declared to return `bool`.
+
+The argument is checked rather than parsed with the same vocabulary because
+parsing would move which spellings invert rather than remove the inversion:
+`"on"`, `"enabled"` and `"y"` are absent from that vocabulary, so each would
+silently resolve to secure while reading as an opt-in.

--- a/docs/device-connect.md
+++ b/docs/device-connect.md
@@ -129,7 +129,7 @@ You rarely touch more than one or two of these. Grouped by what they control:
 | Variable | Default | What it does |
 |----------|---------|--------------|
 | `MESSAGING_CREDENTIALS_FILE` | unset | **The one var to enable mTLS.** A single `*.creds.json` bundling CA + cert + key. Works D2D or brokered. |
-| `DEVICE_CONNECT_ALLOW_INSECURE` | unset (secure) | `true` = skip auth/encryption. **Trusted, isolated LAN only**; logs a warning. |
+| `DEVICE_CONNECT_ALLOW_INSECURE` | unset (secure) | `true`/`1`/`yes` = skip auth/encryption; every other spelling is secure. **Trusted, isolated LAN only**; logs a warning. The string vocabulary is this variable's - the `allow_insecure=` argument must be a boolean and refuses a string, since `"false"` is truthy. |
 
 #### Authorization & safety — who may do what
 

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -26,6 +26,7 @@ from device_connect_edge import DeviceRuntime
 from strands_robots.device_connect.reachy_mini_driver import ReachyMiniDriver
 from strands_robots.device_connect.robot_driver import RobotDeviceDriver
 from strands_robots.device_connect.sim_driver import SimulationDeviceDriver
+from strands_robots.utils import is_boolean
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +54,57 @@ def resolve_allow_insecure(
 
     Extracted as a pure function so the secure-by-default posture is unit
     testable without standing up a DeviceRuntime.
+
+    The two sources carry the same setting in different shapes, and each is held
+    to its own declared type rather than to the other's. An environment variable
+    is a string by construction, so *env_value* is **parsed**: only
+    ``("true", "1", "yes")`` opt in and every other spelling is secure. The
+    argument is declared ``bool | None``, so it is **checked**: a non-boolean is
+    refused rather than parsed with that same vocabulary.
+
+    Checking the argument is what keeps the two sources from disagreeing about
+    one value. A non-empty string is truthy, so returning the argument as given
+    made ``resolve_allow_insecure("false")`` enable insecure transport while
+    ``DEVICE_CONNECT_ALLOW_INSECURE=false`` disabled it: every falsy spelling
+    inverted, and only on the path documented here as the higher precedence.
+    Parsing the argument with the environment vocabulary instead would move
+    which spellings invert rather than remove the inversion - ``"on"``,
+    ``"enabled"`` and ``"y"`` are absent from that vocabulary, so each would
+    silently resolve to secure while reading as an opt-in.
+
+    Args:
+        explicit: The caller's setting, or ``None`` to fall through to the
+            environment variable. Must be a python or numpy boolean when given.
+        env_value: The raw ``DEVICE_CONNECT_ALLOW_INSECURE`` value, or ``None``
+            when it is unset.
+
+    Returns:
+        Whether insecure transport is enabled, always as a real ``bool`` - so a
+        numpy boolean from a caller's own comparison satisfies the annotation
+        and the identity assertions the runtime's setting is pinned with.
+
+    Raises:
+        ValueError: If *explicit* is neither a boolean nor ``None``, or
+            *env_value* is neither a string nor ``None``.
     """
     if explicit is not None:
-        return explicit
+        if not is_boolean(explicit):
+            raise ValueError(
+                f"allow_insecure must be a bool or None, got {explicit!r}. A string "
+                "spelling is read only from DEVICE_CONNECT_ALLOW_INSECURE, where "
+                f"{_INSECURE_TRUE} opt in and anything else is secure; passed as this "
+                "argument a non-empty string is truthy, so 'false' would enable insecure "
+                "transport rather than refuse it."
+            )
+        return bool(explicit)
     if env_value is not None:
+        if not isinstance(env_value, str):
+            raise ValueError(
+                f"env_value must be a str or None, got {env_value!r}. It carries the raw "
+                "DEVICE_CONNECT_ALLOW_INSECURE value, which is a string by construction; a "
+                "caller that has already resolved a boolean should pass it as the explicit "
+                "argument instead, where it is checked rather than parsed."
+            )
         return env_value.lower() in _INSECURE_TRUE
     return False
 
@@ -88,7 +136,10 @@ async def init_device_connect(
             None = auto-detect from MESSAGING_BACKEND env var (default "zenoh").
         tenant: Device Connect tenant namespace.
         allow_insecure: Allow insecure (unencrypted, unauthenticated)
-            transport. None = auto-detect: respects the
+            transport. Must be a boolean or None; a string spelling such as
+            ``"false"`` is refused here rather than read, because the string
+            vocabulary belongs to DEVICE_CONNECT_ALLOW_INSECURE and a non-empty
+            string is truthy as an argument. None = auto-detect: respects the
             DEVICE_CONNECT_ALLOW_INSECURE env var if set, otherwise defaults
             to False (secure). Insecure transport must be explicitly opted
             into; a prominent warning is logged whenever it is active.

--- a/tests/test_allow_insecure_setting_domain.py
+++ b/tests/test_allow_insecure_setting_domain.py
@@ -1,0 +1,222 @@
+"""One setting, two sources: the ``allow_insecure`` resolver must not disagree with itself.
+
+:func:`~strands_robots.device_connect.resolve_allow_insecure` resolves a single
+security posture from two sources, and its docstring documents the argument as
+outranking the ``DEVICE_CONNECT_ALLOW_INSECURE`` environment variable. The two
+sources carry that setting in different shapes, so each is held to its own
+declared type: an environment variable is a string by construction and is
+*parsed*, while the argument is declared ``bool | None`` and is *checked*.
+
+Returning the argument as given made the two sources disagree about the same
+value. A non-empty string is truthy, so ``"false"`` supplied as the argument
+enabled insecure transport while ``DEVICE_CONNECT_ALLOW_INSECURE=false`` disabled
+it - the inversion landing only on the path documented as the higher precedence,
+and only for the spellings that mean *off*.
+
+The existing hardening pins are what made that invisible: every case there that
+passes a string passes it as ``env_value``, and every case that passes the
+argument passes a genuine ``bool``. The string vocabulary was enumerated for one
+source and never for the other.
+
+``TestParsingTheArgumentWasRejectedForAMeasuredReason`` records why the argument
+is refused rather than parsed with the environment vocabulary, so that choice is
+measured here rather than restated as a preference.
+
+Every reference to the package goes through :func:`_device_connect`, which
+imports it inside the call as the sibling suites do. Importing it at module scope
+would bind the real ``device_connect_edge`` submodules during collection, before
+the modules that substitute them for their own use can - and this module sorts
+ahead of those, so a module-scope import breaks them.
+"""
+
+import asyncio
+from typing import Any
+
+import numpy as np
+import pytest
+
+#: String spellings of a boolean that an operator, a config file or a CLI could
+#: hand to either source, split by what the environment vocabulary makes them
+#: mean - because that is the posture the argument path has to agree with.
+OPT_IN_SPELLINGS = ("true", "1", "yes")
+OFF_SPELLINGS = ("false", "False", "FALSE", "no", "0", "off")
+UNRECOGNISED_SPELLINGS = ("on", "enabled", "y", "banana", "")
+
+#: Every non-boolean the argument path can receive. ``None`` is excluded: it is
+#: the documented "fall through to the environment" sentinel, not a bad value.
+NOT_A_BOOLEAN: tuple[Any, ...] = (
+    *OPT_IN_SPELLINGS,
+    *OFF_SPELLINGS,
+    *UNRECOGNISED_SPELLINGS,
+    0,
+    1,
+    0.0,
+    1.0,
+    [],
+    [0],
+    {},
+    {"insecure": True},
+    object(),
+)
+
+
+def _device_connect() -> Any:
+    """Import the integration package inside the call rather than at module scope.
+
+    See this module's docstring: a module-scope import binds the real transport
+    submodules during collection and breaks the suites that substitute them.
+    """
+    import strands_robots.device_connect as module
+
+    return module
+
+
+def _resolve(explicit: Any = None, env_value: Any = None) -> Any:
+    """Call the resolver with values outside its declared parameter types.
+
+    One funnel so the deliberately off-type arguments below need no per-call type
+    suppression: the point of every case here is what the runtime does with a
+    value a caller really can supply, not what a checker accepts.
+    """
+    return _device_connect().resolve_allow_insecure(explicit, env_value)
+
+
+class TestTheTwoSourcesNeverDisagreeAboutOneValue:
+    """The headline invariant, stated over the spellings rather than the types.
+
+    For any spelling of the setting, the argument path must not resolve to a
+    posture the environment path would not give it. It may refuse - a string is
+    not a declared boolean - but it must never silently invert.
+    """
+
+    @pytest.mark.parametrize("spelling", OFF_SPELLINGS + OPT_IN_SPELLINGS + UNRECOGNISED_SPELLINGS)
+    def test_no_spelling_resolves_to_opposite_postures(self, spelling: str) -> None:
+        env_posture = _resolve(None, spelling)
+        assert isinstance(env_posture, bool)
+        try:
+            arg_posture = _resolve(spelling)
+        except ValueError:
+            return  # refused, so there is no second posture to disagree with
+        assert bool(arg_posture) == env_posture, (
+            f"{spelling!r} resolves to {'insecure' if arg_posture else 'secure'} as the argument "
+            f"and {'insecure' if env_posture else 'secure'} as the environment variable"
+        )
+
+    @pytest.mark.parametrize("spelling", OFF_SPELLINGS)
+    def test_an_off_spelling_never_enables_insecure_transport(self, spelling: str) -> None:
+        """The severe half: a caller writing *off* must not get *on*."""
+        assert _resolve(None, spelling) is False
+        with pytest.raises(ValueError, match="allow_insecure must be a bool or None"):
+            _resolve(spelling)
+
+
+class TestTheArgumentIsCheckedAgainstItsDeclaredType:
+    """A value outside ``bool | None`` is refused, and the refusal is actionable."""
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_a_non_boolean_argument_is_refused(self, value: Any) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _resolve(value)
+        assert "allow_insecure" in str(excinfo.value)
+
+    def test_the_refusal_names_the_value_and_the_source_that_does_parse_strings(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _resolve("false")
+        message = str(excinfo.value)
+        assert "bool or None" in message
+        assert "'false'" in message
+        assert "DEVICE_CONNECT_ALLOW_INSECURE" in message
+        for spelling in OPT_IN_SPELLINGS:
+            assert spelling in message
+
+
+class TestABooleanIsHonoredAndNormalized:
+    """Every boolean is accepted, and the declared ``bool`` return is a real one."""
+
+    def test_the_documented_arguments_are_unchanged(self) -> None:
+        assert _resolve(None, None) is False
+        assert _resolve(True, "false") is True
+        assert _resolve(False, "true") is False
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(np.True_, True), (np.False_, False), (np.array(True), True), (np.array(False), False)],
+        ids=["np.True_", "np.False_", "np.array(True)", "np.array(False)"],
+    )
+    def test_a_numpy_boolean_is_normalized_to_a_real_bool(self, value: Any, expected: bool) -> None:
+        """A comparison result is a boolean the annotation should accept.
+
+        It is returned as a real ``bool`` so the identity assertions the runtime's
+        setting is pinned with keep holding for it.
+        """
+        assert _resolve(value) is expected
+
+
+class TestTheEnvironmentPathStillParses:
+    """The parsed source is unchanged, and its own declared type is enforced too."""
+
+    @pytest.mark.parametrize("spelling", OPT_IN_SPELLINGS)
+    def test_an_opt_in_spelling_enables_insecure_transport(self, spelling: str) -> None:
+        assert _resolve(None, spelling) is True
+
+    @pytest.mark.parametrize("spelling", OFF_SPELLINGS + UNRECOGNISED_SPELLINGS)
+    def test_every_other_spelling_is_secure(self, spelling: str) -> None:
+        assert _resolve(None, spelling) is False
+
+    @pytest.mark.parametrize("value", [123, 1.0, True, False, ["true"], {}], ids=repr)
+    def test_a_non_string_env_value_is_refused(self, value: Any) -> None:
+        """It carries a raw environment value, which is a string by construction.
+
+        Refused rather than left to raise ``AttributeError`` from ``.lower()``, so
+        the whole declared ``-> bool`` return is total.
+        """
+        with pytest.raises(ValueError, match="env_value must be a str or None"):
+            _resolve(None, value)
+
+
+class TestParsingTheArgumentWasRejectedForAMeasuredReason:
+    """Why the argument is checked rather than parsed with the same vocabulary.
+
+    Parsing would move which spellings invert rather than remove the inversion:
+    the environment vocabulary has no entry for several natural opt-in spellings,
+    so each would resolve to secure while reading as an opt-in.
+    """
+
+    @pytest.mark.parametrize("spelling", ["on", "enabled", "y"])
+    def test_an_opt_in_spelling_outside_the_vocabulary_would_read_as_secure(self, spelling: str) -> None:
+        assert spelling not in _device_connect()._INSECURE_TRUE
+        assert _resolve(None, spelling) is False
+
+    def test_the_vocabulary_is_the_one_the_refusal_quotes(self) -> None:
+        assert _device_connect()._INSECURE_TRUE == OPT_IN_SPELLINGS
+
+
+class TestTheRefusalPrecedesTheRuntime:
+    """A refused setting must not reach the transport, or warn about a posture."""
+
+    def test_a_string_argument_never_constructs_a_runtime(self, monkeypatch, caplog) -> None:
+        import logging
+        from unittest.mock import patch
+
+        monkeypatch.delenv("DEVICE_CONNECT_ALLOW_INSECURE", raising=False)
+        module = _device_connect()
+        built: list[dict[str, Any]] = []
+
+        class _FatalRuntime:
+            def __init__(self, **kwargs: Any) -> None:
+                built.append(kwargs)
+                raise AssertionError("the refused setting reached the transport")
+
+        class _Robot:
+            tool_name_str = "so100"
+
+        async def _go() -> None:
+            with patch.object(module, "DeviceRuntime", _FatalRuntime):
+                await module.init_device_connect(_Robot(), peer_id="p1", allow_insecure="false")
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.device_connect"):
+            with pytest.raises(ValueError, match="allow_insecure must be a bool or None"):
+                asyncio.run(_go())
+
+        assert built == []
+        assert [r for r in caplog.records if "INSECURE mode" in r.getMessage()] == []


### PR DESCRIPTION
## The defect

`resolve_allow_insecure` resolves a single security posture from two sources, and its docstring documents the argument as outranking `DEVICE_CONNECT_ALLOW_INSECURE`. The environment value was **parsed** — only `("true", "1", "yes")` opt in — while the argument was **returned as given**:

```python
if explicit is not None:
    return explicit                              # whatever it is
if env_value is not None:
    return env_value.lower() in _INSECURE_TRUE   # strict
return False
```

A non-empty string is truthy, so the two sources disagreed about the same value. Measured on `66a16f0c`:

| spelling | as the argument | as `DEVICE_CONNECT_ALLOW_INSECURE` |
|---|---|---|
| `"false"` | **insecure** | secure |
| `"no"` | **insecure** | secure |
| `"0"` | **insecure** | secure |
| `"off"` | **insecure** | secure |
| `"on"` | **insecure** | secure |
| `"enabled"` | **insecure** | secure |
| `"true"` / `"1"` / `"yes"` | insecure | insecure |

6 of 9 spellings resolved to opposite postures, and the inversion landed only on the path documented as the higher precedence — every spelling that means *off* enabled insecure transport.

End to end, with the environment variable unset:

```
init_device_connect(robot, allow_insecure="false")
  -> WARNING "Device Connect is running in INSECURE mode (unencrypted, unauthenticated transport)."
  -> DeviceRuntime(allow_insecure='false')
```

The caller asked to withhold insecure transport, the library announced it was active, and the string reached the runtime. `resolve_allow_insecure` is exported in `device_connect.__all__` and both `init_device_connect` and `init_device_connect_sync` forward to it.

Two smaller breaks of the same declared contract, in a function annotated `-> bool`:

- A numpy boolean — what a caller's own comparison produces — was returned raw, so `np.array(False)` came back as an `ndarray`. The runtime's setting is pinned with identity assertions (`is False` / `is True`), which that value cannot satisfy.
- A non-string `env_value` raised `AttributeError: 'int' object has no attribute 'lower'` rather than reporting anything.

## Why it was invisible

Every existing case that passes a string passes it as `env_value`; every case that passes the argument passes a genuine `bool`:

```python
assert resolve_allow_insecure(True, "false") is True     # argument: a real bool
assert resolve_allow_insecure(None, "false") is False    # string: the env parameter
```

The string vocabulary was enumerated for one source and never for the other, so a green suite could not see the two sources disagree.

## The change

Each source is held to its own declared type rather than to the other's:

- `env_value` is still **parsed** — a string is the only shape an environment variable has.
- `explicit`, declared `bool | None`, is **checked** through the shared `utils.is_boolean` predicate, and normalized with `bool(...)` so the declared return is real for a numpy boolean.
- A non-string `env_value` is refused, which makes the `-> bool` return total.

The refusal names the value and the source that does read strings:

```
allow_insecure must be a bool or None, got 'false'. A string spelling is read only from
DEVICE_CONNECT_ALLOW_INSECURE, where ('true', '1', 'yes') opt in and anything else is
secure; passed as this argument a non-empty string is truthy, so 'false' would enable
insecure transport rather than refuse it.
```

The guard runs before the runtime is constructed and before the INSECURE-mode warning, so a refused setting reaches no transport and announces no posture.

### Rejected alternative: parsing the argument with the same vocabulary

Measured rather than assumed. The environment vocabulary is `("true", "1", "yes")`, so parsing the argument with it would move which spellings invert instead of removing the inversion — `"on"`, `"enabled"` and `"y"` are absent from it, and each would silently resolve to **secure** while reading as an opt-in. `TestParsingTheArgumentWasRejectedForAMeasuredReason` pins that, so the choice stays measured rather than becoming a preference.

## Measured

![allow_insecure setting domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/allow-insecure-domain/allow_insecure_domain.png)

Both halves come from one script run inside a checkout of `main` and inside this change; each dump records its own tree and the figure generator asserts they differ, then asserts every rendered number. No policy, simulation, rendering, recording or asset behaviour changes, so the artifact is a measurement rather than a rollout.

The three boolean arguments — `True`, `False`, `None` — are **byte-identical on both trees**, including the runtime setting and whether the warning fired.

## Tests

`tests/test_allow_insecure_setting_domain.py`, 74 tests, zero existing tests changed.

The headline test is stated over the spellings rather than the types: for any spelling, the argument path must not resolve to a posture the environment path would not give it. It may refuse — a string is not a declared boolean — but it must never silently invert.

Alongside it: the argument domain and its message content, boolean normalization (including numpy), the environment path unchanged, the measured reason the argument is not parsed, and a guard-placement test asserting a refused setting constructs no runtime and logs no posture warning.

Pre-fix, with `strands_robots/device_connect/__init__.py` reverted to `66a16f0c` and the tests kept: **51 failed, 23 passed**.

```
AssertionError: the refused setting reached the transport
assert np.True_ is True
AttributeError: 'int' object has no attribute 'lower'
Failed: DID NOT RAISE ValueError
```

The 23 that pass are the over-reach controls — the environment path's documented vocabulary, the boolean and `None` arguments, and the measured-reason premise — none of which this change alters.

The file imports the package inside its helpers rather than at module scope. A module-scope import binds the real transport submodules during collection, before the modules that substitute them for their own use can, and this module sorts ahead of those; verified both alone and with the whole `device_connect` group in alphabetical order.

## Gate

Verified on `2788811`, base `66a16f0c`. `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` reports no overlap against `614a96ef`, so these results are not invalidated by the four paths `main` gained since.

- `ruff check strands_robots tests tests_integ` — clean
- `ruff format --check strands_robots tests tests_integ` — 1130 files already formatted
- `mypy strands_robots tests tests_integ` — 14 errors, all in `examples/isaac_gs`, 0 elsewhere; the error set is byte-identical to a pristine `66a16f0c` worktree of the same working copy, so it is environmental rather than introduced
- `MUJOCO_GL=egl python -m pytest tests` — **25467 passed, 257 skipped, 0 failed** in 564.88s
