### PR TITLE
test(simulation/mujoco): pin the no-GL-context contract on get_frame

### DIFF
--- a/changelog.d/2129-no-gl-context-contract-on-get-frame.md
+++ b/changelog.d/2129-no-gl-context-contract-on-get-frame.md
@@ -1,0 +1,20 @@
+### Quality: pin the no-OpenGL-context contract on `get_frame`, the renderer consumer that raises
+
+`_get_renderer` returning `None` (no EGL/OSMesa on the host) is answered
+independently by each of its four consumers, and the channels deliberately
+differ: `render` / `render_depth` return a `status=error` agent-tool envelope,
+`_get_sim_observation` skips the camera, and `get_frame` -- which returns raw
+`(rgb, depth)` ndarrays -- raises `RuntimeError`. Three of the four were pinned;
+`get_frame`, the only one that raises, was not, so nothing held it to the
+actionable "install EGL or OSMesa" text and nothing stopped it being
+"harmonised" onto the envelope channel. That would be silently unsafe: a
+two-key envelope unpacks without complaint at a `rgb, depth = sim.get_frame(...)`
+call site, handing the consumer the strings `"status"` and `"content"` and
+failing far from the missing GL context.
+
+Pins the missing cell plus the two documented in-process consumers whose own
+message only names GL because `get_frame` raises
+(`HybridCompositor.render` propagates it; `get_world_point` carries the text
+into its tool envelope), and adds a drift guard so a fifth consumer of the
+shared renderer helper has to decide and record its own no-GL channel. Tests
+only -- no behaviour changes, and none of the new tests needs a GL context.

--- a/tests/simulation/mujoco/test_render_no_gl_context_message.py
+++ b/tests/simulation/mujoco/test_render_no_gl_context_message.py
@@ -1,23 +1,42 @@
-"""render / render_depth surface a clean error when no OpenGL context exists.
+"""Every renderer consumer surfaces a clean, actionable no-OpenGL-context error.
 
 When the offscreen renderer cannot be built (no EGL/OSMesa GL context on the
-host), :meth:`render` and :meth:`render_depth` short-circuit with a structured
-``status=error`` agent-tool dict instead of raising. That message is read
-verbatim by an LLM caller, so it must be a clean sentence: no stray leading or
-trailing whitespace, and it must name the failure and the actionable fix
-(install EGL/OSMesa).
+host), ``_get_renderer`` returns ``None`` and each of its four consumers has to
+answer for itself. They deliberately do *not* share one channel:
+
+* :meth:`render` / :meth:`render_depth` are agent tools, so they short-circuit
+  with a structured ``status=error`` dict. That text is read verbatim by an LLM
+  caller, so it must be a clean sentence: no stray leading or trailing
+  whitespace, naming both the failure and the actionable fix.
+* :meth:`get_frame` returns raw ``(rgb, depth)`` ndarrays to in-process
+  consumers, so it **raises** ``RuntimeError`` with the same actionable text.
+  Mirroring its siblings would be silently unsafe: a two-key envelope unpacks
+  without complaint at a ``rgb, depth = sim.get_frame(...)`` call site, handing
+  the consumer the strings ``"status"`` and ``"content"`` instead of failing.
+* ``_get_sim_observation`` skips the camera and keeps the rest of the
+  observation (pinned next to the other camera-failure paths, in
+  ``test_observation_camera_failure_resilience``).
+
+Both documented in-process consumers of :meth:`get_frame` depend on the raise
+for their own message to name GL:
+:class:`~strands_robots.rendering.HybridCompositor` propagates it, and
+``get_world_point`` catches it and carries the text into its tool envelope.
 
 The renderer-None branch is exercised deterministically by monkeypatching
-``_get_renderer`` to return ``None``, so the test runs on every runner
-regardless of the local GL driver.
+``_get_renderer`` to return ``None``, so these tests run on every runner
+regardless of the local GL driver -- no test here needs a GL context.
 """
 
 from __future__ import annotations
+
+import ast
+import inspect
 
 import pytest
 
 pytest.importorskip("mujoco")
 
+from strands_robots.simulation.mujoco import rendering  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
 
@@ -56,3 +75,136 @@ def test_render_depth_reports_clean_message_when_no_gl_context(sim, monkeypatch)
     assert "Depth rendering unavailable" in text
     assert "OpenGL" in text
     assert ("EGL" in text) or ("OSMesa" in text)
+
+
+# ---------------------------------------------------------------------------
+# get_frame: the raw-frame surface, whose channel is a raise
+# ---------------------------------------------------------------------------
+
+
+def test_get_frame_raises_a_clean_message_when_no_gl_context(sim, monkeypatch):
+    """The third renderer consumer answers with the same actionable sentence.
+
+    ``get_frame`` documents ``RuntimeError`` for "no GL context available"; this
+    pins that the text it raises is as actionable as the two agent-tool
+    surfaces' envelopes, so a caller on a GL-free host learns the same fix from
+    whichever surface they reached.
+    """
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sim.get_frame(camera_name="default", width=4, height=3)
+
+    text = str(excinfo.value)
+    assert text == text.strip()
+    assert "Rendering unavailable" in text
+    assert "OpenGL" in text
+    assert ("EGL" in text) or ("OSMesa" in text)
+
+
+def test_get_frame_raises_rather_than_returning_an_envelope(sim, monkeypatch):
+    """The raw-frame surface must not be "harmonised" onto the envelope channel.
+
+    ``get_frame``'s consumers unpack its return value as a two-tuple, and a
+    two-key envelope dict unpacks without complaint -- so returning one here
+    would hand a consumer the strings ``"status"`` and ``"content"`` and fail
+    much later, far from the missing GL context. The raise is what keeps the
+    failure at its cause.
+    """
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    with pytest.raises(RuntimeError):
+        sim.get_frame(camera_name="default", width=4, height=3)
+
+    # The premise that makes the two channels genuinely different: this is what
+    # a consumer's ``rgb, depth = ...`` would silently bind if the envelope were
+    # returned instead of raised.
+    envelope = {"status": "error", "content": [{"text": "Rendering unavailable ..."}]}
+    first, second = envelope
+    assert (first, second) == ("status", "content")
+
+
+# ---------------------------------------------------------------------------
+# The two documented in-process consumers of get_frame
+# ---------------------------------------------------------------------------
+
+
+def test_the_compositor_surfaces_the_actionable_message(sim, monkeypatch):
+    """``HybridCompositor`` -- named in ``get_frame``'s own docstring -- propagates it."""
+    hybrid = pytest.importorskip("strands_robots.rendering")
+    sim.add_camera(name="look", position=[0.6, -0.5, 0.4], target=[0.0, 0.0, 0.1])
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        hybrid.HybridCompositor(sim).render("look")
+
+    text = str(excinfo.value)
+    assert "OpenGL" in text
+    assert ("EGL" in text) or ("OSMesa" in text)
+
+
+def test_get_world_point_carries_the_actionable_message_into_its_envelope(sim, monkeypatch):
+    """The pixel-grounding tool converts the raise into its own error envelope.
+
+    ``get_world_point`` is an agent tool, so it must not raise -- but the text a
+    caller reads only names GL because ``get_frame`` raised something
+    actionable rather than returning an empty frame.
+    """
+    sim.add_camera(name="look", position=[0.6, -0.5, 0.4], target=[0.0, 0.0, 0.1])
+    monkeypatch.setattr(sim, "_get_renderer", lambda w, h: None)
+
+    result = sim.get_world_point(camera_name="look", pixels=[[2, 1]], width=4, height=3)
+
+    text = _error_text(result)
+    assert "OpenGL" in text
+    assert ("EGL" in text) or ("OSMesa" in text)
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: a fifth consumer must decide and pin its own channel
+# ---------------------------------------------------------------------------
+
+#: Every consumer of ``_get_renderer``, and where its ``renderer is None``
+#: channel is pinned.  Keyed on the method name so a consumer added later fails
+#: this test until someone decides what it does without a GL context.
+_NO_GL_CHANNEL = {
+    "render": "error envelope (this module)",
+    "render_depth": "error envelope (this module)",
+    "get_frame": "raises RuntimeError (this module)",
+    "_get_sim_observation": "skips the camera (test_observation_camera_failure_resilience)",
+}
+
+
+def _renderer_consumers() -> set[str]:
+    """Method names that ask ``_get_renderer`` for an offscreen renderer."""
+    source = inspect.getsource(rendering)
+    tree = ast.parse(source)
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if node.name == "_get_renderer":
+            continue
+        segment = ast.get_source_segment(source, node) or ""
+        if "self._get_renderer(" in segment:
+            found.add(node.name)
+    return found
+
+
+def test_every_renderer_consumer_has_a_pinned_no_gl_channel():
+    """The no-GL matrix is complete.
+
+    ``_get_renderer`` returning ``None`` is not an error in itself -- each
+    consumer chooses how to answer, and the choices genuinely differ (envelope,
+    raise, skip).  A new consumer that never decides would silently inherit
+    whatever falls out of its own control flow, so this pins the set.
+    """
+    consumers = _renderer_consumers()
+
+    assert consumers, "no _get_renderer consumers found -- the scan is looking in the wrong module"
+    assert consumers == set(_NO_GL_CHANNEL), (
+        "the set of _get_renderer consumers changed: "
+        f"unpinned={sorted(consumers - set(_NO_GL_CHANNEL))} "
+        f"stale={sorted(set(_NO_GL_CHANNEL) - consumers)}. "
+        "Decide what the new consumer does without a GL context, pin it, and record it here."
+    )


### PR DESCRIPTION
## Problem

`RenderingMixin._get_renderer` returns `None` when no offscreen GL context can be built (no EGL/OSMesa on the host). It has **four** consumers, and they deliberately do *not* share one channel:

| consumer | no-GL channel | pinned before |
|---|---|---|
| `render` | `status=error` agent-tool envelope | yes |
| `render_depth` | `status=error` agent-tool envelope | yes |
| `_get_sim_observation` | skips the camera, keeps the rest | yes |
| **`get_frame`** | **raises `RuntimeError`** | **no** |

`get_frame` is the raw-frame surface — it hands `(rgb, depth)` ndarrays to in-process consumers rather than an envelope — so it is the only one that raises, and it was the only one nothing drove. `rendering.py:1302` (the raise itself) was unexecuted by the whole suite.

Two consequences went unpinned with it:

**1. Nothing held the message to its actionable text.** `get_frame` documents `RuntimeError` for "no GL context available" in its own `Raises:` block; nothing checked that the sentence a caller reads still names OpenGL and the fix, the way the two envelope surfaces are checked.

**2. Nothing stopped it being "harmonised" onto its siblings' channel** — and that would be silently unsafe, not merely different. A two-key envelope unpacks *without complaint* at a consumer's `rgb, depth = sim.get_frame(...)` call site:

```python
>>> a, b = {"status": "error", "content": [{"text": "Rendering unavailable ..."}]}
>>> (a, b)
('status', 'content')
>>> np.asarray(a).shape
()
```

So returning an envelope here would bind the strings `"status"` and `"content"` into a consumer's rgb/depth locals and fail much later, far from the missing GL context. Both documented in-process consumers depend on the raise for their own message to name GL at all — measured with `_get_renderer` forced to `None`:

- `HybridCompositor.render` (named in `get_frame`'s docstring) propagates `RuntimeError: Rendering unavailable (no OpenGL context). Install EGL or OSMesa ...`
- `get_world_point` catches it and carries the text into its tool envelope: `get_world_point failed to render camera frame: Rendering unavailable (no OpenGL context). Install EGL or OSMesa ...`

## Change

Tests only — no production line changes. `tests/simulation/mujoco/test_render_no_gl_context_message.py` already owns this contract, so the five new cases go there and its module docstring is rewritten to state the full contract (four consumers, three channels, and why the raw-frame one differs) rather than only the two envelope surfaces:

1. `get_frame` raises a clean, actionable message — **the missing matrix cell, and the only new line of coverage.**
2. `get_frame` raises rather than returning an envelope, with the unpack hazard above as the stated reason.
3. `HybridCompositor.render` surfaces the actionable message.
4. `get_world_point` carries it into its own error envelope.
5. A drift guard: the set of `_get_renderer` consumers is AST-derived and pinned, so a fifth consumer fails this test until someone decides and records its no-GL channel.

`_get_renderer` is monkeypatched to return `None`, so **none of the seven tests in the module needs a GL context** — verified by re-running the module with the renderer probe forced off (`7 passed`).

## Why the new tests are load-bearing

The production code is correct, so these tests pass on unmodified `main`; what they fail on is a regression. Six plausible ones, each AST-scoped to its enclosing function, run against two arms — the new cases, and the **290** tests already covering `get_frame`, the renderer-`None` family and the compositor (`test_get_frame_camera_params.py`, `test_observation_camera_failure_resilience.py`, `tests/rendering/`, plus this module's two pre-existing tests):

| | regression introduced | new tests | suite as it stands |
|---|---|---|---|
| M1 | `get_frame` returns the envelope instead of raising | 4 failed | 0 — blind |
| M2 | `get_frame` drops the renderer-`None` guard | 4 failed | 0 — blind |
| M3 | `get_frame` loses the actionable install hint | 3 failed | 0 — blind |
| M4 | `get_frame` raises a message naming neither GL nor the fix | 3 failed | 0 — blind |
| M5 | `get_world_point` stops converting the raise to an envelope | 1 failed | 0 — blind |
| M6 | a fifth renderer consumer ships undecided | 1 failed | 0 — blind |

6 of 6 caught by the new tests, 0 of 6 by the existing suite (290 passed on every mutation) — and each is caught by a **different subset**, so the five tests are not copies of one another. Both mutated sources are restored in a `finally` and asserted byte-identical.

M6 is worth a note: modelling it as an extra `_get_renderer` call *inside* an existing consumer was **not** caught, correctly — an existing consumer has already decided its channel. Re-modelled faithfully as a new consumer *method*, the drift guard catches it.

## Coverage

`rendering.py:1302` was missing in the full-suite report at this base and is now covered. On the module subset (this file + `test_get_frame_camera_params.py` + `test_observation_camera_failure_resilience.py` + `tests/rendering/`), deselecting only the five new cases as the before-arm:

- `rendering.py` 629 → 628 missing, with `1302` gone from the missing list
- `simulation/base.py` 660 → 633 missing (the `get_world_point` render path)
- 290 → 295 passed

## Artifact

![no-GL-context contract](https://raw.githubusercontent.com/cagataycali/robots/artifacts/no-gl-context-contract/no_gl_context_contract.png)

Left: a real headless MuJoCo frame through the surface under test (`sim.get_frame('look', 640, 520)` — rgb `(520, 640, 3)` uint8, metric depth 0.61–50.0 m, 90.4% saturated), included to ground what a GL-capable host gets and to show that this PR moves none of it. On a host with no EGL/OSMesa there is no frame at all, and what a caller gets instead is the contract in the right-hand panel. Every number in the figure is re-derived from the measurement dump and asserted by the generator; [capture / compose / mutation scripts](https://github.com/cagataycali/robots/tree/artifacts/no-gl-context-contract).

## Out of scope

`render` and `render_depth` do not *document* their no-GL error envelope in their own docstrings (only `get_frame` documents its raise). Making both channels discoverable from the docstrings is a separate, prose-only change and is not bundled here.

## Gate

Base `99cb7f7d`, head `465689e4`. The overlap check reports no overlap (0 paths changed on `upstream/main` in that span) and `compare` reports `behind_by=0`, so the tree these numbers describe is the merge result.

- `MUJOCO_GL=egl pytest tests` — **27571 passed, 257 skipped, 0 failed** (608.53s). Pristine `main` at the same base is 27566 passed / 257 skipped, and 27566 + 5 new = 27571.
- Module alone: 7 passed (0.65s). On a GL-free host: 7 passed.
- Repo-wide root guards + `Args:` completeness + the GL-gate guard: 428 passed.
- `ruff check` clean, `ruff format --check` 1163 files already formatted, `mypy strands_robots tests tests_integ` **0 errors outside `examples/isaac_gs`** (the 14 there are byte-identical to a pristine-base worktree of the same working copy, i.e. environmental).
