### PR TITLE
test(sim): pin the spec-snapshot refusal contract every scene mutation depends on

### DIFF
--- a/changelog.d/2099-spec-snapshot-refusal-coverage.md
+++ b/changelog.d/2099-spec-snapshot-refusal-coverage.md
@@ -1,0 +1,16 @@
+### Quality: pin the spec-snapshot refusal contract every scene mutation depends on
+
+Every MuJoCo scene mutation that is only validated by the recompile it precedes
+takes a deep copy of the live `MjSpec` first, and that copy is the only way
+back. `_snapshot_spec`'s docstring states the consequence for a caller -- "A
+caller that cannot snapshot must refuse its mutation rather than proceed with no
+way back" -- because a mutation applied with nothing to restore leaves an orphan
+in the spec, and an orphan makes every later scene mutation fail to recompile.
+
+That refusal had never been exercised. The helper's failure branch and all three
+callers' refusals were unreached, so nothing verified that `add_robot`,
+`actuate_robot` and `patch_scene_mjcf` decline rather than mutate blind -- each
+through a different channel. The new tests drive a refused `MjSpec.copy` through
+all three public surfaces and assert the whole cost of the refusal: the compiled
+model is unchanged, the mutation's own element is absent, the scene is still
+mutable, and the identical call succeeds once the failure clears.

--- a/tests/simulation/mujoco/test_spec_snapshot_refusal.py
+++ b/tests/simulation/mujoco/test_spec_snapshot_refusal.py
@@ -1,0 +1,224 @@
+"""The ``_snapshot_spec`` refusal contract: no way back means no mutation.
+
+Every scene mutation that is only validated by the recompile it precedes takes a
+deep copy of the live ``MjSpec`` first, via
+:func:`strands_robots.simulation.mujoco.scene_ops._snapshot_spec`. That snapshot
+is the only way back: the spec can carry state that exists ONLY on the spec and
+is absent from the ``_world`` registries - weld equalities from
+``attach_bodies``, actuators from ``actuate_robot``, bodies from
+``patch_scene_mjcf`` - so a rebuild-from-registry rollback would silently drop
+them.
+
+The helper's docstring states the consequence for a caller: "A caller that
+cannot snapshot must refuse its mutation rather than proceed with no way back."
+Proceeding anyway is the failure this contract exists to prevent - a mutation
+applied to the live spec with nothing to restore leaves an orphan behind, and an
+orphan makes every LATER scene mutation fail to recompile, bricking the whole
+world after one bad call.
+
+Three callers share the helper and each refuses through its OWN channel, which
+is why one test per surface is not one test three times:
+
+* ``add_robot`` -> ``inject_robot_into_scene`` returns ``False``, and the caller
+  also unwinds the ``_world.robots`` registry entry it had already made,
+* ``actuate_robot`` -> ``actuate_robot_in_scene`` returns ``False``,
+* ``patch_scene_mjcf`` -> raises ``RuntimeError``, which the facade converts.
+
+Each test asserts the whole cost of the refusal rather than only its status: the
+compiled model is unchanged, the mutation's own element is absent, the scene is
+still mutable, and - because a copy failure is transient - the identical call
+succeeds once it clears. A caller that proceeded without a snapshot would fail
+that last assertion, not the first.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_actuate_robot import MINI_ARM_URDF  # noqa: E402
+
+_LOGGER_NAME = "strands_robots.simulation.mujoco.scene_ops"
+
+# The two failures the helper's ``except`` names. ``MjSpec.copy`` is a pybind11
+# binding, so both are plausible for a spec the copy cannot represent.
+_REFUSED_COPIES = [
+    pytest.param(RuntimeError("MjSpec.copy unavailable"), id="RuntimeError"),
+    pytest.param(ValueError("MjSpec.copy rejected the spec"), id="ValueError"),
+]
+
+
+class _SpecWithNoCopy:
+    """Stands in for a live spec whose deep copy cannot be taken."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def copy(self) -> object:
+        raise self._exc
+
+
+def _refuse_snapshots(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the snapshot every scene mutation takes fail.
+
+    Patches the binding rather than the helper so the refusal enters through the
+    same call the production path makes. ``monkeypatch.undo()`` in the tests
+    models the failure clearing, which is what lets the retry assertion show the
+    refusal cost the caller nothing permanent.
+    """
+
+    def _boom(_self: object) -> object:
+        raise RuntimeError("simulated MjSpec.copy failure")
+
+    monkeypatch.setattr(mj.MjSpec, "copy", _boom)
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_spec_snapshot_refusal", mesh=False)
+    s.create_world()
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+@pytest.fixture
+def arm_sim(sim, tmp_path):
+    """A world holding an actuator-less URDF arm, ready for ``actuate_robot``."""
+    urdf = tmp_path / "mini_arm.urdf"
+    urdf.write_text(MINI_ARM_URDF)
+    assert sim.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+    assert sim._world is not None
+    assert sim._world._model.nu == 0, "the arm must load actuator-less for this test"
+    return sim
+
+
+def _body_id(sim: Simulation, name: str) -> int:
+    assert sim._world is not None
+    return int(mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, name))
+
+
+class TestTheSnapshotHelperReportsAFailedCopy:
+    @pytest.mark.parametrize("exc", _REFUSED_COPIES)
+    def test_a_refused_copy_reports_no_snapshot(self, exc: BaseException, caplog) -> None:
+        """A copy the binding refuses is reported as "no snapshot", with the reason."""
+        with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+            assert scene_ops._snapshot_spec(_SpecWithNoCopy(exc), context="inject_robot 'arm'") is None
+
+        logged = caplog.text
+        assert "cannot snapshot the scene spec" in logged
+        # The caller's context is what tells an operator WHICH mutation refused.
+        assert "inject_robot 'arm'" in logged
+        assert str(exc) in logged
+
+    def test_an_unexpected_failure_propagates(self) -> None:
+        """Only the two named failures mean "no snapshot"; anything else propagates.
+
+        Folding an unknown failure into ``None`` would let a caller report a
+        clean refusal for a fault it has not diagnosed, so the narrow ``except``
+        is part of the contract.
+        """
+        with pytest.raises(TypeError, match="not a spec"):
+            scene_ops._snapshot_spec(_SpecWithNoCopy(TypeError("not a spec")), context="ctx")
+
+    def test_a_working_copy_hands_back_an_independent_spec(self, sim: Simulation) -> None:
+        """Non-vacuity: on a real live spec the helper returns a distinct copy."""
+        assert sim._world is not None
+        spec = sim._world._backend_state["spec"]
+        backup = scene_ops._snapshot_spec(spec, context="ctx")
+        assert backup is not None
+        assert backup is not spec
+
+
+class TestAddRobotRefusesWithoutAWayBack:
+    def test_the_robot_is_refused_and_the_refusal_costs_nothing(
+        self, sim: Simulation, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        urdf = tmp_path / "mini_arm.urdf"
+        urdf.write_text(MINI_ARM_URDF)
+        assert sim._world is not None
+        nbody_before = sim._world._model.nbody
+
+        _refuse_snapshots(monkeypatch)
+        refused = sim.add_robot(name="arm", urdf_path=str(urdf))
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        assert "arm" in refused["content"][0]["text"]
+        # Nothing was attached, and the registry entry the caller's name claimed
+        # was unwound - so the name is free rather than half-taken.
+        assert sim._world._model.nbody == nbody_before
+        assert "arm" not in sim._world.robots
+
+        # The scene is still mutable, and the identical add succeeds once the
+        # copy failure clears. A mutation applied with no way back would have
+        # left an orphan that makes both of these fail.
+        assert (
+            sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])["status"]
+            == "success"
+        )
+        assert sim.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+        assert sim._world._model.nbody > nbody_before
+        assert "arm" in sim._world.robots
+
+
+class TestActuateRobotRefusesWithoutAWayBack:
+    def test_the_surgery_is_refused_and_no_actuator_is_added(
+        self, arm_sim: Simulation, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sim = arm_sim
+        assert sim._world is not None
+
+        _refuse_snapshots(monkeypatch)
+        refused = sim.actuate_robot(robot_name="arm", kp=30.0)
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        assert "arm" in refused["content"][0]["text"]
+        # actuate_robot rewrites option, joints, geoms and actuators together,
+        # which is why it needs a snapshot at all: none of it was applied.
+        assert sim._world._model.nu == 0
+        assert list(sim._world.robots["arm"].actuator_ids) == []
+
+        assert (
+            sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])["status"]
+            == "success"
+        )
+        assert sim.actuate_robot(robot_name="arm", kp=30.0)["status"] == "success"
+        assert sim._world._model.nu > 0
+
+
+class TestPatchSceneMjcfRefusesWithoutAWayBack:
+    def test_the_batch_is_refused_with_the_reason_and_nothing_is_patched(
+        self, sim: Simulation, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert sim._world is not None
+        nbody_before = sim._world._model.nbody
+        ops = [{"op": "add_body", "name": "marker", "pos": [0.3, 0, 0.2]}]
+
+        _refuse_snapshots(monkeypatch)
+        refused = sim.patch_scene_mjcf(ops)
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        message = refused["content"][0]["text"]
+        # This caller refuses by raising, so the reason has to survive the
+        # facade's conversion to the tool envelope rather than being flattened
+        # into a bare "patch failed".
+        assert "snapshot" in message.lower()
+        assert sim._world._model.nbody == nbody_before
+        assert _body_id(sim, "marker") == -1
+
+        assert (
+            sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])["status"]
+            == "success"
+        )
+        assert sim.patch_scene_mjcf(ops)["status"] == "success"
+        assert _body_id(sim, "marker") >= 0


### PR DESCRIPTION
## Problem

Every MuJoCo scene mutation that is only validated by the recompile it precedes
deep-copies the live `MjSpec` first, via `scene_ops._snapshot_spec`. That copy is
the only way back: the spec can carry state that exists **only** on the spec and
is absent from the `_world` registries -- weld equalities from `attach_bodies`,
actuators from `actuate_robot`, bodies from `patch_scene_mjcf` -- so a
rebuild-from-registry rollback would silently drop them.

The helper's docstring states the consequence for a caller:

> A caller that cannot snapshot must refuse its mutation rather than proceed with
> no way back.

Proceeding anyway is the failure that rule exists to prevent: a mutation applied
with nothing to restore leaves an orphan in the spec, and an orphan makes every
**later** scene mutation fail to recompile -- bricking the whole world after one
bad call. That is the same blast radius `inject_robot_into_scene`'s own rollback
was added for.

**None of it was exercised.** The helper's failure branch and all three callers'
refusals were unreached, and `_snapshot_spec` appeared zero times under `tests/`:

```
scene_ops.py   107-109  _snapshot_spec         except -> log + return None
scene_ops.py       638  inject_robot_into_scene  if backup_spec is None: return False
scene_ops.py      1159  actuate_robot_in_scene   if backup_spec is None: return False
scene_ops.py      1592  patch_scene_mjcf         if backup_spec is None: raise RuntimeError
```

Three callers, three **different** refusal channels, so this is not one test
three times.

## Measured behaviour

Driving a refused `MjSpec.copy` through each public surface on a live world:

| surface | channel | verdict | scene after | still mutable | identical retry |
|---|---|---|---|---|---|
| `add_robot` | `inject_robot_into_scene` -> `False` | `error: Failed to inject robot 'arm' into scene.` | `nbody` unchanged, `_world.robots` empty | yes | succeeds |
| `actuate_robot` | `actuate_robot_in_scene` -> `False` | `error: actuate_robot: spec recompile failed for 'arm' (spec restored, see logs).` | `nu == 0`, `actuator_ids == []` | yes | succeeds |
| `patch_scene_mjcf` | raises `RuntimeError`, facade converts | `error: MJCF patch failed: failed to snapshot spec before patch (see logs)` | `nbody` unchanged, the op's body absent | yes | succeeds |

And the helper itself: `RuntimeError` -> `None`, `ValueError` -> `None`,
`TypeError` -> **propagates** (the narrow `except` is deliberate -- folding an
undiagnosed failure into `None` would let a caller report a clean refusal for a
fault it has not identified).

Every refusal names the operation and costs the caller nothing permanent, which
is why each test asserts the *whole* cost of the refusal rather than only its
status. The last column is the load-bearing one: a caller that proceeded without
a snapshot leaves an orphan, and the orphan is what makes the retry fail.

## Change

One new test module, `tests/simulation/mujoco/test_spec_snapshot_refusal.py` --
6 tests (7 cases, 0.60 s, no GL):

- the helper reports "no snapshot" for each failure its `except` names, with the
  caller's context in the log, and propagates anything else;
- non-vacuity: on a real live spec it returns a distinct copy;
- one test per public surface asserting refusal + model unchanged + element
  absent + scene still mutable + identical retry succeeds.

**No production line changes** (`git diff --stat upstream/main...HEAD` is 2 files,
240 insertions, 0 deletions).

## Fails pre-fix

A tests-only change cannot fail against unmodified source, so the evidence is a
mutation table -- each guard removed in turn, scoped to the target function's AST
line range (the two `if backup_spec is None: return False` blocks are textually
identical, so file-wide replacement would hit the wrong one), then restored and
the source asserted byte-identical:

| mutation | result |
|---|---|
| `_snapshot_spec`: drop the `try`/`except` so a copy failure propagates | **5 failed**, 2 passed |
| `inject_robot_into_scene`: drop the no-snapshot refusal | **1 failed**, 6 passed |
| `actuate_robot_in_scene`: drop the no-snapshot refusal | **1 failed**, 6 passed |
| `patch_scene_mjcf`: drop the no-snapshot refusal | **1 failed**, 6 passed |

Each caller mutation is caught by exactly its own test, which is the measurement
that the three surfaces are distinct rather than redundant.

## Coverage

`tests/simulation/mujoco` with the repo's own `--cov` target, the before arm
ignoring only the new file so both arms carry identical conditions:

```
before  scene_ops.py  587  21  96%   107-109, ..., 638, 735-737, ..., 1159, ..., 1592
after   scene_ops.py  587  15  97%   275, 297, ..., 735-737, 1028, 1034, 1432
2694 -> 2701 passed (exactly the 7 new cases)
```

The 6 targeted lines are gone and nothing else moved.

## No visual artifact

The diff contains no production file: no policy, simulation, rendering,
recording or asset behaviour changes, so there is nothing a rollout could show
that main would not show identically. The measured tables above are the evidence.

## Gate

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **27122 passed, 257 skipped, 0 failed** (595 s)
- `ruff check strands_robots tests tests_integ` -> clean; `ruff format --check` -> 1151 files already formatted
- `mypy strands_robots tests tests_integ` -> `Success: no issues found in 1148 source files`
- repo-wide root guards + `Args:` completeness -> 414 passed
- `scripts/assemble_changelog.py --check` -> OK (271 pending)
- `scripts/check_merge_base_overlap.py` -> no overlap (0 paths changed in that span); rebased onto `c1d64be` before the suite, so the numbers above describe the tree that merges
