### PR TITLE
fix(lerobot_teleoperate): refuse a non-boolean execution-posture flag instead of reading it by truthiness

### DIFF
--- a/changelog.d/2074-lerobot-teleoperate-execution-flag-domain.md
+++ b/changelog.d/2074-lerobot-teleoperate-execution-flag-domain.md
@@ -1,0 +1,26 @@
+### Fixed: an execution-posture flag `lerobot_teleoperate` cannot honor is refused instead of read by truthiness
+
+`lerobot_teleoperate`'s `background` and `auto_accept_calibration` choose how the
+tool *runs* the command it built, rather than what appears on the argv, so the
+per-mode flag table that covers the builder's flags has no entry to scope them
+by. Both were read as `if <flag>:`, and every non-empty string is truthy, so the
+words an operator reaches for when opting out selected the affirmative posture:
+`background="false"` detached the session instead of running the foreground one
+that was asked for, and `auto_accept_calibration="false"` still wrote two
+newlines into the child's stdin, accepting whatever calibration prompt the robot
+was showing. `None`, `[]` and `0` took the negative branch just as silently,
+without ever being a declared spelling of it. Both are reachable from an agent -
+the tool spec declares each `{"type": "boolean", "default": true}`.
+
+`auto_accept_calibration` is the sharper of the two: the posture `background`
+reaches is at least reported back, since the envelope carries `"background"`, a
+pid and a log file, while nothing anywhere reports that stdin was written to.
+
+Both are now checked against the shared `boolean_flag_error` domain at the top of
+the `start` / `dagger` branch, so a refused call builds no argv, records no
+session and starts no process, and the refusal reads identically to the one the
+builder's own flags already give. The check is scoped to that branch because no
+other action reads either flag. `auto_accept_calibration` and
+`dagger_record_autonomous` also gain the tool-spec descriptions they were missing
+- a model deciding whether to withhold a calibration was reading the generated
+placeholder `"Parameter auto_accept_calibration"`.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -174,6 +174,58 @@ def _flag_error(mode: str, supplied: dict[str, Any]) -> str | None:
     return None
 
 
+# The two flags the per-mode table above cannot scope, because neither is a
+# parameter of :func:`build_lerobot_command`: no mode emits them and no argv
+# records them. They choose how :func:`lerobot_teleoperate` *runs* the command it
+# has already built - ``background`` gates the detach, log file and session
+# persistence, and ``auto_accept_calibration`` gates a thread writing two
+# newlines into the child's stdin ~2s in, which accepts whatever calibration
+# prompt the robot is showing.
+#
+# Both were read as ``if <flag>:``, and every non-empty string is truthy, so an
+# opt-out selected the affirmative posture (#2074, measured on ``3ce3da7``):
+#
+#   background="false"               ->  detached, not the foreground run asked for
+#   auto_accept_calibration="false"  ->  a calibration accepted by no operator
+#
+# ``auto_accept_calibration`` is the sharper of the two. The posture
+# ``background`` reaches is at least reported - the returned envelope carries
+# ``"background": True``, a pid and a log file, so a caller who asked for the
+# foreground can see it did not get it - while nothing anywhere reports that
+# stdin was written to.
+#
+# A flat tuple rather than a per-mode map: both are read unconditionally for a
+# ``start`` / ``dagger`` call, so the effectiveness question
+# :data:`_MODE_FLAG_OPTIONS` answers does not arise for them. They are read by no
+# other action, which is why the check is scoped to that branch rather than to
+# the whole tool - refusing ``background`` for an ``action="list"`` that never
+# reads it would be a false rejection.
+_EXECUTION_FLAGS: tuple[str, ...] = ("background", "auto_accept_calibration")
+
+
+def _execution_flag_error(supplied: dict[str, Any]) -> str | None:
+    """Error text for the first execution-posture flag the tool cannot honor.
+
+    The same shared :func:`~strands_robots.utils.boolean_flag_error` domain
+    :func:`_flag_error` applies to the argv flags, so a posture flag is refused
+    identically wherever it is supplied rather than merely equivalently. Only the
+    context differs: these are refused by the tool and not by the builder, and
+    the message says so.
+
+    Args:
+        supplied: Every flag named in :data:`_EXECUTION_FLAGS`, as supplied by
+            the caller.
+
+    Returns:
+        An error message naming the flag and its domain, or ``None`` when both
+        can be honoured.
+    """
+    for param in _EXECUTION_FLAGS:
+        if error := boolean_flag_error(supplied[param], param, "lerobot_teleoperate"):
+            return error
+    return None
+
+
 class SessionManager:
     """Manage teleoperation sessions with persistence."""
 
@@ -721,7 +773,11 @@ def lerobot_teleoperate(
     Args:
         action: Action to perform (start, stop, list, status, replay)
         session_name: Session identifier (auto-generated for start, required for stop/status)
-        background: Run session in background with logging (default: True)
+        background: Run session in background with logging (default: True).
+            Must be a boolean: it selects an execution posture rather than
+            scaling a quantity, so a truthy spelling of off such as
+            ``"false"`` is refused rather than detaching the session it reads
+            as declining to detach.
 
         robot_type: Robot type identifier
         robot_port: Serial port for single-arm robots
@@ -763,6 +819,17 @@ def lerobot_teleoperate(
         fps: Teleoperation control loop frequency
         teleop_time_s: Session duration limit
         play_sounds: Enable audio feedback
+        auto_accept_calibration: Answer the calibration prompt on the session's
+            behalf, by writing two newlines into the process's stdin shortly
+            after it starts. Withhold it (``False``) to answer the prompt
+            yourself; nothing reports that stdin was written to, so an
+            unintended acceptance is not visible afterwards. Must be a boolean,
+            on the same reasoning as ``background``.
+
+        dagger_record_autonomous: Record the autonomous rollout episodes into the
+            corrections dataset as well, rather than only the teleoperated
+            takeovers. Must be a boolean; a truthy spelling of off would
+            otherwise land autonomous episodes in a corrections dataset.
 
     Returns:
         Dict with operation status and results:
@@ -783,6 +850,14 @@ def lerobot_teleoperate(
 
     try:
         if action in ("start", "dagger"):
+            # Before anything is named, recorded or launched: a refused call must
+            # leave no session behind and start no process (see
+            # :data:`_EXECUTION_FLAGS`).
+            if error := _execution_flag_error(
+                {"background": background, "auto_accept_calibration": auto_accept_calibration}
+            ):
+                return {"status": "error", "content": [{"text": error}]}
+
             # Generate session name if not provided
             if not session_name:
                 session_name = f"teleop_{int(time.time())}"

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -27,11 +27,19 @@ The flags are checked against the shared
 the requested mode actually emits: refusing a flag a mode never puts on the argv
 would be a false rejection, which is the same scoping rule the numeric knobs use
 (``tests/tools/test_lerobot_teleoperate_numeric_domain.py``).
+
+``lerobot_teleoperate``'s own ``background`` and ``auto_accept_calibration`` were
+read by truthiness for the same reason and are refused by the *tool*, since
+neither is a builder parameter and no argv records them - they select an
+execution posture. That half is #2074, and the last class here is where its
+scope, its ordering and the boundary between the two checks are pinned.
 """
 
 from __future__ import annotations
 
 import inspect
+import io
+import subprocess
 from typing import Any
 
 import numpy as np
@@ -168,6 +176,58 @@ def _dagger(**overrides: Any) -> list[str]:
 def _token(argv: list[str], flag: str) -> str | None:
     """The token following ``flag``, or ``None`` when the flag is absent."""
     return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The joined text blocks of a tool envelope."""
+    return "\n".join(item["text"] for item in result["content"] if "text" in item)
+
+
+def _never(label: str) -> Any:
+    """A stand-in that fails the test if the tool ever reaches it."""
+
+    def _call(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError(f"{label} must not be reached for a refused call")
+
+    return _call
+
+
+class _FakePopen:
+    """A launched process, without launching one."""
+
+    pid = 4321
+
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+
+
+def _record_popen(calls: list[str]) -> Any:
+    """A ``subprocess.Popen`` stand-in recording the kwargs the tool chose.
+
+    Whether ``stdin`` is passed at all is the observable
+    ``auto_accept_calibration`` decision - the newlines themselves are written by
+    a daemon thread two seconds later, which no test should wait for.
+    """
+
+    class _Recorder:
+        kwargs: dict[str, Any] = {}
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:
+            calls.append("Popen")
+            self.kwargs = kwargs
+            return _FakePopen()
+
+    return _Recorder()
+
+
+def _record_run(calls: list[str]) -> Any:
+    """A ``subprocess.run`` stand-in reporting a clean exit."""
+
+    def _call(*args: Any, **kwargs: Any) -> Any:
+        calls.append("run")
+        return subprocess.CompletedProcess(args=list(args[0]) if args else [], returncode=0, stdout="", stderr="")
+
+    return _call
 
 
 class TestAnUnattendedRecordingCannotBeTalkedIntoUploading:
@@ -447,28 +507,228 @@ class TestTheSharedDomainIsTheOneApplied:
             _record(dataset_video="false")
 
 
-class TestTheToolsOwnExecutionFlagsStayOutOfScope:
-    """``background`` and ``auto_accept_calibration`` are not builder flags.
+class TestTheToolsOwnExecutionFlagsAreRefusedByTheToolInstead:
+    """``background`` and ``auto_accept_calibration`` select an execution posture.
 
-    Neither reaches an argv: they choose how ``lerobot_teleoperate`` runs the
-    command it built - detached with a log file, and whether a newline is written
-    to the child's stdin to accept a calibration prompt. They are parameters of
-    the tool alone, have no per-mode table to be scoped by, and are read after
-    the builder has returned. Pinned rather than assumed, so this boundary is
-    measured; tracked separately.
+    Neither reaches an argv, so :data:`_MODE_FLAG_OPTIONS` has no entry to scope
+    them by: they choose how ``lerobot_teleoperate`` *runs* the command the
+    builder returned - detached with a log file and a persisted session, and
+    whether two newlines are written into the child's stdin to accept whatever
+    calibration prompt the robot is showing. Both were read as ``if <flag>:``, so
+    every non-empty string selected the affirmative posture:
+
+    * ``background="false"`` detached the session, rather than running the
+      foreground one that was asked for;
+    * ``auto_accept_calibration="false"`` accepted a calibration no operator saw.
+
+    The second is the sharper of the two: ``background``'s resulting posture is at
+    least *reported* - the envelope carries ``"background": True``, a pid and a
+    log file - while nothing anywhere reports that stdin was written to.
+
+    So they are refused by the tool, at the top of the ``start`` / ``dagger``
+    branch, against the same shared domain the builder flags use. The class this
+    replaces pinned the boundary while they were out of scope; the structural half
+    of it is kept below, because "not a builder flag" is still what makes a
+    tool-level check the right place for them.
     """
+
+    def _start(self, **overrides: Any) -> dict[str, Any]:
+        """A ``start`` call through the tool, with a named session."""
+        kwargs: dict[str, Any] = {
+            "action": "start",
+            "session_name": "exec-flag",
+            "robot_type": "so101_follower",
+            "robot_port": "/dev/ttyACM1",
+            "teleop_type": "so101_leader",
+            "teleop_port": "/dev/ttyACM0",
+        }
+        kwargs.update(overrides)
+        return _run_tool(**kwargs)
+
+    # -- the refusal ------------------------------------------------------
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    @pytest.mark.parametrize("value", NOT_A_BOOLEAN)
+    def test_an_unusable_execution_flag_is_refused(
+        self, flag: str, value: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing may be launched or persisted for a refused call.
+
+        Both branches are barred, not just the detaching one: ``background=0`` is
+        falsy and would previously have reached ``subprocess.run`` in the
+        foreground, which is a posture nobody declared either.
+        """
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _never("subprocess.Popen"))
+        monkeypatch.setattr(tele_mod.subprocess, "run", _never("subprocess.run"))
+
+        result = self._start(**{flag: value})
+
+        assert result["status"] == "error"
+        assert flag in _text(result)
+        assert tele_mod.SessionManager().get_session("exec-flag") is None
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_dagger_refuses_it_without_the_rollout_entry_point(
+        self, flag: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The same caller mistake must report the same way on any lerobot.
+
+        The check precedes the builder, and therefore the lerobot-version
+        preflight inside it, so an unusable flag is named rather than masked by an
+        upgrade hint on an install that has no rollout entry point.
+        """
+        monkeypatch.setattr(tele_mod.importlib.util, "find_spec", lambda *a, **k: None)
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _never("subprocess.Popen"))
+
+        result = self._start(action="dagger", policy_path="lerobot/act_so101", **{flag: "false"})
+
+        assert result["status"] == "error"
+        assert flag in _text(result)
+
+    def test_the_refusal_precedes_the_argv_build(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A refused call must not build a command line at all."""
+        monkeypatch.setattr(tele_mod, "build_lerobot_command", _never("build_lerobot_command"))
+
+        result = self._start(background="false")
+
+        assert result["status"] == "error"
+        assert "background" in _text(result)
+
+    def test_the_refusal_precedes_the_duplicate_session_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The flag is named, not the session, when both would be reported."""
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _never("subprocess.Popen"))
+        tele_mod.SessionManager().add_session("exec-flag", {"pid": 1})
+
+        result = self._start(background="false")
+
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "background" in text
+        assert "already exists" not in text
+
+    def test_the_refusal_is_an_error_envelope_and_not_a_raise(self) -> None:
+        """Matching every other refusal on this surface; the tool returns."""
+        result = self._start(auto_accept_calibration="false")
+        assert result["status"] == "error"
+        assert result["content"][0]["text"]
+
+    # -- the shared domain ------------------------------------------------
+
+    def test_the_message_is_the_shared_domains_message(self) -> None:
+        expected = boolean_flag_error("false", "background", "lerobot_teleoperate")
+        assert expected is not None
+        assert _text(self._start(background="false")) == expected
+
+    def test_the_message_names_the_tool_and_not_the_builder(self) -> None:
+        """These are the tool's own parameters, so the context must say so."""
+        text = _text(self._start(auto_accept_calibration="false"))
+        assert "lerobot_teleoperate" in text
+        assert "build_lerobot_command" not in text
+
+    def test_the_message_explains_why_it_is_not_parsed(self) -> None:
+        assert "checked rather than parsed" in _text(self._start(background="off"))
+
+    # -- the postures a usable flag still selects -------------------------
+
+    @pytest.mark.parametrize("value, expected", A_BOOLEAN)
+    def test_a_usable_background_still_selects_its_posture(
+        self, value: Any, expected: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``np.False_`` must still reach the foreground run, not be refused."""
+        calls: list[str] = []
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", _record_popen(calls))
+        monkeypatch.setattr(tele_mod.subprocess, "run", _record_run(calls))
+
+        result = self._start(background=value)
+
+        assert result["status"] == "success"
+        assert calls == ["Popen" if expected else "run"]
+
+    @pytest.mark.parametrize("value, expected", A_BOOLEAN)
+    def test_a_usable_auto_accept_still_selects_its_posture(
+        self, value: Any, expected: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The stdin pipe is the decision; ``np.False_`` must withhold it."""
+        calls: list[str] = []
+        popen = _record_popen(calls)
+        monkeypatch.setattr(tele_mod.subprocess, "Popen", popen)
+
+        assert self._start(auto_accept_calibration=value)["status"] == "success"
+        assert ("stdin" in popen.kwargs) is expected
+
+    # -- scope ------------------------------------------------------------
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_an_action_that_reads_neither_flag_refuses_nothing(self, flag: str) -> None:
+        """Refusing a flag an action never reads would be a false rejection."""
+        assert _run_tool(action="list", **{flag: "false"})["status"] == "success"
+
+    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
+    def test_replay_is_out_of_scope_because_it_reads_neither(self, flag: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replay runs in the foreground unconditionally and answers no prompt."""
+        calls: list[str] = []
+        monkeypatch.setattr(tele_mod.subprocess, "run", _record_run(calls))
+
+        result = _run_tool(
+            action="replay",
+            robot_type="so101_follower",
+            robot_port="/dev/ttyACM1",
+            dataset_repo_id="user/pick",
+            **{flag: "false"},
+        )
+
+        assert result["status"] == "success"
+        assert calls == ["run"]
 
     @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
     def test_they_are_tool_parameters_and_not_builder_parameters(self, flag: str) -> None:
+        """The reason there is no per-mode table to route them through."""
         assert flag in inspect.signature(lerobot_teleoperate).parameters
         assert flag not in inspect.signature(build_lerobot_command).parameters
 
     @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
-    def test_the_builder_neither_reads_nor_refuses_them(self, flag: str) -> None:
-        """They arrive in ``**kwargs`` and are ignored, as they were before."""
+    def test_the_builder_still_neither_reads_nor_refuses_them(self, flag: str) -> None:
+        """They arrive in ``**kwargs`` and are ignored, as they always were."""
         assert _record(**{flag: "false"}) == _record()
 
-    @pytest.mark.parametrize("flag", ["background", "auto_accept_calibration"])
-    def test_they_are_not_in_the_flag_table(self, flag: str) -> None:
-        named = {name for names in tele_mod._MODE_FLAG_OPTIONS.values() for name in names}
-        assert flag not in named
+    # -- the two checks cannot drift into each other ----------------------
+
+    def test_the_execution_flags_are_named_by_no_mode(self) -> None:
+        """A flag is a posture of the tool or of the argv, never both."""
+        emitted = {flag for flags in tele_mod._MODE_FLAG_OPTIONS.values() for flag in flags}
+        numeric = {knob for knobs in tele_mod._MODE_NUMERIC_OPTIONS.values() for knob in knobs}
+        assert not set(tele_mod._EXECUTION_FLAGS) & (emitted | numeric)
+
+    def test_every_execution_flag_is_a_bool_parameter_of_the_tool(self) -> None:
+        params = inspect.signature(lerobot_teleoperate).parameters
+        adrift = sorted(
+            flag
+            for flag in tele_mod._EXECUTION_FLAGS
+            if flag not in params or params[flag].annotation not in (bool, "bool")
+        )
+        assert not adrift, f"_EXECUTION_FLAGS names non-bool non-parameters: {adrift}"
+
+    def test_no_execution_flag_is_left_unchecked(self) -> None:
+        """Both are checked, and the check is reached through the shared domain."""
+        usable = dict.fromkeys(tele_mod._EXECUTION_FLAGS, True)
+        assert tele_mod._execution_flag_error(usable) is None
+        for flag in tele_mod._EXECUTION_FLAGS:
+            error = tele_mod._execution_flag_error({**usable, flag: "false"})
+            assert error == boolean_flag_error("false", flag, "lerobot_teleoperate")
+
+    def test_every_boolean_the_tool_refuses_is_described_to_the_model(self) -> None:
+        """A model choosing whether to withhold a flag reads this string.
+
+        The generated placeholder ``"Parameter <name>"`` says nothing about the
+        posture it selects, and a flag that is now refused for being mis-spelled
+        is one an agent needs the description of.
+        """
+        params = inspect.signature(lerobot_teleoperate).parameters
+        schema = lerobot_teleoperate.tool_spec["inputSchema"]["json"]["properties"]
+        undocumented = sorted(
+            name
+            for name, param in params.items()
+            if param.annotation in (bool, "bool")
+            and schema[name].get("description", "").startswith(f"Parameter {name}")
+        )
+        assert not undocumented, f"boolean flags with a placeholder description: {undocumented}"


### PR DESCRIPTION
Closes #2074

## The defect

#2073 gave the flags `build_lerobot_command` puts on the lerobot argv a domain, scoped by a per-mode table. Two flags in the same module were left out of it, because neither reaches an argv: they choose how `lerobot_teleoperate` *runs* the command already built.

```python
background: bool = True               # gates the detach, log file and session persistence
auto_accept_calibration: bool = True  # gates writing two newlines into the child's stdin
```

Both were read as `if <flag>:`, so every non-empty string was truthy. Measured on `3ce3da7`, unchanged by #2073:

| supplied | branch taken | what it means |
|---|---|---|
| `background="false"` | the background branch | detached with a log file and a persisted session, rather than the foreground run that was asked for |
| `auto_accept_calibration="false"` | the auto-accept branch | a thread writes two `\n` into the child's stdin ~2 s in, accepting whatever calibration prompt the robot is showing |
| `background=0.0` / `None` / `[]` | the foreground branch | the negative posture, without ever being a declared spelling of it |

`auto_accept_calibration` is the sharper of the two. The posture `background` reaches is at least *reported* - the returned envelope carries `"background": True`, a pid and a `log_file`, so a caller who asked for the foreground can see it did not get it. Nothing anywhere reports that stdin was written to; on real hardware that is a calibration prompt accepted by no operator.

Both are reachable from an agent: the tool spec declares each `{"type": "boolean", "default": true}`.

## The change

The domain needed no decision - `boolean_flag_error`, the same one #2073 made this module a caller of. Only the *placement* did, since there is no table to route these through:

```python
_EXECUTION_FLAGS: tuple[str, ...] = ("background", "auto_accept_calibration")
```

reached from the top of the `start` / `dagger` branch, before the session name is resolved. Four details worth stating:

- **A flat tuple, not a per-mode map.** Both are read unconditionally for a `start` / `dagger` call, so the effectiveness question `_MODE_FLAG_OPTIONS` answers does not arise for them. Inventing a second scoping rule is exactly what #2073 declined to do in one diff; this is the rule that fits.
- **Scoped to that branch, not to the whole tool.** No other action reads either flag - `replay` runs in the foreground unconditionally and answers no prompt - so refusing one for an `action="list"` would be a false rejection. Pinned for `list` and `replay`.
- **First statement in the branch.** It therefore precedes the duplicate-session check, the argv build (and so the lerobot-version preflight inside it) and the subprocess. A refused call records no session, builds no command line and starts no process; each of those is pinned separately, including that the message names the flag rather than an existing session or an upgrade hint.
- **An error envelope, not a raise**, matching every other refusal on this surface. The builder raises because it is a builder; the tool returns.

The context is `lerobot_teleoperate` rather than `build_lerobot_command`, because that is where the refusal happens - pinned, along with the message being the shared domain's own rather than a local equivalent.

### The two documentation entries

`auto_accept_calibration` had no `Args:` entry, so its tool-spec description was the generated placeholder `"Parameter auto_accept_calibration"`. A model deciding whether to withhold a calibration is reading that string, and a flag that is now *refused* for being mis-spelled is one an agent needs the description of. `dagger_record_autonomous` had the same placeholder for the same reason, so both are written, and a drift test asserts no boolean parameter of this tool carries a placeholder description.

The three non-boolean placeholders in the same docstring (`policy_path`, `dagger_input_device`, `dagger_num_episodes`) are deliberately left alone - they belong to no domain this PR introduces, and the test is scoped to booleans so it does not quietly claim them.

## Out of scope, deliberately

`TestTheToolsOwnExecutionFlagsStayOutOfScope` from #2073 is **replaced rather than deleted**, as that PR's description and #2074 both asked. Its structural half is kept - these are still not builder parameters, still absent from `_MODE_FLAG_OPTIONS`, and the builder still ignores them - because "not a builder flag" is what makes a tool-level check the right place. Only the "and therefore not refused" half becomes the corrected contract.

## Verification

Measured in a clean checkout on base `586109c` (#2073's squash), python 3.13. The authoring runner had no `lerobot` / `torch` / `mujoco`, so the suites needing them were left to CI; every suite that reaches this module is run below.

- **Pre-fix proof** - source reverted to `586109c`, the new tests kept: **31 failed / 136 passed**. The 17 new tests that pass are the over-reach controls - `list` and `replay` refusing nothing, the flags remaining absent from the builder's signature and tables, the usable spellings still selecting their posture - which were already correct and must stay correct.
- **New tests**: 48 (the file goes 125 -> 167), `tests/tools/test_lerobot_teleoperate_flag_domain.py`, 5.9 s - no lerobot, no real subprocess, no optional backend. The `auto_accept_calibration` assertion is on whether `stdin` is passed to `Popen`, which is the decision point; the newlines themselves are written by a daemon thread two seconds later, which no test waits for.
- **The module's existing suites**: the numeric sibling, `tests/test_tool_result_contract.py`, `tests/simulation/test_replay_episode_index_domain.py` and `tests/mesh/test_iot_provisioning_flag_domain.py` (the `boolean_flag_error` audit) -> **503 passed, 2 skipped**, **zero existing-test changes** beyond the one class this replaces.
- **`tests/tools` before and after** (three `lerobot`-importing files excluded identically in both runs): 12 failed / 1584 passed -> 12 failed / **1626** passed. The 12 failures are byte-identical in both runs and are all `No module named 'lerobot'`.
- **`tests/tools/test_lerobot_teleoperate.py`**, the module's own behavioural suite, is **5 failed / 51 passed on both trees**, the same five `lerobot` imports.
- **Full `tests/`**, same flags on both trees: 443 failed / 19505 passed / 1348 skipped / 915 errors -> 443 failed / **19547** passed / 1348 skipped / 915 errors. The passed delta is **+42**, exactly the net new tests; failures and errors are unchanged, and are the missing optional backends in this runner.
- **Lint**: `ruff check strands_robots tests` clean, `ruff format --check` clean, `mypy` clean on both changed files.
- **Doc drift**: no `docs/` or `examples/` page documents either flag, so there is nothing else to keep in step. Changelog fragment added; `tests/test_changelog_fragments.py` and `tests/test_changelog_format.py` pass (30).
- **Merge-base overlap**: none. `main` was at `586109c` at intake and at the push.

## §13 round changelog

**Round 0** - initial submission.