### PR TITLE
fix(examples): use the parameter names the dispatch router accepts, and surface its refusals

### DIFF
--- a/changelog.d/2091-example-dispatch-parameter-names.md
+++ b/changelog.d/2091-example-dispatch-parameter-names.md
@@ -1,0 +1,23 @@
+### Fixed: the sim VLA example passed parameter names the dispatch router refuses, and discarded the refusal
+
+`examples/vla/molmoact2_sim_pickplace.py` passed `camera_name` to `add_camera`
+(whose parameter is `name`) and to `get_observation` (which takes `robot_name` /
+`skip_images`). `camera_name` is the render-side spelling -- correct for
+`render`, `render_depth`, `get_frame`, `get_camera_params` and `get_world_point`
+-- so both mistakes read plausible.
+
+Neither call checked its result. The router reports an unknown parameter by
+RETURNING `{"status": "error", ...}` rather than raising, so the example ran on
+with only the `default` camera: the policy was handed an observation without the
+`front` view it was trained on and failed much later complaining about missing
+image keys, pointing at the policy rather than at the call that was refused.
+Both parameters are corrected and every dispatch in the example now goes through
+a `_must` helper that raises on an error envelope, matching
+`examples/lerobot/collect_train_run_molmoact2.py`.
+
+A new guard statically scans every example for calls written with a literal
+action name and a literal parameter dict and checks each name against the
+router's own acceptance rule, derived from the live engine class so it tracks
+the router rather than drifting from it. It matches by call shape rather than by
+callee name, so an example that wraps the router in a local `_must` helper is
+still covered.

--- a/examples/vla/molmoact2_sim_pickplace.py
+++ b/examples/vla/molmoact2_sim_pickplace.py
@@ -21,6 +21,7 @@ import argparse
 import asyncio
 import logging
 import time
+from typing import Any
 
 from strands_robots import Robot
 from strands_robots.policies import create_policy
@@ -29,6 +30,23 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("molmoact2_sim")
 
 REPO = "allenai/MolmoAct2-SO100_101"
+
+
+def _must(sim: Any, action: str, params: dict[str, Any]) -> Any:
+    """Dispatch a sim action and fail loud on error.
+
+    The dispatch router reports a bad parameter by RETURNING
+    ``{"status": "error", ...}`` rather than raising. Discarding that result lets
+    scene setup silently no-op: an ``add_camera`` that never ran leaves the world
+    holding only the default camera, so the policy is handed an observation
+    without the view it was trained on and fails much later complaining about
+    missing image keys -- pointing at the policy rather than at the call that was
+    refused. Per AGENTS.md ("no silent defaults on error"), surface it here.
+    """
+    result = sim._dispatch_action(action, params)
+    if isinstance(result, dict) and result.get("status") == "error":
+        raise RuntimeError(f"sim action {action!r} failed: {result.get('content', result)}")
+    return result
 
 
 def main():
@@ -46,10 +64,14 @@ def main():
     log.info("Simulation world created: %s", sim.tool_name)
 
     # Add a camera to the sim world for visual observations.
-    sim._dispatch_action(
+    _must(
+        sim,
         "add_camera",
         {
-            "camera_name": "front",
+            # ``add_camera`` names the new camera with ``name``. ``camera_name``
+            # is the render-side spelling (render / render_depth / get_frame /
+            # get_camera_params / get_world_point); the router rejects it here.
+            "name": "front",
             "position": [0.5, 0.0, 0.5],
             "target": [0.0, 0.0, 0.1],
             "width": 640,
@@ -67,21 +89,24 @@ def main():
     policy.reset()
 
     # Retrieve initial sim state to verify observation keys.
-    state = sim._dispatch_action("get_state", {})
+    state = _must(sim, "get_state", {})
     log.info("Sim state keys: %s", list(state.keys()) if isinstance(state, dict) else "N/A")
 
     async def run():
         period = 1.0 / args.hz
         for step in range(args.steps):
             # In sim mode, observations come from MuJoCo rendering.
-            obs_result = sim._dispatch_action("get_observation", {"camera_name": "front"})
+            # ``get_observation`` takes ``robot_name`` / ``skip_images`` and
+            # returns EVERY attached camera, so there is no per-call camera
+            # selector to pass here.
+            obs_result = _must(sim, "get_observation", {})
             t = time.time()
             actions = await policy.get_actions(obs_result, args.task)
             dt = time.time() - t
             a = actions[0]
             log.info("step %d infer=%.2fs action=%s", step, dt, {k: round(v, 1) for k, v in a.items()})
             if not args.dry_run:
-                sim._dispatch_action("set_joint_positions", {"positions": a})
+                _must(sim, "set_joint_positions", {"positions": a})
             await asyncio.sleep(max(0, period - dt))
 
     try:

--- a/tests/test_examples_dispatch_action_params.py
+++ b/tests/test_examples_dispatch_action_params.py
@@ -168,7 +168,6 @@ class TestTheAcceptanceMirrorAgreesWithTheRouter:
             ("get_world_point", "camera_name", True),
             ("run_policy", "camera_name", True),  # folded into video.camera
         ],
-        ids=lambda v: str(v),
     )
     def test_mirror_verdict(self, action: str, param: str, accepted: bool) -> None:
         allowed = _accepted_params(action)

--- a/tests/test_examples_dispatch_action_params.py
+++ b/tests/test_examples_dispatch_action_params.py
@@ -1,0 +1,176 @@
+"""Examples must not pass a parameter the dispatch router refuses.
+
+``sim._dispatch_action(action, params)`` reports an unknown parameter by
+RETURNING ``{"status": "error", ...}`` rather than raising, so an example that
+discards the result silently no-ops. The observed defect (#244): a sim VLA
+example passed ``camera_name`` to ``add_camera``, whose parameter is ``name``.
+``camera_name`` is the render-side spelling (``render`` / ``render_depth`` /
+``get_frame`` / ``get_camera_params`` / ``get_world_point``), so the mistake
+reads plausible -- and because the envelope was dropped the world kept only its
+default camera and the policy failed much later complaining about missing image
+keys, pointing at the policy instead of the refused call.
+
+This statically scans every example for ``_dispatch_action`` calls written with
+a literal action name and a literal parameter dict, and checks each parameter
+name against the router's own acceptance rule. The accepted set is DERIVED from
+the live engine class (its ``_ACTION_ALIASES`` / ``_FIELD_ALIASES`` /
+``_ROUTER_PASSTHROUGH`` plus ``inspect.signature``) rather than hand-listed, so
+the guard tracks the router instead of drifting from it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+
+_EXAMPLES_DIR = Path(inspect.getfile(MuJoCoSimEngine)).resolve().parents[3] / "examples"
+
+# Actions that fold flat video keys into a structured ``video`` dict; the router
+# accepts those flat keys at its boundary even though the method takes ``video``.
+_VIDEO_FOLDING_ACTIONS = frozenset({"run_policy", "start_policy", "eval_policy", "evaluate_benchmark"})
+_VIDEO_FLAT_KEYS = frozenset({"output_path", "fps", "camera_name"})
+
+
+def _accepted_params(action: str) -> frozenset[str] | None:
+    """Names the router accepts for ``action``, or ``None`` if it accepts anything.
+
+    Mirrors ``MuJoCoSimEngine._validate_and_build_kwargs``: a method declaring
+    ``**kwargs`` legitimately passes residual keys through, so the router skips
+    the unknown-key check for it and so does this guard.
+    """
+    method_name = MuJoCoSimEngine._ACTION_ALIASES.get(action, action)
+    method = getattr(MuJoCoSimEngine, method_name, None)
+    if method is None or action.startswith("_"):
+        return frozenset()  # unknown action: no parameter is acceptable
+    sig = inspect.signature(method)
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return None
+    named = {
+        n
+        for n, p in sig.parameters.items()
+        if n != "self" and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    accepted = named | set(MuJoCoSimEngine._FIELD_ALIASES) | set(MuJoCoSimEngine._ROUTER_PASSTHROUGH)
+    if action in _VIDEO_FOLDING_ACTIONS:
+        accepted |= _VIDEO_FLAT_KEYS
+    # name/robot_name are aliased in both directions by the router.
+    if "name" in named:
+        accepted.add("robot_name")
+    if "robot_name" in named:
+        accepted.add("name")
+    return frozenset(accepted)
+
+
+def _is_router_action(action: str) -> bool:
+    """True when ``action`` names a real dispatchable method on the engine."""
+    if action.startswith("_"):
+        return False
+    method_name = MuJoCoSimEngine._ACTION_ALIASES.get(action, action)
+    return callable(getattr(MuJoCoSimEngine, method_name, None))
+
+
+def _literal_dispatch_calls(source: str) -> list[tuple[int, str, tuple[str, ...]]]:
+    """``(lineno, action, param_names)`` for each literal action + params call.
+
+    Matched by SHAPE rather than by callee name: any call passing an adjacent
+    ``("<known action>", {literal dict})`` positional pair. Examples routinely
+    wrap the router in a local ``_must(sim, action, params)`` helper that raises
+    on an error envelope, and a scanner keyed on ``_dispatch_action`` would go
+    blind on exactly the examples that handle errors correctly. Requiring the
+    string to name a real engine method keeps the shape from matching unrelated
+    two-argument calls.
+    """
+    found: list[tuple[int, str, tuple[str, ...]]] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        for first, second in zip(node.args, node.args[1:], strict=False):
+            if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
+                continue
+            if not isinstance(second, ast.Dict) or not _is_router_action(first.value):
+                continue
+            keys = [k.value for k in second.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+            if len(keys) != len(second.keys):
+                continue  # a non-literal key: nothing static to check
+            found.append((node.lineno, first.value, tuple(keys)))
+    return found
+
+
+def _example_sources() -> list[Path]:
+    return sorted(p for p in _EXAMPLES_DIR.rglob("*.py") if p.is_file())
+
+
+def _all_calls() -> list[tuple[Path, int, str, tuple[str, ...]]]:
+    calls: list[tuple[Path, int, str, tuple[str, ...]]] = []
+    for path in _example_sources():
+        for lineno, action, keys in _literal_dispatch_calls(path.read_text(encoding="utf-8")):
+            calls.append((path, lineno, action, keys))
+    return calls
+
+
+class TestExamplesUseParametersTheRouterAccepts:
+    """Every literal ``_dispatch_action`` in an example must name real parameters."""
+
+    def test_no_example_passes_a_parameter_the_router_refuses(self) -> None:
+        offenders: list[str] = []
+        for path, lineno, action, keys in _all_calls():
+            accepted = _accepted_params(action)
+            if accepted is None:
+                continue
+            for key in keys:
+                if key not in accepted:
+                    rel = path.relative_to(_EXAMPLES_DIR.parent)
+                    offenders.append(
+                        f"{rel}:{lineno}: action {action!r} does not accept {key!r}; valid: {sorted(accepted)}"
+                    )
+        assert not offenders, "examples pass parameters the dispatch router refuses:\n" + "\n".join(offenders)
+
+    def test_the_scan_finds_the_examples_it_is_meant_to_cover(self) -> None:
+        """Non-vacuity: a mis-rooted scan must not report a clean sweep over nothing."""
+        calls = _all_calls()
+        assert calls, f"no literal _dispatch_action calls found under {_EXAMPLES_DIR}"
+        actions = {action for _, _, action, _ in calls}
+        assert "add_camera" in actions, f"add_camera call not discovered; found {sorted(actions)}"
+
+    def test_a_planted_bad_parameter_is_detected(self) -> None:
+        """Meta: an empty offender list must mean clean sources, not a blind scanner."""
+        for planted in (
+            'sim._dispatch_action("add_camera", {"camera_name": "front"})\n',
+            '_must(sim, "add_camera", {"camera_name": "front"})\n',  # the wrapper form
+        ):
+            calls = _literal_dispatch_calls(planted)
+            assert calls == [(1, "add_camera", ("camera_name",))], (planted, calls)
+        accepted = _accepted_params("add_camera")
+        assert accepted is not None
+        assert "camera_name" not in accepted
+        assert "name" in accepted
+
+
+class TestTheAcceptanceMirrorAgreesWithTheRouter:
+    """The derived set must match what the live router actually does."""
+
+    @pytest.mark.parametrize(
+        ("action", "param", "accepted"),
+        [
+            ("add_camera", "name", True),
+            ("add_camera", "camera_name", False),  # the #244 defect
+            ("add_camera", "position", True),
+            ("get_observation", "robot_name", True),
+            ("get_observation", "camera_name", False),  # same file, same mistake
+            ("render", "camera_name", True),  # the render-side spelling is correct here
+            ("get_world_point", "camera_name", True),
+            ("run_policy", "camera_name", True),  # folded into video.camera
+        ],
+        ids=lambda v: str(v),
+    )
+    def test_mirror_verdict(self, action: str, param: str, accepted: bool) -> None:
+        allowed = _accepted_params(action)
+        assert allowed is not None, f"{action} accepts **kwargs; nothing to assert"
+        assert (param in allowed) is accepted


### PR DESCRIPTION
## Problem

`examples/vla/molmoact2_sim_pickplace.py` passes `camera_name` to two actions that do not accept it:

| line | action | parameter passed | the action's parameters |
|---|---|---|---|
| 49 | `add_camera` | `camera_name` | `fov, height, name, parent_body, position, target, width` |
| 77 | `get_observation` | `camera_name` | `robot_name, skip_images` |

`camera_name` is the **render-side** spelling and is correct for `render`, `render_depth`, `get_frame`, `get_camera_params` and `get_world_point` — which is exactly why both mistakes read plausible.

**Neither call checked its result.** The dispatch router reports an unknown parameter by *returning* `{"status": "error", ...}` rather than raising, and all four `_dispatch_action` calls in this example discarded the return value. So it did not fail at camera creation — it ran on:

```
add_camera  -> status=error   "Unknown parameter 'camera_name' for action 'add_camera'."
list_cameras ->               only 'default'
observation  ->               image keys ['default']      <- no 'front'
```

The policy was then handed an observation without the `front` view it was trained on and failed much later complaining about missing image keys, pointing the reader at the policy or the embodiment rather than at the call that was refused.

## Change

- `add_camera`: `camera_name` -> `name`.
- `get_observation`: the parameter is dropped. It takes `robot_name` / `skip_images` and returns *every* attached camera, so there is no per-call camera selector to pass.
- Every dispatch in the example routes through a `_must` helper that raises on an error envelope.

That last part is not new invention: `examples/lerobot/collect_train_run_molmoact2.py` already does exactly this, and its docstring already documented the trap —

> Note: `add_camera` takes `name` (not `camera_name`); the dispatch router rejects unknown kwargs. `render` is the action that takes `camera_name`. Every call is routed through `_must` so a schema mismatch fails loud instead of silently producing a camera-less scene.

…while its `_must` docstring states the consequence: *"a camera that never gets added means the recorded dataset has no frames and inference sees no images."* The rule was written down; this example was the one not following it.

## Guard

A parameter fix alone would rot, so `tests/test_examples_dispatch_action_params.py` scans every example for calls written with a literal action name and a literal parameter dict and checks each name against the router's acceptance rule. The accepted set is **derived from the live engine class** (`_ACTION_ALIASES`, `_FIELD_ALIASES`, `_ROUTER_PASSTHROUGH`, `inspect.signature`, the `**kwargs` skip, the `name`/`robot_name` two-way alias, and the flat-video-key folding), so it tracks the router instead of drifting from it.

It matches by **call shape** rather than callee name — any `("<known action>", {literal dict})` positional pair. That detail was found by the guard's own non-vacuity test: a scanner keyed on `_dispatch_action` goes blind on exactly the examples that handle errors correctly, because they wrap the router in a local `_must`. Requiring the string to name a real engine method keeps the shape from matching unrelated two-argument calls.

Three companions: an exact-discovery non-vacuity test, a planted-defect meta-test covering **both** the bare and the wrapped call form, and a mirror-fidelity table pinning that the derived set agrees with the router on the cases that matter (`add_camera`/`name` accepted, `add_camera`/`camera_name` refused, `render`/`camera_name` accepted, `run_policy`/`camera_name` accepted via video folding).

## Verification

Pre-fix (example reverted to `upstream/main`, guard kept) — the guard names **both** sites:

```
examples/vla/molmoact2_sim_pickplace.py:49: action 'add_camera' does not accept 'camera_name';
  valid: [... 'fov', 'height', 'name', 'parent_body', 'position', 'target', 'width']
examples/vla/molmoact2_sim_pickplace.py:77: action 'get_observation' does not accept 'camera_name';
  valid: [... 'robot_name', 'skip_images']
1 failed, 10 passed
```

Post-fix: `11 passed`. The 10 that pass pre-fix are the mirror-fidelity and meta tests, which are properties of the router rather than of the example.

Gate on Thor at `1890003d`:

- `MUJOCO_GL=egl pytest tests` -> **27012 passed, 257 skipped, 0 failed** (661s)
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` -> clean, 1146 files
- `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1143 source files`
- `scripts/check_merge_base_overlap.py` -> no overlap, 0 paths changed in that span; `compare` reports `behind_by=0`, so the tree these numbers describe is the merge result

## Artifact

The view the policy is actually fed, measured headless in MuJoCo (`MUJOCO_GL=egl`). One tree — the only variable is the parameter name. Panels differ on **75.3%** of pixels; both are real renders.

![what the policy is fed](https://raw.githubusercontent.com/cagataycali/robots/artifacts/example-dispatch-parameter-names/camera_param_244.png)

Capture and compose scripts, the raw measurements and the two probes are on the `artifacts/example-dispatch-parameter-names` branch.

## Round 1 — clearing the CodeQL note (no production change)

`py/unnecessary-lambda` flagged `ids=lambda v: str(v)` on `test_mirror_verdict`. The rule names two readings — "use that object directly" would be `ids=str` — so I measured which is right before editing. All three parameters are ASCII strings and bools, so pytest's default already produces exactly what the lambda produced:

| `ids=` | ids | md5 of the id set |
| --- | --- | --- |
| `lambda v: str(v)` (before) | 8 | `3dd4ff02504457f199f2357cebebb284` |
| `str` | 8 | `3dd4ff02504457f199f2357cebebb284` |
| removed (default) | 8 | `3dd4ff02504457f199f2357cebebb284` |

Byte-identical, so the argument stated nothing and `ids=str` would have left an argument that does literally nothing. **Removed** it instead — which also makes the file consistent with the suite: of 1789 `parametrize` blocks this was the only one wrapping a callable without transforming it, and the other 14 `ids=lambda` all derive something the default cannot, so none of them is touched.

Verified with a mirror of the rule's predicate, validated against the alert before being trusted: it reproduces alert 882 exactly at line 171 columns 13-29 and reports nothing afterwards (`pre-fix [(171, 13, 29)]` -> `post-fix []`). Script: [`rule_mirror.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/unnecessary-lambda-ids/rule_mirror.py)

No new test: the property at stake *is* the generated id set, and the eight parametrized cases are what exercise it — the table above is the measurement, so an extra assertion would only restate it. Re-gated at head `26f6445`: `MUJOCO_GL=egl pytest tests` -> **27012 passed, 257 skipped, 0 failed** (622s), the same count as the pre-round run since the diff removes an argument rather than a case; `ruff check` / `ruff format --check` clean over 1146 files; `mypy` 0 errors outside `examples/isaac_gs`; the 8 collected ids unchanged; scoped module 11 passed. Diff is `1 file changed, 1 deletion(-)`, no production line.

