### PR TITLE
test(simulation/isaac): drive the pixel floor on both camera readbacks

### DIFF
--- a/changelog.d/2170-isaac-camera-readback-pixel-domain.md
+++ b/changelog.d/2170-isaac-camera-readback-pixel-domain.md
@@ -1,0 +1,26 @@
+### Quality: drive the pixel-count floor on Isaac's two camera readback surfaces
+
+`positive_count_error` is the shared pixel floor for `width`/`height`, and its
+docstring names the whole family it backs - `add_camera` plus the render family
+(`render`, `get_frame`, `get_camera_params`) on every simulation backend - with
+the invariant that the same camera configuration cannot be refused on one
+backend and accepted on another. Four Isaac methods apply it; only two were ever
+driven. No test called `IsaacSimulation.get_frame` or `get_camera_params` at
+all, so on the two raw in-process readback surfaces neither the refusal nor the
+success path had ever run: a regression that kept the guard call and dropped the
+`raise` would have satisfied the existing structural sweep.
+
+`get_frame`'s `Raises:` entry also named only one of its two `ValueError`
+causes - the native-resolution mismatch - while its sibling `get_camera_params`
+named both, so a caller reading the narrower docstring could not discover the
+floor its code enforces. Both `Args:` entries now state it as well.
+
+The new module drives both surfaces over the shared probe set and asserts each
+refusal is the shared domain's verdict verbatim, pins that the guard precedes
+every RTX handle read, keeps the Isaac-specific native-resolution check as the
+over-reach control, and covers the values the readbacks exist to return - the
+`(rgb, depth)` shapes and dtypes and the documented USD-prim-to-OpenGL basis
+correction. A structural check requires any future public surface taking
+`width`/`height` to apply the floor or forward the value to a sibling that does.
+No Isaac Sim runtime or GPU is needed: the guard runs before the handle is read
+and the handle itself is duck-typed.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3718,10 +3718,10 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
 
         Args:
             camera_name: a camera previously added via ``add_camera``.
-            width: must be ``None`` or the camera's native render width --
-                Isaac RTX cameras render at the resolution fixed at
-                ``add_camera`` time; a mismatch raises rather than silently
-                dropping the requested size.
+            width: must be ``None`` or the camera's native render width, and
+                a positive integer when supplied -- Isaac RTX cameras render at
+                the resolution fixed at ``add_camera`` time; a mismatch raises
+                rather than silently dropping the requested size.
             height: same contract as ``width``.
 
         Returns:
@@ -3731,8 +3731,8 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
             RuntimeError: no world, headless render mode, camera without an
                 RTX handle, or an RTX render failure.
             KeyError: unknown camera name.
-            ValueError: ``width``/``height`` differ from the camera's native
-                render resolution.
+            ValueError: ``width``/``height`` is not a positive integer, or
+                differs from the camera's native render resolution.
         """
         with self._lock:
             if not self._world_created:

--- a/tests/simulation/isaac/test_camera_readback_pixel_domain.py
+++ b/tests/simulation/isaac/test_camera_readback_pixel_domain.py
@@ -1,0 +1,384 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: Isaac's two camera *readback* surfaces refuse an unusable
+pixel count, and each names the parameter that was wrong.
+
+:func:`~strands_robots.utils.positive_count_error` is the shared pixel floor,
+and its docstring names the whole family it backs: "the ``width`` / ``height``
+of ``add_camera`` and of the render family (``render``, ``get_frame``,
+``get_camera_params``) on every simulation backend", with the invariant that
+"the same camera configuration cannot be refused on one backend and accepted on
+another". Four Isaac methods apply it. Two of them were driven:
+``add_camera`` (by ``test_add_camera_numeric_validation.py``, whose docstring
+states the same parity invariant against the MuJoCo sibling) and the internal
+``_render_frame`` that ``render`` forwards to. The two **readback** surfaces
+were not: no test in this package called ``get_frame`` or
+``get_camera_params`` at all, so neither their refusal nor their success path
+had ever run.
+
+The two undriven surfaces are exactly the two whose failure *channel* differs.
+``add_camera`` returns the agent-tool ``{"status": "error"}`` envelope and
+``_render_frame`` returns ``(None, None, {"error": ...})``; ``get_frame`` and
+``get_camera_params`` are the raw in-process surfaces documented to **raise** on
+every degraded path, so a compositing consumer can never silently receive black
+pixels. A structural sweep can show the guard is *wired* at all four; only a
+behavioural test can show it *refuses*, and a regression that kept the call and
+dropped the ``raise`` would satisfy the former.
+
+What each class pins:
+
+* ``TestBothReadbackSurfacesRefuseAnUnusablePixelCount`` - the refusal text is
+  the shared domain's verdict verbatim, so neither surface can drift into a
+  locally reworded copy.
+* ``TestTheRefusalPrecedesTheHandleRead`` - the guard runs before the RTX handle
+  is touched, so a refused size costs no render.
+* ``TestTheNativeResolutionCheckStillFires`` - the over-reach control: a
+  perfectly usable count that simply differs from the camera's native size
+  still gets the native-resolution message, not the domain message.
+* ``TestUsableSizesAndTheOmissionStillWork`` - the accepted side, including
+  ``None`` (membership, not truthiness, decides "omitted").
+* ``TestTheReadbackContract`` - the values these surfaces exist to return: the
+  ``(rgb, depth)`` shapes and dtypes, and the fixed USD-prim-to-OpenGL basis
+  correction ``get_camera_params`` documents.
+* ``TestTheDomainIsDocumented`` - ``get_frame``'s ``Raises:`` entry named only
+  the native-resolution mismatch while its code refuses two distinct causes,
+  and its sibling ``get_camera_params`` named both. A caller reading the
+  narrower docstring could not discover the floor.
+* ``TestEveryPublicDimsSurfaceIsAccountedFor`` - a fifth public surface taking
+  ``width``/``height`` must either apply the shared floor or forward the value
+  to a sibling that does.
+
+None of this needs Isaac Sim or a GPU. The dims guard runs before the handle is
+read, and the handle itself is duck-typed, so the accepted paths are exercised
+too - the skeleton-via-``__new__`` fixture shape the sibling
+``add_camera`` module uses.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _CameraState
+from strands_robots.utils import positive_count_error
+
+#: The camera's native render size. Both readback surfaces accept only this
+#: size or ``None``, so every "usable" probe below uses it.
+NATIVE_W, NATIVE_H = 64, 48
+
+#: Pixel counts outside the shared floor. ``0`` and a negative are the counts
+#: no renderer can produce; ``True``/``False`` are ``int`` subclasses that would
+#: read as the sizes 1 and 0; ``2.7`` and ``64.0`` are the fractional and
+#: integral floats ``int()`` would silently accept; ``nan``/``inf`` are the
+#: non-finite pair; ``"64"``, ``[64]`` and ``np.int64(64)`` are the spellings
+#: whose value is right but whose type the pixel consumers refuse.
+UNUSABLE: list[Any] = [0, -8, True, False, 2.7, 64.0, float("nan"), float("inf"), "64", [64], np.int64(64)]
+UNUSABLE_IDS = ["0", "-8", "True", "False", "2.7", "64.0", "nan", "inf", "str-64", "list-64", "np.int64-64"]
+
+
+class _FakeCameraHandle:
+    """Duck-typed stand-in for the Isaac ``Camera`` sensor handle.
+
+    Only the four reads the two surfaces under test perform are implemented.
+    Values are distinct constants so a transposed or dropped read is visible.
+    """
+
+    def __init__(self) -> None:
+        self.reads: list[str] = []
+
+    def get_intrinsics_matrix(self) -> np.ndarray:
+        self.reads.append("intrinsics")
+        return np.array([[50.0, 0.0, 32.0], [0.0, 50.0, 24.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+
+    def get_world_pose(self) -> tuple[np.ndarray, np.ndarray]:
+        self.reads.append("pose")
+        return np.array([1.0, 2.0, 3.0]), np.array([1.0, 0.0, 0.0, 0.0])
+
+    def get_rgba(self) -> np.ndarray:
+        self.reads.append("rgba")
+        return np.full((NATIVE_H, NATIVE_W, 4), 200, dtype=np.uint8)
+
+    def get_depth(self) -> np.ndarray:
+        self.reads.append("depth")
+        return np.full((NATIVE_H, NATIVE_W), 1.5, dtype=np.float32)
+
+
+class _FatalCameraHandle(_FakeCameraHandle):
+    """A handle whose every read fails, so reaching it cannot go unnoticed."""
+
+    def _boom(self) -> Any:
+        raise AssertionError("the refused size reached the RTX handle")
+
+    get_intrinsics_matrix = _boom  # type: ignore[assignment]
+    get_world_pose = _boom  # type: ignore[assignment]
+    get_rgba = _boom  # type: ignore[assignment]
+    get_depth = _boom  # type: ignore[assignment]
+
+
+def _engine(handle: _FakeCameraHandle | None = None) -> IsaacSimulation:
+    """Skeleton ``IsaacSimulation`` carrying only what the readbacks read.
+
+    ``render_mode`` must not be ``"headless"``: both surfaces refuse that mode
+    before they reach the dims guard, and ``get_frame`` says so explicitly.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode="rtx_realtime", camera_width=NATIVE_W, camera_height=NATIVE_H)
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+
+    cam = _CameraState("cam", "/World/cameras/cam", NATIVE_W, NATIVE_H)
+    cam.handle = handle if handle is not None else _FakeCameraHandle()
+    engine._cameras["cam"] = cam
+    return engine
+
+
+def _call(engine: IsaacSimulation, method: str, **kwargs: Any) -> Any:
+    """Invoke a readback surface with deliberately off-type pixel counts.
+
+    ``width``/``height`` are annotated ``int | None``, and half the probe set is
+    outside that annotation on purpose - the runtime domain is what is under
+    test. Splatting through one funnel keeps that intent in a single place
+    instead of a suppression at every call site.
+    """
+    return getattr(engine, method)(**kwargs)
+
+
+#: The two raw readback surfaces and the context string each passes to the
+#: shared domain, so a refusal names the method the caller actually called.
+READBACKS = [("get_frame", "get_frame"), ("get_camera_params", "get_camera_params")]
+
+
+class TestBothReadbackSurfacesRefuseAnUnusablePixelCount:
+    """The refusal is the shared domain's verdict, verbatim.
+
+    Asserting equality rather than a substring is what pins "one rule, one
+    wording": a surface that grew its own message would still name the
+    parameter and still raise, and only this comparison would notice.
+    """
+
+    @pytest.mark.parametrize("method,context", READBACKS)
+    @pytest.mark.parametrize("param", ["width", "height"])
+    @pytest.mark.parametrize("value", UNUSABLE, ids=UNUSABLE_IDS)
+    def test_the_message_is_the_shared_domains_verdict(self, method: str, context: str, param: str, value: Any) -> None:
+        expected = positive_count_error(value, param, context)
+        assert expected is not None, "probe value must be outside the shared domain"
+        with pytest.raises(ValueError) as excinfo:
+            _call(_engine(), method, camera_name="cam", **{param: value})
+        assert str(excinfo.value) == expected
+
+
+class TestTheRefusalPrecedesTheHandleRead:
+    """A refused size costs no render.
+
+    The guard sits above every ``cam.handle`` read, so a camera whose handle
+    fails on contact still reports the pixel count as the problem.
+    """
+
+    @pytest.mark.parametrize("method,context", READBACKS)
+    @pytest.mark.parametrize("value", [0, -8, "64"], ids=["0", "-8", "str-64"])
+    def test_no_handle_read_happens(self, method: str, context: str, value: Any) -> None:
+        handle = _FatalCameraHandle()
+        with pytest.raises(ValueError) as excinfo:
+            _call(_engine(handle), method, camera_name="cam", width=value)
+        assert str(excinfo.value) == positive_count_error(value, "width", context)
+        assert handle.reads == []
+
+    @pytest.mark.parametrize("method", ["get_frame", "get_camera_params"])
+    def test_a_usable_size_does_reach_the_handle(self, method: str) -> None:
+        """Non-vacuity: the handle is reached when the size is usable."""
+        handle = _FakeCameraHandle()
+        _call(_engine(handle), method, camera_name="cam", width=NATIVE_W)
+        assert handle.reads
+
+
+class TestTheNativeResolutionCheckStillFires:
+    """Over-reach control: the floor did not swallow the resolution check.
+
+    A positive integer is inside the shared domain, so it must reach the
+    Isaac-specific native-resolution comparison and be refused by *that*
+    message instead.
+    """
+
+    @pytest.mark.parametrize(
+        "method,param,value",
+        [
+            ("get_frame", "width", NATIVE_W * 2),
+            ("get_frame", "height", NATIVE_H + 1),
+            ("get_camera_params", "width", 1),
+            ("get_camera_params", "height", NATIVE_H * 3),
+        ],
+    )
+    def test_a_usable_but_mismatched_size_reports_the_resolution(self, method: str, param: str, value: int) -> None:
+        assert positive_count_error(value, param, method) is None
+        with pytest.raises(ValueError) as excinfo:
+            _call(_engine(), method, camera_name="cam", **{param: value})
+        message = str(excinfo.value)
+        # The two surfaces word their mismatch differently ("the resolution
+        # fixed at add_camera time" vs "only valid at the native render
+        # resolution"); what both must do is name the requested size, the
+        # camera's actual size, and the remedy.
+        assert f"requested {param}={value}" in message, message
+        assert f"{NATIVE_W}x{NATIVE_H}" in message, message
+        assert "Re-add the camera with the desired size." in message, message
+        assert "must be a positive integer" not in message, message
+
+
+class TestUsableSizesAndTheOmissionStillWork:
+    """The accepted side, including the documented ``None``.
+
+    Membership decides "omitted", not truthiness - reading ``0`` as absent is
+    the failure the shared floor exists to prevent, and it would look identical
+    to a passing test here without the ``0`` case in ``UNUSABLE`` above.
+    """
+
+    @pytest.mark.parametrize("method", ["get_frame", "get_camera_params"])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"width": None},
+            {"height": None},
+            {"width": NATIVE_W},
+            {"height": NATIVE_H},
+            {"width": NATIVE_W, "height": NATIVE_H},
+        ],
+        ids=["omitted", "width-None", "height-None", "native-width", "native-height", "both-native"],
+    )
+    def test_the_readback_succeeds(self, method: str, kwargs: dict[str, Any]) -> None:
+        result = _call(_engine(), method, camera_name="cam", **kwargs)
+        assert result is not None
+
+
+class TestTheReadbackContract:
+    """The values these two surfaces exist to return."""
+
+    def test_get_frame_returns_rgb_and_metric_depth(self) -> None:
+        rgb, depth = _engine().get_frame("cam")
+        assert rgb.shape == (NATIVE_H, NATIVE_W, 3)
+        assert rgb.dtype == np.uint8
+        assert depth is not None
+        assert depth.shape == (NATIVE_H, NATIVE_W)
+        assert depth.dtype == np.float32
+        # The alpha channel is dropped, not averaged in.
+        assert np.array_equal(np.unique(rgb), np.array([200], dtype=np.uint8))
+        assert float(depth[0, 0]) == pytest.approx(1.5)
+
+    def test_get_camera_params_reports_the_native_size_and_intrinsics(self) -> None:
+        params = _engine().get_camera_params("cam")
+        assert (params.width, params.height) == (NATIVE_W, NATIVE_H)
+        assert np.allclose(params.K, [[50.0, 0.0, 32.0], [0.0, 50.0, 24.0], [0.0, 0.0, 1.0]])
+
+    def test_the_prim_to_opengl_basis_correction_is_applied(self) -> None:
+        """The fixed USD-prim-to-GL rotation the docstring documents.
+
+        With an identity prim orientation the returned basis is exactly the
+        documented mapping - prim +X -> GL -Z, prim +Y -> GL -X, prim +Z ->
+        GL +Y - so a dropped or transposed correction is visible rather than
+        merely plausible.
+        """
+        params = _engine().get_camera_params("cam")
+        rotation = np.asarray(params.T_world_cam)[:3, :3]
+        expected = np.array([[0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        assert np.allclose(rotation, expected), rotation
+        # The prim's world position is carried through untouched.
+        assert np.allclose(np.asarray(params.T_world_cam)[:3, 3], [1.0, 2.0, 3.0])
+
+
+class TestTheDomainIsDocumented:
+    """Both readback docstrings must name the pixel-count cause.
+
+    They apply a byte-identical guard, so a caller reading either one must be
+    able to discover the floor. ``get_frame``'s ``Raises:`` named only the
+    native-resolution mismatch, which is the narrower of its two ValueError
+    causes.
+    """
+
+    @pytest.mark.parametrize("method", ["get_frame", "get_camera_params"])
+    def test_the_valueerror_entry_names_the_pixel_floor(self, method: str) -> None:
+        doc = inspect.getdoc(getattr(IsaacSimulation, method)) or ""
+        raises = doc.split("Raises:", 1)
+        assert len(raises) == 2, f"{method} documents no Raises: section"
+        body = " ".join(raises[1].split())
+        assert "positive integer" in body, body
+
+    @pytest.mark.parametrize("method", ["get_frame", "get_camera_params"])
+    def test_the_args_entry_names_the_pixel_floor(self, method: str) -> None:
+        doc = inspect.getdoc(getattr(IsaacSimulation, method)) or ""
+        args = doc.split("Args:", 1)
+        assert len(args) == 2, f"{method} documents no Args: section"
+        body = " ".join(args[1].split("Raises:", 1)[0].split())
+        assert "positive integer when supplied" in body, body
+
+
+def _dims_surfaces() -> dict[str, tuple[bool, bool]]:
+    """Map every public ``IsaacSimulation`` method taking ``width``/``height``.
+
+    Returns ``{name: (applies_the_floor, forwards_the_value)}``. Scoping to
+    public methods excludes the internal ``_render_frame`` (which guards
+    anyway) and ``_create_camera_prim`` (a terminal consumer of already
+    validated dims) by construction rather than by an exemption list.
+    """
+    src = inspect.getsource(inspect.getmodule(IsaacSimulation))  # type: ignore[arg-type]
+    tree = ast.parse(src)
+    out: dict[str, tuple[bool, bool]] = {}
+    for cls in tree.body:
+        if not isinstance(cls, ast.ClassDef) or cls.name != "IsaacSimulation":
+            continue
+        for fn in cls.body:
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if fn.name.startswith("_"):
+                continue
+            names = {a.arg for a in fn.args.args + fn.args.kwonlyargs}
+            dims = names & {"width", "height"}
+            if not dims:
+                continue
+            guards = False
+            forwards = False
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Call):
+                    continue
+                called = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+                if called == "positive_count_error":
+                    guards = True
+                    continue
+                passed = {a.id for a in node.args if isinstance(a, ast.Name)}
+                passed |= {k.value.id for k in node.keywords if isinstance(k.value, ast.Name)}
+                if dims <= passed:
+                    forwards = True
+            out[fn.name] = (guards, forwards)
+    return out
+
+
+class TestEveryPublicDimsSurfaceIsAccountedFor:
+    """A fifth public dims surface must guard or forward, not neither."""
+
+    def test_the_known_surfaces_are_the_ones_measured(self) -> None:
+        """Non-vacuity: a scan that found nothing would pass every assertion."""
+        assert set(_dims_surfaces()) == {"render", "get_frame", "get_camera_params", "add_camera"}
+
+    @pytest.mark.parametrize("name", ["render", "get_frame", "get_camera_params", "add_camera"])
+    def test_it_applies_the_floor_or_forwards_the_value(self, name: str) -> None:
+        guards, forwards = _dims_surfaces()[name]
+        assert guards or forwards, f"{name} neither applies the pixel floor nor forwards width/height"
+
+    def test_the_two_readbacks_apply_the_floor_themselves(self) -> None:
+        """They raise rather than returning an envelope, so they cannot delegate."""
+        for name in ("get_frame", "get_camera_params"):
+            assert _dims_surfaces()[name][0], f"{name} must apply the shared floor itself"


### PR DESCRIPTION
## Problem

`positive_count_error` is the shared pixel floor for `width`/`height`, and its
docstring names the whole family it backs and the invariant it exists for:

> A camera's pixel dimensions - the `width` / `height` of `add_camera` and of the
> render family (`render`, `get_frame`, `get_camera_params`) on every simulation
> backend. [...] the floor itself must not differ between them: the same camera
> configuration cannot be refused on one backend and accepted on another.

Four `IsaacSimulation` methods apply it. **Two of them were ever driven.**
`add_camera` has a dedicated regression module that states the same parity
invariant against the MuJoCo sibling, and the internal `_render_frame` that
`render` forwards to is exercised too. But no test in `tests/simulation/isaac/`
called `get_frame` or `get_camera_params` **at all** - so on the two raw
in-process readback surfaces neither the refusal nor the success path had ever
run. Their whole method bodies were unreached.

The two undriven surfaces are exactly the two whose failure **channel** differs.
`add_camera` returns the agent-tool `{"status": "error"}` envelope and
`_render_frame` returns `(None, None, {"error": ...})`; `get_frame` and
`get_camera_params` are documented to **raise** on every degraded path, so a
compositing consumer such as `HybridCompositor` can never silently receive black
pixels with zero depth. A structural sweep can show a guard is *wired*; only a
behavioural test can show it *refuses*, and the mutation table below measures
exactly that gap.

`get_frame`'s `Raises:` entry also named only one of its two `ValueError`
causes - the native-resolution mismatch - while its sibling `get_camera_params`
named both. A caller reading the narrower docstring could not discover the floor
its code enforces.

## Change

* Both readback docstrings now state the pixel floor, in `Args:` and `Raises:`.
  This is the only production edit, and it is docstring-only: the
  docstring-stripped AST digest is unchanged at `1b53820cfff68a07`.
* A new module drives both surfaces over the shared probe set. Each refusal is
  asserted **equal** to the shared domain's verdict, not merely matching a
  substring, so neither surface can drift into a locally reworded copy.
* Guard placement is pinned with a handle whose every read raises: a refused
  size reads nothing (`reads == []`), and a usable one does
  (`reads == ['rgba', 'depth']`) as the non-vacuity control.
* The Isaac-specific native-resolution check is kept as the over-reach control -
  a perfectly usable count that simply differs from the camera's native size
  must still get *that* message.
* The values the readbacks exist to return are covered: the `(rgb, depth)`
  shapes and dtypes, and the fixed USD-prim-to-OpenGL basis correction the
  docstring documents (`+X -> -Z`, `+Y -> -X`, `+Z -> +Y`).
* A structural check requires any future public surface taking `width`/`height`
  to apply the floor or forward the value to a sibling that does.

No Isaac Sim runtime and no GPU: the guard runs before the RTX handle is read,
and the handle itself is duck-typed, so the accepted paths run too. 81 tests in
0.38 s.

## Measured

Eight plausible regressions, each against this PR's module and against the 553
pre-existing Isaac tests:

| mutation | this PR | pre-existing Isaac suite |
|---|---|---|
| M1 `get_frame`: delete the pixel-floor guard | 27 failed | 0 failed |
| M2 `get_frame`: keep the call, drop the `raise` | 25 failed | 0 failed |
| M3 `get_camera_params`: delete the guard | 27 failed | 0 failed |
| M4 `get_camera_params`: keep the call, drop the `raise` | 25 failed | 0 failed |
| M5 `get_frame`: reword the refusal locally | 25 failed | 0 failed |
| M6 `get_frame`: widen to the integral-real domain | 27 failed | 0 failed |
| M7 `get_camera_params`: drop the prim->GL correction | 1 failed | 0 failed |
| M8 `get_frame`: silently drop the depth buffer | 1 failed | 0 failed |

8 of 8 caught here, **0 of 8** by the suite as it stands. M2 and M4 are the shape
a structural sweep cannot see by construction.

Coverage, `tests/simulation/isaac` subset (before arm deselects only the new
classes, so both arms run the identical file list):

| | missing | covered |
|---|---|---|
| `isaac/simulation.py` before | 960 | 46.76% |
| `isaac/simulation.py` after | 902 | 49.97% |

58 lines newly covered, 0 regressions. Both refusal cells (`get_frame` and
`get_camera_params`) closed.

## Artifact

![Isaac camera readback pixel floor](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-camera-readback-pixel-domain/isaac-camera-readback-pixel-domain.png)

Row 1 is the 4-surface x 10-probe refusal matrix - 20 of 40 cells driven before,
40 of 40 after. Every cell already refused correctly; none had been exercised.
Row 2 is the mutation table. Row 3 is a real headless MuJoCo render of the
sibling readback: the floor is cross-backend, so the MuJoCo surface is the one
that can be photographed on a host without Isaac Sim, and it is the control that
the shared rule is untouched. Capture and compose scripts, and the JSON every
rendered number is asserted against, are on the
[artifacts branch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-camera-readback-pixel-domain/README.md).

Because the production diff is docstring-only, no policy, simulation, rendering,
recording or asset behaviour changes - the render is a control, not a before/after.

## Verification

Full suite on the merge base:

```
28262 passed, 257 skipped, 0 failed in 723.65s   (MUJOCO_GL=egl, -p no:randomly)
```

Pristine `upstream/main` at the same commit is 28181 passed / 257 skipped, so
28181 + 81 new = 28262 accounts for the delta exactly.

Pre-fix (docstring reverted to `upstream/main`, the new tests kept):
**2 failed / 79 passed** - both failures are the `get_frame` documentation pins.
The 79 that pass are the behavioural cells (the production guard is already
correct) and the `get_camera_params` documentation pins, whose docstring already
named both causes; those are the over-reach controls.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`. `mypy` reports 14 errors, all in `examples/isaac_gs` and 0
outside it, byte-identical to a pristine-base worktree control - a local
environment artifact, not this branch.

`scripts/check_merge_base_overlap.py`: *"No overlap. This branch edits nothing
that upstream/main has changed since the two diverged at 666a1363."*
