### PR TITLE
test: key the GL-gate guard's non-vacuity pin on modules, not on an assertion count

### DIFF
--- a/changelog.d/2125-gl-gate-non-vacuity-keyed-on-modules.md
+++ b/changelog.d/2125-gl-gate-non-vacuity-keyed-on-modules.md
@@ -1,0 +1,20 @@
+### Quality: key the GL-gate guard's non-vacuity pin on modules, not on an assertion count
+
+``tests/test_mujoco_render_assertions_are_gl_gated.py`` held two non-vacuity pins over
+one ``frozenset`` of module paths, and the second compared a count of render assertions
+to a count of modules. Those are different quantities, equal today only because each of
+the four in-scope modules happens to carry exactly one render-success assertion, and
+nothing stated that invariant.
+
+The guard's own remedy text tells a contributor to "split the render assertion into its
+own case". Doing that inside a module already in scope moved the assertion count and not
+the module set, so the required check went red on a diff that complied with the
+instruction, reporting ``assert 5 == 4`` - two bare integers naming neither the module
+nor the new assertion, and no pin to update.
+
+Both pins are now one, keyed on modules in both directions and reporting the module by
+name: an in-scope module that stops contributing a gated assertion, and a gated module
+that is not listed. Every vacuity the two old pins caught - a survey that finds nothing,
+a scan rooted somewhere unexpected, an assertion that stops being gated - is still
+caught. Adding a second correctly gated assertion to a listed module now needs no pin
+updated; a new module entering scope still fails, and now names itself.

--- a/tests/test_mujoco_render_assertions_are_gl_gated.py
+++ b/tests/test_mujoco_render_assertions_are_gl_gated.py
@@ -23,6 +23,10 @@ needs no exemption list.
 Three gating forms are accepted, all of which stop the assertion from running
 without a context: the probe's marker on the test function, the same marker on
 its class, or an in-function ``gl_available()`` skip. All three are in use.
+
+The rule's own non-vacuity pin is keyed on modules, never on a count of
+assertions: splitting one render call into its own gated case is what the remedy
+below asks for, and must not move a number a contributor then has to chase.
 """
 
 from __future__ import annotations
@@ -166,6 +170,18 @@ def survey(root: pathlib.Path) -> tuple[dict[str, list[int]], dict[str, list[int
     return ungated, gated, other_backend
 
 
+def unaccounted_modules(gated: dict[str, list[int]], expected: frozenset[str]) -> tuple[set[str], set[str]]:
+    """Return (in-scope modules with no gated assertion, gated modules not expected).
+
+    Both sides are keyed on modules. A count of gated assertions is a different
+    quantity from a count of modules: splitting one render assertion into its own
+    case -- exactly what this guard's remedy text asks a contributor to do -- moves
+    the first and not the second, so comparing them would fail a diff that did
+    precisely the right thing, with no pin left to update.
+    """
+    return set(expected) - set(gated), set(gated) - set(expected)
+
+
 class TestEveryMuJoCoRenderAssertionIsGated:
     def test_no_module_asserts_a_render_succeeded_without_the_probe(self) -> None:
         ungated, _, _ = survey(_tests_root())
@@ -177,14 +193,22 @@ class TestEveryMuJoCoRenderAssertionIsGated:
             f"tests.simulation.mujoco._gl_probe and split the render assertion into its own case."
         )
 
-    def test_the_survey_covers_the_modules_it_is_meant_to(self) -> None:
-        """Non-vacuity: a scan that found nothing must not read as a clean sweep."""
-        ungated, gated, _ = survey(_tests_root())
-        assert set(ungated) | set(gated) == EXPECTED_IN_SCOPE
+    def test_every_module_the_survey_covers_contributes_a_gated_assertion(self) -> None:
+        """Non-vacuity: a scan that found nothing must not read as a clean sweep.
 
-    def test_every_in_scope_assertion_is_accounted_for(self) -> None:
+        Keyed on modules in both directions, which is also the module-set check
+        this replaces: a module whose assertion stopped being gated leaves
+        ``gated`` and is reported here by name, and a scan rooted somewhere
+        unexpected reports every entry as missing.
+        """
         _, gated, _ = survey(_tests_root())
-        assert sum(len(lines) for lines in gated.values()) == len(EXPECTED_IN_SCOPE)
+        missing, unexpected = unaccounted_modules(gated, EXPECTED_IN_SCOPE)
+        assert not missing and not unexpected, (
+            f"the survey no longer accounts for EXPECTED_IN_SCOPE: {sorted(missing)} contribute no "
+            f"gated render assertion, and {sorted(unexpected)} are not listed. Add or drop the "
+            f"module path. Adding a second gated assertion to a module already listed is not a "
+            f"change to this pin."
+        )
 
 
 class TestTheScopeIsTheMujocoRequirement:
@@ -221,6 +245,25 @@ def test_planted(sim):
 """
 
 
+_PLANTED_TWO_GATED = """
+import pytest
+
+mujoco = pytest.importorskip("mujoco")
+
+from tests.simulation.mujoco._gl_probe import requires_gl  # noqa: E402
+
+
+@requires_gl
+def test_planted_one(sim):
+    assert sim.render(camera_name="default")["status"] == "success"
+
+
+@requires_gl
+def test_planted_two(sim):
+    assert sim.render_depth(camera_name="default")["status"] == "success"
+"""
+
+
 class TestTheSurveyDetectsWhatItClaimsTo:
     """A scanner that silently matched nothing would look like a clean tree."""
 
@@ -249,3 +292,47 @@ class TestTheSurveyDetectsWhatItClaimsTo:
         """The rule is about rendering, not about every envelope in the suite."""
         tree = ast.parse('assert sim.step(n_steps=5)["status"] == "success"\n')
         assert render_success_assertions(tree) == []
+
+
+class TestThePinIsKeyedOnModulesNotOnAnAssertionCount:
+    """Splitting a render assertion into its own case must need no pin updated.
+
+    That split is what this guard's remedy text instructs, so a pin that moved
+    with the number of assertions would turn the required check red on a diff
+    that complied with it -- and report only two bare integers.
+    """
+
+    def test_a_second_gated_assertion_in_a_listed_module_is_accounted_for(self, tmp_path: pathlib.Path) -> None:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_TWO_GATED, encoding="utf-8")
+        ungated, gated, _ = survey(root)
+        assert not ungated
+        assert unaccounted_modules(gated, frozenset({"tests/test_planted.py"})) == (set(), set())
+
+    def test_the_module_and_assertion_counts_are_different_quantities(self, tmp_path: pathlib.Path) -> None:
+        """One module, two gated assertions: why a count cannot stand in for a set."""
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_TWO_GATED, encoding="utf-8")
+        _, gated, _ = survey(root)
+        assert set(gated) == {"tests/test_planted.py"}
+        assert sum(len(lines) for lines in gated.values()) == 2
+
+    def test_a_listed_module_contributing_nothing_gated_is_reported(self, tmp_path: pathlib.Path) -> None:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_UNGATED, encoding="utf-8")
+        _, gated, _ = survey(root)
+        missing, unexpected = unaccounted_modules(gated, frozenset({"tests/test_planted.py"}))
+        assert missing == {"tests/test_planted.py"}
+        assert not unexpected
+
+    def test_a_module_that_is_not_listed_is_reported(self, tmp_path: pathlib.Path) -> None:
+        root = tmp_path / "tests"
+        root.mkdir()
+        (root / "test_planted.py").write_text(_PLANTED_GATED, encoding="utf-8")
+        _, gated, _ = survey(root)
+        missing, unexpected = unaccounted_modules(gated, frozenset())
+        assert not missing
+        assert unexpected == {"tests/test_planted.py"}


### PR DESCRIPTION
Closes #2125.

## Problem

`tests/test_mujoco_render_assertions_are_gl_gated.py` carried two non-vacuity pins over one `frozenset` of **module paths**, and the second compared a count of **render assertions** to a count of **modules**:

```python
EXPECTED_IN_SCOPE = frozenset({ ...four module paths... })

def test_the_survey_covers_the_modules_it_is_meant_to(self) -> None:
    assert set(ungated) | set(gated) == EXPECTED_IN_SCOPE          # modules == modules

def test_every_in_scope_assertion_is_accounted_for(self) -> None:
    assert sum(len(lines) for lines in gated.values()) == len(EXPECTED_IN_SCOPE)
```

Those are two different quantities. They are equal today (4 == 4) only because each of the four in-scope modules happens to carry exactly one render-success assertion. Nothing states that invariant, and nothing would lead a contributor to preserve it.

The failure is triggered **by complying with the guard**. Its own remedy text reads:

> Import `requires_gl` from `tests.simulation.mujoco._gl_probe` and split the render assertion into its own case.

Splitting an assertion into its own case inside a module already in scope moves the assertion count and leaves the module set exactly correct, so there is no pin to update and the message is:

```
assert sum(len(lines) for lines in gated.values()) == len(EXPECTED_IN_SCOPE)
AssertionError: assert 5 == 4
```

Two bare integers, naming neither the module, nor the new assertion, nor what would make it pass.

Latent rather than live: main is green, and no open PR trips it. This is a trap for the next contributor, not a current breakage.

## Change

One pin, keyed on modules in both directions, via a small `unaccounted_modules(gated, expected)` helper so the corrected quantity is testable with the planted fixtures this module already uses:

```python
def unaccounted_modules(gated, expected) -> tuple[set[str], set[str]]:
    return set(expected) - set(gated), set(gated) - set(expected)
```

It reports the module by name: an in-scope module that stops contributing a gated assertion, and a gated module that is not listed. Splitting one assertion into two cases moves neither.

## Measured

Each scenario applied to the real tree and reverted, `git status --porcelain` empty afterwards.

| scenario | on main | with this PR |
|---|---|---|
| a second gated assertion added to a module already listed (what the remedy text instructs) | `1 failed, 9 passed` -- `assert 5 == 4` | `13 passed`, no pin to update |
| a new module enters scope, correctly gated | `2 failed, 8 passed` | `1 failed, 12 passed`, and the failure names the module |

The second still fails, which is right: a module entering scope is worth a reviewer's attention, and updating a module-scope pin is a legible ask. What changed is that it now reads `not {'tests/simulation/mujoco/test_zz_planted_new_module.py'}` rather than `5 == 4`.

### Nothing is lost by replacing two pins with one

Every vacuity the two old pins caught is still caught. Measured with upstream's copy of the module beside this one, the same mutation applied to both:

| mutation of the survey | the two old pins | the single new pin |
|---|---|---|
| `survey` finds nothing | both fail | fails |
| nothing classified as gated | the count pin fails | fails |
| scan rooted at a subdirectory | both fail | fails |

### The corrected quantity is load-bearing, not merely documented

| mutation of the new pin | result |
|---|---|
| the pin compares counts again | 3 of the 4 new tests fail, including the split-assertion case |
| the `missing` half is dropped | 1 fails |
| the `unexpected` half is dropped | 1 fails |

## Artifact

The guard governs assertions about rendering, and this PR changes neither the rule nor its scope. The frame below is what the four gated assertions verify -- a headless MuJoCo render taken after a refused non-string entity lookup, which is exactly the liveness check the in-scope case makes -- shown so the thing being guarded is concrete, alongside the two measurement tables.

![non-vacuity pin keyed on modules](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-gate-non-vacuity/artifact.png)

Capture and mutation scripts: [`artifacts/gl-gate-non-vacuity`](https://github.com/cagataycali/robots/tree/artifacts/gl-gate-non-vacuity). Every number rendered in the figure is asserted against the capture's own JSON dump before it is saved.

## Scope

Tests only. No production line changes, so nothing in policy, simulation, rendering, recording or asset handling moves.

Deliberately unchanged, all three measured correct: the gating rule itself, `RENDER_ATTRS`, and the `OTHER_BACKEND` discriminator. `EXPECTED_IN_SCOPE` keeps its four entries and now has exactly one meaning.

## Gate

Base `99cb7f7d`. `MUJOCO_GL=egl python -m pytest tests` -> **27569 passed, 257 skipped, 0 failed** in 641.79s. That attributes exactly: pristine main at this base is 27566, and this PR adds four tests and replaces one, so 27566 + 4 - 1 = 27569. The guard module itself goes 10 -> 13 tests.

`ruff check` and `ruff format --check` clean on `strands_robots tests tests_integ`. `mypy strands_robots tests tests_integ` reports 0 errors outside `examples/isaac_gs`, and its error set is byte-identical to a pristine checkout of the base in the same working copy. `scripts/assemble_changelog.py --check` OK. `scripts/check_merge_base_overlap.py` reports no overlap.
