### PR TITLE
fix(simulation/mujoco): stop advertising an action the tool_spec enum omits

### DIFF
--- a/changelog.d/2138-tool-spec-description-enum-parity.md
+++ b/changelog.d/2138-tool-spec-description-enum-parity.md
@@ -1,0 +1,23 @@
+### Fixed: the MuJoCo tool_spec description no longer advertises an action the schema omits
+
+`tool_spec`'s description enumerates the action surface as `Actions (77 total):
+[Category] ...`, and that sentence listed 78 names. The surplus one was
+`save_episode`, under `[Recording]` beside `start_recording` and
+`stop_recording`, while the `action` enum did not offer it - so a model
+following the description would emit a value a schema-constrained decoder
+cannot select, and the documented call came back rejected.
+
+Dropping the name rather than publishing it is what the surrounding state
+already decided: `save_episode` is declared deliberately Python-only in the
+dispatchable-but-unadvertised inventory, and `run_policy(n_episodes=N)` is the
+published multi-episode path that flushes a boundary per episode. Nothing an
+agent could reach was lost, and no Python caller is affected - the router still
+resolves `save_episode` by name.
+
+Both existing drift checks passed throughout, because both read the enum: one
+asks whether each *enum* entry appears in the text, so a surplus name is not a
+value it iterates, and the other compared the stated `77` against `len(enum)`,
+which agreed. The count literal was the one signal the lists had diverged, and
+it was measured against the enum rather than against the list it introduces.
+The converse direction is now pinned - every name the category lists carry must
+be in the enum, and the stated count must match the number of names listed.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4117,7 +4117,7 @@ class MuJoCoSimEngine(
                 "[Motion primitives] move_to (Cartesian EE transport via IK; not collision-aware), "
                 "set_gripper (open/close set-point), rotate_wrist (wrist-yaw set-point holding position); "
                 "[Scene MJCF] replace_scene_mjcf, patch_scene_mjcf, raycast, multi_raycast; "
-                "[Recording] start_recording, save_episode, stop_recording, get_recording_status, "
+                "[Recording] start_recording, stop_recording, get_recording_status, "
                 "start_cameras_recording, stop_cameras_recording, get_cameras_recording_status; "
                 "[Randomize] randomize, set_obs_noise (additive Gaussian sensor noise on observations and rendered frames); "
                 "[Benchmark] list_benchmarks, register_benchmark_from_file, register_builtin_benchmarks, evaluate_benchmark; "

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -330,6 +330,133 @@ def test_tool_spec_description_action_count_matches_enum(sim: Simulation) -> Non
     )
 
 
+# The converse direction: a described action the enum does not publish
+#
+# The two checks above pin ``enum -> description``: every enum entry is named in
+# the text, and the stated count equals ``len(enum)``. Neither can observe the
+# other direction, and the description carried a name the enum never offered -
+# ``save_episode``, listed under ``[Recording]`` beside ``start_recording`` and
+# ``stop_recording`` while absent from the enum and declared deliberately
+# Python-only in ``_PYTHON_ONLY_ACTIONS`` below.
+#
+# Both existing checks passed throughout. The membership scan only ever asks
+# whether each *enum* entry appears in the text, so a surplus name is not a
+# value it iterates. The count check compared the stated ``77`` against
+# ``len(enum)``, which agreed - the sentence was consistent with the enum while
+# introducing a list of 78 names, so the one number that would have contradicted
+# it was the one nobody counted.
+#
+# The direction matters because the two failures are not symmetric. An enum entry
+# missing from the text is undiscoverable but selectable. A name in the text that
+# the enum lacks is the reverse: the model is told to use an action the
+# schema-constrained decoder cannot emit, so following the documentation produces
+# a rejected call.
+#
+# ``describe()`` is deliberately wider than both and is not checked here - it
+# lists 90 methods, 13 of them Python-only, because it is the developer-facing
+# inventory. The description is not: it enumerates the *action* surface under a
+# count, which is what makes a name in it that the enum lacks a defect rather
+# than breadth.
+
+
+def _described_actions(description: str) -> list[str]:
+    """The capability names the description's ``Actions (...)`` sentence lists.
+
+    Parsed structurally rather than by harvesting every identifier-shaped word.
+    The categories carry parenthesised asides holding prose and ``;``
+    (``move_to (Cartesian EE transport via IK; not collision-aware)``), and the
+    final category is followed by a closing sentence that names ``destroy()``
+    a second time, so a word-harvesting scan would read both as list items - and
+    would fail this for a prose word that happened to match a Python-only method
+    name, which is not a drift. Asides are stripped, the trailing sentence is
+    cut, and only a bare identifier standing alone as a list item counts.
+    """
+    tail = description[description.index("Actions (") :]
+    names: list[str] = []
+    for segment in re.findall(r"\[[^\]]+\]([^\[]*)", tail):
+        segment = re.sub(r"\([^()]*\)", "", segment)
+        segment = segment.split(". ")[0]
+        for item in re.split(r"[;,]", segment):
+            item = item.strip().rstrip(".").strip()
+            if re.fullmatch(r"[a-z_][a-z0-9_]*", item):
+                names.append(item)
+    return names
+
+
+def test_tool_spec_description_names_no_action_the_enum_omits(sim: Simulation) -> None:
+    """Prose may not promise an action the decoder cannot select.
+
+    This is the direction that broke. ``save_episode`` stays reachable from
+    Python and stays in ``_PYTHON_ONLY_ACTIONS``; what it may not do is appear in
+    the model-facing action list. ``run_policy(n_episodes=N)`` is the published
+    multi-episode path, so nothing an agent could reach was lost by dropping it.
+    """
+    described = set(_described_actions(sim.tool_spec["description"]))
+    enum = set(sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"])
+
+    unpublished = sorted(described - enum)
+    assert not unpublished, (
+        "the tool_spec description lists these actions but the enum does not offer them, so a "
+        "model following the description emits a value the schema rejects; publish them in the "
+        f"enum or drop them from the description: {unpublished}"
+    )
+
+
+def test_tool_spec_description_action_count_matches_the_names_it_lists(sim: Simulation) -> None:
+    """``Actions (N total)`` is a claim about the list, not only about the enum.
+
+    The companion check above compares the same literal against ``len(enum)``.
+    Both are needed and neither implies the other: the stated count was ``77``
+    and the enum held 77, so that check passed while the sentence listed 78
+    names. Counting the list is what turns the literal into a claim that can
+    contradict the text carrying it.
+    """
+    description = sim.tool_spec["description"]
+    described = _described_actions(description)
+
+    m = re.search(r"Actions \((\d+) total\)", description)
+    assert m is not None, "tool_spec description must state 'Actions (N total)'"
+    stated = int(m.group(1))
+    assert stated == len(described), (
+        f"tool_spec description says {stated} actions but its category lists name {len(described)}: {sorted(described)}"
+    )
+
+
+def test_tool_spec_description_lists_no_action_twice(sim: Simulation) -> None:
+    """The count check compares lengths, so a repeat would mask an omission.
+
+    ``destroy`` appears twice in the description - once as a ``[World]`` action
+    and once in the closing ``Call destroy() at session end`` sentence - and if
+    the parser read the second occurrence the totals would still agree while one
+    action went unlisted. Pinned on the parser rather than on the text so the
+    sentence stays free to mention an action again in prose.
+    """
+    described = _described_actions(sim.tool_spec["description"])
+    repeated = sorted({name for name in described if described.count(name) > 1})
+    assert not repeated, f"the description's action lists name these more than once: {repeated}"
+
+
+def test_a_described_action_absent_from_the_enum_is_reported(sim: Simulation) -> None:
+    """Planted-defect meta-test: the parity check above is not vacuous.
+
+    It asserts a set is empty, which is the shape that also passes when the
+    parser finds nothing at all - and the parser is the part most likely to stop
+    matching if the description is reworded. A description carrying one extra
+    name must report exactly that name, and the real one must stay clean.
+    """
+    description = sim.tool_spec["description"]
+    enum = set(sim.tool_spec["inputSchema"]["json"]["properties"]["action"]["enum"])
+
+    assert len(_described_actions(description)) > 1, (
+        "the parser found no action list to check; the description's "
+        "'Actions (N total): [Category] a, b, c' shape has changed"
+    )
+
+    planted = description.replace("[Recording] start_recording,", "[Recording] teleport_everything, start_recording,")
+    assert set(_described_actions(planted)) - enum == {"teleport_everything"}
+    assert not set(_described_actions(description)) - enum, "the real description must stay published"
+
+
 # Vector-arity contract
 #
 # ``_validate_and_build_kwargs`` step 2 refuses any vector param whose component


### PR DESCRIPTION
Closes #2138

## The defect

`tool_spec` ships two model-facing lists of the same thing: the `action` enum, which constrains a schema-driven decoder, and the description's `Actions (N total): [Category] ...` sentence, which is prose the model reads alongside it. They did not name the same set.

Measured at `bb4f58e` by reading the live `tool_spec` off a constructed `Simulation(mesh=False)`:

| | value |
|---|---|
| `action` enum entries | **77** |
| distinct capability names in the description's category lists | **78** |
| stated literal | `Actions (77 total)` |
| described - enum | `['save_episode']` |
| enum - described | `[]` (clean) |

The sentence claimed 77 actions and then listed 78. The surplus name was `save_episode`, under `[Recording]` beside `start_recording` and `stop_recording`, while the enum did not offer it - so a model following the description emits a value a schema-constrained decoder cannot select, and the documented call comes back rejected.

The two failure directions are not symmetric, which is what makes this one worth its own guard. An enum entry missing from the prose is undiscoverable but still selectable. A prose name the enum lacks is the reverse: following the documentation is what produces the rejection.

## Why neither existing check could see it

`tests/simulation/mujoco/test_tool_spec.py` already carries a "Description vs. enum drift contract" with two checks. Both passed throughout, and both read the enum:

| check | what it asks | why it is blind here |
|---|---|---|
| `test_tool_spec_description_mentions_every_enum_action` | is each **enum** entry present in the text? | it iterates the enum, so a surplus name in the prose is never a value it looks at |
| `test_tool_spec_description_action_count_matches_enum` | does the stated literal equal `len(enum)`? | `77 == 77` agreed - the sentence was consistent with the enum while introducing a list of 78 |

The second row is the sharp one. The count literal was the only signal the lists had diverged, and it was compared against the enum rather than against the list it introduces - so the one number that would have contradicted the text was the one nobody counted. No other test in `tests/` parses the description string; the `described -> enum` direction had never been asserted.

## Why the name was dropped rather than published

This is the resolution that settles no open question:

1. `_PYTHON_ONLY_ACTIONS` already declares `save_episode` deliberately unadvertised, so matching the prose to it reverses nothing. Publishing it in the enum instead would reverse that recorded decision, and whether the advertised set should grow is the open question in #2093 - not something to absorb into a drift fix.
2. **No agent-reachable capability is lost.** `run_policy(n_episodes=N)` is in the enum and flushes an episode boundary per episode; both sibling backends' `describe()` text says to prefer it over hand-rolled `save_episode` calls.
3. **No behaviour changes.** The router still resolves `save_episode` by `getattr`, so every Python caller is unaffected. Only the prose stops promising it to a model.

If the preference is instead to publish it, that is a one-line change on top and the guard added here enforces either resolution - it asserts the two lists agree, not which way.

## `describe()` is a third surface and is deliberately wider

Recorded so it is not mistaken for the same defect: `describe()["methods"]` lists **90** methods, **13** absent from the enum (`save_episode`, `get_observation`, `send_action`, `run_multi_policy`, `verify_dataset_episodes`, `robot_joint_names`, `robot_action_keys`, and the six teleop entries). That breadth is intended - it is the developer-facing inventory, and Isaac and Newton publish `save_episode` there too.

The `tool_spec` description is not that. It enumerates the *action* surface under a count, and for 77 of its 78 names it was exactly the enum - none of the other 12 `describe()`-only methods appears in it. `save_episode` was the single leak, which is what makes it an omission rather than a house style. `describe()` is left alone and is not checked by the new guard.

## The change

One name removed from a string literal, plus the missing direction pinned.

- `strands_robots/simulation/mujoco/simulation.py` - drop `save_episode` from the `[Recording]` list. One line.
- `tests/simulation/mujoco/test_tool_spec.py` - placed with its two siblings rather than at the end of the file, so the three directions of one contract read together:
  - `test_tool_spec_description_names_no_action_the_enum_omits` - the direction that broke.
  - `test_tool_spec_description_action_count_matches_the_names_it_lists` - the new half of the count claim. Neither half implies the other, which is the whole reason the defect survived: the existing check compares the same literal against `len(enum)`.
  - `test_tool_spec_description_lists_no_action_twice` - the count check compares lengths, so a repeat would mask an omission. `destroy` legitimately appears twice in the description (once as a `[World]` action, once in the closing `Call destroy() at session end` sentence), so this pins the parser rather than the text and leaves the prose free to mention an action again.
  - `test_a_described_action_absent_from_the_enum_is_reported` - planted-defect meta-test. The parity check asserts a set is empty, which is also the shape that passes when the parser finds nothing, and the parser is the part most likely to stop matching if the description is reworded.

### Parsing is structural, not word-harvesting

Deliberate, and the reason the helper exists rather than a regex inline: the categories carry parenthesised asides holding prose and `;` (`move_to (Cartesian EE transport via IK; not collision-aware)`), and the closing sentence names `destroy()` a second time. A scan that harvested identifier-shaped words would read both as list items, and would fail on a future prose word that happened to match a Python-only method name - a failure that is not a drift. Asides are stripped, the trailing sentence is cut, and only a bare identifier standing alone as a list item counts.

## Verification

The guard was run against the pre-fix description to confirm it fails for the right reason, and the two pre-existing checks passed in that same run - which is the claim about their blindness, executed rather than asserted:

```
=== pre-fix description ===
FAILED test_tool_spec_description_names_no_action_the_enum_omits
  - ... publish them in the enum or drop them from the description: ['save_episode']
FAILED test_tool_spec_description_action_count_matches_the_names_it_lists
  - tool_spec description says 77 actions but its category lists name 78
FAILED test_a_described_action_absent_from_the_enum_is_reported
3 failed, 22 passed

=== with the fix ===
25 passed
```

- `ruff check` and `ruff format --check` clean on both files; `mypy` clean on the engine.
- Rest of the MuJoCo suite is byte-identical before and after: `50 failed, 1256 passed, 48 skipped, 17 errors` on both clean `main` and this branch. Those failures are environmental in this runner - missing robot assets (`No model found for 'so100'`) and GL-dependent modules that abort without EGL/OSMesa - and were baselined on clean `main` rather than assumed.

## Note for #2093

One finding worth carrying to that thread, which this PR does not act on: #2093 prices option **B1** as "refuse a non-enum action in `stream`, before delegating", at zero in-tree cost. Two things narrow that pricing.

First, there are **two** agent-facing delegation sites, not one - `stream` at `simulation.py:4144` and `__call__` at `:3961`, the latter documented as mirroring "the agent-facing dispatch path" and the one the issue's own `sim(action="set_obs_noise", ...)` evidence used. A refusal in `stream` alone leaves `__call__` wider.

Second, B1 could not have been adopted as stated while this drift was live: refusing non-enum actions would have refused `save_episode`, an action the description advertised. That contradiction is now gone, so B1 is cleanly decidable - which is a reason to keep it in #2093 rather than settle it here.
