### PR TITLE
fix(newton): a "gl" viewer window size is on the same floor as a frame's

### DIFF
--- a/changelog.d/2083-newton-viewer-window-size-domain.md
+++ b/changelog.d/2083-newton-viewer-window-size-domain.md
@@ -1,0 +1,22 @@
+### Fixed: a Newton `"gl"` viewer window size is on the same floor as a frame's
+
+`NewtonSimEngine.open_viewer` sized its OpenGL window from `width` / `height`
+without applying a domain, so a pixel count the same engine refuses for a frame
+was forwarded verbatim into `ViewerGL`. Measured against a recording stand-in
+for the viewer, 12 of 13 values were refused by `render(...)` and accepted here:
+`0`, `-4`, `-1`, `2.7`, `640.0`, `True`, `False`, `"big"`, `"640"`, `nan`, `inf`
+and `[640]`.
+
+The consequence is the one the neighbouring `port` guard already states in its
+own comment: the engine holds a single viewer slot, so
+`open_viewer("gl", width=0, height=0)` returned `status="success"`, built a
+zero-pixel window and filled the slot -- after which the obvious recovery,
+calling `open_viewer` again with a usable size, was answered
+`"Viewer already open (gl)."` under `status="success"` and built nothing. The
+caller was left with a window they had not asked for and no way to replace it.
+
+Both dimensions now go through `positive_count_error`, the floor `add_camera`
+and the render family already share, applied on the `"gl"` branch alone (the
+`"viser"` and `"null"` viewers are never handed a size, exactly as `port` is
+checked only on the branch that binds it) and before the lock, so a refused size
+constructs nothing and the slot stays free.

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -210,9 +210,13 @@ Viewer kinds (the `viewer` argument):
 - `"auto"` (default) - opens the `"gl"` window when a display server is
   present (`DISPLAY` / `WAYLAND_DISPLAY` set), otherwise falls back to
   `"viser"` so headless hosts still get a live view.
-- `"gl"` - `newton.viewer.ViewerGL` native OpenGL window. Requires a display;
-  on a headless host `open_viewer("gl")` returns a structured error pointing at
-  `"viser"` or `render(...)` instead of crashing.
+- `"gl"` - `newton.viewer.ViewerGL` native OpenGL window, sized by `width` /
+  `height` (default `1280x720`). Requires a display; on a headless host
+  `open_viewer("gl")` returns a structured error pointing at `"viser"` or
+  `render(...)` instead of crashing. The window size is a pixel count on the
+  same floor `add_camera` and `render(...)` apply - a positive `int` - so a
+  resolution this backend refuses for a frame is refused for a window too, and
+  a refused size leaves the single viewer slot free for the retry.
 - `"viser"` - `newton.viewer.ViewerViser` browser dashboard served at
   `http://localhost:<port>` (default `8080`). Works headless - no display
   required - which makes it the right choice for live inspection on a remote

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1813,8 +1813,14 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 than forwarded as an ephemeral-bind request, because this
                 surface advertises the requested port in the dashboard URL
                 instead of reading the assigned one back.
-            width: Window width in pixels for the ``"gl"`` viewer.
-            height: Window height in pixels for the ``"gl"`` viewer.
+            width: Window width in pixels for the ``"gl"`` viewer, an
+                ``int`` ``>= 1`` on the same shared floor
+                (:func:`~strands_robots.utils.positive_count_error`) that
+                ``add_camera`` and the render family apply, so one pixel
+                count cannot be refused for a frame and accepted for a
+                window. Read only by the ``"gl"`` branch, so ``"viser"``
+                and ``"null"`` ignore it.
+            height: Window height in pixels, same domain as ``width``.
 
         Returns:
             Agent-tool ``status``/``content`` dict. On success the ``content``
@@ -1859,6 +1865,20 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         # retry with a usable port is refused as "Viewer already open".
         if kind == "viser" and (port_error := tcp_port_error(port, "port", type(self).__name__)) is not None:
             return {"status": "error", "content": [{"text": port_error}]}
+        # Only the gl branch reads ``width`` / ``height``, so the domain is
+        # applied on that branch alone, exactly as ``port`` is applied on the
+        # viser branch above. The floor is the one ``add_camera`` and the
+        # render family already share, so a resolution this backend refuses
+        # for a frame is not accepted for a window. Before the lock for the
+        # same single-slot reason: a value forwarded verbatim that happens not
+        # to raise inside ``ViewerGL`` fills the one viewer slot, and the
+        # retry with a usable size is then answered "Viewer already open"
+        # under ``status="success"`` - so the caller is left with the window
+        # they did not ask for and no way to replace it.
+        if kind == "gl":
+            for _param, _value in (("width", width), ("height", height)):
+                if (dim_error := positive_count_error(_value, _param, "open_viewer")) is not None:
+                    return {"status": "error", "content": [{"text": dim_error}]}
         with self._lock:
             try:
                 vmod = self._nt.viewer

--- a/tests/simulation/newton/test_viewer_port_domain.py
+++ b/tests/simulation/newton/test_viewer_port_domain.py
@@ -333,19 +333,41 @@ class TestNoSimulationSurfaceShipsAnUnguardedPort:
         assert _calls_the_shared_domain(functions[0])
 
 
-class TestNeighbouringViewerAxesStayOutOfScope:
-    """``width`` / ``height`` are a different domain and are not settled here.
+class TestTheNeighbouringWindowSizeIsSettledElsewhere:
+    """``width`` / ``height`` are a different domain, and it is now applied.
 
-    They are pixel counts read only by the ``"gl"`` window, not an index into
-    the TCP port space, so they belong to the ``positive_whole_number_error``
-    family this module says nothing about. Pinned rather than omitted so the
-    boundary is a stated scope decision, and so this reads as the premise to
-    replace if that axis is taken up - not as an oversight.
+    This class replaces the premise it used to hold - that an unusable ``"gl"``
+    window size was accepted and forwarded verbatim - because that axis has since
+    been taken up. They are pixel counts, so they belong to
+    :func:`~strands_robots.utils.positive_count_error`, the floor this backend's
+    ``add_camera`` and render family already share (an integral float is refused
+    there rather than coerced, because a dimension is consumed directly as an
+    array bound - which is why it is that domain and not the looser
+    ``positive_whole_number_error`` used for frame rates).
+
+    The behavioural coverage lives with the rest of that quantity, in
+    ``tests/simulation/test_camera_pixel_count_domain.py``, so this file stays
+    about the port. What is kept here is the property the two guards share and
+    which this module's own measurement established: each is applied only on the
+    branch that reads it.
     """
 
     @pytest.mark.parametrize("bad", (0, -1, 1280.5, NAN, True, "1280", None))
-    def test_an_unusable_gl_window_size_is_still_accepted(self, bad: Any) -> None:
+    def test_an_unusable_gl_window_size_is_refused_on_the_branch_that_reads_it(self, bad: Any) -> None:
         stub = _viewer_stub(has_display=True)
         result = NewtonSimEngine.open_viewer(stub, "gl", width=bad, height=bad)
+        assert result["status"] == "error", (bad, result)
+        assert stub.built == []
+
+    @pytest.mark.parametrize("bad", (0, -1, 1280.5, NAN, True, "1280", None))
+    def test_the_viser_branch_ignores_it_and_so_does_not_check_it(self, bad: Any) -> None:
+        """The mirror image of the port scoping this module measures.
+
+        ``ViewerViser`` is never handed a width, so refusing one for it would be
+        a false rejection - exactly the reason ``port`` is checked only when the
+        viser branch is the one that will bind it.
+        """
+        stub = _viewer_stub(has_display=True)
+        result = NewtonSimEngine.open_viewer(stub, "viser", port=8080, width=bad, height=bad)
         assert result["status"] == "success", (bad, result)
-        assert stub.built == [("gl", {"width": bad, "height": bad})]
+        assert stub.built == [("viser", {"port": 8080})]

--- a/tests/simulation/test_camera_pixel_count_domain.py
+++ b/tests/simulation/test_camera_pixel_count_domain.py
@@ -5,9 +5,10 @@
 ``width`` / ``height`` reach two surfaces on every simulation backend - the
 ``add_camera`` that fixes a camera's resolution, and the render family
 (``render`` / ``get_frame`` / ``get_camera_params``) that can override it per
-call. MuJoCo validated both through ``_validate_render_dims``; Newton and Isaac
-validated neither, and coerced with a bare ``int(...)`` that refuses nothing
-useful. Coercion is validation only when the coercion rejects.
+call - and a third on Newton alone, ``open_viewer``, which sizes the ``"gl"``
+window. MuJoCo validated the first two through ``_validate_render_dims``;
+Newton and Isaac validated neither, and coerced with a bare ``int(...)`` that
+refuses nothing useful. Coercion is validation only when the coercion rejects.
 
 Measured on both backends before the fix:
 
@@ -35,7 +36,20 @@ Measured on both backends before the fix:
   echoed the caller's raw value (``"Camera 'cam' added (2.7x480, ...)"`` /
   ``"(Truex480, ...)"``) - reporting a resolution that was never registered.
 
-The fix routes all four surfaces through
+* **One quantity, two contracts, decided by which method was called.** Newton's
+  ``open_viewer`` sized its ``"gl"`` window from the same "how many pixels"
+  value and applied no domain at all, so 12 of the 13 dimensions below were
+  refused by ``render`` and forwarded verbatim into ``ViewerGL`` on the same
+  engine, in the same session. The consequence is the one the neighbouring
+  ``port`` guard already states in its own comment: the engine holds a single
+  viewer slot, so ``open_viewer("gl", width=0, height=0)`` returned
+  ``status="success"``, built a zero-pixel window and filled the slot - after
+  which the obvious recovery, calling ``open_viewer`` again with a usable size,
+  was answered ``"Viewer already open (gl)."`` under ``status="success"`` and
+  built nothing. The caller was left with the window they did not ask for and
+  no way to replace it.
+
+The fix routes all five surfaces through
 :func:`~strands_robots.utils.positive_count_error`, the domain MuJoCo's floor
 already implements: a true ``int`` (``bool`` refused - it is an ``int`` subclass
 whose ``True`` would act as a silent 1) that is ``>= 1``. A pixel dimension is
@@ -55,8 +69,11 @@ already establish exercise it in every environment.
 
 from __future__ import annotations
 
+import ast
+import inspect
 import types
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -68,6 +85,7 @@ from strands_robots.utils import positive_count_error
 
 from .isaac.test_add_camera_numeric_validation import _engine as _isaac_engine
 from .newton.test_add_camera_numeric_validation import _engine_stub
+from .newton.test_viewer_port_domain import _viewer_stub
 
 #: Pixel dimensions no camera can be built or rendered at. Each was accepted or
 #: raised past the tool-result contract on both backends before the fix.
@@ -280,6 +298,248 @@ class TestNewtonRenderFamily:
         result = NewtonSimEngine.render(stub, camera_name="default", width=0)  # type: ignore[arg-type]
         assert result["status"] == "error", result
         assert "width must be a positive integer" in result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# Newton: the interactive viewer window                                       #
+# --------------------------------------------------------------------------- #
+def _newton_open_viewer(stub: Any, **kwargs: Any) -> dict[str, Any]:
+    """``open_viewer`` with arguments deliberately outside its annotations.
+
+    Same ``**kwargs: Any`` boundary as ``_newton_add_camera`` above, and for the
+    same reason: the contract under test is what happens at runtime to a value
+    an agent dispatching this tool can pass, not what a type checker it never
+    runs would have said.
+    """
+    return NewtonSimEngine.open_viewer(stub, **kwargs)  # type: ignore[arg-type]
+
+
+class TestNewtonViewerDimensions:
+    """The ``"gl"`` window size is the same floor as a frame's.
+
+    ``_viewer_stub(has_display=True)`` is the sibling port-domain file's stand-in
+    ``self``: it records every viewer it constructs, so these tests assert a
+    refusal built *nothing* rather than only that it reported an error. The guard
+    precedes the lock and every viewer construction, so none of this needs
+    ``newton`` / ``warp`` or a display.
+    """
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_unusable_dimension_is_refused(self, param, bad):
+        stub = _viewer_stub(has_display=True)
+        result = _newton_open_viewer(stub, viewer="gl", **{param: bad})
+        assert result["status"] == "error", (param, bad, result)
+        assert param in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_a_refused_dimension_constructs_no_viewer(self, param, bad):
+        """Nothing is built, so nothing occupies the single viewer slot."""
+        stub = _viewer_stub(has_display=True)
+        _newton_open_viewer(stub, viewer="gl", **{param: bad})
+        assert stub.built == []
+        assert stub._viewer is None
+
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_the_retry_after_a_refusal_still_opens(self, param):
+        """The recovery a forwarded value denied: refuse, then open normally.
+
+        This is the property the defect removed. Pre-fix the refused call built a
+        zero-pixel window and took the slot, so this second call returned
+        ``"Viewer already open"`` - a success result for a window the caller
+        never asked for, with no way to replace it.
+        """
+        stub = _viewer_stub(has_display=True)
+        assert _newton_open_viewer(stub, viewer="gl", **{param: 0})["status"] == "error"
+        retry = _newton_open_viewer(stub, viewer="gl", width=1280, height=720)
+        assert retry["status"] == "success", retry
+        assert stub.built == [("gl", {"width": 1280, "height": 720})]
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    def test_a_usable_dimension_is_forwarded_exactly(self, good):
+        """A floor, not a tightening - and the value reaches ``ViewerGL`` unchanged."""
+        stub = _viewer_stub(has_display=True)
+        result = _newton_open_viewer(stub, viewer="gl", width=good, height=good)
+        assert result["status"] == "success", result
+        assert stub.built == [("gl", {"width": good, "height": good})]
+
+    def test_the_defaults_are_unchanged(self):
+        stub = _viewer_stub(has_display=True)
+        assert _newton_open_viewer(stub, viewer="gl")["status"] == "success"
+        assert stub.built == [("gl", {"width": 1280, "height": 720})]
+
+    def test_auto_resolving_to_gl_is_checked_too(self):
+        """``"auto"`` becomes ``"gl"`` when a display is present, so it is the gl branch."""
+        stub = _viewer_stub(has_display=True)
+        assert _newton_open_viewer(stub, viewer="auto", width=0)["status"] == "error"
+        assert stub.built == []
+
+    def test_the_missing_display_is_still_reported_first(self):
+        """A headless host's more fundamental problem keeps naming itself.
+
+        Ordering matters: without a display no window of any size can open, so
+        that refusal is the actionable one and the dimension guard must not
+        shadow it.
+        """
+        stub = _viewer_stub(has_display=False)
+        result = _newton_open_viewer(stub, viewer="gl", width=0)
+        assert result["status"] == "error"
+        assert "no display server" in result["content"][0]["text"]
+
+
+class TestOnlyTheGlBranchReadsTheDimensions:
+    """The domain is applied where the value is read, as ``port``'s already is.
+
+    ``"viser"`` and ``"null"`` never pass ``width`` / ``height`` to a viewer, so
+    refusing a dimension for them would be a false rejection - the same scoping
+    the sibling ``port`` guard takes by checking only the viser branch.
+    """
+
+    @pytest.mark.parametrize("kind", ["viser", "null"])
+    @pytest.mark.parametrize("bad", (0, -1, 2.7, "big", None))
+    def test_a_branch_that_ignores_the_size_still_opens(self, kind, bad):
+        stub = _viewer_stub(has_display=True)
+        result = _newton_open_viewer(stub, viewer=kind, width=bad, height=bad)
+        assert result["status"] == "success", (kind, bad, result)
+        assert [built_kind for built_kind, _ in stub.built] == [kind]
+
+    def test_the_port_domain_still_applies_to_viser(self):
+        """Non-vacuity for the scoping above: viser is checked, on its own knob."""
+        stub = _viewer_stub(has_display=True)
+        result = _newton_open_viewer(stub, viewer="viser", port=0)
+        assert result["status"] == "error", result
+        assert "port" in result["content"][0]["text"]
+        assert stub.built == []
+
+
+def _render_dims_verdict(param: str, value: Any) -> str:
+    """``"refused"`` / ``"accepted"`` for the funnel the render surfaces share.
+
+    ``_resolve_camera_view`` is where ``render`` / ``get_frame`` /
+    ``get_camera_params`` apply the domain, and it *raises* ``ValueError`` -
+    ``render`` converts that into an envelope. It is used here rather than
+    ``render`` itself because the newton-free stub cannot rasterize a frame, so a
+    *usable* dimension would come back as a renderer error and read as a
+    refusal. The funnel is the layer that answers the question this parity is
+    about, and it is the same one ``TestNewtonRenderFamily`` above asserts on.
+    """
+    try:
+        _newton_resolve(_newton_stub(), "default", **{param: value})
+    except ValueError:
+        return "refused"
+    return "accepted"
+
+
+class TestTheViewerAgreesWithTheRenderFamily:
+    """One engine, one pixel quantity: the two surfaces cannot disagree.
+
+    This is the assertion that fails pre-fix for every unusable row - the render
+    family refused each of them and ``open_viewer`` accepted it, in the same
+    session - and the reason the viewer belongs to this file rather than to a
+    domain of its own.
+    """
+
+    @pytest.mark.parametrize("bad", _BAD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_a_dimension_the_render_family_refuses_is_refused_by_the_viewer(self, param, bad):
+        render_verdict = _render_dims_verdict(param, bad)
+        viewer_verdict = _verdict(
+            lambda: _newton_open_viewer(_viewer_stub(has_display=True), viewer="gl", **{param: bad})
+        )
+        assert render_verdict == viewer_verdict == "refused", (
+            f"{param}={bad!r}: render={render_verdict}, open_viewer={viewer_verdict}"
+        )
+
+    @pytest.mark.parametrize("good", _GOOD_DIMS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    def test_a_usable_dimension_is_accepted_by_both(self, param, good):
+        """A floor, not a tightening, on both surfaces at once."""
+        render_verdict = _render_dims_verdict(param, good)
+        viewer_verdict = _verdict(
+            lambda: _newton_open_viewer(_viewer_stub(has_display=True), viewer="gl", **{param: good})
+        )
+        assert render_verdict == viewer_verdict == "accepted", (
+            f"{param}={good!r}: render={render_verdict}, open_viewer={viewer_verdict}"
+        )
+
+    def test_the_shared_rule_is_a_floor_and_not_a_ceiling(self):
+        """A ray tracer has no framebuffer to overflow, so a huge size is legal.
+
+        Pinned because ``_GOOD_DIMS`` already carries ``5000`` for the same
+        reason: it makes the parity above a statement about the floor rather
+        than about refusal in general.
+        """
+        huge = 10**9
+        assert _render_dims_verdict("width", huge) == "accepted"
+        assert (
+            _verdict(lambda: _newton_open_viewer(_viewer_stub(has_display=True), viewer="gl", width=huge)) == "accepted"
+        )
+
+
+class TestNoNewtonDimensionSurfaceDrifts:
+    """Every public Newton surface taking a pixel dimension reaches the domain.
+
+    Structural rather than behavioural, because the defect this closes was a
+    surface nobody had connected to a rule the module already applied twice. A
+    method satisfies the guard by calling the shared helper itself or by handing
+    the value to ``_resolve_camera_view``, the funnel the render family shares -
+    so a fourth render entry point costs nothing, while a new one that sizes
+    something of its own has to say why.
+    """
+
+    _FUNNEL = "_resolve_camera_view"
+    _GUARD = "positive_count_error"
+    #: The public surfaces taking a pixel dimension today. Pinned exactly so a
+    #: mis-rooted scan reporting a clean sweep over nothing fails instead.
+    _EXPECTED = frozenset({"add_camera", "render", "get_frame", "get_camera_params", "open_viewer"})
+
+    @staticmethod
+    def _classify(src: str) -> dict[str, str]:
+        """Map each public dimension-taking method to how it reaches the domain."""
+        found: dict[str, str] = {}
+        for cls in ast.walk(ast.parse(src)):
+            if not isinstance(cls, ast.ClassDef):
+                continue
+            for fn in ast.iter_child_nodes(cls):
+                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef) or fn.name.startswith("_"):
+                    continue
+                args = fn.args
+                names = {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs}
+                if not {"width", "height"} & names:
+                    continue
+                calls = {
+                    n.func.attr if isinstance(n.func, ast.Attribute) else getattr(n.func, "id", "")
+                    for n in ast.walk(fn)
+                    if isinstance(n, ast.Call)
+                }
+                if TestNoNewtonDimensionSurfaceDrifts._GUARD in calls:
+                    found[fn.name] = "guards"
+                elif TestNoNewtonDimensionSurfaceDrifts._FUNNEL in calls:
+                    found[fn.name] = "forwards"
+                else:
+                    found[fn.name] = "adrift"
+        return found
+
+    @property
+    def _source(self) -> str:
+        return Path(inspect.getfile(NewtonSimEngine)).read_text()
+
+    def test_the_expected_surfaces_are_the_ones_found(self):
+        assert set(self._classify(self._source)) == set(self._EXPECTED)
+
+    def test_no_surface_is_adrift(self):
+        adrift = sorted(name for name, how in self._classify(self._source).items() if how == "adrift")
+        assert not adrift, f"{adrift} take a pixel dimension without reaching {self._GUARD}"
+
+    def test_the_scan_detects_a_planted_surface(self):
+        """Without this the sweep above could pass by matching nothing."""
+        planted = self._source + (
+            "\n\nclass _Planted:\n"
+            "    def open_window(self, *, width: int = 1, height: int = 1) -> None:\n"
+            "        self._build(width, height)\n"
+        )
+        assert self._classify(planted).get("open_window") == "adrift"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

`NewtonSimEngine.open_viewer` sizes its OpenGL window from `width` / `height` and applied no domain to either, so a pixel count the **same engine** refuses for a frame was forwarded verbatim into `ViewerGL`.

Measured against a recording stand-in for `newton.viewer`, comparing each value against `_resolve_camera_view` — the funnel `render` / `get_frame` / `get_camera_params` apply the domain in — **12 of 13 dimensions disagreed**:

| `width=` | `render(...)` | `open_viewer("gl")` | window built |
|---|---|---|---|
| `0` | refused | **accepted** | `0x720` |
| `-4` | refused | **accepted** | `-4x720` |
| `-1` | refused | **accepted** | `-1x720` |
| `2.7` | refused | **accepted** | `2.7x720` |
| `640.0` | refused | **accepted** | `640.0x720` |
| `True` | refused | **accepted** | `Truex720` |
| `False` | refused | **accepted** | `Falsex720` |
| `"big"` | refused | **accepted** | `bigx720` |
| `"640"` | refused | **accepted** | `640x720` |
| `nan` | refused | **accepted** | `nanx720` |
| `inf` | refused | **accepted** | `infx720` |
| `[640]` | refused | **accepted** | `[640]x720` |
| `10**9` | accepted | accepted | `1000000000x720` |

The last row is correct agreement, not a divergence: the shared rule is a floor and a ray tracer has no framebuffer to overflow.

### The consequence is the one the neighbouring guard already states

`open_viewer`'s `port` check carries this comment, twelve lines above the unguarded dimensions:

> Placed before the lock because a refusal must construct no viewer: the viewer is a single slot, and a value forwarded verbatim that happens not to raise inside `ViewerViser` fills it, after which the obvious retry with a usable port is refused as "Viewer already open".

That is exactly what a forwarded dimension did:

```
open_viewer("gl", width=0, height=0)
   -> success    window built: 0x0
open_viewer("gl", width=1280, height=720)   # the retry
   -> success    window built: 0x0
   -> "Viewer already open (gl)."
```

The caller is left with a zero-pixel window they did not ask for, a `status="success"` on both calls, and no way to replace it.

### Why this surface was missed

Two of the three pixel-dimension surfaces on this engine already share the floor — `add_camera` calls `positive_count_error` directly and the render family reaches it through `_resolve_camera_view`. The domain's own test module states the scope as *"`width` / `height` reach two surfaces on every simulation backend"*, which is why a third one on Newton alone was never connected to it. Its `Args` entry said only `"Window width in pixels for the \"gl\" viewer."`, with no domain, while `port` two lines above carries a full paragraph.

## Change

Both dimensions now go through `positive_count_error`, the floor `add_camera` and `_resolve_camera_view` already apply:

- **On the `"gl"` branch alone.** `ViewerViser` and `ViewerNull` are never handed a size, so refusing one for them would be a false rejection — the same scoping `port` takes by checking only the branch that binds it. `"auto"` resolving to `"gl"` is checked, because that is the gl branch.
- **Before the lock**, for the single-slot reason above, so a refused size constructs nothing and the retry still opens.
- **After the missing-display refusal**, which stays first: on a headless host no window of any size can open, so that is the actionable message and the dimension guard must not shadow it. Pinned.

`positive_count_error` rather than the looser `positive_whole_number_error` for the reason the domain's module already records: a dimension is consumed directly as an array bound, where an integral float raises rather than being coerced.

## Tests

Added to `tests/simulation/test_camera_pixel_count_domain.py`, the module that owns this quantity, whose docstring is corrected to name the third surface. It already supplies `_BAD_DIMS` / `_GOOD_DIMS` / `_verdict` / `_newton_stub`; the viewer stand-in comes from the sibling port-domain file, so nothing is rebuilt and none of it needs `newton` / `warp` or a display.

- `TestNewtonViewerDimensions` — every unusable dimension refused naming the parameter; **a refused dimension constructs no viewer**; the retry after a refusal still opens; a usable dimension forwarded to `ViewerGL` exactly; defaults unchanged; `"auto"` covered; the missing display still reported first.
- `TestOnlyTheGlBranchReadsTheDimensions` — `"viser"` / `"null"` still open with any size (the scoping), and the `port` domain still fires for viser (its non-vacuity).
- `TestTheViewerAgreesWithTheRenderFamily` — the cross-surface parity that fails pre-fix on every unusable row, plus that both accept `10**9` so the parity is a statement about the floor.
- `TestNoNewtonDimensionSurfaceDrifts` — structural: every public Newton method taking a pixel dimension either calls the helper or forwards to `_resolve_camera_view`, with the surface set pinned exactly and a planted-defect meta-test.

`tests/simulation/newton/test_viewer_port_domain.py::TestNeighbouringViewerAxesStayOutOfScope` asserted the unguarded size as current behaviour and said so — *"this reads as the premise to replace if that axis is taken up"*. It is replaced by `TestTheNeighbouringWindowSizeIsSettledElsewhere`, which keeps the property the two guards share (each applied only on the branch that reads it) and points at the file that now owns the quantity. Its docstring also named the wrong family (`positive_whole_number_error`); corrected.

### Pre-fix proof

Source reverted to `upstream/main`, tests kept:

```
89 failed, 383 passed
```

The structural guard names the surface with no prose:

```
AssertionError: ['open_viewer'] take a pixel dimension without reaching positive_count_error
```

## Verification

Run in a private clone at `b47ffafd` (rebased onto it, so these numbers describe the tree that merges; `scripts/check_merge_base_overlap.py` reports no overlap, 0 paths changed in the span).

| gate | result |
|---|---|
| `MUJOCO_GL=egl pytest tests -q --no-cov -p no:randomly` | **26532 passed, 257 skipped, 0 failed** (563s) |
| pristine `upstream/main`, same command | 26412 passed, 257 skipped (+120 = this PR's tests) |
| `ruff check strands_robots tests tests_integ` | All checks passed |
| `ruff format --check` | 1141 files already formatted |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy |
| `assemble_changelog.py --check` | OK |

Zero existing-test changes other than the replaced premise class above.

<details>
<summary>One earlier full-suite run reported a single unrelated failure; attribution</summary>

`tests/simulation/test_rollout_seed_is_applied_or_refused.py::TestTheSeedIsAppliedOnTheEvalPath::test_the_seeded_eval_matches_its_sibling_run_policy_contract` failed once, then passed on the re-run above. It asserts two identically-seeded `run_policy` runs draw the same stream; the failing run's stream was the correct one **shifted by one draw**, i.e. a concurrent consumer of the process-wide `random`.

Measured: it passes alone, with its whole file alone, and with this PR's file immediately ahead of it in the same deterministic order; and driven directly the stream is `[0.32383276483316237, 0.15084917392450192, ...]` independent of the incoming global RNG state across five pre-seeds. This PR adds no thread and no RNG consumer. Not touched here.
</details>

**Round 1 note -- no code change.** The changelog fragment was renamed
`changelog.d/2081-...` -> `changelog.d/2083-...` to match this PR's number
(two sibling PRs took 2081 and 2082 while this was being verified). The tree
the gate numbers above describe differs from the pushed head only in that
filename; `assemble_changelog.py --check` and
`tests/test_changelog_fragments.py tests/test_changelog_format.py` were re-run
after the rename (OK, 30 passed).

## Artifact

Every cell measured by one script run once per tree, each run printing the tree it imported from; the figure asserts all thirteen rows, both slot ledgers and the grounding frame against the two dumps before saving.

![Newton viewer window size versus frame size: 12 of 13 disagreements before, 0 after; the single-slot ledger; and the honored 1280x720 render](https://raw.githubusercontent.com/cagataycali/robots/artifacts/newton-viewer-dims/newton_viewer_dims.png)

The bottom panel is a real offscreen frame at the viewer's default `1280x720`, rendered independently on both trees: `max|main - this change| = 1/255` over 1280x720 px, i.e. renderer noise. The honored path is untouched, and that size is exactly what a refused one now leaves the single slot free for. Scripts and their assertions are on the `artifacts/newton-viewer-dims` branch.

