### PR TITLE
test(simulation): drive start_recording's caller-input refusals on Newton and Isaac

### DIFF
--- a/changelog.d/2140-recording-preflight-refusals-across-backends.md
+++ b/changelog.d/2140-recording-preflight-refusals-across-backends.md
@@ -1,0 +1,22 @@
+### Quality: drive `start_recording`'s caller-input refusals on the Newton and Isaac backends
+
+`start_recording` refuses four caller inputs before it touches a dataset - the
+`fps` domain, the `push_to_hub` / `overwrite` posture flags, the `cameras` name
+list, and a rate an in-flight rollout is not capturing at. Every backend's copy
+was proven to *call* each shared guard by an AST sweep, on the stated grounds
+that the Isaac and Newton backends "need their simulators installed to drive".
+Both backends already have skeleton harnesses that drive `start_recording`
+end to end without those simulators, and the three caller-input guards run
+above the lerobot-extra probe, so none of them needs the dataset stack either.
+
+A structural pin proves the guard is *called*, never that its refusal is
+*returned*: keeping the call and dropping the `return` satisfies it. Measured,
+six of eight such mutations across the two backends were invisible to the 287
+tests covering these contracts. `tests/simulation/test_recording_preflight_refusals_across_backends.py`
+drives the three reachable refusals on both backends - byte-identical to the
+shared domain's own verdict - and pins that each returns before any dataset
+directory is created, before the recording flag is set and before the
+lerobot-extra probe. The fourth refusal is shown to be *unreachable* there
+rather than untested: the rate guard reads `_active_rollout_rates`, which only
+the MuJoCo backend overrides. The four sweeps' docstrings now record which half
+each one holds.

--- a/tests/simulation/test_camera_name_list_contract.py
+++ b/tests/simulation/test_camera_name_list_contract.py
@@ -289,7 +289,12 @@ def _cameras_surfaces(source: str) -> list[tuple[str, bool]]:
 
 
 class TestGuardIsWiredAtEveryBackendSurface:
-    """A backend cannot add a ``cameras`` subset without the shared domain."""
+    """A backend cannot add a ``cameras`` subset without the shared domain.
+
+    Wired, not returned: this sweep is satisfied by a surface that calls the
+    domain and drops the refusal, so each backend's returned ``cameras``
+    refusal is driven in ``test_recording_preflight_refusals_across_backends.py``.
+    """
 
     def test_every_public_cameras_surface_resolves_the_shared_domain(self) -> None:
         unguarded: list[str] = []

--- a/tests/simulation/test_dataset_recording_fps_contract.py
+++ b/tests/simulation/test_dataset_recording_fps_contract.py
@@ -165,7 +165,10 @@ def _start_recording_calls_the_shared_guard(module_path: Path) -> bool:
     """True when the module's ``start_recording`` calls the shared fps guard.
 
     Parsed by AST so backends whose optional dependencies (Isaac Sim, Newton)
-    are not installed are still checked.
+    are not installed are still checked. It proves the guard is *called*, never
+    that its refusal is *returned* - a copy that keeps the call and drops the
+    ``return`` satisfies it - so the returned refusal is driven per backend in
+    ``test_recording_preflight_refusals_across_backends.py``.
     """
     tree = ast.parse(module_path.read_text(encoding="utf-8"))
     for node in ast.walk(tree):

--- a/tests/simulation/test_recording_posture_flag_domain.py
+++ b/tests/simulation/test_recording_posture_flag_domain.py
@@ -291,7 +291,10 @@ def _flags_checked_by(source: str, function: str) -> set[str]:
     """Flag names passed to the shared posture guard inside *function*.
 
     Parsed by AST so backends whose optional dependencies (Isaac Sim, Newton)
-    are not installed are still checked.
+    are not installed are still checked. It proves the guard is *called*, never
+    that its refusal is *returned* - a copy that keeps the call and drops the
+    ``return`` satisfies it - so the returned refusal is driven per backend in
+    ``test_recording_preflight_refusals_across_backends.py``.
     """
     checked: set[str] = set()
     for node in ast.walk(ast.parse(source)):

--- a/tests/simulation/test_recording_preflight_refusals_across_backends.py
+++ b/tests/simulation/test_recording_preflight_refusals_across_backends.py
@@ -1,0 +1,337 @@
+"""Every backend's ``start_recording`` must *return* the refusals it wires.
+
+``start_recording`` makes four caller-input refusals before it touches a
+dataset - the ``fps`` domain, the two posture flags, the ``cameras`` name list
+and a rate an in-flight rollout is not capturing at - and each one is a domain
+shared with the other backends. Three sibling contract modules already prove
+every backend *calls* the shared guard:
+
+* ``test_dataset_recording_fps_contract.py`` for ``fps``,
+* ``test_recording_posture_flag_domain.py`` for ``push_to_hub`` / ``overwrite``,
+* ``test_camera_name_list_contract.py`` for ``cameras``,
+* ``test_recording_rate_matches_control_frequency.py`` for the rollout rate.
+
+All four do it by parsing the module with ``ast``, on the stated grounds that
+"the Isaac and Newton backends need their simulators installed to drive". That
+reason is not what the tree shows: ``tests/simulation/isaac/test_dataset_recording.py``
+and ``tests/simulation/newton/test_dataset_recording.py`` both drive the same
+method end to end through a skeleton engine built with ``__new__``, and each of
+those modules says so in its own docstring - "without the Isaac Sim Kit
+runtime", "without the optional Newton/Warp physics stack". The three guards
+that reject caller input also sit *above* the lerobot-extra probe by design, so
+none of them needs the dataset stack either.
+
+A structural pin proves the guard is *called*, never that its refusal is
+*returned*: keeping the call and discarding the ``return`` satisfies it. On the
+one backend a driver had ever exercised (MuJoCo) all four refusals were
+returned; on the two the sweeps alone covered, none of the four had ever run.
+This module drives them, closing the six reachable cells:
+
+===============  ===========  ===========  ===========
+refusal          MuJoCo       Newton       Isaac
+===============  ===========  ===========  ===========
+``fps``          driven       **added**    **added**
+posture flags    driven       **added**    **added**
+``cameras``      driven       **added**    **added**
+rollout rate     driven       unreachable  unreachable
+===============  ===========  ===========  ===========
+
+The fourth cell is *provably* unreachable on these two backends rather than
+untested: the guard compares against
+:meth:`~strands_robots.simulation.base.SimEngine._active_rollout_rates`, which
+only the MuJoCo backend overrides, so both of these inherit an empty mapping
+and the guard returns ``None`` for every ``fps``. Its structural pin is the
+right tool for it and stays - it is what stops a backend that grows an
+asynchronous rollout later from inheriting a ``start_recording`` that skipped
+the check.
+
+Runs on a minimal install: the refusals precede the lerobot-extra probe, and
+none of the imports here pulls MuJoCo, Isaac Sim, Newton, Warp or lerobot in
+(pinned below).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+from strands_robots.simulation.models import SimRobot, SimWorld
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.simulation.recording import (
+    dataset_recording_option_error,
+    dataset_recording_posture_error,
+)
+from strands_robots.utils import name_list_error
+
+_SO100_JOINTS = ["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]
+
+# Probe values are declared here rather than imported from the three contract
+# modules: each of those does ``pytest.importorskip("mujoco")`` at module level,
+# and importing a constant from one would inherit that skip - on exactly the
+# install these refusals have to hold on. TestTheProbeValuesAreOutsideTheSharedDomains
+# below pins each list against the shared domain that owns it, so a value that
+# stops being refused fails here instead of silently weakening a case.
+UNUSABLE_FPS: list[Any] = [0, -5, 2.7, float("nan"), float("inf"), True, "30", None, [30]]
+POSTURE_FLAGS = ("push_to_hub", "overwrite")
+TRUTHY_NON_BOOLEANS: list[Any] = ["false", "no", "off", "0", 1, float("nan")]
+UNUSABLE_CAMERA_LISTS: list[Any] = ["wrist", ["front", "front"], {"front": 1}, ["front", 3], ["front", ""]]
+
+
+def _isaac_engine() -> Any:
+    """A skeleton ``IsaacSimulation`` with no Isaac Sim Kit runtime.
+
+    Same shape as the harness ``tests/simulation/isaac/test_dataset_recording.py``
+    uses: ``__new__`` plus exactly the attributes the recording path reads, so
+    the fixture stays honest about what ``start_recording`` depends on.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode="rtx_realtime")
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {
+        "so100": _RobotState(
+            name="so100",
+            prim_path="/World/Robots/so100",
+            joint_names=list(_SO100_JOINTS),
+            data_config="so100",
+        )
+    }
+    engine._cameras = {}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._recording_state_dict = {}
+    engine._action_controllers = {}
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._replicated = False
+    engine._num_envs_active = 1
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+def _newton_engine() -> Any:
+    """A ``NewtonSimEngine`` over a hand-built world, with no Newton/Warp stack."""
+    world = SimWorld()
+    world.robots["so100"] = SimRobot(
+        name="so100", urdf_path="so100.xml", data_config="so100", joint_names=list(_SO100_JOINTS)
+    )
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = world
+    engine._model = object()  # non-None sentinel: "world created"
+    engine.default_width = 64
+    engine.default_height = 48
+    return engine
+
+
+BACKENDS = [
+    pytest.param(_isaac_engine, id="isaac"),
+    pytest.param(_newton_engine, id="newton"),
+]
+
+
+def _start(factory: Any, root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+    """Call ``start_recording`` on a fresh engine from *factory*.
+
+    ``**kwargs`` carries deliberately unusable values, so it is typed ``Any``
+    rather than restated per parameter.
+    """
+    target = str(root) if root is not None else "/tmp/strands-never-created"
+    return factory().start_recording(repo_id="local/preflight_probe", root=target, **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+class TestTheProbeValuesAreOutsideTheSharedDomains:
+    """Non-vacuity: every probe value really is one its shared domain refuses."""
+
+    @pytest.mark.parametrize("fps", UNUSABLE_FPS, ids=repr)
+    def test_every_fps_probe_is_refused_by_the_shared_domain(self, fps: Any) -> None:
+        assert dataset_recording_option_error("start_recording", fps) is not None
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS, ids=repr)
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    def test_every_posture_probe_is_refused_by_the_shared_domain(self, flag: str, value: Any) -> None:
+        assert dataset_recording_posture_error("start_recording", flag, value) is not None
+
+    @pytest.mark.parametrize("cameras", UNUSABLE_CAMERA_LISTS, ids=repr)
+    def test_every_camera_probe_is_refused_by_the_shared_domain(self, cameras: Any) -> None:
+        assert name_list_error(cameras, "cameras", "start_recording") is not None
+
+    def test_a_usable_value_is_accepted_by_each_shared_domain(self) -> None:
+        """Over-reach control: the domains do not refuse everything."""
+        assert dataset_recording_option_error("start_recording", 30) is None
+        assert dataset_recording_posture_error("start_recording", "overwrite", True) is None
+        assert name_list_error(["front", "wrist"], "cameras", "start_recording") is None
+
+
+class TestEveryBackendReturnsTheFpsRefusal:
+    """A rate no dataset can be written at is refused, not reported as started."""
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("fps", UNUSABLE_FPS, ids=repr)
+    def test_the_call_is_refused_and_names_the_parameter(self, factory: Any, fps: Any) -> None:
+        result = _start(factory, fps=fps)
+        assert result["status"] == "error"
+        assert "fps" in _text(result)
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("fps", UNUSABLE_FPS, ids=repr)
+    def test_the_refusal_is_the_shared_verdict_verbatim(self, factory: Any, fps: Any) -> None:
+        """The backend returns the shared domain's answer, not a local re-wording."""
+        assert _start(factory, fps=fps) == dataset_recording_option_error("start_recording", fps)
+
+
+class TestEveryBackendReturnsThePostureRefusal:
+    """A posture flag is checked, not parsed - a truthy opt-out is refused."""
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS, ids=repr)
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    def test_the_call_is_refused_and_names_the_flag(self, factory: Any, flag: str, value: Any) -> None:
+        posture: dict[str, Any] = {flag: value}
+        result = _start(factory, **posture)
+        assert result["status"] == "error"
+        assert flag in _text(result)
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    def test_the_refusal_is_the_shared_verdict_verbatim(self, factory: Any, flag: str) -> None:
+        posture: dict[str, Any] = {flag: "false"}
+        assert _start(factory, **posture) == dataset_recording_posture_error("start_recording", flag, "false")
+
+
+class TestEveryBackendReturnsTheCameraListRefusal:
+    """``cameras`` is an ordered list of distinct names on every backend."""
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("cameras", UNUSABLE_CAMERA_LISTS, ids=repr)
+    def test_the_call_is_refused_and_names_the_parameter(self, factory: Any, cameras: Any) -> None:
+        result = _start(factory, cameras=cameras)
+        assert result["status"] == "error"
+        assert "cameras" in _text(result)
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize("cameras", UNUSABLE_CAMERA_LISTS, ids=repr)
+    def test_the_refusal_is_the_shared_verdict_verbatim(self, factory: Any, cameras: Any) -> None:
+        assert _text(_start(factory, cameras=cameras)) == name_list_error(cameras, "cameras", "start_recording")
+
+
+class TestARefusedStartTouchesNoDataset:
+    """Each refusal is returned before anything on disk or in state moves."""
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"fps": 2.7}, id="fps"),
+            pytest.param({"overwrite": "false"}, id="overwrite"),
+            pytest.param({"push_to_hub": "no"}, id="push_to_hub"),
+            pytest.param({"cameras": "wrist"}, id="cameras"),
+        ],
+    )
+    def test_no_dataset_directory_is_created(self, factory: Any, kwargs: Any, tmp_path: Path) -> None:
+        target = tmp_path / "never"
+        assert _start(factory, root=target, **kwargs)["status"] == "error"
+        assert not target.exists()
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"fps": 2.7}, id="fps"),
+            pytest.param({"overwrite": "false"}, id="overwrite"),
+            pytest.param({"cameras": "wrist"}, id="cameras"),
+        ],
+    )
+    def test_recording_is_not_marked_active(self, factory: Any, kwargs: Any) -> None:
+        engine = factory()
+        assert engine.start_recording(repo_id="local/p", root="/tmp/strands-never", **kwargs)["status"] == "error"
+        state = engine._recording_state()
+        assert state is not None
+        assert not state.get("recording")
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"fps": 2.7}, id="fps"),
+            pytest.param({"overwrite": "false"}, id="overwrite"),
+            pytest.param({"cameras": "wrist"}, id="cameras"),
+        ],
+    )
+    def test_the_refusal_precedes_the_lerobot_extra_probe(
+        self, factory: Any, kwargs: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Placement, in the guards' own words: "before the lerobot-extra probe".
+
+        The probe is made fatal with an ``AssertionError`` - the enclosing
+        ``except ImportError`` cannot swallow it - so reaching it fails loudly
+        instead of degrading into the extra-missing report.
+        """
+        from strands_robots import dataset_recorder
+
+        def _fatal() -> str | None:
+            raise AssertionError("the refusal must precede the lerobot-extra probe")
+
+        monkeypatch.setattr(dataset_recorder, "lerobot_dataset_import_error", _fatal)
+        assert _start(factory, **kwargs)["status"] == "error"
+
+
+class TestTheRollingRateRefusalIsUnreachableOnTheseBackends:
+    """The fourth refusal is provably dead here, so its structural pin is right."""
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    def test_neither_backend_reports_an_in_flight_rollout_rate(self, factory: Any) -> None:
+        assert factory()._active_rollout_rates() == {}
+
+    @pytest.mark.parametrize("factory", BACKENDS)
+    def test_the_guard_returns_none_for_every_probe_rate(self, factory: Any) -> None:
+        engine = factory()
+        for fps in (30, 50, 1):
+            assert engine._validate_recording_start_rate(fps, "start_recording") is None
+
+    def test_mujoco_is_the_backend_that_overrides_the_rate_source(self) -> None:
+        """Non-vacuity: the empty mapping above is inherited, not universal.
+
+        Read from the source so the assertion holds without a MuJoCo install.
+        """
+        import strands_robots.simulation as simulation_pkg
+
+        root = Path(simulation_pkg.__file__).parent
+        overriding = {
+            backend
+            for backend in ("mujoco", "newton", "isaac")
+            for module in sorted((root / backend).glob("*.py"))
+            if "def _active_rollout_rates(" in module.read_text(encoding="utf-8")
+        }
+        assert overriding == {"mujoco"}, overriding
+
+
+class TestTheRefusalsNeedNoOptionalDependency:
+    """The whole module runs on an install with none of the simulators."""
+
+    def test_importing_the_surfaces_pulls_no_heavy_module(self) -> None:
+        """Measured in a child interpreter: this module's imports stay light."""
+        program = (
+            "import sys\n"
+            "from strands_robots.simulation.isaac.simulation import IsaacSimulation\n"
+            "from strands_robots.simulation.newton.simulation import NewtonSimEngine\n"
+            "from strands_robots.simulation.recording import dataset_recording_option_error\n"
+            "from strands_robots.utils import name_list_error\n"
+            "heavy = ('mujoco', 'lerobot', 'newton', 'warp', 'isaacsim', 'omni')\n"
+            "print(sorted(m for m in heavy if m in sys.modules))\n"
+        )
+        out = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, check=True, timeout=180)
+        assert out.stdout.strip().endswith("[]"), out.stdout

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -637,10 +637,18 @@ _START_RECORDING_BACKENDS = (
 def test_every_backend_start_recording_checks_the_running_rollout_rate(module):
     """``start_recording`` is per backend, so each copy must reach the shared guard.
 
-    Pinned structurally rather than behaviourally because the Isaac and Newton
-    backends need their simulators installed to drive, and a backend that grows
-    an asynchronous rollout later must not inherit a ``start_recording`` that
-    silently skipped the check.
+    Structural rather than behavioural for a measured reason: this refusal is
+    unreachable on the Isaac and Newton backends. The guard compares against
+    :meth:`~strands_robots.simulation.base.SimEngine._active_rollout_rates`,
+    which only the MuJoCo backend overrides, so both of the others inherit an
+    empty mapping and it returns ``None`` for every ``fps``. Pinning the call
+    is what stops a backend that grows an asynchronous rollout later from
+    inheriting a ``start_recording`` that silently skipped the check.
+
+    The three sibling refusals that *are* reachable there - ``fps``, the
+    posture flags and ``cameras`` - are driven per backend in
+    ``test_recording_preflight_refusals_across_backends.py``, which also pins the
+    inherited empty mapping this reason rests on.
     """
     assert "_validate_recording_start_rate" in _self_calls(module, "start_recording"), (
         f"{module}::start_recording does not check the running rollout rate"


### PR DESCRIPTION
## Problem

`start_recording` refuses four caller inputs before it touches a dataset:

| refusal | shared domain | Newton line | Isaac line |
|---|---|---|---|
| `fps` | `dataset_recording_option_error` | 161 | 230 |
| `push_to_hub` / `overwrite` | `dataset_recording_posture_error` | 172 | 241 |
| `cameras` | `name_list_error` | 180 | 249 |
| in-flight rollout rate | `_validate_recording_start_rate` | 187 | 256 |

Four sibling contract modules already prove every backend's copy **calls** each
shared guard, by parsing the module with `ast`. Each states the same reason for
not driving it, e.g.

> Pinned structurally rather than behaviourally because the Isaac and Newton
> backends need their simulators installed to drive

That reason is not what the tree shows. `tests/simulation/isaac/test_dataset_recording.py`
and `tests/simulation/newton/test_dataset_recording.py` both drive this exact
method end to end through a skeleton engine built with `__new__`, and each says
so in its own docstring - "without the Isaac Sim Kit runtime", "without the
optional Newton/Warp physics stack". The three caller-input guards also sit
**above** the lerobot-extra probe by design, so none needs the dataset stack
either. Measured: all three refusals return their message on both skeletons with
`lerobot` blocked at the import system, byte-identical to MuJoCo's.

A structural pin proves the guard is *called*, never that its refusal is
*returned* - keeping the call and dropping the `return` satisfies it. On MuJoCo,
the one backend a driver had ever exercised, all four refusals were returned. On
Newton and Isaac **none of the eight cells had ever run**.

## Change

Tests and docstrings only; no production line changes.

`tests/simulation/test_recording_preflight_refusals_across_backends.py` drives
the three reachable refusals on both backends (137 cases, 0.4 s) and pins, per
backend and per refusal:

- the call is refused and the message names the parameter;
- the result **equals the shared domain's own verdict** - not a local re-wording,
  so the three backends cannot drift on wording;
- the refusal is returned before any dataset directory is created, before the
  recording flag is set, and before the lerobot-extra probe (made fatal with an
  `AssertionError`, which the enclosing `except ImportError` cannot swallow);
- every probe value really is one the shared domain refuses, with an over-reach
  control that a usable value is accepted.

The fourth refusal is shown **unreachable** on these two backends rather than
left untested: the guard compares against `_active_rollout_rates`, which only
the MuJoCo backend overrides, so both inherit an empty mapping and it returns
`None` for every `fps`. That is pinned too, with a non-vacuity check that MuJoCo
is the one backend overriding it. Its structural pin is the right tool and stays.

The four sweeps' docstrings now record which half each holds, and the rate one's
stated reason is replaced by the measured one.

## Measurement

![refusal coverage and mutation matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recording-preflight-refusals/refusal-coverage-and-mutation-matrix.png)

Every cell is read from a JSON dump; the generator asserts each rendered number
before saving. Capture and compose scripts plus `facts.json` are on the
[`artifacts/recording-preflight-refusals`](https://github.com/cagataycali/robots/tree/artifacts/recording-preflight-refusals)
branch.

### Mutation table

Two styles per refusal, against two arms - the new module, and the 287
pre-existing tests covering these four contracts. Each mutation is scoped to the
target function and the file restored byte-identically.

| mutation | style | new module | pre-existing |
|---|---|---|---|
| isaac: delete the fps guard | DELETE | 15 failed | 1 failed |
| isaac: discard the fps refusal | DISCARD | 15 failed | **0 - blind** |
| isaac: discard the posture refusal | DISCARD | 18 failed | **0 - blind** |
| isaac: discard the cameras refusal | DISCARD | 6 failed | **0 - blind** |
| newton: delete the fps guard | DELETE | 15 failed | 1 failed |
| newton: discard the fps refusal | DISCARD | 15 failed | **0 - blind** |
| newton: discard the posture refusal | DISCARD | 18 failed | **0 - blind** |
| newton: discard the cameras refusal | DISCARD | 6 failed | **0 - blind** |

8 of 8 caught by the new module; **6 of 8 invisible** to the pre-existing suite -
exactly the DISCARD style a structural sweep cannot see. The 2 it does catch are
the DELETEs, which is the sweeps doing their job.

Because the production code is correct, these tests pass on unmodified `main`;
what they fail on is a regression, and the table above is that evidence.

### Coverage

Full-suite, `--cov=strands_robots`:

| file | before | after |
|---|---|---|
| `simulation/newton/recording.py` | 8 missing, 94.8% | 5 missing, **96.8%** |
| `simulation/isaac/recording.py` | 22 missing, 86.7% | 19 missing, **88.5%** |

`isaac/recording.py` was the lowest-covered file on `main` outside the
optional-dependency-gated modules. Six lines closed; the two that remain in this
family are the provably unreachable rate cell.

## Gate

Base `04fd6680`; `scripts/check_merge_base_overlap.py` reports no overlap
(0 paths changed on `upstream/main` in that span).

- `MUJOCO_GL=egl pytest tests` - **28043 passed, 257 skipped, 0 failed** (723 s)
- `ruff check` / `ruff format --check strands_robots tests tests_integ` - clean, 1170 files
- `mypy strands_robots tests tests_integ` - 0 errors outside `examples/isaac_gs`;
  the 14 there are byte-identical to a pristine checkout of the same base
- new module alone: 137 passed in 0.4 s, needing no MuJoCo, Isaac Sim, Newton,
  Warp or lerobot
- `assemble_changelog.py --check` - OK

No policy, simulation, rendering, recording or asset behaviour changes, so the
artifact above is the coverage and mutation measurement rather than a rollout.

## Out of scope

The remaining uncovered lines in these two modules are a different concern each
with its own owner: the lerobot-extra-unavailable report, the resume branch, the
schema-safe camera-name alias, the recorder-init `except`, and the observation
probe. This change is scoped to the refusals `start_recording` makes on caller
input before it touches a dataset.
