### PR TITLE
fix(dataset_recorder): check the publication posture flags instead of reading them by truthiness

### DIFF
--- a/changelog.d/2087-bucket-publication-posture-flags.md
+++ b/changelog.d/2087-bucket-publication-posture-flags.md
@@ -1,0 +1,19 @@
+### Fixed: the dataset-publication posture flags are checked instead of read by truthiness
+
+`sync_dataset_to_bucket` allowlist-validates `bucket` and `run_id` before it runs
+anything, and its own docstring says so. The three flags in that same signature -
+`create`, `private` and `delete` - reached `hf buckets create` / `hf sync` raw, and so
+did `private` on `DatasetRecorder.push_to_hub` beside it. Each selects a posture on a
+remote store, so each now goes through `boolean_flag_error`, the domain the mesh
+provisioning entry points already apply to their own capability flags.
+
+Read by truthiness they failed toward the permissive posture in both directions.
+`delete="false"`, `"no"`, `"off"` and `"0"` - the spellings an operator reaches for
+when opting out - are truthy, so each appended `--delete` and mirror-deleted remote
+files absent locally; `private=0`, `""`, `None` and `[]` are falsy, so each dropped
+`--private` and created the bucket public. Every one returned `status="success"`.
+The refusal is placed ahead of the CLI probe, so a flag outside its domain now reports
+identically whether or not `hf` is installed and reaches neither subprocess.
+
+`sync_to_bucket` forwards all three flags and so inherits the refusal; a structural
+test keeps it that way. Both booleans still build a byte-identical command line.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -156,7 +156,7 @@ from strands_robots.dataset_recorder import DatasetRecorder, has_lerobot_dataset
 | `recorder.save_episode()` | Finalise episode. |
 | `recorder.clear_episode_buffer()` | Discard buffer. |
 | `recorder.finalize()` | Flush and close. |
-| `recorder.push_to_hub(tags=None, private=False)` | Upload to HuggingFace. |
+| `recorder.push_to_hub(tags=None, private=False)` | Upload to HuggingFace. `private` must be a boolean — it selects the repo's visibility. |
 | `has_lerobot_dataset()` | Cached import check (True if `LeRobotDataset` imports). |
 | `lerobot_dataset_import_error()` | `None` if it imports, else why not - names the missing package and the install that supplies it. Use this when reporting to a human. |
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -629,8 +629,8 @@ log), and the rollout continues.
 | `save_episode()` | Flush buffer as a new episode |
 | `clear_episode_buffer()` | Discard current episode |
 | `finalize()` | Write metadata, stats, close writers |
-| `push_to_hub(tags=None, private=False)` | Upload to a versioned HF dataset repo |
-| `sync_to_bucket(bucket, run_id=None, private=True)` | Sync to a mutable HF Storage Bucket (`hf://buckets/...`) — Xet-deduped collection target; needs the `hf` CLI. `bucket` (`name` or `org/name`) and `run_id` (single segment) are allowlist-validated (`[A-Za-z0-9._-]`, no traversal) before the sync |
+| `push_to_hub(tags=None, private=False)` | Upload to a versioned HF dataset repo. `private` selects the published repo's visibility, so it must be a boolean — a truthy spelling of off such as `"false"` would otherwise select the opposite posture |
+| `sync_to_bucket(bucket, run_id=None, private=True)` | Sync to a mutable HF Storage Bucket (`hf://buckets/...`) — Xet-deduped collection target; needs the `hf` CLI. `bucket` (`name` or `org/name`) and `run_id` (single segment) are allowlist-validated (`[A-Za-z0-9._-]`, no traversal) before the sync, and `create` / `private` / `delete` must each be a boolean — `delete` mirror-deletes remote files absent locally, so a truthy `"false"` must not select it |
 
 ## Read back
 

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -34,6 +34,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.utils import (
+    boolean_flag_error,
     lerobot_version,
     name_list_error,
     non_negative_whole_number_error,
@@ -162,6 +163,17 @@ def sync_dataset_to_bucket(
     path is agent-reachable via ``stop_recording(bucket=, run_id=)``. A
     rejected value returns ``{"status": "error", ...}`` without running ``hf``.
 
+    ``create``, ``private`` and ``delete`` select *postures* rather than
+    scaling a quantity, so each is checked against
+    :func:`~strands_robots.utils.boolean_flag_error` before the ``hf`` CLI is
+    even located - the same domain the mesh provisioning entry points apply to
+    their own capability flags. Read by truthiness they fail toward the
+    permissive posture in *both* directions, because every non-empty string is
+    truthy and every falsy non-boolean takes the other branch:
+    ``delete="false"`` - the spelling an operator reaches for when opting out -
+    appends ``--delete`` and mirror-deletes remote files absent locally, while
+    ``private=0`` drops ``--private`` and creates the bucket *public*.
+
     The shard layout is already Xet/bucket-friendly at lerobot's defaults
     (100 MB data parquet / 200 MB video MP4 shards), and ``meta/`` MUST
     ship or downstream loses normalization stats.
@@ -173,15 +185,25 @@ def sync_dataset_to_bucket(
         run_id: Subpath inside the bucket; defaults to the dataset directory
             name (``Path(root).name``).
         create: Create the bucket first (pre-existing bucket is not an error).
+            Must be a boolean.
         private: Create the bucket as private (only used with ``create=True``).
+            Must be a boolean.
         delete: Forward ``--delete`` to ``hf sync`` (mirror semantics -
-            remove remote files absent locally).
+            remove remote files absent locally). Must be a boolean.
 
     Returns:
         ``{"status": "success", "bucket_uri": ...}`` or
         ``{"status": "error", "message": ...}``. Never raises on ``hf``
-        failure; errors are surfaced in the result dict.
+        failure; errors are surfaced in the result dict. A flag outside its
+        domain is reported the same way, without locating or running the CLI.
     """
+    # Before the CLI probe so the same caller mistake reports identically
+    # whether or not `hf` is installed, and so a refused posture flag can
+    # never reach `hf buckets create` or `hf sync`.
+    for flag_name, flag_value in (("create", create), ("private", private), ("delete", delete)):
+        if flag_error := boolean_flag_error(flag_value, flag_name, "sync_dataset_to_bucket"):
+            return {"status": "error", "message": flag_error}
+
     import subprocess
 
     hf = _hf_executable()
@@ -1659,7 +1681,7 @@ class DatasetRecorder:
 
         Args:
             tags: Optional tags for the dataset
-            private: Upload as private dataset
+            private: Upload as private dataset. Must be a boolean.
 
         Refuses to publish an empty dataset (no frames written or no episode
         saved). Pushing then would create a Hub repo containing only
@@ -1671,7 +1693,20 @@ class DatasetRecorder:
         Returns:
             Dict with push status. ``status="error"`` (no Hub call made) when
             the dataset is empty.
+
+        ``private`` selects the published repository's visibility, so it is
+        checked against :func:`~strands_robots.utils.boolean_flag_error`
+        ahead of the empty-dataset state check and any Hub call: the flag is
+        a property of this call rather than of the recorder, so the same
+        mistake reports identically whether or not the dataset happens to be
+        empty. It is otherwise forwarded verbatim to LeRobot, whose own
+        parameter is ``bool | None`` where ``None`` means *use the namespace
+        default* - a third visibility this signature's ``bool`` does not
+        describe, and one a caller reading ``private: bool = False`` would not
+        expect to select.
         """
+        if flag_error := boolean_flag_error(private, "private", "push_to_hub"):
+            return {"status": "error", "message": flag_error}
         if self.frame_count == 0 or self.episode_count == 0:
             msg = (
                 f"refusing to push empty dataset {self.dataset.repo_id} "

--- a/tests/test_bucket_publication_posture_flags.py
+++ b/tests/test_bucket_publication_posture_flags.py
@@ -121,21 +121,26 @@ class _FakeHubDataset:
         self.pushed.append(private)
 
 
-class _Recorder(recorder_mod.DatasetRecorder):
-    """A recorder with a chosen frame/episode count, built without LeRobot."""
+def _recorder(dataset: _FakeHubDataset, *, frames: int = 10, episodes: int = 1) -> recorder_mod.DatasetRecorder:
+    """A recorder with a chosen frame/episode count, built without LeRobot.
 
-    def __init__(self, dataset: _FakeHubDataset, *, frames: int = 10, episodes: int = 1) -> None:
-        self.dataset = dataset  # type: ignore[assignment]
-        self.frame_count = frames
-        self.episode_count = episodes
+    ``DatasetRecorder.__init__`` only records the dataset handed to it, so the
+    fake above constructs the shipped class fully; the counts are then set to
+    the state under test. Constructing the real class rather than subclassing it
+    keeps the methods exercised here the shipped ones.
+    """
+    recorder = recorder_mod.DatasetRecorder(dataset)
+    recorder.frame_count = frames
+    recorder.episode_count = episodes
+    return recorder
 
 
-def _push(recorder: _Recorder, **kwargs: Any) -> dict[str, Any]:
+def _push(recorder: recorder_mod.DatasetRecorder, **kwargs: Any) -> dict[str, Any]:
     """Funnel so deliberately off-type flags need no per-call suppression."""
     return recorder.push_to_hub(**kwargs)
 
 
-def _sync_via_recorder(recorder: _Recorder, **kwargs: Any) -> dict[str, Any]:
+def _sync_via_recorder(recorder: recorder_mod.DatasetRecorder, **kwargs: Any) -> dict[str, Any]:
     """Funnel for the delegate, for the same reason as :func:`_push`."""
     return recorder.sync_to_bucket("acme/robotdata", run_id="run1", **kwargs)
 
@@ -155,7 +160,7 @@ class TestTheDomainIsTheSharedOne:
         assert result["message"] == boolean_flag_error("false", flag, "sync_dataset_to_bucket")
 
     def test_the_push_message_is_the_shared_one_verbatim(self) -> None:
-        result = _push(_Recorder(_FakeHubDataset()), private="false")
+        result = _push(_recorder(_FakeHubDataset()), private="false")
         assert result["message"] == boolean_flag_error("false", "private", "push_to_hub")
 
 
@@ -219,13 +224,13 @@ class TestTheRefusalPrecedesEveryProbeAndSideEffect:
 
     def test_the_push_refusal_reaches_no_hub_call(self) -> None:
         dataset = _FakeHubDataset()
-        result = _push(_Recorder(dataset), private="false")
+        result = _push(_recorder(dataset), private="false")
         assert result["status"] == "error"
         assert dataset.pushed == [], "the refused call published to the Hub"
 
     def test_the_push_refusal_does_not_depend_on_the_recorder_being_non_empty(self) -> None:
         """An empty recorder still reports the flag, not its own state."""
-        empty = _Recorder(_FakeHubDataset(), frames=0, episodes=0)
+        empty = _recorder(_FakeHubDataset(), frames=0, episodes=0)
         result = _push(empty, private="false")
         assert "private" in result["message"]
         assert "empty dataset" not in result["message"]
@@ -237,7 +242,7 @@ class TestThePushVisibilityFlagIsChecked:
     @pytest.mark.parametrize("value", UNUSABLE, ids=IDS)
     def test_an_unusable_visibility_is_refused(self, value: Any) -> None:
         dataset = _FakeHubDataset()
-        result = _push(_Recorder(dataset), private=value)
+        result = _push(_recorder(dataset), private=value)
         assert result["status"] == "error"
         assert "private" in result["message"]
         assert dataset.pushed == []
@@ -245,7 +250,7 @@ class TestThePushVisibilityFlagIsChecked:
     @pytest.mark.parametrize("value", [True, False], ids=["private", "public"])
     def test_a_boolean_visibility_is_forwarded_verbatim(self, value: bool) -> None:
         dataset = _FakeHubDataset()
-        result = _push(_Recorder(dataset), private=value)
+        result = _push(_recorder(dataset), private=value)
         assert result["status"] == "success"
         assert dataset.pushed == [value]
 
@@ -257,7 +262,7 @@ class TestTheDelegateInheritsTheRule:
     def test_the_recorder_method_refuses_the_same_value(
         self, wire: _RecordingSubprocess, finalized: pathlib.Path, flag: str
     ) -> None:
-        recorder = _Recorder(_FakeHubDataset(root=str(finalized)))
+        recorder = _recorder(_FakeHubDataset(root=str(finalized)))
         result = _sync_via_recorder(recorder, **{flag: "false"})
         assert result["status"] == "error"
         assert flag in result["message"]
@@ -267,7 +272,7 @@ class TestTheDelegateInheritsTheRule:
         self, wire: _RecordingSubprocess, finalized: pathlib.Path
     ) -> None:
         """The delegation clause is not satisfied by a delegate that never runs."""
-        recorder = _Recorder(_FakeHubDataset(root=str(finalized)))
+        recorder = _recorder(_FakeHubDataset(root=str(finalized)))
         result = _sync_via_recorder(recorder, delete=True)
         assert result["status"] == "success"
         assert wire.mirror_deleted

--- a/tests/test_bucket_publication_posture_flags.py
+++ b/tests/test_bucket_publication_posture_flags.py
@@ -145,6 +145,27 @@ def _sync_via_recorder(recorder: recorder_mod.DatasetRecorder, **kwargs: Any) ->
     return recorder.sync_to_bucket("acme/robotdata", run_id="run1", **kwargs)
 
 
+class TestTheDoubleIsARealRecorder:
+    """The surface under test is driven on the production class, not a stand-in.
+
+    A hand-written ``__init__`` sets whichever attributes the methods under test
+    happen to read today - three of the thirteen
+    :meth:`~strands_robots.dataset_recorder.DatasetRecorder.__init__` sets - so
+    ``push_to_hub`` and ``sync_to_bucket`` would be read off a recorder
+    production cannot build, and the omission would be silent because neither
+    method reads the other ten. Comparing the double's attributes against a
+    reference recorder's is what keeps the stand-in from coming back.
+    """
+
+    def test_the_double_carries_every_attribute_production_sets(self) -> None:
+        reference = recorder_mod.DatasetRecorder(_FakeHubDataset())
+        assert set(vars(_recorder(_FakeHubDataset()))) == set(vars(reference))
+
+    def test_the_double_reports_the_counts_it_was_given(self) -> None:
+        recorder = _recorder(_FakeHubDataset(), frames=7, episodes=3)
+        assert (recorder.frame_count, recorder.episode_count) == (7, 3)
+
+
 class TestTheDomainIsTheSharedOne:
     """The values below are refused by the shared posture domain, not locally."""
 

--- a/tests/test_bucket_publication_posture_flags.py
+++ b/tests/test_bucket_publication_posture_flags.py
@@ -1,0 +1,419 @@
+"""The publication-posture flags of the dataset-publication surface are checked.
+
+``sync_dataset_to_bucket`` allowlist-validates ``bucket`` and ``run_id`` before
+any subprocess, and its own docstring says so. The three flags in that same
+signature - ``create``, ``private`` and ``delete`` - were read by truthiness,
+and so was ``private`` on :meth:`DatasetRecorder.push_to_hub` beside it. Each
+selects a *posture* on a remote store rather than scaling a quantity, which is
+:func:`~strands_robots.utils.boolean_flag_error`'s documented family.
+
+Read by truthiness these fail toward the permissive posture in *both*
+directions. Every non-empty string is truthy, so ``delete="false"`` - the
+spelling an operator reaches for when opting out - appended ``--delete`` to
+``hf sync`` and mirror-deleted remote files absent locally. Every falsy
+non-boolean takes the other branch, so ``private=0`` dropped ``--private`` and
+created the bucket public. Both returned ``status="success"``.
+
+The module is imported under an alias so a test can reach the private
+``_hf_executable`` / ``_huggingface_hub_version_error`` probes it monkeypatches.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots import dataset_recorder as recorder_mod
+from strands_robots.utils import boolean_flag_error
+
+#: Flags on this module's publication surface. Each selects a posture on a
+#: remote store: whether a bucket is created, whether it is private, and
+#: whether the sync mirror-deletes remote files that are absent locally.
+PUBLICATION_FLAGS = ("create", "private", "delete")
+
+#: Truthy non-booleans. Every one of these selected the *permissive* posture:
+#: ``delete`` mirror-deleted, ``create`` created a bucket.
+TRUTHY_NON_BOOLEANS: list[Any] = ["false", "no", "off", "0", "true", 1, 2.5, float("nan"), [0], {"a": 1}]
+
+#: Falsy non-booleans. Every one of these selected the *other* posture without
+#: ever being a declared spelling of it: ``private=0`` created a public bucket.
+FALSY_NON_BOOLEANS: list[Any] = [0, 0.0, "", None, [], {}]
+
+UNUSABLE: list[Any] = [*TRUTHY_NON_BOOLEANS, *FALSY_NON_BOOLEANS]
+
+
+def _label(value: Any) -> str:
+    """Stable, address-free id for a probe value."""
+    return f"{type(value).__name__}-{value!r}"
+
+
+IDS = [_label(v) for v in UNUSABLE]
+
+
+class _RecordingSubprocess:
+    """Records every argv ``sync_dataset_to_bucket`` would run, and runs none."""
+
+    def __init__(self) -> None:
+        self.argv: list[list[str]] = []
+        self.returncode = 0
+        self.stdout = ""
+        self.stderr = ""
+
+    def run(self, cmd: Any, **_kw: Any) -> _RecordingSubprocess:
+        self.argv.append(list(cmd))
+        return self
+
+    @property
+    def mirror_deleted(self) -> bool:
+        """Whether any recorded argv carries ``hf sync --delete``."""
+        return any("--delete" in c for c in self.argv)
+
+    @property
+    def created_private(self) -> bool:
+        """Whether any recorded argv creates the bucket with ``--private``."""
+        return any("--private" in c for c in self.argv)
+
+    @property
+    def created_bucket(self) -> bool:
+        """Whether any recorded argv runs ``hf buckets create``."""
+        return any(len(c) > 1 and c[1] == "buckets" for c in self.argv)
+
+
+@pytest.fixture
+def wire(monkeypatch: pytest.MonkeyPatch) -> _RecordingSubprocess:
+    """A recorded ``hf`` CLI: the flags reach an argv, never a real process."""
+    rec = _RecordingSubprocess()
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", rec.run)
+    monkeypatch.setattr(recorder_mod, "_hf_executable", lambda: "/usr/bin/hf")
+    monkeypatch.setattr(recorder_mod, "_huggingface_hub_version_error", lambda: None)
+    return rec
+
+
+@pytest.fixture
+def finalized(tmp_path: pathlib.Path) -> pathlib.Path:
+    """A dataset root that passes the ``meta/`` finalization check."""
+    (tmp_path / "meta").mkdir()
+    return tmp_path
+
+
+def _sync(root: pathlib.Path, **kwargs: Any) -> dict[str, Any]:
+    """Funnel so deliberately off-type flags need no per-call suppression."""
+    return recorder_mod.sync_dataset_to_bucket(root, "acme/robotdata", run_id="run1", **kwargs)
+
+
+class _FakeHubDataset:
+    """Records what reaches LeRobot's ``push_to_hub``, and reaches no Hub."""
+
+    repo_id = "acme/robotdata"
+
+    def __init__(self, root: str = "/nonexistent") -> None:
+        self.pushed: list[Any] = []
+        # ``sync_to_bucket`` reads this to build the local root it forwards.
+        self.root = root
+
+    def push_to_hub(self, tags: Any = None, private: Any = None) -> None:
+        self.pushed.append(private)
+
+
+class _Recorder(recorder_mod.DatasetRecorder):
+    """A recorder with a chosen frame/episode count, built without LeRobot."""
+
+    def __init__(self, dataset: _FakeHubDataset, *, frames: int = 10, episodes: int = 1) -> None:
+        self.dataset = dataset  # type: ignore[assignment]
+        self.frame_count = frames
+        self.episode_count = episodes
+
+
+def _push(recorder: _Recorder, **kwargs: Any) -> dict[str, Any]:
+    """Funnel so deliberately off-type flags need no per-call suppression."""
+    return recorder.push_to_hub(**kwargs)
+
+
+def _sync_via_recorder(recorder: _Recorder, **kwargs: Any) -> dict[str, Any]:
+    """Funnel for the delegate, for the same reason as :func:`_push`."""
+    return recorder.sync_to_bucket("acme/robotdata", run_id="run1", **kwargs)
+
+
+class TestTheDomainIsTheSharedOne:
+    """The values below are refused by the shared posture domain, not locally."""
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=IDS)
+    def test_the_shared_domain_refuses_every_probe_value(self, value: Any) -> None:
+        assert boolean_flag_error(value, "delete", "sync_dataset_to_bucket") is not None
+
+    @pytest.mark.parametrize("flag", PUBLICATION_FLAGS)
+    def test_the_bucket_sync_message_is_the_shared_one_verbatim(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, flag: str
+    ) -> None:
+        result = _sync(finalized, **{flag: "false"})
+        assert result["message"] == boolean_flag_error("false", flag, "sync_dataset_to_bucket")
+
+    def test_the_push_message_is_the_shared_one_verbatim(self) -> None:
+        result = _push(_Recorder(_FakeHubDataset()), private="false")
+        assert result["message"] == boolean_flag_error("false", "private", "push_to_hub")
+
+
+class TestTheBucketSyncRefusesANonBooleanPosture:
+    """Every flag, every unusable value, on the function that owns the rule."""
+
+    @pytest.mark.parametrize("flag", PUBLICATION_FLAGS)
+    @pytest.mark.parametrize("value", UNUSABLE, ids=IDS)
+    def test_an_unusable_flag_is_refused_and_runs_no_cli(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, flag: str, value: Any
+    ) -> None:
+        result = _sync(finalized, **{flag: value})
+        assert result["status"] == "error"
+        assert flag in result["message"]
+        assert wire.argv == [], "the refused call reached the hf CLI"
+
+
+class TestTheTruthinessReadFailedTowardThePermissivePosture:
+    """The two directions the old read inverted, pinned as the reason it changed."""
+
+    @pytest.mark.parametrize("value", ["false", "no", "off", "0"], ids=["false", "no", "off", "zero"])
+    def test_a_truthy_spelling_of_off_no_longer_mirror_deletes(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, value: str
+    ) -> None:
+        result = _sync(finalized, delete=value)
+        assert result["status"] == "error"
+        assert not wire.mirror_deleted, "hf sync --delete ran for a spelling that reads as off"
+
+    @pytest.mark.parametrize("value", [0, "", None, []], ids=["zero", "empty-str", "None", "empty-list"])
+    def test_a_falsy_non_boolean_no_longer_creates_a_public_bucket(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, value: Any
+    ) -> None:
+        result = _sync(finalized, private=value)
+        assert result["status"] == "error"
+        assert not wire.created_bucket, "a bucket was created for a value that is not a posture"
+
+
+class TestTheRefusalPrecedesEveryProbeAndSideEffect:
+    """Guard placement: nothing is located, run or published for a refused flag."""
+
+    @pytest.mark.parametrize("flag", PUBLICATION_FLAGS)
+    def test_the_bucket_sync_refusal_precedes_the_cli_probe(
+        self, monkeypatch: pytest.MonkeyPatch, finalized: pathlib.Path, flag: str
+    ) -> None:
+        def fatal() -> str:
+            raise AssertionError("the refused call probed for the hf CLI")
+
+        monkeypatch.setattr(recorder_mod, "_hf_executable", fatal)
+        result = _sync(finalized, **{flag: "false"})
+        assert result["status"] == "error"
+        assert flag in result["message"]
+
+    def test_the_bucket_sync_reports_the_flag_with_no_cli_installed(
+        self, monkeypatch: pytest.MonkeyPatch, finalized: pathlib.Path
+    ) -> None:
+        """The same mistake reports identically whether or not ``hf`` exists."""
+        monkeypatch.setattr(recorder_mod, "_hf_executable", lambda: None)
+        result = _sync(finalized, delete="false")
+        assert "delete" in result["message"]
+        assert "hf` CLI not found" not in result["message"]
+
+    def test_the_push_refusal_reaches_no_hub_call(self) -> None:
+        dataset = _FakeHubDataset()
+        result = _push(_Recorder(dataset), private="false")
+        assert result["status"] == "error"
+        assert dataset.pushed == [], "the refused call published to the Hub"
+
+    def test_the_push_refusal_does_not_depend_on_the_recorder_being_non_empty(self) -> None:
+        """An empty recorder still reports the flag, not its own state."""
+        empty = _Recorder(_FakeHubDataset(), frames=0, episodes=0)
+        result = _push(empty, private="false")
+        assert "private" in result["message"]
+        assert "empty dataset" not in result["message"]
+
+
+class TestThePushVisibilityFlagIsChecked:
+    """``private`` decides whether a published dataset is world-readable."""
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=IDS)
+    def test_an_unusable_visibility_is_refused(self, value: Any) -> None:
+        dataset = _FakeHubDataset()
+        result = _push(_Recorder(dataset), private=value)
+        assert result["status"] == "error"
+        assert "private" in result["message"]
+        assert dataset.pushed == []
+
+    @pytest.mark.parametrize("value", [True, False], ids=["private", "public"])
+    def test_a_boolean_visibility_is_forwarded_verbatim(self, value: bool) -> None:
+        dataset = _FakeHubDataset()
+        result = _push(_Recorder(dataset), private=value)
+        assert result["status"] == "success"
+        assert dataset.pushed == [value]
+
+
+class TestTheDelegateInheritsTheRule:
+    """``sync_to_bucket`` forwards the flags, so it inherits the refusal."""
+
+    @pytest.mark.parametrize("flag", PUBLICATION_FLAGS)
+    def test_the_recorder_method_refuses_the_same_value(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, flag: str
+    ) -> None:
+        recorder = _Recorder(_FakeHubDataset(root=str(finalized)))
+        result = _sync_via_recorder(recorder, **{flag: "false"})
+        assert result["status"] == "error"
+        assert flag in result["message"]
+        assert wire.argv == []
+
+    def test_the_recorder_method_still_syncs_with_a_usable_posture(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path
+    ) -> None:
+        """The delegation clause is not satisfied by a delegate that never runs."""
+        recorder = _Recorder(_FakeHubDataset(root=str(finalized)))
+        result = _sync_via_recorder(recorder, delete=True)
+        assert result["status"] == "success"
+        assert wire.mirror_deleted
+
+
+class TestAUsablePostureIsUnchanged:
+    """The accepted domain is untouched: both booleans still reach the same argv."""
+
+    def test_the_default_posture_builds_the_same_two_commands(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path
+    ) -> None:
+        result = _sync(finalized)
+        assert result["status"] == "success"
+        assert wire.created_bucket and wire.created_private
+        assert not wire.mirror_deleted
+
+    def test_an_explicit_mirror_delete_still_reaches_the_cli(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path
+    ) -> None:
+        result = _sync(finalized, delete=True)
+        assert result["status"] == "success"
+        assert wire.mirror_deleted
+
+    def test_an_explicit_public_bucket_still_omits_private(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path
+    ) -> None:
+        result = _sync(finalized, private=False)
+        assert result["status"] == "success"
+        assert wire.created_bucket and not wire.created_private
+
+    def test_skipping_creation_still_syncs(self, wire: _RecordingSubprocess, finalized: pathlib.Path) -> None:
+        result = _sync(finalized, create=False)
+        assert result["status"] == "success"
+        assert not wire.created_bucket
+        assert any(len(c) > 1 and c[1] == "sync" for c in wire.argv)
+
+    @pytest.mark.parametrize("value", [True, False], ids=["true", "false"])
+    def test_numpy_booleans_are_honoured_like_python_ones(
+        self, wire: _RecordingSubprocess, finalized: pathlib.Path, value: bool
+    ) -> None:
+        """The shared domain accepts ``np.bool_``, so this surface must too."""
+        np = pytest.importorskip("numpy")
+        result = _sync(finalized, delete=np.bool_(value))
+        assert result["status"] == "success"
+        assert wire.mirror_deleted is value
+
+
+# ---------------------------------------------------------------------------
+# Structural sweep: no publication-posture flag may reach the wire unchecked.
+# ---------------------------------------------------------------------------
+
+_MODULE_PATH = pathlib.Path(inspect.getfile(recorder_mod))
+_DOMAIN = "boolean_flag_error"
+
+
+def _module_tree(source: str | None = None) -> ast.Module:
+    return ast.parse(source if source is not None else _MODULE_PATH.read_text())
+
+
+def _boolean_flags(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Publication-posture flags this function declares, ``bool``-annotated."""
+    out = []
+    for arg in fn.args.args + fn.args.kwonlyargs:
+        if arg.arg not in PUBLICATION_FLAGS or arg.annotation is None:
+            continue
+        if ast.unparse(arg.annotation).strip() == "bool":
+            out.append(arg.arg)
+    return out
+
+
+def _guarded(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Flags handed to the shared domain, directly or through a guard loop."""
+    guarded: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name == _DOMAIN:
+                for arg in list(node.args) + [kw.value for kw in node.keywords]:
+                    if isinstance(arg, ast.Name):
+                        guarded.add(arg.id)
+        # for flag_name, flag_value in (("create", create), ...):
+        if isinstance(node, ast.For) and isinstance(node.iter, ast.Tuple | ast.List):
+            for element in node.iter.elts:
+                if isinstance(element, ast.Tuple):
+                    for item in element.elts:
+                        if isinstance(item, ast.Name):
+                            guarded.add(item.id)
+    return guarded
+
+
+def _forwarded(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Flags passed on by keyword under their own name, so the callee decides."""
+    forwarded: set[str] = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg and isinstance(kw.value, ast.Name) and kw.value.id == kw.arg:
+                forwarded.add(kw.arg)
+    return forwarded
+
+
+def _surfaces(source: str | None = None) -> dict[str, tuple[list[str], set[str], set[str]]]:
+    """Public surfaces declaring a publication flag, with their verdicts."""
+    found: dict[str, tuple[list[str], set[str], set[str]]] = {}
+    for node in ast.walk(_module_tree(source)):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name.startswith("_"):
+            continue
+        flags = _boolean_flags(node)
+        if flags:
+            found[node.name] = (flags, _guarded(node), _forwarded(node))
+    return found
+
+
+class TestEveryPublicationFlagIsCheckedOrForwarded:
+    """A flag reaching the wire unchecked cannot ship from this module."""
+
+    def test_the_expected_surfaces_are_the_ones_found(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep."""
+        assert set(_surfaces()) == {"sync_dataset_to_bucket", "sync_to_bucket", "push_to_hub"}
+
+    def test_the_owner_checks_all_three_flags(self) -> None:
+        flags, guarded, _forward = _surfaces()["sync_dataset_to_bucket"]
+        assert sorted(flags) == sorted(PUBLICATION_FLAGS)
+        assert set(flags) <= guarded
+
+    def test_no_surface_leaves_a_flag_unchecked_and_unforwarded(self) -> None:
+        adrift = {
+            name: sorted(set(flags) - guarded - forwarded)
+            for name, (flags, guarded, forwarded) in _surfaces().items()
+            if set(flags) - guarded - forwarded
+        }
+        assert not adrift, f"publication flags reaching the wire unchecked: {adrift}"
+
+    def test_the_sweep_detects_a_planted_unchecked_surface(self) -> None:
+        """A scanner that silently matched nothing would look like a clean module."""
+        planted = _MODULE_PATH.read_text() + (
+            "\n\ndef publish_somewhere(target: str, *, delete: bool = False) -> None:\n"
+            '    """Planted surface that reads a posture flag with no domain."""\n'
+            "    if delete:\n"
+            "        _run_mirror_delete(target)\n"
+        )
+        surfaces = _surfaces(planted)
+        assert "publish_somewhere" in surfaces
+        flags, guarded, forwarded = surfaces["publish_somewhere"]
+        assert set(flags) - guarded - forwarded == {"delete"}


### PR DESCRIPTION
## Problem

`sync_dataset_to_bucket` allowlist-validates `bucket` and `run_id` before it runs anything, and its own docstring says so:

> `bucket` and `run_id` are validated against an allowlist **before any subprocess or URI interpolation** [...] This path is agent-reachable via `stop_recording(bucket=, run_id=)`. A rejected value returns `{"status": "error", ...}` without running `hf`.

The three flags in that same signature — `create`, `private`, `delete` — reached `hf buckets create` / `hf sync` raw, and so did `private` on `DatasetRecorder.push_to_hub` beside it. Each selects a **posture on a remote store** rather than scaling a quantity, which is exactly the family `utils.boolean_flag_error` documents ("an IoT policy that grants a capability or withholds it, a confirmation gate in front of a destructive action, or a preview mode").

Read by truthiness they failed toward the permissive posture in **both** directions:

| supplied | what reached the remote (main) |
| --- | --- |
| `delete="false"` / `"no"` / `"off"` / `"0"` | truthy, so `hf sync ... --delete` — **mirror-deletes remote files absent locally** |
| `private=0` / `""` / `None` / `[]` | falsy, so `--private` dropped — **bucket created public** |
| `private="false"` | truthy, so `--private` **added** — the opposite of what it reads as |
| `create=0` | bucket creation skipped, then the sync targets a bucket that does not exist |

All of them returned `status="success"`. The four `delete` spellings are the ones an operator reaches for when opting out, and `--delete` is destructive against a store the caller does not see.

Measured, on both surfaces, over the ten off-type values below:

**a posture the caller never expressed reached the remote in 40 of 40 cells on `main`, and 0 of 40 with this change.**

## Change

One guard loop in the function whose docstring already says input validation lives there "exactly once", plus the `private` beside it on `push_to_hub`:

```python
for flag_name, flag_value in (("create", create), ("private", private), ("delete", delete)):
    if flag_error := boolean_flag_error(flag_value, flag_name, "sync_dataset_to_bucket"):
        return {"status": "error", "message": flag_error}
```

* **Placement.** Ahead of the `hf` CLI probe, so the same caller mistake reports identically whether or not `hf` is installed — and reaches neither subprocess. On `push_to_hub` the check precedes the empty-dataset state check, because the flag is a property of the call rather than of the recorder.
* **`sync_to_bucket` inherits it.** It forwards all three flags to the owner, so one guard covers it; a structural test keeps the forwarding real rather than assumed.
* **No new helper.** `boolean_flag_error` already exists and its docstring states why it is shared ("the flags sit in more than one module, and the accepted domain must not diverge"). This is the third module to use it.
* **Argument, not environment.** A flag arrives already typed, so it is checked rather than parsed. Parsing would only move which spellings invert — `"on"`, `"enabled"` and `"y"` are absent from every such vocabulary here and would then select the *restrictive* posture while reading as an opt-in.

## Scope

Covered: the publication-posture flags of this module's remote-publication surface. `private` means the same thing on both functions, so guarding one and not the other would leave one parameter name with two contracts in one module.

Deliberately not covered, with reasons:

* **`overwrite`** on `create` / `resume` / `start_recording` — a *local* filesystem gate across four surfaces whose refusal path is already documented via `FileExistsError`. Its own change.
* **`use_videos` / `streaming_encoding` / `strict`** — encoding and error-posture concerns, not publication.
* **The ~90 other unguarded `bool` parameters package-wide** — an unguarded boolean is the norm here, so a repo-wide rule would be over-reach. The narrowing is a publication or destructive posture on a *remote* store.

## Tests

`tests/test_bucket_publication_posture_flags.py`, 114 tests, no `hf` CLI, no network, no Hub:

* the domain is the shared one (message asserted **verbatim** against `boolean_flag_error`, so it cannot drift into a local copy);
* every flag × every off-type value refused on both surfaces, with `wire.argv == []` — the refusal reaches no CLI;
* the two inverted directions pinned as the reason it changed: no `--delete` for a truthy spelling of off, no bucket created for a falsy non-boolean;
* placement: `_hf_executable` made fatal, and the flag is still reported; refusal reported identically with no CLI installed; no Hub call for a refused `private`; an *empty* recorder still reports the flag rather than its own state;
* the accepted domain is untouched — both booleans, `np.bool_`, and each of the four honoured postures still build the same command line;
* the delegate refuses the same value **and** still syncs with a usable one, so the forwarding clause is not satisfied by a delegate that never runs;
* a structural sweep over the module: every public surface declaring a publication flag either checks it or forwards it under its own name, with an exact expected-surface set (non-vacuity) and a planted-unchecked-surface meta-test.

**Pre-fix** (source at `upstream/main`, tests kept): **87 failed / 27 passed**, the structural test naming all three adrift flags:

```
AssertionError: publication flags reaching the wire unchecked:
    {'sync_dataset_to_bucket': ['create', 'delete', 'private']}
```

The 27 that pass pre-fix are the premise tests (the shared domain already refuses these values), the accepted-value controls, the non-vacuity assertion and the planted-defect meta — the tests that stop the guard reaching further than the four flags.

**Zero existing tests changed.** No call site in `tests/`, `docs/` or `examples/` passes a non-boolean to any of these flags.

## Artifact

The change is transport-layer: it alters which `hf` command line is built, and no policy, simulation, rendering, dataset-recording or asset behaviour. So the artifact is a wire trace rather than a rollout — the two `hf` invocations, verbatim, per tree.

![dataset publication posture flags](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dataset-publish-posture-flags/posture-flags.png)

Top: the verdict matrix, 40 cells, red where a posture the caller never expressed reached the remote. Middle: the command line the two decisive values built — `delete="false"` produced `hf sync ... --delete` on `main` and no command at all now; `private=0` produced `hf buckets create acme/robotdata` with no `--private`. Bottom: the no-regression ledger — **all 4 honoured command lines are byte-identical across the two trees**.

Generators and the two measured dumps are on the [artifact branch](https://github.com/cagataycali/robots/tree/artifacts/dataset-publish-posture-flags); each dump records its own source tree and the compose step asserts the two differ, so the before/after pair cannot be two runs of one tree.

## Gate

Base `7f2f53ad`. `main` has since advanced to `c5c4c6b0`; the two diffs are disjoint (`comm -12` of the changed-path sets is empty, 0 lines), and `scripts/check_merge_base_overlap.py` reports *"No overlap [...] the checks on this branch were computed against a base that cannot have invalidated them"*.

* `MUJOCO_GL=egl pytest tests -q --no-cov -p no:randomly` — **26801 passed, 257 skipped, 0 failed** (567 s), re-run at the current head `6d51d02`
* `ruff check strands_robots tests tests_integ` — clean
* `ruff format --check strands_robots tests tests_integ` — 1143 files already formatted
* `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine `upstream/main` worktree of the same working copy
* `scripts/assemble_changelog.py --check` — OK

## Round 1 — review feedback

**`93dd834` test(dataset_recorder): construct the real recorder instead of subclassing it without `super().__init__`**

Code scanning (alert 881, *missing call to superclass `__init__`*) was the only failing check. The publication-posture double subclassed `DatasetRecorder` and set just the three attributes the methods under test read, so it never ran the base `__init__` — and a future base-class invariant could then go unbuilt here with no test noticing.

`DatasetRecorder.__init__` only records the dataset handed to it, so the fake dataset already in this file constructs the shipped class fully. A factory now does that and sets the frame/episode counts to the state under test; the subclass is gone, so the methods exercised are the shipped ones rather than a subclass's.

Test-only, no source change, and no test's assertions changed — the same 114 cases. Re-verified at `93dd834`: `pytest tests/test_bucket_publication_posture_flags.py` **114 passed**, `ruff check` / `ruff format --check tests` clean (889 files), `mypy` no issues.

## Round 2 — pin the property the subclass violated

**`6d51d02` test(dataset_recorder): pin that the posture-flag double is a real recorder**

Round 1 removed the subclass but left the property that made it wrong unpinned, so the stand-in could come back the next time this file grows a fixture. `TestTheDoubleIsARealRecorder` now compares the double's attributes against a reference recorder's.

Measured on `80bc91b0`, the subclass carried **3 of the 13** fields `DatasetRecorder.__init__` sets, missing `default_task`, `strict`, `_closed`, `dropped_frame_count`, `episode_frame_count`, `camera_key_map`, `_warned_camera_mismatch`, `_cached_state_keys`, `_cached_action_keys` and `_state_source_keys`. The new test fails there naming all ten:

```
Full diff:
  {
-     '_cached_action_keys', '_cached_state_keys', '_closed',
-     '_state_source_keys', '_warned_camera_mismatch', 'camera_key_map',
      'dataset',
-     'default_task', 'dropped_frame_count',
      'episode_count',
-     'episode_frame_count',
      'frame_count',
-     'strict',
  }
```

The other **115 tests in that file pass on the same pre-fix tree**, which is the point: none of those ten fields is read by `push_to_hub` or `sync_to_bucket` today, so the stand-in's omission was silent and no assertion in the file could see it. The second new test is the over-reach control — it passes pre-fix, because the counts were the three things the subclass *did* set.

An AST mirror of the rule's own predicate (a class with a base defining `__init__`, and no call to a base `__init__`) reports `_Recorder` at line 124 on `80bc91b0` — the same file and line as alert 881, which is what makes its verdict on the fix trustworthy — and reports nothing at `6d51d02`.

Round 1's verification was scoped to this one file; the full suite at the current head is in **Gate** above. Tests only in both rounds; no production line changed, so no new artifact — the wire trace above still describes the shipped behaviour.
