### PR TITLE
test(simulation/mujoco): drive move_to on a body-framed end-effector

### DIFF
--- a/changelog.d/2168-move-to-body-frame-end-effector.md
+++ b/changelog.d/2168-move-to-body-frame-end-effector.md
@@ -1,0 +1,15 @@
+### Quality: drive `move_to` on a body-framed end-effector
+
+`move_to` auto-discovers its end-effector frame, and its docstring names three
+outcomes - a TCP-like site, else a hand/tool body, else the kinematic chain's
+tail. Two of the three are bodies, and the frame is reported to the caller
+(`frame`, `frame_type`, `ee_position`, `ee_orientation_wxyz`) as well as being
+where `position_error_m` - the value `reached` is decided on - is measured.
+
+Every arm in the motion-primitive suite declares a TCP site, so the primitive
+had only ever run on the site branch and the body arm of its pose readback was
+unexercised. Both body routes are now driven end to end against a real MuJoCo
+scene, and the readback is pinned to the body's frame origin rather than its
+inertial frame: mink optimizes the frame origin, so reading the inertial frame
+would leave the solver and the convergence check measuring different points.
+`_frame_world_pose` now documents which of the two body frames it reads.

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -439,6 +439,15 @@ class MotionPrimitivesMixin:
     ) -> tuple[np.ndarray, np.ndarray]:
         """World position + wxyz quaternion of a site/body frame from live data.
 
+        For ``frame_type="body"`` this reads the body's FRAME ORIGIN
+        (``data.xpos`` / ``data.xquat``), not its inertial/CoM frame
+        (``data.xipos``) - the two are distinct whenever the body's mass is not
+        centred on its origin. mink optimizes the frame origin, and
+        :meth:`move_to` decides ``reached`` by comparing this readback against
+        the same target the solver was given, so reading the inertial frame here
+        would leave the solver and the convergence check measuring points that
+        are metres-scale apart on some models and never converge.
+
         Callers must have run a kinematics pass so ``xpos``/``xmat`` are
         current, and must hold ``self._lock``.
         """

--- a/tests/simulation/mujoco/test_move_to_body_frame_end_effector.py
+++ b/tests/simulation/mujoco/test_move_to_body_frame_end_effector.py
@@ -1,0 +1,258 @@
+"""``move_to`` on a body-framed end-effector.
+
+``move_to`` does not take an EE frame: it auto-discovers one per robot namespace
+with :func:`strands_robots.simulation.ik.discover_ee_frame`, whose three
+documented outcomes its own docstring names - "TCP-like site, else hand/tool
+body, else the chain's leaf body". Two of those three are ``"body"``, and the
+frame is not an internal detail: the primitive reports ``frame`` /
+``frame_type`` / ``ee_position`` / ``ee_orientation_wxyz`` in its json payload,
+and measures ``position_error_m`` - the value the ``reached`` flag is decided
+on - at that frame every control tick.
+
+The discovery function is pinned exhaustively, all three branches, by
+``tests/policies/vera/test_ee_frame_discovery.py``. Its consumer was not: every
+arm in the motion-primitive suite declares an ``ee_site``, so ``move_to`` had
+only ever run on the site branch, and the one ``frame_type`` assertion in the
+tree pins ``"site"``. The body arm of the readback - both discovery routes that
+reach it, the pose it reports and the convergence decision it drives - had never
+executed.
+
+The distinction that matters is which body frame is read. MuJoCo carries two per
+body: the frame origin (``xpos``/``xquat``) and the inertial/CoM frame
+(``xipos``), and on the arm below they are 25 mm apart. mink optimizes the frame
+origin, so reading ``xipos`` would leave the solver and the convergence check
+measuring points 25 mm apart - and with the documented default ``tol`` of 10 mm
+a perfectly solved target could then never converge, reporting a servo timeout
+for a pose that had already arrived. That agreement is pinned here directly.
+
+The arm mirrors the shared ``ARM_XML`` kinematics with the TCP site and the jaw
+removed, because a site-less model is what routes discovery to a body at all.
+Its tip carries a ``fromto`` capsule, so the frame origin and the inertial frame
+are genuinely distinct rather than coincident. Two names for one physical body
+give the two body routes: ``hand`` matches a body hint, ``link4`` matches none
+and is found as the chain tail.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("mink")
+
+from strands_robots.simulation.ik import discover_ee_frame  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_motion_primitives import ARM_XML, REACHABLE  # noqa: E402
+
+# ARM_XML's kinematics without the TCP site and without the jaw. ``{tip}`` names
+# the tool-mount body: "hand" matches ``_BODY_HINTS``, "link4" matches nothing
+# and is reached as the kinematic chain's tail. The tip geom is a ``fromto``
+# capsule, so its inertial frame sits 25 mm from the body origin.
+_BODY_ARM_TEMPLATE = """
+<mujoco model="body_frame_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+    <geom density="2000"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+        <body name="link2" pos="0 0 0.2">
+          <joint name="shoulder_lift" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/>
+          <body name="link3" pos="0.15 0 0">
+            <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+            <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.018"/>
+            <body name="{tip}" pos="0.15 0 0">
+              <joint name="wrist_roll" type="hinge" axis="1 0 0" range="-3.0 3.0"/>
+              <geom type="capsule" fromto="0 0 0 0.05 0 0" size="0.015"/>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan" joint="shoulder_pan" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="shoulder_lift" joint="shoulder_lift" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="elbow" joint="elbow" kp="20" dampratio="1" ctrlrange="-3.14 3.14"/>
+    <position name="wrist_roll" joint="wrist_roll" kp="5" dampratio="1" ctrlrange="-3.0 3.0"/>
+  </actuator>
+</mujoco>
+"""
+
+# ``tol`` is looser than the residual this 4-DOF arm leaves on ``REACHABLE`` so
+# ``move_to`` enters its servo loop instead of refusing the target up front.
+_TOL = 0.02
+_MAX_STEPS = 400
+
+
+def _arm_xml(tip: str) -> str:
+    """The site-less arm with ``tip`` naming its tool-mount body."""
+    xml = _BODY_ARM_TEMPLATE.format(tip=tip)
+    assert "<site" not in xml, "a TCP site would route discovery to the site branch"
+    return xml
+
+
+def _sim_with(tmp_path: Any, tip: str) -> Any:
+    """A world holding the site-less arm under the ``arm/`` namespace."""
+    path = tmp_path / f"{tip}_arm.xml"
+    path.write_text(_arm_xml(tip))
+    sim = Simulation(backend="mujoco", mesh=False)
+    assert sim.create_world()["status"] == "success"
+    added = sim.add_robot(name="arm", urdf_path=str(path))
+    assert added["status"] == "success", added
+    return sim
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    """The primitive's structured payload."""
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+def _reach(sim: Any) -> dict[str, Any]:
+    """Drive ``move_to`` to ``REACHABLE`` and return its payload."""
+    result = sim.move_to(robot_name="arm", position=REACHABLE, tol=_TOL, max_steps=_MAX_STEPS)
+    assert result["status"] == "success", result
+    return _json_block(result)
+
+
+@pytest.fixture
+def hand_body_sim(tmp_path):
+    """Arm whose tool-mount body matches a body hint (discovery route 2)."""
+    sim = _sim_with(tmp_path, "hand")
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+@pytest.fixture
+def leaf_body_sim(tmp_path):
+    """Arm whose tool-mount body matches no hint (discovery route 3)."""
+    sim = _sim_with(tmp_path, "link4")
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+class TestTheShippedArmOnlyEverExercisedTheSiteRoute:
+    """Why the body arm of the readback had no coverage.
+
+    Not a contract on ``move_to`` - a premise about the suite. If the shared arm
+    stopped resolving a site these tests would be measuring the same route as
+    every other primitive test, so the gap they close is asserted rather than
+    assumed.
+    """
+
+    def test_the_shared_arm_resolves_a_site(self, tmp_path):
+        sim = _sim_with(tmp_path, "hand")
+        try:
+            path = tmp_path / "shared_arm.xml"
+            path.write_text(ARM_XML)
+            assert sim.add_robot(name="shared", urdf_path=str(path))["status"] == "success"
+            assert discover_ee_frame(sim._world._model, "shared/") == ("shared/ee_site", "site")
+        finally:
+            sim.cleanup()
+
+    def test_the_body_framed_arm_declares_no_site(self, tmp_path):
+        sim = _sim_with(tmp_path, "hand")
+        try:
+            assert int(sim._world._model.nsite) == 0
+        finally:
+            sim.cleanup()
+
+
+class TestMoveToTracksTheDiscoveredBodyFrame:
+    """Both documented body routes reach the target and report the frame used."""
+
+    def test_the_body_hint_route_reaches_and_reports_its_frame(self, hand_body_sim):
+        payload = _reach(hand_body_sim)
+        assert payload["reached"] is True
+        assert payload["position_error_m"] <= _TOL
+        assert payload["frame"] == "arm/hand"
+        assert payload["frame_type"] == "body"
+
+    def test_the_chain_tail_route_reaches_and_reports_its_frame(self, leaf_body_sim):
+        payload = _reach(leaf_body_sim)
+        assert payload["reached"] is True
+        assert payload["position_error_m"] <= _TOL
+        assert payload["frame"] == "arm/link4"
+        assert payload["frame_type"] == "body"
+
+    def test_both_routes_resolve_one_physical_frame(self, hand_body_sim, leaf_body_sim):
+        """Same kinematics, same tool-mount body, two names - so one answer.
+
+        The two arms differ only in the tip body's name, which is what selects
+        the discovery route. A route that resolved a different body would report
+        a different pose for an identical scene.
+        """
+        hand, leaf = _reach(hand_body_sim), _reach(leaf_body_sim)
+        assert hand["frame"] != leaf["frame"], "the two arms must exercise different names"
+        assert hand["ee_position"] == pytest.approx(leaf["ee_position"])
+        assert hand["position_error_m"] == pytest.approx(leaf["position_error_m"])
+
+
+class TestTheReportedPoseIsTheBodyFrameNotTheInertialFrame:
+    """MuJoCo carries two frames per body; the reported one is the frame origin."""
+
+    def test_the_arm_distinguishes_the_two_frames(self, hand_body_sim):
+        """Premise: without an inertial offset the next two tests are vacuous."""
+        _reach(hand_body_sim)
+        data = hand_body_sim._world._data
+        bid = _body_id(hand_body_sim, "arm/hand")
+        offset = float(np.linalg.norm(np.asarray(data.xipos[bid]) - np.asarray(data.xpos[bid])))
+        assert offset > 0.02, f"tip inertial frame only {offset:.4f} m from its origin"
+
+    def test_reported_position_is_the_frame_origin(self, hand_body_sim):
+        payload = _reach(hand_body_sim)
+        data = hand_body_sim._world._data
+        bid = _body_id(hand_body_sim, "arm/hand")
+        assert payload["ee_position"] == pytest.approx(list(np.asarray(data.xpos[bid], dtype=float)))
+        assert payload["ee_position"] != pytest.approx(list(np.asarray(data.xipos[bid], dtype=float)))
+
+    def test_reported_orientation_is_the_frame_quaternion(self, hand_body_sim):
+        payload = _reach(hand_body_sim)
+        data = hand_body_sim._world._data
+        bid = _body_id(hand_body_sim, "arm/hand")
+        assert payload["ee_orientation_wxyz"] == pytest.approx(list(np.asarray(data.xquat[bid], dtype=float)))
+
+
+class TestTheSolverAndTheConvergenceCheckShareOneFrame:
+    """The frame the IK optimizes is the frame ``reached`` is decided at."""
+
+    def test_position_error_is_measured_at_the_reported_frame(self, hand_body_sim):
+        payload = _reach(hand_body_sim)
+        expected = float(np.linalg.norm(np.asarray(payload["ee_position"]) - np.asarray(REACHABLE, dtype=float)))
+        assert payload["position_error_m"] == pytest.approx(expected)
+
+    def test_the_ik_bridge_reads_the_same_frame_back(self, hand_body_sim):
+        """mink's forward pose for the settled configuration is the reported one.
+
+        A readback of a different frame of the same body would leave the solver
+        optimizing one point and the servo measuring another.
+        """
+        from strands_robots.simulation.ik import MinkIKBridge
+
+        payload = _reach(hand_body_sim)
+        model, data = hand_body_sim._world._model, hand_body_sim._world._data
+        bridge = MinkIKBridge(model, payload["frame"], payload["frame_type"])
+        pose = bridge.ee_pose(np.array(data.qpos, dtype=np.float64, copy=True))
+        assert list(pose[:3, 3]) == pytest.approx(payload["ee_position"])
+
+
+def _body_id(sim: Any, name: str) -> int:
+    """Compiled body index for ``name``."""
+    import mujoco as mj
+
+    bid = int(mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, name))
+    assert bid >= 0, f"body {name!r} not in the compiled model"
+    return bid


### PR DESCRIPTION
## Problem

`move_to` does not take an end-effector frame. It auto-discovers one per robot
namespace with `discover_ee_frame`, whose three outcomes its own docstring names:

> The end-effector frame is auto-discovered per robot namespace
> (`discover_ee_frame`: TCP-like site, else hand/tool body, else the chain's leaf body)

Two of those three are bodies, and the frame is not an internal detail. The
primitive reports `frame`, `frame_type`, `ee_position` and `ee_orientation_wxyz`
in its json payload, and measures `position_error_m` — the value `reached` is
decided on — at that frame on **every control tick**.

`discover_ee_frame` is pinned exhaustively, all three branches, by
`tests/policies/vera/test_ee_frame_discovery.py` (11 assertions). Its consumer
was not. Every arm in the motion-primitive suite declares an `ee_site`, so
`move_to` had only ever run on the site branch, and the single `frame_type`
assertion in the tree pins `"site"`:

```python
# tests/simulation/mujoco/test_motion_primitives.py
assert payload["frame_type"] == "site"
```

So the body arm of `_frame_world_pose` — both discovery routes that reach it, the
pose it reports, and the convergence decision it drives — had never executed.

## Why the body arm is worth pinning rather than line-chasing

MuJoCo carries two frames per body: the frame origin (`xpos` / `xquat`) and the
inertial/CoM frame (`xipos`). They differ whenever a body's mass is not centred
on its origin. mink optimizes the frame **origin**, so the readback has to match
it — otherwise the solver and the convergence check measure different points.

Measured on the arm added here, where the two frames are 25 mm apart:

| measured at | error vs the target | outcome |
|---|---|---|
| the body frame origin (what is reported) | **19.74 mm** | ≤ tol 20 mm → `reached` |
| the inertial frame of the same body | **42.50 mm** | 2.1× tol → **never converges** |

mink's forward pose for the settled configuration agrees with the frame origin to
**0.00 mm** and differs from the inertial frame by 20.54 mm. Under the documented
default `tol` of 10 mm, a readback of the wrong body frame would report a servo
timeout for a pose that had already arrived.

## Change

One new test module, `tests/simulation/mujoco/test_move_to_body_frame_end_effector.py`
(10 tests), on a real MuJoCo scene — no asset downloads:

- **premise** — the shared arm resolves a site, and the new arm declares none, so
  the gap being closed is asserted rather than assumed;
- **both body routes end to end** — a body-hint tip (`arm/hand`) and a chain-tail
  tip (`arm/link4`) each reach the target and report their own `frame` /
  `frame_type`. The two arms are identical geometry differing only in the tip
  body's name, which is what selects the route, so they must report one answer;
- **which body frame** — `ee_position` is the frame origin and not the inertial
  frame, `ee_orientation_wxyz` is the frame quaternion, with a premise test that
  the arm's two frames are genuinely distinct so neither assertion is vacuous;
- **one frame for solver and servo** — `position_error_m` equals
  `‖ee_position − target‖`, and mink's forward pose for the settled configuration
  is the reported position.

`_frame_world_pose` gains a docstring paragraph naming which of the two body
frames it reads and why. Docstring only: the AST with docstrings stripped is
byte-identical (`793be4a083be6e6e` before and after), so no executable line
changes and no library behaviour changes.

## Regressions this catches

Because the production code is correct, the new tests pass on unmodified `main`;
what they fail on is a regression. Each was applied to
`motion_primitives.py` with an AST-scoped anchor (`in_fn=1`, `in_file=1` for all
five) and reverted byte-identically:

| mutation | new module | 161 pre-existing motion-primitive tests |
|---|---|---|
| M1 body position reads the inertial frame (`xipos`) | 8 failed | **0 failed** |
| M2 body quaternion reports identity | 1 failed | **0 failed** |
| M3 readback assumes a site frame | 8 failed | **0 failed** |
| M4 IK bridge built on a hardcoded site frame | 8 failed | **0 failed** |
| M5 payload reports a hardcoded `frame_type` | 3 failed | **0 failed** |

All five are invisible to the suite as it stands.

## Coverage

`motion_primitives.py` 19 → 17 missing lines, 95.2% → 95.8%; repository total
1821 → 1819. The two lines closed are exactly the body arm of
`_frame_world_pose`. (In the after-list every line below the new docstring shifts
by +9, e.g. `569 → 578` — the only lines that disappear are the two targeted.)

## Visual artifact

Headless MuJoCo (`MUJOCO_GL=egl`). Panels 1–2 are real renders of the scene the
new tests drive; panel 3 zooms the tool-mount body so the 25 mm between the two
candidate frames is visible. Every number printed in the figure is re-derived
from the capture dump and asserted before the figure is written.

![move_to on a body-framed end-effector](https://raw.githubusercontent.com/cagataycali/robots/artifacts/move-to-body-frame/move-to-body-frame.png)

Capture and compose scripts, the raw renders, the measurement dump and the
mutation scripts: [`artifacts/move-to-body-frame`](https://github.com/cagataycali/robots/tree/artifacts/move-to-body-frame).

## Gate

Verified at `06e62df` on base `666a1363`, headless EGL:

- `MUJOCO_GL=egl python -m pytest tests` — **28191 passed, 257 skipped, 0 failed**
  (731.78s). Base is 28181, so the delta is exactly the 10 new tests.
- `ruff check strands_robots tests tests_integ` — clean; `ruff format --check` —
  1176 files already formatted.
- `mypy strands_robots tests tests_integ` — 14 errors, all in `examples/isaac_gs`,
  0 outside it. Error set is byte-identical to a pristine `666a1363` worktree
  control (environment-only, not introduced here).
- `scripts/check_merge_base_overlap.py` — no overlap; `upstream/main` is unchanged
  at `666a1363`, so the gate above describes the tree that merges.

## Out of scope

The other uncovered lines in `move_to` are separate contracts, each with its own
fixture needs: the three refusals (no frame discovered, no joint-transmission
actuators, every actuated joint classified as a gripper), the keyframe restart
seed, and the servo-timeout return. None is about which frame the primitive
tracks.
