### PR TITLE
refactor(simulation/mujoco): apply the pose rule once in add_camera, not twice

### DIFF
--- a/changelog.d/2116-add-camera-pose-rule-one-owner.md
+++ b/changelog.d/2116-add-camera-pose-rule-one-owner.md
@@ -1,0 +1,22 @@
+### Quality: `add_camera` applies the pose rule once, not twice
+
+`MuJoCoSimEngine.add_camera` validated `position` and `target` twice - a
+`coerce_pose_vector` call per parameter, then a loop re-running the non-coercing
+twin `pose_vector_error` over the values that call had just returned. The second
+application could not refuse anything: both helpers read a pose through the same
+`_read_pose_vector`, so a value the coercing guard accepts is by construction one
+the twin accepts, and the two substituted defaults are literal finite 3-vectors.
+Measured on a 20-value probe set across both parameters, with the second
+application neutered to always return `None`, it was invoked 24 times and 0 of 40
+outcomes changed.
+
+It was dead code carrying a live comment - the comment justified the loop with
+the two failures the guard above it now owns - so a reader asking which check
+owned the pose contract found two answers, and the line was permanently
+unreachable by any test. The loop and its now-unused import are removed, leaving
+one owner per pose parameter; the accepted and refused domains are unchanged.
+Re-inserting the loop verbatim is invisible to all 2,937 pre-existing MuJoCo
+backend tests, so the invariant that makes one owner sufficient is now pinned:
+one application per parameter, the coercing guard's totality over the twin's
+domain, and the degenerate-orientation comparison below it reading a substituted
+default and a normalized NumPy pose.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -114,7 +114,6 @@ from strands_robots.utils import (
     entity_name_error,
     finite_vector_error,
     non_negative_whole_number_error,
-    pose_vector_error,
     positive_finite_number_error,
     positive_whole_number_error,
     reserved_camera_name_error,
@@ -3250,17 +3249,12 @@ class MuJoCoSimEngine(
         target, _terr = coerce_pose_vector("add_camera", "target", target, 3)
         if _terr is not None:
             return {"status": "error", "content": [{"text": _terr}]}
+        # ``coerce_pose_vector`` above owns the pose rule for both parameters:
+        # anything reaching here is either a validated 3-vector of plain floats or
+        # ``None``, so the defaults below - and the element-wise comparison after
+        # them - operate on numbers that are already known to be finite.
         pos = [1.0, 1.0, 1.0] if position is None else position
         tgt = [0.0, 0.0, 0.0] if target is None else target
-        for _lbl, _vec in (("position", pos), ("target", tgt)):
-            # Validate shape AND finiteness up front. The degenerate-orientation
-            # check below does ``abs(pos[i] - tgt[i])`` element-wise, so a
-            # non-numeric element (e.g. ["a", ...]) would otherwise raise a bare
-            # TypeError there, and a nan/inf slips silently into the camera's
-            # baked xyaxes (fwd /= flen divides by nan -> a degenerate camera
-            # that renders garbage while reporting success). NumPy scalars ok.
-            if (e := pose_vector_error("add_camera", _lbl, _vec, 3)) is not None:
-                return {"status": "error", "content": [{"text": e}]}
         # Degenerate orientation: position == target means no well-defined look direction.
         if all(abs(pos[i] - tgt[i]) < 1e-9 for i in range(3)):
             return {

--- a/tests/simulation/mujoco/test_add_camera_pose_rule_has_one_owner.py
+++ b/tests/simulation/mujoco/test_add_camera_pose_rule_has_one_owner.py
@@ -1,0 +1,250 @@
+"""Regression tests: ``add_camera`` applies the pose rule once, not twice.
+
+``add_camera`` bakes ``position`` and ``target`` into the camera's ``xyaxes``, so
+both are validated up front. For two weeks it validated them *twice*: a
+``coerce_pose_vector`` call per parameter, and then a loop that re-ran the
+non-coercing twin ``pose_vector_error`` over the very values that call had just
+returned.
+
+The second application could not refuse anything. Both helpers read a pose
+through the same ``_read_pose_vector``, so a value ``coerce_pose_vector``
+accepts is by construction a value ``pose_vector_error`` accepts, and the two
+substituted defaults are literal finite 3-vectors. Measured on a 20-value probe
+set x both parameters, with the second application neutered to always return
+``None``: it was invoked 24 times and **0 of 40** outcomes changed.
+
+That made it dead code carrying a live comment. The comment justified the loop
+with the two failures its own guard now owns - a non-numeric element reaching
+the element-wise ``abs(pos[i] - tgt[i])`` comparison below, and a ``nan``/``inf``
+slipping into the baked ``xyaxes`` - so a reader asking "which check owns the
+pose contract here?" found two answers and no way to tell them apart. The line
+was also permanently unreachable, so no test could ever cover it.
+
+These tests pin the three properties that make one owner correct and keep it
+that way:
+
+* ``add_camera`` applies the pose rule exactly once per pose parameter, and no
+  scene-construction method in the backend re-checks an already-coerced pose.
+  This is what fails if the second application returns.
+* ``coerce_pose_vector`` is total over the domain ``pose_vector_error`` judges -
+  it refuses everything the twin would refuse, and everything it accepts the
+  twin accepts. This is *why* the second application was removable rather than
+  merely redundant, so a future weakening of the surviving guard fails here
+  instead of silently reopening the hole the loop was written for.
+* the degenerate-orientation guard that sat immediately below the deleted loop
+  still fires. Its explicit case - two identical literal triples - is pinned by
+  ``TestAddCameraTargetOrients`` in ``test_input_validation.py``; the two cases
+  that reach it by a route the deleted loop stood in the middle of are not, so
+  they are pinned here: a pair that becomes identical only after a default is
+  substituted, and a NumPy pair, which reaches the element-wise comparison as
+  plain floats only because the surviving guard normalizes it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import simulation as sim_mod  # noqa: E402
+from strands_robots.utils import coerce_pose_vector, pose_vector_error  # noqa: E402
+
+Simulation = sim_mod.Simulation
+
+#: The two shared helpers that judge a pose vector. ``coerce_pose_vector``
+#: validates and normalizes; ``pose_vector_error`` only reports. A method needs
+#: exactly one of them per pose parameter.
+POSE_RULE_HELPERS = ("coerce_pose_vector", "pose_vector_error")
+
+#: The MuJoCo scene-construction methods that take a caller-supplied pose.
+POSE_TAKING_METHODS = ("add_object", "add_robot", "move_object", "add_camera")
+
+#: Values no pose parameter can honor. Each must be refused by the surviving
+#: guard, and none may reach the element-wise comparison below it.
+UNUSABLE: list[Any] = [
+    [0.5, 0.3],
+    [0.5, 0.3, 0.2, 0.1],
+    [],
+    "abc",
+    3,
+    True,
+    [float("nan"), 0.0, 0.0],
+    [float("inf"), 0.0, 0.0],
+    [-float("inf"), 0.0, 0.0],
+    ["a", 1.0, 2.0],
+    [None, 1.0, 2.0],
+    {"x": 1},
+    [10**400, 0.0, 0.0],
+    np.array(1.0),
+]
+
+#: Values a pose parameter honors, including the NumPy spellings pose
+#: arithmetic produces.
+USABLE: list[Any] = [
+    [0.55, 0.0, 0.35],
+    (0.55, 0.0, 0.35),
+    np.array([0.55, 0.0, 0.35]),
+    [np.float32(0.55), np.float64(0.0), 0.35],
+    [np.int64(1), 0, 0],
+]
+
+#: The defaults ``add_camera`` substitutes for an omitted parameter. They travel
+#: the same path as a supplied pose, so the rule must accept them too.
+SUBSTITUTED_DEFAULTS: list[list[float]] = [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_add_camera_pose_rule_sim", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _pose_rule_calls(source: str, method: str) -> list[str]:
+    """Names of the pose-rule helpers ``method`` calls, in source order.
+
+    ``ast.walk`` is breadth-first, so the calls are ordered by position here
+    rather than taken in traversal order.
+    """
+    fn = next(n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.FunctionDef) and n.name == method)
+    calls = [
+        (c.lineno, c.col_offset, c.func.id)
+        for c in ast.walk(fn)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name) and c.func.id in POSE_RULE_HELPERS
+    ]
+    return [name for _lineno, _col, name in sorted(calls)]
+
+
+def _backend_source() -> str:
+    """The shipped backend source, located from the module object."""
+    return pathlib.Path(inspect.getfile(sim_mod)).read_text(encoding="utf-8")
+
+
+def _text(result: dict[str, Any]) -> str:
+    return next(c["text"] for c in result["content"] if "text" in c)
+
+
+class TestThePoseRuleHasOneOwner:
+    """Each pose parameter is judged by exactly one helper."""
+
+    def test_add_camera_applies_the_rule_once_per_pose_parameter(self) -> None:
+        """Two pose parameters, two calls, both to the coercing guard.
+
+        The second application was a loop over ``(("position", pos), ("target",
+        tgt))`` re-running ``pose_vector_error`` on values ``coerce_pose_vector``
+        had already returned.
+        """
+        assert _pose_rule_calls(_backend_source(), "add_camera") == [
+            "coerce_pose_vector",
+            "coerce_pose_vector",
+        ]
+
+    @pytest.mark.parametrize("method", POSE_TAKING_METHODS)
+    def test_no_scene_method_re_checks_an_already_coerced_pose(self, method: str) -> None:
+        """Whoever coerces a pose owns it; nothing re-reports on the result."""
+        calls = _pose_rule_calls(_backend_source(), method)
+        assert calls, f"{method} takes a pose but calls no pose-rule helper"
+        assert set(calls) == {"coerce_pose_vector"}, f"{method} re-checks a coerced pose: {calls}"
+
+    def test_a_second_application_would_be_detected(self) -> None:
+        """The scanner is not vacuous: a planted re-check is reported."""
+        planted = _backend_source().replace(
+            '        target, _terr = coerce_pose_vector("add_camera", "target", target, 3)\n',
+            '        target, _terr = coerce_pose_vector("add_camera", "target", target, 3)\n'
+            '        _ = pose_vector_error("add_camera", "target", target, 3)\n',
+            1,
+        )
+        baseline = _pose_rule_calls(_backend_source(), "add_camera")
+        assert _pose_rule_calls(planted, "add_camera") == [*baseline, "pose_vector_error"]
+
+
+class TestTheCoercingGuardIsTotal:
+    """``coerce_pose_vector`` refuses everything its non-coercing twin would.
+
+    This is the invariant that made the second application removable. Both
+    helpers defer to ``_read_pose_vector``; these tests pin the consequence so
+    the surviving guard cannot be narrowed without a failure here.
+    """
+
+    @pytest.mark.parametrize("vec", UNUSABLE)
+    def test_an_unusable_pose_is_refused_by_the_coercing_guard(self, vec: Any) -> None:
+        value, err = coerce_pose_vector("add_camera", "position", vec, 3)
+        assert err is not None, f"{vec!r} passed the coercing guard"
+        assert value is None
+        # ... and the twin agrees, so neither ordering of the two would differ.
+        assert pose_vector_error("add_camera", "position", vec, 3) is not None
+
+    @pytest.mark.parametrize("vec", USABLE)
+    def test_an_accepted_pose_is_one_the_twin_also_accepts(self, vec: Any) -> None:
+        value, err = coerce_pose_vector("add_camera", "position", vec, 3)
+        assert err is None, err
+        assert value is not None
+        assert pose_vector_error("add_camera", "position", value, 3) is None
+
+    @pytest.mark.parametrize("default", SUBSTITUTED_DEFAULTS)
+    def test_the_substituted_defaults_satisfy_the_rule(self, default: list[float]) -> None:
+        assert pose_vector_error("add_camera", "position", default, 3) is None
+
+    def test_an_omitted_pose_is_not_refused(self) -> None:
+        """``None`` means omitted, so the caller's own default applies."""
+        assert coerce_pose_vector("add_camera", "position", None, 3) == (None, None)
+
+
+class TestTheSurvivingGuardReportsTheSharedVerdict:
+    """``add_camera``'s refusal is the shared rule's message, verbatim."""
+
+    @pytest.mark.parametrize("param", ["position", "target"])
+    @pytest.mark.parametrize("vec", UNUSABLE)
+    def test_an_unusable_pose_is_refused_with_the_shared_message(self, sim, param: str, vec: Any) -> None:
+        kwargs: dict[str, Any] = {"position": [0.55, 0.0, 0.35], "target": [0.2, 0.0, 0.05]}
+        kwargs[param] = vec
+        result = sim.add_camera("cam", **kwargs)
+        assert result["status"] == "error", result
+        assert _text(result) == coerce_pose_vector("add_camera", param, vec, 3)[1]
+        assert "cam" not in sim._world.cameras
+
+    def test_a_usable_pose_still_registers_the_camera(self, sim) -> None:
+        result = sim.add_camera("front", position=np.array([0.55, 0.0, 0.35]), target=[0.2, 0.0, 0.05])
+        assert result["status"] == "success", result
+        assert "front" in sim._world.cameras
+        # Normalized to plain floats, as the coercing guard documents.
+        assert sim._world.cameras["front"].position == [0.55, 0.0, 0.35]
+
+
+class TestTheGuardBelowTheDeletedCheckStillFires:
+    """The degenerate-orientation refusal sat directly under the dead loop.
+
+    The explicit case is already pinned by ``TestAddCameraTargetOrients`` in
+    ``test_input_validation.py``. These two are the ones the deleted loop stood
+    between: the comparison reading a substituted default, and the comparison
+    reading a pose the surviving guard normalized out of NumPy.
+    """
+
+    def test_a_pose_that_only_collides_with_a_default_is_refused(self, sim) -> None:
+        """The substituted default participates in the comparison.
+
+        ``target`` defaults to the origin, so a camera placed at the origin has
+        no look direction even though the caller named only one of the two.
+        """
+        result = sim.add_camera("cam", position=[0.0, 0.0, 0.0])
+        assert result["status"] == "error", result
+        assert "no look direction" in _text(result)
+        assert "cam" not in sim._world.cameras
+
+    def test_a_numpy_pose_reaches_the_comparison_as_floats(self, sim) -> None:
+        """A NumPy pair that is degenerate is still caught.
+
+        Before the pose rule was applied by membership this raised a bare
+        ``ValueError`` from the truthiness read; the comparison below now sees
+        plain floats.
+        """
+        result = sim.add_camera("cam", position=np.array([0.4, 0.4, 0.4]), target=np.array([0.4, 0.4, 0.4]))
+        assert result["status"] == "error", result
+        assert "no look direction" in _text(result)


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.add_camera` validated `position` and `target` **twice**: a
`coerce_pose_vector` call per parameter, and then a loop re-running the non-coercing twin
`pose_vector_error` over the very values that call had just returned.

The second application could not refuse anything. Both helpers read a pose through the same
`_read_pose_vector` (`pose_vector_error` is literally `_read_pose_vector(...)[1]`), so a value
`coerce_pose_vector` accepts is by construction one the twin accepts, and the two substituted
defaults are literal finite 3-vectors. Measured over 15 values x both parameters, with the second
application neutered to always return `None`:

| | main |
|---|---|
| second application invoked at runtime | **12 times** |
| outcomes it changed | **0 of 30** |

A wider 20-value sweep across both parameters gave the same answer: invoked 24 times, **0 of 40**
outcomes changed.

So it was dead code carrying a live comment. The comment justified the loop with the two failures
the guard above it now owns - a non-numeric element reaching the element-wise
`abs(pos[i] - tgt[i])` comparison below, and a `nan`/`inf` slipping into the baked `xyaxes` -
so a reader asking *which check owns the pose contract here?* found two answers and no way to tell
them apart. The line was also permanently unreachable, so no test could ever cover it.

`git blame` shows how it got there, and it is a tidy sequence rather than an oversight anyone
should have caught by reading:

1. the loop was added as the **only** pose guard;
2. `coerce_pose_vector` was later inserted *above* it, taking over its job;
3. #1699 - "apply **one** pose-vector rule to every entry point that takes a pose" - retargeted both
   the coercing calls and the loop's call onto the shared helpers, leaving two applications of that
   one rule inside a single entry point.

## Change

Remove the loop and the import only it needed. `add_camera` now applies the pose rule once per
pose parameter, and a short comment records that the values below it are already validated - the
same note `add_object` and `add_robot` already carry. Net **-10 / +4** lines of source.

The accepted and refused domains are unchanged: 30 verdict cells (15 values x 2 parameters)
compared across the two trees, **0 differing**.

## Why one owner is sufficient

That is the invariant the removed loop nominally protected, so it is now pinned rather than
implied: `coerce_pose_vector` refuses everything `pose_vector_error` would refuse, everything it
accepts the twin accepts, and both substituted defaults satisfy the rule. A future narrowing of the
surviving guard fails there instead of silently reopening the hole the loop was written for.

## Tests

New: `tests/simulation/mujoco/test_add_camera_pose_rule_has_one_owner.py` (59 cases, GL-free,
0.85 s).

* **one owner** - `add_camera` applies the rule exactly once per pose parameter, and no
  scene-construction method in the backend re-checks an already-coerced pose. A planted re-check is
  detected, so the scanner is not vacuous.
* **totality** - the invariant above, over the unusable/usable/default probe sets.
* **the shared verdict** - each unusable pose is refused with the shared rule's message *verbatim*
  (`text == coerce_pose_vector(...)[1]`), the camera is not registered, and a usable NumPy pose
  still registers normalized to plain floats.
* **the guard below the deleted loop** - the degenerate-orientation refusal still fires for the two
  cases the loop stood between: a pair that becomes identical only after a default is substituted,
  and a NumPy pair. (Its explicit literal case was already pinned by `TestAddCameraTargetOrients`
  in `test_input_validation.py`; these two were not.)

**Pre-fix** (source reverted to `main`, tests kept): **2 failed / 57 passed**, the failure naming
the defect verbatim -

```
add_camera re-checks a coerced pose: ['coerce_pose_vector', 'coerce_pose_vector', 'pose_vector_error']
```

The other 57 pass pre-fix by design: they pin invariants that already held, which is *why* the
deletion is safe. The owning file `test_add_object_camera_vector_validation.py` passes **24/24 both
ways** - the measurement that the loop was dead.

## Mutation table

Each mutation applied to one AST-scoped function, restored byte-identically afterwards.

| mutation | new module | pre-existing suite |
|---|---|---|
| re-insert the removed loop **verbatim** | 2 failed - **caught** | 2937 passed - **invisible to all of `tests/simulation/mujoco`** |
| `coerce_pose_vector` stops propagating the read's refusal | 42 failed - caught | 185 failed - caught |
| delete the degenerate-orientation refusal | 3 failed - caught | caught only by `test_input_validation.py`'s explicit case |

The first row is the point: the archaeology recurring is invisible to every pre-existing MuJoCo
backend test, and is caught only by the one-owner pin.

## Gate

```
MUJOCO_GL=egl pytest tests   ->  27523 passed, 257 skipped, 0 failed (611 s)
ruff check strands_robots tests tests_integ            ->  All checks passed
ruff format --check strands_robots tests tests_integ   ->  1160 files already formatted
mypy strands_robots tests tests_integ                  ->  0 errors outside examples/isaac_gs
```

`main` at the same commit is 27464 passed, so the +59 is exactly the new cases and no existing test
changed. The `examples/isaac_gs` mypy errors are environmental: the error set is byte-identical to a
pristine checkout of the same base in the same working copy. `scripts/check_merge_base_overlap.py`
reports no overlap and `compare` reports `behind_by=0`, so the tree these numbers describe is the
merge result.

## Artifact

![add_camera pose rule](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-camera-pose-rule/artifact.png)

Row 1 is one camera created through `add_camera` with a NumPy pose and rendered from, on both trees:
`max|delta| = 1/255` with **0 pixels** differing above threshold, and the stored pose is plain
floats either way - the surviving path is untouched. Row 2 is the 30-cell verdict parity. Row 3 is
the neutering measurement and the blast radius. Every number in the figure is asserted against the
two capture dumps before it is drawn; the scripts are on
[`artifacts/add-camera-pose-rule`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/add-camera-pose-rule/README.md).

## Out of scope

`scene_ops`'s patch-op table also calls `pose_vector_error`, correctly - it judges a raw op field
with nothing to coerce into, which is what the non-coercing twin is for. This change removes only
the application that re-judged an already-coerced value.

## Round changelog

### Round 1 - absorbed `main` so CI compiles this against #2111

- #2111 (`remove_camera` refuses a recompile it cannot roll back) merged as `ed6bcff8` and
  edits the **same file** as this change, `simulation/mujoco/simulation.py`. Merged `main`
  into the branch so the suite runs on the composition rather than on a base that predates
  it. `232fa2e4` -> `1fec437b`, a plain fast-forward; no history was rewritten.
- **The merge is free and the diff a reviewer would read is unchanged.** `git show --cc` on
  the merge is **0 lines**, and this pull request's own diff against its new merge base is
  byte-identical at `3 files, +276/-10`.
- **The two changes do not interact**, checked rather than assumed. They edit disjoint
  functions ~100 lines apart (`add_camera` at 3253, `remove_camera` at 3362) and git
  auto-merged with no conflict. The load-bearing check is the import this change removes:
  `pose_vector_error` has **0** remaining references in the composed `simulation.py`, so
  nothing #2111 added depends on the symbol dropped here. Neither test file names the
  other's surface (0 references each way), so there is no premise-test collision of the
  kind that broke `main` once before with two green, non-conflicting pull requests editing
  one MuJoCo function.
- **Corrects one claim in the Gate section above.** It records `behind_by=0`, which was true
  when those numbers were taken and is not a standing property: `main` has since moved, so
  the full-suite figures quoted there describe the pre-merge tree. The composition itself is
  what this round's CI run measures. Nothing else in the description changes - no source
  line moved in this round.
