### PR TITLE
test(tools): cover the wrapper-mount probe behind the deterministic GR00T skip

### DIFF
--- a/changelog.d/2092-gr00t-wrapper-mount-probe-coverage.md
+++ b/changelog.d/2092-gr00t-wrapper-mount-probe-coverage.md
@@ -1,0 +1,17 @@
+### Quality: the wrapper-mount probe behind the deterministic GR00T skip is now tested
+
+`_container_has_wrapper_mount` decides whether an already-running container may be
+handed back for a `deterministic=True` start. A container started without the wrapper
+mount cannot serve one - the exec'd `python /srv_wrap.py` dies inside the container long
+after `start_container` returned success - so the probe reports the mount absent and the
+caller fails fast with an actionable "recreate with `force=True`" error.
+
+The two lifecycle tests that reach that branch replace the probe with a stub returning
+`True`/`False`, so they pinned what the caller does with each answer and nothing about
+how the answer is produced: the probe's whole body was unexecuted. Its contract is now
+pinned - a mount at the wrapper path is detected, a path that merely contains it (say
+`/srv_wrap.py.bak`) is not, and every docker invocation failure (non-zero exit, missing
+binary, OS error) reports the mount absent rather than passing silently - together with
+both lifecycle outcomes driven through the real probe instead of a stub.
+
+No library behaviour changes.

--- a/tests/tools/test_gr00t_wrapper_mount_detection.py
+++ b/tests/tools/test_gr00t_wrapper_mount_detection.py
@@ -1,0 +1,148 @@
+"""The wrapper-mount probe behind the ``deterministic=True`` idempotent skip.
+
+:func:`~strands_robots.tools.gr00t_inference._container_has_wrapper_mount` is the
+predicate that decides whether an already-running container may be handed back
+for a deterministic ``start``. A container started without the wrapper mount
+cannot serve one: the exec'd ``python /srv_wrap.py`` would die inside the
+container long after ``start_container`` returned success, so the probe must
+report the mount absent and let the caller fail fast with the actionable
+"recreate with force=True" error.
+
+The two lifecycle tests that reach that branch replace the probe with a stub
+returning ``True``/``False``, so they pin what the *caller* does with each
+answer and nothing about how the answer is produced. This module pins the probe
+itself: how it reads ``docker inspect`` output, and that both lifecycle outcomes
+still hold when the real probe - not a stub - supplies the answer.
+
+Every claim its docstring makes is pinned here: a mount at the wrapper path is
+detected, anything else is reported absent, and any docker invocation failure
+(non-zero exit, missing binary, OS error) is reported absent rather than
+passing silently.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+gi = importlib.import_module("strands_robots.tools.gr00t_inference")
+
+from tests.tools.test_gr00t_deterministic import _container_kwargs  # noqa: E402
+
+WRAPPER_PATH = gi._DETERMINISTIC_WRAPPER_CONTAINER_PATH
+
+# Shape captured from a real ``docker inspect --format
+# '{{range .Mounts}}{{.Destination}}<LF>{{end}}'`` run (Docker 29.0.0): one
+# destination per line, plus a trailing empty line from the final range
+# iteration. The ``<LF>`` is a real newline - the format string is a plain
+# Python literal, so the escape is resolved before docker ever sees it.
+MOUNTED = f"{WRAPPER_PATH}\n/data\n\n"
+NOT_MOUNTED = "/data\n/checkpoints\n\n"
+NO_MOUNTS = "\n"
+
+
+def _inspect_returning(stdout: str, returncode: int = 0) -> Any:
+    """A ``subprocess.run`` stand-in for the probe's ``docker inspect`` call."""
+
+    def fake_run(cmd: list[str], *a: Any, **kw: Any) -> Any:
+        return MagicMock(stdout=stdout, stderr="", returncode=returncode)
+
+    return fake_run
+
+
+class TestTheProbeReadsDockerInspectOutput:
+    """The probe's own contract: what it makes of what docker prints."""
+
+    def test_a_mount_at_the_wrapper_path_is_detected(self) -> None:
+        with patch.object(gi.subprocess, "run", side_effect=_inspect_returning(MOUNTED)):
+            assert gi._container_has_wrapper_mount("gr00t") is True
+
+    def test_other_mounts_only_are_reported_absent(self) -> None:
+        with patch.object(gi.subprocess, "run", side_effect=_inspect_returning(NOT_MOUNTED)):
+            assert gi._container_has_wrapper_mount("gr00t") is False
+
+    def test_a_container_with_no_mounts_is_reported_absent(self) -> None:
+        with patch.object(gi.subprocess, "run", side_effect=_inspect_returning(NO_MOUNTS)):
+            assert gi._container_has_wrapper_mount("gr00t") is False
+
+    @pytest.mark.parametrize(
+        "destination",
+        [f"{WRAPPER_PATH}.bak", f"{WRAPPER_PATH}2", f"/opt{WRAPPER_PATH}"],
+        ids=["suffixed", "digit-suffixed", "nested-under-another-prefix"],
+    )
+    def test_a_path_merely_containing_the_wrapper_path_is_not_a_match(self, destination: str) -> None:
+        """The probe matches a whole destination, not a substring of one.
+
+        A container bind-mounting ``/srv_wrap.py.bak`` has no wrapper at
+        ``/srv_wrap.py``, so treating it as mounted would let a deterministic
+        start skip onto a container that cannot serve it - the exact outcome the
+        probe exists to prevent.
+        """
+        with patch.object(gi.subprocess, "run", side_effect=_inspect_returning(f"{destination}\n\n")):
+            assert gi._container_has_wrapper_mount("gr00t") is False
+
+    def test_a_non_zero_docker_exit_is_reported_absent(self) -> None:
+        """``docker inspect`` failing (a vanished container) must not read as mounted."""
+        with patch.object(gi.subprocess, "run", side_effect=_inspect_returning(MOUNTED, returncode=1)):
+            assert gi._container_has_wrapper_mount("gr00t") is False
+
+    @pytest.mark.parametrize(
+        "failure",
+        [FileNotFoundError("docker"), OSError("docker daemon unreachable")],
+        ids=["docker-binary-missing", "os-error"],
+    )
+    def test_a_failed_docker_invocation_is_reported_absent(self, failure: Exception) -> None:
+        with patch.object(gi.subprocess, "run", side_effect=failure):
+            assert gi._container_has_wrapper_mount("gr00t") is False
+
+    def test_the_probe_asks_docker_for_the_named_container_s_mount_destinations(self) -> None:
+        """Pins the premise the fixtures above rest on: one destination per line."""
+        seen: list[list[str]] = []
+
+        def fake_run(cmd: list[str], *a: Any, **kw: Any) -> Any:
+            seen.append(list(cmd))
+            return MagicMock(stdout=MOUNTED, stderr="", returncode=0)
+
+        with patch.object(gi.subprocess, "run", side_effect=fake_run):
+            gi._container_has_wrapper_mount("some-container")
+
+        assert len(seen) == 1
+        cmd = seen[0]
+        assert cmd[:3] == ["docker", "inspect", "--format"]
+        assert cmd[-1] == "some-container"
+        fmt = cmd[3]
+        assert ".Mounts" in fmt and ".Destination" in fmt
+        # A real newline, not a literal backslash-n: docker prints one
+        # destination per line, which is what makes the token split exact.
+        assert "\n" in fmt
+
+
+class TestTheDeterministicSkipThroughTheRealProbe:
+    """Both lifecycle outcomes, with the real probe supplying the answer."""
+
+    @staticmethod
+    def _start_with_inspect(stdout: str) -> dict[str, Any]:
+        def fake_run(cmd: list[str], *a: Any, **kw: Any) -> Any:
+            if cmd[:2] == ["docker", "inspect"]:
+                return MagicMock(stdout=stdout, stderr="", returncode=0)
+            raise AssertionError(f"docker must not be invoked for {cmd[:2]}")
+
+        with (
+            patch.object(gi, "_container_state", return_value="running"),
+            patch.object(gi.subprocess, "run", side_effect=fake_run),
+        ):
+            return gi._start_container(**_container_kwargs(deterministic=True, force=False))
+
+    def test_a_running_container_without_the_mount_fails_fast(self) -> None:
+        result = self._start_with_inspect(NOT_MOUNTED)
+        assert result["status"] == "error"
+        assert "force=True" in result["message"]
+        assert WRAPPER_PATH in result["message"]
+
+    def test_a_running_container_with_the_mount_is_skipped(self) -> None:
+        result = self._start_with_inspect(MOUNTED)
+        assert result["status"] == "success"
+        assert result["skipped"] is True


### PR DESCRIPTION
## Problem

`_container_has_wrapper_mount` is the predicate behind the `deterministic=True`
idempotent skip in `gr00t_inference`. When `start_container` finds a container
already running and `force=False`, it asks the probe whether that container has
the determinism wrapper bind-mounted at `/srv_wrap.py`. A container started
without it cannot serve a deterministic start — the exec'd `python /srv_wrap.py`
dies inside the container long after `start_container` returned success — so the
probe reports the mount absent and the caller fails fast with an actionable
"recreate with `force=True`" error instead of skipping onto a container that
cannot work.

The two lifecycle tests that reach that branch replace the probe with a stub:

```python
patch.object(gi, "_container_has_wrapper_mount", return_value=False),
patch.object(gi, "_container_has_wrapper_mount", return_value=True),
```

So they pin what the *caller* does with each answer, and nothing about how the
answer is produced. The probe's whole body was unexecuted — the caller line is
covered while lines 1621-1632 are not — which means none of the three claims its
own docstring makes was verified:

- a mount at the wrapper path is detected,
- a non-zero `docker inspect` exit reports the mount absent,
- "Any docker invocation failure returns False, which surfaces as the actionable
  'recreate with force=True' error rather than a silent pass."

The failure direction matters: if the probe ever reported a mount that is not
there, a deterministic start would report success on a container that cannot
serve one — the exact outcome the probe exists to prevent.

## Change

Tests only. No production line changes.

A new module pins the probe's contract, and pins both lifecycle outcomes driven
through the **real** probe rather than a stub:

- a mount at the wrapper path is detected; other mounts only, and no mounts at
  all, are reported absent;
- a destination that merely *contains* the wrapper path (`/srv_wrap.py.bak`,
  `/srv_wrap.py2`, `/opt/srv_wrap.py`) is **not** a match — the probe compares
  whole destinations, so a substring implementation would let a deterministic
  start skip onto a container with no wrapper at `/srv_wrap.py`;
- a non-zero `docker inspect` exit, a missing `docker` binary, and an `OSError`
  each report the mount absent;
- the probe asks docker for the named container's mount destinations, and the
  format string carries a real newline — the premise that makes the token split
  exact, and the premise the fixtures rest on;
- with the real probe supplying the answer, a running container without the
  mount fails fast with the `force=True` message, and one with the mount is
  skipped.

Fixture shape was captured from a real `docker inspect --format
'{{range .Mounts}}{{.Destination}}<LF>{{end}}'` run (Docker 29.0.0): one
destination per line plus a trailing blank line from the final range iteration.
The `<LF>` is a real newline — the format string is a plain Python literal, so
the escape is resolved before docker ever sees it.

## Coverage

Measured over `tests/tools` with `--cov=strands_robots.tools.gr00t_inference`,
identical command both arms (the second arm adds only the new module):

| | Stmts | Miss | Cover | Missing |
|---|---|---|---|---|
| before | 484 | 24 | 95% | `351, 1494, 1621-1632, 2025-2039` |
| after | 484 | **17** | **96%** | `351, 1494, 2025-2039` |

The `1621-1632` block — the probe's entire body — is closed. Both arms report the
same 18 pre-existing failures in `test_use_lerobot.py` (an artifact of narrowing
`--cov` to one module on a subset, present with and without this change), and
passed goes 1940 → 1952, exactly the 12 new cases.

The remaining 15 lines are the `if __name__ == "__main__":` usage banner, which
is a printed demo rather than behaviour; `351` and `1494` are single defensive
branches.

## The tests have teeth

Three mutations of the probe, each applied to the function only (verified unique
inside its line range, since two sibling helpers share the same `except` clause):

| mutation | result |
|---|---|
| `in result.stdout` instead of `in result.stdout.split()` | **3 failed** — every whole-token case |
| `if result.returncode != 0: return False` removed | **1 failed** |
| `except (FileNotFoundError, OSError)` narrowed to `(FileNotFoundError,)` | **1 failed** — `OSError` escapes |

Each mutation was reverted and the tree confirmed byte-identical to the commit.

## Gate

At `bdd5fb05` (rebased onto it before verifying, so these numbers describe the
tree that merges; the overlap check reports `0 path(s) changed on upstream/main
in that span` and `compare` reports `behind_by=0`):

- `MUJOCO_GL=egl pytest tests` — **27065 passed, 257 skipped, 0 failed** (595s)
- `ruff check strands_robots tests tests_integ` — all checks passed
- `ruff format --check strands_robots tests tests_integ` — 1148 files already formatted
- `mypy strands_robots tests tests_integ` — 14 errors, all in `examples/isaac_gs`,
  **0 outside**; the error set is byte-identical to the same command on a
  pristine checkout of the base, so it is pre-existing and environment-dependent
- repo-wide guards + `Args:` completeness — 414 passed
- `scripts/assemble_changelog.py --check` — OK
- new module alone — 12 passed in 0.45s (no docker, no network)

No visual artifact: this adds a test module and a changelog fragment and changes
no policy, simulation, rendering, recording or asset behaviour. The evidence for
a test-only change is the coverage delta and the mutation table above.
