### PR TITLE
fix(mesh/iot): refuse a non-boolean provisioning flag instead of reading it by truthiness

### DIFF
--- a/changelog.d/2063-iot-provisioning-flag-boolean-domain.md
+++ b/changelog.d/2063-iot-provisioning-flag-boolean-domain.md
@@ -1,0 +1,35 @@
+### Fixed: refuse a non-boolean IoT provisioning flag instead of reading it by truthiness
+
+`mesh.iot` has two public entry points carrying `bool` flags, and every one of
+them selects a *posture* rather than scaling a quantity. Each was read by
+truthiness, so every non-boolean spelling of *off* - `"false"`, `"no"`, `"off"`,
+`"0"`, all truthy - selected the permissive branch.
+
+`provision_robot(allow_estop_publish=...)` is a security opt-out: `False` swaps
+the robot's certificate onto `strands-robot-no-estop`, identical to the default
+policy but without the `AllowSafetyEstop` publish grant, for the case its own
+module comment calls the common one - a robot that should obey fleet stops but
+never issue one. Measured against a recording IoT client, `allow_estop_publish`
+of `"false"`, `"no"`, `"off"`, `"0"`, `1` or `math.nan` all provisioned
+successfully onto the grant-bearing `strands-robot` policy, so the opt-out failed
+open and the certificate could originate a fleet-wide stop (and arm a Will on
+it). The attachment is durable: it persists on the certificate until someone
+re-provisions. The flag also had no `Args:` entry, so a caller could not look up
+that it takes a boolean.
+
+`bootstrap_account(confirm=...)` is the confirmation gate in front of an
+account-wide create, documented as "Must be True to actually create resources".
+`confirm="false"` with `dry_run=False` left `not confirm` False and entered the
+create path. `dry_run="false"` was the mirror image - the caller asked to leave
+preview mode, stayed in it, and was told nothing.
+
+All four flags (`allow_estop_publish`, `confirm`, `dry_run`, `force_update`) now
+route through a shared `boolean_flag_error` domain, checked before any AWS call
+and before `boto3` is even resolved, so a refused call leaves no Thing, policy or
+certificate behind. A flag arrives already typed, unlike an environment variable
+whose only shape is a string, so it is checked rather than parsed: parsing would
+only move which spellings invert, since `"on"`, `"enabled"` and `"y"` are absent
+from every such vocabulary here and would then read as an opt-in while selecting
+the restrictive posture. The two declared spellings are unchanged, and the numpy
+booleans a comparison produces are normalised to the `bool` the downstream
+readers are annotated for.

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -46,6 +46,8 @@ from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any
 
+from strands_robots.utils import boolean_flag_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -972,9 +974,27 @@ def bootstrap_account(
         was created vs skipped.
 
     Raises:
-        ValueError: If confirm=False and dry_run=False, or if account_id_expected
+        ValueError: If any of *confirm*, *dry_run* or *force_update* is not a
+            boolean, if confirm=False and dry_run=False, or if account_id_expected
             does not match the resolved account.
     """
+    # Checked before the confirmation gate below, so that gate reads real
+    # booleans: a truthy spelling of off such as confirm="false" would
+    # otherwise leave ``not confirm`` False and provision the whole account,
+    # and dry_run="false" would stay in preview while reading as a request to
+    # leave it.
+    for flag_name, flag_value in (
+        ("confirm", confirm),
+        ("dry_run", dry_run),
+        ("force_update", force_update),
+    ):
+        if flag_error := boolean_flag_error(flag_value, flag_name, "bootstrap_account"):
+            raise ValueError(flag_error)
+    # Normalised so every downstream reader - the gate, the preview branch and
+    # _ensure_estop_lambda's ``force_update`` - sees the ``bool`` it is
+    # annotated for; is_boolean also accepts a numpy boolean.
+    confirm, dry_run, force_update = bool(confirm), bool(dry_run), bool(force_update)
+
     if not dry_run and not confirm:
         raise ValueError(
             "bootstrap_account() creates persistent AWS resources. "

--- a/strands_robots/mesh/iot/provision.py
+++ b/strands_robots/mesh/iot/provision.py
@@ -53,6 +53,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from strands_robots.utils import boolean_flag_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -426,11 +428,22 @@ def provision_robot(
         region: AWS region. Defaults to the default boto3 session region.
         cert_dir: Where to write certs. Defaults to ``~/.strands_robots/iot``.
         attributes: Optional thing-attribute dict (<=3 keys, <=800 chars total).
+        allow_estop_publish: When True (default) the robot certificate gets the
+            ``strands-robot`` policy, which may publish ``strands/safety/estop``
+            and therefore originate a fleet-wide stop. Pass False for the common
+            case - a robot that should obey fleet stops but never issue one - and
+            the certificate gets ``strands-robot-no-estop`` instead, identical
+            but without the ``AllowSafetyEstop`` publish grant. Must be a
+            boolean: the flag selects a posture rather than scaling a quantity,
+            so a truthy spelling of off is refused rather than read as True.
 
     Returns:
         :class:`ProvisionedThing` describing the artefacts.
 
     Raises:
+        ValueError: If *thing_name* is outside the accepted charset, or
+            *allow_estop_publish* is not a boolean. Both are checked before
+            any AWS call, so a refused call provisions nothing.
         ImportError: If ``boto3`` is not installed.
         botocore.exceptions.ClientError: For AWS-side failures (auth, throttling).
 
@@ -443,6 +456,16 @@ def provision_robot(
     """
 
     _validate_thing_name(thing_name)
+    # Checked before boto3 is even resolved: a refused flag must leave no
+    # Thing, policy or certificate behind. Reading it by truthiness would
+    # send every non-boolean spelling of off - "false", "no", "0" - to the
+    # grant-bearing policy, so the opt-out would fail open.
+    if flag_error := boolean_flag_error(allow_estop_publish, "allow_estop_publish", "provision_robot"):
+        raise ValueError(flag_error)
+    # Normalised so the value handed to _robot_policy_doc, and echoed in the
+    # log below, really is the ``bool`` both are annotated for: is_boolean
+    # also accepts a numpy boolean, which is not a ``bool`` subclass.
+    allow_estop_publish = bool(allow_estop_publish)
     boto3 = _require_boto3()
     iot = boto3.client("iot", region_name=region)
     region = iot.meta.region_name

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2322,3 +2322,62 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str) ->
         "e.g. extra_flags={'dataset.eval_split': 0.1, 'eval_steps': 1000}, and "
         "the split will hold out a tenth of each task."
     )
+
+
+def boolean_flag_error(value: Any, param: str, context: str) -> str | None:
+    """Return an error message unless *value* is a python or numpy boolean.
+
+    The domain for a flag whose two values select two *postures* rather than
+    scaling a quantity: an IoT policy that grants a capability or withholds it
+    (:func:`~strands_robots.mesh.iot.provision.provision_robot`'s
+    ``allow_estop_publish``), a confirmation gate in front of a destructive
+    action, or a preview mode
+    (:func:`~strands_robots.mesh.iot.bootstrap.bootstrap_account`'s ``confirm``,
+    ``dry_run`` and ``force_update``).
+
+    Reading such a flag by truthiness is what this refuses. Every non-empty
+    string is truthy, so ``"false"``, ``"no"``, ``"off"`` and ``"0"`` - the
+    spellings an operator reaches for when opting out - select the *permissive*
+    posture: a security opt-out that fails open, and a confirmation gate that
+    confirms. A non-zero number and ``math.nan`` read the same way, and ``None``
+    or ``[]`` silently take the other branch without ever being a declared
+    spelling of it.
+
+    There is no vocabulary to parse as a fallback either. A flag arrives already
+    typed, unlike an environment variable whose only shape is a string, so the
+    honest answer is to check it. Parsing would only move which spellings invert:
+    ``"on"``, ``"enabled"`` and ``"y"`` are absent from every such vocabulary in
+    this package, and each would then resolve to the *restrictive* posture while
+    reading as an opt-in.
+
+    It lives here rather than beside one of its callers because the flags sit in
+    more than one module, and the accepted domain must not diverge: a spelling
+    one provisioning entry point refuses cannot be honoured by the next. It is
+    also the inverse of the numeric domains above - those reject a boolean
+    through :func:`is_boolean` because ``bool`` is an ``int`` subclass that would
+    pass as a silent ``1``, while this one requires the boolean they turn away.
+
+    Distinct from
+    :func:`~strands_robots.device_connect.resolve_allow_insecure`, which answers
+    a related question and is not a caller of this: it resolves one setting from
+    two sources, so its domain is ``bool | None`` - ``None`` is the documented
+    spelling for *fall through to the environment variable* - and its refusal
+    names that variable's own opt-in vocabulary. This domain has one source and
+    no such sentinel, so it refuses ``None`` along with every other non-boolean.
+
+    Args:
+        value: The flag as supplied.
+        param: Parameter name, for the message.
+        context: Caller label the message is prefixed with.
+
+    Returns:
+        The error text, or None when *value* is a boolean and can be honoured.
+    """
+    if is_boolean(value):
+        return None
+    return (
+        f"{context}: {param} must be a boolean, got {_refusal_repr(value)}. "
+        "It selects a posture rather than scaling a quantity, so it is checked "
+        "rather than parsed - a truthy spelling of off, such as 'false', would "
+        "otherwise select the opposite posture from the one it reads as."
+    )

--- a/tests/mesh/test_iot_provisioning_flag_domain.py
+++ b/tests/mesh/test_iot_provisioning_flag_domain.py
@@ -1,0 +1,405 @@
+"""A provisioning posture flag is checked, not read by truthiness.
+
+``mesh.iot`` has exactly two public entry points carrying ``bool``-annotated
+flags, and every one of them selects a *posture* rather than scaling a quantity:
+
+* :func:`~strands_robots.mesh.iot.provision.provision_robot`'s
+  ``allow_estop_publish`` chooses between the ``strands-robot`` policy, which
+  grants ``AllowSafetyEstop``, and ``strands-robot-no-estop``, which withholds
+  it. It is a security *opt-out*.
+* :func:`~strands_robots.mesh.iot.bootstrap.bootstrap_account`'s ``confirm``
+  gates a destructive account-wide create, ``dry_run`` selects preview mode and
+  ``force_update`` overwrites an existing E-stop Lambda.
+
+Read by truthiness, every non-boolean spelling of *off* selects the permissive
+branch: ``"false"``, ``"no"``, ``"off"`` and ``"0"`` are all truthy, so the
+opt-out fails open and the confirmation gate confirms. These tests pin that each
+flag is now refused instead, before any AWS call, and that the two usable
+postures are unchanged.
+
+The fake IoT client here records what it was asked to create rather than
+asserting on a mock, so "the refused call provisioned nothing" and "the deny
+posture really omits the grant" are both direct observations.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.mesh.iot.bootstrap as bootstrap_mod
+import strands_robots.mesh.iot.provision as provision_mod
+from strands_robots.utils import boolean_flag_error
+
+ESTOP_SID = "AllowSafetyEstop"
+
+#: Values no posture flag can be built from. Each is truthy (and would select
+#: the permissive branch) unless marked otherwise in the comment.
+UNUSABLE: list[Any] = [
+    "false",  # truthy
+    "no",  # truthy
+    "off",  # truthy
+    "0",  # truthy
+    "yes",
+    "True",
+    0,  # falsy, but never a declared spelling
+    1,
+    2.5,
+    math.nan,  # truthy
+    None,  # falsy
+    [],  # falsy
+    ["false"],
+    {},
+    object(),
+]
+
+#: Booleans every flag must keep honouring, including the numpy spellings a
+#: comparison produces.
+USABLE: list[Any] = [True, False, np.True_, np.False_, np.array(True), np.array(False)]
+
+
+class _NotFound(Exception):
+    """Stands in for ``iot.exceptions.ResourceNotFoundException``."""
+
+
+class _RecordingIot:
+    """Minimal AWS IoT stand-in that records everything it is asked to create."""
+
+    class _Exceptions:
+        ResourceNotFoundException = _NotFound
+
+    class _Meta:
+        region_name = "us-west-2"
+
+    exceptions = _Exceptions()
+    meta = _Meta()
+
+    def __init__(self) -> None:
+        self.created_things: list[str] = []
+        self.created_policies: dict[str, dict[str, Any]] = {}
+        self.attached_policies: list[str] = []
+        self.issued_certs = 0
+
+    def describe_thing(self, **_kw: Any) -> Any:
+        raise _NotFound()
+
+    def create_thing(self, thingName: str, **_kw: Any) -> dict[str, str]:  # noqa: N803 - boto3 casing
+        self.created_things.append(thingName)
+        return {"thingArn": f"arn:aws:iot:us-west-2:1:thing/{thingName}"}
+
+    def get_policy(self, **_kw: Any) -> Any:
+        raise _NotFound()
+
+    def create_policy(self, policyName: str, policyDocument: str, **_kw: Any) -> dict[str, str]:  # noqa: N803
+        self.created_policies[policyName] = json.loads(policyDocument)
+        return {"policyArn": f"arn:aws:iot:us-west-2:1:policy/{policyName}"}
+
+    def list_thing_principals(self, **_kw: Any) -> dict[str, list[str]]:
+        return {"principals": []}
+
+    def create_keys_and_certificate(self, **_kw: Any) -> dict[str, Any]:
+        self.issued_certs += 1
+        return {
+            "certificateArn": "arn:aws:iot:us-west-2:1:cert/abc",
+            "certificateId": "abc",
+            "certificatePem": "PEM",
+            "keyPair": {"PrivateKey": "KEY"},
+        }
+
+    def attach_policy(self, policyName: str, target: str) -> None:  # noqa: N803
+        self.attached_policies.append(policyName)
+
+    def attach_thing_principal(self, **_kw: Any) -> None:
+        return None
+
+    def describe_endpoint(self, **_kw: Any) -> dict[str, str]:
+        return {"endpointAddress": "x.iot.us-west-2.amazonaws.com"}
+
+    def touched(self) -> bool:
+        """True when any resource was created, attached or issued."""
+        return bool(self.created_things or self.created_policies or self.attached_policies or self.issued_certs)
+
+
+@pytest.fixture
+def iot(monkeypatch: pytest.MonkeyPatch) -> _RecordingIot:
+    """Wire a recording IoT client in and stub the pinned-CA download."""
+    client = _RecordingIot()
+
+    class _Boto3:
+        @staticmethod
+        def client(_name: str, region_name: str | None = None) -> _RecordingIot:
+            return client
+
+    monkeypatch.setattr(provision_mod, "_require_boto3", lambda: _Boto3())
+    monkeypatch.setattr(provision_mod, "_ensure_ca", lambda ca_path: ca_path.write_text("CA"))
+    return client
+
+
+def _provision(cert_dir: Path, **kwargs: Any) -> Any:
+    """Call ``provision_robot`` through one funnel.
+
+    Splatted so a deliberately off-type flag reaches the runtime guard as an
+    operator would supply it, rather than being reported by the type checker.
+    """
+    return provision_mod.provision_robot("probe-bot", cert_dir=cert_dir, **kwargs)
+
+
+def _bootstrap(**kwargs: Any) -> Any:
+    """Call ``bootstrap_account`` through one funnel, for the same reason."""
+    return bootstrap_mod.bootstrap_account(**kwargs)
+
+
+class TestTheDomain:
+    """``boolean_flag_error`` accepts a boolean and nothing else."""
+
+    @pytest.mark.parametrize("value", USABLE, ids=[repr(v) for v in USABLE])
+    def test_a_boolean_is_accepted(self, value: Any) -> None:
+        assert boolean_flag_error(value, "confirm", "ctx") is None
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=[repr(v)[:24] for v in UNUSABLE])
+    def test_a_non_boolean_is_refused(self, value: Any) -> None:
+        assert boolean_flag_error(value, "confirm", "ctx") is not None
+
+    def test_the_message_names_the_context_the_parameter_and_the_value(self) -> None:
+        msg = boolean_flag_error("false", "allow_estop_publish", "provision_robot")
+        assert msg is not None
+        assert msg.startswith("provision_robot: allow_estop_publish must be a boolean")
+        assert "'false'" in msg
+
+    def test_it_is_the_inverse_of_the_numeric_domains(self) -> None:
+        """A boolean is exactly what the numeric domains refuse and this requires."""
+        from strands_robots.utils import positive_finite_number_error
+
+        assert positive_finite_number_error(True, "hz", "ctx") is not None
+        assert boolean_flag_error(True, "confirm", "ctx") is None
+        assert positive_finite_number_error(1.5, "hz", "ctx") is None
+        assert boolean_flag_error(1.5, "confirm", "ctx") is not None
+
+
+class TestProvisionRobotHonoursBothPostures:
+    """The two declared spellings still select the two policies they always did."""
+
+    def test_true_grants_the_estop_publish_statement(self, iot: _RecordingIot, tmp_path: Path) -> None:
+        result = _provision(tmp_path, allow_estop_publish=True)
+
+        assert result.policy_name == provision_mod.ROBOT_POLICY_NAME
+        sids = [st.get("Sid") for st in iot.created_policies[result.policy_name]["Statement"]]
+        assert ESTOP_SID in sids
+        assert iot.attached_policies == [provision_mod.ROBOT_POLICY_NAME]
+
+    def test_false_withholds_the_estop_publish_statement(self, iot: _RecordingIot, tmp_path: Path) -> None:
+        result = _provision(tmp_path, allow_estop_publish=False)
+
+        assert result.policy_name == provision_mod.ROBOT_NO_ESTOP_POLICY_NAME
+        sids = [st.get("Sid") for st in iot.created_policies[result.policy_name]["Statement"]]
+        assert ESTOP_SID not in sids
+        assert iot.attached_policies == [provision_mod.ROBOT_NO_ESTOP_POLICY_NAME]
+
+    def test_the_default_is_the_grant_bearing_policy(self, iot: _RecordingIot, tmp_path: Path) -> None:
+        result = _provision(tmp_path)
+        assert result.policy_name == provision_mod.ROBOT_POLICY_NAME
+
+    @pytest.mark.parametrize("value", [np.False_, np.array(False)], ids=["np.False_", "np.array(False)"])
+    def test_a_numpy_false_selects_the_deny_posture_as_a_real_bool(
+        self, iot: _RecordingIot, tmp_path: Path, value: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The normalisation is load-bearing: ``_robot_policy_doc`` is annotated ``bool``."""
+        seen: list[Any] = []
+        real = provision_mod._robot_policy_doc
+
+        def _spy(*, allow_estop_publish: Any) -> Any:
+            seen.append(allow_estop_publish)
+            return real(allow_estop_publish=allow_estop_publish)
+
+        monkeypatch.setattr(provision_mod, "_robot_policy_doc", _spy)
+
+        result = _provision(tmp_path, allow_estop_publish=value)
+
+        assert result.policy_name == provision_mod.ROBOT_NO_ESTOP_POLICY_NAME
+        assert seen == [False]
+        assert type(seen[0]) is bool
+
+
+class TestProvisionRobotRefusesANonBooleanOptOut:
+    """A truthy spelling of *off* must not resolve to the grant-bearing policy."""
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=[repr(v)[:24] for v in UNUSABLE])
+    def test_it_is_refused(self, iot: _RecordingIot, tmp_path: Path, value: Any) -> None:
+        with pytest.raises(ValueError, match=r"allow_estop_publish must be a boolean"):
+            _provision(tmp_path, allow_estop_publish=value)
+
+    @pytest.mark.parametrize("value", ["false", "no", "off", "0"], ids=["false", "no", "off", "0"])
+    def test_the_refused_call_provisions_nothing(self, iot: _RecordingIot, tmp_path: Path, value: Any) -> None:
+        """No Thing, no policy, no certificate - the guard precedes every AWS call."""
+        with pytest.raises(ValueError):
+            _provision(tmp_path, allow_estop_publish=value)
+
+        assert not iot.touched()
+        assert list(tmp_path.glob("*.pem")) == []
+        assert list(tmp_path.glob("*.key")) == []
+
+    def test_the_refusal_does_not_need_boto3(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Placed ahead of the optional-dependency probe, so it reports the same either way."""
+
+        def _no_boto3() -> Any:
+            raise AssertionError("the refused call resolved boto3")
+
+        monkeypatch.setattr(provision_mod, "_require_boto3", _no_boto3)
+
+        with pytest.raises(ValueError, match=r"allow_estop_publish must be a boolean"):
+            _provision(tmp_path, allow_estop_publish="false")
+
+
+class TestBootstrapAccountRefusesANonBooleanFlag:
+    """The confirmation gate must read a real boolean, not a truthy string."""
+
+    @pytest.fixture(autouse=True)
+    def _no_aws(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _no_boto3() -> Any:
+            raise AssertionError("a refused call resolved boto3")
+
+        monkeypatch.setattr(bootstrap_mod, "_require_boto3", _no_boto3)
+
+    @pytest.mark.parametrize("flag", ["confirm", "dry_run", "force_update"])
+    @pytest.mark.parametrize("value", ["false", "no", 1, math.nan, None], ids=["false", "no", "1", "nan", "None"])
+    def test_each_flag_is_refused(self, flag: str, value: Any) -> None:
+        with pytest.raises(ValueError, match=rf"{flag} must be a boolean"):
+            _bootstrap(**{flag: value})
+
+    def test_a_truthy_confirm_no_longer_satisfies_the_gate(self) -> None:
+        """Pre-fix ``not confirm`` was False for ``"false"``, so the create path ran."""
+        with pytest.raises(ValueError, match=r"confirm must be a boolean"):
+            _bootstrap(confirm="false", dry_run=False)
+
+    def test_a_truthy_dry_run_is_refused_instead_of_silently_previewing(self) -> None:
+        """``dry_run="false"`` reads as a request to leave preview and stayed in it."""
+        with pytest.raises(ValueError, match=r"dry_run must be a boolean"):
+            _bootstrap(dry_run="false", confirm=False)
+
+    def test_the_documented_refusal_is_unchanged(self) -> None:
+        with pytest.raises(ValueError, match=r"creates persistent AWS resources"):
+            _bootstrap(confirm=False, dry_run=False)
+
+    def test_the_flag_check_precedes_the_gate(self) -> None:
+        """A bad flag reports the flag, not the gate, even when the gate would also fire."""
+        with pytest.raises(ValueError) as excinfo:
+            _bootstrap(confirm="false", dry_run="false")
+        assert "must be a boolean" in str(excinfo.value)
+        assert "creates persistent AWS resources" not in str(excinfo.value)
+
+
+class TestBootstrapAccountStillPreviews:
+    """The usable postures keep working, including the default dry run."""
+
+    def test_the_default_previews_without_creating(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        class _Sts:
+            class _Meta:
+                region_name = "us-west-2"
+
+            meta = _Meta()
+
+            def get_caller_identity(self) -> dict[str, str]:
+                return {"Account": "111122223333"}
+
+        class _Boto3:
+            @staticmethod
+            def client(name: str, region_name: str | None = None) -> Any:
+                if name == "sts":
+                    return _Sts()
+                raise AssertionError(f"the preview created a {name} client")
+
+        monkeypatch.setattr(bootstrap_mod, "_require_boto3", lambda: _Boto3())
+
+        _bootstrap()
+
+        # The preview writes to stderr (see the ``file=sys.stderr`` in bootstrap).
+        assert "[dry_run]" in capsys.readouterr().err
+
+
+class TestEveryPostureFlagRoutesThroughTheDomain:
+    """A future flag in this package cannot ship reading itself by truthiness."""
+
+    @staticmethod
+    def _flag_surfaces(src: str) -> dict[str, list[str]]:
+        """Public top-level functions in *src* mapped to their ``bool`` parameters."""
+        found: dict[str, list[str]] = {}
+        for node in ast.parse(src).body:
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            args = node.args
+            flags = [
+                a.arg
+                for a in (args.posonlyargs + args.args + args.kwonlyargs)
+                if a.annotation is not None and ast.unparse(a.annotation) == "bool"
+            ]
+            if flags:
+                found[node.name] = flags
+        return found
+
+    @staticmethod
+    def _calls_the_domain(src: str, name: str) -> bool:
+        fn = next(n for n in ast.parse(src).body if isinstance(n, ast.FunctionDef) and n.name == name)
+        return any(
+            isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "boolean_flag_error"
+            for n in ast.walk(fn)
+        )
+
+    @classmethod
+    def _package_sources(cls) -> dict[str, str]:
+        root = Path(inspect.getfile(provision_mod)).parent
+        return {p.name: p.read_text(encoding="utf-8") for p in sorted(root.glob("*.py"))}
+
+    def test_the_expected_surfaces_are_discovered(self) -> None:
+        """Non-vacuity: a scan root resolving elsewhere would report nothing."""
+        found = {
+            f"{name}::{fn}": flags
+            for name, src in self._package_sources().items()
+            for fn, flags in self._flag_surfaces(src).items()
+        }
+        assert found == {
+            "bootstrap.py::bootstrap_account": ["confirm", "dry_run", "force_update"],
+            "provision.py::provision_robot": ["allow_estop_publish"],
+        }
+
+    def test_no_surface_reads_a_posture_flag_by_truthiness(self) -> None:
+        adrift = {
+            f"{name}::{fn}": flags
+            for name, src in self._package_sources().items()
+            for fn, flags in self._flag_surfaces(src).items()
+            if not self._calls_the_domain(src, fn)
+        }
+        assert adrift == {}, f"public mesh.iot flags not routed through boolean_flag_error: {adrift}"
+
+    def test_the_scanner_detects_a_planted_surface(self) -> None:
+        """A guard that matched nothing would report a clean package either way."""
+        planted = "def provision_thing(*, replace_existing: bool = False) -> None:\n    return None\n"
+        assert self._flag_surfaces(planted) == {"provision_thing": ["replace_existing"]}
+        assert not self._calls_the_domain(planted, "provision_thing")
+
+
+class TestTheFlagIsDocumented:
+    """The opt-out is discoverable: a caller can look up that it takes a boolean."""
+
+    def test_provision_robot_documents_allow_estop_publish(self) -> None:
+        doc = inspect.getdoc(provision_mod.provision_robot) or ""
+        entries = re.search(r"^Args:\n(.*?)(?=\n\S|\Z)", doc, re.S | re.M)
+        assert entries is not None
+        assert "allow_estop_publish:" in entries.group(1)
+        assert "boolean" in entries.group(1)
+
+    def test_provision_robot_documents_the_refusal(self) -> None:
+        doc = inspect.getdoc(provision_mod.provision_robot) or ""
+        raises = re.search(r"^Raises:\n(.*?)(?=\n\S|\Z)", doc, re.S | re.M)
+        assert raises is not None
+        assert "ValueError" in raises.group(1)
+        assert "allow_estop_publish" in raises.group(1)


### PR DESCRIPTION
## Problem

`mesh.iot` has exactly two public entry points carrying `bool`-annotated flags, and
every one of those flags selects a **posture** rather than scaling a quantity. Each
was read by truthiness, so every non-boolean spelling of *off* — `"false"`, `"no"`,
`"off"`, `"0"`, all truthy — selected the permissive branch.

**`provision_robot(allow_estop_publish=...)` is a security opt-out that failed open.**
`False` swaps the robot certificate onto `strands-robot-no-estop`, identical to the
default policy but with the `AllowSafetyEstop` publish statement removed, for the case
the module's own comment calls the common one — *a robot that should obey fleet stops
but never issue one*. Measured against a recording IoT client:

| `allow_estop_publish=` | outcome | policy attached to the cert | grants estop |
|---|---|---|---|
| `True` | provisioned | `strands-robot` | yes (correct) |
| `False` | provisioned | `strands-robot-no-estop` | no (correct) |
| `"false"` | provisioned | `strands-robot` | **yes** |
| `"no"` | provisioned | `strands-robot` | **yes** |
| `"off"` | provisioned | `strands-robot` | **yes** |
| `"0"` | provisioned | `strands-robot` | **yes** |
| `1` | provisioned | `strands-robot` | **yes** |
| `math.nan` | provisioned | `strands-robot` | **yes** |

The operator believes they withheld the grant; the certificate can originate a
fleet-wide E-stop, and arm a Will on that topic. The attachment is durable — it
persists on the certificate until someone re-provisions. The flag also had no `Args:`
entry, so a caller could not look up that it takes a boolean at all.

**`bootstrap_account(confirm=...)` is the confirmation gate in front of an
account-wide create**, documented as *"Must be True to actually create resources"*
with `Raises: ValueError if confirm=False and dry_run=False`. `confirm="false"` left
`not confirm` False, so the gate passed and the create path ran. `dry_run="false"` is
the mirror image: the caller asked to leave preview mode, stayed in it, and was told
nothing.

| `bootstrap_account(...)` | main | this change |
|---|---|---|
| `confirm=True, dry_run=False` | account create path entered | unchanged |
| `confirm=False, dry_run=False` | the documented refusal | unchanged |
| `confirm="false", dry_run=False` | **account create path entered** | refused |
| `confirm="no", dry_run=False` | **account create path entered** | refused |
| `dry_run=True` (default) | preview | unchanged |
| `dry_run="false", confirm=False` | **previewed silently** | refused |

Nothing caught this: every existing test of the estop posture exercises the *private*
`_robot_policy_doc(allow_estop_publish=...)` with genuine booleans, so the public
flag was never driven with anything else.

## Change

All four flags — `allow_estop_publish`, `confirm`, `dry_run`, `force_update` — route
through one new `utils.boolean_flag_error` domain, built on the existing `is_boolean`
predicate. It is the inverse of the numeric domains in that module: those reject a
boolean because `bool` is an `int` subclass that would pass as a silent `1`, while
this one requires the boolean they turn away.

The check runs **before any AWS call and before `boto3` is even resolved**, so a
refused call leaves no Thing, no policy and no certificate behind, and it reports the
same way whether or not the optional dependency is installed. In
`bootstrap_account` it also precedes the confirmation gate, so that gate reads real
booleans and a bad flag reports the flag rather than the gate.

A flag arrives already typed, unlike an environment variable whose only shape is a
string, so it is **checked rather than parsed**. Parsing would only move which
spellings invert: `"on"`, `"enabled"` and `"y"` are absent from every such vocabulary
in this package, so each would resolve to the *restrictive* posture while reading as
an opt-in.

`allow_estop_publish` gains its missing `Args:` entry, and `Raises:` now names the
`ValueError` that both it and the pre-existing `thing_name` validation produce.

## Scope

- **`resolve_allow_insecure` is not a caller and is not folded in.** It resolves one
  setting from *two* sources, so its domain is `bool | None` (`None` is the documented
  spelling for *fall through to the environment variable*) and its refusal names that
  variable's own opt-in vocabulary. The new domain has one source and no such
  sentinel, so it refuses `None` too. The relationship is recorded in the new
  docstring so the two are not merged later by mistake.
- Numpy booleans, which a caller's own comparison produces, are accepted and
  normalised to the `bool` that `_robot_policy_doc` and `_ensure_estop_lambda` are
  annotated for.
- The private `_robot_policy_doc` and `_ensure_estop_lambda` keep no guard of their
  own: both receive an already-checked value.

## Tests

`tests/mesh/test_iot_provisioning_flag_domain.py`, 73 tests, no network and no AWS —
the fake IoT client *records* what it was asked to create, so "the refused call
provisioned nothing" and "the deny posture really omits the grant" are direct
observations rather than mock assertions.

- the domain accepts every boolean spelling (including `np.bool_` and a 0-d array) and
  refuses 15 others; the message names the context, the parameter and the value
- both declared postures still select their two policies, and the default is still the
  grant-bearing one
- a refused `provision_robot` leaves `touched() == False` and no `*.pem` / `*.key` on
  disk, and reports without resolving `boto3`
- `bootstrap_account` refuses each of its three flags, the flag check precedes the
  gate, the documented refusal is unchanged, and the default still previews
- a structural guard: every public function in `mesh/iot/` with a `bool` parameter
  must call the domain, with the discovered surface set pinned exactly (non-vacuity)
  and a planted-surface meta-test so a scanner that matched nothing cannot pass
- the `Args:` and `Raises:` entries are pinned, so the flag stays discoverable

Pre-fix (call sites reverted to the base, the new domain kept so the module still
imports): **43 failed / 30 passed** → **73 passed**. The 30 that pass pre-fix are the
over-reach controls — the unit domain, the two accepted postures, the unchanged
documented refusal, and the scanner metas.

## Gate

Base `4bc99a62`, head `93bf9573`. The gate below was measured at `00f81f9f`; the
only change since is the changelog fragment's filename (`2062-` -> `2063-`, to match
this PR's number), so no source or test line differs.

- `MUJOCO_GL=egl pytest tests` → **25632 passed, 257 skipped, 0 failed** (614s), zero
  existing-test churn
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` → clean
  (1132 files)
- `mypy strands_robots tests tests_integ` → `Success: no issues found in 1129 source files`
- `scripts/assemble_changelog.py --check` → OK; `scripts/check_merge_base_overlap.py` → no overlap

## Measured verdicts

Every cell below is read from two dumps of one script, run once in a worktree at the
base and once on this branch; the generator asserts each rendered number against them
and that the two runs resolved to different trees. Cells are coloured by whether the
outcome honours the flag's own declared posture, so an *accepted* value is green where
that is correct. Outcomes that do not: **9 of 14 → 0 of 14**.

![measured verdicts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/iot-provisioning-flag-boolean-domain/artifact.png)

This changes no policy, simulation, rendering, recording or asset behaviour, so the
artifact is a measured verdict table rather than a rollout. The capture and compose
scripts and both JSON dumps are alongside it.

