### PR TITLE
fix(policies/lerobot_local): report an RTC leftover that cannot be re-anchored

### DIFF
--- a/changelog.d/2161-rtc-reanchor-degradation-reported.md
+++ b/changelog.d/2161-rtc-reanchor-degradation-reported.md
@@ -1,0 +1,23 @@
+### Fixed: a relative-action RTC leftover that cannot be re-anchored now says so
+
+For a relative-action flow policy (pi0 / pi0.5 / pi0-FAST), the unexecuted tail
+of a chunk is only valid in the coordinate frame of the observation that
+produced it. `LerobotLocalPolicy` therefore keeps that tail in absolute robot
+coordinates so the next chunk can be re-expressed against the moved state;
+`_absolute_rtc_leftover` performs the conversion and returns `None` when it
+cannot. Three conditions produce that `None` and only one is benign - an
+absolute-action policy has no frame shift to undo. The other two, a bridge with
+no postprocessor and a postprocessor that does not yield a plain action tensor,
+left a relative-action policy carrying a stale-frame prefix into every
+subsequent chunk with no signal at all, behind `_resolve_rtc_rebase_steps`'
+INFO line announcing that re-anchoring was enabled.
+
+That is the same consequence `_resolve_rtc_rebase_steps` already warns about
+when LeRobot's re-anchor helper is unavailable ("the chunk-seam prefix will be
+carried in a STALE coordinate frame"), and which its own regression test pins as
+"warn once ... never crash or silently drop the prefix". Both degradations now
+report once per policy in that wording, naming the cause alongside the effect,
+using the module's existing one-shot warn latch. The benign absolute-action case
+stays silent, and a postprocessor that *raises* stays fatal rather than being
+downgraded to a silent frame shift. The method's docstring previously named two
+conditions for three exits; it now names all three and which are degradations.

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -637,6 +637,15 @@ class LerobotLocalPolicy(Policy):
         # their model index, and the degradation is surfaced rather than
         # silent (mirrors _resolve_state_order's all-missing guard).
         self._state_missing_keys_warned: bool = False
+        # Warn at most once per policy when relative-action RTC re-anchoring is
+        # enabled but the leftover cannot be converted to absolute coordinates.
+        # The consequence is the one _resolve_rtc_rebase_steps warns about for a
+        # missing LeRobot helper - a stale-frame chunk-seam prefix - so it is
+        # surfaced the same way instead of degrading silently behind that
+        # method's "re-anchoring enabled" INFO line. Per-policy, not per-episode
+        # (the bridge's postprocessor shape does not change across a reset), so
+        # reset() deliberately leaves it latched.
+        self._rtc_reanchor_degraded_warned: bool = False
         # Telemetry parallel to generic_state_keys_used: flipped True the
         # first time a resolved state key is missing from the observation
         # so run_policy / eval_policy can surface a machine-checkable signal.
@@ -1861,18 +1870,60 @@ class LerobotLocalPolicy(Policy):
         full chunk then slicing.
 
         Returns ``None`` (disabling re-anchoring this step, falling back to the
-        model-space leftover) when the policy is not relative-action or the
-        postprocessor does not yield a plain action tensor.
+        model-space leftover) in three cases, only the first of which is benign:
+
+        - The policy is not relative-action (``_rtc_relative_step`` unset). Its
+          frame does not move, so there is nothing to re-anchor and nothing to
+          report.
+        - The processor bridge has no postprocessor.
+        - The postprocessor does not yield a plain action tensor.
+
+        The last two are degradations rather than no-ops: the policy *is*
+        relative-action, so every following chunk blends a stale-frame prefix -
+        exactly the outcome :meth:`_resolve_rtc_rebase_steps` warns about when
+        the LeRobot re-anchor helper is unavailable. Both therefore warn once per
+        policy instead of degrading silently behind that method's
+        "re-anchoring enabled" INFO line.
+
+        A postprocessor that *raises* is out of scope here: ``postprocess``
+        documents ``RuntimeError``, and propagating it keeps a broken pipeline
+        fatal rather than downgrading it to a silent frame shift.
         """
         if self._rtc_relative_step is None:
             return None
         bridge = self._processor_bridge
         if bridge is None or not bridge.has_postprocessor:
+            self._warn_reanchor_degraded("the processor bridge has no postprocessor")
             return None
         absolute = bridge.postprocess(leftover_model.clone())
         if not isinstance(absolute, torch.Tensor):
+            self._warn_reanchor_degraded(f"the postprocessor returned {type(absolute).__name__}, not a tensor")
             return None
         return absolute.detach()
+
+    def _warn_reanchor_degraded(self, reason: str) -> None:
+        """Report a relative-action leftover that could not be re-anchored, once.
+
+        Mirrors the wording :meth:`_resolve_rtc_rebase_steps` uses for the same
+        consequence when the LeRobot re-anchor helper is missing, so the two
+        routes to a stale-frame chunk seam read alike. Latched per policy: this
+        is a pipeline-shape problem that will recur on every inference, and
+        :meth:`_absolute_rtc_leftover` runs once per chunk.
+
+        Args:
+            reason: Why the absolute conversion was unavailable, interpolated
+                into the warning so the cause is named alongside the effect.
+        """
+        if self._rtc_reanchor_degraded_warned:
+            return
+        logger.warning(
+            "Relative-action RTC re-anchoring is enabled for '%s' but the chunk leftover "
+            "could not be converted to absolute coordinates (%s); the chunk-seam prefix "
+            "will be carried in a STALE coordinate frame.",
+            type(self._policy).__name__,
+            reason,
+        )
+        self._rtc_reanchor_degraded_warned = True
 
     def _predict_with_rtc(self, batch: dict[str, Any]) -> torch.Tensor:
         """Run inference using predict_action_chunk with RTC kwargs.

--- a/tests/policies/lerobot_local/test_rtc_reanchor_degradation_is_reported.py
+++ b/tests/policies/lerobot_local/test_rtc_reanchor_degradation_is_reported.py
@@ -1,0 +1,338 @@
+"""Relative-action RTC re-anchoring reports the conversions it cannot make.
+
+:meth:`~strands_robots.policies.lerobot_local.policy.LerobotLocalPolicy._absolute_rtc_leftover`
+converts the unexecuted tail of a chunk into absolute robot coordinates so the
+NEXT chunk can be re-anchored against the moved robot state. It returns ``None``
+in three cases, and only the first is benign:
+
+* the policy is not relative-action - its frame does not move, so there is
+  nothing to re-anchor and nothing to report;
+* the processor bridge has no postprocessor;
+* the postprocessor does not yield a plain action tensor.
+
+The last two are degradations rather than no-ops. The policy *is*
+relative-action, so every following chunk blends a stale-frame prefix - the
+outcome ``_resolve_rtc_rebase_steps`` warns about when LeRobot's re-anchor
+helper is unavailable, and which the sibling module's
+``test_relative_action_falls_back_when_reanchor_helper_unavailable`` pins as
+"warn once ... never crash or silently drop the prefix". Both of these took that
+same degradation silently, behind the INFO line announcing that re-anchoring was
+enabled.
+
+These tests drive all three fallbacks: the benign one stays silent, both
+degradations report once naming their cause and the stale-frame consequence, the
+latch survives ``reset()`` (a pipeline shape does not change between episodes),
+and the degraded prefix that actually reaches the denoiser is measured. The scope
+boundary is pinned too - a postprocessor that *raises* stays fatal rather than
+being downgraded to a silent ``None``.
+"""
+
+import importlib
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("lerobot.processor")
+
+import torch  # noqa: E402
+from lerobot.processor import (  # noqa: E402
+    AbsoluteActionsProcessorStep,
+    RelativeActionsProcessorStep,
+)
+from lerobot.processor.converters import create_transition  # noqa: E402
+from lerobot.processor.pipeline import DataProcessorPipeline  # noqa: E402
+from lerobot.utils.constants import OBS_STATE  # noqa: E402
+
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy  # noqa: E402
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+_LOGGER_NAME = "strands_robots.policies.lerobot_local.policy"
+_ACTION_DIM = 4
+_CHUNK_LEN = 6
+_EXEC_HORIZON = 2
+
+
+def _lerobot_has_reanchor_helper() -> bool:
+    """True when the installed lerobot ships ``reanchor_relative_rtc_prefix``.
+
+    Probed by string import + ``hasattr`` (never ``from ... import``) because on
+    lerobot 0.5.1 importing ``lerobot.policies.rtc`` executes a module whose
+    dataclass fails to build, raising TypeError at load time rather than cleanly
+    missing the symbol.
+    """
+    try:
+        module = importlib.import_module("lerobot.policies.rtc")
+    except (ImportError, TypeError):
+        return False
+    return hasattr(module, "reanchor_relative_rtc_prefix")
+
+
+# _absolute_rtc_leftover is reached only once _rtc_relative_step is set, and
+# _resolve_rtc_rebase_steps sets it only when the re-anchor helper resolves. The
+# end-to-end cases therefore need the helper; the direct-call cases set the
+# precondition themselves and do not.
+_requires_reanchor = pytest.mark.skipif(
+    not _lerobot_has_reanchor_helper(),
+    reason="lerobot.policies.rtc.reanchor_relative_rtc_prefix unavailable (added after lerobot 0.5.1)",
+)
+
+
+def _model_chunk() -> torch.Tensor:
+    """A deterministic ``(1, T, A)`` action chunk in model (relative) space."""
+    return torch.arange(_CHUNK_LEN * _ACTION_DIM, dtype=torch.float32).reshape(1, _CHUNK_LEN, _ACTION_DIM)
+
+
+def _model_leftover() -> torch.Tensor:
+    """The tail a consumer does not execute this step: ``chunk[exec_horizon:]``."""
+    return _model_chunk().squeeze(0)[_EXEC_HORIZON:]
+
+
+def _make_rtc_policy(
+    preprocessor: DataProcessorPipeline | None,
+    postprocessor: DataProcessorPipeline | None,
+) -> tuple[Any, list[Any]]:
+    """An RTC-enabled policy wired to a real bridge, capturing the fed prefix.
+
+    The inner LeRobot policy is a mock whose ``predict_action_chunk`` records the
+    ``prev_chunk_left_over`` it is handed, so a test can assert on the prefix the
+    denoiser actually receives rather than on internal state.
+    """
+    with patch.object(LerobotLocalPolicy, "_load_model"):
+        policy = LerobotLocalPolicy(pretrained_name_or_path="test/model")
+
+    policy._loaded = True
+    policy._device = torch.device("cpu")
+
+    inner = MagicMock()
+    inner.config = MagicMock()
+    inner.config.action_feature_names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+
+    captured: list[Any] = []
+
+    def _predict(_batch: Any, **kwargs: Any) -> torch.Tensor:
+        captured.append(kwargs.get("prev_chunk_left_over"))
+        return _model_chunk()
+
+    inner.predict_action_chunk.side_effect = _predict
+    policy._policy = inner
+
+    policy._rtc_enabled = True
+    policy._rtc_execution_horizon = _EXEC_HORIZON
+    # Deterministic zero inference delay: the world is paused, 0 steps elapse.
+    policy.rtc_observed_delay_steps = 0
+    policy._processor_bridge = ProcessorBridge(preprocessor=preprocessor, postprocessor=postprocessor)
+    return policy, captured
+
+
+def _relative_policy_with_relative_step() -> tuple[Any, Any, list[Any]]:
+    """A policy whose preprocessor carries an enabled relative-action step."""
+    names = [f"j{i}.pos" for i in range(_ACTION_DIM)]
+    relative_step = RelativeActionsProcessorStep(enabled=True, action_names=names)
+    policy, captured = _make_rtc_policy(
+        preprocessor=DataProcessorPipeline(steps=[relative_step]),
+        postprocessor=DataProcessorPipeline(
+            steps=[AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)]
+        ),
+    )
+    return policy, relative_step, captured
+
+
+def _prime_state(relative_step: Any, state: torch.Tensor) -> None:
+    """Cache ``state`` as the relative step's reference (mimics a preprocess pass)."""
+    relative_step(create_transition(observation={OBS_STATE: state}))
+
+
+def _drop_postprocessor(policy: Any) -> None:
+    """Rebuild the bridge with its preprocessor intact and no postprocessor.
+
+    The preprocessor's step objects are carried over, so the enabled
+    relative-action step survives: replacing them would make the policy read as
+    absolute-action and take the benign fallback instead of this one.
+    """
+    policy._processor_bridge = ProcessorBridge(
+        preprocessor=DataProcessorPipeline(steps=policy._processor_bridge.preprocessor_steps),
+        postprocessor=None,
+    )
+
+
+def _postprocessor_yields_a_dict(policy: Any) -> None:
+    """Make the postprocessor return a mapping instead of a plain action tensor."""
+    policy._processor_bridge.postprocess = lambda action: {"action": action}
+
+
+def _postprocessor_raises(policy: Any) -> None:
+    """Make the postprocessor fail the way ``ProcessorBridge.postprocess`` documents."""
+
+    def _boom(_action: Any) -> Any:
+        raise RuntimeError("Postprocessor pipeline failed: boom")
+
+    policy._processor_bridge.postprocess = _boom
+
+
+# Every fallback that is a degradation, with the cause its report must name.
+_DEGRADATIONS: list[tuple[str, Any, str]] = [
+    ("no_postprocessor", _drop_postprocessor, "no postprocessor"),
+    ("non_tensor_output", _postprocessor_yields_a_dict, "not a tensor"),
+]
+_DEGRADATION_IDS = [name for name, _apply, _reason in _DEGRADATIONS]
+
+
+def _degraded_policy(apply_degradation: Any) -> Any:
+    """A relative-action policy whose absolute conversion cannot be made."""
+    policy, _relative_step, _captured = _relative_policy_with_relative_step()
+    # The documented precondition for reaching the bridge guards: the policy was
+    # detected as relative-action, so its leftover genuinely needs re-anchoring.
+    policy._rtc_relative_step = object()
+    apply_degradation(policy)
+    return policy
+
+
+class TestTheBenignFallbackStaysSilent:
+    """An absolute-action policy has nothing to re-anchor, so it reports nothing."""
+
+    def test_an_absolute_action_policy_returns_none_without_reporting(self, caplog):
+        policy, _relative_step, _captured = _relative_policy_with_relative_step()
+        policy._rtc_relative_step = None  # absolute-action: frame does not move
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            assert policy._absolute_rtc_leftover(_model_leftover()) is None
+
+        assert caplog.records == []
+        assert policy._rtc_reanchor_degraded_warned is False
+
+    @_requires_reanchor
+    def test_a_healthy_relative_action_policy_reports_nothing(self, caplog):
+        policy, relative_step, _captured = _relative_policy_with_relative_step()
+        state = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        _prime_state(relative_step, state)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with torch.inference_mode():
+                policy._predict_with_rtc({})
+
+        # The conversion succeeded, so there is a leftover to re-anchor with.
+        assert policy._rtc_prev_chunk_abs is not None
+        assert torch.allclose(policy._rtc_prev_chunk_abs, _model_leftover() + state)
+        assert caplog.records == []
+
+
+class TestEveryDegradedFallbackIsReported:
+    """A relative-action leftover that cannot be converted says so, once."""
+
+    @pytest.mark.parametrize(
+        ("apply_degradation", "expected_cause"),
+        [(apply, cause) for _name, apply, cause in _DEGRADATIONS],
+        ids=_DEGRADATION_IDS,
+    )
+    def test_it_returns_none_and_warns(self, apply_degradation, expected_cause, caplog):
+        policy = _degraded_policy(apply_degradation)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            assert policy._absolute_rtc_leftover(_model_leftover()) is None
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, [r.getMessage() for r in caplog.records]
+        assert expected_cause in warnings[0].getMessage()
+
+    @pytest.mark.parametrize(
+        "apply_degradation",
+        [apply for _name, apply, _cause in _DEGRADATIONS],
+        ids=_DEGRADATION_IDS,
+    )
+    def test_the_report_names_the_stale_frame_consequence(self, apply_degradation, caplog):
+        # Naming the cause is not enough: the reader has to learn what it costs,
+        # which is the wording _resolve_rtc_rebase_steps already uses.
+        policy = _degraded_policy(apply_degradation)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            policy._absolute_rtc_leftover(_model_leftover())
+
+        assert caplog.records, "the degradation was not reported at all"
+        message = caplog.records[0].getMessage()
+        assert "STALE coordinate frame" in message
+        assert "chunk-seam prefix" in message
+
+
+class TestTheReportIsLatchedPerPolicy:
+    """One warning per policy, not one per chunk - and not one per episode."""
+
+    @pytest.mark.parametrize(
+        "apply_degradation",
+        [apply for _name, apply, _cause in _DEGRADATIONS],
+        ids=_DEGRADATION_IDS,
+    )
+    def test_many_chunks_report_once(self, apply_degradation, caplog):
+        policy = _degraded_policy(apply_degradation)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            for _ in range(12):
+                assert policy._absolute_rtc_leftover(_model_leftover()) is None
+
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+    def test_reset_leaves_the_latch_set(self, caplog):
+        # The bridge's postprocessor shape does not change between episodes, so
+        # re-arming would re-report a condition the operator has already been
+        # told about. reset() re-arms the per-episode action diagnostics only.
+        policy = _degraded_policy(_drop_postprocessor)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            policy._absolute_rtc_leftover(_model_leftover())
+            assert policy._rtc_reanchor_degraded_warned is True
+
+            policy.reset()
+            assert policy._rtc_reanchor_degraded_warned is True
+            policy._absolute_rtc_leftover(_model_leftover())
+
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+class TestTheDegradationReachesTheDenoiser:
+    """What the report is about: the prefix actually fed to the model."""
+
+    @_requires_reanchor
+    def test_a_degraded_policy_feeds_the_stale_model_space_prefix(self, caplog):
+        policy, relative_step, captured = _relative_policy_with_relative_step()
+        _drop_postprocessor(policy)
+
+        state1 = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        _prime_state(relative_step, state1)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with torch.inference_mode():
+                policy._predict_with_rtc({})
+
+            # No absolute copy, so the next chunk has nothing to re-anchor with.
+            assert policy._rtc_prev_chunk_abs is None
+
+            # The state moves between chunks - exactly when a stale frame hurts.
+            state2 = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+            _prime_state(relative_step, state2)
+            with torch.inference_mode():
+                policy._predict_with_rtc({})
+
+        leftover_model = _model_leftover()
+        prefix = captured[1]
+        assert prefix is not None
+        # Carried in the frame of the PREVIOUS observation, not the current one.
+        assert torch.allclose(prefix, leftover_model)
+        assert not torch.allclose(prefix, leftover_model + state1 - state2)
+        # And the operator was told, rather than left to infer it from the seam.
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+class TestARaisingPostprocessorStaysFatal:
+    """Scope boundary: a broken pipeline is not downgraded to a silent fallback."""
+
+    def test_the_runtime_error_propagates(self, caplog):
+        policy = _degraded_policy(_postprocessor_raises)
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            with pytest.raises(RuntimeError, match="Postprocessor pipeline failed"):
+                policy._absolute_rtc_leftover(_model_leftover())
+
+        # Loud already: adding a warning here would report a failure that is
+        # about to be raised anyway.
+        assert caplog.records == []
+        assert policy._rtc_reanchor_degraded_warned is False


### PR DESCRIPTION
## Problem

For a relative-action flow policy (pi0 / pi0.5 / pi0-FAST), the unexecuted tail of a chunk is only valid in the coordinate frame of the observation that produced it. `LerobotLocalPolicy` therefore keeps that tail in absolute robot coordinates so the next chunk can be re-expressed against the moved state. `_absolute_rtc_leftover` performs that conversion and returns `None` when it cannot — in **three** cases, of which only the first is benign:

| fallback | policy is relative-action? | prefix fed to the denoiser | reported on `main`? |
|---|---|---|---|
| `_rtc_relative_step` unset (absolute-action) | no | model-space, **correctly** — its frame does not move | — (benign) |
| the bridge has no postprocessor | **yes** | **stale model-space** | **silent** |
| the postprocessor yields a non-tensor | **yes** | **stale model-space** | **silent** |

Measured by driving `_predict_with_rtc` twice with the robot state moved between chunks: in both degraded rows the policy *is* detected as relative-action, `_rtc_prev_chunk_abs` stays `None`, the re-anchor guard in `_predict_with_rtc` therefore fails, and every following chunk blends a prefix carried in the *previous* observation's frame — with **zero** log records, immediately after `_resolve_rtc_rebase_steps` logged `RTC relative-action re-anchoring enabled`. The only signal an operator has says the opposite of what is happening.

That is the same consequence the module already reports elsewhere. When LeRobot's re-anchor helper is unavailable, `_resolve_rtc_rebase_steps` warns that *"the chunk-seam prefix will be carried in a STALE coordinate frame"*, and that path's own regression test pins the contract as **"warn once … never crash or silently drop the prefix"**. These two exits took the identical degradation without it.

## Change

Both degraded exits now report once per policy, in that same wording, naming the cause beside the effect — via the module's existing one-shot warn latch (`_rtc_freq_warned`, `_state_key_mismatch_warned`, `_state_missing_keys_warned`, `_action_dim_warned` are four precedents). `_absolute_rtc_leftover` runs once per chunk, so a latch rather than a per-inference line.

The latch sits with the per-*policy* flags, not the per-*episode* one: a bridge's postprocessor shape does not change between episodes, so `reset()` deliberately leaves it set (it re-arms the action diagnostics only).

Two scope boundaries are kept and pinned rather than assumed:

- The **benign** absolute-action fallback stays silent — it is a no-op, not a degradation.
- A postprocessor that **raises** stays fatal. `ProcessorBridge.postprocess` documents `RuntimeError`, and propagating it keeps a broken pipeline loud instead of downgrading it to a silent frame shift.

The docstring named two conditions for three exits; it now names all three and which are degradations.

## Measured

![RTC re-anchoring degradation report](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rtc-reanchor-degradation/rtc_reanchor_degradation.png)

The top panel is the prefix actually handed to `predict_action_chunk` as `prev_chunk_left_over`. The state moved by `[9, 18, 27, 36]` between the two chunks, so the stale and re-anchored prefixes differ by exactly that shift — a frame error of up to 36 on every dimension of the tail. The healthy path is byte-identical on both trees; the change is only what the operator is told.

| | upstream/main | this PR |
|---|---|---|
| degradations left silent | **2 of 2** | **0 of 2** |
| benign fallback | silent | silent (unchanged) |
| healthy path | re-anchored | re-anchored (unchanged) |
| raising postprocessor | `RuntimeError` | `RuntimeError` (unchanged) |

`capture.py`, `compose.py` and both JSON dumps are on the artifact branch; the figure generator asserts every rendered value against them and refuses to draw if the two arms measured the same tree.

## Tests

`tests/policies/lerobot_local/test_rtc_reanchor_degradation_is_reported.py` — 11 cases driving **all three** fallbacks, so the method's whole `None`-returning contract is covered rather than one third of it:

- the benign absolute-action exit returns `None` and reports nothing;
- a healthy relative-action policy converts the leftover and reports nothing;
- each degradation returns `None` and warns exactly once, naming its cause;
- each warning names the stale-frame consequence, not just the cause;
- the report is latched across 12 chunks, and survives `reset()`;
- the degraded prefix reaching the denoiser is measured end to end — carried in the previous observation's frame, and *not* the re-anchored value;
- a raising postprocessor propagates, with nothing reported and the latch untouched.

`_absolute_rtc_leftover` had **no** test references at all before this; its two degraded exits were the only uncovered lines in the file.

**Pre-fix**: with `strands_robots/policies/lerobot_local/policy.py` reverted to `main` and the new tests kept — **10 failed, 1 passed**. Every failure states the defect (`AssertionError: the degradation was not reported at all`, `assert 0 == 1`, `AttributeError: … has no attribute '_rtc_reanchor_degraded_warned'`). The one pass is the healthy-path control, which was never broken.

## Gate

Rebased onto `666a1363` before verifying, so these numbers describe the tree that merges.

- `MUJOCO_GL=egl python -m pytest tests` — **28192 passed, 257 skipped, 0 failed** (615s)
- `ruff check` / `ruff format --check` `strands_robots tests tests_integ` — clean (1176 files)
- `mypy strands_robots tests tests_integ` — **0 errors** outside `examples/isaac_gs`; the 14 there are byte-identical to a pristine `upstream/main` worktree of the same working copy (environment-only)
- repo-wide guards (changelog, docstring refs, internal paths, unreachable statements, `Args:` completeness, vacuous comparisons) — 420 passed
- `scripts/check_merge_base_overlap.py` — no overlap, 0 paths changed on `upstream/main` in that span
- `tests/policies/lerobot_local` — 945 passed / 2 skipped (934 before, 11 added), no existing test changed
