### PR TITLE
fix(lerobot_teleoperate): emit play_sounds for the modes whose lerobot entry point declares it

### DIFF
--- a/changelog.d/2072-lerobot-teleoperate-play-sounds-argv.md
+++ b/changelog.d/2072-lerobot-teleoperate-play-sounds-argv.md
@@ -1,0 +1,40 @@
+### Fixed: `play_sounds` reaches the lerobot argv instead of being advertised and dropped
+
+`lerobot_teleoperate` declared `play_sounds: bool = True`, documented it as
+"Enable audio feedback", forwarded it to `build_lerobot_command`, and
+`build_lerobot_command` declared it too - and then read it nowhere. No mode put
+it on an argv, so the documented option did nothing at all in either position,
+and a model could set it through the tool spec
+(`{"type": "boolean", "default": true}`) and be told nothing. Measured on
+`f9c05ba4`:
+
+```python
+build_lerobot_command(**BASE, play_sounds=True) == build_lerobot_command(**BASE, play_sounds=False)
+# -> True
+```
+
+Where the flag belongs is decided by lerobot rather than by symmetry. Against
+`lerobot==0.6.1`, the floor of this package's `[lerobot]` extra, three of the four
+entry points this module drives declare the field on their top-level
+`@parser.wrap()` config - `RecordConfig` (`lerobot_record.py:188`),
+`ReplayConfig` (`lerobot_replay.py:99`) and `RolloutConfig`
+(`rollout/configs.py:256`) - so it is spelled `--play_sounds` and not nested
+under `--dataset.*`. It is now emitted for `record`, `replay` and `dagger`, and
+each of those modes checks it against the shared `boolean_flag_error` domain, so
+a string such as `"false"` is refused rather than read by truthiness.
+
+Plain teleoperation is deliberately excluded: `TeleoperateConfig` declares no
+such field and the entry point makes no `log_say` call, so there the flag would
+be an unrecognized argument rather than an accepted no-op - the same failure the
+removed pre-0.5 flat flags cause. It therefore emits nothing for `play_sounds`
+and refuses no value for it, which is the per-mode scoping the numeric knobs
+already use.
+
+The flag is emitted unconditionally as an explicit `true`/`false` literal, like
+`dataset_video`, rather than only when set, like `display_data`. That split
+follows the upstream default rather than a style preference: lerobot defaults
+`play_sounds` to `True`, so absence says `True` too, and the explicit literal is
+the only spelling of the opt-out that can reach the CLI at all.
+
+This supersedes the note in the previous entry that `replay` emits no boolean
+flag: it now emits exactly one.

--- a/changelog.d/2072-lerobot-teleoperate-play-sounds-argv.md
+++ b/changelog.d/2072-lerobot-teleoperate-play-sounds-argv.md
@@ -38,3 +38,10 @@ the only spelling of the opt-out that can reach the CLI at all.
 
 This supersedes the note in the previous entry that `replay` emits no boolean
 flag: it now emits exactly one.
+
+Both halves were needed. The tool spec sits on `lerobot_teleoperate` rather than
+on `build_lerobot_command`, and the tool's `replay` dispatch built its argv
+without forwarding `play_sounds` - so making the builder honor the flag left the
+argv reading `--play_sounds true` on the only model-reachable path to replay, and
+a non-boolean was not refused there either. The dispatch now forwards it, pinned
+at the tool level, since a builder-level test cannot observe a dropped forward.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -469,6 +469,15 @@ def build_lerobot_command(
             Plain teleoperation ignores it: ``TeleoperateConfig`` has no such
             field, so emitting it there would be an unrecognized argument.
 
+            Every caller reaching a mode that emits it must forward it. Making
+            the builder honor a flag is only half the fix, because the tool spec
+            sits on :func:`lerobot_teleoperate` rather than here: the ``replay``
+            dispatch omitted this kwarg, so the builder's default won whatever
+            the agent asked for, and the argv read ``--play_sounds true`` on the
+            only model-reachable path to replay. Pinned at the tool level, not
+            just here, since a builder-level test cannot observe a dropped
+            forward.
+
     Returns:
         The argv list, beginning with ``["python", "-m", "lerobot.scripts...."]``.
 
@@ -1233,6 +1242,7 @@ def lerobot_teleoperate(
                     dataset_repo_id=dataset_repo_id,
                     replay_episode=replay_episode,
                     display_data=display_data,
+                    play_sounds=play_sounds,
                 )
             except Exception as e:
                 return {"status": "error", "content": [{"text": f"Replay command build failed: {str(e)}"}]}

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -132,15 +132,49 @@ def _numeric_option_error(mode: str, supplied: dict[str, Any]) -> str | None:
 # ``[]`` took the other branch just as silently, without ever being a declared
 # spelling of it.
 #
-# ``replay`` is absent because it emits no flag at all - its argv is unchanged by
-# every flag in this module, so refusing one there would be a false rejection,
-# the same scoping rule :data:`_MODE_NUMERIC_OPTIONS` encodes. ``play_sounds`` is
-# in no tuple for that same reason: nothing reads it anywhere (#2072), so it is
-# excluded here by construction rather than by an exemption.
+# ``teleoperate`` carries only ``display_data`` because lerobot's
+# ``TeleoperateConfig`` declares no other field this module offers: refusing a
+# flag a mode never puts on its argv would be a false rejection, the same scoping
+# rule :data:`_MODE_NUMERIC_OPTIONS` encodes.
+#
+# ``play_sounds`` is scoped by that same table rather than exempted from it. It
+# was previously in no tuple because no mode emitted it at all - declared,
+# documented and forwarded, and then read by nothing (#2072), so a domain would
+# have refused values for an option that had no effect either way. It is now
+# emitted for the three entry points that accept it, which is what makes the
+# domain honest rather than decorative. Measured against ``lerobot==0.6.1``, the
+# version this package's ``[lerobot]`` extra floors:
+#
+#   lerobot/scripts/lerobot_record.py:188   RecordConfig.play_sounds  = True
+#   lerobot/scripts/lerobot_replay.py:99    ReplayConfig.play_sounds  = True
+#   lerobot/rollout/configs.py:256          RolloutConfig.play_sounds = True
+#   lerobot/scripts/lerobot_teleoperate.py  TeleoperateConfig - absent
+#
+# All three are fields of the top-level ``@parser.wrap()`` config, so the flag is
+# spelled ``--play_sounds`` rather than nested. ``teleoperate`` is excluded
+# because that entry point never speaks - it holds no ``log_say`` call and no
+# such field - so emitting the flag there would not be a silent no-op but an
+# unrecognized argument, which is the failure the class docstring above warns the
+# removed pre-0.5 flat flags cause.
+#
+# ``play_sounds`` is emitted *unconditionally* as an explicit literal, like
+# ``dataset_video`` and ``dataset_push_to_hub``, rather than only when set, like
+# ``display_data`` and ``record_resume``. That split is not a style choice: it
+# follows the upstream default. A flag lerobot defaults to ``False`` is expressed
+# by its presence, so omitting it says "false" exactly; a flag lerobot defaults
+# to ``True`` cannot express an opt-out by omission at all, so the only spelling
+# of ``play_sounds=False`` that reaches the CLI is the explicit literal.
 _MODE_FLAG_OPTIONS: dict[str, tuple[str, ...]] = {
-    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data"),
+    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data", "play_sounds"),
     "teleoperate": ("display_data",),
-    "dagger": ("dagger_record_autonomous", "dataset_push_to_hub", "dataset_video", "display_data"),
+    "replay": ("play_sounds",),
+    "dagger": (
+        "dagger_record_autonomous",
+        "dataset_push_to_hub",
+        "dataset_video",
+        "display_data",
+        "play_sounds",
+    ),
 }
 
 
@@ -428,6 +462,12 @@ def build_lerobot_command(
             (resolved from ``dataset_repo_id``) so lerobot HEAD's repo_id
             timestamp-stamping never relocates the on-disk dataset.
         replay_episode: Episode index to replay (``--dataset.episode``).
+        play_sounds: Emit ``--play_sounds true|false`` for the modes whose lerobot
+            entry point declares the field - ``record``, ``replay`` and
+            ``dagger``. Always explicit, because lerobot defaults it to ``True``
+            and an opt-out therefore cannot be expressed by omitting the flag.
+            Plain teleoperation ignores it: ``TeleoperateConfig`` has no such
+            field, so emitting it there would be an unrecognized argument.
 
     Returns:
         The argv list, beginning with ``["python", "-m", "lerobot.scripts...."]``.
@@ -461,11 +501,14 @@ def build_lerobot_command(
         "dataset_video": dataset_video,
         "display_data": display_data,
         "dagger_record_autonomous": dagger_record_autonomous,
+        "play_sounds": play_sounds,
     }
     if action == "replay":
         if not dataset_repo_id:
             raise ValueError("dataset_repo_id is required for replay action")
         if error := _numeric_option_error("replay", numeric_options):
+            raise ValueError(error)
+        if error := _flag_error("replay", flag_options):
             raise ValueError(error)
         cmd = ["python", "-m", "lerobot.scripts.lerobot_replay"]
         cmd.extend(
@@ -475,6 +518,7 @@ def build_lerobot_command(
         if dataset_root:
             cmd.extend(["--dataset.root", dataset_root])
         cmd.extend(["--dataset.fps", str(int(dataset_fps))])
+        cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
         return cmd
 
     if action == "start":
@@ -513,6 +557,7 @@ def build_lerobot_command(
             cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
             if display_data:
                 cmd.extend(["--display_data", "true"])
+            cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
             return cmd
 
         # Simple teleoperation mode -> lerobot-teleoperate.
@@ -533,6 +578,11 @@ def build_lerobot_command(
             cmd.extend(["--teleop_time_s", str(teleop_time_s)])
         if display_data:
             cmd.extend(["--display_data", "true"])
+        # No ``--play_sounds`` here, and deliberately not for symmetry's sake:
+        # lerobot's ``TeleoperateConfig`` declares no such field and the entry
+        # point makes no ``log_say`` call, so the flag would be an unrecognized
+        # argument rather than an accepted no-op. Plain teleoperation has no
+        # audio to suppress; see the note on :data:`_MODE_FLAG_OPTIONS`.
         return cmd
 
     if action == "dagger":
@@ -593,6 +643,7 @@ def build_lerobot_command(
         cmd.extend(["--fps", str(int(fps))])
         if display_data:
             cmd.extend(["--display_data", "true"])
+        cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
         return cmd
 
     raise ValueError(f"Unknown action: {action}")
@@ -818,7 +869,11 @@ def lerobot_teleoperate(
         display_data: Show live camera feeds and telemetry
         fps: Teleoperation control loop frequency
         teleop_time_s: Session duration limit
-        play_sounds: Enable audio feedback
+        play_sounds: Enable lerobot's spoken event announcements ("Recording
+            episode 3", "Stop recording"). Effective for recording, replay and
+            dagger; plain teleoperation emits no audio and ignores it. Must be a
+            boolean - a string such as ``"false"`` is refused rather than read by
+            truthiness, since every non-empty string is truthy.
         auto_accept_calibration: Answer the calibration prompt on the session's
             behalf, by writing two newlines into the process's stdin shortly
             after it starts. Withhold it (``False``) to answer the prompt

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import inspect
 import io
+import re
 import subprocess
 from typing import Any
 
@@ -429,6 +430,95 @@ class TestPlaySoundsReachesTheArgv:
         with pytest.raises(ValueError) as excinfo:
             _replay(play_sounds="false")
         assert str(excinfo.value) == boolean_flag_error("false", "play_sounds", "build_lerobot_command")
+
+
+class TestTheToolForwardsPlaySoundsOnEveryModeThatEmitsIt:
+    """A flag the builder honors is still dropped if a dispatch omits it.
+
+    The tool spec is on :func:`lerobot_teleoperate`, not on
+    ``build_lerobot_command``, so the model-reachable surface is the tool. The
+    ``replay`` dispatch built its argv without forwarding ``play_sounds``, so the
+    builder's ``True`` default won whatever the caller asked for and the argv read
+    ``--play_sounds true`` - the #2072 defect exactly, surviving for one of the
+    three modes that emit the flag, while the builder's own tests passed.
+
+    Every assertion here is therefore made through the tool, which is the only
+    level at which a dropped forward is observable at all.
+    """
+
+    @staticmethod
+    def _replay_argv(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> list[str]:
+        """The argv the tool's ``replay`` dispatch actually hands to lerobot."""
+        seen: list[list[str]] = []
+
+        def _run(*args: Any, **kwargs: Any) -> Any:
+            seen.append(list(args[0]))
+            return subprocess.CompletedProcess(args=list(args[0]), returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(tele_mod.subprocess, "run", _run)
+        kwargs: dict[str, Any] = {
+            "action": "replay",
+            "robot_type": "so101_follower",
+            "robot_port": "/dev/ttyACM1",
+            "dataset_repo_id": "user/pick",
+        }
+        kwargs.update(overrides)
+        assert _run_tool(**kwargs)["status"] == "success"
+        assert len(seen) == 1
+        return seen[0]
+
+    def test_the_replay_dispatch_forwards_the_opt_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fails on pre-fix code, where the argv read ``--play_sounds true``."""
+        assert _token(self._replay_argv(monkeypatch, play_sounds=False), "--play_sounds") == "false"
+
+    def test_the_replay_dispatch_forwards_the_opt_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert _token(self._replay_argv(monkeypatch, play_sounds=True), "--play_sounds") == "true"
+
+    def test_the_replay_dispatch_defaults_to_sounds_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Omitting it keeps lerobot's own default rather than silently muting."""
+        assert _token(self._replay_argv(monkeypatch), "--play_sounds") == "true"
+
+    def test_the_replay_dispatch_reports_a_non_boolean(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The domain must be reachable through the tool, not only the builder."""
+
+        def _forbidden(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("a refused replay must not launch lerobot")
+
+        monkeypatch.setattr(tele_mod.subprocess, "run", _forbidden)
+        result = _run_tool(
+            action="replay",
+            robot_type="so101_follower",
+            robot_port="/dev/ttyACM1",
+            dataset_repo_id="user/pick",
+            play_sounds="false",
+        )
+        assert result["status"] == "error"
+        assert "play_sounds must be a boolean" in " ".join(
+            block["text"] for block in result["content"] if "text" in block
+        )
+
+    def test_every_mode_that_emits_the_flag_is_forwarded_it(self) -> None:
+        """The drift guard: a new dispatch that emits it must forward it too.
+
+        Reads the source of every ``build_lerobot_command(`` call in the module
+        and requires each one whose action can emit the flag to name it. A
+        builder-level table cannot express this - the omission is at the call
+        site - so the call sites are the thing asserted.
+        """
+        source = inspect.getsource(tele_mod)
+        # ``def build_lerobot_command(`` is the definition, not a call site; its
+        # own signature names the parameter and would pass vacuously.
+        call_sites = [
+            match for match in re.finditer(r"(?<!def )\bbuild_lerobot_command\(", source) if match.start() > 0
+        ]
+        assert call_sites, "no build_lerobot_command call sites found; the guard has gone blind"
+        dropped = []
+        for match in call_sites:
+            argument_list = source[match.end() : source.index(")", match.end())]
+            if "play_sounds=play_sounds" not in argument_list:
+                line = source[: match.start()].count("\n") + 1
+                dropped.append(line)
+        assert not dropped, f"build_lerobot_command call(s) not forwarding play_sounds, at line(s): {dropped}"
 
 
 class TestPlainTeleoperationIsUnaffected:

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -343,8 +343,8 @@ class TestOnlyTheFlagsAModeEmitsAreChecked:
         "flag",
         ["record_resume", "dataset_push_to_hub", "dataset_video", "display_data", "dagger_record_autonomous"],
     )
-    def test_replay_refuses_no_flag_and_its_argv_is_unchanged(self, flag: str) -> None:
-        """``lerobot-replay`` emits no boolean flag at all."""
+    def test_replay_refuses_no_other_mode_s_flag(self, flag: str) -> None:
+        """``lerobot-replay`` emits none of these; ``play_sounds`` is its only flag."""
         assert _replay(**{flag: "false"}) == _replay()
 
     @pytest.mark.parametrize(
@@ -363,35 +363,92 @@ class TestOnlyTheFlagsAModeEmitsAreChecked:
         assert _dagger(record_resume="false") == _dagger()
 
 
-class TestPlaySoundsIsExcludedByConstruction:
-    """No mode emits ``play_sounds``, so no mode may refuse a value for it.
+class TestPlaySoundsReachesTheArgv:
+    """``play_sounds`` is emitted for the entry points that declare it (#2072).
 
-    The parameter is declared, documented and forwarded, and then read by
-    nothing - so giving it a domain here would be a false rejection for an option
-    that has no effect either way. It is absent from the table for the same
-    reason ``replay`` is, rather than by an exemption. Whether it should be
-    emitted or removed is #2072; this class pins the state that issue describes,
-    so it fails the day the answer lands and the exclusion stops being true.
+    It was previously declared, documented, forwarded - and read by nothing, so
+    the documented option did nothing at all and a caller who set it was told
+    nothing. Where it goes is decided by lerobot rather than by symmetry, measured
+    against ``lerobot==0.6.1`` (the floor of this package's ``[lerobot]`` extra):
+
+    * ``RecordConfig.play_sounds`` (``lerobot_record.py:188``);
+    * ``ReplayConfig.play_sounds`` (``lerobot_replay.py:99``);
+    * ``RolloutConfig.play_sounds`` (``rollout/configs.py:256``);
+    * ``TeleoperateConfig`` - **no such field**, and the entry point makes no
+      ``log_say`` call, so plain teleoperation has no audio to suppress.
+
+    All three are fields of the top-level ``@parser.wrap()`` config, so the flag
+    is spelled ``--play_sounds`` and not nested under ``--dataset.*``. The
+    teleoperate exclusion is therefore not an oversight to be tidied up later: the
+    flag there would be an unrecognized argument, which is the failure mode the
+    module docstring records for the removed pre-0.5 flat flags.
+
+    The first test is the one #2072 named as failing before this landed.
     """
 
-    def test_no_mode_emits_it(self) -> None:
-        for name, tuple_ in tele_mod._MODE_FLAG_OPTIONS.items():
-            assert "play_sounds" not in tuple_, f"mode {name!r} now emits play_sounds; give it a domain"
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    def test_the_argv_differs_between_true_and_false(self, builder: Any) -> None:
+        """The assertion #2072 asked for: the flag has to reach the command line."""
+        assert builder(play_sounds=True) != builder(play_sounds=False)
 
-    @pytest.mark.parametrize("builder", [_record, _teleop, _replay])
-    def test_the_argv_is_identical_either_way(self, builder: Any) -> None:
-        assert builder(play_sounds=True) == builder(play_sounds=False)
+    def test_the_dagger_argv_differs_between_true_and_false(self, _rollout_entry_point: None) -> None:
+        assert _dagger(play_sounds=True) != _dagger(play_sounds=False)
 
-    def test_the_dagger_argv_is_identical_either_way(self, _rollout_entry_point: None) -> None:
-        assert _dagger(play_sounds=True) == _dagger(play_sounds=False)
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    def test_both_postures_are_explicit_literals(self, builder: Any) -> None:
+        """Omission cannot express the opt-out, because lerobot defaults it to ``True``.
 
-    def test_no_argv_carries_a_sound_token(self) -> None:
-        for argv in (_record(), _teleop(), _replay()):
-            assert [token for token in argv if "sound" in token.lower()] == []
+        This is why ``play_sounds`` is emitted unconditionally, like
+        ``dataset_video``, rather than only when set, like ``display_data``: for a
+        flag upstream already defaults to ``True``, absence says ``True`` too, so
+        ``False`` has exactly one spelling that reaches the CLI.
+        """
+        assert _token(builder(play_sounds=True), "--play_sounds") == "true"
+        assert _token(builder(play_sounds=False), "--play_sounds") == "false"
 
-    def test_a_non_boolean_is_consequently_not_refused(self) -> None:
-        """Not an oversight: nothing reads it, so nothing can misread it."""
-        assert _record(play_sounds="false") == _record()
+    def test_the_dagger_postures_are_explicit_literals(self, _rollout_entry_point: None) -> None:
+        assert _token(_dagger(play_sounds=True), "--play_sounds") == "true"
+        assert _token(_dagger(play_sounds=False), "--play_sounds") == "false"
+
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    def test_the_flag_is_not_nested_under_dataset(self, builder: Any) -> None:
+        """``play_sounds`` is a top-level config field, not a ``DatasetRecordConfig`` one."""
+        assert "--dataset.play_sounds" not in builder(play_sounds=False)
+
+    def test_the_modes_that_emit_it_are_exactly_the_ones_that_declare_it(self) -> None:
+        emitting = {name for name, tuple_ in tele_mod._MODE_FLAG_OPTIONS.items() if "play_sounds" in tuple_}
+        assert emitting == {"record", "replay", "dagger"}
+
+    @pytest.mark.parametrize("value", ["false", "off", None, [], 0, 1])
+    def test_a_non_boolean_is_now_refused(self, value: Any) -> None:
+        """The domain follows the emission: a flag that reaches an argv is checked."""
+        with pytest.raises(ValueError, match="play_sounds must be a boolean"):
+            _record(play_sounds=value)
+
+    def test_the_refusal_names_the_shared_domain(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _replay(play_sounds="false")
+        assert str(excinfo.value) == boolean_flag_error("false", "play_sounds", "build_lerobot_command")
+
+
+class TestPlainTeleoperationIsUnaffected:
+    """The over-reach control for #2072, in both directions.
+
+    ``lerobot-teleoperate`` declares no ``play_sounds``, so it must neither emit
+    the flag - that would be an unrecognized argument, not a harmless no-op - nor
+    refuse a value for it, which would be a false rejection of the same shape the
+    per-mode scoping exists to prevent.
+    """
+
+    def test_it_emits_no_sound_flag(self) -> None:
+        assert [token for token in _teleop() if "sound" in token.lower()] == []
+
+    def test_its_argv_is_identical_either_way(self) -> None:
+        assert _teleop(play_sounds=True) == _teleop(play_sounds=False)
+
+    @pytest.mark.parametrize("value", ["false", None, []])
+    def test_it_refuses_no_value_for_a_flag_it_ignores(self, value: Any) -> None:
+        assert _teleop(play_sounds=value) == _teleop()
 
 
 class TestTheRefusalPrecedesEverythingItWouldOtherwiseReach:
@@ -459,9 +516,14 @@ class TestTheFlagTableCannotDriftFromTheBuilder:
     def test_every_mode_in_the_table_is_one_the_builder_dispatches(self) -> None:
         assert set(tele_mod._MODE_FLAG_OPTIONS) <= set(tele_mod._MODE_NUMERIC_OPTIONS)
 
-    def test_replay_is_absent_because_it_emits_no_flag(self) -> None:
-        """Absence is the assertion, so a flag added to replay fails here."""
-        assert "replay" not in tele_mod._MODE_FLAG_OPTIONS
+    def test_replay_emits_exactly_one_flag(self) -> None:
+        """The tuple is the assertion, so a flag added to replay fails here.
+
+        ``replay`` was absent from this table until #2072: ``ReplayConfig`` does
+        declare ``play_sounds``, and it is the only flag in this module that entry
+        point accepts.
+        """
+        assert tele_mod._MODE_FLAG_OPTIONS["replay"] == ("play_sounds",)
         assert "replay" in tele_mod._MODE_NUMERIC_OPTIONS
 
     def test_no_mode_names_a_flag_the_supplied_dict_cannot_answer(self) -> None:
@@ -473,7 +535,14 @@ class TestTheFlagTableCannotDriftFromTheBuilder:
             assert tele_mod._flag_error(mode, every_flag_usable) is None
 
     def test_a_mode_absent_from_the_table_refuses_nothing(self) -> None:
-        assert tele_mod._flag_error("replay", {}) is None
+        """The ``.get(mode, ())`` default, not a mode that happens to be missing.
+
+        Every mode the builder dispatches now carries at least one flag, so this
+        asserts the lookup's own default rather than a property of the table -
+        which is what kept it meaningful when ``replay`` joined it in #2072.
+        """
+        assert "no-such-mode" not in tele_mod._MODE_FLAG_OPTIONS
+        assert tele_mod._flag_error("no-such-mode", {}) is None
 
     def test_the_flags_are_reported_in_the_order_the_argv_emits_them(self) -> None:
         """Two unusable flags in one call must report deterministically."""

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -37,6 +37,8 @@ scope, its ordering and the boundary between the two checks are pinned.
 
 from __future__ import annotations
 
+import contextlib
+import importlib
 import inspect
 import io
 import re
@@ -430,6 +432,42 @@ class TestPlaySoundsReachesTheArgv:
         with pytest.raises(ValueError) as excinfo:
             _replay(play_sounds="false")
         assert str(excinfo.value) == boolean_flag_error("false", "play_sounds", "build_lerobot_command")
+
+    @pytest.mark.parametrize(("supplied", "expected"), A_BOOLEAN)
+    def test_a_numpy_boolean_is_honored_like_a_python_one(self, supplied: Any, expected: bool) -> None:
+        """The shared domain accepts a numpy boolean, so the emitter must render one.
+
+        ``boolean_flag_error`` admits ``np.True_`` and ``np.False_`` because a
+        posture read off an array-shaped config or a NumPy comparison arrives that
+        way. A value the check accepts has to reach the argv as one of the two
+        literals the CLI parses, not as ``np.False_``'s ``repr``.
+        """
+        assert _token(_record(play_sounds=supplied), "--play_sounds") == ("true" if expected else "false")
+
+    @pytest.mark.parametrize(("builder", "config"), [(_record, "RecordConfig"), (_replay, "ReplayConfig")])
+    @pytest.mark.parametrize("supplied", [True, False])
+    def test_lerobot_parses_the_emitted_argv_back_to_the_requested_value(
+        self, builder: Any, config: str, supplied: bool
+    ) -> None:
+        """The round trip, through the real CLI parser rather than a stub.
+
+        Every other test here asserts what this module *emits*. This one asserts
+        what lerobot *reads*, which is the half that decides whether the flag is
+        spelled correctly: a token the parser silently ignores, or nests, or reads
+        as its opposite would satisfy an emission assertion and still leave the
+        session running the posture nobody asked for. Parsing the argv back with
+        ``draccus`` - the parser ``@parser.wrap()`` uses - closes that gap, and it
+        is also what pins the flag as top level rather than under ``--dataset.*``.
+        """
+        draccus = pytest.importorskip("draccus")
+        pytest.importorskip("lerobot")
+        importlib.import_module("lerobot.policies")  # registers the policy choices
+        module = "lerobot.scripts." + ("lerobot_record" if config == "RecordConfig" else "lerobot_replay")
+        config_class = getattr(importlib.import_module(module), config)
+        argv = builder(play_sounds=supplied)[3:]  # drop ["python", "-m", <module>]
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            parsed = draccus.parse(config_class=config_class, args=argv)
+        assert parsed.play_sounds is supplied
 
 
 class TestTheToolForwardsPlaySoundsOnEveryModeThatEmitsIt:


### PR DESCRIPTION
Closes #2072

`lerobot_teleoperate` declared `play_sounds: bool = True`, documented it as
"Enable audio feedback", forwarded it to `build_lerobot_command`, and
`build_lerobot_command` declared it too - and then read it nowhere. No mode put
it on an argv, so the documented option did nothing at all in either position.
It is reachable from a model through the tool spec
(`{"type": "boolean", "default": true}`), so an agent could set it and be told
nothing.

```python
build_lerobot_command(**BASE, play_sounds=True) == build_lerobot_command(**BASE, play_sounds=False)
# -> True    (before)
# -> False   (after, for record / replay / dagger)
```

## Which direction, and why

#2072 left two options open: emit the flag, or stop advertising it. The deciding
evidence is upstream, not preference. Measured against `lerobot==0.6.1` - the
floor of this package's `[lerobot]` extra, not the 0.5 the module's docstring
still describes - three of the four entry points this module drives declare the
field, all on the **top-level** `@parser.wrap()` config:

| mode | lerobot config | declares `play_sounds` | emitted here |
|---|---|---|---|
| `record` | `RecordConfig` (`lerobot_record.py:188`) | yes | `--play_sounds true\|false` |
| `replay` | `ReplayConfig` (`lerobot_replay.py:99`) | yes | `--play_sounds true\|false` |
| `dagger` | `RolloutConfig` (`rollout/configs.py:256`) | yes | `--play_sounds true\|false` |
| `teleoperate` | `TeleoperateConfig` | **no such field** | nothing |

So removal would have deleted a capability lerobot genuinely supports in three of
four modes. Because the field is top-level in all three, the flag is spelled
`--play_sounds` and not nested under `--dataset.*`; a test pins that spelling
through lerobot's own parser rather than by assertion on this module's output.

## Both halves of the path, not just the builder

Making the builder honor the flag is only half the fix, because the tool spec sits
on `lerobot_teleoperate` rather than on `build_lerobot_command`. The tool's
`replay` dispatch called the builder **without** forwarding `play_sounds`, so the
builder's `True` default won whatever the agent asked for - the argv read
`--play_sounds true` on the only model-reachable path to replay, and a non-boolean
was not refused there because it never reached the domain check. That is the
#2072 defect surviving for one of the three modes that emit the flag, and no
builder-level test can observe it. The dispatch now forwards the kwarg, pinned at
the tool level and guarded against recurrence at every call site.

## Plain teleoperation is excluded on purpose

Not an oversight left for a follow-up: `TeleoperateConfig` declares no such field
and that entry point makes no `log_say` call, so it never speaks. Emitting the
flag there would be an **unrecognized argument** - the same failure this module's
docstring already records for the removed pre-0.5 flat flags - rather than a
harmless no-op. `teleoperate` therefore emits nothing for `play_sounds` and
refuses no value for it, which is the same per-mode scoping the numeric knobs and
the other boolean flags already use. Both directions are pinned, since a false
rejection is as much a defect as a dropped flag.

## Emit shape follows the upstream default, not a style preference

The module already splits two ways, and the split turns out to be principled:

| upstream default | example | emitted |
|---|---|---|
| `False` | `display_data`, `record_resume`, `dagger_record_autonomous` | only when set - absence says `false` exactly |
| `True` | `dataset_video`, `dataset_push_to_hub`, **`play_sounds`** | always, as an explicit literal |

lerobot defaults `play_sounds` to `True`, so omission also says `True`, and the
explicit literal is the *only* spelling of `play_sounds=False` that can reach the
CLI at all. `play_sounds` also joins `_MODE_FLAG_OPTIONS`, so it now picks up the
shared `boolean_flag_error` domain in the same step - `"false"` is refused rather
than read by truthiness, which for a posture flag would have selected the
opposite posture on a command line the caller cannot read a failure back from.

## Test evidence

The pin #2073 left behind (`TestPlaySoundsIsExcludedByConstruction`) was written
to fail the day this answer landed, and it did; it is replaced rather than
deleted, so the invariant it guarded still has a reader:

- `TestPlaySoundsReachesTheArgv` - the argv differs between `True` and `False`
  for all three modes (the assertion #2072 named as failing), both postures are
  explicit literals, the flag is not nested under `--dataset.*`, the emitting set
  is exactly `{record, replay, dagger}`, and a non-boolean is refused with the
  shared domain's own message.
- `TestTheToolForwardsPlaySoundsOnEveryModeThatEmitsIt` - the argv the **tool**
  hands to lerobot, captured through a patched `subprocess.run`: the opt-out, the
  opt-in, the default, a non-boolean reported without launching anything, and a
  drift guard over every `build_lerobot_command` call site (excluding the
  definition, which would pass vacuously on its own signature).
- `TestPlainTeleoperationIsUnaffected` - the over-reach control in both
  directions: no sound token on the argv, identical argv either way, and no value
  refused for a flag it ignores.
- `test_a_numpy_boolean_is_honored_like_a_python_one` - `boolean_flag_error`
  admits `np.True_` / `np.False_`, so a value the domain **accepts** has to reach
  the argv as one of the two literals the CLI parses rather than as a repr.
- `test_lerobot_parses_the_emitted_argv_back_to_the_requested_value` - the only
  test here that asserts what lerobot *reads* instead of what this module emits,
  which is the half that decides whether the flag is spelled correctly: a token
  the parser ignores, nests, or reads as its opposite would satisfy every
  emission assertion above and still leave the session running the posture nobody
  asked for. The round trip goes through `draccus` - the parser `@parser.wrap()`
  uses - for both `RecordConfig` and `ReplayConfig`. It is the one check that
  needs the `[lerobot]` extra, so it skips when `draccus` is absent, which is
  exactly the `+4 skipped` in the table below.
- Two drift guards moved with their subject: `replay` now asserts its exact
  one-flag tuple, and the absent-mode guard asserts the `.get(mode, ())` default
  rather than a mode that merely happened to be missing.

Re-measured at round-3 head as a delta against the untouched base - same command,
same environment, one run each, on a runner without the `[lerobot]` extra:

| `pytest tests/tools/ --continue-on-collection-errors` | base (`7cea3bb`) | this branch (`7e4bacd`) |
|---|---|---|
| passed | 1626 | **1649** (+23) |
| skipped | 21 | 25 (+4) |
| failed | 12 | 12 (same) |
| collection errors | 3 | 3 (same) |

The 12 failures and 3 collection errors are identical and pre-existing - every
one is `No module named 'lerobot'` where the extra is not installed - so the
whole effect of the change is **+23 passes**, plus the 4 parser round trips that
run only where the extra is. `ruff check` and `ruff format --check` are clean on
both changed files, and none of the three files carries a non-ASCII byte.

## Round changelog

- **Round 1** (`5216d6f`): initial implementation - `play_sounds` emitted for
  `record`, `replay` and `dagger`, scoped by `_MODE_FLAG_OPTIONS`, with the
  builder-level pins and the two moved drift guards.
- **Round 2** (`35222f6`): review feedback - the tool's `replay` dispatch dropped
  the kwarg, so the builder's default won on the only model-reachable path to
  replay and a non-boolean was not refused there. Forwarded it, corrected the
  docstring claim to state the forwarding obligation rather than assert an
  effectiveness the dispatch did not deliver, and added five tool-level
  assertions including a call-site drift guard. Three of the five fail on pre-fix
  code, verified by reverting only the forward.
- **Round 3** (`7e4bacd`): tests only, no production change. A sibling attempt at
  this same defect (#2078, opened minutes after this one and now closed as the
  duplicate) carried two measurements this branch did not, so they were absorbed
  before closing it and nothing it verified is lost: the numpy-boolean rendering
  check, and the round trip through lerobot's own parser that pins the flag as
  top-level rather than under `--dataset.*`. The suite delta above was
  re-measured at this head, superseding the round-2 figures, which were taken on
  a differently-provisioned runner and so were not comparable to it.