### PR TITLE
test(teleop): pin the rate domain on the third publish entry point

### DIFF
--- a/changelog.d/2132-teleop-publish-rate-domain.md
+++ b/changelog.d/2132-teleop-publish-rate-domain.md
@@ -1,0 +1,20 @@
+### Quality: pin the rate domain on the third teleop entry point
+
+`Robot.start_teleop_publish` refuses an `hz` its publish loop cannot honor -
+`1 / hz` is the period - and the rate-guard suite's own docstring names it as one
+of the three entry points sharing
+`strands_robots.utils.positive_finite_number_error`. It was the one the suite
+never drove: the `teleoperate(publish=True)` tests reach the mesh publisher
+through a stand-in host whose `start_teleop_publish` records the call and returns
+success without validating anything, so the real method's refusal had never run.
+
+That refusal also sits ahead of the teardown of any publisher already registered
+under the same device name, and its comment states why - a rejected call must not
+stop a live stream. The identifier half of that ordering contract was pinned; the
+rate half was not.
+
+Five tests close it: every unusable rate is refused in the shared domain's exact
+words, a refused rate registers no publisher and publishes nothing, a live
+publisher survives a refused rate, an accepted rate does replace and stop it (the
+mirror, without which nothing distinguishes "the guard runs first" from "there is
+no teardown"), and the entry point and `InputPublisher` agree on every value.

--- a/tests/test_teleop_rate_and_duration_guards.py
+++ b/tests/test_teleop_rate_and_duration_guards.py
@@ -17,15 +17,27 @@ where the caller could see it:
 The same rate knob reaches the mesh publish loop through
 ``Robot.start_teleop_publish`` and :class:`InputPublisher`, so all three entry
 points share one domain: :func:`strands_robots.utils.positive_finite_number_error`.
+
+All three are driven here, including the hardware entry point in the middle of
+that chain. It is the only guard a direct caller passes through - the
+``teleoperate(publish=True)`` tests reach the publisher through a stand-in host
+whose ``start_teleop_publish`` validates nothing - and it sits ahead of the
+teardown of any publisher already registered under that device name, so a
+refused rate must leave a live stream alone rather than stopping it first.
 """
 
 from __future__ import annotations
 
 import math
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import numpy as np
 import pytest
 
+from strands_robots.hardware_robot import Robot as HardwareRobot
+from strands_robots.hardware_robot import RobotTaskState
 from strands_robots.mesh.input import InputPublisher
 from strands_robots.simulation.base import SimEngine
 from strands_robots.utils import positive_finite_number_error
@@ -162,3 +174,111 @@ class TestOneDomainForEveryRateAndDurationKnob:
     def test_a_numpy_rate_is_usable_but_a_bool_is_not(self):
         assert positive_finite_number_error(np.float32(50.0), "hz", "teleoperate") is None
         assert positive_finite_number_error(True, "hz", "teleoperate") == ("teleoperate: hz must be > 0, got True.")
+
+
+class _FakeMesh:
+    """Minimal live mesh: a peer_id plus a publish that records payloads."""
+
+    def __init__(self, peer_id: str = "leader-1") -> None:
+        self.peer_id = peer_id
+        self.alive = True
+        self.published: list[tuple[str, Any]] = []
+
+    def publish(self, topic: str, payload: Any) -> None:
+        self.published.append((topic, payload))
+
+
+class _LivePublisher:
+    """Stand-in for a running publisher that records being stopped."""
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> dict[str, Any]:
+        self.stopped = True
+        return {}
+
+
+def _hardware_robot() -> Any:
+    """A hardware ``Robot`` carrying only the teleop state the guard reads."""
+    hw = HardwareRobot.__new__(HardwareRobot)
+    hw.tool_name_str = "rate_guard_arm"
+    hw.mesh = _FakeMesh()
+    hw.peer_id = "leader-1"
+    hw.robot = object()
+    hw._task_state = RobotTaskState()
+    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rate_guard")
+    hw._shutdown_event = threading.Event()
+    hw._task_admission = threading.Lock()
+    hw._task_claimed = False
+    return hw
+
+
+class TestTheHardwarePublishEntryPointSharesTheRateDomain:
+    """``Robot.start_teleop_publish`` refuses a rate its publish loop cannot honor.
+
+    The third entry point named in this module's docstring, driven directly. The
+    ``teleoperate(publish=True)`` tests above reach the mesh publisher through
+    :class:`~tests.test_teleop.FakePublishHost`, whose ``start_teleop_publish``
+    records the call and returns success without validating anything, so the real
+    method's own refusal never ran. That refusal is the only one a direct caller
+    passes through: the mixin validates ``hz`` before forwarding it, and
+    :class:`InputPublisher` raises rather than reporting, which a caller holding
+    an agent-tool envelope cannot use.
+    """
+
+    @pytest.mark.parametrize("hz", UNUSABLE)
+    def test_unusable_rate_is_refused_in_the_shared_domains_words(self, hz):
+        """One rule, one wording - the entry point adds only its own name."""
+        hw = _hardware_robot()
+        result = hw.start_teleop_publish(teleoperator=FakeTeleop({"a.pos": 1.0}), hz=hz)
+        assert result["status"] == "error"
+        assert result["content"][0]["text"] == positive_finite_number_error(hz, "hz", "start_teleop_publish")
+
+    @pytest.mark.parametrize("hz", [0, float("nan"), True])
+    def test_a_refused_rate_registers_no_publisher(self, hz):
+        """Nothing is constructed, so no loop thread divides by the bad rate."""
+        hw = _hardware_robot()
+        assert hw.start_teleop_publish(teleoperator=FakeTeleop({"a.pos": 1.0}), hz=hz)["status"] == "error"
+        assert getattr(hw, "_input_publishers", {}) == {}
+        assert hw.mesh.published == []
+
+    def test_a_refused_rate_leaves_a_live_publisher_running(self):
+        """The guard precedes the teardown, so a rejected call loses no stream."""
+        hw = _hardware_robot()
+        live = _LivePublisher()
+        hw._input_publishers = {"leader": live}
+        result = hw.start_teleop_publish(teleoperator=FakeTeleop({"a.pos": 1.0}), device_name="leader", hz=0)
+        assert result["status"] == "error"
+        assert live.stopped is False
+        assert hw._input_publishers == {"leader": live}
+
+    def test_a_usable_rate_replaces_the_live_publisher(self):
+        """The mirror: the teardown the guard precedes does happen when accepted."""
+        hw = _hardware_robot()
+        live = _LivePublisher()
+        hw._input_publishers = {"leader": live}
+        result = hw.start_teleop_publish(teleoperator=FakeTeleop({"a.pos": 1.0}), device_name="leader", hz=50.0)
+        try:
+            assert result["status"] == "success"
+            assert live.stopped is True
+            assert hw._input_publishers["leader"] is not live
+            assert hw._input_publishers["leader"].hz == 50.0
+        finally:
+            hw._input_publishers["leader"].stop()
+
+    @pytest.mark.parametrize("hz", UNUSABLE + [1, 50.0, np.float32(2.5)])
+    def test_the_entry_point_and_the_constructor_agree(self, hz):
+        """Neither surface may accept a rate the other refuses."""
+        hw = _hardware_robot()
+        result = hw.start_teleop_publish(teleoperator=FakeTeleop({"a.pos": 1.0}), hz=hz)
+        entry_refused = result["status"] == "error"
+        try:
+            InputPublisher(mesh=_FakeMesh(), teleoperator=object(), hz=hz)
+        except ValueError:
+            constructor_refused = True
+        else:
+            constructor_refused = False
+        assert entry_refused is constructor_refused
+        if not entry_refused:
+            hw._input_publishers["leader"].stop()


### PR DESCRIPTION
## Problem

`tests/test_teleop_rate_and_duration_guards.py`'s module docstring names three entry points that share one rate domain:

> The same rate knob reaches the mesh publish loop through `Robot.start_teleop_publish` and `InputPublisher`, so all three entry points share one domain: `positive_finite_number_error`.

It drove two of them. `Robot.start_teleop_publish`'s own refusal — `hardware_robot.py:2650` — had never executed anywhere in the suite.

The reason it stayed invisible is that the `teleoperate(publish=True)` tests reach the mesh publisher through `tests.test_teleop.FakePublishHost`, whose `start_teleop_publish` records the call and returns `status="success"` without validating anything. So the path was exercised and the guard was not. It is also the only rate guard a *direct* caller passes through: the mixin validates `hz` before forwarding it, and `InputPublisher` raises rather than returning an envelope, which a caller holding an agent-tool result cannot use.

The same refusal sits ahead of the teardown of any publisher already registered under that device name, and the method's comment states why:

> Both arguments are validated up front, before the teardown of any publisher already registered under this device name: a rejected call must not stop a live stream.

`tests/mesh/test_teleop_identifier_source_scoping.py` pins that ordering for the `device_name` half (`test_rejected_publish_leaves_a_live_stream_running`). The `hz` half was unpinned, so nothing in the suite distinguished "the guard runs before the teardown" from "there is no teardown at all".

## Change

Tests only — no production line changes. Five tests in a new class in the module that already owns this domain:

| test | property |
|---|---|
| `test_unusable_rate_is_refused_in_the_shared_domains_words` | the envelope text equals `positive_finite_number_error(hz, "hz", "start_teleop_publish")` verbatim, over all 11 unusable values — one rule, one wording |
| `test_a_refused_rate_registers_no_publisher` | nothing is constructed and nothing is published, so no loop thread divides by the bad rate |
| `test_a_refused_rate_leaves_a_live_publisher_running` | the ordering half the comment states, for `hz` |
| `test_a_usable_rate_replaces_the_live_publisher` | the mirror — the teardown the guard precedes *does* happen when the rate is accepted |
| `test_the_entry_point_and_the_constructor_agree` | cross-surface parity with `InputPublisher` over every unusable and usable value |

The module docstring gains a paragraph recording that all three entry points are now driven, and why the middle one needs its own coverage.

## Measured

![measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-publish-rate-domain/teleop_publish_rate_domain.png)

Every cell is read from [`measurements.json`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-publish-rate-domain/measurements.json); [`compose.py`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-publish-rate-domain/compose.py) asserts each number before saving. This change touches no policy, simulation, rendering, recording or asset behaviour, so the figure is the coverage and mutation measurement rather than a rollout.

### These tests necessarily pass on unmodified `main`

The production code is correct — this is a contract that was never pinned, not a defect. What they fail on is a regression, so the mutation table is the evidence. Each mutation of `start_teleop_publish` was run against two arms: the new class (30 cases) and the pre-existing cases over the same four test files (254 cases).

| mutation | new class | pre-existing suite |
|---|---|---|
| M1 delete the `hz` guard | 26 failed | **0 failed** |
| M2 move the guard below the teardown | 1 failed | **0 failed** |
| M3 keep the call, discard the refusal | 26 failed | **0 failed** |
| M4 a hand-rolled guard replaces the shared domain | 24 failed | **0 failed** |
| M5 delete the replacement teardown | 1 failed | 1 failed |
| (unmutated control) | 30 passed | 254 passed |

4 of 5 are invisible to the suite as it stands. **M2 is the exact ordering regression the method's comment warns about** — moving the guard below the teardown stops a live publisher on a rejected call, and 254 pre-existing tests stay green. M3 is what a structural "the guard is called" assertion cannot see. M5 is caught by both, because the publish-side replacement is already exercised by `test_hardware_robot_lifecycle.py`; it is included so the mirror is not mistaken for new coverage.

Coverage over the same four test files: `strands_robots/hardware_robot.py` missing **243 → 242**, with line 2650 leaving the missing list.

## Out of scope

`hardware_robot.py:2731` — the receive-side replacement (`start_teleop_receive` stopping an existing receiver for the same key) — is also unexecuted, so the same mirror is missing for `start_teleop_receive`. That is the other file's contract (`tests/mesh/test_teleop_identifier_source_scoping.py`) and a different argument set; folding it in would put two contracts across two modules in one change.

## Gate

Base `2efb05fc`, head `39f107d6`. Run on a machine with EGL, MuJoCo 3.11.0, torch 2.11.0+cu130.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly` → **27707 passed, 257 skipped, 0 failed** (608.88s). Pristine `main` at the same commit is 27677 passed / 257 skipped, and 27677 + 30 new cases = 27707.
- `ruff check strands_robots tests tests_integ` → All checks passed
- `ruff format --check strands_robots tests tests_integ` → 1166 files already formatted
- `mypy strands_robots tests tests_integ` → 14 errors, all in `examples/isaac_gs`, 0 outside it; the error set is byte-identical to a pristine `upstream/main` worktree of the same working copy, i.e. environmental and not introduced here.
- repo-wide guards (changelog x2, dangling doc refs, internal paths, unreachable statements, vacuous comparisons, `Args:` completeness) → 420 passed
- `scripts/assemble_changelog.py --check` → OK; `scripts/check_merge_base_overlap.py` → no overlap (0 paths changed on `upstream/main` in that span)
