### PR TITLE
fix(lerobot_teleoperate): emit --play_sounds for the modes whose entry point accepts it

### DIFF
--- a/changelog.d/2072-lerobot-teleoperate-play-sounds-emission.md
+++ b/changelog.d/2072-lerobot-teleoperate-play-sounds-emission.md
@@ -1,0 +1,21 @@
+### Fixed: `build_lerobot_command` emits `--play_sounds` for the modes that accept it
+
+`play_sounds` was declared on `build_lerobot_command` and on the `lerobot_teleoperate`
+tool, documented as "Enable audio feedback", forwarded from the tool to the builder -
+and then emitted by nothing. Every mode returned a byte-identical argv for `True` and
+`False`, so `play_sounds=False` - the request an unattended session on a shared machine
+makes - was silently the default, on a detached subprocess's command line the supplying
+call cannot read a failure back from.
+
+Three of lerobot's four entry points declare the field: `RecordConfig`, `ReplayConfig`
+and `RolloutConfig`. Those modes now emit `--play_sounds true|false` explicitly - like
+`--dataset.video`, so this signature's own default is what the session runs with rather
+than whatever the lerobot config happens to default to - and the flag is checked against
+the shared `boolean_flag_error` domain, so a truthy spelling of off such as `"false"` is
+refused instead of selecting the opposite posture. Plain teleoperation still emits
+nothing for it: `TeleoperateConfig` does not declare the field and that CLI exits with
+`unrecognized arguments: --play_sounds`, so refusing a value there would be a false
+rejection.
+
+`play_sounds` also gains an `Args:` entry on `build_lerobot_command`, which had declared
+and consumed it without documenting it.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -132,15 +132,24 @@ def _numeric_option_error(mode: str, supplied: dict[str, Any]) -> str | None:
 # ``[]`` took the other branch just as silently, without ever being a declared
 # spelling of it.
 #
-# ``replay`` is absent because it emits no flag at all - its argv is unchanged by
-# every flag in this module, so refusing one there would be a false rejection,
-# the same scoping rule :data:`_MODE_NUMERIC_OPTIONS` encodes. ``play_sounds`` is
-# in no tuple for that same reason: nothing reads it anywhere (#2072), so it is
-# excluded here by construction rather than by an exemption.
+# ``teleoperate`` is the one mode that emits no ``play_sounds``: lerobot's
+# ``TeleoperateConfig`` does not declare the field, and its CLI exits with
+# ``unrecognized arguments: --play_sounds`` when it is passed one. ``RecordConfig``,
+# ``ReplayConfig`` and ``RolloutConfig`` each declare it, so those three modes emit
+# it and are checked for it here - the same scoping rule
+# :data:`_MODE_NUMERIC_OPTIONS` encodes, driven by what each entry point accepts
+# rather than by an exemption.
 _MODE_FLAG_OPTIONS: dict[str, tuple[str, ...]] = {
-    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data"),
+    "record": ("record_resume", "dataset_push_to_hub", "dataset_video", "display_data", "play_sounds"),
+    "replay": ("play_sounds",),
     "teleoperate": ("display_data",),
-    "dagger": ("dagger_record_autonomous", "dataset_push_to_hub", "dataset_video", "display_data"),
+    "dagger": (
+        "dagger_record_autonomous",
+        "dataset_push_to_hub",
+        "dataset_video",
+        "display_data",
+        "play_sounds",
+    ),
 }
 
 
@@ -428,6 +437,12 @@ def build_lerobot_command(
             (resolved from ``dataset_repo_id``) so lerobot HEAD's repo_id
             timestamp-stamping never relocates the on-disk dataset.
         replay_episode: Episode index to replay (``--dataset.episode``).
+        play_sounds: Emit ``--play_sounds true|false`` for the audio cues lerobot
+            speaks between episodes. Emitted explicitly, like ``dataset_video``,
+            so this signature's own default is what the session runs with rather
+            than whatever the lerobot config happens to default to. Plain
+            teleoperation omits it: ``TeleoperateConfig`` does not declare the
+            field and that CLI refuses the flag outright.
 
     Returns:
         The argv list, beginning with ``["python", "-m", "lerobot.scripts...."]``.
@@ -461,11 +476,14 @@ def build_lerobot_command(
         "dataset_video": dataset_video,
         "display_data": display_data,
         "dagger_record_autonomous": dagger_record_autonomous,
+        "play_sounds": play_sounds,
     }
     if action == "replay":
         if not dataset_repo_id:
             raise ValueError("dataset_repo_id is required for replay action")
         if error := _numeric_option_error("replay", numeric_options):
+            raise ValueError(error)
+        if error := _flag_error("replay", flag_options):
             raise ValueError(error)
         cmd = ["python", "-m", "lerobot.scripts.lerobot_replay"]
         cmd.extend(
@@ -475,6 +493,7 @@ def build_lerobot_command(
         if dataset_root:
             cmd.extend(["--dataset.root", dataset_root])
         cmd.extend(["--dataset.fps", str(int(dataset_fps))])
+        cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
         return cmd
 
     if action == "start":
@@ -513,6 +532,7 @@ def build_lerobot_command(
             cmd.extend(["--dataset.video", "true" if dataset_video else "false"])
             if display_data:
                 cmd.extend(["--display_data", "true"])
+            cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
             return cmd
 
         # Simple teleoperation mode -> lerobot-teleoperate.
@@ -593,6 +613,7 @@ def build_lerobot_command(
         cmd.extend(["--fps", str(int(fps))])
         if display_data:
             cmd.extend(["--display_data", "true"])
+        cmd.extend(["--play_sounds", "true" if play_sounds else "false"])
         return cmd
 
     raise ValueError(f"Unknown action: {action}")

--- a/tests/tools/test_lerobot_teleoperate_flag_domain.py
+++ b/tests/tools/test_lerobot_teleoperate_flag_domain.py
@@ -37,6 +37,8 @@ scope, its ordering and the boundary between the two checks are pinned.
 
 from __future__ import annotations
 
+import contextlib
+import importlib
 import inspect
 import io
 import subprocess
@@ -363,35 +365,104 @@ class TestOnlyTheFlagsAModeEmitsAreChecked:
         assert _dagger(record_resume="false") == _dagger()
 
 
-class TestPlaySoundsIsExcludedByConstruction:
-    """No mode emits ``play_sounds``, so no mode may refuse a value for it.
+class TestPlaySoundsReachesEveryModeThatCanHonorIt:
+    """``play_sounds`` is emitted by the three modes whose entry point takes it.
 
-    The parameter is declared, documented and forwarded, and then read by
-    nothing - so giving it a domain here would be a false rejection for an option
-    that has no effect either way. It is absent from the table for the same
-    reason ``replay`` is, rather than by an exemption. Whether it should be
-    emitted or removed is #2072; this class pins the state that issue describes,
-    so it fails the day the answer lands and the exclusion stops being true.
+    It was declared, documented and forwarded, and then emitted by nothing, so
+    ``play_sounds=False`` - the request an unattended session on a shared machine
+    makes - produced an argv byte-identical to the default and the audio cues
+    played anyway. Measured on ``586109c``, all four modes returned the same argv
+    for ``True`` and ``False``.
+
+    The scoping is what each lerobot entry point accepts, not a preference:
+    ``RecordConfig``, ``ReplayConfig`` and ``RolloutConfig`` declare the field,
+    while ``TeleoperateConfig`` does not and that CLI exits with ``unrecognized
+    arguments: --play_sounds``. So plain teleoperation still emits nothing for it
+    and still refuses nothing for it, and the other three both emit and check.
     """
 
-    def test_no_mode_emits_it(self) -> None:
-        for name, tuple_ in tele_mod._MODE_FLAG_OPTIONS.items():
-            assert "play_sounds" not in tuple_, f"mode {name!r} now emits play_sounds; give it a domain"
+    def test_the_lerobot_entry_points_declare_what_the_table_claims(self) -> None:
+        """The premise the scoping rests on, read off the installed lerobot."""
+        import dataclasses
 
-    @pytest.mark.parametrize("builder", [_record, _teleop, _replay])
-    def test_the_argv_is_identical_either_way(self, builder: Any) -> None:
-        assert builder(play_sounds=True) == builder(play_sounds=False)
+        pytest.importorskip("lerobot")
+        declares = {}
+        for module, name in (
+            ("lerobot.scripts.lerobot_record", "RecordConfig"),
+            ("lerobot.scripts.lerobot_replay", "ReplayConfig"),
+            ("lerobot.scripts.lerobot_rollout", "RolloutConfig"),
+            ("lerobot.scripts.lerobot_teleoperate", "TeleoperateConfig"),
+        ):
+            config = getattr(importlib.import_module(module), name)
+            declares[name] = "play_sounds" in {f.name for f in dataclasses.fields(config)}
+        assert declares == {
+            "RecordConfig": True,
+            "ReplayConfig": True,
+            "RolloutConfig": True,
+            "TeleoperateConfig": False,
+        }
 
-    def test_the_dagger_argv_is_identical_either_way(self, _rollout_entry_point: None) -> None:
-        assert _dagger(play_sounds=True) == _dagger(play_sounds=False)
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    @pytest.mark.parametrize(("supplied", "emitted"), [(True, "true"), (False, "false")])
+    def test_the_requested_posture_reaches_the_argv(self, builder: Any, supplied: bool, emitted: str) -> None:
+        assert _token(builder(play_sounds=supplied), "--play_sounds") == emitted
 
-    def test_no_argv_carries_a_sound_token(self) -> None:
-        for argv in (_record(), _teleop(), _replay()):
-            assert [token for token in argv if "sound" in token.lower()] == []
+    @pytest.mark.parametrize(("supplied", "emitted"), [(True, "true"), (False, "false")])
+    def test_the_dagger_argv_carries_it_too(self, _rollout_entry_point: None, supplied: bool, emitted: str) -> None:
+        assert _token(_dagger(play_sounds=supplied), "--play_sounds") == emitted
 
-    def test_a_non_boolean_is_consequently_not_refused(self) -> None:
-        """Not an oversight: nothing reads it, so nothing can misread it."""
-        assert _record(play_sounds="false") == _record()
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    def test_the_two_postures_are_no_longer_the_same_argv(self, builder: Any) -> None:
+        assert builder(play_sounds=True) != builder(play_sounds=False)
+
+    def test_it_is_emitted_explicitly_rather_than_only_when_withheld(self) -> None:
+        """The declared default must not depend on lerobot's own default."""
+        assert "--play_sounds" in _record()
+
+    def test_plain_teleoperation_still_omits_it(self) -> None:
+        """``TeleoperateConfig`` has no such field; emitting it would be fatal."""
+        argv = _teleop(play_sounds=False)
+        assert [token for token in argv if "sound" in token.lower()] == []
+
+    @pytest.mark.parametrize("builder", [_record, _replay])
+    @pytest.mark.parametrize("value", ["false", "off", None, [], 0, 1])
+    def test_a_value_no_posture_can_be_read_from_is_refused(self, builder: Any, value: Any) -> None:
+        with pytest.raises(ValueError, match="play_sounds"):
+            builder(play_sounds=value)
+
+    def test_the_dagger_mode_refuses_it_too(self, _rollout_entry_point: None) -> None:
+        with pytest.raises(ValueError, match="play_sounds"):
+            _dagger(play_sounds="false")
+
+    @pytest.mark.parametrize("value", ["false", None, [], 0])
+    def test_plain_teleoperation_refuses_nothing_for_it(self, value: Any) -> None:
+        """Refusing a flag a mode never emits would be a false rejection."""
+        assert _teleop(play_sounds=value) == _teleop()
+
+    @pytest.mark.parametrize(("supplied", "emitted"), [(np.True_, "true"), (np.False_, "false")])
+    def test_a_numpy_boolean_is_still_honored(self, supplied: Any, emitted: str) -> None:
+        assert _token(_record(play_sounds=supplied), "--play_sounds") == emitted
+
+    def test_the_refusal_precedes_the_argv(self) -> None:
+        """Nothing is built for a value the session could not have honored."""
+        with pytest.raises(ValueError, match="play_sounds"):
+            _replay(play_sounds="false")
+
+    @pytest.mark.parametrize(("builder", "config"), [(_record, "RecordConfig"), (_replay, "ReplayConfig")])
+    @pytest.mark.parametrize("supplied", [True, False])
+    def test_lerobot_parses_the_emitted_argv_back_to_the_requested_value(
+        self, builder: Any, config: str, supplied: bool
+    ) -> None:
+        """The round trip, through the real CLI parser rather than a stub."""
+        draccus = pytest.importorskip("draccus")
+        pytest.importorskip("lerobot")
+        importlib.import_module("lerobot.policies")  # registers the policy choices
+        module = "lerobot.scripts." + ("lerobot_record" if config == "RecordConfig" else "lerobot_replay")
+        config_class = getattr(importlib.import_module(module), config)
+        argv = builder(play_sounds=supplied)[3:]  # drop ["python", "-m", <module>]
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            parsed = draccus.parse(config_class=config_class, args=argv)
+        assert parsed.play_sounds is supplied
 
 
 class TestTheRefusalPrecedesEverythingItWouldOtherwiseReach:
@@ -459,9 +530,13 @@ class TestTheFlagTableCannotDriftFromTheBuilder:
     def test_every_mode_in_the_table_is_one_the_builder_dispatches(self) -> None:
         assert set(tele_mod._MODE_FLAG_OPTIONS) <= set(tele_mod._MODE_NUMERIC_OPTIONS)
 
-    def test_replay_is_absent_because_it_emits_no_flag(self) -> None:
-        """Absence is the assertion, so a flag added to replay fails here."""
-        assert "replay" not in tele_mod._MODE_FLAG_OPTIONS
+    def test_replay_is_present_because_it_now_emits_one(self) -> None:
+        """``replay`` emitted no flag until it emitted ``--play_sounds``.
+
+        It was absent from the table while its argv carried no flag at all; the
+        entry is what gives the one flag it does emit a domain.
+        """
+        assert tele_mod._MODE_FLAG_OPTIONS["replay"] == ("play_sounds",)
         assert "replay" in tele_mod._MODE_NUMERIC_OPTIONS
 
     def test_no_mode_names_a_flag_the_supplied_dict_cannot_answer(self) -> None:
@@ -473,7 +548,9 @@ class TestTheFlagTableCannotDriftFromTheBuilder:
             assert tele_mod._flag_error(mode, every_flag_usable) is None
 
     def test_a_mode_absent_from_the_table_refuses_nothing(self) -> None:
-        assert tele_mod._flag_error("replay", {}) is None
+        """Every dispatched mode is in the table now, so name one that is not."""
+        assert "calibrate" not in tele_mod._MODE_FLAG_OPTIONS
+        assert tele_mod._flag_error("calibrate", {}) is None
 
     def test_the_flags_are_reported_in_the_order_the_argv_emits_them(self) -> None:
         """Two unusable flags in one call must report deterministically."""


### PR DESCRIPTION
## Problem

`play_sounds` was declared on `build_lerobot_command`, declared again on the `lerobot_teleoperate` tool, documented as *"Enable audio feedback"*, forwarded from the tool to the builder — and then emitted by nothing.

Measured on `586109c`, every mode returned a **byte-identical argv** for `True` and `False`:

| mode | `play_sounds=True` | `play_sounds=False` | argv identical |
|---|---|---|---|
| `record` | no flag emitted | no flag emitted | **yes** |
| `replay` | no flag emitted | no flag emitted | **yes** |
| `dagger` | no flag emitted | no flag emitted | **yes** |
| `teleoperate` | no flag emitted | no flag emitted | yes |

The argv goes to a subprocess launched with `start_new_session=True`, so the call that supplied the value cannot read that back: `lerobot_teleoperate` returns `status="success"` with a pid. Pushing the emitted argv through lerobot's own CLI parser shows what the session really ran with:

| mode | requested | main runs with | this change runs with |
|---|---|---|---|
| `record` | `True` | `True` | `True` |
| `record` | `False` | **`True`** | `False` |
| `replay` | `True` | `True` | `True` |
| `replay` | `False` | **`True`** | `False` |

So `play_sounds=False` — the request an unattended session on a shared machine makes — was silently the default.

## Why the flag belongs on three of the four modes

The scoping is what each lerobot entry point accepts, read off the installed package rather than chosen:

| lerobot config | declares `play_sounds` | strands mode |
|---|---|---|
| `RecordConfig` | yes | `record` |
| `ReplayConfig` | yes | `replay` |
| `RolloutConfig` | yes | `dagger` |
| `TeleoperateConfig` | **no** | `teleoperate` |

Passing the flag to the teleoperate CLI exits with `unrecognized arguments: --play_sounds`, so plain teleoperation must keep emitting nothing for it — and must keep refusing nothing for it, since refusing a flag a mode never puts on the argv would be a false rejection. That is the same scoping rule the numeric knobs already use.

## Change

`record`, `replay` and `dagger` now emit `--play_sounds true|false`. It is emitted **explicitly** in both directions, like `--dataset.video`, so this signature's own default is what the session runs with rather than whatever the lerobot config happens to default to.

Those three modes also gain the flag in `_MODE_FLAG_OPTIONS`, so it is checked against the shared `boolean_flag_error` domain. Without that, giving the flag an effect would have introduced a new instance of the failure `dataset_push_to_hub` and `record_resume` were given a domain for: `"false"` and `"off"` are truthy, so a spelling that reads as opting out would have selected the opposite posture. `replay` joins that table because it now emits a flag at all — it was absent while its argv carried none.

`play_sounds` also gains an `Args:` entry on `build_lerobot_command`, which had declared and consumed it without documenting it.

## Two existing tests pinned the previous state, by design

`TestPlaySoundsIsExcludedByConstruction` said so in its own docstring — *"Whether it should be emitted or removed is #2072; this class pins the state that issue describes, so it fails the day the answer lands"* — and its assertion message read `mode {name!r} now emits play_sounds; give it a domain`. It is replaced by `TestPlaySoundsReachesEveryModeThatCanHonorIt`, which pins the corrected contract including the lerobot-side premise the scoping rests on and a round trip through the real CLI parser.

`test_replay_is_absent_because_it_emits_no_flag` becomes `test_replay_is_present_because_it_now_emits_one`, and `test_a_mode_absent_from_the_table_refuses_nothing` now names a mode that really is absent, since every dispatched mode is in the table.

## Measured

![play_sounds emission](https://raw.githubusercontent.com/cagataycali/robots/artifacts/play-sounds-emission/play_sounds.png)

Left is `main`, right is this change: what `build_lerobot_command` does with each spelling, per mode. Cells are green when the outcome is what that mode can honor — the usable booleans emitted, everything unusable refused, and `teleoperate` correctly emitting and refusing nothing. **Divergences: 24 of 32 cells on `main` → 0 of 32.** The round-trip table and the argv tail below it are the same measurements quoted above.

This change touches the command builder only; no policy, simulation, rendering, dataset-recorder or asset behaviour changes, so the artifact is a wire trace rather than a rollout. The capture and compose scripts and both raw measurement dumps are on the [artifact branch](https://github.com/cagataycali/robots/tree/artifacts/play-sounds-emission).

## Gate — Thor, `MUJOCO_GL=egl`, at `7cea3bb`

| check | result |
|---|---|
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check` | 1139 files already formatted |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs` (14 there, byte-identical to a pristine `upstream/main` worktree of the same working copy) |
| `pytest tests` | **26284 passed, 257 skipped, 0 failed** (548s) |
| `pytest tests/tools/` + repo-wide root guards | 2333 passed, 1 skipped |
| `scripts/assemble_changelog.py --check` | OK (255 pending) |
| `scripts/check_merge_base_overlap.py` | No overlap |

Pre-fix proof — source reverted to `upstream/main`, the new tests kept: **28 failed / 167 passed**, the sharpest failure being `assert True is False ... ReplayConfig(...play_sounds=True)` — lerobot's own parser reporting that a `False` request was lost. Identical failing count (28) at the previous base `586109c`, where the passing count was 125 before #2076's tests joined the file, so the rebase preserved the contract.

Closes #2072.
