### PR TITLE
test(simulation): drive the recording lifecycle guards on Isaac and Newton

### DIFF
--- a/changelog.d/2152-recording-lifecycle-guard-parity.md
+++ b/changelog.d/2152-recording-lifecycle-guard-parity.md
@@ -1,0 +1,12 @@
+### Quality: drive the recording lifecycle guards on the Isaac and Newton capture paths
+
+`IsaacSimulation` and `NewtonSimEngine` each define their own `start_recording` and
+per-step capture hook in their backend mixin, so the guards around them are independent
+copies of one contract rather than one shared implementation. Newton's lifecycle-guard
+module pinned most of them and Isaac had no equivalent at all, leaving the resume branch,
+the recorder-creation failure path and both hook early-outs undriven there; the early-out
+that fires while `stop_recording` flushes the trailing episode - flag already False, the
+recorder still attached - was driven on neither backend. Adds the Isaac module and
+Newton's missing case, so a failed recorder creation is known to reset `recording`, an
+existing dataset is known to resume rather than be recreated, and the hook is known to
+return without writing a frame when there is no recorder or recording has already stopped.

--- a/tests/simulation/isaac/test_recording_lifecycle_guards.py
+++ b/tests/simulation/isaac/test_recording_lifecycle_guards.py
@@ -1,0 +1,204 @@
+"""Isaac recording lifecycle guards: the error, guard and no-op paths.
+
+The happy path (start -> capture -> save_episode -> parquet) and the
+dataset-stack unavailability report are covered by ``test_dataset_recording``.
+This module pins the surrounding contracts a happy-path recording never
+exercises, mirroring the Newton module of the same name:
+
+* A recorder-creation failure resets ``recording`` to False - so the engine is
+  not left wedged "recording" with no recorder - and returns an error rather
+  than raising past the tool boundary.
+* An existing on-disk dataset resumes (appends) instead of recreating, and the
+  create path does not also run.
+* The per-step capture hook is a safe no-op in every state it can be called in
+  with nothing to write, so it never raises inside the run-policy loop: an
+  unknown robot (covered by ``test_dataset_recording``), no recorder attached,
+  and recording already stopped.
+
+``IsaacSimulation`` and ``NewtonSimEngine`` each define ``start_recording`` and
+``_make_run_policy_hook`` in their own backend mixin - the shared
+``DatasetRecordingMixin`` carries the lifecycle around them, not these guards -
+so these are independent copies of one contract, and a guard driven on one
+backend says nothing about the other.
+
+The engine is built through ``__new__`` (as in ``test_dataset_recording``) so
+the recording lifecycle runs without the Isaac Sim Kit runtime. The hook guards
+need no optional dependency; the ``start_recording`` guards need the ``lerobot``
+extra and are gated below.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+
+_SO100_JOINTS = ["Rotation", "Pitch", "Elbow", "Wrist_Pitch", "Wrist_Roll", "Jaw"]
+
+
+def _make_engine(robots: dict[str, _RobotState] | None = None) -> IsaacSimulation:
+    """Build a skeleton IsaacSimulation without booting the Isaac Kit runtime."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode="rtx_realtime")
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = robots if robots is not None else {}
+    engine._cameras = {}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._recording_state_dict = {}
+    engine._action_controllers = {}
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._replicated = False
+    engine._num_envs_active = 1
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    return engine
+
+
+def _engine_with_robot(name: str = "so100") -> IsaacSimulation:
+    return _make_engine(
+        {
+            name: _RobotState(
+                name=name,
+                prim_path=f"/World/Robots/{name}",
+                joint_names=list(_SO100_JOINTS),
+                data_config="so100",
+            )
+        }
+    )
+
+
+class _RejectingRecorder:
+    """Recorder mid-flush: any further frame write is a hard error.
+
+    ``DatasetRecordingMixin.stop_recording`` flips ``recording`` to False and
+    only then flushes the trailing episode, leaving the recorder attached
+    across ``save_episode()``. A rollout thread whose hook fires inside that
+    window holds exactly this object, so the write the flag guard prevents is
+    not hypothetical.
+    """
+
+    def __init__(self) -> None:
+        self.add_frame_calls = 0
+
+    def add_frame(self, *_args: Any, **_kwargs: Any) -> None:
+        self.add_frame_calls += 1
+        raise RuntimeError("add_frame after the episode was saved")
+
+
+def _observation() -> dict[str, float]:
+    return {joint: 0.0 for joint in _SO100_JOINTS}
+
+
+class TestRunPolicyHookGuards:
+    """The per-step hook's early-outs. No optional dependency required."""
+
+    def test_hook_is_noop_without_recorder(self) -> None:
+        # recording flagged True but no recorder attached: the hook must return
+        # early rather than raise, so a run-policy loop never crashes mid-rollout.
+        engine = _engine_with_robot()
+        hook = engine._make_run_policy_hook("so100", "pick")
+        assert hook is not None
+        state = engine._recording_state()
+        assert state is not None
+        state["recording"] = True
+        state["dataset_recorder"] = None
+
+        hook(0, _observation(), _observation())  # must not raise
+
+        # Isaac's ``_RobotState`` does not declare ``policy_steps`` - the hook
+        # sets it dynamically, where Newton's ``SimRobot`` declares the field -
+        # so it is read through getattr, and its presence is itself evidence the
+        # hook body ran rather than the hook never having been called.
+        assert getattr(engine._robots["so100"], "policy_steps", None) == 1
+
+    def test_hook_is_noop_after_recording_stops(self) -> None:
+        # The state stop_recording leaves while it flushes the trailing episode:
+        # the flag is already False and the recorder is still attached. The flag
+        # is read first, so the hook must return before touching the recorder.
+        engine = _engine_with_robot()
+        hook = engine._make_run_policy_hook("so100", "pick")
+        assert hook is not None
+        recorder = _RejectingRecorder()
+        state = engine._recording_state()
+        assert state is not None
+        state["recording"] = False
+        state["dataset_recorder"] = recorder
+
+        hook(4, _observation(), _observation())  # must not raise
+
+        assert recorder.add_frame_calls == 0
+        # The counter still advances: the hook ran and returned early rather
+        # than not having been called at all.
+        assert getattr(engine._robots["so100"], "policy_steps", None) == 5
+
+
+# --- start_recording lifecycle (needs the lerobot extra) --------------------
+
+pytest.importorskip("lerobot")
+
+import strands_robots.dataset_recorder as dataset_recorder  # noqa: E402
+
+
+class TestStartRecordingGuards:
+    def test_recorder_creation_failure_resets_recording_flag(self, monkeypatch, tmp_path) -> None:
+        # start_recording sets recording=True before creating the recorder, so a
+        # failing create() must put it back: otherwise the engine is wedged
+        # "recording" with nothing attached and every later frame is dropped by
+        # the hook's recorder guard while stop_recording reports no recorder.
+        def _boom(**_kwargs: Any) -> None:
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(dataset_recorder.DatasetRecorder, "create", staticmethod(_boom))
+        engine = _engine_with_robot()
+
+        result = engine.start_recording(repo_id="owner/name", root=str(tmp_path / "ds"))
+
+        assert result["status"] == "error"
+        # The cause is surfaced rather than raising past the tool boundary.
+        assert "disk full" in result["content"][0]["text"]
+        state = engine._recording_state()
+        assert state is not None
+        assert state["recording"] is False
+        assert state.get("dataset_recorder") is None
+
+    def test_existing_dataset_resumes_instead_of_recreating(self, monkeypatch, tmp_path) -> None:
+        # A dataset dir carrying meta/ must take the resume (append) branch:
+        # resume() is called and attached, create() does not run, and the
+        # schema is verified against the recorder that came back.
+        dataset_dir = tmp_path / "existing_ds"
+        (dataset_dir / "meta").mkdir(parents=True)
+
+        resumed_sentinel = object()
+        created: list[bool] = []
+        verified: list[Any] = []
+
+        monkeypatch.setattr(
+            dataset_recorder.DatasetRecorder,
+            "resume",
+            staticmethod(lambda **_kwargs: resumed_sentinel),
+        )
+        monkeypatch.setattr(
+            dataset_recorder.DatasetRecorder,
+            "create",
+            staticmethod(lambda **_kwargs: created.append(True)),
+        )
+        engine = _engine_with_robot()
+        monkeypatch.setattr(engine, "_verify_resume_schema", lambda recorder, *a, **k: verified.append(recorder))
+
+        result = engine.start_recording(repo_id="owner/name", root=str(dataset_dir))
+
+        assert result["status"] == "success"
+        state = engine._recording_state()
+        assert state is not None
+        assert state["dataset_recorder"] is resumed_sentinel
+        assert created == []  # create() must not run on the resume branch
+        assert verified == [resumed_sentinel]  # the resumed schema is checked

--- a/tests/simulation/newton/test_recording_lifecycle_guards.py
+++ b/tests/simulation/newton/test_recording_lifecycle_guards.py
@@ -11,8 +11,9 @@ happy-path recording never exercises:
   rather than raising past the tool boundary.
 * The default ``root=None`` resolves the on-disk dataset dir from ``repo_id``.
 * An existing on-disk dataset resumes (appends) instead of recreating.
-* The per-frame capture hook is a safe no-op when the robot is unknown or no
-  recorder is attached, so it never raises inside the run-policy loop.
+* The per-frame capture hook is a safe no-op in every state it can be called
+  in with nothing to write, so it never raises inside the run-policy loop: an
+  unknown robot, no recorder attached, and recording already stopped.
 
 The engine is built through ``__new__`` (as in ``test_dataset_recording``) so
 the recording lifecycle runs without the optional Newton/Warp physics stack.
@@ -122,6 +123,24 @@ class TestStartRecordingGuards:
         assert created == []  # create() must not run on the resume branch
 
 
+class _RejectingRecorder:
+    """Recorder mid-flush: any further frame write is a hard error.
+
+    ``DatasetRecordingMixin.stop_recording`` flips ``recording`` to False and
+    only then flushes the trailing episode, leaving the recorder attached
+    across ``save_episode()``. A rollout thread whose hook fires inside that
+    window holds exactly this object, so the write the flag guard prevents is
+    not hypothetical.
+    """
+
+    def __init__(self):
+        self.add_frame_calls = 0
+
+    def add_frame(self, *_args, **_kwargs):
+        self.add_frame_calls += 1
+        raise RuntimeError("add_frame after the episode was saved")
+
+
 class TestRunPolicyHookGuards:
     def test_hook_is_none_for_unknown_robot(self):
         engine = _make_engine(_world_with_robot())
@@ -141,3 +160,23 @@ class TestRunPolicyHookGuards:
         hook(0, obs, action)  # must not raise
 
         assert engine._world.robots["so100"].policy_steps == 1
+
+    def test_hook_is_noop_after_recording_stops(self):
+        # The state stop_recording leaves while it flushes the trailing episode:
+        # the flag is already False and the recorder is still attached. The flag
+        # is read first, so the hook must return before touching the recorder.
+        engine = _make_engine(_world_with_robot())
+        hook = engine._make_run_policy_hook("so100", "pick")
+        assert hook is not None
+        recorder = _RejectingRecorder()
+        engine._world._backend_state["recording"] = False
+        engine._world._backend_state["dataset_recorder"] = recorder
+
+        obs = {j: 0.0 for j in _SO100_JOINTS}
+        action = {j: 0.0 for j in _SO100_JOINTS}
+        hook(4, obs, action)  # must not raise
+
+        assert recorder.add_frame_calls == 0
+        # The counter still advances: the hook ran and returned early rather
+        # than not having been called at all.
+        assert engine._world.robots["so100"].policy_steps == 5


### PR DESCRIPTION
## What

`IsaacSimulation` and `NewtonSimEngine` each define `start_recording` and
`_make_run_policy_hook` in their **own** backend mixin — the shared
`DatasetRecordingMixin` carries the lifecycle *around* them, not these guards. So the
guards are independent copies of one contract, and one driven on one backend says
nothing about the other.

Newton has a dedicated lifecycle-guard module for exactly these paths. Isaac had none,
so on Isaac the resume branch, the recorder-creation failure path and **both** per-step
hook early-outs had never been executed. Locating each contract by anchor text and
looking the line up in the coverage report:

| contract | isaac | newton |
|---|---|---|
| `start_recording`: a failed recorder creation resets `recording` | never run (L401) | driven (L371) |
| `start_recording`: an existing dataset resumes (appends) | never run (L371) | driven (L340) |
| capture hook: no-op when the recorder is absent | never run (L561) | driven (L495) |
| capture hook: no-op when recording has stopped | **never run** (L558) | **never run** (L492) |

5 of 8 cells never executed. The last row was driven on **neither** backend, and
Newton's guard-module docstring says why nobody noticed — it enumerated two of the
hook's three no-write states ("when the robot is unknown or no recorder is attached"),
and the third is unnamed.

## The state that third guard is for

It is not a defensive branch. `DatasetRecordingMixin.stop_recording` flips the flag
first and only then flushes:

```python
state["recording"] = False          # recording.py:600
recorder = state.get("dataset_recorder", None)
...
pending = getattr(recorder, "episode_frame_count", 0)
if pending > 0:
    save_result = recorder.save_episode()   # recording.py:628 - recorder still attached
```

so across `save_episode()` the state is *flag off, recorder still attached*. A rollout
thread whose hook fires in that window holds a recorder mid-flush, and the flag check is
the only thing between it and a frame write. Measured on both backends, the write it
prevents is `RuntimeError: add_frame after the episode was saved`.

## What this adds

* `tests/simulation/isaac/test_recording_lifecycle_guards.py`, mirroring the Newton
  module: the two `start_recording` lifecycle guards and both hook early-outs.
* Newton's missing early-out case, and its module docstring now names all three
  no-write states rather than two.

Both new hook tests assert the recorder was never written to *and* that the step counter
still advanced — the hook ran and returned early rather than not having been called.

## Do the new tests hold the contract?

Six plausible regressions, each against the 5 new tests and against the 38 pre-existing
recording tests over the same code:

| mutation | these 5 new tests | the 38 pre-existing |
|---|---|---|
| *(unmutated control)* | 5 passed | 38 passed |
| M1 isaac: drop the recording-flag early-out | 1 failed / 4 passed | 0 failed ← blind |
| M2 isaac: keep the flag check, discard its `return` | 1 failed / 4 passed | 0 failed ← blind |
| M3 isaac: drop the recorder-absent early-out | 1 failed / 4 passed | 0 failed ← blind |
| M4 isaac: a failed `create` no longer resets the flag | 1 failed / 4 passed | 0 failed ← blind |
| M5 isaac: the resume result is never attached | 1 failed / 4 passed | 0 failed ← blind |
| M6 newton: drop the recording-flag early-out | 1 failed / 4 passed | 0 failed ← blind |

6 of 6 caught; 6 of 6 invisible to the suite as it stands — including M2, which keeps the
guard's condition and discards only its effect, the shape a structural "the guard is
called" check cannot see by construction. Each anchor is scoped to its enclosing function
by AST and the sources are restored byte-identically; `return` appears twice inside
`_hook`, so that scoping is load-bearing rather than decorative.

Because the production code is correct, the new tests necessarily **pass** on unmodified
main — what they fail on is a regression, and the table above is that evidence.

## Coverage

| file | before | after |
|---|---|---|
| `simulation/isaac/recording.py` | 15 missing, 90.9% | 5 missing, **97.0%** |
| `simulation/newton/recording.py` | 2 missing, 98.7% | 1 missing, **99.4%** |

Closed: isaac `368-371, 400-403, 558, 561`; newton `492`.

## Out of scope, deliberately

Isaac's five remaining lines are separate concerns, not part of this contract: the
schema-safe camera-name alias (L338), the `run_on_main` probe route (L420) and the
probe-frame-unavailable native-size fallback (L484-485). L256 is
`_validate_recording_start_rate`'s refusal, which is unreachable on Isaac and Newton by
construction — only MuJoCo overrides `_active_rollout_rates`, so both inherit `{}` and the
guard returns `None` for every fps. Newton's remaining L187 is that same line.

MuJoCo is absent from the matrix on purpose: its hook lives in `simulation/mujoco/simulation.py`
with cooperative-stop handling and reads the recording flag as a positive branch, not as an
early-out — a different shape, and already fully covered.

## Verification

Tests only. `git diff --numstat upstream/main HEAD -- strands_robots/` is **empty**: 0
production lines changed, so no recording, policy, rendering or asset behaviour can move.

* Full suite: `MUJOCO_GL=egl pytest tests` — **28179 passed, 257 skipped, 0 failed**
  (28174 on main + the 5 new tests).
* `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
* `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`; the 14
  there are byte-identical to a pristine checkout of the same base.
* `scripts/check_merge_base_overlap.py`: no overlap — 0 paths changed on `main` in the span.

The gate above ran at `dcde47fb`; the pushed head `d7803a28` differs from it only in the
changelog fragment's filename (`2151-` → `2152-`, renamed to match this PR's number once it
was assigned). No test or source line differs.

## Artifact

The change moves no runtime behaviour, so the artifact is the measurement rather than a
rollout: the contract matrix, the mutation table and the coverage delta, every cell derived
from the coverage report and a re-run of the mutations.

![Recording lifecycle guard parity](https://raw.githubusercontent.com/cagataycali/robots/artifacts/recording-lifecycle-guard-parity/recording_lifecycle_guard_parity.png)

The capture and compose scripts plus the raw `facts.json` are on the
[`artifacts/recording-lifecycle-guard-parity`](https://github.com/cagataycali/robots/tree/artifacts/recording-lifecycle-guard-parity)
branch; `compose.py` asserts every rendered number against `facts.json` before saving.

