### PR TITLE
test(tools): pin every unusable-input branch in harness_memory

### DIFF
--- a/changelog.d/2126-harness-memory-unusable-inputs.md
+++ b/changelog.d/2126-harness-memory-unusable-inputs.md
@@ -1,0 +1,20 @@
+### Quality: pin every unusable-input branch in the harness-memory tool, and document the two raises that had no `Raises:` entry
+
+`strands_robots/tools/harness_memory.py` has five branches that report an
+unusable input or store, and together they were the module's entire uncovered
+set. Four refuse -- the simulation tool spec carries no `action` enum, a trace
+entry or a summary cannot be serialized, a global-rule store is not valid
+UTF-8 -- and one degrades, recording an unknown library version in trace
+provenance when the distribution metadata is absent rather than failing the
+save. Each is a documented contract that nothing exercised, so a regression in
+any of them was invisible: six plausible ones are caught by the new tests and
+none by the 71 cases the module's tests already ran.
+
+Two of them reach a caller through `HarnessMemory` rather than through the
+tool, and neither documented that it can raise. `load_rules` and `append_rule`
+both propagate the non-UTF-8 `ValueError`, and `load_rules` does so
+all-or-nothing: rules are loaded together into one prompt, so returning a
+partial mapping would present a store that could not be read as a kind with no
+rules. Both now carry a `Raises:` entry stating that, and the behaviour it
+describes is pinned. No behaviour changes -- the refusals and the fallback are
+the ones that already shipped.

--- a/strands_robots/tools/harness_memory.py
+++ b/strands_robots/tools/harness_memory.py
@@ -440,7 +440,22 @@ class HarnessMemory:
         return sorted(tasks)
 
     def append_rule(self, kind: str, text: str) -> int:
-        """Append one rule line under *kind*; returns the new rule count."""
+        """Append one rule line under *kind*.
+
+        Args:
+            kind: Rule kind to append under; a key of ``_RULE_FILES``.
+            text: Validated single-line rule text.
+
+        Returns:
+            The new rule count for *kind*.
+
+        Raises:
+            ValueError: If *kind* already holds ``_MAX_RULES_PER_KIND`` rules,
+                or if its store is not valid UTF-8 -- the existing rules are
+                counted before one more is appended, so a store that cannot be
+                read cannot be appended to either. The other kind is
+                unaffected: each kind has its own file.
+        """
         self._ensure_dirs()
         path = self.global_dir / _RULE_FILES[kind]
         existing = self._read_rules(path)
@@ -451,7 +466,19 @@ class HarnessMemory:
         return len(existing) + 1
 
     def load_rules(self) -> dict[str, list[str]]:
-        """Return all global rules keyed by kind."""
+        """Return all global rules keyed by kind.
+
+        Returns:
+            One list per key of ``_RULE_FILES``. A kind with no store yet maps
+            to an empty list.
+
+        Raises:
+            ValueError: If any store is not valid UTF-8. The read is
+                all-or-nothing rather than per-kind: rules are loaded together
+                into one prompt, so returning a partial mapping would present a
+                store that could not be read as a kind with no rules. The
+                message names the file to repair or remove.
+        """
         return {kind: self._read_rules(self.global_dir / fname) for kind, fname in _RULE_FILES.items()}
 
     @staticmethod

--- a/tests/tools/test_harness_memory_unusable_inputs.py
+++ b/tests/tools/test_harness_memory_unusable_inputs.py
@@ -1,0 +1,247 @@
+"""Every branch of ``harness_memory`` that reports an unusable input or store.
+
+The module has five such branches, and together they were its entire uncovered
+set: four refuse and one degrades.
+
+* the action vocabulary cannot be read -- the simulation tool spec is present
+  but does not carry an ``action`` enum (``get_valid_actions``);
+* a trace entry cannot be serialized (``_validate_trace``);
+* a summary cannot be serialized (``_validate_summary``);
+* the distribution metadata is absent, so trace provenance records an unknown
+  version instead of failing the save (``_version_string``) -- the one
+  degradation rather than a refusal;
+* a global-rule store is not valid UTF-8 (``HarnessMemory._read_rules``).
+
+Each one is a documented contract that nothing exercised. The two that reach a
+caller through :class:`HarnessMemory` rather than through the tool -- an
+unreadable store seen from ``load_rules`` and from ``append_rule`` -- had no
+``Raises:`` entry at all, so their all-or-nothing read was undocumented as well
+as unpinned; this module pins the behaviour those entries now describe.
+
+The tool converts all four refusals into the ``{"status": "error"}`` envelope
+rather than raising, so both the library-level reason and the tool-level report
+are asserted: the reason has to name the input or the file, because the remedy
+is to repair the thing it names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.harness_memory as hm
+from tests.tool_result_contract import assert_strands_tool_result, tool_json
+
+TRACE: list[dict[str, Any]] = [{"action": "run_policy", "instruction": "grasp the bowl"}]
+SUMMARY: dict[str, Any] = {"strategy": "approach, grasp, lift", "avoid": ["empty grasp"]}
+
+
+@pytest.fixture
+def memory_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point STRANDS_MEMORY_DIR at a temp dir so the store is isolated."""
+    d = tmp_path / "memory"
+    monkeypatch.setenv("STRANDS_MEMORY_DIR", str(d))
+    return d
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate every content ``text`` field of a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _circular() -> dict[str, Any]:
+    """A dict json.dumps refuses with ValueError rather than TypeError."""
+    d: dict[str, Any] = {"action": "run_policy"}
+    d["self"] = d
+    return d
+
+
+def _foreign_object() -> dict[str, Any]:
+    """A dict json.dumps refuses with TypeError."""
+    return {"action": "run_policy", "handle": object()}
+
+
+# Both members of the ``except (TypeError, ValueError)`` tuple the two payload
+# validators share: an unencodable value raises TypeError, a cycle ValueError.
+UNSERIALIZABLE = [
+    pytest.param(_foreign_object, id="foreign-object-TypeError"),
+    pytest.param(_circular, id="circular-reference-ValueError"),
+]
+
+
+class TestTheActionVocabularyCannotBeRead:
+    """``get_valid_actions`` reads the simulation tool spec for the enum.
+
+    A spec that parses as JSON but does not carry ``properties.action.enum``
+    leaves the trace vocabulary undefined, so no trace can be validated. The
+    refusal has to name the file, since that file is what has to be repaired.
+    """
+
+    def _spec(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: object) -> Path:
+        spec = tmp_path / "tool_spec.json"
+        spec.write_text(json.dumps(payload), encoding="utf-8")
+        monkeypatch.setattr(hm, "_sim_tool_spec_path", lambda: spec)
+        monkeypatch.setattr(hm, "_valid_actions_cache", None)
+        return spec
+
+    def test_a_spec_without_an_action_enum_is_refused_naming_the_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spec = self._spec(tmp_path, monkeypatch, {"properties": {"action": {}}})
+        with pytest.raises(ValueError, match="malformed simulation tool spec") as excinfo:
+            hm.get_valid_actions()
+        assert str(spec) in str(excinfo.value)
+
+    def test_a_spec_whose_properties_is_not_a_mapping_is_refused_the_same_way(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The TypeError arm of the same handler, not the KeyError arm."""
+        self._spec(tmp_path, monkeypatch, {"properties": ["action"]})
+        with pytest.raises(ValueError, match="malformed simulation tool spec"):
+            hm.get_valid_actions()
+
+    def test_a_refused_read_leaves_the_vocabulary_cache_unpoisoned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The vocabulary is cached in a module global; a failure must not cache.
+
+        Repairing the same file and asking again has to return the real
+        vocabulary, or one malformed read would disable trace validation for
+        the rest of the process.
+        """
+        spec = self._spec(tmp_path, monkeypatch, {"properties": {"action": {}}})
+        with pytest.raises(ValueError, match="malformed simulation tool spec"):
+            hm.get_valid_actions()
+        spec.write_text(json.dumps({"properties": {"action": {"enum": ["step", "render"]}}}), encoding="utf-8")
+        actions = hm.get_valid_actions()
+        assert {"step", "render"} <= actions
+
+    def test_the_tool_reports_it_instead_of_raising(
+        self, memory_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._spec(tmp_path, monkeypatch, {"properties": {"action": {}}})
+        result = hm.harness_memory(action="save_trace", task="t0", trace=TRACE, summary=SUMMARY)
+        assert_strands_tool_result(result)
+        assert result["status"] == "error"
+        assert "malformed simulation tool spec" in _texts(result)
+
+
+class TestAPayloadThatCannotBeSerialized:
+    """A trace entry or summary that ``json.dumps`` refuses.
+
+    Both validators size the payload by serializing it, so an unencodable value
+    is caught where the size is measured. The reason names which entry, because
+    a trace is a list and the index is the only way to find the offender.
+    """
+
+    @pytest.mark.parametrize("factory", UNSERIALIZABLE)
+    def test_a_trace_entry_is_refused_naming_its_index(self, factory: Any) -> None:
+        with pytest.raises(ValueError, match=r"trace\[1\] is not JSON-serializable"):
+            hm._validate_trace([{"action": "run_policy"}, factory()])
+
+    @pytest.mark.parametrize("factory", UNSERIALIZABLE)
+    def test_a_summary_is_refused(self, factory: Any) -> None:
+        with pytest.raises(ValueError, match="summary is not JSON-serializable"):
+            hm._validate_summary(factory())
+
+    def test_an_unserializable_trace_writes_no_file(self, memory_dir: Path) -> None:
+        """The refusal precedes the write, so no torn pair is left behind."""
+        result = hm.harness_memory(action="save_trace", task="t0", trace=[_foreign_object()], summary=SUMMARY)
+        assert_strands_tool_result(result)
+        assert result["status"] == "error"
+        assert "not JSON-serializable" in _texts(result)
+        assert not list(memory_dir.rglob("t0*")), "a refused save wrote a file"
+
+    def test_an_unserializable_summary_writes_no_file(self, memory_dir: Path) -> None:
+        result = hm.harness_memory(action="save_trace", task="t0", trace=TRACE, summary={"why": object()})
+        assert_strands_tool_result(result)
+        assert result["status"] == "error"
+        assert "not JSON-serializable" in _texts(result)
+        assert not list(memory_dir.rglob("t0*")), "a refused save wrote a file"
+
+
+class TestProvenanceWhenTheDistributionMetadataIsAbsent:
+    """A running-from-source checkout has no installed distribution metadata.
+
+    Provenance is recorded beside every trace, so this has to degrade rather
+    than refuse: an unknown version is still a saveable, loadable trace.
+    """
+
+    def test_the_version_falls_back_to_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def absent(name: str) -> str:
+            raise hm._importlib_metadata.PackageNotFoundError(name)
+
+        monkeypatch.setattr(hm._importlib_metadata, "version", absent)
+        assert hm._version_string() == "unknown"
+
+    def test_the_trace_still_saves_and_loads(self, memory_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        def absent(name: str) -> str:
+            raise hm._importlib_metadata.PackageNotFoundError(name)
+
+        monkeypatch.setattr(hm._importlib_metadata, "version", absent)
+        saved = hm.harness_memory(action="save_trace", task="t0", trace=TRACE, summary=SUMMARY)
+        assert saved["status"] == "success"
+        assert tool_json(saved)["provenance"]["strands_robots_version"] == "unknown"
+        loaded = hm.harness_memory(action="load_trace", task="t0")
+        assert loaded["status"] == "success"
+        assert tool_json(loaded)["trace"] == TRACE
+
+
+class TestARuleStoreThatIsNotUtf8:
+    """A global-rule store whose bytes are not valid UTF-8.
+
+    Rules are plain text appended a line at a time, so a store can be edited
+    or truncated outside the tool. Reading one is all-or-nothing on purpose:
+    ``load_rules`` feeds one prompt, and a per-kind fallback would present an
+    unreadable store as a kind with no rules.
+    """
+
+    def _corrupt(self, memory_dir: Path, kind: str = "success_rule") -> Path:
+        memory = hm.HarnessMemory()
+        memory._ensure_dirs()
+        memory.append_rule("failure_model", "a grasp that does not move the object is empty")
+        store = memory.global_dir / hm._RULE_FILES[kind]
+        store.write_bytes(b"a readable line\n\xff\xfe not utf-8\n")
+        return store
+
+    def test_the_refusal_names_the_file(self, memory_dir: Path) -> None:
+        store = self._corrupt(memory_dir)
+        with pytest.raises(ValueError, match="is not valid UTF-8") as excinfo:
+            hm.HarnessMemory().load_rules()
+        assert store.name in str(excinfo.value)
+
+    def test_the_read_is_all_or_nothing(self, memory_dir: Path) -> None:
+        """The readable kind is available, and the aggregate read still refuses.
+
+        A per-kind fallback would return this kind and present the unreadable
+        one as empty. Refusing instead is what keeps "no rules of that kind"
+        from meaning "that store could not be read".
+        """
+        self._corrupt(memory_dir)
+        memory = hm.HarnessMemory()
+        healthy = memory.global_dir / hm._RULE_FILES["failure_model"]
+        assert hm.HarnessMemory._read_rules(healthy) == ["a grasp that does not move the object is empty"]
+        with pytest.raises(ValueError, match="is not valid UTF-8"):
+            memory.load_rules()
+
+    def test_a_healthy_store_still_reads_and_appends(self, memory_dir: Path) -> None:
+        """Non-vacuity for the two tests above: the fixture's healthy kind works.
+
+        Each kind has its own file, so the corruption is scoped to writes on the
+        corrupt kind only.
+        """
+        self._corrupt(memory_dir)
+        memory = hm.HarnessMemory()
+        assert memory.append_rule("failure_model", "re-localize after every reset") == 2
+        with pytest.raises(ValueError, match="is not valid UTF-8"):
+            memory.append_rule("success_rule", "verify placement before declaring done")
+
+    def test_the_tool_reports_it_instead_of_raising(self, memory_dir: Path) -> None:
+        store = self._corrupt(memory_dir)
+        result = hm.harness_memory(action="load_rules")
+        assert_strands_tool_result(result)
+        assert result["status"] == "error"
+        assert store.name in _texts(result)


### PR DESCRIPTION
## Problem

`strands_robots/tools/harness_memory.py` has five branches that report an unusable input or store. Together they were the module's **entire** uncovered set — 10 lines, 96% — and every one of them is a documented contract that nothing exercised:

| function | when | the reason it reports (measured) |
|---|---|---|
| `get_valid_actions` | the simulation tool spec parses but carries no `action` enum | `malformed simulation tool spec at <spec>: 'enum'` |
| `_validate_trace` | a trace entry cannot be serialized | `trace[1] is not JSON-serializable: Object of type object is not JSON serializable` |
| `_validate_summary` | a summary cannot be serialized | `summary is not JSON-serializable: Object of type object is not JSON serializable` |
| `_version_string` | the distribution metadata is absent | returns `'unknown'` — the one **degradation** rather than a refusal |
| `HarnessMemory._read_rules` | a rule store is not valid UTF-8 | `rule store at success_rules.txt is not valid UTF-8 (...)` |

Two of them reach a caller through `HarnessMemory` rather than through the tool, and **neither documented that it can raise**. `load_rules` and `append_rule` both propagate that `ValueError`; `load_rules`' docstring was a bare one-liner and `append_rule`'s said only that it returns a count.

`load_rules` also reads *all-or-nothing*, which was undocumented as well as unpinned. That is the right behaviour and this PR does not change it — rules are loaded together into one prompt, so returning a partial mapping would present a store that could not be read as a kind with no rules. But nothing said so, and nothing held it in place.

## Change

Tests and docstrings. No behaviour change: the production diff is docstrings only, and the docstring-stripped AST digest is unchanged at `819de46739e52f52` (asserted before the file was written).

* `tests/tools/test_harness_memory_unusable_inputs.py` — 16 cases over the five branches. Both members of the `except (TypeError, ValueError)` tuple the two payload validators share are exercised (an unencodable value raises `TypeError`, a cycle `ValueError`), as are both arms of `get_valid_actions`' `except (KeyError, TypeError)`.
* `load_rules` and `append_rule` gain a `Raises:` entry. `load_rules`' states the all-or-nothing property and why; `append_rule`'s states that a store which cannot be read cannot be appended to either, because the existing rules are counted first — and that the other kind is unaffected, since each kind has its own file.

Three of the new tests are not coverage but contract:

* a refused vocabulary read leaves the module-level cache unpoisoned — repairing the same spec and asking again returns the real vocabulary, so one malformed read cannot disable trace validation for the rest of the process;
* an unserializable trace or summary writes no file, so the refusal precedes the write and no torn pair is left behind;
* the readable kind returns `['a grasp that does not move the object is empty']` on its own while `load_rules` still refuses — the assertion that distinguishes all-or-nothing from a per-kind fallback.

## Measured

Because the production code is correct, the new tests necessarily pass on unmodified `main`. What they fail on is a regression, so the evidence is a mutation table: each of six plausible regressions applied to the branch it targets (AST-scoped to the enclosing function, source restored byte-identically after each), run against both arms without `-x`.

| mutation | new tests | the 71 cases already there |
|---|---|---|
| M1 malformed-spec handler dropped | 4 failed | 0 failed |
| M2 trace serializability handler dropped | 3 failed | 0 failed |
| M3 summary serializability handler dropped | 3 failed | 0 failed |
| M4 version fallback dropped | 2 failed | 0 failed |
| M5 non-UTF-8 handler dropped | 4 failed | 0 failed |
| M6 `load_rules` swallows the read error per kind (silent partial) | 3 failed | 0 failed |
| **caught** | **6 of 6** | **0 of 6** |

M6 is the one worth singling out: swallowing per kind and returning `[]` for the unreadable store is the regression the all-or-nothing test exists to catch, and it was invisible to every test the module already had.

Coverage, same file list with the new module deselected for the before arm:

```
strands_robots/tools/harness_memory.py   96% (10 missing)  ->  100% (0 missing)
71 passed  ->  87 passed
```

## Artifact

Nothing in policy, simulation, rendering, recording or asset handling changes, so a rollout is not the right artifact here. The figure is the coverage and mutation measurement — every cell read from the two JSON dumps and asserted before the image is saved.

![harness_memory unusable-input branches](https://raw.githubusercontent.com/cagataycali/robots/artifacts/harness-memory-unusable-inputs/harness_memory_unusable_inputs.png)

Capture, mutation and compose scripts plus the raw JSON: [`artifacts/harness-memory-unusable-inputs`](https://github.com/cagataycali/robots/tree/artifacts/harness-memory-unusable-inputs).

## Gate

Base `99cb7f7d`. `scripts/check_merge_base_overlap.py` reports no overlap (0 paths changed on `main` in that span) and `compare` reports `behind_by=0`, so the tree these numbers describe is the merge result.

```
MUJOCO_GL=egl pytest tests -q -p no:randomly --no-cov
  27584 passed, 257 skipped, 0 failed in 612s

ruff check strands_robots tests tests_integ          All checks passed!
ruff format --check strands_robots tests tests_integ 1164 files already formatted
mypy strands_robots tests tests_integ                0 errors outside examples/
```

Pristine `main` at the same commit measures 27566 passed / 257 skipped, so the +18 is fully accounted for: 16 new cases, plus 2 from the repo-wide `Args:`-completeness sweep, which `append_rule` newly enters by declaring an `Args:` block (both its parameters are named).

The 14 `mypy` errors are all in `examples/isaac_gs` and are environmental to this checkout: the error set is byte-identical to a pristine-base worktree control, compared after normalising line numbers.

## Scope

`rendering.py`'s `get_frame` is the other one-hole matrix in this area — three of the four `_get_renderer` callers exercise their "no OpenGL context" refusal and `get_frame`'s does not. Different module, different contract, its own change.
