### PR TITLE
fix(hardware_robot): judge policy_port before the arm is connected

### DIFF
--- a/changelog.d/2079-hardware-policy-port-domain.md
+++ b/changelog.d/2079-hardware-policy-port-domain.md
@@ -1,0 +1,18 @@
+### Fixed: a hardware task's `policy_port` is judged before the arm is connected
+
+`Robot.start_task` and the `execute` chokepoint validated `duration` and
+`n_steps` before claiming the motors bus, but read `policy_port` only inside
+the async task body - after `_connect_robot` had energized the arm. A port no
+policy could ever be built from therefore spent the whole bring-up window (a
+motors-bus handshake plus per-camera warmup, seconds on a real arm) before
+failing, and `start_task` reported `status="success"` and "Task started" for
+it because the failure surfaced on the executor thread. A supplied-but-falsy
+`0` / `False` was reported as `"policy_port is required"`, telling the caller a
+port they had passed was missing.
+
+Both entry points now check it beside the budget, on the shared
+`tcp_port_error` domain the policy providers already apply, so the same port
+cannot be accepted by the arm's task entry points and refused by the provider
+they hand it to. A refused port connects nothing and leaves the command bus
+free. `_execute_task_sync` skips the check when a pre-built `policy_object` is
+given, because the port is not read on that path.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -59,6 +59,15 @@ name it in the error. That includes the `CONNECTING` bring-up window - a motors
 bus handshake plus per-camera warmup, seconds on a real arm - not just
 `RUNNING`. Call `stop_task()` to hand the bus over early.
 
+Every rollout knob is judged before that bring-up window, not inside it.
+`duration` must be positive and finite, `n_steps` a positive count, and
+`policy_port` a port in `1-65535` - the same domain the policy providers
+themselves apply, so a port the arm accepts is a port the provider can dial.
+`policy_port` is required unless `run_policy` is given a pre-built
+`policy_object`, which is the one case where the port is not read. A value none
+of them can honor is reported by name, with the arm still disconnected and the
+command bus still free for a task that could run.
+
 `cleanup()` (and `stop()`, which delegates to it) is terminal: it latches a
 shutdown, releases the task executor, tears down the mesh and ROS bridges, and
 disconnects the robot. It holds whatever state the robot is in - never

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -42,6 +42,7 @@ from strands_robots.utils import (
     positive_count_error,
     positive_finite_number_error,
     require_optional,
+    tcp_port_error,
 )
 
 if TYPE_CHECKING:
@@ -1135,7 +1136,13 @@ class Robot(TeleopMixin, AgentTool):
     async def _get_policy(
         self, policy_port: int | None = None, policy_host: str = "localhost", policy_provider: str = "groot"
     ) -> Policy:
-        """Create policy on-the-fly from invocation parameters."""
+        """Create policy on-the-fly from invocation parameters.
+
+        The public entry points refuse an unusable ``policy_port`` before the
+        arm is connected (:meth:`_policy_port_error`), so the falsy check below
+        is the floor for a direct call to this private helper rather than the
+        first place a caller's port is judged.
+        """
         from .policies import create_policy
 
         if not policy_port:
@@ -1631,6 +1638,67 @@ class Robot(TeleopMixin, AgentTool):
             return {"status": "error", "content": [{"text": error}]}
         return None
 
+    @staticmethod
+    def _policy_port_error(policy_port: Any, method: str) -> dict[str, Any] | None:
+        """Reject a ``policy_port`` no policy can be built from.
+
+        ``policy_port`` is the one caller-supplied value that decides whether a
+        policy exists at all: :meth:`_get_policy` hands it to
+        :func:`~strands_robots.policies.create_policy`, whose provider
+        constructor dials it. Every other rollout knob is checked before the
+        motors bus is claimed - see :meth:`_duration_error` and
+        :meth:`_n_steps_error`, whose call sites document why a budget "is
+        refused before the arm is commanded rather than after". This one was
+        read only inside :meth:`_execute_task_async`, *after*
+        :meth:`_connect_robot` had energized the arm, so a port that can never
+        build a policy still ran the whole bring-up window that method's own
+        comment describes as "a motors-bus handshake plus per-camera warmup -
+        seconds on a real arm". :meth:`start_task` additionally reported
+        ``status="success"`` and "Task started" for it, because the failure
+        surfaced on the executor thread with nobody left to tell.
+
+        ``None`` is the "not supplied" spelling and is refused here for the same
+        reason it is refused in :meth:`_get_policy`: without a pre-built
+        ``policy_object`` there is nothing to build a policy from. Every other
+        value is checked against
+        :func:`~strands_robots.utils.tcp_port_error`, the shared domain whose
+        docstring already names "the policy providers that dial one (``groot``,
+        ``moveit2``, ``cosmos3``, ``lerobot_async``, ``vera``)" - the very
+        providers this path forwards to - so the same port cannot be accepted by
+        the arm's task entry points and refused by the provider they hand it to.
+
+        That domain also names the value the caller supplied. A supplied-but-
+        unusable ``0`` / ``False`` used to be reported as
+        ``"policy_port is required for robot operation"``: falsy, so
+        :meth:`_get_policy` read it as absent and told the caller a port they
+        had passed was missing.
+
+        Args:
+            policy_port: The caller-supplied port to validate, or ``None`` when
+                none was supplied.
+            method: Public entry point name, used to prefix the message.
+
+        Returns:
+            A tool-shaped error dict naming ``policy_port``, or ``None`` when a
+            policy can be built from the value.
+        """
+        if policy_port is None:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"{method}: policy_port is required to build a policy "
+                            "(pass the port of the policy server, or use run_policy "
+                            "with a pre-built policy_object)."
+                        )
+                    }
+                ],
+            }
+        if error := tcp_port_error(policy_port, "policy_port", method):
+            return {"status": "error", "content": [{"text": error}]}
+        return None
+
     def _shutdown_error(self, method: str) -> dict[str, Any] | None:
         """Refuse a rollout on a robot whose ``cleanup()`` has already run.
 
@@ -1747,9 +1815,26 @@ class Robot(TeleopMixin, AgentTool):
         """Execute task synchronously in thread - no new event loop.
 
         This is the chokepoint the agent-tool ``execute`` action and the mesh
-        ``execute`` dispatch reach directly, so it both validates the
-        peer-supplied budget and claims the motors bus before the arm is
-        commanded.
+        ``execute`` dispatch reach directly, so it validates the peer-supplied
+        budget and the policy endpoint, then claims the motors bus, all before
+        the arm is commanded.
+
+        Args:
+            instruction: Natural-language instruction passed to the policy.
+            policy_port: Port of the policy server to query. Required unless
+                ``policy_object`` is given, and validated on the shared
+                :func:`~strands_robots.utils.tcp_port_error` domain before the
+                arm is connected - see :meth:`_policy_port_error`.
+            policy_host: Host of the policy server.
+            policy_provider: Provider name used to build the policy.
+            duration: Wall-clock budget in seconds; positive and finite.
+            policy_object: A pre-built policy. When given, the provider/port
+                pair is not read and ``policy_port`` is not validated.
+            n_steps: Optional cap on applied actions; ``None`` for no cap.
+
+        Returns:
+            Tool-shaped result for the finished rollout, or an error naming the
+            offending parameter.
         """
         # Validated here as well as at the public methods below: a peer-supplied
         # budget is refused before the arm is commanded rather than after. The
@@ -1760,6 +1845,13 @@ class Robot(TeleopMixin, AgentTool):
         if err := self._duration_error(duration, "execute_task"):
             return err
         if err := self._n_steps_error(n_steps, "execute_task"):
+            return err
+        # Same reasoning one parameter over: a port no policy can be built from
+        # is refused before the arm is connected rather than after. Gated on
+        # ``policy_object``, because a pre-built policy makes the port inert -
+        # ``_execute_task_async`` never reads it on that path - and refusing a
+        # value the call ignores would be a false rejection.
+        if policy_object is None and (err := self._policy_port_error(policy_port, "execute_task")):
             return err
         if err := self._claim_task(instruction):
             return err
@@ -1879,7 +1971,13 @@ class Robot(TeleopMixin, AgentTool):
 
         Args:
             instruction: Natural-language instruction passed to the policy.
-            policy_port: Port of the policy server to query.
+            policy_port: Port of the policy server to query. Required: this
+                entry point takes no pre-built policy, so the port is the only
+                thing a policy can be built from. Validated on the shared
+                :func:`~strands_robots.utils.tcp_port_error` domain before the
+                task is submitted, so a port no policy can be built from is
+                reported here instead of as a started task that connects the
+                arm and then fails on the executor thread.
             policy_host: Host of the policy server.
             policy_provider: Provider name used to build the policy.
             duration: Wall-clock budget in seconds. Must be positive and
@@ -1907,6 +2005,13 @@ class Robot(TeleopMixin, AgentTool):
         if err := self._shutdown_error("start_task"):
             return err
         if err := self._duration_error(duration, "start_task"):
+            return err
+        # Unconditional here, unlike ``_execute_task_sync``: this entry point
+        # takes no ``policy_object``, so the port is always the only thing a
+        # policy can be built from. Pre-fix every unusable value returned
+        # "Task started" and failed on the executor thread after the arm was
+        # already connected.
+        if err := self._policy_port_error(policy_port, "start_task"):
             return err
 
         # Claim the bus here, not on the executor thread: this method returns

--- a/tests/test_hardware_after_shutdown.py
+++ b/tests/test_hardware_after_shutdown.py
@@ -373,7 +373,13 @@ class TestAHealthyRolloutIsUnaffected:
         assert bus.connect_calls == 1
 
     def test_start_task_before_cleanup_still_submits(self, hw: HwRobot, bus: Bus):
-        result = hw.start_task("healthy")
+        """A well-formed start still submits; the shutdown guard is the only refusal.
+
+        The port is explicit because ``start_task`` now judges it before the
+        submit: an absent ``policy_port`` is refused on its own terms (no policy
+        can be built from it), which would mask the property under test here.
+        """
+        result = hw.start_task("healthy", policy_port=5555)
 
         assert result["status"] == "success"
         assert "Task started" in _text(result)

--- a/tests/test_hardware_policy_port_domain.py
+++ b/tests/test_hardware_policy_port_domain.py
@@ -1,0 +1,348 @@
+"""Behavior tests for the accepted ``policy_port`` domain of a hardware task.
+
+``policy_port`` is the one caller-supplied value that decides whether a policy
+exists at all: ``Robot._get_policy`` hands it to ``create_policy``, whose
+provider constructor dials it. Its siblings in the same signature are refused
+before the motors bus is claimed - ``duration`` and ``n_steps`` both are, and
+the call sites say why ("a peer-supplied budget is refused before the arm is
+commanded rather than after"). The port was read only inside
+``_execute_task_async``, *after* ``_connect_robot`` had energized the arm.
+
+These tests pin that a port no policy can be built from is refused where the
+budget already is:
+
+    - the refusal precedes ``_connect_robot``, so the bring-up window that
+      method's own comment describes as "a motors-bus handshake plus per-camera
+      warmup - seconds on a real arm" is not spent on a call that cannot start;
+    - it precedes the bus claim, so a rejected port does not take the arm away
+      from a rollout that could still run;
+    - ``start_task`` reports it instead of ``status="success"`` / "Task started"
+      followed by a failure on the executor thread, where nobody is left to tell;
+    - a supplied-but-unusable ``0`` / ``False`` is named as invalid rather than
+      reported as ``"policy_port is required"``, which said a port the caller
+      passed was missing;
+    - a pre-built ``policy_object`` makes the port inert on
+      ``_execute_task_sync``, so it is not validated there - refusing a value the
+      call never reads would be a false rejection;
+    - every port that IS usable still connects and reaches the policy build;
+    - the accepted domain is the shared ``tcp_port_error`` one the policy
+      providers themselves apply, so the same port cannot be accepted by the
+      arm's task entry points and refused by the provider they hand it to.
+
+No serial/USB hardware is touched: the driver is an in-memory fake, the connect
+path is a recording stub, and the policy is a structural stub.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.hardware_robot as hardware_robot
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from strands_robots.utils import tcp_port_error
+from tests.test_hardware_control_loop_rate_guard import _FakeArm
+
+# Ports no policy can be built from. ``0`` asks the kernel for an ephemeral port
+# rather than naming one to dial; the out-of-range values have nothing to
+# connect to; ``True``/``False`` are ``int`` subclasses that would act as
+# silent ports 1 and 0; the rest are not port numbers at all. ``None`` is
+# excluded here and covered on its own: it is the "not supplied" spelling, so
+# its message differs.
+UNUSABLE_PORTS: list[Any] = [
+    0,
+    -1,
+    65536,
+    99999,
+    float("nan"),
+    float("inf"),
+    True,
+    False,
+    2.7,
+    "5555",
+    [5555],
+    np.int64(5555),
+]
+
+# Ports that name a socket a provider can dial.
+USABLE_PORTS: list[Any] = [1, 5555, 65535]
+
+
+class _Policy:
+    """Structural stand-in for a policy: the members the control loop reads."""
+
+    supports_rtc = False
+    execution_horizon = 1
+
+    def set_control_frequency(self, hz: float) -> None:
+        return None
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        return None
+
+    def reset(self, seed: int | None = None) -> None:
+        return None
+
+    async def get_actions(self, observation: Any, instruction: str) -> list[dict[str, Any]]:
+        return [{"j0.pos": 0.1}]
+
+
+@pytest.fixture
+def hw() -> Any:
+    """A ``Robot`` wired to an in-memory arm, with a *recording* connect path.
+
+    ``robot.connects`` counts every ``_connect_robot`` call, which is what makes
+    "the refusal precedes the bring-up window" an observation rather than a
+    claim. ``robot.robot.sent_actions`` records every command that reached the
+    arm.
+    """
+    robot = HwRobot.__new__(HwRobot)
+    robot.tool_name_str = "test_arm"
+    robot.action_horizon = 1
+    robot.data_config = None
+    robot.control_frequency = 50.0
+    robot.action_sleep_time = 1.0 / 50.0
+    robot._task_state = RobotTaskState()
+    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._shutdown_event = threading.Event()
+    robot._stop_requested = threading.Event()
+    robot._task_admission = threading.Lock()
+    robot._task_claimed = False
+    robot.mesh = None
+    robot.peer_id = None
+    robot.robot = _FakeArm()
+    robot.connects = []  # type: ignore[attr-defined]
+
+    async def _connected() -> tuple[bool, str]:
+        robot.connects.append(True)  # type: ignore[attr-defined]
+        return (True, "")
+
+    async def _ready() -> bool:
+        return True
+
+    def _init_policy(policy: Any) -> Any:
+        return _ready()
+
+    def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+        return None
+
+    robot._connect_robot = _connected  # type: ignore[method-assign]
+    robot._initialize_policy = _init_policy  # type: ignore[method-assign]
+    robot._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+    try:
+        yield robot
+    finally:
+        robot._shutdown_event.set()
+        robot._task_state.status = TaskStatus.STOPPED
+        robot._executor.shutdown(wait=False)
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The text of a tool-shaped result."""
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+class TestUnusablePortRefusedBeforeTheArmIsTouched:
+    """The port is judged where the budget already is: before connect, before the claim."""
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS, ids=repr)
+    def test_execute_task_sync_refuses_without_connecting(self, hw: Any, port: Any) -> None:
+        result = hw._execute_task_sync("pick", policy_port=port, duration=0.05)
+
+        assert result["status"] == "error"
+        assert "policy_port" in _text(result)
+        assert hw.connects == [], "the refused port still ran the bring-up window"
+        assert hw._task_claimed is False, "the refused port took the motors bus"
+        assert hw.robot.sent_actions == []
+
+    @pytest.mark.parametrize("port", UNUSABLE_PORTS, ids=repr)
+    def test_start_task_refuses_instead_of_reporting_a_started_task(self, hw: Any, port: Any) -> None:
+        result = hw.start_task("pick", policy_port=port, duration=0.05)
+
+        assert result["status"] == "error"
+        assert "policy_port" in _text(result)
+        assert "Task started" not in _text(result)
+        assert hw._task_state.task_future is None, "work was submitted for a port that cannot build a policy"
+        assert hw.connects == []
+        assert hw._task_claimed is False
+
+    @pytest.mark.parametrize("entry", ["execute_task", "start_task"])
+    def test_a_missing_port_is_reported_as_required(self, hw: Any, entry: str) -> None:
+        """``None`` is the "not supplied" spelling, so it says required - early."""
+        if entry == "execute_task":
+            result = hw._execute_task_sync("pick", policy_port=None, duration=0.05)
+        else:
+            result = hw.start_task("pick", policy_port=None, duration=0.05)
+
+        assert result["status"] == "error"
+        assert "policy_port is required" in _text(result)
+        assert entry in _text(result)
+        assert hw.connects == []
+
+
+class TestTheMessageNamesTheValueTheCallerSupplied:
+    """A supplied port is not reported as a missing one."""
+
+    @pytest.mark.parametrize("port", [0, False], ids=["0", "False"])
+    def test_a_falsy_supplied_port_is_named_not_called_missing(self, hw: Any, port: Any) -> None:
+        """Pre-fix these read as absent: falsy, so ``_get_policy`` said "required"."""
+        result = hw.start_task("pick", policy_port=port, duration=0.05)
+
+        text = _text(result)
+        assert f"invalid policy_port: {port!r}" in text
+        assert "is required" not in text
+
+    def test_an_out_of_range_port_names_the_range(self, hw: Any) -> None:
+        result = hw.start_task("pick", policy_port=99999, duration=0.05)
+
+        assert "invalid policy_port: 99999 (expected 1-65535)" in _text(result)
+
+
+class TestABudgetIsStillJudgedFirst:
+    """Adding a port check does not reorder the checks that were already there."""
+
+    def test_an_unusable_budget_is_reported_before_the_port(self, hw: Any) -> None:
+        result = hw._execute_task_sync("pick", policy_port=99999, duration=0)
+
+        assert "duration must be > 0" in _text(result)
+        assert "policy_port" not in _text(result)
+        assert hw.connects == []
+
+
+class TestAPreBuiltPolicyMakesThePortInert:
+    """``_execute_task_sync`` does not read the port when a policy is supplied."""
+
+    def test_a_bad_port_is_ignored_when_a_policy_object_is_given(self, hw: Any) -> None:
+        result = hw._execute_task_sync("pick", policy_port=99999, policy_object=_Policy(), n_steps=3)
+
+        assert "policy_port" not in _text(result)
+        assert hw.connects == [True], "a rollout that never reads the port still has to connect"
+        assert len(hw.robot.sent_actions) == 3
+
+    def test_a_missing_port_is_ignored_when_a_policy_object_is_given(self, hw: Any) -> None:
+        result = hw._execute_task_sync("pick", policy_object=_Policy(), n_steps=2)
+
+        assert "policy_port" not in _text(result)
+        assert len(hw.robot.sent_actions) == 2
+
+
+class TestAUsablePortStillRuns:
+    """The guard refuses exactly the unusable ports and nothing else."""
+
+    @pytest.mark.parametrize("port", USABLE_PORTS, ids=repr)
+    def test_a_usable_port_reaches_the_policy_build(self, hw: Any, port: Any) -> None:
+        """The port passes the guard, the arm connects, and the rollout runs."""
+        result = hw._execute_task_sync("pick", policy_port=port, policy_provider="mock", duration=0.2)
+
+        assert "policy_port" not in _text(result)
+        assert hw.connects == [True], "a usable port was refused before connect"
+        assert hw.robot.sent_actions, "a usable port did not reach the control loop"
+
+    @pytest.mark.parametrize("port", USABLE_PORTS, ids=repr)
+    def test_a_usable_port_still_submits(self, hw: Any, port: Any) -> None:
+        result = hw.start_task("pick", policy_port=port, policy_provider="mock", duration=0.2)
+
+        assert result["status"] == "success"
+        assert "Task started" in _text(result)
+        future = hw._task_state.task_future
+        assert future is not None
+        future.result(timeout=30)
+        assert hw.connects == [True]
+
+
+class TestTheDomainMatchesTheProviderThatDialsIt:
+    """One rule: what the entry point accepts is what the provider accepts."""
+
+    @pytest.mark.parametrize("port", [*UNUSABLE_PORTS, *USABLE_PORTS], ids=repr)
+    def test_entry_point_and_shared_domain_agree(self, hw: Any, port: Any) -> None:
+        shared_refuses = tcp_port_error(port, "policy_port", "start_task") is not None
+        result = hw.start_task("pick", policy_port=port, policy_provider="mock", duration=0.05)
+        entry_refuses = "policy_port" in _text(result)
+
+        assert entry_refuses is shared_refuses, f"verdicts differ for policy_port={port!r}"
+
+    def test_the_message_is_the_shared_one_verbatim(self, hw: Any) -> None:
+        result = hw.start_task("pick", policy_port=70000, policy_provider="mock", duration=0.05)
+
+        assert _text(result) == tcp_port_error(70000, "policy_port", "start_task")
+
+
+def _policy_port_surfaces(source: str) -> dict[str, tuple[bool, bool]]:
+    """Map every method declaring ``policy_port`` to ``(checks, forwards)``.
+
+    ``checks`` is a call to the guard; ``forwards`` is passing the parameter on
+    to another call, which is how the internal relay methods satisfy the rule.
+    """
+    tree = ast.parse(source)
+    found: dict[str, tuple[bool, bool]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        args = node.args
+        names = {a.arg for a in (args.posonlyargs + args.args + args.kwonlyargs)}
+        if "policy_port" not in names:
+            continue
+        checks = False
+        forwards = False
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            attr = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if attr == "_policy_port_error":
+                checks = True
+                continue
+            passed = [a for a in call.args if isinstance(a, ast.Name)]
+            passed += [k.value for k in call.keywords if isinstance(k.value, ast.Name)]
+            if any(a.id == "policy_port" for a in passed):
+                forwards = True
+        found[node.name] = (checks, forwards)
+    return found
+
+
+def _shipped_surfaces() -> dict[str, tuple[bool, bool]]:
+    """:func:`_policy_port_surfaces` applied to the shipped module."""
+    return _policy_port_surfaces(pathlib.Path(inspect.getfile(hardware_robot)).read_text(encoding="utf-8"))
+
+
+class TestEveryPortTakingSurfaceIsAccountedFor:
+    """A new task entry point cannot ship without deciding what it does with the port."""
+
+    # The two public/chokepoint entries that must judge the port themselves.
+    ENTRY_POINTS = frozenset({"_execute_task_sync", "start_task"})
+    # Relays that hand it on unchanged, plus the private builder that is the
+    # floor for a direct call.
+    RELAYS = frozenset({"_drive_claimed_task", "_run_control_loop", "_execute_task_async"})
+    FLOOR = frozenset({"_get_policy"})
+    # The rule itself, which takes the value in order to judge it.
+    OWNER = frozenset({"_policy_port_error"})
+
+    def test_the_surface_set_is_the_expected_one(self) -> None:
+        assert set(_shipped_surfaces()) == self.ENTRY_POINTS | self.RELAYS | self.FLOOR | self.OWNER
+
+    def test_each_entry_point_checks_the_port(self) -> None:
+        surfaces = _shipped_surfaces()
+        adrift = sorted(name for name in self.ENTRY_POINTS if not surfaces[name][0])
+        assert adrift == [], f"entry point(s) not checking policy_port: {adrift}"
+
+    def test_each_relay_hands_the_port_on(self) -> None:
+        surfaces = _shipped_surfaces()
+        adrift = sorted(name for name in self.RELAYS if not surfaces[name][1])
+        assert adrift == [], f"relay(s) not forwarding policy_port: {adrift}"
+
+    def test_the_scanner_sees_an_unchecked_entry_point(self) -> None:
+        """Non-vacuity: an entry point that drops the check is reported."""
+        planted = (
+            "class Robot:\n"
+            "    def start_task(self, instruction, policy_port=None):\n"
+            "        return self._drive(instruction, policy_port)\n"
+        )
+        assert _policy_port_surfaces(planted) == {"start_task": (False, True)}


### PR DESCRIPTION
## Problem

`policy_port` is the one caller-supplied value that decides whether a policy exists at all: `Robot._get_policy` hands it to `create_policy`, whose provider constructor dials it.

Its siblings in the same signature are judged before the motors bus is claimed, and the call sites say why:

> Validated here as well as at the public methods below: a peer-supplied budget is refused **before the arm is commanded rather than after**. The check is stateless, so it runs before the claim - a rejected budget must not take the bus away from a rollout that could still start.

The port was read only inside `_execute_task_async`, **after** `_connect_robot` had energized the arm - past the window that method's own comment describes as "a motors-bus handshake plus per-camera warmup - seconds on a real arm".

Measured on `start_task` with `policy_provider="groot"` against an in-memory arm with a recording connect path, **7 of 8 probe ports** diverged from that contract:

| `policy_port` | main | this change |
|---|---|---|
| `5555` (usable) | success, arm connected, reaches the server | unchanged |
| `0` | success, **arm connected**, then *"policy_port is required for robot operation"* | `error: start_task: invalid policy_port: 0 (expected 1-65535)`, arm untouched |
| `-1` / `65536` / `99999` | success, **arm connected**, then `Gr00tPolicy: invalid port: ...` | refused by name, arm untouched |
| `nan` / `inf` / `True` / `False` / `2.7` / `'5555'` / `[5555]` | success, **arm connected** | refused by name, arm untouched |
| `None` | success, **arm connected**, then *"policy_port is required"* | `error: start_task: policy_port is required to build a policy`, arm untouched |

Three consequences, all measured:

1. **The arm is energized for a call that can never run.** Every unusable port produced `connects=1`. The guarded sibling `duration` produces `connects=0` for the same method.
2. **`start_task` reports success.** The failure surfaces on the executor thread, where nobody is left to tell - the caller is handed `status="success"` and *"Task started"*.
3. **A bad port denies the bus to a good task.** The claim is taken before the submit, so the doomed task holds the single command bus through its whole bring-up. A concurrent well-formed `start_task(policy_port=5555)` was turned away with *"Task already running: bad port - so101_follower drives one rollout at a time"*.

Plus a misdiagnosis: a supplied-but-falsy `0` / `False` was reported as *"policy_port is required"* - falsy, so `_get_policy` read it as absent and told the caller a port they had passed was missing. Out-of-range values were named by `Gr00tPolicy`, implicating the policy server rather than the argument.

## Change

`Robot._policy_port_error` checks the port beside the budget in both entry points that take it, before the claim and before connect:

- `None` -> the "not supplied" message, reported early instead of from inside the task body.
- anything else -> `utils.tcp_port_error`, whose own docstring already names *"the policy providers that dial one (`groot`, `moveit2`, `cosmos3`, `lerobot_async`, `vera`)"* - the very providers this path forwards to. One rule, so the same port cannot be accepted by the arm's task entry points and refused by the provider they hand it to.

`_execute_task_sync` skips the check when a pre-built `policy_object` is given, because `_execute_task_async` never reads the port on that path and refusing a value the call ignores would be a false rejection. `start_task` takes no `policy_object`, so it is unconditional there. Check order is unchanged otherwise: an unusable `duration` is still reported first.

`_get_policy`'s falsy check is left in place and documented as the floor for a direct call to that private helper.

## Measured artifact

![measured verdict grid and bus-denial sequence](https://raw.githubusercontent.com/cagataycali/robots/artifacts/hardware-policy-port-domain/policy_port_domain.png)

Every cell is read from two JSON dumps produced by one capture script run in a `main` checkout and on the branch; the compose step asserts the two dumps came from different trees and re-derives the divergence counts it prints (`main 7 of 8 -> 0 of 8`). Scripts and dumps: [`artifacts/hardware-policy-port-domain`](https://github.com/cagataycali/robots/tree/artifacts/hardware-policy-port-domain). No serial/USB hardware is touched.

## Tests

`tests/test_hardware_policy_port_domain.py`, 58 tests, 1.9 s, no hardware:

- the refusal precedes `_connect_robot` (`connects == []`) and the claim (`_task_claimed is False`) on both entry points, and `start_task` submits no work;
- a falsy supplied port is **named**, not reported as missing;
- `duration` is still judged first, so the new check does not reorder the existing ones;
- a pre-built `policy_object` makes the port inert - a bad port there still runs the rollout;
- every usable port still connects and reaches the control loop;
- **parity**: the entry point's verdict equals `tcp_port_error`'s over the whole probe set, and the message is the shared one verbatim;
- a structural scan of the shipped module pins that every method declaring `policy_port` is accounted for - the two entry points check it, the three relays forward it, `_get_policy` is the floor - with a planted-defect meta-test so the scanner cannot pass vacuously.

Pre-fix (source reverted to `main`, tests kept): **44 failed / 14 passed**, e.g.

```
FAILED ...::test_execute_task_sync_refuses_without_connecting[0]
  AssertionError: the refused port still ran the bring-up window
FAILED ...::test_start_task_refuses_instead_of_reporting_a_started_task[99999]
  assert 'policy_port' in "Task: 'pick' - error ... Error: Gr00tPolicy: invalid port: 99999"
```

The 14 that pass are the over-reach controls (usable ports, the pre-built-policy path, the budget-first ordering) - they are what stop the guard reaching further than the unusable set.

One existing test changed: `test_start_task_before_cleanup_still_submits` used a port-less `start_task` as a shortcut to reach the submit. Its subject is the shutdown guard, so it now passes an explicit `policy_port=5555` with the reason in its docstring; the property it pins is unchanged.

## Gate

At `7cea3bb3` (`upstream/main`, unmoved; `check_merge_base_overlap.py` reports no overlap):

- `MUJOCO_GL=egl pytest tests -q --no-cov` -> **26314 passed, 257 skipped, 0 failed** (589 s)
- `ruff check` / `ruff format --check` `strands_robots tests tests_integ` -> clean (1140 files)
- `mypy strands_robots tests tests_integ` -> 14 errors, **all in `examples/isaac_gs`, 0 elsewhere**, and byte-identical to a pristine `upstream/main` worktree of the same working copy (environment-only, not from this branch)
- `scripts/assemble_changelog.py --check` -> OK

## Out of scope

- The mesh `execute` / `start` dispatch already bounds a peer-supplied `policy_port` in `validate_command` before it reaches these methods; this closes the direct-API and agent-tool path.
- `RobotDeviceDriver.execute` coalesces `policy_port or None` before forwarding, which is existing documented behaviour and pinned by its own tests; it inherits the new refusal for `None`.
- `policy_host` is a hostname, a different axis with its own mesh-side allowlist.
