### PR TITLE
fix(policies/cosmos3): report which tensors a too-old diffusers could not fill

### DIFF
--- a/changelog.d/2169-cosmos3-diffusers-checkpoint-mismatch.md
+++ b/changelog.d/2169-cosmos3-diffusers-checkpoint-mismatch.md
@@ -1,0 +1,32 @@
+### Fixed: report which tensors a too-old diffusers could not fill for a Cosmos 3 checkpoint
+
+`Cosmos3Policy(backend="diffusers")` now refuses a checkpoint the installed
+`diffusers` cannot build, instead of letting it through on randomly initialized
+weights. `Cosmos3OmniPipeline.from_pretrained` does not raise on an architecture
+mismatch - it logs "newly initialized" warnings and leaves the unmatched
+parameters on the `meta` device - so with `nvidia/Cosmos3-Edge` (built against
+diffusers 0.40.0.dev0) on diffusers 0.39.0, 112 of 633 transformer parameters
+were left unfilled and the only symptom was a bare
+`NotImplementedError: Cannot copy out of meta tensor` from the following device
+copy, naming neither diffusers, nor its version, nor the checkpoint. The
+backend's one actionable remedy was reachable only through `ImportError`, which
+that state never raises. The load now reports the checkpoint, the installed
+diffusers, the unfilled tensors and the upgrade command, and reports it before
+the device copy - so the silent case, where the copy happens to succeed, is
+caught too.
+
+Packaging on the same axis. `Cosmos3OmniPipeline` and `CosmosActionCondition`
+first ship in diffusers 0.39.0 (0.36.0, 0.37.1 and 0.38.0 carry neither), so:
+
+- the `cosmos3-diffusers` extra's floor moves `>=0.30` -> `>=0.39`;
+- the `[tool.uv]` diffusers override moves `>=0.38.0` -> `>=0.39`. A uv override
+  *replaces* a requirement rather than intersecting with it, so at `>=0.38.0` it
+  silently discarded the extra's floor and `uv.lock` pinned diffusers 0.38.0 - a
+  release carrying no `Cosmos3OmniPipeline` at all. 0.39 clears both the CVE
+  floor the override exists for (fixed in 0.38.0) and the capability floor;
+- `uv.lock` now resolves diffusers 0.39.0;
+- the install hint no longer claims the pipeline is source-only.
+
+`nvidia/Cosmos3-Nano` loads cleanly on diffusers 0.39.0 and 0.40.0.dev0 alike, so
+the required diffusers is a property of the checkpoint rather than of the library:
+that is why a version range cannot express it and the load reports it instead.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -60,13 +60,25 @@ Cosmos3Policy can run Cosmos 3 two ways. The default is unchanged.
 | backend | how it runs | install | extra outputs |
 |---------|-------------|---------|---------------|
 | `service` (default) | WebSocket to the Cosmos Framework RoboLab policy server (holds the GPU out-of-process) | `strands-robots[cosmos3-service]` (msgpack + websockets, numpy-agnostic) | none (server video discarded) |
-| `diffusers` | in-process via native `diffusers` (`Cosmos3OmniPipeline`) | `strands-robots[cosmos3-diffusers]` + diffusers-from-source | world video + sound on `last_rollout` |
+| `diffusers` | in-process via native `diffusers` (`Cosmos3OmniPipeline`) | `strands-robots[cosmos3-diffusers]` (floors diffusers 0.39, the first release shipping the pipeline) | world video + sound on `last_rollout` |
 
 ```bash
 # in-process backend (heavy GPU stack: diffusers + torch)
-uv pip install "strands-robots[cosmos3-diffusers]" \
-    'diffusers @ git+https://github.com/huggingface/diffusers'
+uv pip install "strands-robots[cosmos3-diffusers]"
 ```
+
+`Cosmos3OmniPipeline` and `CosmosActionCondition` first ship in diffusers 0.39.0,
+which the extra floors. A checkpoint newer than that floor can need a newer
+diffusers still - `nvidia/Cosmos3-Edge` is built against 0.40.0.dev0, which at the
+time of writing ships only from source:
+
+```bash
+uv pip install 'diffusers @ git+https://github.com/huggingface/diffusers'
+```
+
+Loading a checkpoint the installed diffusers cannot build is refused, naming the
+tensors it could not fill - `from_pretrained` itself only warns and leaves them
+uninitialized, so without that check the pipeline would run on random weights.
 
 The `cosmos3-diffusers` extra is native `diffusers` + `torch` + `transformers`
 (no extra wrapper package). It composes with `numpy>=2` (and therefore with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,13 +66,15 @@ cosmos3-service = [
 # unaffected. diffusers composes with numpy>=2, so this extra is co-installable
 # with cosmos3-service and lerobot.
 #
-# Cosmos3OmniPipeline ships only in diffusers-from-source (>0.38); the version
-# floor here is a lower bound, but install the git pin alongside this extra to
-# get the Cosmos3OmniPipeline + CosmosActionCondition symbols:
-#   uv pip install strands-robots[cosmos3-diffusers] \
-#       'diffusers @ git+https://github.com/huggingface/diffusers'
+# The floor is the CAPABILITY floor, not a nominal lower bound: measured against
+# the released wheels, Cosmos3OmniPipeline + CosmosActionCondition first ship in
+# diffusers 0.39.0 (0.36.0/0.37.1/0.38.0 carry neither symbol), so any floor below
+# it resolves to a diffusers that cannot build the pipeline at all. A checkpoint
+# newer than the floor can still need a newer diffusers than it (Cosmos3-Edge is
+# built against 0.40.0.dev0); that is a per-checkpoint fact a version range cannot
+# express, so Cosmos3DiffusersBackend reports it at load time instead.
 cosmos3-diffusers = [
-    "diffusers>=0.30",
+    "diffusers>=0.39",
     "torch>=2.0",
     "transformers>=4.40",
     "accelerate>=0.26",
@@ -517,12 +519,16 @@ constraint-dependencies = [
     "pyopenssl>=26.0.0",
 ]
 override-dependencies = [
-    # SECURITY: diffusers <0.36 is vulnerable to a GHSA trust_remote_code bypass
-    # + a TOCTOU RCE (fixed in 0.38.0). diffusers is only exercised by the
-    # cosmos3-diffusers extra (Cosmos3Policy backend="diffusers"); lerobot core
-    # does not import it at runtime, so forcing >=0.38 is safe and clears the
-    # Dependabot alerts.
-    "diffusers>=0.38.0",
+        # SECURITY + CAPABILITY: diffusers <0.36 is vulnerable to a GHSA
+    # trust_remote_code bypass + a TOCTOU RCE (fixed in 0.38.0). uv *overrides*
+    # replace a requirement rather than intersecting with it, so this pin is the
+    # effective floor for the whole resolution and must not fall below the
+    # cosmos3-diffusers extra's own floor - at 0.38.0 it silently discarded that
+    # floor and locked a diffusers carrying no Cosmos3OmniPipeline. 0.39 clears
+    # both bounds (the CVE fix landed in 0.38.0; the pipeline first ships in
+    # 0.39.0). diffusers is only exercised by the cosmos3-diffusers extra
+    # (Cosmos3Policy backend="diffusers"); lerobot core does not import it.
+    "diffusers>=0.39",
 ]
 
 # Auto-select the right PyTorch wheel for the host accelerator. On NVIDIA

--- a/strands_robots/policies/cosmos3/policy_diffusers.py
+++ b/strands_robots/policies/cosmos3/policy_diffusers.py
@@ -43,6 +43,7 @@ co-installable with ``cosmos3-service`` and ``lerobot``.
 from __future__ import annotations
 
 import logging
+from importlib import metadata as _metadata
 from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
@@ -60,6 +61,66 @@ ALL_MODES = ("policy", "forward_dynamics", "inverse_dynamics")
 _DEFAULT_MODEL = "nvidia/Cosmos3-Nano"
 
 
+def _unloaded_checkpoint_tensors(pipe: Any) -> list[str]:
+    """Pipeline parameters the checkpoint load left on the ``meta`` device.
+
+    ``Cosmos3OmniPipeline.from_pretrained`` does **not** raise when the
+    installed ``diffusers`` builds a different architecture than the checkpoint
+    holds: it logs "newly initialized" / "not used when initializing" warnings
+    and leaves every unmatched parameter on the ``meta`` device (no data). A
+    non-empty result therefore means the pipeline is carrying randomly
+    initialized weights, whatever ``from_pretrained`` returned.
+
+    Only parameters are scanned: a mismatched Cosmos 3 load leaves unmatched
+    *parameters* on meta and no buffers, so a buffer scan would add no signal.
+    Non-module components (the tokenizer, the scheduler, ``None`` slots) have no
+    ``named_parameters`` and are skipped.
+
+    Args:
+        pipe: A loaded ``Cosmos3OmniPipeline`` (anything exposing ``.components``).
+
+    Returns:
+        ``"<component>.<parameter>"`` names still on the meta device, in
+        iteration order (empty when the checkpoint was fully consumed).
+    """
+    components = getattr(pipe, "components", None)
+    if not isinstance(components, dict):
+        return []
+    unloaded: list[str] = []
+    for component_name, component in components.items():
+        named_parameters = getattr(component, "named_parameters", None)
+        if not callable(named_parameters):
+            continue
+        for parameter_name, parameter in named_parameters():
+            if getattr(getattr(parameter, "device", None), "type", None) == "meta":
+                unloaded.append(f"{component_name}.{parameter_name}")
+    return unloaded
+
+
+def _checkpoint_mismatch_hint(model: str, unloaded: list[str]) -> str:
+    """Actionable message when the installed diffusers cannot load ``model``.
+
+    Names the checkpoint, the installed diffusers, how many tensors were left
+    uninitialized, and the version the checkpoint asks for - so the caller is
+    not left with ``diffusers``' bare
+    ``NotImplementedError: Cannot copy out of meta tensor``, which names none of
+    them.
+    """
+    try:
+        installed = _metadata.version("diffusers")
+    except Exception:  # pragma: no cover - metadata is present wherever diffusers is
+        installed = "unknown"
+    return (
+        f"Cosmos 3 checkpoint {model!r} was not fully loaded by the installed diffusers "
+        f"({installed}): {len(unloaded)} tensor(s) were left uninitialized on the meta "
+        f"device (e.g. {unloaded[:3]}), so the pipeline would run on randomly initialized "
+        f"weights. Install a diffusers that supports this checkpoint:\n"
+        "  uv pip install 'diffusers @ git+https://github.com/huggingface/diffusers'\n"
+        "Then retry. Or pick a checkpoint the installed diffusers supports, or run the "
+        "model out-of-process: Cosmos3Policy(backend='service', host=..., port=...)."
+    )
+
+
 class _PipelineCallable(Protocol):
     """Minimal structural type for the injectable Cosmos3OmniPipeline."""
 
@@ -72,10 +133,11 @@ def _install_hint() -> str:
     return (
         "Cosmos3Policy(backend='diffusers') needs the optional native 'diffusers' "
         "stack (diffusers + torch + transformers), which was not importable. "
-        "Cosmos3OmniPipeline ships only in diffusers-from-source (>0.38), so install "
-        "the git pin alongside the extra:\n"
-        "  uv pip install strands-robots[cosmos3-diffusers] "
-        "'diffusers @ git+https://github.com/huggingface/diffusers'\n"
+        "Cosmos3OmniPipeline first ships in diffusers 0.39.0, which the "
+        "'cosmos3-diffusers' extra floors:\n"
+        "  uv pip install strands-robots[cosmos3-diffusers]\n"
+        "A newer checkpoint can need a newer diffusers than that floor; when one "
+        "does, the load reports which tensors it could not fill.\n"
         "Then retry. Or use the service backend (no in-process GPU load): "
         "Cosmos3Policy(backend='service', host=..., port=...)."
     )
@@ -203,6 +265,14 @@ class Cosmos3DiffusersBackend:
         if not self.enable_safety_checker:
             from_pretrained_kwargs["enable_safety_checker"] = False
         pipe = Cosmos3OmniPipeline.from_pretrained(self.model, **from_pretrained_kwargs)
+        # ``from_pretrained`` returns successfully even when the installed diffusers
+        # builds a different architecture than the checkpoint holds - it only warns and
+        # leaves the unmatched weights on the meta device. Refuse here, before the
+        # device copy, so the caller gets the upgrade instruction rather than either
+        # randomly initialized weights or diffusers' bare meta-tensor NotImplementedError.
+        unloaded = _unloaded_checkpoint_tensors(pipe)
+        if unloaded:
+            raise RuntimeError(_checkpoint_mismatch_hint(self.model, unloaded))
         pipe = pipe.to(device)
         self.device = device
         return pipe

--- a/tests/policies/cosmos3/test_diffusers_checkpoint_mismatch.py
+++ b/tests/policies/cosmos3/test_diffusers_checkpoint_mismatch.py
@@ -1,0 +1,219 @@
+"""``Cosmos3DiffusersBackend`` refuses a checkpoint the installed diffusers cannot build.
+
+``Cosmos3OmniPipeline.from_pretrained`` does not raise when the installed
+``diffusers`` builds a different architecture than the checkpoint holds: it logs
+"newly initialized" / "not used when initializing" warnings and leaves every
+unmatched parameter on the ``meta`` device. Measured against the released wheels
+with ``nvidia/Cosmos3-Edge`` (built against diffusers 0.40.0.dev0):
+
+* diffusers 0.39.0 - ``from_pretrained`` returns a pipeline with 112 of 633
+  transformer parameters still on ``meta``; the only symptom was
+  ``NotImplementedError: Cannot copy out of meta tensor`` out of the *next*
+  statement, naming neither diffusers, nor its version, nor the checkpoint.
+* diffusers 0.40.0.dev0 - 0 of 549 on ``meta``, loads and runs.
+
+``nvidia/Cosmos3-Nano`` loads cleanly on both, so the required diffusers is a
+property of the checkpoint rather than of the library, which is why this is
+reported at load time instead of pinned as a version range.
+
+The module's ``_install_hint`` covers only the ImportError path; on a diffusers
+that *has* the symbol but is too old for the checkpoint the import succeeds, so
+that remedy was unreachable on exactly the state it exists for. These pin the
+refusal, its placement (before the device copy, so the failure costs no 9 GB
+transfer and the silent-random-weights case is caught too), and that a healthy
+load is untouched.
+
+No GPU and no weights: the pipeline is injected through the ``sys.modules``
+seam the safety-checker tests use, and a parameter stand-in only needs a
+``.device.type``, so the matrix runs with neither torch nor diffusers installed.
+"""
+
+import sys
+import types
+
+import pytest
+
+from strands_robots.policies.cosmos3 import Cosmos3DiffusersBackend
+from strands_robots.policies.cosmos3.embodiments import get_embodiment
+from strands_robots.policies.cosmos3.policy_diffusers import (
+    _checkpoint_mismatch_hint,
+    _unloaded_checkpoint_tensors,
+)
+
+
+def _param(device_type):
+    """A stand-in for a torch parameter: the scan reads only ``.device.type``."""
+    return types.SimpleNamespace(device=types.SimpleNamespace(type=device_type))
+
+
+class FakeModule:
+    """A pipeline component exposing ``named_parameters`` like ``torch.nn.Module``."""
+
+    def __init__(self, **params):
+        self._params = params
+
+    def named_parameters(self):
+        return list(self._params.items())
+
+
+class FakePipe:
+    """A ``Cosmos3OmniPipeline`` stand-in: a ``components`` dict plus ``to``."""
+
+    def __init__(self, components):
+        self.components = components
+        self.to_calls = []
+
+    def to(self, device):
+        self.to_calls.append(device)
+        return self
+
+
+def _loaded_pipe():
+    """Every parameter on a real device: the checkpoint was fully consumed."""
+    return FakePipe(
+        {
+            "transformer": FakeModule(**{"layers.0.norm_q.weight": _param("cpu")}),
+            "vae": FakeModule(**{"encoder.conv.weight": _param("cpu")}),
+        }
+    )
+
+
+def _mismatched_pipe():
+    """Two transformer parameters left on ``meta`` - the 0.39.0-with-Edge shape."""
+    return FakePipe(
+        {
+            "transformer": FakeModule(
+                **{
+                    "layers.0.self_attn.norm_q.weight": _param("meta"),
+                    "layers.0.mlp.gate_proj.weight": _param("meta"),
+                    "layers.0.self_attn.q_proj.weight": _param("cpu"),
+                }
+            ),
+            "vae": FakeModule(**{"encoder.conv.weight": _param("cpu")}),
+        }
+    )
+
+
+def _install_fake_diffusers(monkeypatch, pipe):
+    """Point ``from diffusers import Cosmos3OmniPipeline`` at ``pipe``."""
+
+    class FakeOmniPipeline:
+        @classmethod
+        def from_pretrained(cls, model, **kwargs):
+            return pipe
+
+    fake = types.ModuleType("diffusers")
+    fake.Cosmos3OmniPipeline = FakeOmniPipeline
+    fake.CosmosActionCondition = object
+    monkeypatch.setitem(sys.modules, "diffusers", fake)
+
+
+class TestUnloadedCheckpointTensors:
+    """The scan is an exact test of "did the load consume the checkpoint"."""
+
+    def test_names_every_parameter_left_on_meta(self):
+        assert _unloaded_checkpoint_tensors(_mismatched_pipe()) == [
+            "transformer.layers.0.self_attn.norm_q.weight",
+            "transformer.layers.0.mlp.gate_proj.weight",
+        ]
+
+    def test_a_fully_loaded_pipeline_reports_nothing(self):
+        assert _unloaded_checkpoint_tensors(_loaded_pipe()) == []
+
+    def test_non_module_components_are_skipped_not_crashed(self):
+        """A real pipeline's ``components`` holds a tokenizer, a scheduler and
+        ``None`` slots alongside the modules; none has ``named_parameters``."""
+        pipe = FakePipe(
+            {
+                "text_tokenizer": object(),
+                "scheduler": object(),
+                "sound_tokenizer": None,
+                "safety_checker": None,
+                "transformer": FakeModule(**{"w": _param("meta")}),
+            }
+        )
+        assert _unloaded_checkpoint_tensors(pipe) == ["transformer.w"]
+
+    def test_a_pipeline_without_a_components_mapping_reports_nothing(self):
+        assert _unloaded_checkpoint_tensors(types.SimpleNamespace()) == []
+
+
+class TestTheRefusalIsActionable:
+    """The message must name what diffusers' own error does not."""
+
+    def test_names_the_checkpoint_the_version_the_count_and_the_remedy(self):
+        text = _checkpoint_mismatch_hint("nvidia/Cosmos3-Edge", ["transformer.a", "transformer.b"])
+        assert "nvidia/Cosmos3-Edge" in text
+        assert "2 tensor(s)" in text
+        assert "transformer.a" in text
+        assert "diffusers" in text
+        assert "git+https://github.com/huggingface/diffusers" in text
+        assert "backend='service'" in text
+
+    def test_says_why_it_matters_rather_than_only_that_it_failed(self):
+        text = _checkpoint_mismatch_hint("m", ["t.a"])
+        assert "randomly initialized" in text
+
+
+class TestLoadPipelineRefusesAMismatchedCheckpoint:
+    """The refusal must precede the device copy, and spare a healthy load."""
+
+    def test_refuses_and_names_the_unfilled_tensors(self, monkeypatch):
+        pipe = _mismatched_pipe()
+        _install_fake_diffusers(monkeypatch, pipe)
+        with pytest.raises(RuntimeError, match="was not fully loaded"):
+            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), model="nvidia/Cosmos3-Edge", device="cpu")
+
+    def test_the_refusal_precedes_the_device_copy(self, monkeypatch):
+        """``pipe.to(device)`` moves the whole checkpoint (9 GB for Cosmos3-Edge)
+        and is where diffusers' bare meta-tensor error surfaced; refusing first
+        also catches the case where the copy happens to succeed on random weights.
+        """
+        pipe = _mismatched_pipe()
+        _install_fake_diffusers(monkeypatch, pipe)
+        with pytest.raises(RuntimeError):
+            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu")
+        assert pipe.to_calls == [], "a refused load must not copy the checkpoint to the device"
+
+    def test_a_fully_loaded_checkpoint_still_reaches_the_device(self, monkeypatch):
+        """Non-vacuity: the guard must not refuse the supported checkpoints
+        (``nvidia/Cosmos3-Nano`` loads with 0 meta parameters on both versions)."""
+        pipe = _loaded_pipe()
+        _install_fake_diffusers(monkeypatch, pipe)
+        backend = Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu")
+        assert pipe.to_calls == ["cpu"]
+        assert backend._pipeline is pipe
+
+
+class TestTheInstallHintNoLongerClaimsSourceOnly:
+    """``Cosmos3OmniPipeline`` first shipped in diffusers 0.39.0, a PyPI release,
+    so the ImportError remedy must not tell callers the symbol is source-only."""
+
+    def test_the_import_error_hint_names_the_extra_and_not_a_source_only_claim(self, monkeypatch):
+        import strands_robots.policies.cosmos3.policy_diffusers as pd
+
+        monkeypatch.setitem(sys.modules, "diffusers", None)
+        with pytest.raises(ImportError) as excinfo:
+            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu")
+        text = str(excinfo.value)
+        assert "strands-robots[cosmos3-diffusers]" in text
+        assert "0.39.0" in text
+        assert "ships only in diffusers-from-source" not in text
+        assert "_checkpoint_mismatch_hint" not in text, "a caller-facing hint must not name a private symbol"
+        assert pd._install_hint() == text
+
+
+class TestTheScanMatchesRealTorchSemantics:
+    """The stand-in reads ``.device.type``; pin that a real torch meta parameter
+    presents the same way, so the fakes above are not a private convention."""
+
+    def test_a_real_meta_parameter_is_detected(self):
+        torch = pytest.importorskip("torch")
+
+        class TorchModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.on_meta = torch.nn.Parameter(torch.empty(2, device="meta"))
+                self.on_cpu = torch.nn.Parameter(torch.zeros(2))
+
+        assert _unloaded_checkpoint_tensors(FakePipe({"transformer": TorchModule()})) == ["transformer.on_meta"]

--- a/tests/policies/cosmos3/test_diffusers_checkpoint_mismatch.py
+++ b/tests/policies/cosmos3/test_diffusers_checkpoint_mismatch.py
@@ -26,6 +26,8 @@ load is untouched.
 No GPU and no weights: the pipeline is injected through the ``sys.modules``
 seam the safety-checker tests use, and a parameter stand-in only needs a
 ``.device.type``, so the matrix runs with neither torch nor diffusers installed.
+Running torch-less costs one explicit argument, ``dtype=_SERVED_DTYPE`` -- see
+that constant.
 """
 
 import sys
@@ -39,6 +41,23 @@ from strands_robots.policies.cosmos3.policy_diffusers import (
     _checkpoint_mismatch_hint,
     _unloaded_checkpoint_tensors,
 )
+
+# ``_load_pipeline`` resolves its dtype string against the imported torch module.
+# The backend defaults to ``"bfloat16"``, which the numpy-backed torch stand-in
+# ``conftest`` installs when real torch is absent deliberately does *not* serve -
+# ``float16`` and ``bfloat16`` are both pinned as reaches past its subset in
+# ``tests/test_torch_stand_in_serves_or_skips.py``. That stand-in's serve-or-skip
+# contract is defeated here by the three-argument ``getattr(torch_mod, dtype,
+# None)`` the resolver uses: the default swallows the ``AttributeError`` half,
+# and with it the skip, so an unserved dtype arrives as ``None`` and is reported
+# as ``ValueError: Unknown torch dtype 'bfloat16'`` -- a message about the
+# caller's dtype string, on a run whose actual shortfall is the absent extra.
+#
+# So these cases name a dtype the stand-in serves. They pin the checkpoint scan,
+# not dtype resolution, and the dtype reaches only the injected fake pipeline's
+# ``from_pretrained`` kwargs. Dropping the argument passes under real torch and
+# fails in the torch-less environment the module docstring above promises.
+_SERVED_DTYPE = "float32"
 
 
 def _param(device_type):
@@ -162,7 +181,12 @@ class TestLoadPipelineRefusesAMismatchedCheckpoint:
         pipe = _mismatched_pipe()
         _install_fake_diffusers(monkeypatch, pipe)
         with pytest.raises(RuntimeError, match="was not fully loaded"):
-            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), model="nvidia/Cosmos3-Edge", device="cpu")
+            Cosmos3DiffusersBackend(
+                embodiment=get_embodiment("umi"),
+                model="nvidia/Cosmos3-Edge",
+                device="cpu",
+                dtype=_SERVED_DTYPE,
+            )
 
     def test_the_refusal_precedes_the_device_copy(self, monkeypatch):
         """``pipe.to(device)`` moves the whole checkpoint (9 GB for Cosmos3-Edge)
@@ -172,7 +196,7 @@ class TestLoadPipelineRefusesAMismatchedCheckpoint:
         pipe = _mismatched_pipe()
         _install_fake_diffusers(monkeypatch, pipe)
         with pytest.raises(RuntimeError):
-            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu")
+            Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu", dtype=_SERVED_DTYPE)
         assert pipe.to_calls == [], "a refused load must not copy the checkpoint to the device"
 
     def test_a_fully_loaded_checkpoint_still_reaches_the_device(self, monkeypatch):
@@ -180,7 +204,7 @@ class TestLoadPipelineRefusesAMismatchedCheckpoint:
         (``nvidia/Cosmos3-Nano`` loads with 0 meta parameters on both versions)."""
         pipe = _loaded_pipe()
         _install_fake_diffusers(monkeypatch, pipe)
-        backend = Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu")
+        backend = Cosmos3DiffusersBackend(embodiment=get_embodiment("umi"), device="cpu", dtype=_SERVED_DTYPE)
         assert pipe.to_calls == ["cpu"]
         assert backend._pipeline is pipe
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -1015,3 +1015,90 @@ def test_the_floor_check_rejects_a_lock_below_a_declared_floor() -> None:
     assert _unsatisfied_floors(constraints, {"cbor2": [Version("5.9.0"), Version("5.8.0")]}) == ["cbor2"]
     # A package the lock does not resolve at all is not a violation.
     assert _unsatisfied_floors(constraints, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Cosmos 3 diffusers capability floor.
+#
+# The cosmos3-diffusers extra exists so Cosmos3Policy(backend="diffusers") can
+# build a diffusers.Cosmos3OmniPipeline. Measured against the released wheels,
+# that symbol (and CosmosActionCondition) first ships in diffusers 0.39.0 -
+# 0.36.0, 0.37.1 and 0.38.0 carry neither - so a floor below 0.39 resolves to a
+# diffusers the extra cannot use at all, and the backend's only remedy for that
+# state is an ImportError hint the caller reaches after installing. The floor
+# must therefore be the capability floor, not a nominal lower bound.
+#
+# The [tool.uv] override-dependencies diffusers pin cannot be left below that
+# floor: a uv *override* REPLACES a requirement rather than intersecting with it,
+# so it is the effective floor for the whole resolution. At >=0.38.0 it silently
+# discarded the extra's floor and uv locked diffusers 0.38.0 - a release carrying
+# no Cosmos3OmniPipeline at all.
+# ---------------------------------------------------------------------------
+
+_DIFFUSERS_WITHOUT_COSMOS3_OMNI = ("0.30.0", "0.36.0", "0.37.1", "0.38.0")
+_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI = "0.39.0"
+
+
+def test_cosmos3_diffusers_floor_ships_the_omni_pipeline() -> None:
+    """The extra's diffusers floor must exclude every release lacking the pipeline."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    extra = data["project"]["optional-dependencies"]["cosmos3-diffusers"]
+    reqs = [Requirement(r) for r in extra]
+    req = next((r for r in reqs if r.name == "diffusers"), None)
+    assert req is not None, f"cosmos3-diffusers must declare diffusers, got {[r.name for r in reqs]}"
+    for lacking in _DIFFUSERS_WITHOUT_COSMOS3_OMNI:
+        assert Version(lacking) not in req.specifier, (
+            f"diffusers {lacking} ships no Cosmos3OmniPipeline, so the cosmos3-diffusers "
+            f"floor must exclude it; got {req.specifier}"
+        )
+    assert Version(_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI) in req.specifier, (
+        f"diffusers {_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI} is the first release shipping "
+        f"Cosmos3OmniPipeline and must stay installable; got {req.specifier}"
+    )
+
+
+def test_the_diffusers_uv_override_does_not_undercut_the_capability_floor() -> None:
+    """The uv override must dominate both the CVE floor and the capability floor.
+
+    A uv ``override-dependencies`` entry *replaces* every requirement for that
+    package instead of intersecting with it, so it is the effective floor for the
+    whole resolution: an override below the ``cosmos3-diffusers`` floor silently
+    discards it. Measured - with the override at ``>=0.38.0`` and the extra at
+    ``>=0.39``, ``uv lock`` pinned diffusers 0.38.0, which ships no
+    ``Cosmos3OmniPipeline``. The override must therefore stay at or above the
+    extra's floor while still excluding the releases the CVE fix predates.
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    overrides = data.get("tool", {}).get("uv", {}).get("override-dependencies", [])
+    diffusers_overrides = [Requirement(o) for o in overrides if Requirement(o).name == "diffusers"]
+    assert diffusers_overrides, (
+        f"the diffusers override must stay declared in [tool.uv].override-dependencies, got {overrides}"
+    )
+    for req in diffusers_overrides:
+        assert Version("0.37.1") not in req.specifier, (
+            f"the diffusers override must still exclude the unpatched 0.37.1; got {req}"
+        )
+        for lacking in _DIFFUSERS_WITHOUT_COSMOS3_OMNI:
+            assert Version(lacking) not in req.specifier, (
+                f"a uv override replaces the extra's requirement, so it must not admit "
+                f"diffusers {lacking} (no Cosmos3OmniPipeline); got {req}"
+            )
+        assert Version(_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI) in req.specifier, (
+            f"the override must keep diffusers {_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI} installable; got {req}"
+        )
+
+
+def test_the_lockfile_pins_a_diffusers_that_ships_the_omni_pipeline() -> None:
+    """The committed lock must not pin a diffusers the extra cannot use.
+
+    The floors above are declarations; this is the resolved fact a
+    ``uv sync``/``uv run`` user actually gets.
+    """
+    lock = tomllib.loads((_REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked = sorted({p["version"] for p in lock.get("package", []) if p["name"] == "diffusers" and p.get("version")})
+    assert locked, "uv.lock must resolve diffusers (the cosmos3-diffusers extra declares it)"
+    for version in locked:
+        assert Version(version) >= Version(_FIRST_DIFFUSERS_WITH_COSMOS3_OMNI), (
+            f"uv.lock pins diffusers {version}, which ships no Cosmos3OmniPipeline; "
+            f"run `uv lock` after raising the floor"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ constraints = [
     { name = "twisted", specifier = ">=26.4.0" },
     { name = "ujson", specifier = ">=5.12.1" },
 ]
-overrides = [{ name = "diffusers", specifier = ">=0.38.0" }]
+overrides = [{ name = "diffusers", specifier = ">=0.39" }]
 
 [[package]]
 name = "absl-py"
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "diffusers"
-version = "0.38.0"
+version = "0.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1075,9 +1075,9 @@ dependencies = [
     { name = "requests" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/ed/255d3dfd4a2271dffc8f1895f9d2720b3bf1beaecf02148bb5604439e594/diffusers-0.38.0.tar.gz", hash = "sha256:1e094ec5c16f18c42fb89d37f07a94cf9aab3ebbe527ab059c609597b8857626", size = 4328401, upload-time = "2026-05-01T05:42:15.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/81/6095237b86a3116c4789f28c4435d5296c00c0fc74ffde99008fd6b3a36c/diffusers-0.39.0.tar.gz", hash = "sha256:14bb1d98c85a0e463d734c99aaa73b480a7bc9bad22af30fbf730ef8f09c1d67", size = 4651240, upload-time = "2026-07-03T08:48:47.904Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/c0/3237566ea6e3a542f3c0669a253d62fe75f27b84b3d7bd4fb3b5ee89d73c/diffusers-0.38.0-py3-none-any.whl", hash = "sha256:18e53f9e539096320470f62c6360a6fd5727ff28cffda566265316e13fcdb612", size = 5245919, upload-time = "2026-05-01T05:42:12.779Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3f/7469c46e9d22307ea686bab687d70e6bf328722952f9d10339f5e913e608/diffusers-0.39.0-py3-none-any.whl", hash = "sha256:912aca51b5787365110806e984d5555735bf8a461073bb8459029d0bca7870ef", size = 5631176, upload-time = "2026-07-03T08:48:45.337Z" },
 ]
 
 [[package]]
@@ -5095,7 +5095,7 @@ requires-dist = [
     { name = "device-connect-agent-tools", marker = "extra == 'device-connect'", specifier = ">=0.1.0" },
     { name = "device-connect-edge", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "device-connect-edge", marker = "extra == 'device-connect'", specifier = ">=0.2.0" },
-    { name = "diffusers", marker = "extra == 'cosmos3-diffusers'", specifier = ">=0.30" },
+    { name = "diffusers", marker = "extra == 'cosmos3-diffusers'", specifier = ">=0.39" },
     { name = "eclipse-zenoh", marker = "extra == 'all'", specifier = ">=1.0.0,<2.0.0" },
     { name = "eclipse-zenoh", marker = "extra == 'mesh'", specifier = ">=1.0.0,<2.0.0" },
     { name = "eclipse-zenoh", marker = "extra == 'mesh-iot'", specifier = ">=1.0.0,<2.0.0" },


### PR DESCRIPTION
## Problem

`Cosmos3OmniPipeline.from_pretrained` does not raise when the installed `diffusers`
builds a different architecture than the checkpoint holds. It logs "newly
initialized" / "not used when initializing" warnings and leaves every unmatched
parameter on the `meta` device. Measured on an NVIDIA Thor with
`nvidia/Cosmos3-Edge` (built against diffusers 0.40.0.dev0):

| installed diffusers | `from_pretrained` | transformer params on `meta` | what the caller sees |
| --- | --- | --- | --- |
| 0.39.0 | returns a pipeline | **112 of 633** | `NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() ...` from the **next** statement |
| 0.40.0.dev0 | returns a pipeline | 0 of 549 | loads and runs |

The only symptom was that bare `NotImplementedError` out of `pipe.to(device)`. It
names neither `diffusers`, nor its version, nor the checkpoint, nor a remedy - and
the backend's one actionable remedy (install a newer diffusers) lived behind
`ImportError`, which this state never raises. So the module's remedy was
unreachable on exactly the case it exists for.

`nvidia/Cosmos3-Nano` loads cleanly on both versions, so the required diffusers is
a property of the **checkpoint**, not of the library - which is why a version range
cannot express it.

## Change

`_load_pipeline` scans the loaded pipeline for parameters still on the `meta`
device and refuses **before** the device copy:

```
RuntimeError: Cosmos 3 checkpoint 'nvidia/Cosmos3-Edge' was not fully loaded by the
installed diffusers (0.39.0): 112 tensor(s) were left uninitialized on the meta
device (e.g. ['transformer.layers.0.self_attn.norm_q.weight', ...]), so the pipeline
would run on randomly initialized weights. Install a diffusers that supports this
checkpoint:
  uv pip install 'diffusers @ git+https://github.com/huggingface/diffusers'
Then retry. Or pick a checkpoint the installed diffusers supports, or run the model
out-of-process: Cosmos3Policy(backend='service', host=..., port=...).
```

Refusing before the copy matters twice: the copy moves the whole checkpoint (9 GB
for Cosmos3-Edge), and it is not guaranteed to fail - where it succeeds, the
pipeline would run on random weights and produce plausible-looking output. That is
the silent half this catches.

Packaging on the same axis. Scanning each released wheel for the symbol:

| diffusers release | `Cosmos3OmniPipeline` | `CosmosActionCondition` |
| --- | --- | --- |
| 0.36.0 | absent | absent |
| 0.37.1 | absent | absent |
| 0.38.0 | absent | absent |
| 0.39.0 | **present** | **present** |

so:

| declaration | on main | with this change |
| --- | --- | --- |
| `[cosmos3-diffusers]` `diffusers` | `>=0.30` | `>=0.39` |
| `[tool.uv] override-dependencies` | `>=0.38.0` | `>=0.39` |
| `uv.lock` resolves `diffusers` | `0.38.0` (no pipeline) | `0.39.0` |

The override matters: a uv **override replaces** a requirement rather than
intersecting with it, so at `>=0.38.0` it silently discarded the extra's floor and
`uv lock` pinned diffusers 0.38.0 - a release carrying no `Cosmos3OmniPipeline` at
all. 0.39 clears both the CVE floor the override exists for (fixed in 0.38.0) and
the capability floor, so it strengthens the security pin rather than weakening it.
The install hint drops its now-false "ships only in diffusers-from-source" claim.

Both floors resolve to the same 25 packages today (`pip install --dry-run` before
and after: `added=[] removed=[] version_changes={}` for the extra), so the extra
bump changes what is *permitted* - a lockfile, a constraint file, a pre-existing
environment - rather than what installs.

## Why this shape

Two candidate fixes were measured and rejected:

- **Pin `diffusers` to the version Cosmos3-Edge needs.** It is a `.dev0` build with
  no release, and `Cosmos3-Nano` needs no such pin. A range cannot express a
  per-checkpoint requirement.
- **Let `from_pretrained`'s warnings stand.** They are logged, not raised, and the
  first hard failure is a torch internal three frames away. On a run with logging
  at WARNING they are the only trace, and they name no remedy.

`Args:`-documented public API is unchanged; the two new helpers are private.

## Tests

`tests/policies/cosmos3/test_diffusers_checkpoint_mismatch.py` (11 cases, 0.06 s) -
no GPU, no weights, and no `torch`/`diffusers` needed for the matrix: the pipeline
is injected through the same `sys.modules` seam the safety-checker tests use, and a
parameter stand-in only needs `.device.type`. The three cases that reach
`_load_pipeline` name `dtype="float32"` so that claim holds on a torch-less run too -
see round 1. One `importorskip("torch")` case pins
that a real `torch.empty(device="meta")` parameter presents the same way, so the
stand-ins are not a private convention.

Pinned: the scan's exact output shape; a fully loaded pipeline reports nothing;
non-module components (tokenizer, scheduler, `None` slots) are skipped rather than
crashing; the refusal precedes `pipe.to(device)` (`to_calls == []`); a healthy
checkpoint still reaches the device (non-vacuity); the message names the
checkpoint, the version, the count, a sample tensor and both remedies; and the
`ImportError` hint no longer claims the pipeline is source-only.

`tests/test_dependency_audit.py` gains three: the extra's floor must exclude every
release lacking the pipeline; the uv override must not undercut it (the hole above);
and the committed lock must not pin a pipeline-less diffusers.

**Pre-fix proof** - source + `pyproject.toml` reverted to `upstream/main`, tests
kept (the three helper-unit classes stripped, since the symbols do not exist there):
**4 failed / 36 passed**.

```
FAILED ...::test_refuses_and_names_the_unfilled_tensors - Failed: DID NOT RAISE RuntimeError
FAILED ...::test_the_refusal_precedes_the_device_copy   - Failed: DID NOT RAISE RuntimeError
FAILED ...::test_the_import_error_hint_names_the_extra_and_not_a_source_only_claim
FAILED ...::test_cosmos3_diffusers_floor_ships_the_omni_pipeline
        - assert Version('0.30.0') not in SpecifierSet('>=0.30')
```

The 36 that pass pre-fix are the over-reach controls (a healthy load still reaches
the device) and the premise pins. Post-fix: 47 passed / 1 skipped.

The repo's own lockfile-parity gates caught the manifest edit before I did, and
their messages named the fix: `specifier-drift: diffusers under
[cosmos3-diffusers] -- declared >=0.39, recorded >=0.30` and `diffusers locked at
['0.38.0'] but [cosmos3-diffusers] declares a floor of 0.39`.

## Artifact

![cosmos3 checkpoint mismatch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cosmos3-checkpoint-mismatch/cosmos3_checkpoint_mismatch.png)

Top row is a real `nvidia/Cosmos3-Edge` forward-dynamics rollout on Thor **with the
guard in place**: 17 frames at 20 fps, loaded in 13.67 s with 0 of 745 parameters
unfilled, inferred in 2.23 s at 8.98 GB peak. That is the non-vacuity proof on real
hardware - the guard refuses the mismatch without refusing the supported pair. The
lower rows are the measured report matrix and the packaging ledger; every number in
the figure is asserted against the run's own JSON dumps by the generator, which also
asserts the generated video is not static (mean |last - first| = 0.4193) and that the
border is clean. Capture + compose scripts and the raw dumps are on the
[artifacts branch](https://github.com/cagataycali/robots/tree/artifacts/cosmos3-checkpoint-mismatch).

## Gate

Base `666a1363`, head `6b3ed03`.

> The gate below ran on `d8c5499`; `890e483` differs from it **only** in the
> changelog fragment's filename (`2168-` -> `2169-`, renamed to this PR's number
> after opening). No source, test or manifest line changed.

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov -p no:randomly` -> **28195
  passed / 257 skipped / 0 failed** in 620 s (pristine `666a1363`: 28184 + 11 new)
- `ruff check strands_robots tests tests_integ` -> All checks passed
- `ruff format --check strands_robots tests tests_integ` -> 1176 files already formatted
- `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/isaac_gs`**;
  the 14 there are byte-identical to a pristine-`666a1363` worktree control
- `uv lock` -> `Updated diffusers v0.38.0 -> v0.39.0`, no other package added,
  removed or changed
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> No
  overlap (0 paths changed on `upstream/main` in that span)

## Round changelog

### Round 1 - `6b3ed03`

One commit, one concern: the test matrix did not run in the environment its own
docstring promised.

**Found by measurement, not by review.** Composing every open PR against `main`
and running each one's own tests in a plain `[sim-mujoco,dev]` environment - no
`cosmos3-diffusers` extra, so no real `torch` - turned up 3 failures here on a
tree that is `behind_by=0`. CI is green because CI installs the extra, so this
was invisible to the required check.

```
FAILED ...::test_refuses_and_names_the_unfilled_tensors
FAILED ...::test_the_refusal_precedes_the_device_copy
FAILED ...::test_a_fully_loaded_checkpoint_still_reaches_the_device
  ValueError: Unknown torch dtype 'bfloat16'. Use e.g. 'bfloat16', 'float16', or 'float32'.
```

**Cause.** Those three reach `_load_pipeline` with the backend's default
`dtype="bfloat16"`. The numpy-backed torch stand-in `tests/conftest.py` installs
when real torch is absent deliberately does *not* serve that attribute -
`float16` and `bfloat16` are both pinned as reaches past its subset in
`tests/test_torch_stand_in_serves_or_skips.py::test_a_measured_reach_is_reported_as_a_skip`.

The stand-in's serve-or-skip contract could not report it, and that part
generalises beyond this PR. `MissingMockAttribute` is deliberately *both* an
`AttributeError` and a `pytest.skip.Exception`, so an unguarded reach is a skip
naming the remedy. But `_resolve_torch_dtype` reads the dtype with a
three-argument `getattr(torch_mod, dtype, None)`, and that default swallows the
`AttributeError` half - and the skip with it. Probed directly:

| access | result |
| --- | --- |
| `torch.bfloat16` | raises `MissingMockAttribute` -> skip, remedy named |
| `getattr(torch, "bfloat16", None)` | **`None`**, silently |
| `getattr(torch, "float32", None)` | `np.float32` (served) |

So the miss arrived as `None` and was reported as a message that recommends the
value it just rejected, blaming the caller's dtype string on a run whose actual
shortfall is the absent extra.

**Fix.** Name a dtype the stand-in serves. These cases pin the checkpoint scan,
not dtype resolution, and the dtype reaches only the injected fake pipeline's
`from_pretrained` kwargs, so nothing they assert changes.

**Two alternatives rejected, both for the same reason** - a test-fixture gap must
not drive production, and the fixture's gap here is deliberate:

- *Serve `bfloat16`/`float16` in the stand-in.* It would break the pinned reach
  contract above, which exists so that a test needing real torch is reported as a
  skip rather than as a failure naming neither the mock nor the extra.
- *Change `_resolve_torch_dtype`'s message.* Under real torch an absent attribute
  genuinely **is** an unknown dtype, so the message is correct where it ships.

**Measured, file alone:**

| environment | before | after |
| --- | --- | --- |
| real torch present (what CI runs) | 11 passed | 11 passed |
| torch-less, stand-in installed | **3 failed**, 8 passed | 10 passed, 1 skipped |

The remaining skip is the case that needs real torch by nature (a real
`torch.empty(device="meta")` parameter), reported correctly by the contract.

Also verified on this head: `tests/test_torch_stand_in_serves_or_skips.py` 42
passed / 1 skipped (reach contract intact); the guard sweep
`tests/policies/cosmos3/ tests/test_torch_stand_in_serves_or_skips.py
tests/test_dependency_audit.py` plus the four repo-wide root guards -> 257 passed
/ 4 skipped; `ruff check` + `ruff format --check` clean;
`scripts/assemble_changelog.py --check` -> `changelog fragments OK`. The one
collection error in `tests/policies/cosmos3/` (`test_msgpack_numpy_wire_format.py`,
absent `msgpack`) reproduces byte-for-byte on a pristine `main` worktree in the
same environment, so it is environmental rather than from this diff.

Diff is one file, +27/-3, tests only. No production or manifest line changed
since `890e483`.
