### PR TITLE
test(simulation): pin the policy_kwargs refusal start_policy never returned

### DIFF
--- a/changelog.d/2113-start-policy-policy-kwargs-refusal.md
+++ b/changelog.d/2113-start-policy-policy-kwargs-refusal.md
@@ -1,0 +1,17 @@
+### Quality: pin the `policy_kwargs` refusal `start_policy` never returned
+
+`_validate_policy_mapping` guards two opaque keyword bags -- `policy_config`
+(splatted by `create_policy`) and `policy_kwargs` (splatted by
+`Policy.get_actions`) -- across four rollout entry points. Seven of those eight
+`(surface, parameter)` refusals were returned by some case in the suite. The
+eighth, `start_policy`'s `policy_kwargs`, never was, and it is the cell the
+guard exists for: both splats happen on the worker thread, so without the
+pre-flight the caller is told a policy started for a rollout that never produces
+an action. Unlike the recording-rate guard on the same method there is no
+structural sweep over this one either, so deleting the guard outright was also
+invisible to the module's other sixteen cases.
+
+One behavioural case now pins it: the verdict, the envelope as the shared
+`policy_mapping_error()` message verbatim, that no worker was submitted and the
+robot is not marked running, and that the rejected call never consumed the
+per-robot slot. Tests only; no library behaviour changes.

--- a/tests/simulation/test_policy_config_mapping_validation.py
+++ b/tests/simulation/test_policy_config_mapping_validation.py
@@ -138,6 +138,45 @@ class TestRolloutRejectsUnsplattablePolicyMapping:
         assert started["status"] == "success", started
         sim_with_arm.stop_policy(robot_name="arm1")
 
+    def test_start_policy_reports_a_policy_kwargs_error_instead_of_a_false_started(self, sim_with_arm):
+        """The last unexercised cell of this guard's refusal matrix.
+
+        ``_validate_policy_mapping`` guards two keyword bags across four rollout
+        entry points. Seven of those eight ``(surface, parameter)`` refusals were
+        returned by some case in the suite; ``start_policy``'s ``policy_kwargs``
+        was the one that never had - and it is the cell whose consequence the
+        guard exists for. Both bags are splatted on the worker thread
+        (``policy_config`` by ``create_policy``, ``policy_kwargs`` one control
+        step later by ``get_actions``), so without the pre-flight the caller is
+        told a policy started for a rollout that never produces an action. The
+        sibling case above pins that for ``policy_config`` only, and a guard
+        whose refusal is never returned cannot be told from one whose ``return``
+        was dropped.
+        """
+        bad = ["target_pose=[0, 0, 0]"]
+        result = sim_with_arm.start_policy(
+            robot_name="arm1",
+            policy_provider="mock",
+            policy_kwargs=bad,
+            n_steps=4,
+            control_frequency=30.0,
+        )
+        assert result["status"] == "error", result
+        # Verbatim: the entry point adds nothing but its own name to the shared
+        # message, so the two bags cannot drift apart in how they are reported.
+        assert result["content"][0]["text"] == f"start_policy: {policy_mapping_error(bad, 'policy_kwargs')}"
+        # Refused above ``self._executor.submit``, so no worker was ever created
+        # and the robot is not marked running...
+        assert sim_with_arm._policy_threads == {}
+        assert sim_with_arm._world.robots["arm1"].policy_running is False
+        # ...which means the rejected call never consumed the per-robot slot: an
+        # otherwise identical start is still accepted.
+        started = sim_with_arm.start_policy(
+            robot_name="arm1", policy_provider="mock", n_steps=2, control_frequency=30.0
+        )
+        assert started["status"] == "success", started
+        sim_with_arm.stop_policy(robot_name="arm1")
+
     def test_eval_policy_rejects_policy_config_before_running_episodes(self, sim_with_arm):
         result = sim_with_arm.eval_policy(
             robot_name="arm1",


### PR DESCRIPTION
## What

One behavioural case pinning `start_policy`'s `policy_kwargs` refusal. Tests only — no
library behaviour changes.

## Why

`_validate_policy_mapping` guards two opaque keyword bags across four rollout entry
points: `policy_config`, splatted by `create_policy`, and `policy_kwargs`, splatted by
`Policy.get_actions`. That is an eight-cell refusal matrix, and seven of the eight cells
had returned their refusal in some case in the suite:

| surface | `policy_config` | `policy_kwargs` |
|---|---|---|
| `SimEngine.run_policy` | yes | yes |
| `SimEngine.eval_policy` | yes | yes |
| `SimEngine.evaluate_benchmark` | yes | yes |
| `MuJoCoSimEngine.start_policy` | yes | **no** |

The missing cell is the one the guard was added for. This module's own docstring lists it:

> `start_policy(policy_config=[...])` returned `status="success"` — the splat failed on the
> background thread, inside the future, so the caller was told a policy had started that
> never produced a single action.

Both bags land inside that future — `policy_config` as the policy is built, `policy_kwargs`
one control step later — so both need the pre-flight, and only the first was exercised.

## Why the module's other cases were not enough

The guard mutated two ways, each run against the new case and against the module's
sixteen pre-existing cases:

| mutation | the new case | the 16 pre-existing cases |
|---|---|---|
| drop the guard entirely | 1 failed | **16 passed — invisible** |
| keep the call, discard the `return err` | 1 failed | **16 passed — invisible** |

Unlike the recording-rate guard on this same method, `_validate_policy_mapping` has no
structural sweep asserting it is called, so *both* mutations were undetected rather than
just the second. Source restored byte-identically after each; anchor confirmed unique
inside `start_policy` (1 occurrence in the method, 1 in the file).

## What the case pins

Placed directly after its `policy_config` sibling, in the same class:

- the verdict is a structured error naming `policy_kwargs`, its type and a correct example;
- the envelope is `f"start_policy: {policy_mapping_error(value, 'policy_kwargs')}"`
  **verbatim**, so the entry point adds nothing but its own name and the two bags cannot
  drift apart in how they are reported (the same verbatim style the eval-facade cases use);
- no worker was submitted and the robot is not marked `policy_running` — the guard sits
  above `self._executor.submit`;
- the rejected call never consumed the per-robot slot, so an otherwise identical
  `start_policy` is still accepted.

## Coverage

On this branch `strands_robots/simulation/mujoco/simulation.py` is **23 missing / 99%**,
and the refusal line is gone from its miss list. Measured on the file alone with the
repo's own coverage target, the new case is what reaches it — the line is still listed as
missing when the case is deselected.

With this cell closed, a sweep over the whole package for a public method whose guard
block has *some* refusal lines covered and others not reports **0**.

## Artifact

No library behaviour changes here, so the figure's job is to show what the case pins:
that a well-formed call runs, and that the refusal is returned synchronously and costs
nothing. Every cell is re-derived from the measurement dump by the compose script, which
asserts each claim before saving.

![start_policy refuses an unsplattable policy_kwargs before it submits](https://raw.githubusercontent.com/cagataycali/robots/artifacts/policy-kwargs-refusal-2113/policy_kwargs_refusal.png)

Panel 3 is taken after `start_policy(policy_kwargs=[...])` against the same arm: **0 of
471,200 pixels changed** beyond renderer noise (max delta 1/255) versus panel 1, and the
identical call retried afterwards is accepted. Panel 2 is a real 120-step `start_policy`
rollout, differing from panel 1 on 16.3% of pixels — so the refused panel is not simply a
rollout that never moves.

Capture, compose and mutation scripts:
[`artifacts/policy-kwargs-refusal-2113`](https://github.com/cagataycali/robots/tree/artifacts/policy-kwargs-refusal-2113).

## Relationship to #2112

#2112 pinned the *recording-rate* refusal on `start_policy` and `run_multi_policy` and
scoped this cell out as "the `_validate_policy_mapping` contract with its own owner ... a
separate change". This is that change: a different guard, a different owner, a different
file, and it completes the matrix above. Rebased onto the commit that merged #2112, so
the two are composed here; zero file overlap between them.

## Gate

Base is `upstream/main` (`6a712bad`, the merge of #2112);
`check_merge_base_overlap.py` reports *"No overlap ... the checks on this branch were
computed against a base that cannot have invalidated them"*, so the tree verified below is
the merge result.

- `MUJOCO_GL=egl pytest tests -q -p no:randomly` -> **27435 passed, 257 skipped, 0 failed**
  in 702s. Main at `6a712bad` is 27434, so the delta is exactly the one new case and there
  is zero existing-test churn.
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean
  (1159 files).
- `mypy strands_robots tests tests_integ`: 14 errors, **all** in `examples/isaac_gs`, 0
  elsewhere — byte-identical to a pristine worktree of the same working copy, so
  environmental rather than introduced.
- `tests/simulation/test_policy_config_mapping_validation.py` alone: 17 passed (was 16).
  The seven repo-wide root guards plus the `Args:`-completeness sweep: 433 passed.
  `scripts/assemble_changelog.py --check`: OK.
