### PR TITLE
test(benchmarks/libero): drive the max_steps refusal on every surface that carries it

### DIFF
--- a/changelog.d/2117-libero-max-steps-domain-refusal.md
+++ b/changelog.d/2117-libero-max-steps-domain-refusal.md
@@ -1,0 +1,18 @@
+### Quality: drive the LIBERO `max_steps` refusal on every surface that carries it
+
+`LiberoAdapter.__init__` bounds `max_steps` with the shared strict-count domain,
+and its own comment records what the bound is for: the value becomes the
+benchmark's per-episode `range(max_steps)` bound, so a zero or negative horizon
+runs episodes of zero length that still report a 0% success rate. The rejecting
+half of that domain had never executed. Every existing test passed a usable
+horizon, so the constructor, both `from_*` classmethods and `load_libero_suite`
+all forwarded the parameter with the refusal unverified -- while the sibling
+`init_jitter` refusal one branch above was exercised.
+
+Adds `tests/benchmarks/libero/test_libero_max_steps_domain.py`, which drives the
+refusal on all four surfaces, asserts each message equals the shared helper's
+verdict rather than a local copy, pins that the suite loader's `except ValueError`
+registers no task and reports the value once per task file, keeps a usable
+horizon and the `None` "not supplied" spelling as controls, and adds a structural
+sweep so a fifth surface cannot read the horizon without the domain. No library
+behaviour changes.

--- a/tests/benchmarks/libero/test_libero_max_steps_domain.py
+++ b/tests/benchmarks/libero/test_libero_max_steps_domain.py
@@ -1,0 +1,225 @@
+"""The ``max_steps`` horizon domain on every LiberoAdapter construction surface.
+
+``LiberoAdapter.__init__`` bounds ``max_steps`` with the shared strict-count
+domain, and its own comment states what the bound is for: the value becomes the
+benchmark's per-episode ``range(max_steps)`` bound, so a zero or negative
+horizon runs episodes of zero length that still report a 0% success rate, and an
+``int()`` coercion alone would truncate ``2.7`` to 2 and read ``True`` as 1.
+
+Four public surfaces carry the parameter -- the constructor plus
+:meth:`~strands_robots.benchmarks.libero.LiberoAdapter.from_text`,
+:meth:`~strands_robots.benchmarks.libero.LiberoAdapter.from_file` and
+:func:`~strands_robots.benchmarks.libero.load_libero_suite`, the last three
+forwarding into the constructor -- and the refusal reaches the caller through
+two different channels:
+
+* the three adapter surfaces raise ``ValueError`` carrying the shared domain's
+  verdict verbatim;
+* the suite loader wraps each ``from_file`` in a ``except ... ValueError``
+  whose contract is to skip a malformed task and continue, so an unusable
+  horizon registers **no** task, returns normally, and reports the refusal once
+  per task file at WARNING level.
+
+The sibling ``init_jitter`` refusal one branch above is exercised by the
+existing suite; this one was not, on any surface, so the domain's whole
+rejecting half was unverified. These tests drive it on all four and pin the
+wording against the shared helper rather than against a local copy, so a
+re-worded or widened domain cannot pass unnoticed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.benchmarks.libero import LiberoAdapter, load_libero_suite, parse_bddl
+from strands_robots.utils import positive_count_error, positive_whole_number_error
+
+_BDDL = "(define (problem pick_cube) (:goal (grasped cube_1)))"
+
+# Keep construction free of scene generation and camera installs: this module is
+# about the horizon parameter, and neither step is reached before the guard.
+_INERT: dict[str, Any] = {"auto_generate_scene": False, "install_cameras": False}
+
+#: Values no ``range()`` bound can consume. ``None`` is deliberately absent --
+#: it is the documented "not supplied" spelling and is pinned separately.
+UNUSABLE = [
+    pytest.param(0, id="zero"),
+    pytest.param(-5, id="negative"),
+    pytest.param(True, id="True"),
+    pytest.param(False, id="False"),
+    pytest.param(2.7, id="fractional"),
+    pytest.param(3.0, id="integral-float"),
+    pytest.param(math.nan, id="nan"),
+    pytest.param(math.inf, id="inf"),
+    pytest.param("10", id="numeric-string"),
+    pytest.param([4], id="list"),
+]
+
+#: Values the *wider* whole-number domain admits and the strict count domain
+#: does not. They separate the two shared helpers, so a widened domain fails.
+STRICT_ONLY = [
+    pytest.param(3.0, id="integral-float"),
+    pytest.param(np.int64(7), id="numpy-int"),
+    pytest.param(np.float64(4.0), id="numpy-integral-float"),
+]
+
+
+def _via_init(value: Any, tmp_path: pathlib.Path) -> LiberoAdapter:
+    return LiberoAdapter(parse_bddl(_BDDL), max_steps=value, **_INERT)
+
+
+def _via_from_text(value: Any, tmp_path: pathlib.Path) -> LiberoAdapter:
+    return LiberoAdapter.from_text(_BDDL, max_steps=value, **_INERT)
+
+
+def _via_from_file(value: Any, tmp_path: pathlib.Path) -> LiberoAdapter:
+    path = tmp_path / "task.bddl"
+    path.write_text(_BDDL)
+    return LiberoAdapter.from_file(path, max_steps=value, **_INERT)
+
+
+#: The three surfaces whose refusal channel is a raise.
+RAISING_SURFACES: list[Any] = [
+    pytest.param(_via_init, id="__init__"),
+    pytest.param(_via_from_text, id="from_text"),
+    pytest.param(_via_from_file, id="from_file"),
+]
+
+
+def _suite_dir(tmp_path: pathlib.Path, tasks: tuple[str, ...] = ("task_a", "task_b")) -> pathlib.Path:
+    """A ``libero_spatial`` directory holding one well-formed BDDL per task."""
+    suite_dir = tmp_path / "libero_spatial"
+    suite_dir.mkdir()
+    for task in tasks:
+        (suite_dir / f"{task}.bddl").write_text(_BDDL)
+    return suite_dir
+
+
+def _load(suite_dir: pathlib.Path, value: Any) -> dict[str, LiberoAdapter]:
+    return load_libero_suite(
+        "libero_spatial",
+        bddl_dir=suite_dir,
+        max_steps=value,
+        load_init_states=False,
+        adapter_kwargs=dict(_INERT),
+    )
+
+
+class TestEveryAdapterSurfaceRefusesAnUnusableHorizon:
+    """The constructor and both classmethods refuse, with the shared wording."""
+
+    @pytest.mark.parametrize("build", RAISING_SURFACES)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_refusal_carries_the_shared_domains_verdict(
+        self, build: Callable[[Any, pathlib.Path], LiberoAdapter], value: Any, tmp_path: pathlib.Path
+    ) -> None:
+        """Message equality, not a substring: a locally re-worded copy would drift."""
+        expected = positive_count_error(value, "max_steps", "LiberoAdapter")
+        assert expected is not None, "probe value must be outside the domain"
+        with pytest.raises(ValueError) as excinfo:
+            build(value, tmp_path)
+        assert str(excinfo.value) == expected
+
+
+class TestTheSuiteLoaderNamesTheValueAndRegistersNothing:
+    """The loader's channel differs: it skips, continues and reports per task."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_no_task_registers_and_every_report_names_the_value(
+        self, value: Any, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        suite_dir = _suite_dir(tmp_path)
+        with caplog.at_level("WARNING"):
+            registered = _load(suite_dir, value)
+        assert registered == {}
+        skipped = [rec.getMessage() for rec in caplog.records if "Skipping LIBERO task" in rec.getMessage()]
+        assert len(skipped) == 2, skipped
+        expected = positive_count_error(value, "max_steps", "LiberoAdapter")
+        assert expected is not None, "probe value must be outside the domain"
+        assert all(expected in message for message in skipped), skipped
+
+
+class TestAUsableHorizonIsStillHonored:
+    """The over-reach control: nothing the domain admits became harder to pass."""
+
+    @pytest.mark.parametrize("build", RAISING_SURFACES)
+    def test_a_positive_integer_is_stored_verbatim(
+        self, build: Callable[[Any, pathlib.Path], LiberoAdapter], tmp_path: pathlib.Path
+    ) -> None:
+        assert build(250, tmp_path).max_steps == 250
+
+    def test_the_loader_registers_every_task_with_the_horizon(self, tmp_path: pathlib.Path) -> None:
+        registered = _load(_suite_dir(tmp_path), 250)
+        assert sorted(registered) == ["libero-spatial-task_a", "libero-spatial-task_b"]
+        assert {adapter.max_steps for adapter in registered.values()} == {250}
+
+    @pytest.mark.parametrize("build", RAISING_SURFACES)
+    def test_none_means_not_supplied_and_keeps_the_class_default(
+        self, build: Callable[[Any, pathlib.Path], LiberoAdapter], tmp_path: pathlib.Path
+    ) -> None:
+        """The guard is gated on ``is not None``, so ``None`` is not a refusal."""
+        assert build(None, tmp_path).max_steps == LiberoAdapter.max_steps
+
+
+class TestTheStrictCountDomainIsTheOneApplied:
+    """A widened domain would admit these, so the choice of helper is pinned."""
+
+    @pytest.mark.parametrize("value", STRICT_ONLY)
+    def test_a_value_only_the_whole_number_domain_admits_is_refused(self, value: Any, tmp_path: pathlib.Path) -> None:
+        assert positive_whole_number_error(value, "max_steps", "LiberoAdapter") is None
+        with pytest.raises(ValueError, match="max_steps"):
+            _via_from_text(value, tmp_path)
+
+
+def _max_steps_surfaces() -> dict[str, tuple[bool, bool]]:
+    """Map each public ``max_steps`` surface to ``(guards, forwards)``.
+
+    Rooted at the package that defines :class:`LiberoAdapter` rather than a path
+    literal, so the scan follows a rename.
+    """
+    root = pathlib.Path(inspect.getfile(LiberoAdapter)).parent
+    found: dict[str, tuple[bool, bool]] = {}
+    for path in sorted(root.rglob("*.py")):
+        source = path.read_text()
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            # A constructor is a public surface; every other private helper
+            # receives an already-validated value.
+            if node.name.startswith("_") and node.name != "__init__":
+                continue
+            if "max_steps" not in [a.arg for a in node.args.args + node.args.kwonlyargs]:
+                continue
+            segment = ast.get_source_segment(source, node) or ""
+            guards = "positive_count_error(max_steps" in segment
+            forwards = "max_steps=max_steps" in segment
+            found[f"{path.name}::{node.name}"] = (guards, forwards)
+    return found
+
+
+class TestNoMaxStepsSurfaceDrifts:
+    """A fifth surface cannot start reading the horizon without the domain."""
+
+    def test_the_surfaces_are_the_four_known_ones(self) -> None:
+        assert set(_max_steps_surfaces()) == {
+            "adapter.py::__init__",
+            "adapter.py::from_file",
+            "adapter.py::from_text",
+            "suite.py::load_libero_suite",
+        }
+
+    def test_every_surface_either_guards_or_forwards(self) -> None:
+        adrift = {name for name, (guards, forwards) in _max_steps_surfaces().items() if not (guards or forwards)}
+        assert not adrift, f"{sorted(adrift)} read max_steps without the shared domain"
+
+    def test_the_owner_is_the_constructor(self) -> None:
+        owners = {name for name, (guards, _forwards) in _max_steps_surfaces().items() if guards}
+        assert owners == {"adapter.py::__init__"}


### PR DESCRIPTION
## Problem

`LiberoAdapter.__init__` bounds `max_steps` with the shared strict-count domain, and its own comment records exactly what the bound is for:

```python
if max_steps is not None:
    # ... the value becomes this benchmark's per-episode ``range(max_steps)``
    # bound, so ``int()`` alone silently truncated ``2.7`` to 2, read ``True``
    # as 1, and let a zero or negative horizon through to run episodes of zero
    # length that still report a 0% success rate.
    if error := positive_count_error(max_steps, "max_steps", type(self).__name__):
        raise ValueError(error)
```

**That `raise` had never executed.** `adapter.py:541` was in the missing-lines set of a full `--cov` run, so the whole rejecting half of the domain was unverified — on every surface that carries the parameter. Four public surfaces do:

| surface | role |
|---|---|
| `LiberoAdapter(...)` | owner — calls the domain |
| `LiberoAdapter.from_text(...)` | forwards `max_steps=max_steps` |
| `LiberoAdapter.from_file(...)` | forwards `max_steps=max_steps` |
| `load_libero_suite(...)` | forwards into `from_file` per task |

Every existing test passes a *usable* horizon (`720`, `75`, `42`), and no structural test asserts the guard is called — while the sibling `init_jitter` refusal one branch above (`adapter.py:532`) **is** exercised. So the asymmetry was inside one constructor: two guards, one verified.

## The refusal reaches a caller through two different channels

Measured, one construction per cell, no `robosuite`/`libero` installed:

| surface | `0` | `-5` | `True` | `2.7` | `3.0` | `nan` | `inf` | `'10'` | `[4]` | channel |
|---|---|---|---|---|---|---|---|---|---|---|
| `LiberoAdapter(...)` | refused | refused | refused | refused | refused | refused | refused | refused | refused | raises `ValueError` |
| `from_text(...)` | refused | refused | refused | refused | refused | refused | refused | refused | refused | raises `ValueError` |
| `from_file(...)` | refused | refused | refused | refused | refused | refused | refused | refused | refused | raises `ValueError` |
| `load_libero_suite(...)` | 0 registered | 0 registered | 0 registered | 0 registered | 0 registered | 0 registered | 0 registered | 0 registered | 0 registered | skips each task, returns |

The loader is the interesting row. Its per-task `except (BDDLParseError, FileNotFoundError, ValueError)` exists to skip a malformed task and continue, and `ValueError` is what the guard raises — so an unusable horizon registers **no** task, returns normally, and reports the refusal once per task file at WARNING level:

```
Skipping LIBERO task task_a.bddl: LiberoAdapter: max_steps must be a positive integer, got 2.7.
```

Control, on both trees: `max_steps=250` → 2 of 2 tasks registered with `max_steps == 250`, and the three adapter surfaces store `250` verbatim.

## Change

Adds `tests/benchmarks/libero/test_libero_max_steps_domain.py` (53 cases). No production line changes.

* **`TestEveryAdapterSurfaceRefusesAnUnusableHorizon`** — drives all three raising surfaces over the probe set and asserts `str(exc) == positive_count_error(value, "max_steps", "LiberoAdapter")`. Message *equality*, not a substring: a locally re-worded copy of the rule would drift silently past a substring match.
* **`TestTheSuiteLoaderNamesTheValueAndRegistersNothing`** — pins the second channel: nothing registers, and the shared verdict appears verbatim in one report per task file.
* **`TestAUsableHorizonIsStillHonored`** — the over-reach control. A positive integer is stored on all four surfaces, and `None` still means *not supplied* (the guard is gated on `is not None`), so the class default survives.
* **`TestTheStrictCountDomainIsTheOneApplied`** — `3.0`, `np.int64(7)` and `np.float64(4.0)` are admitted by the wider `positive_whole_number_error` and refused here, so *which* shared helper is applied is pinned rather than implied.
* **`TestNoMaxStepsSurfaceDrifts`** — an AST sweep rooted at `inspect.getfile(LiberoAdapter).parent` (not a path literal): the surfaces are exactly the four known ones, each either guards or forwards, and the owner is the constructor. A fifth surface cannot start reading the horizon without the domain.

## Would a regression be caught?

There is no production change here, so these tests necessarily pass on unmodified `main` — the code is correct. What they fail on is a regression, and that is the evidence worth quoting. Each mutation was applied to the guard with its anchor AST-scoped to `__init__`'s own line range (`in___init__=1  in_file=1` for all three) and the source restored byte-identically afterwards:

| mutation | these new tests | the 539 pre-existing libero tests |
|---|---|---|
| M1 — drop the guard entirely | **45 failed** | 539 passed — blind |
| M2 — keep the call, discard the `raise` | **43 failed** | 539 passed — blind |
| M3 — widen to `positive_whole_number_error` | **45 failed** | 539 passed — blind |

M2 is the shape a structural *"the guard is called"* pin cannot see: the call stays, only the refusal is discarded. It leaves two more of the new tests passing than M1 for exactly that reason — the structural sweep is satisfied — which is why the behavioural half is what carries the contract.

## Coverage

`tests/benchmarks/libero`, repo `--cov` target, same file list both arms:

| | `adapter.py:541` | `adapter.py` missing | tests |
|---|---|---|---|
| before | **missing** | 49 (97%) | 539 passed |
| after | **covered** | 48 (97%) | 592 passed |

## Measurement

![max_steps domain measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/libero-max-steps-domain/max_steps_domain.png)

No policy, simulation, rendering, recording or asset behaviour changes, so the artifact is the measurement above rather than a rollout. Every rendered cell is read from a single capture dump, and the compose step asserts each one before saving (the coverage flip, the three blind columns, and that all three raising surfaces refuse the whole probe set). Scripts: [`artifacts/libero-max-steps-domain`](https://github.com/cagataycali/robots/tree/artifacts/libero-max-steps-domain).

## Gate

Verified at `0dabdaf0`, rebased onto `10e95068`:

* `MUJOCO_GL=egl python -m pytest tests` → **27522 passed, 257 skipped, 0 failed** (602s). Pristine `main` at the previous base was 27464; the delta is `#2115`'s tests plus these 53.
* `ruff check strands_robots tests tests_integ` → clean; `ruff format --check` → 1160 files already formatted.
* `mypy strands_robots tests tests_integ` → 14 errors, all in `examples/isaac_gs`, 0 outside. The error set is byte-identical to a pristine `10e95068` worktree of the same working copy after normalising line numbers, so it is environmental and pre-existing.
* `scripts/assemble_changelog.py --check` → OK; `scripts/check_merge_base_overlap.py` → no overlap, 0 paths changed on `upstream/main` in that span, so `behind_by=0` and the tree gated above is the merge result.
* `tests/benchmarks/libero` alone → 592 passed / 28 skipped in 11s.

## Out of scope

* **The loader's classification.** `load_libero_suite` files a caller-parameter mistake under *"skipped N malformed"* and repeats the report once per task file — on a 90-task suite, 90 identical warnings and an empty registry. It is not silent (every report carries the parameter, the value and the class), so it is actionable as it stands; whether a caller-value error should be separated from a malformed task, and reported once before the loop, is a contract question about that function rather than something to settle inside a coverage change. These tests pin today's observable facts so the question stays visible.
* **`init_jitter`.** Its refusal is already exercised, and its hand-rolled `float(...) < 0` comparison is a different axis from this parameter's domain.
