### PR TITLE
fix(lerobot_teleoperate): refuse a non-boolean mode flag instead of reading it by truthiness

### DIFF
--- a/changelog.d/2073-lerobot-teleoperate-flag-boolean-domain.md
+++ b/changelog.d/2073-lerobot-teleoperate-flag-boolean-domain.md
@@ -1,0 +1,29 @@
+### Fixed: a boolean flag the lerobot argv cannot honor is refused instead of read by truthiness
+
+`build_lerobot_command` read all five of its boolean flags for truthiness. Each
+selects a *posture* rather than scaling a quantity - `dataset_video` picks the
+literal `"true"` or `"false"` on the argv, `record_resume` decides whether
+`--resume true` appears at all - and every non-empty string is truthy, so the
+words an operator reaches for when opting out selected the **opposite** posture
+from the one they read as:
+
+- `dataset_push_to_hub="false"` emitted `--dataset.push_to_hub true`, so a
+  detached, unattended recording uploaded its dataset to the Hub;
+- `record_resume="false"` emitted `--resume true`, appending into an existing
+  dataset - preserving its already-stamped `repo_id` - instead of creating the
+  fresh one that was asked for;
+- `dagger_record_autonomous="off"` emitted `--strategy.record_autonomous true`,
+  recording autonomous rollout episodes into a corrections dataset;
+- `display_data="false"` emitted `--display_data true`.
+
+`None` and `[]` took the other branch just as silently, without ever being a
+declared spelling of it. Nothing reported any of these: the argv goes to a
+subprocess launched with `start_new_session=True`, the call returns
+`status="success"` with a pid, and the lerobot CLI parses every one of those
+argvs without complaint - it is simply told the opposite posture.
+
+Each flag is now checked against the shared `boolean_flag_error` domain the mesh
+provisioning entry points already apply, and only for the flags the requested
+mode actually emits: the scoping comes from a per-mode table beside the numeric
+one, so `replay` - which emits no flag - refuses none, and a flag a mode never
+puts on its argv is never a false rejection.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -24,6 +24,7 @@ import psutil
 from strands import tool
 
 from strands_robots.utils import (
+    boolean_flag_error,
     non_negative_whole_number_error,
     positive_finite_number_error,
     positive_whole_number_error,
@@ -108,6 +109,67 @@ def _numeric_option_error(mode: str, supplied: dict[str, Any]) -> str | None:
         if value is None and param in _OPTIONAL_OPTIONS:
             continue
         if error := check(value, param, "build_lerobot_command"):
+            return error
+    return None
+
+
+# The boolean flags each command mode actually puts on the lerobot argv, in the
+# order that argv emits them. Each selects a posture rather than scaling a
+# quantity - ``dataset_video`` picks the literal ``"true"`` or ``"false"``, while
+# ``record_resume`` decides whether ``--resume true`` appears at all - and both
+# spellings were read by truthiness, where every non-empty string is truthy. So
+# the words an operator reaches for when opting out selected the *opposite*
+# posture from the one they read as, on a command line the supplying call cannot
+# read a failure back from. Measured on ``3ce3da7``:
+#
+#   dataset_push_to_hub="false"   ->  --dataset.push_to_hub true
+#   record_resume="false"         ->  --resume true
+#   dagger_record_autonomous="off"->  --strategy.record_autonomous true
+#
+# The first uploads an unattended recording to the Hub, the second appends into
+# an existing dataset instead of creating the fresh one that was asked for, and
+# the third records autonomous episodes into a corrections dataset. ``None`` and
+# ``[]`` took the other branch just as silently, without ever being a declared
+# spelling of it.
+#
+# ``replay`` is absent because it emits no flag at all - its argv is unchanged by
+# every flag in this module, so refusing one there would be a false rejection,
+# the same scoping rule :data:`_MODE_NUMERIC_OPTIONS` encodes. ``play_sounds`` is
+# in no tuple for that same reason: nothing reads it anywhere (#2072), so it is
+# excluded here by construction rather than by an exemption.
+_MODE_FLAG_OPTIONS: dict[str, tuple[str, ...]] = {
+    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data"),
+    "teleoperate": ("display_data",),
+    "dagger": ("dagger_record_autonomous", "dataset_push_to_hub", "dataset_video", "display_data"),
+}
+
+
+def _flag_error(mode: str, supplied: dict[str, Any]) -> str | None:
+    """Error text for the first boolean flag ``mode`` emits but cannot honor.
+
+    Each flag is checked against the shared
+    :func:`~strands_robots.utils.boolean_flag_error` domain - the one the mesh
+    provisioning entry points already apply - so a posture flag is refused
+    identically wherever it is supplied rather than merely equivalently.
+
+    No coercion follows the check, unlike
+    :func:`~strands_robots.mesh.iot.bootstrap.bootstrap_account`: every reader
+    here either selects a literal or gates a ``cmd.extend``, and the numpy
+    booleans ``boolean_flag_error`` also accepts drive both correctly.
+
+    Args:
+        mode: A key of :data:`_MODE_FLAG_OPTIONS`; decides which flags are
+            effective. A mode absent from that map emits none of them and is
+            never refused here.
+        supplied: Every flag named in :data:`_MODE_FLAG_OPTIONS`, as supplied by
+            the caller.
+
+    Returns:
+        An error message naming the flag and its domain, or ``None`` when every
+        flag this mode emits is usable.
+    """
+    for param in _MODE_FLAG_OPTIONS.get(mode, ()):
+        if error := boolean_flag_error(supplied[param], param, "build_lerobot_command"):
             return error
     return None
 
@@ -320,9 +382,10 @@ def build_lerobot_command(
 
     Raises:
         ValueError: If ``action`` is unknown, ``replay`` is requested without
-            ``dataset_repo_id``, or a numeric knob the requested mode emits
-            cannot be honored (see :data:`_OPTION_DOMAINS`). The refusal
-            precedes the argv, so no subprocess is launched.
+            ``dataset_repo_id``, or a numeric knob (see :data:`_OPTION_DOMAINS`)
+            or boolean flag (see :data:`_MODE_FLAG_OPTIONS`) the requested mode
+            emits cannot be honored. The refusal precedes the argv, so no
+            subprocess is launched.
     """
     # Every numeric knob below is interpolated into a detached subprocess's
     # command line, which is not a channel this call can read a failure back
@@ -336,6 +399,16 @@ def build_lerobot_command(
         "fps": fps,
         "replay_episode": replay_episode,
         "teleop_time_s": teleop_time_s,
+    }
+    # The boolean flags reach that same command line, but as a posture rather
+    # than a magnitude, so an unusable value does not fail there - it selects the
+    # other posture and reports success. Same per-mode scoping.
+    flag_options: dict[str, Any] = {
+        "record_resume": record_resume,
+        "dataset_push_to_hub": dataset_push_to_hub,
+        "dataset_video": dataset_video,
+        "display_data": display_data,
+        "dagger_record_autonomous": dagger_record_autonomous,
     }
     if action == "replay":
         if not dataset_repo_id:
@@ -356,6 +429,8 @@ def build_lerobot_command(
         if dataset_repo_id:
             # Recording mode -> lerobot-record (pure data collection via teleop).
             if error := _numeric_option_error("record", numeric_options):
+                raise ValueError(error)
+            if error := _flag_error("record", flag_options):
                 raise ValueError(error)
             from strands_robots.dataset_recorder import resolve_dataset_dir
 
@@ -391,6 +466,8 @@ def build_lerobot_command(
         # Simple teleoperation mode -> lerobot-teleoperate.
         if error := _numeric_option_error("teleoperate", numeric_options):
             raise ValueError(error)
+        if error := _flag_error("teleoperate", flag_options):
+            raise ValueError(error)
         cmd = ["python", "-m", "lerobot.scripts.lerobot_teleoperate"]
         cmd.extend(
             _robot_args(robot_type, robot_port, robot_id, robot_left_arm_port, robot_right_arm_port, robot_cameras)
@@ -423,6 +500,8 @@ def build_lerobot_command(
         # Before the lerobot-version preflight below, so the same caller mistake
         # reports identically whether or not the rollout entry point is present.
         if error := _numeric_option_error("dagger", numeric_options):
+            raise ValueError(error)
+        if error := _flag_error("dagger", flag_options):
             raise ValueError(error)
 
         # lerobot.scripts.lerobot_rollout (the DAgger entry point) landed in

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -1,0 +1,463 @@
+"""``build_lerobot_command`` must refuse a boolean mode flag it can only misread.
+
+Every flag this builder emits selects a *posture*, not a magnitude: ``dataset_video``
+picks the literal ``"true"`` or ``"false"`` on the argv, while ``record_resume``
+decides whether ``--resume true`` appears at all. Both were read by truthiness,
+and every non-empty string is truthy, so the words an operator reaches for when
+opting out selected the opposite posture from the one they read as. Measured on
+``3ce3da7``:
+
+* ``dataset_push_to_hub="false"`` emitted ``--dataset.push_to_hub true``, so a
+  detached, unattended recording uploaded its dataset to the Hub;
+* ``record_resume="false"`` emitted ``--resume true``, appending into an existing
+  dataset - and preserving its already-stamped repo_id - instead of creating the
+  fresh one that was asked for;
+* ``dagger_record_autonomous="off"`` emitted ``--strategy.record_autonomous
+  true``, recording autonomous rollout episodes into a corrections dataset;
+* ``display_data="false"`` emitted ``--display_data true``.
+
+``None`` and ``[]`` took the other branch just as silently, without ever being a
+declared spelling of it. None of these is reported anywhere: the argv goes to a
+subprocess launched with ``start_new_session=True``, the tool returns
+``status="success"`` with a pid, and the CLI parses every one of these argvs
+without complaint - it is simply told the opposite posture.
+
+The flags are checked against the shared
+:func:`~strands_robots.utils.boolean_flag_error` domain, and only for the flags
+the requested mode actually emits: refusing a flag a mode never puts on the argv
+would be a false rejection, which is the same scoping rule the numeric knobs use
+(``tests/tools/test_lerobot_teleoperate_numeric_domain.py``).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+from strands_robots.utils import boolean_flag_error
+
+build_lerobot_command = tele_mod.build_lerobot_command
+lerobot_teleoperate = tele_mod.lerobot_teleoperate
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Keep the module-level session store inside the test's temp dir."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+@pytest.fixture
+def _rollout_entry_point(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Present the lerobot rollout module so the ``dagger`` preflight passes.
+
+    ``dagger`` needs lerobot>=0.6.0 installed to reach its argv at all; the flag
+    refusal is deliberately placed *before* that preflight, so these tests pin
+    the refusal on both sides of it (see
+    :class:`TestTheRefusalPrecedesTheLerobotVersionPreflight`).
+    """
+    real_find_spec = tele_mod.importlib.util.find_spec
+
+    def _find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "lerobot.scripts.lerobot_rollout":
+            return object()
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(tele_mod.importlib.util, "find_spec", _find_spec)
+
+
+# A value in no boolean's domain. The four strings are the spellings an operator
+# reaches for when opting out, and each is truthy; ``nan`` and ``0.7`` are truthy
+# numbers; ``None`` and ``[]`` are falsy values that are not a declared spelling
+# of the negative posture either.
+NOT_A_BOOLEAN = [
+    pytest.param("false", id="str-false"),
+    pytest.param("no", id="str-no"),
+    pytest.param("off", id="str-off"),
+    pytest.param("0", id="str-zero"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(0.7, id="fractional"),
+    pytest.param(1, id="int-one"),
+    pytest.param(0, id="int-zero"),
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty-list"),
+]
+
+# Both python spellings plus the numpy booleans ``boolean_flag_error`` accepts,
+# which arrive from an array-shaped config or a NumPy comparison.
+A_BOOLEAN = [
+    pytest.param(True, True, id="true"),
+    pytest.param(False, False, id="false"),
+    pytest.param(np.True_, True, id="np-true"),
+    pytest.param(np.False_, False, id="np-false"),
+]
+
+
+def _record(**overrides: Any) -> list[str]:
+    """A ``lerobot-record`` argv (``start`` + a dataset repo id)."""
+    kwargs: dict[str, Any] = {
+        "action": "start",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "teleop_type": "so101_leader",
+        "teleop_port": "/dev/ttyACM0",
+        "dataset_repo_id": "user/pick",
+        "dataset_single_task": "pick the cube",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _teleop(**overrides: Any) -> list[str]:
+    """A ``lerobot-teleoperate`` argv (``start`` with no dataset)."""
+    kwargs: dict[str, Any] = {
+        "action": "start",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "teleop_type": "so101_leader",
+        "teleop_port": "/dev/ttyACM0",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _replay(**overrides: Any) -> list[str]:
+    """A ``lerobot-replay`` argv."""
+    kwargs: dict[str, Any] = {
+        "action": "replay",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "dataset_repo_id": "user/pick",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _dagger(**overrides: Any) -> list[str]:
+    """A ``lerobot-rollout --strategy.type=dagger`` argv."""
+    kwargs: dict[str, Any] = {
+        "action": "dagger",
+        "robot_type": "so101_follower",
+        "robot_port": "/dev/ttyACM1",
+        "teleop_type": "so101_leader",
+        "teleop_port": "/dev/ttyACM0",
+        "dataset_repo_id": "user/pick",
+        "policy_path": "lerobot/act_so101",
+    }
+    kwargs.update(overrides)
+    return build_lerobot_command(**kwargs)
+
+
+def _token(argv: list[str], flag: str) -> str | None:
+    """The token following ``flag``, or ``None`` when the flag is absent."""
+    return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+class TestAnUnattendedRecordingCannotBeTalkedIntoUploading:
+    """``dataset_push_to_hub`` is the flag with the widest blast radius.
+
+    A recording session is detached and unattended by design, and the Hub push
+    happens at the end of it. A truthy spelling of off therefore published a
+    dataset with no one watching, and the call that asked for the opposite had
+    already returned ``status="success"``.
+    """
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_record_refuses_a_non_boolean_push_to_hub(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="dataset_push_to_hub"):
+            _record(dataset_push_to_hub=value)
+
+    def test_the_opt_out_spelling_no_longer_selects_the_upload(self) -> None:
+        """Pre-fix this emitted ``--dataset.push_to_hub true``."""
+        with pytest.raises(ValueError, match="dataset_push_to_hub"):
+            _record(dataset_push_to_hub="false")
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_dagger_refuses_a_non_boolean_push_to_hub(self, value: Any, _rollout_entry_point: None) -> None:
+        """DAgger appends corrections to a dataset and pushes the same way."""
+        with pytest.raises(ValueError, match="dataset_push_to_hub"):
+            _dagger(dataset_push_to_hub=value)
+
+    @pytest.mark.parametrize(("value", "expected"), A_BOOLEAN)
+    def test_a_boolean_still_selects_the_posture_it_names(self, value: Any, expected: bool) -> None:
+        token = _token(_record(dataset_push_to_hub=value), "--dataset.push_to_hub")
+        assert token == ("true" if expected else "false")
+
+
+class TestAFreshRecordingCannotBeTurnedIntoAnAppend:
+    """``record_resume`` chooses between two datasets, not between two verbosities.
+
+    Resume preserves an existing, already-stamped ``repo_id`` and appends to the
+    data at the resolved root; a fresh record stamps a new one. A truthy spelling
+    of off silently merged one operator's episodes into another's dataset.
+    """
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_record_refuses_a_non_boolean_resume(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="record_resume"):
+            _record(record_resume=value)
+
+    def test_the_opt_out_spelling_no_longer_selects_the_append(self) -> None:
+        """Pre-fix this emitted ``--resume true``."""
+        with pytest.raises(ValueError, match="record_resume"):
+            _record(record_resume="false")
+
+    def test_a_true_resume_still_emits_the_flag(self) -> None:
+        assert _token(_record(record_resume=True), "--resume") == "true"
+
+    def test_a_false_resume_still_omits_the_flag(self) -> None:
+        """Absence is how a fresh record is spelled; that is unchanged."""
+        assert "--resume" not in _record(record_resume=False)
+
+    def test_a_numpy_false_resume_omits_the_flag_too(self) -> None:
+        """The check accepts a numpy boolean, so the emitter must handle one."""
+        assert "--resume" not in _record(record_resume=np.False_)
+
+
+class TestTheRemainingFlagsShareTheSameDomain:
+    """``dataset_video``, ``display_data`` and ``dagger_record_autonomous``."""
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_record_refuses_a_non_boolean_video_setting(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="dataset_video"):
+            _record(dataset_video=value)
+
+    @pytest.mark.parametrize(("value", "expected"), A_BOOLEAN)
+    def test_a_boolean_video_setting_reaches_the_argv(self, value: Any, expected: bool) -> None:
+        assert _token(_record(dataset_video=value), "--dataset.video") == ("true" if expected else "false")
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_record_refuses_a_non_boolean_display_data(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="display_data"):
+            _record(display_data=value)
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_teleoperate_refuses_a_non_boolean_display_data(self, value: Any) -> None:
+        with pytest.raises(ValueError, match="display_data"):
+            _teleop(display_data=value)
+
+    def test_a_true_display_data_still_emits_the_flag(self) -> None:
+        assert _token(_teleop(display_data=True), "--display_data") == "true"
+
+    def test_a_false_display_data_still_omits_the_flag(self) -> None:
+        assert "--display_data" not in _teleop(display_data=False)
+
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_dagger_refuses_a_non_boolean_record_autonomous(self, value: Any, _rollout_entry_point: None) -> None:
+        with pytest.raises(ValueError, match="dagger_record_autonomous"):
+            _dagger(dagger_record_autonomous=value)
+
+    def test_a_true_record_autonomous_still_emits_the_flag(self, _rollout_entry_point: None) -> None:
+        argv = _dagger(dagger_record_autonomous=True)
+        assert _token(argv, "--strategy.record_autonomous") == "true"
+
+    def test_a_false_record_autonomous_still_omits_the_flag(self, _rollout_entry_point: None) -> None:
+        assert "--strategy.record_autonomous" not in _dagger(dagger_record_autonomous=False)
+
+
+class TestOnlyTheFlagsAModeEmitsAreChecked:
+    """A caller must never be refused for a flag the requested mode ignores.
+
+    This is the over-reach control for the whole change: the same unusable value
+    that is refused above must be accepted here, because no argv carries it.
+    """
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["record_resume", "dataset_push_to_hub", "dataset_video", "display_data", "dagger_record_autonomous"],
+    )
+    def test_replay_refuses_no_flag_and_its_argv_is_unchanged(self, flag: str) -> None:
+        """``lerobot-replay`` emits no boolean flag at all."""
+        assert _replay(**{flag: "false"}) == _replay()
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["record_resume", "dataset_push_to_hub", "dataset_video", "dagger_record_autonomous"],
+    )
+    def test_teleoperate_reads_only_display_data(self, flag: str) -> None:
+        """Plain teleoperation emits no ``--dataset.*`` flag and no strategy."""
+        assert _teleop(**{flag: "false"}) == _teleop()
+
+    def test_record_ignores_the_dagger_strategy_flag(self) -> None:
+        assert _record(dagger_record_autonomous="false") == _record()
+
+    def test_dagger_ignores_the_record_resume_flag(self, _rollout_entry_point: None) -> None:
+        """``lerobot-rollout`` has no ``--resume``; the flag is never emitted."""
+        assert _dagger(record_resume="false") == _dagger()
+
+
+class TestPlaySoundsIsExcludedByConstruction:
+    """No mode emits ``play_sounds``, so no mode may refuse a value for it.
+
+    The parameter is declared, documented and forwarded, and then read by
+    nothing - so giving it a domain here would be a false rejection for an option
+    that has no effect either way. It is absent from the table for the same
+    reason ``replay`` is, rather than by an exemption. Whether it should be
+    emitted or removed is #2072; this class pins the state that issue describes,
+    so it fails the day the answer lands and the exclusion stops being true.
+    """
+
+    def test_no_mode_emits_it(self) -> None:
+        for name, tuple_ in tele_mod._MODE_FLAG_OPTIONS.items():
+            assert "play_sounds" not in tuple_, f"mode {name!r} now emits play_sounds; give it a domain"
+
+    @pytest.mark.parametrize("builder", [_record, _teleop, _replay])
+    def test_the_argv_is_identical_either_way(self, builder: Any) -> None:
+        assert builder(play_sounds=True) == builder(play_sounds=False)
+
+    def test_the_dagger_argv_is_identical_either_way(self, _rollout_entry_point: None) -> None:
+        assert _dagger(play_sounds=True) == _dagger(play_sounds=False)
+
+    def test_no_argv_carries_a_sound_token(self) -> None:
+        for argv in (_record(), _teleop(), _replay()):
+            assert [token for token in argv if "sound" in token.lower()] == []
+
+    def test_a_non_boolean_is_consequently_not_refused(self) -> None:
+        """Not an oversight: nothing reads it, so nothing can misread it."""
+        assert _record(play_sounds="false") == _record()
+
+
+class TestTheRefusalPrecedesEverythingItWouldOtherwiseReach:
+    """Nothing may be launched, persisted or preflighted for a refused call."""
+
+    def test_the_tool_reports_the_refusal_without_starting_a_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _never(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("subprocess.Popen must not be reached for a refused call")
+
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _never)
+        result = lerobot_teleoperate(
+            action="start",
+            robot_type="so101_follower",
+            robot_port="/dev/ttyACM1",
+            teleop_type="so101_leader",
+            teleop_port="/dev/ttyACM0",
+            dataset_repo_id="user/pick",
+            dataset_push_to_hub="false",
+            session_name="refused-flag",
+        )
+        assert result["status"] == "error"
+        text = "\n".join(item.get("text", "") for item in result["content"] if "text" in item)
+        assert "dataset_push_to_hub" in text
+        assert tele_mod.SessionManager().get_session("refused-flag") is None
+
+    def test_dagger_refuses_the_flag_without_the_rollout_entry_point(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The same caller mistake must report the same way on any lerobot.
+
+        Placed before the version preflight, so an unusable flag is named rather
+        than being masked by an upgrade hint on an older install.
+        """
+        monkeypatch.setattr(tele_mod.importlib.util, "find_spec", lambda *args, **kwargs: None)
+        with pytest.raises(ValueError, match="dagger_record_autonomous"):
+            _dagger(dagger_record_autonomous="false")
+
+    def test_a_numeric_refusal_still_comes_first(self) -> None:
+        """Both are refusals; the order is chosen rather than incidental.
+
+        The numeric knobs are checked first so their messages - and the tests
+        that pin them - are unchanged by this addition.
+        """
+        with pytest.raises(ValueError, match="dataset_fps"):
+            _record(dataset_fps=0, dataset_push_to_hub="false")
+
+
+class TestTheFlagTableCannotDriftFromTheBuilder:
+    """The table is the record of what each mode emits; keep it measurable."""
+
+    def test_every_flag_a_mode_emits_is_a_real_parameter(self) -> None:
+        params = set(inspect.signature(build_lerobot_command).parameters)
+        named = {flag for flags in tele_mod._MODE_FLAG_OPTIONS.values() for flag in flags}
+        unknown = sorted(named - params)
+        assert not unknown, f"_MODE_FLAG_OPTIONS names non-parameters: {unknown}"
+
+    def test_every_flag_a_mode_emits_is_declared_a_bool(self) -> None:
+        """A flag whose annotation is not ``bool`` belongs to another domain."""
+        params = inspect.signature(build_lerobot_command).parameters
+        named = {flag for flags in tele_mod._MODE_FLAG_OPTIONS.values() for flag in flags}
+        # The module has no ``from __future__ import annotations``, so the
+        # annotation is the ``bool`` type itself; accept the string spelling too
+        # so adding that import does not silently disarm this check.
+        adrift = sorted(flag for flag in named if params[flag].annotation not in (bool, "bool"))
+        assert not adrift, f"_MODE_FLAG_OPTIONS names non-bool parameters: {adrift}"
+
+    def test_every_mode_in_the_table_is_one_the_builder_dispatches(self) -> None:
+        assert set(tele_mod._MODE_FLAG_OPTIONS) <= set(tele_mod._MODE_NUMERIC_OPTIONS)
+
+    def test_replay_is_absent_because_it_emits_no_flag(self) -> None:
+        """Absence is the assertion, so a flag added to replay fails here."""
+        assert "replay" not in tele_mod._MODE_FLAG_OPTIONS
+        assert "replay" in tele_mod._MODE_NUMERIC_OPTIONS
+
+    def test_no_mode_names_a_flag_the_supplied_dict_cannot_answer(self) -> None:
+        """Guards the ``supplied[param]`` lookup against a typo in the table."""
+        every_flag_usable = dict.fromkeys(
+            {flag for flags in tele_mod._MODE_FLAG_OPTIONS.values() for flag in flags}, True
+        )
+        for mode in tele_mod._MODE_FLAG_OPTIONS:
+            assert tele_mod._flag_error(mode, every_flag_usable) is None
+
+    def test_a_mode_absent_from_the_table_refuses_nothing(self) -> None:
+        assert tele_mod._flag_error("replay", {}) is None
+
+    def test_the_flags_are_reported_in_the_order_the_argv_emits_them(self) -> None:
+        """Two unusable flags in one call must report deterministically."""
+        with pytest.raises(ValueError, match="record_resume"):
+            _record(record_resume="false", dataset_video="false")
+
+    def test_the_flag_and_numeric_tables_name_disjoint_options(self) -> None:
+        """A knob is a magnitude or a posture, never both."""
+        numeric = {knob for knobs in tele_mod._MODE_NUMERIC_OPTIONS.values() for knob in knobs}
+        flags = {flag for flags in tele_mod._MODE_FLAG_OPTIONS.values() for flag in flags}
+        assert not numeric & flags
+
+
+class TestTheSharedDomainIsTheOneApplied:
+    """The refusal must be the shared one, not a local equivalent of it."""
+
+    def test_the_message_is_the_shared_domains_message(self) -> None:
+        expected = boolean_flag_error("false", "dataset_push_to_hub", "build_lerobot_command")
+        assert expected is not None
+        with pytest.raises(ValueError) as excinfo:
+            _record(dataset_push_to_hub="false")
+        assert str(excinfo.value) == expected
+
+    def test_the_message_names_the_builder_as_the_context(self) -> None:
+        with pytest.raises(ValueError, match="build_lerobot_command"):
+            _record(dataset_video="false")
+
+    def test_the_message_explains_why_it_is_not_parsed(self) -> None:
+        """A caller who wrote ``"false"`` needs to know it was not read as off."""
+        with pytest.raises(ValueError, match="checked rather than parsed"):
+            _record(dataset_video="false")
+
+
+class TestTheToolsOwnExecutionFlagsStayOutOfScope:
+    """``background`` and ``auto_accept_calibration`` are not builder flags.
+
+    Neither reaches an argv: they choose how ``lerobot_teleoperate`` runs the
+    command it built - detached with a log file, and whether a newline is written
+    to the child's stdin to accept a calibration prompt. They are parameters of
+    the tool alone, have no per-mode table to be scoped by, and are read after
+    the builder has returned. Pinned rather than assumed, so this boundary is
+    measured; tracked separately.
+    """
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_they_are_tool_parameters_and_not_builder_parameters(self, flag: str) -> None:
+        assert flag in inspect.signature(lerobot_teleoperate).parameters
+        assert flag not in inspect.signature(build_lerobot_command).parameters
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_the_builder_neither_reads_nor_refuses_them(self, flag: str) -> None:
+        """They arrive in ``**kwargs`` and are ignored, as they were before."""
+        assert _record(**{flag: "false"}) == _record()
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_they_are_not_in_the_flag_table(self, flag: str) -> None:
+        named = {name for names in tele_mod._MODE_FLAG_OPTIONS.values() for name in names}
+        assert flag not in named

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -44,6 +44,17 @@ build_lerobot_command = tele_mod.build_lerobot_command
 lerobot_teleoperate = tele_mod.lerobot_teleoperate
 
 
+def _run_tool(**kwargs: Any) -> dict[str, Any]:
+    """Call the agent tool through one funnel.
+
+    The flag value under test is deliberately outside the declared ``bool``,
+    which is the point; mypy does not narrow a splatted ``dict[str, Any]``, so
+    routing the call through here states that once rather than suppressing it at
+    the call site.
+    """
+    return dict(lerobot_teleoperate(**kwargs))
+
+
 @pytest.fixture(autouse=True)
 def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
     """Keep the module-level session store inside the test's temp dir."""
@@ -331,7 +342,7 @@ class TestTheRefusalPrecedesEverythingItWouldOtherwiseReach:
             raise AssertionError("subprocess.Popen must not be reached for a refused call")
 
         monkeypatch.setattr(tele_mod.subprocess, "Popen", _never)
-        result = lerobot_teleoperate(
+        result = _run_tool(
             action="start",
             robot_type="so101_follower",
             robot_port="/dev/ttyACM1",


### PR DESCRIPTION
## The defect

`build_lerobot_command` checks every numeric knob the requested mode emits against a shared domain, scoped by `_MODE_NUMERIC_OPTIONS`. Its **boolean** flags reach the same command line and were read by truthiness.

Each one selects a *posture* rather than scaling a quantity: `dataset_video` picks the literal `"true"` or `"false"` on the argv, `record_resume` decides whether `--resume true` appears at all. Every non-empty string is truthy, so the words an operator reaches for when opting out selected the **opposite** posture from the one they read as. Measured on `3ce3da7` (record mode, `so101` leader/follower):

| supplied | argv on `main` | what it means |
|---|---|---|
| `dataset_push_to_hub="false"` | `--dataset.push_to_hub true` | a detached, unattended recording uploads its dataset to the Hub |
| `record_resume="false"` | `--resume true` | appends into an existing dataset, preserving its already-stamped `repo_id`, instead of creating the fresh one asked for |
| `dagger_record_autonomous="off"` | `--strategy.record_autonomous true` | autonomous rollout episodes land in a corrections dataset |
| `display_data="false"` | `--display_data true` | |

`"no"`, `"off"`, `"0"` and `nan` behave identically. `None` and `[]` fail the other way - they took the negative branch just as silently, without ever being a declared spelling of it.

Nothing reports any of this. The argv goes to a subprocess launched with `start_new_session=True`, which is not a channel the supplying call can read a failure back from; the call returns `status="success"` with a pid, and the lerobot CLI parses every one of those argvs without complaint - it is simply told the opposite posture. Unlike an unusable *number*, which at least fails inside lerobot minutes later, a misread flag never surfaces at all.

All five flags are reachable from an agent: the tool spec declares each as `{"type": "boolean"}`, and a model that emits `"false"` for one gets the `true` behaviour.

## The change

A per-mode flag table beside the numeric one, and the shared `boolean_flag_error` domain - the same one `provision_robot` and `bootstrap_account` already apply - reached from each mode's dispatch:

```python
_MODE_FLAG_OPTIONS: dict[str, tuple[str, ...]] = {
    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data"),
    "teleoperate": ("display_data",),
    "dagger": ("dagger_record_autonomous", "dataset_push_to_hub", "dataset_video", "display_data"),
}
```

Four details worth stating:

- **`replay` is absent, not empty.** It emits no flag at all - its argv is provably unchanged by every flag in the module - so refusing one there would be a false rejection. Absence is the assertion, so a flag added to `replay` fails the pinned test rather than silently escaping the domain.
- **`play_sounds` is excluded by construction.** No mode emits it, so giving it a domain would be a false rejection for an option that has no effect either way. Whether it should be emitted or removed is #2072; this PR pins the state that issue describes - no tuple names it, the argv is identical for `True` / `False` in all four modes, and a non-boolean is consequently *not* refused - so the exclusion fails the day that question is answered.
- **The numeric check still runs first.** Both are refusals; the order is chosen rather than incidental, so every existing numeric message and the tests pinning them are untouched. Pinned.
- **The dagger refusal precedes the lerobot-version preflight**, matching where the numeric one sits, so the same caller mistake is named identically on a lerobot that has no rollout entry point instead of being masked by an upgrade hint. Pinned.

No coercion follows the check, unlike `bootstrap_account`: every reader here either selects a literal or gates a `cmd.extend`, and the numpy booleans `boolean_flag_error` also accepts drive both correctly - pinned for `record_resume=np.False_`, which must still omit the flag.

## Out of scope, deliberately

`lerobot_teleoperate`'s own `background` and `auto_accept_calibration` are also read by truthiness. Neither reaches an argv: they choose how the tool *runs* the command it built - detached with a log file, and whether a newline is written to the child's stdin to accept a calibration prompt. They are parameters of the tool alone, have no per-mode table to be scoped by, and are read after the builder has returned, so folding them in would mean inventing a second scoping rule in the same diff. The boundary is pinned in `TestTheToolsOwnExecutionFlagsStayOutOfScope` so it is measured rather than assumed, and filed as #2074.

## Verification

Measured in a clean checkout on base `3ce3da7`, python 3.13. The authoring runner had no `lerobot` / `torch` / `mujoco`, so the suites needing them were left to CI; every suite that reaches this module is run below. (A gate run with all three present is reported under round 1.)

- **Pre-fix proof** - source reverted to `3ce3da7`, the new tests kept: **88 failed / 37 passed**. The 37 that pass are the over-reach controls (`replay` and `teleoperate` ignoring the flags they do not emit, the `play_sounds` argv equalities, the usable spellings reaching the argv, the tool-level scope boundary) - they were already correct and must stay correct.
- **New tests**: 125, `tests/tools/test_lerobot_teleoperate_flag_domain.py`, 0.7 s - no lerobot, no subprocess, no optional backend.
- **The module's existing suites**: `tests/tools/test_lerobot_teleoperate_numeric_domain.py` (57), `tests/test_tool_result_contract.py`, `tests/simulation/test_replay_episode_index_domain.py`, `tests/mesh/test_iot_provisioning_flag_domain.py` (the `boolean_flag_error` audit) -> **336 passed, 2 skipped**, **zero existing-test changes**.
- **`tests/tools` before and after**: 12 failed / 1459 passed -> 12 failed / **1584** passed (+125, exactly the new tests). The 12 failures are byte-identical in both runs and are all `No module named 'lerobot'` in this runner, not of this branch.
- **Lint**: `ruff check` clean, `ruff format --check` clean on both changed files.
- **Merge-base overlap**: none. `main` advanced by one commit (#2069) during this work; it touched `benchmark_spec.py` and its test only, so these numbers describe the tree that merges.

## §13 round changelog

**Round 0** - initial submission.

**Round 1** - `a0fe71b`: lint was red before the tests ran, so none of the 125 had executed. `mypy` refused the one call that passes an off-`bool` value to the decorated tool (`arg-type` at `test_lerobot_teleoperate_flag_domain.py:341`); the value being outside the declared `bool` is that test's subject, so the call is routed through a single documented `_run_tool(**kwargs: Any)` funnel rather than suppressed per site. Test file only, +12/-1, no assertion changes and no source changes.

Verified on `a0fe71b`: `mypy` clean on the file in-tree, **182 passed** across this file and its numeric sibling, `ruff check` / `ruff format --check` clean. A gate run carrying `lerobot`, `torch` and `mujoco` - the three the authoring runner lacked - reports `MUJOCO_GL=egl pytest tests` at **26083 passed, 257 skipped, 0 failed**, and `mypy strands_robots tests tests_integ` at 0 errors outside `examples/isaac_gs`, so the 12 environment failures reported under round 0 were the runner rather than the branch.