### PR TITLE
fix(dataset_recorder): refuse a camera frame shape create cannot honor

### DIFF
--- a/changelog.d/2067-dataset-recorder-frame-shape-domain.md
+++ b/changelog.d/2067-dataset-recorder-frame-shape-domain.md
@@ -1,0 +1,35 @@
+### Fixed: `DatasetRecorder.create` refuses a camera frame shape it cannot honor
+
+`camera_dims` and the `video_width` / `video_height` pair are one quantity in two
+spellings -- the recorder declares each camera at
+`camera_dims.get(camera, (video_height, video_width))` -- and neither was
+checked. The shape is a declaration rather than a resize, so whatever was given
+went straight into the LeRobot feature as `(3, height, width)` and was not
+compared against a real frame until the first `add_frame`.
+
+The quiet one was an entry keyed by a name `camera_keys` does not declare: that
+lookup never finds it, so the camera it was meant for silently took the global
+pair instead. A camera streaming 240x320, declared as
+`camera_dims={"imagee": (240, 320)}` against `camera_keys=["image"]`, was
+declared `(3, 480, 640)` from the defaults -- nothing logged, the dataset
+created. A component that is not a positive integer was written in as given, so
+the schema declared `(3, 480, nan)`, `(3, 480, '640')` or `(3, 480, True)`; and a
+value that is not a two-element sequence unpacked as a bare `TypeError`, a
+non-mapping `camera_dims` as a bare `AttributeError` from the lookup, and a NumPy
+integer width as `TypeError: Object of type int64 is not JSON serializable` from
+the metadata write -- none of which named the parameter or the method.
+
+Both spellings now go through the shared `positive_count_error` per component,
+with `camera_dims` additionally held to being a mapping whose every key is a
+declared camera and whose every value is a `(height, width)` pair. The strict-int
+domain is the one the consumer honors: a pixel count is written into
+`meta/info.json`, where an integral float lands as `480.0`. The refusal sits in
+the same guard block as the schema column names, ahead of the same two side
+effects -- the lazy lerobot import, so one caller mistake reports identically on
+a minimal install, and the on-disk target, which `overwrite=True` removes.
+
+`camera_dims=None` / `{}` still mean "not supplied", a list pair is still
+accepted, and with no camera declared neither spelling is read, so nothing that
+could be honored is refused. `fps` is the recorder's other unchecked schema
+option; it is a rate rather than a frame shape and already has a named owner at
+the `start_recording` facade, so it is tracked separately.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -501,6 +501,48 @@ Both mistakes used to be accepted and only surfaced in the recorded data:
 `robot_features` / `action_features`, or from `joint_names` for the action
 columns.
 
+### Camera frame shape must be a usable pixel count
+
+`camera_dims` and the `video_width` / `video_height` pair are one quantity in two
+spellings: the recorder declares each camera at
+`camera_dims.get(camera, (video_height, video_width))`, so the mapping sets the
+shape of the cameras it covers and the pair sets the shape of every other one.
+Note the order - `camera_dims` is `(height, width)`, the reverse of the pair.
+
+It is a **declaration, not a resize** - the recorder rescales nothing - so
+whatever is given goes straight into the LeRobot feature as `(3, height, width)`.
+`create()` refuses a shape it cannot honor, on the same shared domain and in the
+same place as the column names above:
+
+```python
+DatasetRecorder.create(repo_id="user/d", camera_keys=["image"],
+                       camera_dims={"imagee": (240, 320)})   # ValueError: not a declared camera
+DatasetRecorder.create(repo_id="user/d", camera_keys=["image"],
+                       camera_dims={"image": (240,)})        # ValueError: not a (height, width) pair
+DatasetRecorder.create(repo_id="user/d", camera_keys=["image"],
+                       video_width=0)                        # ValueError: must be a positive integer
+```
+
+Three mistakes used to be accepted, and none was reported near the parameter that
+caused it:
+
+- A key `camera_keys` does not declare is **never looked up**, so the camera it
+  was meant for silently took the global pair instead. A camera streaming
+  240x320 declared as `camera_dims={"imagee": (240, 320)}` against
+  `camera_keys=["image"]` was declared `(3, 480, 640)` from the defaults -
+  nothing logged, dataset created, and the mismatch surfacing later against
+  `add_frame`.
+- A component that is **not a positive integer** was written in as given, so the
+  schema declared `(3, 480, nan)` or `(3, 480, '640')` and no frame could match
+  it. A pixel count is written into `meta/info.json`, so it has to be a true
+  `int`: an integral float would be declared as `480.0`, and a NumPy integer is
+  not JSON-serializable.
+- A value that is **not a two-element sequence** unpacked as a bare `TypeError`,
+  and a non-mapping `camera_dims` as a bare `AttributeError` from the lookup.
+
+`camera_dims=None` and `{}` still mean "not supplied" - every camera then takes
+the global pair. Passing the shape as a list rather than a tuple is accepted.
+
 ### Re-recording into an existing `repo_id`
 
 `DatasetRecorder.create()` builds a **fresh** dataset. If the resolved dataset

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -21,6 +21,7 @@ Usage:
     recorder.push_to_hub()
 """
 
+import difflib
 import importlib.util
 import json
 import logging
@@ -32,7 +33,13 @@ from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import lerobot_version, name_list_error, non_negative_whole_number_error
+from strands_robots.utils import (
+    lerobot_version,
+    name_list_error,
+    non_negative_whole_number_error,
+    positive_count_error,
+    sequence_length,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -668,6 +675,105 @@ def unrecordable_action_columns_error(
     )
 
 
+def _frame_shape_error(
+    camera_dims: Any,
+    camera_keys: Sequence[str] | None,
+    video_width: Any,
+    video_height: Any,
+    context: str = "DatasetRecorder.create",
+) -> str | None:
+    """Error text when the declared camera frame shape cannot be honored.
+
+    ``camera_dims`` and the ``video_width`` / ``video_height`` pair are one
+    quantity in two spellings. :meth:`DatasetRecorder._build_features` reads
+    ``camera_dims.get(camera, (video_height, video_width))`` once per declared
+    camera, so the pair is the shape of every camera the mapping does not
+    cover. Both spellings are checked here on the same domain: a value refused
+    through one and accepted through the other would let the same unusable
+    shape into the schema by choosing where to write it.
+
+    The shape is a declaration rather than a resize - the recorder rescales
+    nothing - so it goes straight into the LeRobot feature as ``(3, height,
+    width)`` and is not compared against a real frame until the first
+    ``add_frame``. Three mistakes could not be honored as written and were
+    reported nowhere near the parameter that caused them:
+
+    * A key ``camera_keys`` does not declare is dropped by that ``.get``, so
+      the camera it was meant for silently takes the global pair instead and
+      the schema declares a shape that camera does not stream. This is the
+      quiet one: nothing is logged, the dataset is created, and the mismatch
+      surfaces later against ``add_frame``.
+    * A component that is not a positive integer is written into the feature
+      as given - ``(3, 480, nan)``, ``(3, 480, '640')`` - so the schema
+      declares a shape no frame can match.
+    * A value that is not a two-element sequence unpacks as a bare
+      ``TypeError`` / ``ValueError``, and a non-mapping ``camera_dims`` as a
+      bare ``AttributeError`` from the ``.get`` - none of which names this
+      parameter.
+
+    :func:`~strands_robots.utils.positive_count_error` owns the component
+    domain because a pixel count here is written into ``meta/info.json``: it
+    has to be a true ``int``. An integral float lands in the schema as
+    ``480.0``, and a ``numpy`` integer raises ``TypeError: Object of type
+    int64 is not JSON serializable`` from the metadata write, so the wider
+    whole-number domain would accept values this consumer refuses.
+
+    Args:
+        camera_dims: Per-camera ``{name: (height, width)}`` mapping, or None.
+        camera_keys: The camera names the schema declares. Authoritative: it is
+            the only source of camera names, and where it is empty no image
+            feature is built, so neither spelling is read.
+        video_width: Fallback frame width for every camera not covered above.
+        video_height: Fallback frame height for every camera not covered above.
+        context: Caller name for the message prefix.
+
+    Returns:
+        The first problem found, or None when the declared shape is usable.
+    """
+    declared = list(camera_keys or ())
+
+    # The pair is read exactly where ``_build_features`` reads it - per declared
+    # camera - so with no camera declared it decides nothing and is left alone.
+    if declared:
+        for value, param in ((video_width, "video_width"), (video_height, "video_height")):
+            if text := positive_count_error(value, param, context):
+                return text
+
+    if camera_dims is None:
+        return None
+    if not isinstance(camera_dims, Mapping):
+        return (
+            f"{context}: camera_dims must be a mapping of camera name to a "
+            f"(height, width) pair, got {type(camera_dims).__name__}. Its entries are "
+            f"read per declared camera, so a non-mapping cannot be looked up at all."
+        )
+    if camera_dims and not declared:
+        return (
+            f"{context}: camera_dims declares a frame shape for "
+            f"{sorted(map(str, camera_dims))} but no camera is declared. Pass the same "
+            f"names as camera_keys, or drop camera_dims - with no camera_keys no image "
+            f"feature is built, so every entry would be ignored."
+        )
+    for name, dims in camera_dims.items():
+        if name not in declared:
+            hint = difflib.get_close_matches(str(name), declared, n=1, cutoff=0.6)
+            suggestion = f" Did you mean {hint[0]!r}?" if hint else ""
+            return (
+                f"{context}: camera_dims key {name!r} is not a declared camera."
+                f"{suggestion} Declared cameras: {declared}. An entry keyed by any other "
+                f"name is never looked up, so that camera would be declared at the global "
+                f"video_height/video_width instead of the shape given here."
+            )
+        if isinstance(dims, str | bytes | Mapping) or sequence_length(dims) != 2:
+            return (
+                f"{context}: camera_dims[{name!r}] must be a (height, width) pair of positive integers, got {dims!r}."
+            )
+        for value, axis in zip(dims, ("height", "width"), strict=True):
+            if text := positive_count_error(value, f"camera_dims[{name!r}] {axis}", context):
+                return text
+    return None
+
+
 class RecordingFrameError(RuntimeError):
     """A frame the dataset recorder could not write, in fail-fast mode.
 
@@ -803,12 +909,20 @@ class DatasetRecorder:
                 here is declared at its own shape rather than the global one; a
                 camera absent from the mapping (or ``None``, the default) takes
                 ``(video_height, video_width)``.
+                Every key has to be a name ``camera_keys`` declares: an entry
+                keyed by anything else is never looked up, so that camera would
+                be declared at the global pair instead of the shape given here.
+                Each value is a two-element ``(height, width)`` of positive
+                integers.
             video_width/video_height: Declared frame shape for every camera
                 ``camera_dims`` does not cover. A declaration rather than a
                 resize - the recorder rescales nothing - so a camera streaming
                 another size is declared at a shape it does not have. This is why
                 the backends pass ``camera_dims`` read from the live cameras
                 instead of relying on this pair.
+                Each is a positive integer - a pixel count is written into
+                ``meta/info.json``, so an integral float would be declared as
+                ``480.0`` and a ``numpy`` integer is not JSON-serializable.
             joint_names: List of DISTINCT joint names (alternative to
                 robot_features for sim). These become the ``observation.state``
                 column names, and add_frame reads each one out of the
@@ -863,9 +977,14 @@ class DatasetRecorder:
         Raises:
             ValueError: ``camera_keys``, ``joint_names`` or ``action_names`` is
                 not a list of distinct non-blank names (a bare string, a
-                mapping, or a repeated name). Refused before the on-disk target
-                is touched, so an ``overwrite=True`` call that is refused leaves
-                an existing dataset intact.
+                mapping, or a repeated name); or the declared camera frame shape
+                cannot be honored - ``camera_dims`` is not a mapping, is keyed by
+                a name ``camera_keys`` does not declare, or holds anything but a
+                ``(height, width)`` pair of positive integers, or
+                ``video_width`` / ``video_height`` is not a positive integer.
+                Refused before the on-disk target is touched, so an
+                ``overwrite=True`` call that is refused leaves an existing
+                dataset intact.
             FileExistsError: The resolved dataset directory already holds a
                 dataset and ``overwrite`` is False.
         """
@@ -896,6 +1015,18 @@ class DatasetRecorder:
         ):
             if value and (text := name_list_error(value, param, "DatasetRecorder.create")):
                 raise ValueError(text)
+        # ``camera_dims`` and the ``video_width`` / ``video_height`` pair are the
+        # other half of the same schema declaration: they set the frame shape of
+        # every declared camera. Checked on the same shared domain, in the same
+        # place and for the same two reasons as the names above - before the
+        # lerobot extra is probed, so one caller mistake reports identically on
+        # every install, and before the on-disk target is touched, because
+        # ``overwrite=True`` removes an existing dataset and a refusal arriving
+        # after that would already have destroyed it. Runs after the loop above
+        # so ``camera_keys`` is known to be a list of distinct names before it is
+        # used as the authoritative set of camera names.
+        if text := _frame_shape_error(camera_dims, camera_keys, video_width, video_height):
+            raise ValueError(text)
 
         # Lazy import - this is where we actually need lerobot
         LeRobotDatasetCls = _get_lerobot_dataset_class()

--- a/tests/test_dataset_schema_frame_shape_domain.py
+++ b/tests/test_dataset_schema_frame_shape_domain.py
@@ -1,0 +1,397 @@
+"""``DatasetRecorder.create`` refuses a camera frame shape it cannot honor.
+
+``camera_dims`` and the ``video_width`` / ``video_height`` pair are one quantity
+in two spellings. ``_build_features`` reads
+``camera_dims.get(camera, (video_height, video_width))`` once per declared
+camera, so the mapping sets the shape of the cameras it covers and the pair sets
+the shape of every other one. The shape is a *declaration*, not a resize - the
+recorder rescales nothing - so whatever is given goes straight into the LeRobot
+feature as ``(3, height, width)`` and is not compared against a real frame until
+the first ``add_frame``.
+
+Three mistakes could not be honored as written, and none of them was reported
+anywhere near the parameter that caused it:
+
+* **A key ``camera_keys`` does not declare is dropped by that ``.get``.** This
+  is the quiet one. Nothing is logged, the dataset is created, and the camera
+  the entry was meant for silently takes the global pair instead - so a camera
+  streaming 240x320, declared as ``camera_dims={"imagee": (240, 320)}`` against
+  ``camera_keys=["image"]``, was declared ``(3, 480, 640)`` from the defaults.
+* **A component that is not a positive integer is written in as given**, so the
+  schema declared ``(3, 480, nan)``, ``(3, 480, '640')``, ``(3, 480, [640])``
+  or ``(3, 480, True)`` and no frame could ever match it.
+* **A value that is not a two-element sequence** unpacks as a bare ``TypeError``
+  / ``ValueError`` (``cannot unpack non-iterable int object``), and a
+  non-mapping ``camera_dims`` as a bare ``AttributeError`` from the ``.get``
+  (``'list' object has no attribute 'get'``) - none of which names this
+  parameter or this method.
+
+The component domain is the shared
+:func:`~strands_robots.utils.positive_count_error`, which is the strict-``int``
+one because a pixel count here is written into ``meta/info.json``: an integral
+float is declared as ``480.0`` and a ``numpy`` integer raises
+``TypeError: Object of type int64 is not JSON serializable`` from the metadata
+write, so the wider whole-number domain would accept values this consumer
+refuses.
+
+The refusal sits in the same guard block, and is placed ahead of the same two
+side effects, as the schema *column name* lists checked by the sibling module
+``tests/test_dataset_schema_column_names_distinct.py``: ahead of the lazy
+lerobot import, so the same caller mistake reports identically on a minimal
+install (which is why every refusal test here runs without the extra), and ahead
+of the on-disk target, which ``overwrite=True`` removes.
+"""
+
+import ast
+import inspect
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots import dataset_recorder as recorder_mod
+from strands_robots.utils import positive_count_error
+
+# Reached through the module alias rather than a second from-import: the
+# guard-placement tests read the module's own source, and one handle for one
+# module keeps that unambiguous.
+DatasetRecorder = recorder_mod.DatasetRecorder
+
+# Values no pixel count can be built from. ``positive_count_error`` owns this
+# domain; the labels are reused as parametrize ids.
+UNUSABLE_COUNTS: list[tuple[str, Any]] = [
+    ("zero", 0),
+    ("negative", -64),
+    ("fractional", 2.7),
+    ("integral_float", 320.0),
+    ("bool", True),
+    ("nan", math.nan),
+    ("inf", math.inf),
+    ("numeric_string", "640"),
+    ("none", None),
+    ("list", [640]),
+    ("numpy_int", np.int64(320)),
+]
+
+# Pairs that are not a ``(height, width)`` of two components.
+UNUSABLE_PAIRS: list[tuple[str, Any]] = [
+    ("scalar", 480),
+    ("one_element", (480,)),
+    ("three_elements", (480, 640, 3)),
+    ("none", None),
+    ("string_of_two", "hw"),
+    ("mapping", {"height": 480, "width": 640}),
+    ("zero_dim_array", np.array(480)),
+]
+
+# ``camera_dims`` values that are not a mapping at all.
+NON_MAPPINGS: list[tuple[str, Any]] = [
+    ("list_of_pairs", [(240, 320)]),
+    ("bare_string", "image"),
+    ("scalar", 480),
+    ("tuple", (240, 320)),
+]
+
+
+class _FakeLeRobotDataset:
+    """Stand-in for ``LeRobotDataset``, recording whether ``create`` was reached."""
+
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, features: dict[str, Any]) -> None:
+        self.repo_id = "local/fake"
+        self.features = features
+        self.meta = None
+
+    @classmethod
+    def create(cls, **kwargs: Any) -> "_FakeLeRobotDataset":
+        cls.calls.append(kwargs)
+        return cls(kwargs.get("features", {}))
+
+
+def _create(**kwargs: Any) -> DatasetRecorder:
+    """Call ``DatasetRecorder.create`` with keywords the signature disallows.
+
+    Most tests here pass a value the parameter's annotation forbids (a bare
+    string where ``int`` is declared, a scalar where a ``(height, width)`` pair
+    is) because that is precisely the caller mistake the runtime guard exists
+    for. Routing them through one ``**kwargs: Any`` funnel states that intent
+    once instead of scattering per-call type suppressions.
+    """
+    return DatasetRecorder.create(**kwargs)
+
+
+@pytest.fixture
+def fake_lerobot(monkeypatch: pytest.MonkeyPatch) -> type[_FakeLeRobotDataset]:
+    """Route ``create`` onto a fake dataset class, so no lerobot extra is needed."""
+    _FakeLeRobotDataset.calls = []
+    monkeypatch.setattr(recorder_mod, "_get_lerobot_dataset_class", lambda: _FakeLeRobotDataset)
+    return _FakeLeRobotDataset
+
+
+@pytest.fixture
+def no_lerobot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make reaching the lazy lerobot import fatal.
+
+    A refusal must be decided before ``create`` probes the dataset extra, so the
+    same caller mistake is reported the same way on a minimal install.
+    """
+
+    def _fatal() -> Any:
+        raise AssertionError("the lerobot extra was probed before the frame shape was checked")
+
+    monkeypatch.setattr(recorder_mod, "_get_lerobot_dataset_class", _fatal)
+
+
+class TestAnEntryForAnUndeclaredCameraIsRefused:
+    """The quiet half: an unlooked-up entry, and the camera declared at the pair."""
+
+    def test_a_mistyped_camera_name_is_refused_and_named(self, no_lerobot: None) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _create(
+                repo_id="local/probe",
+                camera_keys=["image"],
+                camera_dims={"imagee": (240, 320)},
+            )
+        text = str(excinfo.value)
+        assert "camera_dims" in text, text
+        assert "'imagee'" in text, text
+        assert "Did you mean 'image'?" in text, text
+        assert "['image']" in text, text
+
+    def test_an_unrelated_key_is_refused_without_inventing_a_suggestion(self, no_lerobot: None) -> None:
+        """A near match is offered; an unrelated name only gets the declared list."""
+        with pytest.raises(ValueError) as excinfo:
+            _create(
+                repo_id="local/probe",
+                camera_keys=["image", "wrist_image"],
+                camera_dims={"joint1": (240, 320)},
+            )
+        text = str(excinfo.value)
+        assert "Did you mean" not in text, text
+        assert "['image', 'wrist_image']" in text, text
+
+    def test_dims_for_a_camera_less_dataset_are_refused(self, no_lerobot: None) -> None:
+        """With no ``camera_keys`` no image feature is built, so every entry is ignored."""
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", joint_names=["j1"], camera_dims={"image": (240, 320)})
+        text = str(excinfo.value)
+        assert "no camera is declared" in text, text
+        assert "camera_keys" in text, text
+
+    def test_the_declared_camera_keeps_its_own_shape(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+        """The control: spelled correctly, the entry wins over the global pair."""
+        _create(
+            repo_id="local/probe",
+            camera_keys=["image"],
+            camera_dims={"image": (240, 320)},
+            video_width=640,
+            video_height=480,
+        )
+        features = fake_lerobot.calls[0]["features"]
+        assert features["observation.images.image"]["shape"] == (3, 240, 320)
+
+
+class TestUnusableFrameShapesAreRefused:
+    """Neither spelling of the shape accepts a component that is not a pixel count."""
+
+    @pytest.mark.parametrize("param", ["video_width", "video_height"])
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE_COUNTS, ids=[c[0] for c in UNUSABLE_COUNTS])
+    def test_global_pair_component_refused(self, no_lerobot: None, param: str, label: str, value: Any) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", camera_keys=["image"], **{param: value})
+        text = str(excinfo.value)
+        assert param in text, text
+        assert "must be a positive integer" in text, text
+        assert "DatasetRecorder.create" in text, text
+
+    @pytest.mark.parametrize("axis", ["height", "width"])
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE_COUNTS, ids=[c[0] for c in UNUSABLE_COUNTS])
+    def test_per_camera_component_refused(self, no_lerobot: None, axis: str, label: str, value: Any) -> None:
+        dims = (value, 320) if axis == "height" else (240, value)
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": dims})
+        text = str(excinfo.value)
+        assert f"camera_dims['image'] {axis}" in text, text
+        assert "must be a positive integer" in text, text
+
+    @pytest.mark.parametrize(("label", "value"), UNUSABLE_PAIRS, ids=[c[0] for c in UNUSABLE_PAIRS])
+    def test_a_value_that_is_not_a_height_width_pair_is_refused(self, no_lerobot: None, label: str, value: Any) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": value})
+        text = str(excinfo.value)
+        assert "camera_dims['image']" in text, text
+        assert "(height, width) pair" in text, text
+
+    @pytest.mark.parametrize(("label", "value"), NON_MAPPINGS, ids=[c[0] for c in NON_MAPPINGS])
+    def test_a_non_mapping_camera_dims_is_refused(self, no_lerobot: None, label: str, value: Any) -> None:
+        """Its entries are looked up per camera, so a non-mapping cannot be read."""
+        with pytest.raises(ValueError) as excinfo:
+            _create(repo_id="local/probe", camera_keys=["image"], camera_dims=value)
+        text = str(excinfo.value)
+        assert "camera_dims must be a mapping" in text, text
+        assert type(value).__name__ in text, text
+
+
+class TestUsableFrameShapesStillReachTheDataset:
+    """The over-reach controls: nothing that could be honored is refused."""
+
+    @pytest.mark.parametrize(
+        ("label", "kwargs"),
+        [
+            ("defaults", {}),
+            ("explicit_pair", {"video_width": 320, "video_height": 240}),
+            ("dims_none", {"camera_dims": None}),
+            ("dims_empty", {"camera_dims": {}}),
+            ("dims_tuple", {"camera_dims": {"image": (240, 320)}}),
+            ("dims_list", {"camera_dims": {"image": [240, 320]}}),
+            ("dims_and_pair", {"camera_dims": {"image": (240, 320)}, "video_width": 640}),
+        ],
+    )
+    def test_accepted(self, fake_lerobot: type[_FakeLeRobotDataset], label: str, kwargs: dict[str, Any]) -> None:
+        _create(repo_id="local/probe", camera_keys=["image"], **kwargs)
+        assert len(fake_lerobot.calls) == 1
+
+    def test_a_list_pair_is_honored_as_given(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+        """A list is accepted because the consumer honors it - the annotation says tuple."""
+        _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": [240, 320]})
+        features = fake_lerobot.calls[0]["features"]
+        assert features["observation.images.image"]["shape"] == (3, 240, 320)
+
+
+class TestARefusedCreateLeavesTheTargetAlone:
+    """The refusal precedes the on-disk work, so nothing is destroyed by it."""
+
+    def test_overwrite_does_not_remove_an_existing_dataset(
+        self, tmp_path: Path, fake_lerobot: type[_FakeLeRobotDataset]
+    ) -> None:
+        """``overwrite=True`` removes the target directory - a refusal must not."""
+        root = tmp_path / "ds"
+        (root / "meta").mkdir(parents=True)
+        (root / "meta" / "info.json").write_text('{"fps": 30}')
+
+        raised: Exception | None = None
+        try:
+            _create(
+                repo_id="local/probe",
+                root=str(root),
+                camera_keys=["image"],
+                camera_dims={"imagee": (240, 320)},
+                overwrite=True,
+            )
+        except ValueError as exc:
+            raised = exc
+
+        # Assert the surviving target first: that is the consequence that matters,
+        # and it is what a refusal arriving after ``_prepare_create_target`` would
+        # already have destroyed.
+        assert (root / "meta" / "info.json").is_file(), "the refused call deleted the dataset"
+        assert fake_lerobot.calls == [], "the refused call still built a dataset"
+        assert raised is not None, "the undeclared camera_dims key was not refused"
+        assert "is not a declared camera" in str(raised), str(raised)
+
+    def test_a_usable_call_does_reach_the_dataset_target(
+        self, tmp_path: Path, fake_lerobot: type[_FakeLeRobotDataset]
+    ) -> None:
+        """The control: the same call with the key spelled correctly is not refused."""
+        _create(
+            repo_id="local/probe",
+            root=str(tmp_path / "fresh"),
+            camera_keys=["image"],
+            camera_dims={"image": (240, 320)},
+        )
+        assert len(fake_lerobot.calls) == 1
+
+
+class TestTheDomainCannotDriftFromTheSharedRule:
+    """The component check delegates rather than restating the numeric domain."""
+
+    @pytest.mark.parametrize(
+        ("label", "value"),
+        UNUSABLE_COUNTS + [("plain_int", 320), ("large", 4096)],
+        ids=[c[0] for c in UNUSABLE_COUNTS] + ["plain_int", "large"],
+    )
+    def test_both_spellings_agree_with_positive_count_error(self, label: str, value: Any) -> None:
+        """A component refused as ``video_width`` is refused inside ``camera_dims`` too."""
+        shared_refuses = positive_count_error(value, "x", "y") is not None
+        via_pair = recorder_mod._frame_shape_error(None, ["image"], value, 480) is not None
+        via_dims = recorder_mod._frame_shape_error({"image": (480, value)}, ["image"], 640, 480) is not None
+        assert via_pair is shared_refuses, f"video_width verdict differs for {value!r}"
+        assert via_dims is shared_refuses, f"camera_dims verdict differs for {value!r}"
+
+    def test_the_message_is_the_shared_one_verbatim(self) -> None:
+        """No second wording for the same rule."""
+        assert recorder_mod._frame_shape_error(None, ["image"], 0, 480) == positive_count_error(
+            0, "video_width", "DatasetRecorder.create"
+        )
+
+    def test_the_helper_reports_no_problem_for_a_usable_shape(self) -> None:
+        assert recorder_mod._frame_shape_error({"image": (240, 320)}, ["image"], 640, 480) is None
+        assert recorder_mod._frame_shape_error(None, [], 0, 0) is None
+
+
+class TestGuardPlacement:
+    """``create`` checks the shape before either of its two side effects."""
+
+    def test_the_call_forwards_every_parameter_of_the_quantity(self) -> None:
+        """A future edit cannot drop one of the four from the guard call."""
+        source = inspect.getsource(DatasetRecorder.create)
+        tree = ast.parse(inspect.cleandoc(source).replace("@classmethod\n", "", 1))
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+
+        call = next(
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_frame_shape_error"
+        )
+        forwarded = [ast.unparse(arg) for arg in call.args]
+        assert forwarded == ["camera_dims", "camera_keys", "video_width", "video_height"], forwarded
+
+    def test_the_shape_is_checked_before_the_lerobot_probe_and_the_target(self) -> None:
+        """Source order: name lists, then the shape, then any work."""
+        source = inspect.getsource(DatasetRecorder.create)
+        tree = ast.parse(inspect.cleandoc(source).replace("@classmethod\n", "", 1))
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+
+        def called_names(node: ast.AST) -> set[str]:
+            return {
+                child.func.attr if isinstance(child.func, ast.Attribute) else getattr(child.func, "id", "")
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+            }
+
+        index_of = {
+            name: i
+            for i, stmt in enumerate(func.body)
+            for name in called_names(stmt)
+            if name in {"name_list_error", "_frame_shape_error", "_get_lerobot_dataset_class"}
+        }
+        assert index_of["name_list_error"] < index_of["_frame_shape_error"], index_of
+        assert index_of["_frame_shape_error"] < index_of["_get_lerobot_dataset_class"], index_of
+
+
+class TestNeighbouringSurfacesStayOutOfScope:
+    """Premise pins, so a follow-up is not closed by accident.
+
+    ``fps`` is the recorder's other unvalidated schema option, but it is a rate
+    rather than a frame shape and it already has a named owner one layer up
+    (``dataset_recording_option_error``, applied by every backend's
+    ``start_recording``). It is deliberately untouched here; these assert the
+    behaviour that ships so the difference is recorded rather than implied.
+    """
+
+    @pytest.mark.parametrize("value", [2.7, math.nan, math.inf, True])
+    def test_an_unusable_fps_is_still_accepted_by_the_recorder(
+        self, fake_lerobot: type[_FakeLeRobotDataset], value: Any
+    ) -> None:
+        _create(repo_id="local/probe", camera_keys=["image"], fps=value)
+        assert len(fake_lerobot.calls) == 1
+
+    def test_a_camera_less_create_does_not_read_the_pair(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+        """With no camera declared the pair decides nothing, so it is left alone."""
+        _create(repo_id="local/probe", joint_names=["j1"], video_width=0, video_height=-8)
+        assert len(fake_lerobot.calls) == 1


### PR DESCRIPTION
## The defect

`camera_dims` and the `video_width` / `video_height` pair are **one quantity in two
spellings**. `_build_features` declares each camera at

```python
cam_h, cam_w = camera_dims.get(cam_name, (video_height, video_width))
```

so the mapping sets the shape of the cameras it covers and the pair sets the shape of
every other one. Neither was checked. The shape is a *declaration*, not a resize -
the recorder rescales nothing - so whatever is given goes straight into the LeRobot
feature as `(3, height, width)` and is not compared against a real frame until the
first `add_frame`.

Three mistakes could not be honored as written, and none was reported anywhere near
the parameter that caused it. Measured on `6de04db3`, one `DatasetRecorder.create`
per row:

| `camera_dims` / pair | `create()` | declared shape | outcome |
|---|---|---|---|
| `{"image": (240, 320)}` | success | `(3, 240, 320)` | correct |
| **`{"imagee": (240, 320)}`** | **success** | **`(3, 480, 640)`** | **entry never looked up; camera declared at the global pair** |
| `{"image": (2.7, 640)}` | success | `(3, 2.7, 640)` | no frame can match |
| `{"image": (0, 0)}` / `(-8, 640)` / `(nan, 640)` | success | as given | no frame can match |
| `{"image": 480}` / `(480,)` / `(480, 640, 3)` / `None` | - | - | bare `TypeError` / `ValueError` from an unpack |
| `camera_dims=[(240, 320)]` (not a mapping) | - | - | bare `AttributeError: 'list' object has no attribute 'get'` |
| `video_width=0` / `-64` / `2.7` / `True` / `nan` / `'640'` / `[640]` | success | `(3, 480, <as given>)` | no frame can match |
| `video_width=np.int64(320)` | - | - | bare `TypeError: Object of type int64 is not JSON serializable` |

The first bold row is the quiet one, and the reason this is worth a guard rather than
a docstring. Nothing is logged, the dataset directory is created, and the camera the
entry was meant for is declared at a shape it does not stream - the mismatch surfaces
later against `add_frame`, naming that method rather than `camera_dims`. With
`overwrite=True` the caller's previous dataset has already been removed by then.

## The change

Both spellings now go through the shared
[`positive_count_error`](https://github.com/strands-labs/robots/blob/main/strands_robots/utils.py)
per component, with `camera_dims` additionally held to being a mapping whose every key
is a declared camera and whose every value is a `(height, width)` pair. One private
`_frame_shape_error` beside its single caller decides only the shape-specific parts -
mapping-ness, key membership, pair arity - and delegates the numeric domain, so there
is no second wording for the same rule (pinned: the message for a bad `video_width`
is `positive_count_error`'s output verbatim).

It sits in the **same guard block** as the schema *column name* lists, ahead of the
same two side effects and for the same two reasons already written there: ahead of the
lazy lerobot import, so one caller mistake reports identically on a minimal install,
and ahead of the on-disk target, because `overwrite=True` removes an existing dataset
and a refusal arriving after that would already have destroyed it.

Why the **strict-int** domain rather than the wider whole-number one: a pixel count
here is written into `meta/info.json`. An integral float is declared as `480.0`, and a
NumPy integer raises `TypeError: Object of type int64 is not JSON serializable` from
the metadata write - so the wider domain would accept values this consumer refuses.
`positive_count_error` and the consumer agree exactly.

`create` is the only surface: `_build_features` has one caller, and `resume` reads the
shape off disk.

## Out of scope, deliberately

`fps` is the recorder's other unchecked schema option (`fps=2.7` / `nan` / `inf`
create the dataset and save **0 frames**; `True` records at 1 fps). It is a *rate*
rather than a frame shape and already has a named owner one layer up -
`dataset_recording_option_error`, applied by every backend's `start_recording` - so it
is a separate slice, tracked in #2068 and pinned here as a premise in
`TestNeighbouringSurfacesStayOutOfScope` so it cannot be closed by accident.

## Not refused (over-reach controls)

`camera_dims=None` / `{}` still mean "not supplied"; a **list** pair is accepted
because the consumer honors it; and with no camera declared neither spelling is read,
so the pair is left alone there - the guard's condition mirrors the one
`_build_features` uses. All pinned.

## Artifact

A 12-step headless MuJoCo rollout with a camera streaming **240x320**, recorded
through the direct `DatasetRecorder` API. Both trees encode the **same** rendered
frames, because the recorder is the variable under test and two independent renders
differ by noise that lossy H.264 amplifies.

![camera frame shape](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dataset-frame-shape/frame_shape.png)

Top row is the round trip: the rendered frame, and the frame decoded back out of each
tree's own MP4 for the correctly-keyed run. Those two are **byte-identical
(`max|delta| = 0`)**, 12 frames each - the recording path is unchanged. Bottom row is
the mistyped key: `success` and `(3, 480, 640)` on main against a `ValueError` naming
the key here. Every cell is read from the two runs' JSON dumps and asserted in the
figure generator, which also asserts the two dumps came from different trees.

## Gate

At `6de04db3` (re-checked against `24766c32`: `check_merge_base_overlap.py` reports
no overlap, so these stand):

- `MUJOCO_GL=egl pytest tests -q --no-cov` -> **25755 passed, 257 skipped, 0 failed**
  (567s). **Zero existing-test changes.**
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean.
  mypy reports 14 errors, all in `examples/isaac_gs`, **0 outside** - byte-identical to
  a pristine `upstream/main` worktree of the same working copy, so environmental.
- `scripts/assemble_changelog.py --check` OK; `tests/test_changelog_fragments.py`
  and `tests/test_changelog_format.py` pass.
- New file alone: 91 tests in 0.57s - no lerobot extra, no GL.
- The gated tree differs from this head only in the changelog fragment's
  filename (`2066-` -> `2067-`, renamed to the real PR number after opening);
  `assemble_changelog.py --check` and both changelog guards were re-run after it.

**Pre-fix proof** (source reverted to `upstream/main`, tests kept): **76 failed,
15 passed**. The 15 that pass are the over-reach controls (a usable shape still
reaches the dataset) and the out-of-scope premise pins, which is what stops the guard
reaching further than the values it should refuse.

