### PR TITLE
fix(tools): describe every parameter an agent tool exposes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,21 @@ hatch run format            # ruff check --fix, ruff format
     transitive; move the bound there if it ever becomes direct. Pinned by
     tests/test_dependency_audit.py.
 
+13. **Every parameter an agent tool exposes needs its own `Args:` entry** - a
+    `@tool` function's input schema is derived from its docstring by
+    `docstring_parser`, and the decorator substitutes the placeholder
+    `"Parameter <name>"` for any parameter it cannot find there. The model
+    driving the tool reads that schema and nothing else, so a placeholder makes
+    the parameter undiscoverable however carefully the source explains it.
+    Three spellings produce one, and the last two read as documentation in the
+    source, which is what makes the loss silent: the entry is absent; the entry
+    sits under a section header other than `Args:`, which the parser discards
+    entirely (prose reaches the tool description only when it appears *before*
+    `Args:`); or one entry names several parameters at once (`a / b: ...`),
+    which is read as a single parameter literally named `"a / b"` and therefore
+    describes neither. Pinned by
+    tests/tools/test_agent_tool_parameter_descriptions.py.
+
 ## PR Workflow
 
 1. Create the feature branch **on your fork**. Branch creation in the base

--- a/changelog.d/2090-agent-tool-parameter-descriptions.md
+++ b/changelog.d/2090-agent-tool-parameter-descriptions.md
@@ -1,0 +1,18 @@
+### Fixed: agent tools no longer expose parameters the model cannot learn anything about
+
+A `@tool` function's input schema is derived from its docstring, and the decorator
+substitutes the placeholder `"Parameter <name>"` for any parameter it cannot find in
+the `Args:` section. Thirteen parameters across `gr00t_inference`, `lerobot_teleoperate`
+and `train_policy` reached the model that way, including `remove_volumes` (which
+discards downloaded checkpoints), `lifecycle` (whose `"teardown"` phase removes the
+container) and `hf_repo` (required for `download_checkpoint`). Ten of the thirteen were
+described in the source already: seven sat under a `Container lifecycle args` header the
+parser discards - along with the paragraph explaining why the build repo and image are
+operator-configured rather than agent parameters - and three shared one
+`lora_r / lora_alpha / lora_target_modules:` entry, which is read as a single parameter
+named `"lora_r / lora_alpha / lora_target_modules"` and so described none of them.
+
+Every parameter of all sixteen bound tools now describes itself, the operator-configured
+note moved ahead of `Args:` so it reaches the tool description too, and a guard checks
+both directions of the rule: no exposed parameter may carry the placeholder, and no
+docstring entry may name a parameter the tool does not have.

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -595,6 +595,19 @@ def gr00t_inference(
         The default stays ``"n1.5"`` for back-compat. N1.7 users must opt in
         explicitly: ``gr00t_inference(action="start", ..., protocol="n1.7")``.
 
+    Operator-configured, not agent parameters:
+        The build source repo/tag/clone-dir, the container image, bind-mount
+        volumes, and the container command are operator-config-driven: an
+        agent-supplied git URL would clone an attacker tree and ``bash
+        docker/build.sh`` it (host RCE). ``build_image`` clones
+        ``$STRANDS_GR00T_REPO_URL`` (allowlisted; default the canonical NVIDIA
+        repo) at ``$STRANDS_GR00T_REPO_TAG`` into ``$STRANDS_BASE_DIR/Isaac-GR00T``;
+        the image is resolved from ``STRANDS_GR00T_IMAGE`` and validated against
+        ``STRANDS_GR00T_IMAGE_ALLOW``. Extend the URL allowlist for private
+        mirrors via ``STRANDS_GR00T_REPO_URL_ALLOW``. The container is started
+        with ``hf_local_dir`` → ``/data/checkpoints`` and
+        ``~/.cache/huggingface`` → ``/root/.cache/huggingface`` mounted.
+
     Args:
         action: Action to perform (see Actions above).
         checkpoint_path: Path to model checkpoint directory (required for ``start``/``restart``).
@@ -648,35 +661,32 @@ def gr00t_inference(
             deterministic-algorithms mode) by forwarding them into the
             container. Default ``False`` - byte-identical to the previous
             behavior.
-
-    Container lifecycle args (used by ``build_image``, ``download_checkpoint``,
-    ``start_container``, ``lifecycle``):
-        (The build source repo/tag/clone-dir, the container image, bind-mount
-        volumes, and the container command are operator-config-driven, NOT
-        agent parameters: an agent-supplied git URL would clone an attacker
-        tree and ``bash docker/build.sh`` it (host RCE). ``build_image`` clones
-        ``$STRANDS_GR00T_REPO_URL`` (allowlisted; default the canonical NVIDIA
-        repo) at ``$STRANDS_GR00T_REPO_TAG`` into ``$STRANDS_BASE_DIR/Isaac-GR00T``;
-        the image is resolved from ``STRANDS_GR00T_IMAGE`` and validated against
-        ``STRANDS_GR00T_IMAGE_ALLOW``. Extend the URL allowlist for private
-        mirrors via ``STRANDS_GR00T_REPO_URL_ALLOW``.)
         hf_repo: HuggingFace dataset/model id (e.g., ``"nvidia/GR00T-N1.7-LIBERO"``).
-            Required for ``download_checkpoint``.
+            Required for ``download_checkpoint``. Read by ``download_checkpoint``
+            and by ``lifecycle="full"``.
         hf_subfolder: Subfolder pattern within the HF repo (e.g.,
             ``"libero_spatial"``). When set, only files matching
             ``<subfolder>/*`` are downloaded.
         hf_local_dir: Where to download the checkpoint. Defaults to
-            ``$STRANDS_BASE_DIR/checkpoints/<basename(hf_repo)>``.
-        hf_token: HuggingFace API token (gated repos). Falls back to
-            ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` env vars.
-            Defaults to mounting ``hf_local_dir`` → ``/data/checkpoints`` and
-            ``~/.cache/huggingface`` → ``/root/.cache/huggingface``.
-        lifecycle: ``"full"`` (default - chain build → download → start_container
-            → start) or ``"teardown"`` (rm container + volumes).
-        remove_volumes: When ``lifecycle="teardown"``, also remove docker volumes
-            (default: ``False`` to preserve checkpoint mounts).
-        force: For idempotent steps - rebuild image, redownload checkpoint, or
-            recreate container even when the artefact is already present.
+            ``$STRANDS_BASE_DIR/checkpoints/<basename(hf_repo)>``. Also the host
+            side of the ``/data/checkpoints`` bind mount, so it is confined to
+            the base directory rather than accepted anywhere on the host.
+        hf_token: HuggingFace API token, for gated repos. Falls back to the
+            ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` env vars, which is the
+            preferred way to supply it - a token passed here travels through the
+            tool call.
+        lifecycle: Which phase ``action="lifecycle"`` runs: ``"full"`` (default -
+            chain ``build_image`` → ``download_checkpoint`` → ``start_container``
+            → ``start`` and wait for the port) or ``"teardown"`` (remove the
+            container). Ignored by every other action.
+        remove_volumes: Under ``lifecycle="teardown"``, also remove the
+            container's docker volumes. Default ``False``, which preserves the
+            checkpoint and HuggingFace-cache mounts; passing ``True`` discards
+            downloaded checkpoints, so a later ``lifecycle="full"`` re-downloads.
+        force: Override the idempotence of the setup steps - rebuild the image,
+            re-download the checkpoint, or recreate the container even when the
+            artefact is already present. Default ``False``, which makes a
+            re-run after a crash resume rather than repeat work.
 
     Returns:
         Dict with operation results. Common fields:

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -894,6 +894,14 @@ def lerobot_teleoperate(
             corrections dataset as well, rather than only the teleoperated
             takeovers. Must be a boolean; a truthy spelling of off would
             otherwise land autonomous episodes in a corrections dataset.
+        policy_path: Checkpoint the ``dagger`` action rolls out autonomously
+            between human takeovers. Required for ``dagger``; ignored by every
+            other action.
+        dagger_input_device: How the operator seizes control during a ``dagger``
+            rollout - ``"keyboard"`` (default) or ``"pedal"``. Any other value
+            is refused.
+        dagger_num_episodes: Cap on the corrections collected in one ``dagger``
+            session. A positive whole number, or None for no cap.
 
     Returns:
         Dict with operation status and results:

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -124,12 +124,18 @@ def train_policy(
         method: Tuning strategy - ``"full"`` | ``"lora"`` | ``"expert_only"`` |
             ``"frozen_backbone"``. ``lora`` and ``expert_only`` are mutually
             exclusive.
-        lora_r / lora_alpha / lora_target_modules: LoRA hyperparameters, read
-            only when ``method="lora"``. ``lora_r`` is the adapter rank and
-            ``lora_alpha`` the numerator of its ``lora_alpha / lora_r`` scaling,
-            so each must be a positive integer; omit one to keep peft's default.
-            A zero alpha trains an adapter whose scaling is ``0.0`` and which
-            therefore cannot change the model, so it is refused rather than run.
+        lora_r: LoRA adapter rank, read only when ``method="lora"``. A positive
+            integer, or None to keep peft's default. It is the denominator of
+            the ``lora_alpha / lora_r`` scaling, so anything else is refused by
+            preflight.
+        lora_alpha: Numerator of the LoRA ``lora_alpha / lora_r`` scaling, read
+            only when ``method="lora"``. A positive integer, or None to keep
+            peft's default. Zero trains an adapter whose scaling is ``0.0`` and
+            which therefore cannot change the model, so it is refused rather
+            than run.
+        lora_target_modules: Comma-separated module names the LoRA adapters are
+            attached to, read only when ``method="lora"``. Omit to keep the
+            backend's default target set.
         tune: Fine-grained component toggles for GR00T
             (``{"llm","visual","projector","diffusion"}``).
         val_episodes: Hold out the LAST N episodes for validation; the run

--- a/tests/tools/test_agent_tool_parameter_descriptions.py
+++ b/tests/tools/test_agent_tool_parameter_descriptions.py
@@ -1,0 +1,241 @@
+"""Every parameter an agent tool exposes must describe itself to the model.
+
+A ``@tool`` function's input schema is derived from its docstring by
+``docstring_parser``. When an entry for a parameter is not found in the
+``Args:`` section, the decorator substitutes the placeholder
+``"Parameter <name>"`` - a string that names the parameter and says nothing
+about it. The model driving the tool reads that schema and nothing else, so a
+parameter with a placeholder description is undiscoverable: it cannot be
+learned that ``hf_repo`` is required for one action, that ``remove_volumes``
+discards downloaded checkpoints, or which two values ``dagger_input_device``
+accepts.
+
+Three spellings produce a placeholder, and the second two look like
+documentation in the source, which is what makes the loss silent:
+
+* the entry is absent;
+* the entry sits under a section header other than ``Args:``, where the parser
+  discards it (``TestTheMechanism`` pins this, and it also drops the prose from
+  the tool description);
+* one entry names several parameters at once (``a / b: ...``), which the parser
+  reads as a single parameter literally named ``"a / b"``, matching none of
+  them.
+
+The two assertions below are the consumer-side and the producer-side view of
+the same rule: no exposed parameter may carry the placeholder, and no docstring
+entry may name a parameter the function does not have. Both read live objects,
+so neither needs an exemption list.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import pathlib
+import pkgutil
+from typing import Any
+
+import docstring_parser
+import pytest
+
+import strands_robots.tools as tools_pkg
+
+# Every bound agent tool in the package. Derived from the package object rather
+# than a path literal, so a module added later is covered without an edit.
+_TOOLS_DIR = pathlib.Path(tools_pkg.__file__).parent
+
+
+def _bound_tools() -> list[tuple[str, str, Any]]:
+    """Return ``(module, name, tool)`` for every ``@tool`` in the package."""
+    found: list[tuple[str, str, Any]] = []
+    for info in pkgutil.iter_modules([str(_TOOLS_DIR)]):
+        if info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"strands_robots.tools.{info.name}")
+        for name, obj in vars(module).items():
+            spec = getattr(obj, "tool_spec", None)
+            if isinstance(spec, dict) and spec.get("name") == name:
+                found.append((info.name, name, obj))
+    return sorted(found)
+
+
+_BOUND_TOOLS = _bound_tools()
+_IDS = [f"{mod}.{name}" for mod, name, _ in _BOUND_TOOLS]
+
+# The tools this guard is known to cover. An exact set, so a scan that resolved
+# somewhere else - or stopped finding tools - fails rather than passing over
+# nothing.
+_EXPECTED_TOOLS = frozenset(
+    {
+        "download_assets",
+        "gr00t_inference",
+        "harness_memory",
+        "lerobot_calibrate",
+        "lerobot_camera",
+        "lerobot_teleoperate",
+        "lerobot_train",
+        "pose_tool",
+        "robot_mesh",
+        "run_policy",
+        "serial_tool",
+        "train_policy",
+        "use_lerobot",
+        "use_ros",
+        "use_rosbridge",
+        "use_rtps",
+    }
+)
+
+
+def _placeholder(name: str) -> str:
+    """The description the decorator substitutes for an undocumented param."""
+    return f"Parameter {name}"
+
+
+def _source_function(module_name: str, func_name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    module = importlib.import_module(f"strands_robots.tools.{module_name}")
+    assert module.__file__ is not None
+    tree = ast.parse(pathlib.Path(module.__file__).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == func_name:
+            return node
+    raise AssertionError(f"{module_name}.{func_name} not found in source")
+
+
+def _declared_parameters(func: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    args = func.args
+    return {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs}
+
+
+class TestEveryExposedParameterIsDescribed:
+    """The consumer-side view: what the model receives."""
+
+    def test_the_scan_finds_every_known_tool(self) -> None:
+        assert {name for _mod, name, _tool in _BOUND_TOOLS} == _EXPECTED_TOOLS
+
+    @pytest.mark.parametrize(("module_name", "func_name", "tool"), _BOUND_TOOLS, ids=_IDS)
+    def test_no_parameter_carries_the_placeholder_description(
+        self, module_name: str, func_name: str, tool: Any
+    ) -> None:
+        properties = tool.tool_spec["inputSchema"]["json"]["properties"]
+        undescribed = sorted(
+            name for name, schema in properties.items() if schema.get("description", "").strip() == _placeholder(name)
+        )
+        assert undescribed == [], (
+            f"{module_name}.{func_name} exposes parameters the model cannot learn anything "
+            f"about: {undescribed}. Give each one an entry in the Args: section of "
+            f"{func_name}'s docstring."
+        )
+
+
+class TestEveryDocstringEntryNamesARealParameter:
+    """The producer-side view: what the docstring claims to document."""
+
+    @pytest.mark.parametrize(("module_name", "func_name", "tool"), _BOUND_TOOLS, ids=_IDS)
+    def test_no_entry_names_a_parameter_the_tool_does_not_have(
+        self, module_name: str, func_name: str, tool: Any
+    ) -> None:
+        func = _source_function(module_name, func_name)
+        declared = _declared_parameters(func)
+        parsed = docstring_parser.parse(ast.get_docstring(func) or "")
+        unmatched = sorted(p.arg_name for p in parsed.params if p.arg_name not in declared)
+        assert unmatched == [], (
+            f"{module_name}.{func_name} has Args: entries naming no parameter: {unmatched}. "
+            f"An entry covering several parameters at once is read as one parameter with "
+            f"that literal name, so it describes none of them - give each its own entry."
+        )
+
+
+class TestTheMechanism:
+    """Pin why the three spellings lose the text, so the rule explains itself."""
+
+    def test_an_entry_under_another_section_header_is_discarded(self) -> None:
+        parsed = docstring_parser.parse(
+            "Short.\n"
+            "\n"
+            "    Args:\n"
+            "        documented: Reaches the schema.\n"
+            "\n"
+            "    Container lifecycle args:\n"
+            "        orphan: Reads as documentation and reaches nothing.\n"
+        )
+        assert [p.arg_name for p in parsed.params] == ["documented"]
+
+    def test_one_entry_naming_several_parameters_matches_none_of_them(self) -> None:
+        parsed = docstring_parser.parse("Short.\n\n    Args:\n        lora_r / lora_alpha: Two at once.\n")
+        assert [p.arg_name for p in parsed.params] == ["lora_r / lora_alpha"]
+
+    def test_prose_reaches_the_description_only_before_args(self) -> None:
+        before = docstring_parser.parse(
+            "Short.\n\n    Operator-configured:\n        KEPT.\n\n    Args:\n        documented: Reaches the schema.\n"
+        )
+        after = docstring_parser.parse(
+            "Short.\n"
+            "\n"
+            "    Args:\n"
+            "        documented: Reaches the schema.\n"
+            "\n"
+            "    Operator-configured:\n"
+            "        DROPPED.\n"
+        )
+        assert "KEPT." in (before.long_description or "")
+        assert "DROPPED." not in (after.long_description or "")
+
+
+class TestTheGuardWouldNoticeARegression:
+    """A scan that matched nothing would report a clean sweep."""
+
+    def test_a_planted_undocumented_parameter_is_reported(self) -> None:
+        properties = {
+            "described": {"description": "Something useful."},
+            "planted": {"description": _placeholder("planted")},
+        }
+        undescribed = [
+            name for name, schema in properties.items() if schema.get("description", "").strip() == _placeholder(name)
+        ]
+        assert undescribed == ["planted"]
+
+    def test_a_planted_multi_parameter_entry_is_reported(self) -> None:
+        parsed = docstring_parser.parse("Short.\n\n    Args:\n        real: Fine.\n        one, two: Both at once.\n")
+        unmatched = [p.arg_name for p in parsed.params if p.arg_name not in {"real", "one", "two"}]
+        assert unmatched == ["one, two"]
+
+
+class TestTheLifecycleParametersAreDiscoverable:
+    """The seven options the container-lifecycle actions read (see #148).
+
+    Their descriptions existed in the source under a ``Container lifecycle
+    args`` header, which the parser drops, so none of them reached the model.
+    """
+
+    LIFECYCLE_PARAMETERS = (
+        "hf_repo",
+        "hf_subfolder",
+        "hf_local_dir",
+        "hf_token",
+        "lifecycle",
+        "remove_volumes",
+        "force",
+    )
+
+    def test_each_lifecycle_option_describes_itself(self) -> None:
+        from strands_robots.tools.gr00t_inference import gr00t_inference
+
+        properties = gr00t_inference.tool_spec["inputSchema"]["json"]["properties"]
+        for name in self.LIFECYCLE_PARAMETERS:
+            description = properties[name].get("description", "").strip()
+            assert description != _placeholder(name)
+            assert len(description) > len(_placeholder(name))
+
+    def test_a_destructive_option_says_what_it_destroys(self) -> None:
+        from strands_robots.tools.gr00t_inference import gr00t_inference
+
+        properties = gr00t_inference.tool_spec["inputSchema"]["json"]["properties"]
+        assert "checkpoint" in properties["remove_volumes"]["description"]
+
+    def test_the_operator_configured_note_reaches_the_description(self) -> None:
+        from strands_robots.tools.gr00t_inference import gr00t_inference
+
+        description = gr00t_inference.tool_spec["description"]
+        assert "host RCE" in description
+        assert "STRANDS_GR00T_REPO_URL_ALLOW" in description


### PR DESCRIPTION
## Problem

A `@tool` function's input schema is derived from its docstring. When the decorator cannot find an entry for a parameter in the `Args:` section, it substitutes the placeholder `"Parameter <name>"` - a string that names the parameter and says nothing about it. The model driving the tool reads that schema and nothing else.

Measured across all 16 bound agent tools, **13 parameters reached the model as a placeholder**:

| tool | parameters |
|---|---|
| `gr00t_inference` | `hf_repo`, `hf_subfolder`, `hf_local_dir`, `hf_token`, `lifecycle`, `remove_volumes`, `force` |
| `lerobot_teleoperate` | `policy_path`, `dagger_input_device`, `dagger_num_episodes` |
| `train_policy` | `lora_r`, `lora_alpha`, `lora_target_modules` |

The seven on `gr00t_inference` are precisely the container-lifecycle options, whose stated purpose is that "an LLM driving the AgentTool can fully orchestrate a GR00T eval from a single prompt" (module docstring, #148). From the schema alone it cannot be learned that `hf_repo` is required for `download_checkpoint`, that `lifecycle="teardown"` removes the container, that `remove_volumes=True` discards downloaded checkpoints, or that `dagger_input_device` accepts exactly two values.

## Ten of the thirteen were already described

That is what makes the loss silent - the text is in the source and simply does not arrive:

- **Seven** sat under a `Container lifecycle args (used by ...)` section header. `docstring_parser` recognises `Args:` and discards an unknown section entirely, so all seven entries vanished - **and so did the paragraph explaining why the build repo, image and volumes are operator-configured rather than agent parameters** (an agent-supplied git URL would clone an attacker tree and `bash docker/build.sh` it). Prose reaches the tool description only when it appears *before* `Args:`; that section came after, so it reached neither the parameters nor the description.
- **Three** shared one entry, `lora_r / lora_alpha / lora_target_modules: ...`. The parser reads that as a single parameter literally named `"lora_r / lora_alpha / lora_target_modules"`, which matches none of the three - so the entry described nothing while reading as documentation for all of them.
- **Three** (`lerobot_teleoperate`'s dagger options) were genuinely absent.

Each mechanism is pinned directly against `docstring_parser` in `TestTheMechanism`, so the rule explains itself rather than asserting itself.

## Change

- The seven lifecycle entries move into `Args:`, in signature order.
- The operator-configured note moves **ahead of** `Args:`, so it now reaches the tool description as well as a human reading the source. One sentence in it documented default volume mounts under `hf_token`, where it did not belong; it moves into that note.
- The combined LoRA entry splits into three, one per parameter.
- `lerobot_teleoperate`'s `policy_path`, `dagger_input_device` and `dagger_num_episodes` get the entries they never had.
- `AGENTS.md` gains Key Conventions #13 stating the rule and naming all three spellings.

No production behaviour changes: only docstrings, plus a new test module and one AGENTS.md convention. This touches no policy, simulation, rendering, recording or asset behaviour, so the artifact below is a measurement of the schema rather than a rollout.

## Guard

`tests/tools/test_agent_tool_parameter_descriptions.py` pins both directions of the rule over every bound tool, discovered from the package object rather than a path literal:

- **consumer side** - no parameter of a tool's input schema may carry the `"Parameter <name>"` placeholder;
- **producer side** - no docstring entry may name a parameter the tool does not have (this is what a combined `a / b:` entry looks like from the outside).

Plus a non-vacuity assertion on the exact 16-tool set, so a scan that resolved elsewhere fails rather than reporting a clean sweep over nothing, and planted-defect tests for both directions.

## Measured

![agent tool parameter descriptions](https://raw.githubusercontent.com/cagataycali/robots/artifacts/agent-tool-parameter-descriptions/agent_tool_parameter_descriptions.png)

Every cell is read from a live `tool_spec` by one script run unchanged in a worktree at `main` and in this branch; the generator asserts the two dumps came from different trees and re-derives every number it prints. Scripts and both JSON dumps: [`artifacts/agent-tool-parameter-descriptions`](https://github.com/cagataycali/robots/tree/artifacts/agent-tool-parameter-descriptions).

| | main | this change |
|---|---|---|
| placeholder parameters (16 tools) | 13 | 0 |
| docstring entries naming no parameter | 1 | 0 |
| `"host RCE"` note in the `gr00t_inference` description | absent | present |

## Gate

Base `1890003d`. `scripts/check_merge_base_overlap.py`: *No overlap ... 0 path(s) changed on `upstream/main` in that span.*

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1146 files).
- `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`. The 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy (environmental, pre-existing).
- `MUJOCO_GL=egl pytest tests`: **27042 passed, 257 skipped, 0 failed** (601s). Zero existing tests changed.
- Pre-fix proof, at this same base, with the source reverted to `main` and the new tests kept: **7 failed, 34 passed**, each failure quoting the defect (`assert 'Parameter hf_repo' != 'Parameter hf_repo'`, `assert 'checkpoint' in 'Parameter remove_volumes'`, `'host RCE'` absent from the description). The 34 that pass are the three mechanism pins, the planted-defect tests and the 13 tools that were already clean - which is what keeps the guard from over-reaching.
