### PR TITLE
fix(simulation): refuse a cleanup stop budget the policy join cannot measure

### DIFF
--- a/changelog.d/2065-cleanup-policy-stop-budget-domain.md
+++ b/changelog.d/2065-cleanup-policy-stop-budget-domain.md
@@ -1,0 +1,26 @@
+### Fixed: a `cleanup` stop budget the join cannot measure abandoned a live policy worker
+
+`MuJoCoSimEngine.cleanup` waits on each live policy Future before nulling the
+world, because a worker still inside `mj_step` on freed arrays is a
+stale-pointer segfault. That wait is
+`Future.result(timeout=policy_stop_timeout)`, and the caller-supplied budget
+reached it unchecked. `Future.result` measures its wait as
+`time.monotonic() + timeout`, so `0`, a negative value and `nan` expired it
+before its first check and `inf` - the spelling that reads as "wait as long as
+it takes" - raised `OverflowError` out of that arithmetic. Measured against a
+live 50 Hz rollout, the documented default waited for the worker to unwind
+while `inf`, `nan`, `0` and `-1` each returned in ~11 ms with the worker still
+running and the world freed; `True` silently capped a 5 s budget at 1 s. A
+non-real budget was worse still: `Future.result` raised `TypeError`, and the
+`%.1f` in the join's own warning then raised too, so the record reporting the
+skipped wait was dropped and the operator saw nothing at all.
+
+`policy_stop_timeout` is now held to the same positive-finite domain every
+other span of time is (`positive_finite_number_error`). A budget outside it is
+reported against the parameter it came from and resolved to the documented
+default - the same thing `None` already means - rather than refused, because
+`cleanup` is the release path that `__exit__` and the finalizer both call:
+raising would leak the world, the executor and the renderers for a value error.
+The resolved budget is normalized to `float`, which is load-bearing rather than
+cosmetic - the shared guard accepts any real scalar and `Future.result` refuses
+a `np.float32`.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -115,6 +115,7 @@ from strands_robots.utils import (
     finite_vector_error,
     non_negative_whole_number_error,
     pose_vector_error,
+    positive_finite_number_error,
     positive_whole_number_error,
     reserved_camera_name_error,
     sequence_length,
@@ -210,6 +211,55 @@ def _validated_mesh_handle(mesh: Any) -> Any:
         "resolves the STRANDS_MESH kill switch and attaches a client; or attach one "
         "yourself after construction: sim.mesh = init_mesh(sim, peer_id=...)."
     )
+
+
+def _resolve_policy_stop_timeout(policy_stop_timeout: float | None, default: float) -> float:
+    """Seconds :meth:`MuJoCoSimEngine.cleanup` waits per live policy future.
+
+    ``None`` is the documented "no preference" spelling and resolves to
+    ``default``. A value outside the domain
+    :func:`strands_robots.utils.positive_finite_number_error` accepts cannot
+    express a preference either, so it resolves to ``default`` as well and the
+    reason is logged against the parameter it came from.
+
+    Only a positive finite budget can be honored.
+    ``concurrent.futures.Future.result`` measures its wait as
+    ``time.monotonic() + timeout``, so ``0``, a negative value and ``nan``
+    expire it before the first check, and ``inf`` - the spelling that reads as
+    "wait as long as it takes" - raises ``OverflowError`` out of that
+    arithmetic. Each of those abandons a policy worker that may still be inside
+    ``mj_step`` on the world ``cleanup`` is about to free, which is the
+    stale-pointer window the bounded join exists to close; a non-real budget
+    additionally makes the ``%.1f`` in the join's own warning raise, so the
+    record that would have reported the skipped wait is dropped. Resolving to
+    ``default`` keeps the join, so a budget the join cannot measure costs the
+    caller the faster teardown they asked for rather than the protection.
+
+    Returning a plain ``float`` is load-bearing rather than cosmetic: the shared
+    guard accepts any real scalar, and ``Future.result`` raises ``TypeError``
+    for a ``np.float32`` budget read out of a config array.
+
+    Args:
+        policy_stop_timeout: Caller-supplied budget in seconds, or ``None``.
+        default: Budget to use when none was supplied, or when the supplied one
+            is outside the domain the join can measure.
+
+    Returns:
+        Seconds to wait per live policy future - always a positive finite
+        ``float``.
+    """
+    if policy_stop_timeout is None:
+        return float(default)
+    reason = positive_finite_number_error(policy_stop_timeout, "policy_stop_timeout", "cleanup")
+    if reason is None:
+        return float(policy_stop_timeout)
+    logger.warning(
+        "%s Waiting the default %.1fs instead, so the bounded join that keeps a live policy "
+        "worker's pointers out of the freed world still happens.",
+        reason,
+        default,
+    )
+    return float(default)
 
 
 # Actions consumed open-loop from each policy's chunk before it is re-queried,
@@ -5116,10 +5166,18 @@ class MuJoCoSimEngine(
              landing inside one of its control ticks.
 
         Args:
-            policy_stop_timeout: Seconds to wait per active policy future.
-                ``None`` (default) uses
-                ``_DEFAULT_POLICY_STOP_TIMEOUT`` (5s). Set to a small value
-                in tests that want fast teardown.
+            policy_stop_timeout: Seconds to wait per active policy future - a
+                positive finite number, validated by the same rule every other
+                span of time is (:func:`strands_robots.utils.positive_finite_number_error`).
+                ``None`` (default) uses ``_DEFAULT_POLICY_STOP_TIMEOUT`` (5s).
+                Set to a small value in tests that want fast teardown. A budget
+                the join cannot measure - ``0``, a negative value, ``nan``,
+                ``inf`` or a non-real - is reported and resolved to that same
+                default rather than refused: every one of them expires the wait
+                before its first check, and abandoning a live worker is the
+                stale-pointer window step 2 exists to close, so the safe budget
+                is the honest reading of "no usable preference". Teardown always
+                completes; see :func:`_resolve_policy_stop_timeout`.
         """
         # Detach from the mesh network first (if attached). A truthy
         # ``self.mesh`` is any object exposing ``.stop()``; falsy values
@@ -5164,7 +5222,7 @@ class MuJoCoSimEngine(
             finally:
                 self.mesh = None
 
-        timeout = policy_stop_timeout if policy_stop_timeout is not None else self._DEFAULT_POLICY_STOP_TIMEOUT
+        timeout = _resolve_policy_stop_timeout(policy_stop_timeout, self._DEFAULT_POLICY_STOP_TIMEOUT)
 
         # Step 1 + 2: cooperative stop + bounded join BEFORE nulling world.
         # The ``policy_running`` flag is read by the MuJoCo-specific

--- a/tests/simulation/mujoco/test_cleanup_policy_stop_budget.py
+++ b/tests/simulation/mujoco/test_cleanup_policy_stop_budget.py
@@ -1,0 +1,247 @@
+"""``cleanup``'s per-future stop budget is held to a domain the join can measure.
+
+``MuJoCoSimEngine.cleanup`` waits on each live policy Future before nulling the
+world, because a worker still inside ``mj_step`` on freed arrays is a
+stale-pointer segfault (GH #116). That wait is
+``Future.result(timeout=policy_stop_timeout)``, and ``Future.result`` measures
+its budget as ``time.monotonic() + timeout``: ``0``, a negative value and
+``nan`` expire it before the first check, ``inf`` raises ``OverflowError`` out
+of the arithmetic, and a non-real raises ``TypeError``. Every one of them
+abandons the worker the join exists to await, and a non-real additionally makes
+the ``%.1f`` in the join's own warning raise so the record reporting the skipped
+wait is dropped.
+
+These pin that such a budget is reported and resolved to the documented default
+rather than used, and - the half a refusal would break - that teardown still
+completes. ``None`` remains the "no preference" spelling, and the resolver
+returns a plain ``float`` because ``Future.result`` refuses a ``np.float32``
+the shared guard accepts.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import (
+    MuJoCoSimEngine,
+    _resolve_policy_stop_timeout,
+)
+from strands_robots.utils import positive_finite_number_error
+
+DEFAULT = MuJoCoSimEngine._DEFAULT_POLICY_STOP_TIMEOUT
+
+# Budgets ``Future.result`` cannot measure. Each is grouped by what it does to
+# the wait, because the groups need different assertions below.
+EXPIRES_IMMEDIATELY: list[Any] = [0, 0.0, -1.0, -0.5, math.nan, -math.inf, False]
+RAISES_OVERFLOW: list[Any] = [math.inf]
+RAISES_TYPE_ERROR: list[Any] = ["5", [5], {}, object()]
+SILENT_ONE_SECOND: list[Any] = [True]
+UNUSABLE: list[Any] = [*EXPIRES_IMMEDIATELY, *RAISES_OVERFLOW, *RAISES_TYPE_ERROR, *SILENT_ONE_SECOND]
+
+# Budgets the join can measure, including the NumPy spellings the shared guard
+# accepts and a real config array would produce.
+USABLE: list[Any] = [0.001, 0.5, 2.0, 5.0, 30.0, np.float32(0.25), np.float64(1.5), np.int64(3)]
+
+
+class _RecordingFuture:
+    """Stand-in for a live policy Future that records the budget it is joined with.
+
+    ``done()`` is ``False`` so ``_prune_done_futures`` keeps it, and ``result``
+    returns rather than blocking - the assertion is the budget the join
+    *requested*, which is exact on any host, not a wall-clock duration.
+    """
+
+    def __init__(self) -> None:
+        self.timeouts: list[Any] = []
+
+    def done(self) -> bool:
+        return False
+
+    def cancelled(self) -> bool:
+        return False
+
+    def running(self) -> bool:
+        return True
+
+    def cancel(self) -> bool:
+        return False
+
+    def result(self, timeout: Any = None) -> None:
+        self.timeouts.append(timeout)
+
+
+def _sim() -> Any:
+    """A world with no robots - enough for ``cleanup`` to run its join."""
+    sim: Any = MuJoCoSimEngine(tool_name="cleanup_budget", mesh=False)
+    sim.create_world()
+    return sim
+
+
+def _joined_with(budget: Any, *, supplied: bool = True) -> tuple[list[Any], Any]:
+    """Budgets the join requested, plus the sim, after one ``cleanup``."""
+    sim = _sim()
+    fut = _RecordingFuture()
+    sim._policy_threads["arm"] = fut
+    if supplied:
+        sim.cleanup(policy_stop_timeout=budget)
+    else:
+        sim.cleanup()
+    return fut.timeouts, sim
+
+
+class TestTheResolverAcceptsExactlyWhatTheSharedRuleDoes:
+    """The domain is the shared positive-finite rule, not a second opinion."""
+
+    @pytest.mark.parametrize("budget", UNUSABLE)
+    def test_a_budget_the_shared_rule_refuses_resolves_to_the_default(self, budget: Any) -> None:
+        assert positive_finite_number_error(budget, "policy_stop_timeout", "cleanup") is not None
+        assert _resolve_policy_stop_timeout(budget, DEFAULT) == DEFAULT
+
+    @pytest.mark.parametrize("budget", USABLE)
+    def test_a_budget_the_shared_rule_accepts_is_used_as_given(self, budget: Any) -> None:
+        assert positive_finite_number_error(budget, "policy_stop_timeout", "cleanup") is None
+        assert _resolve_policy_stop_timeout(budget, DEFAULT) == pytest.approx(float(budget))
+
+    def test_none_is_the_documented_no_preference_spelling(self) -> None:
+        assert _resolve_policy_stop_timeout(None, DEFAULT) == DEFAULT
+
+    @pytest.mark.parametrize("budget", [*USABLE, *UNUSABLE, None])
+    def test_the_resolved_budget_is_always_a_plain_positive_finite_float(self, budget: Any) -> None:
+        resolved = _resolve_policy_stop_timeout(budget, DEFAULT)
+        assert type(resolved) is float
+        assert resolved > 0.0 and math.isfinite(resolved)
+
+
+class TestAnUnmeasurableBudgetIsReported:
+    """A budget that is not used must say so, naming the parameter and the value."""
+
+    @pytest.mark.parametrize("budget", UNUSABLE)
+    def test_the_warning_names_the_parameter_and_the_default_it_fell_back_to(
+        self, budget: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.simulation"):
+            _resolve_policy_stop_timeout(budget, DEFAULT)
+        assert "policy_stop_timeout" in caplog.text
+        assert f"{DEFAULT:.1f}s" in caplog.text
+
+    @pytest.mark.parametrize("budget", [*USABLE, None])
+    def test_a_usable_budget_is_not_reported(self, budget: Any, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.mujoco.simulation"):
+            _resolve_policy_stop_timeout(budget, DEFAULT)
+        assert "policy_stop_timeout" not in caplog.text
+
+
+class TestTheJoinIsAwaitedWithTheResolvedBudget:
+    """End to end: what ``cleanup`` hands ``Future.result`` for a live worker."""
+
+    @pytest.mark.parametrize("budget", UNUSABLE)
+    def test_an_unmeasurable_budget_does_not_reach_the_join(self, budget: Any) -> None:
+        joined, _sim_ = _joined_with(budget)
+        assert joined == [DEFAULT]
+
+    @pytest.mark.parametrize("budget", [0.001, 0.5, 2.0, np.float64(1.5)])
+    def test_a_usable_budget_reaches_the_join_unchanged(self, budget: Any) -> None:
+        joined, _sim_ = _joined_with(budget)
+        assert joined == [pytest.approx(float(budget))]
+
+    def test_omitting_the_budget_joins_with_the_documented_default(self) -> None:
+        joined, _sim_ = _joined_with(None, supplied=False)
+        assert joined == [DEFAULT]
+
+    def test_the_join_is_reached_rather_than_skipped(self) -> None:
+        """The worker is still awaited - the budget is resolved, not dropped."""
+        joined, _sim_ = _joined_with(math.inf)
+        assert len(joined) == 1
+
+
+class TestTeardownStillCompletesAfterAnUnmeasurableBudget:
+    """The half a refusal would break: ``cleanup`` releases everything regardless.
+
+    ``cleanup`` is the release path - ``__exit__`` and the finalizer both call
+    it - so raising on a bad budget would leak the world, the executor and the
+    renderers for a value error. Resolving to the safe default keeps the
+    contract its docstring states.
+    """
+
+    @pytest.mark.parametrize("budget", [math.inf, math.nan, 0.0, -1.0, "5", True])
+    def test_the_world_and_the_executor_are_released(self, budget: Any) -> None:
+        joined, sim = _joined_with(budget)
+        assert sim._world is None
+        with pytest.raises(RuntimeError):
+            sim._executor.submit(lambda: None)
+
+    @pytest.mark.parametrize("budget", [math.inf, "5"])
+    def test_cleanup_does_not_raise(self, budget: Any) -> None:
+        sim = _sim()
+        sim.cleanup(policy_stop_timeout=budget)  # must not raise
+
+
+class TestTheJoinWarningCanNoLongerBeDropped:
+    """A non-real budget used to silence the very record that reported it.
+
+    The join logs ``"...did not stop within %.1fs..."`` with the budget. Python's
+    logging calls ``handleError`` when a record cannot be formatted, so with a
+    ``str`` budget the operator got neither the wait nor the warning about it.
+    The resolver hands that ``%.1f`` a ``float``, so the record always renders.
+    """
+
+    @pytest.mark.parametrize("budget", UNUSABLE)
+    def test_the_resolved_budget_always_renders_in_the_join_warning(self, budget: Any) -> None:
+        resolved = _resolve_policy_stop_timeout(budget, DEFAULT)
+        record = logging.LogRecord(
+            name="strands_robots.simulation.mujoco.simulation",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=0,
+            msg="cleanup: policy on '%s' did not stop within %.1fs: %s",
+            args=("arm", resolved, "reason"),
+            exc_info=None,
+        )
+        assert f"{DEFAULT:.1f}s" in record.getMessage()
+
+    @pytest.mark.parametrize("budget", ["5", [5]])
+    def test_the_raw_budget_would_have_broken_that_same_format(self, budget: Any) -> None:
+        record = logging.LogRecord(
+            name="strands_robots.simulation.mujoco.simulation",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=0,
+            msg="cleanup: policy on '%s' did not stop within %.1fs: %s",
+            args=("arm", budget, "reason"),
+            exc_info=None,
+        )
+        with pytest.raises(TypeError, match="must be real number"):
+            record.getMessage()
+
+
+class TestNormalizingToFloatIsLoadBearing:
+    """``Future.result`` is stricter than the shared guard, so the cast is not cosmetic."""
+
+    def test_future_result_refuses_a_numpy_float32_the_guard_accepts(self) -> None:
+        # Bound through ``Any`` because the point is what the runtime does with a
+        # budget the annotation does not describe but the shared guard accepts.
+        budget: Any = np.float32(0.05)
+        assert positive_finite_number_error(budget, "policy_stop_timeout", "cleanup") is None
+        executor = ThreadPoolExecutor(max_workers=1)
+        gate = threading.Event()
+        future = executor.submit(gate.wait, 5.0)
+        try:
+            with pytest.raises(TypeError):
+                future.result(timeout=budget)
+            # The resolved value is the same budget in a shape the join accepts.
+            with pytest.raises(TimeoutError):
+                future.result(timeout=_resolve_policy_stop_timeout(budget, DEFAULT))
+        finally:
+            gate.set()
+            executor.shutdown(wait=True)
+
+    def test_the_join_receives_a_plain_float_for_a_numpy_budget(self) -> None:
+        joined, _sim_ = _joined_with(np.float32(0.25))
+        assert type(joined[0]) is float


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.cleanup` awaits each live policy Future before nulling the world. Its own docstring says why: nulling `self._world` while a worker is still inside `mj_step(world._model, world._data)` "is a SIGSEGV waiting to happen", so step 2 is a **bounded join** and step 4 only frees the world once workers have unwound.

That wait is `Future.result(timeout=policy_stop_timeout)`, and the caller's budget reached it unchecked:

```python
timeout = policy_stop_timeout if policy_stop_timeout is not None else self._DEFAULT_POLICY_STOP_TIMEOUT
```

`Future.result` measures its wait as `time.monotonic() + timeout`. So `0`, a negative value and `nan` expire it before its first check, `inf` — the spelling that reads as *wait as long as it takes* — raises `OverflowError` out of that sum, and a non-real raises `TypeError`. Every one of them **skips the join entirely** and frees the world under a live worker. `except Exception` around the join swallows all three, so the run continues to step 4 regardless.

A non-real budget is worse still. The join's own warning is `"...did not stop within %.1fs..."` with the budget interpolated, so `'5'` makes the record unformattable; Python logging routes that to `handleError` and the record is **dropped**. The operator gets neither the wait nor the warning that it was skipped.

## Measured

One rollout per row: `start_policy` at 50 Hz, sleep 0.5 s, one `cleanup`. "worker awaited" is the join completing before the world is freed.

| budget | main — waited | worker awaited | reported | this change — waited | worker awaited | reported |
|---|---|---|---|---|---|---|
| *omitted* | 0.0249 s | yes | n/a | 0.0197 s | yes | n/a |
| `2.0` | 0.0274 s | yes | n/a | 0.0219 s | yes | n/a |
| `inf` | 0.0109 s | **NO — abandoned** | yes | 0.0270 s | yes | yes |
| `nan` | 0.0108 s | **NO — abandoned** | yes | 0.0198 s | yes | yes |
| `0.0` | 0.0116 s | **NO — abandoned** | yes | 0.0162 s | yes | yes |
| `-1.0` | 0.0114 s | **NO — abandoned** | yes | 0.0189 s | yes | yes |
| `True` | 0.0205 s | yes | **no — silent 1 s cap** | 0.0190 s | yes | yes |
| `'5'` | 0.0110 s | **NO — abandoned** | **record DROPPED** | 0.0195 s | yes | yes |
| `np.float32(0.25)` | 0.0104 s | **NO — abandoned** | yes | 0.0317 s | yes | n/a |

A live worker was abandoned in **6 of 9** cases on main and **0 of 9** here. Log records dropped: **1 → 0**. `cleanup` raised in 0 of 18 runs on either tree.

`True` is the quiet one: an `int` subclass, so a 5 s default silently became a 1 s budget with nothing reported.

## Change

`policy_stop_timeout` is held to the same positive-finite domain every other span of time in the library is — `positive_finite_number_error`, whose docstring already covers "a rollout or teleop `duration` in seconds". A private `_resolve_policy_stop_timeout` resolves the effective budget:

- `None` → the documented default. Unchanged.
- usable → used as given, normalized to `float`.
- outside the domain → **reported against its parameter and resolved to that same default**.

**Why resolve rather than refuse.** `cleanup` is the release path: `__exit__` calls it, and so does the finalizer. Raising at the top of it would leak the world, the executor and the renderers for a value error, breaking the "Release every resource owned by this Simulation instance" contract its docstring opens with. The parameter already has a spelling for *no preference* — `None` — and a budget the join cannot measure cannot express one either, so resolving it to the safe default is the honest reading. The caller loses the faster teardown they asked for, not the protection. `TestTeardownStillCompletesAfterAnUnmeasurableBudget` pins that half.

Normalizing to `float` is load-bearing rather than cosmetic: the shared guard accepts any real scalar so a `np.float32` read out of a config array passes it, and `Future.result` raises `TypeError` for exactly that value. Guard decides usability, cast makes it consumable.

Because the resolved budget is always a positive finite `float`, the `%.1f` in the join's existing warning can no longer raise — the dropped-record path closes as a consequence, pinned separately.

## Scope

`NewtonSimEngine.cleanup` declares the same keyword and delegates to `destroy()`. `SimEngine.start_policy` is a synchronous fallback that documents "\[an engine with\] its `ThreadPoolExecutor` should override", which MuJoCo does; Newton has neither `_executor` nor `_policy_threads`, so there is no join for a budget to bound there. That makes its copy an inert signature-parity keyword, and the repo's existing call on such a keyword — Newton's `randomize(position_noise=)` — is to leave it alone rather than report on a value the backend never reads. Isaac and the ABC take no such parameter.

## Artifact

Measured end to end on both trees by [`capture.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cleanup-policy-stop-budget/capture.py) and composed by [`compose.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cleanup-policy-stop-budget/compose.py), which asserts the two dumps came from different trees and re-derives every count the figure states.

![cleanup stop budget](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cleanup-policy-stop-budget/artifact_cleanup_budget.png)

The lower-left panel is a normal `run_policy(1.2 s @ 50 Hz)` followed by `cleanup(policy_stop_timeout=2.0)`, rendered headless on both trees: every joint identical to 6 dp, render `max|delta| = 1/255` over 126 of 380800 px (renderer noise). The rollout path is untouched — only what a budget the join cannot measure does changes.

## Tests

`tests/simulation/mujoco/test_cleanup_policy_stop_budget.py`, 110 tests:

- the resolver accepts exactly what the shared rule does, in both directions, and always returns a positive finite `float`
- `None` remains the documented no-preference spelling
- an unusable budget is reported naming the parameter; a usable one is not
- end to end through `cleanup`: the budget the join is actually awaited with, for every case above
- teardown still releases the world and shuts the executor down after an unusable budget, and `cleanup` does not raise
- the join's `%.1f` warning always renders for the resolved budget, and would have raised for the raw one
- `Future.result` refuses the `np.float32` the guard accepts, so the cast is not redundant

**Pre-fix** (source reverted to `main`, main's superseded expression declared locally so every behavioural test still runs): **70 failed / 40 passed**. Post-fix: **110 passed**. The 40 that pass pre-fix are the usable-value controls and the teardown-completes class — already true, and the property a refusal would have broken.

## Gate

At `6de04db3`:

- `MUJOCO_GL=egl pytest tests` → **25774 passed / 257 skipped / 0 failed** (545 s)
- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ` → clean, 1134 files
- `mypy strands_robots tests tests_integ` → 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine `upstream/main` checkout of the same working copy
- root guards (changelog, docstring xrefs, unreachable statements, `Args:` completeness) → 410 passed
- `scripts/check_merge_base_overlap.py` → no overlap
- rebased onto `6de04db3` after #2063 and #2064 landed: both diffs 351 lines, diff-of-diffs 0 content lines; the pre-fix proof is identical at both bases
