### PR TITLE
fix(simulation): list what IS registered whatever the requested entity name's type

### DIFF
--- a/changelog.d/2103-unknown-entity-listing-name-type.md
+++ b/changelog.d/2103-unknown-entity-listing-name-type.md
@@ -1,0 +1,18 @@
+### Fixed: an unknown-entity message lists what IS registered whatever the requested name's type
+
+`registered()` is total so a name that cannot be a registry key - a list, a dict, an
+int, `None` - is *reported* rather than raising `TypeError: unhashable type`. The
+five unknown-entity messages could not honor that handoff: each gated its whole
+tail on `if known and isinstance(requested, str)`, but only the `difflib`
+close-match needs a string. For every non-`str` name the availability listing and
+the discovery action were suppressed too, and three of the five then asserted a
+falsehood - `Robot '['front']' not found. No robots in the scene; add one with
+action='add_robot'.` with a robot registered. The other two returned the bare
+dead-end `"<Kind> 'X' not found."` these helpers were introduced to eliminate.
+
+The type test now guards only the suggestion, via a shared `close_match_hint()`;
+what is registered is a fact about the world, so it is listed for every name type
+and the empty-scene claim is made only when the scene really is empty. Two lookups
+that raised *before* their own report - `get_sensor_data` and `load_state` - are
+total as well, so the message is reached at all. A `str` name's message is
+byte-identical.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -105,6 +105,41 @@ def reject_setup_kwargs(kwargs: Mapping[str, Any]) -> None:
     )
 
 
+def close_match_hint(requested: object, known: Sequence[str]) -> str:
+    """The ``" Did you mean: a, b?"`` fragment of an unknown-entity message.
+
+    Returns ``""`` when there is no usable suggestion, so a caller can append
+    it unconditionally.
+
+    This is the *only* part of an unknown-entity message that needs
+    ``requested`` to be a :class:`str`: :func:`difflib.get_close_matches`
+    compares character sequences, and a name of another type has none. What is
+    registered - and the discovery action that lists it - is a property of the
+    world alone, so it must not be gated on the requested name's type. Owning
+    that distinction here is what keeps the two from being conflated again: one
+    ``isinstance`` test guarding both suppressed the whole listing for every
+    non-``str`` name, and such a name is exactly what
+    :func:`strands_robots.simulation.models.registered` routes to these
+    messages - it is total so an unhashable name is reported rather than
+    raising, and the report it hands off to has to be usable.
+
+    Args:
+        requested: Caller-supplied entity name, of any type.
+        known: Entity names that are registered.
+
+    Returns:
+        A leading-space ``" Did you mean: ...?"`` fragment, or ``""`` when
+        ``requested`` is not a string, nothing is registered, or no registered
+        name is close enough to suggest.
+    """
+    if not isinstance(requested, str) or not known:
+        return ""
+    matches = difflib.get_close_matches(requested, list(known), n=3, cutoff=0.4)
+    if not matches:
+        return ""
+    return " Did you mean: " + ", ".join(matches) + "?"
+
+
 def unknown_kwargs_error(method: str, kwargs: Mapping[str, Any], accepted: Sequence[str]) -> dict[str, Any] | None:
     """Return a tool-envelope error for keyword arguments a method cannot use.
 
@@ -658,7 +693,7 @@ class SimEngine(ABC):
             raise ValueError("No robots registered in the simulation. Add a robot first (add_robot or Robot factory).")
         raise ValueError(f"Multiple robots registered; specify robot_name. Available: {names}")
 
-    def _unknown_robot_msg(self, requested: str) -> str:
+    def _unknown_robot_msg(self, requested: object) -> str:
         """Actionable 'robot not found' message for the backend-agnostic facade.
 
         Keeps the "Robot 'X' not found." prefix (the consistent error shape the
@@ -669,13 +704,19 @@ class SimEngine(ABC):
         :meth:`list_robots` primitive, so every backend inherits it; the MuJoCo
         engine overrides with a ``self._world.robots``-backed variant. Mirrors the
         ``_unknown_object_msg`` / ``_unknown_camera_msg`` pattern (#1299/#1303/#1306).
+
+        ``requested`` is typed ``object`` because a name of any type reaches here:
+        :func:`~strands_robots.simulation.models.registered` is total, so a name
+        that cannot be a registry key resolves to "no such entity" and is
+        reported rather than raising. Only the close match needs a string (see
+        :func:`close_match_hint`); what is registered is a fact about the world,
+        so it is listed for every name type instead of being replaced by an
+        "empty scene" claim that would be false.
         """
         known = self.list_robots()
         msg = f"Robot '{requested}' not found."
-        if known and isinstance(requested, str):
-            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
-            if matches:
-                msg += " Did you mean: " + ", ".join(matches) + "?"
+        if known:
+            msg += close_match_hint(requested, known)
             msg += f" Available robots: {known}. Use action='list_robots' to see all."
         else:
             msg += " No robots in the scene; add one with action='add_robot'."

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -107,7 +107,7 @@ class ManipulationMixin:
         def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
             """Provided by ``Simulation``; declared here for type-checkers."""
 
-        def _unknown_robot_msg(self, requested: str) -> str:
+        def _unknown_robot_msg(self, requested: object) -> str:
             """Provided by ``Simulation``; declared here for type-checkers."""
 
     # -- shared guards -----------------------------------------------------

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -140,7 +140,7 @@ class MotionPrimitivesMixin:
         def _require_no_running_policy(self, action_name: str, robot_name: str | None = None) -> dict[str, Any] | None:
             """Provided by ``Simulation``; declared here for type-checkers."""
 
-        def _unknown_robot_msg(self, requested: str) -> str:
+        def _unknown_robot_msg(self, requested: object) -> str:
             """Provided by ``Simulation``; declared here for type-checkers."""
 
         def _resolve_single_robot(self, robot_name: str | None) -> str:

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -22,7 +22,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
-from strands_robots.simulation.base import _BOOLEAN_STATE_REASON
+from strands_robots.simulation.base import _BOOLEAN_STATE_REASON, close_match_hint
+from strands_robots.simulation.models import registered
 from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
@@ -471,7 +472,7 @@ class PhysicsMixin:
         def _require_world(self) -> dict[str, Any] | None:
             """Refuse a call made before ``create_world``."""
 
-        def _unknown_robot_msg(self, requested: str) -> str:
+        def _unknown_robot_msg(self, requested: object) -> str:
             """Build the "robot not found" message with close-match hints."""
 
         def _validate_mass(self, mass: Any, method: str, param: str = "mass") -> dict[str, Any] | None:
@@ -562,7 +563,7 @@ class PhysicsMixin:
             return err
 
         checkpoints = getattr(self._world, "_checkpoints", {})
-        if name not in checkpoints:
+        if not registered(checkpoints, name):
             available = list(checkpoints.keys()) if checkpoints else ["none"]
             return {
                 "status": "error",
@@ -814,7 +815,7 @@ class PhysicsMixin:
                     return int(mid)
         return -1
 
-    def _unknown_mj_entity_msg(self, kind: str, requested: str) -> str:
+    def _unknown_mj_entity_msg(self, kind: str, requested: object) -> str:
         """Actionable "<kind> not found" message for the physics/introspection
         lookups (``get_body_state`` / ``get_jacobian`` / ``set_body_properties`` /
         ``set_geom_properties`` / ``get_sensor_data`` ...): name the entity, offer
@@ -829,6 +830,13 @@ class PhysicsMixin:
         error shape (T15 in ``test_agenttool_contract``) is unaffected.
 
         ``kind`` is one of ``"Body" | "Site" | "Geom" | "Sensor" | "Joint"``.
+
+        ``requested`` is typed ``object``: a name of any type reaches here, and
+        only the close match needs a string (see
+        :func:`~strands_robots.simulation.base.close_match_hint`). The
+        available-entity listing is a fact about the compiled model, so it is
+        emitted for every name type rather than being suppressed into a bare
+        ``"<Kind> 'X' not found."`` dead end.
         """
         import mujoco as _mj
 
@@ -844,12 +852,8 @@ class PhysicsMixin:
             "Joint": (_mj.mjtObj.mjOBJ_JOINT, model.njnt),
         }[kind]
         known = [nm for i in range(int(count)) if (nm := _mj.mj_id2name(model, obj_type, i)) and nm != "world"]
-        if known and isinstance(requested, str):
-            import difflib
-
-            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
-            if matches:
-                msg += " Did you mean: " + ", ".join(matches) + "?"
+        if known:
+            msg += close_match_hint(requested, known)
             shown = known if len(known) <= 30 else known[:30] + ["..."]
             plural = {
                 "Body": "bodies",
@@ -1617,7 +1621,7 @@ class PhysicsMixin:
                 "type": int(model.sensor_type[i]),
             }
 
-        if sensor_name and sensor_name not in sensors:
+        if sensor_name and not registered(sensors, sensor_name):
             return {"status": "error", "content": [{"text": self._unknown_mj_entity_msg("Sensor", sensor_name)}]}
 
         lines = [f"Sensors ({len(sensors)}/{model.nsensor}):"]

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -58,7 +58,7 @@ from strands.tools.tools import AgentTool
 from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolSpec, ToolUse
 
-from strands_robots.simulation.base import SimEngine, reject_setup_kwargs
+from strands_robots.simulation.base import SimEngine, close_match_hint, reject_setup_kwargs
 from strands_robots.simulation.model_registry import (
     count_sim_robots,
     list_available_models,
@@ -1174,25 +1174,21 @@ class MuJoCoSimEngine(
         msg += " Use action='list_urdfs' to see all available robots."
         return msg
 
-    def _unknown_object_msg(self, requested: str) -> str:
+    def _unknown_object_msg(self, requested: object) -> str:
         """Actionable 'object not found' message: name it, offer a close-match,
         and point at the discovery surface - consistent with the camera
         render/record error paths and ``_unknown_model_msg`` (#1299) rather
         than a dead-end "Object 'X' not found."."""
         known = list(self._world.objects.keys()) if self._world is not None else []
         msg = f"Object '{requested}' not found."
-        if known and isinstance(requested, str):
-            import difflib
-
-            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
-            if matches:
-                msg += " Did you mean: " + ", ".join(matches) + "?"
+        if known:
+            msg += close_match_hint(requested, known)
             msg += f" Available objects: {known}. Use action='list_objects' to see all."
         else:
             msg += " No objects in the scene; add one with action='add_object'."
         return msg
 
-    def _unknown_camera_msg(self, requested: str) -> str:
+    def _unknown_camera_msg(self, requested: object) -> str:
         """Actionable 'camera not found' message for ``remove_camera`` - lists the
         renderable cameras (like the render/record error paths already do) plus a
         close-match, so a typo is fixable in-place without a discovery round-trip.
@@ -1204,16 +1200,12 @@ class MuJoCoSimEngine(
         teaches, mirroring the ``list_objects`` hint in ``_unknown_object_msg``."""
         known = self._list_camera_names()
         msg = f"Camera '{requested}' not found."
-        if known and isinstance(requested, str):
-            import difflib
-
-            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
-            if matches:
-                msg += " Did you mean: " + ", ".join(matches) + "?"
+        if known:
+            msg += close_match_hint(requested, known)
             msg += f" Available: {known}. Use action='list_cameras' to see all."
         return msg
 
-    def _unknown_robot_msg(self, requested: str) -> str:
+    def _unknown_robot_msg(self, requested: object) -> str:
         """Actionable 'robot not found' message: name it, offer a close-match,
         and list the robots in the world - consistent with ``_unknown_object_msg`` /
         ``_unknown_camera_msg`` / ``_unknown_model_msg`` (#1299/#1303) rather than a
@@ -1221,12 +1213,8 @@ class MuJoCoSimEngine(
         into a discovery round-trip on every typo."""
         known = list(self._world.robots.keys()) if self._world is not None else []
         msg = f"Robot '{requested}' not found."
-        if known and isinstance(requested, str):
-            import difflib
-
-            matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
-            if matches:
-                msg += " Did you mean: " + ", ".join(matches) + "?"
+        if known:
+            msg += close_match_hint(requested, known)
             msg += f" Available robots: {known}. Use action='list_robots' to see all."
         else:
             msg += " No robots in the scene; add one with action='add_robot'."

--- a/tests/simulation/mujoco/test_unknown_entity_message_name_type.py
+++ b/tests/simulation/mujoco/test_unknown_entity_message_name_type.py
@@ -1,0 +1,364 @@
+"""The unknown-entity messages list what IS registered whatever the name's type.
+
+``registered()`` is deliberately total (#1776): a name that cannot be a registry
+key - a list, a dict, an int, ``None`` - resolves to "no such entity" so it is
+*reported* through the unknown-entity message rather than raising
+``TypeError: unhashable type`` out of a method whose only documented failure
+channel is the agent-tool dict. Its docstring says so: such a name "resolves to
+``False``, which lets the caller report it with the message it already has".
+
+Those messages could not honor that handoff. Each gated its whole tail on one
+condition, ``if known and isinstance(requested, str)``, but only the
+:func:`difflib.get_close_matches` suggestion needs a string. So for every
+non-``str`` name the availability listing and the discovery action - facts about
+the world, not about the requested name - were suppressed too, and three of the
+five helpers then fell into an ``else`` that asserted a falsehood:
+
+    Robot '['front']' not found. No robots in the scene; add one with action='add_robot'.
+
+with ``arm`` registered. The remaining two returned the bare dead-end
+``"<Kind> 'X' not found."`` that #1299/#1303/#1306 introduced these helpers to
+eliminate - ``test_missing_entity_error_messages`` states that contract: the
+message "names the entity, offers a close match, lists the available names, and
+points at the discovery action".
+
+A non-``str`` name is not exotic here: ``robot_name`` is the *first positional*
+parameter of ``move_to`` / ``set_gripper`` / ``rotate_wrist``, so
+``sim.move_to([0.2, 0.0, 0.1])`` lands a position list in it.
+
+These tests pin the split: what is registered is reported for every name type,
+the empty-scene claim is only made when the scene really is empty, and a
+``str`` name's message is unchanged. GL-free (``mesh=False``, no rendering).
+"""
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.base import SimEngine, close_match_hint  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+ARM_MJCF = """<mujoco model="arm"><compiler angle="radian"/>
+ <worldbody><body name="base" pos="0 0 0.05"><geom type="box" size="0.05 0.05 0.05"/>
+  <body name="link" pos="0 0 0.06"><joint name="pan" type="hinge" axis="0 0 1" range="-2 2" damping="4"/>
+   <geom type="capsule" fromto="0 0 0 0.18 0 0" size="0.02"/>
+   <site name="tcp" pos="0.18 0 0" size="0.005"/></body></body></worldbody>
+ <actuator><position name="a_pan" joint="pan" kp="50" ctrlrange="-2 2"/></actuator>
+ <sensor><framepos name="tcp_pos" objtype="site" objname="tcp"/></sensor></mujoco>
+"""
+
+# Names that cannot be a registry key, so registered() routes them here.
+NOT_A_NAME: list[Any] = [
+    pytest.param(["arm"], id="list"),
+    pytest.param({"name": "arm"}, id="dict"),
+    pytest.param(7, id="int"),
+    pytest.param(None, id="None"),
+    pytest.param(2.5, id="float"),
+]
+
+# ``get_sensor_data`` reads ``sensor_name`` behind ``if sensor_name and ...``, so
+# ``None`` is its documented "every sensor" spelling rather than a bad name.
+# Derived, so a value added above cannot quietly escape the strict subset.
+NOT_A_NAME_STRICT = [case for case in NOT_A_NAME if case.id != "None"]
+
+# The falsehood each of the three "else" branches used to assert.
+FALSE_EMPTY_CLAIMS = ("No robots in the scene", "No objects in the scene")
+
+
+@pytest.fixture
+def populated(tmp_path):
+    """A scene that really does hold a robot, an object and a camera."""
+    arm = tmp_path / "arm.xml"
+    arm.write_text(ARM_MJCF, encoding="utf-8")
+    sim = Simulation(tool_name="test_unknown_entity_name_type", mesh=False)
+    assert sim.create_world(gravity=[0, 0, 0])["status"] == "success"
+    assert sim.add_robot(name="arm", urdf_path=str(arm))["status"] == "success"
+    assert (
+        sim.add_object(name="crate", shape="box", size=[0.06, 0.06, 0.06], position=[0.3, 0, 0.03])["status"]
+        == "success"
+    )
+    assert sim.add_camera(name="look", position=[0.5, -0.4, 0.3], target=[0, 0, 0.1])["status"] == "success"
+    yield sim
+    sim.cleanup()
+
+
+@pytest.fixture
+def empty_world():
+    """A world with no robots and no objects, so the empty-scene claim is true."""
+    sim = Simulation(tool_name="test_unknown_entity_name_type_empty", mesh=False)
+    assert sim.create_world(gravity=[0, 0, 0])["status"] == "success"
+    yield sim
+    sim.cleanup()
+
+
+def _messages(sim: Simulation, requested: Any) -> dict[str, str]:
+    """Every unknown-entity message the helpers produce for one requested name."""
+    return {
+        "base.robot": SimEngine._unknown_robot_msg(sim, requested),
+        "mujoco.robot": sim._unknown_robot_msg(requested),
+        "mujoco.object": sim._unknown_object_msg(requested),
+        "mujoco.camera": sim._unknown_camera_msg(requested),
+        "entity.Body": sim._unknown_mj_entity_msg("Body", requested),
+        "entity.Joint": sim._unknown_mj_entity_msg("Joint", requested),
+        "entity.Sensor": sim._unknown_mj_entity_msg("Sensor", requested),
+    }
+
+
+def _text(result: dict[str, Any]) -> str:
+    assert result["status"] == "error", result
+    return next(block["text"] for block in result["content"] if "text" in block)
+
+
+class TestTheListingIsNotGatedOnTheNameType:
+    """What is registered is a fact about the world, not about the requested name."""
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_every_helper_still_lists_what_is_registered(self, populated, requested):
+        for label, msg in _messages(populated, requested).items():
+            assert "Available" in msg, f"{label} gave a dead end for {requested!r}: {msg}"
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_no_helper_claims_the_populated_scene_is_empty(self, populated, requested):
+        for label, msg in _messages(populated, requested).items():
+            for claim in FALSE_EMPTY_CLAIMS:
+                assert claim not in msg, f"{label} asserted {claim!r} for {requested!r}: {msg}"
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_every_helper_still_names_the_requested_value(self, populated, requested):
+        """The caller has to be able to see which value was rejected."""
+        for label, msg in _messages(populated, requested).items():
+            assert f"'{requested}'" in msg, f"{label} did not name {requested!r}: {msg}"
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_no_suggestion_is_invented_for_a_name_with_no_characters_to_match(self, populated, requested):
+        """difflib is the one part that genuinely needs a string, so it stays out."""
+        for label, msg in _messages(populated, requested).items():
+            assert "Did you mean" not in msg, f"{label} suggested a match for {requested!r}: {msg}"
+
+
+class TestThePublicSurfacesReportIt:
+    """Driven through the public API, not the private helpers."""
+
+    def test_a_positional_position_lands_in_robot_name_and_is_reported_usefully(self, populated):
+        """``move_to``'s first positional is ``robot_name`` - the realistic mistake."""
+        text = _text(populated.move_to([0.2, 0.0, 0.1], position=[0.2, 0.0, 0.1], max_steps=2))
+        assert "Available robots: ['arm']" in text, text
+        assert "No robots in the scene" not in text, text
+
+    @pytest.mark.parametrize(
+        ("label", "call", "expected"),
+        [
+            ("set_gripper", lambda s: s.set_gripper(["arm"], state="open", steps=2), "Available robots: ['arm']"),
+            (
+                "rotate_wrist",
+                lambda s: s.rotate_wrist(["arm"], target_yaw=0.1, max_steps=2),
+                "Available robots: ['arm']",
+            ),
+            ("send_action", lambda s: s.send_action({"a_pan": 0.1}, robot_name=["arm"]), "Available robots: ['arm']"),
+            ("move_object", lambda s: s.move_object(["crate"], position=[0.1, 0, 0.1]), "Available objects: ['crate']"),
+            ("remove_object", lambda s: s.remove_object(["crate"]), "Available objects: ['crate']"),
+            ("get_body_state", lambda s: s.get_body_state(["arm/base"]), "Available bodies:"),
+            ("get_sensor_data", lambda s: s.get_sensor_data(["tcp_pos"]), "Available sensors:"),
+        ],
+    )
+    def test_the_surface_lists_what_is_registered(self, populated, label, call, expected):
+        text = _text(call(populated))
+        assert expected in text, f"{label}: {text}"
+        for claim in FALSE_EMPTY_CLAIMS:
+            assert claim not in text, f"{label} asserted {claim!r}: {text}"
+
+
+class TestAStringNameIsUnaffected:
+    """Over-reach control: the dominant path keeps its close match and listing."""
+
+    def test_a_typo_still_gets_a_close_match_and_the_listing(self, populated):
+        for label, msg in _messages(populated, "arm0").items():
+            assert "Available" in msg, f"{label}: {msg}"
+        assert "Did you mean: arm?" in populated._unknown_robot_msg("arm0")
+        assert "Did you mean: crate?" in populated._unknown_object_msg("crat")
+
+    def test_the_robot_message_is_the_documented_shape(self, populated):
+        assert populated._unknown_robot_msg("arm0") == (
+            "Robot 'arm0' not found. Did you mean: arm? Available robots: ['arm']. Use action='list_robots' to see all."
+        )
+
+
+class TestTheEmptySceneClaimStillHolds:
+    """Non-vacuity: the ``else`` branch is only reached when the scene IS empty."""
+
+    @pytest.mark.parametrize("requested", [pytest.param("arm", id="str"), *NOT_A_NAME])
+    def test_an_empty_world_is_reported_as_empty(self, empty_world, requested):
+        assert "No robots in the scene" in empty_world._unknown_robot_msg(requested)
+        assert "No objects in the scene" in empty_world._unknown_object_msg(requested)
+        assert "No robots in the scene" in SimEngine._unknown_robot_msg(empty_world, requested)
+
+
+class TestCloseMatchHint:
+    """The one place that needs a ``str`` - and the only thing it decides."""
+
+    def test_a_close_string_is_suggested(self):
+        assert close_match_hint("crat", ["crate", "table"]) == " Did you mean: crate?"
+
+    def test_several_matches_are_ordered_and_capped(self):
+        hint = close_match_hint("arm", ["arm0", "arm1", "arm2", "arm3"])
+        assert hint.startswith(" Did you mean: ")
+        assert hint.count(",") == 2, hint  # n=3
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_a_name_with_no_characters_to_match_yields_nothing(self, requested):
+        assert close_match_hint(requested, ["crate"]) == ""
+
+    def test_an_empty_registry_yields_nothing(self):
+        assert close_match_hint("crate", []) == ""
+
+    def test_a_string_with_no_close_match_yields_nothing(self):
+        assert close_match_hint("zzzzzzzz", ["crate", "table"]) == ""
+
+    def test_the_fragment_is_appendable_as_is(self):
+        """It carries its own leading space so a caller appends it unconditionally."""
+        assert close_match_hint("crat", ["crate"]).startswith(" ")
+        assert close_match_hint(["crate"], ["crate"]) == ""
+
+
+class TestTheReportIsReachedAtAll:
+    """Two lookups raised before their own report, so the message never ran.
+
+    ``registered()`` makes the world registries total, but two dict membership
+    tests built locally were still bare: ``sensor_name not in sensors`` in
+    ``get_sensor_data`` and ``name not in checkpoints`` in ``load_state``. Both
+    sit directly in front of a "not found. Available: [...]" report, so an
+    unhashable name raised ``TypeError: unhashable type`` out of a method whose
+    only documented failure channel is the agent-tool dict - the exact escape
+    ``registered()`` exists to close, one statement earlier.
+    """
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME_STRICT)
+    def test_get_sensor_data_reports_instead_of_raising(self, populated, requested):
+        text = _text(populated.get_sensor_data(requested))
+        assert "Available sensors:" in text, text
+        assert f"'{requested}'" in text, text
+
+    def test_an_omitted_sensor_name_still_reads_every_sensor(self, populated):
+        """``None`` is the documented "no filter" spelling, not a bad name."""
+        result = populated.get_sensor_data(None)
+        assert result["status"] == "success", result
+        payload = next(b["json"] for b in result["content"] if "json" in b)
+        assert set(payload["sensors"]) == {"arm/tcp_pos"}, payload
+
+    @pytest.mark.parametrize("requested", NOT_A_NAME)
+    def test_load_state_reports_instead_of_raising(self, populated, requested):
+        assert populated.save_state(name="cp1")["status"] == "success"
+        text = _text(populated.load_state(requested))
+        assert "Checkpoint" in text and "not found" in text, text
+        assert "Available: ['cp1']" in text, text
+
+    def test_a_real_sensor_name_still_reads_it(self, populated):
+        """Over-reach control: the honored lookup is unchanged."""
+        result = populated.get_sensor_data("arm/tcp_pos")
+        assert result["status"] == "success", result
+        payload = next(b["json"] for b in result["content"] if "json" in b)
+        assert "arm/tcp_pos" in payload["sensors"], payload
+
+    def test_a_real_checkpoint_still_loads(self, populated):
+        """Over-reach control: the honored lookup is unchanged."""
+        assert populated.save_state(name="cp1")["status"] == "success"
+        assert populated.load_state("cp1")["status"] == "success"
+
+
+# -- structural guard ------------------------------------------------------
+
+# Derived from a symbol this module already imports, so a rename cannot
+# silently point the sweep at a directory that holds no helpers.
+_SCAN_ROOT = pathlib.Path(inspect.getfile(close_match_hint)).parent
+
+_EXPECTED_HELPERS = {
+    "base.py::_unknown_robot_msg",
+    "mujoco/manipulation.py::_unknown_robot_msg",
+    "mujoco/motion_primitives.py::_unknown_robot_msg",
+    "mujoco/physics.py::_unknown_mj_entity_msg",
+    "mujoco/physics.py::_unknown_robot_msg",
+    "mujoco/simulation.py::_unknown_camera_msg",
+    "mujoco/simulation.py::_unknown_model_msg",
+    "mujoco/simulation.py::_unknown_object_msg",
+    "mujoco/simulation.py::_unknown_robot_msg",
+}
+
+
+def _unknown_entity_helpers(source: str) -> dict[str, ast.FunctionDef]:
+    """Map ``name`` -> node for every ``_unknown_*_msg`` helper in *source*."""
+    tree = ast.parse(source)
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("_unknown_") and node.name.endswith("_msg")
+    }
+
+
+def _gates_on_the_name_type(node: ast.FunctionDef) -> bool:
+    """True when the helper tests the requested name's type itself."""
+    for call in ast.walk(node):
+        if not (isinstance(call, ast.Call) and isinstance(call.func, ast.Name) and call.func.id == "isinstance"):
+            continue
+        if call.args and isinstance(call.args[0], ast.Name) and call.args[0].id == "requested":
+            return True
+    return False
+
+
+def _discovered() -> dict[str, ast.FunctionDef]:
+    found: dict[str, ast.FunctionDef] = {}
+    for path in sorted(_SCAN_ROOT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        for name, node in _unknown_entity_helpers(source).items():
+            found[f"{path.relative_to(_SCAN_ROOT).as_posix()}::{name}"] = node
+    return found
+
+
+class TestNoHelperGatesTheListingOnTheNameType:
+    """A sixth helper cannot ship the conflation this change removed."""
+
+    def test_the_scan_found_the_known_helpers(self):
+        """Non-vacuity: a mis-rooted scan must not report a clean sweep."""
+        assert set(_discovered()) == _EXPECTED_HELPERS, set(_discovered())
+
+    def test_no_helper_tests_the_requested_names_type(self):
+        offenders = sorted(qualname for qualname, node in _discovered().items() if _gates_on_the_name_type(node))
+        assert not offenders, (
+            "An unknown-entity message must not decide what to list from the requested "
+            "name's type: only the difflib suggestion needs a string, and gating the "
+            "availability listing on it suppresses a fact about the world for every "
+            "non-str name. Use close_match_hint(requested, known) and branch on "
+            f"`known` alone. Offenders: {offenders}"
+        )
+
+    def test_the_scanner_detects_a_planted_conflation(self):
+        planted = (
+            "def _unknown_thing_msg(self, requested: object) -> str:\n"
+            '    """Planted."""\n'
+            "    known = self.things()\n"
+            "    msg = f\"Thing '{requested}' not found.\"\n"
+            "    if known and isinstance(requested, str):\n"
+            '        msg += f" Available: {known}."\n'
+            "    return msg\n"
+        )
+        helpers = _unknown_entity_helpers(planted)
+        assert set(helpers) == {"_unknown_thing_msg"}
+        assert _gates_on_the_name_type(helpers["_unknown_thing_msg"])
+
+    def test_the_scanner_accepts_the_fixed_shape(self):
+        fixed = (
+            "def _unknown_thing_msg(self, requested: object) -> str:\n"
+            '    """Fixed."""\n'
+            "    known = self.things()\n"
+            "    msg = f\"Thing '{requested}' not found.\"\n"
+            "    if known:\n"
+            "        msg += close_match_hint(requested, known)\n"
+            '        msg += f" Available: {known}."\n'
+            "    return msg\n"
+        )
+        helpers = _unknown_entity_helpers(fixed)
+        assert not _gates_on_the_name_type(helpers["_unknown_thing_msg"])


### PR DESCRIPTION
## Problem

`registered()` is deliberately total. Its docstring says why:

> A bare `name in registry` cannot say that: the membership test itself raises `TypeError: unhashable type` for a name that is not hashable (a list, a dict, a set), so the unknown-entity error path the test guards is never reached [...] This test is total instead: every name resolves to a verdict, and a name that cannot be a key resolves to `False`, **which lets the caller report it with the message it already has**.

The messages it hands off to could not honor that. All five gated their whole tail on **one** condition:

```python
if known and isinstance(requested, str):
    matches = difflib.get_close_matches(requested, known, n=3, cutoff=0.4)
    ...
    msg += f" Available robots: {known}. Use action='list_robots' to see all."
else:
    msg += " No robots in the scene; add one with action='add_robot'."
```

Only `difflib` needs a string. What is registered — and the discovery action that lists it — is a fact about the world, so for every non-`str` name a fact about the world was suppressed because of the *requested name's type*. Three of the five then fell into an `else` that asserted a falsehood, and two returned the bare dead end these helpers exist to eliminate.

Measured in a scene holding robot `arm`, object `crate` and camera `look`, with `requested = ['front']`:

| message | main | this change |
|---|---|---|
| Robot (facade) | `No robots in the scene; add one with action='add_robot'.` | `Available robots: ['arm']. Use action='list_robots' to see all.` |
| Robot (MuJoCo) | `No robots in the scene; ...` | `Available robots: ['arm']. ...` |
| Object | `No objects in the scene; add one with action='add_object'.` | `Available objects: ['crate']. ...` |
| Camera | `Camera '['front']' not found.` (nothing else) | `Available: ['default', 'look']. ...` |
| Body | `Body '['front']' not found.` | `Available bodies: ['arm/base', 'arm/link', ...]` |
| Joint | `Joint '['front']' not found.` | `Available joints: ['arm/pan', ...]` |
| Sensor | `Sensor '['front']' not found.` | `Available sensors: ['arm/tcp_pos']` |

7 of 7 messages did not report what was registered; 3 of them stated the scene was empty while it was not.

This is not an exotic input. `robot_name` is the **first positional** parameter of `move_to` / `set_gripper` / `rotate_wrist`, so `sim.move_to([0.2, 0.0, 0.1])` lands a position list in it — and an agent then reads "no robots in the scene" and adds a second robot instead of fixing the argument.

Two lookups also raised **before** their own report, so the message never ran at all: `get_sensor_data` (`sensor_name not in sensors`) and `load_state` (`name not in checkpoints`) — the same escape `registered()` exists to close, one statement earlier.

## Change

- New `simulation.base.close_match_hint(requested, known)` owns the one decision that genuinely needs a `str` and returns `""` otherwise, so a caller appends it unconditionally. It replaces five copies of the same `difflib` block.
- The five helpers now branch on `known` alone, so the listing and the empty-scene claim are decided by the world.
- `get_sensor_data` and `load_state` route their membership test through `registered()`.
- `requested` is typed `object` at each helper — which is what actually arrives.
- A structural sweep over `strands_robots/simulation/` fails if any `_unknown_*_msg` tests the requested name's type again, with an exact expected-helper set (non-vacuity) plus planted-defect and planted-fix meta-tests.

`_unknown_model_msg` needed no change: it already appends its discovery action unconditionally and keeps its `difflib` call inside a broad `except`, which is the in-repo precedent — as is the render path, which has always listed `Available: [...]` regardless of the name's type.

**Nothing changes for a `str` name.** All 7 messages are byte-identical, verified by running one probe in both trees; a genuinely empty scene is still reported empty (pinned); and no suggestion is invented for a name with no characters to match.

## Visual artifact

The change is in `simulation/`, so it carries a headless MuJoCo render whose job is to prove the honored path is untouched: the same scene rendered independently in the two trees agrees to `max|main - branch| = 1/255` over 257,600 px, after 60 `send_action` ticks that leave `arm/link` identical in both.

![unknown-entity listing vs requested name type](https://raw.githubusercontent.com/cagataycali/robots/artifacts/unknown-entity-listing-name-type/artifact_unknown_entity.png)

Every number the figure renders is asserted by its generator against the two JSON dumps, including that the dumps came from different trees, that the `str`-name messages are byte-identical, and the 7→0 / 2→0 counts. Capture and compose scripts: [`capture.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/unknown-entity-listing-name-type/capture.py), [`compose.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/unknown-entity-listing-name-type/compose.py).

## Tests

`tests/simulation/mujoco/test_unknown_entity_message_name_type.py`, 62 cases, GL-free (`mesh=False`), 1.7 s:

- every helper lists what is registered, names the rejected value, and claims no empty scene, for a list / dict / int / `None` / float
- the public surfaces (`move_to`, `set_gripper`, `rotate_wrist`, `send_action`, `move_object`, `remove_object`, `get_body_state`, `get_sensor_data`) report it too
- **over-reach controls**: a `str` typo keeps its close match and listing, the robot message is pinned verbatim, an empty world is still reported empty, `get_sensor_data(None)` still reads every sensor (its documented "no filter" spelling), and a real sensor name / checkpoint still resolves
- `close_match_hint` unit contract, including that it is the *only* thing the type decides
- the structural sweep + its two meta-tests

**Pre-fix** (source at `0ed22087`, tests kept): **25 failed / 37 passed**. The sweep names all five adrift helpers:

```
Offenders: ['base.py::_unknown_robot_msg', 'mujoco/physics.py::_unknown_mj_entity_msg',
 'mujoco/simulation.py::_unknown_camera_msg', 'mujoco/simulation.py::_unknown_object_msg',
 'mujoco/simulation.py::_unknown_robot_msg']
```

The 37 that pass pre-fix are the `close_match_hint` unit cases (against a local stand-in of the contract), the empty-scene non-vacuity cases and the `str`-name controls — they are what stop the change reaching further than the type gate.

## Gate

Base `0ed22087`, head `29f7cbfa`. Zero existing-test changes.

- `MUJOCO_GL=egl pytest tests` — **27187 passed / 257 skipped / 0 failed** (613 s)
- `ruff check strands_robots tests tests_integ` — clean; `ruff format --check` — 1153 files already formatted
- `mypy strands_robots tests tests_integ` — 14 errors, **all** in `examples/isaac_gs`, **0 outside**; the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy, so it is environmental
- `scripts/assemble_changelog.py --check` — OK (274 pending)
- `scripts/check_merge_base_overlap.py` — *"No overlap. This branch edits nothing that `upstream/main` has changed since the two diverged"*. The 3 paths main gained are under `tools/`, disjoint from these files and from the sweep's scan root, and main's `_unknown_*_msg` set is exactly the 9 the sweep pins — so the sweep's verdict is unchanged on the merge.
