### PR TITLE
fix(benchmarks/libero): probe both kinematics reads at Isaac controller install

### DIFF
--- a/changelog.d/2135-isaac-install-probes-both-kinematics-reads.md
+++ b/changelog.d/2135-isaac-install-probes-both-kinematics-reads.md
@@ -1,0 +1,22 @@
+### Fixed: the LIBERO Isaac action-controller install now probes both kinematics reads
+
+`LiberoAdapter._try_install_isaac_action_controller` probes at install time so
+that, in its own words, "a broken kinematics read surfaces as a loud install
+error at episode start (where the strict/non-strict policy applies) instead of
+as one error envelope per action mid-eval". It probed only the Jacobian, and
+translated only a `RuntimeError` from the getter.
+
+`IsaacDeltaEEFController` reads two things per action: the Jacobian, and the arm
+joint state via `get_observation`. The install validated the arm joints against
+`robot_joint_names` (the articulation DOFs) instead, so an engine whose
+observation omits or renames an arm joint, or reports a non-finite one, passed
+the install with `_action_controller_error` unset and then failed every action -
+the still-robot-with-a-green-eval shape the probe exists to prevent. A malformed
+Jacobian payload also escaped as a bare `IndexError`, `ValueError` or
+`KeyError`, outside the `_ControllerInstallError` contract the method documents,
+so the caller's strict/non-strict policy never applied to it.
+
+The probe now asserts exactly the preconditions the per-action solve re-checks -
+the shape and finiteness of both reads - and every probe failure is a
+`_ControllerInstallError`. A controller that installs can no longer fail the
+solver on its first action.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -2813,8 +2813,9 @@ class LiberoAdapter(BenchmarkProtocol):
         Raises:
             _ControllerInstallError: The engine IS an Isaac engine but the
                 setup is broken - zero or multiple robots, missing Franka
-                joints, unreadable Jacobian, or a rejected install. These are
-                fixable setup bugs, so the caller applies the same
+                joints, an unreadable or malformed Jacobian, an arm joint
+                state the observation cannot supply, or a rejected install.
+                These are fixable setup bugs, so the caller applies the same
                 strict/non-strict policy as the MuJoCo path.
         """
         # Typed ``Any``: SimEngine's base surface declares none of these
@@ -2864,21 +2865,58 @@ class LiberoAdapter(BenchmarkProtocol):
                     f"observation keys: {sorted(obs)}"
                 ) from missing_joint
 
-        # Probe the Jacobian once at install time so a broken kinematics
-        # read surfaces as a loud install error at episode start (where the
+        # Probe BOTH kinematics reads once at install time so a broken read
+        # surfaces as a loud install error at episode start (where the
         # strict/non-strict policy applies) instead of as one error
         # envelope per action mid-eval. The physics tensor view exists by
         # now: the runner's warm-up and the scene load have stepped the
         # world.
+        #
+        # The properties asserted here are exactly the preconditions
+        # ``IsaacDeltaEEFController._solve_arm_targets`` re-checks on every
+        # action - the shape and the finiteness of the Jacobian and of the
+        # arm joint state - so a controller that installs cannot fail the
+        # solver on its first action. Probing the joint state is not implied
+        # by the Jacobian probe: the joint check above reads
+        # ``robot_joint_names`` (the articulation DOFs) while the solver
+        # reads ``get_observation``, and an engine whose observation omits or
+        # renames an arm joint satisfies the first and not the second.
         try:
             probe = jacobian_fn()
-        except RuntimeError as e:
+        except Exception as e:
+            # Translation path, not a swallow: the documented contract is that
+            # any broken setup lands as _ControllerInstallError so the caller's
+            # strict/non-strict policy applies. A malformed Jacobian payload
+            # raises whatever numpy makes of it - measured IndexError (too few
+            # columns), ValueError (ragged rows) and KeyError (no "jacp") - so
+            # an enumerated tuple cannot be complete, and each of those would
+            # otherwise escape this method's Raises: contract. The OSC install
+            # path above translates an unexpected failure class the same way.
             raise _ControllerInstallError(
                 f"Isaac delta-EEF controller cannot read the '{_ISAAC_FRANKA_EEF_LINK}' Jacobian: {e}"
             ) from e
         if probe.shape != (6, len(arm_joints)):
             raise _ControllerInstallError(
                 f"Isaac Jacobian probe returned shape {probe.shape}; expected (6, {len(arm_joints)})"
+            )
+        if not np.all(np.isfinite(probe)):
+            raise _ControllerInstallError(
+                f"Isaac Jacobian probe for '{_ISAAC_FRANKA_EEF_LINK}' returned non-finite values; "
+                "the differential-IK solve refuses to solve on those"
+            )
+        try:
+            q_probe = np.asarray(joint_positions_fn(), dtype=np.float64)
+        except Exception as e:
+            # Same translation, same reason: a KeyError naming the arm joint
+            # the observation lacks is a setup bug, and it is the read the
+            # Jacobian probe cannot vouch for.
+            raise _ControllerInstallError(
+                f"Isaac delta-EEF controller cannot read the arm joint state of '{robot_name}': {e}"
+            ) from e
+        if not np.all(np.isfinite(q_probe)):
+            raise _ControllerInstallError(
+                f"Isaac joint-state probe for '{robot_name}' returned non-finite values; "
+                "the differential-IK solve refuses to solve on those"
             )
 
         controller = IsaacDeltaEEFController(

--- a/tests/benchmarks/libero/test_isaac_action_controller_install.py
+++ b/tests/benchmarks/libero/test_isaac_action_controller_install.py
@@ -181,3 +181,222 @@ class TestNonIsaacEnginesKeepDegradedPath:
         adapter = _adapter()  # strict
         adapter._install_action_controller(object())
         assert adapter._action_controller_error is not None
+
+
+def _jac_payload(jacp: list, jacr: list, nv: int) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "content": [{"text": "Jacobian"}, {"json": {"jacp": jacp, "jacr": jacr, "nv": nv}}],
+    }
+
+
+class _ObsOmitsArmJoint(_FakeIsaacSim):
+    """``robot_joint_names`` lists every Franka joint; the observation omits one.
+
+    The install's joint check reads the articulation DOFs while the solver
+    reads ``get_observation``, so this engine satisfies the first and not the
+    second - the mismatch a Jacobian probe cannot see.
+    """
+
+    def get_observation(self, robot_name=None, *, skip_images=False):  # noqa: ARG002
+        return {n: 0.1 for n in self.joint_names if n != ARM[3]}
+
+
+class _ObsNamespacesItsKeys(_FakeIsaacSim):
+    """Every joint is present, under a per-robot key prefix."""
+
+    def get_observation(self, robot_name=None, *, skip_images=False):  # noqa: ARG002
+        return {f"robot/{n}": 0.1 for n in self.joint_names}
+
+
+class _ObsNonFinite(_FakeIsaacSim):
+    def get_observation(self, robot_name=None, *, skip_images=False):  # noqa: ARG002
+        obs = {n: 0.1 for n in self.joint_names}
+        obs[ARM[3]] = float("nan")
+        return obs
+
+
+class _JacNonFinite(_FakeIsaacSim):
+    def get_jacobian(self, **kwargs):
+        payload = super().get_jacobian(**kwargs)
+        payload["content"][1]["json"]["jacp"][0][0] = float("nan")
+        return payload
+
+
+class _JacTooFewColumns(_FakeIsaacSim):
+    """Fewer columns than the articulation reports - numpy raises IndexError."""
+
+    def get_jacobian(self, **kwargs):  # noqa: ARG002
+        return _jac_payload(np.eye(3, 4).tolist(), np.eye(3, 4).tolist(), 4)
+
+
+class _JacRaggedRows(_FakeIsaacSim):
+    """Rows of unequal width - numpy raises ValueError."""
+
+    def get_jacobian(self, **kwargs):  # noqa: ARG002
+        nv = len(ALL_JOINTS)
+        return _jac_payload([[1.0] * nv, [1.0] * (nv - 1), [1.0] * nv], np.eye(3, nv).tolist(), nv)
+
+
+class _JacPayloadLacksJacp(_FakeIsaacSim):
+    """A payload shaped like a Jacobian answer but missing the linear block."""
+
+    def get_jacobian(self, **kwargs):  # noqa: ARG002
+        return {"status": "success", "content": [{"text": "Jacobian"}, {"json": {"nv": len(ALL_JOINTS)}}]}
+
+
+class _JacSevenRows(_FakeIsaacSim):
+    """Six rows expected; seven supplied."""
+
+    def get_jacobian(self, **kwargs):  # noqa: ARG002
+        nv = len(ALL_JOINTS)
+        return _jac_payload(np.eye(3, nv).tolist(), np.eye(4, nv).tolist(), nv)
+
+
+class _InstallRefused(_FakeIsaacSim):
+    def install_action_controller(self, robot_name: str, controller: Any) -> dict[str, Any]:  # noqa: ARG002
+        return {"status": "error", "content": [{"text": "physics simulation view not created yet"}]}
+
+
+# Every way a kinematics read the controller depends on can be broken, paired
+# with the read it breaks. Each must reach the caller as a
+# ``_ControllerInstallError`` so the strict/non-strict policy applies.
+BROKEN_ENGINES = [
+    pytest.param(_ObsOmitsArmJoint, "joint state", id="observation-omits-an-arm-joint"),
+    pytest.param(_ObsNamespacesItsKeys, "joint state", id="observation-namespaces-its-keys"),
+    pytest.param(_ObsNonFinite, "joint-state probe", id="observation-non-finite"),
+    pytest.param(_JacNonFinite, "Jacobian probe", id="jacobian-non-finite"),
+    pytest.param(_JacTooFewColumns, "Jacobian", id="jacobian-too-few-columns"),
+    pytest.param(_JacRaggedRows, "Jacobian", id="jacobian-ragged-rows"),
+    pytest.param(_JacPayloadLacksJacp, "Jacobian", id="jacobian-payload-lacks-jacp"),
+    pytest.param(_JacSevenRows, "Jacobian probe", id="jacobian-seven-rows"),
+    pytest.param(_InstallRefused, "refused the controller", id="install-refused"),
+]
+
+
+class TestEveryBrokenKinematicsReadIsLoudAtInstall:
+    """The install probe covers what the per-action solver checks.
+
+    ``_try_install_isaac_action_controller`` probes at install time so that,
+    in its own words, "a broken kinematics read surfaces as a loud install
+    error at episode start (where the strict/non-strict policy applies)
+    instead of as one error envelope per action mid-eval".
+
+    Before this class the probe read only the Jacobian and translated only a
+    ``RuntimeError`` from the getter, so four broken reads installed a
+    controller with ``_action_controller_error`` unset and then failed every
+    action, and three malformed Jacobian payloads escaped as a bare
+    ``IndexError`` / ``ValueError`` / ``KeyError`` - outside the
+    ``_ControllerInstallError`` contract the docstring's ``Raises:`` states,
+    so the strict/non-strict policy never applied to them.
+    """
+
+    @pytest.mark.parametrize(("engine_cls", "phrase"), BROKEN_ENGINES)
+    def test_strict_mode_raises_a_controller_install_error(self, engine_cls, phrase):
+        adapter = _adapter(strict_action_controller=True)
+        with pytest.raises(_ControllerInstallError) as excinfo:
+            adapter._install_action_controller(engine_cls())
+        assert phrase in str(excinfo.value)
+
+    @pytest.mark.parametrize(("engine_cls", "phrase"), BROKEN_ENGINES)
+    def test_non_strict_mode_records_the_failure_instead_of_installing(self, engine_cls, phrase, caplog):
+        adapter = _adapter(strict_action_controller=False)
+        sim = engine_cls()
+        with caplog.at_level("WARNING"):
+            adapter._install_action_controller(sim)
+        assert adapter._action_controller_error is not None
+        assert phrase in adapter._action_controller_error
+        assert adapter._isaac_action_controller_robot is None
+
+    @pytest.mark.parametrize(("engine_cls", "phrase"), BROKEN_ENGINES)
+    def test_no_controller_is_left_installed_on_the_engine(self, engine_cls, phrase):  # noqa: ARG002
+        """A refused install must not leave a controller that would convert
+        actions against the broken read."""
+        adapter = _adapter(strict_action_controller=False)
+        sim = engine_cls()
+        adapter._install_action_controller(sim)
+        assert sim.installed == {}
+
+
+class TestAnAcceptedInstallCanConvertItsFirstAction:
+    """The invariant that ties the probe to the solver.
+
+    ``IsaacDeltaEEFController._solve_arm_targets`` re-checks the shape and
+    finiteness of both reads on every action. If the install probe asserts the
+    same properties, then an accepted install cannot fail the solver on its
+    first action - so for every engine, either the install refuses or the
+    conversion succeeds, and never "installed, then fails per action".
+    """
+
+    @pytest.mark.parametrize(
+        ("engine_cls", "phrase"),
+        [*BROKEN_ENGINES, pytest.param(_FakeIsaacSim, "", id="healthy-engine")],
+    )
+    def test_install_refuses_or_the_first_conversion_succeeds(self, engine_cls, phrase):  # noqa: ARG002
+        adapter = _adapter(strict_action_controller=True)
+        sim = engine_cls()
+        try:
+            adapter._install_action_controller(sim)
+        except _ControllerInstallError:
+            return  # refused at install - the other half of the contract
+        controller = sim.installed["robot"]
+        targets = controller.compute_joint_targets({"x": 0.01, "gripper": 1.0})
+        assert set(targets) == set(ALL_JOINTS)
+
+
+class TestTheProbeIsAFixedInstallTimeCost:
+    def test_each_read_is_probed_once(self):
+        """The probe must be a one-off install cost, not a per-action read."""
+        calls = {"obs": 0, "jac": 0}
+
+        class _Counting(_FakeIsaacSim):
+            def get_observation(self, robot_name=None, *, skip_images=False):
+                calls["obs"] += 1
+                return super().get_observation(robot_name, skip_images=skip_images)
+
+            def get_jacobian(self, **kwargs):
+                calls["jac"] += 1
+                return super().get_jacobian(**kwargs)
+
+        adapter = _adapter(strict_action_controller=True)
+        adapter._install_action_controller(_Counting())
+        assert calls == {"obs": 1, "jac": 1}
+
+    def test_the_healthy_engine_still_installs_and_converts(self):
+        """Over-reach control: the probe refuses nothing a working engine does."""
+        adapter = _adapter(strict_action_controller=True)
+        sim = _FakeIsaacSim()
+        adapter._install_action_controller(sim)
+        assert adapter._action_controller_error is None
+        assert adapter._isaac_action_controller_robot == "robot"
+        targets = sim.installed["robot"].compute_joint_targets({"x": 1.0, "gripper": 1.0})
+        assert targets["panda_joint1"] > 0.1
+
+
+class TestTheSolverStillOwnsTheChecksTheProbeCannotMake:
+    """Scope boundary, measured rather than asserted."""
+
+    def test_the_joint_state_width_needs_no_install_check(self):
+        """The injected closure builds exactly one element per arm joint, so a
+        width mismatch is unreachable from this call site - an install-time
+        width check would be dead code. The solver keeps its own check because
+        it accepts any injected callable."""
+        adapter = _adapter(strict_action_controller=True)
+        sim = _FakeIsaacSim(joint_names=[*ALL_JOINTS, "extra_joint"])
+        adapter._install_action_controller(sim)
+        controller = sim.installed["robot"]
+        assert len(controller.arm_joint_names) == len(ARM)
+        q = controller._joint_positions_fn()
+        assert np.asarray(q).shape == (len(ARM),)
+
+    def test_the_solver_refuses_a_short_joint_state_from_any_other_caller(self):
+        """The solver's own width check stays reachable for a hand-built
+        controller, which is why the probe does not duplicate it."""
+        controller = IsaacDeltaEEFController(
+            arm_joint_names=list(ARM),
+            gripper_joint_names=list(GRIP),
+            joint_positions_fn=lambda: np.zeros(3),
+            jacobian_fn=lambda: np.eye(6, len(ARM)),
+        )
+        with pytest.raises(RuntimeError, match="joint_positions_fn returned shape"):
+            controller.compute_joint_targets({"x": 0.01})


### PR DESCRIPTION
## Problem

`LiberoAdapter._try_install_isaac_action_controller` probes at install time, and its own comment says exactly why:

> Probe the Jacobian once at install time so a broken kinematics read surfaces as a loud install error at episode start (where the strict/non-strict policy applies) instead of as one error envelope per action mid-eval.

`IsaacDeltaEEFController` reads **two** things on every action - the Jacobian, and the arm joint state via `get_observation`. Only the Jacobian was probed, and only a `RuntimeError` from the getter was translated.

The joint-state read is not implied by the Jacobian read. The install validates the arm joints against `robot_joint_names` (the articulation DOFs) while `_solve_arm_targets` reads `get_observation`, so an engine that satisfies the first and not the second passes the install and fails every action. `IsaacSimulation.get_observation` also returns `{}` rather than an error for an unknown robot, so that surface cannot be assumed healthy because the Jacobian answered.

Measured at `8c20c792`, one broken engine per row, `strict_action_controller=True`:

| broken kinematics read | install | per action |
|---|---|---|
| observation omits an arm joint | accepted, `_action_controller_error = None` | 26/26 conversions fail |
| observation namespaces its keys | accepted, `_action_controller_error = None` | 26/26 conversions fail |
| observation reports a non-finite joint | accepted, `_action_controller_error = None` | 26/26 conversions fail |
| Jacobian contains a non-finite value | accepted, `_action_controller_error = None` | 26/26 conversions fail |
| Jacobian has too few columns | bare `IndexError` | - |
| Jacobian has ragged rows | bare `ValueError` | - |
| Jacobian payload has no `jacp` | bare `KeyError` | - |
| `get_jacobian` returns `status: error` | `_ControllerInstallError` | - |
| Jacobian has 7 rows | `_ControllerInstallError` | - |
| `install_action_controller` refuses | `_ControllerInstallError` | - |

Two distinct failures. Four reads install a controller with `_action_controller_error` unset, so non-strict mode records nothing and strict mode has nothing to raise - the still-robot-with-a-green-eval shape the probe exists to prevent, and the shape this method's docstring names as the defect it fixed. Three malformed Jacobian payloads escape as a bare exception, outside the `_ControllerInstallError` contract the docstring's `Raises:` states, so the caller's strict/non-strict policy never applies to them.

## Change

The probe now asserts exactly the preconditions `_solve_arm_targets` re-checks on every action - the shape and finiteness of both reads - and every probe failure is a `_ControllerInstallError`. That single rule closes both failures, and it gives the invariant a name: **a controller that installs cannot fail the solver on its first action.**

`except Exception` on the two probes is a translation path, not a swallow. Four reasons, in the comment: the documented contract is that any broken setup lands as `_ControllerInstallError`; a malformed payload raises whatever numpy makes of it (measured `IndexError`, `ValueError`, `KeyError`), so an enumerated tuple is not complete; the sibling OSC install path in the same method translates an unexpected failure class the same way; and each of those classes would otherwise escape the `Raises:` contract.

The `Raises:` entry now names the malformed-Jacobian and joint-state classes.

## Scope

A width check on the joint-state probe would be **dead code** and is deliberately absent: the injected closure builds exactly one element per arm joint, so a width mismatch is unreachable from this call site. The solver keeps its own width check because it accepts any injected callable, and `TestTheSolverStillOwnsTheChecksTheProbeCannotMake` pins both halves of that split.

## Tests

`tests/benchmarks/libero/test_isaac_action_controller_install.py`, 9 -> 50 cases:

- `TestEveryBrokenKinematicsReadIsLoudAtInstall` - the nine broken engines above x (strict raises / non-strict records / no controller left installed).
- `TestAnAcceptedInstallCanConvertItsFirstAction` - the invariant, over all nine plus the healthy engine: either the install refuses, or the first conversion succeeds. Never "installed, then fails per action".
- `TestTheProbeIsAFixedInstallTimeCost` - each read is probed exactly once, and the healthy engine still installs and converts (over-reach control).
- `TestTheSolverStillOwnsTheChecksTheProbeCannotMake` - the scope boundary above, measured.

**Pre-fix proof**, source reverted to `8c20c792` with the new tests kept: **29 failed, 21 passed**. The failures are the defect verbatim - `Failed: DID NOT RAISE _ControllerInstallError` for the four silent reads, and bare `IndexError` / `ValueError` / `KeyError` for the three escaping payloads. The 21 that pass are the nine pre-existing cases plus the controls (the healthy engine, the two classes that already refused correctly, and the scope boundary), which is what keeps the change from over-reaching.

## Artifact

The production `IsaacDeltaEEFController` driven through the real install path over an engine exposing the Isaac action seam backed by a real MuJoCo Franka, so the install decision and the joint targets are both real. Isaac Sim is not required to reach the install decision - the adapter's probe is duck-typed.

![Isaac install kinematics probe](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-install-kinematics-probe/isaac-install-kinematics-probe.png)

Panel 1 is identical across trees (`max |delta| = 2/255`), so the honored path is untouched: install accepted, 26/26 applied, hand z 0.6188 -> 0.3603 m. Panels 2 and 3 are also identical (`max |delta| = 2/255`) - the physics is unchanged, and the whole difference is what the caller is told and when. Panel 1 differs from its own start frame on 20.7% of pixels, so the controller measurably moves the arm.

Capture, compose and both JSON dumps are on the artifact branch. `compose.py` reads every number it renders from the two dumps, asserts the captures ran in different trees, and refuses to save unless the honored render matches across trees and the arm measurably moves.

## Gate

Base `8c20c792`. `MUJOCO_GL=egl pytest tests`: **27803 passed, 257 skipped, 0 failed** (618 s). `ruff check` and `ruff format --check` clean over 1168 files. `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a pristine-base worktree of the same checkout. `assemble_changelog.py --check` OK. The seven repo-wide guards plus the `Args:` sweep: 420 passed. Merge-base overlap check: no overlap, 0 paths changed in that span.
