### PR TITLE
fix(simulation/mujoco): refuse a size component a <fromto> fixes

### DIFF
--- a/changelog.d/2166-fromto-fixed-geom-size-refused.md
+++ b/changelog.d/2166-fromto-fixed-geom-size-refused.md
@@ -1,0 +1,18 @@
+### Fixed: `set_geom_properties` refuses a size component a `<fromto>` fixes
+
+A geom declared with `<fromto>` gives its extent along its own axis as two
+endpoints, and the compiler fixes part of its `geom_size` row from them rather
+than reading it from `size` - the axis extent, plus a box's or ellipsoid's
+cross-section, which is made square from the first component. Resizing one of
+those components reported success and then lost the change twice over: the value
+was written into the spec's `size` row where the next scene recompile discarded
+it, and the owning body's inertial row - re-derived from that same spec - kept
+describing the extent the endpoints still declared. A `fromto` capsule resized
+from a 0.15 m to a 0.30 m half-length therefore collided as the new shape while
+resisting rotation as the old one, and reverted to 0.15 m at the next unrelated
+`add_object`.
+
+Such a change is now refused before either representation is touched, with a
+message naming the component, the value the compiler keeps producing and how to
+change it. The components a `fromto` leaves alone - a capsule's or cylinder's
+radius - are unaffected and still recorded durably.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1906,10 +1906,13 @@ class PhysicsMixin:
             # is above; the components the fromto leaves alone still apply.
             # ``_coerce_finite_vector`` returns a value whenever it reports no
             # error, so the cast carries that proof rather than re-testing it.
+            # It also fixed the length at this geom type's exact component count,
+            # and every component a fromto fixes falls inside that count - 1 of a
+            # capsule's / cylinder's 2, 1 and 2 of a box's / ellipsoid's 3 - so
+            # each index below is in range. A bounds check here would stand in
+            # for that proof while reading as though a short vector could arrive.
             requested = cast("list[float]", size)
             for index, (component, follows) in sorted(fromto_fixed_size_components(self._world, gid).items()):
-                if index >= len(requested):
-                    continue
                 expected = float(requested[follows]) if follows is not None else float(model.geom_size[gid][index])
                 if float(requested[index]) == expected:
                     continue

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -31,6 +31,7 @@ from strands_robots.simulation.mujoco.backend import (
     mj_name_to_id,
 )
 from strands_robots.simulation.mujoco.scene_ops import (
+    fromto_fixed_size_components,
     persist_body_mass,
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
@@ -1780,6 +1781,10 @@ class PhysicsMixin:
           2 for a capsule/cylinder, 3 for a box/ellipsoid/plane. Mesh, height
           field and SDF geoms take their extent from asset data and define no
           ``geom_size`` component, so ``size`` is refused for them.
+          A geom declared with ``<fromto>`` has the compiler fix its extent
+          along that axis (and a box's / ellipsoid's cross-section), so a
+          change to one of those components is refused - pass the value the
+          compiler produces to resize the components it leaves alone.
 
         All numeric inputs are validated before any model write: ``color``,
         ``friction`` and ``size`` must contain only finite numbers (``nan`` /
@@ -1890,6 +1895,40 @@ class PhysicsMixin:
             )
             if err:
                 return err
+
+            # A geom declared with <fromto> has part of its geom_size fixed by
+            # the compiler rather than read from ``size``, and re-derived on
+            # every compile. Writing such a component would report a resize the
+            # next scene recompile discards, and would leave the body's inertial
+            # row - re-derived below from the spec, which the endpoints still
+            # govern - describing the old extent while the model collided as the
+            # requested one. Refused for the same reason an asset-defined extent
+            # is above; the components the fromto leaves alone still apply.
+            # ``_coerce_finite_vector`` returns a value whenever it reports no
+            # error, so the cast carries that proof rather than re-testing it.
+            requested = cast("list[float]", size)
+            for index, (component, follows) in sorted(fromto_fixed_size_components(self._world, gid).items()):
+                if index >= len(requested):
+                    continue
+                expected = float(requested[follows]) if follows is not None else float(model.geom_size[gid][index])
+                if float(requested[index]) == expected:
+                    continue
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"set_geom_properties: geom '{geom_name or gid}' declares a <fromto>, "
+                                f"so the compiler fixes its {component} (size component {index + 1} of "
+                                f"a {gtype}) rather than reading it from 'size'. A change to it cannot "
+                                f"be recorded durably: the next scene recompile restores {expected}. "
+                                f"Pass {expected} for that component to resize the ones the fromto "
+                                f"leaves alone, edit the fromto to resize along its axis, or declare "
+                                f"the geom with an explicit size, pos and quat."
+                            )
+                        }
+                    ],
+                }
 
         label = geom_name or f"geom_{gid}"
         changes = []

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -23,6 +23,8 @@ Public API:
   under ``{robot_name}/``, then recompile.
 * :func:`refresh_body_inertial_from_geometry` - re-derive a body's mass /
   center of mass / inertia after one of its geoms was resized at runtime.
+* :func:`fromto_fixed_size_components` - which ``geom_size`` components a geom's
+  ``<fromto>`` fixes, so a resize of one can be refused rather than reported.
 
 Every function takes a ``SimWorld`` whose ``_backend_state["spec"]`` holds the
 live ``MjSpec``. They return ``True`` on success, ``False`` on failure (matching
@@ -33,6 +35,7 @@ from __future__ import annotations
 
 import difflib
 import logging
+import math
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -378,6 +381,11 @@ def persist_geom_properties(
             supplied are written, matching the model write: the unused tail of
             the spec's 3-wide row keeps its declared value.
 
+    A ``size`` component the geom's ``<fromto>`` fixes cannot be made durable by
+    writing this row at all; :func:`fromto_fixed_size_components` reports those
+    and the caller refuses such a change before reaching here, so what is written
+    below is what the next compile reproduces.
+
     Returns:
         ``None`` once the value is recorded, otherwise the reason it could not be.
     """
@@ -395,6 +403,57 @@ def persist_geom_properties(
     if size is not None:
         spec_geom.size[: len(size)] = size
     return None
+
+
+def fromto_fixed_size_components(world: SimWorld, geom_id: int) -> dict[int, tuple[str, int | None]]:
+    """Return the ``geom_size`` components a geom's ``<fromto>`` fixes.
+
+    ``fromto`` gives a geom's extent along its own axis as two endpoints, and the
+    compiler then FIXES part of its ``geom_size`` row rather than reading it from
+    ``size``: the axis extent comes from the endpoints, and for a box or ellipsoid
+    the cross-section is additionally made square by copying the first component.
+    Those components are re-derived on every compile, so a value written into the
+    spec's ``size`` row never reaches the model - the resize is reported and then
+    discarded by the next scene recompile, and an inertial row re-derived from the
+    spec (see :func:`refresh_body_inertial_from_geometry`) describes the extent the
+    endpoints still declare rather than the requested one.
+
+    Only the fixed components are affected. A capsule's or cylinder's radius still
+    comes from ``size``, so a caller can resize it and have the change recorded
+    durably; callers use this mapping to refuse a change to the rest instead of
+    reporting it.
+
+    Args:
+        world: The scene holding the live spec.
+        geom_id: Compiled geom index, already resolved by the caller.
+
+    Returns:
+        ``{index: (name, follows)}`` for each fixed component, where ``follows``
+        is the ``size`` index whose value that component copies, or ``None`` when
+        the segment endpoints fix it. Empty when nothing is fixed - which covers a
+        geom with no ``fromto``, a geom type ``fromto`` cannot be used with, and a
+        spec that cannot resolve ``geom_id``.
+    """
+    mj = _ensure_mujoco()
+    spec = _get_spec(world)
+    if spec is None:
+        return {}
+    spec_geom, _reason = _spec_element_by_id(spec.geoms, geom_id, "geom")
+    if spec_geom is None:
+        return {}
+    # MuJoCo marks an unset spec field with NaN in its first element, so a
+    # ``fromto`` only describes this geom when it was actually declared.
+    fromto = spec_geom.fromto
+    if fromto is None or math.isnan(float(fromto[0])):
+        return {}
+    geom = mj.mjtGeom
+    fixed: dict[int, dict[int, tuple[str, int | None]]] = {
+        int(geom.mjGEOM_CAPSULE): {1: ("half-length", None)},
+        int(geom.mjGEOM_CYLINDER): {1: ("half-length", None)},
+        int(geom.mjGEOM_BOX): {1: ("y half-extent", 0), 2: ("z half-extent", None)},
+        int(geom.mjGEOM_ELLIPSOID): {1: ("y semi-axis", 0), 2: ("z semi-axis", None)},
+    }
+    return fixed.get(int(spec_geom.type), {})
 
 
 def refresh_body_inertial_from_geometry(world: SimWorld, geom_id: int) -> str | None:

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -68,6 +68,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::eject_body_from_scene",
     "scene_ops.py::eject_camera_from_scene",
     "scene_ops.py::eject_robot_from_scene",
+    "scene_ops.py::fromto_fixed_size_components",
     "scene_ops.py::inject_camera_into_scene",
     "scene_ops.py::inject_object_into_scene",
     "scene_ops.py::inject_robot_into_scene",

--- a/tests/simulation/mujoco/test_runtime_setters_survive_recompile.py
+++ b/tests/simulation/mujoco/test_runtime_setters_survive_recompile.py
@@ -10,6 +10,13 @@ These tests pin the contract for every runtime property the MuJoCo backend lets 
 caller set - a body's mass, a geom's colour / friction / size, and the world's
 gravity / timestep - and check the durable value equals the one the setter
 reported, so the fast path and the recompile cannot drift apart.
+
+Part of a ``geom_size`` row can be beyond a setter's reach: a geom declared with
+``<fromto>`` has the compiler fix its extent along that axis, and a box's or
+ellipsoid's cross-section as well, so a value written into the spec's ``size``
+row for one of those components never survives a compile. Such a change is
+refused rather than reported, and the tests below pin both halves - the refusal,
+and that the components the ``fromto`` leaves alone still apply durably.
 """
 
 from __future__ import annotations
@@ -18,6 +25,7 @@ import numpy as np
 import pytest
 
 from strands_robots.simulation.mujoco.scene_ops import (
+    fromto_fixed_size_components,
     persist_body_mass,
     persist_geom_properties,
     persist_world_option,
@@ -47,6 +55,60 @@ SCENE = """<mujoco>
 </mujoco>"""
 
 
+# Every geom type ``fromto`` can be used with, each declaring its axis extent by
+# endpoints, plus a plain capsule declaring the same extent through ``size``.
+# Densities make every body derive its inertial row from geometry, so a resize
+# that slipped through would also leave mass and inertia describing another shape.
+FROMTO_SCENE = """<mujoco>
+  <compiler angle="radian"/>
+  <worldbody>
+    <geom name="floor" type="plane" size="3 3 0.1"/>
+    <body name="cap_body" pos="0 0 0.6">
+      <freejoint/>
+      <geom name="cap" type="capsule" fromto="0 0 -0.15  0 0 0.15" size="0.04" density="800"/>
+    </body>
+    <body name="cyl_body" pos="0.4 0 0.6">
+      <freejoint/>
+      <geom name="cyl" type="cylinder" fromto="0 0 -0.2  0 0 0.2" size="0.05" density="800"/>
+    </body>
+    <body name="box_body" pos="0.8 0 0.6">
+      <freejoint/>
+      <geom name="bx" type="box" fromto="0 0 -0.1  0 0 0.1" size="0.03 0.03" density="800"/>
+    </body>
+    <body name="ell_body" pos="1.2 0 0.6">
+      <freejoint/>
+      <geom name="ell" type="ellipsoid" fromto="0 0 -0.07  0 0 0.07" size="0.02 0.02" density="800"/>
+    </body>
+    <body name="plain_body" pos="1.6 0 0.6">
+      <freejoint/>
+      <geom name="plain" type="capsule" size="0.04 0.15" density="800"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+
+# One case per type ``fromto`` governs: the geom, its type, the fixed component a
+# resize would violate (index, name, the value the compiler keeps producing), a
+# size that changes it, and a size that changes only what the fromto leaves alone.
+# The axis extent is component 2 of a capsule / cylinder and component 3 of a box /
+# ellipsoid, so the refused component differs by type.
+FROMTO_CASES = [
+    ("cap", "capsule", 1, "half-length", 0.15, [0.04, 0.30], [0.08, 0.15]),
+    ("cyl", "cylinder", 1, "half-length", 0.20, [0.05, 0.44], [0.09, 0.20]),
+    ("bx", "box", 2, "z half-extent", 0.10, [0.03, 0.03, 0.22], [0.06, 0.06, 0.10]),
+    ("ell", "ellipsoid", 2, "z semi-axis", 0.07, [0.02, 0.02, 0.19], [0.05, 0.05, 0.07]),
+]
+FROMTO_IDS = [case[1] for case in FROMTO_CASES]
+
+# A box's / ellipsoid's cross-section is made square from the first component, so
+# its second one is fixed to whatever the caller passes first rather than to the
+# value the geom compiles to today: (geom, type, name, size, expected).
+FROMTO_SQUARE_CASES = [
+    ("bx", "box", "y half-extent", [0.06, 0.03, 0.10], 0.06),
+    ("ell", "ellipsoid", "y semi-axis", [0.05, 0.04, 0.07], 0.05),
+]
+FROMTO_SQUARE_IDS = [case[1] for case in FROMTO_SQUARE_CASES]
+
+
 @pytest.fixture
 def sim():
     """A world holding one crate, torn down after the test."""
@@ -66,6 +128,16 @@ def dual_sim():
     engine = Simulation(tool_name="recompile_dual", backend="mujoco", mesh=False)
     engine.create_world()
     assert engine.replace_scene_mjcf(SCENE)["status"] == "success"
+    yield engine
+    engine.cleanup()
+
+
+@pytest.fixture
+def fromto_sim():
+    """A world whose geoms declare their axis extent with ``fromto``."""
+    engine = Simulation(tool_name="recompile_fromto", backend="mujoco", mesh=False)
+    engine.create_world()
+    assert engine.replace_scene_mjcf(FROMTO_SCENE)["status"] == "success"
     yield engine
     engine.cleanup()
 
@@ -164,6 +236,130 @@ class TestWorldOptionsSurviveRecompile:
         assert sim.set_timestep(timestep=0.001)["status"] == "success"
         model = _recompile(sim)
         assert float(model.opt.timestep) == pytest.approx(0.001)
+
+
+class TestFromtoFixedSizeIsRefused:
+    """A ``geom_size`` component a ``<fromto>`` fixes is refused, not reported."""
+
+    PARAMS = ("geom", "geom_type", "index", "component", "expected", "changed", "others")
+
+    @pytest.mark.parametrize(PARAMS, FROMTO_CASES, ids=FROMTO_IDS)
+    def test_changing_a_fixed_component_writes_nothing(
+        self, fromto_sim, geom, geom_type, index, component, expected, changed, others
+    ):
+        """Refused before either representation is touched, for every governed type."""
+        model = fromto_sim._world._model
+        geom_id = _geom(model, geom)
+        body_id = int(model.geom_bodyid[geom_id])
+        spec_geom = fromto_sim._world._backend_state["spec"].geoms[geom_id]
+        before_model = model.geom_size[geom_id].copy()
+        before_spec = np.array(spec_geom.size).copy()
+        before_mass = float(model.body_mass[body_id])
+        before_inertia = model.body_inertia[body_id].copy()
+
+        result = fromto_sim.set_geom_properties(geom_name=geom, size=changed)
+
+        assert result["status"] == "error", result
+        assert np.allclose(model.geom_size[geom_id], before_model)
+        assert np.allclose(np.array(spec_geom.size), before_spec)
+        assert float(model.body_mass[body_id]) == pytest.approx(before_mass)
+        assert np.allclose(model.body_inertia[body_id], before_inertia)
+
+    @pytest.mark.parametrize(PARAMS, FROMTO_CASES, ids=FROMTO_IDS)
+    def test_the_refusal_names_the_component_and_a_remedy(
+        self, fromto_sim, geom, geom_type, index, component, expected, changed, others
+    ):
+        """The message names fromto, the component it fixes, and what to do instead."""
+        text = fromto_sim.set_geom_properties(geom_name=geom, size=changed)["content"][0]["text"]
+        assert text.startswith("set_geom_properties: ")
+        assert "<fromto>" in text
+        assert f"{component} (size component {index + 1} of a {geom_type})" in text
+        assert f"restores {expected}" in text
+        assert "edit the fromto to resize along its axis" in text
+
+    @pytest.mark.parametrize(PARAMS, FROMTO_CASES, ids=FROMTO_IDS)
+    def test_changing_only_what_the_fromto_leaves_alone_survives_a_recompile(
+        self, fromto_sim, geom, geom_type, index, component, expected, changed, others
+    ):
+        """The fixed components are out of reach; the rest is still recorded durably.
+
+        This is what refusing every resize of a ``fromto`` geom would have cost:
+        thickening such a capsule is honored today, and the inertial row the setter
+        reports is the one the next recompile reproduces.
+        """
+        model = fromto_sim._world._model
+        geom_id = _geom(model, geom)
+        body_id = int(model.geom_bodyid[geom_id])
+
+        assert fromto_sim.set_geom_properties(geom_name=geom, size=others)["status"] == "success"
+        reported_size = model.geom_size[geom_id].copy()
+        reported_mass = float(model.body_mass[body_id])
+        reported_inertia = model.body_inertia[body_id].copy()
+        assert reported_size[index] == pytest.approx(expected)
+
+        recompiled = _recompile(fromto_sim, name=f"trigger_{geom}")
+
+        assert np.allclose(recompiled.geom_size[geom_id], reported_size)
+        assert float(recompiled.body_mass[body_id]) == pytest.approx(reported_mass)
+        assert np.allclose(recompiled.body_inertia[body_id], reported_inertia)
+
+    @pytest.mark.parametrize(
+        ("geom", "geom_type", "component", "size", "expected"),
+        FROMTO_SQUARE_CASES,
+        ids=FROMTO_SQUARE_IDS,
+    )
+    def test_a_square_cross_section_is_fixed_to_the_first_component(
+        self, fromto_sim, geom, geom_type, component, size, expected
+    ):
+        """A fromto box's second component follows its first, so passing today's fails.
+
+        The compiler copies component 1 over component 2, so what that component
+        must equal is the caller's own first value - not the value the geom
+        currently compiles to.
+        """
+        model = fromto_sim._world._model
+        before = model.geom_size[_geom(model, geom)].copy()
+
+        result = fromto_sim.set_geom_properties(geom_name=geom, size=size)
+
+        assert result["status"] == "error", result
+        assert component in result["content"][0]["text"]
+        assert f"restores {expected}" in result["content"][0]["text"]
+        assert np.allclose(model.geom_size[_geom(model, geom)], before)
+
+    def test_a_geom_declaring_its_size_directly_is_unaffected(self, fromto_sim):
+        """The same type without a fromto resizes every component as before."""
+        model = fromto_sim._world._model
+        geom_id = _geom(model, "plain")
+
+        assert fromto_sim.set_geom_properties(geom_name="plain", size=[0.06, 0.33])["status"] == "success"
+        recompiled = _recompile(fromto_sim, name="trigger_plain")
+
+        assert np.allclose(recompiled.geom_size[geom_id][:2], [0.06, 0.33])
+
+    def test_the_helper_reports_only_the_components_a_fromto_fixes(self, fromto_sim):
+        """Empty for anything a fromto does not govern, so nothing is over-refused."""
+        world = fromto_sim._world
+        model = world._model
+
+        assert fromto_fixed_size_components(world, _geom(model, "cap")) == {1: ("half-length", None)}
+        assert fromto_fixed_size_components(world, _geom(model, "cyl")) == {1: ("half-length", None)}
+        assert fromto_fixed_size_components(world, _geom(model, "bx")) == {
+            1: ("y half-extent", 0),
+            2: ("z half-extent", None),
+        }
+        assert fromto_fixed_size_components(world, _geom(model, "ell")) == {
+            1: ("y semi-axis", 0),
+            2: ("z semi-axis", None),
+        }
+        # declares its size directly, a type fromto cannot be used with, and an id
+        # the spec cannot resolve
+        assert fromto_fixed_size_components(world, _geom(model, "plain")) == {}
+        assert fromto_fixed_size_components(world, _geom(model, "floor")) == {}
+        assert fromto_fixed_size_components(world, 10_000) == {}
+
+        world._backend_state.pop("spec")
+        assert fromto_fixed_size_components(world, _geom(model, "cap")) == {}
 
 
 class TestRefusedWhenTheChangeCannotBeRecorded:

--- a/tests/simulation/mujoco/test_runtime_setters_survive_recompile.py
+++ b/tests/simulation/mujoco/test_runtime_setters_survive_recompile.py
@@ -34,6 +34,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
 mujoco = pytest.importorskip("mujoco")
 
 from strands_robots import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco.physics import _GEOM_SIZE_LAYOUTS  # noqa: E402
 
 # Two bodies covering both ways MuJoCo derives an inertial: "explicit" declares
 # its own <inertial> (explicitinertial, as every menagerie robot link does),
@@ -360,6 +361,35 @@ class TestFromtoFixedSizeIsRefused:
 
         world._backend_state.pop("spec")
         assert fromto_fixed_size_components(world, _geom(model, "cap")) == {}
+
+    def test_every_fixed_component_is_within_the_accepted_size_length(self, fromto_sim):
+        """The refusal indexes the caller's ``size`` on this, so nothing guards it.
+
+        ``set_geom_properties`` requires a size of the geom type's exact component
+        count and then indexes that vector at every component the helper reports -
+        including the one a square cross-section copies from. Both indices have to
+        fall inside the accepted count for each type a ``fromto`` governs, which is
+        a property of the two tables together rather than of either alone, and the
+        reason the refusal needs no bounds check to stand in for it.
+        """
+        world = fromto_sim._world
+        model = world._model
+
+        for geom_name, gtype, *_rest in FROMTO_CASES:
+            fixed = fromto_fixed_size_components(world, _geom(model, geom_name))
+            assert fixed, f"{gtype} declares a fromto, so the helper must report what it fixes"
+            assert gtype in _GEOM_SIZE_LAYOUTS, f"{gtype} accepts no size, so it cannot be resized at all"
+            accepted = _GEOM_SIZE_LAYOUTS[gtype][0]
+
+            for index, (_component, follows) in fixed.items():
+                assert 0 <= index < accepted, f"{gtype} fixes component {index} of an accepted {accepted}"
+                if follows is None:
+                    continue
+                assert 0 <= follows < accepted, f"{gtype} copies component {follows} of an accepted {accepted}"
+                # The remedy is "pass the value the compiler produces", so the
+                # component a fixed one copies must itself be settable - if it
+                # were fixed too, no size could satisfy both.
+                assert follows not in fixed, f"{gtype} component {index} copies a component that is fixed too"
 
 
 class TestRefusedWhenTheChangeCannotBeRecorded:


### PR DESCRIPTION
## Problem

A MuJoCo geom can declare its extent along its own axis with `<fromto>`, giving
two endpoints instead of a size — the natural way to write a link, and what most
hand-written MJCF does. The compiler then **fixes** part of that geom's
`geom_size` row from the endpoints rather than reading it from `size`: the axis
extent (component 2 of a capsule or cylinder, component 3 of a box or ellipsoid),
and for a box or ellipsoid the cross-section as well, which is made square by
copying the first component.

`set_geom_properties(size=...)` wrote such a component and reported success. The
change was then lost twice over, because the write went into the spec's `size`
row that the compiler does not read for it:

```
capsule declared fromto="-0.15 0 0  0.15 0 0" size="0.05" density="800"

set_geom_properties(geom_name="cap", size=[0.05, 0.30])
  -> status "success",  "Geom 'cap': size -> [0.05, 0.3, 0.0]"

model geom_size   [0.05, 0.3, 0.0]      <- collides as a 0.30 m capsule
body mass         2.303835 kg           <- still the 0.15 m capsule's
body inertia Ixx  0.027515              <- still the 0.15 m capsule's

add_object(name="unrelated", ...)        # any unrelated scene mutation
model geom_size   [0.05, 0.15, 0.0]     <- the resize is gone, nothing reported it
```

So between the two calls the body **collided as the new shape while resisting
rotation as the old one** — `refresh_body_inertial_from_geometry` re-derives the
inertial row from the spec, and the spec's endpoints still declared 0.15 m — and
then the geometry silently reverted at the next `add_object` / `add_camera` /
`add_robot`. The same held for a box's or ellipsoid's second component, where the
value is discarded even without a recompile because the compiler copies the first
component over it.

`tests/simulation/mujoco/test_runtime_setters_survive_recompile.py` exists to pin
"the durable value equals the one the setter reported" for exactly these
properties. Its scene had no `fromto` geom, which is why nothing caught this.

## What changes

* `scene_ops.fromto_fixed_size_components(world, geom_id)` answers the spec
  question: which `geom_size` components a geom's `<fromto>` fixes, and for each
  whether the endpoints fix it or it copies another component. Empty for a geom
  with no `fromto`, a type `fromto` cannot be used with, and an id the spec
  cannot resolve.
* `set_geom_properties` refuses a change to one of those components before the
  lock and before any write, naming the component, the value the compiler keeps
  producing, and how to proceed:

  > `set_geom_properties: geom 'cap' declares a <fromto>, so the compiler fixes
  > its half-length (size component 2 of a capsule) rather than reading it from
  > 'size'. A change to it cannot be recorded durably: the next scene recompile
  > restores 0.15. Pass 0.15 for that component to resize the ones the fromto
  > leaves alone, edit the fromto to resize along its axis, or declare the geom
  > with an explicit size, pos and quat.`

* Docs: the `size` bullet in `set_geom_properties`, the `scene_ops` module
  summary, and a note in `persist_geom_properties` recording that what it writes
  is now what the next compile reproduces.

**Nothing that worked is narrowed.** The components a `fromto` leaves alone are
untouched: thickening the same capsule with `size=[0.09, 0.15]` is honored on
both trees and is durable, mass and inertia included (`8.550159 kg`, identical
before and after a recompile). That is why the refusal is per-component rather
than a blanket refusal of every resize on a `fromto` geom.

## Why this shape

The refusal sits beside the existing mesh / height-field / SDF refusal in the
same pre-flight block — the same "can this geom's extent be honored" decision,
with the same envelope — rather than in `persist_geom_properties`, which is
documented as spec-only and has no reason to read the compiled model.

Two mechanisms fix a component, so the mapping records which: the endpoints
(expected value = what the geom compiles to today) or the first component
(expected value = the caller's own first value). Collapsing them would have let
`size=[0.06, 0.03, 0.10]` on a `fromto` box through, which durably produces
`[0.06, 0.06, 0.10]` — a new instance of the defect being fixed. My own new test
caught that: the second mechanism is not in the MuJoCo `fromto` prose and only
shows up when the two cross-section components differ.

## Verification (Thor, MUJOCO_GL=egl, base `666a1363`)

* **Pre-fix** — `physics.py` reverted to `upstream/main`, tests kept:
  **10 failed / 19 passed**, e.g. `"Geom 'cap': size → [0.04, 0.3, 0.0]"` and
  `assert 'success' == 'error'`. The 6 new tests that pass pre-fix are the
  over-reach controls (the components a `fromto` leaves alone already worked) and
  the helper's own contract.
* **Full suite** — `MUJOCO_GL=egl pytest tests -q --no-cov -p no:randomly`:
  **28197 passed / 257 skipped / 0 failed** in 616s (28181 + 16 new cases), with
  no existing test changed.
* **Lint** — `ruff check` clean, `ruff format --check` clean (1175 files),
  `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`,
  **0 outside**, and the error set is byte-identical to a detached worktree of the
  same base — pre-existing and environmental.
* **Overlap** — `scripts/check_merge_base_overlap.py`: no overlap, 0 paths
  changed on `upstream/main` in that span; `compare` reports `behind_by=0`, so
  the tree these numbers describe is the merge result.

> **Note — no code change after the gate.** The verification above ran at `103374be`; the pushed head `a6b94441` differs from it only in the changelog fragment's filename (`2165-` → `2166-`, renamed to this PR's number once it was assigned). `scripts/assemble_changelog.py --check` and the two changelog guards were re-run after the rename.

## Round 2 - self-audit before first review

No review feedback yet; this is an author-initiated correctness pass on the diff
above, pushed as its own commit so the two concerns stay separable in the trail.

* **Dropped an unreachable bounds check in the refusal loop.**
  `_coerce_finite_vector` already fixes `size` at the geom type's exact component
  count (`accepted_lengths`) before the loop runs, so `index >= len(requested)`
  cannot hold for any component a `<fromto>` fixes - 1 of a capsule's or
  cylinder's 2, and 1 and 2 of a box's or ellipsoid's 3. It was dead code
  (convention 10), and worse, it read as though a short vector could arrive -
  contradicting the exact-count validation immediately above it, which exists
  precisely because a partial `size` used to mix the caller's components with the
  compiled ones. The proof now lives in the comment, in the same shape as the
  neighbouring note on why the `cast` is sound.
* **Pinned the invariant that proof rests on**, since it spans two tables that
  are edited apart (`_GEOM_SIZE_LAYOUTS` in `physics.py`,
  `fromto_fixed_size_components` in `scene_ops.py`) and neither one alone implies
  it: every fixed index, and every index a square cross-section copies from,
  falls inside the accepted count - and no fixed component copies one that is
  itself fixed, since then no `size` could satisfy the remedy the message names.

### Verification (this round)

* `tests/simulation/mujoco/test_runtime_setters_survive_recompile.py`:
  **30 passed** (29 + 1 new).
* **The new test is not vacuous** - two mutations of
  `fromto_fixed_size_components`, each failing with the message that names the
  defect:

  | mutation | result |
  |---|---|
  | capsule fixes component index 2 | `capsule fixes component 2 of an accepted 2` |
  | box's y copies z, itself fixed | `box component 1 copies a component that is fixed too` |

* `tests/simulation/mujoco/` against the merge base `666a1363`, same interpreter
  and flags, in a detached worktree: the failing-and-erroring node-id **set is
  identical** (128 ids, all GL-context failures in this GL-less runner - the
  Thor/EGL numbers above are the clean ones), and this branch adds **+17
  passes**, matching the 16 cases of round 1 plus the 1 above. So nothing here is
  introduced and nothing is masked.
* `ruff check` and `ruff format --check` clean on both touched files.

## Artifact

![fromto-fixed geom_size](https://raw.githubusercontent.com/cagataycali/robots/artifacts/fromto-fixed-geom-size/fromto-fixed-geom-size.png)

Six real headless renders of the same capsule, cropped to it; the black posts are
static geoms at ±0.30 m, the requested half-length. Top row is `upstream/main`:
as declared, after the call that reported success (visibly at the posts, while the
caption's mass and inertia are still the short capsule's), then after one
unrelated `add_object` — back to 0.15 m. Bottom row is this PR: the refusal is
byte-identical to the frame on its left, and the radius-only resize is still
honored and durable. Cropped pixels differing: 17.4% when `main` grew the capsule
and 17.4% again when it reverted, 0.0% for the refusal, 37.3% for the honored
radius change. Every caption and table cell is read back from the two JSON dumps
by `compose.py`, which fails if any claim drifts; the capture and compose scripts
are on the artifacts branch.

