### PR TITLE
fix(mesh): expose a stop tool on the ROS 2 bridge

### DIFF
--- a/changelog.d/2142-ros2-bridge-stop-tool.md
+++ b/changelog.d/2142-ros2-bridge-stop-tool.md
@@ -1,0 +1,15 @@
+### Fixed: `RosBridgedRobot` now exposes a `stop_<node>` agent tool
+
+A ROS 2 velocity command latches: `drive()` with no `duration` publishes a single
+`cmd_vel` message and the base keeps it until something else is published -- the
+contract `RosbridgeRobot`'s own drive tool description states as "without
+duration the last command latches until stop". All three mobile-base bridges
+carry a public `stop()` that publishes a zero `Twist`, and the rosbridge and
+RTPS bridges expose it as a named agent tool. The ROS 2 bridge did not, so an
+agent handed `RosBridgedRobot.tools` could start motion and had no tool to end
+it; its only halt was a `drive` at zero velocity, which is the idiom `stop()`
+exists to name.
+
+`tools` now builds `stop_<node>` unconditionally, alongside `drive`, so the
+three transports agree on the capability an agent is given. A structural test
+requires any future bridge owning a `drive`/`stop` pair to expose the halt too.

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -306,7 +306,7 @@ print(turtle.get_pose())                 # one odom/pose sample
 turtle.stop()
 
 # Or hand the robot to an agent - its capabilities become named tools
-# (drive_turtlesim, get_pose_turtlesim, ...):
+# (drive_turtlesim, stop_turtlesim, get_pose_turtlesim, ...):
 agent = Agent(tools=turtle.tools)
 agent("drive forward for two seconds, then tell me the pose")
 ```

--- a/strands_robots/mesh/ros_bridge.py
+++ b/strands_robots/mesh/ros_bridge.py
@@ -332,12 +332,24 @@ class RosBridgedRobot:
         The returned tools are bound to this instance and uniquely named with
         the ``node_name`` suffix so multiple bridged robots can coexist in a
         single ``Agent(tools=[...])`` call without name collisions.
+
+        ``drive`` and ``stop`` are always both present: a velocity command with
+        no ``duration`` latches until another command arrives, so a caller that
+        can start motion must be able to end it without knowing that a
+        zero-velocity drive is the halt idiom.
         """
         suffix = self.node_name.strip("/").replace("/", "_")
 
         @tool(name=f"drive_{suffix}", description=f"Drive the {self.node_name} robot (linear/angular velocity).")
         def drive(linear: float = 0.0, angular: float = 0.0, duration: float | None = None) -> dict[str, Any]:
             return self.drive(linear=linear, angular=angular, duration=duration)
+
+        @tool(
+            name=f"stop_{suffix}",
+            description=f"Immediately stop the {self.node_name} robot (zero velocity).",
+        )
+        def stop() -> dict[str, Any]:
+            return self.stop()
 
         @tool(name=f"get_pose_{suffix}", description=f"Read the current pose/odometry of the {self.node_name} robot.")
         def get_pose() -> dict[str, Any]:
@@ -357,7 +369,7 @@ class RosBridgedRobot:
         def navigate(x: float, y: float, yaw: float = 0.0, timeout: float = 120.0) -> dict[str, Any]:
             return self.navigate_to(x=x, y=y, yaw=yaw, timeout=timeout)
 
-        agent_tools: list[AgentTool] = [drive, get_pose]
+        agent_tools: list[AgentTool] = [drive, stop, get_pose]
         if self.scan_topic:
             agent_tools.append(get_scan)
         if self.nav_action:

--- a/tests/mesh/test_bridge_stop_tool_parity.py
+++ b/tests/mesh/test_bridge_stop_tool_parity.py
@@ -1,0 +1,275 @@
+"""Every mobile-base bridge that can start motion also exposes a stop tool.
+
+All three transports publish a *latching* velocity command: with no ``duration``
+a single ``cmd_vel`` message leaves the base moving until another command
+arrives. :class:`~strands_robots.mesh.RosbridgeRobot`'s own drive tool
+description states that contract - "without duration the last command latches
+until stop" - and every bridge carries a public ``stop()`` that publishes a zero
+``Twist``.
+
+Two of the three exposed that halt as a named agent tool. The ROS 2 bridge did
+not, so an agent handed ``RosBridgedRobot.tools`` could start motion and had no
+tool to end it; its only halt was a ``drive`` at zero velocity, which is exactly
+the idiom ``stop()`` exists to name. These tests pin the parity behaviourally on
+every transport, and structurally require any future bridge owning a
+``drive``/``stop`` pair to expose the halt too.
+
+They also drive the remaining forwarding closures each ``tools`` property
+builds. That is what kept the gap invisible: of the ten closures these three
+bridges construct, four were never invoked through the tool, so nothing
+observed which capabilities the surface actually reached.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.ros_bridge as ros_mod
+import strands_robots.mesh.rosbridge_robot as rbr_mod
+import strands_robots.mesh.rtps_robot as rtps_mod
+from strands_robots.mesh import RosBridgedRobot, RosbridgeRobot, RtpsRobot
+
+ZERO_TWIST = {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+
+class _Recorder:
+    """Records the kwargs of each forwarded transport call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+def _ros(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setattr(ros_mod, "use_ros", rec)
+    return RosBridgedRobot.from_ros(node_name="rover", cmd_vel_topic="/cmd_vel", odom_topic="/odom")
+
+
+def _rosbridge(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setattr(rbr_mod, "use_rosbridge", rec)
+    return RosbridgeRobot(node_name="rover", cmd_vel_topic="/cmd_vel", odom_topic="/odom")
+
+
+def _rtps(rec: _Recorder, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.setattr(rtps_mod, "use_rtps", rec)
+    return RtpsRobot.from_rtps(node_name="rover", cmd_vel_topic="/cmd_vel")
+
+
+#: Every transport that turns a mobile base into strands agent tools.
+BRIDGES = [
+    pytest.param(_ros, id="ros2-rclpy"),
+    pytest.param(_rosbridge, id="rosbridge-websocket"),
+    pytest.param(_rtps, id="rtps-dds"),
+]
+
+
+def _tools(robot: Any) -> dict[str, Any]:
+    return {t.tool_name: t for t in robot.tools}
+
+
+# Cross-transport parity -------------------------------------------------------
+
+
+@pytest.mark.parametrize("build", BRIDGES)
+def test_a_bridge_exposing_a_drive_tool_also_exposes_a_stop_tool(build: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transport that can start motion must offer the halt in the same set."""
+    names = set(_tools(build(_Recorder(), monkeypatch)))
+    assert "drive_rover" in names, f"no drive tool to pair a halt with: {sorted(names)}"
+    assert "stop_rover" in names, f"drive without a halt: {sorted(names)}"
+
+
+@pytest.mark.parametrize("build", BRIDGES)
+def test_the_stop_tool_publishes_a_zero_velocity_twist(build: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The halt is a real zero command on the wire, not just a present name."""
+    rec = _Recorder()
+    stop_tool: Any = _tools(build(rec, monkeypatch))["stop_rover"]
+    rec.calls.clear()
+    result = stop_tool()
+    assert result["status"] == "success"
+    (call,) = rec.calls
+    assert call["action"] == "publish"
+    assert call["topic"] == "/cmd_vel"
+    assert call["fields"] == ZERO_TWIST
+
+
+@pytest.mark.parametrize("build", BRIDGES)
+def test_a_drive_tool_with_no_duration_publishes_one_latching_command(
+    build: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The premise: one message, non-zero, and no automatic stop after it.
+
+    This is why the halt has to be reachable - the base keeps the last command
+    until something else is published.
+    """
+    rec = _Recorder()
+    drive_tool: Any = _tools(build(rec, monkeypatch))["drive_rover"]
+    rec.calls.clear()
+    drive_tool(linear=0.5)
+    (call,) = rec.calls  # a single publish, with no trailing zero
+    assert call["count"] == 1
+    assert call["fields"]["linear"]["x"] == pytest.approx(0.5)
+
+
+def test_the_ros2_stop_tool_is_present_without_any_optional_topic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The halt is unconditional, unlike get_scan and navigate."""
+    robot = _ros(_Recorder(), monkeypatch)
+    assert robot.scan_topic is None and robot.nav_action is None
+    names = set(_tools(robot))
+    assert "stop_rover" in names
+    assert "get_scan_rover" not in names and "navigate_rover" not in names
+
+
+def test_the_ros2_stop_tool_forwards_to_the_instance_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tool is the documented ``stop()``, not a re-implementation."""
+    rec = _Recorder()
+    robot = _ros(rec, monkeypatch)
+    stop_tool: Any = _tools(robot)["stop_rover"]
+
+    rec.calls.clear()
+    stop_tool()
+    via_tool = list(rec.calls)
+    rec.calls.clear()
+    robot.stop()
+    assert via_tool == rec.calls
+
+
+# The forwarding closures that were never invoked through the tool -------------
+
+
+def test_the_ros2_pose_and_scan_tools_forward_to_the_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(ros_mod, "use_ros", rec)
+    robot = RosBridgedRobot("rover", "/cmd_vel", "/odom", scan_topic="/scan")
+    tools = _tools(robot)
+
+    pose_tool: Any = tools["get_pose_rover"]
+    rec.calls.clear()
+    pose_tool()
+    assert rec.calls[0]["action"] == "echo" and rec.calls[0]["topic"] == "/odom"
+
+    scan_tool: Any = tools["get_scan_rover"]
+    rec.calls.clear()
+    scan_tool()
+    assert rec.calls[0]["action"] == "echo" and rec.calls[0]["topic"] == "/scan"
+
+
+def test_the_rosbridge_stop_and_scan_tools_forward_to_the_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(rbr_mod, "use_rosbridge", rec)
+    robot = RosbridgeRobot(node_name="rover", cmd_vel_topic="/cmd_vel", odom_topic="/odom", scan_topic="/scan")
+    tools = _tools(robot)
+
+    stop_tool: Any = tools["stop_rover"]
+    rec.calls.clear()
+    stop_tool()
+    assert rec.calls[0]["fields"] == ZERO_TWIST
+
+    scan_tool: Any = tools["get_scan_rover"]
+    rec.calls.clear()
+    scan_tool()
+    assert rec.calls[0]["topic"] == "/scan"
+
+
+# Structural: a future transport cannot ship a drive without a halt ------------
+
+#: Bridge classes that own a mobile base's drive/stop pair today.
+EXPECTED_DRIVE_STOP_CLASSES = {"RosBridgedRobot", "RosbridgeRobot", "RtpsRobot"}
+
+
+def _mesh_dir() -> pathlib.Path:
+    """Derive the scanned package from an imported symbol, not a path literal."""
+    return pathlib.Path(inspect.getfile(ros_mod)).parent
+
+
+def _declared_tool_name_prefix(decorator: ast.expr) -> str | None:
+    """Return the literal head of a ``@tool(name=...)`` value, or None.
+
+    The name is written as an f-string (``f"stop_{suffix}"``), so the leading
+    literal is the first element of the ``JoinedStr``; a plain string name is
+    read whole. Reading the keyword structurally keeps the survey independent
+    of how the source spells its quotes.
+    """
+    if not isinstance(decorator, ast.Call):
+        return None
+    for kw in decorator.keywords:
+        if kw.arg != "name":
+            continue
+        if isinstance(kw.value, ast.JoinedStr) and kw.value.values:
+            head = kw.value.values[0]
+            if isinstance(head, ast.Constant) and isinstance(head.value, str):
+                return head.value
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
+
+
+def _stop_tool_survey(source: str) -> tuple[set[str], set[str]]:
+    """Return (classes owning a drive/stop pair, those whose tools build a stop).
+
+    A class qualifies when it defines public ``drive`` and ``stop`` methods and
+    a ``tools`` property; it satisfies the rule when that property contains a
+    ``@tool`` closure whose declared name starts with ``stop_``.
+    """
+    owning: set[str] = set()
+    exposing: set[str] = set()
+    for cls in (n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.ClassDef)):
+        methods = {m.name for m in cls.body if isinstance(m, ast.FunctionDef | ast.AsyncFunctionDef)}
+        if not {"drive", "stop", "tools"} <= methods:
+            continue
+        owning.add(cls.name)
+        for member in cls.body:
+            if not (isinstance(member, ast.FunctionDef) and member.name == "tools"):
+                continue
+            for closure in member.body:
+                if not isinstance(closure, ast.FunctionDef):
+                    continue
+                for dec in closure.decorator_list:
+                    prefix = _declared_tool_name_prefix(dec)
+                    if prefix is not None and prefix.startswith("stop_"):
+                        exposing.add(cls.name)
+    return owning, exposing
+
+
+def _survey_mesh() -> tuple[set[str], set[str]]:
+    owning: set[str] = set()
+    exposing: set[str] = set()
+    for path in sorted(_mesh_dir().rglob("*.py")):
+        own, exp = _stop_tool_survey(path.read_text())
+        owning |= own
+        exposing |= exp
+    return owning, exposing
+
+
+def test_every_bridge_owning_a_drive_stop_pair_builds_a_stop_tool() -> None:
+    owning, exposing = _survey_mesh()
+    assert owning - exposing == set(), f"drive/stop bridges with no stop tool: {sorted(owning - exposing)}"
+
+
+def test_the_survey_finds_the_bridges_it_is_meant_to_cover() -> None:
+    """Non-vacuity: an empty or mis-rooted scan must not read as compliant."""
+    owning, _ = _survey_mesh()
+    assert owning == EXPECTED_DRIVE_STOP_CLASSES, sorted(owning)
+
+
+def test_the_survey_flags_a_bridge_whose_tools_omit_the_stop() -> None:
+    """Planted defect: the rule must fail for a drive/stop pair with no halt."""
+    planted = """
+class _PlantedBridge:
+    def drive(self): ...
+    def stop(self): ...
+    def tools(self):
+        @tool(name=f"drive_{suffix}", description="d")
+        def drive(): ...
+        return [drive]
+"""
+    owning, exposing = _stop_tool_survey(planted)
+    assert owning == {"_PlantedBridge"}
+    assert exposing == set()

--- a/tests/mesh/test_ros_bridge.py
+++ b/tests/mesh/test_ros_bridge.py
@@ -107,8 +107,14 @@ def test_get_scan_with_topic_echoes(rec: _Recorder) -> None:
 
 
 def test_tools_are_named_per_instance() -> None:
+    """Every unconditional capability is exposed, suffixed with the node name.
+
+    ``stop`` is in this set because a drive without a ``duration`` latches:
+    this assertion previously recorded its absence, which is what kept the
+    missing halt tool invisible.
+    """
     names = {t.tool_name for t in _turtle().tools}
-    assert names == {"drive_turtlesim", "get_pose_turtlesim"}
+    assert names == {"drive_turtlesim", "stop_turtlesim", "get_pose_turtlesim"}
 
 
 def test_tools_include_scan_only_when_configured() -> None:


### PR DESCRIPTION
## Problem

A ROS 2 velocity command latches. `RosBridgedRobot.drive()` with no `duration`
publishes a **single** `cmd_vel` message and the base holds it until something
else is published — the contract `RosbridgeRobot`'s own drive tool description
states as *"without duration the last command latches until stop"*.

All three mobile-base bridges carry a public `stop()` that publishes a zero
`Twist`. Two of the three also exposed it as a named agent tool. The ROS 2
bridge did not:

| transport | `stop()` method | `stop_<node>` tool |
|---|---|---|
| `RosBridgedRobot` (rclpy) | yes | **missing** |
| `RosbridgeRobot` (websocket) | yes | yes |
| `RtpsRobot` (cyclonedds) | yes | yes |

So an agent handed `RosBridgedRobot.tools` could start motion and had no tool to
end it. Measured on one session — `drive_rover(linear=0.5)` publishes one
message at `linear.x = 0.5` and the surface offers `{drive_rover,
get_pose_rover}`. The only halt available was `drive_rover(linear=0, angular=0)`,
i.e. the caller having to know that a zero-velocity drive is the halt idiom,
which is exactly what `stop()` exists to name.

`docs/ros2-integration.md` already lists `stop()` as a first-class capability
and its example comment enumerated the tools as `drive_turtlesim,
get_pose_turtlesim, ...`.

## Change

`tools` now builds `stop_<node>` unconditionally, next to `drive`, so the three
transports agree on the capability an agent is given. The property docstring
records why the pair is unconditional (unlike `get_scan` and `navigate`, which
stay gated on their optional topic/action).

Four lines of behaviour; the rest is the test that would have caught it.

## Why it was invisible

`test_tools_are_named_per_instance` asserted the **exact** set
`{drive_turtlesim, get_pose_turtlesim}`, so the absence was recorded as intent.
It now includes the halt and says so in its docstring.

Underneath that, of the ten forwarding closures these three bridges construct,
**four had never been invoked through the tool** (`get_pose`/`get_scan` on the
ROS 2 bridge, `stop`/`get_scan` on the rosbridge one) — nothing observed which
capabilities the surface actually reached. The new module drives all of them.

## Artifact

One agent session, recorded off the forwarded `use_ros` call (no ROS 2 present).
The drive is byte-identical on both trees; the difference is only what the agent
can reach next.

![ROS 2 bridge stop tool](https://raw.githubusercontent.com/cagataycali/robots/artifacts/ros2-stop-tool/ros2_stop_tool.png)

Capture and compose scripts plus both JSON dumps: [`artifacts/ros2-stop-tool`](https://github.com/cagataycali/robots/tree/artifacts/ros2-stop-tool).
Each arm records the tree it imported from, and the figure asserts every number
in it against those two dumps before saving.

## Tests

`tests/mesh/test_bridge_stop_tool_parity.py` (16 cases):

- **parity**, parametrized over all three transports — a bridge exposing a drive
  tool exposes a stop tool; that stop tool publishes a zero `Twist` on `cmd_vel`;
  a drive with no `duration` publishes one non-zero latching message (the premise).
- the ROS 2 halt is present with **no** optional topic configured, and forwards to
  the documented `stop()` rather than re-implementing it (asserted by comparing the
  wire from the tool against the wire from the method).
- the four previously-uninvoked closures.
- **structural**: every class in `strands_robots/mesh/` owning a public
  `drive`/`stop` pair and a `tools` property must build a `stop_`-prefixed tool.
  Self-maintaining, with a non-vacuity pin on the exact class set
  (`{RosBridgedRobot, RosbridgeRobot, RtpsRobot}`) and a planted-defect meta-test.
  The tool name is read from the decorator's `name` keyword structurally, so the
  rule does not depend on how the source spells its quotes.

Pre-fix (source at `9e0b77b9`, tests kept): **6 failed / 28 passed** —

```
test_a_bridge_exposing_a_drive_tool_also_exposes_a_stop_tool[ros2-rclpy]
test_the_stop_tool_publishes_a_zero_velocity_twist[ros2-rclpy]
test_the_ros2_stop_tool_is_present_without_any_optional_topic
test_the_ros2_stop_tool_forwards_to_the_instance_method
test_every_bridge_owning_a_drive_stop_pair_builds_a_stop_tool
test_ros_bridge.py::test_tools_are_named_per_instance
```

The two sibling transports pass every parity case before the fix — that is what
keeps the rule from over-reaching.

## Relationship to #1722

#1722 converges on the same contract from the other direction: its shared
`MobileBaseRobot.tools()` builds `stop_<suffix>` for every transport. That PR
would subsume where this closure lives, and these tests are keyed on the public
`.tools` property rather than the closure's location, so they carry over as its
regression net.

## Gate

- `MUJOCO_GL=egl pytest tests` — **28059 passed, 257 skipped, 0 failed** (614 s).
  Pristine `9e0b77b9` is 28043 passed / 257 skipped: `28043 + 16 = 28059`.
- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` — clean (1171 files).
- `mypy strands_robots tests tests_integ` — 0 errors outside `examples/isaac_gs`;
  the 14 there are byte-identical to a pristine `9e0b77b9` worktree in the same
  environment, so they are not from this branch.
- `scripts/check_merge_base_overlap.py` — no overlap; `compare` reports
  `behind_by=0`, so the gated tree is the merge result.
