### PR TITLE
fix(simulation): refuse a benchmark robot set its own evaluation cannot honor

### DIFF
--- a/changelog.d/2069-benchmark-supported-robots-domain.md
+++ b/changelog.d/2069-benchmark-supported-robots-domain.md
@@ -1,0 +1,24 @@
+### Fixed: `DeclarativeBenchmark` refuses a `supported_robots` its own evaluation cannot honor
+
+`DeclarativeBenchmark` has two construction paths. `from_dict` refused a
+`supported_robots` that was not a list of strings and refused a `default_robot`
+outside it; `__init__` stored `list(supported_robots)` raw. Of the nine checks
+`from_dict` runs, only `max_steps` was mirrored - and its comment states the
+reason for all of them.
+
+So a single robot name spelled without the list, `supported_robots="panda"`, was
+accepted: `str` is iterable per character, so the benchmark declared five
+one-letter robots. `list_benchmarks()` advertised
+`robots=['p', 'a', 'n', 'd', 'a']`, and `evaluate_benchmark(robot_name="panda")`
+then returned `status="error"` refusing the benchmark's *own* `default_robot` and
+naming those five as the allowed set. `supported_robots=""` failed the other way:
+it stored `[]`, this parameter's documented "any robot" spelling, silently
+widening a restricted benchmark to every robot.
+
+Both paths now share the `name_list_error` domain - the same way they already
+share `max_steps`' count domain - and `__init__` mirrors the `default_robot`
+membership check, so a benchmark can no longer declare a robot set that its own
+default robot is outside of. The shape is checked before membership: on a bare
+string the membership message would report
+`'panda' not in ['p', 'a', 'n', 'd', 'a']`, describing the symptom rather than
+the mistake. An empty list is still accepted and still means "any robot".

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -12,7 +12,7 @@ Spec schema (top-level keys)::
 
     name: string                          # required
     max_steps: int                        # default 300
-    supported_robots: list[str]           # default [] (any)
+    supported_robots: list[str]           # default [] (any); must contain default_robot
     default_robot: string                 # required - registry data_config
     scene: string                         # optional MJCF/URDF path for sim.load_scene()
     instruction: string                   # optional natural-language task command
@@ -68,7 +68,7 @@ from strands_robots.simulation.benchmark import (
     register_benchmark,
 )
 from strands_robots.simulation.predicates import PREDICATE_REGISTRY, make_predicate, predicate_kind
-from strands_robots.utils import positive_count_error, require_optional
+from strands_robots.utils import name_list_error, positive_count_error, require_optional
 
 if TYPE_CHECKING:
     import random
@@ -333,6 +333,30 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         instruction: str = "",
     ):
         self._name = name
+        # Mirrors the two checks ``from_dict`` runs on this value, for the
+        # reason the ``max_steps`` mirror below states: a directly constructed
+        # benchmark must not carry a robot set the evaluation loop has to
+        # refuse later. ``list()`` alone read a single name passed as a bare
+        # string one character at a time, so ``supported_robots="panda"``
+        # became five one-letter robots, ``list_benchmarks`` advertised them,
+        # and the evaluation then refused the benchmark's own ``default_robot``
+        # by naming them.
+        #
+        # Shape first: on a bare string the membership check below would report
+        # ``'panda' not in ['p', 'a', 'n', 'd', 'a']``, which describes the
+        # symptom rather than the mistake. Ungated, unlike the callers that
+        # derive the list when it is falsy - an empty list is this parameter's
+        # documented "any robot" spelling and ``name_list_error`` accepts it,
+        # while ``""`` is a mistyped name that would otherwise widen the
+        # benchmark to every robot silently.
+        if error := name_list_error(supported_robots, "supported_robots", type(self).__name__):
+            raise ValueError(error)
+        if supported_robots and default_robot not in supported_robots:
+            raise ValueError(
+                f"{type(self).__name__}: default_robot={default_robot!r} not in "
+                f"supported_robots={list(supported_robots)}; either add it to "
+                "supported_robots or leave supported_robots empty for any-robot benchmarks"
+            )
         self._supported_robots = list(supported_robots)
         self._default_robot = default_robot
         # Mirrors the check ``from_dict`` runs on the raw spec value, so a
@@ -364,6 +388,13 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         Implements :attr:`BenchmarkProtocol.supported_robots`. Returns a fresh
         copy so callers cannot mutate the compiled spec. An empty list (the
         spec omitted the key) means "any robot".
+
+        The constructor holds this to the shared
+        :func:`~strands_robots.utils.name_list_error` domain: several distinct
+        non-blank names, as a list or tuple rather than a single bare string,
+        and containing :attr:`default_robot` whenever it is non-empty. So the
+        names read back here are the names that were asked for, and a benchmark
+        cannot declare a robot set that its own default robot is outside of.
         """
         return list(self._supported_robots)
 
@@ -472,8 +503,13 @@ class DeclarativeBenchmark(BenchmarkProtocol):
             raise ValueError("spec.default_robot: required non-empty string")
 
         supported_robots = spec.get("supported_robots", [])
-        if not isinstance(supported_robots, list) or not all(isinstance(r, str) for r in supported_robots):
-            raise ValueError("spec.supported_robots: must be a list of strings")
+        # Shared name-list domain, so the key a spec file sets and the keyword a
+        # direct construction passes cannot drift apart on what they accept -
+        # the same reason ``max_steps`` below shares its count domain. The
+        # hand-rolled check this replaces accepted a repeated name and a blank
+        # one, neither of which names a robot the registry can resolve.
+        if error := name_list_error(supported_robots, "supported_robots", "spec"):
+            raise ValueError(error)
 
         # default_robot should be in supported_robots (unless list is empty = any)
         if supported_robots and default_robot not in supported_robots:

--- a/tests/simulation/test_benchmark_supported_robots_domain.py
+++ b/tests/simulation/test_benchmark_supported_robots_domain.py
@@ -1,0 +1,231 @@
+"""``DeclarativeBenchmark`` holds ``supported_robots`` to the shared name-list domain.
+
+``DeclarativeBenchmark`` has two construction paths and they applied different
+checks to the same value. ``from_dict`` refused a ``supported_robots`` that was
+not a list of strings; ``__init__`` stored ``list(supported_robots)`` raw. Only
+``max_steps`` was mirrored across the two, and its comment states the reason for
+all of them - a directly constructed benchmark must not carry a value the
+evaluation loop has to refuse later.
+
+Measured on ``24766c3`` (mujoco 3.11.0, ``MUJOCO_GL=egl``), constructing directly
+with ``supported_robots="panda"`` - one name, spelled without the list:
+
+* ``supported_robots`` read back as ``['p', 'a', 'n', 'd', 'a']``, five names the
+  caller never wrote, because ``str`` is iterable per character.
+* ``sim.list_benchmarks()`` - the discovery surface - advertised
+  ``robots=['p', 'a', 'n', 'd', 'a']``.
+* ``sim.evaluate_benchmark(benchmark_name=..., robot_name="panda")`` returned
+  ``status="error"`` with ``robot 'panda' has data_config='panda', but benchmark
+  DeclarativeBenchmark supports ['p', 'a', 'n', 'd', 'a']`` - the evaluation
+  refusing the benchmark's *own* ``default_robot`` and naming the five
+  one-letter robots as the allowed set.
+* ``supported_robots=""`` was worse in the other direction: it stored ``[]``,
+  which is this parameter's documented "any robot" spelling, so a mistyped name
+  silently widened the benchmark to every robot instead of restricting it.
+
+The same values through ``from_dict`` were all refused. These tests pin the two
+paths to one rule.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.utils import name_list_error
+
+# Values ``supported_robots`` cannot be honored as. Each is refused by the shared
+# domain for a stated reason; the ids name the mistake rather than the value.
+UNUSABLE: list[Any] = [
+    pytest.param("panda", id="bare-string"),
+    pytest.param("", id="empty-string"),
+    pytest.param({"panda": 1}, id="mapping"),
+    pytest.param(["panda", "panda"], id="repeated-name"),
+    pytest.param(["panda", 7], id="non-string-entry"),
+    pytest.param(["panda", ""], id="blank-entry"),
+    pytest.param([None], id="none-entry"),
+    pytest.param(7, id="int"),
+    pytest.param(3.5, id="float"),
+    pytest.param(None, id="none"),
+]
+
+# Spellings that name a robot set the evaluation loop can honor. ``[]`` is the
+# documented "any robot" case and must stay accepted - it is why the shape check
+# is not gated on a truthy value the way the ``image_keys`` callers gate theirs.
+USABLE: list[Any] = [
+    pytest.param(["panda"], id="one-name"),
+    pytest.param(["panda", "aloha"], id="two-names"),
+    pytest.param(("panda",), id="tuple"),
+    pytest.param([], id="empty-any-robot"),
+]
+
+
+def _make(**overrides: Any) -> DeclarativeBenchmark:
+    """Construct a benchmark directly, with ``overrides`` splatted in.
+
+    Splatted rather than passed positionally so a deliberately off-type value
+    reaches the runtime guard as an agent or a caller would supply it, instead
+    of being reported by the type checker at each call site.
+    """
+    kwargs: dict[str, Any] = {
+        "name": "probe",
+        "supported_robots": ["panda"],
+        "default_robot": "panda",
+        "max_steps": 10,
+        "success_fn": lambda _sim: False,
+        "failure_fn": lambda _sim: False,
+        "reward_terms": [],
+    }
+    kwargs.update(overrides)
+    return DeclarativeBenchmark(**kwargs)
+
+
+def _from_spec(**overrides: Any) -> DeclarativeBenchmark:
+    """Compile the equivalent spec dict, so both paths see the same value."""
+    spec: dict[str, Any] = {
+        "name": "probe",
+        "default_robot": "panda",
+        "max_steps": 10,
+        "supported_robots": ["panda"],
+    }
+    spec.update(overrides)
+    return DeclarativeBenchmark.from_dict(spec)
+
+
+def _refuses(build: Any, **overrides: Any) -> str | None:
+    """Return the refusal text, or ``None`` when the value was accepted."""
+    try:
+        build(**overrides)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+class TestAnUnusableRobotSetIsRefusedAtConstruction:
+    """Direct construction refuses what it cannot honor, naming the parameter."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_value_is_refused(self, value: Any) -> None:
+        text = _refuses(_make, supported_robots=value)
+        assert text is not None, f"{value!r} was accepted as supported_robots"
+        assert "supported_robots" in text, text
+        assert "DeclarativeBenchmark" in text, text
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_is_the_shared_domains_own_answer(self, value: Any) -> None:
+        """Byte-identical to the shared rule, so no second wording can drift in."""
+        assert _refuses(_make, supported_robots=value) == name_list_error(
+            value, "supported_robots", "DeclarativeBenchmark"
+        )
+
+
+class TestAUsableRobotSetIsUnchanged:
+    """Every spelling the evaluation loop can honor still constructs."""
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_the_value_is_accepted(self, value: Any) -> None:
+        bench = _make(supported_robots=value, default_robot=(list(value) or ["panda"])[0])
+        assert bench.supported_robots == list(value)
+
+    def test_an_empty_list_still_means_any_robot(self) -> None:
+        """The documented any-robot case, with a default outside the (empty) set."""
+        bench = _make(supported_robots=[], default_robot="anything")
+        assert bench.supported_robots == []
+        assert bench.default_robot == "anything"
+
+    def test_a_tuple_is_normalized_to_a_list(self) -> None:
+        """``list()`` is load-bearing: the domain accepts a tuple, the property
+        is a ``list[str]``, and callers mutate the copy they are handed."""
+        bench = _make(supported_robots=("panda", "aloha"))
+        assert bench.supported_robots == ["panda", "aloha"]
+        assert isinstance(bench.supported_robots, list)
+
+
+class TestTheTwoConstructionPathsAgree:
+    """One rule, so a benchmark is not refused from a spec file and accepted
+    when constructed directly - the property ``max_steps`` already had."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_neither_path_accepts_what_the_other_refuses(self, value: Any) -> None:
+        direct = _refuses(_make, supported_robots=value)
+        spec = _refuses(_from_spec, supported_robots=value)
+        assert (direct is None) == (spec is None), (
+            f"{value!r}: direct={direct!r} spec={spec!r} - the two paths disagree"
+        )
+        assert direct is not None and spec is not None
+
+    @pytest.mark.parametrize("value", USABLE)
+    def test_both_paths_accept_a_usable_set(self, value: Any) -> None:
+        default = (list(value) or ["panda"])[0]
+        assert _refuses(_make, supported_robots=value, default_robot=default) is None
+        # A spec file cannot express a tuple, so compare on the list form.
+        assert _refuses(_from_spec, supported_robots=list(value), default_robot=default) is None
+
+    def test_the_spec_path_names_the_spec_key(self) -> None:
+        """Both paths share the rule but keep their own context, so the message
+        says where the value came from - as the ``max_steps`` pair does."""
+        spec = _refuses(_from_spec, supported_robots="panda")
+        assert spec == name_list_error("panda", "supported_robots", "spec")
+        assert spec is not None and spec.startswith("spec: ")
+
+
+class TestTheShapeIsCheckedBeforeMembership:
+    """Order matters: on a bare string the membership check would describe the
+    symptom (``'panda' not in ['p', 'a', 'n', 'd', 'a']``) rather than the
+    mistake, so the shape refusal has to come first."""
+
+    def test_a_bare_string_reports_the_bare_string(self) -> None:
+        text = _refuses(_make, supported_robots="panda")
+        assert text is not None
+        assert "not a single string" in text, text
+        assert "not in supported_robots" not in text, text
+
+    def test_the_character_reading_is_quoted_so_the_mistake_is_visible(self) -> None:
+        text = _refuses(_make, supported_robots="panda")
+        assert text is not None
+        assert "['p', 'a', 'n', 'd', 'a']" in text, text
+
+
+class TestABenchmarkCannotExcludeItsOwnDefaultRobot:
+    """The invariant the bare string broke: a declared robot set that the
+    benchmark's own ``default_robot`` is outside of is refused, as
+    ``from_dict`` already refused it."""
+
+    def test_a_default_outside_a_non_empty_set_is_refused(self) -> None:
+        text = _refuses(_make, supported_robots=["panda"], default_robot="aloha")
+        assert text is not None
+        assert "not in supported_robots" in text, text
+        assert "'aloha'" in text, text
+
+    def test_both_paths_refuse_it(self) -> None:
+        assert _refuses(_make, supported_robots=["panda"], default_robot="aloha") is not None
+        assert _refuses(_from_spec, supported_robots=["panda"], default_robot="aloha") is not None
+
+    def test_a_default_inside_the_set_is_accepted(self) -> None:
+        bench = _make(supported_robots=["panda", "aloha"], default_robot="aloha")
+        assert bench.default_robot == "aloha"
+
+
+class TestNeighbouringFieldsStayOutOfScope:
+    """``from_dict`` also checks ``name`` / ``scene`` / ``instruction`` as
+    strings, and those mirrors are a separate question: they need a string
+    domain this module does not have, and each fails loudly at its consumer
+    rather than silently widening the robot set. Pinned so the boundary of this
+    change is measured rather than assumed."""
+
+    def test_a_non_string_name_is_still_accepted_directly(self) -> None:
+        assert _refuses(_make, name=7) is None
+
+    def test_a_non_string_scene_is_still_accepted_directly(self) -> None:
+        assert _refuses(_make, scene=42) is None
+
+    def test_a_non_string_instruction_is_still_accepted_directly(self) -> None:
+        assert _refuses(_make, instruction=42) is None
+
+    def test_max_steps_keeps_its_own_mirrored_domain(self) -> None:
+        """The one mirror that already existed, unchanged by this."""
+        text = _refuses(_make, max_steps=2.7)
+        assert text is not None
+        assert "max_steps" in text, text


### PR DESCRIPTION
## The defect

`DeclarativeBenchmark` has two construction paths, and they applied different checks to the same value.

`from_dict` refuses a `supported_robots` that is not a list of strings, and refuses a `default_robot` outside it. `__init__` did `self._supported_robots = list(supported_robots)` raw. Of the **nine** checks `from_dict` runs, only `max_steps` was mirrored — and its comment states the reason for all of them:

> Mirrors the check `from_dict` runs on the raw spec value, so a directly constructed benchmark cannot carry a horizon the evaluation loop has to refuse later.

So one robot name, spelled without the list, was accepted. `str` is iterable per character, so `supported_robots="panda"` declared **five one-letter robots**. Measured on `24766c3` (mujoco 3.11.0, `MUJOCO_GL=egl`, panda + `MockPolicy`):

| | direct construction on `main` |
|---|---|
| `supported_robots` reads back as | `['p', 'a', 'n', 'd', 'a']` |
| `sim.list_benchmarks()` advertises | `robots=['p', 'a', 'n', 'd', 'a'], default=panda` |
| `sim.evaluate_benchmark(robot_name="panda")` | `status="error"` — `robot 'panda' has data_config='panda', but benchmark DeclarativeBenchmark supports ['p', 'a', 'n', 'd', 'a']` |

The evaluation refuses the benchmark's **own** `default_robot`, and names the five one-letter robots as the allowed set. Nothing between the constructor and that message could report the actual mistake.

`supported_robots=""` fails the other way: it stored `[]`, which is this parameter's documented *"any robot"* spelling — so a mistyped name silently **widened** a restricted benchmark to every robot rather than restricting it.

Six spellings diverged between the two paths (`"panda"`, `""`, a `Mapping`, a non-string entry, a `None` entry, an `int`); a repeated name and a blank entry were accepted by both.

## The change

Both paths now share the `name_list_error` domain — the way they already share `max_steps`' count domain — and `__init__` mirrors the `default_robot` membership check, so a benchmark can no longer declare a robot set that its own default robot is outside of.

Two details worth stating:

- **Shape before membership.** On a bare string the membership check would report `'panda' not in ['p', 'a', 'n', 'd', 'a']`, which describes the symptom rather than the mistake. The shape refusal comes first; pinned.
- **Ungated, unlike the `image_keys` callers.** Those gate the check on a truthy value because a falsy value means "not supplied" and the list is derived. Here an empty list is the documented *"any robot"* spelling, which `name_list_error` accepts, while `""` is a mistyped name — gating on truthiness would have left exactly the silent-widening case open.

`from_dict`'s hand-rolled check is replaced by the shared call, so the two messages cannot drift; each keeps its own context, so a spec file is told `spec: …` and a direct construction `DeclarativeBenchmark: …`, matching the `max_steps` pair.

## Out of scope, deliberately

`from_dict` also checks `name` / `scene` / `instruction` as strings, and `__init__` still does not. Those mirrors need a single-name string domain this module does not have — `entity_name_error` is documented as the creation-site counterpart to the simulation registries and its reasons are MuJoCo's (its unnamed-entity sentinel, NUL truncation in the compiled model), so reusing it here would be reusing a helper outside its stated scope. Each of those also fails at its consumer rather than silently changing which robots a benchmark accepts. The boundary is pinned in `TestNeighbouringFieldsStayOutOfScope` so it is measured rather than assumed, and filed separately.

## Verification

Measured in a clean checkout, `MUJOCO_GL=egl`, mujoco 3.11.0, arm64.

- **Pre-fix proof** — source reverted to `upstream/main`, the new tests kept: **35 failed / 15 passed**. The 15 that pass are the over-reach controls (every usable spelling, the out-of-scope neighbours, `max_steps`) and the spec-path halves, which were already correct.
- **New tests**: 50, `tests/simulation/test_benchmark_supported_robots_domain.py`, 0.09 s — no MuJoCo, no optional backend.
- **Existing benchmark suites**: `tests/simulation/test_benchmark*.py tests/simulation/test_builtin_benchmark*.py tests/simulation/test_policy_runner_benchmark.py tests/benchmarks/` → **793 passed, 28 skipped**, **zero existing-test changes**. All four direct constructions in the tree already pass `[]` or a matching name.
- **Full suite**: `MUJOCO_GL=egl pytest tests` → **25824 passed, 257 skipped, 0 failed** in 573.65 s.
- **Lint**: `ruff check` clean, `ruff format --check` 1135 files, `mypy strands_robots tests tests_integ` → 14 errors, all in `examples/isaac_gs`, **0 outside**, error set byte-identical to a pristine `upstream/main` worktree of the same working copy (an artefact of the local editable install, not of this branch).
- **Merge-base overlap**: no overlap; 0 paths changed on `upstream/main` in that span, so these numbers describe the tree that merges.

## What it looks like

Three real headless renders of the same rig, plus the verbatim report each path produces.

![DeclarativeBenchmark supported_robots domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/benchmark-supported-robots/benchmark_supported_robots.png)

Left is the reference: `supported_robots=['panda']`, the 120-step evaluation runs and the arm moves. Middle is `main` with the same name spelled as a bare string — constructed, registered, advertised with five one-letter robots, and the evaluation refused, so the arm never stepped. Right is this change, refusing at construction.

The self-audit in the compose step asserts the claims rather than captioning them: the honored evaluation is identical on both trees (same status, same end pose, render `max|delta| = 1/255`), the two "nothing ran" states agree to `max|delta| = 1/255` — so the physics is untouched and the whole difference is *what the caller is told, and how early* — and the reference rollout differs from them on 22.7% of pixels, so it demonstrably ran. Capture and compose scripts and both measured JSON dumps are on the artifact branch beside the figure.
