### PR TITLE
fix(simulation/isaac): hold the two STRANDS_ISAAC switches to a stated vocabulary instead of an open-ended falsy side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,8 +1080,8 @@ touches ROS 2.
 | `STRANDS_TRUST_REMOTE_CODE` | Set `1` to allow HF `trust_remote_code` for `lerobot_local` | unset |
 | `STRANDS_ROBOTS_NO_DYLD_SHIM` | Set `1` to disable the macOS auto-fix that puts Homebrew ffmpeg on the dyld path for torchcodec video streaming (see [Recording & streaming datasets](#recording--streaming-datasets)) | unset |
 | `MUJOCO_GL` | MuJoCo GL backend (`egl`, `osmesa`, `glfw`) | auto |
-| `STRANDS_ISAAC_HEADLESS` | Isaac Sim backend: run without a GUI (`true`/`1`/`yes` = headless). Overrides `IsaacConfig(headless=...)` | unset (config default `true`) |
-| `STRANDS_ISAAC_RTX_PATHTRACING` | Isaac Sim backend: set `true`/`1`/`yes` to enable RTX path-tracing (photorealistic, slow) instead of the default render mode | unset |
+| `STRANDS_ISAAC_HEADLESS` | Isaac Sim backend: run without a GUI. On (`1`/`true`/`yes`/`on`) = headless, off (`0`/`false`/`no`/`off`) = windowed, any other spelling is refused. Overrides `IsaacConfig(headless=...)` ([#2062](https://github.com/strands-labs/robots/issues/2062)) | unset (config default `true`) |
+| `STRANDS_ISAAC_RTX_PATHTRACING` | Isaac Sim backend: on (`1`/`true`/`yes`/`on`) enables RTX path-tracing (photorealistic, slow) instead of the default render mode; off leaves the render mode alone, any other spelling is refused | unset |
 | `STRANDS_ISAAC_NUCLEUS_URL` | Isaac Sim backend: override the Omniverse Nucleus asset-server URL | unset (Isaac default) |
 | `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
 | `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |
@@ -1131,14 +1131,19 @@ touches ROS 2.
 
 These are read by the built-in, in-tree Isaac Sim backend
 (`pip install 'strands-robots[sim-isaac]'`) when it builds its
-`IsaacConfig`; an explicit `create_simulation("isaac", ...)` kwarg always wins.
-See [`docs/simulation/isaac.md`](docs/simulation/isaac.md).
+`IsaacConfig`. An explicit `create_simulation("isaac", ...)` kwarg wins for
+`nucleus_url`; the two switches override their field whenever they are set
+([#2062](https://github.com/strands-labs/robots/issues/2062)). Both switches
+accept `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off` (case-insensitive,
+surrounding whitespace ignored); unset or empty leaves the field alone and any
+other spelling is refused. See
+[`docs/simulation/isaac.md`](docs/simulation/isaac.md).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `STRANDS_ISAAC_NUCLEUS_URL` | Override the Omniverse Nucleus server URL (when `nucleus_url` is not passed) | unset (Isaac defaults) |
-| `STRANDS_ISAAC_HEADLESS` | Truthy (`1`/`true`/`yes`) forces headless; falsy forces a window | unset (uses `headless` kwarg) |
-| `STRANDS_ISAAC_RTX_PATHTRACING` | Truthy forces `render_mode="rtx_pathtracing"` | unset |
+| `STRANDS_ISAAC_HEADLESS` | On forces headless; off forces a window | unset (uses `headless` kwarg) |
+| `STRANDS_ISAAC_RTX_PATHTRACING` | On forces `render_mode="rtx_pathtracing"`; off leaves `render_mode` alone | unset |
 
 </details>
 

--- a/changelog.d/2064-isaac-env-switch-vocabulary.md
+++ b/changelog.d/2064-isaac-env-switch-vocabulary.md
@@ -1,0 +1,27 @@
+### Fixed: an unrecognized `STRANDS_ISAAC_*` switch value is refused rather than read as off
+
+`STRANDS_ISAAC_HEADLESS` and `STRANDS_ISAAC_RTX_PATHTRACING` are documented as
+two-sided switches -- "Truthy (`1`/`true`/`yes`) forces headless; falsy forces a
+window" -- but only the truthy side was enumerated, and "falsy" was implemented
+as everything else. A spelling that means *on* therefore selected *off*:
+`STRANDS_ISAAC_HEADLESS=on` and `=enabled` both opened a window, so did a
+leading space or a trailing newline (the read had no `.strip()`), and so did a
+set-but-empty value -- which is what an undefined `${{ vars.* }}` interpolation
+in a GitHub Actions `env:` block produces. 9 of 17 measured spellings forced a
+window without meaning off, on the one flag whose purpose is to keep Isaac Sim
+off a display. The neighbouring pathtracing read differed on the same input: it
+silently ignored an unrecognized spelling rather than inverting on it.
+
+Both reads now go through one reader over four symmetric pairs -- `1`/`0`,
+`true`/`false`, `yes`/`no`, `on`/`off` -- case-insensitive and
+whitespace-stripped. Unset or empty means absent and keeps the `IsaacConfig`
+field. Any other spelling raises `ValueError` naming both vocabularies and the
+reason it refuses instead of choosing a side. Adding `on`/`off` is what keeps
+every spelling that already resolved correctly working while the inverting ones
+stop; closing the off side is unavoidable, because while any unlisted spelling
+reads as off, every spelling that means on reads as off too.
+
+Precedence is unchanged: the environment still outranks the field for these two
+switches while the sibling `STRANDS_ISAAC_NUCLEUS_URL` is the other way round.
+That contradiction is documented three times and implemented twice, and is
+tracked as a contract decision in #2062 rather than settled here.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -156,13 +156,32 @@ rejected eagerly. The commonly used fields:
 ### Environment variables
 
 The Isaac backend reads three `STRANDS_ISAAC_*` variables (resolved when
-`IsaacConfig` is constructed). An explicit kwarg always wins over the env var.
+`IsaacConfig` is constructed). `STRANDS_ISAAC_NUCLEUS_URL` is read only when
+`nucleus_url` is not passed, so there the kwarg wins; the two switches override
+their field whenever they are set. Which of those two directions the switches
+*should* have is [#2062](https://github.com/strands-labs/robots/issues/2062).
+
+Both switches accept four symmetric pairs, case-insensitively and ignoring
+surrounding whitespace:
+
+| on | off |
+|----|-----|
+| `1` | `0` |
+| `true` | `false` |
+| `yes` | `no` |
+| `on` | `off` |
+
+Unset -- or set to an empty value, which is what an undefined `${{ vars.* }}`
+interpolation in a GitHub Actions `env:` block produces -- leaves the field
+alone. Any other spelling raises `ValueError` naming both vocabularies, rather
+than falling through to the off side: `STRANDS_ISAAC_HEADLESS=enabled` used to
+open a window.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `STRANDS_ISAAC_NUCLEUS_URL` | Override the Omniverse Nucleus server URL when `nucleus_url` is not passed | unset (Isaac defaults) |
-| `STRANDS_ISAAC_HEADLESS` | Truthy (`1`/`true`/`yes`) forces `headless`; falsy forces windowed | unset (uses `headless` kwarg) |
-| `STRANDS_ISAAC_RTX_PATHTRACING` | Truthy forces `render_mode="rtx_pathtracing"` | unset |
+| `STRANDS_ISAAC_HEADLESS` | On forces `headless`; off forces windowed | unset (uses `headless` kwarg) |
+| `STRANDS_ISAAC_RTX_PATHTRACING` | On forces `render_mode="rtx_pathtracing"`; off leaves `render_mode` alone | unset |
 
 ## Capabilities and parity
 

--- a/strands_robots/simulation/isaac/config.py
+++ b/strands_robots/simulation/isaac/config.py
@@ -16,6 +16,78 @@ RENDER_MODES = ("headless", "rtx_realtime", "rtx_pathtracing")
 # Supported physics solvers in Isaac Sim
 PHYSICS_SOLVERS = ("physx_gpu", "physx_cpu")
 
+# Spellings ``STRANDS_ISAAC_HEADLESS`` and ``STRANDS_ISAAC_RTX_PATHTRACING``
+# accept. Both are documented as two-sided switches -- "truthy forces headless;
+# falsy forces windowed" -- so both sides are enumerated, as four symmetric
+# pairs, rather than only the opt-in one. The pairing is the point: with a
+# truthy list and an open-ended falsy side, ``on`` and ``off`` both resolved to
+# off, so the pair contradicted itself and the truthy side leaked into the falsy
+# one. ``y``/``n`` and ``t``/``f`` are deliberately absent -- no measured caller
+# sets them, and each addition widens a contract that is now total.
+#
+# Kept local to this module per AGENTS.md Key Convention 11: the two callers are
+# in this file, and the one existing shared reader,
+# ``simulation.safe_output.env_flag``, answers a different question (see
+# ``_env_switch``).
+ENV_SWITCH_ON = ("1", "true", "yes", "on")
+ENV_SWITCH_OFF = ("0", "false", "no", "off")
+
+
+def _env_switch(name: str) -> bool | None:
+    """Read environment variable ``name`` as a two-sided on/off switch.
+
+    Args:
+        name: Environment variable to read.
+
+    Returns:
+        ``True`` for :data:`ENV_SWITCH_ON`, ``False`` for
+        :data:`ENV_SWITCH_OFF` (case-insensitive, surrounding whitespace
+        ignored), and ``None`` when the variable is unset or set to an empty
+        value -- the shell's spelling of absent, which an undefined
+        ``${{ vars.* }}`` interpolation in a GitHub Actions ``env:`` block also
+        produces. ``None`` means the corresponding :class:`IsaacConfig` field
+        is left as the caller set it.
+
+    Raises:
+        ValueError: ``name`` is set to any other spelling. Resolving an
+            unrecognized spelling to a side would be a silent default on a
+            value the caller got wrong (Key Convention 6), and the side it
+            silently took was "off": read that way,
+            ``STRANDS_ISAAC_HEADLESS=on`` opens a window on a runner that has
+            no display, which is the outcome the variable exists to prevent.
+
+            Narrowing the off side is the unavoidable half of this trade. While
+            any unlisted spelling resolves to off, every spelling that means on
+            resolves to off too, so the truthy side cannot be made whole
+            without closing the falsy one. Refusing is what makes that visible
+            instead of silent, and it is self-clearing: the message names both
+            vocabularies and the variable is re-read on the next construction.
+
+    ``safe_output.env_flag`` is deliberately not reused. It is documented as a
+    one-sided opt-in and returns ``bool``, so it collapses "set to off" and
+    "unset" into the same answer. That is correct for an ``ALLOW_ABS``-style
+    flag, whose only job is to grant a permission, and wrong here: these two
+    variables must be able to force the non-default side, so they need the
+    third outcome ``None`` that a ``bool`` cannot carry.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if not value:
+        return None
+    if value in ENV_SWITCH_ON:
+        return True
+    if value in ENV_SWITCH_OFF:
+        return False
+    raise ValueError(
+        f"{name}={raw!r} is not a recognized switch value. Use one of {ENV_SWITCH_ON} "
+        f"to turn it on or one of {ENV_SWITCH_OFF} to turn it off (case-insensitive); "
+        f"leave it unset or empty to keep the value the IsaacConfig field already has. "
+        f"It is refused rather than read as off because an unrecognized spelling is as "
+        f"likely to mean on -- {name}=on would otherwise resolve to off."
+    )
+
 
 @dataclass
 class IsaacConfig:
@@ -30,6 +102,10 @@ class IsaacConfig:
         CUDA device string. ``"cuda:0"`` (default) or ``"cuda:N"``.
     headless : bool
         Run without GUI. Default True (required for cloud/CI runners).
+        ``STRANDS_ISAAC_HEADLESS`` overrides this field when set: one of
+        ``("1", "true", "yes", "on")`` forces headless, one of
+        ``("0", "false", "no", "off")`` forces windowed, empty or unset leaves
+        the field alone, and any other spelling is refused.
     physics_dt : float
         Physics timestep in seconds. Default 1/120 s.
     rendering_dt : float
@@ -38,6 +114,10 @@ class IsaacConfig:
         Rendering pipeline: ``"headless"`` (no rendering),
         ``"rtx_realtime"`` (fast, rasterization-based),
         ``"rtx_pathtracing"`` (slow, photorealistic). Default ``"headless"``.
+        ``STRANDS_ISAAC_RTX_PATHTRACING`` set to one of
+        ``("1", "true", "yes", "on")`` overrides this field with
+        ``"rtx_pathtracing"``; one of ``("0", "false", "no", "off")``, empty or
+        unset leaves the field alone, and any other spelling is refused.
     gravity : tuple[float, float, float]
         Gravity vector. Default (0.0, 0.0, -9.81) (Z-up convention).
     ground_plane : bool
@@ -105,14 +185,15 @@ class IsaacConfig:
         if self.nucleus_url is None:
             self.nucleus_url = os.environ.get("STRANDS_ISAAC_NUCLEUS_URL")
 
-        # Resolve headless from environment if env says otherwise
-        headless_env = os.environ.get("STRANDS_ISAAC_HEADLESS")
+        # Resolve headless from environment, which outranks the field when set
+        headless_env = _env_switch("STRANDS_ISAAC_HEADLESS")
         if headless_env is not None:
-            self.headless = headless_env.lower() in ("true", "1", "yes")
+            self.headless = headless_env
 
-        # Resolve RTX pathtracing from environment
-        rtx_env = os.environ.get("STRANDS_ISAAC_RTX_PATHTRACING")
-        if rtx_env is not None and rtx_env.lower() in ("true", "1", "yes"):
+        # Resolve RTX pathtracing from environment. Only the on side acts: this
+        # switch names one mode, so its off side is "do not force it" rather
+        # than a second mode to select, and it leaves render_mode alone.
+        if _env_switch("STRANDS_ISAAC_RTX_PATHTRACING"):
             self.render_mode = "rtx_pathtracing"
 
     @classmethod

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -17,8 +17,11 @@ Thread safety:
     - ``step()`` must not run concurrently with ``add_robot()``
 
 Environment variables:
-    - STRANDS_ISAAC_HEADLESS: Override headless mode (true/false)
-    - STRANDS_ISAAC_RTX_PATHTRACING: Enable RTX pathtracing (true/false)
+    - STRANDS_ISAAC_HEADLESS: Override headless mode. On (1/true/yes/on) forces
+      headless, off (0/false/no/off) forces windowed, unset or empty keeps the
+      ``IsaacConfig`` field, and any other spelling is refused
+    - STRANDS_ISAAC_RTX_PATHTRACING: Enable RTX pathtracing, same vocabulary;
+      its off side leaves ``render_mode`` alone rather than selecting a mode
     - STRANDS_ISAAC_NUCLEUS_URL: Override Nucleus asset server URL
 """
 

--- a/tests/simulation/isaac/test_isaac_env_switch_domain.py
+++ b/tests/simulation/isaac/test_isaac_env_switch_domain.py
@@ -1,0 +1,311 @@
+"""The two ``IsaacConfig`` boolean environment switches are held to one vocabulary.
+
+``STRANDS_ISAAC_HEADLESS`` and ``STRANDS_ISAAC_RTX_PATHTRACING`` are both
+documented as two-sided switches -- ``docs/simulation/isaac.md`` and the README
+each say "Truthy (``1``/``true``/``yes``) forces headless; falsy forces a
+window" -- but only the truthy side was enumerated. Everything else fell through
+to the falsy branch, so a spelling that means *on* forced the outcome the
+variable exists to prevent:
+
+===========================  ====================  ====================
+``STRANDS_ISAAC_HEADLESS``   before                after
+===========================  ====================  ====================
+``"on"``                     windowed             headless
+``"enabled"``                windowed             refused
+``" true"`` (whitespace)     windowed             headless
+``""`` (set but empty)       windowed             the field is kept
+``"false"`` / ``"0"``        windowed             windowed
+``"true"`` / ``"1"``         headless             headless
+===========================  ====================  ====================
+
+The headline test is stated over spellings rather than over types: no spelling
+that a reader would call *on* may resolve to *off*. It may be refused -- an
+unrecognized spelling is not a documented side -- but it must never silently
+land on the opposite side of the switch it names.
+
+Solver-free: every assertion here constructs an ``IsaacConfig`` only, which
+runs before Isaac Sim's ``SimulationApp`` exists and needs no ``isaacsim``.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_isaac_env(monkeypatch):
+    """Neither switch may be inherited from the runner that runs these tests."""
+    monkeypatch.delenv("STRANDS_ISAAC_HEADLESS", raising=False)
+    monkeypatch.delenv("STRANDS_ISAAC_RTX_PATHTRACING", raising=False)
+
+
+def _config(**kwargs):
+    from strands_robots.simulation.isaac.config import IsaacConfig
+
+    return IsaacConfig(**kwargs)
+
+
+def _vocabularies():
+    from strands_robots.simulation.isaac.config import ENV_SWITCH_OFF, ENV_SWITCH_ON
+
+    return ENV_SWITCH_ON, ENV_SWITCH_OFF
+
+
+# Spellings a reader would call "on" that are in neither documented vocabulary.
+# Each one resolved to windowed before this change.
+UNLISTED_ON_SPELLINGS = ("enabled", "y", "t", "Y", "yeah", "affirmative", "2")
+
+# Spellings that carry no side at all. These were windowed too.
+UNLISTED_MEANINGLESS_SPELLINGS = ("maybe", "banana", "-1", "None", "null")
+
+
+class TestTheDocumentedVocabularyResolves:
+    """Each listed spelling selects the side it names, on both switches."""
+
+    def test_every_on_spelling_forces_headless(self, monkeypatch):
+        on, _ = _vocabularies()
+        for spelling in on:
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            assert _config(headless=False).headless is True, spelling
+
+    def test_every_off_spelling_forces_windowed(self, monkeypatch):
+        _, off = _vocabularies()
+        for spelling in off:
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            assert _config(headless=True).headless is False, spelling
+
+    def test_the_two_vocabularies_are_symmetric_pairs(self):
+        """The defect was an enumerated on side against an open-ended off side."""
+        on, off = _vocabularies()
+        assert len(on) == len(off)
+        assert set(on).isdisjoint(off)
+        assert ("on" in on) and ("off" in off)
+
+    def test_case_is_ignored_on_both_sides(self, monkeypatch):
+        for spelling, expected in (("TRUE", True), ("On", True), ("FALSE", False), ("Off", False)):
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            assert _config().headless is expected, spelling
+
+    def test_surrounding_whitespace_is_ignored(self, monkeypatch):
+        """A trailing newline is what a heredoc or a file-sourced value carries."""
+        for spelling in (" true", "true\n", "\ttrue\t", " 1 "):
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            assert _config(headless=False).headless is True, spelling
+
+    def test_the_resolved_value_is_a_real_bool(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "yes")
+        assert _config().headless is True
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "no")
+        assert _config().headless is False
+
+
+class TestNoSpellingThatMeansOnResolvesToOff:
+    """The headline property, stated over spellings rather than over types."""
+
+    def test_an_unlisted_on_spelling_is_never_read_as_off(self, monkeypatch):
+        for spelling in UNLISTED_ON_SPELLINGS:
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            with pytest.raises(ValueError, match="not a recognized switch value"):
+                _config()
+
+    def test_a_meaningless_spelling_is_never_read_as_off(self, monkeypatch):
+        for spelling in UNLISTED_MEANINGLESS_SPELLINGS:
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            with pytest.raises(ValueError, match="not a recognized switch value"):
+                _config()
+
+    def test_both_parties_asking_for_headless_cannot_produce_a_window(self, monkeypatch):
+        """The measured worst case: a caller passing headless=True plus an operator
+        setting the switch to an opt-in spelling resolved to a window."""
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "on")
+        assert _config(headless=True).headless is True
+
+    def test_the_off_side_stayed_intact_for_every_spelling_it_already_had(self, monkeypatch):
+        """Closing the off side is the cost of making the on side whole, so the
+        spellings that already meant off must keep meaning off rather than start
+        raising."""
+        for spelling in ("false", "0", "no", "off"):
+            monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", spelling)
+            assert _config().headless is False, spelling
+
+
+class TestAnEmptyValueIsAbsentRatherThanOff:
+    """A set-but-empty variable is the shell's spelling of unset."""
+
+    def test_an_empty_value_keeps_the_field(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "")
+        assert _config().headless is True
+        assert _config(headless=False).headless is False
+
+    def test_a_whitespace_only_value_keeps_the_field(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "   ")
+        assert _config(headless=False).headless is False
+
+    def test_an_unset_variable_keeps_the_field(self):
+        assert _config().headless is True
+        assert _config(headless=False).headless is False
+
+    def test_an_empty_value_does_not_force_pathtracing(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", "")
+        assert _config(render_mode="rtx_realtime").render_mode == "rtx_realtime"
+
+
+class TestTheRefusalNamesBothVocabularies:
+    """A refusal a caller cannot act on is a different defect."""
+
+    def test_the_message_names_the_variable_and_the_value(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "enabled")
+        with pytest.raises(ValueError) as excinfo:
+            _config()
+        message = str(excinfo.value)
+        assert "STRANDS_ISAAC_HEADLESS" in message
+        assert "'enabled'" in message
+
+    def test_the_message_lists_both_sides(self, monkeypatch):
+        on, off = _vocabularies()
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "maybe")
+        with pytest.raises(ValueError) as excinfo:
+            _config()
+        message = str(excinfo.value)
+        for spelling in on + off:
+            assert repr(spelling) in message, spelling
+
+    def test_the_message_says_empty_and_unset_keep_the_field(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "maybe")
+        with pytest.raises(ValueError) as excinfo:
+            _config()
+        assert "unset or empty" in str(excinfo.value)
+
+    def test_the_message_states_why_it_refuses_instead_of_reading_off(self, monkeypatch):
+        """Without the reason, refusing looks stricter than the alternative
+        rather than the only reading that is not a silent inversion."""
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "maybe")
+        with pytest.raises(ValueError) as excinfo:
+            _config()
+        assert "would otherwise resolve to off" in str(excinfo.value)
+
+    def test_the_refusal_names_the_pathtracing_variable_when_that_is_the_one_set(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", "enabled")
+        with pytest.raises(ValueError) as excinfo:
+            _config()
+        assert "STRANDS_ISAAC_RTX_PATHTRACING" in str(excinfo.value)
+        assert "STRANDS_ISAAC_HEADLESS" not in str(excinfo.value)
+
+
+class TestThePathtracingSwitchIsHeldToTheSameVocabulary:
+    """The neighbouring read did not invert, but it did silently ignore."""
+
+    def test_an_on_spelling_forces_pathtracing(self, monkeypatch):
+        on, _ = _vocabularies()
+        for spelling in on:
+            monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", spelling)
+            assert _config().render_mode == "rtx_pathtracing", spelling
+
+    def test_an_off_spelling_leaves_the_render_mode_alone(self, monkeypatch):
+        """This switch names one mode, so its off side is "do not force it"
+        rather than a second mode to select."""
+        _, off = _vocabularies()
+        for spelling in off:
+            monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", spelling)
+            assert _config(render_mode="rtx_realtime").render_mode == "rtx_realtime", spelling
+            assert _config().render_mode == "headless", spelling
+
+    def test_an_unlisted_spelling_is_refused_rather_than_ignored(self, monkeypatch):
+        for spelling in UNLISTED_ON_SPELLINGS + UNLISTED_MEANINGLESS_SPELLINGS:
+            monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", spelling)
+            with pytest.raises(ValueError, match="not a recognized switch value"):
+                _config()
+
+    def test_both_switches_can_be_set_together(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "off")
+        monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", "on")
+        config = _config()
+        assert config.headless is False
+        assert config.render_mode == "rtx_pathtracing"
+
+
+class TestTheSharedOptInReaderWasNotReusedForAMeasuredReason:
+    """Measured rather than asserted, so the choice stays checkable."""
+
+    def test_env_flag_cannot_express_the_third_outcome(self, monkeypatch):
+        """``safe_output.env_flag`` returns ``bool``, so "set to off" and
+        "unset" are the same answer -- which is why it cannot back a switch
+        that has to force the non-default side."""
+        from strands_robots.simulation.safe_output import env_flag
+
+        monkeypatch.delenv("A_SWITCH", raising=False)
+        assert env_flag("A_SWITCH") is False
+        monkeypatch.setenv("A_SWITCH", "false")
+        assert env_flag("A_SWITCH") is False
+
+    def test_env_switch_distinguishes_the_three_outcomes(self, monkeypatch):
+        from strands_robots.simulation.isaac.config import _env_switch
+
+        monkeypatch.delenv("A_SWITCH", raising=False)
+        assert _env_switch("A_SWITCH") is None
+        monkeypatch.setenv("A_SWITCH", "false")
+        assert _env_switch("A_SWITCH") is False
+        monkeypatch.setenv("A_SWITCH", "true")
+        assert _env_switch("A_SWITCH") is True
+
+    def test_env_flag_keeps_its_one_sided_contract(self, monkeypatch):
+        """The opt-in reader is not widened by this change: an unrecognized
+        spelling there still means "not opted in" and raises nothing, because a
+        permission grant has no off side to confuse it with."""
+        from strands_robots.simulation.safe_output import env_flag
+
+        monkeypatch.setenv("A_SWITCH", "enabled")
+        assert env_flag("A_SWITCH") is False
+
+
+class TestNeighbouringSurfacesStayOutOfScope:
+    """Boundary pins. Replace rather than delete these if the scope moves."""
+
+    def test_the_environment_still_outranks_the_field(self, monkeypatch):
+        """Precedence is untouched here. ``docs/simulation/isaac.md`` says an
+        explicit kwarg always wins while the README also says this variable
+        overrides ``IsaacConfig(headless=...)``, and the two cannot both hold --
+        that contradiction is a contract decision, not this vocabulary defect."""
+        monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "false")
+        assert _config(headless=True).headless is False
+
+    def test_the_sibling_url_variable_keeps_the_opposite_precedence(self, monkeypatch):
+        """Same function, other direction: the field wins for ``nucleus_url``.
+        Pinned so the contradiction cannot be resolved by accident."""
+        monkeypatch.setenv("STRANDS_ISAAC_NUCLEUS_URL", "omniverse://from-env")
+        assert _config().nucleus_url == "omniverse://from-env"
+        assert _config(nucleus_url="omniverse://explicit").nucleus_url == "omniverse://explicit"
+
+    def test_the_headless_field_itself_is_not_type_checked(self):
+        """A non-bool passed directly is still accepted. That is the argument
+        domain rather than the environment vocabulary, and it is a separate
+        change."""
+        assert _config(headless="false").headless == "false"
+
+
+class TestNoIsaacEnvSwitchSurfaceDrifts:
+    """A new switch in this module cannot skip the shared reader."""
+
+    def _source(self):
+        from pathlib import Path
+
+        from strands_robots.simulation.isaac import config
+
+        return Path(config.__file__).read_text(encoding="utf-8")
+
+    def test_every_isaac_switch_is_read_through_env_switch(self):
+        source = self._source()
+        assert source.count('_env_switch("STRANDS_ISAAC_') == 2
+
+    def test_only_the_url_variable_is_read_directly(self):
+        """``nucleus_url`` is a string rather than a switch, so it is the one
+        legitimate direct read. Any other would be a switch bypassing the
+        vocabulary."""
+        source = self._source()
+        direct = [line.strip() for line in source.splitlines() if 'os.environ.get("STRANDS_ISAAC' in line]
+        assert direct == ['self.nucleus_url = os.environ.get("STRANDS_ISAAC_NUCLEUS_URL")']
+
+    def test_no_inline_truthiness_vocabulary_survives(self):
+        """The defect's shape was an inline truthy list. One is left, inside the
+        reader, expressed as the two named vocabularies rather than a literal."""
+        source = self._source()
+        assert '.lower() in ("true"' not in source
+        assert '.lower() in ("1"' not in source


### PR DESCRIPTION
## The defect

`STRANDS_ISAAC_HEADLESS` and `STRANDS_ISAAC_RTX_PATHTRACING` are documented as **two-sided** switches. `docs/simulation/isaac.md` and the README each say:

> Truthy (`1`/`true`/`yes`) forces headless; **falsy forces a window**

Only the truthy side was ever enumerated. "Falsy" was implemented as *everything that is not truthy*:

```python
headless_env = os.environ.get("STRANDS_ISAAC_HEADLESS")
if headless_env is not None:
    self.headless = headless_env.lower() in ("true", "1", "yes")
```

So a spelling that means **on** selected **off**. Measured on `4bc99a6`, one `IsaacConfig()` per cell:

| `STRANDS_ISAAC_HEADLESS` | resolved to | a reader would call it |
|---|---|---|
| `"true"` / `"TRUE"` / `"1"` / `"yes"` | headless | on - correct |
| `"false"` / `"no"` / `"0"` / `"off"` | windowed | off - correct |
| **`"on"`** | **windowed** | on |
| **`"enabled"`** | **windowed** | on |
| **`"y"`** / **`"t"`** | **windowed** | on |
| **`" true"`** (leading space) | **windowed** | on |
| **`"true\n"`** (trailing newline) | **windowed** | on |
| **`""`** (set but empty) | **windowed** | absent |
| **`"  "`** (whitespace only) | **windowed** | absent |
| `"maybe"` | windowed | neither |

**9 of 17 measured spellings forced a window without meaning off**, and the flag whose entire purpose is to keep Isaac Sim off a display is the one that inverts. Two of those rows are not typos at all:

- `" true"` / `"true\n"` - the read is `.lower()` with no `.strip()`, unlike `robot.py`, `safe_output.py`, `_zenoh_config.py`, `ros_telemetry.py`, `reachy_transport.py` and `mujoco/backend.py`, which all `.strip().lower()`. A value sourced from a file or a heredoc carries the newline.
- `""` - a **set-but-empty** variable, which is exactly what an undefined `${{ vars.* }}` interpolation in a GitHub Actions `env:` block produces. `os.environ.get(...) is not None` is true for it, so the empty string was read as a decision rather than as absence, and it decided *windowed* on a runner with no display.

End to end, with a caller who explicitly asked for headless:

```
STRANDS_ISAAC_HEADLESS=on  python -c "...IsaacConfig(headless=True).headless"
  -> False
```

Both parties asked for headless. The result was a window.

### The neighbouring read disagreed on the same input

Three lines below, `STRANDS_ISAAC_RTX_PATHTRACING` is guarded differently:

```python
if rtx_env is not None and rtx_env.lower() in ("true", "1", "yes"):
```

Because the truthiness test gates the *assignment* rather than producing the value, an unrecognized spelling there **silently does nothing** instead of inverting. So one function contained two boolean environment reads that disagreed about what an unrecognized spelling means - one inverted, one ignored - and neither refused.

## Why it was invisible

The two existing tests pass a spelling from the enumerated side of each switch:

```python
monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "false")
assert IsaacConfig().headless is False
monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "1")
assert IsaacConfig().headless is True
```

`"false"` is the one falsy spelling that a truthy-list-plus-fallthrough gets right *by construction*, so it cannot distinguish "the off side is enumerated" from "the off side is whatever is left". A green suite could not see the two sides disagree.

## The change

One reader, `_env_switch(name) -> bool | None`, used by both switches. Four **symmetric pairs**, case-insensitive, whitespace-stripped:

| on | off |
|----|-----|
| `1` | `0` |
| `true` | `false` |
| `yes` | `no` |
| `on` | `off` |

Empty or unset returns `None`, meaning absent, and the `IsaacConfig` field is kept. Anything else raises `ValueError`:

```
STRANDS_ISAAC_HEADLESS='on' is not a recognized switch value. Use one of
('1', 'true', 'yes', 'on') to turn it on or one of ('0', 'false', 'no', 'off') to
turn it off (case-insensitive); leave it unset or empty to keep the value the
IsaacConfig field already has. It is refused rather than read as off because an
unrecognized spelling is as likely to mean on -- STRANDS_ISAAC_HEADLESS=on would
otherwise resolve to off.
```

The symmetry is the load-bearing part. `on` and `off` previously **both** resolved to off, so the pair contradicted itself; adding `on`/`off` to the vocabularies is what makes each spelling that currently works keep working while the inverting ones stop. `y`/`n` and `t`/`f` are deliberately absent - no measured caller sets them.

**Narrowing the off side is the unavoidable half of this trade, and it is stated rather than glossed.** While any unlisted spelling resolves to off, every spelling that means *on* resolves to off too - the truthy side cannot be made whole without closing the falsy one. Refusing is what makes that visible instead of silent, and it is self-clearing: the message names both vocabularies and the variable is re-read on the next construction.

The guard runs inside `__post_init__`, so a refused switch constructs no `IsaacConfig` and therefore reaches no `SimulationApp`.

### Rejected alternative: reuse `safe_output.env_flag`

There is already a shared env-boolean reader, and it was measured rather than assumed unsuitable. `env_flag` is documented as a one-sided **opt-in** and returns `bool`, so `"false"` and unset are the same answer:

```python
assert env_flag("A_SWITCH") is False   # unset
monkeypatch.setenv("A_SWITCH", "false")
assert env_flag("A_SWITCH") is False   # set to off
```

That is correct for an `ALLOW_ABS`-style permission grant, whose only job is to grant, and wrong here: these two switches must be able to force the **non-default** side, so they need a third outcome a `bool` cannot carry. `TestTheSharedOptInReaderWasNotReusedForAMeasuredReason` pins both halves, including that `env_flag`'s own one-sided contract is **not** widened by this change.

### Why the reader is local

Per AGENTS.md Key Convention 11: two callers, both in this file. The other ten boolean environment reads in the tree carry a *documented one-sided* vocabulary (`device_connect` states "anything else is secure"), so lifting this into `utils.py` would change their contracts, not share a name. That is a separate decision and nothing here touches them.

## Explicitly not in scope: precedence

While measuring this I found that `IsaacConfig.__post_init__` implements **two** precedence directions in nine consecutive lines - the field wins for `nucleus_url`, the environment wins for both switches - and that three documentation statements cover those lines without agreeing. Filed as **#2062** with the measurements, because it is a contract decision rather than a defect, and it is the kind that has to be settled before code.

This change leaves precedence byte-identical and **pins it**, in `TestNeighbouringSurfacesStayOutOfScope`, so #2062 cannot be closed by accident:

```python
def test_the_environment_still_outranks_the_field(self, monkeypatch): ...
def test_the_sibling_url_variable_keeps_the_opposite_precedence(self, monkeypatch): ...
def test_the_headless_field_itself_is_not_type_checked(self): ...
```

Those are premise tests: replace rather than delete them when #2062 lands.

## Tests

`tests/simulation/isaac/test_isaac_env_switch_domain.py`, **32 tests, zero existing tests changed**. Solver-free - constructing an `IsaacConfig` needs no `isaacsim`.

The headline test is stated over spellings rather than over types: no spelling a reader would call *on* may resolve to *off*. It may be refused - an unrecognized spelling is not a documented side - but it must never silently land on the opposite side of the switch it names. Alongside it: both vocabularies on both switches, case and whitespace normalization, empty-as-absent, the refusal's content including the reason it refuses, the pathtracing switch held to the same vocabulary, the measured reason `env_flag` was not reused, the three out-of-scope pins, and a `TestNoIsaacEnvSwitchSurfaceDrifts` scanner asserting both switches go through the reader and that `nucleus_url` is the only remaining direct `os.environ.get("STRANDS_ISAAC` read.

Pre-fix, with `strands_robots/simulation/isaac/config.py` reverted to `4bc99a6` and the tests kept: **22 failed, 10 passed**.

```
AssertionError: assert False is True          # "on" resolved to windowed
AssertionError:  true                         # whitespace
Failed: DID NOT RAISE ValueError
AssertionError: assert 'headless' == 'rtx_pathtracing'
```

The 10 that pass are the over-reach controls - the spellings the truthy list already got right, `env_flag`'s unchanged one-sided contract, and the three precedence/argument pins - none of which this change alters.

## Docs

All four sites that describe these variables now state one vocabulary, and no site is left contradicting the code:

- `docs/simulation/isaac.md` - the pair table, empty-as-absent, the refusal, and the per-variable precedence with a pointer to #2062 (the sentence "An explicit kwarg always wins over the env var" was false for two of the three variables it covered).
- `README.md` - both env-var tables, same correction.
- `IsaacConfig`'s class docstring - the `headless` and `render_mode` entries said nothing about their environment variables, while `nucleus_url` three lines away named its own.
- `simulation.py`'s module docstring - `(true/false)` replaced with the vocabulary.

## Gate

Verified on `1d7bdad`, base `4bc99a6`. `scripts/check_merge_base_overlap.py --base-ref origin/main --head HEAD` reports no overlap (0 paths changed on `main` since the divergence), so these results cannot have been invalidated by the base.

- `ruff check strands_robots tests` - clean
- `ruff format --check strands_robots tests` - 1089 files already formatted
- `mypy strands_robots/simulation/isaac/config.py tests/simulation/isaac/test_isaac_env_switch_domain.py` - no issues
- `MUJOCO_GL=egl pytest tests/simulation/isaac` - **406 passed, 31 skipped, 0 failed**
- `MUJOCO_GL=egl pytest tests --continue-on-collection-errors` in a `[sim-mujoco,dev]` environment (no torch / lerobot / pyserial, so a large fixed set is uncollectable here) - **17083 passed, 621 failed, 591 skipped, 1495 errors**. The same command on a stashed, pristine `4bc99a6` in the same environment gives **17051 passed, 621 failed, 591 skipped, 1495 errors** - so the delta is exactly the **+32** tests this PR adds, and the failure, skip and error sets are unchanged. The full suite runs in CI with every extra installed.
