### PR TITLE
fix(sim): refuse a string pose vector on its type, not its length

### DIFF
--- a/changelog.d/2141-pose-vector-string-refusal.md
+++ b/changelog.d/2141-pose-vector-string-refusal.md
@@ -1,0 +1,7 @@
+Fixed: a string passed where a pose vector belongs is now refused on its type
+rather than on its length. `add_camera(target="cube")` reported `'target' must be
+a 3-element vector, got 4 ('cube')`, describing the string's character count as
+though it were a component count; `target="box"` reported `elements must be
+numbers` instead, because a 3-character string reaches the element read rather
+than the length gate. One mistake drew three different messages, two of them
+pointing at the wrong thing to fix.

--- a/changelog.d/2141-pose-vector-string-refusal.md
+++ b/changelog.d/2141-pose-vector-string-refusal.md
@@ -1,7 +1,0 @@
-Fixed: a string passed where a pose vector belongs is now refused on its type
-rather than on its length. `add_camera(target="cube")` reported `'target' must be
-a 3-element vector, got 4 ('cube')`, describing the string's character count as
-though it were a component count; `target="box"` reported `elements must be
-numbers` instead, because a 3-character string reaches the element read rather
-than the length gate. One mistake drew three different messages, two of them
-pointing at the wrong thing to fix.

--- a/changelog.d/2144-pose-vector-string-refusal.md
+++ b/changelog.d/2144-pose-vector-string-refusal.md
@@ -1,0 +1,12 @@
+### Fixed: a string passed where a pose vector belongs is refused on its type, not its length
+
+`add_camera(target="cube")` reported `'target' must be a 3-element vector, got 4
+('cube')`, describing the string's character count as though it were a component
+count; `target="box"` reported `elements must be numbers` instead, because a
+3-character string reaches the element read rather than the length gate. One
+mistake drew three different messages, two of them pointing at the wrong thing to
+fix.
+
+The type check now runs before the length probe, so every string draws one
+refusal that names the parameter and the type it was given. No verdict changes -
+a string was already refused in each case.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1777,6 +1777,34 @@ def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int)
     # an oversized ``int`` that CPython itself refuses to convert, escaped this
     # guard and the structured contract its callers document. Both verdicts below
     # are unchanged, including the text for a value carrying no readable length.
+    # A str/bytes is refused on TYPE, before its length is asked for, because it
+    # carries one and the answer is meaningless: it counts characters, not
+    # components. ``add_camera(target="cube")`` - a plausible call, since a camera
+    # aimed at a named body is what the parameter looks like it takes - was refused
+    # as ``'target' must be a 3-element vector, got 4 ('cube')``, which reports the
+    # string's character count as though it were a component count and points the
+    # caller at fixing the length rather than the type.
+    #
+    # Every string is refused either way - ``"123"`` reaches the element read and is
+    # refused there, on its characters - so this changes no verdict, only which
+    # question the caller is sent to fix. That is the whole point: the two refusals
+    # a string currently draws are picked by its LENGTH, so the same mistake reads
+    # as three unrelated problems. At ``expected_len`` 3, ``target="box"`` reports
+    # ``elements must be numbers``, ``target="cube"`` reports a wrong element
+    # *count*, and ``target="0.1,0.2,0.3"`` reports a count of 11. One of those
+    # names the actual error and the other two describe the string's characters as
+    # though they were components.
+    #
+    # :func:`image_keys_error` already refuses str/bytes this way on the name-list
+    # path next door, for the same reason (a string is iterable per character), so
+    # this is one library rule applied to the surface that was missing it.
+    if isinstance(vec, str | bytes):
+        return [], (
+            f"{method}: '{param_name}' must be a list/tuple of {expected_len} numbers, "
+            f"got {type(vec).__name__} {_refusal_container_repr(vec)}. A string carries a "
+            f"length, but it counts characters rather than components, so it cannot be read "
+            f"as a pose - pass the {expected_len} numbers themselves."
+        )
     length = sequence_length(vec)
     if length is None:
         return [], (

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -385,11 +385,28 @@ class TestIsaacAddObject:
         assert "'orientation'" in result["content"][0]["text"]
 
     def test_a_string_position_is_no_longer_read_per_character(self):
-        """``list("abc")`` produced the 3-"component" position ``['a','b','c']``."""
+        """``list("abc")`` produced the 3-"component" position ``['a','b','c']``.
+
+        This asserted ``"must be numbers"``, which was the ELEMENT read's verdict
+        and so held only for a string whose length happened to equal the component
+        count: ``"abc"`` reached that read, while ``"cube"`` was refused one gate
+        earlier as a wrong-length *vector*. A string is now refused on its type
+        before its length is consulted, so the property this test is named for -
+        the characters are never read as components - is checked on the property
+        itself rather than on whichever downstream guard the length routed it to.
+        """
         stub = _isaac_stub()
-        result = IsaacSimulation.add_object(stub, "crate", position="abc")
-        assert result["status"] == "error"
-        assert "must be numbers" in result["content"][0]["text"]
+        for text in ("abc", "cube", "0.1,0.2,0.3"):
+            result = IsaacSimulation.add_object(stub, "crate", position=text)
+            assert result["status"] == "error", (text, result)
+            message = result["content"][0]["text"]
+            assert "'position'" in message
+            assert "str" in message
+            # No character of the string may appear as a component, and no count of
+            # them as a component count.
+            assert "-element vector" not in message
+            assert "must be numbers" not in message
+            assert stub._objects == {}
 
     def test_a_numpy_pose_is_accepted_and_echoed_as_plain_floats(self):
         stub = _isaac_stub()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -388,6 +388,30 @@ class TestPoseVectorDomain:
         assert values is None
         assert error and error.startswith("m: 'position'")
 
+    @pytest.mark.parametrize("text", ["box", "cube", "0.1,0.2,0.3", "123", b"abc"])
+    def test_a_string_is_refused_on_its_type_not_its_length(self, text):
+        """A string names its own type in the refusal, whatever its length.
+
+        Every one of these was already refused, so this pins WHICH question the
+        caller is sent to fix. A string carries a length, so before the type guard
+        the verdict was picked by that length: at ``expected_len`` 3, ``"box"``
+        drew ``elements must be numbers``, ``"cube"`` drew a wrong element *count*
+        of 4, and ``"0.1,0.2,0.3"`` drew a count of 11 - one mistake reported three
+        ways, two of them describing the string's characters as though they were
+        pose components. ``add_camera(target="cube")`` is the call that found it,
+        a camera aimed at a named body being what the parameter looks like it takes.
+        """
+        values, error = coerce_pose_vector("add_camera", "target", text, 3)
+        assert values is None
+        assert error is not None
+        assert error.startswith("add_camera: 'target' must be a list/tuple of 3 numbers")
+        assert type(text).__name__ in error
+        # The character count must not appear as a component count. "123" would
+        # make this vacuous by containing its own digits, so it is checked on the
+        # phrase the length gate produces rather than on the number.
+        assert "-element vector" not in error
+        assert "elements must be numbers" not in error
+
 
 class TestLerobotVersion:
     """``lerobot_version`` degrades instead of raising.


### PR DESCRIPTION
## What

`coerce_pose_vector` asked `sequence_length()` how many components a value has before
asking whether it is a kind of value that *has* components. A string carries a length, so
the verdict a string drew was picked by that length rather than by its type.

At `expected_len` 3, one mistake produced three different messages:

| call | refusal | what it points at |
|---|---|---|
| `add_object(position="box")` | `'position' elements must be numbers, got 'box'` | the elements |
| `add_camera(target="cube")` | `'target' must be a 3-element vector, got 4 ('cube')` | the **length** |
| `add_camera(target="0.1,0.2,0.3")` | `must be a 3-element vector, got 11` | the **length** |

Every string was already refused, so **no verdict changes** - what changes is which
question the caller is sent to fix. Two of those three describe the string's *character*
count as though it were a component count.

`add_camera(target="cube")` is the call that found it, while building a scene from the
public API for a blog figure: a camera aimed at a named body is what the parameter looks
like it takes, and `must be a 3-element vector, got 4` reads as though a cube position were
nearly right.

## Fix

Refuse `str | bytes` before the length probe, naming the type. This is the verdict
`image_keys_error` already applies on the name-list path next door for the same reason (a
string is iterable per character), so it is one library rule reaching the surface that was
missing it.

## The premise test this invalidates

`tests/simulation/test_pose_vector_domain_across_backends.py::test_a_string_position_is_no_longer_read_per_character`
asserted `"must be numbers"` - the *element read's* wording, which held only for a string
whose length happened to equal the component count. Replaced rather than deleted: it now
checks the property it is named for, across three string lengths, on all of which the
characters must not surface as components.

## Verification

- 5 new parametrized cases in `TestPoseVectorDomain`, verified to **fail on pre-fix code**
  (5 failed / 5 passed).
- `tests/test_utils.py` + `tests/test_conversion_escape_is_closed.py`: 169 passed.
- `tests/simulation/test_pose_vector_domain_across_backends.py`: 196 passed.
- Failure set over `-k "pose or camera or add_object or add_camera or coerce"` is
  **identical to the base** (39 pre-existing failures from optional deps absent in the
  local venv, unchanged), with +5 passes.
- `ruff check` clean over `strands_robots/` and `tests/`; `ruff format --check` clean.
