### PR TITLE
fix(simulation/mujoco): refuse an unadvertised action at the agent boundary

### DIFF
--- a/changelog.d/2093-agent-boundary-refuses-unpublished-action.md
+++ b/changelog.d/2093-agent-boundary-refuses-unpublished-action.md
@@ -1,0 +1,25 @@
+### Changed: an action the MuJoCo tool schema does not advertise is refused at the agent boundary
+
+`_dispatch_action` resolves an action with `getattr` and no allowlist, so every public
+method of the engine is dispatchable while `tool_spec.json`'s `action` enum advertises a
+curated 77-entry subset. That width is a deliberate Python convenience, but it reached a
+model as well: the two agent-facing entry points - `__call__`, the form the README markets
+as `robot(action="...")`, and `stream`, which the agent runtime drives - forwarded any name
+straight to the router. So the 23 dispatchable-but-unadvertised capabilities were invocable
+by a model that was never told they existed, including the `TeleopMixin` cluster, which
+drives real hardware from a host input device.
+
+Both entry points now refuse a non-enum action before dispatching, and the refusal
+distinguishes the two cases a caller needs told apart: a name that resolves to no method
+stays `Unknown action`, while one that resolves to a method held back from the enum reports
+that it exists and is reachable from Python only. Previously the second case ran, and its
+own error message could recommend a further unadvertised action - `stream(action="teleoperate")`
+answered `No teleoperators attached. Use attach_teleop() first.`, coaching the model toward
+a second capability its schema never advertised.
+
+`_dispatch_action` keeps its full width: the refusal lives at the boundary, not in the
+router, so direct Python callers are unaffected and every held-back capability stays
+reachable through its own method. The allowlist is derived from the schema rather than
+restated beside it, so the published set cannot drift from what the model is told exists.
+
+Resolves the remaining question in #2093; the inventory side landed earlier in #2104.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -275,6 +275,12 @@ _TOOL_SPEC_PATH = Path(__file__).parent / "tool_spec.json"
 with open(_TOOL_SPEC_PATH) as _f:
     _TOOL_SPEC_SCHEMA: dict[str, Any] = json.load(_f)
 
+# The actions the schema advertises to a model, derived from the schema rather
+# than restated beside it: a second list would be a second thing to keep true,
+# and the failure it produces - refusing an action the model was told to use -
+# is exactly what the guard below exists to prevent.
+_PUBLISHED_ACTIONS: frozenset[str] = frozenset(_TOOL_SPEC_SCHEMA["properties"]["action"]["enum"])
+
 
 class MuJoCoSimEngine(
     TeleopMixin,
@@ -3922,14 +3928,67 @@ class MuJoCoSimEngine(
 
     # AgentTool Interface
 
+    def _unpublished_action_error(self, action: str) -> dict[str, Any] | None:
+        """Refuse an action the tool schema does not advertise to a model.
+
+        The router (:meth:`_dispatch_action`) resolves by ``getattr`` with no
+        allowlist, so every public method stays callable from Python. That
+        breadth is deliberate, but it is a *Python* contract: a model is handed
+        the ``action`` enum and nothing else, so an action outside it is one
+        the model was never told exists, and dispatching it makes the tool's
+        behaviour wider than the contract it publishes (#2093).
+
+        Two verdicts, because a caller needs different things from them. A name
+        that resolves to no method is a typo. A name that resolves to a method
+        held back from the enum is a curation decision, and reporting that as
+        "unknown" sends a reader hunting for a misspelling that is not there -
+        the method is right where they left it.
+
+        Args:
+            action: The action name as the entry point received it.
+
+        Returns:
+            An error dict when the action is not published, else ``None`` to
+            let dispatch proceed. A non-string is not this guard's verdict to
+            give: the entry points already answer it, and ``__call__`` answers
+            it before reaching here.
+        """
+        if not isinstance(action, str) or action in _PUBLISHED_ACTIONS or action in self._ACTION_ALIASES:
+            return None
+
+        # Probe the class, never the instance: the type carries properties as
+        # well as methods, and evaluating one to word a refusal would run
+        # engine code on the error path.
+        target = self._ACTION_ALIASES.get(action, action)
+        if not action.startswith("_") and callable(getattr(type(self), target, None)):
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            f"Action '{action}' is not available to an agent. It exists on this "
+                            "simulation but is deliberately not published in tool_spec, so it is "
+                            "reachable from Python only. See tool_spec for the actions you can use."
+                        )
+                    }
+                ],
+            }
+        return {"status": "error", "content": [{"text": f"Unknown action: {action}"}]}
+
     def __call__(self, action: str = "", **kwargs: Any) -> dict[str, Any]:
         """Dispatch an action directly: ``sim(action="render", camera_name="topdown")``.
 
         This makes the Simulation usable as a plain callable in addition to
         being a Strands ``AgentTool``. It mirrors the agent-facing dispatch
-        path (``_dispatch_action``): the same validation, field-aliasing, and
-        per-action method routing apply, and the return value is the standard
-        ``{"status", "content"}`` dict.
+        path: the same validation, field-aliasing, and per-action method
+        routing apply, and the return value is the standard ``{"status",
+        "content"}`` dict.
+
+        Mirroring the *agent* path is what this form is for, so it is narrower
+        than ``_dispatch_action`` in exactly one way: an action the tool schema
+        does not publish is refused here rather than routed (#2093). Reaching a
+        deliberately Python-only capability is what its own method is for -
+        ``sim.get_observation(...)`` rather than ``sim(action=...)``.
 
         The README markets ``Robot("so100")`` as something you can drive with
         ``robot(action="...")``; without this method that contract raised
@@ -3958,7 +4017,11 @@ class MuJoCoSimEngine(
                     }
                 ],
             }
-        return self._dispatch_action(action.strip(), kwargs)
+        requested = action.strip()
+        refusal = self._unpublished_action_error(requested)
+        if refusal is not None:
+            return refusal
+        return self._dispatch_action(requested, kwargs)
 
     @property
     def tool_name(self) -> str:
@@ -4141,7 +4204,8 @@ class MuJoCoSimEngine(
         try:
             tool_use_id = tool_use.get("toolUseId", "")
             input_data = tool_use.get("input", {})
-            result = self._dispatch_action(input_data.get("action", ""), input_data)
+            requested = input_data.get("action", "")
+            result = self._unpublished_action_error(requested) or self._dispatch_action(requested, input_data)
             yield ToolResultEvent(dict(toolUseId=tool_use_id, **result))  # type: ignore[typeddict-item]
         except Exception as e:
             yield ToolResultEvent(
@@ -5018,15 +5082,19 @@ class MuJoCoSimEngine(
         Resolution is ``getattr`` by name with no allowlist, so the router is
         deliberately wider than ``tool_spec.json``'s ``action`` enum: the enum is
         the curated agent-facing subset, and a public method absent from it stays
-        callable as ``sim(action="...")`` from Python. That breadth is intended,
-        and it is accounted for: every public method of this class is either
+        callable from Python through this method. That breadth is intended, and
+        it is accounted for: every public method of this class is either
         published in that enum or recorded as deliberately Python-only, and one
         that is neither fails the backend's tool-spec guards. So a newly added
-        method cannot become agent-dispatchable-but-unadvertised in silence, and
-        a deliberate omission stays distinguishable from an oversight. Whether
-        the router should instead refuse a non-enum action, making behaviour
-        match the advertised contract, is the open question in #2093; this states
-        today's contract without settling it.
+        method cannot become dispatchable-but-unadvertised in silence, and a
+        deliberate omission stays distinguishable from an oversight.
+
+        That width no longer reaches an agent. Both agent-facing entry points
+        (:meth:`__call__` and :meth:`stream`) refuse a non-enum action first,
+        via :meth:`_unpublished_action_error`, so what a model can invoke is
+        exactly what it was advertised - the resolution of #2093. Calling this
+        method directly bypasses that refusal deliberately: it is the Python
+        path, and the width is what makes it useful there.
         """
         method_name = self._ACTION_ALIASES.get(action, action)
         method = getattr(self, method_name, None)

--- a/tests/simulation/mujoco/test_agent_boundary_refuses_unpublished_action.py
+++ b/tests/simulation/mujoco/test_agent_boundary_refuses_unpublished_action.py
@@ -1,0 +1,254 @@
+"""The agent-facing entry points refuse an action the tool schema never advertised.
+
+``_dispatch_action`` resolves by ``getattr`` with no allowlist, so every public
+method of the engine is dispatchable while ``tool_spec.json``'s ``action`` enum
+advertises a curated 77-entry subset. That width is a deliberate *Python*
+convenience, but it used to reach a model too: an agent is handed the enum and
+nothing else, so the 23 dispatchable-but-unadvertised capabilities - including
+the ``TeleopMixin`` cluster, which drives real hardware from a host input
+device - were invocable by name from a model that was never told they existed.
+
+#2093 priced the two candidate refusal sites. This pins the one that was chosen:
+the two agent-facing entry points (``__call__`` and ``stream``) refuse a
+non-enum action, and ``_dispatch_action`` itself stays wide so the Python path
+is unchanged. Both halves matter, and the second is the one a regression would
+break silently - ``examples/`` reaches ``get_observation`` through the router
+directly, and every Python-only capability has its own ``.method()`` callers.
+
+The Python-only inventory is imported from ``test_tool_spec`` rather than
+restated: that set is what the tool-spec guards maintain, and a second copy
+would drift from it in exactly the direction that makes this suite pass while
+the contract is broken.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import (  # noqa: E402
+    _PUBLISHED_ACTIONS,
+    _TOOL_SPEC_PATH,
+    MuJoCoSimEngine,
+    Simulation,
+)
+from tests.simulation.mujoco.test_tool_spec import _PYTHON_ONLY_ACTIONS  # noqa: E402
+
+_NOT_FOR_AGENTS = "is not available to an agent"
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="agent_boundary_test", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _text(result: dict) -> str:
+    return result["content"][0]["text"]
+
+
+def _is_agent_refusal(result: object) -> bool:
+    """True when *result* is the unadvertised-action refusal.
+
+    Deliberately total over any return value: the Python path hands back
+    whatever the method returns, which for several of these is a plain float or
+    a dataclass rather than a tool-result dict.
+    """
+    if not isinstance(result, dict) or result.get("status") != "error":
+        return False
+    first = (result.get("content") or [{}])[0]
+    return _NOT_FOR_AGENTS in (first.get("text") or "")
+
+
+def _stream_once(sim, action, **params) -> dict:
+    """Drive one agent tool call through ``stream`` and return its result dict."""
+
+    async def _run():
+        tool_use = {"toolUseId": "tu-1", "input": {"action": action, **params}}
+        return [event async for event in sim.stream(tool_use, {})]
+
+    events = asyncio.run(_run())
+    assert len(events) == 1
+    return events[0].tool_result
+
+
+# The published set is derived, not restated.
+
+
+def test_published_actions_is_exactly_the_schema_enum():
+    """The guard's allowlist is the advertised enum itself, with nothing added.
+
+    A hand-maintained second list is the failure this is written against: it
+    would let the tool refuse an action its own schema tells the model to use.
+    """
+    spec = json.loads(Path(_TOOL_SPEC_PATH).read_text())
+    assert _PUBLISHED_ACTIONS == frozenset(spec["properties"]["action"]["enum"])
+
+
+# __call__ - the plain-callable form the README markets.
+
+
+@pytest.mark.parametrize("action", sorted(_PYTHON_ONLY_ACTIONS))
+def test_call_refuses_every_deliberately_python_only_action(sim, action):
+    """No member of the Python-only inventory is reachable as sim(action=...)."""
+    result = sim(action=action)
+    assert result["status"] == "error"
+    assert _NOT_FOR_AGENTS in _text(result)
+
+
+def test_call_refusal_names_the_action_and_points_at_the_schema(sim):
+    """The refusal is actionable: it names the action and where the list lives."""
+    text = _text(sim(action="teleoperate"))
+    assert "teleoperate" in text
+    assert "tool_spec" in text
+
+
+def test_call_refuses_a_python_only_action_before_reading_its_parameters(sim):
+    """The refusal precedes validation, so a valid call is refused on the action
+    alone rather than drawing a parameter complaint that implies it would work."""
+    result = sim(action="get_observation", robot_name="nope", skip_images=True)
+    assert result["status"] == "error"
+    assert _NOT_FOR_AGENTS in _text(result)
+    assert "Unknown parameter" not in _text(result)
+
+
+def test_call_reports_a_nonexistent_action_as_unknown_not_as_python_only(sim):
+    """A typo keeps the "Unknown action" verdict: it is a different problem from
+    a capability held back on purpose, and conflating them sends a reader
+    hunting for a misspelling that is not there."""
+    result = sim(action="teleprot")
+    assert result["status"] == "error"
+    assert "Unknown action: teleprot" in _text(result)
+    assert _NOT_FOR_AGENTS not in _text(result)
+
+
+def test_call_reports_a_property_as_unknown_without_evaluating_it(sim):
+    """A non-callable attribute is not a capability, so it reads as unknown.
+
+    The guard probes the class rather than the instance for this reason: a
+    property evaluated to word a refusal would run engine code on the error
+    path, and ``tool_name`` is a property that exists on the type.
+    """
+    result = sim(action="tool_name")
+    assert result["status"] == "error"
+    assert "Unknown action: tool_name" in _text(result)
+
+
+def test_call_still_dispatches_a_published_action(sim):
+    """The positive control: the 77 advertised actions are unaffected."""
+    result = sim(action="step", n_steps=2)
+    assert result["status"] == "success"
+    assert "2 steps" in _text(result)
+
+
+def test_call_still_strips_whitespace_before_the_published_check(sim):
+    """Trimming happens first, so a padded published action is not refused as
+    unadvertised - the guard sees the same name dispatch would have seen."""
+    assert sim(action="  get_state  ")["status"] == "success"
+
+
+def test_call_blank_action_keeps_its_own_message(sim):
+    """An empty action is answered by the entry point's own check, which is more
+    specific than the unadvertised-action refusal."""
+    result = sim(action="   ")
+    assert result["status"] == "error"
+    assert "requires action=" in _text(result)
+
+
+# Aliases - the advertised spelling is what counts.
+
+
+@pytest.mark.parametrize("alias", sorted(MuJoCoSimEngine._ACTION_ALIASES))
+def test_an_action_alias_is_accepted_at_the_agent_boundary(sim, alias):
+    """Aliases exist so a model's alternate spelling routes; refusing one would
+    defeat that. Every alias is in the enum today, so this holds through the
+    enum - it is written to catch an alias added outside it, which is the case
+    where the guard would silently break the alias mechanism."""
+    assert sim(action=alias)["status"] == "success"
+
+
+def test_an_alias_target_method_name_is_not_itself_advertised(sim):
+    """``list_robots`` is the published name; ``list_robots_info`` is the method
+    it resolves to and is not advertised, so a model naming the internal
+    spelling is refused. Deliberate: the enum is the contract."""
+    result = sim(action="list_robots_info")
+    assert result["status"] == "error"
+    assert _NOT_FOR_AGENTS in _text(result)
+
+
+# stream() - the path the agent runtime actually drives.
+
+
+@pytest.mark.parametrize("action", ["get_observation", "teleoperate", "save_episode"])
+def test_stream_refuses_a_python_only_action(sim, action):
+    """The refusal covers the async AgentTool path, not only the callable form.
+
+    Guarding one entry point and not the other would make the advertised
+    contract hold on the form a test reaches for and not on the form a model
+    actually arrives through.
+    """
+    result = _stream_once(sim, action)
+    assert result["status"] == "error"
+    assert _NOT_FOR_AGENTS in _text(result)
+
+
+def test_stream_refusal_carries_the_tool_use_id(sim):
+    """A refused call is still a well-formed tool result, so the runtime can
+    match it to the request rather than dropping it."""
+    result = _stream_once(sim, "teleoperate")
+    assert result["toolUseId"] == "tu-1"
+
+
+def test_stream_reports_a_nonexistent_action_as_unknown(sim):
+    result = _stream_once(sim, "definitely_not_an_action")
+    assert result["status"] == "error"
+    assert "Unknown action: definitely_not_an_action" in _text(result)
+
+
+def test_stream_still_dispatches_a_published_action(sim):
+    result = _stream_once(sim, "get_state")
+    assert result["status"] == "success"
+
+
+# The Python path is deliberately untouched.
+
+
+@pytest.mark.parametrize("action", sorted(_PYTHON_ONLY_ACTIONS - {"cleanup", "teleoperate", "stop_teleoperate"}))
+def test_the_router_still_reaches_every_python_only_action(sim, action):
+    """``_dispatch_action`` keeps its full width: the refusal lives at the two
+    agent entry points, not in the router.
+
+    This is the half a regression would break invisibly - ``examples/`` calls
+    ``sim._dispatch_action("get_observation", ...)`` directly. The assertion is
+    only that the action is *reached*, not that it succeeds: most need a robot,
+    a recording session or a GL context, and their own suites cover their
+    behaviour. ``cleanup`` and the teleop start/stop pair are excluded because
+    reaching them tears down or blocks the fixture rather than returning a
+    verdict.
+
+    Reaching the method is what is asserted, in the two shapes that can prove
+    it. Several of these return a native value - ``physics_timestep`` a float,
+    ``get_camera_params`` a dataclass, ``describe`` a dict with no ``content``
+    key - and that alone shows the Python path is unmediated. Others raise
+    (``get_frame`` needs OpenGL). Either is past the guard, because the guard
+    returns a dict and never raises.
+    """
+    try:
+        result = sim._dispatch_action(action, {})
+    except Exception:
+        return
+    assert not _is_agent_refusal(result)
+
+
+def test_the_router_still_refuses_a_leading_underscore_action(sim):
+    """Unchanged: a private name was never dispatchable and still is not."""
+    result = sim._dispatch_action("_compile_world", {"action": "_compile_world"})
+    assert result["status"] == "error"
+    assert "Unknown action" in _text(result)


### PR DESCRIPTION
## What

`_dispatch_action` resolves an action with a bare `getattr` and no allowlist, so all **105** public methods of the engine are dispatchable while `tool_spec.json`'s `action` enum advertises **77**. That width is a deliberate Python convenience and #2104 made it accountable (every public method is either published or recorded in `_PYTHON_ONLY_ACTIONS`).

But it was not only a Python contract. Both agent-facing entry points forwarded whatever name arrived straight to the router:

| entry point | audience |
|---|---|
| `__call__` | the form the README markets as `robot(action="...")` |
| `stream` | what the agent runtime actually drives |

So the **23** dispatchable-but-unadvertised capabilities were invocable by a model that was never told they exist - including the `TeleopMixin` cluster (`teleoperate`, `attach_teleop`, `stop_teleoperate`, ...), which drives real hardware from a host input device.

The sharpest demonstration is that the tool was *coaching* the model toward them. On pre-fix code:

```
stream(action="teleoperate")
-> status=error  "No teleoperators attached. Use attach_teleop() first."
```

A model that reached an unadvertised action was handed the name of a second one as the remedy. Neither is in the enum it was given.

This is also the rule AGENTS.md already states, applied to the one surface that was missing it - *LLM Input Safety*: every parameter on an agent-callable tool ("`@tool` decorated function, `AgentTool.stream` dispatch handler") must be validated "via regex allowlist, **enum match**, or range check", and "never accept arbitrary strings into enumerable surfaces". `action` is an enumerable surface with a published enum, fed directly from the model.

## Fix

Both entry points call one guard, `_unpublished_action_error`, before dispatching. `_dispatch_action` itself is unchanged and stays wide.

Two verdicts, because they are different problems for the caller:

| input | verdict |
|---|---|
| resolves to no method (`teleprot`) | `Unknown action: teleprot` - unchanged wording |
| resolves to a held-back method (`teleoperate`) | exists, `not available to an agent`, reachable from Python only |

Reporting the second as "unknown" would send a reader hunting for a misspelling that is not there - the method is right where they left it.

The allowlist is **derived** from the schema (`frozenset(_TOOL_SPEC_SCHEMA["properties"]["action"]["enum"])`), not restated beside it. A hand-maintained copy is the failure this is written against: it would let the tool refuse an action its own schema told the model to use - which is the contradiction #2139 had to remove for `save_episode`.

Aliases are accepted (`list_robots`, `list_cameras`): they exist so a model's alternate spelling routes, and refusing one would defeat the mechanism. Both are in the enum today, so the test guards against an alias added *outside* it.

## Which option this is, and why not the other

#2093 offered A (publish an inventory + guard) and B (say the router is wider, optionally refuse). A landed in #2104 and B's docstring half in #2106; the only undecided part was B's optional half. This is that half, at the site the issue's own pricing identified as costing nothing - and the two corrections in the issue's last comment are both incorporated: there are **two** agent-facing delegation sites, not one (`__call__` at 3961 and `stream` at 4144), and both are guarded, because guarding one would make the advertised contract hold on the form a test reaches for and not on the form a model arrives through.

The refusal deliberately does **not** go in `_dispatch_action` (option B2). That is the Python path, and the width is what makes it useful there.

## Verification

**In-tree cost of the refusal: zero.** Measured over every `git ls-files` path in `tests/`, `tests_integ/`, `examples/`, `docs/`, `samples/`, `scripts/`, `strands_robots/`: **no** non-enum action reaches a Simulation through `__call__` or `stream` anywhere. The only in-tree callers of a Python-only action go through the router directly (`examples/vla/molmoact2_sim_pickplace.py`, `examples/lerobot/collect_train_run_molmoact2.py`, `examples/12_domain_randomization.py`) and are untouched by design.

- **61 new tests, and 30 of them fail on pre-fix code** - measured by reverting only the two wirings and keeping the guard importable, which isolates the behaviour change: `30 failed, 31 passed` before, `61 passed` after. The 31 that pass both ways are the positive controls (published actions still dispatch, the router still reaches all 23, a typo still reads `Unknown action`).
- **No regression across the blast radius.** Every mujoco test file touching `_dispatch_action` / `stream` / `sim(action=` - 26 files, 725 passed - has an **identical** failure set before and after (10 pre-existing failures from robot assets and GL absent in a bare venv). `comm -13` over the sorted `FAILED` lines is empty.
- Repo-wide root guards: `tests/test_changelog_fragments.py`, `test_changelog_format.py`, `test_docstrings_no_dangling_doc_refs.py`, `test_source_strings_no_internal_file_paths.py` plus the new file - **101 passed**. `python3 scripts/assemble_changelog.py --check` -> `changelog fragments OK (315 pending)`.
- `ruff check` and `ruff format --check` clean; `mypy` clean on the changed module.

One detail worth flagging for review: the guard probes the **class**, not the instance (`getattr(type(self), target, None)`). Evaluating a property to word a refusal would run engine code on the error path, and `tool_name` is a property on the type. Pinned by `test_call_reports_a_property_as_unknown_without_evaluating_it`.

## Docs

The two docstrings that stated the old contract are updated in the same commit, since #2106 landed that invariant deliberately: `_dispatch_action` now records that its width no longer reaches an agent, and `__call__` records that it is narrower in exactly one way. No doc under `docs/` or `README.md` invokes a Python-only action through `action=`, so nothing else drifted.

## Scope

`__call__` / `stream` / `tool_spec` / `_dispatch_action` exist only on the MuJoCo engine - Isaac and Newton have no entry point of this shape - so this creates no cross-backend parity gap.

Out of scope, deliberately: `stream` does not `.strip()` its action the way `__call__` does, so a padded name from a model is refused rather than trimmed. That is today's behaviour too (it was `Unknown action`), so no verdict changes here; making the two entry points agree on trimming is a separate concern.

Fixes #2093
