### PR TITLE
test(mesh): pin the two second-line guards on the wire-authorisation path

### DIFF
--- a/changelog.d/2124-mesh-second-line-guards-pinned.md
+++ b/changelog.d/2124-mesh-second-line-guards-pinned.md
@@ -1,0 +1,15 @@
+### Quality: pin the two second-line guards on the mesh wire-authorisation path
+
+`validate_command`'s control-character post-check on `policy_host` and
+`_load_acl_file`'s `O_NOFOLLOW` refusal both exist for a stated reason: the
+first check in front of each one can be widened or raced, and the second is
+what keeps the boundary closed when it is. Both were unreached by the suite,
+so either could have been removed with every test green.
+
+Three assertions could not tell the two layers apart and are now exact:
+`test_rejects_crlf_in_policy_host` accepted either layer's message;
+`test_acl_load_refuses_symlink` matched a lowercase `symlink` that pytest's
+own `tmp_path` supplies, so it passed for any `ValueError` naming the path;
+and `test_validate_command_finite_numerics`'s module docstring credited
+`_coerce_int`'s `int(...)` wrap for refusals its explicit guards make. Tests
+only -- no library behaviour changes.

--- a/tests/mesh/test_acl_config.py
+++ b/tests/mesh/test_acl_config.py
@@ -8,12 +8,22 @@ loader.
 
 from __future__ import annotations
 
+import errno
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 from strands_robots.mesh import _acl_config as ac
+
+_ENABLED_ACL = {
+    "enabled": True,
+    "default_permission": "deny",
+    "rules": [],
+    "subjects": [],
+    "policies": [],
+}
 
 
 @pytest.fixture(autouse=True)
@@ -439,11 +449,22 @@ class TestACLFileSymlinkAndTOCTOU:
     """Pin regressions for review feedback: ACL load must defeat symlink
     swap and TOCTOU on the size check.
 
-    Mirrors the audit-log discipline (O_NOFOLLOW + bounded read).
+    Mirrors the audit-log discipline (O_NOFOLLOW + bounded read). That
+    discipline is two checks, and each is pinned separately here
+    because only one of them is reachable without racing the loader:
+    ``test_acl_load_refuses_symlink`` exercises the static
+    ``is_symlink`` reject, and
+    ``test_acl_load_refuses_a_symlink_that_raced_past_the_static_check``
+    exercises the ``O_NOFOLLOW`` half that exists for the window
+    between the two syscalls.
     """
 
     def test_acl_load_refuses_symlink(self, tmp_path):
-        """A symlink at STRANDS_MESH_ACL_FILE must be rejected, not followed."""
+        """The static ``is_symlink`` check rejects a symlink, not follows it.
+
+        This pins the first of the two checks. The second is pinned by
+        ``test_acl_load_refuses_a_symlink_that_raced_past_the_static_check``.
+        """
         import os as _os
 
         from strands_robots.mesh._acl_config import _load_acl_file
@@ -466,7 +487,19 @@ class TestACLFileSymlinkAndTOCTOU:
         try:
             _load_acl_file(link)
         except ValueError as exc:
-            assert "SYMLINK" in str(exc) or "symlink" in str(exc).lower(), exc
+            # Match the uppercase word the static branch uses rather than a
+            # lowercase "symlink". pytest derives ``tmp_path`` from the test
+            # name, and this test's name contains that word, so a lowercase
+            # match is satisfied by the path in the message rather than by
+            # its reason -- including for the O_NOFOLLOW refusal, whose
+            # reason reads "Too many levels of symbolic links". That is why
+            # the two checks were previously indistinguishable here.
+            msg = str(exc)
+            assert "it is a SYMLINK" in msg, msg
+            # The static branch raises directly; the raced branch chains the
+            # OSError it caught, so the absence of a cause is the other half
+            # of telling them apart.
+            assert exc.__cause__ is None, exc.__cause__
         else:
             raise AssertionError(
                 "loader followed symlink instead of refusing -- ACL file gate must "
@@ -489,6 +522,58 @@ class TestACLFileSymlinkAndTOCTOU:
             assert "bytes" in str(exc) or "refusing" in str(exc).lower(), exc
         else:
             raise AssertionError("loader accepted oversized ACL file -- size cap not enforced")
+
+    @pytest.mark.skipif(
+        not getattr(os, "O_NOFOLLOW", 0),
+        reason="symlink semantics differ on Windows; O_NOFOLLOW is 0 there",
+    )
+    def test_acl_load_refuses_a_symlink_that_raced_past_the_static_check(self, tmp_path, monkeypatch):
+        """``O_NOFOLLOW`` refuses when the static check is raced.
+
+        ``is_symlink()`` and ``os.open()`` are two syscalls, so a
+        regular file can be swapped for a symlink between them --
+        which is the window ``O_NOFOLLOW`` exists to close, and the
+        half the static-check test above cannot reach. Racing the
+        static check is the only way to exercise it, so it is made to
+        answer False for this path while the file on disk is a symlink.
+        """
+        from strands_robots.mesh._acl_config import _load_acl_file
+
+        target = tmp_path / "real.json5"
+        target.write_text(json.dumps(_ENABLED_ACL))
+        link = tmp_path / "link.json5"
+        os.symlink(str(target), str(link))
+
+        real_is_symlink = Path.is_symlink
+        monkeypatch.setattr(
+            Path,
+            "is_symlink",
+            lambda self: False if str(self) == str(link) else real_is_symlink(self),
+        )
+
+        with pytest.raises(ValueError) as exc:
+            _load_acl_file(link)
+
+        msg = str(exc.value)
+        assert "refusing to load ACL file" in msg, msg
+        # Not the static branch: that one names the word SYMLINK, so
+        # matching it here would mean the race was not modelled.
+        assert "SYMLINK" not in msg, msg
+        cause = exc.value.__cause__
+        assert isinstance(cause, OSError), cause
+        assert cause.errno == errno.ELOOP, cause
+
+    def test_the_raced_refusal_is_about_the_symlink_not_the_contents(self, tmp_path):
+        """Control: the same file loads when it is reached directly.
+
+        Without this, a loader that refused every file would satisfy
+        the test above.
+        """
+        from strands_robots.mesh._acl_config import _load_acl_file
+
+        target = tmp_path / "real.json5"
+        target.write_text(json.dumps(_ENABLED_ACL))
+        assert _load_acl_file(target)["enabled"] is True
 
 
 class TestJSON5DepSwap:

--- a/tests/mesh/test_policy_host_charset_gate.py
+++ b/tests/mesh/test_policy_host_charset_gate.py
@@ -103,11 +103,16 @@ class TestIsSafePolicyHostStandaloneCharsetGate:
 
 
 class TestValidateCommandPolicyHostStillRejectsControlBytes:
-    """Pin: ``validate_command`` still raises on CRLF in ``policy_host``.
+    """Pin: ``validate_command`` refuses a CRLF ``policy_host``.
 
-    The R6 post-check is now redundant with the R7 in-function gate,
-    but kept as defence-in-depth. This test pins both layers fail
-    closed on the same input.
+    Two layers can refuse this input and only one of them runs.
+    ``is_safe_policy_host`` applies the charset rule before its
+    internal strip, so the membership gate refuses first and the
+    post-check below it is unreachable while the two agree. These
+    tests therefore pin *which* layer refuses, so the pair stays
+    distinguishable; the post-check is exercised on its own in
+    ``TestThePostCheckHoldsWhenTheMembershipGateIsWidened``, which is
+    the only way to reach it.
     """
 
     def test_rejects_crlf_in_policy_host(self) -> None:
@@ -120,12 +125,14 @@ class TestValidateCommandPolicyHostStillRejectsControlBytes:
                     "policy_provider": "mock",
                 }
             )
-        # Either message is acceptable: the in-function gate raises
-        # "not in allowlist" because the charset gate fails before
-        # membership compare; or the post-check raises "contains
-        # control characters". Both are correct fail-closed outcomes.
-        msg = str(exc.value).lower()
-        assert "policy_host" in msg or "control" in msg
+        # Pin which layer refuses. The membership gate rejects the host
+        # because its charset check runs before the internal strip, so
+        # the message names the allowlist. Accepting either message
+        # here would make the two layers indistinguishable, which is
+        # how the post-check went unexercised.
+        msg = str(exc.value)
+        assert "not in allowlist" in msg, msg
+        assert "control characters" not in msg, msg
 
     def test_rejects_nul_in_policy_host(self) -> None:
         with pytest.raises(ValidationError):
@@ -137,6 +144,93 @@ class TestValidateCommandPolicyHostStillRejectsControlBytes:
                     "policy_provider": "mock",
                 }
             )
+
+
+_CONTROL_HOSTS = [
+    pytest.param("localhost\r\n", id="crlf"),
+    pytest.param("localhost\n", id="lf"),
+    pytest.param("localhost\r", id="cr"),
+    pytest.param("localhost\t", id="tab"),
+    pytest.param("localhost\x00", id="nul"),
+    pytest.param("l\x1bocalhost", id="esc"),
+]
+
+
+def _widen_membership_gate(monkeypatch) -> None:
+    """Make the membership gate accept every host.
+
+    Models the change the post-check's comment names: an allowlist
+    compare that no longer applies the charset rule itself.
+    """
+    monkeypatch.setattr(security, "is_safe_policy_host", lambda host: True)
+
+
+def _execute_with_host(host: str) -> dict:
+    return {
+        "action": "execute",
+        "instruction": "go",
+        "policy_host": host,
+        "policy_provider": "mock",
+    }
+
+
+class TestThePostCheckHoldsWhenTheMembershipGateIsWidened:
+    """Pin the ``policy_host`` post-check, the second of the two layers.
+
+    The post-check exists for one stated reason, recorded beside it: the
+    validator boundary rejects regardless of how the membership compare
+    is implemented, so a future refactor of the allowlist cannot
+    silently drop the wire rejection. While the membership gate applies
+    the same charset rule the post-check is unreachable, which is
+    exactly why nothing exercised it -- and why that refactor could
+    remove it with the suite green.
+
+    Widening the membership gate is the change its comment anticipates,
+    so these tests do that and assert the boundary still refuses.
+    """
+
+    @pytest.mark.parametrize("host", _CONTROL_HOSTS)
+    def test_it_refuses_every_control_byte_class(self, host, monkeypatch) -> None:
+        _widen_membership_gate(monkeypatch)
+        with pytest.raises(ValidationError) as exc:
+            validate_command(_execute_with_host(host))
+        assert "control characters" in str(exc.value), str(exc.value)
+
+    def test_the_refusal_is_the_post_check_and_not_the_membership_gate(self, monkeypatch) -> None:
+        """The message names the reason, not the allowlist.
+
+        With the gate widened the allowlist has nothing to say about
+        this host, so a message mentioning it would mean the refusal
+        came from somewhere other than the post-check.
+        """
+        _widen_membership_gate(monkeypatch)
+        with pytest.raises(ValidationError) as exc:
+            validate_command(_execute_with_host("localhost\r\nX-Injected: 1"))
+        msg = str(exc.value)
+        assert "control characters" in msg, msg
+        assert "allowlist" not in msg, msg
+        assert "policy_host" in msg, msg
+
+    def test_the_injection_shaped_host_never_reaches_the_validated_output(self, monkeypatch) -> None:
+        """A refused host is not written to ``out``.
+
+        The post-check runs before ``out["policy_host"] = policy_host``,
+        so there is no partially validated command for a caller to act
+        on.
+        """
+        _widen_membership_gate(monkeypatch)
+        with pytest.raises(ValidationError):
+            validate_command(_execute_with_host("localhost\r\nX-Injected: 1"))
+
+    def test_a_clean_host_still_passes_once_the_gate_is_widened(self, monkeypatch) -> None:
+        """Control: the post-check refuses control bytes, not every host.
+
+        Without this a post-check that rejected unconditionally would
+        satisfy the tests above.
+        """
+        _widen_membership_gate(monkeypatch)
+        out = validate_command(_execute_with_host("localhost"))
+        assert out["policy_host"] == "localhost"
 
 
 class TestMaxOverrideCodeLenConstant:

--- a/tests/mesh/test_validate_command_finite_numerics.py
+++ b/tests/mesh/test_validate_command_finite_numerics.py
@@ -8,11 +8,20 @@ Two defences in the numeric coercion helpers in
   (IEEE-754), so a payload like ``{"duration": NaN}`` would pass the
   bounds clamp, reach the robot adapter, and turn ``time.sleep(nan)``
   / ``time.monotonic() + nan`` into a never-terminating deadline.
-* ``_coerce_int`` wraps ``int(...)`` so NaN/inf and overflowing values
-  raise :class:`ValidationError` instead of bare ``ValueError`` /
-  ``OverflowError``. ``_exec_cmd`` only catches ``ValidationError``,
-  so a bare exception would bypass the structured ``command_rejected``
-  audit + wire response and surface as a generic "dispatch error".
+* ``_coerce_int`` refuses the same values, but through the explicit
+  guards above its ``int(...)`` call rather than through the wrap: a
+  non-finite float is rejected by the ``math.isfinite`` check, and an
+  int too large for the bound is rejected by the range compare. The
+  wrap is what makes ``_coerce_float`` fail closed -- ``float(10**400)``
+  really does raise ``OverflowError`` there -- and its ``_coerce_int``
+  twin is unreachable for values that clear those guards, because
+  ``int()`` on a finite int or float cannot raise. Either way the
+  rejection class is :class:`ValidationError`, which is what matters:
+  ``_exec_cmd`` only catches that, so a bare exception would bypass
+  the structured ``command_rejected`` audit + wire response and
+  surface as a generic "dispatch error". The tests below pin the
+  guard that does the work, so removing it is caught here rather than
+  silently promoting the wrap into the load-bearing check.
 
 These tests pin the rejection class + path on every numeric field
 that flows through ``validate_command`` so a future refactor that
@@ -114,3 +123,26 @@ def test_isnan_check_independent_from_bounds():
     assert not math.isfinite(float("nan")), "sanity"
     with pytest.raises(ValidationError, match="finite"):
         validate_command(_execute_cmd(duration=float("nan")))
+
+
+def test_the_int_finite_guard_is_what_refuses_a_non_finite_step_count():
+    """Pin the guard, not just the rejection class.
+
+    ``_coerce_int``'s explicit ``math.isfinite`` check is what refuses
+    NaN; the ``try``/``except`` around ``int(...)`` never sees it. If
+    that check is removed the wrap catches ``int(nan)`` instead and the
+    message changes, so asserting the message keeps the guard in place.
+    """
+    with pytest.raises(ValidationError, match="must be finite"):
+        validate_command({"action": "step", "steps": float("nan")})
+
+
+def test_an_out_of_range_int_step_count_is_refused_by_the_bound_not_by_overflow():
+    """An int has no float range to overflow, so the bound is the guard.
+
+    ``float(10**400)`` raises ``OverflowError`` and is why
+    ``_coerce_float`` needs its wrap; ``int(10**400)`` is the identity,
+    so the same value reaches the range compare here instead.
+    """
+    with pytest.raises(ValidationError, match="out of bounds"):
+        validate_command({"action": "step", "steps": 10**400})


### PR DESCRIPTION
## Problem

Two guards on the mesh wire-authorisation path are each the *second* of two
checks, and each one's own comment records why it is kept — because the check in
front of it can be widened or raced:

`strands_robots/mesh/security.py:872-877`

```python
# R7 defence-in-depth. ``is_safe_policy_host`` now applies the
# same charset gate before its internal strip, so this
# post-check is redundant for in-process call sites. Kept
# ... a future refactor
# of the allowlist must not silently drop the wire rejection.
```

`strands_robots/mesh/_acl_config.py:157`

```python
# ELOOP under O_NOFOLLOW = symlink raced ahead of the static check.
```

Neither had ever been reached by a test. Measured on `99cb7f7d`, both were
uncovered by the full suite, so **either could have been deleted with every test
green** — and each is the last thing standing between the wire and, respectively,
a CRLF-bearing `policy_host` and a symlink swapped in under the file that gates
wire authorisation.

The reason they went unexercised is that three assertions could not tell the two
layers apart:

| assertion | why it could not distinguish them |
|---|---|
| `test_rejects_crlf_in_policy_host` | `assert "policy_host" in msg or "control" in msg` — satisfied by either layer, and measured, only the membership gate ever runs (`policy_host='localhost\r\n' not in allowlist`). Its class docstring claimed to pin "both layers". |
| `test_acl_load_refuses_symlink` | `assert ... or "symlink" in str(exc).lower()`. pytest derives `tmp_path` from the test name, and this test's name **contains** `symlink`, so the word arrives in every message via the path. Verified: with the static check deleted the message reads `Too many levels of symbolic links` — no `symlink` substring — and the assertion **still passes**. |
| `test_validate_command_finite_numerics` (module docstring) | credited `_coerce_int`'s `int(...)` wrap for refusing NaN/inf and overflow. Measured, its explicit `math.isfinite` check and its range compare do that work; the wrap is unreachable, because `int()` on a finite int or float cannot raise and `int(10**400)` is the identity. Its `_coerce_float` twin genuinely does need the wrap — `float(10**400)` raises `OverflowError` — which is why one is covered and the other is not. |

## Change

Tests and docstrings only. No production line changes.

* **The `policy_host` post-check** is now exercised on its own, by widening the
  membership gate — the change its comment anticipates — and asserting the
  boundary still refuses all six control-byte classes (`\r\n`, `\n`, `\r`, `\t`,
  `\x00`, `\x1b`), that the message names the reason rather than the allowlist,
  and that a clean host still passes (so the check refuses control bytes, not
  every host).
* **The `O_NOFOLLOW` refusal** is now exercised by racing the static check past
  a real symlink, asserting the refusal is chained from `OSError` with
  `errno == errno.ELOOP` and does *not* carry the static branch's `SYMLINK`
  wording. A control asserts the same file loads when reached directly.
* **The three assertions above** now state which layer refused: an exact message
  for the membership gate, `"it is a SYMLINK"` plus `__cause__ is None` for the
  static check, and two tests pinning that `_coerce_int`'s explicit guards — not
  its wrap — are what refuse.

## Why these tests pass on unmodified `main`

They do, and that is expected: the production code is correct. What they fail on
is a regression, so the evidence is a mutation table — each plausible removal
applied to the source, run against this PR's tests and against `main`'s own
copies of the same three files.

| | regression | this PR's tests (106) | `main`'s tests (93) |
|---|---|---|---|
| M1 | delete the `policy_host` post-check | **8 failed** | 93 passed — blind |
| M2 | drop `O_NOFOLLOW` from the open flags | **1 failed** | 93 passed — blind |
| M3 | narrow the ELOOP handler so the race escapes raw | **1 failed** | 93 passed — blind |
| M4 | delete `_coerce_int`'s finite guard | **1 failed** | 93 passed — blind |
| M5 | delete the static `is_symlink` check | **1 failed** | 93 passed — blind |

**5 of 5 caught here, 0 of 5 by `main`.** M5 is the sharpest: `main`'s assertion
is satisfied by its own `tmp_path`, so deleting the static check — leaving only
the `O_NOFOLLOW` half — is invisible to it.

Each anchor was AST-scoped to its enclosing function and asserted unique inside
it before replacement; the sources were verified byte-identical after every row.

## Complete accounting of the layer

These are the only two modules that decide wire authorisation, and this is every
uncovered line in them, before and after:

| module | `main` | this PR |
|---|---|---|
| `mesh/security.py` | 3 uncovered (99.3%) | **2** (99.6%) |
| `mesh/_acl_config.py` | 4 uncovered (98.4%) | **2** (99.2%) |

The four that remain are unreachable by construction, not deferred:

* `security.py:732-733` — `_coerce_int`'s `except (ValueError, OverflowError)`.
  Every value that would make `int()` raise is rejected by a guard above it:
  `nan`/`inf` by `math.isfinite`, `str`/`bool`/`list` by the type check, and
  `10**400` by the range compare (`int()` of an int is the identity). Both new
  tests in `test_validate_command_finite_numerics` pin that, so removing a guard
  and silently promoting the wrap into the load-bearing check is caught.
* `_acl_config.py:604,607` — type-narrowing `return None` on a thread-local
  whose only writer stores the mypy-pinned `tuple[dict | None, str | None]`.

## Out of scope

* `tools/robot_mesh.py:1187,1207` — the two "validate-before-HITL contract
  broken" raises, which the code notes are explicit rather than `assert` because
  `assert` is stripped under `python -O`. Same *shape*, but the tool layer rather
  than the wire boundary, and its own concern.
* Any change to what the guards accept. This pins the existing contract.

## Measured artifact

Every cell below is re-derived by `capture.py` running inside this checkout;
`compose.py` asserts each rendered value against that dump before saving.

![measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-second-line-guards/mesh-second-line-guards.png)

Scripts and the raw dump:
[capture.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-second-line-guards/capture.py) ·
[compose.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-second-line-guards/compose.py) ·
[measured.json](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-second-line-guards/measured.json)

No policy, simulation, rendering, recording or asset behaviour changes, so the
artifact is the coverage and mutation measurement rather than a rollout.

## Gate

Base `99cb7f7d` (rebased onto it before verifying, so these numbers describe the
tree that merges; `check_merge_base_overlap.py` reports no overlap, 0 paths
changed on `main` in that span).

* `MUJOCO_GL=egl pytest tests` — **27579 passed, 257 skipped, 0 failed** (610s).
* `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` —
  clean. `mypy` reports 14 errors, all in `examples/isaac_gs`, 0 elsewhere; the
  error set is byte-identical to a pristine-`main` worktree of the same working
  copy, so it is environmental.
* The three touched files: 93 → **106** passed.
* `scripts/assemble_changelog.py --check` OK.

The gate above ran on `2a8b01c6`. The pushed head `a792dc6f` differs from it only
in the changelog fragment's **filename** (`2122-` renamed to `2124-` once the PR
number was known); no test or source line changed, and
`assemble_changelog.py --check` plus both changelog guards were re-run after the
rename.

<details>
<summary>An earlier full run reported one failure in an unrelated seeded-eval test</summary>

`tests/simulation/test_rollout_seed_is_applied_or_refused.py::TestTheSeedIsAppliedOnTheEvalPath::test_two_evals_at_the_same_seed_draw_the_same_actions`
failed once. Attribution:

* passes alone (1 passed) and across its own file (124 passed);
* passes with this PR's three files collected immediately ahead of it (230 passed);
* this diff adds **zero** lines mentioning `random`/`seed` and touches only
  `tests/mesh/` plus a changelog fragment — no production code;
* the two streams are entirely different rather than offset (`0.9443…` vs
  `0.4320…` at index 0), which is a concurrent consumer of the process-wide
  `random` between the two `evaluate()` calls, not a property of the tree;
* a second full run on the identical commit is clean (27579 passed).

</details>

