### PR TITLE
docs(simulation/mujoco): state the router-breadth invariant instead of pointing at the test tree

### DIFF
--- a/changelog.d/2106-test-tree-crossref-guard.md
+++ b/changelog.d/2106-test-tree-crossref-guard.md
@@ -1,0 +1,13 @@
+### Quality: shipped source may not cross-reference the test tree in either spelling
+
+The guard that refuses a test-file citation in `strands_robots` matched only a
+`.py` filename, so the same dead end written as a dotted module path - a
+`:mod:`/`:data:` role such as `tests.simulation.mujoco.test_tool_spec.X` - read
+as a checkable cross-reference and passed. It is not checkable: the wheel ships
+`strands_robots` alone, so `import tests.simulation` raises `ModuleNotFoundError`
+for anyone who installed the distribution, and renaming the test moves the target
+just as silently as the filename form does.
+
+Both spellings are now refused, with the narrowing pinned: a slash path into
+another project's repository (an upstream `tests/authentication.rs`) names a file
+outside this distribution and stays ordinary prose.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5000,14 +5000,14 @@ class MuJoCoSimEngine(
         deliberately wider than ``tool_spec.json``'s ``action`` enum: the enum is
         the curated agent-facing subset, and a public method absent from it stays
         callable as ``sim(action="...")`` from Python. That breadth is intended,
-        but until it was declared it was also unmeasured - a newly added public
-        method became agent-dispatchable-but-unadvertised, and no test could tell
-        that apart from a deliberate omission.
-        :data:`~tests.simulation.mujoco.test_tool_spec._PYTHON_ONLY_ACTIONS` is
-        that declaration, so a new public method now fails there until it is
-        either published in the enum or recorded as Python-only. Whether the router should instead refuse a
-        non-enum action, making behaviour match the advertised contract, is the
-        open question in #2093; this states today's contract without settling it.
+        and it is accounted for: every public method of this class is either
+        published in that enum or recorded as deliberately Python-only, and one
+        that is neither fails the backend's tool-spec guards. So a newly added
+        method cannot become agent-dispatchable-but-unadvertised in silence, and
+        a deliberate omission stays distinguishable from an oversight. Whether
+        the router should instead refuse a non-enum action, making behaviour
+        match the advertised contract, is the open question in #2093; this states
+        today's contract without settling it.
         """
         method_name = self._ACTION_ALIASES.get(action, action)
         method = getattr(self, method_name, None)

--- a/tests/test_docstrings_no_dangling_doc_refs.py
+++ b/tests/test_docstrings_no_dangling_doc_refs.py
@@ -11,10 +11,12 @@ Three dangling-reference classes are pinned here:
    distribution - every such pointer is a dead end for a reader.
 2. ``~L<line>`` self-references, which silently drift out of date as soon as
    the surrounding file changes.
-3. Citations of a test file by name, under either pytest naming convention -
-   the ``test_foo.py`` prefix and the ``foo_test.py`` suffix. The published
-   wheel ships no test tree, so the pointer is a dead end for a package
-   reader, and it rots the moment that test is renamed.
+3. Citations of the test tree, in either spelling: a test file by name under
+   either pytest naming convention - the ``test_foo.py`` prefix and the
+   ``foo_test.py`` suffix - and a dotted module path into the test package,
+   such as a ``:mod:``/``:data:`` cross-reference role. The published wheel
+   ships no test tree, so the pointer is a dead end for a package reader, and
+   it rots the moment that test is renamed.
 
 All three fail loudly here so they cannot creep back into the package.
 """
@@ -99,3 +101,45 @@ def test_test_file_ref_matches_both_pytest_naming_conventions() -> None:
     assert _TEST_FILE_REF.findall("the e2e_agent_test.py fix history") == ["e2e_agent_test.py"]
     assert _TEST_FILE_REF.findall("the smolvla_test.py harness") == ["smolvla_test.py"]
     assert _TEST_FILE_REF.findall("delegates to factory.py at import") == []
+
+
+# The same third class has a second spelling that the filename pattern above
+# cannot see: a dotted module path into this repository's test package, written
+# as a Sphinx role (``:mod:`` / ``:data:``) or in prose. It reads as a checkable
+# cross-reference and is not one - ``import tests.simulation`` raises
+# ModuleNotFoundError for anyone who installed the distribution, because the
+# wheel ships ``strands_robots`` alone, and renaming the test moves the target
+# just as silently as the filename form does. Only the dotted form is matched: a
+# slash path such as an upstream project's ``tests/authentication.rs`` names a
+# file in someone else's repository and is ordinary prose.
+_TEST_MODULE_REF = re.compile(r"\btests\.[A-Za-z_][A-Za-z0-9_]*")
+
+
+def test_no_reference_to_the_test_package_as_a_module() -> None:
+    offenders = {
+        str(path.relative_to(_PKG_ROOT)): sorted(set(matches))
+        for path in _package_sources()
+        if (matches := _TEST_MODULE_REF.findall(path.read_text(encoding="utf-8")))
+    }
+    assert not offenders, (
+        f"shipped source cross-references this repository's test package: {offenders}. "
+        "The distribution ships no test tree, so the target cannot be imported by a "
+        "package consumer and the reference still rots on rename - a Sphinx role does "
+        "not make it checkable. Describe the invariant inline next to the code instead."
+    )
+
+
+def test_test_module_ref_matches_the_dotted_form_only() -> None:
+    """Pin the dotted spelling, and pin the narrowing that keeps this guard clean.
+
+    The package scan above passes trivially on a clean tree, so it would notice
+    neither this pattern being dropped nor it being widened to any mention of the
+    word. A role into the test package must match under either role name, while a
+    slash path into another project's repository must not - those name a file
+    outside this distribution and are ordinary prose.
+    """
+    assert _TEST_MODULE_REF.findall(":data:`~tests.simulation.mujoco.test_tool_spec.X`") == ["tests.simulation"]
+    assert _TEST_MODULE_REF.findall("see :mod:`tests.mesh.test_acl` for the pin") == ["tests.mesh"]
+    assert _TEST_MODULE_REF.findall("mirrors zenoh's tests/authentication.rs config") == []
+    assert _TEST_MODULE_REF.findall("mirrors the upstream tests/notebooks layout") == []
+    assert _TEST_MODULE_REF.findall("covered by the tests. See below.") == []


### PR DESCRIPTION
## The pointer

`_dispatch_action`'s docstring, added in #2104, points at the declaration that
accounts for the router's breadth by dotted module path:

```
:data:`~tests.simulation.mujoco.test_tool_spec._PYTHON_ONLY_ACTIONS` is
that declaration, ...
```

That reads as a checkable Sphinx cross-reference. It is not one. Measured with
the distribution importable and the working directory outside the repository:

| reference | outcome |
|---|---|
| `strands_robots.simulation.mujoco.simulation` | resolvable |
| `tests.simulation.mujoco.test_tool_spec` | `ModuleNotFoundError: No module named 'tests.simulation'` |

`pyproject.toml` says why: `wheel packages = ['strands_robots']`. The published
distribution ships no test tree, so the target cannot exist for anyone who
installed it, and renaming the test moves it just as silently as the
`test_tool_spec.py` filename form that preceded it.

Both dangling-reference guards state that remedy in their own failure text -
*"Describe the invariant inline next to the code instead of citing a test
filename."* So this states the invariant instead of pointing at where it is
pinned:

> every public method of this class is either published in that enum or
> recorded as deliberately Python-only, and one that is neither fails the
> backend's tool-spec guards

Every substantive claim in the paragraph is preserved - that the breadth is
deliberate, that `sim(action=...)` stays callable from Python, that a new method
cannot become dispatchable-but-unadvertised in silence, and that whether the
router should instead refuse a non-enum action is the open question in #2093.
Only the pointer changes. As a side effect the paragraph re-wraps: its longest
line goes from 107 characters to 81.

## Why the guard missed it

`_TEST_FILE_REF` matches a `.py` filename, so the same dead end written as a
module path passed. That is the hole this reference went through, and it is
worth closing rather than fixing one instance of by hand: the guard's own
module docstring calls citing the test tree a dangling-reference *class*.

The addition is the dotted spelling only, `\btests\.[A-Za-z_][A-Za-z0-9_]*`, and
the narrowing is deliberate and measured. A broader "any pointer into `tests/`"
rule would need two exemptions on main today:

| pre-existing reference | what it names |
|---|---|
| `mesh/_acl_config.py` -> `tests/authentication.rs` | a file in Zenoh's repository |
| `simulation/model_registry.py` -> `tests/notebooks` | a directory in another project |

Both are ordinary prose about somebody else's tree, and an exemption list is
where the next hole hides. The dotted form has zero hits on the package before
this pointer was introduced, so it needs none - and
`test_test_module_ref_matches_the_dotted_form_only` pins that narrowing so the
pattern can be neither dropped nor widened into "any mention of the word".

## Fails pre-fix

Against today's `main` (source reverted, new guards kept):

```
FAILED tests/test_docstrings_no_dangling_doc_refs.py::test_no_reference_to_the_test_package_as_a_module
  shipped source cross-references this repository's test package:
  {'simulation/mujoco/simulation.py': ['tests.simulation']}
1 failed, 6 passed
```

With the paragraph fixed: `7 passed`.

## No behaviour changes, mechanically

The executable AST of `simulation.py` with docstrings stripped is byte-identical
before and after (`sha256(ast.dump(...))[:16] = 34f49501f100a63e` both sides),
while the docstring text differs. Nothing in this PR changes a policy,
simulation behaviour, rendering, recording or an asset, so there is no rollout
to show - that digest is the claim.

## Gate

| check | result |
|---|---|
| `MUJOCO_GL=egl pytest tests` | **27270 passed, 257 skipped, 0 failed** (598s) |
| `ruff check` / `ruff format --check` | clean, 1154 files |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine-base control in the same working copy |
| repo-wide guards + `Args:` completeness | 416 passed |
| `scripts/check_merge_base_overlap.py` | No overlap; 0 paths changed on `upstream/main` in that span |
| `scripts/assemble_changelog.py --check` | OK (278 pending) |

Base `b69775c3`. The suite ran on this exact tree.

Refs #2104, #2093.
