### PR TITLE
test: give every recording call its own dataset root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,26 @@ hatch run format            # ruff check --fix, ruff format
     recognise cannot diverge between layers. Pinned by
     tests/test_repr_survives_partial_construction.py.
 
+15. **A recording test names its own dataset root** - `DatasetRecorder.create`
+    and every backend's `start_recording` resolve a `repo_id` with no `root` to
+    `$HF_LEROBOT_HOME/{repo_id}`, i.e. `~/.cache/huggingface/lerobot/{repo_id}`
+    by default, and `_prepare_create_target` *inspects* that directory before
+    any injected fake dataset class is reached. So a unit test that writes
+    nothing to the shared cache still reads it, and its verdict depends on what
+    the developer's cache already holds. Measured across 39 such call sites: one
+    unrelated dataset planted at `local/probe` turned 133 passed into 22 failed,
+    every failure a `FileExistsError` naming a path in `$HOME` rather than the
+    test's own resolution - which is what makes it hard to attribute. Pass
+    `root=str(tmp_path / "dataset")`, including at the sites refused before the
+    root is resolved: requiring it of those too keeps the rule one line with no
+    exemptions, where the alternative has to model which guard fires first. Note
+    a `repo_id` is as often positional as keyword (`create("user/data", ...)`) and
+    the two forms are the same exposure. Rebinding the dataset home suite-wide
+    would close the class in one line and would also break the one test that
+    legitimately asserts the documented default, which is why the rule lives at
+    the call site. `tests_integ/` records real datasets and is out of scope.
+    Pinned by tests/test_recording_root_is_not_the_shared_cache.py.
+
 ## PR Workflow
 
 1. Create the feature branch **on your fork**. Branch creation in the base

--- a/changelog.d/2143-recording-root-is-not-the-shared-cache.md
+++ b/changelog.d/2143-recording-root-is-not-the-shared-cache.md
@@ -1,0 +1,34 @@
+### Quality: a recording unit test's dataset root is its own, not the developer's
+
+`DatasetRecorder.create` and every backend's `start_recording` resolve a
+`repo_id` with no `root` to `$HF_LEROBOT_HOME/{repo_id}` - by default
+`~/.cache/huggingface/lerobot/{repo_id}`. 39 call sites across nine test
+modules relied on that shorthand. They inject a fake dataset class and write
+nothing to the shared cache, but `_prepare_create_target` resolves and
+*inspects* that path before the fake is reached, so a unit test's verdict
+depended on what the developer's cache already held.
+
+Instrumenting `_lerobot_home` across the unit suite recorded 65 test instances
+in four modules resolving the shared home, 58 of them onto the single id
+`local/probe` - a name any scratch script reaches for. One unrelated dataset
+planted there took the fps-domain and frame-shape suites from 133 passed to
+22 failed / 111 passed, every failure the same `FileExistsError` naming a
+directory in `$HOME` rather than the test's own resolution, which is what makes
+it hard to attribute.
+
+Six of the offenders passed `repo_id` *positionally*
+(`DatasetRecorder.create("user/data", joint_names=["j1"])`), which is invisible
+to a keyword-only rule; one dataset planted at `user/data` took
+`tests/test_dataset_recorder.py` from 4 failed to 10 failed.
+
+Every site now passes `root=str(tmp_path / "dataset")`, including the nine that
+are refused before the root is resolved - requiring it of those too keeps the
+rule one line with no exemptions, instead of modelling which guard fires first.
+`tests/test_recording_root_is_not_the_shared_cache.py` reads both the keyword
+and the positional form and resolves each module's `_create(**kwargs)` funnel by
+AST rather than by name. The rule is keyed on the call site rather than on the
+resolution because rebinding the dataset home suite-wide would also break the
+one test that legitimately asserts the real default. Afterwards exactly one test
+resolves the shared home - that fallback test, which compares a path and reads
+nothing - and with a stray dataset planted at all six ids the suite's failure
+set is unchanged.

--- a/tests/simulation/isaac/test_dataset_recording.py
+++ b/tests/simulation/isaac/test_dataset_recording.py
@@ -128,16 +128,16 @@ def _drive_episode(engine: IsaacSimulation, robot_name: str, instruction: str, n
 # --- guards (no lerobot required) -------------------------------------------
 
 
-def test_start_recording_without_world_errors() -> None:
+def test_start_recording_without_world_errors(tmp_path) -> None:
     engine = _make_engine(robots={"so100": _robot()})
     engine._world_created = False
-    result = engine.start_recording(repo_id="local/nope")
+    result = engine.start_recording(repo_id="local/nope", root=str(tmp_path / "dataset"))
     assert result["status"] == "error"
     assert "No world" in result["content"][0]["text"]
 
 
-def test_start_recording_without_robots_errors() -> None:
-    result = _make_engine().start_recording(repo_id="local/nope")
+def test_start_recording_without_robots_errors(tmp_path) -> None:
+    result = _make_engine().start_recording(repo_id="local/nope", root=str(tmp_path / "dataset"))
     assert result["status"] == "error"
     assert "add_robot" in result["content"][0]["text"]
 

--- a/tests/simulation/mujoco/test_recording_backends.py
+++ b/tests/simulation/mujoco/test_recording_backends.py
@@ -49,19 +49,19 @@ class TestStartRecordingErrorWithoutLerobot:
     fallback was never covered.
     """
 
-    def test_extra_absent_points_to_start_cameras_recording(self, sim, monkeypatch):
+    def test_extra_absent_points_to_start_cameras_recording(self, sim, monkeypatch, tmp_path):
         import strands_robots.dataset_recorder as dr
 
         reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
         monkeypatch.setattr(dr, "lerobot_dataset_import_error", lambda: reason)
-        result = sim.start_recording(repo_id="local/test_rec")
+        result = sim.start_recording(repo_id="local/test_rec", root=str(tmp_path / "dataset"))
         assert result["status"] == "error"
         text = result["content"][0]["text"]
         assert "start_cameras_recording" in text
         # Surfaced verbatim, so the caller sees which dependency is missing.
         assert reason in text
 
-    def test_broken_import_falls_through_to_structured_error(self, sim, monkeypatch):
+    def test_broken_import_falls_through_to_structured_error(self, sim, monkeypatch, tmp_path):
         import strands_robots.dataset_recorder as dr
 
         # Simulate a partial/broken lerobot install: the symbol is gone, so the
@@ -69,7 +69,7 @@ class TestStartRecordingErrorWithoutLerobot:
         # which must be swallowed into the same actionable error rather than
         # propagating a traceback out of the tool call.
         monkeypatch.delattr(dr, "DatasetRecorder", raising=False)
-        result = sim.start_recording(repo_id="local/test_rec")
+        result = sim.start_recording(repo_id="local/test_rec", root=str(tmp_path / "dataset"))
         assert result["status"] == "error"
         text = result["content"][0]["text"]
         assert "start_cameras_recording" in text

--- a/tests/simulation/mujoco/test_recording_paths.py
+++ b/tests/simulation/mujoco/test_recording_paths.py
@@ -73,11 +73,11 @@ def sim_with_two_robots():
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def test_start_recording_no_world_returns_graceful_error():
+def test_start_recording_no_world_returns_graceful_error(tmp_path):
     from strands_robots.simulation import Simulation
 
     s = Simulation()
-    r = s.start_recording(repo_id="local/nope", task="t")
+    r = s.start_recording(repo_id="local/nope", root=str(tmp_path / "dataset"), task="t")
     assert r["status"] == "error"
     assert "No world" in r["content"][0]["text"]
     s.destroy()
@@ -646,7 +646,7 @@ def test_get_recording_status_text_is_ascii_idle_and_recording(sim_with_two_robo
 # they pass with or without the lerobot extra installed.
 
 
-def test_start_recording_without_lerobot_points_at_mp4_fallback(sim_with_two_robots, monkeypatch):
+def test_start_recording_without_lerobot_points_at_mp4_fallback(sim_with_two_robots, monkeypatch, tmp_path):
     """When the lerobot extra is absent, start_recording does not crash: it
     returns an error that names the lerobot extra and the plain-MP4 fallback."""
     import strands_robots.dataset_recorder as dr
@@ -654,7 +654,7 @@ def test_start_recording_without_lerobot_points_at_mp4_fallback(sim_with_two_rob
     reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
     monkeypatch.setattr(dr, "lerobot_dataset_import_error", lambda: reason)
 
-    r = sim_with_two_robots.start_recording(repo_id="local/no_lerobot", task="t")
+    r = sim_with_two_robots.start_recording(repo_id="local/no_lerobot", root=str(tmp_path / "dataset"), task="t")
     assert r["status"] == "error"
     text = r["content"][0]["text"]
     # The diagnosis is surfaced verbatim: a caller must be told WHICH

--- a/tests/simulation/newton/test_dataset_recording.py
+++ b/tests/simulation/newton/test_dataset_recording.py
@@ -180,11 +180,11 @@ def test_multi_robot_namespaced_schema(tmp_path):
     assert info["total_episodes"] == 2
 
 
-def test_start_recording_without_world_errors():
+def test_start_recording_without_world_errors(tmp_path):
     engine = NewtonSimEngine.__new__(NewtonSimEngine)
     engine._world = None
     engine._model = None
-    result = engine.start_recording(repo_id="local/nope")
+    result = engine.start_recording(repo_id="local/nope", root=str(tmp_path / "dataset"))
     assert result["status"] == "error"
     assert "No world" in result["content"][0]["text"]
 

--- a/tests/simulation/newton/test_recording_lifecycle_guards.py
+++ b/tests/simulation/newton/test_recording_lifecycle_guards.py
@@ -50,14 +50,14 @@ def _world_with_robot(name: str = "so100") -> SimWorld:
 
 
 class TestStartRecordingGuards:
-    def test_missing_lerobot_extra_returns_actionable_error(self, monkeypatch):
+    def test_missing_lerobot_extra_returns_actionable_error(self, monkeypatch, tmp_path):
         # When the lerobot extra is absent, start_recording must not dead-end in
         # dataset creation - it returns an error that names the install extra.
         reason = "lerobot is not installed (ModuleNotFoundError: No module named 'lerobot'). Install lerobot >= 0.6.0 with: pip install 'strands-robots[lerobot]'"
         monkeypatch.setattr(dataset_recorder, "lerobot_dataset_import_error", lambda: reason)
         engine = _make_engine(_world_with_robot())
 
-        result = engine.start_recording(repo_id="local/sim_recording")
+        result = engine.start_recording(repo_id="local/sim_recording", root=str(tmp_path / "dataset"))
 
         assert result["status"] == "error"
         text = result["content"][0]["text"]
@@ -65,12 +65,12 @@ class TestStartRecordingGuards:
         assert reason in text
         assert "strands-robots[lerobot]" in text
 
-    def test_no_world_returns_error(self):
+    def test_no_world_returns_error(self, tmp_path):
         engine = NewtonSimEngine.__new__(NewtonSimEngine)
         engine._world = None
         engine._model = None
 
-        result = engine.start_recording(repo_id="local/sim_recording")
+        result = engine.start_recording(repo_id="local/sim_recording", root=str(tmp_path / "dataset"))
 
         assert result["status"] == "error"
         assert "create_world" in result["content"][0]["text"]

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -1098,12 +1098,14 @@ def test_create_passes_vcodec_directly_when_supported(monkeypatch):
     assert recorder.dataset.repo_id == "user/data"
 
 
-def test_create_wraps_vcodec_in_camera_encoder_on_052(monkeypatch):
+def test_create_wraps_vcodec_in_camera_encoder_on_052(monkeypatch, tmp_path):
     """On 0.5.2+ (camera_encoder= kwarg), the vcodec is wrapped in a
     VideoEncoderConfig and the backend kwargs are forwarded."""
     constructed = _install_video_encoder_config(monkeypatch)
     _patch_lerobot_dataset(monkeypatch, _FakeDatasetCameraEncoderCreate)
-    DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1", video_backend="pyav")
+    DatasetRecorder.create(
+        "user/data", root=str(tmp_path / "dataset"), joint_names=["j1"], vcodec="libsvtav1", video_backend="pyav"
+    )
 
     sent = _FakeDatasetCameraEncoderCreate.last_create_kwargs
     assert sent["video_backend"] == "pyav"
@@ -1168,7 +1170,7 @@ class _VideoBackendProbeResume:
         return cls(repo_id, root=root)
 
 
-def test_create_omits_video_backend_by_default(monkeypatch):
+def test_create_omits_video_backend_by_default(monkeypatch, tmp_path):
     """Regression: video_backend defaults to None and must NOT be forwarded to
     LeRobot.create() unless explicitly set.
 
@@ -1183,7 +1185,7 @@ def test_create_omits_video_backend_by_default(monkeypatch):
     _install_video_encoder_config(monkeypatch)
     _patch_lerobot_dataset(monkeypatch, _VideoBackendProbeCreate)
 
-    DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1")
+    DatasetRecorder.create("user/data", root=str(tmp_path / "dataset"), joint_names=["j1"], vcodec="libsvtav1")
 
     assert _VideoBackendProbeCreate.last_create_kwargs["video_backend"] == "__unset__"
 
@@ -1199,17 +1201,19 @@ def test_resume_omits_video_backend_by_default(monkeypatch):
     assert _VideoBackendProbeResume.last_resume_kwargs["video_backend"] == "__unset__"
 
 
-def test_create_forwards_video_backend_when_explicitly_set(monkeypatch):
+def test_create_forwards_video_backend_when_explicitly_set(monkeypatch, tmp_path):
     """When a caller explicitly passes a valid decode backend, it IS forwarded."""
     _install_video_encoder_config(monkeypatch)
     _patch_lerobot_dataset(monkeypatch, _VideoBackendProbeCreate)
 
-    DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1", video_backend="pyav")
+    DatasetRecorder.create(
+        "user/data", root=str(tmp_path / "dataset"), joint_names=["j1"], vcodec="libsvtav1", video_backend="pyav"
+    )
 
     assert _VideoBackendProbeCreate.last_create_kwargs["video_backend"] == "pyav"
 
 
-def test_create_warns_when_video_encoder_config_missing(monkeypatch, caplog):
+def test_create_warns_when_video_encoder_config_missing(monkeypatch, caplog, tmp_path):
     """If create() wants camera_encoder= but VideoEncoderConfig can't be
     imported, the recorder warns and proceeds with camera_encoder unset rather
     than crashing the recording setup."""
@@ -1219,14 +1223,14 @@ def test_create_warns_when_video_encoder_config_missing(monkeypatch, caplog):
     _patch_lerobot_dataset(monkeypatch, _FakeDatasetCameraEncoderCreate)
 
     with caplog.at_level("WARNING"):
-        DatasetRecorder.create("user/data", joint_names=["j1"], vcodec="libsvtav1")
+        DatasetRecorder.create("user/data", root=str(tmp_path / "dataset"), joint_names=["j1"], vcodec="libsvtav1")
 
     sent = _FakeDatasetCameraEncoderCreate.last_create_kwargs
     assert sent["camera_encoder"] is None
     assert any("VideoEncoderConfig" in rec.message for rec in caplog.records)
 
 
-def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch):
+def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch, tmp_path):
     """A minimal create() lacking streaming_encoding / video_backend must not be
     handed those kwargs (version-tolerant forwarding, no TypeError)."""
 
@@ -1253,7 +1257,7 @@ def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch):
             return cls(repo_id, root=root)
 
     _patch_lerobot_dataset(monkeypatch, _FakeDatasetMinimalCreate)
-    recorder = DatasetRecorder.create("user/data", joint_names=["j1"])
+    recorder = DatasetRecorder.create("user/data", root=str(tmp_path / "dataset"), joint_names=["j1"])
 
     sent = _FakeDatasetMinimalCreate.last_create_kwargs
     # The default codec "h264" is already an allowlist-valid codec name and is
@@ -1262,12 +1266,13 @@ def test_create_forwards_optional_kwargs_only_when_supported(monkeypatch):
     assert recorder.dataset.repo_id == "user/data"
 
 
-def test_create_builds_features_from_joints_and_cameras(monkeypatch):
+def test_create_builds_features_from_joints_and_cameras(monkeypatch, tmp_path):
     """create() derives the LeRobot ``features`` schema from joint_names and
     camera_keys and hands it to the underlying dataset constructor."""
     _patch_lerobot_dataset(monkeypatch, _FakeDatasetVcodecCreate)
     DatasetRecorder.create(
         "user/data",
+        root=str(tmp_path / "dataset"),
         joint_names=["shoulder", "elbow"],
         camera_keys=["top"],
         video_height=240,

--- a/tests/test_dataset_recorder_fps_domain.py
+++ b/tests/test_dataset_recorder_fps_domain.py
@@ -152,25 +152,33 @@ class TestUnusableRatesAreRefused:
     """Every rate above is refused, naming the parameter and the method."""
 
     @pytest.mark.parametrize(("label", "value"), UNUSABLE_RATES, ids=[r[0] for r in UNUSABLE_RATES])
-    def test_refused_naming_the_parameter_and_the_method(self, no_lerobot: None, label: str, value: Any) -> None:
+    def test_refused_naming_the_parameter_and_the_method(
+        self, no_lerobot: None, label: str, value: Any, tmp_path: Path
+    ) -> None:
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", joint_names=["j1"], fps=value)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=value)
         text = str(excinfo.value)
         assert "fps" in text, text
         assert "must be a positive whole number" in text, text
         assert "DatasetRecorder.create" in text, text
 
-    def test_a_rate_past_the_float_range_is_refused_for_its_own_reason(self, no_lerobot: None) -> None:
+    def test_a_rate_past_the_float_range_is_refused_for_its_own_reason(self, no_lerobot: None, tmp_path: Path) -> None:
         """``10**400`` *is* a positive whole number, so that text would be false."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", joint_names=["j1"], fps=10**400)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=10**400)
         text = str(excinfo.value)
         assert "fps must be within the range of a 64-bit float" in text, text
 
-    def test_a_camera_dataset_is_refused_on_the_same_rate(self, no_lerobot: None) -> None:
+    def test_a_camera_dataset_is_refused_on_the_same_rate(self, no_lerobot: None, tmp_path: Path) -> None:
         """The rate is not a per-camera property, so a declared camera changes nothing."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": (240, 320)}, fps=math.nan)
+            _create(
+                repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
+                camera_keys=["image"],
+                camera_dims={"image": (240, 320)},
+                fps=math.nan,
+            )
         assert "fps must be a positive whole number" in str(excinfo.value)
 
 
@@ -179,19 +187,21 @@ class TestUsableRatesStillReachTheDataset:
 
     @pytest.mark.parametrize(("label", "value"), USABLE_RATES, ids=[r[0] for r in USABLE_RATES])
     def test_accepted_and_declared_as_given(
-        self, fake_lerobot: type[_FakeLeRobotDataset], label: str, value: Any
+        self, fake_lerobot: type[_FakeLeRobotDataset], label: str, value: Any, tmp_path: Path
     ) -> None:
-        _create(repo_id="local/probe", joint_names=["j1"], fps=value)
+        _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=value)
         assert len(fake_lerobot.calls) == 1
         # Forwarded verbatim: the guard refuses, it does not coerce, so the rate
         # the dataset declares is the one the caller passed.
         assert fake_lerobot.calls[0]["fps"] is value
 
-    def test_the_default_rate_is_inside_the_domain(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+    def test_the_default_rate_is_inside_the_domain(
+        self, fake_lerobot: type[_FakeLeRobotDataset], tmp_path: Path
+    ) -> None:
         """A default the guard refuses would break every call that omits it."""
         default = inspect.signature(DatasetRecorder.create).parameters["fps"].default
         assert positive_whole_number_error(default, "fps", "DatasetRecorder.create") is None
-        _create(repo_id="local/probe", joint_names=["j1"])
+        _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"])
         assert fake_lerobot.calls[0]["fps"] == default
 
 
@@ -245,20 +255,20 @@ class TestTheRuleIsTheFacadesRule:
         ids=[r[0] for r in UNUSABLE_RATES] + [f"usable_{r[0]}" for r in USABLE_RATES],
     )
     def test_both_surfaces_reach_the_same_verdict(
-        self, fake_lerobot: type[_FakeLeRobotDataset], label: str, value: Any
+        self, fake_lerobot: type[_FakeLeRobotDataset], label: str, value: Any, tmp_path: Path
     ) -> None:
         facade_refuses = dataset_recording_option_error("start_recording", value) is not None
         try:
-            _create(repo_id="local/probe", joint_names=["j1"], fps=value)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=value)
             create_refuses = False
         except ValueError:
             create_refuses = True
         assert create_refuses is facade_refuses, f"verdict differs for {value!r}"
 
-    def test_the_message_is_the_shared_one_verbatim(self, no_lerobot: None) -> None:
+    def test_the_message_is_the_shared_one_verbatim(self, no_lerobot: None, tmp_path: Path) -> None:
         """No second wording for the same rule - only the surface name differs."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", joint_names=["j1"], fps=2.7)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=2.7)
         assert str(excinfo.value) == positive_whole_number_error(2.7, "fps", "DatasetRecorder.create")
 
     def test_the_facade_states_the_same_rule_against_its_own_name(self) -> None:
@@ -320,7 +330,7 @@ class TestNeighbouringSurfacesStayOutOfScope:
         assert "fps" not in inspect.signature(DatasetRecorder.resume).parameters
 
     def test_the_rate_is_not_compared_against_a_capture_frequency_here(
-        self, fake_lerobot: type[_FakeLeRobotDataset]
+        self, fake_lerobot: type[_FakeLeRobotDataset], tmp_path: Path
     ) -> None:
         """A rate a rollout is not capturing at is the facades' check, not this one.
 
@@ -329,5 +339,5 @@ class TestNeighbouringSurfacesStayOutOfScope:
         the recorder cannot see. So ``create`` accepts any usable rate on its own
         terms; only the domain moved here.
         """
-        _create(repo_id="local/probe", joint_names=["j1"], fps=1)
+        _create(repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], fps=1)
         assert len(fake_lerobot.calls) == 1

--- a/tests/test_dataset_schema_column_names_distinct.py
+++ b/tests/test_dataset_schema_column_names_distinct.py
@@ -123,10 +123,10 @@ class TestUnusableNameListsAreRefused:
     @pytest.mark.parametrize("param", NAME_LIST_PARAMS)
     @pytest.mark.parametrize(("label", "value", "expected"), UNUSABLE, ids=[c[0] for c in UNUSABLE])
     def test_refused_with_the_mistake_named(
-        self, no_lerobot: None, param: str, label: str, value: Any, expected: str
+        self, no_lerobot: None, param: str, label: str, value: Any, expected: str, tmp_path: Path
     ) -> None:
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", **{param: value})
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), **{param: value})
         text = str(excinfo.value)
         assert expected in text, text
         assert param in text, text
@@ -135,10 +135,10 @@ class TestUnusableNameListsAreRefused:
     @pytest.mark.parametrize("param", NAME_LIST_PARAMS)
     @pytest.mark.parametrize(("label", "value"), USABLE, ids=[c[0] for c in USABLE])
     def test_usable_name_lists_still_reach_the_dataset(
-        self, fake_lerobot: type[_FakeLeRobotDataset], param: str, label: str, value: Any
+        self, fake_lerobot: type[_FakeLeRobotDataset], param: str, label: str, value: Any, tmp_path: Path
     ) -> None:
         """``None`` / ``[]`` still mean "not supplied"; distinct names are accepted."""
-        _create(repo_id="local/probe", **{param: value})
+        _create(repo_id="local/probe", root=str(tmp_path / "dataset"), **{param: value})
         assert len(fake_lerobot.calls) == 1
 
 
@@ -191,11 +191,12 @@ class TestTheDomainCannotDriftFromTheSharedRule:
         param: str,
         label: str,
         value: Any,
+        tmp_path: Path,
     ) -> None:
         """A value the shared domain refuses is refused here, and vice versa."""
         shared_refuses = bool(value) and name_list_error(value, param, "x") is not None
         try:
-            _create(repo_id="local/probe", **{param: value})
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), **{param: value})
             create_refuses = False
         except ValueError:
             create_refuses = True

--- a/tests/test_dataset_schema_frame_shape_domain.py
+++ b/tests/test_dataset_schema_frame_shape_domain.py
@@ -148,10 +148,11 @@ def no_lerobot(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestAnEntryForAnUndeclaredCameraIsRefused:
     """The quiet half: an unlooked-up entry, and the camera declared at the pair."""
 
-    def test_a_mistyped_camera_name_is_refused_and_named(self, no_lerobot: None) -> None:
+    def test_a_mistyped_camera_name_is_refused_and_named(self, no_lerobot: None, tmp_path: Path) -> None:
         with pytest.raises(ValueError) as excinfo:
             _create(
                 repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
                 camera_keys=["image"],
                 camera_dims={"imagee": (240, 320)},
             )
@@ -161,11 +162,12 @@ class TestAnEntryForAnUndeclaredCameraIsRefused:
         assert "Did you mean 'image'?" in text, text
         assert "['image']" in text, text
 
-    def test_an_unrelated_key_is_refused_without_inventing_a_suggestion(self, no_lerobot: None) -> None:
+    def test_an_unrelated_key_is_refused_without_inventing_a_suggestion(self, no_lerobot: None, tmp_path: Path) -> None:
         """A near match is offered; an unrelated name only gets the declared list."""
         with pytest.raises(ValueError) as excinfo:
             _create(
                 repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
                 camera_keys=["image", "wrist_image"],
                 camera_dims={"joint1": (240, 320)},
             )
@@ -173,18 +175,26 @@ class TestAnEntryForAnUndeclaredCameraIsRefused:
         assert "Did you mean" not in text, text
         assert "['image', 'wrist_image']" in text, text
 
-    def test_dims_for_a_camera_less_dataset_are_refused(self, no_lerobot: None) -> None:
+    def test_dims_for_a_camera_less_dataset_are_refused(self, no_lerobot: None, tmp_path: Path) -> None:
         """With no ``camera_keys`` no image feature is built, so every entry is ignored."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", joint_names=["j1"], camera_dims={"image": (240, 320)})
+            _create(
+                repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
+                joint_names=["j1"],
+                camera_dims={"image": (240, 320)},
+            )
         text = str(excinfo.value)
         assert "no camera is declared" in text, text
         assert "camera_keys" in text, text
 
-    def test_the_declared_camera_keeps_its_own_shape(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+    def test_the_declared_camera_keeps_its_own_shape(
+        self, fake_lerobot: type[_FakeLeRobotDataset], tmp_path: Path
+    ) -> None:
         """The control: spelled correctly, the entry wins over the global pair."""
         _create(
             repo_id="local/probe",
+            root=str(tmp_path / "dataset"),
             camera_keys=["image"],
             camera_dims={"image": (240, 320)},
             video_width=640,
@@ -199,9 +209,11 @@ class TestUnusableFrameShapesAreRefused:
 
     @pytest.mark.parametrize("param", ["video_width", "video_height"])
     @pytest.mark.parametrize(("label", "value"), UNUSABLE_COUNTS, ids=[c[0] for c in UNUSABLE_COUNTS])
-    def test_global_pair_component_refused(self, no_lerobot: None, param: str, label: str, value: Any) -> None:
+    def test_global_pair_component_refused(
+        self, no_lerobot: None, param: str, label: str, value: Any, tmp_path: Path
+    ) -> None:
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], **{param: value})
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), camera_keys=["image"], **{param: value})
         text = str(excinfo.value)
         assert param in text, text
         assert "must be a positive integer" in text, text
@@ -209,27 +221,43 @@ class TestUnusableFrameShapesAreRefused:
 
     @pytest.mark.parametrize("axis", ["height", "width"])
     @pytest.mark.parametrize(("label", "value"), UNUSABLE_COUNTS, ids=[c[0] for c in UNUSABLE_COUNTS])
-    def test_per_camera_component_refused(self, no_lerobot: None, axis: str, label: str, value: Any) -> None:
+    def test_per_camera_component_refused(
+        self, no_lerobot: None, axis: str, label: str, value: Any, tmp_path: Path
+    ) -> None:
         dims = (value, 320) if axis == "height" else (240, value)
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": dims})
+            _create(
+                repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
+                camera_keys=["image"],
+                camera_dims={"image": dims},
+            )
         text = str(excinfo.value)
         assert f"camera_dims['image'] {axis}" in text, text
         assert "must be a positive integer" in text, text
 
     @pytest.mark.parametrize(("label", "value"), UNUSABLE_PAIRS, ids=[c[0] for c in UNUSABLE_PAIRS])
-    def test_a_value_that_is_not_a_height_width_pair_is_refused(self, no_lerobot: None, label: str, value: Any) -> None:
+    def test_a_value_that_is_not_a_height_width_pair_is_refused(
+        self, no_lerobot: None, label: str, value: Any, tmp_path: Path
+    ) -> None:
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": value})
+            _create(
+                repo_id="local/probe",
+                root=str(tmp_path / "dataset"),
+                camera_keys=["image"],
+                camera_dims={"image": value},
+            )
         text = str(excinfo.value)
         assert "camera_dims['image']" in text, text
         assert "(height, width) pair" in text, text
 
     @pytest.mark.parametrize(("label", "value"), NON_MAPPINGS, ids=[c[0] for c in NON_MAPPINGS])
-    def test_a_non_mapping_camera_dims_is_refused(self, no_lerobot: None, label: str, value: Any) -> None:
+    def test_a_non_mapping_camera_dims_is_refused(
+        self, no_lerobot: None, label: str, value: Any, tmp_path: Path
+    ) -> None:
         """Its entries are looked up per camera, so a non-mapping cannot be read."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], camera_dims=value)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), camera_keys=["image"], camera_dims=value)
         text = str(excinfo.value)
         assert "camera_dims must be a mapping" in text, text
         assert type(value).__name__ in text, text
@@ -250,13 +278,20 @@ class TestUsableFrameShapesStillReachTheDataset:
             ("dims_and_pair", {"camera_dims": {"image": (240, 320)}, "video_width": 640}),
         ],
     )
-    def test_accepted(self, fake_lerobot: type[_FakeLeRobotDataset], label: str, kwargs: dict[str, Any]) -> None:
-        _create(repo_id="local/probe", camera_keys=["image"], **kwargs)
+    def test_accepted(
+        self, fake_lerobot: type[_FakeLeRobotDataset], label: str, kwargs: dict[str, Any], tmp_path: Path
+    ) -> None:
+        _create(repo_id="local/probe", root=str(tmp_path / "dataset"), camera_keys=["image"], **kwargs)
         assert len(fake_lerobot.calls) == 1
 
-    def test_a_list_pair_is_honored_as_given(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+    def test_a_list_pair_is_honored_as_given(self, fake_lerobot: type[_FakeLeRobotDataset], tmp_path: Path) -> None:
         """A list is accepted because the consumer honors it - the annotation says tuple."""
-        _create(repo_id="local/probe", camera_keys=["image"], camera_dims={"image": [240, 320]})
+        _create(
+            repo_id="local/probe",
+            root=str(tmp_path / "dataset"),
+            camera_keys=["image"],
+            camera_dims={"image": [240, 320]},
+        )
         features = fake_lerobot.calls[0]["features"]
         assert features["observation.images.image"]["shape"] == (3, 240, 320)
 
@@ -388,22 +423,28 @@ class TestNeighbouringSurfacesStayOutOfScope:
     """
 
     @pytest.mark.parametrize("value", [2.7, math.nan, math.inf, True])
-    def test_an_unusable_fps_is_refused_without_naming_the_frame_shape(self, no_lerobot: None, value: Any) -> None:
+    def test_an_unusable_fps_is_refused_without_naming_the_frame_shape(
+        self, no_lerobot: None, value: Any, tmp_path: Path
+    ) -> None:
         """Refused on the rate domain - see tests/test_dataset_recorder_fps_domain.py."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], fps=value)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), camera_keys=["image"], fps=value)
         text = str(excinfo.value)
         assert "fps must be a positive whole number" in text, text
         assert "camera_dims" not in text, text
         assert "video_width" not in text, text
 
-    def test_a_usable_fps_leaves_the_shape_refusals_intact(self, no_lerobot: None) -> None:
+    def test_a_usable_fps_leaves_the_shape_refusals_intact(self, no_lerobot: None, tmp_path: Path) -> None:
         """The control: a usable rate does not shadow the frame-shape refusal."""
         with pytest.raises(ValueError) as excinfo:
-            _create(repo_id="local/probe", camera_keys=["image"], video_width=0, fps=30)
+            _create(repo_id="local/probe", root=str(tmp_path / "dataset"), camera_keys=["image"], video_width=0, fps=30)
         assert "video_width" in str(excinfo.value)
 
-    def test_a_camera_less_create_does_not_read_the_pair(self, fake_lerobot: type[_FakeLeRobotDataset]) -> None:
+    def test_a_camera_less_create_does_not_read_the_pair(
+        self, fake_lerobot: type[_FakeLeRobotDataset], tmp_path: Path
+    ) -> None:
         """With no camera declared the pair decides nothing, so it is left alone."""
-        _create(repo_id="local/probe", joint_names=["j1"], video_width=0, video_height=-8)
+        _create(
+            repo_id="local/probe", root=str(tmp_path / "dataset"), joint_names=["j1"], video_width=0, video_height=-8
+        )
         assert len(fake_lerobot.calls) == 1

--- a/tests/test_recording_root_is_not_the_shared_cache.py
+++ b/tests/test_recording_root_is_not_the_shared_cache.py
@@ -1,0 +1,211 @@
+"""No recording test resolves its dataset root from the developer's shared cache.
+
+A `repo_id` without a `root` is not a neutral shorthand in a unit test. Both
+`DatasetRecorder.create` and every backend's `start_recording` resolve the pair
+through :func:`~strands_robots.dataset_recorder.resolve_dataset_dir`, which
+falls back to ``$HF_LEROBOT_HOME/{repo_id}`` -- by default
+``~/.cache/huggingface/lerobot/{repo_id}`` -- and `_prepare_create_target` then
+**resolves and inspects that shared path** before any injected fake dataset
+class is reached. So the test writes nothing there, and still reads it.
+
+Measured on ``9e0b77b9``, before the call sites this module guards were given a
+root. Instrumenting ``_lerobot_home`` across the whole unit suite recorded
+**65 test instances in 4 modules** resolving the shared home, 58 of them onto
+the single id ``local/probe``. Planting one unrelated dataset there::
+
+    mkdir -p ~/.cache/huggingface/lerobot/local/probe/meta
+    echo '{"fps":30}' > ~/.cache/huggingface/lerobot/local/probe/meta/info.json
+
+turned ``tests/test_dataset_recorder_fps_domain.py`` plus
+``tests/test_dataset_schema_frame_shape_domain.py`` from 133 passed into
+**22 failed, 111 passed**, every failure the same ``FileExistsError`` naming a
+path in ``$HOME``; removing it returned 133 passed. ``local/probe`` is a name
+any scratch script reaches for, so the exposure is latent rather than
+theoretical -- and it is hard to attribute, because the failure implicates the
+dataset stack and a directory in ``$HOME``, not the test's own resolution.
+
+A `repo_id` is supplied positionally as often as by keyword, and the two forms
+are the same exposure. `DatasetRecorder.create("user/data", joint_names=["j1"])`
+in ``tests/test_dataset_recorder.py`` resolves ``$HF_LEROBOT_HOME/user/data``
+exactly as the keyword form resolves ``local/probe``: measured on the same
+commit, one unrelated dataset planted at ``user/data`` took that module from
+4 failed to **10 failed** -- six tests, each on the same ``FileExistsError``.
+So the rule reads the first positional argument too; a keyword-only rule passes
+a file with six live offenders in it.
+
+Why the rule is keyed on the *call site* and not on the resolution:
+
+- Rebinding the dataset home for the whole suite (an autouse fixture pointing
+  ``_lerobot_home`` at ``tmp_path``) would close the class in one line, and it
+  would also break the one test that legitimately depends on the real default:
+  ``test_resolve_dataset_dir_falls_back_to_default_home_when_lerobot_absent``
+  asserts the resolved path equals ``Path.home() / ".cache" / ...``. That test
+  resolves a path and never touches the disk, which is precisely the
+  distinction a home-level guard cannot draw and a call-site rule gets for
+  free: it is not a recording call, so this module never looks at it.
+- Some guarded call sites are refused *before* the root is resolved (the
+  missing-lerobot-extra and no-world guards), so they are inert today.
+  Requiring a root of them anyway keeps this rule one line with no exemptions;
+  the alternative has to model which guard fires first, which is a fact about
+  the implementation and not about the test.
+
+With the roots below supplied, the same instrumentation records exactly **one**
+test resolving the shared home -- the fallback test named above, which compares
+a path and reads nothing -- and the full unit suite's failure set is unchanged
+with a stray dataset planted at all six ids the offenders used.
+
+``DatasetRecorder.resume`` is deliberately not an entry point here: unlike
+``create`` it forwards ``repo_id`` / ``root`` to ``LeRobotDataset`` without
+resolving the pair itself and without ``_prepare_create_target``, so it neither
+resolves the shared home in this repo nor inspects the target first. The
+instrumentation agrees - no ``resume`` test reached the home.
+
+``tests_integ/`` deliberately records real datasets and may want the shared
+home, so the scan is scoped to ``tests/``.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+from pathlib import Path
+
+_TESTS_ROOT = Path(__file__).resolve().parent
+
+# `start_recording` is reimplemented per backend and always reached through an
+# instance, so it is matched on the attribute name for any receiver.
+_ENTRY_ATTRS = frozenset({"start_recording"})
+_ENTRY_QUALIFIED = frozenset({("DatasetRecorder", "create")})
+
+
+def _is_entry_call(call: ast.Call) -> bool:
+    """Is this call a dataset-recording entry point?"""
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr in _ENTRY_ATTRS:
+        return True
+    return isinstance(func.value, ast.Name) and (func.value.id, func.attr) in _ENTRY_QUALIFIED
+
+
+def _kwarg_forwarders(tree: ast.Module) -> frozenset[str]:
+    """Names of module-level helpers that funnel ``**kwargs`` into an entry point.
+
+    Three of the guarded modules route their calls through a local
+    ``_create(**kwargs)`` so the type suppression for a deliberately-wrong
+    keyword is stated once. The `repo_id` is supplied at the *caller*, so the
+    caller is where the `root` has to be required - resolving the funnel by AST
+    keeps that automatic instead of hard-coding a helper name.
+    """
+    forwarders = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for call in ast.walk(node):
+            if (
+                isinstance(call, ast.Call)
+                and _is_entry_call(call)
+                and any(keyword.arg is None for keyword in call.keywords)
+            ):
+                forwarders.add(node.name)
+                break
+    return frozenset(forwarders)
+
+
+def _names_a_repo_id(call: ast.Call, *, direct: bool) -> bool:
+    """Does this call supply a `repo_id`?
+
+    `repo_id` is the first parameter of `DatasetRecorder.create` and of every
+    backend's `start_recording`, so a *direct* call supplies it either by
+    keyword or as the first positional argument, and the positional form is the
+    one `tests/test_dataset_recorder.py` uses.
+
+    A call routed through a local helper is read by keyword only. The helper's
+    first parameter is whatever that helper declares -- `_record_episode(sim,
+    tmp_path / "ds")` and `_start(factory, fps=fps)` both lead a positional
+    with something other than a `repo_id` -- so reading position through a
+    forwarder would flag 15 calls that name no dataset at all.
+    """
+    if direct and call.args:
+        return True
+    return any(kw.arg == "repo_id" for kw in call.keywords)
+
+
+def _recording_calls(path: Path) -> list[tuple[ast.Call, bool, set[str]]]:
+    """Every recording-entry call in ``path``, with how it was reached."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    forwarders = _kwarg_forwarders(tree)
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        direct = _is_entry_call(node)
+        is_forwarded = isinstance(node.func, ast.Name) and node.func.id in forwarders
+        if direct or is_forwarded:
+            found.append((node, direct, {kw.arg for kw in node.keywords if kw.arg}))
+    return found
+
+
+@functools.cache
+def _scan() -> dict[Path, list[tuple[ast.Call, bool, set[str]]]]:
+    return {path: _recording_calls(path) for path in sorted(_TESTS_ROOT.rglob("test_*.py"))}
+
+
+def test_a_recording_call_that_names_a_repo_id_also_names_a_root() -> None:
+    """A unit test's dataset directory is its own, not the developer's."""
+    offenders = [
+        f"{path.relative_to(_TESTS_ROOT)}:{call.lineno}"
+        for path, calls in _scan().items()
+        for call, direct, keywords in calls
+        if _names_a_repo_id(call, direct=direct) and "root" not in keywords
+    ]
+    assert not offenders, (
+        "these recording calls pass a repo_id with no root, so they resolve a "
+        "dataset directory under $HF_LEROBOT_HOME (by default "
+        "~/.cache/huggingface/lerobot) and their verdict depends on what is "
+        "already in the developer's cache - pass root=str(tmp_path / 'dataset'):\n" + "\n".join(offenders)
+    )
+
+
+def test_the_scan_reaches_the_modules_that_record() -> None:
+    """Non-vacuity, keyed on modules rather than on a call count.
+
+    A count would have to be edited by whoever adds a recording test, which
+    makes it a number kept in step by hand rather than a floor. The modules
+    below own the recording entry points this rule exists for: if the matcher
+    stops recognising a call shape, they are what stops being scanned.
+    """
+    scanned = {str(path.relative_to(_TESTS_ROOT)) for path, calls in _scan().items() if calls}
+    for module in (
+        "test_dataset_recorder_fps_domain.py",
+        "test_dataset_schema_frame_shape_domain.py",
+        "test_dataset_schema_column_names_distinct.py",
+        "simulation/mujoco/test_recording_paths.py",
+        "simulation/newton/test_dataset_recording.py",
+        "simulation/isaac/test_dataset_recording.py",
+        "test_dataset_recorder.py",
+    ):
+        assert module in scanned, (
+            f"{module} contains recording calls the scan no longer sees, so the "
+            "rule above passes because it inspects nothing"
+        )
+
+
+def test_the_scan_still_reads_a_positional_repo_id() -> None:
+    """The positional half of the rule is pinned separately from the keyword half.
+
+    Six live offenders passed `repo_id` positionally, so a matcher that quietly
+    stopped reading position would take the rule back to where it started while
+    both tests above still passed.
+    """
+    positional = [
+        call
+        for path, calls in _scan().items()
+        if path.name == "test_dataset_recorder.py"
+        for call, direct, _keywords in calls
+        if direct and call.args
+    ]
+    assert positional, (
+        "no direct recording call in test_dataset_recorder.py is seen to pass a "
+        "positional repo_id, so the rule now rests on the keyword form alone"
+    )


### PR DESCRIPTION
## What

39 dataset-recording call sites across 9 test modules passed a `repo_id` with no
`root`, so `DatasetRecorder.create` / `start_recording` resolved the dataset
directory out of the developer's shared LeRobot cache under `$HF_LEROBOT_HOME`
(by default `~/.cache/huggingface/lerobot`). These tests inject a fake dataset
class and write nothing there - but `_prepare_create_target` **resolves and
inspects** that shared path before the fake is reached, so the outcome of a unit
test depended on what was already in the cache.

Each site now passes `root=str(tmp_path / "dataset")`, and a guard keeps it that
way.

## Measured on `9e0b77b9`

Instrumenting `_lerobot_home` across the whole unit suite (a throwaway pytest
plugin, not committed) recorded **65 test instances in 4 modules** resolving the
shared home - 58 onto the single id `local/probe`.

Planting one unrelated dataset there:

```
mkdir -p ~/.cache/huggingface/lerobot/local/probe/meta
echo '{"fps":30}' > ~/.cache/huggingface/lerobot/local/probe/meta/info.json
```

| shared cache | `test_dataset_recorder_fps_domain.py` + `test_dataset_schema_frame_shape_domain.py` |
|---|---|
| clean | 133 passed |
| one unrelated dataset at `local/probe` | **22 failed**, 111 passed |
| removed again | 133 passed |

Every failure is the same, and it names a path in `$HOME` rather than the test's
own resolution - which is what makes it hard to attribute:

```
FileExistsError: A LeRobotDataset already exists at
/home/<user>/.cache/huggingface/lerobot/local/probe. Pass overwrite=True ...
```

## Two corrections to the issue, both from measurement

The issue scoped this by AST as 33 sites in 8 files. Instrumenting the
resolution instead disagreed in both directions, and the rule here follows the
measurement:

1. **`tests/test_dataset_recorder.py` was missing from the issue's list**, and it
   holds six live offenders that pass `repo_id` **positionally** -
   `DatasetRecorder.create("user/data", joint_names=["j1"])`. A keyword-only rule
   cannot see them. One stray dataset planted at `user/data` takes that module
   from **4 failed to 10 failed**, on the same `FileExistsError`. The guard
   therefore reads the first positional argument of a *direct* entry call too.
2. **The 9 simulation sites are inert**, as the issue suspected: they are refused
   before the root is resolved, and none of them appears in the instrumentation.
   They are still given a root, because requiring it of every site keeps the rule
   one line with no exemptions - the alternative has to model which guard fires
   first, which is a fact about the implementation rather than about the test.

## Why the rule is keyed on the call site, not on the resolution

An autouse fixture pointing `_lerobot_home` at `tmp_path` would close the class
in one line. It would also break the one test that legitimately depends on the
real default: `test_resolve_dataset_dir_falls_back_to_default_home_when_lerobot_absent`
asserts the resolved path equals `Path.home() / ".cache" / ...`. That test
resolves a path and touches no disk - precisely the distinction a home-level
guard cannot draw and a call-site rule gets for free, since it is not a
recording call.

The positional rule is scoped to *direct* entry calls for the same reason.
`repo_id` is provably the first parameter of `create` / `start_recording`, but a
local helper's first parameter is whatever it declares - `_record_episode(sim,
tmp_path / "ds")`, `_start(factory, fps=fps)` - so reading position through a
forwarder flags 15 calls that name no dataset at all. Through a forwarder the
`repo_id` is read by keyword only.

`DatasetRecorder.resume` is deliberately not an entry point: unlike `create` it
forwards `repo_id` / `root` to `LeRobotDataset` without resolving the pair itself
and without `_prepare_create_target`, and no `resume` test reached the home in
the instrumentation.

## Verification

- The two suites from the issue's measurement, with the same planted cache:
  **main 22 failed / 111 passed -> this branch 133 passed**.
- `tests/test_dataset_recorder.py` with `user/data` planted: **10 failed -> 4
  failed** (its clean-cache baseline).
- Re-running the instrumentation on this branch: **65 -> 1** test resolves the
  shared home, and that one is the resolver's own documented-fallback test, which
  compares a path and reads nothing.
- Full unit suite with a stray dataset planted at **all six** ids the offenders
  used: the failure set is **byte-identical** to `main`'s on a clean cache
  (`diff` empty; 440 pre-existing failures in this environment, all missing
  optional deps - mujoco / torch / newton / huggingface_hub).
- Guard behaviour: it lists all 39 sites before the change, passes after, and
  removing a single `root` again fails it naming that one line - so the remedy it
  asks for is the remedy that satisfies it.
- `ruff check tests/` and `ruff format --check` clean.

The non-vacuity pin is keyed on **modules** rather than on a call count (the
lesson from #2127): a count is a number kept in step by hand. The positional
half of the rule is pinned separately, so a matcher that quietly stopped reading
position cannot take the rule back to where it started while the other tests
still pass.

Tests and docs only; no production code is touched.

Fixes #2141

## Review rounds

**Round 0** - initial submission, three commits:

| commit | what |
|---|---|
| `85482fd` | the 39 roots + `tests/test_recording_root_is_not_the_shared_cache.py` |
| `bbd3a7c` | `changelog.d/2143-recording-root-is-not-the-shared-cache.md` |
| `c9a2e57` | AGENTS.md key convention 15, recording the rule and naming its guard |
