### PR TITLE
test(tools): pin the two connect() states the roslibpy double could not express

### DIFF
--- a/changelog.d/2133-rosbridge-connect-state-coverage.md
+++ b/changelog.d/2133-rosbridge-connect-state-coverage.md
@@ -1,0 +1,13 @@
+### Quality: pin the two `use_rosbridge` connection states the roslibpy double could not express
+
+`_RosbridgeBackend.connect` branches on six states; four were pinned. The two that were not are
+the recovery states a real bridge produces, and one of them looked covered: the test named for the
+auto-reconnecting factory installed a *non-data* descriptor over `is_connected`, which an instance
+attribute set by `run()` silently shadows, so the scripted reads were never consulted and the test
+returned from the plain cache-hit branch instead of the wait loop it names.
+
+The double can now express a dial that reports ready while the connector reads as disconnected -
+`run()` waits on a one-shot `on_ready` event, while `is_connected` live-reads
+`connector.state == "connected"`, so returning from the first does not imply the second. The
+descriptor gained `__set__` so the scripted reads decide, plus an assertion that the loop really
+polled. `use_rosbridge.py` goes from 97.7% to 98.85% covered, with `connect`'s state matrix at 6 of 6.

--- a/tests/tools/test_use_rosbridge.py
+++ b/tests/tools/test_use_rosbridge.py
@@ -65,6 +65,7 @@ class _FakeService:
 class _FakeRos:
     instances: list[_FakeRos] = []
     fail_next_connect = False
+    ready_without_connection = False
     scripted_responses: dict[str, dict[str, Any]] = {}
     scripted_messages: dict[str, list[dict[str, Any]]] = {}
 
@@ -95,9 +96,26 @@ class _FakeRos:
         self.service_calls: list[tuple[str, str, dict[str, Any], float | None]] = []
         _FakeRos.instances.append(self)
 
+    # ``run(timeout)`` and ``is_connected`` are two independent signals in the
+    # real client, so returning from the first does not imply the second:
+    #
+    #     run()          waits on a one-shot ``on_ready`` event and raises
+    #                    RosTimeoutError if it never fires
+    #     is_connected   is a live read of ``connector.state == "connected"``,
+    #                    re-evaluated on every access
+    #         - roslibpy 1.8.1, Ros.run / RosBridgeClientFactory.is_connected
+    #
+    # A connector that dropped after signalling ready therefore returns from
+    # ``run()`` with ``is_connected`` reading False, and the tool guards that
+    # state separately from a raised dial. ``ready_without_connection``
+    # reproduces it: without it this double could only ever express "raised" or
+    # "connected", so the guard was unreachable and the two refusals - which
+    # differ in the text a caller is shown - could not be told apart.
     def run(self, timeout: float | None = None) -> None:
         if _FakeRos.fail_next_connect:
             raise RuntimeError("connection refused")
+        if _FakeRos.ready_without_connection:
+            return
         self.is_connected = True
 
     def terminate(self) -> None:
@@ -109,6 +127,7 @@ class _FakeRos:
 def fake_roslibpy(monkeypatch: pytest.MonkeyPatch) -> _types.ModuleType:
     _FakeRos.instances = []
     _FakeRos.fail_next_connect = False
+    _FakeRos.ready_without_connection = False
     _FakeRos.scripted_responses = {}
     _FakeRos.scripted_messages = {}
     mod = _types.ModuleType("roslibpy")
@@ -229,8 +248,17 @@ def test_stale_connection_reused_when_factory_reconnects(fake_roslibpy: _types.M
     first = fake_roslibpy.Ros.instances[0]  # type: ignore[attr-defined]
 
     class _Flapping:
-        # is_connected reads False twice (initial check + first wait poll),
-        # then True - simulating the auto-reconnecting factory recovering.
+        # is_connected reads False twice (initial check + first wait poll), then
+        # True - simulating the auto-reconnecting factory recovering.
+        #
+        # ``__set__`` is what makes this a DATA descriptor, and it is load
+        # bearing rather than decorative: ``run()`` already stored
+        # ``is_connected`` in the instance dict, and an instance attribute
+        # shadows a non-data descriptor. Without ``__set__`` the scripted reads
+        # are never consulted, ``getattr`` returns the stored True, and the tool
+        # returns from the plain cache-hit branch - so this test passed while
+        # exercising the same path as test_connection_cached_per_host_port and
+        # the wait loop it names stayed unreached.
         def __init__(self) -> None:
             self.reads = 0
 
@@ -238,11 +266,19 @@ def test_stale_connection_reused_when_factory_reconnects(fake_roslibpy: _types.M
             self.reads += 1
             return self.reads > 2
 
-    type(first).is_connected = _Flapping()  # type: ignore[assignment]
+        def __set__(self, obj: Any, value: bool) -> None:
+            """Absorb writes so the scripted reads decide, not the instance dict."""
+
+    flapping = _Flapping()
+    type(first).is_connected = flapping  # type: ignore[assignment]
     try:
         result = use_rosbridge(action="status", timeout=1.0)
         assert "connected to" in _texts(result)
         assert len(fake_roslibpy.Ros.instances) == 1  # type: ignore[attr-defined]  # same object reused
+        # The wait loop really polled: read 1 is the cache-hit check, read 2 the
+        # first poll (both False), read 3 the recovery. Anything less means the
+        # tool answered from a stored attribute and never entered the loop.
+        assert flapping.reads >= 3, f"wait loop not entered; is_connected read {flapping.reads} time(s)"
     finally:
         del type(first).is_connected  # restore instance-attribute behavior
 
@@ -259,6 +295,57 @@ def test_failed_dial_cached_and_recovers(fake_roslibpy: _types.ModuleType) -> No
     result = use_rosbridge(action="status")
     assert "connected to" in _texts(result)
     assert len(fake_roslibpy.Ros.instances) == 1  # type: ignore[attr-defined]
+
+
+def test_ready_without_connection_is_reported_not_connected(fake_roslibpy: _types.ModuleType) -> None:
+    """A dial that reports ready without a live connector is not a connection."""
+    fake_roslibpy.Ros.ready_without_connection = True  # type: ignore[attr-defined]
+    result = use_rosbridge(action="status")
+    assert result["status"] == "success"  # status reports, it does not fail
+    assert "not connected" in _texts(result)
+    assert "rosbridge_server" in _texts(result)
+    assert "connected to" not in _texts(result)
+
+
+def test_ready_without_connection_is_an_error_for_an_action(fake_roslibpy: _types.ModuleType) -> None:
+    """The same state reaches an action through the error envelope, not `status`'s success one."""
+    fake_roslibpy.Ros.ready_without_connection = True  # type: ignore[attr-defined]
+    result = use_rosbridge(action="list_topics")
+    assert result["status"] == "error"
+    assert "could not connect to rosbridge" in _texts(result)
+
+
+def test_ready_without_connection_is_distinguishable_from_a_raised_dial(
+    fake_roslibpy: _types.ModuleType,
+) -> None:
+    """The two refusals differ in text, so a caller can tell which one happened.
+
+    A raised dial appends the library exception; a connector that reported ready
+    and then read as disconnected has no exception to name.
+    """
+    fake_roslibpy.Ros.fail_next_connect = True  # type: ignore[attr-defined]
+    raised = _texts(use_rosbridge(action="status", timeout=0.2))
+    assert "connection refused" in raised  # the library error is carried through
+
+    fake_roslibpy.Ros.fail_next_connect = False  # type: ignore[attr-defined]
+    fake_roslibpy.Ros.ready_without_connection = True  # type: ignore[attr-defined]
+    # A different port is a different cache key, so this dials fresh rather than
+    # answering from the entry the first half left behind.
+    ready = _texts(use_rosbridge(action="status", port=9091, timeout=0.2))
+    assert "not connected" in ready
+    assert "connection refused" not in ready
+
+
+def test_ready_without_connection_entry_stays_cached_and_recovers(
+    fake_roslibpy: _types.ModuleType,
+) -> None:
+    """The half-open entry is kept, so the retry reuses it once the connector is up."""
+    fake_roslibpy.Ros.ready_without_connection = True  # type: ignore[attr-defined]
+    assert "not connected" in _texts(use_rosbridge(action="status", timeout=0.2))
+    orphan = fake_roslibpy.Ros.instances[0]  # type: ignore[attr-defined]
+    orphan.is_connected = True  # connector finished coming up
+    assert "connected to" in _texts(use_rosbridge(action="status"))
+    assert len(fake_roslibpy.Ros.instances) == 1  # type: ignore[attr-defined]  # never re-dialed
 
 
 def test_unknown_action_errors(fake_roslibpy: _types.ModuleType) -> None:


### PR DESCRIPTION
## Problem

`_RosbridgeBackend.connect` distinguishes six states when a caller asks for a connection. Four were pinned. The two that were not are exactly the recovery states a real bridge produces — and one of them *looked* pinned.

| state the tool distinguishes | line | pinned before |
|---|---|---|
| new connection, `run()` raised | L204 | yes |
| new connection, ready but connector down | L209 | **no** |
| new connection, connected | L213 | yes |
| cached, connected | L215 | yes |
| cached, dropped, recovers during wait | L219 | **no** |
| cached, dropped, never recovers | L221 | yes |

**L219 — a test that passed while exercising a different branch.** `test_stale_connection_reused_when_factory_reconnects` scripts `is_connected` to drive the reconnect wait loop, and its comment describes the intended sequence exactly ("reads False twice … then True"). But it installed a *non-data* descriptor — only `__get__` — and `run()` had already stored `is_connected` in the instance dict. An instance attribute shadows a non-data descriptor, so the scripted reads were never consulted, `getattr` returned the stored `True`, and the tool returned from the plain cache-hit branch: the same path `test_connection_cached_per_host_port` already covers. Measured on a clean tree, both spellings:

| descriptor installed | scripted reads | branch the tool took | test's assertion |
|---|---|---|---|
| non-data (`__get__` only) | **0** | plain cache hit (L214-215) | passes |
| data (`__get__` + `__set__`) | 3 | wait loop (L217-219) | passes |

The assertion passes either way, which is why nothing caught it.

**L209 — a state the double could not express.** In roslibpy 1.8.1 `run(timeout)` and `is_connected` are two independent signals: `run()` waits on a one-shot `on_ready` event and raises `RosTimeoutError` if it never fires, while `is_connected` live-reads `connector.state == "connected"` on every access. Returning from the first does not imply the second, so a connector that dropped after signalling ready returns from `run()` with `is_connected` reading `False` — and the tool guards that separately, with a **different message**, because there is no library exception to name. `_FakeRos.run()` could only ever raise or connect, so the guard was unreachable and the two refusals could not be told apart.

This matters because the two states reach a caller through different channels: `status` reports them in its informational success envelope, while any other action reports them as an error.

## Change

Tests only — no production line changes.

- `_FakeRos.ready_without_connection` reproduces the ready-but-disconnected state, in the same style as the existing `fail_next_connect` flag, with the two-signal contract recorded on `run()`. This follows the double's own stated principle: reproducing the client's contract "is what makes this double stand in for the client's contract instead of a more permissive one" — the comment that already lists two defects a more permissive fake let through (#1835, #1822).
- `_Flapping` gains `__set__`, making it a data descriptor the instance attribute cannot shadow, plus an assertion that the loop really polled (`reads >= 3`) so it cannot silently revert.
- Four tests: the state is reported through `status`'s informational envelope and through an action's error envelope, its text stays distinguishable from a raised dial, and the half-open entry is kept so a retry reuses it once the connector comes up.

`connect()`'s state matrix goes 4 → 6 of 6; `use_rosbridge.py` 97.7% → 98.85% (missing `[209, 219, 345, 408]` → `[345, 408]`).

## Does the pin hold?

Because the production code is correct, the new tests pass on unmodified `main` — what they fail on is a regression. Each was applied to a clean tree and run against both copies of the test file:

| plausible regression | this PR | main's copy |
|---|---|---|
| M1 delete the ready-without-connection guard | 4 failed / 33 passed | **0 failed / 33 passed** |
| M2 give it the raised-dial wording (indistinguishable) | 1 failed / 36 passed | **0 failed / 33 passed** |
| M3 wait loop never returns early | 1 failed / 36 passed | **0 failed / 33 passed** |
| M4 do not cache a not-yet-connected entry | 5 failed / 32 passed | 4 failed / 29 passed |
| M5 revert `__set__` (non-data descriptor again) | 1 failed / 36 passed | n/a (test-side) |

Three of the four production regressions were invisible to main's copy. M4 is caught by both — `main` already pins cell-1 caching, and saying so is what makes the other three credible. M5 is the shadowing defect itself, caught by the read-count assertion. Every mutation anchor was AST-scoped to `connect()` (`in_fn=1, in_file=1` printed for each) and both sources restored byte-identically.

## Measurement

![use_rosbridge connect() state coverage](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rosbridge-connect-states/rosbridge-connect-states.png)

Every cell is read from a JSON dump of the real coverage and mutation runs; the generator asserts each rendered number before saving. Capture, mutation and compose scripts: [`artifacts/rosbridge-connect-states`](https://github.com/cagataycali/robots/tree/artifacts/rosbridge-connect-states). This change touches no policy, simulation, rendering, recording or asset behaviour, so the figure is the coverage and mutation measurement rather than a rollout.

## Gate

At `upstream/main` `2efb05fc`:

- `MUJOCO_GL=egl python -m pytest tests` → **27681 passed / 257 skipped / 0 failed** (637s). Pristine `main` is 27677 + 4 new = 27681, so no existing test changed behaviour.
- `ruff check` + `ruff format --check strands_robots tests tests_integ` clean (1166 files).
- `mypy strands_robots tests tests_integ` → 14 errors, all in `examples/isaac_gs`, byte-identical to a pristine-`main` worktree of the same working copy (environment, not this branch).
- `scripts/check_merge_base_overlap.py` → no overlap; 0 paths changed on `upstream/main` in that span, so the base cannot have invalidated the checks.

## Out of scope

`use_rosbridge.py`'s two remaining uncovered lines (L345 invalid-service-name, L408 `publish` missing topic/type) are validation refusals on a different surface with their own owner, not part of `connect()`'s state matrix.
