### PR TITLE
fix(simulation/isaac): bound every numeric knob of the delta-EEF controller

### DIFF
--- a/changelog.d/2137-isaac-delta-eef-numeric-domain.md
+++ b/changelog.d/2137-isaac-delta-eef-numeric-domain.md
@@ -1,0 +1,24 @@
+### Fixed: the Isaac delta-EEF controller accepted `inf` for every scale it bounds, and any value at all for a gripper reference
+
+`IsaacDeltaEEFController.__init__` bounded `pos_scale`, `rot_scale` and
+`damping` with an order comparison (`> 0`), and bounded the `joint_limits`
+clip table with another (`lower > upper`). An order comparison cannot reject
+`inf` -- `inf > 0` is `True` -- and it cannot see a `nan` row either, since
+`nan > nan` is `False`. `gripper_open` and `gripper_close` had no numeric
+bound at all. Every such value was accepted at construction and then made
+`compute_joint_targets` return `nan` for all nine joints, which
+`send_action`'s action-value domain refuses one action at a time while
+naming the *joint* it was handed -- so a bad scale read as a per-action
+embodiment problem rather than as the configuration it was. A non-finite
+`gripper_close` was worse than loud: approach and hold actions were
+unaffected and it surfaced only at the first grasp.
+
+Each numeric knob now clears the shared scalar domain the rest of the
+library uses -- `positive_finite_number_error` for the two scales and the
+damping lambda, `finite_number_error` for the two gripper references (a
+joint reference of either sign is usable) -- and the limits table is checked
+for finiteness before it is checked for order. A refused value is reported
+against the parameter it came from, before either injected kinematics read
+is called. The guards also make the constructor's own message reachable for
+a non-numeric value, which previously escaped as a bare `float()` conversion
+error.

--- a/strands_robots/simulation/isaac/delta_eef.py
+++ b/strands_robots/simulation/isaac/delta_eef.py
@@ -49,6 +49,8 @@ from typing import Any
 
 import numpy as np
 
+from strands_robots.utils import finite_number_error, positive_finite_number_error
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["IsaacDeltaEEFController", "TASK_SPACE_ACTION_KEYS"]
@@ -121,17 +123,22 @@ class IsaacDeltaEEFController:
         ``arm_joint_names`` order (PhysX row convention).
     joint_limits : array-like or None
         Optional ``(len(arm_joint_names), 2)`` lower/upper position limits;
-        targets are clipped into them. ``None`` disables clipping.
+        targets are clipped into them. ``None`` disables clipping. Every
+        bound must be finite -- a non-finite one clips every target to
+        ``nan``.
     pos_scale, rot_scale : float
         Metres / radians of task-space delta for a saturated (+/-1) input
-        channel. Defaults match robosuite ``OSC_POSE`` (#168).
+        channel. Defaults match robosuite ``OSC_POSE`` (#168). Both must
+        be positive and finite (:func:`~strands_robots.utils.positive_finite_number_error`).
     damping : float
-        DLS damping ``lambda`` (> 0). Keeps the solve bounded near
-        singularities.
+        DLS damping ``lambda``. Keeps the solve bounded near
+        singularities; must be positive and finite
+        (:func:`~strands_robots.utils.positive_finite_number_error`).
     gripper_open, gripper_close : float
         Joint position target written to every gripper joint for an
         open / close command. Defaults match the Franka USD's 0..0.04 m
-        prismatic fingers.
+        prismatic fingers. Either sign is usable, so only finiteness is
+        constrained (:func:`~strands_robots.utils.finite_number_error`).
 
     Concurrency: stateless between calls and does not touch the stage;
     safe to call from the thread driving ``send_action`` (which holds the
@@ -163,10 +170,23 @@ class IsaacDeltaEEFController:
             raise ValueError(f"arm and gripper joint names overlap: {sorted(overlap)}.")
         if not callable(joint_positions_fn) or not callable(jacobian_fn):
             raise TypeError("joint_positions_fn and jacobian_fn must be callables.")
-        if not (float(pos_scale) > 0.0 and float(rot_scale) > 0.0):
-            raise ValueError(f"pos_scale/rot_scale must be > 0, got {pos_scale!r}/{rot_scale!r}.")
-        if not float(damping) > 0.0:
-            raise ValueError(f"damping must be > 0, got {damping!r}.")
+        # Every numeric knob below is bounded by the shared scalar domain
+        # rather than by an order comparison. An order comparison cannot
+        # reject ``inf`` (``inf > 0`` is True), and each of these values
+        # multiplies or is added to the DLS solve, so an accepted ``inf``
+        # makes every joint target ``nan`` -- refused one action at a time
+        # by ``send_action``'s action-value domain, which names the joint it
+        # was handed and cannot know the value came from here.
+        for _param, _value in (("pos_scale", pos_scale), ("rot_scale", rot_scale), ("damping", damping)):
+            if error := positive_finite_number_error(_value, _param, "IsaacDeltaEEFController"):
+                raise ValueError(error)
+        # A gripper reference is a joint position, so both signs are
+        # legitimate and only finiteness is constrained. Unguarded, a
+        # non-finite one is latent: the controller runs healthy through
+        # every approach action and fails at the first grasp.
+        for _param, _value in (("gripper_open", gripper_open), ("gripper_close", gripper_close)):
+            if error := finite_number_error(_value, _param, "IsaacDeltaEEFController"):
+                raise ValueError(error)
 
         self.arm_joint_names = arm
         self.gripper_joint_names = grip
@@ -185,6 +205,15 @@ class IsaacDeltaEEFController:
             if limits.shape != (len(arm), 2):
                 raise ValueError(
                     f"joint_limits must have shape ({len(arm)}, 2) to match arm_joint_names, got {limits.shape}."
+                )
+            if not np.all(np.isfinite(limits)):
+                # Checked before the lower/upper comparison below, which
+                # cannot see a non-finite bound: ``nan > nan`` is False, so
+                # an all-nan table passes it and then clips every target to
+                # nan in ``compute_joint_targets``.
+                raise ValueError(
+                    "IsaacDeltaEEFController: joint_limits must be finite (no nan/inf); "
+                    "a non-finite bound clips every joint target to nan."
                 )
             if np.any(limits[:, 0] > limits[:, 1]):
                 raise ValueError("joint_limits has a lower bound above its upper bound.")

--- a/tests/simulation/isaac/test_delta_eef_constructor_domain.py
+++ b/tests/simulation/isaac/test_delta_eef_constructor_domain.py
@@ -1,0 +1,408 @@
+"""Every refusal ``IsaacDeltaEEFController.__init__`` makes, end to end (#1812).
+
+The controller's constructor takes five numeric knobs, and each one either
+multiplies the DLS differential-IK solve (``pos_scale`` / ``rot_scale`` /
+``damping``) or is written straight into a joint target (``gripper_open`` /
+``gripper_close``), plus a ``joint_limits`` table every target is clipped
+into. Three of them were bounded by an **order comparison** (``> 0``,
+``lower > upper``); an order comparison cannot reject ``inf`` (``inf > 0``
+is ``True``) and two of them were not bounded at all. Every such value was
+accepted at construction and then made ``compute_joint_targets`` return
+``nan`` for every joint, which ``send_action``'s action-value domain refuses
+one action at a time -- naming the *joint* it was handed, never the
+constructor parameter the value came from.
+
+This module pins that whole matrix:
+
+* :class:`TestNumericConstructorDomain` -- each of the five numeric knobs
+  reports the shared scalar domain's verdict verbatim, so the accepted
+  domain cannot drift from the one every other surface enforces.
+* :class:`TestAnOrderComparisonCannotSeeInf` -- the premise, executable:
+  ``inf`` satisfies ``> 0`` and ``nan > nan`` is ``False``, which is why
+  neither shape can bound these values.
+* :class:`TestJointLimitsMustBeFinite` -- the table's finiteness check runs
+  *before* its lower/upper comparison, which the premise above cannot see.
+* :class:`TestGripperReferenceIsLoadBearing` -- an unguarded non-finite
+  gripper reference is latent: approach and hold are unaffected and only
+  the first *close* produces ``nan``.
+* :class:`TestRefusalsThatHadNoTest` -- the four refusals the constructor
+  already made that nothing exercised (duplicate arm names, a
+  non-callable injected read, a non-positive scale, an inverted limit row).
+* :class:`TestToScalarFallback` -- the documented "everything else ->
+  ``default`` after a WARNING log" coercion branch.
+* :class:`TestARefusedValueNeverBecomesAPerActionEnvelope` -- the engine
+  seam, and the reason the constructor is the right place to refuse.
+* :class:`TestEveryNumericKnobIsJudged` -- a drift guard, so a sixth
+  numeric knob cannot ship unbounded.
+
+Fully mocked articulation: no Isaac Sim install is needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import math
+import pathlib
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac import delta_eef as delta_eef_mod
+from strands_robots.simulation.isaac.delta_eef import (
+    DEFAULT_POS_SCALE,
+    IsaacDeltaEEFController,
+    _to_scalar,
+)
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.utils import finite_number_error, positive_finite_number_error
+
+from .test_backend_parity import (  # noqa: F401 - fake_isaacsim_types is a fixture
+    _FakeArticulation,
+    _seed_running_world,
+    fake_isaacsim_types,
+)
+from .test_delta_eef_controller import ARM, DAMPING, GRIP
+
+JOINTS = ARM + GRIP
+
+#: Values no scalar domain in this repository accepts. ``inf`` is the one the
+#: replaced order comparisons let through the front door; ``nan`` they refused
+#: only because ``nan > 0`` is ``False``, and ``True`` because ``bool`` is an
+#: ``int`` subclass whose ``1`` would be a silent 20x scale.
+UNUSABLE = [
+    pytest.param(0.0, id="zero"),
+    pytest.param(-1.0, id="negative"),
+    pytest.param(math.nan, id="nan"),
+    pytest.param(math.inf, id="inf"),
+    pytest.param(-math.inf, id="neg-inf"),
+    pytest.param(True, id="bool"),
+    pytest.param("0.05", id="numeric-string"),
+    pytest.param(None, id="none"),
+    pytest.param([0.05], id="list"),
+]
+
+#: Values only the signed domain accepts -- a gripper reference is a joint
+#: position, so a negative reference is a legitimate configuration.
+SIGNED_ONLY = [pytest.param(0.0, id="zero"), pytest.param(-0.01, id="negative")]
+
+#: The three knobs that scale or damp the solve, and the shared domain each
+#: one is judged by. ``joint_limits`` is a table rather than a scalar and has
+#: :class:`TestJointLimitsMustBeFinite` to itself.
+POSITIVE_KNOBS = ("pos_scale", "rot_scale", "damping")
+SIGNED_KNOBS = ("gripper_open", "gripper_close")
+
+
+def _build(**overrides: Any) -> IsaacDeltaEEFController:
+    """Construct a controller, funnelling deliberately off-type overrides.
+
+    The numeric parameters are annotated ``float``, so a test that hands one
+    a string or ``None`` -- the whole point here -- is an ``arg-type`` error
+    at the call site. Splatting through one ``**kwargs: Any`` funnel keeps
+    the deliberate part in the parametrization instead of in a suppression.
+    """
+    kwargs: dict[str, Any] = {
+        "arm_joint_names": ARM,
+        "gripper_joint_names": GRIP,
+        "joint_positions_fn": lambda: np.zeros(7),
+        "jacobian_fn": lambda: np.eye(6, 7),
+    }
+    kwargs.update(overrides)
+    return IsaacDeltaEEFController(**kwargs)
+
+
+class TestNumericConstructorDomain:
+    """Each numeric knob reports the shared domain's verdict verbatim."""
+
+    @pytest.mark.parametrize("param", POSITIVE_KNOBS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_positive_knob_reports_the_shared_domain_verbatim(self, param: str, value: Any) -> None:
+        expected = positive_finite_number_error(value, param, "IsaacDeltaEEFController")
+        assert expected is not None, "probe value must be outside the domain"
+        with pytest.raises(ValueError) as excinfo:
+            _build(**{param: value})
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize("param", SIGNED_KNOBS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_signed_knob_reports_the_shared_domain_verbatim(self, param: str, value: Any) -> None:
+        expected = finite_number_error(value, param, "IsaacDeltaEEFController")
+        if expected is None:
+            # A gripper reference may legitimately be zero or negative; the
+            # signed domain accepts it and so must the constructor.
+            _build(**{param: value})
+            return
+        with pytest.raises(ValueError) as excinfo:
+            _build(**{param: value})
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize("param", SIGNED_KNOBS)
+    @pytest.mark.parametrize("value", SIGNED_ONLY)
+    def test_a_gripper_reference_may_be_zero_or_negative(self, param: str, value: float) -> None:
+        controller = _build(**{param: value})
+        assert getattr(controller, f"_{param}") == pytest.approx(value)
+
+    @pytest.mark.parametrize("param", POSITIVE_KNOBS + SIGNED_KNOBS)
+    def test_the_default_is_inside_its_own_domain(self, param: str) -> None:
+        """The shipped default must satisfy the domain it is judged by."""
+        default = inspect.signature(IsaacDeltaEEFController).parameters[param].default
+        judge = positive_finite_number_error if param in POSITIVE_KNOBS else finite_number_error
+        assert judge(default, param, "IsaacDeltaEEFController") is None
+
+    def test_a_refused_knob_is_named_not_the_joint_it_would_have_poisoned(self) -> None:
+        """The refusal names the parameter, which the per-action one cannot."""
+        with pytest.raises(ValueError, match=r"^IsaacDeltaEEFController: pos_scale must be > 0"):
+            _build(pos_scale=math.inf)
+
+
+class TestAnOrderComparisonCannotSeeInf:
+    """The premise the replaced guards rested on, measured rather than asserted."""
+
+    def test_inf_satisfies_a_positive_order_comparison(self) -> None:
+        assert math.inf > 0.0, "an order comparison cannot reject inf"
+
+    def test_nan_fails_both_directions_of_an_order_comparison(self) -> None:
+        assert not (math.nan > 0.0)
+        assert not (math.nan <= 0.0)
+
+    def test_nan_bounds_pass_an_inverted_limit_comparison(self) -> None:
+        limits = np.full((len(ARM), 2), math.nan)
+        assert not np.any(limits[:, 0] > limits[:, 1]), "lower>upper cannot see a nan row"
+
+    def test_the_domain_refuses_what_the_order_comparison_accepted(self) -> None:
+        for param in POSITIVE_KNOBS:
+            with pytest.raises(ValueError, match=r"must be > 0, got inf"):
+                _build(**{param: math.inf})
+
+
+class TestJointLimitsMustBeFinite:
+    """The clip table is checked for finiteness before it is checked for order."""
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            pytest.param([math.nan, math.nan], id="both-nan"),
+            pytest.param([0.0, math.nan], id="upper-nan"),
+            pytest.param([math.nan, 1.0], id="lower-nan"),
+            pytest.param([-math.inf, 1.0], id="lower-neg-inf"),
+            pytest.param([0.0, math.inf], id="upper-inf"),
+        ],
+    )
+    def test_a_non_finite_bound_is_refused(self, row: list[float]) -> None:
+        with pytest.raises(ValueError, match=r"joint_limits must be finite \(no nan/inf\)"):
+            _build(joint_limits=[list(row)] * len(ARM))
+
+    def test_the_inverted_row_check_is_still_reachable(self) -> None:
+        """Finiteness runs first, so the order check keeps its own message."""
+        with pytest.raises(ValueError, match="lower bound above its upper bound"):
+            _build(joint_limits=[[1.0, 0.0]] * len(ARM))
+
+    def test_a_usable_table_still_clips(self) -> None:
+        controller = _build(joint_limits=[[-0.01, 0.01]] * len(ARM))
+        targets = controller.compute_joint_targets({"x": 1.0})
+        assert targets[ARM[0]] == pytest.approx(0.01)
+
+    def test_none_still_disables_clipping(self) -> None:
+        controller = _build(joint_limits=None)
+        targets = controller.compute_joint_targets({"x": 1.0})
+        assert targets[ARM[0]] == pytest.approx(DEFAULT_POS_SCALE / (1.0 + DAMPING**2), abs=1e-6)
+
+
+class TestGripperReferenceIsLoadBearing:
+    """A gripper reference reaches a target, so a bad one is latent."""
+
+    def test_open_and_close_write_their_configured_references(self) -> None:
+        controller = _build(gripper_open=0.031, gripper_close=-0.002)
+        opened = controller.compute_joint_targets({"gripper": 1.0})
+        closed = controller.compute_joint_targets({"gripper": 0.0})
+        for joint in GRIP:
+            assert opened[joint] == pytest.approx(0.031)
+            assert closed[joint] == pytest.approx(-0.002)
+
+    def test_a_close_reference_is_unread_until_the_first_close(self) -> None:
+        """Why an unguarded reference was latent, not loud.
+
+        ``gripper_close`` is read only by a close command, so an unusable one
+        left approach and hold actions untouched and surfaced at the grasp.
+        The reference is now refused at construction; this pins the read
+        pattern that made it latent.
+        """
+        controller = _build(gripper_close=-0.002)
+        assert set(controller.compute_joint_targets({"gripper": 1.0})) >= set(GRIP)
+        assert not set(controller.compute_joint_targets({"gripper": 0.5})) & set(GRIP)
+        assert set(controller.compute_joint_targets({"gripper": 0.0})) >= set(GRIP)
+
+
+class TestRefusalsThatHadNoTest:
+    """The four refusals the constructor already made and nothing exercised."""
+
+    def test_duplicate_arm_joint_names_are_refused(self) -> None:
+        with pytest.raises(ValueError, match="contains duplicates"):
+            _build(arm_joint_names=[ARM[0]] + ARM)
+
+    @pytest.mark.parametrize("param", ["joint_positions_fn", "jacobian_fn"])
+    @pytest.mark.parametrize("value", [None, 42, "callable"])
+    def test_a_non_callable_injected_read_is_refused(self, param: str, value: Any) -> None:
+        with pytest.raises(TypeError, match="must be callables"):
+            _build(**{param: value})
+
+    @pytest.mark.parametrize("param", POSITIVE_KNOBS)
+    def test_a_non_positive_scale_is_refused(self, param: str) -> None:
+        with pytest.raises(ValueError, match=rf"{param} must be > 0, got 0\.0"):
+            _build(**{param: 0.0})
+
+    def test_an_inverted_limit_row_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="lower bound above its upper bound"):
+            _build(joint_limits=[[0.1, -0.1]] * len(ARM))
+
+
+class TestToScalarFallback:
+    """The documented "everything else -> default after a WARNING" branch."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(None, id="none"),
+            pytest.param([], id="empty-list"),
+            pytest.param({}, id="dict"),
+            pytest.param("abc", id="non-numeric-string"),
+            pytest.param([None], id="list-of-none"),
+            pytest.param(np.array([]), id="empty-array"),
+        ],
+    )
+    def test_an_uncoercible_channel_falls_back_to_the_default(self, value: Any) -> None:
+        assert _to_scalar(value, default=0.0) == 0.0
+        assert _to_scalar(value, default=0.25) == 0.25
+
+    def test_the_fallback_logs_a_warning_naming_the_value(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=delta_eef_mod.__name__):
+            assert _to_scalar("abc") == 0.0
+        assert any("could not coerce action value" in r.getMessage() for r in caplog.records)
+        assert any("'abc'" in r.getMessage() for r in caplog.records)
+
+    def test_an_uncoercible_channel_is_a_no_op_delta_not_a_raise(self) -> None:
+        """A malformed channel degrades that one axis, it does not abort the step."""
+        controller = _build()
+        targets = controller.compute_joint_targets({"x": 1.0, "y": None, "roll": "abc"})
+        assert all(np.isfinite(list(targets.values())))
+        assert targets[ARM[0]] == pytest.approx(DEFAULT_POS_SCALE / (1.0 + DAMPING**2), abs=1e-6)
+
+
+class _NanController:
+    """Stand-in whose conversion returns the non-finite targets a bad knob made."""
+
+    def compute_joint_targets(self, action: Any) -> dict[str, float]:  # noqa: ARG002 - fixed output
+        return dict.fromkeys(JOINTS, math.nan)
+
+    def reset(self) -> None:
+        return None
+
+
+class TestARefusedValueNeverBecomesAPerActionEnvelope:
+    """The engine seam: why the constructor is the right place to refuse."""
+
+    def test_a_non_finite_target_is_reported_against_a_joint_name(self, fake_isaacsim_types) -> None:  # noqa: F811, ARG002
+        """The failure a bad knob used to produce, once per action.
+
+        ``send_action``'s action-value domain sees only the converted target,
+        so it names the joint it was handed. That message is correct about
+        the value it has and cannot name the constructor parameter the value
+        came from -- which is the whole reason the knob is bounded up front.
+        """
+        sim = IsaacSimulation()
+        articulation = _FakeArticulation()
+        _seed_running_world(sim, JOINTS, articulation)
+        assert sim.install_action_controller("arm", _NanController())["status"] == "success"
+
+        result = sim.send_action({"x": 1.0, "gripper": 1.0}, robot_name="arm")
+        text = " ".join(block.get("text", "") for block in result["content"])
+        assert result["status"] == "error", result
+        assert "must be finite" in text
+        assert ARM[0] in text
+        assert "pos_scale" not in text
+        assert articulation.last_action is None, "a non-finite target must not be applied"
+
+    def test_a_usable_configuration_still_applies(self, fake_isaacsim_types) -> None:  # noqa: F811, ARG002
+        sim = IsaacSimulation()
+        articulation = _FakeArticulation()
+        _seed_running_world(sim, JOINTS, articulation)
+        assert sim.install_action_controller("arm", _build())["status"] == "success"
+
+        result = sim.send_action({"x": 1.0, "gripper": 1.0}, robot_name="arm")
+        assert result["status"] == "success", result
+        assert articulation.last_action is not None
+
+    def test_the_refusal_precedes_any_use_of_the_injected_reads(self) -> None:
+        """A refused knob never calls the callables it was handed."""
+        calls: list[str] = []
+
+        def positions() -> Any:
+            calls.append("q")
+            return np.zeros(7)
+
+        def jacobian() -> Any:
+            calls.append("jac")
+            return np.eye(6, 7)
+
+        with pytest.raises(ValueError):
+            _build(joint_positions_fn=positions, jacobian_fn=jacobian, damping=math.inf)
+        assert calls == []
+
+
+class TestEveryNumericKnobIsJudged:
+    """Drift guard: a sixth numeric knob cannot ship unbounded."""
+
+    @staticmethod
+    def _judged_params(source: str) -> set[str]:
+        """Parameter names appearing in a domain-guard tuple in ``__init__``."""
+        tree = ast.parse(source)
+        init = next(
+            node
+            for cls in tree.body
+            if isinstance(cls, ast.ClassDef) and cls.name == "IsaacDeltaEEFController"
+            for node in cls.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+        judged: set[str] = set()
+        for node in ast.walk(init):
+            if not isinstance(node, ast.Tuple) or len(node.elts) != 2:
+                continue
+            label, value = node.elts
+            if (
+                isinstance(label, ast.Constant)
+                and isinstance(label.value, str)
+                and isinstance(value, ast.Name)
+                and label.value == value.id
+            ):
+                judged.add(label.value)
+        return judged
+
+    @staticmethod
+    def _float_params() -> set[str]:
+        """Keyword-only ``float`` parameters of the constructor."""
+        signature = inspect.signature(IsaacDeltaEEFController)
+        return {name for name, parameter in signature.parameters.items() if parameter.annotation in ("float", float)}
+
+    def test_the_scanner_finds_the_known_knobs(self) -> None:
+        """Non-vacuity: an empty scan must not read as a clean sweep."""
+        source = pathlib.Path(inspect.getfile(delta_eef_mod)).read_text(encoding="utf-8")
+        assert self._judged_params(source) == set(POSITIVE_KNOBS) | set(SIGNED_KNOBS)
+        assert self._float_params() == set(POSITIVE_KNOBS) | set(SIGNED_KNOBS)
+
+    def test_every_float_parameter_is_judged_by_a_shared_domain(self) -> None:
+        source = pathlib.Path(inspect.getfile(delta_eef_mod)).read_text(encoding="utf-8")
+        adrift = sorted(self._float_params() - self._judged_params(source))
+        assert not adrift, f"numeric knob(s) reaching the solve unbounded: {adrift}"
+
+    def test_the_scanner_sees_a_planted_unbounded_knob(self) -> None:
+        """Meta: an added knob outside every guard tuple is reported."""
+        source = pathlib.Path(inspect.getfile(delta_eef_mod)).read_text(encoding="utf-8")
+        planted = source.replace(
+            "        gripper_close: float = 0.0,\n",
+            "        gripper_close: float = 0.0,\n        stiffness: float = 1.0,\n",
+            1,
+        )
+        assert planted != source
+        assert "stiffness" not in self._judged_params(planted)


### PR DESCRIPTION
## Problem

`IsaacDeltaEEFController.__init__` takes five numeric knobs. Three of them
multiply the DLS differential-IK solve (`pos_scale`, `rot_scale`, `damping`),
two are written straight into a joint target (`gripper_open`,
`gripper_close`), and a `joint_limits` table clips every target. Three were
bounded by an **order comparison** (`> 0`, `lower > upper`) and two were not
bounded at all.

An order comparison cannot reject `inf` -- `inf > 0` is `True` -- and it
cannot see a non-finite limit row either, since `nan > nan` is `False`. So
every one of these values was accepted at construction and then made
`compute_joint_targets` return `nan` for all nine joints:

| constructor value | before | first action | after |
|---|---|---|---|
| `pos_scale = inf` | accepted | 0 of 26 applied, 26 refused | refused, names `pos_scale` |
| `rot_scale = inf` | accepted | 0 of 26 applied, 26 refused | refused |
| `damping = inf` | accepted | 0 of 26 applied, 26 refused | refused |
| `joint_limits` all-`nan` | accepted | every target clipped to `nan` | refused |
| `gripper_open = inf` | accepted | `nan` finger target on the first open | refused |
| `gripper_close = nan` | accepted | **approach and hold unaffected; `nan` at the first grasp** | refused |
| `pos_scale = 'abc'` | bare `float()` `ValueError` | -- | refused, names `pos_scale` |
| `pos_scale = 0.05` (default) | accepted | 26 of 26 applied | accepted, unchanged |
| `gripper_close = -0.002` | accepted | applied | accepted, unchanged |

Two things make this worse than a late failure.

**The report names the wrong thing.** A `nan` target is refused by
`send_action`'s action-value domain, once per action:

```
send_action: action value for key 'panda_joint1' must be finite (no nan/inf), got nan.
```

That message is correct about the value it has, and it cannot be anything
else -- the domain sees only the converted target and has no way to know it
came from a constructor parameter. So a mis-set scale reads as a per-action
problem with the robot's action keys.

**A gripper reference is latent.** `gripper_close` is read only by a close
command, so an unusable one leaves every approach and hold action untouched
and surfaces at the first grasp.

## Change

Each numeric knob now clears the shared scalar domain the rest of the library
uses, before either injected kinematics read is called:

* `positive_finite_number_error` for `pos_scale`, `rot_scale` and `damping` --
  its docstring already names "a dimensionless multiplier" as its family.
* `finite_number_error` for `gripper_open` / `gripper_close` -- a joint
  reference of either sign is usable, so only finiteness is constrained.
* `joint_limits` is checked for finiteness **before** it is checked for
  order, which the premise above cannot see.

This also makes the constructor's own message reachable for a non-numeric
value: `pos_scale='abc'` previously escaped as a bare `float()` conversion
error naming neither the parameter nor the class.

## Why this shape

`WBCConfig.__post_init__` and `MotionBricksConfig.__post_init__` already
route their scales and signed scalars through these two helpers with the
class name as the message context; this mirrors them. Nothing new is
introduced.

Blast radius is zero: the only in-tree construction
(`LiberoAdapter._try_install_isaac_action_controller`) passes the four
required arguments and relies on every default, and each shipped default is
pinned as inside its own domain.

## Out of scope

`joint_limits='abc'` still surfaces as `np.asarray`'s
`could not convert string to float: 'abc'`. That is a non-numeric table
rather than a non-finite one -- a different axis, and the message is already
a `ValueError` that says what went wrong.

## Tests

`tests/simulation/isaac/test_delta_eef_constructor_domain.py`, 94 cases, no
Isaac Sim install required. It closes the whole refusal matrix, not just the
new part -- `TestControllerErrors` pinned 4 of the constructor's 8 refusals,
and the module's documented `_to_scalar` fallback had none:

* each knob reports the shared domain's verdict **verbatim** (`str(exc) ==
  helper(...)`), so the accepted domain cannot drift from the shared one;
* the premise, executable: `inf > 0` is `True`, `nan > nan` is `False`;
* the four refusals that already existed and nothing exercised (duplicate arm
  names, a non-callable injected read, a non-positive scale, an inverted limit
  row);
* the documented "everything else -> `default` after a WARNING log" coercion
  branch, including that a malformed channel degrades one axis rather than
  aborting the step;
* the engine seam -- a `nan` target really is reported against a joint name
  and nothing is applied, which is the reason the knob is bounded up front;
* a refused knob never calls the callables it was handed;
* a drift guard: every `float`-annotated constructor parameter must appear in
  a domain-guard tuple, with a non-vacuity pin and a planted-knob meta-test.

Pre-fix (source reverted, tests kept): **52 failed / 42 passed**, the drift
guard naming all five adrift knobs:

```
AssertionError: numeric knob(s) reaching the solve unbounded:
['damping', 'gripper_close', 'gripper_open', 'pos_scale', 'rot_scale']
```

The 42 that pass are the premise pins, the accepted-value controls, the
`_to_scalar` fallback and the pre-existing refusals -- they are what stops the
guards over-reaching.

Coverage of `strands_robots/simulation/isaac/delta_eef.py`: **91% -> 100%**
(94 statements, 8 missing -> 0), measured over the same file list with the new
cases deselected (1089 -> 1183 passed).

## Gate

Base `af27e58f`, head `3f456d2e`.

* `MUJOCO_GL=egl python -m pytest tests` -- **27902 passed, 257 skipped, 0
  failed** (612 s)
* `ruff check strands_robots tests tests_integ` -- clean
* `ruff format --check strands_robots tests tests_integ` -- clean (1169 files)
* `mypy strands_robots tests tests_integ` -- 0 errors outside
  `examples/isaac_gs`
* `scripts/check_merge_base_overlap.py` -- no overlap, 0 paths changed on
  `upstream/main` in that span
* `scripts/assemble_changelog.py --check` -- OK

## Artifact

The controller reads current joint positions and the end-effector Jacobian
through injected callables, so backing those with a compiled MuJoCo Panda
runs the production conversion unchanged and gives its joint targets a real
physical consequence. Isaac Sim is not required to reach either constructor
decision. Panels are real headless renders.

![Every numeric knob of IsaacDeltaEEFController, before and after](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-delta-eef-numeric-domain/isaac-delta-eef-numeric-domain.png)

Panel 1 is the usable configuration: 26 of 26 actions applied, 31.0% of
pixels differ from the settled pose, and it is **identical on both trees**
(0.00% differing, max|delta| = 2/255 -- renderer noise). Panels 2 and 3 are
**identical to each other** (0.00% differing, max|delta| = 1/255): the
physics is untouched either way, and the whole difference is what the caller
is told and how early. The capture and compose scripts are published beside
the figure; `compose.py` asserts every number it renders.
