### PR TITLE
fix: __repr__ must not hide the constructor refusal that produced the object

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,18 @@ hatch run format            # ruff check --fix, ruff format
     which is read as a single parameter literally named `"a / b"` and therefore
     describes neither. Pinned by
     tests/tools/test_agent_tool_parameter_descriptions.py.
+14. **`__repr__` must not raise** - it is what a traceback, a debugger and a
+    failing assertion render, so it must not be the thing that hides a failure.
+    A class that validates its own arguments raises before it assigns the
+    attributes its `__repr__` reads, and the raising frame keeps that half-built
+    instance alive: rendering it reports `[AttributeError ... raised in repr()]`
+    naming an attribute that has nothing to do with the refusal under
+    investigation. Wrap the body in `try` / `except AttributeError` and return
+    `strands_robots.utils.partial_construction_repr(self)`, which reports the
+    lifecycle fact and deliberately names no attribute so nobody is sent
+    chasing one. That helper owns the wording, so the phrase a reader learns to
+    recognise cannot diverge between layers. Pinned by
+    tests/test_repr_survives_partial_construction.py.
 
 ## PR Workflow
 

--- a/changelog.d/2130-repr-survives-partial-construction.md
+++ b/changelog.d/2130-repr-survives-partial-construction.md
@@ -1,0 +1,20 @@
+### Fixed: `__repr__` no longer hides the constructor refusal that produced a half-built object
+
+`repr` is what a traceback, a debugger and a failing assertion render. Ten
+classes read instance attributes their `__init__` assigns only *after*
+validating the caller's arguments, so a refusal left an instance whose
+rendering reported `[AttributeError ... raised in repr()]` naming an attribute
+unrelated to the refusal. `RosBridgedRobot(node_name="bad name!")` raised
+`ValueError: invalid node_name: 'bad name!'`, and rendering the instance the
+raising frame still held reported `'RosBridgedRobot' object has no attribute
+'node_name'` - sending the reader after an attribute instead of the value they
+had already passed.
+
+`RosBridgedRobot`, `RosbridgeRobot`, `RtpsRobot`, `HardwareRtpsBridge`,
+`InputPublisher`, `InputReceiver`, `Mesh`, `PeerInfo`, `DatasetRecorder` and
+`ProcessorBridge` now report the lifecycle fact instead, through the new
+`strands_robots.utils.partial_construction_repr`. It names no attribute, so
+nobody is sent chasing one, and it owns the wording `IsaacSimulation` already
+used - which now routes through it - so the phrase a reader recognises in a
+traceback cannot diverge between layers. A fully constructed instance is
+unaffected.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -38,6 +38,7 @@ from strands_robots.utils import (
     lerobot_version,
     name_list_error,
     non_negative_whole_number_error,
+    partial_construction_repr,
     positive_count_error,
     positive_whole_number_error,
     sequence_length,
@@ -1772,7 +1773,10 @@ class DatasetRecorder:
         return str(self.dataset.root)
 
     def __repr__(self) -> str:
-        return f"DatasetRecorder(repo_id={self.repo_id}, episodes={self.episode_count}, frames={self.frame_count})"
+        try:
+            return f"DatasetRecorder(repo_id={self.repo_id}, episodes={self.episode_count}, frames={self.frame_count})"
+        except AttributeError:
+            return partial_construction_repr(self)
 
 
 # Shared replay-episode helpers

--- a/strands_robots/hardware_rtps_bridge.py
+++ b/strands_robots/hardware_rtps_bridge.py
@@ -44,7 +44,12 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.ros_telemetry import RosTelemetryBase
-from strands_robots.utils import dds_domain_id_error, positive_finite_number_error, require_optional
+from strands_robots.utils import (
+    dds_domain_id_error,
+    partial_construction_repr,
+    positive_finite_number_error,
+    require_optional,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -379,7 +384,10 @@ class HardwareRtpsBridge(RosTelemetryBase):
         self._participant = None
 
     def __repr__(self) -> str:
-        return (
-            f"HardwareRtpsBridge(robot={self._robot_name!r}, domain_id={self._domain_id}, "
-            f"enable_commands={self._enable_commands})"
-        )
+        try:
+            return (
+                f"HardwareRtpsBridge(robot={self._robot_name!r}, domain_id={self._domain_id}, "
+                f"enable_commands={self._enable_commands})"
+            )
+        except AttributeError:
+            return partial_construction_repr(self)

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -41,6 +41,7 @@ from strands_robots.mesh.session import (
 from strands_robots.mesh.session import (
     get_peers as _session_get_peers,
 )
+from strands_robots.utils import partial_construction_repr
 
 logger = logging.getLogger(__name__)
 
@@ -494,8 +495,11 @@ class Mesh(SensorLoopsMixin):
         self._safety_sn_lock = threading.Lock()
 
     def __repr__(self) -> str:
-        state = "alive" if self._running else "stopped"
-        return f"Mesh(peer_id={self.peer_id!r}, type={self.peer_type!r}, {state})"
+        try:
+            state = "alive" if self._running else "stopped"
+            return f"Mesh(peer_id={self.peer_id!r}, type={self.peer_type!r}, {state})"
+        except AttributeError:
+            return partial_construction_repr(self)
 
     def _refuse_under_permissive_default_acl(self) -> bool:
         """Refuse-to-start gate per issue #218.

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -33,7 +33,7 @@ from strands_robots.mesh.security import (
     validate_mesh_identifier,
 )
 from strands_robots.mesh.session import hz_from_env
-from strands_robots.utils import positive_finite_number_error
+from strands_robots.utils import partial_construction_repr, positive_finite_number_error
 
 _log_safety_event: Callable[..., None] | None
 try:  # audit is best-effort; never let an import issue break teleop apply
@@ -166,8 +166,11 @@ class InputPublisher:
         self._start_time = 0.0
 
     def __repr__(self) -> str:
-        state = "running" if self._running else "stopped"
-        return f"InputPublisher(device={self.device_name!r}, method={self.method!r}, {state})"
+        try:
+            state = "running" if self._running else "stopped"
+            return f"InputPublisher(device={self.device_name!r}, method={self.method!r}, {state})"
+        except AttributeError:
+            return partial_construction_repr(self)
 
     @property
     def topic(self) -> str:
@@ -352,8 +355,11 @@ class InputReceiver:
         self._start_time = 0.0
 
     def __repr__(self) -> str:
-        state = "running" if self._running else "stopped"
-        return f"InputReceiver(source={self.source_peer_id!r}, device={self.device_name!r}, {state})"
+        try:
+            state = "running" if self._running else "stopped"
+            return f"InputReceiver(source={self.source_peer_id!r}, device={self.device_name!r}, {state})"
+        except AttributeError:
+            return partial_construction_repr(self)
 
     @property
     def topic(self) -> str:

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -46,6 +46,7 @@ from strands.types.tools import AgentTool
 from strands_robots.tools.use_ros import use_ros
 from strands_robots.utils import (
     finite_number_error,
+    partial_construction_repr,
     positive_finite_number_error,
     positive_whole_number_error,
 )
@@ -364,7 +365,10 @@ class RosBridgedRobot:
         return agent_tools
 
     def __repr__(self) -> str:
-        return (
-            f"RosBridgedRobot(node_name={self.node_name!r}, cmd_vel_topic={self.cmd_vel_topic!r}, "
-            f"odom_topic={self.odom_topic!r}, scan_topic={self.scan_topic!r})"
-        )
+        try:
+            return (
+                f"RosBridgedRobot(node_name={self.node_name!r}, cmd_vel_topic={self.cmd_vel_topic!r}, "
+                f"odom_topic={self.odom_topic!r}, scan_topic={self.scan_topic!r})"
+            )
+        except AttributeError:
+            return partial_construction_repr(self)

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -38,6 +38,7 @@ from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_rosbridge import _HOST_RE, _transport_port_error, use_rosbridge
 from strands_robots.utils import (
     finite_number_error,
+    partial_construction_repr,
     positive_finite_number_error,
     positive_whole_number_error,
     tcp_port_error,
@@ -319,7 +320,10 @@ class RosbridgeRobot:
         return agent_tools
 
     def __repr__(self) -> str:
-        return (
-            f"RosbridgeRobot(node_name={self.node_name!r}, ws://{self.host}:{self.port}, "
-            f"cmd_vel_topic={self.cmd_vel_topic!r}, odom_topic={self.odom_topic!r})"
-        )
+        try:
+            return (
+                f"RosbridgeRobot(node_name={self.node_name!r}, ws://{self.host}:{self.port}, "
+                f"cmd_vel_topic={self.cmd_vel_topic!r}, odom_topic={self.odom_topic!r})"
+            )
+        except AttributeError:
+            return partial_construction_repr(self)

--- a/strands_robots/mesh/rtps_robot.py
+++ b/strands_robots/mesh/rtps_robot.py
@@ -41,6 +41,7 @@ from strands.types.tools import AgentTool
 from strands_robots.tools.use_rtps import use_rtps
 from strands_robots.utils import (
     finite_number_error,
+    partial_construction_repr,
     positive_finite_number_error,
     positive_whole_number_error,
 )
@@ -198,7 +199,10 @@ class RtpsRobot:
         return [drive, stop]
 
     def __repr__(self) -> str:
-        return (
-            f"RtpsRobot(node_name={self.node_name!r}, cmd_vel_topic={self.cmd_vel_topic!r}, "
-            f"cmd_vel_type={self.cmd_vel_type!r})"
-        )
+        try:
+            return (
+                f"RtpsRobot(node_name={self.node_name!r}, cmd_vel_topic={self.cmd_vel_topic!r}, "
+                f"cmd_vel_type={self.cmd_vel_type!r})"
+            )
+        except AttributeError:
+            return partial_construction_repr(self)

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -41,6 +41,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from strands_robots.utils import partial_construction_repr
+
 logger = logging.getLogger(__name__)
 
 
@@ -244,7 +246,10 @@ class PeerInfo:
         }
 
     def __repr__(self) -> str:
-        return f"PeerInfo(peer_id={self.peer_id!r}, type={self.peer_type!r}, age={self.age:.1f}s)"
+        try:
+            return f"PeerInfo(peer_id={self.peer_id!r}, type={self.peer_type!r}, age={self.age:.1f}s)"
+        except AttributeError:
+            return partial_construction_repr(self)
 
 
 # Peer registry - shared across all Mesh instances in the same process

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -17,7 +17,7 @@ Architecture:
 import logging
 from typing import Any
 
-from ...utils import require_optional
+from ...utils import partial_construction_repr, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -890,9 +890,12 @@ class ProcessorBridge:
             self._postprocessor.reset()
 
     def __repr__(self) -> str:
-        pre = f"pre={len(self._preprocessor)}steps" if self._preprocessor else "pre=None"
-        post = f"post={len(self._postprocessor)}steps" if self._postprocessor else "post=None"
-        return f"ProcessorBridge({pre}, {post})"
+        try:
+            pre = f"pre={len(self._preprocessor)}steps" if self._preprocessor else "pre=None"
+            post = f"post={len(self._postprocessor)}steps" if self._postprocessor else "post=None"
+            return f"ProcessorBridge({pre}, {post})"
+        except AttributeError:
+            return partial_construction_repr(self)
 
     def get_info(self) -> dict[str, Any]:
         """Return a summary dict describing the processor bridge state.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -51,6 +51,7 @@ from strands_robots.utils import (
     entity_name_error,
     name_list_error,
     non_negative_whole_number_error,
+    partial_construction_repr,
     positive_count_error,
     positive_whole_number_error,
     step_aborted_msg,
@@ -6309,4 +6310,4 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                 f"world={'created' if self._world_created else 'none'})"
             )
         except AttributeError:
-            return f"IsaacSimulation(partially constructed, id=0x{id(self):x})"
+            return partial_construction_repr(self)

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2381,3 +2381,30 @@ def boolean_flag_error(value: Any, param: str, context: str) -> str | None:
         "rather than parsed - a truthy spelling of off, such as 'false', would "
         "otherwise select the opposite posture from the one it reads as."
     )
+
+
+def partial_construction_repr(obj: object) -> str:
+    """Describe an object whose ``__init__`` did not finish, naming no attribute.
+
+    ``repr`` is what a traceback, a debugger and a failing assertion render, so
+    it must not be the thing that hides a failure. A class that validates its
+    own arguments raises before it assigns the attributes its ``__repr__``
+    reads, and the raising frame keeps that half-built instance alive - so
+    rendering it reports ``[AttributeError ... raised in repr()]`` naming an
+    attribute that has nothing to do with the refusal under investigation.
+    Returning this instead reports the lifecycle fact that *is* relevant, and
+    deliberately names no attribute so nobody is sent chasing one.
+
+    The wording lives here rather than beside any one caller because those
+    callers sit in different layers - the ROS 2 / rosbridge / RTPS transport
+    bridges, the teleop input streams, the dataset recorder, the peer registry
+    and the simulation engines - and the phrase a reader learns to recognise in
+    a traceback must not diverge between them.
+
+    Args:
+        obj: The partially constructed object being rendered.
+
+    Returns:
+        ``"<ClassName>(partially constructed, id=0x...)"``.
+    """
+    return f"{type(obj).__name__}(partially constructed, id=0x{id(obj):x})"

--- a/tests/test_repr_survives_partial_construction.py
+++ b/tests/test_repr_survives_partial_construction.py
@@ -116,16 +116,36 @@ def _renders_a_half_built_instance(cls: type) -> str | None:
     ``__new__`` is called directly, and the class bound through ``Any`` to say so:
     skipping ``__init__`` is the point, because it produces the worst case of the
     state a refusal leaves behind - an instance on which no attribute exists yet.
+
+    The handler catches ``Exception`` and stops there. A failure inside ``repr``
+    is the answer being collected - it is the defect this module pins - so it has
+    to become a verdict rather than abort the survey. An interrupt is not an
+    answer about a ``repr``, though: swallowing ``BaseException`` would record an
+    operator's Ctrl-C as "this class cannot render a half-built instance", fail
+    the assertion naming the wrong cause, and carry on to the next class.
+    ``pytest``'s own ``skip`` and ``fail`` outcomes derive from ``BaseException``
+    for the same reason, so they have to reach the runner instead of becoming a
+    verdict about the class under survey.
     """
     factory: Any = cls
     obj = factory.__new__(factory)
     try:
         rendered = repr(obj)
-    except BaseException as exc:  # noqa: BLE001 - any failure here is the defect
+    except Exception as exc:  # noqa: BLE001 - a repr failure is a verdict, control flow is not
         return f"{type(exc).__name__}: {exc}"
     if cls.__name__ not in rendered:
         return f"does not identify its type: {rendered!r}"
     return None
+
+
+def _raising_repr(exc: BaseException) -> type:
+    """A class whose ``__repr__`` raises, so the classifier's handler width is observable."""
+
+    class _Raising:
+        def __repr__(self) -> str:
+            raise exc
+
+    return _Raising
 
 
 DISCOVERED = _classes_defining_repr()
@@ -369,3 +389,50 @@ class TestTheFallbackWordingHasOneOwner:
     def test_the_helper_is_the_only_definition_of_the_wording(self) -> None:
         source = textwrap.dedent(inspect.getsource(partial_construction_repr))
         assert FALLBACK_PHRASE in source
+
+
+class TestTheReprClassifierCollectsFailuresWithoutSwallowingControlFlow:
+    """``_renders_a_half_built_instance`` must catch a repr failure and only that.
+
+    The classifier turns "what did this class's ``repr`` do with a half-built
+    instance" into a verdict string so the survey above can compare every class
+    in the package. A raise is one of the answers it has to collect - the
+    escaping ``AttributeError`` is the defect this file pins - so a failure
+    inside ``repr`` cannot be allowed to abort the survey. An interrupt is not
+    an answer about a ``repr``, though: recording one as "this class cannot
+    render a half-built instance" would fail the assertion naming the wrong
+    cause and carry on to the next class. Both halves are pinned here because
+    the correct handler is the one that satisfies both.
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            AttributeError("'RosBridgedRobot' object has no attribute 'node_name'"),
+            TypeError("unsupported format string passed to NoneType.__format__"),
+            RuntimeError("Rendering unavailable (no OpenGL context)"),
+        ],
+        ids=["AttributeError", "TypeError", "RuntimeError"],
+    )
+    def test_a_repr_failure_is_collected_as_a_verdict(self, exc: Exception) -> None:
+        """The escape this file exists to pin must reach the survey, not the runner."""
+        problem = _renders_a_half_built_instance(_raising_repr(exc))
+        assert problem == f"{type(exc).__name__}: {exc}"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            KeyboardInterrupt(),
+            SystemExit(1),
+            pytest.skip.Exception("the optional dependency this repr reads is absent"),
+            pytest.fail.Exception("the fixture for this class is incomplete"),
+        ],
+        ids=["KeyboardInterrupt", "SystemExit", "pytest.skip", "pytest.fail"],
+    )
+    def test_control_flow_reaches_the_runner_instead_of_becoming_a_verdict(self, exc: BaseException) -> None:
+        # Executable premise: each of these derives from BaseException without
+        # deriving from Exception, which is the whole reason the handler width
+        # is observable at all.
+        assert not isinstance(exc, Exception), f"{type(exc).__name__} no longer tests the handler width"
+        with pytest.raises(type(exc)):
+            _renders_a_half_built_instance(_raising_repr(exc))

--- a/tests/test_repr_survives_partial_construction.py
+++ b/tests/test_repr_survives_partial_construction.py
@@ -1,0 +1,371 @@
+"""``__repr__`` must survive an instance whose ``__init__`` never finished.
+
+``repr`` is what a traceback, a debugger and a failing assertion render. A class
+that validates its own arguments raises *before* it assigns the attributes its
+``__repr__`` reads, and the raising frame keeps that half-built instance alive -
+so rendering it reports ``[AttributeError ... raised in repr()]`` naming an
+attribute that has nothing to do with the refusal under investigation. Pytest
+shows it as::
+
+    assert <[AttributeError("'RosBridgedRobot' object has no attribute
+    'node_name'") raised in repr()] RosBridgedRobot object at 0x...> is None
+
+which sends the reader after ``node_name`` when the real failure was
+``ValueError: invalid node_name: 'bad!'`` - the value they already passed.
+
+This module pins the contract behaviourally rather than structurally, because a
+static check cannot tell a repr that *would* raise from one whose attributes
+happen to be assigned early enough: the survey below constructs the worst case
+of a half-built instance (``cls.__new__(cls)``, where no attribute exists at
+all) and renders it. That needs no heuristic and therefore no exemption list.
+
+Three properties are pinned:
+
+* every class in the package that defines ``__repr__`` renders a half-built
+  instance without raising, and still identifies its own type;
+* a real, documented constructor refusal leaves an instance a reader can render,
+  reporting the lifecycle fact and naming no attribute;
+* a fully constructed instance is unaffected - it still names its fields, and
+  never claims to be partially constructed.
+
+The fallback wording has one owner,
+:func:`strands_robots.utils.partial_construction_repr`, so the phrase a reader
+learns to recognise in a traceback cannot diverge between the transport
+bridges, the teleop input streams, the dataset recorder, the peer registry and
+the simulation engines.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+import strands_robots
+from strands_robots.dataset_recorder import DatasetRecorder
+from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
+from strands_robots.mesh.core import Mesh
+from strands_robots.mesh.input import InputPublisher, InputReceiver
+from strands_robots.mesh.ros_bridge import RosBridgedRobot
+from strands_robots.mesh.rosbridge_robot import RosbridgeRobot
+from strands_robots.mesh.rtps_robot import RtpsRobot
+from strands_robots.mesh.security import ValidationError
+from strands_robots.mesh.session import PeerInfo
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+from strands_robots.utils import partial_construction_repr
+
+#: The phrase the shared fallback reports. Pinned here so a rewording has to be
+#: a deliberate edit in two places rather than a silent drift in one.
+FALLBACK_PHRASE = "partially constructed"
+
+#: Every class in the package that defines ``__repr__``, as
+#: ``"<module path relative to the package>::<class>"``. Asserted to equal what
+#: the survey discovers, so a class that grows a ``__repr__`` later has to be
+#: triaged here rather than joining the untested set silently.
+EXPECTED_REPR_CLASSES = frozenset(
+    {
+        "dataset_recorder::DatasetRecorder",
+        "hardware_rtps_bridge::HardwareRtpsBridge",
+        "mesh/core::Mesh",
+        "mesh/input::InputPublisher",
+        "mesh/input::InputReceiver",
+        "mesh/ros_bridge::RosBridgedRobot",
+        "mesh/rosbridge_robot::RosbridgeRobot",
+        "mesh/rtps_robot::RtpsRobot",
+        "mesh/session::PeerInfo",
+        "policies/lerobot_local/processor::ProcessorBridge",
+        "simulation/isaac/simulation::IsaacSimulation",
+    }
+)
+
+
+def _package_root() -> pathlib.Path:
+    """Locate the installed package from the imported module, never a path literal."""
+    return pathlib.Path(inspect.getfile(strands_robots)).parent
+
+
+def _classes_defining_repr() -> dict[str, type]:
+    """Discover, and import, every class in the package that defines ``__repr__``."""
+    root = _package_root()
+    found: dict[str, type] = {}
+    for path in sorted(root.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "def __repr__" not in source:
+            continue
+        rel = path.relative_to(root).with_suffix("")
+        dotted = "strands_robots." + str(rel).replace("/", ".")
+        dotted = dotted.removesuffix(".__init__")
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if not any(isinstance(f, ast.FunctionDef) and f.name == "__repr__" for f in node.body):
+                continue
+            key = f"{str(rel).removesuffix('/__init__')}::{node.name}"
+            found[key] = getattr(importlib.import_module(dotted), node.name)
+    return found
+
+
+def _renders_a_half_built_instance(cls: type) -> str | None:
+    """Return the failure for ``repr`` on a half-built ``cls``, or ``None`` if it survives.
+
+    ``__new__`` is called directly, and the class bound through ``Any`` to say so:
+    skipping ``__init__`` is the point, because it produces the worst case of the
+    state a refusal leaves behind - an instance on which no attribute exists yet.
+    """
+    factory: Any = cls
+    obj = factory.__new__(factory)
+    try:
+        rendered = repr(obj)
+    except BaseException as exc:  # noqa: BLE001 - any failure here is the defect
+        return f"{type(exc).__name__}: {exc}"
+    if cls.__name__ not in rendered:
+        return f"does not identify its type: {rendered!r}"
+    return None
+
+
+DISCOVERED = _classes_defining_repr()
+
+
+def _live_self(exc: BaseException, cls: type) -> Any:
+    """Return the half-built ``cls`` the raising frame still holds, as a reader sees it."""
+    tb, found = exc.__traceback__, None
+    while tb is not None:
+        candidate = tb.tb_frame.f_locals.get("self")
+        if type(candidate) is cls:
+            found = candidate
+        tb = tb.tb_next
+    return found
+
+
+class _Mesh:
+    """The members the input streams touch before they validate their arguments."""
+
+    peer_id = "arm"
+    alive = True
+
+    def subscribe(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def unsubscribe(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def _fake_mesh() -> Any:
+    """Return the structural mesh stand-in the input streams accept.
+
+    Annotated ``Any`` because a real :class:`strands_robots.mesh.core.Mesh` would
+    need a live session, and neither stream reads more than the members above
+    before the validation this module drives.
+    """
+    return _Mesh()
+
+
+class _Robot:
+    tool_name_str = "arm"
+
+
+class _Dataset:
+    repo_id = "user/dataset"
+    root = pathlib.Path("/tmp")
+
+
+#: ``(class, the refusal it raises, a call that triggers it, the attribute the
+#: old repr reported)``. Every refusal here is the class's own validation of the
+#: caller's arguments - the reward for which used to be a traceback naming the
+#: attribute in the fourth column instead of the value in the message.
+REFUSALS: list[tuple[type, type[Exception], Any, str]] = [
+    (
+        RosBridgedRobot,
+        ValueError,
+        lambda: RosBridgedRobot(node_name="bad name!", cmd_vel_topic="/cmd_vel", odom_topic="/odom"),
+        "node_name",
+    ),
+    (
+        RosbridgeRobot,
+        ValueError,
+        lambda: RosbridgeRobot(
+            node_name="bad name!",
+            cmd_vel_topic="/cmd_vel",
+            odom_topic="/odom",
+            host="127.0.0.1",
+            port=9090,
+        ),
+        "node_name",
+    ),
+    (RtpsRobot, ValueError, lambda: RtpsRobot(node_name="bad name!", cmd_vel_topic="/cmd_vel"), "node_name"),
+    (HardwareRtpsBridge, ValueError, lambda: HardwareRtpsBridge(None, domain_id=99999), "_robot_name"),
+    (
+        InputPublisher,
+        ValueError,
+        lambda: InputPublisher(_fake_mesh(), object(), device_name="leader", hz=0),
+        "_running",
+    ),
+    (InputReceiver, ValidationError, lambda: InputReceiver(_fake_mesh(), object(), source_peer_id="**"), "_running"),
+]
+
+#: ``(label, a call that succeeds, a field the repr must name)``.
+#: ``HardwareRtpsBridge`` is absent because a working instance needs cyclonedds;
+#: its refusal path above needs none, which is the half this module is about.
+BUILDABLE: list[tuple[str, Any, str]] = [
+    (
+        "RosBridgedRobot",
+        lambda: RosBridgedRobot(node_name="/turtle1", cmd_vel_topic="/cmd_vel", odom_topic="/odom"),
+        "/turtle1",
+    ),
+    (
+        "RosbridgeRobot",
+        lambda: RosbridgeRobot(
+            node_name="/turtle1", cmd_vel_topic="/cmd_vel", odom_topic="/odom", host="127.0.0.1", port=9090
+        ),
+        "9090",
+    ),
+    ("RtpsRobot", lambda: RtpsRobot(node_name="/arm", cmd_vel_topic="/cmd_vel"), "/arm"),
+    ("Mesh", lambda: Mesh(_Robot(), peer_id="arm", peer_type="robot"), "arm"),
+    ("PeerInfo", lambda: PeerInfo(peer_id="arm", peer_type="robot", last_seen=0.0), "arm"),
+    ("DatasetRecorder", lambda: DatasetRecorder(dataset=_Dataset()), "user/dataset"),
+    ("InputPublisher", lambda: InputPublisher(_fake_mesh(), object(), device_name="leader", hz=50.0), "leader"),
+    (
+        "InputReceiver",
+        lambda: InputReceiver(_fake_mesh(), object(), source_peer_id="peer", device_name="leader"),
+        "peer",
+    ),
+    ("ProcessorBridge", lambda: ProcessorBridge(None, None), "pre=None"),
+]
+
+
+class TestEveryReprSurvivesAHalfBuiltInstance:
+    """The contract, over every class in the package that defines ``__repr__``."""
+
+    @pytest.mark.parametrize("key", sorted(DISCOVERED))
+    def test_a_half_built_instance_renders(self, key: str) -> None:
+        problem = _renders_a_half_built_instance(DISCOVERED[key])
+        assert problem is None, (
+            f"{key}: repr on an instance whose __init__ did not finish {problem}. "
+            "Wrap the body in try/except AttributeError and return "
+            "strands_robots.utils.partial_construction_repr(self)."
+        )
+
+    def test_the_survey_covers_the_classes_this_module_names(self) -> None:
+        assert set(DISCOVERED) == set(EXPECTED_REPR_CLASSES)
+
+    def test_the_survey_detects_a_planted_defect(self) -> None:
+        class _Raises:
+            def __repr__(self) -> str:
+                return f"_Raises({self.missing})"  # type: ignore[attr-defined]
+
+        assert "AttributeError" in (_renders_a_half_built_instance(_Raises) or "")
+
+    def test_the_survey_detects_a_repr_that_hides_its_type(self) -> None:
+        class _Anonymous:
+            def __repr__(self) -> str:
+                return "<something>"
+
+        problem = _renders_a_half_built_instance(_Anonymous)
+        assert problem is not None and "does not identify its type" in problem
+
+
+class TestARefusedConstructorStaysDiagnosable:
+    """A validation refusal must not be hidden by the repr of what it refused."""
+
+    @pytest.mark.parametrize(
+        ("cls", "refusal", "make", "attribute"),
+        REFUSALS,
+        ids=[cls.__name__ for cls, _, _, _ in REFUSALS],
+    )
+    def test_the_half_built_instance_reports_the_lifecycle_fact(
+        self, cls: type, refusal: type[Exception], make: Any, attribute: str
+    ) -> None:
+        with pytest.raises(refusal) as excinfo:
+            make()
+        half_built = _live_self(excinfo.value, cls)
+        assert half_built is not None, "the raising frame no longer holds the instance"
+        rendered = repr(half_built)
+        assert FALLBACK_PHRASE in rendered
+        assert cls.__name__ in rendered
+        assert attribute not in rendered, (
+            f"the repr names {attribute!r}, which is what sent readers chasing an "
+            "attribute rather than reading the refusal"
+        )
+
+    @pytest.mark.parametrize(
+        ("cls", "refusal", "make", "attribute"),
+        REFUSALS,
+        ids=[cls.__name__ for cls, _, _, _ in REFUSALS],
+    )
+    def test_the_refusal_itself_still_describes_the_argument(
+        self, cls: type, refusal: type[Exception], make: Any, attribute: str
+    ) -> None:
+        with pytest.raises(refusal) as excinfo:
+            make()
+        message = str(excinfo.value)
+        assert message, "the refusal must say something"
+        assert FALLBACK_PHRASE not in message, "the refusal is about the argument, not the lifecycle"
+
+
+class TestAFullyBuiltInstanceIsUnaffected:
+    """The tolerance must not swallow a working repr - the over-reach control."""
+
+    @pytest.mark.parametrize(("label", "make", "field"), BUILDABLE, ids=[b[0] for b in BUILDABLE])
+    def test_it_still_names_its_fields(self, label: str, make: Any, field: str) -> None:
+        rendered = repr(make())
+        assert field in rendered
+        assert FALLBACK_PHRASE not in rendered
+
+
+class TestTheFallbackWordingHasOneOwner:
+    """One rule, one wording - so a traceback reads the same in every layer."""
+
+    def test_every_tolerant_repr_delegates_to_the_shared_helper(self) -> None:
+        root = _package_root()
+        adrift: list[str] = []
+        tolerant = 0
+        for path in sorted(root.rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            if "def __repr__" not in source:
+                continue
+            for node in ast.walk(ast.parse(source)):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                for fn in node.body:
+                    if not (isinstance(fn, ast.FunctionDef) and fn.name == "__repr__"):
+                        continue
+                    handlers = [h for t in ast.walk(fn) if isinstance(t, ast.Try) for h in t.handlers]
+                    if not handlers:
+                        continue
+                    tolerant += 1
+                    body = ast.unparse(fn)
+                    if "partial_construction_repr(self)" not in body:
+                        adrift.append(f"{path.relative_to(root)}::{node.name}")
+        assert tolerant == len(EXPECTED_REPR_CLASSES), tolerant
+        assert adrift == [], f"these reprs re-implement the fallback: {adrift}"
+
+    def test_no_repr_spells_the_phrase_itself(self) -> None:
+        root = _package_root()
+        offenders: list[str] = []
+        for path in sorted(root.rglob("*.py")):
+            source = path.read_text(encoding="utf-8")
+            if "def __repr__" not in source:
+                continue
+            for node in ast.walk(ast.parse(source)):
+                if isinstance(node, ast.FunctionDef) and node.name == "__repr__":
+                    if FALLBACK_PHRASE in ast.unparse(node):
+                        offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+        assert offenders == [], f"the phrase must come from the shared helper: {offenders}"
+
+    def test_the_helper_names_no_attribute_and_identifies_the_type(self) -> None:
+        class _Example:
+            pass
+
+        rendered = partial_construction_repr(_Example())
+        assert rendered.startswith("_Example(")
+        assert FALLBACK_PHRASE in rendered
+        assert "id=0x" in rendered
+
+    def test_the_helper_is_the_only_definition_of_the_wording(self) -> None:
+        source = textwrap.dedent(inspect.getsource(partial_construction_repr))
+        assert FALLBACK_PHRASE in source


### PR DESCRIPTION
## Problem

`repr` is what a traceback, a debugger and a failing assertion render, so it must not be the thing that hides a failure.

Ten classes read instance attributes their `__init__` assigns only **after** validating the caller's arguments, and the raising frame keeps that half-built instance alive. Rendering it therefore reported an `AttributeError` naming an attribute unrelated to the refusal under investigation:

```python
>>> RosBridgedRobot(node_name="bad name!", cmd_vel_topic="/cmd_vel", odom_topic="/odom")
ValueError: invalid node_name: 'bad name!' (expected a ROS 2 graph name like /turtle1/cmd_vel)
```

That message is correct and actionable. But the instance the raising frame still holds renders as:

```
assert <[AttributeError("'RosBridgedRobot' object has no attribute 'node_name'")
         raised in repr()] RosBridgedRobot object at 0xffff86c0c590> is None
```

so the reader is sent after `node_name` — an attribute — instead of reading the value they had already passed. Every one of these classes validates its own arguments; the reward for a refusal was a traceback that obscured it.

Measured on `2efb05fc`: **10 of the 11 classes** in the package that define `__repr__` raise on an instance whose `__init__` did not finish. Six of them do so on a real, documented refusal — `RosBridgedRobot`, `RosbridgeRobot`, `RtpsRobot` and `HardwareRtpsBridge` (`ValueError` from their own argument validation), and `InputPublisher` / `InputReceiver` (`hz must be > 0`, a wildcard `source_peer_id`).

`IsaacSimulation.__repr__` already carried the tolerance and its docstring already argued for it — "it must not be the thing that hides a failure … name no attribute so nobody is sent chasing one". The rule was written down and applied to one class of eleven.

## Change

Add `strands_robots.utils.partial_construction_repr` and route every `__repr__` in the package through it on `AttributeError`. It reports the lifecycle fact and deliberately names no attribute, so nobody is sent chasing one.

The same refusal now renders as:

```
assert RosBridgedRobot(partially constructed, id=0xffff9d4b4590) is None
```

The helper **owns the wording**, and `IsaacSimulation.__repr__` now delegates to it, so the phrase a reader learns to recognise in a traceback cannot diverge between the transport bridges, the teleop input streams, the dataset recorder, the peer registry and the simulation engines. It lives in `utils.py` because those callers sit in different layers and `utils` imports only the standard library.

Per class the change is a `try` / `except AttributeError` around the existing body and one name added to an existing `utils` import — 101 insertions, 31 deletions across 11 files.

## Why this shape

**Behavioural, not structural.** A static check cannot tell a repr that *would* raise from one whose attributes happen to be assigned early enough — a heuristic over `__init__` flagged `DatasetRecorder` as at-risk when it assigns `self.dataset` first, and would have needed an exemption list. The guard instead constructs the worst case of a half-built instance (`cls.__new__(cls)`, on which no attribute exists at all) and renders it. That is exact, so it needs no heuristic and no exemptions.

**Universal, not the six.** The rule "`__repr__` must not raise" is simpler to state than "the classes whose validator precedes their assignments", covers every class with one line each, and lets the guard be a survey with an exact expected set rather than a hand-list. Fixing only the six measurably-at-risk classes would have left four raising and a guard that needed the heuristic above.

`AGENTS.md` gains this as convention 14.

## Tests

`tests/test_repr_survives_partial_construction.py` — 46 cases, no optional dependency, 0.8 s:

- the survey over every AST-discovered class defining `__repr__`: a half-built instance renders and still identifies its type;
- per-class named tests driving the six **real** refusals: the raising frame still holds the instance, its repr reports the lifecycle fact, and it does **not** name the attribute that used to be reported;
- the refusal message itself still describes the argument (it must not become a lifecycle message);
- the over-reach control: a fully constructed instance still names its fields and never claims to be partially constructed;
- non-vacuity — the discovered set equals the eleven this module names, so a class that grows a `__repr__` later must be triaged rather than joining the untested set silently;
- planted-defect metas for both survey verdicts (a repr that raises, and one that hides its type);
- one-owner pins: every tolerant repr delegates to the shared helper, and no `__repr__` spells the phrase itself.

Pre-fix (call sites reverted to `upstream/main`, `utils.py` kept so the module still imports), at this branch's base:

```
18 failed, 21 passed     ->  39 passed
```

The 21 that pass pre-fix are the over-reach controls (nine fully-built reprs unchanged, six refusal messages unchanged), the metas, the non-vacuity assertion and `IsaacSimulation`'s already-tolerant row — they are what stops the change reaching further than the diagnostic path.

## Artifact

![repr survives partial construction](https://raw.githubusercontent.com/cagataycali/robots/artifacts/repr-partial-construction/repr-partial-construction.png)

Every cell is measured by one script run on each tree; the compose step asserts each rendered number and that the two arms resolved different trees. No policy, simulation, rendering, recording or asset behaviour changes, and the figure says so with measurements rather than prose:

| claim | measured |
| --- | --- |
| a fully constructed instance still names its fields | 9 of 9 reprs byte-identical across trees |
| nothing outside diagnostic rendering moved | 10 of 10 touched modules: identical AST with `__repr__` and its `utils` import removed |
| the refusal message is unchanged | identical on both trees |
| the simulation is untouched | headless MuJoCo render `max abs delta = 1/255`, 0 of 268,800 pixels changed above a threshold of 8 |

[capture.py / compose.py and both JSON dumps](https://github.com/cagataycali/robots/tree/artifacts/repr-partial-construction).

## Round 1 — the classifier's handler width

`_renders_a_half_built_instance` does not report a failure; it turns a repr outcome into a
**verdict string** the survey then compares (`assert problem is None`) for every class in the
package. Catching `BaseException` made an interrupt one of those verdicts: an operator's
Ctrl-C was recorded as *"this class cannot render a half-built instance"*, failed the
assertion naming the wrong cause, and the survey carried on to the next class. `pytest`'s own
`skip` and `fail` outcomes derive from `BaseException` for the same reason, so a repr that
reads an absent optional dependency became a verdict rather than a skip.

Measured over the three candidate widths x the nine outcomes a classifier can be handed:

| handler | library outcome collected | control flow reaches the runner |
| --- | --- | --- |
| `except BaseException` | 5/5 | 0/4 |
| no handler | 2/5 | 4/4 |
| `except Exception` | **5/5** | **4/4** |

Exactly one width satisfies both halves — which is also why deleting the catch is not the fix:
it loses the three escapes (`AttributeError`, `TypeError`, `RuntimeError`) the survey exists to
collect. Both directions are therefore pinned, in a new
`TestTheReprClassifierCollectsFailuresWithoutSwallowingControlFlow` that mirrors the shape
already reviewed in `tests/simulation/test_create_world_difficulty_domain.py`: three cases
assert a repr failure still becomes a verdict, four assert control flow reaches the runner, and
each of those four carries the executable premise `assert not isinstance(exc, Exception)` so
the class cannot quietly stop testing the handler width.

![handler width decision table](https://raw.githubusercontent.com/cagataycali/robots/artifacts/repr-partial-construction/round1/handler-width-decision-table.png)

Pre-fix, with only the handler token reverted and the new tests kept:

```
4 failed, 3 passed  ->  7 passed
```

The 3 that pass are the library direction the wide handler also collected — they are what stops
the new class being satisfied by removing the catch. A validated mirror of
`py/catch-base-exception` scoped to `tests/` reproduces the alert's line *and* column range
exactly (124, columns 5-33) on the previous head and reports 0 hits in the file now; the two
grandfathered handlers elsewhere in `tests/` are untouched (3 -> 2 across the tree).

Tests only in this round — no production line moves. [Scripts and the JSON
dump](https://github.com/cagataycali/robots/tree/artifacts/repr-partial-construction/round1).

## Gate

Base `2efb05fc` (unchanged; the overlap check reports 0 paths changed on `upstream/main` in that span, and `compare` reports `behind_by=0`), head `c6036ec8`.

- `MUJOCO_GL=egl python -m pytest tests` — **27723 passed, 257 skipped, 0 failed** (636.42 s) at head `c6036ec8`. Pristine at this base is 27677; the delta is exactly the 46 new cases (39 + round 1's 7).
- `ruff check strands_robots tests tests_integ` — clean; `ruff format --check` — 1167 files already formatted.
- `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs`, whose 14 are unrelated to this change and identical on a pristine checkout of the same base.
- repo-wide root guards plus the `Args:` sweep — 422 passed.
- `scripts/assemble_changelog.py --check` — OK; `scripts/check_merge_base_overlap.py` — no overlap, 0 paths changed on `upstream/main` in that span.
- No existing test changed.

