### PR TITLE
fix(mesh): record an MQTT5 client teardown the IoT transport could not finish

### DIFF
--- a/changelog.d/2172-iot-client-teardown-failure-reported.md
+++ b/changelog.d/2172-iot-client-teardown-failure-reported.md
@@ -1,0 +1,20 @@
+### Fixed: `IotMqttTransport` records every MQTT5 client teardown it could not finish
+
+`self._client.stop()` is called from four places in the AWS IoT transport, each
+tearing down a client the transport is about to stop referencing. Two of them
+contained a failing teardown and logged it at debug; the construction-failure
+one states the policy in a comment ("a stop() error here ... must not mask the
+original failure. Log at debug and move on."). The other two did not follow it.
+
+The connect-timeout path called `stop()` unwrapped, so a raising teardown left
+`connect()` - documented to return `False` when the broker is unreachable within
+`connect_timeout` - raising `RuntimeError` instead, with `self._client` still set
+and its IO thread still running. `close()` swallowed the same failure into a bare
+`pass` and then logged "IoT mesh session closed", the only line an operator gets
+and the opposite of what happened; because `close()` drops the client reference
+either way, nothing can reach that client afterwards to retry.
+
+Both now tolerate the failure and record it - the timeout path at debug beside
+the two paths it mirrors, `close()` at warning because it is the only teardown
+whose visible report is otherwise a success. A structural test pins the rule
+across all four sites so a fifth cannot ship without it.

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -364,6 +364,10 @@ class IotMqttTransport:
         Returns ``True`` once connected, ``False`` if the SDK is missing,
         configuration is invalid, or the broker is unreachable within
         ``connect_timeout`` seconds.
+
+        Every failure is reported through that return value, including one where
+        tearing the half-open client down is itself what fails: a ``stop()``
+        that raises is recorded at debug and does not replace the ``False``.
         """
         with self._lock:
             if self._client is not None and self._connected.is_set():
@@ -451,7 +455,15 @@ class IotMqttTransport:
                     self._endpoint,
                     self._connect_timeout,
                 )
-                self._client.stop()
+                try:
+                    self._client.stop()
+                except Exception as stop_exc:
+                    # Same contract as the construction-failure path above: the
+                    # connect() has already failed and we return False
+                    # regardless, so a stop() error here must not replace that
+                    # report with a raise out of a method documented to return
+                    # bool. Log at debug and move on.
+                    logger.debug("IoT client stop after connect timeout: %s", stop_exc)
                 self._client = None
                 return False
 
@@ -463,14 +475,32 @@ class IotMqttTransport:
             return True
 
     def close(self) -> None:
-        """Disconnect and tear down the MQTT5 client. Idempotent."""
+        """Disconnect and tear down the MQTT5 client. Idempotent.
+
+        A ``stop()`` that raises does not prevent teardown - the client
+        reference is dropped either way. That is what makes the failure worth
+        recording rather than swallowing: nothing can reach that client
+        afterwards to retry, so the WARNING is the only trace an operator gets
+        of an IO thread and socket that may still be open.
+        """
         with self._lock:
             if self._client is None:
                 return
             try:
                 self._client.stop()
-            except Exception:
-                pass
+            except Exception as exc:
+                # The two connect()-side teardowns log this; close() is the
+                # public one, and it is the only path whose visible report is a
+                # success, so a silent swallow leaves "session closed" as the
+                # sole record of a client that did not stop. Warn rather than
+                # debug: the reference is dropped below either way, so nothing
+                # can reach that client afterwards to retry.
+                logger.warning(
+                    "IoT MQTT client stop() failed during close (thing=%s): %s; "
+                    "its IO thread and socket may still be open",
+                    self._thing_name,
+                    exc,
+                )
             self._client = None
             self._connected.clear()
             self._handlers.clear()

--- a/tests/mesh/test_iot_client_teardown_failures.py
+++ b/tests/mesh/test_iot_client_teardown_failures.py
@@ -1,0 +1,275 @@
+"""``IotMqttTransport`` records every MQTT5 client teardown it could not finish.
+
+The transport calls ``self._client.stop()`` from four places, all of them a
+teardown of a client it is about to stop referencing:
+
+* the reconnect path, stopping a stale client left by a broker drop;
+* the construction-failure path in :meth:`~IotMqttTransport.connect`;
+* the connect-timeout path in the same method;
+* :meth:`~IotMqttTransport.close`.
+
+``stop()`` tears down an IO thread and a socket, so it is exactly the call that
+fails when the thing it is tearing down is already broken - which is the state
+each of these four paths is reacting to. The first two contain that and log at
+debug, and the construction-failure one states the policy in a comment: the
+connect has already failed, so *"a stop() error here ... must not mask the
+original failure. Log at debug and move on."*
+
+The other two did not follow it. The timeout path called ``stop()`` unwrapped,
+so a raising teardown left :meth:`connect` - documented to return ``False`` for
+a broker that is unreachable within ``connect_timeout`` - raising instead, with
+``self._client`` still set and its IO thread still running. ``close()`` swallowed
+the same failure into a bare ``pass`` and then logged *"IoT mesh session
+closed"*, which is the only line an operator gets and says the opposite of what
+happened; because ``close()`` drops the reference either way, nothing can reach
+that client afterwards to retry.
+
+The sibling module :mod:`tests.mesh.test_iot_reconnect_client_lifecycle` already
+pins the two synchronous raise sources on the connect path - ``mtls_from_path``
+and ``start()`` - with the same reasoning ("the mesh stays OFF rather than
+crashing the host"). ``stop()`` is the third, and it was the one left out.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.transport.iot_transport as iot_transport
+from strands_robots.mesh.transport.iot_transport import IotMqttTransport
+
+from .test_iot_reconnect_client_lifecycle import _FakeClient, _make_certs
+
+LOGGER_NAME = "strands_robots.mesh.transport.iot_transport"
+STOP_FAILURE = "io thread already gone"
+
+
+class _StopRaises(_FakeClient):
+    """A client whose teardown fails - the state each path is reacting to."""
+
+    def stop(self) -> None:
+        self.stopped = True  # the attempt happened; the teardown did not finish
+        raise RuntimeError(STOP_FAILURE)
+
+
+class _NoConnack(_FakeClient):
+    """Starts without ever firing CONNACK, so ``connect()`` times out."""
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _NoConnackStopRaises(_NoConnack):
+    def stop(self) -> None:
+        self.stopped = True
+        raise RuntimeError(STOP_FAILURE)
+
+
+def _transport(tmp_path: Any, thing: str = "thor-arm") -> IotMqttTransport:
+    return IotMqttTransport(
+        thing_name=thing,
+        endpoint="x-ats.iot.us-west-2.amazonaws.com",
+        cert_dir=str(_make_certs(tmp_path, thing)),
+        connect_timeout=0.05,
+    )
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, cls: type[_FakeClient]) -> list[_FakeClient]:
+    """Make ``mtls_from_path`` build *cls*; return the list of built clients."""
+    import awsiot.mqtt5_client_builder as builder
+
+    built: list[_FakeClient] = []
+
+    def fake_mtls_from_path(**kwargs: Any) -> _FakeClient:
+        client = cls(**kwargs)
+        built.append(client)
+        return client
+
+    monkeypatch.setattr(builder, "mtls_from_path", fake_mtls_from_path)
+    return built
+
+
+class TestConnectTimeoutContainsTheTeardownFailure:
+    """A timeout whose teardown fails is still reported as a timeout."""
+
+    def test_a_stop_failure_on_the_timeout_path_still_returns_false(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        built = _install(monkeypatch, _NoConnackStopRaises)
+        transport = _transport(tmp_path)
+
+        assert transport.connect() is False
+        assert built[0].stopped is True, "the teardown was not attempted"
+
+    def test_the_client_reference_is_dropped_when_the_timeout_teardown_fails(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install(monkeypatch, _NoConnackStopRaises)
+        transport = _transport(tmp_path)
+
+        transport.connect()
+
+        # Left set, the next connect() would reach the reconnect path with a
+        # client this one already failed to stop.
+        assert transport._client is None
+        assert transport.is_alive() is False
+
+    def test_the_timeout_teardown_failure_is_recorded_at_debug(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _install(monkeypatch, _NoConnackStopRaises)
+        transport = _transport(tmp_path)
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            transport.connect()
+
+        debug = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(STOP_FAILURE in m for m in debug), f"teardown failure unrecorded: {debug}"
+        # The timeout itself is still the headline report.
+        assert any("timed out" in r.getMessage() for r in caplog.records)
+
+    def test_a_clean_timeout_records_no_teardown_failure(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        built = _install(monkeypatch, _NoConnack)
+        transport = _transport(tmp_path)
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            assert transport.connect() is False
+
+        assert built[0].stopped is True
+        assert not [r for r in caplog.records if STOP_FAILURE in r.getMessage()]
+
+
+class TestCloseRecordsTheTeardownFailure:
+    """``close()`` is the only teardown whose visible report is a success."""
+
+    def test_a_stop_failure_during_close_is_recorded(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _install(monkeypatch, _StopRaises)
+        transport = _transport(tmp_path)
+        assert transport.connect() is True
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            transport.close()
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "a failed client teardown left no trace at all"
+        assert any(STOP_FAILURE in m and "thor-arm" in m for m in warnings), warnings
+
+    def test_close_completes_when_stop_fails(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, _StopRaises)
+        transport = _transport(tmp_path)
+        assert transport.connect() is True
+        transport._handlers["strands/*/state"] = [lambda _sample: None]
+
+        transport.close()  # must not raise: teardown is best-effort by contract
+
+        assert transport._client is None
+        assert transport._handlers == {}
+        assert transport.is_alive() is False
+
+    def test_a_clean_close_warns_about_nothing(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        built = _install(monkeypatch, _FakeClient)
+        transport = _transport(tmp_path)
+        assert transport.connect() is True
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            transport.close()
+
+        assert built[0].stopped is True
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestThePreExistingTeardownsStillRecord:
+    """The two connect-path teardowns that already followed the policy."""
+
+    def test_the_reconnect_stale_stop_failure_is_recorded(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        built = _install(monkeypatch, _StopRaises)
+        transport = _transport(tmp_path)
+        assert transport.connect() is True
+        transport._connected.clear()  # broker-side drop; the client object lingers
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            assert transport.connect() is True
+
+        assert len(built) == 2, "the reconnect did not build a fresh client"
+        assert built[0].stopped is True
+        debug = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(STOP_FAILURE in m for m in debug), debug
+
+    def test_the_construction_failure_teardown_is_recorded(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        class _StartRaisesStopRaises(_StopRaises):
+            def start(self) -> None:
+                raise RuntimeError("io thread failed to launch")
+
+        built = _install(monkeypatch, _StartRaisesStopRaises)
+        transport = _transport(tmp_path)
+
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            assert transport.connect() is False
+
+        assert transport._client is None
+        assert built[0].stopped is True
+        debug = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(STOP_FAILURE in m for m in debug), debug
+
+
+def _teardown_handlers(source: str) -> list[tuple[int, bool]]:
+    """Every ``try`` whose body stops the client, with whether it logs.
+
+    Returns ``(lineno, logs)`` per handler so a site that tolerates a teardown
+    failure without recording it is visible as ``logs=False``.
+    """
+    tree = ast.parse(source)
+    found: list[tuple[int, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        body = "\n".join(ast.get_source_segment(source, stmt) or "" for stmt in node.body)
+        if "_client.stop()" not in body:
+            continue
+        for handler in node.handlers:
+            text = "\n".join(ast.get_source_segment(source, stmt) or "" for stmt in handler.body)
+            found.append((handler.lineno, "logger." in text))
+    return sorted(found)
+
+
+class TestEveryClientTeardownRecordsItsFailure:
+    """One rule for all four sites, so a fifth cannot ship without it."""
+
+    def test_every_client_teardown_handler_logs(self) -> None:
+        source = inspect.getsource(iot_transport)
+        silent = [lineno for lineno, logs in _teardown_handlers(source) if not logs]
+        assert not silent, f"client teardown failure tolerated without a record at line(s) {silent}"
+
+    def test_the_module_still_has_the_four_teardown_sites(self) -> None:
+        source = inspect.getsource(iot_transport)
+        assert len(_teardown_handlers(source)) == 4, _teardown_handlers(source)
+        assert source.count("_client.stop()") == 4
+
+    def test_the_scanner_sees_a_planted_silent_swallow(self) -> None:
+        planted = (
+            "class T:\n"
+            "    def close(self):\n"
+            "        try:\n"
+            "            self._client.stop()\n"
+            "        except Exception:\n"
+            "            pass\n"
+        )
+        assert _teardown_handlers(planted) == [(5, False)]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

`IotMqttTransport` calls `self._client.stop()` from four places. Every one of them
is tearing down a client the transport is about to stop referencing:

| # | site | reacting to |
|---|---|---|
| 1 | `connect()` reconnect path | a broker drop left a stale client whose IO thread is still open |
| 2 | `connect()` construction-failure path | `mtls_from_path` or `start()` raised |
| 3 | `connect()` CONNACK-timeout path | the broker did not answer inside `connect_timeout` |
| 4 | `close()` | the public teardown |

`stop()` shuts down an IO thread and a socket, so it is precisely the call that
fails when the thing being torn down is already broken — which is the state all
four of these paths exist to react to.

Sites 1 and 2 contain that failure and log it at debug. Site 2 states the policy
in a comment:

> a stop() error here (e.g. client never reached a startable state) must
> not mask the original failure. **Log at debug and move on.**

Sites 3 and 4 did not follow it.

**Site 3 called `stop()` unwrapped.** `connect()` documents "Returns `True` once
connected, `False` if the SDK is missing, configuration is invalid, or the broker
is unreachable within `connect_timeout` seconds" — a bool for every failure mode.
Measured against a client that never fires CONNACK and whose `stop()` raises,
`connect()` raised `RuntimeError` instead of returning `False`, and left
`self._client` set with its IO thread still running. The identical scenario with a
working `stop()` returns `False` and clears the reference, so the teardown failure
was the only difference.

**Site 4 swallowed it into a bare `pass`** and then logged
`INFO IoT mesh session closed (thing=thor-arm)`. That was the only line an
operator got, and it says the opposite of what happened. Because `close()` drops
the client reference either way, nothing can reach that client afterwards to
retry — so the reconnect path's own protection (stop the stale client before
building a new one) can no longer help.

## Change

Both now tolerate the failure and record it, so all four sites obey the policy the
module already wrote down:

- **site 3** logs at debug, beside the two paths it mirrors, and still returns
  `False` with the reference cleared;
- **site 4** logs at **warning** — it is the only teardown whose visible report is
  otherwise a success, so a debug line would leave "session closed" as the loudest
  thing said about a client that did not stop.

`connect()`'s and `close()`'s docstrings now state the guarantee, and a structural
test asserts every `try` in the module whose body stops the client has a handler
that logs — so a fifth teardown site cannot ship without one.

Nothing else changes: the `stop()` call count is unchanged, and both clean-teardown
controls (a clean timeout, a clean close) are byte-identical on the two trees.

## Measured

![IoT client teardown ledger](https://raw.githubusercontent.com/cagataycali/robots/artifacts/iot-teardown-failure-reported/iot_teardown_ledger.png)

| site | main: raised? | main: recorded | this PR: raised? | this PR: recorded |
|---|---|---|---|---|
| reconnect stale client | no | DEBUG | no | DEBUG |
| construction failure | no | DEBUG | no | DEBUG |
| **CONNACK timeout** | **RuntimeError** (client left set) | **nothing** | no | DEBUG |
| **`close()`** | no | **nothing** | no | **WARNING** |

Paths violating the module's own stated policy: **2 of 4 → 0 of 4**.

This change touches no policy, simulation, rendering, recording or asset
behaviour, so the artifact is the measurement rather than a rollout: the figure's
generator re-derives every cell from the two per-tree JSON dumps and asserts each
one before saving.

## Tests

`tests/mesh/test_iot_client_teardown_failures.py`, 12 cases, 0.74s, no broker and
no network. It reuses the `_FakeClient` / `_make_certs` fixtures from
`tests/mesh/test_iot_reconnect_client_lifecycle.py` — the sibling module that
already pins the other two synchronous raise sources on the connect path with the
same reasoning ("the mesh stays OFF rather than crashing the host"). `stop()` was
the third, and it was the one left out.

Would a regression be caught? Five plausible reversions, two arms:

| reversion | new module | 156 pre-existing IoT-transport tests |
|---|---|---|
| timeout `stop()` unwrapped again | 4 failed | 0 failed ← blind |
| timeout tolerates but drops the log line | 2 failed | 0 failed ← blind |
| `close()` back to a bare swallow | 2 failed | 0 failed ← blind |
| `close()` records at debug, not warning | 1 failed | 0 failed ← blind |
| `close()` warning omits the thing name | 2 failed | 0 failed ← blind |

5 of 5 caught here, **0 of 5 visible to the suite as it stands**. The second row is
the shape a "the guard is called" structural check cannot see by construction,
which is why the behavioural half carries the contract.

## Out of scope

The five lines still uncovered in this module are the pub/sub bookkeeping family,
a different contract: the topic-policy fallthrough for a top-level kind with no
matching suffix, the explicit-`DROP` return in `put()`, and `_unsubscribe`'s
handler-already-gone and no-client early returns.

## Gate

Base `666a1363`, head `43c4b2c1`.

> The gate below ran at `a7298fb3`. The only change since is the changelog
> fragment's filename, renamed `2171-` → `2172-` once this PR had a number;
> `scripts/assemble_changelog.py --check` and both changelog guards were
> re-run after the rename (30 passed). No source or test line differs.

- **Pre-fix** (source reverted, the new tests kept): **6 failed / 6 passed**. The
  three timeout tests fail with `RuntimeError: io thread already gone`, `close()`
  fails with "a failed client teardown left no trace at all", and the structural
  test names the offender: `client teardown failure tolerated without a record at
  line(s) [472]`, printing the matrix `[(379, True), (438, True), (472, False)]`.
  The 6 that pass are the clean-teardown controls, the two already-obeying paths
  and the planted-defect meta-test — they are what stops the change over-reaching.
- **Coverage**, `iot_transport.py` over `tests/mesh`: 13 missing → 5 missing,
  95% → 98%. The 8 closed lines are exactly the four teardown handlers.
- **Full suite**: `MUJOCO_GL=egl pytest tests` → **28193 passed / 257 skipped /
  0 failed** in 617s (28181 on main + 12 new).
- **Lint**: `ruff check` clean, `ruff format --check` clean (1176 files),
  `mypy strands_robots tests tests_integ` reports **0 errors outside
  `examples/isaac_gs`**; the 14 there are byte-identical to a pristine checkout of
  the same base.
- `scripts/check_merge_base_overlap.py`: no overlap, 0 paths changed on
  `upstream/main` since the two diverged.

