### PR TITLE
test(zmq): stop requiring a live round trip inside a 2 ms socket budget

### DIFF
--- a/changelog.d/2094-zmq-round-trip-budget-headroom.md
+++ b/changelog.d/2094-zmq-round-trip-budget-headroom.md
@@ -1,0 +1,15 @@
+### Quality: a live ZMQ round trip is no longer required inside a 2 ms budget
+
+`tests/test_zmq_timeout_ms_domain.py` asserted `client.ping() is True` for every
+usable `timeout_ms`, including a 2 ms one. A fresh REQ socket pays the TCP
+connect and the ZMQ handshake on its first call, and that cost is scheduler-bound
+rather than transport-bound, so the assertion held on an idle host and failed
+under CPU contention - it measured the runner rather than the value reaching the
+socket.
+
+The property the file exists to pin - that the coerced budget is what the socket
+was configured with - is asserted through `getsockopt` for every usable spelling,
+which needs no clock. The live round trip now runs only for budgets with headroom
+over the connect cost, a set derived from the usable table rather than written out
+beside it, and a structural guard keeps a live answer from being required inside a
+budget the scheduler can exceed.

--- a/tests/test_zmq_timeout_ms_domain.py
+++ b/tests/test_zmq_timeout_ms_domain.py
@@ -16,6 +16,9 @@ The tests are grouped by what they protect rather than by client:
   and it is asserted on behaviour rather than on the raise.
 * :class:`TestABudgetTheSiblingTransportsAcceptIsUsableHere` - the coercion,
   which is what makes this a fix rather than only a refusal.
+* :class:`TestNoRoundTripIsAssertedInsideAScheduleBoundBudget` - structural, so
+  a live answer is never required inside a budget the host's scheduler can
+  exceed on a loaded runner.
 * :class:`TestZmqStillTreatsTheseValuesAsMeasured` - premise tests. They assert
   ``pyzmq``'s behaviour, not ours, so a future ``pyzmq`` that changes any of it
   fails here first rather than silently invalidating the reasoning above.
@@ -95,10 +98,30 @@ UNUSABLE: list[tuple[str, Any]] = [
 #: itself refuses and this domain therefore has to normalise.
 USABLE: list[tuple[str, Any, int]] = [
     ("the-default", 15000, 15000),
-    ("one-millisecond", 2, 2),
+    ("two-milliseconds", 2, 2),
     ("integral-float-from-a-json-config", 15000.0, 15000),
     ("the-ceiling-itself", MAX_ZMQ_TIMEOUT_MS, MAX_ZMQ_TIMEOUT_MS),
 ]
+
+#: Smallest budget a live round trip is asserted inside.
+#:
+#: A fresh REQ socket pays the TCP connect and the ZMQ handshake on its first
+#: call, and that cost is scheduler-bound rather than transport-bound: measured
+#: over a loopback sidecar on an idle host it is p50 0.24 ms / max 0.51 ms, and
+#: under CPU contention it crosses 2 ms. So an answer required to arrive inside
+#: a 2 ms budget asserts the host's scheduler, not the budget reaching the
+#: socket - which is the property this file exists to pin, and which
+#: ``getsockopt`` states exactly and without a clock. Budgets at or above this
+#: floor keep three orders of magnitude of headroom over the connect cost, so
+#: their round trip is a statement about the transport again.
+MIN_ROUND_TRIP_BUDGET_MS = 1000
+
+#: The usable budgets a live round trip is asserted inside.
+#:
+#: Derived from :data:`USABLE` rather than written out, so a budget added there
+#: cannot acquire a wall-clock assertion by also being added to a second list,
+#: and a tight one cannot be given one by hand.
+ROUND_TRIP: list[tuple[str, Any, int]] = [row for row in USABLE if row[2] >= MIN_ROUND_TRIP_BUDGET_MS]
 
 CLIENTS = [Gr00tInferenceClient, MoveIt2InferenceClient]
 
@@ -372,9 +395,15 @@ class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
 
     @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
     @pytest.mark.parametrize(("label", "value", "expected"), USABLE, ids=[c[0] for c in USABLE])
-    def test_a_usable_budget_is_stored_as_an_int_and_still_pings(
+    def test_a_usable_budget_is_stored_as_an_int_and_reaches_both_socket_options(
         self, cls: type, label: str, value: Any, expected: int
     ) -> None:
+        """Every usable spelling, asserted without a clock.
+
+        ``getsockopt`` states the whole property this class exists to pin - that
+        the coerced value is what the transport was configured with - and states
+        it for the smallest usable budget as exactly as for the default one.
+        """
         with sidecar_for(cls) as sidecar:
             client = cls(host="127.0.0.1", port=sidecar.port, timeout_ms=value)
             try:
@@ -382,6 +411,25 @@ class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
                 assert type(client.timeout_ms) is int
                 assert client.socket.getsockopt(zmq.RCVTIMEO) == expected
                 assert client.socket.getsockopt(zmq.SNDTIMEO) == expected
+            finally:
+                client.socket.close()
+                client.context.term()
+
+    @pytest.mark.parametrize("cls", CLIENTS, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize(("label", "value", "expected"), ROUND_TRIP, ids=[c[0] for c in ROUND_TRIP])
+    def test_a_usable_budget_with_round_trip_headroom_still_answers(
+        self, cls: type, label: str, value: Any, expected: int
+    ) -> None:
+        """The coerced budget still reaches a live sidecar.
+
+        Parametrised over :data:`ROUND_TRIP` rather than :data:`USABLE`: the
+        answer has to arrive inside the budget under test, so a budget without
+        headroom over the connect cost would assert the host's scheduler here
+        rather than the transport. See :data:`MIN_ROUND_TRIP_BUDGET_MS`.
+        """
+        with sidecar_for(cls) as sidecar:
+            client = cls(host="127.0.0.1", port=sidecar.port, timeout_ms=value)
+            try:
                 assert client.ping() is True
             finally:
                 client.socket.close()
@@ -414,6 +462,120 @@ class TestABudgetTheSiblingTransportsAcceptIsUsableHere:
         finally:
             client.socket.close()
             client.context.term()
+
+
+class TestNoRoundTripIsAssertedInsideAScheduleBoundBudget:
+    """Structural: a live answer is only required where the budget has room.
+
+    The assertion this replaces read ``assert client.ping() is True`` inside a
+    2 ms budget, so it held on an idle host and failed under CPU contention -
+    a property of the scheduler rather than of the value reaching the socket.
+    Checked over this module's own source rather than by naming today's tests,
+    so the shape cannot return under a different name.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        """This module's own source.
+
+        Read through ``__file__`` rather than a path literal, so the scan
+        follows the module if it is ever renamed.
+        """
+        return pathlib.Path(__file__).read_text()
+
+    @staticmethod
+    def _asserts_a_live_answer(fn: ast.AST) -> bool:
+        """Whether this subtree contains ``assert <x>.ping() is True``."""
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Compare) or not node.ops:
+                continue
+            if not isinstance(node.ops[0], ast.Is):
+                continue
+            right = node.comparators[0]
+            if not (isinstance(right, ast.Constant) and right.value is True):
+                continue
+            left = node.left
+            if isinstance(left, ast.Call) and isinstance(left.func, ast.Attribute) and left.func.attr == "ping":
+                return True
+        return False
+
+    @staticmethod
+    def _parametrize_tables(fn: ast.FunctionDef) -> set[str]:
+        """Names of the module-level tables this test is parametrised over."""
+        tables: set[str] = set()
+        for dec in fn.decorator_list:
+            if not (isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute)):
+                continue
+            if dec.func.attr != "parametrize" or len(dec.args) < 2:
+                continue
+            values = dec.args[1]
+            if isinstance(values, ast.Name):
+                tables.add(values.id)
+        return tables
+
+    @classmethod
+    def _tests_requiring_a_live_answer(cls, source: str) -> dict[str, set[str]]:
+        """Map ``test name -> parametrised tables`` for every such test."""
+        found: dict[str, set[str]] = {}
+        for fn in ast.walk(ast.parse(source)):
+            if not isinstance(fn, ast.FunctionDef) or not fn.name.startswith("test_"):
+                continue
+            if cls._asserts_a_live_answer(fn):
+                found[fn.name] = cls._parametrize_tables(fn)
+        return found
+
+    def test_the_scan_finds_every_test_requiring_a_live_answer(self) -> None:
+        """Non-vacuity: a scan that found nothing would pass everything below."""
+        assert set(self._tests_requiring_a_live_answer(self._source())) == {
+            "test_the_default_budget_reaches_a_live_sidecar",
+            "test_a_usable_budget_with_round_trip_headroom_still_answers",
+        }
+
+    def test_no_live_answer_is_required_inside_a_budget_without_headroom(self) -> None:
+        offenders = {
+            name: sorted(tables)
+            for name, tables in self._tests_requiring_a_live_answer(self._source()).items()
+            if "USABLE" in tables
+        }
+        assert not offenders, f"these require an answer inside a budget with no headroom: {offenders}"
+
+    def test_the_scanner_detects_a_live_answer_over_the_full_table(self) -> None:
+        """The scanner is answering the question, not returning ``{}``."""
+        planted = (
+            "@pytest.mark.parametrize(('label', 'value', 'expected'), USABLE)\n"
+            "def test_planted(label, value, expected):\n"
+            "    client = build(timeout_ms=value)\n"
+            "    assert client.ping() is True\n"
+        )
+        assert self._tests_requiring_a_live_answer(planted) == {"test_planted": {"USABLE"}}
+
+        no_round_trip = "def test_planted():\n    assert client.timeout_ms == 2\n"
+        assert self._tests_requiring_a_live_answer(no_round_trip) == {}
+
+    def test_the_round_trip_table_is_the_headroom_subset_of_usable(self) -> None:
+        """Derived, so the two cannot drift apart."""
+        assert ROUND_TRIP == [row for row in USABLE if row[2] >= MIN_ROUND_TRIP_BUDGET_MS]
+
+    def test_the_floor_excludes_a_budget_and_keeps_one(self) -> None:
+        """Non-vacuity for the derivation: the floor is doing work.
+
+        A floor that excluded nothing would leave the wall-clock assertion in
+        place; one that excluded everything would delete the round trip instead
+        of moving it.
+        """
+        assert ROUND_TRIP
+        assert len(ROUND_TRIP) < len(USABLE)
+        assert [row[2] for row in USABLE if row not in ROUND_TRIP] == [2]
+
+    def test_the_excluded_budget_keeps_every_assertion_needing_no_clock(self) -> None:
+        """No coverage was traded away: it is still checked over the full table."""
+        socket_option_test = next(
+            fn
+            for fn in ast.walk(ast.parse(self._source()))
+            if isinstance(fn, ast.FunctionDef)
+            and fn.name == "test_a_usable_budget_is_stored_as_an_int_and_reaches_both_socket_options"
+        )
+        assert "USABLE" in self._parametrize_tables(socket_option_test)
 
 
 @requires_wire


### PR DESCRIPTION
## Problem

`tests/test_zmq_timeout_ms_domain.py` asserted `client.ping() is True` for every
usable `timeout_ms`, and one of those budgets is 2 ms:

```python
USABLE = [("the-default", 15000, 15000), ("one-millisecond", 2, 2), ...]

def test_a_usable_budget_is_stored_as_an_int_and_still_pings(...):
    ...
    assert client.socket.getsockopt(zmq.RCVTIMEO) == expected
    assert client.ping() is True          # <- inside a 2 ms budget
```

A fresh REQ socket pays the TCP connect and the ZMQ handshake on its **first**
call, and that cost is scheduler-bound rather than transport-bound. So the
assertion did not measure the coerced budget reaching the socket - the property
this file exists to pin - it measured whether the runner scheduled the handshake
within 2 ms.

It holds on an idle host and fails on a loaded one. `main` is red on it now:

```
FAILED tests/test_zmq_timeout_ms_domain.py::TestABudgetTheSiblingTransportsAcceptIsUsableHere
       ::test_a_usable_budget_is_stored_as_an_int_and_still_pings
       [one-millisecond-MoveIt2InferenceClient] - assert False is True
       + where False = ping()
1 failed, 27052 passed, 257 skipped in 775.96s
```

## Measured

Fresh-socket connect + handshake + round trip, pooled n=120 per load state
(contention = 16 CPU spinners on a 14-core host, each under `sys.settrace` to
emulate the coverage tracer CI runs under):

| host | p50 | p95 | max | samples over 2 ms |
| --- | --- | --- | --- | --- |
| idle | 0.228 ms | 0.294 ms | 0.495 ms | **0 / 120** |
| under contention | 0.162 ms | 2.056 ms | 4.139 ms | **8 / 120** |

The median is unaffected; it is the tail that crosses the budget, which is why
this presents as a flake rather than a constant failure.

Verdict of the file itself, 5 runs per cell:

| tree | idle | under contention |
| --- | --- | --- |
| `main` (bdd5fb05) | 5 / 5 runs pass | **2 of 5 runs failed** (2 cases each - both clients) |
| this change | 5 / 5 runs pass | **0 of 5 runs failed** |

A heavier-load sample failed `main` on 5 of 5 runs. The failing cases are always
the `one-millisecond` row, on both clients.

## Change

The property that holds for **every** usable budget - the coerced value is what
the transport was configured with - is asserted through `getsockopt`, which needs
no clock. That assertion is unchanged and still runs over the full table,
including the 2 ms row.

The live round trip moves to the budgets with headroom over the connect cost:

```python
MIN_ROUND_TRIP_BUDGET_MS = 1000
ROUND_TRIP = [row for row in USABLE if row[2] >= MIN_ROUND_TRIP_BUDGET_MS]
```

`ROUND_TRIP` is **derived** from `USABLE` rather than written out beside it, so a
budget added to the table cannot acquire a wall-clock assertion by also being
added to a second list, and a tight one cannot be given one by hand. The floor
keeps three orders of magnitude over the worst connect cost measured under load,
so a round trip asserted inside it is a statement about the transport again.

`TestNoRoundTripIsAssertedInsideAScheduleBoundBudget` scans this module's own
source and refuses a test that requires a live answer over the full table, so the
shape cannot return under a different name. It carries the usual non-vacuity and
planted-defect pins, plus one asserting the excluded row keeps every assertion
that needs no clock - no coverage was traded away.

The row's label is corrected too: it read `one-millisecond` for a value of `2`.

Two other `ping()` assertions in the file are untouched and were never
host-dependent: one uses the 15000 ms default, and one asserts `is False` against
an unbound port. Every other `ping() is True` in `tests/` is `MagicMock`-backed,
so this was the only live-sidecar round trip inside a tight budget.

## Artifact

![ZMQ round-trip budget headroom](https://raw.githubusercontent.com/cagataycali/robots/artifacts/zmq-round-trip-budget/zmq_round_trip_budget.png)

Every number in the figure is re-derived from the two measurement dumps by the
compose step, which also asserts the two arms measured different trees. The
capture and compose scripts are alongside the image.

No library behaviour changes - this is a test-quality change, so the artifact is
the measurement it rests on rather than a rollout.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean (1147 files)
- `mypy strands_robots tests tests_integ`: **0 errors outside `examples/isaac_gs`** (14 there, pre-existing and byte-identical on a pristine `upstream/main` worktree of the same working copy)
- `MUJOCO_GL=egl pytest tests`: **27065 passed, 257 skipped, 0 failed** in 594 s, against `main`'s `1 failed, 27052 passed`
- Target file: 130 -> 142 tests; 6/6 clean runs under the contention that fails `main`
- `scripts/assemble_changelog.py --check`: OK; `tests/test_changelog_fragments.py tests/test_changelog_format.py`: 30 passed
- `scripts/check_merge_base_overlap.py`: no overlap - the 2 paths `main` gained since `bdd5fb05` are `changelog.d/2092-*` and `tests/tools/test_gr00t_wrapper_mount_detection.py`, both disjoint from this branch
