### PR TITLE
fix(simulation): check the recording posture flags instead of reading them by truthiness

### DIFF
--- a/changelog.d/2088-recording-posture-flag-domain.md
+++ b/changelog.d/2088-recording-posture-flag-domain.md
@@ -1,0 +1,11 @@
+### Fixed: a `start_recording` posture flag is checked instead of read by truthiness
+
+`start_recording(push_to_hub=, overwrite=)` and `stop_recording(push_to_hub=)` read two
+*posture* flags by truthiness, so every non-empty string selected the branch the caller was
+opting out of. `overwrite="false"` reached the wipe branch and deleted the dataset it was
+meant to append to - measured on MuJoCo, a dataset holding one recorded episode came back
+with that episode gone while `start_recording` returned `status="success"` - and
+`push_to_hub="false"` published the finished dataset to the Hub. Both are now checked on
+the shared `utils.boolean_flag_error` domain through the new
+`simulation.recording.dataset_recording_posture_error`, on all three backends, ahead of the
+lerobot-extra probe and ahead of anything on disk.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -152,6 +152,19 @@ When `root` already contains a LeRobotDataset (a `meta/` directory),
 LeRobotDataset, and is **not empty** is left untouched and reported as an error
 rather than clobbered - pass `overwrite=True` or choose a new/empty `root`.
 
+`overwrite` and `push_to_hub` select a **posture**, so both must be booleans and
+are checked before anything is created, resumed, wiped or published. Neither is
+read by truthiness: every non-empty string is truthy, so `overwrite="false"` -
+the spelling an operator reaches for when opting out - used to reach the wipe
+branch and delete the dataset it was meant to append to, and
+`push_to_hub="false"` used to publish it at `stop_recording`. Both now report the
+flag instead:
+
+```python
+sim.start_recording(repo_id="user/my_dataset", root=root, fps=30, overwrite="false")
+# -> error: "start_recording: overwrite must be a boolean, got 'false'. ..."
+```
+
 A resume inherits the existing dataset's schema, so `fps` must match the rate it
 was created at - a resume cannot change it. Requesting a different rate is
 refused, naming the on-disk value, rather than appending frames timestamped on

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -55,6 +55,7 @@ from strands_robots.simulation.models import registered
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
+    dataset_recording_posture_error,
 )
 from strands_robots.utils import name_list_error
 
@@ -178,7 +179,9 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 the ``repo_id`` resolution above rather than being joined to it.
                 See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
                 for the full precedence.
-            push_to_hub: Publish to the Hub at ``stop_recording``.
+            push_to_hub: Publish to the Hub at ``stop_recording``. Must be a
+                boolean - a publication posture is not read by truthiness
+                (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), universally decodable including by OpenCV's
                 VideoCapture. Use "libsvtav1" (AV1) for smaller files;
@@ -191,6 +194,9 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
                 recorded into, and a non-empty non-dataset directory is reported
                 as an error rather than clobbered - the four outcomes of
                 :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
+                Must be a boolean: a truthy non-boolean opt-out reached the
+                wipe branch and deleted the dataset it was meant to append
+                to (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every registered RTX camera is recorded. Pass a
                 subset to scope the dataset to exactly those views - matching
@@ -222,6 +228,17 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``push_to_hub`` and ``overwrite`` select postures, not quantities, so
+        # each is checked on the shared boolean-flag domain before any dataset is
+        # created, resumed or wiped - and before the lerobot-extra probe, so the
+        # same caller mistake reports the same way on every install. Read by
+        # truthiness both failed toward the branch the caller was opting out of:
+        # ``overwrite="false"`` deleted the dataset it was meant to append to,
+        # and ``push_to_hub="false"`` published it (see
+        # dataset_recording_posture_error).
+        for _flag, _value in (("push_to_hub", push_to_hub), ("overwrite", overwrite)):
+            if error := dataset_recording_posture_error("start_recording", _flag, _value):
+                return error
         # ``cameras`` names an ordered list of DISTINCT camera names, so it is
         # refused on the shared name-list domain before any dataset is created. Neither
         # mistake this catches could be honored as written: a single name passed

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -16,6 +16,7 @@ from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujo
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
+    dataset_recording_posture_error,
 )
 from strands_robots.utils import name_list_error
 
@@ -118,7 +119,9 @@ class RecordingMixin(DatasetRecordingMixin):
                 the ``repo_id`` resolution above rather than being joined to it.
                 See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
                 for the full precedence.
-            push_to_hub: Publish to the Hub at ``stop_recording``.
+            push_to_hub: Publish to the Hub at ``stop_recording``. Must be a
+                boolean - a publication posture is not read by truthiness
+                (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             overwrite: When True, wipe any existing dataset at the resolved
                 directory and record from scratch. When False (default) an
                 existing dataset is RESUMED (episodes appended), a pre-existing
@@ -126,6 +129,9 @@ class RecordingMixin(DatasetRecordingMixin):
                 recorded into, and a non-empty non-dataset directory is reported
                 as an error rather than clobbered - the four outcomes of
                 :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
+                Must be a boolean: a truthy non-boolean opt-out reached the
+                wipe branch and deleted the dataset it was meant to append
+                to (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), which decodes everywhere - including OpenCV's
                 VideoCapture, used by many downstream VLM video readers - so a
@@ -162,6 +168,17 @@ class RecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``push_to_hub`` and ``overwrite`` select postures, not quantities, so
+        # each is checked on the shared boolean-flag domain before any dataset is
+        # created, resumed or wiped - and before the lerobot-extra probe, so the
+        # same caller mistake reports the same way on every install. Read by
+        # truthiness both failed toward the branch the caller was opting out of:
+        # ``overwrite="false"`` deleted the dataset it was meant to append to,
+        # and ``push_to_hub="false"`` published it (see
+        # dataset_recording_posture_error).
+        for _flag, _value in (("push_to_hub", push_to_hub), ("overwrite", overwrite)):
+            if error := dataset_recording_posture_error("start_recording", _flag, _value):
+                return error
         # ``cameras`` names an ordered list of DISTINCT camera names, so it is
         # refused on the shared name-list domain before any dataset is created. Neither
         # mistake this catches could be honored as written: a single name passed

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -30,6 +30,7 @@ from strands_robots.simulation.models import registered
 from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
+    dataset_recording_posture_error,
 )
 from strands_robots.utils import name_list_error
 
@@ -115,7 +116,9 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 the ``repo_id`` resolution above rather than being joined to it.
                 See :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`
                 for the full precedence.
-            push_to_hub: Publish to the Hub at ``stop_recording``.
+            push_to_hub: Publish to the Hub at ``stop_recording``. Must be a
+                boolean - a publication posture is not read by truthiness
+                (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             vcodec: Video codec for the per-camera MP4 streams. Defaults to
                 "h264" (H.264), universally decodable including by OpenCV's
                 VideoCapture (used by many downstream VLM video readers). Use
@@ -129,6 +132,9 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
                 recorded into, and a non-empty non-dataset directory is reported
                 as an error rather than clobbered - the four outcomes of
                 :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`.
+                Must be a boolean: a truthy non-boolean opt-out reached the
+                wipe branch and deleted the dataset it was meant to append
+                to (:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`).
             cameras: Camera names to record into the dataset. When ``None``
                 (default) every named scene camera is recorded. Pass a subset
                 (e.g. ``cameras=["camera1", "camera2"]``) to scope the dataset
@@ -153,6 +159,17 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         # which optional extras this install has.
         if error := dataset_recording_option_error("start_recording", fps):
             return error
+        # ``push_to_hub`` and ``overwrite`` select postures, not quantities, so
+        # each is checked on the shared boolean-flag domain before any dataset is
+        # created, resumed or wiped - and before the lerobot-extra probe, so the
+        # same caller mistake reports the same way on every install. Read by
+        # truthiness both failed toward the branch the caller was opting out of:
+        # ``overwrite="false"`` deleted the dataset it was meant to append to,
+        # and ``push_to_hub="false"`` published it (see
+        # dataset_recording_posture_error).
+        for _flag, _value in (("push_to_hub", push_to_hub), ("overwrite", overwrite)):
+            if error := dataset_recording_posture_error("start_recording", _flag, _value):
+                return error
         # ``cameras`` names an ordered list of DISTINCT camera names, so it is
         # refused on the shared name-list domain before any dataset is created. Neither
         # mistake this catches could be honored as written: a single name passed

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -32,7 +32,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.utils import positive_whole_number_error
+from strands_robots.utils import boolean_flag_error, positive_whole_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,48 @@ def dataset_recording_option_error(method: str, fps: Any) -> dict[str, Any] | No
         ``None`` when the value is usable.
     """
     if text := positive_whole_number_error(fps, "fps", method):
+        return {"status": "error", "content": [{"text": text}]}
+    return None
+
+
+def dataset_recording_posture_error(method: str, param: str, value: Any) -> dict[str, Any] | None:
+    """Reject a recording posture flag that was not supplied as a boolean.
+
+    Sibling of :func:`dataset_recording_option_error` for the two flags in the
+    same ``start_recording`` signature that select a *posture* rather than
+    scaling a quantity, and for the ``push_to_hub`` that
+    :meth:`DatasetRecordingMixin.stop_recording` accepts as an override. Shared
+    by every backend (MuJoCo, Newton, Isaac) for the same reason the ``fps``
+    guard is: the three surfaces must not disagree on what a usable value is.
+
+    The domain is :func:`~strands_robots.utils.boolean_flag_error` - the one the
+    mesh provisioning entry points and ``lerobot_teleoperate``'s execution flags
+    already apply to their own posture flags. Read by truthiness instead, both
+    flags fail toward the branch the caller was opting *out* of, because every
+    non-empty string is truthy:
+
+    * ``overwrite="false"`` (also ``"no"``, ``"off"``, ``"0"``, ``1``, ``nan``)
+      reached :meth:`DatasetRecordingMixin._prepare_dataset_target` as True and
+      deleted the caller's dataset with ``shutil.rmtree``. That method already refuses to
+      clobber a non-empty *non*-dataset directory, so the one path it deleted
+      without asking was a real LeRobotDataset - the recorded episodes the caller
+      meant to append to. ``start_recording`` returned ``status="success"``.
+    * ``push_to_hub="false"`` (same spellings) was stashed on the recording state
+      and *published* the finished dataset to the Hub at ``stop_recording``.
+
+    Neither could be honoured as written, and neither failure is recoverable:
+    the episodes are gone, and an upload cannot be taken back.
+
+    Args:
+        method: Public method name, used to prefix the error message.
+        param: Flag name, for the message.
+        value: The flag as supplied.
+
+    Returns:
+        A structured ``{"status": "error", ...}`` dict naming *param*, or
+        ``None`` when the value is a boolean and can be honoured.
+    """
+    if text := boolean_flag_error(value, param, method):
         return {"status": "error", "content": [{"text": text}]}
     return None
 
@@ -412,9 +454,17 @@ class DatasetRecordingMixin:
         * existing NON-empty, non-dataset dir: raise ``ValueError`` with an
           actionable message instead of clobbering unrelated files.
 
+        ``overwrite`` is a *posture*, and every public caller checks it on
+        :func:`dataset_recording_posture_error` first, so the value arriving here
+        is a boolean. That bound matters because the branch below is the only one
+        that deletes a real LeRobotDataset without asking: a truthy non-boolean -
+        ``"false"``, the spelling an operator reaches for when opting out - used
+        to land in it.
+
         Args:
             dataset_dir: Resolved on-disk dataset root.
-            overwrite: When True, replace any existing target.
+            overwrite: When True, replace any existing target. Bounded to a
+                boolean by every public caller.
 
         Returns:
             True if an existing dataset should be resumed (append), False if a
@@ -527,7 +577,9 @@ class DatasetRecordingMixin:
             push_to_hub: Publish to a versioned HF *dataset* repo (the finished
                 artifact). Overrides the ``push_to_hub`` set at start_recording.
                 Requires an open recording session; on the idle path this
-                returns ``status="error"`` instead of a silent no-op.
+                returns ``status="error"`` instead of a silent no-op. Must be a
+                boolean: a publication posture is not read by truthiness
+                (:func:`dataset_recording_posture_error`).
             bucket: If set (e.g. ``"my-org/robot-fave"``), sync the dataset into
                 a mutable HF Storage Bucket instead of/in addition to the dataset
                 repo - the Phase 1/2 collection target (Xet-deduped, overwrite in
@@ -535,6 +587,12 @@ class DatasetRecordingMixin:
                 sim finalized (errors if there is none).
             run_id: Optional subpath inside the bucket (defaults to dataset name).
         """
+        # ``push_to_hub`` selects whether the finished dataset is published, so
+        # it is checked before it is read - by the idle path just below and by
+        # the upload after the episode is finalized. Read by truthiness a
+        # non-boolean opt-out ("false", "no", "off", "0") published the dataset.
+        if error := dataset_recording_posture_error("stop_recording", "push_to_hub", push_to_hub):
+            return error
         state = self._recording_state()
         if state is None or not state.get("recording", False):
             return self._stop_recording_idle(push_to_hub=push_to_hub, bucket=bucket, run_id=run_id)

--- a/tests/simulation/test_recording_posture_flag_domain.py
+++ b/tests/simulation/test_recording_posture_flag_domain.py
@@ -1,0 +1,348 @@
+"""A recording posture flag must be a boolean, not anything truthy.
+
+``start_recording`` takes two flags that select a *posture* rather than scaling
+a quantity, and both were read by truthiness. Every non-empty string is truthy,
+so ``"false"`` / ``"no"`` / ``"off"`` / ``"0"`` - the spellings an operator
+reaches for when opting out - selected the branch the caller was opting *out*
+of, and each failure is unrecoverable:
+
+* ``overwrite="false"`` reached
+  :meth:`~strands_robots.simulation.recording.DatasetRecordingMixin._prepare_dataset_target`
+  as True and ``shutil.rmtree``-d the dataset. Measured end to end on MuJoCo: a
+  dataset holding one recorded episode, re-opened to append a second, came back
+  with one episode - the first was deleted - and ``start_recording`` returned
+  ``status="success"`` throughout. That method already refuses to clobber a
+  non-empty *non*-dataset directory, so the one thing it deleted without asking
+  was a real LeRobotDataset.
+* ``push_to_hub="false"`` was stashed on the recording state and *published* the
+  finished dataset to the Hub at ``stop_recording``. Six values that are not
+  booleans uploaded it.
+
+``fps``, in the same signature, has been checked on a shared domain since the
+rate defect it caused; these two had none. They are now checked on
+:func:`~strands_robots.utils.boolean_flag_error` through the shared
+:func:`~strands_robots.simulation.recording.dataset_recording_posture_error`,
+ahead of the lerobot-extra probe and ahead of anything on disk, so the same
+mistake reports the same way on every install and on every backend.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.simulation as simulation_pkg
+from strands_robots.simulation.recording import (
+    DatasetRecordingMixin,
+    dataset_recording_posture_error,
+)
+from strands_robots.utils import boolean_flag_error
+
+pytest.importorskip("mujoco")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# One actuated hinge: enough for run_policy to drive something and for the
+# dataset schema to declare joint/action columns, with no asset download.
+_ARM_XML = """
+<mujoco model="posture_flag_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <body name="base" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1"/>
+      <geom name="link" type="capsule" fromto="0 0 0 0.2 0 0" size="0.03"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="30"/>
+  </actuator>
+</mujoco>
+"""
+
+#: Flags whose truthiness used to be read instead of their type.
+POSTURE_FLAGS = ["push_to_hub", "overwrite"]
+
+#: Values no posture can be read from. The four string spellings and the
+#: non-zero number are the ones that selected the *permissive* branch; ``None``
+#: and ``[]`` silently took the other one without ever being a declared
+#: spelling of it.
+UNUSABLE_FLAGS = [
+    "false",
+    "no",
+    "off",
+    "0",
+    "true",
+    1,
+    0,
+    "",
+    None,
+    [],
+    float("nan"),
+]
+
+#: The truthy non-booleans: each one selected the branch that deletes a dataset
+#: (``overwrite``) or publishes it (``push_to_hub``).
+TRUTHY_NON_BOOLEANS = ["false", "no", "off", "0", "true", 1, float("nan")]
+
+
+@pytest.fixture
+def sim(tmp_path):
+    model = tmp_path / "posture_flag_arm.xml"
+    model.write_text(_ARM_XML)
+    s = Simulation(tool_name="posture_flag", mesh=False)
+    s.create_world()
+    s.add_robot("arm", urdf_path=str(model))
+    yield s
+    s.cleanup()
+
+
+def _text(result: dict[str, Any]) -> str:
+    return " ".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+def _episode_count(root: Path) -> int | None:
+    info = root / "meta" / "info.json"
+    if not info.exists():
+        return None
+    return int(json.loads(info.read_text())["total_episodes"])
+
+
+def _record_one_episode(sim, root: Path, **kwargs: Any) -> dict[str, Any]:
+    """Open a session, drive four control steps, save. Returns the start result."""
+    started = sim.start_recording(repo_id="local/posture_flag", fps=30, root=str(root), **kwargs)
+    if started["status"] == "success":
+        rollout = sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=4, control_frequency=30.0)
+        assert rollout["status"] == "success", rollout
+        assert sim.stop_recording()["status"] == "success"
+    return started
+
+
+class TestThePostureDomain:
+    """The shared guard is the boolean-flag domain, and nothing more."""
+
+    @pytest.mark.parametrize("param", POSTURE_FLAGS)
+    @pytest.mark.parametrize("value", UNUSABLE_FLAGS)
+    def test_a_non_boolean_reports_the_flag_the_method_and_the_value(self, param, value):
+        error = dataset_recording_posture_error("start_recording", param, value)
+        assert error is not None
+        assert error["status"] == "error"
+        text = error["content"][0]["text"]
+        assert "start_recording" in text
+        assert param in text
+        assert repr(value) in text
+
+    @pytest.mark.parametrize("param", POSTURE_FLAGS)
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_boolean_is_accepted(self, param, value):
+        assert dataset_recording_posture_error("start_recording", param, value) is None
+
+    @pytest.mark.parametrize("value", [*UNUSABLE_FLAGS, True, False])
+    def test_the_guard_adds_nothing_to_the_shared_domain(self, value):
+        """The envelope carries the shared message verbatim - no second rule."""
+        error = dataset_recording_posture_error("start_recording", "overwrite", value)
+        text = boolean_flag_error(value, "overwrite", "start_recording")
+        if text is None:
+            assert error is None
+        else:
+            assert error is not None
+            assert error["content"][0]["text"] == text
+
+
+class TestOverwriteNoLongerDeletesTheDatasetItWasOptingOutOf:
+    """The measured defect: a truthy non-boolean wiped recorded episodes."""
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_the_recorded_episode_survives_a_refused_overwrite(self, sim, tmp_path, value):
+        pytest.importorskip("lerobot")
+        root = tmp_path / "dataset"
+        assert _record_one_episode(sim, root)["status"] == "success"
+        assert _episode_count(root) == 1
+
+        refused = sim.start_recording(repo_id="local/posture_flag", fps=30, root=str(root), overwrite=value)
+
+        assert refused["status"] == "error", refused
+        assert "overwrite" in _text(refused)
+        # The whole point: the caller's episode is still there.
+        assert _episode_count(root) == 1, "the refused call deleted the dataset"
+        assert (root / "meta").is_dir()
+
+    def test_both_documented_postures_still_do_what_they_say(self, sim, tmp_path):
+        """``False`` appends, ``True`` records from scratch."""
+        pytest.importorskip("lerobot")
+        root = tmp_path / "dataset"
+        _record_one_episode(sim, root, overwrite=False)
+        _record_one_episode(sim, root, overwrite=False)
+        assert _episode_count(root) == 2, "overwrite=False must append"
+
+        _record_one_episode(sim, root, overwrite=True)
+        assert _episode_count(root) == 1, "overwrite=True must record from scratch"
+
+
+class TestPushToHubNoLongerPublishesWhenOptedOut:
+    """A publication posture is not read by truthiness."""
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_start_recording_refuses_before_the_session_opens(self, sim, tmp_path, value):
+        root = tmp_path / "dataset"
+        refused = sim.start_recording(repo_id="local/posture_flag", fps=30, root=str(root), push_to_hub=value)
+
+        assert refused["status"] == "error", refused
+        assert "push_to_hub" in _text(refused)
+        # No half-open session, and nothing on disk: the refusal precedes both.
+        assert "idle" in _text(sim.get_recording_status()).lower()
+        assert not root.exists() or not any(root.iterdir())
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_stop_recording_refuses_without_uploading(self, sim, tmp_path, monkeypatch, value):
+        pytest.importorskip("lerobot")
+        import strands_robots.dataset_recorder as dataset_recorder
+
+        uploads: list[Any] = []
+
+        def spy(self, tags=None, private=True):
+            uploads.append({"tags": tags, "private": private})
+            return {"status": "success", "content": [{"text": "pushed"}]}
+
+        monkeypatch.setattr(dataset_recorder.DatasetRecorder, "push_to_hub", spy)
+
+        root = tmp_path / "dataset"
+        started = sim.start_recording(repo_id="local/posture_flag", fps=30, root=str(root))
+        assert started["status"] == "success", started
+        assert (
+            sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=4, control_frequency=30.0)["status"]
+            == "success"
+        )
+
+        refused = sim.stop_recording(push_to_hub=value)
+
+        assert refused["status"] == "error", refused
+        assert "push_to_hub" in _text(refused)
+        assert uploads == [], "the refused stop_recording published the dataset"
+
+    def test_a_boolean_override_still_publishes(self, sim, tmp_path, monkeypatch):
+        pytest.importorskip("lerobot")
+        import strands_robots.dataset_recorder as dataset_recorder
+
+        uploads: list[Any] = []
+        monkeypatch.setattr(
+            dataset_recorder.DatasetRecorder,
+            "push_to_hub",
+            lambda self, tags=None, private=True: (
+                uploads.append(tags) or {"status": "success", "content": [{"text": "pushed"}]}
+            ),
+        )
+
+        root = tmp_path / "dataset"
+        assert sim.start_recording(repo_id="local/posture_flag", fps=30, root=str(root))["status"] == "success"
+        assert (
+            sim.run_policy(robot_name="arm", policy_provider="mock", n_steps=4, control_frequency=30.0)["status"]
+            == "success"
+        )
+
+        stopped = sim.stop_recording(push_to_hub=True)
+
+        assert stopped["status"] == "success", stopped
+        assert len(uploads) == 1
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_the_idle_path_reports_the_flag_too(self, sim, value):
+        """No session open: the flag is judged before the idle branch reads it."""
+        refused = sim.stop_recording(push_to_hub=value)
+
+        assert refused["status"] == "error", refused
+        assert "push_to_hub" in _text(refused)
+
+
+class TestTheRefusalPrecedesTheLerobotProbe:
+    """The same mistake must report the same way on every install."""
+
+    @pytest.mark.parametrize("param", POSTURE_FLAGS)
+    def test_the_flag_is_named_even_when_the_dataset_stack_is_missing(self, sim, tmp_path, monkeypatch, param):
+        import strands_robots.dataset_recorder as dataset_recorder
+
+        def fatal(*_args, **_kwargs):
+            raise AssertionError("the refused call reached the lerobot-extra probe")
+
+        monkeypatch.setattr(dataset_recorder, "lerobot_dataset_import_error", fatal)
+
+        refused = sim.start_recording(
+            repo_id="local/posture_flag",
+            fps=30,
+            root=str(tmp_path / "dataset"),
+            **{param: "false"},
+        )
+
+        assert refused["status"] == "error"
+        assert param in _text(refused)
+
+
+def _flags_checked_by(source: str, function: str) -> set[str]:
+    """Flag names passed to the shared posture guard inside *function*.
+
+    Parsed by AST so backends whose optional dependencies (Isaac Sim, Newton)
+    are not installed are still checked.
+    """
+    checked: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.FunctionDef) and node.name == function):
+            continue
+        for call in ast.walk(node):
+            if not (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "dataset_recording_posture_error"
+            ):
+                continue
+            for arg in call.args[1:]:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    checked.add(arg.value)
+        # A per-flag loop names the flags in the iterated tuple instead.
+        for loop in ast.walk(node):
+            if not isinstance(loop, ast.For):
+                continue
+            body = ast.unparse(ast.Module(body=list(loop.body), type_ignores=[]))
+            if "dataset_recording_posture_error" not in body:
+                continue
+            for element in ast.walk(loop.iter):
+                if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                    checked.add(element.value)
+    return checked
+
+
+def _backend_recording_source(backend: str) -> str:
+    path = Path(simulation_pkg.__file__).parent / backend / "recording.py"
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("backend", ["mujoco", "newton", "isaac"])
+def test_every_backend_start_recording_checks_both_flags(backend):
+    """No backend may accept a posture the others refuse."""
+    checked = _flags_checked_by(_backend_recording_source(backend), "start_recording")
+    assert set(POSTURE_FLAGS) <= checked, (
+        f"{backend}/recording.py start_recording must check {POSTURE_FLAGS} "
+        f"via dataset_recording_posture_error; found {sorted(checked)}"
+    )
+
+
+def test_the_shared_stop_recording_checks_its_override():
+    """The one ``stop_recording`` every backend inherits judges the override."""
+    source = Path(inspect.getfile(DatasetRecordingMixin))
+    checked = _flags_checked_by(source.read_text(encoding="utf-8"), "stop_recording")
+    assert "push_to_hub" in checked, sorted(checked)
+
+
+def test_the_scanner_detects_an_unchecked_flag():
+    """Non-vacuity: a start_recording with no guard must be reported."""
+    planted = "def start_recording(self, push_to_hub=False, overwrite=False):\n    return {'status': 'success'}\n"
+    assert _flags_checked_by(planted, "start_recording") == set()


### PR DESCRIPTION
## Problem

`start_recording` takes two flags that select a **posture** rather than scaling a quantity, and both were read by truthiness. Every non-empty string is truthy, so `"false"` / `"no"` / `"off"` / `"0"` -- the spellings an operator reaches for when opting out -- selected the branch the caller was opting *out* of. Neither failure is recoverable: the episodes are gone, and an upload cannot be taken back.

Measured end to end on MuJoCo with `lerobot` installed:

```python
sim.start_recording(repo_id="user/ds", root=root, fps=30)          # -> 1 episode / 8 frames
sim.start_recording(repo_id="user/ds", root=root, fps=30, overwrite="false")
# -> status="success"
# -> dataset now holds 1 episode / 12 frames: the 8-frame episode was DELETED
```

The value reached `_prepare_dataset_target` as `True` and `shutil.rmtree`-d the dataset the caller was re-opening in order to append to it. That method already refuses to clobber a non-empty **non**-dataset directory ("Refusing to overwrite unrelated files"), so the one thing it deleted without asking was a real `LeRobotDataset`. `"no"`, `"off"`, `"0"`, `1` and `nan` did the same; nothing was logged and nothing failed.

The other flag publishes rather than deletes:

```python
sim.start_recording(..., push_to_hub="false")   # stashed on the recording state
sim.stop_recording()                            # -> UPLOADED to the Hub
sim.stop_recording(push_to_hub="false")         # -> UPLOADED, directly
```

Six non-boolean values uploaded the finished dataset. `None` and `[]` take the other branch without ever being a declared spelling of it.

`fps`, in the **same signature**, has been checked on a shared domain since the rate defect it caused -- `dataset_recording_option_error`, whose docstring says it exists "so the three surfaces cannot disagree on what a usable `fps` is". These two flags had no equivalent.

## Change

A new sibling of that guard, `simulation.recording.dataset_recording_posture_error`, delegating to the shared `utils.boolean_flag_error` domain -- the one the mesh provisioning entry points and `lerobot_teleoperate`'s execution flags already apply to their own posture flags. It is the envelope-returning half of one rule, not a rule of its own: a test asserts the message is the shared domain's **verbatim**.

Wired at every public surface that reads either flag:

| surface | flags checked |
|---|---|
| `MuJoCoSimEngine.start_recording` | `push_to_hub`, `overwrite` |
| `NewtonSimEngine.start_recording` | `push_to_hub`, `overwrite` |
| `IsaacSimulation.start_recording` | `push_to_hub`, `overwrite` |
| `DatasetRecordingMixin.stop_recording` | `push_to_hub` |

Placement is deliberate and pinned: in `start_recording` the check sits immediately after the `fps` guard, which puts it **ahead of the lerobot-extra probe** (so the same caller mistake reports the same way on every install -- pinned with the probe monkeypatched fatal) and **ahead of anything on disk** (so a refusal cannot have deleted the caller's episodes, opened a half session, or written a file). In `stop_recording` it is the first statement after the docstring, ahead of both readers of the flag.

Both documented postures behave exactly as before: `overwrite=False` appends, `overwrite=True` records from scratch, a boolean `push_to_hub` still publishes. `_prepare_dataset_target` keeps its four documented outcomes; its docstring now names the bound its callers apply.

**Out of scope, deliberately:** `_prepare_dataset_target` itself is private and every public caller now bounds the flag before reaching it, so it takes no guard of its own -- adding one would be a second copy of the rule. `bucket=` / `run_id=` are strings, a different axis.

## Verification

Full suite on the tree that merges (rebased onto `a0e62870`, so `#2087`'s 25 new tests are included), Python 3.13, MuJoCo 3.11 headless (`MUJOCO_GL=egl`), lerobot 0.6.2:

```
MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly
27001 passed, 257 skipped, 0 failed  (597.68s)
```

Zero existing tests changed. Lint exactly as CI runs it:

```
ruff check strands_robots tests tests_integ      All checks passed!
ruff format --check strands_robots tests tests_integ    1145 files already formatted
mypy strands_robots tests tests_integ            0 errors outside examples/isaac_gs
```
<sub>The 14 `examples/isaac_gs` errors are an artifact of this checkout's editable-install root: the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy (`sed 's/:[0-9]*:/:L:/' | sort` on both, then `diff`).</sub>

Repo-wide guards: `414 passed`. `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> "No overlap ... 0 path(s) changed on `upstream/main` in that span". `scripts/assemble_changelog.py --check` -> OK.

**Pre-fix proof** (the four source files reverted to `upstream/main`, the 76 new tests kept -- a stand-in for the new symbol keeps the module importable so every behavioural test runs rather than one collection error). Identical at the pre-rebase and post-rebase base, so the rebase preserved the contract:

```
27 failed, 49 passed
  7  the recorded episode survives a refused overwrite   (it was deleted)
  7  start_recording refuses before the session opens    (it opened)
  7  stop_recording refuses without uploading            (it uploaded)
  3  every backend start_recording checks both flags     (found [])
  2  the flag is named even without the dataset stack    (the probe ran first)
  1  the shared stop_recording checks its override       (found set())
```

The 49 that pass pre-fix are the over-reach controls and the domain tests: the domain itself is `boolean_flag_error`'s and already correct, both booleans were already honoured, the append/fresh postures already worked, and the idle `stop_recording` path already reported a truthy `push_to_hub` (for a different reason -- "nothing to publish"). Keeping them is what stops the guard reaching further than the two flags.

## Artifact

`capture.py` is run unchanged in a `upstream/main` worktree and in this branch; each run records its own import tree, and the figure generator asserts the two halves came from different trees and re-derives every number below from the two JSON dumps.

![overwrite posture](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recording-posture-flag-domain/recording-posture-flag-domain.png)

The MuJoCo render is byte-comparable across the two trees (max |delta| = 1/255, renderer noise) -- the physics and the recording path are untouched; the whole difference is what the flag is allowed to mean. The frame strip is decoded back out of the dataset's own MP4, so the episode `main` deleted was a real, complete recording. On this branch the figure also follows the advice the refusal gives (`overwrite=False`) and gets the append that was asked for: 2 episodes / 20 frames.

Capture script, both measured dumps and a README: [`artifacts/recording-posture-flag-domain`](https://github.com/cagataycali/robots/tree/artifacts/recording-posture-flag-domain).
