### PR TITLE
test(device_connect): drive the Reachy transport's three degradation branches

### DIFF
--- a/changelog.d/2120-reachy-transport-degradation-branches.md
+++ b/changelog.d/2120-reachy-transport-degradation-branches.md
@@ -1,0 +1,16 @@
+### Quality: drive the Reachy transport's three degradation branches
+
+`strands_robots.device_connect.reachy_transport` carries three tolerance branches
+that keep a hardware link usable when the environment is imperfect, and none of
+them was exercised. `ZenohLink.start` registers two byte-identical wrapper
+callbacks and its docstring states the drop-a-malformed-frame contract for both
+topics, but only the joints wrapper had ever been driven with a bad frame.
+`resolve_host` passes an unresolvable hostname through unchanged, with only its
+resolve path pinned. `WebSocketLink.start` falls back to the legacy
+`extra_headers` keyword when `websockets.connect` cannot be introspected -- the
+path that carries the bearer credential, so a change dropping the headers there
+would have connected unauthenticated with the whole suite green.
+
+Six tests now cover all three, a dropped frame is shown to leave the
+subscription still delivering, and the two production docstrings that omitted
+the fallback they carry now describe it.

--- a/strands_robots/device_connect/reachy_transport.py
+++ b/strands_robots/device_connect/reachy_transport.py
@@ -23,7 +23,18 @@ ImuCallback = Callable[[dict[str, Any]], None]
 
 
 def resolve_host(host: str) -> str:
-    """Resolve hostname to IP address."""
+    """Resolve a hostname to an IP address, falling back to the name itself.
+
+    Args:
+        host: The hostname or literal address to resolve.
+
+    Returns:
+        The resolved address, or ``host`` unchanged when the resolver cannot
+        answer for it. An mDNS ``.local`` name is the common case: the stdlib
+        resolver may fail for a name the link's own dialer can still reach, so
+        a lookup failure degrades to passing the name through rather than
+        refusing a host that is very likely reachable.
+    """
     try:
         return socket.gethostbyname(host)
     except socket.gaierror:
@@ -265,6 +276,12 @@ class WebSocketLink(HardwareLink):
         daemon token is configured, warning once when it is not) and spawns the
         background task that dispatches incoming frames to ``on_joints`` /
         ``on_imu``.
+
+        The header keyword is chosen by introspecting ``websockets.connect``:
+        releases >=12 accept ``additional_headers``, older ones
+        ``extra_headers``. When that signature cannot be read the legacy
+        spelling is used, so a configured bearer credential still reaches the
+        daemon instead of the connect losing its ``Authorization`` header.
         """
         import websockets
 

--- a/tests/test_reachy_transport_links.py
+++ b/tests/test_reachy_transport_links.py
@@ -9,12 +9,24 @@ Exercises the real-time I/O abstractions in
   WebSocket, including the command-type mapping and the read loop.
 - ``api`` REST helper error handling (HTTP error -> structured body, generic
   failure -> ``{"error": ...}``).
+- ``resolve_host`` -- both branches of hostname resolution, including the
+  lookup-failure fallback that passes an unresolvable name through unchanged.
+
+Each of those surfaces also carries a *degradation* branch, exercised here for
+the same reason: a link that dies on one imperfect input is indistinguishable
+from a disconnected robot. A malformed sensor frame is dropped so the
+subscription survives, the WebSocket header keyword falls back to the legacy
+spelling when ``websockets.connect`` cannot be introspected (so a configured
+bearer credential is not lost), and an unresolvable hostname is passed through
+rather than refused.
 
 All transports are mocked; no hardware, daemon, or network is touched.
 """
 
 import asyncio
+import inspect
 import json
+import socket
 import sys
 import unittest
 import urllib.error
@@ -68,7 +80,8 @@ class TestZenohLink(unittest.TestCase):
         self.assertEqual(joints_seen, [{"pos": [1, 2, 3]}])
         self.assertEqual(imu_seen, [{"accel": [0, 0, 9.8]}])
 
-    def test_malformed_frame_is_dropped_without_raising(self):
+    def test_malformed_joints_frame_is_dropped_without_raising(self):
+        """Covers the joints topic; its IMU twin is pinned by the test below."""
         transport = MagicMock()
         transport.subscribe = AsyncMock()
         link = ZenohLink(transport, prefix="p")
@@ -80,6 +93,52 @@ class TestZenohLink(unittest.TestCase):
         # Invalid JSON must be swallowed so the subscription stays alive.
         _run(on_joints_cb(b"not-json{"))
         self.assertEqual(joints_seen, [])
+
+    def test_malformed_imu_frame_is_dropped_and_subscription_survives(self):
+        """The IMU topic carries the same tolerance as the joints topic.
+
+        ``start`` registers two byte-identical wrapper callbacks and its
+        docstring states the contract for both topics, but only the joints
+        wrapper had ever been driven with a malformed frame. A dropped frame
+        must also leave the subscription usable, so a good frame arriving
+        afterwards is still forwarded -- swallowing the error is not the same
+        as staying alive.
+        """
+        transport = MagicMock()
+        transport.subscribe = AsyncMock()
+        link = ZenohLink(transport, prefix="p")
+        imu_seen: list = []
+
+        _run(link.start(on_joints=lambda d: None, on_imu=imu_seen.append))
+        on_imu_cb = transport.subscribe.call_args_list[1].args[1]
+
+        _run(on_imu_cb(b"not-json{"))
+        self.assertEqual(imu_seen, [])
+
+        # The subscription must still deliver after the bad frame.
+        _run(on_imu_cb(json.dumps({"accel": [0, 0, 9.8]}).encode()))
+        self.assertEqual(imu_seen, [{"accel": [0, 0, 9.8]}])
+
+    def test_a_raising_consumer_does_not_kill_either_subscription(self):
+        """The tolerance is ``except Exception``, not a JSON-decode guard.
+
+        A well-formed frame whose consumer raises must be dropped just like a
+        malformed one: the wrapper is the only thing between a buggy driver
+        callback and a dead sensor topic.
+        """
+        transport = MagicMock()
+        transport.subscribe = AsyncMock()
+
+        def boom(_frame):
+            raise RuntimeError("consumer blew up")
+
+        _run(ZenohLink(transport, prefix="p").start(on_joints=boom, on_imu=boom))
+        good = json.dumps({"pos": [1]}).encode()
+
+        for index in (0, 1):
+            callback = transport.subscribe.call_args_list[index].args[1]
+            # Must not raise out of the wrapper for either topic.
+            _run(callback(good))
 
     def test_send_cmd_publishes_encoded_json_to_command_topic(self):
         transport = MagicMock()
@@ -165,6 +224,85 @@ class TestWebSocketLink(unittest.TestCase):
         headers = kwargs.get("additional_headers") or kwargs.get("extra_headers")
         self.assertEqual(headers, {"Authorization": "Bearer secret-token"})
 
+    def test_modern_connect_receives_the_additional_headers_keyword(self):
+        """Control: with an introspectable ``connect``, the modern keyword wins.
+
+        ``start`` picks the keyword by reading ``websockets.connect``'s
+        signature. Pinning that choice is what makes the fallback below a
+        distinguishable outcome rather than a coincidence of the default.
+        """
+        import os
+
+        os.environ["REACHY_DAEMON_TOKEN"] = "secret-token"
+        fake_ws = _FakeWS()
+        seen: dict = {}
+
+        async def _connect(url, *, additional_headers=None, extra_headers=None, ssl=None):
+            seen["additional_headers"] = additional_headers
+            seen["extra_headers"] = extra_headers
+            return fake_ws
+
+        fake_websockets = MagicMock()
+        fake_websockets.connect = _connect
+
+        async def scenario():
+            with patch.dict(sys.modules, {"websockets": fake_websockets}):
+                link = WebSocketLink("h", 1)
+                await link.start(on_joints=lambda m: None, on_imu=lambda m: None)
+                await link.stop()
+
+        _run(scenario())
+        self.assertEqual(seen["additional_headers"], {"Authorization": "Bearer secret-token"})
+        self.assertIsNone(seen["extra_headers"])
+
+    def test_authorization_survives_when_the_connect_signature_is_unreadable(self):
+        """A C-implemented ``connect`` must not cost the bearer credential.
+
+        ``inspect.signature`` raises for a builtin, and the header keyword is
+        chosen from that signature. The fallback exists so the legacy spelling
+        is used instead of the headers being dropped -- but nothing pinned that
+        the token still reaches ``connect`` on that path, so a mutation that
+        dropped the headers there would connect unauthenticated in silence.
+        """
+        import os
+
+        os.environ["REACHY_DAEMON_TOKEN"] = "secret-token"
+        fake_ws = _FakeWS()
+        seen: dict = {}
+
+        async def _connect(url, *, additional_headers=None, extra_headers=None, ssl=None):
+            seen["additional_headers"] = additional_headers
+            seen["extra_headers"] = extra_headers
+            return fake_ws
+
+        fake_websockets = MagicMock()
+        fake_websockets.connect = _connect
+        real_signature = inspect.signature
+        probed: list = []
+
+        def _unreadable_signature(obj, *args, **kwargs):
+            if obj is _connect:
+                probed.append(obj)
+                raise ValueError("no signature found for builtin <built-in function connect>")
+            return real_signature(obj, *args, **kwargs)
+
+        async def scenario():
+            with (
+                patch.dict(sys.modules, {"websockets": fake_websockets}),
+                patch("inspect.signature", _unreadable_signature),
+            ):
+                link = WebSocketLink("h", 1)
+                await link.start(on_joints=lambda m: None, on_imu=lambda m: None)
+                await link.stop()
+
+        _run(scenario())
+
+        # Non-vacuity: the signature probe was attempted and really did fail.
+        self.assertEqual(len(probed), 1)
+        # The credential reaches connect under the legacy spelling, not dropped.
+        self.assertEqual(seen["extra_headers"], {"Authorization": "Bearer secret-token"})
+        self.assertIsNone(seen["additional_headers"])
+
     def test_read_loop_routes_messages_by_type(self):
         joints_seen: list = []
         imu_seen: list = []
@@ -230,6 +368,24 @@ class TestWebSocketLink(unittest.TestCase):
             self.assertTrue(fake_ws.closed)
 
         _run(scenario())
+
+
+class TestResolveHost(unittest.TestCase):
+    """``resolve_host`` answers with an address, or with the name it was given."""
+
+    def test_a_resolvable_name_is_translated_to_its_address(self):
+        with patch("socket.gethostbyname", return_value="10.1.2.3"):
+            self.assertEqual(reachy_transport.resolve_host("reachy-mini.local"), "10.1.2.3")
+
+    def test_an_unresolvable_name_is_returned_verbatim(self):
+        """A lookup failure degrades to the name rather than refusing the host.
+
+        mDNS ``.local`` names are the common case: the stdlib resolver may not
+        answer for a name the link's own dialer can still reach, so the caller
+        gets a host it can try instead of an exception.
+        """
+        with patch("socket.gethostbyname", side_effect=socket.gaierror(-2, "Name or service not known")):
+            self.assertEqual(reachy_transport.resolve_host("reachy-mini.local"), "reachy-mini.local")
 
 
 class TestRestApiErrorHandling(unittest.TestCase):


### PR DESCRIPTION
## Problem

`strands_robots/device_connect/reachy_transport.py` carries three *degradation* branches -- the places a Reachy Mini link keeps working when the environment is imperfect. None of them was exercised, and the module's entire uncovered set was exactly those three:

| branch | lines | what it protects | what was pinned |
| --- | --- | --- | --- |
| `ZenohLink.start` -> `_on_imu` | 230-231 | a malformed IMU frame is dropped so the subscription survives | its byte-identical **joints** twin, only |
| `resolve_host` | 29-30 | an unresolvable hostname is passed through rather than refused | the resolve path, only |
| `WebSocketLink.start` header keyword | 286-287 | the bearer credential survives a `connect` whose signature cannot be read | nothing |

Two of those are asymmetries rather than plain gaps:

- `ZenohLink.start` registers **two byte-identical wrapper callbacks** and its docstring states the contract for both topics ("malformed frames are dropped so the subscription stays alive"), but `test_malformed_frame_is_dropped_without_raising` drove only the joints callback. Its name read as covering the contract while covering one topic.
- `resolve_host` had a test for the branch that resolves and none for the branch that does not.

The third is the consequential one. The header keyword is chosen by introspecting `websockets.connect`: releases >=12 accept `additional_headers`, older ones `extra_headers`. When that signature cannot be read (a C-implemented `connect` raises `ValueError` from `inspect.signature`) the code falls back to the legacy spelling -- and that is the path carrying `Authorization: Bearer <token>`. Nothing pinned that the credential survives it, so a change dropping the headers there would have connected **unauthenticated** with the whole suite green.

## Change

Six tests in the module's existing owner file, and two production docstrings that omitted the fallback they carry.

- `test_malformed_imu_frame_is_dropped_and_subscription_survives` -- and it asserts the *stronger* half of the docstring's claim: after the bad frame a good frame is still forwarded. Swallowing the error is not the same as staying alive.
- `test_a_raising_consumer_does_not_kill_either_subscription` -- the tolerance is `except Exception`, not a JSON-decode guard, so a well-formed frame whose consumer raises must be dropped too. Pinned on both topics.
- `test_modern_connect_receives_the_additional_headers_keyword` -- a control. It pins which keyword the introspection picks, which is what makes the fallback below a *distinguishable* outcome rather than a coincidence of the default (the pre-existing token test accepts either spelling).
- `test_authorization_survives_when_the_connect_signature_is_unreadable` -- the fallback, with a non-vacuity assertion that the signature probe really was attempted and really did fail.
- `TestResolveHost` -- both branches of its two-branch contract.

`test_malformed_frame_is_dropped_without_raising` is renamed to `test_malformed_joints_frame_is_dropped_without_raising` so the pair reads honestly about which topic each covers.

The docstring edits are docstrings only: `resolve_host` now documents that a lookup failure returns the name unchanged, and `WebSocketLink.start` now documents the keyword fallback. The docstring-stripped AST digest of the module is unchanged (`e5f2255d642e1e49` before and after), so no executable line moved.

## Measured

Coverage of `reachy_transport.py`, from two full-suite runs: **152 statements, 6 missing, 96.1% -> 0 missing, 100%**; uncovered lines `[29, 30, 230, 231, 286, 287]` -> `[]`.

Behaviour on each branch:

| path | measured |
| --- | --- |
| malformed IMU frame | forwarded `[]`, then a good frame -> `{"accel": [0, 0, 9.8]}` (dropped *and* still delivering) |
| `resolve_host` resolvable | `'reachy-mini.local'` -> `'10.1.2.3'` |
| `resolve_host` unresolvable | `'reachy-mini.local'` -> `'reachy-mini.local'` |
| signature readable | `additional_headers={'Authorization': 'Bearer secret-token'}` |
| signature unreadable | `extra_headers={'Authorization': 'Bearer secret-token'}`, `additional_headers=None` |

Because the production code is correct, these tests necessarily pass on unmodified `main`; what they fail on is a regression. Each mutation was applied inside its target function's own AST line range (anchor `in_fn=1` verified per mutation) and the source restored byte-identically afterwards:

| # | mutation | new 6 tests | pre-existing 16 tests |
| --- | --- | --- | --- |
| M1 | drop the IMU malformed-frame tolerance | caught (2 failed) | **BLIND** -- all 16 passed |
| M2 | IMU wrapper forwards to the joints consumer | caught (1 failed) | caught (1 failed) |
| M3 | drop the `resolve_host` lookup-failure fallback | caught (1 failed) | **BLIND** -- all 16 passed |
| M4 | header fallback drops the headers (connect unauthenticated) | caught (1 failed) | **BLIND** -- all 16 passed |
| M5 | header fallback uses the modern keyword on a legacy `connect` | caught (1 failed) | **BLIND** -- all 16 passed |

4 of 5 were invisible to the suite as it stood. M2 -- the copy-paste slip these two byte-identical callbacks invite -- is honestly caught by the existing forwarding test, which already drives both topics and asserts them separately.

![Reachy transport degradation branches](https://raw.githubusercontent.com/cagataycali/robots/artifacts/reachy-transport-degradation-branches/art_degradation_branches.png)

The change touches no policy, simulation, rendering, recording or asset behaviour, so the artifact is the coverage and mutation measurement rather than a rollout. Every cell is re-derived by a script rather than typed, and the figure asserts each number it draws before saving. Capture and compose scripts are alongside the image on the artifacts branch.

## Gate

Full suite on the rebased head: **27539 passed / 257 skipped / 0 failed** (605s). `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1161 files). `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`, **0 outside** -- byte-identical to a pristine-base worktree control, so environmental. 419 repo-wide guard tests pass, including the `Args:`-completeness sweep that now checks `resolve_host`'s new `Args` block. `scripts/check_merge_base_overlap.py`: "No overlap ... 0 path(s) changed on upstream/main in that span".

The test count attributes arithmetically: 27522 on `cf5b1d34` + 11 from #2118 + these 6 = 27539.

### Note -- no code change after the gate

The gated tree above is `b4dfa371`; the head is `faeeb8d4`, which differs from it only in the changelog fragment's filename (`2119-` -> `2120-`, renamed to this PR's number once it was assigned). `scripts/assemble_changelog.py --check` and both changelog guards were re-run after the rename.

<details>
<summary>One unrelated flake seen on the first of two full runs</summary>

`tests/simulation/test_rollout_seed_is_applied_or_refused.py::TestTheSeedIsAppliedOnTheEvalPath::test_the_seeded_eval_matches_its_sibling_run_policy_contract` failed once, then passed on a second full run of the identical tree. It is a seeded-stream equality over the process-wide `random`, so a concurrent consumer shifts it. Attribution:

- the test alone: 1 passed; its whole file alone: 124 passed; with this PR's file immediately ahead of it: 146 passed
- the same file on a pristine-base worktree: 124 passed
- collection ordinal with `-p no:randomly`: the failing module is 18446, this PR's file is 24947 -- this file runs *after* it, so it cannot influence it
- this diff adds zero lines mentioning `random` or `seed`, and touches no global state

</details>
