### PR TITLE
fix(simulation/mujoco): refuse a camera removal the scene will not recompile without

### DIFF
--- a/changelog.d/2111-remove-camera-refused-recompile.md
+++ b/changelog.d/2111-remove-camera-refused-recompile.md
@@ -1,0 +1,24 @@
+### Fixed: a camera removal the scene will not recompile without is refused, not reported as done
+
+``remove_camera`` deletes the camera element from the live ``MjSpec`` before the
+``spec.recompile`` that validates the result, and a refused recompile leaves the
+compiled model untouched. It logged that refusal at warning level, dropped the
+registry entry anyway and returned ``{"status": "success", ... "removed."}``, so
+the spec stopped declaring a camera the model still had: ``list_cameras`` no
+longer named it while ``render`` and ``get_camera_params`` went on resolving it,
+and the delete landed later, applied by whichever unrelated scene mutation next
+recompiled successfully -- a camera a rollout or recording was reading from
+disappearing at an ``add_object`` call with nothing to attribute it to.
+
+The delete now takes a spec snapshot first and is rolled back out on a refusal,
+which is reported as an error naming the camera and saying it is still
+registered. That is the contract its inverse already had: ``add_camera`` rolls a
+refused add back out and reports it. The registry entry is dropped only once the
+recompile is accepted, so a refused removal leaves the scene -- registry, spec
+and model -- exactly as it was found, and the identical call succeeds once
+whatever made the scene uncompilable clears.
+
+The removal also routes through the shared ``_recompile_preserving_state`` path
+every other scene mutation uses instead of its own ``spec.recompile`` call, so it
+picks up the forward pass that populates camera transforms and the cached-XML
+sync that logs a failed ``spec.to_xml()`` rather than discarding it silently.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -811,6 +811,66 @@ def eject_body_from_scene(world: SimWorld, body_name: str) -> bool:
     return _recompile_preserving_state(world, spec)
 
 
+def eject_camera_from_scene(world: SimWorld, mj_name: str) -> bool:
+    """Remove a camera element from the scene spec and recompile in place.
+
+    The inverse of :func:`inject_camera_into_scene`, and it needs the same way
+    back. ``SpecBuilder.remove_camera`` mutates the live spec before the
+    recompile that validates the result, and a refused ``spec.recompile`` leaves
+    ``world._model`` untouched -- so with no rollback the spec stops declaring
+    the camera while the compiled model still has it. Consumers then disagree
+    about whether the camera exists: ``render`` and ``get_camera_params``
+    resolve it from the model and succeed, while the delete lands later, applied
+    by whichever unrelated mutation next recompiles successfully. Restoring the
+    pre-delete spec keeps a refused removal costing exactly the removal that was
+    refused.
+
+    The rollback reinstalls a snapshot taken before the delete
+    (:func:`_snapshot_spec`) rather than re-adding the camera from its
+    ``SimCamera`` registry entry: a camera discovered inside a robot's URDF can
+    carry element attributes that entry does not model, so re-adding it would
+    restore a different camera. A caller that cannot snapshot refuses the
+    removal rather than proceeding with no way back.
+
+    Args:
+        world: The scene to mutate.
+        mj_name: The camera's name in the MjSpec -- namespaced for a camera
+            discovered inside a robot's URDF, otherwise the registry name.
+
+    Returns:
+        ``True`` when the camera is gone from the spec and the recompiled model
+        is installed, or when the spec never declared it (nothing to eject).
+        ``False`` when there is no spec, the snapshot failed, or the recompile
+        was refused; in the last two cases the scene is left as it was found.
+    """
+    spec = _get_spec(world)
+    if spec is None or world._model is None:
+        logger.error("eject_camera: no spec or model in world")
+        return False
+
+    # Snapshot BEFORE mutating. Without a way back the removal is refused here,
+    # while the scene is still exactly as it was found.
+    backup_spec = _snapshot_spec(spec, context=f"eject_camera {mj_name!r}")
+    if backup_spec is None:
+        return False
+
+    if not SpecBuilder.remove_camera(spec, mj_name):
+        # Nothing was mutated, so there is nothing to roll back. Mirrors
+        # :func:`eject_body_from_scene`: the spec already agrees with where the
+        # caller's registry is heading, so the removal is not an error.
+        logger.warning("Camera '%s' not found in spec - nothing ejected", mj_name)
+        return True
+
+    if _recompile_preserving_state(world, spec):
+        return True
+
+    # The delete landed in the spec but the model it produced was refused, so
+    # the spec is now missing a camera the live model still has. Put the
+    # pre-delete spec back.
+    world._backend_state["spec"] = backup_spec
+    return False
+
+
 def reposition_body_in_scene(
     world: SimWorld,
     body_name: str,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -90,6 +90,7 @@ from strands_robots.simulation.mujoco.recording import RecordingMixin
 from strands_robots.simulation.mujoco.rendering import RenderingMixin
 from strands_robots.simulation.mujoco.scene_ops import (
     eject_body_from_scene,
+    eject_camera_from_scene,
     eject_robot_from_scene,
     inject_camera_into_scene,
     inject_object_into_scene,
@@ -3359,9 +3360,26 @@ class MuJoCoSimEngine(
     def remove_camera(self, name: str) -> dict[str, Any]:
         """Remove a named camera from the live scene.
 
-        Pops the Python-side registry entry and then deletes the camera
-        from the MjSpec via :func:`SpecBuilder.remove_camera` so future
-        renders/compiles no longer see it.
+        Deletes the camera element from the MjSpec and recompiles so ``ncam`` in
+        the live model matches, then drops the Python-side registry entry.
+
+        The registry entry goes only once the recompile has been accepted. A
+        refused ``spec.recompile`` leaves the live model untouched, so dropping
+        the entry first would report a removal the model had not applied:
+        ``list_cameras`` would stop naming a camera ``render`` and
+        ``get_camera_params`` still resolve, and the delete would land later,
+        applied by whichever unrelated mutation next recompiles successfully.
+        This mirrors :meth:`add_camera`, which rolls a refused add back out and
+        reports it rather than claiming the camera exists.
+
+        Args:
+            name: The camera name (as passed to ``add_camera``).
+
+        Returns:
+            A ``{status, content}`` tool result. ``status`` is ``"error"`` when
+            no world exists, ``name`` is unknown, a policy is running, or the
+            scene would not recompile without the camera -- in that last case
+            the camera is still registered and the scene is unchanged.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -3369,26 +3387,26 @@ class MuJoCoSimEngine(
             return {"status": "error", "content": [{"text": self._unknown_camera_msg(name)}]}
         if err := self._require_no_running_policy("remove_camera"):
             return err
-        cam = self._world.cameras.pop(name)
+        cam = self._world.cameras[name]
 
-        spec = self._world._backend_state.get("spec")
-        if spec is not None:
+        if self._world._backend_state.get("spec") is not None:
             # Use the namespaced MuJoCo name if we have it (camera came from
             # a robot's URDF), else the short name.
-            mj_name = cam.name or name
-            SpecBuilder.remove_camera(spec, mj_name)
-            # Recompile so nbody/ncam in _model match the new spec.
-            try:
-                new_model, new_data = spec.recompile(self._world._model, self._world._data)
-                install_compiled_model(self._world, new_model, new_data)
-                try:
-                    with filter_mujoco_attach_noise():
-                        self._world._backend_state["xml"] = spec.to_xml()
-                except Exception:
-                    pass
-            except (ValueError, RuntimeError) as e:
-                logger.warning("remove_camera recompile failed: %s", e)
+            if not eject_camera_from_scene(self._world, cam.name or name):
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"Camera '{name}' was not removed: the scene would not "
+                                "recompile without it. The camera is still registered and "
+                                "the scene is unchanged; the compiler's reason is logged."
+                            )
+                        }
+                    ],
+                }
 
+        del self._world.cameras[name]
         return {"status": "success", "content": [{"text": f"Camera '{name}' removed."}]}
 
     # Simulation Control

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -66,6 +66,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::actuator_joint_id",
     "scene_ops.py::add_weld_constraint",
     "scene_ops.py::eject_body_from_scene",
+    "scene_ops.py::eject_camera_from_scene",
     "scene_ops.py::eject_robot_from_scene",
     "scene_ops.py::inject_camera_into_scene",
     "scene_ops.py::inject_object_into_scene",

--- a/tests/simulation/mujoco/test_remove_camera_refused_recompile.py
+++ b/tests/simulation/mujoco/test_remove_camera_refused_recompile.py
@@ -37,6 +37,7 @@ mj = pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 
 @pytest.fixture
@@ -123,11 +124,13 @@ class TestTheSceneIsLeftAsItWasFound:
         assert _model_cameras(sim) == model_before
 
     def test_every_consumer_still_resolves_the_camera(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The registry, the intrinsics and the renderer give the same answer.
+        """The registry and the intrinsics give the same answer.
 
         Pre-fix ``list_cameras`` stopped naming the camera while
-        ``get_camera_params`` and ``render`` - which resolve it from the model -
-        both went on succeeding.
+        ``get_camera_params`` - which resolves it from the model - went on
+        succeeding. Both consumers read the scene without a GL context, so this
+        pin holds on every host; the renderer is the third consumer and is
+        pinned separately because it additionally needs one.
         """
         _refuse_recompiles(monkeypatch)
         assert sim.remove_camera("watch")["status"] == "error"
@@ -135,6 +138,22 @@ class TestTheSceneIsLeftAsItWasFound:
 
         assert "watch" in sim.list_cameras()
         assert sim.get_camera_params(camera_name="watch") is not None
+
+    @requires_gl
+    def test_the_renderer_still_resolves_the_camera(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``render`` is the consumer that also needs a GL context.
+
+        Kept apart from the registry/intrinsics pin above rather than folded in
+        with it: ``render`` returns ``{'status': 'error'}`` on a host with no
+        EGL/OSMesa for a reason that has nothing to do with resolving the
+        camera, so asserting success unconditionally would fail off-CI with a
+        bare ``'error' != 'success'`` naming neither GL nor the camera. Gating
+        only this case keeps the two GL-free consumers verified everywhere.
+        """
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
         assert sim.render(camera_name="watch", width=64, height=48)["status"] == "success"
 
     def test_the_removal_does_not_land_at_a_later_unrelated_mutation(

--- a/tests/simulation/mujoco/test_remove_camera_refused_recompile.py
+++ b/tests/simulation/mujoco/test_remove_camera_refused_recompile.py
@@ -1,0 +1,228 @@
+"""``remove_camera`` reports a refused recompile instead of claiming the removal.
+
+Deleting a camera mutates the live ``MjSpec`` *before* the ``spec.recompile``
+that validates the result, and a refused recompile leaves ``world._model``
+untouched. So the delete has to be rolled back out of the spec and reported,
+exactly as its inverse does: ``add_camera`` rolls a refused add back out
+(:func:`~strands_robots.simulation.mujoco.scene_ops.inject_camera_into_scene`)
+and returns ``{'status': 'error'}``.
+
+Before the fix ``remove_camera`` logged the refusal at warning level, dropped the
+registry entry anyway and returned ``{'status': 'success', ... "removed."}``.
+That left three observable inconsistencies, and this module pins each one:
+
+* the spec no longer declared the camera while the compiled model still had it,
+  so ``list_cameras`` stopped naming a camera ``render`` and
+  ``get_camera_params`` went on resolving - two consumers of one scene giving
+  opposite answers about whether the camera exists,
+* the delete landed *later*, applied by whichever unrelated mutation next
+  recompiled successfully, so a camera a rollout or recording was reading from
+  disappeared at an ``add_object`` call with nothing to attribute it to,
+* the compiler's reason - the signal that the scene had become uncompilable -
+  reached only the log, so the caller was told the opposite of what happened.
+
+The refusal is deliberately transient here (the recompile is refused only for the
+duration of the patch), which is what lets the last test in each class show the
+refusal cost the caller nothing permanent: the identical removal succeeds once
+the refusal clears.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_remove_camera_refusal", mesh=False)
+    s.create_world()
+    # Two cameras so the surviving one shows the refusal is scoped, and so the
+    # registry's ORDER is observable: the camera under test sits in the middle.
+    assert s.add_camera(name="watch", position=[0.7, -0.7, 0.5], target=[0, 0, 0.1])["status"] == "success"
+    assert s.add_camera(name="keep", position=[0.0, -1.0, 0.6], target=[0, 0, 0.1])["status"] == "success"
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _refuse_recompiles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the recompile that validates a spec mutation fail.
+
+    Patches the binding rather than the helper so the refusal enters through the
+    same call the production path makes. ``monkeypatch.undo()`` models the
+    failure clearing.
+    """
+
+    def _boom(_self: object, *_a: object, **_k: object) -> object:
+        raise ValueError("simulated spec.recompile refusal")
+
+    monkeypatch.setattr(mj.MjSpec, "recompile", _boom)
+
+
+def _model_cameras(sim: Any) -> list[str]:
+    model = sim._world._model
+    return [mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+
+
+def _spec_cameras(sim: Any) -> list[str]:
+    return [cam.name for cam in sim._world._backend_state["spec"].cameras]
+
+
+class TestARefusedRecompileIsReportedNotClaimed:
+    def test_the_removal_reports_an_error_naming_the_camera(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The caller learns the removal did not happen, and which camera."""
+        _refuse_recompiles(monkeypatch)
+        refused = sim.remove_camera("watch")
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        text = refused["content"][0]["text"]
+        assert "watch" in text
+        # The message has to say the camera is STILL THERE, because the caller's
+        # next move depends on it: pre-fix this same call said "removed."
+        assert "still registered" in text
+
+    def test_the_camera_keeps_its_registry_entry_and_its_position(
+        self, sim: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The registry is restored to exactly what it was, order included.
+
+        The entry is dropped only once the recompile is accepted, so a refusal
+        needs no restore and cannot reorder the map - which a pop-then-reinsert
+        rollback would, moving the camera to the end of ``list_cameras``.
+        """
+        before = list(sim._world.cameras)
+
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        assert list(sim._world.cameras) == before
+        assert before.index("watch") < before.index("keep"), "the fixture must not order it last"
+
+
+class TestTheSceneIsLeftAsItWasFound:
+    def test_the_spec_and_the_model_still_agree(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pre-fix the spec lost the camera while the live model kept it."""
+        spec_before, model_before = _spec_cameras(sim), _model_cameras(sim)
+        assert "watch" in spec_before and "watch" in model_before
+
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        assert _spec_cameras(sim) == spec_before
+        assert _model_cameras(sim) == model_before
+
+    def test_every_consumer_still_resolves_the_camera(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The registry, the intrinsics and the renderer give the same answer.
+
+        Pre-fix ``list_cameras`` stopped naming the camera while
+        ``get_camera_params`` and ``render`` - which resolve it from the model -
+        both went on succeeding.
+        """
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        assert "watch" in sim.list_cameras()
+        assert sim.get_camera_params(camera_name="watch") is not None
+        assert sim.render(camera_name="watch", width=64, height=48)["status"] == "success"
+
+    def test_the_removal_does_not_land_at_a_later_unrelated_mutation(
+        self, sim: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused delete must not be applied by the next successful recompile.
+
+        Pre-fix the delete sat in the live spec, so an unrelated ``add_object``
+        recompiled it away: the camera vanished from the model at a call that
+        never mentioned it.
+        """
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        added = sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])
+        assert added["status"] == "success"
+
+        assert "watch" in _model_cameras(sim)
+        assert "watch" in _spec_cameras(sim)
+        assert "watch" in sim.list_cameras()
+
+    def test_no_model_swap_means_outstanding_checkpoints_survive(
+        self, sim: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refused removal installs no model, so it invalidates no checkpoint.
+
+        ``install_compiled_model`` bumps the generation that the ``save_state`` /
+        ``load_state`` fingerprint carries; a refusal never reaches it.
+        """
+        generation_before = sim._world._recompile_generation
+
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        assert sim._world._recompile_generation == generation_before
+
+    def test_the_identical_removal_succeeds_once_the_refusal_clears(
+        self, sim: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scene stays mutable: the refusal cost exactly the refused call."""
+        _refuse_recompiles(monkeypatch)
+        assert sim.remove_camera("watch")["status"] == "error"
+        monkeypatch.undo()
+
+        assert sim.remove_camera("watch")["status"] == "success"
+        assert "watch" not in sim.list_cameras()
+        assert "watch" not in _spec_cameras(sim)
+        assert "watch" not in _model_cameras(sim)
+
+
+class TestTheHonoredRemovalIsUnchanged:
+    def test_a_successful_removal_drops_it_from_registry_spec_and_model(self, sim: Any) -> None:
+        """Non-vacuity: the fix does not turn a working removal into a refusal."""
+        generation_before = sim._world._recompile_generation
+
+        assert sim.remove_camera("watch")["status"] == "success"
+
+        assert "watch" not in sim.list_cameras()
+        assert "watch" not in _spec_cameras(sim)
+        assert "watch" not in _model_cameras(sim)
+        # The surviving camera is untouched, so the removal was scoped.
+        assert "keep" in sim.list_cameras()
+        assert "keep" in _model_cameras(sim)
+        # A successful removal DOES swap the model, so it must invalidate
+        # outstanding checkpoints - the mirror of add_camera.
+        assert sim._world._recompile_generation > generation_before
+
+
+class TestTheEjectHelperMirrorsItsEjectSiblings:
+    def test_a_camera_the_spec_never_declared_is_not_a_failure(self, sim: Any) -> None:
+        """Nothing was mutated, so there is nothing to roll back.
+
+        Mirrors :func:`scene_ops.eject_body_from_scene`, which also reports
+        success for an element the spec does not hold: the caller's registry is
+        the record that matters and the spec already agrees with where it is
+        heading.
+        """
+        assert scene_ops.eject_camera_from_scene(sim._world, "never_declared") is True
+        # ... and the scene it did not touch is still exactly as it was.
+        assert _spec_cameras(sim) == _model_cameras(sim)
+
+    def test_a_refused_recompile_reports_false(self, sim: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The bool the facade branches on is False when the scene was restored."""
+        _refuse_recompiles(monkeypatch)
+        result = scene_ops.eject_camera_from_scene(sim._world, "watch")
+        monkeypatch.undo()
+
+        assert result is False
+        assert "watch" in _spec_cameras(sim)

--- a/tests/simulation/mujoco/test_spec_snapshot_refusal.py
+++ b/tests/simulation/mujoco/test_spec_snapshot_refusal.py
@@ -16,8 +16,8 @@ applied to the live spec with nothing to restore leaves an orphan behind, and an
 orphan makes every LATER scene mutation fail to recompile, bricking the whole
 world after one bad call.
 
-Four callers share the helper and each refuses through its OWN channel, which
-is why one test per surface is not one test four times:
+Five callers share the helper and each refuses through its OWN channel, which
+is why one test per surface is not one test five times:
 
 * ``add_robot`` -> ``inject_robot_into_scene`` returns ``False``, and the caller
   also unwinds the ``_world.robots`` registry entry it had already made,
@@ -25,7 +25,9 @@ is why one test per surface is not one test four times:
 * ``patch_scene_mjcf`` -> raises ``RuntimeError``, which the facade converts,
 * ``detach_bodies`` -> ``remove_equality_constraint`` returns ``False``, and the
   weld it was about to delete is still holding the pair, so the attachment
-  ``attach_bodies`` recorded stays true.
+  ``attach_bodies`` recorded stays true,
+* ``remove_camera`` -> ``eject_camera_from_scene`` returns ``False``, and the
+  caller keeps the ``_world.cameras`` entry it had not dropped yet.
 
 Each test asserts the whole cost of the refusal rather than only its status: the
 compiled model is unchanged, the mutation's own element is absent, the scene is
@@ -266,3 +268,31 @@ class TestDetachBodiesRefusesWithoutAWayBack:
         assert sim.detach_bodies("carrier", "cube")["status"] == "success"
         assert int(sim._world._model.neq) == 0
         assert sim.attachment_involving("cube") is None
+
+
+class TestRemoveCameraRefusesWithoutAWayBack:
+    def test_the_camera_is_kept_and_the_refusal_costs_nothing(
+        self, sim: Simulation, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert sim._world is not None
+        assert sim.add_camera(name="watch", position=[0.7, -0.7, 0.5], target=[0, 0, 0.1])["status"] == "success"
+        ncam_before = int(sim._world._model.ncam)
+
+        _refuse_snapshots(monkeypatch)
+        refused = sim.remove_camera("watch")
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        assert "watch" in refused["content"][0]["text"]
+        # This caller had not dropped its registry entry yet, so refusing before
+        # the delete leaves nothing to unwind - the camera is simply still there.
+        assert "watch" in sim._world.cameras
+        assert int(sim._world._model.ncam) == ncam_before
+
+        assert (
+            sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])["status"]
+            == "success"
+        )
+        assert sim.remove_camera("watch")["status"] == "success"
+        assert "watch" not in sim._world.cameras
+        assert int(sim._world._model.ncam) == ncam_before - 1


### PR DESCRIPTION
## The defect

`remove_camera` deletes the camera element from the live `MjSpec` **before** the
`spec.recompile` that validates the result. A refused recompile leaves
`world._model` untouched — so the delete has to be rolled back and reported.
Instead it logged the refusal at warning level, dropped the registry entry
anyway, and returned `{"status": "success", ... "Camera 'watch' removed."}`.

Measured on a two-camera scene whose recompile is refused (one script run in each
tree, `MUJOCO_GL=egl`):

| after `remove_camera("watch")` | main | this change |
| --- | --- | --- |
| what the caller was told | `success` — "Camera 'watch' removed." | `error` — "…not removed … still registered …" |
| `list_cameras()` | `['default']` | `['default', 'watch']` |
| the compiled model | `['default', 'watch']` ← disagrees with the registry | `['default', 'watch']` ← agrees |
| the live spec | `['default']` ← disagrees with the model | `['default', 'watch']` ← agrees |
| `render('watch')` | `success` ← resolves a camera `list_cameras` denies | `success` ← consistent with all three |
| then one unrelated `add_object` | `success` | `success` |
| the model after that add | `['default']` ← **the camera vanished here** | `['default', 'watch']` ← nothing landed later |
| `render('watch')` after that add | `error` — "Camera 'watch' not found. Available: ['default']" | `success` |

Three consequences, one cause:

- **Consumers disagreed about whether the camera existed.** `list_cameras` stopped
  naming it while `render` and `get_camera_params` — which resolve it from the
  model — went on succeeding.
- **The delete landed later**, applied by whichever unrelated mutation next
  recompiled successfully. A camera a rollout or recording was reading from
  disappeared at an `add_object` call that never mentioned it, with nothing to
  attribute it to.
- **The compiler's reason** — the signal that the scene had become uncompilable —
  reached only the log, while the caller was told the opposite of what happened.

`remove_camera` was the only one of the 15 recompile-touching mutators in
`mujoco/simulation.py` that warned and continued; every other reports an error
envelope. Its own inverse already had the contract this restores: `add_camera`
rolls a refused add back out (`inject_camera_into_scene`) and reports it.

## The change

- New `scene_ops.eject_camera_from_scene(world, mj_name)`, placed with the
  `eject_*` family and the direct inverse of `inject_camera_into_scene`. It
  snapshots the spec via `_snapshot_spec` before mutating, and restores it if the
  recompile is refused. `_snapshot_spec`'s docstring already states the rule this
  applies: *"A caller that cannot snapshot must refuse its mutation rather than
  proceed with no way back."*
- `remove_camera` branches on that result and reports a refusal as an error
  naming the camera and saying it is still registered. **The registry entry is
  dropped only once the recompile is accepted**, so a refusal needs no restore
  and cannot reorder the map — which a pop-then-reinsert rollback would, moving
  the camera to the end of `list_cameras`.
- The removal now routes through the shared `_recompile_preserving_state` path
  every other scene mutation uses, rather than its own `spec.recompile` call.
  `simulation.py:3382` was the only direct `spec.recompile` outside `scene_ops`.
  It picks up the forward pass that populates camera transforms and the
  cached-XML sync that *logs* a failed `spec.to_xml()` where the hand-rolled
  block had `except Exception: pass`. Net −9 lines in `remove_camera`.

The snapshot is used rather than re-adding the camera from its `SimCamera`
registry entry because a camera discovered inside a robot's URDF can carry
element attributes that entry does not model, so re-adding it would restore a
*different* camera.

## Visual artifact

Same scene and same sequence in both trees: a refused `remove_camera("watch")`,
then one unrelated `add_object("crate")`.

![remove_camera refused recompile](https://raw.githubusercontent.com/cagataycali/robots/artifacts/remove-camera-refused-recompile/remove_camera_refused_recompile.png)

Panel A is the view the camera gives, identical in both trees
(`max|main − branch| = 1/255` over the whole frame — renderer noise). Panel B is
main: after the "successful" removal and the later `add_object`, there is **no
view left** — the camera was applied away by a call that never mentioned it.
Panel C is this change: the removal was refused, so the camera survives and the
newly added crate is visible in it (a 122×299 px, 100 %-green-dominant region,
3.98 % of the frame). Every number in the figure is re-derived from the two JSON
dumps by the compose step, which also asserts the two runs came from different
trees. Scripts and measurements: [`artifacts/remove-camera-refused-recompile`](https://github.com/cagataycali/robots/tree/artifacts/remove-camera-refused-recompile).

## Tests

`tests/simulation/mujoco/test_remove_camera_refused_recompile.py` (11 tests — 10
that need no GL context, plus one renderer case gated on the shared `requires_gl`
probe) pins each consequence separately: the refusal is reported and names the camera;
the registry keeps its entry *in its original position*; the spec and the model
still agree; `list_cameras` / `get_camera_params` / `render` give the same answer;
the delete does not land at a later unrelated mutation; no model swap means
outstanding checkpoints survive; and the identical removal succeeds once the
refusal clears. A non-vacuity class pins that a healthy removal still drops the
camera from registry, spec **and** model and still bumps the checkpoint
generation, so the fix cannot be satisfied by refusing everything.

`test_spec_snapshot_refusal.py` gains the fifth `_snapshot_spec` caller. Its
docstring counted **four** callers once #2115 landed `detach_bodies`, each
refusing through its own channel; that count and its bullet list are updated, and
a per-surface class is added — the per-surface classes now number five.

**Pre-fix** (source at base `10e9506`, tests kept, measured before the round-2
GL split): **10 failed / 9 passed**,
every behavioural failure reading `AssertionError: assert 'success' == 'error'`.
The failing set is the same 10 before and after the rebase onto #2115, so the
contract this pins is unchanged by it; the one extra pass is #2115's own
`detach_bodies` surface, which is now part of the base. Post-fix: **19 passed**.
The round-2 split adds one test, so the post-fix total is **20** where a GL
context exists and **19 passed / 1 skipped** without one.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` → **27432 passed / 257 skipped / 0 failed**
  (605 s) at base `b532ec06`. Collected 27676 → 27689 (**+13**): 10 new tests, 1
  added to the snapshot contract, and 2 from the repo-wide `Args:`-completeness
  guard automatically covering the new function in both directions.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean
  (1159 files).
- `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`;
  the 14 there are byte-identical to a pristine `upstream/main` worktree of the
  same working copy, i.e. environmental.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD`: no
  overlap, 0 paths changed on `upstream/main` in that span.
- Re-verified at the post-rebase base `10e9506`: `tests/simulation/mujoco` →
  **2841 passed / 38 skipped**. The 3 failures are all in `test_recording_paths.py`
  and all from `lerobot` being absent in that environment — each reproduces
  identically on a clean `main` checkout, so none is attributable to this branch.
  `ruff check` / `ruff format --check` clean on the touched files.
- Zero existing-test churn: no assertion elsewhere changed.

## Out of scope

- `patch_scene_mjcf(delete_body=…)` produces the same registry/model divergence
  and is **not** a defect: its own success text says the registries were not
  updated, which is that raw escape hatch's documented contract.
- `SpecBuilder.remove_camera` returning `False` for a camera the spec never
  declared is reported as success, mirroring `eject_body_from_scene`, which
  documents the same treatment for a body the spec does not hold.

## Round changelog

### Round 1 — rebase onto `main` after #2115 merged

- #2115 (the `detach_bodies` weld-removal rollback) landed in `main` and left this
  branch `CONFLICTING`. Rebased `a647afd` → `86d93b0` onto `10e9506`; the branch is
  a single commit again.
- The only conflict was `tests/simulation/mujoco/test_spec_snapshot_refusal.py`.
  Both PRs append to the same two places in that shared module: a bullet in the
  `_snapshot_spec` caller list and a per-surface test class at the same anchor.
  **Both sides are kept** — the caller count in the module docstring goes four →
  five, and `TestDetachBodiesRefusesWithoutAWayBack` and
  `TestRemoveCameraRefusesWithoutAWayBack` both stand.
- No production-code conflict, and none possible: `eject_camera_from_scene` and
  #2115's `remove_equality_constraint` are separate helpers, and `remove_camera`
  and `detach_bodies` are separate methods. `scene_ops.py` and `simulation.py`
  auto-merged, and the resulting diff against `main` touches only `remove_camera`
  and adds only `eject_camera_from_scene`.
- Description corrected for the new base: the caller and class counts, the pre-fix
  and post-fix test counts, and a claim that the module asserts the per-surface
  class count — it does not, there is no such assertion, so the claim is dropped
  rather than restated.

### Round 2 — the renderer consumer assumed a GL context

- `test_every_consumer_still_resolves_the_camera` asserted all three consumers in
  one test, including `render(...)["status"] == "success"`. `render` returns an
  error dict on a host with no EGL/OSMesa for a reason unrelated to whether the
  camera still resolves, so that assertion passed only where a GL context happened
  to exist. On a GL-free host the file reported **1 failed** with a bare
  `'error' != 'success'` naming neither GL nor the camera. Found by running this
  branch's own suite on a headless host without EGL/OSMesa.
- Split the renderer case into `test_the_renderer_still_resolves_the_camera`,
  marked with the shared `requires_gl` probe from
  `tests/simulation/mujoco/_gl_probe.py` — the module written for exactly this,
  which probes a real 1x1 offscreen render and skips with a reason naming
  EGL/OSMesa. It is already the convention in 10 sibling modules.
- The registry and intrinsics assertions stay **ungated**: both read the scene
  with no GL context and pin the primary regression (pre-fix `list_cameras`
  stopped naming the camera while `get_camera_params` went on resolving), so
  gating the whole test would have dropped that coverage on every GL-free host.
- The split costs no regression power: with the production fix reverted the
  retained GL-free test still fails, so it is not vacuous. On a GL-free host the
  file goes from 1 opaque failure to **10 passed, 1 skipped** with a named reason.
- Test-only; no production line changed in this round.
