### PR TITLE
test(simulation): pin the recording-rate refusal on the two MuJoCo-only rollout entry points

### DIFF
--- a/changelog.d/2112-mujoco-rollout-entry-point-rate-refusals.md
+++ b/changelog.d/2112-mujoco-rollout-entry-point-rate-refusals.md
@@ -1,0 +1,25 @@
+### Quality: pin the recording-rate refusal on the two MuJoCo-only rollout entry points
+
+Seven surfaces check that a rollout's ``control_frequency`` matches the rate an
+open recording declares. Five had returned the refusal at least once in the test
+suite; ``start_policy`` and ``run_multi_policy`` - the two entry points that
+exist only on the MuJoCo backend - never had. Both were covered by a structural
+sweep asserting the guard is *called*, which cannot distinguish that from a guard
+whose refusal is discarded: dropping the ``return err`` while keeping the call
+leaves all 79 pre-existing cases in the module green.
+
+The sweep gave its reason for staying structural as a driver possibly needing "a
+checkpoint, a benchmark registration or a live background thread to reach".
+Neither of these needs one - the rate guard sits above ``self._executor.submit``,
+so ``start_policy`` returns the refusal on the caller's own thread with no worker
+in existence, which is exactly what its own comment says the placement is for
+("a refusal after submit would report 'started' to a caller whose rollout cannot
+be recorded correctly").
+
+Fifteen behavioural cases now pin, for both entry points: the library defaults
+are refused, the message names both rates, the distortion factor and both
+remedies, the envelope is the shared helper's verbatim, no frame reaches the
+recorder or the dataset, and - for the async path - no worker is submitted and
+the robot is not marked running. Controls pin that an aligned rate still starts
+and still records, and that no recording open is never refused. No library
+behaviour changes.

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -647,6 +647,143 @@ def test_every_backend_start_recording_checks_the_running_rollout_rate(module):
     )
 
 
+class TestTheAsyncEntryPointRefusesBeforeItReportsStarted:
+    """``start_policy`` returns while its rollout continues, so it must refuse synchronously.
+
+    Seven surfaces check the recording rate. Five had returned the refusal at
+    least once; the two that exist only on the MuJoCo backend - ``start_policy``
+    and ``run_multi_policy`` - had not, and were pinned only by the structural
+    sweep below on the stated grounds that a driver may need "a checkpoint, a
+    benchmark registration or a live background thread to reach". Neither of
+    these needs one: the rate guard sits above ``self._executor.submit``, so the
+    refusal is returned on the caller's own thread with no worker in existence.
+
+    That placement is the whole point of the guard here, in ``start_policy``'s
+    own words - "a refusal after submit would report 'started' to a caller whose
+    rollout cannot be recorded correctly". A structural pin cannot see it: it
+    proves the guard is *called*, never that its refusal is *returned*, so
+    discarding the ``return`` while keeping the call satisfies it.
+    """
+
+    def _start(self, sim, control_frequency: float):  # noqa: ANN001, ANN202
+        """Start a long rollout on ``arm``; the horizon outlives any single case."""
+        return sim.start_policy(
+            robot_name="arm",
+            policy_object=_Hold(list(sim.robot_action_keys("arm"))),
+            duration=60.0,
+            control_frequency=control_frequency,
+        )
+
+    def test_the_library_defaults_are_refused(self, sim, tmp_path):
+        _record(sim, tmp_path, fps=30)
+        assert self._start(sim, 50.0)["status"] == "error"
+
+    def test_the_refusal_names_both_rates_and_the_distortion(self, sim, tmp_path):
+        _record(sim, tmp_path, fps=30)
+        text = self._start(sim, 50.0)["content"][0]["text"]
+        assert text.startswith("start_policy: ")
+        assert "declares 30 fps" in text
+        assert "control_frequency=50 Hz" in text
+        assert "1.667x" in text
+
+    def test_the_refusal_names_both_remedies(self, sim, tmp_path):
+        _record(sim, tmp_path, fps=30)
+        text = self._start(sim, 50.0)["content"][0]["text"]
+        assert "control_frequency=30" in text
+        assert "start_recording(fps=50, overwrite=True)" in text
+
+    def test_the_envelope_is_the_shared_helper_verbatim(self, sim, tmp_path):
+        """One rule, one wording: the entry point adds nothing but its own name."""
+        _record(sim, tmp_path, fps=30)
+        assert self._start(sim, 50.0) == dataset_rate_mismatch_error("start_policy", sim._active_recorder(), 50.0)
+
+    def test_no_rollout_is_started(self, sim, tmp_path):
+        """The refusal must not be a false "started": no worker, no running flag."""
+        _record(sim, tmp_path, fps=30)
+        assert self._start(sim, 50.0)["status"] == "error"
+        assert sim._world.robots["arm"].policy_running is False
+        assert sim._policy_threads == {}
+
+    def test_no_frame_is_written(self, sim, tmp_path):
+        root = _record(sim, tmp_path, fps=30)
+        self._start(sim, 50.0)
+        assert sim._active_recorder().frame_count == 0
+        assert _frames_on_disk(root) == 0
+
+    def test_a_matching_rate_still_starts_the_rollout(self, sim, tmp_path):
+        """Control: an aligned rate must still reach the executor and run."""
+        _record(sim, tmp_path, fps=50, name="aligned_async")
+        with _running_rollout(sim, "arm", 50.0):
+            assert sim._world.robots["arm"].policy_running is True
+
+    def test_a_rollout_with_no_recording_open_is_never_refused(self, sim):
+        """Control: the two rates are only comparable while a recording is open."""
+        with _running_rollout(sim, "arm", 50.0):
+            assert sim._world.robots["arm"].policy_running is True
+
+
+class TestTheMultiRobotEntryPointRefusesTheSameDisagreement:
+    """``run_multi_policy`` writes one merged frame per step into the same recording.
+
+    It is the recommended path for capturing two robots into a single dataset, so
+    a rate it cannot honor mislabels the merged episode exactly as the
+    single-robot path does - and it reaches the guard with nothing more than two
+    robots, no checkpoint and no thread.
+    """
+
+    def _policies(self, sim):  # noqa: ANN001, ANN202
+        return {name: _Hold(list(sim.robot_action_keys(name))) for name in ("armA", "armB")}
+
+    def _run(self, sim, control_frequency: float):  # noqa: ANN001, ANN202
+        return sim.run_multi_policy(
+            policies=self._policies(sim),
+            n_steps=10,
+            control_frequency=control_frequency,
+        )
+
+    def test_the_library_defaults_are_refused(self, two_arm_sim, tmp_path):
+        _record(two_arm_sim, tmp_path, fps=30, name="multi_ds")
+        assert self._run(two_arm_sim, 50.0)["status"] == "error"
+
+    def test_the_refusal_names_the_method_both_rates_and_the_distortion(self, two_arm_sim, tmp_path):
+        _record(two_arm_sim, tmp_path, fps=30, name="multi_named")
+        text = self._run(two_arm_sim, 50.0)["content"][0]["text"]
+        assert text.startswith("run_multi_policy: ")
+        assert "declares 30 fps" in text
+        assert "control_frequency=50 Hz" in text
+        assert "1.667x" in text
+
+    def test_the_envelope_is_the_shared_helper_verbatim(self, two_arm_sim, tmp_path):
+        _record(two_arm_sim, tmp_path, fps=30, name="multi_verbatim")
+        assert self._run(two_arm_sim, 50.0) == dataset_rate_mismatch_error(
+            "run_multi_policy", two_arm_sim._active_recorder(), 50.0
+        )
+
+    def test_no_frame_is_written(self, two_arm_sim, tmp_path):
+        root = _record(two_arm_sim, tmp_path, fps=30, name="multi_frames")
+        self._run(two_arm_sim, 50.0)
+        assert two_arm_sim._active_recorder().frame_count == 0
+        assert _frames_on_disk(root) == 0
+
+    def test_no_rollout_is_left_running(self, two_arm_sim, tmp_path):
+        """The refusal precedes every per-robot rollout, so neither arm is driven."""
+        _record(two_arm_sim, tmp_path, fps=30, name="multi_idle")
+        self._run(two_arm_sim, 50.0)
+        assert two_arm_sim._policy_threads == {}
+        assert [two_arm_sim._world.robots[n].policy_running for n in ("armA", "armB")] == [False, False]
+
+    def test_a_matching_rate_still_records_both_robots(self, two_arm_sim, tmp_path):
+        """Control: at an aligned rate the merged capture is unaffected."""
+        root = _record(two_arm_sim, tmp_path, fps=50, name="multi_aligned")
+        assert self._run(two_arm_sim, 50.0)["status"] == "success"
+        assert two_arm_sim.stop_recording()["status"] == "success"
+        assert _frames_on_disk(root) == 10
+
+    def test_a_rollout_with_no_recording_open_is_never_refused(self, two_arm_sim):
+        """Control: with nothing to disagree with, any rate is usable."""
+        assert self._run(two_arm_sim, 50.0)["status"] == "success"
+
+
 _ENTRY_POINTS = {
     "strands_robots/simulation/base.py": ("run_policy", "eval_policy", "evaluate_benchmark"),
     "strands_robots/simulation/mujoco/simulation.py": ("start_policy", "run_multi_policy"),
@@ -678,9 +815,10 @@ def _self_calls(module: str, method: str) -> set[str]:
 def test_every_rollout_entry_point_checks_the_recording_rate(module, method):
     """No rollout driver may capture into a dataset it disagrees with.
 
-    Pinned structurally rather than behaviourally so a driver that needs a
-    checkpoint, a benchmark registration or a live background thread to reach
-    is still covered - and so a newly added driver cannot quietly skip the
+    Every driver in the table also returns its refusal in a behavioural case
+    above, because a structural pin proves only that the guard is *called*:
+    discarding the ``return`` while keeping the call still satisfies this sweep.
+    What it is for is the next driver - one added later cannot quietly skip the
     guard the way ``run_multi_policy`` once skipped ``_validate_action_horizon``.
     """
     assert "_validate_recording_rate" in _self_calls(module, method), (


### PR DESCRIPTION
## What

Fifteen behavioural cases pinning the recording-rate refusal on `start_policy` and
`run_multi_policy`. Tests and one docstring only — no library behaviour changes.

## Why

Seven surfaces check that a rollout's `control_frequency` matches the rate an open
recording declares, because the dataset recorder is driven once per control step with
no decimation: a differing `fps` cannot be honored, only mislabelled.

Five of the seven had returned the refusal at least once in the suite. The two that
exist only on the MuJoCo backend never had:

| surface | refusal returned by a test? |
|---|---|
| `SimEngine.run_policy` | yes |
| `SimEngine.eval_policy` | yes |
| `SimEngine.evaluate_benchmark` | yes |
| `PolicyRunner.run` | yes |
| `PolicyRunner.evaluate` | yes |
| `MuJoCoSimEngine.start_policy` | **no** |
| `MuJoCoSimEngine.run_multi_policy` | **no** |

Both were covered by `test_every_rollout_entry_point_checks_the_recording_rate`, an AST
sweep asserting the guard is *called*. That cannot distinguish a working guard from one
whose refusal is discarded, and the sweep gave its reason for staying structural as a
driver possibly needing *"a checkpoint, a benchmark registration or a live background
thread to reach"*. Neither of these needs one — the rate guard sits above
`self._executor.submit`, so `start_policy` returns the refusal on the caller's own
thread with no worker in existence. That placement is the whole point of the guard here,
in `start_policy`'s own comment:

> a refusal after submit would report "started" to a caller whose rollout cannot be
> recorded correctly

## Why a structural pin was not enough

Each guard mutated two ways, each run against the new cases and against the 79
pre-existing cases in the module:

| entry point | mutation | the 15 new cases | the 79 pre-existing cases |
|---|---|---|---|
| `start_policy` | drop the guard entirely | 5 failed / 10 passed | 1 failed / 78 passed |
| `start_policy` | keep the call, discard the `return err` | 5 failed / 10 passed | **79 passed — invisible** |
| `run_multi_policy` | drop the guard entirely | 4 failed / 11 passed | 1 failed / 78 passed |
| `run_multi_policy` | keep the call, discard the `return err` | 4 failed / 11 passed | **79 passed — invisible** |

The single pre-existing failure in the *drop* rows is the structural sweep noticing the
call is gone. In the *discard* rows — the defect a structural pin is blind to by
construction — the whole module stayed green. Source restored byte-identically after
each mutation.

## What the cases pin

For both entry points: the library defaults (`fps=30` against `control_frequency=50.0`)
are refused; the message names both rates, the 1.667x distortion and both remedies; the
envelope is `dataset_rate_mismatch_error(...)` **verbatim**, so the entry point adds
nothing but its own name; and no frame reaches the recorder or the dataset. For the
async path additionally: no worker is submitted and the robot is not marked running.

Controls pin the guard costs nothing when it should not fire — an aligned rate still
starts the async rollout and still records both robots in the merged path, and a rollout
with no recording open is never refused.

## Coverage

Measured on this module alone with the repo's own coverage target:

| | `mujoco/simulation.py` missing | the two refusal lines | tests |
|---|---|---|---|
| before | 1101 | both **missing** | 79 passed |
| after | 995 | both **covered** | 94 passed |

## Artifact

The library behaviour is unchanged by this PR, so the figure's job is to show what the
new cases pin: that the honored path runs, and that the refusal is returned
synchronously and costs nothing. Every cell is re-derived from the measurement dump by
the compose script, which asserts each claim before saving.

![recording-rate refusal on the two MuJoCo-only rollout entry points](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rate-refusal-2112/rate_refusal.png)

Panel 3 is taken after **both** refusals against an open 30 fps recording while asking
to capture at 50 Hz: 0 of 434,000 pixels changed beyond renderer noise (max delta 1/255)
and the joint state is identical to panel 1. Panel 2 is a real `start_policy` rollout
with no recording open, differing from panel 1 on 21.8% of pixels — so the refusal is
not simply a rollout that never moves.

Capture, compose and mutation scripts:
[`artifacts/rate-refusal-2112`](https://github.com/cagataycali/robots/tree/artifacts/rate-refusal-2112).

## Docstring

`test_every_rollout_entry_point_checks_the_recording_rate` no longer claims it is
structural because a driver may be hard to reach — every driver in its table now returns
its refusal in a behavioural case. It says what the sweep is actually for: the *next*
driver, which cannot quietly skip the guard the way `run_multi_policy` once skipped
`_validate_action_horizon`. The sibling sweep over the three backends' `start_recording`
keeps its own reason (Isaac and Newton are not installed), which still holds.

## Out of scope

`start_policy`'s `policy_kwargs` mapping refusal is also unexercised, but that is the
`_validate_policy_mapping` contract with its own owner, and its sibling `policy_config`
one line above is already covered — a separate change. Measured, it behaves correctly
today: refused, `policy_running` false, no worker.

## Gate

Branch base is `upstream/main` (`b532ec06`) unchanged; `check_merge_base_overlap.py`
reports *"No overlap ... 0 path(s) changed on upstream/main in that span"*, so the tree
verified below is the merge result.

- `MUJOCO_GL=egl pytest tests -q --no-cov -p no:randomly` -> **27434 passed, 257 skipped,
  0 failed** in 606s (pristine base: 27419 passed / 257 skipped, so the delta is exactly
  the 15 new cases; zero existing-test churn).
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean
  (1159 files).
- `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`, 0
  elsewhere — byte-identical to a pristine `b532ec06` worktree of the same working copy,
  so environmental rather than introduced.
- `tests/simulation/test_recording_rate_matches_control_frequency.py` alone: 94 passed in
  9.0s (was 79 in 8.4s). `scripts/assemble_changelog.py --check`: OK.

One collection failure appeared in an earlier run of the suite and was not this branch:
the editable `lerobot` checkout on the machine was replaced mid-run (`ModuleNotFoundError:
No module named 'lerobot.cameras'` at import in 5 camera modules). The re-run above, on
the identical commit, is clean.
