### PR TITLE
fix(simulation/mujoco): publish the vector component counts the router enforces

### DIFF
--- a/changelog.d/2098-tool-spec-vector-arity.md
+++ b/changelog.d/2098-tool-spec-vector-arity.md
@@ -1,0 +1,21 @@
+### Fixed: the MuJoCo tool_spec publishes the vector component counts the router enforces
+
+`_validate_and_build_kwargs` refuses any vector parameter whose component count
+is not in `_VECTOR_PARAM_LENGTHS` - `Parameter 'orientation' must be a list of 4
+numbers, got 3.` Ten `tool_spec.json` properties are validated that way and all
+ten were advertised as an unbounded `array` of `number`, so the one figure a
+model needed to form a valid call was the one figure the schema never published,
+and the arity was discoverable only by being rejected.
+
+`minItems` / `maxItems` are now declared from the router's own table: 3 for
+`position`, `target`, `origin`, `force`, `torque_vec`, `gravity`, `direction`
+and `point`, 4 for `orientation`, and 3..4 for `color`, which accepts rgb or
+rgba. No accepted count changed.
+
+`orientation` also gains a description, because a count cannot pin it:
+`[w, x, y, z]` and `[x, y, z, w]` are both four components, `add_object` assigns
+the value straight to `body.quat`, and MuJoCo reads that scalar-first - so the
+wrong order passes every check the router has and applies a different rotation
+under `status="success"`. The convention was already documented for human
+readers in `docs/simulation/overview.md` and commented in the router's table;
+the agent-facing schema was the one place that omitted it.

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -95,7 +95,9 @@
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "minItems": 3,
+      "maxItems": 3
     },
     "ground_plane": {
       "type": "boolean"
@@ -142,13 +144,18 @@
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "minItems": 3,
+      "maxItems": 3
     },
     "orientation": {
       "type": "array",
       "items": {
         "type": "number"
-      }
+      },
+      "minItems": 4,
+      "maxItems": 4,
+      "description": "Orientation as a unit quaternion in [w, x, y, z] order - scalar first, MuJoCo's convention. Applied verbatim to the body quat, so an [x, y, z, w] vector has the same accepted length and is silently used as a different rotation."
     },
     "size": {
       "type": "array",
@@ -162,6 +169,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 4,
       "description": "Colour in 0..1: [r, g, b] (opaque alpha added) or [r, g, b, a]. Any other component count, including an empty list, is rejected - omit color entirely for the default mid-grey."
     },
     "mass": {
@@ -194,6 +203,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Camera target point"
     },
     "parent_body": {
@@ -371,6 +382,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Force vector [fx, fy, fz] in Newtons"
     },
     "torque_vec": {
@@ -378,6 +391,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Torque vector [tx, ty, tz] in N\u00b7m"
     },
     "point": {
@@ -385,6 +400,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Point of force application [x, y, z]"
     },
     "origin": {
@@ -392,6 +409,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Ray origin [x, y, z]"
     },
     "direction": {
@@ -399,6 +418,8 @@
       "items": {
         "type": "number"
       },
+      "minItems": 3,
+      "maxItems": 3,
       "description": "Ray direction [dx, dy, dz]"
     },
     "directions": {

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -325,3 +325,124 @@ def test_tool_spec_description_action_count_matches_enum(sim: Simulation) -> Non
         f"tool_spec description says {stated} actions but the enum has {len(enum)}; "
         "update the count when adding/removing an action."
     )
+
+
+# Vector-arity contract
+#
+# ``_validate_and_build_kwargs`` step 2 refuses any vector param whose component
+# count is not in ``_VECTOR_PARAM_LENGTHS`` - "Parameter 'orientation' must be a
+# list of 4 numbers, got 3." That refusal is the router's, and until the bounds
+# below were declared the schema said only ``{"type": "array", "items": {"type":
+# "number"}}``: a model forms its call from the schema and nothing else, so the
+# one number it needed was the one number not published, and the arity was
+# discoverable only by being rejected.
+#
+# ``minItems`` / ``maxItems`` are the machine-readable form of that count. Prose
+# is not a substitute: seven of the ten carried the shape in a description
+# (``[x, y, z]``) while three - ``position``, ``gravity``, ``orientation`` - had
+# no description at all, and prose is not read by a schema-constrained decoder.
+#
+# Keyed on the live table rather than a literal copy of it, so a param added
+# there fails here until it is published.
+
+
+def _tool_spec_properties() -> dict[str, Any]:
+    spec_path = Path(__file__).resolve().parents[3] / "strands_robots/simulation/mujoco/tool_spec.json"
+    return json.loads(spec_path.read_text())["properties"]
+
+
+class TestTheSchemaPublishesTheArityTheRouterEnforces:
+    """Every router-validated vector param declares its component count."""
+
+    @staticmethod
+    def _schema_name(param: str) -> str:
+        """The name a caller spells ``param`` as in the schema.
+
+        The router rewrites ``_FIELD_ALIASES`` before validating, so a table
+        entry can be validated under a name no caller ever writes.
+        """
+        props = _tool_spec_properties()
+        if param in props:
+            return param
+        aliases_by_param = {target: field for field, target in Simulation._FIELD_ALIASES.items()}
+        return aliases_by_param.get(param, param)
+
+    def test_every_router_validated_vector_param_is_reachable_in_the_schema(self) -> None:
+        """Each table entry is a schema property, directly or under a field alias.
+
+        Skipping an entry that is absent from the schema would make this class
+        vacuous exactly when it matters: a property renamed out of the schema
+        would stop being checked instead of failing. ``torque`` is the one entry
+        with no property of its own - the router rewrites the schema's
+        ``torque_vec`` to it via ``_FIELD_ALIASES`` before validating - so the
+        alias table is consulted rather than the entry being passed over.
+        """
+        props = _tool_spec_properties()
+
+        unreachable = [param for param in Simulation._VECTOR_PARAM_LENGTHS if self._schema_name(param) not in props]
+        assert not unreachable, (
+            "every _VECTOR_PARAM_LENGTHS entry must be advertised as a tool_spec property, "
+            f"directly or via _FIELD_ALIASES; unreachable: {sorted(unreachable)}"
+        )
+
+    def test_two_spellings_of_one_vector_param_accept_the_same_count(self) -> None:
+        """``torque`` and ``torque_vec`` are one wire field, so one count.
+
+        A field alias means two table entries can resolve to a single schema
+        property, and a property has one pair of bounds. If the entries ever
+        disagreed no bounds could be correct for both, and the next test would
+        report the property twice with contradictory expectations rather than
+        naming the contradiction.
+        """
+        by_property: dict[str, set[tuple[int, ...]]] = {}
+        for param, accepted_lens in Simulation._VECTOR_PARAM_LENGTHS.items():
+            by_property.setdefault(self._schema_name(param), set()).add(tuple(accepted_lens))
+
+        disagreeing = {name: sorted(lens) for name, lens in by_property.items() if len(lens) > 1}
+        assert not disagreeing, f"params sharing one tool_spec property must accept the same counts: {disagreeing}"
+
+    def test_every_router_validated_vector_param_declares_min_and_max_items(self) -> None:
+        """The published bounds equal the counts the router will accept."""
+        props = _tool_spec_properties()
+
+        accepted_by_property: dict[str, set[int]] = {}
+        for param, accepted_lens in Simulation._VECTOR_PARAM_LENGTHS.items():
+            accepted_by_property.setdefault(self._schema_name(param), set()).update(accepted_lens)
+
+        offenders: list[str] = []
+        for name, accepted in sorted(accepted_by_property.items()):
+            schema = props.get(name)
+            if schema is None:
+                continue  # reported by the reachability test above
+            if schema.get("type") != "array":
+                offenders.append(f"{name!r} is validated as a vector but advertised as {schema.get('type')!r}")
+                continue
+            if schema.get("minItems") != min(accepted) or schema.get("maxItems") != max(accepted):
+                offenders.append(
+                    f"{name!r} accepts {sorted(accepted)} components but advertises "
+                    f"minItems={schema.get('minItems')} maxItems={schema.get('maxItems')}"
+                )
+
+        assert not offenders, "tool_spec must publish the component counts the router enforces:\n  - " + "\n  - ".join(
+            offenders
+        )
+
+    def test_orientation_publishes_the_quaternion_component_order(self) -> None:
+        """Arity alone cannot pin ``orientation``, so the order is stated.
+
+        The other nine params are fully described by a count: a rejected length
+        is the only way to get them wrong. ``orientation`` is not. Both
+        ``[w, x, y, z]`` and ``[x, y, z, w]`` are four components, ``add_object``
+        assigns the value straight to ``body.quat``, and MuJoCo reads that
+        scalar-first - so the wrong order passes every check the router has and
+        applies a different rotation under ``status="success"``. A silent wrong
+        answer is the one failure mode the bounds above do not cover, which is
+        why the convention is published rather than left to the count.
+        """
+        orientation = _tool_spec_properties()["orientation"]
+        description = orientation.get("description", "")
+        assert "quaternion" in description.lower(), "orientation must say it is a quaternion, not a 4-vector"
+        assert "[w, x, y, z]" in description, (
+            "orientation must publish the scalar-first component order; an [x, y, z, w] "
+            f"vector is otherwise indistinguishable to a caller. Got: {description!r}"
+        )


### PR DESCRIPTION
## What I measured

`_validate_and_build_kwargs` step 2 refuses any vector parameter whose component count is not in `_VECTOR_PARAM_LENGTHS`:

```
Parameter 'orientation' must be a list of 4 numbers, got 3.
```

Ten `tool_spec.json` properties are validated by that table. Every one of them was advertised as:

```json
{ "type": "array", "items": { "type": "number" } }
```

No `minItems`, no `maxItems` — measured across the whole schema, **no array property declared either**. A model forms its call from the schema and nothing else, so the one number it needed was the one number never published, and the arity was discoverable only by being rejected.

| property | router accepts | advertised |
|---|---|---|
| `position`, `target`, `origin`, `force`, `torque_vec`, `gravity`, `direction`, `point` | exactly 3 | unbounded array of number |
| `orientation` | exactly 4 | unbounded array of number |
| `color` | 3 or 4 | unbounded array of number |

This is the same family as #2093 — the advertised contract narrower than the dispatchable one — read on the parameter axis rather than the action axis. Cross-referenced rather than claimed: #2093's open question is which *actions* belong at the LLM interface, which this does not answer.

## `orientation` is the one a count cannot fix

The other nine are fully described by their arity: a refusal is the only way to get them wrong, and a refusal is at least legible. `orientation` is not.

`[w, x, y, z]` and `[x, y, z, w]` are both four components. `add_object` assigns the value straight to `body.quat` (`scene_ops.py:825`), and MuJoCo reads that scalar-first. So the wrong order passes the length check, passes the numeric check, and applies **a different rotation under `status="success"`** — a silent wrong answer rather than an error. That is the one failure mode bounds cannot cover, so the convention is now stated in the property description.

Worth noting where the convention already lived: `docs/simulation/overview.md:47` documents `orientation=[w,x,y,z]`, and the router's own table comments it (`# quaternion (w,x,y,z)`). Humans reading the docs and developers reading the source both had it. The agent-facing schema — the only artifact a model reads — was the single place that omitted it.

Prose was not a substitute for the bounds either: seven of the ten carried the shape inside a description (`"Ray origin [x, y, z]"`), while `position`, `gravity` and `orientation` had **no description at all**, and a schema-constrained decoder reads neither.

## The change

`tool_spec.json`, +24/-3: `minItems` / `maxItems` on the ten properties, taken from the router's own table, plus a description for `orientation` naming the component order and why the length does not imply it.

**No behaviour change.** `_VECTOR_PARAM_LENGTHS` is untouched, so nothing the router accepted before is refused now and nothing it refused is accepted. What changed is what the schema says about it.

## The guard

Four tests in `tests/simulation/mujoco/test_tool_spec.py`, which already owns the mirror direction of this contract (`test_every_tool_spec_action_has_a_public_method_or_documented_alias`) — one authority for "the schema matches the router" rather than a second module to discover.

- **`..._declares_min_and_max_items`** — keyed on the live `_VECTOR_PARAM_LENGTHS`, not a literal copy, so a parameter added to the table fails here until it is published.
- **`..._is_reachable_in_the_schema`** — every table entry must be a property, directly or through `_FIELD_ALIASES`. This one exists because the obvious implementation is vacuous in the case that matters: `if name in props` would skip `torque`, which has no property of its own (the router rewrites the schema's `torque_vec` to it before validating), and would go on silently skipping any property later renamed out of the schema. It resolves the alias instead of passing over the entry.
- **`..._two_spellings_of_one_vector_param_accept_the_same_count`** — a consequence of the above: two entries can resolve to one property, and a property has one pair of bounds. If `torque` and `torque_vec` ever disagreed, no bounds would be correct for either, and this names the contradiction rather than reporting the property twice with contradictory expectations.
- **`..._orientation_publishes_the_quaternion_component_order`** — asserts the description names the convention, since arity cannot.

**Non-vacuity.** Two of the four fail on the pre-change schema, naming all ten properties:

```
FAILED ...::test_every_router_validated_vector_param_declares_min_and_max_items
  - 'color' accepts [3, 4] components but advertises minItems=None maxItems=None
  - 'direction' accepts [3] components but advertises minItems=None maxItems=None
  ... (10 properties, each named once)
FAILED ...::test_orientation_publishes_the_quaternion_component_order
  AssertionError: orientation must say it is a quaternion, not a 4-vector
```

The other two pass on both trees by design — they guard against a future vacuity, not a present defect.

## Scope

`size` is deliberately excluded. It is a vector property, but it is *not* in `_VECTOR_PARAM_LENGTHS` — its component count is shape-dependent (`box [x,y,z]` vs `sphere [diameter]`), and whether the three backends converge on one per-shape count table is the open contract decision in #1858. Publishing a single `maxItems` for it would pre-empt that. `pixels` and `directions` are arrays-of-arrays whose inner arity is enforced by their own methods rather than by the router's table, so they are outside the invariant this guard states.

## Verification

| | result |
|---|---|
| `ruff format --check` / `ruff check tests strands_robots` | clean |
| `mypy tests/simulation/mujoco/test_tool_spec.py` | clean |
| `test_tool_spec.py` | 16 passed (12 existing + 4 new) |
| affected modules, branch | 138 passed, 9 failed |
| affected modules, clean `main`, same env | 134 passed, **9 failed — identical set** |

The 9 are environmental and pre-exist on the base: this sandbox has no asset fetch, so `so100` never resolves (`No model found for 'so100'`). The whole effect of the change is **+4 passes**. Read as a delta against a control run rather than as an absolute, because the absolute is a property of the host.

Measured on `78491d46`.