### PR TITLE
test(simulation/mujoco): declare the actions the router dispatches but the schema never advertises

### DIFF
--- a/changelog.d/2104-router-enum-breadth-inventory.md
+++ b/changelog.d/2104-router-enum-breadth-inventory.md
@@ -1,0 +1,16 @@
+### Docs: the actions the MuJoCo router dispatches but the schema never advertises are declared
+
+`_dispatch_action` resolves an action with `getattr(self, name)` and no
+allowlist, so every public method on `MuJoCoSimEngine` or its mixins is
+dispatchable, while `tool_spec.json`'s `action` enum advertises a curated
+subset. The enum-to-method direction was already pinned; the reverse was not,
+and it is the one that drifts unobserved - adding a public method made it
+dispatchable-but-unadvertised, and nothing distinguished that from a deliberate
+omission.
+
+The 23 capabilities in that gap are now named in `_PYTHON_ONLY_ACTIONS`, so a
+new public method fails until it is either published in the enum or recorded as
+Python-only. Membership means "dispatchable from Python, deliberately not
+advertised to a model", not "must stay unadvertised": whether these should be
+published, or the router should instead refuse a non-enum action, is the open
+decision in #2093 and is not settled here. No behaviour changes.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5002,10 +5002,10 @@ class MuJoCoSimEngine(
         callable as ``sim(action="...")`` from Python. That breadth is intended,
         but until it was declared it was also unmeasured - a newly added public
         method became agent-dispatchable-but-unadvertised, and no test could tell
-        that apart from a deliberate omission. ``_PYTHON_ONLY_ACTIONS`` in
-        ``tests/simulation/mujoco/test_tool_spec.py`` is that declaration, so a
-        new public method now fails there until it is either published in the enum
-        or recorded as Python-only. Whether the router should instead refuse a
+        that apart from a deliberate omission.
+        :data:`~tests.simulation.mujoco.test_tool_spec._PYTHON_ONLY_ACTIONS` is
+        that declaration, so a new public method now fails there until it is
+        either published in the enum or recorded as Python-only. Whether the router should instead refuse a
         non-enum action, making behaviour match the advertised contract, is the
         open question in #2093; this states today's contract without settling it.
         """

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4995,6 +4995,19 @@ class MuJoCoSimEngine(
 
         Policy-provider kwargs are nested under ``policy_config`` (never
         top-level) so the dispatcher stays backend-agnostic.
+
+        Resolution is ``getattr`` by name with no allowlist, so the router is
+        deliberately wider than ``tool_spec.json``'s ``action`` enum: the enum is
+        the curated agent-facing subset, and a public method absent from it stays
+        callable as ``sim(action="...")`` from Python. That breadth is intended,
+        but until it was declared it was also unmeasured - a newly added public
+        method became agent-dispatchable-but-unadvertised, and no test could tell
+        that apart from a deliberate omission. ``_PYTHON_ONLY_ACTIONS`` in
+        ``tests/simulation/mujoco/test_tool_spec.py`` is that declaration, so a
+        new public method now fails there until it is either published in the enum
+        or recorded as Python-only. Whether the router should instead refuse a
+        non-enum action, making behaviour match the advertised contract, is the
+        open question in #2093; this states today's contract without settling it.
         """
         method_name = self._ACTION_ALIASES.get(action, action)
         method = getattr(self, method_name, None)

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -19,9 +19,12 @@ import pytest
 # Skip the whole module if mujoco isn't available (dev env without [sim-mujoco]).
 pytest.importorskip("mujoco")
 
+import inspect
 import json
 import re
 from pathlib import Path
+
+from strands.types.tools import AgentTool  # noqa: E402
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
@@ -446,3 +449,166 @@ class TestTheSchemaPublishesTheArityTheRouterEnforces:
             "orientation must publish the scalar-first component order; an [x, y, z, w] "
             f"vector is otherwise indistinguishable to a caller. Got: {description!r}"
         )
+
+
+# Router-vs-enum breadth contract
+#
+# ``_dispatch_action`` resolves an action with ``getattr(self, name)`` and no
+# allowlist, so every public method is dispatchable while the ``action`` enum
+# advertises a curated subset. The enum -> method direction is already pinned
+# above (``test_every_tool_spec_action_has_a_public_method_or_documented_alias``);
+# this section pins the direction that was never measured, which is the one that
+# drifts silently. Adding a public method to the engine or any mixin made it
+# agent-dispatchable-but-unadvertised, and nothing could tell that apart from a
+# deliberate omission - so the omissions and the accidents looked identical.
+#
+# Membership in ``_PYTHON_ONLY_ACTIONS`` means "dispatchable from Python,
+# deliberately not advertised to a model". It does NOT mean "must stay
+# unadvertised": publishing any of these is a curation judgement, and whether the
+# router should instead refuse a non-enum action is the open question in #2093.
+# This guard settles neither. It only makes the set unable to change in silence -
+# a new public method fails here until someone writes down which side it is on.
+#
+# Nothing is asserted about the count, deliberately: a number in an assertion
+# message is stale the first time the set legitimately changes, and the failure
+# names the methods either way.
+
+# Grouped by declaring class, which is the unit a reviewer checks against.
+_PYTHON_ONLY_ACTIONS = frozenset(
+    {
+        # MuJoCoSimEngine - lifecycle and introspection, plus the two
+        # move-the-robot paths the motion primitives and run_policy front.
+        "bind_policy_sim_context",
+        "cleanup",
+        "describe",
+        "get_observation",
+        "physics_timestep",
+        "robot_action_keys",
+        "robot_joint_names",
+        "run_multi_policy",
+        "send_action",
+        # RenderingMixin - return arrays / camera intrinsics rather than text.
+        "get_camera_params",
+        "get_frame",
+        "start_cameras_recording_synchronous",
+        # DatasetRecordingMixin
+        "save_episode",
+        "stream_dataset",
+        # SimEngine
+        "verify_dataset_episodes",
+        # ManipulationMixin
+        "attachment_involving",
+        # TeleopMixin - drives real hardware from a host input device.
+        "attach_teleop",
+        "detach_teleop",
+        "get_teleoperate_status",
+        "list_teleops",
+        "stop_teleoperate",
+        "teleoperate",
+        "tool_name_label",
+    }
+)
+
+
+def _dispatchable_public_methods(cls: type = Simulation) -> set[str]:
+    """Names ``_dispatch_action`` will resolve on ``cls``.
+
+    Mirrors the router's own reachability rule rather than restating it: it takes
+    ``getattr`` then ``inspect.signature``, so a public *callable* is the unit,
+    and the leading-underscore names it refuses are excluded here too.
+    """
+    return {name for name, _value in inspect.getmembers(cls, callable) if not name.startswith("_")}
+
+
+def _framework_surface() -> set[str]:
+    """The tool framework's own public surface, which is not a sim capability.
+
+    ``get_display_properties`` / ``mark_dynamic`` / ``stream`` reach the engine by
+    inheriting from ``AgentTool``, so listing them as deliberate sim omissions
+    would be wrong twice: they are not capabilities anyone curated, and a
+    strands-agents upgrade that adds a protocol method would fail the inventory
+    below for a reason that has nothing to do with this schema. Derived from the
+    live base class so that upgrade is absorbed instead of reported.
+    """
+    return {name for name in dir(AgentTool) if not name.startswith("_")}
+
+
+def _enum_targets() -> set[str]:
+    """Every method name the enum reaches, directly or through an action alias."""
+    enum = _tool_spec_properties()["action"]["enum"]
+    return set(enum) | {_LIVE_ALIASES.get(action, action) for action in enum}
+
+
+class TestTheRouterDispatchesOnlyPublishedOrDeclaredActions:
+    """The gap between what dispatches and what is advertised is declared."""
+
+    @staticmethod
+    def _unaccounted(cls: type = Simulation) -> set[str]:
+        return _dispatchable_public_methods(cls) - _enum_targets() - _framework_surface() - _PYTHON_ONLY_ACTIONS
+
+    def test_every_dispatchable_method_is_published_or_declared_python_only(self) -> None:
+        """A public method is either in the enum or named as Python-only.
+
+        This is the forcing function, and the reason it is an equality rather
+        than a subset check is in the companion test below: a method that is
+        quietly deleted should also fail, or the inventory decays into a list of
+        names that no longer mean anything.
+        """
+        unaccounted = self._unaccounted()
+        assert not unaccounted, (
+            "these methods are dispatchable via sim(action=...) but neither advertised in the "
+            "tool_spec enum nor declared in _PYTHON_ONLY_ACTIONS - publish the ones an agent "
+            f"should reach and add the rest to the inventory: {sorted(unaccounted)}"
+        )
+
+    def test_the_inventory_names_only_methods_that_still_exist(self) -> None:
+        """A renamed or removed method leaves the inventory, rather than rotting.
+
+        Without this, the set accumulates names that pin nothing: the test above
+        passes on a subset, so a stale entry is invisible there, and the next
+        reader cannot tell a live deliberate omission from a dead one.
+        """
+        stale = _PYTHON_ONLY_ACTIONS - _dispatchable_public_methods()
+        assert not stale, f"_PYTHON_ONLY_ACTIONS names methods that no longer exist: {sorted(stale)}"
+
+    def test_the_inventory_never_names_an_action_the_enum_publishes(self) -> None:
+        """The two sets are disjoint, so neither can mask the other.
+
+        An entry that is also in the enum would be a contradiction the first test
+        cannot report - subtracting the inventory would hide a published action
+        from the accounting, and the schema would be describing something the
+        inventory calls Python-only.
+        """
+        both = _PYTHON_ONLY_ACTIONS & _enum_targets()
+        assert not both, f"an action cannot be both published and declared Python-only: {sorted(both)}"
+
+    def test_the_framework_surface_hides_no_published_action(self) -> None:
+        """Excluding ``AgentTool``'s surface must not exempt a real capability.
+
+        ``_framework_surface`` is subtracted before the accounting, so a
+        framework method that ever shares a name with a published action would
+        stop being checked here without any test failing. Pinned as an emptiness
+        claim about the overlap so that collision is a failure, not a silence.
+        """
+        collision = _framework_surface() & _enum_targets()
+        assert not collision, (
+            "a tool_spec action shares a name with the AgentTool protocol surface, so the "
+            f"breadth accounting would skip it: {sorted(collision)}"
+        )
+
+    def test_a_newly_added_public_method_is_reported(self) -> None:
+        """Planted-defect meta-test: the accounting is not vacuous.
+
+        Every assertion above is that a set is empty, which is exactly the shape
+        that passes when the measurement silently finds nothing. A subclass
+        carrying one new public method is the condition the first test exists to
+        catch, so it must be reported for that subclass and absent for the real
+        one.
+        """
+
+        class _EngineWithANewCapability(Simulation):
+            def teleport_everything(self) -> dict[str, Any]:
+                raise NotImplementedError
+
+        assert self._unaccounted(_EngineWithANewCapability) == {"teleport_everything"}
+        assert not self._unaccounted(), "the real engine must stay accounted for"


### PR DESCRIPTION
## Summary

`MuJoCoSimEngine._dispatch_action` resolves an action with a bare `getattr(self, name)` and no allowlist, so **every** public method on the engine or any of its eight mixins is dispatchable, while `tool_spec.json`'s `action` enum advertises a curated subset. The enum -> method direction is already pinned (`test_every_tool_spec_action_has_a_public_method_or_documented_alias`). The reverse direction was never measured, and it is the one that drifts unobserved: adding a public method silently made it agent-dispatchable-but-unadvertised, and **nothing could tell that apart from a deliberate omission**.

This PR declares the difference. It changes no behaviour.

## What I measured on this tree (`dbe3c5c`)

| quantity | count |
|---|---|
| public callables on `Simulation` | 105 |
| reachable from the `action` enum (incl. `_ACTION_ALIASES`) | 79 |
| enum targets that do not resolve | **0** |
| inherited from the `AgentTool` protocol | 3 |
| dispatchable, not advertised, not framework | **23** |

`_PYTHON_ONLY_ACTIONS` names those 23, grouped by declaring class. Membership means *"dispatchable from Python, deliberately not advertised to a model"* — **not** *"must stay unadvertised"*.

## Scope: this deliberately does not settle #2093

#2093 asks whether the enum should be widened (option A) or the router should refuse a non-enum action so behaviour matches the advertised contract (option B). Both are curation judgements, and I did not want to presume either — an agent's reachable capability set is exactly the kind of change that should be decided rather than absorbed from a passing test.

So this PR takes the step that is correct under **both** options: enumerate the gap so it cannot change in silence. A new public method now fails until someone records which side of the line it is on. Nothing is published and nothing is refused.

One correction for #2093 while I was in here: its recommended first step was to publish `set_obs_noise`, measured absent at `8101ba1e`. **That gap is already closed** — `set_obs_noise` is in the enum today and all three of its magnitudes (`joint_pos_std`, `joint_vel_std`, `camera_jitter_px`) are schema properties. The issue's headline count is 27; the live figure is 26, and 23 after the framework surface is excluded. I have not edited the issue, only recording it here so the stale recommendation is not re-implemented.

## The `AgentTool` exclusion is derived, not listed

`get_display_properties`, `mark_dynamic` and `stream` reach the engine by inheriting from `AgentTool`. Listing them as deliberate sim omissions would be wrong twice: they are not capabilities anyone curated, and a strands-agents upgrade adding a protocol method would fail this inventory for a reason unrelated to this schema. So the surface is computed from the live base class and that upgrade is absorbed.

That exclusion is itself a hiding place, so `test_the_framework_surface_hides_no_published_action` pins the overlap as empty — a framework method that ever shared a name with a published action would otherwise stop being checked with no test failing. Verified empty today.

## Non-vacuity

Every assertion here is that a set is empty, which is precisely the shape that passes when the measurement finds nothing. Beyond the planted-defect meta-test (a subclass carrying one new public method must be reported), I verified by mutation:

| mutation | result |
|---|---|
| drop `"send_action"` from the inventory | fails, naming `['send_action']` |
| rename `physics_timestep` out from under its entry | fails on both the unaccounted method and the stale entry |

The first test is an accounting identity rather than a subset check, so a quietly deleted method fails too — otherwise the inventory decays into names that pin nothing.

No count is asserted anywhere, deliberately: a number in an assertion message goes stale the first time the set legitimately changes, and the failure names the methods either way.

## Verification

- `tests/simulation/mujoco/test_tool_spec.py`: **21 passed** (16 existing + 5 new)
- `ruff format --check` and `ruff check`: clean on both changed files
- `mypy strands_robots/simulation/mujoco/simulation.py`: `Success: no issues found`
- Dispatch-related files (`test_tool_spec.py`, `test_action_controller_dispatch_contract.py`, `test_benchmark_dispatch.py`): baseline `5 failed, 32 passed` vs this branch `5 failed, 37 passed` — the same 5 pre-existing failures both sides (this sandbox has no EGL/OSMesa and a mocked torch), so the delta is exactly the 5 added tests and no regression.

## Files

- `strands_robots/simulation/mujoco/simulation.py` — one docstring paragraph on `_dispatch_action` stating that the router is deliberately wider than the enum, and pointing at the inventory and at #2093 for the unsettled question. This is the half of #2093's option B that is uncontroversial: say so.
- `tests/simulation/mujoco/test_tool_spec.py` — the inventory and five guards.
- `changelog.d/` fragment.

Refs #2093.