### PR TITLE
test(training): pin the quantile-norm probe's unreadable-registry branches

### DIFF
--- a/changelog.d/2136-quantile-norm-probe-fallback-coverage.md
+++ b/changelog.d/2136-quantile-norm-probe-fallback-coverage.md
@@ -1,0 +1,17 @@
+### Quality: pin the quantile-normalization probe's two unreadable-registry branches
+
+`_policy_uses_quantile_norm` is the only registry probe in the LeRobot trainer that
+calls a config field's `default_factory` rather than looking a field name up, so it
+is the only one with a branch for "the registry holds this policy type but its answer
+cannot be read". That branch, and the sibling "the config declares no such field"
+branch, resolve the same question two deliberately different ways - unknown falls back
+to the documented static set, a missing field is definitively `False` - and neither ran
+under test. `TestOfflineFallback` pinned the offline fallback for three of the four
+gates it covers; the quantile gate was the fourth.
+
+Adds five tests: both branches, the asymmetry between them, a tripwire recording that
+no config lerobot ships omits `normalization_mapping` (so the second branch needs an
+injected registry today), and the consequence at the surface a caller reads - with the
+registry answer unreadable, `validate`'s quantile-stats preflight still warns that a
+`molmoact2` dataset lacking `q01`/`q99` would be mis-normalized. No library behaviour
+changes.

--- a/tests/training/test_lerobot_policy_type_discovery.py
+++ b/tests/training/test_lerobot_policy_type_discovery.py
@@ -14,6 +14,12 @@ reward-model, robot, teleop, and camera surfaces already use. The
 ``method='expert_only'`` gate is discovered the same way, off each config's
 ``train_expert_only`` field.
 
+One gate is discovered slightly differently. The QUANTILES-normalization gate
+reads each config's ``normalization_mapping`` *default* rather than a field
+name, so it is the only probe here that can hold the type and still fail to
+read its answer - and it resolves "unknown" and "declares no such field" two
+deliberately different ways. ``TestQuantileNormRegistryProbe`` pins both.
+
 These tests pin the invariant against whatever lerobot is installed (they read
 its live registry rather than hardcoding type names), so they hold across
 lerobot versions and fail on the pre-fix hardcoded gates whenever the registry
@@ -31,12 +37,14 @@ from strands_robots.training import TrainSpec
 from strands_robots.training.lerobot import (
     _EXPERT_ONLY_POLICY_TYPES_FALLBACK,
     _LEROBOT_POLICY_TYPES_FALLBACK,
+    _QUANTILE_NORM_POLICY_TYPES_FALLBACK,
     _RELATIVE_ACTION_POLICY_TYPES_FALLBACK,
     LerobotTrainer,
     _lerobot_policy_types,
     _policy_registry,
     _policy_supports_expert_only,
     _policy_supports_relative_actions,
+    _policy_uses_quantile_norm,
 )
 
 
@@ -46,6 +54,39 @@ def dataset_root(tmp_path):
     meta.mkdir()
     (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
     return str(tmp_path)
+
+
+def _broken_default_factory() -> dict[str, str]:
+    """A ``default_factory`` that cannot be evaluated (a broken config default)."""
+    raise RuntimeError("config default_factory is broken")
+
+
+@dataclasses.dataclass
+class _UnreadableNormalizationConfig:
+    """Declares ``normalization_mapping``, but its default cannot be read."""
+
+    normalization_mapping: dict[str, str] = dataclasses.field(default_factory=_broken_default_factory)
+
+
+@dataclasses.dataclass
+class _NoNormalizationMappingConfig:
+    """Declares no ``normalization_mapping`` field at all."""
+
+    chunk_size: int = 8
+
+
+def _patch_registry(monkeypatch, cfg_cls) -> None:
+    """Point the live-registry probe at ``cfg_cls`` for the types used below."""
+    assert _QUANTILE_NORM_POLICY_TYPES_FALLBACK, "the static set must be non-empty for the loops below"
+    registry = dict.fromkeys([*_QUANTILE_NORM_POLICY_TYPES_FALLBACK, "act"], cfg_cls)
+    monkeypatch.setattr("strands_robots.training.lerobot._policy_registry", lambda: registry)
+
+
+def _write_stats_without_quantiles(tmp_path) -> None:
+    """Write a v3 ``meta/stats.json`` carrying mean/std/min/max but no ``q01``/``q99``."""
+    feature = {"mean": [0.0], "std": [1.0], "min": [-1.0], "max": [1.0]}
+    stats = {"observation.state": dict(feature), "action": dict(feature)}
+    (tmp_path / "meta" / "stats.json").write_text(json.dumps(stats))
 
 
 def _spec(dataset_root, tmp_path, **extra) -> TrainSpec:
@@ -182,3 +223,78 @@ class TestOfflineFallback:
             assert _policy_supports_expert_only(ptype) is True
         assert _policy_supports_expert_only("act") is False
         assert _policy_supports_expert_only("definitely_not_a_policy") is False
+
+    def test_quantile_norm_falls_back_to_static_set(self, monkeypatch):
+        monkeypatch.setattr("strands_robots.training.lerobot._policy_registry", lambda: None)
+        for ptype in _QUANTILE_NORM_POLICY_TYPES_FALLBACK:
+            assert _policy_uses_quantile_norm(ptype) is True
+        assert _policy_uses_quantile_norm("act") is False
+        assert _policy_uses_quantile_norm("definitely_not_a_policy") is False
+
+
+class TestQuantileNormRegistryProbe:
+    """The quantile gate reads a field's *default*, not just its name.
+
+    :func:`~strands_robots.training.lerobot._policy_uses_quantile_norm` is the
+    only registry probe here that calls a ``default_factory`` instead of looking
+    a field name up, so it is the only one that can hold the type and still fail
+    to read its answer. It resolves that case and "the config declares no such
+    field" two deliberately different ways:
+
+    * an **unreadable default** means the answer is unknown, so the documented
+      static set decides - a ``molmoact2`` run keeps its quantile-stats warning;
+    * a **missing field** is itself the answer - the config does not declare
+      quantile normalization - so the result is ``False`` and the static set is
+      not consulted.
+
+    Collapsing the two would silence ``validate``'s quantile-stats preflight for
+    exactly the policies that need it, which is the consequence the last test
+    here measures at the surface a caller reads.
+    """
+
+    def test_unreadable_default_factory_falls_back_to_static_set(self, monkeypatch):
+        """An unreadable default is unknown, so the static set decides."""
+        _patch_registry(monkeypatch, _UnreadableNormalizationConfig)
+        for ptype in _QUANTILE_NORM_POLICY_TYPES_FALLBACK:
+            assert _policy_uses_quantile_norm(ptype) is True, ptype
+        assert _policy_uses_quantile_norm("act") is False
+
+    def test_config_without_normalization_mapping_is_definitively_false(self, monkeypatch):
+        """A missing field is an answer, not an unknown: the static set is not consulted."""
+        _patch_registry(monkeypatch, _NoNormalizationMappingConfig)
+        for ptype in _QUANTILE_NORM_POLICY_TYPES_FALLBACK:
+            assert _policy_uses_quantile_norm(ptype) is False, ptype
+        assert _policy_uses_quantile_norm("act") is False
+
+    def test_every_registry_config_declares_normalization_mapping(self):
+        """Why the test above must inject a registry rather than name a real type.
+
+        Every config lerobot ships declares ``normalization_mapping``, so the
+        "no such field" branch is unreachable through the live registry today.
+        This fails the day lerobot registers a config without it - at which point
+        that branch becomes reachable for a real policy type.
+        """
+        reg = _policy_registry()
+        if reg is None:
+            pytest.skip("lerobot not installed")
+        assert reg, "lerobot registry unexpectedly empty"
+        lacking = sorted(
+            ptype
+            for ptype, cfg_cls in reg.items()
+            if not any(f.name == "normalization_mapping" for f in dataclasses.fields(cfg_cls))
+        )
+        assert lacking == [], f"now reachable through the live registry: {lacking}"
+
+    def test_unreadable_default_keeps_the_quantile_stats_preflight_firing(self, dataset_root, tmp_path, monkeypatch):
+        """The fallback's purpose, at the surface a caller reads.
+
+        ``validate`` warns when a QUANTILES-normalizing policy is pointed at a
+        dataset whose stats carry no ``q01``/``q99``, because lerobot would
+        mis-normalize or fail at train time. With the registry answer unreadable,
+        the static set is what keeps that warning firing - answering ``False``
+        there instead would let the run start with nothing reported.
+        """
+        _write_stats_without_quantiles(tmp_path)
+        _patch_registry(monkeypatch, _UnreadableNormalizationConfig)
+        problems = LerobotTrainer(device="cpu").validate(_spec(dataset_root, tmp_path, policy_type="molmoact2"))
+        assert any("augment_dataset_quantile_stats" in p for p in problems), problems


### PR DESCRIPTION
## Problem

`strands_robots/training/lerobot.py` discovers eight things from lerobot's live
`PreTrainedConfig` registry, each with a documented static fallback for when that registry is
unavailable. Seven of the eight had fully covered bodies. One did not:

| registry probe | reads | uncovered lines on `main` |
|---|---|---|
| `_policy_registry` | the registry itself | none |
| `_lerobot_policy_types` | the registry keys | none |
| `_policy_supports_relative_actions` | a field **name** | none |
| `_policy_supports_expert_only` | a field **name** | none |
| `_policy_uses_quantile_norm` | a field's **default** | **235, 236, 238** (3 of 11) |
| `_reward_registry` | the registry itself | none |
| `_reward_model_types` | the registry keys | none |
| `_reward_friendly_fields` | a config's fields | none |

The asymmetry is structural rather than accidental. Every other probe answers by looking a field
*name* up, which either finds it or does not. `_policy_uses_quantile_norm` **calls**
`normalization_mapping`'s `default_factory`, so it has a third outcome the others cannot have: the
registry holds the policy type, and its answer still cannot be read.

It resolves that case and the neighbouring "the config declares no such field" case two
deliberately different ways, and neither ran under test:

- an **unreadable default** means the answer is *unknown*, so the documented static set decides
  (L235-236);
- a **missing field** is itself the answer - the config does not declare quantile normalization -
  so the result is `False` and the static set is not consulted (L238).

`TestOfflineFallback` in `tests/training/test_lerobot_policy_type_discovery.py` pins the offline
fallback for three of the four gates that file covers - native types, relative actions,
`expert_only`. The quantile gate was the missing fourth.

## Why it matters

The consumer is `LerobotTrainer.validate`'s quantile-stats preflight. It warns when a
QUANTILES-normalizing policy is pointed at a dataset whose `meta/stats.json` carries no
`q01`/`q99`, because lerobot would mis-normalize or fail at train time, and it prints the
`augment_dataset_quantile_stats` remedy. A wrong `False` from this probe silences that warning.
Measured end to end:

| registry state | policy_type | probe answers | validate() warns? |
|---|---|---|---|
| live registry (control) | `molmoact2` | `True` | yes - mis-normalization flagged |
| unreadable `default_factory` | `molmoact2` | `True` | yes - mis-normalization flagged |
| unreadable `default_factory` | `act` | `False` | no |
| no `normalization_mapping` field | `molmoact2` | `False` | no |

Row 2 is the fallback doing its job: with the registry answer unreadable, the static set is what
keeps the warning firing. Row 4 is the other branch answering correctly - a config that declares
no normalization mapping does not quantile-normalize. Collapsing the two in either direction is a
silent regression, which is what the tests below now catch.

## What this adds

Five tests, no production change:

- `TestOfflineFallback.test_quantile_norm_falls_back_to_static_set` - the missing fourth member,
  written to match its three siblings exactly.
- `TestQuantileNormRegistryProbe.test_unreadable_default_factory_falls_back_to_static_set` -
  L235-236, asserting both directions (a fallback member is `True`, a non-member is `False`).
- `...test_config_without_normalization_mapping_is_definitively_false` - L238, asserting
  `molmoact2` is `False` here, which is what pins the asymmetry against the test above.
- `...test_every_registry_config_declares_normalization_mapping` - a tripwire. All 19 configs
  lerobot ships declare `normalization_mapping`, so the missing-field branch is unreachable
  through the live registry today and the test above must inject a registry. This fails the day
  lerobot registers a config without it, at which point that branch becomes reachable for a real
  policy type.
- `...test_unreadable_default_keeps_the_quantile_stats_preflight_firing` - the consequence at the
  surface a caller reads, driving `validate()` rather than the helper.

The helpers are local to the file and need no optional dependency: two small dataclasses model the
two config shapes, and the registry probe is monkeypatched. `_patch_registry` asserts the static
set is non-empty so the loops over it cannot pass vacuously.

## Fails pre-fix

The production code is correct, so these tests necessarily **pass** on unmodified `main`. What they
fail on is a regression, so the evidence is a mutation table. Each mutation is scoped to
`_policy_uses_quantile_norm` by AST line range (M3's anchor `    return False` occurs twice in the
module, so the scoping is load-bearing), applied, run against both arms, and reverted with the
source asserted byte-identical afterwards. The second arm is `upstream/main`'s own copy of the same
test file.

| mutation | this PR | pre-existing tests |
|---|---|---|
| M1 - drop the `try`/`except` so a broken default propagates | 2 failed / 13 passed | 0 failed / 10 passed |
| M2 - unknown collapses to `False` (silences the preflight) | 2 failed / 13 passed | 0 failed / 10 passed |
| M3 - missing field collapses to the static set | 1 failed / 14 passed | 0 failed / 10 passed |
| M4 - narrow the handler to `except TypeError` | 2 failed / 13 passed | 0 failed / 10 passed |
| unmutated control | 0 failed / 15 passed | 0 failed / 10 passed |

**4 of 4 caught here; 4 of 4 invisible to the suite as it stood.** M2 is the one that matters most -
it is the collapse that makes a `molmoact2` run start against a dataset lerobot will mis-normalize
with nothing reported.

Coverage, measured over the same file list with the five new tests deselected as the before-arm:

| arm | target lines still missing |
|---|---|
| before (5 new tests deselected) | `[235, 236, 238]` |
| after | none |

## Artifact

Tests only - no policy, simulation, rendering, recording or asset behaviour changes, so there is no
rollout to show. The measurement is the artifact: the eight-probe matrix, the mutation table over
both arms, and the consequence table above, every cell re-derived from one capture run and asserted
by the figure generator before it saves.

![quantile-norm probe coverage](https://raw.githubusercontent.com/cagataycali/robots/artifacts/quantile-norm-probe-coverage/quantile-norm-probe-coverage.png)

Capture and compose scripts, plus the census views that located the gap, are on
[`artifacts/quantile-norm-probe-coverage`](https://github.com/cagataycali/robots/tree/artifacts/quantile-norm-probe-coverage).

## Gate

Rebased onto `bb4f58e7` and re-verified there, so the numbers describe the tree that merges.
`scripts/check_merge_base_overlap.py` reports no overlap; `main...head` is `behind_by: 0`.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` - **27808 passed, 257 skipped, 0 failed** (612s).
  Pristine `main` at the previous base was 27762; `main` then gained #2135's 41 tests, and these 5
  make 27808.
- `tests/training/test_lerobot_policy_type_discovery.py` alone - 15 passed in 3.7s (was 10), no GL.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` - clean, 1168 files.
- `mypy strands_robots tests tests_integ` - 14 errors, all in `examples/isaac_gs`, **0 outside**;
  error set byte-identical to a pristine-base worktree of the same working copy, so environmental.
- The seven repo-wide root guards plus the `Args:` completeness sweep - 420 passed.
- `scripts/assemble_changelog.py --check` - OK; exactly one `changelog.d/2136-*` fragment.
- The mutation table and the coverage delta above were both re-derived at the new base and are
  unchanged from the pre-rebase run.
