### PR TITLE
test(simulation/isaac): pin the precedence of the third STRANDS_ISAAC switch

### DIFF
--- a/tests/simulation/isaac/test_isaac_env_switch_domain.py
+++ b/tests/simulation/isaac/test_isaac_env_switch_domain.py
@@ -2,7 +2,8 @@
 
 ``STRANDS_ISAAC_HEADLESS`` and ``STRANDS_ISAAC_RTX_PATHTRACING`` are both
 documented as two-sided switches -- ``docs/simulation/isaac.md`` and the README
-each say "Truthy (``1``/``true``/``yes``) forces headless; falsy forces a
+each said, until the change this module tests rewrote them to enumerate the four
+pairs below, "Truthy (``1``/``true``/``yes``) forces headless; falsy forces a
 window" -- but only the truthy side was enumerated. Everything else fell through
 to the falsy branch, so a spelling that means *on* forced the outcome the
 variable exists to prevent:
@@ -260,10 +261,11 @@ class TestNeighbouringSurfacesStayOutOfScope:
     """Boundary pins. Replace rather than delete these if the scope moves."""
 
     def test_the_environment_still_outranks_the_field(self, monkeypatch):
-        """Precedence is untouched here. ``docs/simulation/isaac.md`` says an
-        explicit kwarg always wins while the README also says this variable
-        overrides ``IsaacConfig(headless=...)``, and the two cannot both hold --
-        that contradiction is a contract decision, not this vocabulary defect."""
+        """Precedence is untouched here. The documentation no longer contradicts
+        itself about it -- ``docs/simulation/isaac.md`` and both README tables
+        now state it per variable and link #2062 -- but *which* direction the two
+        switches should have is still the open contract decision there, so this
+        is pinned rather than resolved."""
         monkeypatch.setenv("STRANDS_ISAAC_HEADLESS", "false")
         assert _config(headless=True).headless is False
 
@@ -273,6 +275,27 @@ class TestNeighbouringSurfacesStayOutOfScope:
         monkeypatch.setenv("STRANDS_ISAAC_NUCLEUS_URL", "omniverse://from-env")
         assert _config().nucleus_url == "omniverse://from-env"
         assert _config(nucleus_url="omniverse://explicit").nucleus_url == "omniverse://explicit"
+
+    def test_the_pathtracing_switch_also_outranks_its_field(self, monkeypatch):
+        """The third variable, and the one whose precedence nothing pinned.
+
+        Its *off* side is already held against an explicit field by
+        ``TestThePathtracingSwitchIsHeldToTheSameVocabulary``. The *on* side was
+        only ever exercised against the default ``render_mode``, so this switch
+        was the one of the three that could reverse to field-wins undetected --
+        measured on ``24766c3`` by gating the assignment on
+        ``self.render_mode == "headless"``: all 406 tests under
+        ``tests/simulation/isaac`` still passed, as did every test module that
+        mentions ``render_mode`` at all.
+
+        Stated over the whole enumeration rather than one representative value:
+        no mode a caller can pass explicitly survives the switch.
+        """
+        from strands_robots.simulation.isaac.config import RENDER_MODES
+
+        monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", "on")
+        for mode in RENDER_MODES:
+            assert _config(render_mode=mode).render_mode == "rtx_pathtracing", mode
 
     def test_the_headless_field_itself_is_not_type_checked(self):
         """A non-bool passed directly is still accepted. That is the argument


### PR DESCRIPTION
## Problem

`IsaacConfig.__post_init__` resolves three `STRANDS_ISAAC_*` variables, and their precedence directions are not uniform. `TestNeighbouringSurfacesStayOutOfScope` pins two of the three:

| variable | direction | pinned by |
|---|---|---|
| `STRANDS_ISAAC_HEADLESS` | environment outranks the field | `test_the_environment_still_outranks_the_field` |
| `STRANDS_ISAAC_NUCLEUS_URL` | field outranks the environment | `test_the_sibling_url_variable_keeps_the_opposite_precedence` |
| `STRANDS_ISAAC_RTX_PATHTRACING` | environment outranks the field | **nothing** |

The third one's *off* side is held against an explicit field already -- `test_an_off_spelling_leaves_the_render_mode_alone` passes `render_mode="rtx_realtime"` and asserts it survives. But every ***on***-side assertion in the tree constructs the config without a `render_mode`:

```python
# test_an_on_spelling_forces_pathtracing
assert _config().render_mode == "rtx_pathtracing"

# test_env_rtx_pathtracing_override (tests/simulation/isaac/test_isaac_backend.py)
assert IsaacConfig().render_mode == "rtx_pathtracing"

# test_both_switches_can_be_set_together
assert config.render_mode == "rtx_pathtracing"
```

So the switch was only ever observed overriding the *default*, never an explicit one. "Forces `render_mode`" and "is applied when `render_mode` was not chosen" are indistinguishable under that assertion, and they are opposite precedence directions.

## Measured

On `24766c3`, one line changed -- field-wins for this switch alone, the other two untouched:

```python
-        if _env_switch("STRANDS_ISAAC_RTX_PATHTRACING"):
+        if _env_switch("STRANDS_ISAAC_RTX_PATHTRACING") and self.render_mode == "headless":
             self.render_mode = "rtx_pathtracing"
```

| suite | before this PR | with this PR |
|---|---|---|
| `tests/simulation/isaac` (406 tests) | **406 passed, 0 failed** | 1 failed |
| the 3 test modules mentioning `render_mode` at all | **84 passed, 0 failed** | 1 failed |

The reversal is invisible tree-wide. Only three test modules reference `render_mode` or `pathtracing`, and none of them detects it. The new pin fails, and names the mode it got:

```
AssertionError: rtx_realtime
assert 'rtx_realtime' == 'rtx_pathtracing'
```

## Change

One pin, placed beside its two siblings so the precedence triple is complete and symmetric:

```python
monkeypatch.setenv("STRANDS_ISAAC_RTX_PATHTRACING", "on")
for mode in RENDER_MODES:
    assert _config(render_mode=mode).render_mode == "rtx_pathtracing", mode
```

Stated over `RENDER_MODES` rather than one representative value: no mode a caller can pass explicitly survives the switch. That is the whole domain of the parameter, so the pin cannot be satisfied by a partial implementation, and it stays correct if a fourth render mode is added.

## Two stale docstring citations, in the same block

Both cite documentation that has since been rewritten, and one of them is the docstring of the pin the new test sits next to.

1. **The `headless` precedence pin** justified itself by a live contradiction: "``docs/simulation/isaac.md`` says an explicit kwarg always wins while the README also says this variable overrides ``IsaacConfig(headless=...)``, and the two cannot both hold". That contradiction is gone -- `docs/simulation/isaac.md` now says "`STRANDS_ISAAC_NUCLEUS_URL` is read only when `nucleus_url` is not passed, so there the kwarg wins; the two switches override their field whenever they are set", and both README tables state precedence per variable and link #2062. Verified: no "always wins" claim about an Isaac env var survives anywhere in `README.md`, `docs/` or `strands_robots/`.

2. **The module docstring** quotes, in the present tense, `"Truthy (1/true/yes) forces headless; falsy forces a window"` as what the two documents "each say". That sentence was replaced by the four-pair table printed immediately below it in the same docstring, so the quotation describes the documents as they were when the defect was measured, not as they are. `grep -rn "Truthy" README.md docs/simulation/isaac.md` returns only an unrelated ROS 2 row. Re-tensed rather than deleted -- the *before* state is what makes the table below it legible.

## Scope

**This does not touch precedence itself, and does not pre-empt #2062.** That issue asks which direction the two switches *should* have; it is a contract decision, and its acceptance criterion 3 requires the existing pins to be *replaced* when a direction changes. A pin that does not exist cannot be replaced, which is why the third variable needed one before that decision lands rather than after.

Its other two criteria are already met, by the change this module tests: precedence is now stated once per variable at all three documentation sites, and `STRANDS_ISAAC_RTX_PATHTRACING` has a stated precedence where it previously had none. What this PR adds is the enforcement half of that second criterion -- the statement existed, nothing held the code to it.

No changelog fragment: `changelog.d/README.md` states "it is fragments, not the log, that behavioural PRs write to", and no library behaviour changes here. `git diff --name-only` is one file, under `tests/`.

## Gate

At `24766c3`, `MUJOCO_GL=osmesa` (this runner has no working EGL):

- `pytest tests` -> **25771 passed / 261 skipped / 0 failed** (1322 s), coverage 94.98% against the 80% floor
- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ` -> clean, 1134 files
- `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1131 source files`
- `scripts/check_merge_base_overlap.py` -> no overlap; 0 paths changed on `main` since the branch diverged
- `scripts/check_changelog_fragment.py` -> no entry added to `[Unreleased]`
- the new pin verified in both directions: passes on `main`'s source, and is the single failure under the one-line reversal above

Refs #2062
