### PR TITLE
fix(simulation): apply the benchmark spec's string checks on both construction paths

### DIFF
--- a/changelog.d/2070-benchmark-string-field-domains.md
+++ b/changelog.d/2070-benchmark-string-field-domains.md
@@ -1,0 +1,26 @@
+### Fixed: `DeclarativeBenchmark` now applies its string checks on both construction paths
+
+`DeclarativeBenchmark` has two construction paths, and they applied different
+checks to the same values. `from_dict` refused a `name`, `default_robot`, `scene`
+or `instruction` that was not a string; the constructor stored each one raw, so a
+directly constructed benchmark could carry a value the evaluation loop -- or the
+policy it drives -- then had to deal with. Only `max_steps` and
+`supported_robots` were mirrored across the two.
+
+Two of the four were silent rather than loud. `instruction=42` was accepted and
+handed to the policy verbatim as its task command, because `PolicyRunner` falls
+back to `spec.instruction` when the caller passes none and cannot tell an `int`
+from an instruction; a language-conditioned policy received a value its tokenizer
+cannot take, and the evaluation reported `status="success"`. A falsy non-string
+`scene` such as `[]` was skipped by the truthiness test in `on_episode_start`, so
+a declared scene was never loaded, also under `status="success"`. A non-string
+`name` was stored and then advertised as the benchmark's id by
+`sim.list_benchmarks()`.
+
+All four now go through one module-level string domain, invoked from both paths
+with their own context, so the key a spec file sets and the keyword a direct
+construction passes are held to the same rule. `default_robot` is checked ahead
+of the `supported_robots` membership test, so a non-string is reported as the
+wrong type rather than as a robot missing from the supported set. The accepted
+side is unchanged: `instruction=""` and `scene=""`/`scene=None` are the
+documented ways to declare neither.

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -47,6 +47,15 @@ Example::
       - {predicate: distance_neg, body_a: gripper, body_b: drawer_handle, weight: 1.0}
       - {predicate: joint_progress, joint: drawer_slide, target: 0.2, weight: 5.0}
 
+Every value in that schema is held to one domain, applied identically whether
+it arrives as a spec key or as a keyword to :meth:`DeclarativeBenchmark.from_dict`
+or the constructor - so a spec file and a direct construction cannot disagree on
+what they accept. ``max_steps`` is a positive whole count, ``supported_robots``
+is a list of distinct non-blank names containing ``default_robot``, and the four
+string fields go through :func:`_spec_string_error`: ``name`` and
+``default_robot`` are non-empty, ``instruction`` is a possibly-empty string, and
+``scene`` is a string or omitted.
+
 Load + register via :func:`register_benchmark_from_file`; agents call this
 through the ``register_benchmark_from_file`` tool action.
 
@@ -60,7 +69,7 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.simulation.benchmark import (
     BenchmarkProtocol,
@@ -92,6 +101,66 @@ _ALLOWED_TOP_LEVEL = frozenset(
         "dense_reward",
     }
 )
+
+
+def _spec_string_error(
+    value: Any,
+    param: str,
+    context: str,
+    *,
+    allow_empty: bool = False,
+    allow_none: bool = False,
+) -> str | None:
+    """Return an error message if ``value`` cannot be honored as ``param``'s text.
+
+    The string half of the spec vocabulary, shared by
+    :meth:`DeclarativeBenchmark.from_dict` and
+    :meth:`DeclarativeBenchmark.__init__` so the key a spec file sets and the
+    keyword a direct construction passes cannot drift apart on what they accept
+    - the same reason ``max_steps`` and ``supported_robots`` share their
+    domains with the shared helpers in :mod:`strands_robots.utils`.
+
+    It lives here rather than there because what it refuses is this module's own
+    vocabulary and nothing else's. The comparable shared helper,
+    :func:`~strands_robots.utils.entity_name_error`, scopes itself in its
+    docstring to the creation sites in the simulation backends, and its reasons
+    are MuJoCo's (``""`` is that engine's unnamed-entity sentinel, a NUL
+    truncates in the compiled model) - neither applies to a benchmark id.
+
+    Two axes, because the four fields differ only along them:
+
+    * ``allow_empty`` - ``name`` and ``default_robot`` are identifiers, so the
+      empty string names nothing; ``instruction`` and ``scene`` are content, and
+      an empty one is the documented "not declared" spelling.
+    * ``allow_none`` - ``scene`` alone is optional, so ``None`` is how a spec
+      says it declares no scene.
+
+    A ``bool`` is refused by the type test rather than separately: it is not a
+    ``str`` at all, unlike the numeric domains where ``bool`` is an ``int``
+    subclass and has to be turned away by name.
+
+    Args:
+        value: The value supplied for ``param``.
+        param: Field name, quoted in the message.
+        context: Where the value came from - ``"spec"`` for a spec dict, the
+            class name for a direct construction.
+        allow_empty: Accept the empty string.
+        allow_none: Accept ``None``.
+
+    Returns:
+        A message naming the field, the accepted set and the type supplied, or
+        ``None`` when the value can be honored.
+    """
+    if value is None:
+        if allow_none:
+            return None
+        return f"{context}: {param} must be a string, got NoneType."
+    if not isinstance(value, str):
+        omitted = " or omitted" if allow_none else ""
+        return f"{context}: {param} must be a string{omitted}, got {type(value).__name__}."
+    if not value and not allow_empty:
+        return f"{context}: {param} must be a non-empty string."
+    return None
 
 
 def _compile_bool_group(
@@ -332,6 +401,29 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         scene: str | None = None,
         instruction: str = "",
     ):
+        # Mirror the four string checks ``from_dict`` runs, for the reason the two
+        # mirrors below state: a directly constructed benchmark must not carry a
+        # value the evaluation loop, or the policy it drives, has to deal with
+        # later. Measured before this: ``instruction=42`` was handed to the
+        # policy verbatim as its task command (``PolicyRunner`` falls back to
+        # ``spec.instruction`` when the caller passes none), and a falsy
+        # non-string ``scene`` such as ``[]`` was skipped by the truthiness test
+        # in :meth:`on_episode_start`, so a declared scene was never loaded -
+        # both under ``status="success"``.
+        #
+        # ``default_robot`` is checked here, ahead of the membership test below:
+        # on ``default_robot=7`` that test would report ``7 not in [...]``, which
+        # describes the symptom rather than the mistake. Same ordering reason as
+        # the shape-before-membership note on ``supported_robots``.
+        cls_name = type(self).__name__
+        if error := _spec_string_error(name, "name", cls_name):
+            raise ValueError(error)
+        if error := _spec_string_error(default_robot, "default_robot", cls_name):
+            raise ValueError(error)
+        if error := _spec_string_error(scene, "scene", cls_name, allow_empty=True, allow_none=True):
+            raise ValueError(error)
+        if error := _spec_string_error(instruction, "instruction", cls_name, allow_empty=True):
+            raise ValueError(error)
         self._name = name
         # Mirrors the two checks ``from_dict`` runs on this value, for the
         # reason the ``max_steps`` mirror below states: a directly constructed
@@ -378,6 +470,10 @@ class DeclarativeBenchmark(BenchmarkProtocol):
 
         Used as the registry key by :func:`register_benchmark_from_file`;
         registering two specs with the same ``name`` overwrites the first.
+
+        The constructor holds this to :func:`_spec_string_error`: a non-empty
+        ``str``, on both construction paths. A non-string was previously stored
+        and then advertised by ``sim.list_benchmarks()`` as the benchmark's id.
         """
         return self._name
 
@@ -405,6 +501,11 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         Implements :attr:`BenchmarkProtocol.default_robot`;
         :meth:`on_episode_start` adds it via ``sim.add_robot`` before the first
         observation when no robot is present.
+
+        The constructor holds this to :func:`_spec_string_error` - a non-empty
+        ``str`` - before the :attr:`supported_robots` membership test, so a
+        non-string is reported as the wrong type rather than as a robot missing
+        from the supported set.
         """
         return self._default_robot
 
@@ -418,6 +519,12 @@ class DeclarativeBenchmark(BenchmarkProtocol):
         caller passes no ``instruction=`` to ``evaluate_benchmark``, so a
         language-conditioned policy (GR00T, OpenVLA, ...) receives the command
         instead of an empty string (the #187 off-task failure mode).
+
+        The constructor holds this to :func:`_spec_string_error`: a ``str``,
+        possibly empty, on both construction paths. That fallback is why the
+        mirror matters - a non-string stored here was handed to the policy
+        verbatim as its task command, so a language-conditioned policy received
+        a value its tokenizer cannot take while the evaluation reported success.
         """
         return self._instruction
 
@@ -495,12 +602,22 @@ class DeclarativeBenchmark(BenchmarkProtocol):
             )
 
         name = spec.get("name")
-        if not isinstance(name, str) or not name:
-            raise ValueError("spec.name: required non-empty string")
+        # Shared string domain, so the key a spec file sets and the keyword a
+        # direct construction passes cannot drift apart on what they accept -
+        # the same reason ``supported_robots`` and ``max_steps`` below share
+        # theirs.
+        if error := _spec_string_error(name, "name", "spec"):
+            raise ValueError(error)
+        # The guard above is what proves the type; the cast only carries that
+        # proof forward for the type checker, which cannot see through a helper
+        # returning a message. Both fields are required, so neither can be None
+        # by the time they reach the constructor.
+        name = cast("str", name)
 
         default_robot = spec.get("default_robot")
-        if not isinstance(default_robot, str) or not default_robot:
-            raise ValueError("spec.default_robot: required non-empty string")
+        if error := _spec_string_error(default_robot, "default_robot", "spec"):
+            raise ValueError(error)
+        default_robot = cast("str", default_robot)
 
         supported_robots = spec.get("supported_robots", [])
         # Shared name-list domain, so the key a spec file sets and the keyword a
@@ -525,12 +642,12 @@ class DeclarativeBenchmark(BenchmarkProtocol):
             raise ValueError(error)
 
         scene = spec.get("scene")
-        if scene is not None and not isinstance(scene, str):
-            raise ValueError(f"spec.scene: must be a string path or omitted, got {type(scene).__name__}")
+        if error := _spec_string_error(scene, "scene", "spec", allow_empty=True, allow_none=True):
+            raise ValueError(error)
 
         instruction = spec.get("instruction", "")
-        if not isinstance(instruction, str):
-            raise ValueError(f"spec.instruction: must be a string or omitted, got {type(instruction).__name__}")
+        if error := _spec_string_error(instruction, "instruction", "spec", allow_empty=True):
+            raise ValueError(error)
 
         success_fn = _compile_bool_group(spec.get("success"), default=False, context="success")
         failure_fn = _compile_bool_group(spec.get("failure"), default=False, context="failure")

--- a/tests/simulation/test_benchmark_string_field_domains.py
+++ b/tests/simulation/test_benchmark_string_field_domains.py
@@ -1,0 +1,287 @@
+"""``DeclarativeBenchmark`` holds its four string fields to one shared domain.
+
+``DeclarativeBenchmark`` has two construction paths that applied different
+checks to the same values. ``from_dict`` refused a non-string ``name`` /
+``default_robot`` / ``scene`` / ``instruction``; ``__init__`` stored each one
+raw. Only ``max_steps`` and ``supported_robots`` were mirrored across the two,
+and the comment on the first states the reason for all of them - a directly
+constructed benchmark must not carry a value the evaluation loop, or the policy
+it drives, has to deal with later.
+
+Measured on ``3ce3da7`` (mujoco 3.11.0, ``MUJOCO_GL=egl``), constructing
+directly and then running ``evaluate_benchmark`` over a two-link arm:
+
+* ``instruction=42`` was accepted, and ``PolicyRunner`` handed it to the policy
+  verbatim: ``get_actions`` received ``42`` where a task command belongs. The
+  fallback that does it (``spec.instruction or ""``) exists so a
+  language-conditioned policy receives the command rather than an empty string,
+  and cannot tell an ``int`` from an instruction. The evaluation reported
+  ``status="success"``.
+* ``scene=[]`` was accepted and then *skipped*: ``on_episode_start`` loads the
+  scene under ``if self._scene:``, so a falsy non-string meant the declared
+  scene was never loaded, again under ``status="success"``.
+* ``scene=42`` was the one loud case - truthy, so ``load_scene(42)`` failed and
+  the evaluation returned an error. That is the behaviour the previous boundary
+  pin described for all four; it holds for this one value only.
+* ``name=7`` was accepted, stored, and advertised by ``list_benchmarks()``.
+
+The same values through ``from_dict`` were all refused. These tests pin the two
+paths to one rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import benchmark_spec as spec_mod
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+
+# The four string fields and the two axes they differ along: whether the empty
+# string is a value they can carry, and whether ``None`` is how the field is
+# omitted. Both are read off the shipped contract rather than asserted here -
+# ``instruction`` defaults to ``""`` and ``scene`` defaults to ``None``.
+FIELDS: dict[str, dict[str, bool]] = {
+    "name": {"allow_empty": False, "allow_none": False},
+    "default_robot": {"allow_empty": False, "allow_none": False},
+    "scene": {"allow_empty": True, "allow_none": True},
+    "instruction": {"allow_empty": True, "allow_none": False},
+}
+
+# Values no string field can be honored as, whatever its axes.
+NOT_A_STRING: list[Any] = [
+    pytest.param(7, id="int"),
+    pytest.param(3.5, id="float"),
+    pytest.param(True, id="bool"),
+    pytest.param(["probe"], id="list"),
+    pytest.param({"name": "probe"}, id="mapping"),
+    pytest.param(object(), id="object"),
+]
+
+
+def _make(**overrides: Any) -> DeclarativeBenchmark:
+    """Construct a benchmark directly, with ``overrides`` splatted in.
+
+    Splatted rather than passed positionally so a deliberately off-type value
+    reaches the runtime guard as an agent or a caller would supply it, instead
+    of being reported by the type checker at each call site.
+    """
+    kwargs: dict[str, Any] = {
+        "name": "probe",
+        "supported_robots": [],
+        "default_robot": "panda",
+        "max_steps": 10,
+        "success_fn": lambda _sim: False,
+        "failure_fn": lambda _sim: False,
+        "reward_terms": [],
+    }
+    kwargs.update(overrides)
+    return DeclarativeBenchmark(**kwargs)
+
+
+def _from_dict(**overrides: Any) -> DeclarativeBenchmark:
+    """Compile the same benchmark from a spec dict, with ``overrides`` merged in."""
+    spec: dict[str, Any] = {"name": "probe", "default_robot": "panda", "max_steps": 10}
+    spec.update(overrides)
+    return DeclarativeBenchmark.from_dict(spec)
+
+
+def _refuses(build: Any, **overrides: Any) -> str | None:
+    """Return the refusal message ``build`` raises, or ``None`` if it accepted."""
+    try:
+        build(**overrides)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+class TestDirectConstructionRefusesANonString:
+    """Every field, every value that is not a ``str`` at all."""
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    @pytest.mark.parametrize("value", NOT_A_STRING)
+    def test_it_is_refused(self, field: str, value: Any) -> None:
+        text = _refuses(_make, **{field: value})
+        assert text is not None, f"{field}={value!r} was accepted"
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    @pytest.mark.parametrize("value", NOT_A_STRING)
+    def test_the_message_names_the_field_and_the_type(self, field: str, value: Any) -> None:
+        text = _refuses(_make, **{field: value})
+        assert text is not None
+        assert field in text, text
+        assert type(value).__name__ in text, text
+        assert "DeclarativeBenchmark" in text, text
+
+
+class TestDirectConstructionRefusesAnEmptyIdentifier:
+    """``name`` and ``default_robot`` name something, so ``""`` names nothing."""
+
+    @pytest.mark.parametrize("field", ["name", "default_robot"])
+    def test_the_empty_string_is_refused(self, field: str) -> None:
+        text = _refuses(_make, **{field: ""})
+        assert text is not None, f"{field}='' was accepted"
+        assert "non-empty" in text, text
+
+    @pytest.mark.parametrize("field", ["scene", "instruction"])
+    def test_the_empty_string_stays_accepted_for_content(self, field: str) -> None:
+        """``instruction=""`` is its default and ``scene=""`` declares no scene."""
+        assert _refuses(_make, **{field: ""}) is None
+
+
+class TestNoneIsOnlyAValueForTheOptionalField:
+    """``scene`` is the one field a spec omits by writing ``None``."""
+
+    def test_a_none_scene_is_accepted(self) -> None:
+        assert _refuses(_make, scene=None) is None
+
+    @pytest.mark.parametrize("field", ["name", "default_robot", "instruction"])
+    def test_a_none_elsewhere_is_refused(self, field: str) -> None:
+        text = _refuses(_make, **{field: None})
+        assert text is not None, f"{field}=None was accepted"
+        assert "NoneType" in text, text
+
+
+class TestUsableValuesAreUntouched:
+    """The accepted side of the domain, so the guard cannot be read as a ban."""
+
+    def test_the_default_construction_is_accepted(self) -> None:
+        bench = _make()
+        assert bench.name == "probe"
+        assert bench.default_robot == "panda"
+        assert bench.instruction == ""
+
+    def test_a_declared_scene_and_instruction_are_kept(self) -> None:
+        bench = _make(scene="scenes/table.xml", instruction="pick the cube")
+        assert bench.instruction == "pick the cube"
+        assert bench.on_episode_start is not None
+
+
+class TestBothConstructionPathsAgree:
+    """The property the mirror exists for: one rule, two paths.
+
+    Parametrized over every field and every unusable value rather than asserting
+    the two messages match - the contexts differ by design (``"spec"`` for a
+    spec file, the class name for a direct construction), so what has to agree
+    is the verdict.
+    """
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    @pytest.mark.parametrize("value", NOT_A_STRING)
+    def test_a_non_string_is_refused_by_both(self, field: str, value: Any) -> None:
+        direct = _refuses(_make, **{field: value})
+        spec = _refuses(_from_dict, **{field: value})
+        assert (direct is None) == (spec is None), f"{field}={value!r}: __init__={direct!r} from_dict={spec!r}"
+        assert direct is not None
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    def test_the_empty_string_verdict_agrees(self, field: str) -> None:
+        direct = _refuses(_make, **{field: ""})
+        spec = _refuses(_from_dict, **{field: ""})
+        assert (direct is None) == (spec is None), f"{field}='': __init__={direct!r} from_dict={spec!r}"
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    def test_the_none_verdict_agrees(self, field: str) -> None:
+        direct = _refuses(_make, **{field: None})
+        spec = _refuses(_from_dict, **{field: None})
+        assert (direct is None) == (spec is None), f"{field}=None: __init__={direct!r} from_dict={spec!r}"
+
+
+class TestTheGuardPrecedesTheMembershipCheck:
+    """A non-string ``default_robot`` names the wrong type, not a missing robot.
+
+    Ordering rather than domain: the membership test below the guard compares
+    ``default_robot`` against ``supported_robots``, so on ``default_robot=7``
+    it would report ``7 not in ['panda']`` - the symptom rather than the
+    mistake. Same reason the ``supported_robots`` shape check runs first.
+    """
+
+    def test_the_type_is_reported_rather_than_the_membership(self) -> None:
+        text = _refuses(_make, supported_robots=["panda"], default_robot=7)
+        assert text is not None
+        assert "must be a string" in text, text
+        assert "not in" not in text, text
+
+    def test_a_genuine_membership_failure_still_reports_membership(self) -> None:
+        """The check the guard runs ahead of is unchanged."""
+        text = _refuses(_make, supported_robots=["panda"], default_robot="aloha")
+        assert text is not None
+        assert "not in" in text, text
+
+
+class TestTheDomainIsTheWholeContribution:
+    """``_spec_string_error`` decides only the two axes it documents.
+
+    Parity between the helper and the two construction paths, so the rule cannot
+    be widened at one call site without the helper agreeing.
+    """
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    @pytest.mark.parametrize("value", NOT_A_STRING)
+    def test_the_helper_and_the_constructor_agree(self, field: str, value: Any) -> None:
+        helper = spec_mod._spec_string_error(value, field, "DeclarativeBenchmark", **FIELDS[field])
+        direct = _refuses(_make, **{field: value})
+        assert (helper is None) == (direct is None), (helper, direct)
+
+    @pytest.mark.parametrize("field", sorted(FIELDS))
+    @pytest.mark.parametrize("value", ["", None])
+    def test_the_helper_and_the_constructor_agree_on_the_axes(self, field: str, value: Any) -> None:
+        helper = spec_mod._spec_string_error(value, field, "DeclarativeBenchmark", **FIELDS[field])
+        direct = _refuses(_make, **{field: value})
+        assert (helper is None) == (direct is None), (field, value, helper, direct)
+
+    def test_a_usable_string_is_accepted_by_the_helper(self) -> None:
+        assert spec_mod._spec_string_error("probe", "name", "ctx") is None
+
+
+# --- structural guard: no string field of either path may skip the helper ---
+
+_STRING_PARAMS = frozenset(FIELDS)
+
+
+def _routed_params(func_name: str) -> set[str]:
+    """Names passed to ``_spec_string_error`` inside ``func_name``.
+
+    Reads the shipped source rather than a copy, so a field added to either
+    construction path without the domain is reported by name.
+    """
+    source = inspect.getsource(DeclarativeBenchmark)
+    tree = ast.parse("class _S:\n" + "\n".join("    " + line for line in source.splitlines()))
+    cls = tree.body[0]
+    assert isinstance(cls, ast.ClassDef)
+    inner = next(n for n in ast.walk(cls) if isinstance(n, ast.ClassDef) and n.name == "DeclarativeBenchmark")
+    func = next(n for n in inner.body if isinstance(n, ast.FunctionDef) and n.name == func_name)
+    routed: set[str] = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Name) and node.func.id == "_spec_string_error"):
+            continue
+        if node.args and isinstance(node.args[0], ast.Name):
+            routed.add(node.args[0].id)
+    return routed
+
+
+class TestNoStringFieldSkipsTheDomain:
+    """Both construction paths must route every string field through the helper."""
+
+    @pytest.mark.parametrize("func_name", ["__init__", "from_dict"])
+    def test_every_string_field_is_routed(self, func_name: str) -> None:
+        routed = _routed_params(func_name)
+        missing = _STRING_PARAMS - routed
+        assert not missing, f"{func_name} does not route {sorted(missing)} through _spec_string_error"
+
+    def test_the_scan_finds_the_known_fields(self) -> None:
+        """Non-vacuity: a scan resolving nothing would satisfy the check above."""
+        assert _routed_params("__init__") == _STRING_PARAMS
+        assert _routed_params("from_dict") == _STRING_PARAMS
+
+    def test_the_shipped_source_is_the_scanned_source(self) -> None:
+        """The scan reads the module under test, not a copy of it."""
+        module = inspect.getmodule(DeclarativeBenchmark)
+        assert module is not None and module.__file__ is not None
+        assert Path(module.__file__).name == "benchmark_spec.py"

--- a/tests/simulation/test_benchmark_supported_robots_domain.py
+++ b/tests/simulation/test_benchmark_supported_robots_domain.py
@@ -208,24 +208,36 @@ class TestABenchmarkCannotExcludeItsOwnDefaultRobot:
         assert bench.default_robot == "aloha"
 
 
-class TestNeighbouringFieldsStayOutOfScope:
-    """``from_dict`` also checks ``name`` / ``scene`` / ``instruction`` as
-    strings, and those mirrors are a separate question: they need a string
-    domain this module does not have, and each fails loudly at its consumer
-    rather than silently widening the robot set. Pinned so the boundary of this
-    change is measured rather than assumed."""
+class TestNeighbouringFieldsAreMirroredToo:
+    """``name`` / ``default_robot`` / ``scene`` / ``instruction`` are mirrored now.
 
-    def test_a_non_string_name_is_still_accepted_directly(self) -> None:
-        assert _refuses(_make, name=7) is None
+    This class previously pinned the opposite - that a non-string in any of the
+    four was still accepted by ``__init__`` - and scoped the boundary of the
+    ``supported_robots`` change. Its stated reason was that each "fails loudly
+    at its consumer rather than silently widening the robot set", and that turned
+    out to hold for one value of one field: a truthy non-string ``scene`` fails
+    in ``load_scene``. ``instruction=42`` was handed to the policy verbatim as
+    its task command and ``scene=[]`` was skipped by a truthiness test, both
+    under ``status="success"``.
 
-    def test_a_non_string_scene_is_still_accepted_directly(self) -> None:
-        assert _refuses(_make, scene=42) is None
+    Kept as the pointer to where those four now live, so the boundary this file
+    draws stays measured: ``supported_robots`` is the name-list domain, and the
+    string fields are the module's own string domain, pinned in
+    ``test_benchmark_string_field_domains``.
+    """
 
-    def test_a_non_string_instruction_is_still_accepted_directly(self) -> None:
-        assert _refuses(_make, instruction=42) is None
+    @pytest.mark.parametrize("field", ["name", "default_robot", "scene", "instruction"])
+    def test_a_non_string_is_refused_directly(self, field: str) -> None:
+        assert _refuses(_make, **{field: 42}) is not None
 
     def test_max_steps_keeps_its_own_mirrored_domain(self) -> None:
-        """The one mirror that already existed, unchanged by this."""
+        """The one mirror that predated both changes, unchanged by either."""
         text = _refuses(_make, max_steps=2.7)
         assert text is not None
         assert "max_steps" in text, text
+
+    def test_supported_robots_keeps_the_name_list_domain(self) -> None:
+        """The mirror this file is about, unchanged by the string domain."""
+        text = _refuses(_make, supported_robots="panda")
+        assert text is not None
+        assert "supported_robots" in text, text


### PR DESCRIPTION
## Problem

`DeclarativeBenchmark` has two construction paths that applied different checks to the same values. `from_dict` refused a `name`, `default_robot`, `scene` or `instruction` that was not a string; `__init__` stored each one raw. Of the nine checks `from_dict` runs, only `max_steps` and `supported_robots` were mirrored — and the comment on the first states the reason for all of them:

> Mirrors the check `from_dict` runs on the raw spec value, so a directly constructed benchmark cannot carry a horizon the evaluation loop has to refuse later.

Two of the four remaining fields were silent rather than loud. Measured on `3ce3da7`, one construction per row, then `evaluate_benchmark` over a two-link arm:

| value | `__init__` | consequence at evaluation |
|---|---|---|
| `instruction=42` | accepted | `status="success"`; the policy's `get_actions` received `42` where the task command belongs |
| `instruction=['pick']` | accepted | `status="success"`; the policy received `['pick']` |
| `scene=[]` | accepted | `status="success"`; the **declared scene was never loaded** |
| `scene=42` | accepted | `status="error"` — the one loud case |
| `name=7` | accepted | `status="success"`; advertised as the benchmark's id by `list_benchmarks()` |
| `default_robot=''` | accepted | `status="success"` |

`instruction` is the sharpest. `PolicyRunner` falls back to `spec.instruction` when the caller passes none, precisely so a language-conditioned policy receives the command rather than an empty string — and `spec.instruction or ""` cannot tell an `int` from an instruction. So a non-string stored here is handed to the policy verbatim as its task specification.

`scene` is the quieter one: `on_episode_start` loads it under `if self._scene:`, so a **falsy** non-string means the declared scene is silently skipped. Only a *truthy* non-string reaches `load_scene` and fails.

## Change

One module-level string domain, `_spec_string_error`, invoked from both construction paths with their own context, so the key a spec file sets and the keyword a direct construction passes are held to the same rule. Two axes, because the four fields differ only along them:

* `allow_empty` — `name` and `default_robot` are identifiers, so `""` names nothing; `instruction` and `scene` are content, and an empty one is the documented "not declared" spelling.
* `allow_none` — `scene` alone is optional, so `None` is how a spec says it declares no scene.

`default_robot` is checked **ahead of** the `supported_robots` membership test: on `default_robot=7` that test would report `7 not in ['panda']`, the symptom rather than the mistake. Same ordering reason the `supported_robots` shape check already states.

The accepted side is unchanged — `instruction=""` and `scene=""` / `scene=None` still declare neither.

### Why the domain lives in this module rather than in `utils.py`

What it refuses is this module's own vocabulary and nothing else's. The comparable shared helper, `entity_name_error`, scopes itself in its docstring to the creation sites in the simulation backends, and its reasons are MuJoCo's — `""` is that engine's unnamed-entity sentinel, a NUL truncates in the compiled model. Neither applies to a benchmark id. A shared single-name string domain may still be worth having (about 17 other sites in the tree hand-roll `not isinstance(x, str) or not x`), but that is a separate sweep with its own scope question, and this module holds four of those sites itself.

## Out of scope

* `register_benchmark_from_file(name=...)` validates the **registry key**, not a spec field, and its message already names the function and quotes the value.
* `_compile_call`'s `predicate` name is a different vocabulary, checked against the predicate registry.

## Visual artifact

The declared scene is the visible half: on `main` a `scene=[]` benchmark reported success with the scene never loaded, so the evaluation ran in a world the benchmark did not describe.

![benchmark string field domains](https://raw.githubusercontent.com/cagataycali/robots/artifacts/benchmark-string-field-domains/benchmark_string_field_domains.png)

* **A** — the scene the benchmark declares, loaded. Rendered independently on both trees and **byte-identical** (`max|delta| = 0/255`), so the honored path is untouched.
* **B** — `main` with `scene=[]`: `status="success"`, and the scene was never loaded. Differs from A on **99.2%** of pixels.
* **C** — the same value refused at construction, before any episode runs. The world in B never existed either way; what changed is that the caller is told.

Capture and compose scripts are beside the image on the same branch; every cell in the table is read from the two runs' JSON dumps, and the generator asserts each claim (including `A_main != A_branch` tree paths) before saving.

## Tests

`tests/simulation/test_benchmark_string_field_domains.py`, 129 tests:

* every field × every non-string value refused by direct construction, with the message naming the field and the type supplied;
* the two axes: `""` refused for the two identifiers and accepted for the two content fields; `None` accepted for `scene` only;
* **parity** — for every field and value, `__init__` and `from_dict` reach the same verdict (the property the mirror exists for; the contexts differ by design, so what has to agree is the verdict, not the text);
* guard order — `default_robot=7` reports the type and not the membership, while a genuine membership failure still reports membership;
* the helper decides only what it documents, checked by looping it and the constructor over the same probe set;
* a structural guard asserting both construction paths route every string field through the helper, with a non-vacuity test pinning the exact four and a check that the scan reads the shipped module.

`TestNeighbouringFieldsStayOutOfScope` in `test_benchmark_supported_robots_domain.py` pinned the opposite — that a non-string in any of the four was still accepted — so it is **replaced** rather than deleted, per the premise-test guidance. Its stated reason was that each "fails loudly at its consumer"; that holds for one value of one field, and the replacement records which.

## Gate

Verified on `9826ae83` (base `3ce3da7a`, mujoco 3.11.0, `MUJOCO_GL=egl`, aarch64):

* **Pre-fix** (source reverted to `upstream/main`, tests kept): **122 failed / 59 passed**. The 59 are the accepted-side controls, the axes that already held, and the `from_dict` half of the parity tests.
* **Post-fix**: `pytest tests` → **26089 passed / 257 skipped / 0 failed** in 566s.
* `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1138 files).
* `mypy strands_robots tests tests_integ`: **0 errors outside `examples/isaac_gs`**. The 14 there are environmental — the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy.
* `scripts/check_merge_base_overlap.py`: no overlap with `upstream/main`.
* Existing-test churn: the 3 boundary pins named above, in one class.

Closes #2070
