### PR TITLE
test(simulation/mujoco): pin the motion primitives' documented robot_name default

### DIFF
--- a/changelog.d/2105-primitive-robot-auto-resolution.md
+++ b/changelog.d/2105-primitive-robot-auto-resolution.md
@@ -1,0 +1,12 @@
+### Quality: pin the motion primitives' documented `robot_name` default
+
+`move_to` / `set_gripper` / `rotate_wrist` each document `robot_name` as
+"defaults to the single robot in the world (errors if ambiguous)", and each
+documents "Never raises.". Every existing primitive test named the robot
+explicitly, so nothing held that default: not the resolution itself, not the
+ambiguity refusal, and not the `ValueError`-to-envelope conversion the
+never-raises contract rests on. All three documented outcomes - one robot, zero
+robots, many robots - are now pinned on all three primitives against a real
+MuJoCo scene. Four mutations of the shared preamble, including one that silently
+resolves the first of two robots rather than refusing, pass the existing 77
+primitive tests and are each caught by these.

--- a/tests/simulation/mujoco/test_primitive_robot_auto_resolution.py
+++ b/tests/simulation/mujoco/test_primitive_robot_auto_resolution.py
@@ -1,0 +1,159 @@
+"""Omitting ``robot_name`` on a motion primitive resolves the sole robot.
+
+``move_to`` / ``set_gripper`` / ``rotate_wrist`` all declare
+``robot_name: str | None = None``, and all three document it as "defaults to the
+single robot in the world (errors if ambiguous)". The default is implemented
+once, in the shared preamble ``_primitive_resolve_robot``, which delegates to
+:meth:`strands_robots.simulation.base.SimEngine._resolve_single_robot` - whose
+three documented outcomes are one robot -> that robot, zero robots ->
+``ValueError``, many -> ``ValueError`` listing the candidates so the caller can
+recover in zero extra calls - and converts either ``ValueError`` into the
+tool-error envelope, because each primitive also documents "Never raises.".
+
+Every other primitive test passes ``robot_name`` explicitly, so none of that had
+coverage: not the default itself, not the ambiguity refusal, and not the envelope
+conversion standing between a bare ``ValueError`` and three methods documented
+never to raise. A silently-resolved wrong robot is the failure mode that matters
+here - with two arms in the scene, resolving either one without being asked
+drives a robot the caller never named - so the ambiguity refusal is pinned as
+carefully as the success.
+
+All three outcomes are pinned on each primitive against a real MuJoCo scene (the
+inline MJCF arm shared with ``test_motion_primitives`` - no asset downloads).
+Resolution runs before any IK solve, so only the tests that expect a ``move_to``
+success or refusal-about-the-target ``importorskip`` on ``mink``; the resolution
+refusals themselves run on bare ``mujoco``.
+"""
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_motion_primitives import ARM_XML, REACHABLE  # noqa: E402
+
+PRIMITIVES = ("move_to", "set_gripper", "rotate_wrist")
+
+# The smallest converging call per primitive. ``tol`` is looser than the residual
+# this 4-DOF arm leaves on ``REACHABLE`` so ``move_to`` enters its servo loop
+# instead of refusing the target up front.
+_CALLS: dict[str, dict[str, Any]] = {
+    "move_to": {"position": REACHABLE, "tol": 0.05, "max_steps": 400},
+    "set_gripper": {"state": "open", "steps": 5},
+    "rotate_wrist": {"target_yaw": 0.3, "tol": 0.05, "max_steps": 300},
+}
+
+
+def _text(result: dict[str, Any]) -> str:
+    """Flatten the envelope's text blocks - the report a caller actually reads."""
+    return " ".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+def _invoke(sim: Any, primitive: str, **extra: Any) -> dict[str, Any]:
+    """Call ``primitive`` with its minimal arguments; ``extra`` adds ``robot_name``."""
+    return getattr(sim, primitive)(**_CALLS[primitive], **extra)
+
+
+def _skip_without_ik(primitive: str) -> None:
+    """``move_to`` needs the mink bridge to judge a target; resolution does not."""
+    if primitive == "move_to":
+        pytest.importorskip("mink")
+
+
+@pytest.fixture
+def arm_path(tmp_path):
+    path = tmp_path / "prim_arm.xml"
+    path.write_text(ARM_XML)
+    return str(path)
+
+
+@pytest.fixture
+def scene(arm_path):
+    """Factory building a world with ``n`` copies of the arm, spaced 0.8 m apart."""
+    built: list[Simulation] = []
+
+    def make(n_robots: int) -> Simulation:
+        s = Simulation(tool_name="test_primitive_robot_auto_resolution", mesh=False)
+        assert s.create_world(gravity=[0, 0, 0])["status"] == "success"
+        for i in range(n_robots):
+            name = "arm" if i == 0 else f"arm{i + 1}"
+            placed = s.add_robot(name, urdf_path=arm_path, position=[0.8 * i, 0.0, 0.0])
+            assert placed["status"] == "success", placed
+        built.append(s)
+        return s
+
+    yield make
+    for s in built:
+        s.cleanup(policy_stop_timeout=2.0)
+
+
+class TestTheSoleRobotIsResolved:
+    """One robot and no ``robot_name`` drives that robot, per all three docstrings."""
+
+    @pytest.mark.parametrize("primitive", PRIMITIVES)
+    def test_omitting_robot_name_drives_the_sole_robot(self, scene, primitive):
+        _skip_without_ik(primitive)
+        result = _invoke(scene(1), primitive)
+        assert result["status"] == "success", _text(result)
+        assert "'arm'" in _text(result)
+
+    @pytest.mark.parametrize("primitive", PRIMITIVES)
+    def test_omitting_is_the_same_call_as_naming_the_sole_robot(self, scene, primitive):
+        """The default is a resolution, not a second code path.
+
+        Two identical fresh worlds are deterministic, so the whole envelope -
+        text and json - is compared rather than just the status.
+        """
+        _skip_without_ik(primitive)
+        omitted = _invoke(scene(1), primitive)
+        named = _invoke(scene(1), primitive, robot_name="arm")
+        assert omitted["status"] == "success", _text(omitted)
+        assert omitted == named
+
+
+class TestAnEmptyWorldIsRefusedWithTheRecovery:
+    """Zero robots and no ``robot_name``: an envelope naming the fix, not a raise."""
+
+    @pytest.mark.parametrize("primitive", PRIMITIVES)
+    def test_an_empty_world_reports_how_to_recover(self, scene, primitive):
+        result = _invoke(scene(0), primitive)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "No robots registered" in text
+        assert "add_robot" in text
+
+
+class TestAmbiguityIsRefusedRatherThanGuessed:
+    """Many robots and no ``robot_name``: refuse, and list the candidates.
+
+    Resolving either arm would drive one the caller never named, so the refusal -
+    and the candidate list that lets the caller correct it in zero extra calls -
+    is the contract rather than the convenience.
+    """
+
+    @pytest.mark.parametrize("primitive", PRIMITIVES)
+    def test_an_ambiguous_scene_names_the_parameter_and_the_candidates(self, scene, primitive):
+        result = _invoke(scene(2), primitive)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "robot_name" in text
+        assert "'arm'" in text
+        assert "'arm2'" in text
+
+    @pytest.mark.parametrize("primitive", PRIMITIVES)
+    def test_naming_a_robot_still_routes_to_it_when_the_scene_is_ambiguous(self, scene, primitive):
+        """The over-reach control: only an OMITTED name is ambiguous.
+
+        Asserted on which robot the report names rather than on the status: the
+        second arm stands 0.8 m from the shared ``REACHABLE`` target, so
+        ``move_to`` correctly reports that target unreachable for it - and naming
+        ``arm2`` in that refusal is itself the proof the call routed there.
+        """
+        _skip_without_ik(primitive)
+        result = _invoke(scene(2), primitive, robot_name="arm2")
+        text = _text(result)
+        assert "'arm2'" in text
+        assert "Multiple robots registered" not in text


### PR DESCRIPTION
## What

`move_to` / `set_gripper` / `rotate_wrist` all declare `robot_name: str | None = None`, and all three document it identically:

> `robot_name`: Robot to move; defaults to the single robot in the world (errors if ambiguous).

That default is implemented once, in the shared `_primitive_resolve_robot` preamble, which delegates to `SimEngine._resolve_single_robot` - whose three documented outcomes are one robot -> that robot, zero robots -> `ValueError`, many -> `ValueError` listing the candidates so the caller can recover in zero extra calls - and converts either `ValueError` into the tool-error envelope, because each primitive also documents "Never raises.".

Every existing primitive test passes `robot_name` explicitly, so none of that had coverage: not the resolution, not the ambiguity refusal, and not the envelope conversion standing between a bare `ValueError` and three methods documented never to raise.

## Why it matters

Four mutations of that preamble pass the 77 existing primitive tests unchanged:

| mutation of the shared preamble | these tests | existing 4 primitive test files |
|---|---|---|
| removes the sole-robot resolution entirely | 12 of 15 fail | **77 pass** |
| stops converting the `ValueError` into an envelope | 6 of 15 fail | **77 pass** |
| silently resolves the first of two robots instead of refusing | 3 of 15 fail | **77 pass** |
| drops the reason from the refusal | 6 of 15 fail | **77 pass** |

The third row is the one that matters: with two arms in a scene, resolving either of them without being asked drives a robot the caller never named. The second is the never-raises contract - unconverted, a bare `ValueError` leaves three methods that document "Never raises.".

## What is pinned

15 tests - three documented outcomes on each of the three primitives - against a real MuJoCo scene (the inline MJCF arm already shared with `test_motion_primitives`, no asset downloads):

- **one robot**: the primitive drives it, and the report names it;
- **omitting is the same call as naming it**: two identical fresh worlds are deterministic, so the whole envelope (text and json) is compared rather than just the status - the default is a resolution, not a second code path;
- **zero robots**: a structured error naming the recovery (`add_robot`), not a raise;
- **many robots**: a structured error naming `robot_name` and listing both candidates;
- **naming a robot still routes to it when the scene is ambiguous**: the over-reach control, asserted on which robot the report names rather than on the status (the second arm stands 0.8 m from the shared target, so `move_to` correctly reports that target unreachable *for it* - naming `arm2` in that refusal is itself the proof the call routed there).

Resolution runs before any IK solve, so only the tests that expect a `move_to` success or target-refusal `importorskip` on `mink`; the resolution refusals themselves run on bare `mujoco`.

## Coverage

`strands_robots/simulation/mujoco/motion_primitives.py` 93% -> 94%, missing lines 29 -> 25, measured over `tests/simulation/mujoco` with and without the new file (2704 -> 2719 tests). The closed gap is exactly the auto-resolve block:

```
before: 112, 163-166, 187, 210, 315, ...
after:  112,          187, 210, 315, ...
```

## Artifact

Real headless MuJoCo renders (`MUJOCO_GL=egl`), one script run per scene, every number in the figure asserted by the generator before it is written:

![robot_name auto-resolution](https://raw.githubusercontent.com/cagataycali/robots/artifacts/robot-name-auto-resolution/robot_name_auto_resolution.png)

Left: the home pose. Middle: `move_to(position=...)` with `robot_name` omitted on a one-robot scene - the sole robot is resolved and driven (24.6% of pixels differ from home). Right: the identical call on a two-robot scene - refused, and nothing moved (max delta against its own home frame 1/255). Omitting the name and naming the sole robot compare **equal as envelopes**; their renders differ by 1/255 only because they come from two independent worlds.

## Scope

Tests only - no production line changes, so no library behaviour moves. The contract is already stated in all three docstrings; what was missing was anything holding it.

## Gate

Run at base `dbe3c5cf` in a clone whose import tree was verified before each measurement:

- `MUJOCO_GL=egl pytest tests` - **27278 passed, 257 skipped, 0 failed** (598 s)
- `ruff check` / `ruff format --check strands_robots tests tests_integ` - clean (1155 files)
- `mypy strands_robots tests tests_integ` - 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy, so they are environmental
- repo-wide root guards + `Args:`-completeness + vacuous-comparison + unreachable-statement - 414 passed
- `scripts/assemble_changelog.py --check` - OK; `scripts/check_merge_base_overlap.py` - no overlap, 0 paths changed in that span

The pushed head differs from the gated tree in exactly one way: the changelog fragment was renamed `2104-` -> `2105-` after the PR number was known (2104 belongs to an unrelated PR). `assemble_changelog.py --check` and both changelog guards were re-run after the rename.

One earlier full run reported a single unrelated failure in `tests/training/test_reward_model_parity.py`, whose sanity assertion AST-scans the installed lerobot source tree on disk. That tree was being re-populated at 05:03:23 while the run was in flight (04:52-05:02); the test passes alone, passes in its own directory, and the re-run above is clean.

