### PR TITLE
fix(simulation/mujoco): restore the equality when a weld removal's recompile is refused

### DIFF
--- a/changelog.d/2115-weld-removal-rollback.md
+++ b/changelog.d/2115-weld-removal-rollback.md
@@ -1,0 +1,14 @@
+### Fixed: a refused weld-removal recompile no longer drops the constraint from the live scene spec
+
+`remove_equality_constraint` deleted the named equality from the live `MjSpec`
+and then recompiled, with no way back if the recompile was refused. `detach_bodies`
+reported the removal as failed while the constraint was already gone from the spec
+and still present in the compiled model, so the identical retry was refused
+permanently as "not found" and the next unrelated scene mutation -- an `add_object`
+that never mentions the weld -- recompiled the spec and silently released the pair.
+
+It now snapshots the spec before the delete and restores it when the recompile is
+refused, matching the way its inverse `add_weld_constraint` already deletes the
+equality it had just added. A refused removal is a no-op, so the attachment
+`attach_bodies` recorded stays true and the identical `detach_bodies` succeeds once
+the refusal clears.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -1124,6 +1124,14 @@ def remove_equality_constraint(world: SimWorld, name: str) -> bool:
 
     Returns ``False`` (logged) when the constraint is missing or the recompile
     fails, so callers can surface a clean error instead of a silent no-op.
+
+    On recompile failure the deletion is rolled back from a pre-delete
+    snapshot, mirroring the way :func:`add_weld_constraint` deletes the
+    equality it had just added. Without that restore a refused recompile leaves
+    the constraint gone from the live spec while the compiled model still holds
+    it, so the caller is told the removal failed, the identical retry is then
+    refused as "not found", and the next unrelated scene mutation recompiles
+    the spec and silently drops the constraint the caller was told still stood.
     """
     spec = _get_spec(world)
     if spec is None or world._model is None:
@@ -1131,8 +1139,17 @@ def remove_equality_constraint(world: SimWorld, name: str) -> bool:
         return False
     for eq in spec.equalities:
         if eq.name == name:
+            # Snapshot before the delete, and only once the constraint is known
+            # to exist: a lookup that finds nothing mutates nothing and so needs
+            # no way back.
+            backup_spec = _snapshot_spec(spec, context="remove_equality_constraint")
+            if backup_spec is None:
+                return False
             spec.delete(eq)
-            return _recompile_preserving_state(world, spec)
+            if not _recompile_preserving_state(world, spec):
+                world._backend_state["spec"] = backup_spec
+                return False
+            return True
     logger.warning("Equality constraint '%s' not found in spec - nothing removed", name)
     return False
 

--- a/tests/simulation/mujoco/test_attach_bodies.py
+++ b/tests/simulation/mujoco/test_attach_bodies.py
@@ -24,6 +24,7 @@ import pytest
 
 mj = pytest.importorskip("mujoco")
 
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
 
@@ -296,3 +297,72 @@ class TestDispatch:
         assert result["status"] == "success", result
         result = sim._dispatch_action("detach_bodies", {"parent": "carrier", "child": "cube"})
         assert result["status"] == "success", result
+
+
+class TestRecompileFailureRecovery:
+    """A weld install or removal whose recompile is refused must leave a way back.
+
+    Both surgeries edit the live spec before the recompile that validates them,
+    so a refused recompile has to undo the edit. What matters to a caller is not
+    the ``error`` status but what the refusal costs: the attachment must be
+    exactly as it was, so the identical call succeeds once the refusal clears,
+    and no later unrelated mutation may apply the edit the caller was told had
+    failed. ``attach_bodies`` and ``detach_bodies`` are each other's inverse, so
+    both directions are pinned here rather than only the one that regressed.
+    """
+
+    def test_a_refused_weld_install_is_reported_and_the_retry_still_attaches(self, two_boxes, monkeypatch):
+        sim = two_boxes
+        orig = scene_ops._recompile_preserving_state
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", lambda *a, **k: False)
+        refused = sim.attach_bodies("carrier", "cube", mode="weld")
+        assert refused["status"] == "error", refused
+        assert "weld recompile failed" in refused["content"][0]["text"]
+        # No attachment recorded, and nothing left behind on the spec.
+        assert sim.attachment_involving("cube") is None
+        assert int(sim._world._model.neq) == 0
+
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", orig)
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        assert int(sim._world._model.neq) == 1
+
+    def test_a_refused_weld_removal_keeps_the_attachment_and_the_retry_detaches(self, two_boxes, monkeypatch):
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        orig = scene_ops._recompile_preserving_state
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", lambda *a, **k: False)
+        refused = sim.detach_bodies("carrier", "cube")
+        assert refused["status"] == "error", refused
+        assert "failed to remove weld constraint" in refused["content"][0]["text"]
+
+        # The refusal is a no-op, so the registry's record of the attachment is
+        # still true: the constraint is on the live spec and in the model.
+        spec = scene_ops._get_spec(sim._world)
+        assert spec is not None
+        assert "attach_weld_carrier__cube" in [eq.name for eq in spec.equalities]
+        assert int(sim._world._model.neq) == 1
+        assert sim.attachment_involving("cube") == "cube"
+
+        # Which is what lets the identical detach succeed once it clears. A spec
+        # that had already lost the constraint would refuse this permanently.
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", orig)
+        assert sim.detach_bodies("carrier", "cube")["status"] == "success"
+        assert int(sim._world._model.neq) == 0
+        assert sim.attachment_involving("cube") is None
+
+    def test_a_refused_weld_removal_does_not_leak_into_a_later_mutation(self, two_boxes, monkeypatch):
+        """A refused detach must not be applied by an unrelated later recompile."""
+        sim = two_boxes
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        orig = scene_ops._recompile_preserving_state
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", lambda *a, **k: False)
+        assert sim.detach_bodies("carrier", "cube")["status"] == "error"
+
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", orig)
+        # add_object never mentions the weld, but it recompiles the live spec.
+        assert (
+            sim.add_object("bystander", shape="box", size=[0.05, 0.05, 0.05], position=[1, 1, 0.5])["status"]
+            == "success"
+        )
+        assert int(sim._world._model.neq) == 1, "an unrelated mutation applied the refused detach"
+        assert sim.attachment_involving("cube") == "cube"

--- a/tests/simulation/mujoco/test_scene_ops_guardrails.py
+++ b/tests/simulation/mujoco/test_scene_ops_guardrails.py
@@ -551,10 +551,12 @@ class TestWeldEqualityConstraintRoundTrip:
 class TestSpecSurgeryFailureRecovery:
     """Spec surgery that fails at recompile must leave the live spec exactly as
     it was, never a half-applied edit. ``add_weld_constraint`` deletes the
-    equality it just appended; ``actuate_robot_in_scene`` restores its
-    pre-surgery XML snapshot. Both return a clean ``False``. The invariant that
+    equality it just appended, ``remove_equality_constraint`` restores a
+    pre-delete snapshot, and ``actuate_robot_in_scene`` restores its
+    pre-surgery snapshot. All three return a clean ``False``. The invariant that
     matters is that a *subsequent* scene mutation still succeeds - a failed edit
-    must not poison later ops.
+    must not poison later ops - and, for the two that are each other's inverse,
+    that the identical call succeeds once the refusal clears.
     """
 
     @pytest.fixture
@@ -573,6 +575,44 @@ class TestSpecSurgeryFailureRecovery:
         world = sim._world
         assert world is not None
         return world
+
+    def test_equality_removal_recompile_failure_restores_the_constraint(
+        self, sim: Simulation, two_body_world: SimWorld, monkeypatch
+    ) -> None:
+        orig_recompile = scene_ops._recompile_preserving_state
+        assert (
+            scene_ops.add_weld_constraint(
+                two_body_world,
+                name="held_weld",
+                parent="anchor",
+                child="cube",
+                relpos=[0.0, 0.0, 0.1],
+                relquat=[1.0, 0.0, 0.0, 0.0],
+            )
+            is True
+        )
+        neq_before = int(two_body_world._model.neq)
+        spec = scene_ops._get_spec(two_body_world)
+        assert spec is not None
+        assert "held_weld" in [eq.name for eq in spec.equalities]
+
+        # Force the post-delete recompile to fail. The deletion must be rolled
+        # back: without that, the constraint is gone from the live spec while
+        # the compiled model still holds it, so the caller is told the removal
+        # failed and the next unrelated recompile applies it anyway.
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", lambda *a, **k: False)
+        assert scene_ops.remove_equality_constraint(two_body_world, "held_weld") is False
+        spec_after = scene_ops._get_spec(two_body_world)
+        assert spec_after is not None
+        assert "held_weld" in [eq.name for eq in spec_after.equalities]
+        assert int(two_body_world._model.neq) == neq_before
+
+        # Not poisoned, and not a permanent refusal: the identical removal
+        # succeeds once the recompile works again. A spec that had already lost
+        # the constraint would report "not found" here instead.
+        monkeypatch.setattr(scene_ops, "_recompile_preserving_state", orig_recompile)
+        assert scene_ops.remove_equality_constraint(two_body_world, "held_weld") is True
+        assert int(two_body_world._model.neq) == neq_before - 1
 
     def test_weld_recompile_failure_removes_equality_and_leaves_spec_usable(
         self, sim: Simulation, two_body_world: SimWorld, monkeypatch

--- a/tests/simulation/mujoco/test_spec_snapshot_refusal.py
+++ b/tests/simulation/mujoco/test_spec_snapshot_refusal.py
@@ -16,13 +16,16 @@ applied to the live spec with nothing to restore leaves an orphan behind, and an
 orphan makes every LATER scene mutation fail to recompile, bricking the whole
 world after one bad call.
 
-Three callers share the helper and each refuses through its OWN channel, which
-is why one test per surface is not one test three times:
+Four callers share the helper and each refuses through its OWN channel, which
+is why one test per surface is not one test four times:
 
 * ``add_robot`` -> ``inject_robot_into_scene`` returns ``False``, and the caller
   also unwinds the ``_world.robots`` registry entry it had already made,
 * ``actuate_robot`` -> ``actuate_robot_in_scene`` returns ``False``,
-* ``patch_scene_mjcf`` -> raises ``RuntimeError``, which the facade converts.
+* ``patch_scene_mjcf`` -> raises ``RuntimeError``, which the facade converts,
+* ``detach_bodies`` -> ``remove_equality_constraint`` returns ``False``, and the
+  weld it was about to delete is still holding the pair, so the attachment
+  ``attach_bodies`` recorded stays true.
 
 Each test asserts the whole cost of the refusal rather than only its status: the
 compiled model is unchanged, the mutation's own element is absent, the scene is
@@ -222,3 +225,44 @@ class TestPatchSceneMjcfRefusesWithoutAWayBack:
         )
         assert sim.patch_scene_mjcf(ops)["status"] == "success"
         assert _body_id(sim, "marker") >= 0
+
+
+class TestDetachBodiesRefusesWithoutAWayBack:
+    def test_the_weld_removal_is_refused_and_the_pair_stays_attached(
+        self, sim: Simulation, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert sim._world is not None
+        for name, z in (("carrier", 0.6), ("cube", 0.45)):
+            assert (
+                sim.add_object(name=name, shape="box", size=[0.08, 0.08, 0.08], position=[0.0, 0.0, z])["status"]
+                == "success"
+            )
+        assert sim.attach_bodies("carrier", "cube", mode="weld")["status"] == "success"
+        neq_before = int(sim._world._model.neq)
+        assert neq_before == 1
+
+        _refuse_snapshots(monkeypatch)
+        refused = sim.detach_bodies("carrier", "cube")
+        monkeypatch.undo()
+
+        assert refused["status"] == "error"
+        assert "cube" in refused["content"][0]["text"]
+        # Nothing was deleted, so the recorded attachment is still true of the
+        # scene: the weld is on the live spec and in the compiled model.
+        spec = scene_ops._get_spec(sim._world)
+        assert spec is not None
+        assert "attach_weld_carrier__cube" in [eq.name for eq in spec.equalities]
+        assert int(sim._world._model.neq) == neq_before
+        assert sim.attachment_involving("cube") == "cube"
+
+        # The scene is still mutable and the identical detach succeeds once the
+        # copy failure clears. A delete applied with no way back would instead
+        # be refused here as "not found", and the add_object would apply it.
+        assert (
+            sim.add_object(name="crate", shape="box", size=[0.1, 0.1, 0.1], position=[0.4, 0, 0.05])["status"]
+            == "success"
+        )
+        assert int(sim._world._model.neq) == neq_before
+        assert sim.detach_bodies("carrier", "cube")["status"] == "success"
+        assert int(sim._world._model.neq) == 0
+        assert sim.attachment_involving("cube") is None


### PR DESCRIPTION
## Problem

`remove_equality_constraint` deletes the named equality from the live `MjSpec` and
then recompiles, with nothing to restore if that recompile is refused:

```python
for eq in spec.equalities:
    if eq.name == name:
        spec.delete(eq)
        return _recompile_preserving_state(world, spec)
```

`detach_bodies` is its only caller, and it reports the removal as failed. But the
deletion has already been applied to the spec, so the caller is told one thing and
the scene holds another.

Measured on a static carrier holding a dynamic cube by a weld, with
`_recompile_preserving_state` forced to fail **for the detach only**:

| | `upstream/main` | this change |
|---|---|---|
| refused `detach_bodies` reports | `error` | `error` |
| weld on the live spec afterwards | **gone** | intact |
| weld in the compiled model afterwards | 1 | 1 |
| the identical retry | **`error` ("not found")** | `success` |
| model `neq` after an unrelated `add_object` | **0** | 1 |
| cube settles at | **0.0849 m** (floor) | 0.4996 m (still held) |
| `attachment_involving("cube")` | `"cube"` | `None` after the retry |

Three consequences follow from the one missing restore:

1. **The refusal is not a no-op.** The equality is gone from the spec while the
   compiled model still has it, so the two disagree and the registry's record of
   the attachment — which `remove_object` / `remove_robot` read to refuse removing
   a welded body — is no longer true of the spec.
2. **The identical retry is refused permanently.** `remove_equality_constraint`
   now cannot find the constraint, logs `not found in spec - nothing removed` and
   returns `False` again. There is no way to detach the pair.
3. **A later unrelated mutation applies it.** `add_object` recompiles the live
   spec, so a call that never mentions the weld releases the pair — the cube the
   caller was told was still held falls to the floor.

## Why this function

Two functions in the MuJoCo backend both delete from the spec *and* recompile,
and they are each other's inverse. `add_weld_constraint` already undoes its edit,
and says so:

> Returns `True` on success. On recompile failure the just-added equality is
> deleted again so the spec stays compilable, and `False` is returned.

`_snapshot_spec` names this exact state as the reason it exists:

> the live spec can carry mutations that exist ONLY on the spec and are absent
> from that registry — **weld equalities from `attach_bodies`**, actuators from
> `actuate_robot_in_scene`, bodies from `patch_scene_mjcf` …

So the function that removes those equalities was the one mutation of that class
with no way back. Every other `.delete(` in the backend is either in
`spec_builder` (a pure spec edit whose caller owns the rollback) or in
`_apply_patch_op`, whose caller `patch_scene_mjcf` snapshots.

## Change

Snapshot before the delete, using the same helper and the same restore the three
existing callers use, and only once the constraint is known to exist — a lookup
that finds nothing mutates nothing and needs no way back.

```python
backup_spec = _snapshot_spec(spec, context="remove_equality_constraint")
if backup_spec is None:
    return False
spec.delete(eq)
if not _recompile_preserving_state(world, spec):
    world._backend_state["spec"] = backup_spec
    return False
return True
```

## Tests

`TestSpecSurgeryFailureRecovery` in `test_scene_ops_guardrails.py` gains the
helper-level contract, beside the two siblings it already pins; its class
docstring named `add_weld_constraint` and `actuate_robot_in_scene` and now names
the third path. `test_attach_bodies.py` gains `TestRecompileFailureRecovery` for
the public pair — both directions, since `attach_bodies` and `detach_bodies` are
each other's inverse and pinning only the one that regressed leaves the symmetry
unstated.

`remove_equality_constraint` also becomes a **fourth** caller of `_snapshot_spec`,
which made two things stale at once: `test_spec_snapshot_refusal.py` opens
"Three callers share the helper and each refuses through its OWN channel", and
the `backup_spec is None` branch this change introduces had no test. That module
gains the class its one-per-surface pattern calls for, and the count and bullet
list are corrected. A test in it asserts the module describes exactly as many
callers as `scene_ops` actually has, so the count cannot go stale again.

Pre-fix, with `scene_ops.py` reverted to `upstream/main` and the tests kept:
**4 failed, 70 passed**

```
FAILED test_attach_bodies.py::TestRecompileFailureRecovery::test_a_refused_weld_removal_does_not_leak_into_a_later_mutation
        AssertionError: an unrelated mutation applied the refused detach
        assert 0 == 1
FAILED test_scene_ops_guardrails.py::TestSpecSurgeryFailureRecovery::test_equality_removal_recompile_failure_restores_the_constraint
        AssertionError: assert 'held_weld' in []
```

The fourth new test — `test_a_refused_weld_install_is_reported_and_the_retry_still_attaches`
— **passes pre-fix**, and that is the point of including it: `add_weld_constraint`
already had this property, so it is the control that shows the two halves of the
pair now agree rather than that both were broken.

## Visual

The carrier is static, so the cube hangs in mid-air only while the weld exists.

![A refused weld removal must leave the constraint in place](https://raw.githubusercontent.com/cagataycali/robots/artifacts/weld-removal-rollback/weld_removal_rollback.png)

One script run unchanged against `upstream/main` (detached worktree) and against
this branch, each arm recording the tree it imported. Panel 1 is the reference and
is identical across the two trees (`max|delta| = 1/255`); panels 2 and 3 differ on
**25.25%** of pixels. The compose step asserts every rendered number against the
two raw dumps, the cross-tree reference identity and the panel-difference floor
before saving. Dumps and method:
[artifacts/weld-removal-rollback](https://github.com/cagataycali/robots/tree/artifacts/weld-removal-rollback).

## Gate

Run in a clean checkout at `876efcab`:

- `MUJOCO_GL=egl python -m pytest tests` — **27440 passed, 257 skipped, 0 failed**
  (603 s). Pristine main at the same commit is 27435 passed, so the delta is
  exactly the 5 new tests and no existing test changed behaviour.
- `ruff check strands_robots tests tests_integ` — clean.
- `ruff format --check strands_robots tests tests_integ` — 1159 files already formatted.
- `mypy strands_robots tests tests_integ` — 14 errors, all in `examples/isaac_gs`,
  0 outside it, and the error set is byte-identical to a pristine-base worktree of
  the same working copy, so it is environmental rather than introduced here.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` — no
  overlap. `upstream/main` has since gained a changelog fragment and a
  `tests/policies/` file, both disjoint from the four paths here.

## Scope

`detach_bodies`' refusal text (`failed to remove weld constraint … (see logs)`) is
unchanged: the reason is in the log line the helper already writes, and rewording
it is a separate concern from having a way back. The kinematic detach branch takes
no spec mutation, so it is unaffected.



## Round 2

Pushed `22e27f0`. `remove_equality_constraint` calling `_snapshot_spec` makes it
the helper's fourth caller, so `test_spec_snapshot_refusal.py` needed the class
its pattern calls for and the corrected count -- and that class is also what
covers the `backup_spec is None` branch introduced here, which round 1 left
untested. No production line changed in this round; the pre-fix proof and the
full-suite figure above are re-measured at the new head.
