### PR TITLE
fix(tools): size the harness-memory summary budget on the payload the store holds

### DIFF
--- a/changelog.d/2107-harness-memory-summary-budget.md
+++ b/changelog.d/2107-harness-memory-summary-budget.md
@@ -1,0 +1,12 @@
+### Fixed: the harness-memory summary budget now covers the payload the store holds
+
+`HarnessMemory.save_trace` writes the caller's summary plus a provenance block
+(timestamp, library version, backend, robot) into one file, and `load_trace`
+re-validates that file before anything reaches planner context. The save side
+measured the caller's payload while the load side measured the caller's payload
+plus provenance, so a summary in the top 140 bytes of the documented 64 KiB
+budget saved with `status="success"` and was then permanently unreadable -- and
+the remedy the load failure names ("delete it with delete_trace and re-save")
+reproduced the same unloadable file. `save_trace` now checks what it is about to
+store, before writing, so every summary a save accepts is one a load accepts.
+The trace budget was already symmetric and is unchanged.

--- a/strands_robots/tools/harness_memory.py
+++ b/strands_robots/tools/harness_memory.py
@@ -85,6 +85,11 @@ _MAX_RULE_CHARS = 2000
 _MAX_RULES_PER_KIND = 1000
 _MAX_TRACE_ENTRIES = 2000
 _MAX_TRACE_BYTES = 5 * 1024 * 1024  # serialized JSONL budget per task
+# Budget for the summary as stored, which is the caller's payload plus the
+# provenance block ``save_trace`` injects. Accounting for the stored payload
+# at both ends is what keeps every summary a save accepts loadable: the load
+# path re-validates the file, so a save-side budget over the caller's payload
+# alone would admit a summary ``load_trace`` then refuses.
 _MAX_SUMMARY_BYTES = 64 * 1024
 
 _TRACE_SUFFIX = ".trace.jsonl"
@@ -212,6 +217,11 @@ def _validate_trace(trace: Any) -> list[dict[str, Any]]:
 def _validate_summary(summary: Any) -> dict[str, Any]:
     """Validate a summary: a JSON object within the size budget.
 
+    Applied to the payload as stored -- :meth:`HarnessMemory.save_trace`
+    passes the caller's summary plus its provenance block, and
+    :meth:`HarnessMemory.load_trace` passes the file it read back -- so both
+    ends account for the same bytes.
+
     Args:
         summary: Untrusted summary payload from the agent.
 
@@ -324,6 +334,13 @@ class HarnessMemory:
         failed save never leaves a torn trace/summary pair or an orphaned
         trace (a summary-less trace would be listed by ``list_tasks`` but
         never loadable by ``load_trace``).
+
+        Raises:
+            ValueError: If the summary as stored -- the caller's payload plus
+                the provenance block written beside it -- exceeds
+                ``_MAX_SUMMARY_BYTES``. Checked here rather than on the
+                caller's payload alone so that every summary a save accepts
+                is one :meth:`load_trace` can read back.
         """
         self._ensure_dirs()
         provenance = {
@@ -334,6 +351,12 @@ class HarnessMemory:
         }
         stored_summary = dict(summary)
         stored_summary["provenance"] = provenance
+        # The budget covers the payload that is stored, not the one passed
+        # in: ``load_trace`` re-validates the file, which carries this
+        # provenance block, so checking the caller's summary alone accepts a
+        # summary the store cannot read back -- and the "delete and re-save"
+        # remedy that failure names reproduces it byte for byte.
+        _validate_summary(stored_summary)
         trace_path = self._trace_path(task)
         summary_path = self._summary_path(task)
         trace_lines = "".join(json.dumps(entry, sort_keys=True) + "\n" for entry in trace)

--- a/tests/tools/test_harness_memory_summary_budget.py
+++ b/tests/tools/test_harness_memory_summary_budget.py
@@ -1,0 +1,249 @@
+"""The summary size budget must cover the payload the store actually holds.
+
+``HarnessMemory.save_trace`` writes the caller's summary plus a provenance block
+(timestamp, library version, backend, robot) into one file, and
+``HarnessMemory.load_trace`` re-validates that file before anything reaches
+planner context. The two ends therefore have to account for the same bytes.
+
+They did not. ``save_trace`` checked the caller's payload while ``load_trace``
+checked the caller's payload *plus* provenance, so a summary in the top 140
+bytes of the documented 64 KiB budget saved with ``status="success"`` and was
+then permanently unreadable::
+
+    save_trace -> success, "Saved trace for task 't0' (1 steps)"
+    load_trace -> error,   "summary too large (65676 > 65536 bytes);
+                            delete it with delete_trace and re-save"
+
+The remedy that message names cannot work: deleting and re-saving the same
+summary reproduces the same unloadable file, measured over three attempts. The
+trace budget is symmetric already (nothing is injected into a trace entry),
+which is what makes the summary the defect rather than the caps being wrong.
+
+What is pinned here:
+
+* a summary whose *stored* size exceeds the budget is refused at save, before
+  any file is written, and an existing pair survives the refusal;
+* every summary a save accepts is one a load accepts -- swept across the
+  boundary rather than asserted at one point;
+* the size the save path checks equals the size the load path recomputes, over
+  payload shapes that round-trip through JSON differently (unicode, floats,
+  nested containers, ``True``/``None``);
+* the trace budget stays symmetric, and the entry-count cap stays a distinct
+  budget from the byte cap, so neither is collapsed into the other.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.harness_memory as hm
+from tests.tool_result_contract import tool_json
+
+TRACE = [{"action": "run_policy", "instruction": "grasp the bowl", "n_steps": 20}]
+
+
+@pytest.fixture
+def memory_dir(tmp_path, monkeypatch):
+    """Point STRANDS_MEMORY_DIR at a temp dir so the store is isolated."""
+    d = tmp_path / "memory"
+    monkeypatch.setenv("STRANDS_MEMORY_DIR", str(d))
+    return d
+
+
+def _summary_of_size(n: int) -> dict[str, Any]:
+    """A summary whose ``json.dumps(sort_keys=True)`` length is exactly *n*."""
+    summary: dict[str, Any] = {"why": "a"}
+    summary["why"] = "a" * (n - len(json.dumps(summary, sort_keys=True)) + 1)
+    assert len(json.dumps(summary, sort_keys=True)) == n
+    return summary
+
+
+def _provenance_overhead() -> int:
+    """Bytes ``save_trace``'s provenance block adds to a stored summary."""
+    provenance = {
+        "saved_at": "2026-01-01T00:00:00+0000",
+        "strands_robots_version": hm._version_string(),
+        "backend": None,
+        "robot": None,
+    }
+    base = {"why": "x"}
+    return len(json.dumps({**base, "provenance": provenance}, sort_keys=True)) - len(json.dumps(base, sort_keys=True))
+
+
+def _stored_summary(memory_dir, task: str) -> dict[str, Any]:
+    return json.loads((memory_dir / "tasks" / f"{task}.summary.json").read_text(encoding="utf-8"))
+
+
+def _files(memory_dir) -> list[str]:
+    tasks = memory_dir / "tasks"
+    return sorted(p.name for p in tasks.iterdir()) if tasks.exists() else []
+
+
+class TestThePremiseThatMakesTheTwoEndsAbleToDisagree:
+    """The store injects bytes the caller never passed, so accounting matters."""
+
+    def test_the_provenance_block_has_a_measurable_size(self, memory_dir):
+        """A stored summary is strictly larger than the one handed in."""
+        summary = {"why": "small"}
+        hm.HarnessMemory().save_trace("t", TRACE, summary)
+        stored = _stored_summary(memory_dir, "t")
+        assert "provenance" in stored
+        passed_in = len(json.dumps(summary, sort_keys=True))
+        held = len(json.dumps(stored, sort_keys=True))
+        assert held > passed_in
+        assert _provenance_overhead() > 0
+
+
+class TestTheBudgetCoversTheStoredPayload:
+    """A summary the store cannot read back must be refused at save time."""
+
+    def test_a_summary_at_the_documented_budget_is_refused(self, memory_dir):
+        """Its stored size exceeds the cap, so saving it would lose the trace."""
+        summary = _summary_of_size(hm._MAX_SUMMARY_BYTES)
+        with pytest.raises(ValueError, match="summary too large"):
+            hm.HarnessMemory().save_trace("t", TRACE, summary)
+
+    def test_the_refusal_quotes_the_stored_size_against_the_cap(self, memory_dir):
+        """The numbers name the payload that was measured, not the cap alone."""
+        summary = _summary_of_size(hm._MAX_SUMMARY_BYTES)
+        with pytest.raises(ValueError) as excinfo:
+            hm.HarnessMemory().save_trace("t", TRACE, summary)
+        expected = len(json.dumps({**summary, "provenance": {}}, sort_keys=True))
+        assert str(hm._MAX_SUMMARY_BYTES) in str(excinfo.value)
+        assert expected > hm._MAX_SUMMARY_BYTES
+
+    def test_the_refusal_writes_no_files(self, memory_dir):
+        """A first save that cannot be read back must leave nothing behind."""
+        summary = _summary_of_size(hm._MAX_SUMMARY_BYTES)
+        with pytest.raises(ValueError):
+            hm.HarnessMemory().save_trace("t", TRACE, summary)
+        assert _files(memory_dir) == []
+
+    def test_the_refusal_leaves_an_existing_pair_intact(self, memory_dir):
+        """A replace that cannot be read back must not disturb the stored pair."""
+        memory = hm.HarnessMemory()
+        memory.save_trace("t", TRACE, {"why": "v1"})
+        with pytest.raises(ValueError):
+            memory.save_trace("t", TRACE, _summary_of_size(hm._MAX_SUMMARY_BYTES))
+        trace, summary = memory.load_trace("t")
+        assert trace == TRACE
+        assert summary["why"] == "v1"
+        assert not list((memory_dir / "tasks").glob("*.tmp"))
+
+    def test_the_tool_surface_refuses_instead_of_reporting_success(self, memory_dir):
+        """The agent-facing envelope must not say a lost trace was saved."""
+        result = hm.harness_memory(
+            action="save_trace",
+            task="t",
+            trace=TRACE,
+            summary=_summary_of_size(hm._MAX_SUMMARY_BYTES),
+        )
+        assert result["status"] == "error"
+        assert "too large" in "\n".join(c.get("text", "") for c in result["content"])
+        assert tool_json(hm.harness_memory(action="list_tasks"))["tasks"] == []
+
+
+class TestEverySavedSummaryLoadsBack:
+    """The invariant the budget exists to provide, not a single data point."""
+
+    def test_no_summary_that_saves_is_unloadable_near_the_boundary(self, memory_dir):
+        """Swept across the boundary: saved implies loadable, with no window."""
+        memory = hm.HarnessMemory()
+        cap = hm._MAX_SUMMARY_BYTES
+        saved = unloadable = 0
+        for size in range(cap - 200, cap + 1):
+            try:
+                memory.save_trace("sweep", TRACE, _summary_of_size(size))
+            except ValueError:
+                continue
+            saved += 1
+            try:
+                memory.load_trace("sweep")
+            except ValueError:
+                unloadable += 1
+        assert saved > 0, "the sweep never reached an accepted size"
+        assert unloadable == 0
+
+    @pytest.mark.parametrize(
+        "summary",
+        [
+            {"why": "plain ascii"},
+            {"why": "wide \u00e9\u00e8 \u4e2d\u6587", "n": 12},
+            {"nested": {"a": [1, 2, {"b": 0.125}]}, "flag": True, "none": None},
+            {"floats": [0.1, 1e-09, 1234567.891], "big": 2**53},
+        ],
+        ids=["ascii", "wide-characters", "nested-containers", "floats"],
+    )
+    def test_the_save_side_size_equals_the_load_side_size(self, memory_dir, monkeypatch, summary):
+        """Both ends must measure the same bytes for a payload to be safe."""
+        measured: list[int] = []
+        real = hm._validate_summary
+
+        def recording(payload: Any) -> dict[str, Any]:
+            measured.append(len(json.dumps(payload, sort_keys=True)))
+            return real(payload)
+
+        monkeypatch.setattr(hm, "_validate_summary", recording)
+        memory = hm.HarnessMemory()
+        memory.save_trace("t", TRACE, summary)
+        assert measured, "save_trace did not measure the payload it stores"
+        on_save = measured[-1]
+        measured.clear()
+        memory.load_trace("t")
+        assert measured, "load_trace did not re-validate the stored summary"
+        assert measured[-1] == on_save
+
+
+class TestTheRemedyTheRefusalNamesNowWorks:
+    """Shrinking the summary must actually produce a loadable store."""
+
+    def test_shrinking_by_the_provenance_overhead_saves_and_loads(self, memory_dir):
+        """The largest summary a caller can hold round-trips unchanged."""
+        memory = hm.HarnessMemory()
+        summary = _summary_of_size(hm._MAX_SUMMARY_BYTES - _provenance_overhead())
+        memory.save_trace("t", TRACE, summary)
+        trace, loaded = memory.load_trace("t")
+        assert trace == TRACE
+        assert loaded["why"] == summary["why"]
+
+
+class TestNeighbouringBudgetsStayOutOfScope:
+    """What must not change: the trace side, and the caps being distinct."""
+
+    def test_an_ordinary_summary_still_round_trips(self, memory_dir):
+        """The overwhelmingly common case is untouched."""
+        memory = hm.HarnessMemory()
+        summary = {"task": "put the bowl on the tray", "success": True, "avoid": ["stale xyz"]}
+        memory.save_trace("t", TRACE, summary)
+        trace, loaded = memory.load_trace("t")
+        assert trace == TRACE
+        assert loaded["avoid"] == summary["avoid"]
+
+    def test_the_trace_budget_is_symmetric_at_both_ends(self, memory_dir):
+        """Nothing is injected into a trace entry, so its accounting matches."""
+        memory = hm.HarnessMemory()
+        trace = [{"action": "get_state", "pad": "a" * 500} for _ in range(20)]
+        on_save = sum(len(json.dumps(entry, sort_keys=True)) for entry in trace)
+        memory.save_trace("t", trace, {"why": "ok"})
+        loaded, _ = memory.load_trace("t")
+        on_load = sum(len(json.dumps(entry, sort_keys=True)) for entry in loaded)
+        assert on_load == on_save
+
+    def test_the_trace_byte_cap_is_distinct_from_the_entry_count_cap(self, memory_dir, monkeypatch):
+        """A trace inside the entry count can still exceed the byte budget.
+
+        Driven through the tool rather than :meth:`HarnessMemory.save_trace`:
+        the trace validator runs at the tool boundary and on load, so that is
+        where the byte budget is observable.
+        """
+        monkeypatch.setattr(hm, "_MAX_TRACE_BYTES", 400)
+        trace = [{"action": "get_state", "pad": "a" * 200} for _ in range(3)]
+        assert len(trace) <= hm._MAX_TRACE_ENTRIES
+        result = hm.harness_memory(action="save_trace", task="t", trace=trace, summary={"why": "ok"})
+        assert result["status"] == "error"
+        text = "\n".join(c.get("text", "") for c in result["content"])
+        assert "trace too large" in text
+        assert "too long" not in text, "the byte budget must not report as the entry-count cap"


### PR DESCRIPTION
## Problem

`HarnessMemory.save_trace` writes the caller's summary **plus a provenance block**
(timestamp, library version, backend, robot) into one file. `load_trace`
re-validates that file before anything reaches planner context, which is the
module's stated reason for re-validating at all: the store is a long-lived
plain-text directory that may have been hand-edited.

The two ends measured different payloads. The save side measured the caller's
summary; the load side measured the caller's summary *plus* provenance. So a
summary in the top **140 bytes** of the documented 64 KiB budget saved with
`status="success"` and was then permanently unreadable:

```
save_trace -> success, "Saved trace for task 't0' (1 steps)"
load_trace -> error,   "stored memory for task 't0' failed re-validation
                        (summary too large (65676 > 65536 bytes));
                        delete it with delete_trace and re-save"
```

The remedy that failure names cannot be carried out. Deleting and re-saving the
same summary reproduces the same unreadable file, measured over three attempts:

| attempt | outcome on `main` |
| --- | --- |
| 1 | refused on load, `delete_trace` + re-save |
| 2 | refused on load, `delete_trace` + re-save |
| 3 | refused on load |

Measured window, stepping one byte at a time through the agent tool: a validated
summary size in **[65397, 65536]** saves and cannot be loaded -- 140 of 140 sizes
in that band, and 0 outside it. The trace budget is symmetric already (nothing is
injected into a trace entry), which is what makes the summary the defect rather
than the caps being wrong.

Separately, `HarnessMemory.save_trace` is public API and carried no summary
budget of its own -- the caller-side check lived only in the tool wrapper -- so a
library caller could store an oversized summary at any size.

## Change

`save_trace` validates the payload it is about to store, before writing:

```python
stored_summary = dict(summary)
stored_summary["provenance"] = provenance
_validate_summary(stored_summary)
```

One call. Both ends now account for the same bytes, so every summary a save
accepts is one a load accepts -- by construction rather than by a subtraction.
It also gives the public `save_trace` the budget it lacked, and because the
two-phase commit writes nothing until after this point, a refused save leaves
the store untouched.

Refusals reuse `_validate_summary`'s existing message, so no pinned text moves.

## Why this shape

Excluding provenance from the load-side accounting was the alternative. It was
rejected: the re-validation exists for the hand-edited case, and provenance is a
key in a file an editor can grow, so exempting it from the size accounting opens
the hole the check is there to close. Validating what is stored needs no
exemption rule and no second constant.

## Measured

![summary budget](https://raw.githubusercontent.com/cagataycali/robots/artifacts/harness-memory-summary-budget/harness_memory_summary_budget.png)

Every cell comes from one capture script run in a worktree at `55492e27` and in
this branch; the compose step asserts the two dumps came from different trees and
re-derives each number before drawing it.

| | `main` | this change |
| --- | --- | --- |
| sizes that save but cannot load (140-byte band, step 1) | 140 | **0** |
| `save_trace` measures the stored payload | no | yes |
| save-side bytes == load-side bytes (4 payload shapes) | 0 of 4 | **4 of 4** |
| agent tool at the budget: `save_trace` / `load_trace` | success / error | error / error |
| the remedy the load failure names | loops | n/a -- refused at save |

The four payload shapes are ascii, wide characters, nested containers with
`True`/`None`, and floats plus `2**53`, because those round-trip through JSON
differently and the accounting has to survive all of them.

## Tests

`tests/tools/test_harness_memory_summary_budget.py`, 15 cases:

* the budget covers the stored payload -- refused at save, no files written, an
  existing pair survives, and the agent tool reports the refusal instead of
  success;
* **every saved summary loads back**, swept across the boundary rather than
  asserted at one point, plus the invariant that the size the save path checks is
  the size the load path recomputes (spied at both call sites, parametrized over
  the four shapes);
* the remedy now works: shrinking by the provenance overhead saves and loads;
* out-of-scope pins -- an ordinary summary still round-trips, the trace budget
  stays symmetric at both ends, and the trace byte cap stays distinct from the
  entry-count cap.

Pre-fix, with the source at `55492e27` and the tests kept: **10 failed, 5 passed**.
The headline failure is `assert 140 == 0` from the sweep. The 5 that pass are the
premise (a stored summary is strictly larger than the one handed in) and the
out-of-scope pins -- they are what keeps the change from reaching further than
this one budget.

Also closes four previously unexercised lines: the summary and trace byte
budgets at both ends.

## Gate

Rebased onto `55492e27` and verified there, so these numbers describe the tree
that merges.

* `MUJOCO_GL=egl pytest tests` -- **27300 passed, 257 skipped, 0 failed** (603.84s).
  Pristine `main` at `38f909a4` measured 27283 passed here; 27300 minus this
  branch's 15 new tests is 27285, which is that number plus the two tests
  #2106 added at `55492e27`. No existing test changed.
* `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` -- clean, 1156 files.
* `mypy strands_robots tests tests_integ` -- 0 errors outside `examples/isaac_gs`; the
  14 there are byte-identical to a pristine worktree at `55492e27` after normalising
  line numbers, so they are environmental to this checkout.
* `scripts/check_merge_base_overlap.py` -- no overlap, 0 paths changed on
  `upstream/main` in that span.
* `scripts/assemble_changelog.py --check` -- OK.

One earlier full run reported a failure in
`tests/training/test_reward_model_parity.py::test_strands_discovery_matches_lerobot_source`
as `assert {...} <= set()`. That test AST-scans the installed lerobot checkout on
disk, and that directory was re-cloned during the run (a lone `clone:` reflog
entry, `src/lerobot/rewards` mtime inside the window), so the scan came back
empty. It passes alone, passes across its whole file, and the two other full runs
of this same tree are clean. Nothing in this branch touches lerobot's rewards
package.

