### PR TITLE
test(simulation): run every dataset-stack unavailability cell without an optional backend

### DIFF
--- a/changelog.d/2150-dataset-stack-cells-need-no-simulator.md
+++ b/changelog.d/2150-dataset-stack-cells-need-no-simulator.md
@@ -1,0 +1,17 @@
+### Quality: run every dataset-stack unavailability cell without an optional backend
+
+The nine cells that pin what `start_recording` reports when the LeRobot dataset
+stack is unusable matter most on a partially provisioned install - and the
+install most likely to be missing the lerobot extra is also the one most likely
+to be missing a simulator. Their MuJoCo engine was a real `Simulation` behind
+`pytest.importorskip("mujoco")`, on the premise that those cells need a compiled
+model. They do not: the block runs before the lock and before any MuJoCo call,
+so the pre-flight reads only a world sentinel, one robot and the two rollout
+maps `_active_rollout_rates` prunes.
+
+With the `mujoco` package blocked at the import system, the module went from
+26 passed / 11 skipped to 39 passed / 0 skipped - the three MuJoCo cells were
+among the 11, so on such an install its own mutation evidence did not hold
+either. Replaces that factory with a `__new__` skeleton matching the Newton and
+Isaac ones beside it, and adds a guard so the requirement cannot creep back.
+Tests only - no library behaviour changes.

--- a/tests/simulation/test_recording_dataset_stack_unavailable_across_backends.py
+++ b/tests/simulation/test_recording_dataset_stack_unavailable_across_backends.py
@@ -33,16 +33,26 @@ above it are owned by
 the rate refusal between them is provably unreachable on Newton and Isaac for
 the reason that module records.
 
-The Isaac and Newton skeletons are the ones that module already builds with
-``__new__``; this block runs before either backend's lock, so neither the Isaac
-Sim Kit runtime nor the Newton/Warp stack is needed. Only the MuJoCo cells need
-a compiled model, so that factory alone is gated.
+All three engines are skeletons built with ``__new__`` - the Isaac and Newton
+ones are the pair that module already builds. This block runs before every
+backend's lock and before any solver call, so none of the three needs its own
+stack, and the MuJoCo cells need no compiled model either: the pre-flight reads
+a world sentinel and the two rollout maps, nothing more. That matters because
+the install most likely to be missing the lerobot extra is also the one most
+likely to be missing a simulator, and a cell that skips there is not pinning a
+contract the sibling MuJoCo class states must "hold in every environment".
+:class:`TestEveryCellRunsWithoutAnOptionalBackend` keeps it that way.
 """
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import inspect
+import pathlib
+import subprocess
+import sys
+import threading
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -51,9 +61,15 @@ import pytest
 
 from strands_robots import dataset_recorder
 from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.models import SimRobot, SimWorld
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 from strands_robots.simulation.newton.simulation import NewtonSimEngine
 
-from .test_recording_preflight_refusals_across_backends import _isaac_engine, _newton_engine
+from .test_recording_preflight_refusals_across_backends import (
+    _SO100_JOINTS,
+    _isaac_engine,
+    _newton_engine,
+)
 
 # Verbatim copy of the diagnosis ``lerobot_dataset_import_error`` produces when
 # the extra is missing, so the "surfaced verbatim" assertions below compare
@@ -107,17 +123,28 @@ CAUSES = [
 
 
 @contextlib.contextmanager
-def _mujoco_engine() -> Iterator[Any]:
-    """A real MuJoCo engine over an empty world - the only cell needing a model."""
-    pytest.importorskip("mujoco")
-    from strands_robots.simulation.mujoco.simulation import Simulation
+def _mujoco_skeleton() -> Iterator[Any]:
+    """A ``MuJoCoSimEngine`` over a hand-built world, with no ``mujoco`` import.
 
-    sim = Simulation(tool_name="dataset_stack_probe", mesh=False)
-    sim.create_world()
-    try:
-        yield sim
-    finally:
-        sim.cleanup()
+    The block under test runs before the lock and before any MuJoCo call, so the
+    engine needs only what the pre-flight reads: a world carrying the "created"
+    sentinels and one robot, plus the two rollout maps ``_active_rollout_rates``
+    prunes. Nothing here compiles a model, so these three cells run on an
+    install that has no ``mujoco`` at all - and no runtime was started, so there
+    is nothing to release.
+    """
+    world = SimWorld()
+    world._model = object()  # non-None sentinel: "world created"
+    world._data = object()
+    world.robots["so100"] = SimRobot(
+        name="so100", urdf_path="so100.xml", data_config="so100", joint_names=list(_SO100_JOINTS)
+    )
+    engine = MuJoCoSimEngine.__new__(MuJoCoSimEngine)
+    engine._world = world
+    engine._lock = threading.RLock()
+    engine._policy_threads = {}
+    engine._policy_rates = {}
+    yield engine
 
 
 @contextlib.contextmanager
@@ -133,7 +160,7 @@ def _isaac_skeleton() -> Iterator[Any]:
 
 
 BACKENDS = [
-    pytest.param(_mujoco_engine, id="mujoco"),
+    pytest.param(_mujoco_skeleton, id="mujoco"),
     pytest.param(_newton_skeleton, id="newton"),
     pytest.param(_isaac_skeleton, id="isaac"),
 ]
@@ -279,3 +306,36 @@ class TestARefusedStartRecordsNothing:
             assert engine._active_recorder() is None
 
         assert not root.exists()
+
+
+class TestEveryCellRunsWithoutAnOptionalBackend:
+    """The nine cells must not need the stacks whose absence they report on.
+
+    The report exists for a partially provisioned install, so a cell that only
+    runs where a simulator happens to be importable is not pinning it there.
+    Every engine above is a ``__new__`` skeleton, and importing the three engine
+    classes must stay free of the heavy modules - so this fails if a factory
+    grows a real runtime, an ``importorskip`` or an eager backend import.
+    """
+
+    def test_importing_the_three_engine_classes_pulls_no_heavy_module(self) -> None:
+        program = (
+            "import sys\n"
+            "from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine\n"
+            "from strands_robots.simulation.newton.simulation import NewtonSimEngine\n"
+            "from strands_robots.simulation.isaac.simulation import IsaacSimulation\n"
+            "heavy = ('mujoco', 'lerobot', 'newton', 'warp', 'isaacsim', 'omni', 'torch')\n"
+            "print(sorted(m for m in heavy if m in sys.modules))\n"
+        )
+        out = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, check=True, timeout=180)
+        assert out.stdout.strip().endswith("[]"), out.stdout
+
+    def test_no_engine_factory_asks_for_an_optional_package(self) -> None:
+        """``importorskip`` in a factory is what made three cells skip before."""
+        source = pathlib.Path(__file__).read_text()
+        tree = ast.parse(source)
+        factories = {"_mujoco_skeleton", "_newton_skeleton", "_isaac_skeleton"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in factories:
+                body = ast.get_source_segment(source, node) or ""
+                assert "importorskip" not in body, f"{node.name} gates on an optional package"


### PR DESCRIPTION
## Problem

`tests/simulation/test_recording_dataset_stack_unavailable_across_backends.py` pins the nine cells of `start_recording`'s dataset-stack report: three causes (the lerobot extra absent, `strands_robots.dataset_recorder` failing to import, the module supplying no `DatasetRecorder`) on three backends. That report exists for a **partially provisioned install** - it is what a caller gets when the dataset stack is not usable.

The install most likely to be missing the lerobot extra is also the one most likely to be missing a simulator. Its MuJoCo engine was a real `Simulation` behind `pytest.importorskip("mujoco")`, on the module's stated premise that "only the MuJoCo cells need a compiled model". Measured with the `mujoco` package blocked at the import system, that costs 11 of the 37 cases - including all three MuJoCo cells of the matrix:

| environment | whole module | the nine matrix cells |
| --- | --- | --- |
| `mujoco` installed | 37 passed | 9/9 ran |
| `mujoco` **absent** | **26 passed / 11 skipped** | **6/9 ran** |

The module's own mutation evidence does not hold there either. Dropping MuJoCo's no-recorder-symbol diagnosis is listed as caught, and on a `mujoco`-free install it is not:

| dropping MuJoCo's no-recorder-symbol diagnosis | result |
| --- | --- |
| `mujoco` installed | 1 failed - caught |
| `mujoco` absent | **0 failed / 11 skipped - invisible** |

The premise is measurably false: the block runs **before the lock and before any MuJoCo call**, so the pre-flight reads only a world "created" sentinel, one robot, and the two rollout maps `_active_rollout_rates` prunes. Nothing there compiles a model.

## What this changes

Tests only - **no production line changes** (`git diff --numstat upstream/main...HEAD -- strands_robots/` is empty).

* Replaces that factory with a `__new__` skeleton, matching the Newton and Isaac ones beside it. All nine cells now run on an install with no `mujoco` at all.
* Adds `TestEveryCellRunsWithoutAnOptionalBackend` so the requirement cannot creep back: importing the three engine classes must pull none of `mujoco`, `lerobot`, `newton`, `warp`, `isaacsim`, `omni` or `torch`, and no engine factory may gate on an optional package.
* Corrects the docstring paragraph that claimed the MuJoCo cells need a compiled model.

The sibling MuJoCo class this module generalises states the contract in its own docstring - the failure modes are exercised "independent of whether lerobot happens to be installed in the test environment) because **the contract must hold in every environment**". A cell that only runs where a simulator happens to be importable is not pinning it there.

### After

| environment | whole module | the nine matrix cells | drop the diagnosis |
| --- | --- | --- | --- |
| `mujoco` installed | 39 passed | 9/9 ran | 2 failed |
| `mujoco` absent | **39 passed / 0 skipped** | **9/9 ran** | **2 failed** |

Coverage on a host that has `mujoco` is unchanged - #2149 already closed those lines here. What changes is *where* that coverage holds.

## Measured

![dataset-stack cells on an install without a simulator](https://raw.githubusercontent.com/cagataycali/robots/artifacts/dataset-stack-no-simulator/dataset_stack_cells_no_simulator.png)

Left: the honored path still records - the last frame decoded back out of a real dataset's own MP4, 1 episode / 24 frames @ 20fps, `start` / `run_policy` / `stop` all `success`. Middle and right: which of the nine cells execute with `mujoco` blocked, before and after.

`mujoco` was blocked with a six-line pytest plugin that deletes the module and its submodules from `sys.modules` and sets `sys.modules["mujoco"] = None`, so `import mujoco` raises `ModuleNotFoundError` and `importorskip` skips. The plugin, the capture and compose scripts and the raw measurements are on the artifacts branch; `compose.py` asserts every number it draws against `measurements.json`.

## Cost

39 cases in 1.1s, and the module needs no optional backend at all now. The only added runtime is the subprocess that pins the no-heavy-import property.

## Gate

Base `7ac0c51b`.

* `MUJOCO_GL=egl python -m pytest tests` -> **28176 total** (pristine at this base is 28174; 28174 + 2 = 28176).
  <details><summary>One pre-existing flake, attributed</summary>

  The final run reported `1 failed, 28175 passed`: `test_rollout_seed_is_applied_or_refused.py::TestTheSeedIsAppliedOnTheEvalPath::test_the_seeded_eval_matches_its_sibling_run_policy_contract`, comparing two draw sequences that are entirely different rather than offset - a concurrent consumer of the process-wide `random`, not an offset in one list.

  * the test alone -> 1 passed; its own file alone -> 124 passed
  * with this module collected immediately ahead of it -> 163 passed
  * this diff adds **0** lines mentioning `random` or `seed`, and **0** production lines
  * an earlier full run of this exact tree -> **28176 passed / 257 skipped / 0 failed**. That tree and this one differ only by the changelog fragment (`git diff --name-only` between them lists one `.md`), so no executable content differs.
  </details>
* `ruff check` / `ruff format --check` on `strands_robots tests tests_integ` -> clean (1174 files).
* `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/`**; the 14 there are byte-identical to a pristine-`main` worktree of the same working copy, so they are environmental.
* Repo-wide root guards + the `Args:` sweep -> 420 passed.
* `scripts/check_merge_base_overlap.py` -> no overlap; `scripts/assemble_changelog.py --check` -> OK.
