### PR TITLE
test(simulation/newton): drive the seed refusal on both randomization entry points

### DIFF
--- a/changelog.d/2148-newton-randomization-seed-refusal.md
+++ b/changelog.d/2148-newton-randomization-seed-refusal.md
@@ -1,0 +1,19 @@
+### Quality: drive the seed refusal on Newton's randomization entry points
+
+`randomize` and `set_obs_noise` store a seed and draw from it later - inside
+`_rebuild` and on the first observation drawn - so both refuse a seed
+`numpy.random.default_rng` cannot take at the call that supplied it. On the
+Newton backend that refusal was pinned structurally only: the cross-backend
+parity check asserts by AST that every backend *calls* the shared
+`randomization_seed_error`, which a call whose verdict is discarded still
+satisfies, and the behavioural pin beside it drives MuJoCo. Both refusal
+branches were unreached, while the sibling range and amplitude guards on the
+same two methods were driven directly.
+
+Adds the behavioural half on Newton, on the pure-Python host the sibling guard
+tests already use, so it needs neither Newton nor Warp: both entry points return
+the shared domain's verdict verbatim, a refused call configures nothing and
+never rebuilds, usable seeds are still applied, and this path keeps
+`default_rng`'s full integer width rather than the narrower ceiling a rollout
+seed carries. `strands_robots/simulation/newton/randomization.py` goes from 98%
+to 100% line coverage. Tests and docstrings only.

--- a/tests/simulation/mujoco/test_randomization_option_guards.py
+++ b/tests/simulation/mujoco/test_randomization_option_guards.py
@@ -233,9 +233,16 @@ class TestRandomizeRefusesUnusablePhysics:
 class TestBackendGuardParity:
     """Every backend with a randomization mixin routes through the shared guards.
 
-    AST-based so it runs with Newton/Isaac uninstalled: a backend that stops
-    calling a guard (or a new backend that never starts) fails here rather than
-    silently re-acquiring its own accepted domain.
+    AST-based so it covers a backend whose optional dependencies are absent, and
+    a backend added later: one that stops calling a guard, or never starts, fails
+    here rather than silently re-acquiring its own accepted domain.
+
+    It is a forward-looking net rather than the pin for the shipped backends,
+    because a call whose verdict is discarded still satisfies it. Both shipped
+    backends drive these refusals behaviourally - MuJoCo above, Newton in
+    ``TestSeedRefusalOnBothEntryPoints`` and its sibling guard classes, which
+    reach the guards on a pure-Python host with neither Newton nor Warp
+    installed.
     """
 
     _GUARD_NAMES = {"randomization_range_error", "finite_non_negative_error", "randomization_seed_error"}

--- a/tests/simulation/newton/test_domain_randomization.py
+++ b/tests/simulation/newton/test_domain_randomization.py
@@ -20,11 +20,16 @@ from __future__ import annotations
 import importlib.util
 import inspect
 import threading
+from typing import Any
 
 import numpy as np
 import pytest
 
-from strands_robots.simulation.base import randomization_range_error
+from strands_robots.simulation.base import (
+    MAX_EVAL_SEED,
+    randomization_range_error,
+    randomization_seed_error,
+)
 from strands_robots.simulation.newton.randomization import (
     _OBS_NOISE_PARAMS,
     _RANDOMIZE_PARAMS,
@@ -280,6 +285,120 @@ def _active_host(builder: _FakeBuilder | None = None) -> _RebuildHost:
     # so the concrete type is irrelevant to the code under test.
     host._world = object()  # type: ignore[assignment]
     return host
+
+
+# --------------------------------------------------------------------------- #
+# Seed domain on both randomization entry points (no Newton required)
+# --------------------------------------------------------------------------- #
+
+_UNUSABLE_SEEDS = [2.5, 3.0, float("nan"), float("inf"), -1, True, False, "7", [7]]
+_USABLE_SEEDS = [None, 0, 7, np.int64(7)]
+
+
+def _seeded(method: str, seed: Any) -> tuple[dict, _NoiseHost]:
+    """Drive one randomization entry point with ``seed``, returning result and host.
+
+    ``seed`` is ``Any`` because the probe values are deliberately outside the
+    ``int | None`` the signatures declare - refusing them is the contract.
+
+    Both seed guards run before ``with self._lock``, so the pure-Python host the
+    sibling guard tests already use reaches them with neither Newton nor Warp
+    installed.
+    """
+    host = _NoiseHost()
+    # randomize() checks only `_world is None`; set_obs_noise() has no world guard.
+    host._world = object()  # type: ignore[assignment]
+    result = host.randomize(seed=seed) if method == "randomize" else host.set_obs_noise(seed=seed)
+    return result, host
+
+
+class TestSeedRefusalOnBothEntryPoints:
+    """A seed ``default_rng`` cannot take is refused at the call that supplied it.
+
+    Both methods store the seed and draw from it later - ``randomize`` inside
+    ``_rebuild``, ``set_obs_noise`` on the first observation drawn - so without
+    the guard an unusable value raises long after the call reported the
+    randomization configured. That deferred consumption is why the guard exists,
+    and the last two tests here pin it as a property of ``default_rng`` rather
+    than as a claim.
+
+    Newton's half of these refusals was pinned structurally only.
+    ``TestBackendGuardParity`` in the MuJoCo module asserts by AST that every
+    backend *calls* :func:`~strands_robots.simulation.base.randomization_seed_error`,
+    which a call whose verdict is discarded still satisfies, and the behavioural
+    pin beside it drives the MuJoCo backend. The sibling range and amplitude
+    guards here are driven directly (``TestRandomizeGuards``,
+    ``TestSetObsNoiseValidation``); the seed was the one shared domain on this
+    backend whose refusal nothing executed.
+    """
+
+    @pytest.mark.parametrize("method", ["randomize", "set_obs_noise"])
+    @pytest.mark.parametrize("seed", _UNUSABLE_SEEDS)
+    def test_the_refusal_is_the_shared_verdict_verbatim(self, method, seed):
+        result, _host = _seeded(method, seed)
+
+        assert result["status"] == "error"
+        # Equality, not a substring: the backend returns the shared domain's
+        # verdict rather than a locally reworded copy that could drift from it.
+        assert result["content"][0]["text"] == randomization_seed_error(seed, method)
+
+    @pytest.mark.parametrize("seed", _UNUSABLE_SEEDS)
+    def test_a_refused_randomize_configures_nothing_and_never_rebuilds(self, seed):
+        host = _active_host()
+
+        assert host.randomize(randomize_physics=True, seed=seed)["status"] == "error"
+        assert host._dr is None
+        # _dr_applied and _dr_light_dir are written by _apply_domain_randomization,
+        # which only runs from _rebuild - so both being unset is the evidence the
+        # refusal returned before the rebuild rather than after it.
+        assert host._dr_applied is None
+        assert host._dr_light_dir is None
+
+    @pytest.mark.parametrize("seed", _UNUSABLE_SEEDS)
+    def test_a_refused_set_obs_noise_configures_nothing_and_builds_no_rng(self, seed):
+        host = _NoiseHost()
+
+        assert host.set_obs_noise(joint_pos_std=0.01, seed=seed)["status"] == "error"
+        assert host._obs_noise is None
+        assert host._obs_noise_rng is None
+
+    @pytest.mark.parametrize("seed", _USABLE_SEEDS)
+    def test_usable_seeds_are_still_applied_on_both_entry_points(self, seed):
+        host = _active_host()
+        assert host.randomize(randomize_physics=True, seed=seed)["status"] == "success"
+        assert host._dr is not None and host._dr_applied is not None
+
+        noise_host = _NoiseHost()
+        assert noise_host.set_obs_noise(joint_pos_std=0.01, seed=seed)["status"] == "success"
+        assert noise_host._obs_noise_rng is not None
+
+    @pytest.mark.parametrize("seed", [2**32, 2**64])
+    def test_this_path_keeps_the_full_default_rng_width(self, seed):
+        """No ceiling here, deliberately: these seeds only reach ``default_rng``.
+
+        A rollout seed is additionally applied through the legacy NumPy global
+        RNG, which refuses anything above ``MAX_EVAL_SEED``; ``default_rng``
+        takes a non-negative integer of any width. Pinning the contrast keeps a
+        future edit from copying the rollout ceiling onto a surface that can
+        honor more than it bounds.
+        """
+        assert randomization_seed_error(seed, "randomize") is None
+        assert randomization_seed_error(seed, "eval_policy", max_seed=MAX_EVAL_SEED) is not None
+
+        host = _active_host()
+        assert host.randomize(randomize_physics=True, seed=seed)["status"] == "success"
+
+        _result, noise_host = _seeded("set_obs_noise", seed)
+        assert noise_host._obs_noise_rng is not None
+
+    @pytest.mark.parametrize("seed", [2.5, float("nan"), "7"])
+    def test_the_deferred_failure_the_guard_prevents_is_real(self, seed):
+        with pytest.raises(TypeError, match="SeedSequence expects int"):
+            np.random.default_rng(seed)
+
+    def test_a_negative_seed_is_refused_by_default_rng_too(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            np.random.default_rng(-1)
 
 
 class TestApplyDomainRandomizationNoSpec:


### PR DESCRIPTION
## Problem

`randomize` and `set_obs_noise` both **store** a seed and draw from it later -
`randomize` inside `_rebuild`, `set_obs_noise` on the first observation drawn -
so both refuse a seed `numpy.random.default_rng` cannot take at the call that
supplied it. Newton's `randomization.py` says why, twice:

```
# The seed is stored now and only reaches ``default_rng`` inside
# ``_rebuild``, so an unusable one would otherwise raise after this call
# already reported the randomization applied.
```

Both of those refusal branches were unreached. Across the two backends that ship
a randomization mixin there are 13 refusal cells (4 shared guards over
`randomize` / `set_obs_noise`); 11 were executed and the 2 that were not are the
same guard on the same backend:

| backend | method | shared guard | line | executed on main |
|---|---|---|---|---|
| mujoco | randomize / set_obs_noise | all 4 | | yes (7 of 7) |
| newton | randomize | `randomization_range_error` | 176 | yes |
| newton | set_obs_noise | `finite_non_negative_error` | 325 | yes |
| **newton** | **randomize** | **`randomization_seed_error`** | **181** | **no** |
| **newton** | **set_obs_noise** | **`randomization_seed_error`** | **330** | **no** |

The gap is structural rather than accidental. `TestBackendGuardParity` asserts
by AST that every backend *calls* the shared guard, and its docstring gives the
reason: "AST-based so it runs with Newton/Isaac uninstalled". That is a real
property, but a call whose verdict is discarded satisfies it, so it cannot pin a
refusal. The behavioural pin beside it
(`test_unusable_seed_is_refused_by_both_randomization_entry_points`) drives the
MuJoCo backend. And the one existing Newton test that passes a seed at all
passes an *accepted* one (`seed=0`), which is why the guard's call line reads as
covered while its refusal never ran.

The stated reason also does not hold for this guard: both seed checks run before
`with self._lock`, and the module's own `_NoiseHost` - the pure-Python host its
sibling guard classes already use - reaches them with neither Newton nor Warp
installed.

## Change

Tests and docstrings only; no production line changes.

- `tests/simulation/newton/test_domain_randomization.py`: a
  `TestSeedRefusalOnBothEntryPoints` class (46 cases) on `_NoiseHost` /
  `_active_host`, so it needs no optional dependency.
- `tests/simulation/mujoco/test_randomization_option_guards.py`: corrects
  `TestBackendGuardParity`'s docstring - its AST scope is a forward-looking net
  for a backend added later or one whose dependencies are absent, not the pin for
  the shipped backends, because a discarded verdict satisfies it.

What the new class pins, and why each assertion is there:

- **The refusal is the shared domain's verdict verbatim** -
  `result["content"][0]["text"] == randomization_seed_error(seed, method)`, over
  9 unusable values x both entry points. Equality rather than a substring: it
  pins that the backend returns the shared verdict instead of a locally reworded
  copy that could drift from it.
- **A refused call configures nothing and never rebuilds** - `_dr` is unset, and
  so are `_dr_applied` / `_dr_light_dir`, which only `_apply_domain_randomization`
  writes and only `_rebuild` calls. Their being unset is the evidence the refusal
  returned before the rebuild rather than after it. Same for `_obs_noise` and
  `_obs_noise_rng`.
- **Usable seeds are still applied** - `None` / `0` / `7` / `np.int64(7)` on both
  entry points, so the guard is not satisfied by refusing everything.
- **This path keeps `default_rng`'s full integer width, deliberately** - `2**32`
  and `2**64` are accepted here and refused by the same rule with the rollout
  ceiling applied. `randomization_seed_error`'s docstring documents that
  asymmetry ("one rule with an explicit bound per destination"); pinning it keeps
  a future edit from copying the rollout ceiling onto a surface that can honor
  more than it bounds.
- **The deferred failure the guard prevents is real** - `default_rng(2.5)` raises
  `TypeError: SeedSequence expects int or sequence of ints` and
  `default_rng(-1)` raises `ValueError`. Pinned as a property of `default_rng`
  rather than asserted in prose, so the guard's reason cannot quietly stop being
  true.

## Evidence

The production code is correct, so these tests pass on unmodified main - what
they fail on is a regression. The mutation table is the evidence. Each anchor is
scoped to its enclosing function by AST (`in_fn=1`, `in_file=1` printed per row)
and the source is asserted byte-identical on restore.

| mutation | this PR's class | the 80 pre-existing |
|---|---|---|
| M1 `randomize`: delete the seed guard | 18 failed | 1 failed |
| M2 `randomize`: call the guard, discard the verdict | 18 failed | **BLIND** |
| M3 `set_obs_noise`: delete the seed guard | 18 failed | 1 failed |
| M4 `set_obs_noise`: call the guard, discard the verdict | 18 failed | **BLIND** |
| M5 `randomize`: reword the reason locally | 9 failed | **BLIND** |
| M6 `randomize`: copy the rollout ceiling onto this path | 2 failed | **BLIND** |
| M7 `set_obs_noise`: copy the rollout ceiling onto this path | 2 failed | **BLIND** |
| (unmutated control) | 46 pass | 80 pass |

7 of 7 caught; 5 of 7 invisible to the pre-existing tests. M1 and M3 are caught
by both - deleting the guard entirely trips the AST parity check, which is
exactly what it is for. The three it cannot see are the ones that keep the call:
a discarded verdict, a locally reworded reason, and a ceiling this path cannot
honor.

Worth recording: M6 initially came back blind to the new class too, because the
full-width test asserted the shared helper and drove only `set_obs_noise`. It now
drives `randomize` as well.

## Coverage

```
strands_robots/simulation/newton/randomization.py   123 stmts   2 missing  98%  ->  0 missing  100%
                                                   (lines 181, 330 - the two seed refusals)
```

Cross-backend refusal matrix: **2 of 13 uncovered -> 0 of 13**.

## Gate

Verified at `8da5a3fb` (gated tree `d5d070de`), in a clean checkout. The head is now
`cfea39e7`, which differs from the gated tree only in the changelog fragment's
filename (`2147-` -> `2148-`, renamed to this PR's number once it was assigned);
`assemble_changelog.py --check` and both changelog guards were re-run after it.

- `MUJOCO_GL=egl python -m pytest tests` -> **28108 passed / 257 skipped / 0 failed** (616s).
  Pristine at this base is 28062; +46 new cases = 28108.
- `ruff check strands_robots tests tests_integ` -> clean.
- `ruff format --check strands_robots tests tests_integ` -> 1172 files already formatted.
- `mypy strands_robots tests tests_integ` -> 14 errors, all in `examples/isaac_gs`,
  **0 outside**; the error set is byte-identical to a pristine worktree of the
  same base (`examples/` is outside CI's lint scope).
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> no overlap.
- `scripts/assemble_changelog.py --check` -> OK.
- `tests/simulation/newton/test_domain_randomization.py` +
  `tests/simulation/mujoco/test_randomization_option_guards.py` -> 126 passed / 11
  skipped in 0.8s. The new class alone is 46 cases in 0.16s.

## Artifact

No policy, simulation, rendering, recording or asset behaviour changes, so the
artifact is the coverage-and-mutation measurement rather than a rollout. Every
number in it is read from a coverage JSON and asserted before the figure is
saved; the capture, mutation and compose scripts are published beside it.

![Newton randomization seed-refusal matrix](https://raw.githubusercontent.com/cagataycali/robots/artifacts/newton-seed-refusal/newton_seed_refusal_matrix.png)

## Scope

Deliberately not covered, with reasons:

- **MuJoCo's three cells the two-file subset does not reach**
  (`unknown_kwargs_error` on both methods, `finite_non_negative_error` on
  `set_obs_noise`) are covered by other modules in the full suite; the matrix
  above is measured from the full-suite run for exactly that reason.
- **Isaac** ships no randomization mixin, so it contributes no cell. The parity
  check already covers a backend that adds one later.
- **The seed's upper bound** is left as it is: unbounded here is what
  `default_rng` can honor, and the contrast with the rollout ceiling is now
  pinned rather than changed.

