### PR TITLE
test(policies): drive the robot_state_keys refusal on every provider that owns it

### DIFF
--- a/changelog.d/2114-state-key-refusal-on-every-provider.md
+++ b/changelog.d/2114-state-key-refusal-on-every-provider.md
@@ -1,0 +1,21 @@
+### Quality: measure the `robot_state_keys` refusal on every provider that owns it
+
+`set_robot_state_keys` is the setter whose list decides which actuator each
+action value is sent to, and nine surfaces validate it through the shared
+`name_list_error` domain. An AST classifier already pinned that each of the nine
+*calls* the domain, but a body that keeps the `name_list_error(...)` call and
+drops the `raise` satisfies that classifier unchanged - so it proves the guard is
+wired, never that it refuses. Only `MockPolicy` and `RemotePolicy` were driven
+behaviourally; measured with coverage over the suite, the `raise ValueError(error)`
+line had never executed on `cosmos3`, `curobo`, `groot`, `lerobot_async`,
+`lerobot_local`, `moveit2` or `vera`.
+
+Each of those seven is now constructed and driven directly: the bare-string
+mistake is refused with the shared domain's message verbatim (equality, so a
+locally re-worded copy cannot drift), a second malformed shape is refused so the
+claim is about the surface rather than one value, a refusal leaves the previously
+bound layout untouched, and a distinct list is still accepted. The table is
+derived from the classifier's own set, so a provider added later fails a test
+rather than quietly joining the structurally-only half.
+
+No library behaviour changes.

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -60,6 +60,17 @@ pinned behaviourally below so the classification cannot hide a silent accept.
 
 ``None`` and an empty list keep their existing "auto-detect" meaning: like every
 other consumer of the shared domain, the check is gated on a truthy value.
+
+The AST classifier below proves that each of the nine owning surfaces CALLS
+the shared domain. It cannot prove that any of them RAISES: a body keeping the
+``name_list_error(...)`` call and dropping the ``raise`` satisfies it unchanged.
+Only ``MockPolicy`` and ``RemotePolicy`` were driven behaviourally, so on the
+other seven the refusal was asserted structurally and had never fired - measured
+with coverage over the suite, the ``raise ValueError(error)`` line was unexecuted
+in ``cosmos3``, ``curobo``, ``groot``, ``lerobot_async``, ``lerobot_local``,
+``moveit2`` and ``vera``. Each is now constructed and driven directly, and the
+table that does so is derived from ``_MUST_VALIDATE`` so a provider added later
+cannot quietly join the structurally-only half.
 """
 
 from __future__ import annotations
@@ -67,6 +78,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import pathlib
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -77,6 +89,7 @@ from strands_robots.policies.composite import CompositePolicy
 from strands_robots.policies.mock import MockPolicy
 from strands_robots.policies.motionbricks.policy import MotionBricksPolicy
 from strands_robots.policies.wbc.policy import WBCConfig, WBCPolicy
+from strands_robots.utils import name_list_error
 
 _PACKAGE = pathlib.Path(strands_robots.__file__).parent
 
@@ -253,8 +266,6 @@ def test_the_state_keys_handler_forwards_the_wire_value_verbatim() -> None:
 
 def test_list_of_a_bare_string_would_pass_the_domain() -> None:
     """Why the coercion had to go: its output is indistinguishable from valid input."""
-    from strands_robots.utils import name_list_error
-
     assert name_list_error("wrist", "robot_state_keys", "c") is not None
     assert name_list_error(list("wrist"), "robot_state_keys", "c") is None
 
@@ -475,3 +486,150 @@ def test_the_by_name_providers_still_tolerate_a_repeated_name() -> None:
     keys = ["floating_base_joint", *WBC_G1_ALL_JOINTS, "left_hip_pitch_joint"]
     policy.set_robot_state_keys(keys)
     assert policy._robot_state_keys == keys
+
+
+# --------------------------------------------------------------------------
+# Behaviour on every provider that owns the check, not only MockPolicy
+# --------------------------------------------------------------------------
+
+
+def _cosmos3() -> Any:
+    """Service backend: the constructor records host/port and dials nothing."""
+    from strands_robots.policies.cosmos3.policy import Cosmos3Policy
+
+    return Cosmos3Policy(backend="service")
+
+
+def _curobo() -> Any:
+    """An injected planner keeps cuRobo itself out of the construction."""
+    from strands_robots.policies.curobo.policy import CuroboPolicy
+
+    return CuroboPolicy(motion_gen=object(), warmup=False)
+
+
+def _groot() -> Any:
+    """Service mode: the ZMQ socket is opened on first inference, not here."""
+    from strands_robots.policies.groot.policy import Gr00tPolicy
+
+    return Gr00tPolicy()
+
+
+def _lerobot_async() -> Any:
+    """Both required kwargs supplied; the inference client connects lazily."""
+    from strands_robots.policies.lerobot_async.policy import LerobotAsyncPolicy
+
+    return LerobotAsyncPolicy(policy_type="act", pretrained_name_or_path="unused/checkpoint")
+
+
+def _lerobot_local() -> Any:
+    """An empty checkpoint path leaves the model unloaded."""
+    from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+
+    return LerobotLocalPolicy()
+
+
+def _moveit2() -> Any:
+    """Service mode: the ZMQ socket is opened on the first plan request."""
+    from strands_robots.policies.moveit2.policy import MoveIt2Policy
+
+    return MoveIt2Policy()
+
+
+def _vera() -> Any:
+    """An injected client with no auto-launch keeps VERA out of the process."""
+    from strands_robots.policies.vera.provider import VeraPolicy
+
+    client: Any = object()  # dependency injection: nothing dials in these tests
+    return VeraPolicy(auto_launch_server=False, client=client)
+
+
+# (surface id as classified above, factory, the attribute the setter binds into,
+# the import its constructor needs). A ``None`` attribute means the provider
+# validates without storing; a ``None`` import means it needs no extra.
+_Surface = tuple[str, "Callable[[], Any]", str | None, str | None]
+
+_OWNING_SURFACES: list[_Surface] = [
+    ("policies/cosmos3/policy.py::Cosmos3Policy", _cosmos3, "robot_state_keys", None),
+    ("policies/curobo/policy.py::CuroboPolicy", _curobo, "_robot_state_keys", None),
+    ("policies/groot/policy.py::Gr00tPolicy", _groot, None, "zmq"),
+    ("policies/lerobot_async/policy.py::LerobotAsyncPolicy", _lerobot_async, "robot_state_keys", None),
+    ("policies/lerobot_local/policy.py::LerobotLocalPolicy", _lerobot_local, "robot_state_keys", "torch"),
+    ("policies/moveit2/policy.py::MoveIt2Policy", _moveit2, "_robot_state_keys", "zmq"),
+    ("policies/vera/provider.py::VeraPolicy", _vera, "_robot_state_keys", None),
+]
+_OWNING_IDS = [surface.split("::")[1] for surface, *_ in _OWNING_SURFACES]
+
+_STORING_SURFACES = [entry for entry in _OWNING_SURFACES if entry[2] is not None]
+_STORING_IDS = [surface.split("::")[1] for surface, *_ in _STORING_SURFACES]
+
+
+def _build(entry: _Surface) -> Any:
+    """Construct the provider, skipping cleanly when its extra is absent."""
+    _, factory, _, requires = entry
+    if requires is not None:
+        pytest.importorskip(requires, reason=f"{requires} needed to construct this provider")
+    return factory()
+
+
+def test_the_behavioural_table_covers_every_surface_that_owns_the_check() -> None:
+    """Derived, so a provider added later cannot skip the behavioural half.
+
+    ``MockPolicy`` and ``RemotePolicy`` are driven by the sections above; these
+    seven are the remainder. A tenth owning surface fails here rather than
+    joining the set whose refusal only the AST classifier ever sees.
+    """
+    driven_above = {"policies/mock.py::MockPolicy", "inference/client.py::RemotePolicy"}
+    assert {entry[0] for entry in _OWNING_SURFACES} | driven_above == _MUST_VALIDATE
+
+
+@pytest.mark.parametrize("entry", _OWNING_SURFACES, ids=_OWNING_IDS)
+def test_every_owning_provider_refuses_the_bare_string(entry: _Surface) -> None:
+    """The headline mistake, refused with the shared domain's message verbatim.
+
+    Equality rather than a substring: the provider has to return the shared
+    verdict, not a locally re-worded copy that could drift from the other eight.
+    """
+    policy = _build(entry)
+    with pytest.raises(ValueError) as excinfo:
+        policy.set_robot_state_keys("shoulder_pan.pos")
+    assert str(excinfo.value) == name_list_error("shoulder_pan.pos", "robot_state_keys", "set_robot_state_keys")
+
+
+@pytest.mark.parametrize("entry", _OWNING_SURFACES, ids=_OWNING_IDS)
+def test_every_owning_provider_refuses_a_non_string_entry(entry: _Surface) -> None:
+    """A second shape, so the claim is about the surface rather than one value."""
+    policy = _build(entry)
+    with pytest.raises(ValueError, match="robot_state_keys"):
+        policy.set_robot_state_keys(["elbow", 2.5])
+
+
+@pytest.mark.parametrize("entry", _STORING_SURFACES, ids=_STORING_IDS)
+def test_a_refusal_leaves_the_previously_bound_layout(entry: _Surface) -> None:
+    """No half-applied layout: for the stored keys the refused call is a no-op."""
+    policy = _build(entry)
+    attribute = entry[2]
+    assert attribute is not None  # _STORING_SURFACES is filtered on this
+    policy.set_robot_state_keys(["elbow", "wrist"])
+    with pytest.raises(ValueError):
+        policy.set_robot_state_keys("gripper")
+    assert getattr(policy, attribute) == ["elbow", "wrist"]
+
+
+def test_the_validate_only_provider_stores_nothing_either_way() -> None:
+    """Gr00t translates keys through its own mappings, so it binds none of them.
+
+    Its setter exists to reach the same verdict as the others rather than to
+    record anything, which is why it has no attribute to check above.
+    """
+    policy = _build(("", _groot, None, "zmq"))
+    with pytest.raises(ValueError, match="robot_state_keys"):
+        policy.set_robot_state_keys("shoulder_pan.pos")
+    policy.set_robot_state_keys(["elbow", "wrist"])
+    assert not hasattr(policy, "robot_state_keys")
+
+
+@pytest.mark.parametrize("entry", _OWNING_SURFACES, ids=_OWNING_IDS)
+def test_every_owning_provider_accepts_a_distinct_list(entry: _Surface) -> None:
+    """The over-reach control: only what the domain names is refused."""
+    policy = _build(entry)
+    policy.set_robot_state_keys(["elbow", "wrist", "shoulder_pan.pos"])

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -546,7 +546,7 @@ def _vera() -> Any:
 # (surface id as classified above, factory, the attribute the setter binds into,
 # the import its constructor needs). A ``None`` attribute means the provider
 # validates without storing; a ``None`` import means it needs no extra.
-_Surface = tuple[str, "Callable[[], Any]", str | None, str | None]
+_Surface = tuple[str, Callable[[], Any], str | None, str | None]
 
 _OWNING_SURFACES: list[_Surface] = [
     ("policies/cosmos3/policy.py::Cosmos3Policy", _cosmos3, "robot_state_keys", None),


### PR DESCRIPTION
## Problem

`set_robot_state_keys` is the setter whose list decides **which actuator each action value is sent to** - the keys `send_action` resolves. Nine surfaces validate it through the shared `name_list_error` domain, and `tests/policies/test_state_key_name_list_contract.py` already pins that parity with an AST classifier.

That classifier proves each of the nine **calls** the domain. It cannot prove any of them **raises**: a body that keeps the `name_list_error(...)` call and drops the `raise` satisfies it unchanged. Only `MockPolicy` and `RemotePolicy` were driven behaviourally, so on the other seven the refusal was asserted structurally and had never fired. Measured with coverage over the whole suite:

| surface | raise line | fired on main? |
|---|---|---|
| `cosmos3/policy.py::Cosmos3Policy` | L341 | never |
| `curobo/policy.py::CuroboPolicy` | L399 | never |
| `groot/policy.py::Gr00tPolicy` | L687 | never |
| `lerobot_async/policy.py::LerobotAsyncPolicy` | L312 | never |
| `lerobot_local/policy.py::LerobotLocalPolicy` | L781 | never |
| `moveit2/policy.py::MoveIt2Policy` | L179 | never |
| `vera/provider.py::VeraPolicy` | L303 | never |

The `ABC` docstring names this explicitly - "each provider binds the names into its own layout, so each refuses at its own entry. That parity is pinned structurally" - so seven public setters carried a documented refusal contract that nothing had exercised.

## Change

Tests only; no production line changes. Each of the seven is constructed and driven directly, with the surface table derived from the classifier's own `_MUST_VALIDATE` set:

- the bare-string mistake (a name that is iterable per character, so it would bind one joint per letter) is refused, with `str(exc)` asserted **equal** to the shared domain's message - equality rather than a substring, so a locally re-worded copy cannot drift from the other eight;
- a second malformed shape (a non-string entry) is refused, so the claim is about the surface rather than one value;
- a refusal leaves the previously bound layout untouched on the six providers that store the keys;
- `Gr00tPolicy` - which validates without storing, because it translates keys through its own mappings - is pinned as binding nothing either way;
- a distinct list is still accepted everywhere, as the over-reach control.

Constructors avoid every optional dependency: cosmos3 in service backend, cuRobo with an injected planner, lerobot_local with an empty checkpoint path, VERA with an injected client and no auto-launch. Only `zmq` (groot, moveit2) is `importorskip`ed, per surface, so the other five still run without it.

The module docstring records the measurement and why the structural half could not cover it. One tidy rides along: `name_list_error` was imported locally inside a single test, and is now imported once at module level.

## Why the structural pin was not enough

Each guard was mutated three ways and **both halves** of the module re-run:

| mutation | the 35 pre-existing tests | the 29 tests added here |
|---|---|---|
| discard the `raise`, keep the call - **all 7 providers** | blind, all 35 pass | caught, 3 failed |
| re-word the message locally (cosmos3) | blind, all 35 pass | caught, 1 failed |
| delete the whole guard (cosmos3) | caught, 1 failed | caught, 3 failed |

The classifier catches only a guard deleted outright. The two mutations that leave a plausible-looking guard in place are invisible to the entire pre-existing suite - which is exactly why the seven refusals had never fired. Mutation anchors were scoped to the setter's own AST line range (the `raise ValueError(error)` text appears up to 6 times per file), and every source was asserted byte-identical after restore.

## Coverage

7 of 7 `raise ValueError(error)` lines go unexecuted -> executed. Module: 35 -> 64 tests (+29). Whole suite 27434 -> 27463 passed, zero existing-test churn.

## Measured artifact

![robot_state_keys refusal coverage and mutation matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-key-refusal-coverage/state_key_refusal_coverage.png)

Every cell is measured in one run and asserted by the generator ([capture.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-key-refusal-coverage/capture.py), [compose.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/state-key-refusal-coverage/compose.py)). The change is tests-only, so no policy, simulation, rendering, recording or asset behaviour changes and there is no rollout to show; the figure is the coverage and mutation measurement instead.

## Verification

Base `6a712bad`, all in one checkout.

- `MUJOCO_GL=egl pytest tests` -> **27463 passed, 257 skipped, 0 failed** in 600s (pristine main at the same commit: 27434 passed / 257 skipped).
- `tests/policies/test_state_key_name_list_contract.py` alone -> 64 passed in 3.1s (no zmq/torch/lerobot/GL needed for the shared path).
- `ruff check` / `ruff format --check strands_robots tests tests_integ` -> clean, 1159 files.
- `mypy strands_robots tests tests_integ` -> 0 errors outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same checkout (verified by diffing both normalised error sets), so they are pre-existing and environmental.
- `scripts/assemble_changelog.py --check` -> OK; `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py` -> 30 passed.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> "No overlap ... 0 path(s) changed on upstream/main in that span", and `compare/main...head` reports `behind_by=0`, so the tree these numbers describe is the merge result.

## Round 2 - one line, no production change

Code scanning flagged `collections.abc.Callable` as an unused import at line 81.
It was: `_Surface` quoted its element, so nothing referenced the name by
expression. ruff resolves names inside string annotations and passes on both
spellings, so the file was clean to the merge-blocking linter and not to the
scanner.

The quoting was also wrong on its own terms - the alias's runtime value did not
carry the type it advertises:

| | `typing.get_args(_Surface)[1]` | its type |
| --- | --- | --- |
| quoted (previous) | `'Callable[[], Any]'` | `str` |
| unquoted (now) | `collections.abc.Callable[[], typing.Any]` | `_CallableGenericAlias` |

Unquoting settles both in one line and matches how the two sibling tables of the
same shape already spell it, in `tests/simulation/test_camera_name_list_contract.py`
and `tests/tools/test_transport_numeric_option_guards.py`.

Scope was measured rather than assumed. A mirror of the rule (an imported name
never referenced outside a string, excluding the `__future__` directive) was
validated against the published alert - it reports exactly `81:1-37 Callable`,
matching the reported line and column range - then run over all 905 files under
`tests/`: the only other findings are a pytest fixture imported for injection and
one instance already open on `main`, neither of this shape and neither new here.
So one line, nothing wider.
[The mirror and its validation transcript](https://github.com/cagataycali/robots/tree/artifacts/state-key-refusal-per-provider).

Re-verified at `444d0b4a`: mirror on the file 1 finding -> 0; collected test ids
64 -> 64, byte-identical under `--collect-only -q -q`; the module 64 passed; full
`MUJOCO_GL=egl pytest tests` **27463 passed, 257 skipped, 0 failed** in 638s
(unchanged, as expected for a change with no runtime effect on the suite);
`ruff check`, `ruff format --check` and `mypy` clean, with the 14
`examples/isaac_gs` findings again byte-identical to a pristine checkout of the
same base. `scripts/check_merge_base_overlap.py` still reports no overlap, and
`upstream/main` is unmoved at `6a712bad`.

No new test accompanies this round and no visual artifact applies: the property
at stake is the alias's runtime value and the generated id set, both measured
above, and nothing in policy, simulation, rendering, recording or asset handling
is touched. The 64 existing parametrized cases are what exercise `_Surface`.
