### PR TITLE
fix(policies/vera): hold gripper_dim_index to the columns the action chunk has

### DIFF
--- a/changelog.d/2097-vera-gripper-column-index-domain.md
+++ b/changelog.d/2097-vera-gripper-column-index-domain.md
@@ -1,0 +1,19 @@
+### Fixed: `decode_vera_delta_chunk_to_targets` holds `gripper_dim_index` to the columns a chunk has
+
+The gripper column was selected with `gidx = gripper_dim_index if gripper_dim_index >= 0 else D - 1`,
+a test that doubles as the only check: whatever failed it was read as the `-1` "trailing column"
+sentinel. So `-5`, `-99` and `nan` were each answered with the *default* trailing column - the value
+the caller meant and the value used differed, with nothing logged and nothing in the result to say so -
+while `2.7`, `inf`, `True`, a numeric string, `None`, a list and an index past the last column reached
+`action_chunk[:, gidx]` or `np.delete` and raised `IndexError`/`TypeError` from numpy about an axis,
+naming neither the parameter nor the function and missing the `ValueError` channel the function
+documents. The value is not only a caller's: the provider reads it from the policy server's metadata
+and forwards it here.
+
+It now routes through `coerce_gripper_dim_index`, beside the sibling that owns the rotation encoding
+width, which delegates numeric-ness, `bool` rejection, finiteness and the float64 range to
+`finite_number_error` and decides only the sentinel and the sign; an in-range index that names no
+column of the chunk is reported against that chunk's width. As for `rotation_dim`, the accepted value
+is normalized to an `int`, so an integral float - what a config read produces, and what
+`int(meta["gripper_dim_index"])` produced on the provider path - now decodes instead of failing to
+index. The index is read only when `has_gripper`, so it is checked only then.

--- a/strands_robots/policies/vera/sim_ik.py
+++ b/strands_robots/policies/vera/sim_ik.py
@@ -177,6 +177,77 @@ class MinkIKBridge(_SharedMinkIKBridge):
     _LOG_LABEL: ClassVar[str] = "VERA MinkIKBridge"
 
 
+#: The ``gripper_dim_index`` value meaning "whichever column is last". VERA's
+#: server metadata uses it as the default, so it is a wire-level sentinel rather
+#: than a convenience: an explicit index and this sentinel are the only two
+#: things a caller can mean. Single owner of that vocabulary -
+#: :func:`coerce_gripper_dim_index` and the resolution in
+#: :func:`decode_vera_delta_chunk_to_targets` are both built from it.
+GRIPPER_INDEX_LAST: int = -1
+
+
+def coerce_gripper_dim_index(value: Any, param: str, context: str) -> tuple[int | None, str | None]:
+    """Validate a gripper-column index and normalize it to an ``int``.
+
+    The accepted set is :data:`GRIPPER_INDEX_LAST` (the trailing column) or a
+    column index ``>= 0``. It is closed for the same reason the encoding width's
+    is: the value selects one column of the action chunk, so there is no third
+    thing it could mean, and no endpoint left to decide.
+
+    Every other value is refused where it is supplied, because none of them is
+    refused usefully further down - the index reaches
+    ``action_chunk[:, gidx]`` and ``np.delete(action_chunk, gidx, axis=1)``:
+
+    * a negative other than the sentinel - ``-5``, ``-99`` - and ``nan`` all fail
+      the ``>= 0`` test the resolution used, so each was answered with the
+      *default*: the trailing column, exactly as if the sentinel had been
+      supplied. A request no column satisfies became the documented default with
+      nothing logged and nothing returned to say so, which is the one outcome a
+      caller cannot detect - the value they meant and the value that was used
+      differ, and both calls report the same clean joint targets.
+    * a non-integral float, ``inf``, ``True`` and a numeric string reach the
+      index itself and raise ``IndexError: only integers, slices ...`` or
+      ``ValueError: boolean array argument obj to delete ...``, naming neither
+      the parameter nor the surface.
+    * ``None`` and a list fail the ``>= 0`` comparison with ``TypeError: '>='
+      not supported between instances of ...``, which is not the ``ValueError``
+      channel this function documents.
+
+    Normalizing is load-bearing rather than cosmetic, exactly as for
+    :func:`coerce_rotation_dim`: the value indexes a column, so an integral
+    float - what a JSON or YAML config read produces, and what
+    ``int(meta["gripper_dim_index"])`` produced on the provider path - has to
+    arrive there as an index. Validation decides whether the value can be
+    honored; the conversion makes the honored one consumable.
+
+    Numeric-ness, ``bool`` rejection, finiteness and the float64 range are
+    :func:`~strands_robots.utils.finite_number_error`'s, whose domain this is a
+    subset of; only the sentinel and the sign are decided here. Whether an
+    in-range index actually addresses a column of *this* chunk needs the chunk's
+    width, so it is checked by
+    :func:`decode_vera_delta_chunk_to_targets` where that width is known.
+
+    Args:
+        value: The caller-supplied gripper-column index.
+        param: The parameter it came from, used in the message.
+        context: Message prefix identifying the surface that received it -
+            normally the public method or function name.
+
+    Returns:
+        ``(index, None)`` when usable, else ``(None, message)``.
+    """
+    if (err := finite_number_error(value, param, context)) is not None:
+        return None, err
+    numeric = float(value)
+    index = int(numeric)
+    if numeric != index or (index < 0 and index != GRIPPER_INDEX_LAST):
+        return None, (
+            f"{context}: {param} must be {GRIPPER_INDEX_LAST} (the trailing column) "
+            f"or a column index >= 0, got {value!r}."
+        )
+    return index, None
+
+
 def decode_vera_delta_chunk_to_targets(
     action_chunk: np.ndarray,
     ik_bridge: MinkIKBridge,
@@ -203,8 +274,11 @@ def decode_vera_delta_chunk_to_targets(
             the two the decoder implements. Any other width is refused up
             front; see the ``Raises`` section.
         has_gripper: Whether the chunk carries a trailing gripper column.
-        gripper_dim_index: Index of the gripper column (``-1`` => last when
-            ``has_gripper``); the value is passed through (binarized by caller).
+        gripper_dim_index: Index of the gripper column, or
+            :data:`GRIPPER_INDEX_LAST` for the trailing one; the value read out
+            of it is passed through (binarized by caller). Read only when
+            ``has_gripper``, and then it must address a column of this chunk;
+            see the ``Raises`` section.
         translation_scale: Multiplier on the translation delta, composed on
             top of the OSC position scale (units match). Must be a positive
             finite number; see the ``Raises`` section for why.
@@ -212,8 +286,10 @@ def decode_vera_delta_chunk_to_targets(
     Raises:
         ValueError: If ``action_chunk`` is not ``[T, D]``, if it carries too
             few pose dims, if ``rotation_dim`` is not one of the encodings
-            :func:`delta_to_matrix` implements, or if ``translation_scale`` is
-            not a positive finite number. An unusable ``rotation_dim`` is
+            :func:`delta_to_matrix` implements, if ``translation_scale`` is
+            not a positive finite number, or if ``gripper_dim_index`` names no
+            column of the chunk - see :func:`coerce_gripper_dim_index` for why
+            an index outside that set is not refused by anything downstream. An unusable ``rotation_dim`` is
             refused here for the same reason the scale is: it indexes the
             rotation block of every step, so a non-integral or non-numeric
             width raised ``TypeError: slice indices must be integers`` out of
@@ -249,6 +325,18 @@ def decode_vera_delta_chunk_to_targets(
     if dim is None:
         raise ValueError(dim_err)
     rotation_dim = dim
+    # Third of the three, same place, same reason: the index selects the gripper
+    # column of every step. Checked only when a gripper column is claimed, since
+    # ``has_gripper=False`` means nothing reads it - refusing a value this call
+    # never consumes would be a false rejection. Whether an in-range index
+    # addresses a column of *this* chunk needs ``D``, so that half is below.
+    if has_gripper:
+        gidx_value, gidx_err = coerce_gripper_dim_index(
+            gripper_dim_index, "gripper_dim_index", "decode_vera_delta_chunk_to_targets"
+        )
+        if gidx_value is None:
+            raise ValueError(gidx_err)
+        gripper_dim_index = gidx_value
     action_chunk = np.asarray(action_chunk, dtype=np.float64)
     if action_chunk.ndim != 2:
         raise ValueError(f"action_chunk must be [T, D]; got {action_chunk.shape}")
@@ -258,7 +346,13 @@ def decode_vera_delta_chunk_to_targets(
     gripper = None
     pose_block = action_chunk
     if has_gripper:
-        gidx = gripper_dim_index if gripper_dim_index >= 0 else D - 1
+        gidx = D - 1 if gripper_dim_index == GRIPPER_INDEX_LAST else gripper_dim_index
+        if gidx >= D:
+            raise ValueError(
+                f"decode_vera_delta_chunk_to_targets: gripper_dim_index {gripper_dim_index} "
+                f"addresses no column of a {D}-wide action chunk (columns 0..{D - 1}, "
+                f"or {GRIPPER_INDEX_LAST} for the trailing one)."
+            )
         gripper = action_chunk[:, gidx].copy()
         pose_block = np.delete(action_chunk, gidx, axis=1)
 

--- a/tests/policies/vera/test_vera_gripper_dim_index_domain.py
+++ b/tests/policies/vera/test_vera_gripper_dim_index_domain.py
@@ -1,0 +1,359 @@
+"""``gripper_dim_index`` selects one column of the action chunk, so it takes a domain.
+
+:func:`~strands_robots.policies.vera.sim_ik.decode_vera_delta_chunk_to_targets`
+splits the gripper column off the chunk before IK with two statements::
+
+    gidx = gripper_dim_index if gripper_dim_index >= 0 else D - 1
+    gripper = action_chunk[:, gidx].copy()
+    pose_block = np.delete(action_chunk, gidx, axis=1)
+
+That ``>= 0`` test is a *selector* as well as the only check: whatever fails it is
+read as the ``-1`` "trailing column" sentinel. Its two siblings in the same
+signature were already held to a domain - ``translation_scale`` in the function's
+first statement, ``rotation_dim`` in its second - and the ``Raises`` section spells
+out why ``rotation_dim`` in particular cannot be left to the arithmetic that
+consumes it: "it indexes the rotation block of every step, so a non-integral or
+non-numeric width raised ``TypeError: slice indices must be integers`` out of
+that slice - naming neither the parameter nor this function". The gripper index
+indexes a *column* of every step and did exactly that.
+
+Measured on ``67ca3ac4``, one real decode per row over a 7-wide
+``[trans(3), rot(3), gripper(1)]`` chunk whose columns are distinguishable, so
+the column actually read is observable:
+
+| ``gripper_dim_index=`` | outcome | gripper read from | cost |
+| --- | --- | --- | --- |
+| ``-1`` / ``6`` / ``0`` | accepted | col 6 / col 6 / col 0 | honored (unchanged) |
+| ``-5`` / ``-99`` | **accepted** | col 6 | silently read as the sentinel |
+| ``nan`` | **accepted** | col 6 | silently read as the sentinel |
+| ``2.7`` / ``6.0`` / ``inf`` | ``IndexError`` | - | ``only integers, slices ...`` |
+| ``True`` | ``ValueError`` | - | ``boolean array argument obj to delete ...`` |
+| ``99`` | ``IndexError`` | - | ``index 99 is out of bounds for axis 1`` |
+| ``'6'`` / ``None`` / ``[6]`` | ``TypeError`` | - | ``'>=' not supported between ...`` |
+
+Two things that table shows.
+
+**Three values were answered with the default.** ``nan >= 0`` is ``False``, and so
+is any negative, so ``-5``, ``-99`` and ``nan`` each resolved to ``D - 1`` - the
+*same* column the ``-1`` sentinel names. A request no column satisfies became the
+documented default, with nothing logged and nothing in the result to say so, so
+the value the caller meant and the value that was used differ and both decodes
+return identical clean joint targets. That is the one outcome a caller cannot
+detect, and it is the reason the check belongs where the value arrives rather than
+in the selector that consumes it.
+
+**Eight escaped naming neither the parameter nor the function.** The index reached
+``action_chunk[:, gidx]`` or ``np.delete``, so the refusal came from numpy about
+an axis, or from the ``>=`` comparison about two types - not from the surface that
+received the value. ``IndexError`` and ``TypeError`` also miss the ``ValueError``
+channel this function documents, so an ``except ValueError`` around the decode did
+not catch them.
+
+The value is not only a caller's: the provider reads it from the policy server's
+metadata (``int(meta.get("gripper_dim_index", -1))``) and forwards it here, so a
+misconfigured server sending ``-5`` reached the silent half and one sending ``99``
+reached the numpy half.
+
+It now routes through
+:func:`~strands_robots.policies.vera.sim_ik.coerce_gripper_dim_index`, beside the
+sibling that owns the encoding width, which delegates numeric-ness, ``bool``
+rejection, finiteness and the float64 range to
+:func:`~strands_robots.utils.finite_number_error` and decides only the sentinel
+and the sign. Two consequences worth pinning: an integral float now *decodes*
+instead of failing to index - ``6.0`` is what a config read produces, and it is
+what ``int()`` produced on the provider path - and an in-range index that names no
+column of *this* chunk is reported against the chunk's width, which needs the
+width and so is checked where the width is known.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+import numpy as np
+
+from strands_robots.policies.vera.sim_ik import (
+    GRIPPER_INDEX_LAST,
+    coerce_gripper_dim_index,
+    decode_vera_delta_chunk_to_targets,
+)
+from strands_robots.utils import finite_number_error
+
+#: Width of the chunk every behavioural test below decodes: 3 translation, 3
+#: rotation, 1 gripper.
+WIDTH = 7
+
+#: Indices a 7-wide chunk can be read with, in the spellings a caller reaches
+#: them by. Integral floats are included deliberately: an index read from JSON or
+#: a YAML config arrives as ``6.0``, and ``int(meta["gripper_dim_index"])`` on the
+#: provider path produced one too.
+USABLE: list[Any] = [GRIPPER_INDEX_LAST, 0, 3, 6, 6.0, np.int64(6), np.float64(0.0)]
+
+#: Indices that name no column: a negative other than the sentinel, and a
+#: fractional one. Refused by the sentinel/sign half of the rule.
+NOT_AN_INDEX: list[Any] = [-2, -5, -99, 2.7, -0.5]
+
+#: Values that are not a usable number at all. Refused by the shared numeric
+#: domain rather than by anything decided here.
+NOT_A_NUMBER: list[Any] = [
+    True,
+    False,
+    "6",
+    "abc",
+    [6],
+    {},
+    None,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    10**400,
+]
+
+UNUSABLE: list[Any] = NOT_AN_INDEX + NOT_A_NUMBER
+
+#: In-range for the rule but not for a 7-wide chunk. Refused where the width is
+#: known rather than by the rule, so it is kept out of :data:`UNUSABLE`.
+PAST_THE_LAST_COLUMN: list[Any] = [7, 8, 99]
+
+
+class _StubBridge:
+    """Duck-typed IK bridge: the decoder touches only these three members."""
+
+    def __init__(self, nq: int = 3) -> None:
+        self.model = type("_M", (), {"nq": nq})()
+
+    def ee_pose(self, q: Any) -> np.ndarray:
+        pose = np.eye(4, dtype=np.float64)
+        pose[:3, 3] = np.asarray(q, dtype=np.float64)[:3]
+        return pose
+
+    def solve(self, target: Any, q: Any) -> np.ndarray:
+        return np.asarray(target, dtype=np.float64)[:3, 3].copy()
+
+
+def _chunk(width: int = WIDTH, steps: int = 3) -> np.ndarray:
+    """A chunk whose every column carries a distinct value.
+
+    That is what makes "which column was read as the gripper" observable: the
+    returned gripper series equals exactly one column of the input.
+    """
+    row = np.arange(1, width + 1, dtype=np.float64) * 0.01
+    return np.tile(row, (steps, 1))
+
+
+def _decode(gripper_dim_index: Any, *, width: int = WIDTH, has_gripper: bool = True) -> Any:
+    """Run the real decoder over a ``width``-wide chunk.
+
+    ``Any`` for the index because these tests deliberately supply values outside
+    the declared ``int``; the bridge is duck-typed, so the decode path needs
+    neither ``mink`` nor ``mujoco``.
+    """
+    bridge: Any = _StubBridge()
+    return decode_vera_delta_chunk_to_targets(
+        _chunk(width),
+        bridge,
+        np.zeros(3, dtype=np.float64),
+        rotation_dim=3,
+        has_gripper=has_gripper,
+        gripper_dim_index=gripper_dim_index,
+    )
+
+
+def _column_read_as_gripper(result: Any, width: int = WIDTH) -> int:
+    """Index of the input column the decode returned as the gripper series."""
+    got = np.asarray(result["gripper"], dtype=np.float64)
+    chunk = _chunk(width)
+    for col in range(width):
+        if np.allclose(got, chunk[:, col]):
+            return col
+    raise AssertionError(f"gripper series {got!r} matches no column of the chunk")
+
+
+class TestTheGripperColumnIndexDomain:
+    """The rule itself, with no chunk, no bridge and no sim stack."""
+
+    def test_an_index_a_chunk_can_be_read_with_is_accepted(self) -> None:
+        for value in USABLE:
+            assert coerce_gripper_dim_index(value, "gripper_dim_index", "ctx") == (int(value), None), value
+
+    def test_an_accepted_index_is_normalized_to_an_int(self) -> None:
+        for value in USABLE:
+            index, error = coerce_gripper_dim_index(value, "gripper_dim_index", "ctx")
+            assert error is None
+            assert type(index) is int, (value, type(index))
+
+    def test_a_value_naming_no_column_is_refused(self) -> None:
+        for value in UNUSABLE:
+            index, error = coerce_gripper_dim_index(value, "gripper_dim_index", "ctx")
+            assert index is None, value
+            assert error, value
+
+    def test_the_refusal_names_the_surface_the_parameter_and_the_value(self) -> None:
+        for value in UNUSABLE:
+            _, error = coerce_gripper_dim_index(value, "gripper_dim_index", "decode_x")
+            assert error is not None
+            assert error.startswith("decode_x: gripper_dim_index "), error
+            assert repr(value) in error, error
+
+    def test_a_number_outside_the_accepted_set_is_told_what_the_set_is(self) -> None:
+        for value in NOT_AN_INDEX:
+            _, error = coerce_gripper_dim_index(value, "gripper_dim_index", "ctx")
+            assert error is not None
+            assert f"must be {GRIPPER_INDEX_LAST} (the trailing column) or a column index >= 0" in error, error
+
+    def test_only_the_sentinel_and_the_sign_are_decided_here(self) -> None:
+        """Everything else is the shared numeric domain's, verbatim.
+
+        This is what stops the two rules drifting apart: the local helper adds a
+        membership decision on top of :func:`finite_number_error` and nothing else,
+        so a value that domain refuses is refused here with that domain's message.
+        """
+        divergent = []
+        for value in [*USABLE, *UNUSABLE, *PAST_THE_LAST_COLUMN]:
+            shared = finite_number_error(value, "gripper_dim_index", "ctx")
+            _, local = coerce_gripper_dim_index(value, "gripper_dim_index", "ctx")
+            if shared is not None and local != shared:
+                divergent.append((value, shared, local))
+        assert divergent == [], divergent
+
+    def test_the_sentinel_is_not_reachable_by_an_equal_looking_value(self) -> None:
+        """``-1.0`` compares equal to the sentinel and is a legitimate spelling.
+
+        ``True``/``False`` also compare equal to ``1``/``0`` but are refused by
+        the shared domain, so a boolean can never arrive as a column index.
+        """
+        assert coerce_gripper_dim_index(-1.0, "gripper_dim_index", "ctx") == (GRIPPER_INDEX_LAST, None)
+        assert coerce_gripper_dim_index(True, "gripper_dim_index", "ctx")[0] is None
+        assert coerce_gripper_dim_index(False, "gripper_dim_index", "ctx")[0] is None
+
+
+class TestTheDecoderRefusesAnIndexItCannotRead:
+    """The behavioural half: a real decode per value."""
+
+    def test_an_unusable_index_is_refused_as_a_value_error(self) -> None:
+        for value in UNUSABLE:
+            try:
+                _decode(value)
+            except ValueError:
+                continue
+            except Exception as exc:  # noqa: BLE001 - the escape is the finding
+                raise AssertionError(f"{value!r} raised {type(exc).__name__}, not ValueError: {exc}") from exc
+            raise AssertionError(f"{value!r} was accepted")
+
+    def test_the_refusal_names_this_function_and_the_parameter(self) -> None:
+        for value in UNUSABLE:
+            try:
+                _decode(value)
+            except ValueError as exc:
+                text = str(exc)
+                assert text.startswith("decode_vera_delta_chunk_to_targets: gripper_dim_index "), text
+            else:  # pragma: no cover - covered by the sibling test
+                raise AssertionError(f"{value!r} was accepted")
+
+    def test_a_negative_other_than_the_sentinel_no_longer_reads_the_last_column(self) -> None:
+        """The silent half of the defect, pinned as a refusal.
+
+        ``-5`` used to resolve to ``D - 1``, the same column the sentinel names,
+        so an index no column satisfies was answered with the default and the
+        substitution was reported nowhere.
+        """
+        assert _column_read_as_gripper(_decode(GRIPPER_INDEX_LAST)) == WIDTH - 1
+        for value in (-2, -5, -99):
+            try:
+                _decode(value)
+            except ValueError as exc:
+                assert "gripper_dim_index" in str(exc)
+            else:
+                raise AssertionError(f"{value!r} was accepted")
+
+    def test_a_non_finite_index_no_longer_reads_the_last_column(self) -> None:
+        for value in (float("nan"), float("inf"), float("-inf")):
+            try:
+                _decode(value)
+            except ValueError as exc:
+                assert "gripper_dim_index" in str(exc)
+            else:
+                raise AssertionError(f"{value!r} was accepted")
+
+    def test_a_usable_index_still_reads_the_column_it_names(self) -> None:
+        assert _column_read_as_gripper(_decode(GRIPPER_INDEX_LAST)) == WIDTH - 1
+        assert _column_read_as_gripper(_decode(WIDTH - 1)) == WIDTH - 1
+        assert _column_read_as_gripper(_decode(0)) == 0
+        assert _column_read_as_gripper(_decode(3)) == 3
+
+    def test_an_integral_float_index_now_decodes_instead_of_failing_to_index(self) -> None:
+        """The capability the normalization adds, mirroring ``rotation_dim``.
+
+        ``6.0`` reached ``action_chunk[:, 6.0]`` and raised ``IndexError: only
+        integers, slices ...`` before this change.
+        """
+        result = _decode(6.0)
+        assert _column_read_as_gripper(result) == WIDTH - 1
+        assert np.asarray(result["qpos"]).shape == (3, 3)
+
+    def test_a_numpy_integer_index_is_still_accepted(self) -> None:
+        """No narrowing: numpy indexing honors it, so the guard must too."""
+        assert _column_read_as_gripper(_decode(np.int64(6))) == WIDTH - 1
+
+
+class TestAnIndexPastTheLastColumnIsReportedAgainstTheChunkWidth:
+    """The half that needs the chunk, so it is checked where the width is known."""
+
+    def test_an_index_past_the_last_column_is_refused(self) -> None:
+        for value in PAST_THE_LAST_COLUMN:
+            try:
+                _decode(value)
+            except ValueError as exc:
+                assert "addresses no column" in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{value!r} was accepted")
+
+    def test_the_refusal_names_the_parameter_the_value_and_the_width(self) -> None:
+        try:
+            _decode(99)
+        except ValueError as exc:
+            text = str(exc)
+        else:  # pragma: no cover - covered by the sibling test
+            raise AssertionError("99 was accepted")
+        assert text.startswith("decode_vera_delta_chunk_to_targets: gripper_dim_index 99 "), text
+        assert f"{WIDTH}-wide action chunk" in text, text
+        assert f"columns 0..{WIDTH - 1}" in text, text
+
+    def test_the_same_index_is_usable_on_a_wider_chunk(self) -> None:
+        """The bound is the chunk's, not the rule's - so it moves with the chunk."""
+        assert _column_read_as_gripper(_decode(7, width=8), width=8) == 7
+
+
+class TestTheIndexIsReadOnlyWhenAGripperColumnIsClaimed:
+    """``has_gripper=False`` means nothing reads it, so nothing may refuse it."""
+
+    def test_an_unusable_index_is_inert_without_a_gripper_column(self) -> None:
+        for value in UNUSABLE + PAST_THE_LAST_COLUMN:
+            result = _decode(value, has_gripper=False)
+            assert result["gripper"] is None, value
+
+    def test_the_pose_width_check_still_reports_a_server_mismatch(self) -> None:
+        """A chunk too narrow for the encoding is still the error it always was."""
+        try:
+            _decode(GRIPPER_INDEX_LAST, width=4)
+        except ValueError as exc:
+            assert "pose dims" in str(exc), str(exc)
+        else:
+            raise AssertionError("a 4-wide chunk was accepted for a 3+3 encoding")
+
+
+class TestTheRuleCostsNoDependency:
+    """Reaching the domain must not drag the sim stack into the light base env."""
+
+    def test_reaching_the_rule_loads_no_heavy_module(self) -> None:
+        probe = (
+            "import sys;"
+            "from strands_robots.policies.vera.sim_ik import coerce_gripper_dim_index as c;"
+            "assert c(-5, 'gripper_dim_index', 'ctx')[0] is None;"
+            "assert c(6.0, 'gripper_dim_index', 'ctx')[0] == 6;"
+            "print(sorted(m for m in ('mink', 'mujoco', 'torch') if m in sys.modules))"
+        )
+        out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True, timeout=180)
+        assert out.stdout.strip() == "[]", out.stdout


### PR DESCRIPTION
## Problem

`decode_vera_delta_chunk_to_targets` splits the gripper column off the action chunk before IK:

```python
gidx = gripper_dim_index if gripper_dim_index >= 0 else D - 1
gripper = action_chunk[:, gidx].copy()
pose_block = np.delete(action_chunk, gidx, axis=1)
```

That `>= 0` test is a *selector* as well as the only check on the value, so whatever fails it is read as the `-1` "trailing column" sentinel.

Both siblings in the same signature were already held to a domain — `translation_scale` in the function's first statement, `rotation_dim` in its second — and the `Raises` section already spells out why `rotation_dim` in particular cannot be left to the arithmetic that consumes it:

> it indexes the rotation block of every step, so a non-integral or non-numeric width raised `TypeError: slice indices must be integers` out of that slice — naming neither the parameter nor this function

The gripper index indexes a *column* of every step and did exactly that.

## Measured

One real decode per row over a 7-wide `[trans(3), rot(3), gripper(1)]` chunk whose columns are distinguishable, so the column actually read is observable:

| `gripper_dim_index=` | main | this change |
| --- | --- | --- |
| `-1` / `6` / `0` | decoded, the column named | unchanged |
| `-5` / `-99` / `nan` | **decoded — answered with the DEFAULT trailing column** | `ValueError` naming the parameter |
| `2.7` / `inf` | `IndexError: only integers, slices ...` | `ValueError` naming the parameter |
| `True` | `ValueError: boolean array argument obj to delete ...` | `ValueError` naming the parameter |
| `'6'` / `None` / `[6]` | `TypeError: '>=' not supported between instances of ...` | `ValueError` naming the parameter |
| `99` (past the last column) | `IndexError: index 99 is out of bounds for axis 1` | `ValueError` naming the parameter **and the chunk width** |
| `6.0` (integral float) | `IndexError: only integers, slices ...` | **decoded** |

**Three values were answered with the default.** `nan >= 0` is `False`, and so is any negative, so `-5`, `-99` and `nan` each resolved to `D - 1` — the *same* column the `-1` sentinel names. A request no column satisfies became the documented default, with nothing logged and nothing in the result to say so, so the value the caller meant and the value used differ and both decodes return identical clean joint targets. On main that is measurable only by comparing against a separate `-1` run: same hand pose, renders agreeing to 1/255.

**Eight escaped naming neither the parameter nor the function**, and outside the `ValueError` channel this function documents — so an `except ValueError` around the decode did not catch them.

The value is not only a caller's: the provider reads it from the policy server's metadata (`int(meta.get("gripper_dim_index", -1))`) and forwards it here, so a misconfigured server sending `-5` reached the silent half and one sending `99` reached the numpy half.

## Change

`gripper_dim_index` now routes through `coerce_gripper_dim_index`, beside the sibling that owns the rotation encoding width. It delegates numeric-ness, `bool` rejection, finiteness and the float64 range to `finite_number_error` and decides only the sentinel and the sign — pinned by a test that loops both over the whole probe set and asserts they never disagree, so the two rules cannot drift apart.

Two halves, because they are knowable in different places:

- **the sentinel and the sign** are a property of the value, so they are checked where it arrives — beside the two existing guards, before the first IK solve;
- **whether an in-range index addresses a column of *this* chunk** needs the chunk's width, so it is checked where the width is known and reports against it (`gripper_dim_index 99 addresses no column of a 7-wide action chunk (columns 0..6, or -1 for the trailing one)`).

The check is gated on `has_gripper`: with no gripper column nothing reads the index, so refusing a value the call never consumes would be a false rejection. Both directions are pinned.

As for `rotation_dim`, the accepted value is normalized to an `int`. That is load-bearing rather than cosmetic — the value indexes a column, so an integral float (what a JSON/YAML config read produces, and what `int(meta["gripper_dim_index"])` produced on the provider path) has to arrive there as an index. `6.0` therefore now decodes instead of failing to index, and `np.int64(6)` stays accepted, so nothing numpy honors is newly refused.

## Visual

One real decode per index spelling onto a MuJoCo Panda through the shipped `MinkIKBridge`, headless (`MUJOCO_GL=egl`), rendered on both trees:

![gripper_dim_index domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/vera-gripper-dim-index/gripper_dim_index.png)

Left is the reference (`-1`): the same decode on both trees leaves the hand at x=0.315 m and the renders agree to **1/255**, so the honored path is untouched. Middle is main's `6.0` — the decode aborted on `IndexError`, so the arm never left home at x=0.088 m. Right is the same call on this branch: decoded, hand back at x=0.315 m. The two `6.0` panels differ on **15.89%** of pixels.

The figure's generator re-derives every number from the two per-tree JSON dumps and asserts them, including that the trees differ, that the reference agrees to ≤2/255, and that on main `-5` is indistinguishable from the sentinel. Capture, compose and probe scripts are beside it on the artifact branch.

## Tests

`tests/policies/vera/test_vera_gripper_dim_index_domain.py`, 20 tests, no `mink`/`mujoco`/`torch` (the bridge the decoder needs is duck-typed on three members) — 0.22 s:

- the domain itself, including that only the sentinel and the sign are decided locally;
- the decoder refuses every unusable spelling as a `ValueError` naming this function and the parameter;
- the silent half pinned as a refusal, and the honored indices still reading the column they name;
- an index past the last column reported against the chunk's width, and the same index usable on a wider chunk;
- the index inert when `has_gripper=False`, and the pre-existing pose-width mismatch still reported as before;
- reaching the rule loads no heavy module (subprocess-checked).

Pre-fix, with `strands_robots/policies/vera/sim_ik.py` reverted to `78491d46` and the tests kept: **8 failed / 12 passed** — identical before and after the rebase, so the contract is unchanged. The 12 that pass are the pure-rule cases (which run against a local stand-in of the contract) plus the honored-value controls, which is what stops the guard reaching further than the one parameter.

## Gate

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov`: **27115 passed, 257 skipped, 0 failed** (660 s), at base `78491d46`.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean (1149 files formatted, no issues in 1146 source files).
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD`: no overlap, 0 paths changed on `upstream/main` in that span — the branch was rebased before the suite ran, so the quoted numbers describe the tree that merges.
- Zero existing tests changed.

## Out of scope

`gripper_is_raw` sits beside this in the server metadata but is a boolean the provider binarizes with, not an index into the chunk, so it takes no part of this domain.
