### PR TITLE
fix(ci): refuse a changelog fragment the assembler would refuse

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -1,7 +1,9 @@
 # .github/workflows/changelog-fragment.yml
 #
-# Refuses a pull request that writes a new entry straight into `CHANGELOG.md`'s
-# `## [Unreleased]` section instead of recording it as a `changelog.d/` fragment.
+# Refuses a pull request that breaks the `changelog.d/` fragment convention in
+# either of the two ways it can be broken: writing a new entry straight into
+# `CHANGELOG.md`'s `## [Unreleased]` section instead of recording it as a fragment,
+# or adding a fragment the assembler would refuse.
 #
 # The rule is stated in `changelog.d/README.md` and in `AGENTS.md`, and its cost
 # is measured rather than stylistic: every branch appends at the same anchor, so
@@ -14,7 +16,23 @@
 # pass, because a fragment that was never written leaves nothing to inspect.
 # See issue #1784 and scripts/check_changelog_fragment.py for the full account.
 #
-# It is a base diff and not a test because `[Unreleased]` on `main` already
+# The second half was measured before it was added. Fragment validity was enforced
+# only by `tests/test_changelog_fragments.py`, inside `call-test-lint / Test and
+# Lint` -- so on #2144, whose only defect was a fragment first line reading
+# `Fixed: ...` instead of `### Fixed: ...`, this job reported SUCCESS in 10s while
+# the required suite reported FAILURE 20.8 minutes later, worded as a test failure
+# on a branch whose diff was 28 lines of `strands_robots/utils.py` and two test
+# files. The check named for the convention passed the one pull request whose only
+# defect was the convention. See issue #2163.
+#
+# Only the fragments the branch adds or modifies are read, never the whole
+# directory: `validate_fragments()` walks all 315 pending fragments, so wiring that
+# in would fail a branch for a malformed fragment already on the base. The rules
+# themselves are the assembler's `FRAGMENT_NAME` and `validate_fragment`, imported
+# rather than restated, so this job and `assemble_changelog.py --check` cannot
+# disagree about whether a fragment is valid.
+#
+# The first half is a base diff and not a test because `[Unreleased]` on `main` already
 # carries 168 entries from before the convention existed, so no static assertion
 # about the section's contents can hold. What is wrong is the act of adding to
 # it, and an act is only visible between two commits.
@@ -48,7 +66,7 @@ permissions:
 
 jobs:
   fragment:
-    name: Refuse a changelog entry written outside a fragment
+    name: Refuse a changelog entry that breaks the fragment convention
     runs-on: ubuntu-latest
 
     steps:
@@ -113,7 +131,7 @@ jobs:
       # commit is used, measured by
       # tests/test_changelog_fragment_gate.py::test_a_merge_commit_head_still_sees_the_branchs_append
       # - but naming the head keeps the report about the commit under review.
-      - name: Check for a changelog entry written outside a fragment
+      - name: Check the branch's entries and the fragments it adds
         env:
           BASE_REF: ${{ github.base_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/changelog.d/2163-changelog-gate-refuses-an-invalid-fragment.md
+++ b/changelog.d/2163-changelog-gate-refuses-an-invalid-fragment.md
@@ -1,0 +1,15 @@
+### Fixed: the changelog gate now refuses a fragment the assembler would refuse
+
+`Changelog Fragment Check` asked only whether an entry had been written into
+`CHANGELOG.md` instead of a `changelog.d/` fragment. It said nothing about whether
+the fragment that *was* written is valid, so a malformed or misnamed fragment
+reached only `tests/test_changelog_fragments.py`, inside the required suite: on one
+pull request whose sole defect was a fragment first line reading `Fixed: ...`
+instead of `### Fixed: ...`, this job reported success in 10 seconds while the
+required suite reported failure 20.8 minutes later, worded as a test failure.
+
+It now also validates the fragments a branch adds or modifies, using
+`assemble_changelog.py`'s own naming and heading rules rather than a second copy of
+either, and annotates the offending file directly. Only the branch's own fragments
+are read, so a fragment already on the base branch is never attributed to it, and
+the remedy stays self-clearing: add the `### `, or rename the file.

--- a/scripts/check_changelog_fragment.py
+++ b/scripts/check_changelog_fragment.py
@@ -25,6 +25,45 @@ one rule with no gate behind it, and a pull request could reach ``APPROVED`` /
 ``SUCCESS`` / ``CLEAN`` having ignored it -- which is how this check came to be
 written.
 
+The second question this answers
+--------------------------------
+A branch that correctly records its change as a fragment adds no heading to the
+log, so the comparison above is silent -- correctly. Nothing in it looks at the
+fragment's own contents, and nothing else fast did either: fragment validity was
+enforced only by ``tests/test_changelog_fragments.py``, inside the one required
+check. Measured on #2144, whose only defect was a fragment first line reading
+``Fixed: ...`` instead of ``### Fixed: ...``::
+
+    Refuse a changelog entry written outside a fragment    SUCCESS      10s
+    call-test-lint / Test and Lint                         FAILURE    20.8 min
+
+The check named for the convention passed it, and the verdict arrived from a
+general suite instead -- 125x later, worded as a test failure on a branch whose
+diff was 28 lines of ``strands_robots/utils.py`` and two test files. A misnamed
+file is the same class reached by a different path: ``collect_fragments`` raises,
+so ``validate_fragments`` returns that one message and the same suite carries it.
+
+So this also validates the fragments the branch *adds or modifies*, using the
+assembler's own ``FRAGMENT_NAME`` and ``validate_fragment`` rather than a second
+copy of either rule -- a copy could refuse a fragment the assembler accepts,
+which is the contradiction #2139 had to remove for ``save_episode``.
+
+Two boundaries are deliberate rather than incidental:
+
+- *Only the branch's own fragments.* ``validate_fragments()`` walks the whole
+  directory, 315 pending fragments of it, so wiring that in would accuse a branch
+  of a malformed fragment already on the base -- the positional-baseline mistake
+  #1879 paid a review round for.
+- *Bodies read from the object database.* ``git show <head>:<path>``, never the
+  working tree, so the verdict stays independent of the checked-out tree. The
+  validator itself does come from the checked-out tree, which in CI is the base
+  branch, and that is deliberate twice over: the base is the only tree guaranteed
+  to carry it, and a branch cannot relax the gate it is judged by in the same diff
+  that trips it.
+
+Both remedies stay self-clearing, as the append one is: add the ``### ``, or
+rename the file. See issue #2163.
+
 Why it is a base diff, not a test
 ---------------------------------
 The obvious pin -- assert ``[Unreleased]`` holds no entries, since the assembler
@@ -89,18 +128,21 @@ Usage
                 by ``test_a_merge_commit_head_still_sees_the_branchs_append``.
 ``--repo``      repository root (default: the current working directory).
 
-Exit status is ``1`` when an unaccounted entry was added, else ``0``.
+Exit status is ``1`` when an unaccounted entry was added or a fragment this
+branch adds is invalid, else ``0``.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import os
 import subprocess
 import sys
 from collections import Counter
 from collections.abc import Iterable, Sequence
 from pathlib import Path
+from types import ModuleType
 
 #: The log the convention protects, and the anchor within it.
 CHANGELOG_PATH = "CHANGELOG.md"
@@ -113,6 +155,53 @@ FRAGMENT_DIR = "changelog.d"
 #: step with ``scripts/assemble_changelog.py``'s ``RESERVED_NAMES``; a deleted
 #: README is not a consumed fragment and must not excuse an added entry.
 RESERVED_NAMES = frozenset({"README.md"})
+
+
+def _load_assembler() -> ModuleType:
+    """Load ``assemble_changelog`` from beside this script.
+
+    By path rather than by name: ``scripts/`` is not a package and is not on
+    ``sys.path`` when this module is loaded by its own tests, which use
+    ``spec_from_file_location``. Loading by path also keeps the import free of a
+    ``sys.path`` mutation at module scope.
+
+    Registered in ``sys.modules`` *before* execution, and not merely returned.
+    ``@dataclass`` resolves its own module to decide whether an annotation is a
+    ``KW_ONLY`` sentinel -- ``sys.modules.get(cls.__module__).__dict__`` -- so a
+    module executed outside the table dies on its first dataclass with
+    ``AttributeError: 'NoneType' object has no attribute '__dict__'``, naming
+    neither this file nor the reason. An already-loaded copy is reused, so the
+    assembler is executed once however many callers ask for it.
+
+    Which tree it comes from is load-bearing. In CI that is the base branch, and
+    both reasons matter: the base is the only tree guaranteed to carry the
+    validator (issue #1791), and a branch therefore cannot relax the naming or
+    heading rule it is judged by in the same diff that trips it.
+    """
+    loaded = sys.modules.get("assemble_changelog")
+    if loaded is not None:
+        return loaded
+
+    path = Path(__file__).resolve().parent / "assemble_changelog.py"
+    spec = importlib.util.spec_from_file_location("assemble_changelog", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load the fragment validator from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["assemble_changelog"] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # Do not leave a half-executed module behind for the next importer to
+        # find and trust. Re-raised lexically, so nothing is swallowed.
+        del sys.modules["assemble_changelog"]
+        raise
+    return module
+
+
+#: The single source of the fragment naming and heading contracts. Reused rather
+#: than restated, so this check and the assembler can never disagree about
+#: whether a fragment is valid.
+_ASSEMBLER = _load_assembler()
 
 
 class GitError(RuntimeError):
@@ -196,6 +285,77 @@ def deleted_fragments(start: str, end: str, repo: Path | None = None) -> tuple[s
     return tuple(sorted(line for line in output.splitlines() if line and Path(line).name not in RESERVED_NAMES))
 
 
+def changed_fragments(start: str, end: str, repo: Path | None = None) -> tuple[str, ...]:
+    """Return the fragment paths this branch adds or modifies, sorted.
+
+    ``--diff-filter=AM``, because those are the fragments the branch is answerable
+    for. A fragment already on the base is not this branch's to fix, and naming it
+    would accuse a branch of a defect it did not introduce.
+
+    ``--no-renames`` so a renamed fragment arrives as an add under its new name,
+    which is the name that has to satisfy the naming rule.
+
+    The reserved and dotfile skips mirror ``collect_fragments``, so a file the
+    assembler never reads as a fragment is not judged as one here either.
+    """
+    output = _git(
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter=AM",
+        f"{start}..{end}",
+        "--",
+        FRAGMENT_DIR,
+        repo=repo,
+    )
+    return tuple(
+        sorted(
+            line
+            for line in output.splitlines()
+            if line and Path(line).name not in RESERVED_NAMES and not Path(line).name.startswith(".")
+        )
+    )
+
+
+def fragment_problems(
+    paths: Iterable[str], head: str, repo: Path | None = None
+) -> tuple[tuple[str, str], ...]:
+    """Return ``(path, problem)`` for every contract violation in those fragments.
+
+    The verdicts are the assembler's own and are passed through verbatim, so the
+    wording a contributor reads here is the wording
+    ``python scripts/assemble_changelog.py --check`` prints locally.
+
+    A name that fails ``FRAGMENT_NAME`` short-circuits: ``collect_fragments``
+    would refuse the whole directory on it, so there is no ``Fragment`` to build
+    and reporting the heading of a file the assembler will not read would be
+    noise.
+
+    Bodies come from ``git show``, never from the working tree, which is what
+    keeps the verdict independent of the checked-out tree.
+    """
+    problems: list[tuple[str, str]] = []
+    for path in paths:
+        name = Path(path).name
+        match = _ASSEMBLER.FRAGMENT_NAME.match(name)
+        if match is None:
+            problems.append(
+                (
+                    path,
+                    f"{name}: not a valid fragment name - expected '<number>-<slug>.md' "
+                    "(lowercase slug, words joined by '-')",
+                )
+            )
+            continue
+        fragment = _ASSEMBLER.Fragment(
+            path=Path(path),
+            number=int(match.group("number")),
+            body=file_at(head, path, repo=repo),
+        )
+        problems.extend((path, problem) for problem in _ASSEMBLER.validate_fragment(fragment))
+    return tuple(problems)
+
+
 def unreleased_entries(changelog_text: str) -> tuple[str, ...]:
     """Return the ``### `` entry headings under ``[Unreleased]``, in file order.
 
@@ -260,6 +420,7 @@ def render_report(
     added: Sequence[str],
     accounted: Sequence[str],
     unaccounted: Sequence[str],
+    problems: Sequence[tuple[str, str]] = (),
 ) -> str:
     """Render the job-summary report for this run."""
     lines = [
@@ -270,11 +431,12 @@ def render_report(
     ]
 
     if not added:
+        # No early return: a branch can add no entry to the log and still add a
+        # fragment the assembler would refuse, which is the #2144 shape.
         lines += [
             f"No entry was added to `{CHANGELOG_PATH}`'s `{UNRELEASED_HEADING}` section.",
             "",
         ]
-        return "\n".join(lines) + "\n"
 
     if unaccounted:
         lines += [
@@ -307,6 +469,33 @@ def render_report(
         lines += [f"- `{entry}`" for entry in accounted]
         lines += [""]
 
+    if problems:
+        lines += [
+            f"This branch adds or changes {len(problems)} changelog fragment"
+            + ("" if len(problems) == 1 else "s")
+            + " the assembler would refuse:",
+            "",
+        ]
+        # The assembler prefixes every verdict with the fragment's own name, and
+        # the line already names the path, so drop that prefix rather than print
+        # the name twice. Only the exact prefix is dropped: an unrecognised
+        # wording is passed through whole rather than sliced blind, and the
+        # annotation below is always the assembler's message byte for byte.
+        for path, problem in problems:
+            prefix = f"{Path(path).name}: "
+            detail = problem[len(prefix) :] if problem.startswith(prefix) else problem
+            lines.append(f"- `{path}`: {detail}")
+        lines += [
+            "",
+            "Each verdict is `python scripts/assemble_changelog.py --check`'s own, so that command "
+            + "reproduces this locally. Only the fragments this branch adds or modifies are read, "
+            + f"so nothing already in `{FRAGMENT_DIR}` is attributed to it.",
+            "",
+            f"An invalid fragment is a hard error rather than a skip - see `{FRAGMENT_DIR}/README.md` - "
+            + "so the entry would otherwise be dropped from the assembled log entirely.",
+            "",
+        ]
+
     return "\n".join(lines) + "\n"
 
 
@@ -333,6 +522,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             for path in deleted_fragments(fork_point, args.head, repo=repo)
             if (entry := fragment_entry(file_at(fork_point, path, repo=repo))) is not None
         ]
+        problems = fragment_problems(
+            changed_fragments(fork_point, args.head, repo=repo), args.head, repo=repo
+        )
     except GitError as error:
         # Loud and non-zero: a check that cannot compute its answer must not
         # report the reassuring one.
@@ -349,6 +541,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         added=added,
         accounted=accounted,
         unaccounted=unaccounted,
+        problems=problems,
     )
 
     print(report, end="")
@@ -364,7 +557,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"record it as {FRAGMENT_DIR}/<number>-<slug>.md instead (see {FRAGMENT_DIR}/README.md)."
         )
 
-    return 1 if unaccounted else 0
+    for path, problem in problems:
+        print(f"::error file={path},line=1::{problem}")
+
+    return 1 if unaccounted or problems else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_changelog_fragment_gate.py
+++ b/tests/test_changelog_fragment_gate.py
@@ -646,3 +646,375 @@ def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> Non
     )
     assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
     assert '--head "$HEAD_SHA"' in workflow, "the commit under test is named, not checked out"
+
+
+# --- the fragment the branch actually wrote -------------------------------------
+#
+# The half above asks whether an entry bypassed the fragment convention. It cannot
+# ask whether the fragment that *was* written is valid: a branch that records its
+# change correctly adds no heading to the log, so the added-entry set is empty and
+# the check is silent. Fragment validity was enforced only by
+# tests/test_changelog_fragments.py, inside the one required check, and on #2144 --
+# whose sole defect was a fragment first line reading `Fixed: ...` -- this job
+# reported SUCCESS in 10s while `call-test-lint / Test and Lint` reported FAILURE
+# 20.8 minutes later, worded as a test failure. See issue #2163.
+#
+# The two boundaries below are the ones worth guarding, because getting either
+# wrong costs more than the gap did: judging the whole directory would fail a
+# branch for a fragment already on the base (#1879), and reading the working tree
+# would break the property that lets CI judge the branch from a base checkout
+# (#1791).
+
+
+#: A fragment body in the shape the assembler accepts.
+_VALID_FRAGMENT = "### Fixed: a change recorded the normal way\n\nBody of the fragment.\n"
+
+#: The #2144 shape: the heading text is there, the `### ` that makes it a heading
+#: is not. This is what a first-time fragment author writes.
+_MALFORMED_FRAGMENT = "Fixed: a change recorded with no entry heading\n\nBody of the fragment.\n"
+
+
+def _load_assembler():  # type: ignore[no-untyped-def]
+    """Load ``assemble_changelog`` the way its own suite does."""
+    path = _REPO_ROOT / "scripts" / "assemble_changelog.py"
+    spec = importlib.util.spec_from_file_location("assemble_changelog", path)
+    assert spec and spec.loader, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["assemble_changelog"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_malformed_fragment_is_refused(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The #2144 shape, which reached the required suite and nothing faster."""
+    _branch(repo)
+    _write(repo, "strands_robots/utils.py", "# the behavioural change\n")
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "fix something, and record it in a fragment with no heading")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    assert "changelog.d/2144-a-malformed-fragment.md" in output
+    assert "first line must be a level-3 entry heading" in output
+
+
+def test_adding_the_missing_heading_prefix_clears_the_check(repo: Path) -> None:
+    """Self-clearing, like the append half: the remedy asked for is the one that satisfies it."""
+    _branch(repo)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "record the change in a fragment with no heading")
+    assert _run(repo) == 1
+
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", f"### {_MALFORMED_FRAGMENT}")
+    _commit(repo, "make the first line an entry heading")
+
+    assert _run(repo) == 0
+
+
+def test_a_misnamed_fragment_is_refused(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The other half of the class, reached by a different path.
+
+    A bad *name* makes ``collect_fragments`` raise, so ``validate_fragments``
+    returns that one message and never inspects any body. ``changelog.d/README.md``
+    calls it out specifically: a stray or misnamed file is a hard error, so an entry
+    can never be silently dropped.
+    """
+    _branch(repo)
+    _write(repo, "changelog.d/Bad_Name.md", _VALID_FRAGMENT)
+    _commit(repo, "record the change in a badly named file")
+
+    assert _run(repo) == 1
+    assert "not a valid fragment name" in capsys.readouterr().out
+
+
+def test_renaming_the_fragment_clears_the_check(repo: Path) -> None:
+    """The name half is self-clearing too."""
+    _branch(repo)
+    _write(repo, "changelog.d/Bad_Name.md", _VALID_FRAGMENT)
+    _commit(repo, "record the change in a badly named file")
+    assert _run(repo) == 1
+
+    _git(repo, "mv", "changelog.d/Bad_Name.md", "changelog.d/2163-a-good-name.md")
+    _commit(repo, "give the fragment a valid name")
+
+    assert _run(repo) == 0
+
+
+def test_an_uppercase_slug_is_refused(repo: Path) -> None:
+    """The naming rule is the assembler's regex, not a substring check on the extension."""
+    _branch(repo)
+    _write(repo, "changelog.d/2163-Bad-Slug.md", _VALID_FRAGMENT)
+    _commit(repo, "record the change with an uppercase slug")
+
+    assert _run(repo) == 1
+
+
+# --- only the branch's own fragments --------------------------------------------
+
+
+def test_a_malformed_fragment_already_on_the_base_is_not_attributed_to_the_branch(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The #1879 boundary, and the reason ``validate_fragments()`` is not wired in whole.
+
+    That function walks the entire directory -- 315 pending fragments on ``main`` --
+    so a branch that touched nothing under ``changelog.d/`` would be failed for
+    somebody else's fragment, and the report would name a file absent from its diff.
+    Accusing a branch of a pre-existing defect is what #1879 spent a review round on.
+    """
+    _write(repo, "changelog.d/1699-already-broken.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "a malformed fragment that is already on the base")
+
+    _branch(repo)
+    _write(repo, "strands_robots/utils.py", "# an unrelated behavioural change\n")
+    _write(repo, "changelog.d/2163-a-good-fragment.md", _VALID_FRAGMENT)
+    _commit(repo, "an unrelated change, recorded correctly")
+
+    assert _run(repo) == 0
+    assert "1699-already-broken.md" not in capsys.readouterr().out
+
+
+def test_a_branch_that_breaks_an_existing_fragment_is_answerable_for_it(repo: Path) -> None:
+    """``--diff-filter=AM``: modifying a fragment makes it the branch's, not only adding one."""
+    _branch(repo)
+    _write(repo, "changelog.d/1700-a-pending-change.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "strip the heading off a fragment that was already valid")
+
+    assert _run(repo) == 1
+
+
+def test_deleting_a_malformed_fragment_is_not_refused(repo: Path) -> None:
+    """A deletion is not the branch adopting it, and the release path deletes fragments."""
+    _write(repo, "changelog.d/1699-already-broken.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "a malformed fragment on the base")
+
+    _branch(repo, "release")
+    (repo / "changelog.d/1699-already-broken.md").unlink()
+    _commit(repo, "drop the malformed fragment")
+
+    assert _run(repo) == 0
+
+
+def test_the_readme_is_not_judged_as_a_fragment(repo: Path) -> None:
+    """Reserved names are documentation. The skip mirrors ``collect_fragments``."""
+    _branch(repo)
+    _write(repo, "changelog.d/README.md", "# changelog.d - news fragments\n\nRevised prose.\n")
+    _commit(repo, "revise the fragment directory's README")
+
+    assert _run(repo) == 0
+
+
+def test_a_dotfile_is_not_judged_as_a_fragment(repo: Path) -> None:
+    """``collect_fragments`` skips dotfiles, so a `.gitkeep` is not a malformed entry."""
+    _branch(repo)
+    _write(repo, "changelog.d/.gitkeep", "")
+    _commit(repo, "keep the directory")
+
+    assert _run(repo) == 0
+
+
+# --- every rule the assembler has, not only the first line ----------------------
+
+
+def test_the_gate_refuses_exactly_what_the_assembler_refuses(repo: Path, tmp_path: Path) -> None:
+    """One rule, one owner.
+
+    The gate imports ``FRAGMENT_NAME`` and ``validate_fragment`` instead of
+    restating either, because a second copy could refuse a fragment the assembler
+    accepts -- the contradiction #2139 had to remove for ``save_episode``. This
+    compares the two verdicts over every rule the assembler has, so a future
+    narrowing to "check the first line" fails here rather than shipping a gate that
+    silently stops asking three of its four questions.
+    """
+    assembler = _load_assembler()
+    cases = (
+        ("2200-a-valid-fragment.md", _VALID_FRAGMENT),
+        ("2200-no-entry-heading.md", _MALFORMED_FRAGMENT),
+        ("2200-an-empty-fragment.md", "\n\n"),
+        ("2200-two-entries.md", "### Fixed: one\n\nBody.\n\n### Added: two\n\nBody.\n"),
+        ("2200-a-forged-version.md", "### Fixed: one\n\n## [9.9.9] - 2026-01-01\n"),
+        ("Bad_Name.md", _VALID_FRAGMENT),
+        ("2200-Bad-Slug.md", _VALID_FRAGMENT),
+    )
+
+    for index, (name, body) in enumerate(cases):
+        directory = tmp_path / f"case{index}"
+        directory.mkdir()
+        (directory / name).write_text(body, encoding="utf-8")
+        assembler_refuses = bool(assembler.validate_fragments(directory))
+
+        branch = f"case{index}"
+        _git(repo, "checkout", "-q", "main")
+        _git(repo, "checkout", "-q", "-b", branch)
+        _write(repo, f"changelog.d/{name}", body)
+        _commit(repo, f"add {name}")
+        gate_refuses = _run(repo) == 1
+
+        assert gate_refuses == assembler_refuses, (
+            f"{name}: gate refuses={gate_refuses}, assembler refuses={assembler_refuses}"
+        )
+
+
+# --- what the reader is told ----------------------------------------------------
+
+
+def test_the_annotation_reproduces_the_assemblers_message(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The annotation is the assembler's wording byte for byte, so the local command matches.
+
+    ``python scripts/assemble_changelog.py --check`` is what a contributor runs to
+    reproduce this, and a paraphrase here would leave them searching its output for
+    a sentence it does not print. The report line drops only the leading file name,
+    which it prints itself.
+    """
+    assembler = _load_assembler()
+    _branch(repo)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "record the change in a fragment with no heading")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+
+    directory = repo / "changelog.d"
+    expected = assembler.validate_fragments(directory)
+    assert len(expected) == 1, f"expected one assembler verdict, got {expected}"
+    assert f"::error file=changelog.d/2144-a-malformed-fragment.md,line=1::{expected[0]}" in output
+    assert "- `changelog.d/2144-a-malformed-fragment.md`: 2144-" not in output, (
+        "the report line must not print the fragment name twice"
+    )
+
+
+def test_the_report_names_the_command_that_reproduces_it(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _branch(repo)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "record the change in a fragment with no heading")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    assert "assemble_changelog.py --check" in output
+    assert "hard error rather than a skip" in output
+
+
+def test_both_halves_are_reported_in_one_run(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A branch can break the convention twice, and one run says so once.
+
+    The report used to return early when no entry had been added, which is exactly
+    the state the #2144 shape is in.
+    """
+    _branch(repo)
+    _append_to_unreleased(repo, _APPENDED)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    _commit(repo, "append to the log and add a malformed fragment")
+
+    assert _run(repo) == 1
+    output = capsys.readouterr().out
+    assert "that no fragment accounts for" in output
+    assert "the assembler would refuse" in output
+
+
+def test_a_valid_fragment_reports_nothing_about_fragments(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Quiet on the path every merged pull request takes."""
+    _branch(repo)
+    _write(repo, "changelog.d/2163-the-normal-path.md", _VALID_FRAGMENT)
+    _commit(repo, "record the change as a valid fragment")
+
+    assert _run(repo) == 0
+    output = capsys.readouterr().out
+    assert "the assembler would refuse" not in output
+    assert "No entry was added" in output
+
+
+# --- the tree the rules are read from -------------------------------------------
+
+
+def test_the_fragment_verdict_does_not_depend_on_the_checked_out_tree(repo: Path) -> None:
+    """Same property as the append half, and CI depends on it for the same reason.
+
+    The workflow checks out the *base* branch and names the head with ``--head``, so
+    the branch's fragment bodies must come from the object database. They do:
+    ``fragment_problems`` reads each one with ``git show <head>:<path>``.
+    """
+    _branch(repo)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    head = _commit(repo, "record the change in a fragment with no heading")
+
+    _git(repo, "checkout", "-q", "main")
+    assert not (repo / "changelog.d/2144-a-malformed-fragment.md").exists()
+
+    assert _run(repo, head) == 1
+
+
+def test_the_validator_survives_a_first_load_of_its_own(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate must work when it is the thing that first imports the assembler.
+
+    ``@dataclass`` resolves its own module through ``sys.modules`` to decide whether
+    an annotation is a ``KW_ONLY`` sentinel, so a module executed by path but never
+    registered there dies on its first dataclass with ``AttributeError: 'NoneType'
+    object has no attribute '__dict__'`` -- naming neither the loader nor the
+    reason. Nothing else here would catch it: every other test in this file runs
+    after some importer has already put ``assemble_changelog`` in the table.
+    """
+    monkeypatch.delitem(sys.modules, "assemble_changelog", raising=False)
+
+    spec = importlib.util.spec_from_file_location("check_changelog_fragment_fresh", _SCRIPT_PATH)
+    assert spec and spec.loader
+    fresh = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "check_changelog_fragment_fresh", fresh)
+    spec.loader.exec_module(fresh)
+
+    _branch(repo)
+    _write(repo, "changelog.d/2144-a-malformed-fragment.md", _MALFORMED_FRAGMENT)
+    head = _commit(repo, "record the change in a fragment with no heading")
+
+    problems = fresh.fragment_problems(fresh.changed_fragments("main", head, repo=repo), head, repo=repo)
+    assert len(problems) == 1
+    assert problems[0][0] == "changelog.d/2144-a-malformed-fragment.md"
+
+
+# --- the readers, directly ------------------------------------------------------
+
+
+def test_changed_fragments_reports_adds_and_modifications_only(repo: Path) -> None:
+    _write(repo, "changelog.d/1699-to-be-deleted.md", _VALID_FRAGMENT)
+    base = _commit(repo, "a fragment on the base")
+
+    _branch(repo)
+    _write(repo, "changelog.d/2163-added.md", _VALID_FRAGMENT)
+    _write(repo, "changelog.d/1700-a-pending-change.md", _VALID_FRAGMENT.replace("Body", "Revised body"))
+    (repo / "changelog.d/1699-to-be-deleted.md").unlink()
+    head = _commit(repo, "add one, modify one, delete one")
+
+    assert check.changed_fragments(base, head, repo=repo) == (
+        "changelog.d/1700-a-pending-change.md",
+        "changelog.d/2163-added.md",
+    )
+
+
+def test_fragment_problems_is_empty_for_a_valid_fragment(repo: Path) -> None:
+    _branch(repo)
+    _write(repo, "changelog.d/2163-valid.md", _VALID_FRAGMENT)
+    head = _commit(repo, "add a valid fragment")
+
+    assert check.fragment_problems(("changelog.d/2163-valid.md",), head, repo=repo) == ()
+
+
+def test_fragment_problems_names_the_path_it_was_given(repo: Path) -> None:
+    """The path in the tuple is the one the annotation needs, not the basename."""
+    _branch(repo)
+    _write(repo, "changelog.d/2163-malformed.md", _MALFORMED_FRAGMENT)
+    head = _commit(repo, "add a malformed fragment")
+
+    problems = check.fragment_problems(("changelog.d/2163-malformed.md",), head, repo=repo)
+    assert [path for path, _ in problems] == ["changelog.d/2163-malformed.md"]
+
+
+def test_the_report_names_a_fragment_problem() -> None:
+    report = check.render_report(
+        base_ref="main",
+        merge_base_sha="0123456789abcdef",
+        added=(),
+        accounted=(),
+        unaccounted=(),
+        problems=(("changelog.d/2163-a-fragment.md", "2163-a-fragment.md: fragment is empty"),),
+    )
+    assert "`changelog.d/2163-a-fragment.md`: fragment is empty" in report
+    assert "the assembler would refuse" in report


### PR DESCRIPTION
## What

`Changelog Fragment Check` asks one question: *was an entry written into `CHANGELOG.md` instead of a `changelog.d/` fragment?* It says nothing about whether the fragment that **was** written is valid. Fragment validity was enforced only by `tests/test_changelog_fragments.py::test_repository_fragments_are_valid`, which lives inside `call-test-lint / Test and Lint`.

So the one check named for the convention passed the one pull request whose only defect *was* the convention. Measured on #2144, whose sole defect is a fragment first line reading `Fixed: ...` instead of `### Fixed: ...`:

| check on `ecba349b` | conclusion | time to verdict |
|---|---|---|
| `Refuse a changelog entry written outside a fragment` | **SUCCESS** | 10s |
| `call-test-lint / Test and Lint` | **FAILURE** | **20.8 min** |

The other ten contexts are `SUCCESS`/`NEUTRAL`, so the rollup shows one red X on a 20-minute suite, on a branch whose diff is 28 lines of `strands_robots/utils.py` and two test files - i.e. it presents as "this branch broke the tests". Attributing it took a hand reproduction of `validate_fragments` in the review thread.

Reproduced against `666a136` in both directions, one commit adding one fragment:

| fragment the branch adds | fast gate | `assemble_changelog.py --check` |
|---|---|---|
| first line `Fixed: ...` (no `### `) | **exit 0**, "No entry was added" | exit 1, names it |
| valid heading, named `Bad_Name.md` | **exit 0**, "No entry was added" | exit 1, "not a valid fragment name" |

The misnamed half matters because it fails through a different path - `collect_fragments` raises, so `validate_fragments` returns that one message and never reads a body - and `changelog.d/README.md` calls it out by name: a stray or misnamed file is a hard error, so an entry can never be silently dropped.

## Why the gate could not see it

By construction, not by oversight. The check compares the `### ` entry headings under `[Unreleased]` at the merge base against the same set at the head. A branch that records its change correctly adds no heading to the log, so the added-entry set is empty and the check is - correctly - silent. Nothing in its question is about a fragment's contents.

That is the mirror of what the script's own docstring already records about the suites it supplements: "Neither can see a fragment that was never written." Neither could this one see a fragment that *was* written badly.

## Fix

`check_changelog_fragment.py` now also validates the fragments the branch **adds or modifies**, and annotates the offending file at line 1. Two new readers, `changed_fragments` and `fragment_problems`; the existing comparison is untouched.

The rules are the assembler's own - `FRAGMENT_NAME` for the name, `validate_fragment` for the contents - imported rather than restated. A second copy could refuse a fragment the assembler accepts, which is the contradiction #2139 had to remove for `save_episode`. The verdicts are passed through verbatim, so `python scripts/assemble_changelog.py --check` reproduces the output locally word for word.

### Three boundaries, each pinned rather than assumed

1. **Only the branch's own fragments.** `validate_fragments()` walks the whole directory - 315 pending fragments - so wiring it in whole would fail a branch for a malformed fragment already on the base, and name a file absent from its diff. That is the positional-baseline mistake #1879 paid a round for. `--diff-filter=AM`, so a deletion (the release path) and a pre-existing fragment are both out of scope, while *modifying* a fragment does make it the branch's.
2. **Bodies read from the object database.** `git show <head>:<path>`, never the working tree, so the verdict stays independent of the checked-out tree - the property that lets CI run the script from the *base* checkout while judging the branch (#1791). Pinned by a fragment-side twin of the existing `test_the_verdict_does_not_depend_on_the_checked_out_tree`.
3. **The validator comes from the base tree**, which is deliberate twice over: the base is the only tree guaranteed to carry it, and a branch therefore cannot relax the naming or heading rule it is judged by in the same diff that trips it.

Both remedies stay self-clearing, as the append one is: add the `### `, or rename the file.

## One implementation detail worth flagging for review

The assembler is loaded by path and **registered in `sys.modules` before execution**. `@dataclass` resolves its own module through that table to decide whether an annotation is a `KW_ONLY` sentinel, so a module executed outside it dies on its first dataclass with `AttributeError: 'NoneType' object has no attribute '__dict__'`, naming neither the loader nor the reason. This was hit for real while writing the change, and no other test in the file would catch a regression - every one of them runs after some importer has already populated the table. `test_the_validator_survives_a_first_load_of_its_own` clears the entry and loads the gate fresh.

## Verification

**Pre-fix**: with `scripts/check_changelog_fragment.py` reverted to `main` and the new tests kept - **16 failed, 43 passed**. Every failure states the defect (`assert 0 == 1`, `gate refuses=False, assembler refuses=True`, `has no attribute 'changed_fragments'`, `render_report() got an unexpected keyword argument 'problems'`).

The **5** new tests that pass both ways are named as controls rather than counted as evidence: `main` never refuses a fragment at all, so the boundary pins (a malformed fragment already on the base, a deletion, `README.md`, a dotfile, quiet-on-valid) are vacuous there. They exist to fail a *future* over-broad implementation, which is the direction this change could go wrong.

- **Dogfood**: the new gate run against this branch's own commit - exit 0.
- Behaviour, all three paths measured end to end: malformed heading refused and named; misnamed file refused and named; adding the `### ` or renaming clears it.
- `tests/test_changelog_fragment_gate.py` - **59 passed** (38 before, 21 added). No existing test changed.
- Changelog + gate + workflow-reading guards: `changelog_fragment_gate`, `changelog_fragments`, `changelog_format`, `closing_reference_gate`, `args_docstring_completeness`, `no_host_paths`, `docstrings_no_dangling_doc_refs`, `source_strings_no_internal_file_paths` - **543 passed**; `codeql_query_filters`, `dependabot_config_location`, `last_push_approval`, `lockfile_parity_gate`, `merge_base_overlap`, `merge_gate_viewer_scope`, `pull_request_trigger_types`, `ref_creation_ruleset_scope` - **134 passed**.
- `python scripts/assemble_changelog.py --check` - `changelog fragments OK (315 pending)`.
- `scripts/check_merge_base_overlap.py` - no overlap, 0 paths changed on `main` in that span; `behind_by` is 0, so the tree CI tests is the merge result.
- `ruff check` and `ruff format --check` clean on the changed test file and the script.
- The script and the workflow are pure ASCII, as `test_no_emoji_in_the_script_or_its_output` requires.

## Scope

The job name becomes drift once the check answers two questions, so it is renamed to `Refuse a changelog entry that breaks the fragment convention`. It is **not** in the ruleset's `required_status_checks` (which lists only `call-test-lint / Test and Lint`), so the rename gates nothing differently.

Deliberately **not** claimed: `main` was never at risk. `test_repository_fragments_are_valid` is inside the required check, so a malformed fragment could not merge and a release could not silently drop an entry. What this buys is attribution - a verdict in 10s naming the file, instead of one in 20.8 minutes worded as a test failure - and it is worth saying plainly rather than overselling the fix.

Out of scope: making the check required, which is a branch-protection decision the workflow header already declines to make on its own; and #2144 itself, whose remedy is a one-line edit by its author.

Closes #2163
