### PR TITLE
fix(simulation/mujoco): drop the cameras mounted on a removed object's body

### DIFF
--- a/changelog.d/2109-remove-object-camera-cascade.md
+++ b/changelog.d/2109-remove-object-camera-cascade.md
@@ -1,0 +1,15 @@
+### Fixed: `remove_object` drops the cameras mounted on the body it removes
+
+A camera added with `add_camera(parent_body=<object>)` expresses its pose in that
+body's frame, so MuJoCo makes it a child element of the body and the recompile
+that follows `remove_object` deletes it. The `world.cameras` registry did not
+follow, so the call reported success while leaving an entry naming a camera the
+renderer could no longer resolve: `list_cameras()` offered it, and `render` /
+`get_camera_params` refused it with `Camera 'watch' not found. Available:
+['default', 'fixed', 'plate_cam', 'watch']` -- naming the missing camera as an
+available alternative to itself. `eject_body_from_scene` now drops those entries
+with a warning naming the camera and the removed body, the same treatment
+`eject_robot_from_scene` already gives a camera whose parent belonged to the
+robot being removed ("stale entries would linger in the registry and confuse
+observation code", in that path's own words). Cameras mounted on other bodies
+and world-fixed cameras are untouched.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -766,7 +766,17 @@ def inject_camera_into_scene(world: SimWorld, cam: SimCamera) -> bool:
 
 
 def eject_body_from_scene(world: SimWorld, body_name: str) -> bool:
-    """Remove a body (by short name) and recompile."""
+    """Remove a body (by short name) and recompile.
+
+    A camera mounted on that body (``SimCamera.parent_body == body_name``) goes
+    with it. The recompile drops the camera element -- it is a child of the body
+    being deleted -- so a surviving registry entry would advertise a camera no
+    consumer can resolve: ``list_cameras`` offers it while ``render`` refuses it
+    as unknown and names it in the same breath as an available alternative. Such
+    entries are dropped with a warning naming the camera and its parent, the same
+    treatment :func:`eject_robot_from_scene` gives a camera whose parent belonged
+    to the robot being removed.
+    """
     spec = _get_spec(world)
     if spec is None or world._model is None:
         logger.error("eject_body: no spec or model in world")
@@ -777,6 +787,21 @@ def eject_body_from_scene(world: SimWorld, body_name: str) -> bool:
         # Matching legacy behaviour: return True so scene state stays consistent
         # (caller has already popped the Python-side dict entry).
         return True
+
+    # Cameras mounted on this body lose the frame their pose is expressed in.
+    # The recompile below drops the camera element with its parent, so the
+    # registry entry has to go too: a stale entry lingers and confuses
+    # observation code, which is the same reason eject_robot_from_scene drops
+    # the cameras of the robot it is ejecting. Keyed by registry name, not
+    # ``cam.name``, because a URDF-discovered camera stores its namespaced
+    # MuJoCo name there.
+    for cam_key in [key for key, cam in world.cameras.items() if cam.parent_body == body_name]:
+        logger.warning(
+            "eject_body: dropping camera %r - it was mounted on the removed body %r.",
+            cam_key,
+            body_name,
+        )
+        del world.cameras[cam_key]
 
     # Objects added at runtime register a mesh asset named f"mesh_{name}".
     # Delete it too so the name is fully reusable and unused assets do not

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2952,6 +2952,13 @@ class MuJoCoSimEngine(
         MjSpec, recompiling the model while preserving the state of the
         remaining bodies.
 
+        A camera mounted on the object (``add_camera(parent_body=name)``) is
+        removed with it: its pose is expressed in that body's frame, so the
+        recompile drops the camera element and the registry entry goes too.
+        ``list_cameras`` therefore never advertises a camera the renderer
+        cannot resolve. Each dropped camera is named in a warning, matching
+        :meth:`remove_robot`.
+
         Args:
             name: The object name (as passed to ``add_object``).
 

--- a/tests/simulation/mujoco/test_remove_object_camera_cascade.py
+++ b/tests/simulation/mujoco/test_remove_object_camera_cascade.py
@@ -1,0 +1,189 @@
+"""``remove_object`` drops the cameras mounted on the body it removes.
+
+A camera added with ``add_camera(parent_body=<object>)`` expresses its pose in
+that body's frame, so MuJoCo makes it a child element of the body. Deleting the
+body therefore deletes the camera at recompile time - the compiled model loses
+it whether or not anyone asked. The Python-side ``world.cameras`` registry did
+not follow, so ``remove_object`` reported success and left an entry naming a
+camera the renderer could no longer resolve. Every camera consumer then
+contradicted itself in one breath: ``list_cameras`` offered ``'watch'`` while
+``render`` / ``get_camera_params`` refused it with
+
+    Camera 'watch' not found. Available: ['default', 'watch']
+
+naming the missing camera as an available alternative. The robot path already
+does the right thing - :func:`~strands_robots.simulation.mujoco.scene_ops.eject_robot_from_scene`
+drops both the robot's own URDF cameras and any camera whose parent body
+belonged to it, each with a warning, because (in its own words) "stale entries
+would linger in the registry and confuse observation code". These tests pin the
+same cascade for the object path and the invariant behind it: the registry
+never advertises a camera the compiled model does not have.
+
+The two over-reach controls matter as much as the cascade: a camera mounted on a
+*different* body and a world-fixed camera must both survive, so the drop is
+scoped to the body actually being removed.
+
+``patch_scene_mjcf(delete_body=...)`` is deliberately not covered - it is the
+raw-MJCF escape hatch and says so in its own result text ("world.robots /
+world.objects / world.cameras registries were NOT updated"), so registry drift
+there is its documented contract rather than a defect.
+
+GL-free: ``mesh=False`` and no rendering, so this runs without a GPU.
+``get_camera_params`` resolves a camera from ``model``/``data`` alone and is the
+consumer used to prove the message no longer offers what it cannot resolve.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+_SCENE_OPS_LOGGER = scene_ops.__name__
+
+# A two-body arm with no meshes and no actuators, so the robot-parity test needs
+# no asset download and runs anywhere the rest of this file does.
+_ARM_XML = """
+<mujoco model="pcam_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.05">
+      <geom type="box" size="0.04 0.04 0.05"/>
+      <body name="link" pos="0 0 0.1">
+        <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" damping="1"/>
+        <geom type="capsule" fromto="0 0 0 0.14 0 0" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _camera_names(sim: Any) -> list[str]:
+    """The registry's own view of which cameras exist."""
+    return list(sim.list_cameras())
+
+
+def _model_camera_count(sim: Any) -> int:
+    """How many cameras the compiled model actually carries."""
+    return int(sim._world._model.ncam)
+
+
+@pytest.fixture
+def sim():
+    """A world with a mounted camera, a camera on another body, and a fixed one."""
+    s = Simulation(tool_name="test_remove_object_camera_cascade_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    s.add_object("crate", shape="box", size=[0.12, 0.12, 0.12], position=[0.3, 0.0, 0.06], mass=0.5)
+    s.add_object("plate", shape="box", size=[0.2, 0.2, 0.02], position=[-0.3, 0.0, 0.01], is_static=True)
+    s.add_camera(name="watch", position=[0.2, -0.2, 0.2], target=[0.0, 0.0, 0.0], parent_body="crate")
+    s.add_camera(name="plate_cam", position=[0.0, -0.2, 0.2], target=[0.0, 0.0, 0.0], parent_body="plate")
+    s.add_camera(name="fixed", position=[0.8, -0.8, 0.6], target=[0.0, 0.0, 0.1])
+    yield s
+    s.cleanup()
+
+
+class TestTheMountedCameraGoesWithItsBody:
+    def test_the_camera_mounted_on_the_removed_object_leaves_the_registry(self, sim) -> None:
+        assert "watch" in _camera_names(sim)
+        assert sim.remove_object("crate")["status"] == "success"
+        assert "watch" not in _camera_names(sim)
+
+    def test_the_registry_agrees_with_the_compiled_model(self, sim) -> None:
+        # The premise: before the removal both views already agree.
+        assert len(_camera_names(sim)) == _model_camera_count(sim)
+        sim.remove_object("crate")
+        assert len(_camera_names(sim)) == _model_camera_count(sim)
+
+    def test_no_consumer_is_offered_the_camera_it_cannot_resolve(self, sim) -> None:
+        sim.remove_object("crate")
+        with pytest.raises(KeyError) as excinfo:
+            sim.get_camera_params(camera_name="watch")
+        message = str(excinfo.value)
+        assert "'watch'" in message, message
+        # The available list is the actionable half of that message, so it must
+        # not name the camera the same sentence reports as missing.
+        available = message.split("Available:", 1)[1]
+        assert "watch" not in available, message
+
+    def test_the_dropped_name_is_reusable(self, sim) -> None:
+        sim.remove_object("crate")
+        result = sim.add_camera(name="watch", position=[0.6, -0.3, 0.3], target=[0.0, 0.0, 0.1])
+        assert result["status"] == "success", result
+        assert sim.get_camera_params(camera_name="watch") is not None
+
+    def test_the_drop_is_reported_with_the_camera_and_the_body(self, sim, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger=_SCENE_OPS_LOGGER):
+            sim.remove_object("crate")
+        dropped = [r.getMessage() for r in caplog.records if "dropping camera" in r.getMessage()]
+        assert len(dropped) == 1, [r.getMessage() for r in caplog.records]
+        assert "'watch'" in dropped[0] and "'crate'" in dropped[0], dropped[0]
+
+
+class TestTheDropIsScopedToTheRemovedBody:
+    def test_a_camera_mounted_on_a_surviving_body_still_resolves(self, sim) -> None:
+        sim.remove_object("crate")
+        assert "plate_cam" in _camera_names(sim)
+        assert sim.get_camera_params(camera_name="plate_cam") is not None
+
+    def test_a_world_fixed_camera_still_resolves(self, sim) -> None:
+        sim.remove_object("crate")
+        assert "fixed" in _camera_names(sim)
+        assert sim.get_camera_params(camera_name="fixed") is not None
+
+    def test_removing_an_object_that_carries_no_camera_drops_nothing(self, sim, caplog) -> None:
+        before = _camera_names(sim)
+        with caplog.at_level(logging.WARNING, logger=_SCENE_OPS_LOGGER):
+            assert sim.remove_object("plate")["status"] == "success"
+        assert "plate_cam" not in _camera_names(sim), "the plate's own camera goes with it"
+        assert "watch" in _camera_names(sim) and "fixed" in _camera_names(sim)
+        assert len(_camera_names(sim)) == len(before) - 1
+        assert len(_camera_names(sim)) == _model_camera_count(sim)
+
+    def test_ejecting_a_body_absent_from_the_spec_drops_nothing(self, sim) -> None:
+        # eject_body_from_scene returns True for a body it cannot find (the
+        # caller has already popped the registry entry). Nothing was removed
+        # from the scene, so no camera may be dropped either.
+        before = _camera_names(sim)
+        assert scene_ops.eject_body_from_scene(sim._world, "no_such_body") is True
+        assert _camera_names(sim) == before
+
+
+class TestTheObjectPathMatchesTheRobotPath:
+    def test_both_removals_leave_the_registry_agreeing_with_the_model(self, tmp_path) -> None:
+        urdf = tmp_path / "arm.xml"
+        urdf.write_text(_ARM_XML)
+        s = Simulation(tool_name="test_remove_object_camera_cascade_parity", mesh=False)
+        try:
+            s.create_world(gravity=[0, 0, -9.81])
+            assert s.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+            s.add_object("crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.3, 0.0, 0.05])
+            assert (
+                s.add_camera(name="wrist", position=[0.05, 0.0, 0.05], target=[0.1, 0.0, 0.0], parent_body="arm/link")[
+                    "status"
+                ]
+                == "success"
+            )
+            assert (
+                s.add_camera(name="watch", position=[0.2, -0.2, 0.2], target=[0.0, 0.0, 0.0], parent_body="crate")[
+                    "status"
+                ]
+                == "success"
+            )
+            assert {"wrist", "watch"} <= set(_camera_names(s))
+
+            assert s.remove_robot("arm")["status"] == "success"
+            assert "wrist" not in _camera_names(s), "the robot path drops its body-mounted camera"
+            assert len(_camera_names(s)) == _model_camera_count(s)
+
+            assert s.remove_object("crate")["status"] == "success"
+            assert "watch" not in _camera_names(s), "the object path must do the same"
+            assert len(_camera_names(s)) == _model_camera_count(s)
+        finally:
+            s.cleanup()


### PR DESCRIPTION
## Problem

A camera added with `add_camera(parent_body=<object>)` expresses its pose in that body's frame, so MuJoCo makes it a **child element of the body**. `remove_object` deletes the body, and the recompile that follows deletes the camera with it — the compiled model loses it whether or not anyone asked.

The `world.cameras` registry did not follow. The call reported success and left an entry naming a camera no consumer could resolve, so every camera surface contradicted itself in one sentence:

```
>>> sim.add_object("crate", ...); sim.add_camera(name="watch", parent_body="crate")
>>> sim.remove_object("crate")
{'status': 'success', 'content': [{'text': "'crate' removed."}]}

>>> sim.list_cameras()
['default', 'fixed', 'plate_cam', 'watch']          # 4 entries
>>> sim._world._model.ncam
3                                                    # 3 cameras

>>> sim.render(camera_name="watch")
{'status': 'error', 'content': [{'text':
    "Camera 'watch' not found. Available: ['default', 'fixed', 'plate_cam', 'watch']"}]}
```

The available list is the actionable half of that message, and it offers `'watch'` as an alternative to itself. `get_camera_params` raises `KeyError` with the same text. The stale entry also blocks recovery: re-adding the camera under that name is refused with `"add_camera: camera 'watch' already exists. Remove it first."`

## Why this shape

The robot path already does the right thing, and its own comment says why. `eject_robot_from_scene` drops the robot's URDF cameras — *"stale entries would linger in the registry and confuse observation code"* — and, via `add_deferred_cameras`, any camera whose parent body belonged to the robot being removed, each with a warning. Measured on the same scene:

| removal | camera mounted on the removed body | `list_cameras()` | render verdict |
|---|---|---|---|
| `remove_robot("panda")` (camera on `panda/hand`) | dropped, warning names the camera and its parent | `['default']` | `Camera 'wrist' not found. Available: ['default']` — coherent |
| `remove_object("crate")` (camera on `crate`) | **left in the registry**, no warning | `['default', 'watch']` | `Camera 'watch' not found. Available: ['default', 'watch']` |

`eject_body_from_scene` now applies the same cascade to the body it ejects. It is keyed by **registry name**, not `cam.name`, because a URDF-discovered camera stores its namespaced MuJoCo name there. The drop sits after the *"body not found in spec"* early return — an ejection that removed nothing drops no camera — and before the recompile, matching the robot path's order.

## Out of scope, deliberately

`patch_scene_mjcf(delete_body=...)` produces the same orphan and is left alone: it is the raw-MJCF escape hatch and its own result text says *"world.robots / world.objects / world.cameras registries were NOT updated"*, so registry drift there is its documented contract rather than a defect.

## Measured behaviour

![remove_object camera cascade](https://raw.githubusercontent.com/cagataycali/robots/artifacts/remove-object-camera-cascade/remove_object_camera_cascade.png)

Panels 1–3 are real headless MuJoCo renders (`MUJOCO_GL=egl`). Panel 1 is the view the mounted camera gave. Panels 2 and 3 are the surviving `plate_cam` (mounted on a *different* body) after the removal on each tree — **byte-identical, `max|delta| = 0/255`**, so the drop is scoped to the body actually being removed. Every cell in the table is read back from the two runs' JSON dumps; the capture and compose scripts are on the artifact branch beside the image.

| | main | this PR |
|---|---|---|
| `list_cameras()` entries vs model `ncam` | 4 vs 3 — disagree | 3 vs 3 — agree |
| `render(camera_name='watch')` available list | names `'watch'` | does not |
| `plate_cam` / `fixed` still resolvable | yes | yes |
| re-add `'watch'` | refused, `"already exists"` | success |

## Tests

`tests/simulation/mujoco/test_remove_object_camera_cascade.py`, 10 cases, GL-free (`mesh=False`, no rendering — `get_camera_params` resolves a camera from `model`/`data` alone), 0.7 s:

- the mounted camera leaves the registry; the registry count equals the model's `ncam` (pinned before *and* after, so the premise is measured)
- no consumer is offered the camera it cannot resolve — the available list must not name it
- the dropped name is reusable
- the drop is warned with the camera and the body
- **over-reach controls**: a camera on a surviving body and a world-fixed camera both still resolve; removing an object that carries no camera drops nothing; ejecting a body absent from the spec drops nothing
- **parity**: with a camera on a robot body and one on an object body, `remove_robot` then `remove_object` must both leave the registry agreeing with the model (asset-free inline MJCF arm)

**Pre-fix** (source at the base, tests kept): **7 failed / 3 passed**. The 3 that pass are the properties the fix must preserve — the world-fixed camera, the camera on another body, and the no-op ejection — so passing before the change is the point of them.

## Gate

Run at `b05b6f47`, rebased onto `9a0a534e` (`behind_by = 0`, so this is the tree that merges):

- `MUJOCO_GL=egl pytest tests` — **27389 passed, 257 skipped, 0 failed** (597 s)
- `ruff check` / `ruff format --check` `strands_robots tests tests_integ` — clean (1158 files)
- `mypy strands_robots tests tests_integ` — 14 errors, all in `examples/isaac_gs`, **0 outside**, error set byte-identical to a pristine-base worktree (environment-only, not from this change)
- `scripts/check_merge_base_overlap.py` — no overlap, 0 paths changed on `upstream/main` in that span
- `scripts/assemble_changelog.py --check` — OK
