### PR TITLE
test: gate every MuJoCo render-success assertion on the shared GL probe

### DIFF
--- a/changelog.d/2119-gl-gate-render-success-assertions.md
+++ b/changelog.d/2119-gl-gate-render-success-assertions.md
@@ -1,0 +1,9 @@
+### Quality: gate every MuJoCo render-success assertion on the shared GL probe
+
+Three test modules asserted `render(...)["status"] == "success"` inline, which
+conflates the property under test with a host graphics capability: `render`
+reports an error on a headless host without EGL/OSMesa, so on such a host the
+suite failed with a bare `'error' != 'success'` naming neither GL nor the
+contract. The render assertion is now split into its own `requires_gl` case in
+each module, so the assertions that need no GL context keep running everywhere,
+and a new guard keeps that the convention for any module added later.

--- a/tests/benchmarks/libero/test_libero_camera_config_domain.py
+++ b/tests/benchmarks/libero/test_libero_camera_config_domain.py
@@ -33,6 +33,7 @@ from typing import Any
 import pytest
 
 from strands_robots.benchmarks.libero.adapter import camera_config_error
+from tests.simulation.mujoco._gl_probe import requires_gl
 
 from .test_libero_camera_install_resilience import (
     PICK_CUBE_BDDL,
@@ -295,7 +296,7 @@ class TestOnTheRealMuJoCoBackend:
         listed = msg.split("Accepted keys:")[1]
         assert declared and all(key in listed for key in declared)
 
-    def test_a_usable_config_installs_and_renders(self):
+    def test_a_usable_config_installs(self):
         sim = self._engine("libero_cam_domain_good")
         try:
             adapter = _adapter()
@@ -305,6 +306,23 @@ class TestOnTheRealMuJoCoBackend:
             assert "image" in sim._world.cameras
             entry = sim._world.cameras["image"]
             assert (entry.width, entry.height) == (320, 320)
+        finally:
+            sim.cleanup()
+
+    @requires_gl
+    def test_a_usable_config_renders(self):
+        """The installed camera is renderable, which needs a host GL context.
+
+        Split from the install case so the resolution the domain governs is
+        still pinned on a headless host without EGL/OSMesa, where ``render``
+        reports an error for a reason unrelated to the camera config.
+        """
+        sim = self._engine("libero_cam_domain_render")
+        try:
+            adapter = _adapter()
+            adapter._cameras = {"image": dict(GOOD)}
+            adapter._install_libero_cameras(sim)
+
             assert sim.render(camera_name="image", width=64, height=64)["status"] == "success"
         finally:
             sim.cleanup()

--- a/tests/simulation/mujoco/test_entity_name_lookup_type_safety.py
+++ b/tests/simulation/mujoco/test_entity_name_lookup_type_safety.py
@@ -40,6 +40,7 @@ mujoco = pytest.importorskip("mujoco")
 
 from strands_robots.simulation import Simulation  # noqa: E402
 from strands_robots.simulation.mujoco.backend import mj_name_to_id  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # Names that cannot identify an entity. ``None`` is the one an agent produces by
 # omitting a value it believes optional; the others cover the neighbouring scalar
@@ -204,6 +205,18 @@ class TestTheSessionSurvives:
         assert sim.apply_force(body_name=None, force=[1.0, 0.0, 0.0])["status"] == "error"
         assert sim.get_body_state(body_name="crate")["status"] == "success"
         assert sim.step(n_steps=5)["status"] == "success"
+
+    @requires_gl
+    def test_the_world_still_renders_after_a_refused_lookup(self, sim) -> None:
+        """Rendering is the one liveness check that needs a host GL context.
+
+        Split from the case above so the assertions that need no GL keep running
+        on a headless host without EGL/OSMesa. Left inline, ``render`` returns
+        ``{"status": "error"}`` there for a reason unrelated to entity-name
+        lookups, and the whole liveness pin was reported as a failure.
+        """
+        _seeded_world(sim)
+        assert sim.get_body_state(body_name=None)["status"] == "error"
         assert sim.render(camera_name="default")["status"] == "success"
 
 

--- a/tests/simulation/test_unhashable_entity_name_is_reported.py
+++ b/tests/simulation/test_unhashable_entity_name_is_reported.py
@@ -30,6 +30,7 @@ from strands_robots.simulation.models import SimRobot, SimWorld, registered, reg
 mj = pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
 
 # A name that cannot key a registry, one per unhashable builtin a caller might
 # plausibly pass by mistake (a single-element list is what wrapping a name in
@@ -211,6 +212,16 @@ def test_a_registered_name_is_unaffected(sim):
     """Guarding the lookup must not cost the lookups that resolve."""
     assert sim.move_object(name="crate", position=[0.25, 0.0, 0.2])["status"] == "success"
     assert sim.get_robot_state(robot_name="arm")["status"] == "success"
+
+
+@requires_gl
+def test_a_registered_camera_name_still_renders(sim):
+    """The camera half of the same contract, which needs a host GL context.
+
+    Split from the case above so its GL-free assertions keep running on a
+    headless host without EGL/OSMesa, where ``render`` reports an error for a
+    reason that has nothing to do with how a name was resolved.
+    """
     assert sim.render(camera_name="look", width=64, height=48)["status"] == "success"
 
 

--- a/tests/test_mujoco_render_assertions_are_gl_gated.py
+++ b/tests/test_mujoco_render_assertions_are_gl_gated.py
@@ -1,0 +1,251 @@
+"""A MuJoCo render-success assertion must be gated on the shared GL probe.
+
+``Simulation.render`` returns ``{"status": "error"}`` on a host with no usable
+offscreen GL context - headless without EGL/OSMesa - for a reason that has
+nothing to do with whatever contract the calling test is pinning. Asserting
+``render(...)["status"] == "success"`` inline therefore conflates the property
+under test with a host graphics capability: it passes only where a GL context
+happens to exist, and elsewhere it reports a bare ``'error' != 'success'`` that
+names neither GL nor the contract.
+
+:mod:`tests.simulation.mujoco._gl_probe` exists for exactly this and is the
+convention in ten sibling modules. This guard keeps it the convention: every
+render-success assertion in a module that requires ``mujoco`` must sit behind
+that probe, so a test added later cannot re-open the confusion.
+
+Scope is the mujoco requirement, not a directory. A module that asserts a render
+succeeded *without* requiring ``mujoco`` renders through some other backend,
+whose availability the MuJoCo probe does not describe - ``tests/simulation/newton``
+gates its own render tests on a Newton-availability marker instead. Keying on the
+requirement rather than on a path excludes those by construction, so this rule
+needs no exemption list.
+
+Three gating forms are accepted, all of which stop the assertion from running
+without a context: the probe's marker on the test function, the same marker on
+its class, or an in-function ``gl_available()`` skip. All three are in use.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+#: Envelope-returning render entry points. ``get_frame`` is excluded: it returns
+#: raw arrays rather than a status envelope, so it cannot carry this assertion.
+RENDER_ATTRS = frozenset({"render", "render_depth", "render_all"})
+
+#: Modules that require ``mujoco`` and assert a render succeeded. Pinned so a
+#: scan rooted somewhere unexpected fails loudly instead of reporting a clean
+#: sweep over nothing.
+EXPECTED_IN_SCOPE = frozenset(
+    {
+        "tests/benchmarks/libero/test_libero_camera_config_domain.py",
+        "tests/simulation/mujoco/test_entity_name_lookup_type_safety.py",
+        "tests/simulation/mujoco/test_remove_camera_refused_recompile.py",
+        "tests/simulation/test_unhashable_entity_name_is_reported.py",
+    }
+)
+
+#: Asserts a render succeeded through another backend, so the MuJoCo probe does
+#: not describe its host requirement. Pinned as the discriminator this rule
+#: rests on rather than as an exemption.
+OTHER_BACKEND = "tests/simulation/newton/test_domain_randomization.py"
+
+
+def _tests_root() -> pathlib.Path:
+    """This module's own directory - the tree the rule covers."""
+    return pathlib.Path(__file__).parent
+
+
+def requires_mujoco(tree: ast.AST) -> bool:
+    """True when *tree* calls ``pytest.importorskip("mujoco")`` anywhere."""
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "importorskip":
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and arg.value == "mujoco":
+                return True
+    return False
+
+
+def render_success_assertions(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``<x>.render*(...)["status"] == "success"`` compare."""
+    lines = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Compare) and len(node.comparators) == 1):
+            continue
+        right = node.comparators[0]
+        if not (isinstance(right, ast.Constant) and right.value == "success"):
+            continue
+        subscript = node.left
+        if not isinstance(subscript, ast.Subscript):
+            continue
+        key = subscript.slice
+        if not (isinstance(key, ast.Constant) and key.value == "status"):
+            continue
+        call = subscript.value
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr in RENDER_ATTRS:
+            lines.append(node.lineno)
+    return lines
+
+
+def probe_names(tree: ast.AST) -> set[str]:
+    """Local names bound by importing from the shared GL probe module."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").endswith("_gl_probe"):
+            names.update(alias.asname or alias.name for alias in node.names)
+    return names
+
+
+Decorated = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+def _decorator_names(node: Decorated) -> set[str]:
+    """Every decorator on *node*, as the bare name applied."""
+    found: set[str] = set()
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            found.add(target.id)
+        elif isinstance(target, ast.Attribute):
+            found.add(target.attr)
+    return found
+
+
+def _enclosing(tree: ast.AST, lineno: int) -> tuple[ast.FunctionDef | ast.AsyncFunctionDef | None, ast.ClassDef | None]:
+    """The innermost function containing *lineno*, and its enclosing class."""
+    function: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    enclosing_class: ast.ClassDef | None = None
+    for node in ast.walk(tree):
+        if not isinstance(node, Decorated):
+            continue
+        if not node.lineno <= lineno <= (node.end_lineno or node.lineno):
+            continue
+        if isinstance(node, ast.ClassDef):
+            enclosing_class = node
+        elif function is None or node.lineno > function.lineno:
+            function = node
+    return function, enclosing_class
+
+
+def is_gated(tree: ast.AST, lineno: int, names: set[str]) -> bool:
+    """True when the assertion at *lineno* cannot run without a GL context."""
+    function, enclosing_class = _enclosing(tree, lineno)
+    if function is None:
+        return False
+    if _decorator_names(function) & names:
+        return True
+    if enclosing_class is not None and _decorator_names(enclosing_class) & names:
+        return True
+    return any(isinstance(node, ast.Name) and node.id in names for node in ast.walk(function))
+
+
+def survey(root: pathlib.Path) -> tuple[dict[str, list[int]], dict[str, list[int]], list[str]]:
+    """Return (ungated, gated, out-of-scope) render-success assertions under *root*."""
+    ungated: dict[str, list[int]] = {}
+    gated: dict[str, list[int]] = {}
+    other_backend: list[str] = []
+    for path in sorted(root.rglob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        lines = render_success_assertions(tree)
+        if not lines:
+            continue
+        label = path.relative_to(root.parent).as_posix()
+        if not requires_mujoco(tree):
+            other_backend.append(label)
+            continue
+        names = probe_names(tree)
+        for lineno in lines:
+            bucket = gated if is_gated(tree, lineno, names) else ungated
+            bucket.setdefault(label, []).append(lineno)
+    return ungated, gated, other_backend
+
+
+class TestEveryMuJoCoRenderAssertionIsGated:
+    def test_no_module_asserts_a_render_succeeded_without_the_probe(self) -> None:
+        ungated, _, _ = survey(_tests_root())
+        assert not ungated, (
+            f"these modules assert a MuJoCo render succeeded without gating it on the shared "
+            f"GL probe: {ungated}. On a headless host without EGL/OSMesa render reports an "
+            f"error for a reason unrelated to the contract under test, so the assertion fails "
+            f"there and names neither cause. Import requires_gl from "
+            f"tests.simulation.mujoco._gl_probe and split the render assertion into its own case."
+        )
+
+    def test_the_survey_covers_the_modules_it_is_meant_to(self) -> None:
+        """Non-vacuity: a scan that found nothing must not read as a clean sweep."""
+        ungated, gated, _ = survey(_tests_root())
+        assert set(ungated) | set(gated) == EXPECTED_IN_SCOPE
+
+    def test_every_in_scope_assertion_is_accounted_for(self) -> None:
+        _, gated, _ = survey(_tests_root())
+        assert sum(len(lines) for lines in gated.values()) == len(EXPECTED_IN_SCOPE)
+
+
+class TestTheScopeIsTheMujocoRequirement:
+    def test_another_backends_render_assertion_is_out_of_scope(self) -> None:
+        """The discriminator, pinned: no mujoco requirement, so a different probe."""
+        _, _, other_backend = survey(_tests_root())
+        assert OTHER_BACKEND in other_backend
+        tree = ast.parse((_tests_root().parent / OTHER_BACKEND).read_text(encoding="utf-8"))
+        assert render_success_assertions(tree)
+        assert not requires_mujoco(tree)
+
+
+_PLANTED_UNGATED = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+
+def test_planted(sim):
+    assert sim.render(camera_name="default")["status"] == "success"
+"""
+
+_PLANTED_GATED = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
+
+
+@requires_gl
+def test_planted(sim):
+    assert sim.render(camera_name="default")["status"] == "success"
+"""
+
+
+class TestTheSurveyDetectsWhatItClaimsTo:
+    """A scanner that silently matched nothing would look like a clean tree."""
+
+    def test_a_planted_ungated_assertion_is_reported(self, tmp_path: pathlib.Path) -> None:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_UNGATED, encoding="utf-8")
+        ungated, gated, _ = survey(root)
+        assert list(ungated) == ["tests/test_planted.py"]
+        assert not gated
+
+    def test_the_same_assertion_behind_the_probe_is_accepted(self, tmp_path: pathlib.Path) -> None:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_GATED, encoding="utf-8")
+        ungated, gated, _ = survey(root)
+        assert not ungated
+        assert list(gated) == ["tests/test_planted.py"]
+
+    @pytest.mark.parametrize("attr", sorted(RENDER_ATTRS))
+    def test_each_render_entry_point_is_recognised(self, attr: str) -> None:
+        tree = ast.parse(f'assert sim.{attr}(camera_name="c")["status"] == "success"\n')
+        assert render_success_assertions(tree) == [1]
+
+    def test_a_non_render_status_assertion_is_not_matched(self) -> None:
+        """The rule is about rendering, not about every envelope in the suite."""
+        tree = ast.parse('assert sim.step(n_steps=5)["status"] == "success"\n')
+        assert render_success_assertions(tree) == []


### PR DESCRIPTION
Closes #2119.

## Problem

`Simulation.render` returns `{"status": "error"}` on a host with no usable offscreen GL context - headless without EGL/OSMesa - for a reason that has nothing to do with whatever contract the calling test is pinning. Three modules asserted `render(...)["status"] == "success"` inline, so on such a host the suite failed with a bare `'error' != 'success'` that named neither GL nor the property under test:

```
FAILED tests/benchmarks/libero/test_libero_camera_config_domain.py::TestOnTheRealMuJoCoBackend::test_a_usable_config_installs_and_renders
FAILED tests/simulation/mujoco/test_entity_name_lookup_type_safety.py::TestTheSessionSurvives::test_the_world_is_still_usable_after_a_refused_lookup
FAILED tests/simulation/test_unhashable_entity_name_is_reported.py::test_a_registered_name_is_unaffected
3 failed, 120 passed
```

Each of those three assertions is one line inside a case whose *other* assertions need no GL context at all, and those are the ones pinning the actual regression. So the failure is doubly unhelpful: it points at a host capability, and it fires on a test whose real subject is a name-resolution or camera-config contract.

`tests/simulation/mujoco/_gl_probe.py` exists for exactly this and is the convention in ten sibling modules. Its docstring records that it replaced a blunt `skipif(CI == "true" ...)` opt-out precisely so GL-backed contracts stop going unverified. These three had not adopted it.

## Change

Each render assertion moves into its own `requires_gl` case. The GL-free assertions stay where they are, so they keep running everywhere rather than being skipped along with the render:

| module | GL-free assertions retained | new `@requires_gl` case |
|---|---|---|
| `test_entity_name_lookup_type_safety.py` | refused lookup, resolvable lookup, `step` | `test_the_world_still_renders_after_a_refused_lookup` |
| `test_unhashable_entity_name_is_reported.py` | `move_object`, `get_robot_state` | `test_a_registered_camera_name_still_renders` |
| `test_libero_camera_config_domain.py` | camera installed at the configured 320x320 | `test_a_usable_config_renders` |

`tests/test_mujoco_render_assertions_are_gl_gated.py` keeps that the convention. **Its scope is the `mujoco` requirement, not a directory**: a module that asserts a render succeeded *without* requiring `mujoco` renders through another backend, whose availability the MuJoCo probe does not describe - `tests/simulation/newton` gates its own render tests on a Newton-availability marker instead. Keying on the requirement rather than on a path excludes those by construction, so the rule needs **no exemption list**. It accepts all three gating forms already in use (the marker on the function, the marker on its class, an in-function `gl_available()` skip).

## The split does not gut the pin

The concern with splitting is quietly dropping coverage. Measured rather than asserted - each module's production behaviour reverted, then only the *retained* GL-free test re-run, on the emulated GL-free host:

| production behaviour reverted | retained GL-free test | outcome |
|---|---|---|
| a non-string name resolves to a real entity instead of "not found" | `TestTheSessionSurvives` | 1 failed |
| a registered name stops resolving | `test_a_registered_name_is_unaffected` | 1 failed |
| the per-camera dimensions are dropped on the way to `add_camera` | `test_a_usable_config_installs` | 1 failed |

All three caught. Unmutated control: each passes. Each anchor was scoped to its target function's AST line range (`in-function=1`, `in-file=1` for all three) and the source restored byte-identically afterwards.

## Measured

| host | `main` | this PR |
|---|---|---|
| GL present | 123 passed | 126 passed |
| GL-free host | **3 failed**, 120 passed | 123 passed, 3 skipped |
| the new guard | 2 failed, 8 passed | 10 passed |

The guard's failure on `main` names every offender and its line, so fixing one needs no search:

```
these modules assert a MuJoCo render succeeded without gating it on the shared GL probe:
{'tests/benchmarks/libero/test_libero_camera_config_domain.py': [308],
 'tests/simulation/mujoco/test_entity_name_lookup_type_safety.py': [207],
 'tests/simulation/test_unhashable_entity_name_is_reported.py': [214]}
```

The GL-free host is emulated by forcing the MuJoCo backend's cached render probe negative, which is the state `_can_render()` reaches where neither EGL nor OSMesa is loadable. The plugin is published with the artifact so the reproduction is one flag.

The guard also earned its keep during this work: #2111 merged a fourth in-scope module while it was in review, and the non-vacuity pin flagged the new module rather than passing over it. That module already gates its render assertion with `requires_gl`, which independently confirms the convention; it is added to the pinned set.

## Artifact

![GL-gated render assertions](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-gate-render-assertions/gl_gate.png)

Top row is the real frame each new `@requires_gl` case verifies, rendered headless through the public envelope - the coverage the split keeps, rather than skips. Below it the measured host matrix and the mutation matrix. Every number in the figure is read from the measurement; none is typed by hand, and the generator asserts each one before saving. Scripts and the raw measurement are on the [artifact branch](https://github.com/cagataycali/robots/tree/artifacts/gl-gate-render-assertions).

Tests only - no production line changes, so nothing in policy, simulation, rendering, recording or asset handling moves.

## Gate

Merge base `52859a48`, `behind_by = 0`, and the merge-base overlap check reports no overlap - the tree these numbers describe is the merge result.

- `MUJOCO_GL=egl pytest tests` -> **27566 passed, 257 skipped, 0 failed** (611s). `+13` over the base: 10 guard cases and the 3 split cases.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` -> clean (1163 files).
- `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/isaac_gs`**; the 14 there are byte-identical to a pristine checkout of the same base in the same working copy, so they are environmental and pre-existing.
- Pre-fix: with the three modules reverted to `main`, the guard reports **2 failed, 8 passed**, naming all three offenders and their lines.
