### PR TITLE
refactor(simulation): promote run_multi_policy to the Simulation base with shared validation

### DIFF
--- a/changelog.d/2157-run-multi-policy-base-contract.md
+++ b/changelog.d/2157-run-multi-policy-base-contract.md
@@ -1,0 +1,18 @@
+### Added: `run_multi_policy` is a base-class contract, with its validation shared across backends
+
+`run_multi_policy` - the synchronized multi-robot driver (per-robot policies
+and instructions, one lockstep physics loop, one merged recording frame per
+timestep) - was a MuJoCo-only method, so Isaac/Newton callers got a bare
+`AttributeError` instead of a contract. It is now documented on
+`strands_robots.simulation.base.SimEngine` next to `run_policy`, with a default
+implementation that returns the structured not-supported error naming the
+backend class (never a silent per-robot fallback, which would interleave
+recording frames). The backend-independent first phase of the MuJoCo loop -
+empty-`policies` rejection, `instructions` normalization, the
+distinct-instructions one-task-per-frame warning, and per-robot
+`action_horizon` normalization - moved into shared base helpers
+(`_validate_multi_policies`, `_normalize_multi_policy_instructions`,
+`_normalize_multi_policy_horizons`) so the upcoming Isaac implementation
+(#2122) cannot drift from MuJoCo's refusal texts. MuJoCo behavior is unchanged:
+its `run_multi_policy` now calls the shared helpers and keeps the
+physics/render/record loop, and every pre-existing test passes unmodified.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2718,6 +2718,233 @@ class SimEngine(ABC):
             if controller_cleanup is not None:
                 controller_cleanup()
 
+    def run_multi_policy(
+        self,
+        policies: dict[str, Policy],
+        instructions: dict[str, str] | str = "",
+        duration: float = 10.0,
+        control_frequency: float = 50.0,
+        action_horizon: int | dict[str, int] = 8,
+        n_steps: int | None = None,
+        max_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Drive MULTIPLE robots, each with its own policy, in ONE synchronized loop.
+
+        The backend-agnostic contract for concurrent multi-robot rollout
+        (e.g. two arms doing a handover, or a bimanual setup). A backend that
+        implements it must honour every clause below - they are what
+        distinguishes this driver from launching one :meth:`start_policy`
+        thread per robot, which steps physics per robot and interleaves
+        single-robot recording frames:
+
+        - **Per-robot policies**: ``policies`` maps each driven robot to its
+          own :class:`~strands_robots.policies.Policy`. Every key must name a
+          robot in the scene; ``policies`` order defines the merged
+          state/action column order.
+        - **Per-robot instructions**: ``instructions`` is either one string
+          applied to all robots or a ``{robot_name: instruction}`` mapping.
+          A mapping key naming no driven robot is rejected rather than
+          silently dropped; a robot omitted from the mapping gets an empty
+          instruction (see :meth:`_normalize_multi_policy_instructions`).
+        - **Per-robot action_horizon**: ``action_horizon`` is either one int
+          applied to all robots or a ``{robot_name: horizon}`` mapping. Every
+          horizon must be a positive integer, and the effective per-robot
+          chunk length is resolved through
+          :func:`~strands_robots.policies.base.resolve_chunk_length` exactly
+          as :meth:`run_policy` resolves its own (see
+          :meth:`_normalize_multi_policy_horizons`).
+        - **Shared control_frequency**: one target Hz for every robot's
+          policy queries, so the robots stay phase-aligned.
+        - **Lockstep physics**: each loop iteration applies EVERY robot's
+          control, then steps physics ONCE - regardless of each robot's
+          individual re-query cadence.
+        - **One merged recording frame per timestep**: when a dataset
+          recording is active, each timestep records a single frame carrying
+          ALL robots' prefixed state/action (``alice__shoulder_pan`` ...)
+          plus all camera images - never one interleaved frame per robot.
+
+        The step horizon follows :meth:`run_policy`'s resolution: ``n_steps``
+        (then its legacy alias ``max_steps``) overrides ``duration``, via
+        :meth:`_resolve_horizon` on the shared positive-count domain.
+
+        This base implementation is a documented refusal, not a fallback: a
+        backend that has no synchronized multi-robot loop must say so rather
+        than silently driving robots one at a time (which would interleave
+        frames and break the merged-frame contract above). The MuJoCo backend
+        overrides it with a full implementation; backends that do not yet
+        (Isaac, Newton) inherit this structured error.
+
+        Args:
+            policies: Mapping ``{robot_name: Policy}`` of the robots to drive.
+            instructions: Single instruction string for all robots, or a
+                ``{robot_name: instruction}`` mapping (see contract above).
+            duration: Episode length in seconds (steps = duration x freq).
+                Used only when no ``n_steps`` / ``max_steps`` is given. Must
+                be a finite positive number.
+            control_frequency: Target Hz for policy queries / physics. Must
+                be a positive number.
+            action_horizon: Actions consumed from each policy's chunk before
+                re-querying it, as one int or a per-robot mapping (see
+                contract above).
+            n_steps: Exact step horizon (overrides ``duration`` when set).
+            max_steps: Legacy alias for ``n_steps``.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict naming this
+            backend class and stating that it does not implement synchronized
+            multi-robot rollout. Implementing backends return the standard
+            status dict with per-robot step counts.
+        """
+        return {
+            "status": "error",
+            "content": [
+                {
+                    "text": f"run_multi_policy: {type(self).__name__} does not implement synchronized "
+                    "multi-robot rollout (per-robot policies driven in one lockstep physics loop with "
+                    "one merged recording frame per timestep). Use the MuJoCo backend, or drive robots "
+                    "individually with run_policy / start_policy (frames are then interleaved per robot, "
+                    "not merged)."
+                }
+            ],
+        }
+
+    @staticmethod
+    def _validate_multi_policies(policies: Mapping[str, Any], method: str) -> dict[str, Any] | None:
+        """Reject an empty ``policies`` mapping at a multi-robot entry point.
+
+        ``policies`` names the robots a synchronized multi-robot driver will
+        drive, so an empty mapping is a caller error: a loop over zero robots
+        would run zero steps and still report ``status="success"`` (the same
+        degenerate-success shape :meth:`_validate_positive_int` exists to
+        refuse). Shared by every backend's ``run_multi_policy`` so the refusal
+        text is identical everywhere.
+
+        Args:
+            policies: The caller-supplied ``{robot_name: Policy}`` mapping.
+            method: Public method name, used to prefix the error message.
+
+        Returns:
+            A structured ``{"status": "error", ...}`` dict, or ``None`` when
+            at least one robot is named.
+        """
+        if not policies:
+            return {"status": "error", "content": [{"text": f"{method}: 'policies' is empty."}]}
+        return None
+
+    @staticmethod
+    def _normalize_multi_policy_instructions(
+        policies: Mapping[str, Any],
+        instructions: Mapping[str, str] | str,
+        method: str,
+        warn_logger: logging.Logger | None = None,
+    ) -> tuple[dict[str, str] | None, dict[str, Any] | None]:
+        """Normalize ``instructions`` to a complete per-robot mapping.
+
+        A single string broadcasts to every driven robot. A mapping is an
+        override layer keyed by robot name: a key that names no robot in this
+        call is a caller error (read with ``.get(r, "")`` it was silently
+        discarded, so a typo'd robot name ran the whole episode on an empty
+        instruction and still reported success - see
+        :meth:`_validate_per_robot_mapping`), while a robot omitted from the
+        mapping legitimately gets an empty instruction. A value that is
+        neither a string nor a mapping is refused up front rather than
+        reaching ``.get()`` and surfacing as a bare ``AttributeError`` past
+        the tool-envelope contract.
+
+        LeRobot stores ONE task string per frame, so when the normalized
+        mapping carries distinct non-empty instructions (e.g. ``{alice:
+        'pour', bob: 'catch'}``) only the first robot's task is recorded - a
+        downstream pipeline that splits by task string would mis-attribute
+        the other robots' frames. That is surfaced here as a
+        ``logger.warning`` (a known limitation, not lost silently).
+
+        Args:
+            policies: ``{robot_name: Policy}`` mapping naming the driven
+                robots (the authoritative key set).
+            instructions: Caller-supplied single string or per-robot mapping.
+            method: Public method name, used to prefix error messages.
+            warn_logger: Logger for the distinct-instructions warning, so the
+                warning is attributed to the calling backend's module rather
+                than to this one. Defaults to this module's logger.
+
+        Returns:
+            ``(instr_map, None)`` with one entry per driven robot, or
+            ``(None, error_dict)``.
+        """
+        if isinstance(instructions, str):
+            instr_map = {r: instructions for r in policies}
+        elif isinstance(instructions, Mapping):
+            if err := SimEngine._validate_per_robot_mapping(instructions, policies, "instructions", method):
+                return None, err
+            instr_map = {r: instructions.get(r, "") for r in policies}
+        else:
+            return None, {
+                "status": "error",
+                "content": [
+                    {
+                        "text": f"{method}: 'instructions' must be a string applied to all robots or a "
+                        f"{{robot_name: instruction}} mapping, got {type(instructions).__name__}."
+                    }
+                ],
+            }
+
+        distinct_tasks = {t for t in instr_map.values() if t}
+        if len(distinct_tasks) > 1:
+            (warn_logger or logger).warning(
+                "%s: %d distinct per-robot instructions supplied (%s) but "
+                "LeRobot records one task per frame; only '%s' (robot '%s') will be stored. "
+                "Per-robot task columns are not yet supported.",
+                method,
+                len(distinct_tasks),
+                sorted(distinct_tasks),
+                instr_map[next(iter(policies))],
+                next(iter(policies)),
+            )
+        return instr_map, None
+
+    @staticmethod
+    def _normalize_multi_policy_horizons(
+        policies: Mapping[str, Any],
+        action_horizon: int | Mapping[str, int],
+        method: str,
+        default_horizon: int = 8,
+    ) -> tuple[dict[str, int] | None, dict[str, Any] | None]:
+        """Normalize ``action_horizon`` to a complete per-robot mapping.
+
+        A single int broadcasts to every driven robot; a ``{robot_name:
+        horizon}`` mapping overrides per robot, with a key naming no driven
+        robot refused (see :meth:`_validate_per_robot_mapping`) and a robot
+        omitted from the mapping keeping ``default_horizon``. Every horizon
+        is validated through :meth:`_validate_action_horizon` - the same
+        guard ``run_policy`` / ``start_policy`` / ``eval_policy`` enforce -
+        rather than coerced: a ``max(1, int(...))`` clamp used to turn ``0``
+        / ``-5`` into a silent 1-action horizon, truncate ``2.7``, and let
+        ``nan`` / ``None`` / ``"x"`` reach ``int()`` as a bare ``ValueError``
+        / ``TypeError`` past the tool-envelope contract.
+
+        Args:
+            policies: ``{robot_name: Policy}`` mapping naming the driven
+                robots (the authoritative key set).
+            action_horizon: Caller-supplied single int or per-robot mapping.
+            method: Public method name, used to prefix error messages.
+            default_horizon: Horizon for robots omitted from a mapping.
+
+        Returns:
+            ``(horizon_map, None)`` with one entry per driven robot, or
+            ``(None, error_dict)``.
+        """
+        if isinstance(action_horizon, Mapping):
+            if err := SimEngine._validate_per_robot_mapping(action_horizon, policies, "action_horizon", method):
+                return None, err
+            for rname, value in action_horizon.items():
+                if err := SimEngine._validate_action_horizon(value, method, f"action_horizon[{rname!r}]"):
+                    return None, err
+            # A robot omitted from the mapping keeps the signature default.
+            return {r: int(action_horizon.get(r, default_horizon)) for r in policies}, None
+        if err := SimEngine._validate_action_horizon(action_horizon, method):
+            return None, err
+        return {r: int(action_horizon) for r in policies}, None
+
     def _stop_when_unresolved_error(self, stop_when: dict[str, Any]) -> dict[str, Any] | None:
         """Structured error if a ``stop_when`` clause references unresolvable entities.
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -49,7 +49,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -4545,8 +4545,8 @@ class MuJoCoSimEngine(
 
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
-        if not policies:
-            return {"status": "error", "content": [{"text": "run_multi_policy: 'policies' is empty."}]}
+        if err := self._validate_multi_policies(policies, "run_multi_policy"):
+            return err
 
         # Validate every robot exists.
         for rname in policies:
@@ -4564,45 +4564,16 @@ class MuJoCoSimEngine(
                 "content": [{"text": f"run_multi_policy: policy already running on {names}. Stop it first."}],
             }
 
-        # Normalize instructions to a per-robot mapping. A mapping key that
-        # names no robot in this call is a caller error: read with .get(r, "")
-        # it was silently discarded, so a typo'd robot name ran the whole
-        # episode on an empty instruction and still reported success. A value
-        # that is neither a string nor a mapping reached .get() and surfaced as
-        # a bare AttributeError past the tool-envelope contract.
-        if isinstance(instructions, str):
-            instr_map = {r: instructions for r in policies}
-        elif isinstance(instructions, Mapping):
-            if err := self._validate_per_robot_mapping(instructions, policies, "instructions", "run_multi_policy"):
-                return err
-            instr_map = {r: instructions.get(r, "") for r in policies}
-        else:
-            return {
-                "status": "error",
-                "content": [
-                    {
-                        "text": "run_multi_policy: 'instructions' must be a string applied to all robots or a "
-                        f"{{robot_name: instruction}} mapping, got {type(instructions).__name__}."
-                    }
-                ],
-            }
-
-        # LeRobot stores ONE task string per frame. If the caller supplied
-        # distinct per-robot instructions (e.g. {alice: 'pour', bob: 'catch'})
-        # only the first robot's task is recorded -- a downstream pipeline that
-        # splits by task string would mis-attribute the other robots' frames.
-        # Surface this as a known limitation rather than losing it silently.
-        _distinct_tasks = {t for t in instr_map.values() if t}
-        if len(_distinct_tasks) > 1:
-            logger.warning(
-                "run_multi_policy: %d distinct per-robot instructions supplied (%s) but "
-                "LeRobot records one task per frame; only '%s' (robot '%s') will be stored. "
-                "Per-robot task columns are not yet supported.",
-                len(_distinct_tasks),
-                sorted(_distinct_tasks),
-                instr_map[next(iter(policies))],
-                next(iter(policies)),
-            )
+        # Normalize instructions to a per-robot mapping through the shared
+        # base helper (one refusal text for every backend), passing this
+        # module's logger so the distinct-instructions one-task-per-frame
+        # warning stays attributed to the MuJoCo loop that records the frame.
+        instr_map, err = self._normalize_multi_policy_instructions(
+            policies, instructions, "run_multi_policy", warn_logger=logger
+        )
+        if err is not None:
+            return err
+        assert instr_map is not None  # for the type checker: err is None <=> instr_map is not None
 
         # Resolve horizon (n_steps / max_steps override duration) through the
         # shared helpers, so this loop guards the same domain as run_policy: a
@@ -4622,26 +4593,15 @@ class MuJoCoSimEngine(
             if err := self._validate_duration(duration, "run_multi_policy"):
                 return err
 
-        # Normalize action_horizon to a per-robot mapping. >=1 actions are
-        # consumed open-loop from each policy's chunk before re-querying, so the
-        # value is validated through the same shared guard run_policy /
-        # start_policy / eval_policy / evaluate_benchmark use. This loop instead
-        # coerced with max(1, int(...)): 0 / -5 silently became a 1-action
-        # horizon (the caller's cadence was never run), 2.7 was truncated, and
-        # nan / None / "x" reached int() and surfaced as a bare ValueError /
-        # TypeError instead of the structured error dict the API contracts.
-        if isinstance(action_horizon, Mapping):
-            if err := self._validate_per_robot_mapping(action_horizon, policies, "action_horizon", "run_multi_policy"):
-                return err
-            for rname, value in action_horizon.items():
-                if err := self._validate_action_horizon(value, "run_multi_policy", f"action_horizon[{rname!r}]"):
-                    return err
-            # A robot omitted from the mapping keeps the signature default.
-            horizon_map = {r: int(action_horizon.get(r, _DEFAULT_ACTION_HORIZON)) for r in policies}
-        else:
-            if err := self._validate_action_horizon(action_horizon, "run_multi_policy"):
-                return err
-            horizon_map = {r: int(action_horizon) for r in policies}
+        # Normalize action_horizon to a per-robot mapping through the shared
+        # base helper, which validates every horizon on the same positive-int
+        # domain run_policy / start_policy / eval_policy use.
+        horizon_map, err = self._normalize_multi_policy_horizons(
+            policies, action_horizon, "run_multi_policy", default_horizon=_DEFAULT_ACTION_HORIZON
+        )
+        if err is not None:
+            return err
+        assert horizon_map is not None  # for the type checker: err is None <=> horizon_map is not None
 
         # Bind robot_state_keys for each policy (per-robot action keys -- the
         # actuators send_action resolves, not the joints; see robot_action_keys).

--- a/tests/simulation/test_run_multi_policy_base_contract.py
+++ b/tests/simulation/test_run_multi_policy_base_contract.py
@@ -1,0 +1,229 @@
+"""The ``run_multi_policy`` base contract and its shared validation helpers.
+
+Promoting ``run_multi_policy`` from a MuJoCo-only method to the
+:class:`~strands_robots.simulation.base.SimEngine` base (#2157, step 1 of the
+#2122 Isaac parity work) has two halves, each pinned here:
+
+* **The base default is a documented refusal.** A backend without a
+  synchronized multi-robot loop must return the structured not-supported
+  error naming its own class - never ``AttributeError`` (there was no
+  contract), never a silent per-robot fallback (which would interleave
+  recording frames and break the merged-frame contract the docstring
+  documents). Isaac and Newton inherit this today; MuJoCo overrides it.
+
+* **The validation/normalization is shared, not duplicated.** The
+  backend-independent first phase of the MuJoCo loop - empty-``policies``
+  rejection, ``instructions`` normalization, the distinct-instructions
+  one-task-per-frame warning, and per-robot ``action_horizon``
+  normalization - lives on the base as
+  :meth:`~strands_robots.simulation.base.SimEngine._validate_multi_policies`,
+  :meth:`~strands_robots.simulation.base.SimEngine._normalize_multi_policy_instructions`
+  and
+  :meth:`~strands_robots.simulation.base.SimEngine._normalize_multi_policy_horizons`,
+  so the upcoming Isaac implementation cannot drift from MuJoCo's refusal
+  texts. The behavioural coverage through the MuJoCo entry point stays in
+  ``tests/simulation/mujoco/test_run_multi_policy_no_recording.py`` and
+  ``tests/simulation/test_run_policy_horizon_validation.py``; these tests
+  drive the helpers directly so a future backend gets the same verdicts
+  without needing a compiled world.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.base import SimEngine
+from strands_robots.simulation.isaac.simulation import IsaacSimulation
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+_TWO_ROBOTS: dict[str, Any] = {"alpha": object(), "beta": object()}
+
+
+def _text(result: dict[str, Any]) -> str:
+    return result["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# The base default: a structured refusal, not a fallback                      #
+# --------------------------------------------------------------------------- #
+class TestTheBaseDefaultRefuses:
+    """A backend without the synchronized loop says so in the tool envelope."""
+
+    @pytest.mark.parametrize("engine_cls", [IsaacSimulation, NewtonSimEngine])
+    def test_a_backend_without_an_override_returns_the_structured_error(self, engine_cls: type[SimEngine]) -> None:
+        """``__new__`` skeleton: the refusal must precede any engine state."""
+        engine = engine_cls.__new__(engine_cls)
+        result = engine.run_multi_policy(policies={"alpha": MockPolicy()}, n_steps=2)
+        assert result["status"] == "error"
+        assert engine_cls.__name__ in _text(result)
+        assert "synchronized" in _text(result)
+        assert "multi-robot" in _text(result)
+
+    def test_the_refusal_names_the_concrete_class_not_the_base(self) -> None:
+        """The error must point at the backend the caller holds."""
+        engine = NewtonSimEngine.__new__(NewtonSimEngine)
+        text = _text(engine.run_multi_policy(policies={"alpha": MockPolicy()}))
+        assert text.startswith("run_multi_policy: NewtonSimEngine does not implement")
+        assert not text.startswith("run_multi_policy: SimEngine ")
+
+    def test_mujoco_overrides_the_default(self) -> None:
+        """The reference implementation must not fall through to the refusal."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        assert MuJoCoSimEngine.run_multi_policy is not SimEngine.run_multi_policy
+
+    def test_mujoco_signature_matches_the_base_contract(self) -> None:
+        """Parameter names, order and defaults agree between base and override.
+
+        Compared by name and default rather than full ``inspect.signature``
+        equality because the annotations are strings under ``from __future__
+        import annotations`` and the two modules spell the ``Policy`` forward
+        reference differently.
+        """
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+        base = inspect.signature(SimEngine.run_multi_policy).parameters
+        override = inspect.signature(MuJoCoSimEngine.run_multi_policy).parameters
+        assert list(base) == list(override)
+        assert {n: p.default for n, p in base.items()} == {n: p.default for n, p in override.items()}
+
+
+# --------------------------------------------------------------------------- #
+# _validate_multi_policies                                                    #
+# --------------------------------------------------------------------------- #
+class TestEmptyPoliciesRejection:
+    def test_an_empty_mapping_is_refused_with_the_pinned_text(self) -> None:
+        result = SimEngine._validate_multi_policies({}, "run_multi_policy")
+        assert result is not None
+        assert _text(result) == "run_multi_policy: 'policies' is empty."
+
+    def test_a_populated_mapping_passes(self) -> None:
+        assert SimEngine._validate_multi_policies(_TWO_ROBOTS, "run_multi_policy") is None
+
+    def test_the_method_name_prefixes_the_refusal(self) -> None:
+        """A future backend entry point reports the refusal under its own name."""
+        result = SimEngine._validate_multi_policies({}, "other_driver")
+        assert result is not None
+        assert _text(result).startswith("other_driver: ")
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_multi_policy_instructions                                        #
+# --------------------------------------------------------------------------- #
+class TestInstructionNormalization:
+    def test_a_single_string_broadcasts_to_every_robot(self) -> None:
+        instr_map, err = SimEngine._normalize_multi_policy_instructions(_TWO_ROBOTS, "pick", "run_multi_policy")
+        assert err is None
+        assert instr_map == {"alpha": "pick", "beta": "pick"}
+
+    def test_a_partial_mapping_defaults_omitted_robots_to_empty(self) -> None:
+        instr_map, err = SimEngine._normalize_multi_policy_instructions(
+            _TWO_ROBOTS, {"alpha": "pour"}, "run_multi_policy"
+        )
+        assert err is None
+        assert instr_map == {"alpha": "pour", "beta": ""}
+
+    def test_a_key_naming_no_driven_robot_is_refused(self) -> None:
+        instr_map, err = SimEngine._normalize_multi_policy_instructions(
+            _TWO_ROBOTS, {"ghost": "pour"}, "run_multi_policy"
+        )
+        assert instr_map is None
+        assert err is not None
+        assert "run_multi_policy: instructions names a robot not driven by this call" in _text(err)
+        assert "ghost" in _text(err)
+
+    @pytest.mark.parametrize("bad", [["pick", "hold"], 12345, None], ids=["list", "int", "none"])
+    def test_a_non_string_non_mapping_value_is_refused(self, bad: Any) -> None:
+        instr_map, err = SimEngine._normalize_multi_policy_instructions(_TWO_ROBOTS, bad, "run_multi_policy")
+        assert instr_map is None
+        assert err is not None
+        assert "run_multi_policy: 'instructions' must be a string" in _text(err)
+        assert type(bad).__name__ in _text(err)
+
+    def test_distinct_instructions_warn_but_still_normalize(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.base"):
+            instr_map, err = SimEngine._normalize_multi_policy_instructions(
+                _TWO_ROBOTS, {"alpha": "pour", "beta": "catch"}, "run_multi_policy"
+            )
+        assert err is None
+        assert instr_map == {"alpha": "pour", "beta": "catch"}
+        assert any("distinct per-robot instructions" in rec.message for rec in caplog.records)
+
+    def test_the_warning_is_attributed_to_the_callers_logger(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A backend passes its own module logger so the warning names the loop
+        that records the frame, not this shared helper."""
+        backend_logger = logging.getLogger("tests.fake_backend.run_multi_policy")
+        with caplog.at_level(logging.WARNING, logger="tests.fake_backend.run_multi_policy"):
+            SimEngine._normalize_multi_policy_instructions(
+                _TWO_ROBOTS, {"alpha": "pour", "beta": "catch"}, "run_multi_policy", warn_logger=backend_logger
+            )
+        warned = [rec for rec in caplog.records if "distinct per-robot instructions" in rec.message]
+        assert [rec.name for rec in warned] == ["tests.fake_backend.run_multi_policy"]
+
+    def test_a_shared_instruction_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One task per frame is exactly representable; nothing to surface."""
+        with caplog.at_level(logging.WARNING):
+            _, err = SimEngine._normalize_multi_policy_instructions(
+                _TWO_ROBOTS, {"alpha": "pick", "beta": "pick"}, "run_multi_policy"
+            )
+        assert err is None
+        assert not any("distinct per-robot instructions" in rec.message for rec in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_multi_policy_horizons                                            #
+# --------------------------------------------------------------------------- #
+class TestHorizonNormalization:
+    def test_a_single_int_broadcasts_to_every_robot(self) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(_TWO_ROBOTS, 4, "run_multi_policy")
+        assert err is None
+        assert horizon_map == {"alpha": 4, "beta": 4}
+
+    def test_a_partial_mapping_defaults_omitted_robots(self) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(
+            _TWO_ROBOTS, {"alpha": 2}, "run_multi_policy", default_horizon=8
+        )
+        assert err is None
+        assert horizon_map == {"alpha": 2, "beta": 8}
+
+    def test_a_key_naming_no_driven_robot_is_refused(self) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(_TWO_ROBOTS, {"ghost": 4}, "run_multi_policy")
+        assert horizon_map is None
+        assert err is not None
+        assert "run_multi_policy: action_horizon names a robot not driven by this call" in _text(err)
+
+    @pytest.mark.parametrize("bad", [0, -5, 2.7, True, "x", float("nan"), None], ids=repr)
+    def test_a_non_positive_int_scalar_is_refused(self, bad: Any) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(_TWO_ROBOTS, bad, "run_multi_policy")
+        assert horizon_map is None
+        assert err is not None
+        assert "run_multi_policy: action_horizon must be a positive integer" in _text(err)
+
+    @pytest.mark.parametrize("bad", [0, -5, 2.7, True], ids=repr)
+    def test_a_non_positive_int_mapping_entry_is_refused_naming_the_entry(self, bad: Any) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(_TWO_ROBOTS, {"alpha": bad}, "run_multi_policy")
+        assert horizon_map is None
+        assert err is not None
+        assert "run_multi_policy: action_horizon['alpha'] must be a positive integer" in _text(err)
+
+    def test_an_empty_mapping_keeps_the_default_for_every_robot(self) -> None:
+        """A mapping is an override layer, so an empty one is legitimate."""
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(
+            _TWO_ROBOTS, {}, "run_multi_policy", default_horizon=8
+        )
+        assert err is None
+        assert horizon_map == {"alpha": 8, "beta": 8}
+
+    def test_a_full_mapping_overrides_every_robot(self) -> None:
+        horizon_map, err = SimEngine._normalize_multi_policy_horizons(
+            _TWO_ROBOTS, {"alpha": 1, "beta": 10}, "run_multi_policy"
+        )
+        assert err is None
+        assert horizon_map == {"alpha": 1, "beta": 10}


### PR DESCRIPTION
# refactor(simulation): promote `run_multi_policy` to the Simulation base with shared validation

Closes #2157

Step 1 of the #2122 Isaac `run_multi_policy` parity work. Pure refactor + base-contract change; no Isaac code in this PR, and **MuJoCo behavior is unchanged** - every pre-existing test passes unmodified.

## What changed

- **`SimEngine.run_multi_policy`** (`strands_robots/simulation/base.py`, next to `run_policy`): the backend-agnostic contract with the exact MuJoCo signature. The docstring documents every clause: per-robot policies, per-robot instructions, per-robot `action_horizon`, shared `control_frequency`, lockstep physics, one merged recording frame per timestep. The default implementation returns the structured `{"status": "error", ...}` dict naming the concrete backend class and stating that it does not implement synchronized multi-robot rollout - deliberately **not** `@abstractmethod` (which would break Newton/Isaac instantiation) and **not** a silent no-op / per-robot fallback (AGENTS.md rules 5/6; a fallback would interleave frames and break the merged-frame contract).
- **Shared validation/normalization helpers** on `SimEngine` (module-level helpers were considered; methods keep them next to the `_validate_per_robot_mapping` / `_validate_action_horizon` guards they compose, and keep `__init__.py` thin):
  - `_validate_multi_policies` - empty-`policies` rejection, preserving the exact `"run_multi_policy: 'policies' is empty."` text.
  - `_normalize_multi_policy_instructions` - str broadcast, `{robot: instruction}` mapping via `_validate_per_robot_mapping` (unmatched key refused), bad-type refusal with the exact error text, and the distinct-instructions one-task-per-frame `logger.warning`. Takes a `warn_logger` so the warning stays attributed to the calling backend's module (the MuJoCo caplog test pins that logger name).
  - `_normalize_multi_policy_horizons` - per-robot `action_horizon` normalization (int or mapping) on the shared positive-int domain, with per-entry error labels (`action_horizon['alice']`) preserved.
- **`MujocoSimulation.run_multi_policy`** now calls the shared helpers. The physics/render/record loop is untouched, as are the backend-specific checks (no-world, unknown-robot, busy-robot).

## What deliberately did NOT move

The `n_steps`/`max_steps`/`duration` step-count resolution and the frequency/recording-rate guards were **already shared** base helpers (`_resolve_horizon`, `_validate_duration`, `_validate_positive_frequency`, `_validate_recording_rate`); the MuJoCo method keeps calling them directly. Two structural tests pin those direct call sites in the MuJoCo method body (`tests/simulation/test_recording_rate_matches_control_frequency.py::test_every_rollout_entry_point_checks_the_recording_rate` and `tests/simulation/test_step_count_domain_across_backends.py::TestNoStepCountSurfaceDrifts`), so wrapping them would have required modifying tests the issue says must stay unmodified - and Isaac gets them for free by calling the same base methods.

## Test surface

- New: `tests/simulation/test_run_multi_policy_base_contract.py` (36 tests)
  - Base default: `IsaacSimulation.__new__` / `NewtonSimEngine.__new__` skeletons return the structured not-supported error naming the backend class; MuJoCo overrides it; parameter names/defaults of the override match the base contract.
  - Direct helper tests: empty policies (exact text), bad instructions type, unknown mapping key, distinct-instructions warning (incl. `warn_logger` attribution), non-positive horizon (scalar and per-entry), per-robot horizon mapping, empty-mapping override layer.
- Unchanged and green: `tests/simulation/mujoco/test_run_multi_policy_no_recording.py`, `tests/simulation/mujoco/test_recording_paths.py::test_b4_synchronized_multi_robot_recording`, `tests/simulation/test_run_policy_horizon_validation.py`, and both structural pins above.

## Acceptance criteria (from #2157)

- [x] `hatch run format && hatch run lint && hatch run test` clean - full suite: **28217 passed, 249 skipped, 0 failed** (coverage 95.33%)
- [x] `run_multi_policy` documented on the base class with a default structured error; MuJoCo overrides it; no behavior change on MuJoCo (existing tests unmodified and green)
- [x] Changelog fragment: `changelog.d/2157-run-multi-policy-base-contract.md`
- [x] PR body carries `Closes #2157`

## Follow-ups (out of scope, tracked under #2122)

- Isaac `run_multi_policy` implementation, recording parity, and the integration test land as follow-up children of #2122.

Board: please move #2157 to **In review** on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (noting here per workflow in case the automation does not).
