### PR TITLE
test(mesh): pin both validate-before-HITL contract guards in robot_mesh

### DIFF
--- a/changelog.d/2128-robot-mesh-validate-before-hitl-guards.md
+++ b/changelog.d/2128-robot-mesh-validate-before-hitl-guards.md
@@ -1,0 +1,15 @@
+### Quality: pin both validate-before-HITL contract guards in `robot_mesh`
+
+`robot_mesh` validates the `send` / `broadcast` command body before raising the
+human-in-the-loop interrupt, then each handler re-reads that pre-validated
+command from a sentinel and refuses when the sentinel is still unset. Both
+guards are an explicit `raise` rather than an `assert` because `assert` is
+stripped under `python -O`, and neither had a test: on today's code the pre-pass
+always sets its sentinel, so both raise bodies were unreached.
+
+Deleting either guard, or replacing one with the `-O`-strippable `assert` its own
+comment warns against, was invisible to all 275 existing `robot_mesh` tests.
+Without the guard the handler dispatches the unset sentinel -- `mesh.broadcast(None)`
+is issued fleet-wide -- and the audit line that follows raises, so the dispatch
+that did happen is never recorded. The `broadcast` comment claimed the loss would
+"silently send an unvalidated cmd"; it is corrected to the measured outcome.

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -1183,6 +1183,8 @@ def robot_mesh(
         # Parse + validation already happened in the pre-interrupt pass
         # above (so the operator approves the validated form). Reuse that
         # result rather than re-parsing the LLM string a second time.
+        # Explicit raise, not assert -- see the broadcast handler below for
+        # why the sentinel check must survive ``python -O``.
         if validated_send_cmd is None:
             raise RuntimeError(
                 "send reached its handler without pre-validation -- validate-before-HITL contract broken"
@@ -1200,9 +1202,11 @@ def robot_mesh(
     if action == "broadcast":
         # Pre-validated above before the HITL interrupt fired, so
         # the cmd here is already a clean validated dict.
-        # Use explicit raise (not assert) -- assert is stripped under
-        # ``python -O`` / ``PYTHONOPTIMIZE=1`` which would silently send
-        # an unvalidated cmd to mesh.broadcast.
+        # Use explicit raise (not assert): assert is stripped under
+        # ``python -O`` / ``PYTHONOPTIMIZE=1``, and with the check gone the
+        # handler dispatches the unset sentinel -- mesh.broadcast(None) is
+        # issued fleet-wide, and the cmd.get(...) on the audit line below
+        # then raises, so the dispatch that did happen is never recorded.
         if validated_broadcast_cmd is None:
             raise RuntimeError(
                 "broadcast reached its handler without pre-validation -- validate-before-HITL contract broken"

--- a/tests/mesh/test_robot_mesh_validate_before_hitl_contract.py
+++ b/tests/mesh/test_robot_mesh_validate_before_hitl_contract.py
@@ -1,0 +1,333 @@
+"""Pin: both validate-before-HITL contract guards in ``robot_mesh``.
+
+``robot_mesh`` parses and validates the ``send`` / ``broadcast`` JSON command
+body BEFORE raising the human-in-the-loop interrupt, so the operator approves
+the validated form rather than the raw model-authored string. Each handler then
+re-reads that pre-validated command from a sentinel local
+(``validated_send_cmd`` / ``validated_broadcast_cmd``) and refuses outright when
+the sentinel is still ``None``: the pre-pass did not run, so the
+validate-before-HITL contract is broken and there is no validated command to
+dispatch.
+
+Both guards are deliberately an explicit ``raise`` rather than an ``assert``.
+``assert`` is stripped under ``python -O`` / ``PYTHONOPTIMIZE=1``, which would
+turn the guard into a no-op on exactly the interpreters a production deployment
+is most likely to run. :class:`TestTheAssertStrippingPremise` measures that
+stripping, so the choice is a pinned property rather than a comment.
+
+Neither guard had a test. Both are second-line: on today's code the pre-pass
+either sets the sentinel or returns an error, so nothing reaches a handler with
+it unset and a coverage report shows both raise bodies dead. They exist for the
+refactor that changes that -- and the measured cost of losing one is not a tidy
+failure. With the ``broadcast`` guard deleted and ``validate_command`` returning
+``None`` (a validator refactored to validate in place), the handler calls
+``mesh.broadcast(None, timeout=30.0)``: a fleet-wide dispatch of a non-command
+leaves the tool, and the ``AttributeError`` that follows lands on the audit line
+*after* the dispatch, so the dispatch is never recorded. The ``send`` half is the
+same against a single targeted peer.
+
+The guards raise rather than returning the tool's structured error envelope on
+purpose: an unset sentinel is a broken internal contract, not a malformed agent
+tool call, so there is no caller mistake to report and failing loudly is the
+fail-closed answer. The structured-error contract for malformed *input* is
+pinned separately.
+
+Reaching a guard needs the refactor its comment names, modelled here by pointing
+``validate_command`` at a validator that returns ``None`` instead of the
+sanitised copy. That leaves the pre-pass succeeding with the sentinel unset --
+exactly the state the guard exists to catch.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+import sys
+import textwrap
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import strands_robots.tools.robot_mesh as rmt
+
+# The two gated actions whose handler re-reads a pre-validated command body,
+# with the transport method each one dispatches through and the call-arg index
+# holding the command. ``send`` targets one peer (``send(target, cmd, ...)``);
+# ``broadcast`` is fleet-wide (``broadcast(cmd, ...)``).
+_PRE_VALIDATED_ACTIONS: list[tuple[str, str, dict[str, Any], int]] = [
+    ("send", "send", {"target": "peer-b", "command": '{"action": "status"}'}, 1),
+    ("broadcast", "broadcast", {"command": '{"action": "status"}'}, 0),
+]
+
+_ACTION_IDS = [a for a, _, _, _ in _PRE_VALIDATED_ACTIONS]
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Any:
+    """Each gated call consumes a per-action rate-limit slot; reset so the cases
+    stay independent of collection order."""
+    rmt._reset_rate_limits()
+    rmt._reset_interrupt_actions_cache()
+    yield
+    rmt._reset_rate_limits()
+    rmt._reset_interrupt_actions_cache()
+
+
+def _approving_ctx() -> MagicMock:
+    """A ToolContext stand-in whose interrupt returns an operator approval, so
+    the gated action reaches its handler rather than stopping at the HITL gate."""
+    ctx = MagicMock(name="ToolContext")
+    ctx.interrupt.return_value = "y"
+    return ctx
+
+
+def _call(**kwargs: Any) -> Any:
+    """Invoke the underlying tool fn (Strands ``@tool`` wraps it as ``.original``)."""
+    fn = getattr(rmt.robot_mesh, "original", rmt.robot_mesh)
+    return fn(tool_context=_approving_ctx(), **kwargs)
+
+
+@pytest.fixture
+def transport() -> Any:
+    """A local mesh stand-in that records what reaches ``send`` / ``broadcast``."""
+    mesh = MagicMock(name="LocalMesh")
+    mesh.peer_id = "local-a"
+    mesh.peer_type = "sim"
+    mesh.inbox = {}
+    mesh.send.return_value = {"ok": True}
+    mesh.broadcast.return_value = [{"ok": True}]
+    with (
+        patch("strands_robots.mesh.get_local_robots", return_value={"local-a": mesh}),
+        patch("strands_robots.mesh.session.get_peers", return_value=[]),
+    ):
+        yield mesh
+
+
+def _validator_returning_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Model the refactor the guards' comment names: a ``validate_command`` that
+    validates in place and returns ``None`` rather than a sanitised copy.
+
+    The pre-pass then completes without error while leaving its sentinel unset --
+    the only way a handler is reached with no validated command to dispatch.
+    """
+    monkeypatch.setattr(rmt._security, "validate_command", lambda cmd: None)
+
+
+def _robot_mesh_ast() -> ast.FunctionDef:
+    """The ``robot_mesh`` FunctionDef, parsed from the shipped module source."""
+    tree = ast.parse(inspect.getsource(rmt))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "robot_mesh":
+            return node
+    raise AssertionError("robot_mesh function not found in the module source")
+
+
+def _is_none_test(node: ast.expr) -> str | None:
+    """Return the sentinel name for a ``<name> is None`` test, else None."""
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1:
+        return None
+    if not isinstance(node.ops[0], ast.Is) or not isinstance(node.left, ast.Name):
+        return None
+    comparator = node.comparators[0]
+    if isinstance(comparator, ast.Constant) and comparator.value is None:
+        return node.left.id
+    return None
+
+
+def _sentinels_assigned() -> set[str]:
+    """Every ``validated_*_cmd`` sentinel the pre-pass assigns."""
+    found: set[str] = set()
+    for node in ast.walk(_robot_mesh_ast()):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id.startswith("validated_") and target.id.endswith("_cmd"):
+                found.add(target.id)
+    return found
+
+
+def _sentinels_guarded_by_a_raise() -> set[str]:
+    """Every sentinel whose ``is None`` branch raises rather than falling through."""
+    found: set[str] = set()
+    for node in ast.walk(_robot_mesh_ast()):
+        if not isinstance(node, ast.If):
+            continue
+        name = _is_none_test(node.test)
+        if name is None or not (name.startswith("validated_") and name.endswith("_cmd")):
+            continue
+        if any(isinstance(inner, ast.Raise) for inner in ast.walk(ast.Module(body=node.body, type_ignores=[]))):
+            found.add(name)
+    return found
+
+
+class TestTheAssertStrippingPremise:
+    """The reason both guards are an explicit ``raise``: ``-O`` strips ``assert``.
+
+    Measured rather than asserted in a comment, so the choice cannot quietly
+    stop being true for the interpreter the package is shipped against.
+    """
+
+    _SNIPPET = textwrap.dedent(
+        """
+        def handler(sentinel):
+            assert sentinel is not None, "contract broken"
+            return "dispatched"
+
+        print(handler(None))
+        """
+    )
+
+    def test_an_assert_fires_on_a_default_interpreter(self) -> None:
+        proc = subprocess.run([sys.executable, "-c", self._SNIPPET], capture_output=True, text=True, check=False)
+        assert proc.returncode != 0
+        assert "AssertionError" in proc.stderr
+        assert "dispatched" not in proc.stdout
+
+    def test_the_same_assert_is_a_no_op_under_dash_o(self) -> None:
+        proc = subprocess.run([sys.executable, "-O", "-c", self._SNIPPET], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == "dispatched"
+
+
+class TestTheGuardsAreExplicitRaisesNotAsserts:
+    """Every pre-validated sentinel is guarded, and guarded by a ``raise``.
+
+    Derived from the shipped source, so a third gated action that grows a
+    validated command body fails here until its handler carries the guard too.
+    """
+
+    def test_the_sentinel_set_is_the_two_known_command_bodies(self) -> None:
+        assert _sentinels_assigned() == {"validated_send_cmd", "validated_broadcast_cmd"}
+
+    def test_every_assigned_sentinel_is_guarded_by_a_raise(self) -> None:
+        assigned = _sentinels_assigned()
+        assert _sentinels_guarded_by_a_raise() == assigned
+
+    def test_no_sentinel_is_guarded_by_an_assert(self) -> None:
+        """An ``assert`` here would be stripped under ``-O`` (see the premise class)."""
+        asserted = {
+            name
+            for node in ast.walk(_robot_mesh_ast())
+            if isinstance(node, ast.Assert)
+            for name in ast.walk(node.test)
+            if isinstance(name, ast.Name) and name.id.startswith("validated_") and name.id.endswith("_cmd")
+        }
+        assert asserted == set()
+
+
+class TestBothHandlersRefuseWithoutPreValidation:
+    """A handler reached with its sentinel unset refuses, naming the contract."""
+
+    @pytest.mark.parametrize(
+        ("action", "_transport_attr", "kwargs", "_cmd_index"), _PRE_VALIDATED_ACTIONS, ids=_ACTION_IDS
+    )
+    def test_the_guard_names_the_action_and_the_broken_contract(
+        self,
+        transport: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        action: str,
+        _transport_attr: str,
+        kwargs: dict[str, Any],
+        _cmd_index: int,
+    ) -> None:
+        _validator_returning_none(monkeypatch)
+        with pytest.raises(RuntimeError) as excinfo:
+            _call(action=action, **kwargs)
+        message = str(excinfo.value)
+        assert action in message
+        assert "validate-before-HITL contract broken" in message
+        assert "without pre-validation" in message
+
+
+class TestNothingIsDispatchedWhenTheContractIsBroken:
+    """The guard runs before the transport, so a broken contract dispatches nothing.
+
+    This is the property whose absence is expensive: without the guard the
+    handler hands ``None`` to the transport, the dispatch really happens, and the
+    ``AttributeError`` that follows lands after it -- so a fleet-wide (or
+    targeted) command is issued and never audited.
+    """
+
+    @pytest.mark.parametrize(
+        ("action", "transport_attr", "kwargs", "_cmd_index"), _PRE_VALIDATED_ACTIONS, ids=_ACTION_IDS
+    )
+    def test_the_transport_is_never_called(
+        self,
+        transport: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        action: str,
+        transport_attr: str,
+        kwargs: dict[str, Any],
+        _cmd_index: int,
+    ) -> None:
+        _validator_returning_none(monkeypatch)
+        with pytest.raises(RuntimeError):
+            _call(action=action, **kwargs)
+        assert getattr(transport, transport_attr).call_args_list == []
+
+    @pytest.mark.parametrize(
+        ("action", "transport_attr", "kwargs", "_cmd_index"), _PRE_VALIDATED_ACTIONS, ids=_ACTION_IDS
+    )
+    def test_no_dispatch_success_is_audited(
+        self,
+        transport: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        action: str,
+        transport_attr: str,
+        kwargs: dict[str, Any],
+        _cmd_index: int,
+    ) -> None:
+        """No ``success=True`` record for a dispatch that never happened."""
+        audited: list[tuple[str, str, bool, str]] = []
+        monkeypatch.setattr(
+            "strands_robots.tools.robot_mesh._audit_tool_action",
+            lambda a, t, ok, detail: audited.append((a, t, ok, detail)),
+        )
+        _validator_returning_none(monkeypatch)
+        with pytest.raises(RuntimeError):
+            _call(action=action, **kwargs)
+        assert [
+            record for record in audited if record[0] == action and record[2] is True and "approved" not in record[3]
+        ] == []
+
+
+class TestTheHonoredPathStillDispatchesTheValidatedCommand:
+    """Non-vacuity: with the real validator each action dispatches, and what
+    reaches the transport is the validator's sanitised copy -- not the raw
+    model-authored string and not ``None``."""
+
+    @pytest.mark.parametrize(
+        ("action", "transport_attr", "kwargs", "cmd_index"), _PRE_VALIDATED_ACTIONS, ids=_ACTION_IDS
+    )
+    def test_the_transport_receives_the_validated_copy(
+        self,
+        transport: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        action: str,
+        transport_attr: str,
+        kwargs: dict[str, Any],
+        cmd_index: int,
+    ) -> None:
+        real = rmt._security.validate_command
+        returned: list[Any] = []
+
+        def _spy(cmd: dict[str, Any]) -> Any:
+            validated = real(cmd)
+            returned.append(validated)
+            return validated
+
+        monkeypatch.setattr(rmt._security, "validate_command", _spy)
+
+        out = _call(action=action, **kwargs)
+
+        assert out["status"] == "success"
+        assert len(returned) == 1
+        dispatched = getattr(transport, transport_attr).call_args.args[cmd_index]
+        assert dispatched is returned[0]
+        assert isinstance(dispatched, dict)
+        assert dispatched["action"] == "status"


### PR DESCRIPTION
## Problem

`robot_mesh` parses and validates the `send` / `broadcast` JSON command body **before** raising the human-in-the-loop interrupt, so the operator approves the validated form rather than the raw model-authored string. Each handler then re-reads that pre-validated command from a sentinel local and refuses when the sentinel is still `None`:

```python
if validated_broadcast_cmd is None:
    raise RuntimeError(
        "broadcast reached its handler without pre-validation -- validate-before-HITL contract broken"
    )
```

Both guards are an explicit `raise` rather than an `assert`, because `assert` is stripped under `python -O` / `PYTHONOPTIMIZE=1`. Neither had a test. On today's code the pre-pass either sets its sentinel or returns an error, so nothing reaches a handler with it unset and both raise bodies sat unreached — `robot_mesh.py:1187` and `:1207` in the coverage report, and `grep` finds zero references to either sentinel or to the guard message anywhere in `tests/`.

That makes them deletable with the suite green. Measured: **deleting either guard, or replacing one with the `-O`-strippable `assert` its own comment warns against, is invisible to all 275 existing `robot_mesh` tests.**

And the cost of losing one is not a tidy failure. With a guard removed and `validate_command` returning `None` (a validator refactored to validate in place), the handler dispatches the unset sentinel:

| tree | action | reached the transport? | wire | outcome |
|---|---|---|---|---|
| this PR | `send` | no — refused first | *not called* | `RuntimeError: send reached its handler without pre-validation …` |
| this PR | `broadcast` | no — refused first | *not called* | `RuntimeError: broadcast reached its handler without pre-validation …` |
| guard removed | `send` | **yes — dispatched** | `send('peer-b', None)` | `AttributeError: 'NoneType' object has no attribute 'get'` |
| guard removed | `broadcast` | **yes — dispatched** | `broadcast(None)` | `AttributeError: 'NoneType' object has no attribute 'get'` |

The `AttributeError` comes from the `cmd.get(...)` on the audit line, which sits *after* the dispatch — so the fleet-wide (or targeted) command is issued and then **never recorded**: 0 audit records for a dispatch that happened.

## Change

`tests/mesh/test_robot_mesh_validate_before_hitl_contract.py`, 13 cases:

* **`TestTheAssertStrippingPremise`** — measures that `-O` really strips an `assert`, so the reason both guards are an explicit `raise` is a pinned property rather than a comment.
* **`TestBothHandlersRefuseWithoutPreValidation`** — each handler, reached with its sentinel unset, raises naming its action and the broken contract.
* **`TestNothingIsDispatchedWhenTheContractIsBroken`** — the transport is never called, and no dispatch-success record is audited. This is the property whose absence is expensive.
* **`TestTheGuardsAreExplicitRaisesNotAsserts`** — derived from the shipped source: every `validated_*_cmd` sentinel the pre-pass assigns is guarded by a `raise`, and none by an `assert`. A third gated action that grows a validated command body fails here until its handler carries the guard too.
* **`TestTheHonoredPathStillDispatchesTheValidatedCommand`** — non-vacuity: with the real validator both actions dispatch, and what reaches the transport is the validator's sanitised copy (`dispatched is returned[0]`), not the raw string and not `None`.

A guard is reached through exactly the refactor its comment names, modelled by pointing `validate_command` at a validator that returns `None` instead of the sanitised copy. That leaves the pre-pass succeeding with the sentinel unset — the state the guard exists to catch.

The `broadcast` comment claimed the loss would "silently send an unvalidated cmd"; corrected to the measured outcome, and the `send` guard gains a one-line pointer to it so both are self-explaining. **Comment-only** — the AST digest of the module is identical before and after (`7dfbf34b3994bb3b`).

## Why the guards raise instead of returning the error envelope

An unset sentinel is a broken *internal* contract, not a malformed agent tool call: there is no caller mistake to report, and failing loudly is the fail-closed answer. The structured-error contract for malformed *input* is pinned separately in `test_robot_mesh_command_validation.py` and is untouched.

## Mutation table

Two arms — this PR's file, and the 275 pre-existing `robot_mesh` tests (7 files). Each anchor was AST-scoped to `robot_mesh` (`in_fn=1 in_file=1` for all five) and the source restored byte-identically.

| mutation | this PR's tests | pre-existing (275) |
|---|---|---|
| delete the `send` guard | 4 failed | **0 failed — blind** |
| delete the `broadcast` guard | 4 failed | **0 failed — blind** |
| `send` guard → `assert` (`-O` strippable) | 5 failed | **0 failed — blind** |
| `broadcast` guard reads the wrong sentinel | 2 failed | 7 failed |
| `broadcast` guard test inverted | 5 failed | 7 failed |
| *(unmutated control)* | 13 passed | 275 passed |

5 of 5 caught here; **3 of 5 invisible** to the suite as it stands. The last two rows break the honored path as well, which is why the existing tests see them — reported rather than claimed as blind.

Because the production behaviour is correct, the new tests pass on unmodified `main`; what they fail on is a regression, and the table above is that evidence.

## Coverage

`strands_robots/tools/robot_mesh.py` 97 → **95** missing lines; `1187` and `1207` leave the missing list. Mesh suite 2994 → 3007 passed (the before arm omits the new file from the path list, so both arms run under identical conditions).

## Gate

* Full suite: **27579 passed / 257 skipped / 0 failed** (610.89s, `MUJOCO_GL=egl`). Exactly attributable: pristine `main` at `99cb7f7d` is 27566, plus the 13 new cases.
* `ruff check` clean · `ruff format --check` 1164 files already formatted.
* `mypy strands_robots tests tests_integ`: 14 errors, **all** in `examples/isaac_gs`, **0 outside**; the error set is byte-identical to a pristine-`main` worktree of the same working copy, so it is environmental and pre-existing.
* `scripts/check_merge_base_overlap.py`: *No overlap … 0 path(s) changed on `upstream/main` in that span* — the gated tree is the merge result.
* `changelog.d` fragment validates (`assemble_changelog.py --check`, 293 pending).

## Artifact

No policy, simulation, rendering, recording or asset behaviour changes here, so there is no rollout to show — the artifact is the measurement. Every cell is read from a JSON dump produced by one capture script and asserted in the figure generator before the PNG is written.

![robot_mesh validate-before-HITL guard measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/robot-mesh-hitl-guards/robot_mesh_hitl_guards.png)

Capture / compose scripts and the raw `art-facts.json` are on the `artifacts/robot-mesh-hitl-guards` branch; each restores `robot_mesh.py` byte-identically.

## Out of scope

* `robot_mesh.py:433-434` (`_audit_tool_action`'s own best-effort failure branch) and the `emergency_stop` / `subscribe` blocks are separate contracts with their own owners.
* Whether a fired guard should also emit an audit record is a design question, not a coverage gap: the guard raises before any dispatch, so there is nothing to record about the mesh.
