### PR TITLE
refactor(simulation): extract backend-agnostic MotionPrimitivesCore from the MuJoCo mixin

### DIFF
--- a/changelog.d/2153-motion-primitives-core.md
+++ b/changelog.d/2153-motion-primitives-core.md
@@ -1,0 +1,13 @@
+### Changed: backend-agnostic core extracted from the MuJoCo motion primitives
+
+The MuJoCo-only `MotionPrimitivesMixin` inlined everything the
+`move_to` / `set_gripper` / `rotate_wrist` primitives share with any future
+backend: the parameter domains (pose-vector coercion, step-budget cap,
+gripper-state and wrist-angle validation), the workspace sanity check, the
+registry gripper-metadata contract (`robots.json` -> `<robot>.gripper`), and
+the structured success/timeout result envelopes. That half now lives in
+`strands_robots.simulation.motion_primitives_base.MotionPrimitivesCore`, which
+imports without MuJoCo, and the mixin inherits from it - zero behavior change
+on MuJoCo, pinned by the existing primitive suites running untouched. Step 1
+of the Isaac motion-primitives parity work (#2123): later children add an
+Isaac adapter on top of the extracted core.

--- a/strands_robots/simulation/motion_primitives_base.py
+++ b/strands_robots/simulation/motion_primitives_base.py
@@ -1,0 +1,384 @@
+"""Backend-agnostic core of the motion primitives - ``move_to`` / ``set_gripper`` / ``rotate_wrist``.
+
+The primitives were introduced for the MuJoCo backend (GH #1645, see
+:mod:`strands_robots.simulation.mujoco.motion_primitives` for the full
+agent-facing contract). This module is the half that never touches an engine
+(extracted per GH #2153, step 1 of the Isaac parity work GH #2123): the
+parameter domains, the registry gripper-metadata contract, the shared name
+heuristics, and the success / timeout envelope builders. Everything here
+operates on plain values so backend adapters cannot drift apart on wording or
+payload shape - an agent reading a ``move_to`` refusal sees the same sentence
+whichever backend produced it.
+
+What stays in a backend adapter
+(:class:`strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin`
+today): robot/world resolution against the backend's own state, actuation
+(``data.ctrl`` writes and the ``mj_step`` tick loop), the kinematics source
+(mink IK on the compiled ``MjModel``), the actuator-name half of gripper
+resolution, and the mid-run abort checks, which read backend-owned state.
+"""
+
+from __future__ import annotations
+
+import math
+import numbers
+from typing import Any
+
+import numpy as np
+
+from strands_robots.registry.robots import get_robot
+from strands_robots.utils import coerce_pose_vector
+
+# Name hints (lowercased substring match on the gripper DOF's name) used to
+# resolve the gripper when the robot registry carries no gripper metadata for
+# the robot's ``data_config``. Matches the existing runtime precedent (vera
+# provider / cosmos3 policy use gripper|finger; SO-100's gripper joint is the
+# "Jaw"). Registry metadata (``robots.json`` -> ``<robot>.gripper``, GH #1658)
+# is authoritative when present; the heuristic is the zero-config fallback for
+# user URDFs / injected MJCF, and an unresolvable gripper returns a structured
+# error listing the candidates so the agent can fall back to send_action.
+_GRIPPER_HINTS = ("gripper", "finger", "jaw")
+
+# Valid values for the registry gripper metadata ``closed`` / ``open`` fields:
+# which END of the gripper's set-point range the state maps to. The registry
+# integrity tests shape-check the shipped robots.json against the same two
+# values.
+_CTRLRANGE_ENDS = ("low", "high")
+
+# Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
+# hinge joint in the robot's chain (the distal roll joint on most serial
+# arms). "Non-gripper" is decided by the shared registry-metadata-first
+# classification, not by _GRIPPER_HINTS alone.
+_WRIST_HINTS = ("wrist_roll", "wrist_yaw", "wrist_rotate", "wrist")
+
+# Hard ceiling on max_steps / steps to prevent unbounded primitive runtime.
+_MAX_PRIMITIVE_STEPS = 10_000
+
+# Workspace sanity radius: a move_to target further than this from the robot's
+# base is rejected up front (meters). Generous on purpose - it guards against
+# unit mistakes (mm vs m), not reachability; true reachability is checked by
+# the kinematics residual.
+_WORKSPACE_SANITY_RADIUS_M = 5.0
+
+# Deterministic IK restart seeds tried when the direct solve from the live
+# configuration stalls in a local minimum (see move_to). Bounded so the worst
+# case is still a sub-second solve budget.
+_IK_RESTART_SEEDS = 8
+
+
+def _is_finite_real(value: Any) -> bool:
+    """True when ``value`` is a real, finite scalar (bool rejected)."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        return False
+    return math.isfinite(float(value))
+
+
+def _err(text: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Structured error tool-result, optionally with a json details block."""
+    content: list[dict[str, Any]] = [{"text": text}]
+    if payload is not None:
+        content.append({"json": payload})
+    return {"status": "error", "content": content}
+
+
+class MotionPrimitivesCore:
+    """Backend-agnostic half of the motion primitives.
+
+    Pure helpers only: nothing here reads engine state, takes locks, or holds
+    attributes, so the class mixes into any simulation backend. The
+    parameter-domain wording and the result payloads live here precisely so
+    every backend answers identically (AGENTS.md: "Match docstrings to
+    semantics").
+    """
+
+    # -- parameter validation -------------------------------------------------
+
+    @staticmethod
+    def _validate_step_budget(action: str, param: str, value: Any) -> dict[str, Any] | None:
+        """Validate an integer control-tick budget (1..``_MAX_PRIMITIVE_STEPS``)."""
+        if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+            return _err(f"{action}: '{param}' must be an integer, got {type(value).__name__}.")
+        if not (1 <= int(value) <= _MAX_PRIMITIVE_STEPS):
+            return _err(f"{action}: '{param}' must be between 1 and {_MAX_PRIMITIVE_STEPS}, got {int(value)}.")
+        return None
+
+    def _validate_move_to_args(
+        self,
+        position: Any,
+        orientation: Any,
+        tol: Any,
+        max_steps: Any,
+    ) -> tuple[np.ndarray | None, np.ndarray | None, int, dict[str, Any] | None]:
+        """Shared ``move_to`` parameter domain (before any engine state is read).
+
+        Returns ``(target, orientation, max_steps, None)`` on success -
+        ``target`` a float64 ``(3,)`` array, ``orientation`` a float64 ``(4,)``
+        array or ``None`` when omitted - or ``(None, None, 0, error)`` when a
+        parameter is off-domain. The pose vectors are validated by the same
+        rule the scene-construction calls use
+        (:func:`strands_robots.utils.coerce_pose_vector`): three/four finite
+        real components, a NumPy array accepted, a ``bool`` refused.
+        """
+        if position is None:
+            return None, None, 0, _err("move_to requires 'position' ([x, y, z] target in meters).")
+        # Same guard the scene-construction entry points use, so a pose
+        # `add_object`/`move_object` refuses is refused here too. `len()` on a
+        # value with no length (a scalar, an iterator) raises a bare TypeError,
+        # which would escape the primitives' documented never-raises contract.
+        position, pos_err = coerce_pose_vector("move_to", "position", position, 3)
+        if pos_err is not None:
+            return None, None, 0, _err(pos_err)
+        assert position is not None  # non-None input yields a non-None result
+        orientation, quat_err = coerce_pose_vector("move_to", "orientation", orientation, 4)
+        if quat_err is not None:
+            return None, None, 0, _err(quat_err)
+        if orientation is not None:
+            quat_norm = float(np.linalg.norm(np.asarray(orientation, dtype=np.float64)))
+            if quat_norm < 1e-8:
+                return (
+                    None,
+                    None,
+                    0,
+                    _err("move_to: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z]."),
+                )
+        if not _is_finite_real(tol) or float(tol) <= 0.0:
+            return None, None, 0, _err(f"move_to: 'tol' must be a positive number of meters, got {tol!r}.")
+        err = self._validate_step_budget("move_to", "max_steps", max_steps)
+        if err is not None:
+            return None, None, 0, err
+        target = np.asarray(position, dtype=np.float64)
+        quat = None if orientation is None else np.asarray(orientation, dtype=np.float64)
+        return target, quat, int(max_steps), None
+
+    def _validate_set_gripper_args(self, state: Any, steps: Any) -> tuple[int, dict[str, Any] | None]:
+        """Shared ``set_gripper`` parameter domain: ``(steps, None)`` or ``(0, error)``."""
+        if state not in ("open", "close"):
+            return 0, _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
+        err = self._validate_step_budget("set_gripper", "steps", steps)
+        if err is not None:
+            return 0, err
+        return int(steps), None
+
+    def _validate_rotate_wrist_args(
+        self, target_yaw: Any, tol: Any, max_steps: Any
+    ) -> tuple[float, int, dict[str, Any] | None]:
+        """Shared ``rotate_wrist`` parameter domain: ``(target_yaw, max_steps, None)`` or ``(0, 0, error)``."""
+        if target_yaw is None:
+            return 0.0, 0, _err("rotate_wrist requires 'target_yaw' (wrist joint set-point in radians).")
+        if not _is_finite_real(target_yaw):
+            return 0.0, 0, _err(f"rotate_wrist: 'target_yaw' must be a finite number of radians, got {target_yaw!r}.")
+        if not _is_finite_real(tol) or float(tol) <= 0.0:
+            return 0.0, 0, _err(f"rotate_wrist: 'tol' must be a positive number of radians, got {tol!r}.")
+        err = self._validate_step_budget("rotate_wrist", "max_steps", max_steps)
+        if err is not None:
+            return 0.0, 0, err
+        return float(target_yaw), int(max_steps), None
+
+    @staticmethod
+    def _workspace_sanity_error(robot_name: str, target: np.ndarray, base: np.ndarray) -> dict[str, Any] | None:
+        """Reject a ``move_to`` target outside the workspace sanity box.
+
+        A unit-mistake guard (mm vs m), not a reachability check - see
+        :data:`_WORKSPACE_SANITY_RADIUS_M`. ``base`` is the robot's base /
+        spawn position in world coordinates, from whichever source the
+        backend owns it in.
+        """
+        base_dist = float(np.linalg.norm(target - np.asarray(base, dtype=np.float64)))
+        if base_dist > _WORKSPACE_SANITY_RADIUS_M:
+            return _err(
+                f"move_to: target {target.tolist()} is {base_dist:.2f} m from robot "
+                f"'{robot_name}' base - outside the {_WORKSPACE_SANITY_RADIUS_M:.0f} m workspace "
+                "sanity box. Check units (meters, world frame)."
+            )
+        return None
+
+    # -- registry gripper metadata (GH #1658) ---------------------------------
+
+    @staticmethod
+    def _get_registry_robot(data_config: str) -> dict[str, Any] | None:
+        """Registry lookup seam for :meth:`_registry_gripper_metadata`.
+
+        Resolves through this module's global ``get_robot``. A backend adapter
+        may override it to keep its historical patch point alive - the MuJoCo
+        mixin does, so patching
+        ``strands_robots.simulation.mujoco.motion_primitives.get_robot`` keeps
+        working for tests and user code.
+        """
+        return get_robot(data_config)
+
+    def _registry_gripper_metadata(self, robot: Any) -> tuple[dict[str, Any] | None, str | None]:
+        """Registry ``gripper`` block for *robot*'s ``data_config``, shape-checked.
+
+        Returns ``(metadata, None)`` when the robot's ``data_config`` resolves
+        to a registry entry with a well-formed ``gripper`` block,
+        ``(None, None)`` when there is no metadata (heuristic fallback
+        applies), and ``(None, reason)`` when a block exists but is malformed
+        (possible via the user-local registry overlay; the shipped
+        ``robots.json`` is shape-checked by tests). A malformed block is a
+        loud error, never a silent heuristic fallback - half-applying it
+        could reintroduce the silent-DOF bug this metadata exists to fix.
+        """
+        data_config = getattr(robot, "data_config", None)
+        if not data_config:
+            return None, None
+        info = self._get_registry_robot(data_config)
+        if not info or "gripper" not in info:
+            return None, None
+        meta = info["gripper"]
+        actuators = meta.get("actuators") if isinstance(meta, dict) else None
+        closed_end = meta.get("closed", "low") if isinstance(meta, dict) else None
+        open_end = meta.get("open", "high") if isinstance(meta, dict) else None
+        if (
+            isinstance(actuators, list)
+            and actuators
+            and all(isinstance(a, str) and a for a in actuators)
+            and closed_end in _CTRLRANGE_ENDS
+            and open_end in _CTRLRANGE_ENDS
+            and closed_end != open_end
+        ):
+            return meta, None
+        return None, (
+            f"registry gripper metadata for data_config '{data_config}' is malformed: {meta!r}. "
+            "Expected {'actuators': [non-empty names], 'closed': 'low'|'high', "
+            "'open': 'low'|'high'} with 'closed' != 'open'. Fix the registry entry "
+            "(user overlay: user_robots.json), or drive the gripper directly with "
+            "action='send_action'."
+        )
+
+    @staticmethod
+    def _gripper_state_end(state: str, meta: dict[str, Any] | None) -> str:
+        """Which END of the set-point range ``state`` maps to (``"low"``/``"high"``).
+
+        The registry metadata's ``closed``/``open`` fields when present, else
+        the open=HIGH / close=LOW convention (correct for SO-100/SO-101 and
+        Franka, but a convention, not a law - the metadata field exists to
+        remove that sign trap for robots with an inverted gripper).
+        """
+        if meta is not None:
+            return str(meta.get("open", "high") if state == "open" else meta.get("closed", "low"))
+        return "high" if state == "open" else "low"
+
+    # -- shared result envelopes ----------------------------------------------
+
+    @staticmethod
+    def _move_to_result(
+        robot_name: str,
+        target: np.ndarray,
+        tol: float,
+        max_steps: int,
+        *,
+        reached: bool,
+        steps_used: int,
+        position_error: float,
+        ik_residual: float,
+        ee_pos: Any,
+        ee_quat: Any,
+        frame_name: str,
+        frame_type: str,
+    ) -> dict[str, Any]:
+        """Success / not-reached envelope for ``move_to``, shared across backends."""
+        payload = {
+            "reached": reached,
+            "steps": steps_used,
+            "position_error_m": position_error,
+            "ik_residual_m": ik_residual,
+            "ee_position": [float(v) for v in ee_pos],
+            "ee_orientation_wxyz": [float(v) for v in ee_quat],
+            "frame": frame_name,
+            "frame_type": frame_type,
+        }
+        if reached:
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            f"move_to: '{robot_name}' EE ({frame_type} '{frame_name}') reached "
+                            f"{target.tolist()} within {float(tol)} m in {steps_used} steps "
+                            f"(error {position_error:.4f} m)."
+                        )
+                    },
+                    {"json": payload},
+                ],
+            }
+        return _err(
+            f"move_to: '{robot_name}' did not reach {target.tolist()} within tol={float(tol)} m "
+            f"after max_steps={max_steps} (residual {position_error:.4f} m; IK residual was "
+            f"{ik_residual:.4f} m). The servo may need more steps, or the pose fights joint "
+            "limits/contacts.",
+            payload,
+        )
+
+    @staticmethod
+    def _set_gripper_result(
+        robot_name: str,
+        state: str,
+        steps: int,
+        actuators: list[str],
+        targets: dict[str, float],
+        setpoint_sources: dict[str, str],
+        gripper_joint_positions: dict[str, float],
+    ) -> dict[str, Any]:
+        """Success envelope for ``set_gripper``, shared across backends.
+
+        All mappings are keyed by the (namespace-stripped) actuator / joint
+        name, so the payload is meaningful to the agent whichever backend
+        resolved the ids.
+        """
+        payload = {
+            "state": state,
+            "actuators": actuators,
+            "targets": targets,
+            "setpoint_sources": setpoint_sources,
+            "gripper_joint_positions": gripper_joint_positions,
+        }
+        return {
+            "status": "success",
+            "content": [
+                {
+                    "text": f"set_gripper: '{robot_name}' gripper commanded {state} ({steps} ticks, actuators {actuators})."
+                },
+                {"json": payload},
+            ],
+        }
+
+    @staticmethod
+    def _rotate_wrist_result(
+        robot_name: str,
+        tol: float,
+        max_steps: int,
+        *,
+        reached: bool,
+        steps_used: int,
+        wrist_name: str,
+        target_yaw: float,
+        final_yaw: float,
+        yaw_error: float,
+    ) -> dict[str, Any]:
+        """Success / not-reached envelope for ``rotate_wrist``, shared across backends."""
+        payload = {
+            "reached": reached,
+            "steps": steps_used,
+            "wrist_joint": wrist_name,
+            "target_yaw": target_yaw,
+            "final_yaw": final_yaw,
+            "yaw_error_rad": yaw_error,
+        }
+        if reached:
+            return {
+                "status": "success",
+                "content": [
+                    {
+                        "text": (
+                            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' reached "
+                            f"{target_yaw:.3f} rad within {float(tol)} rad in {steps_used} steps."
+                        )
+                    },
+                    {"json": payload},
+                ],
+            }
+        return _err(
+            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' did not reach {target_yaw:.3f} rad "
+            f"within tol={float(tol)} rad after max_steps={max_steps} (residual {yaw_error:.4f} rad).",
+            payload,
+        )

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -49,79 +49,48 @@ from __future__ import annotations
 
 import logging
 import math
-import numbers
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
 from strands_robots.simulation.models import registered, registry_entry
+
+# The backend-agnostic half (parameter domains, registry gripper metadata,
+# shared envelopes and name-hint constants) lives in
+# :mod:`strands_robots.simulation.motion_primitives_base` (GH #2123) so the
+# Isaac adapter answers identically. The redundant aliases re-export the
+# moved names at their historical import path.
+from strands_robots.simulation.motion_primitives_base import (
+    _GRIPPER_HINTS as _GRIPPER_HINTS,
+)
+from strands_robots.simulation.motion_primitives_base import (
+    _IK_RESTART_SEEDS as _IK_RESTART_SEEDS,
+)
+from strands_robots.simulation.motion_primitives_base import (
+    _WRIST_HINTS as _WRIST_HINTS,
+)
+from strands_robots.simulation.motion_primitives_base import (
+    MotionPrimitivesCore,
+    _err,
+)
+from strands_robots.simulation.motion_primitives_base import (
+    _is_finite_real as _is_finite_real,
+)
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, mj_name_to_id
-from strands_robots.utils import coerce_pose_vector
 
 logger = logging.getLogger(__name__)
-
-# Name hints (lowercased substring match on the namespace-stripped actuator /
-# joint name) used to resolve the gripper DOF when the robot registry carries
-# no gripper metadata for the robot's ``data_config``. Matches the existing
-# runtime precedent (vera provider / cosmos3 policy use gripper|finger;
-# SO-100's gripper joint is the "Jaw"). Registry metadata
-# (``robots.json`` -> ``<robot>.gripper``, GH #1658) is authoritative when
-# present; the heuristic is the zero-config fallback for user URDFs / injected
-# MJCF, and an unresolvable gripper returns a structured error listing the
-# actuators so the agent can fall back to send_action.
-_GRIPPER_HINTS = ("gripper", "finger", "jaw")
-
-# Valid values for the registry gripper metadata ``closed`` / ``open`` fields:
-# which END of the gripper's set-point range the state maps to (that range is
-# normally the actuator ctrlrange; see _gripper_setpoint_range for the driven-
-# joint substitution). The registry integrity tests shape-check the shipped
-# robots.json against the same two values.
-_CTRLRANGE_ENDS = ("low", "high")
-
-# Wrist-yaw joint hints, most-specific first. Fallback: the last non-gripper
-# hinge joint in the robot's chain (the distal roll joint on most serial
-# arms). "Non-gripper" is decided by the shared registry-metadata-first
-# classification (_resolve_gripper_actuators), not by _GRIPPER_HINTS alone.
-_WRIST_HINTS = ("wrist_roll", "wrist_yaw", "wrist_rotate", "wrist")
 
 # Physics substeps per control tick. Each move_to/rotate_wrist "step" (and each
 # set_gripper "step") re-asserts ctrl then advances this many mj_step calls, so
 # the default budgets stay bounded: move_to(max_steps=200) is at most
 # 200 * 5 = 1000 physics steps (2 s of sim time at the 0.002 s default).
+# Deliberately NOT in motion_primitives_base: it is a MuJoCo physics-substep
+# detail, not part of the backend-agnostic primitive contract.
 _SUBSTEPS_PER_TICK = 5
 
-# Hard ceiling on max_steps / steps to prevent unbounded primitive runtime.
-_MAX_PRIMITIVE_STEPS = 10_000
 
-# Workspace sanity radius: a move_to target further than this from the robot's
-# spawn position is rejected up front (meters). Generous on purpose - it guards
-# against unit mistakes (mm vs m), not reachability; true reachability is
-# checked by the IK residual.
-_WORKSPACE_SANITY_RADIUS_M = 5.0
-
-# Deterministic IK restart seeds tried when the direct solve from the live
-# configuration stalls in a local minimum (see move_to). Bounded so the worst
-# case is still a sub-second solve budget.
-_IK_RESTART_SEEDS = 8
-
-
-def _is_finite_real(value: Any) -> bool:
-    """True when ``value`` is a real, finite scalar (bool rejected)."""
-    if isinstance(value, bool) or not isinstance(value, numbers.Real):
-        return False
-    return math.isfinite(float(value))
-
-
-def _err(text: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Structured error tool-result, optionally with a json details block."""
-    content: list[dict[str, Any]] = [{"text": text}]
-    if payload is not None:
-        content.append({"json": payload})
-    return {"status": "error", "content": content}
-
-
-class MotionPrimitivesMixin:
+class MotionPrimitivesMixin(MotionPrimitivesCore):
     """Analytic motion primitives mixed into ``Simulation``.
 
     **Coupling** (see the :mod:`simulation` top-level docstring): reaches into
@@ -323,44 +292,16 @@ class MotionPrimitivesMixin:
             return name[len(namespace) :]
         return name or ""
 
-    def _registry_gripper_metadata(self, robot: Any) -> tuple[dict[str, Any] | None, str | None]:
-        """Registry ``gripper`` block for *robot*'s ``data_config``, shape-checked.
+    @staticmethod
+    def _get_registry_robot(data_config: str) -> dict[str, Any] | None:
+        """Registry lookup seam (see ``MotionPrimitivesCore._get_registry_robot``).
 
-        Returns ``(metadata, None)`` when the robot's ``data_config`` resolves
-        to a registry entry with a well-formed ``gripper`` block,
-        ``(None, None)`` when there is no metadata (heuristic fallback
-        applies), and ``(None, reason)`` when a block exists but is malformed
-        (possible via the user-local registry overlay; the shipped
-        ``robots.json`` is shape-checked by tests). A malformed block is a
-        loud error, never a silent heuristic fallback - half-applying it
-        could reintroduce the silent-DOF bug this metadata exists to fix.
+        Resolves through this module's ``get_robot`` global so the historical
+        patch point
+        (``strands_robots.simulation.mujoco.motion_primitives.get_robot``)
+        keeps working for tests and user code.
         """
-        data_config = getattr(robot, "data_config", None)
-        if not data_config:
-            return None, None
-        info = get_robot(data_config)
-        if not info or "gripper" not in info:
-            return None, None
-        meta = info["gripper"]
-        actuators = meta.get("actuators") if isinstance(meta, dict) else None
-        closed_end = meta.get("closed", "low") if isinstance(meta, dict) else None
-        open_end = meta.get("open", "high") if isinstance(meta, dict) else None
-        if (
-            isinstance(actuators, list)
-            and actuators
-            and all(isinstance(a, str) and a for a in actuators)
-            and closed_end in _CTRLRANGE_ENDS
-            and open_end in _CTRLRANGE_ENDS
-            and closed_end != open_end
-        ):
-            return meta, None
-        return None, (
-            f"registry gripper metadata for data_config '{data_config}' is malformed: {meta!r}. "
-            "Expected {'actuators': [non-empty names], 'closed': 'low'|'high', "
-            "'open': 'low'|'high'} with 'closed' != 'open'. Fix the registry entry "
-            "(user overlay: user_robots.json), or drive the gripper directly with "
-            "action='send_action'."
-        )
+        return get_robot(data_config)
 
     def _resolve_gripper_actuators(
         self, model: Any, robot: Any
@@ -516,30 +457,13 @@ class MotionPrimitivesMixin:
             or servo convergence times out. Never raises.
         """
         # ---- parameter validation (before touching the world) ----
-        if position is None:
-            return _err("move_to requires 'position' ([x, y, z] target in meters).")
-        # Same guard the scene-construction entry points use, so a pose
-        # `add_object`/`move_object` refuses is refused here too. `len()` on a
-        # value with no length (a scalar, an iterator) raises a bare TypeError,
-        # which would escape this method's documented never-raises contract.
-        position, pos_err = coerce_pose_vector("move_to", "position", position, 3)
-        if pos_err is not None:
-            return _err(pos_err)
-        assert position is not None  # non-None input yields a non-None result
-        orientation, quat_err = coerce_pose_vector("move_to", "orientation", orientation, 4)
-        if quat_err is not None:
-            return _err(quat_err)
-        if orientation is not None:
-            quat_norm = float(np.linalg.norm(np.asarray(orientation, dtype=np.float64)))
-            if quat_norm < 1e-8:
-                return _err("move_to: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z].")
-        if not _is_finite_real(tol) or float(tol) <= 0.0:
-            return _err(f"move_to: 'tol' must be a positive number of meters, got {tol!r}.")
-        err = self._validate_step_budget("move_to", "max_steps", max_steps)
-        if err is not None:
-            return err
-        max_steps = int(max_steps)
-        target = np.asarray(position, dtype=np.float64)
+        # Shared with the Isaac adapter (motion_primitives_base): same
+        # pose-vector rule the scene-construction calls use, same tol /
+        # max_steps domains, same wording.
+        target, target_quat, max_steps, arg_err = self._validate_move_to_args(position, orientation, tol, max_steps)
+        if arg_err is not None:
+            return arg_err
+        assert target is not None  # no error implies a coerced target
 
         # ---- setup under the lock: guards, EE frame, IK solve ----
         with self._lock:
@@ -554,13 +478,9 @@ class MotionPrimitivesMixin:
             namespace = robot.namespace or ""
 
             base = np.asarray(robot.position or (0.0, 0.0, 0.0), dtype=np.float64)
-            base_dist = float(np.linalg.norm(target - base))
-            if base_dist > _WORKSPACE_SANITY_RADIUS_M:
-                return _err(
-                    f"move_to: target {target.tolist()} is {base_dist:.2f} m from robot "
-                    f"'{robot_name}' base - outside the {_WORKSPACE_SANITY_RADIUS_M:.0f} m workspace "
-                    "sanity box. Check units (meters, world frame)."
-                )
+            sanity_err = self._workspace_sanity_error(robot_name, target, base)
+            if sanity_err is not None:
+                return sanity_err
 
             from strands_robots.simulation.ik import discover_ee_frame
 
@@ -613,7 +533,7 @@ class MotionPrimitivesMixin:
                     model,
                     frame_name,
                     frame_type,
-                    orientation_cost=1.0 if orientation is not None else 0.0,
+                    orientation_cost=1.0 if target_quat is not None else 0.0,
                     max_iters=200,
                 )
             except (ImportError, RuntimeError, ValueError) as e:
@@ -622,9 +542,8 @@ class MotionPrimitivesMixin:
             q0 = np.array(data.qpos, dtype=np.float64, copy=True)
             target_pose = np.eye(4, dtype=np.float64)
             target_pose[:3, 3] = target
-            if orientation is not None:
-                quat = np.asarray(orientation, dtype=np.float64)
-                quat = quat / np.linalg.norm(quat)
+            if target_quat is not None:
+                quat = target_quat / np.linalg.norm(target_quat)
                 rot = np.zeros(9, dtype=np.float64)
                 self._mj.mju_quat2Mat(rot, quat)
                 target_pose[:3, :3] = rot.reshape(3, 3)
@@ -724,36 +643,19 @@ class MotionPrimitivesMixin:
                 reached = True
                 break
 
-        payload = {
-            "reached": reached,
-            "steps": steps_used,
-            "position_error_m": position_error,
-            "ik_residual_m": ik_residual,
-            "ee_position": [float(v) for v in ee_pos],
-            "ee_orientation_wxyz": [float(v) for v in ee_quat],
-            "frame": frame_name,
-            "frame_type": frame_type,
-        }
-        if reached:
-            return {
-                "status": "success",
-                "content": [
-                    {
-                        "text": (
-                            f"move_to: '{robot_name}' EE ({frame_type} '{frame_name}') reached "
-                            f"{target.tolist()} within {float(tol)} m in {steps_used} steps "
-                            f"(error {position_error:.4f} m)."
-                        )
-                    },
-                    {"json": payload},
-                ],
-            }
-        return _err(
-            f"move_to: '{robot_name}' did not reach {target.tolist()} within tol={float(tol)} m "
-            f"after max_steps={max_steps} (residual {position_error:.4f} m; IK residual was "
-            f"{ik_residual:.4f} m). The servo may need more steps, or the pose fights joint "
-            "limits/contacts.",
-            payload,
+        return self._move_to_result(
+            robot_name,
+            target,
+            float(tol),
+            max_steps,
+            reached=reached,
+            steps_used=steps_used,
+            position_error=position_error,
+            ik_residual=ik_residual,
+            ee_pos=ee_pos,
+            ee_quat=ee_quat,
+            frame_name=frame_name,
+            frame_type=frame_type,
         )
 
     def set_gripper(
@@ -794,12 +696,10 @@ class MotionPrimitivesMixin:
             cannot be resolved or no source gives usable set-points. Never
             raises.
         """
-        if state not in ("open", "close"):
-            return _err(f'set_gripper: \'state\' must be "open" or "close", got {state!r}.')
-        err = self._validate_step_budget("set_gripper", "steps", steps)
-        if err is not None:
-            return err
-        steps = int(steps)
+        steps, arg_err = self._validate_set_gripper_args(state, steps)
+        if arg_err is not None:
+            return arg_err
+        assert state is not None  # narrowed by the shared validator
 
         with self._lock:
             robot_name_resolved, error = self._primitive_resolve_robot("set_gripper", robot_name)
@@ -834,15 +734,11 @@ class MotionPrimitivesMixin:
                     "Drive it directly with action='send_action' instead."
                 )
 
-            # Which END of the set-point range each state maps to: the registry metadata's
-            # `closed`/`open` fields when present, else the open=HIGH /
-            # close=LOW convention (correct for SO-100/SO-101 and Franka, but
-            # a convention, not a law - the metadata field exists to remove
-            # that sign trap for robots with an inverted gripper).
-            if grip_meta is not None:
-                end = grip_meta.get("open", "high") if state == "open" else grip_meta.get("closed", "low")
-            else:
-                end = "high" if state == "open" else "low"
+            # Which END of the set-point range each state maps to: shared
+            # registry-metadata-first mapping (open=HIGH / close=LOW
+            # convention when no metadata; see
+            # MotionPrimitivesCore._gripper_state_end).
+            end = self._gripper_state_end(state, grip_meta)
 
             targets: dict[int, float] = {}
             setpoint_sources: dict[int, str] = {}
@@ -875,22 +771,15 @@ class MotionPrimitivesMixin:
             act_names = [
                 self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, a), namespace) for a in gripper_acts
             ]
-        payload = {
-            "state": state,
-            "actuators": act_names,
-            "targets": {n: targets[a] for n, a in zip(act_names, gripper_acts, strict=True)},
-            "setpoint_sources": {n: setpoint_sources[a] for n, a in zip(act_names, gripper_acts, strict=True)},
-            "gripper_joint_positions": joint_positions,
-        }
-        return {
-            "status": "success",
-            "content": [
-                {
-                    "text": f"set_gripper: '{robot_name}' gripper commanded {state} ({steps} ticks, actuators {act_names})."
-                },
-                {"json": payload},
-            ],
-        }
+        return self._set_gripper_result(
+            robot_name,
+            state,
+            steps,
+            act_names,
+            {n: targets[a] for n, a in zip(act_names, gripper_acts, strict=True)},
+            {n: setpoint_sources[a] for n, a in zip(act_names, gripper_acts, strict=True)},
+            joint_positions,
+        )
 
     def rotate_wrist(
         self,
@@ -931,17 +820,9 @@ class MotionPrimitivesMixin:
             the target is out of range, or servo convergence times out.
             Never raises.
         """
-        if target_yaw is None:
-            return _err("rotate_wrist requires 'target_yaw' (wrist joint set-point in radians).")
-        if not _is_finite_real(target_yaw):
-            return _err(f"rotate_wrist: 'target_yaw' must be a finite number of radians, got {target_yaw!r}.")
-        if not _is_finite_real(tol) or float(tol) <= 0.0:
-            return _err(f"rotate_wrist: 'tol' must be a positive number of radians, got {tol!r}.")
-        err = self._validate_step_budget("rotate_wrist", "max_steps", max_steps)
-        if err is not None:
-            return err
-        max_steps = int(max_steps)
-        target_yaw = float(target_yaw)
+        target_yaw, max_steps, arg_err = self._validate_rotate_wrist_args(target_yaw, tol, max_steps)
+        if arg_err is not None:
+            return arg_err
 
         with self._lock:
             robot_name_resolved, error = self._primitive_resolve_robot("rotate_wrist", robot_name)
@@ -1033,40 +914,14 @@ class MotionPrimitivesMixin:
                 reached = True
                 break
 
-        payload = {
-            "reached": reached,
-            "steps": steps_used,
-            "wrist_joint": wrist_name,
-            "target_yaw": target_yaw,
-            "final_yaw": final_yaw,
-            "yaw_error_rad": yaw_error,
-        }
-        if reached:
-            return {
-                "status": "success",
-                "content": [
-                    {
-                        "text": (
-                            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' reached "
-                            f"{target_yaw:.3f} rad within {float(tol)} rad in {steps_used} steps."
-                        )
-                    },
-                    {"json": payload},
-                ],
-            }
-        return _err(
-            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' did not reach {target_yaw:.3f} rad "
-            f"within tol={float(tol)} rad after max_steps={max_steps} (residual {yaw_error:.4f} rad).",
-            payload,
+        return self._rotate_wrist_result(
+            robot_name,
+            float(tol),
+            max_steps,
+            reached=reached,
+            steps_used=steps_used,
+            wrist_name=wrist_name,
+            target_yaw=target_yaw,
+            final_yaw=final_yaw,
+            yaw_error=yaw_error,
         )
-
-    # -- validation helpers ---------------------------------------------------
-
-    @staticmethod
-    def _validate_step_budget(action: str, param: str, value: Any) -> dict[str, Any] | None:
-        """Validate an integer control-tick budget (1..``_MAX_PRIMITIVE_STEPS``)."""
-        if isinstance(value, bool) or not isinstance(value, numbers.Integral):
-            return _err(f"{action}: '{param}' must be an integer, got {type(value).__name__}.")
-        if not (1 <= int(value) <= _MAX_PRIMITIVE_STEPS):
-            return _err(f"{action}: '{param}' must be between 1 and {_MAX_PRIMITIVE_STEPS}, got {int(value)}.")
-        return None

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -74,9 +74,6 @@ from strands_robots.simulation.motion_primitives_base import (
     MotionPrimitivesCore,
     _err,
 )
-from strands_robots.simulation.motion_primitives_base import (
-    _is_finite_real as _is_finite_real,
-)
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, mj_name_to_id
 
 logger = logging.getLogger(__name__)

--- a/tests/simulation/mujoco/test_motion_primitive_numeric_domains.py
+++ b/tests/simulation/mujoco/test_motion_primitive_numeric_domains.py
@@ -33,10 +33,8 @@ import pytest
 
 pytest.importorskip("mujoco")
 
-from strands_robots.simulation.mujoco.motion_primitives import (  # noqa: E402
-    MotionPrimitivesMixin,
-    _is_finite_real,
-)
+from strands_robots.simulation.motion_primitives_base import _is_finite_real  # noqa: E402
+from strands_robots.simulation.mujoco.motion_primitives import MotionPrimitivesMixin  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
 from .test_motion_primitives import ARM_XML, REACHABLE  # noqa: E402

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -519,6 +519,11 @@ _NOT_AN_INPUT_DOMAIN = {
     "rollout_rate_mismatch_reason": "compares already-validated rates",
     # Reads a pose back off the USD stage - not caller input.
     "_prim_body_state": "reads state out of the engine",
+    # Measures the distance between a target _validate_move_to_args has already
+    # coerced (its position runs through coerce_pose_vector, which refuses a
+    # boolean component) and the engine-owned robot base position - a boolean
+    # cannot reach the float() here.
+    "_workspace_sanity_error": "measures an already-coerced target against engine state",
 }
 
 _GUARDED_VALIDATORS = {

--- a/tests/simulation/test_motion_primitives_base.py
+++ b/tests/simulation/test_motion_primitives_base.py
@@ -1,0 +1,212 @@
+"""Backend-agnostic motion-primitives core, exercised without an engine.
+
+``MotionPrimitivesCore`` (:mod:`strands_robots.simulation.motion_primitives_base`,
+extracted from the MuJoCo mixin per GH #2153) owns the parameter domains, the
+registry gripper-metadata contract, and the shared result envelopes for
+``move_to`` / ``set_gripper`` / ``rotate_wrist``. The full agent-facing
+behaviour on a live world is pinned by the MuJoCo suites
+(``tests/simulation/mujoco/test_motion_primitives.py`` and siblings); this file
+pins what those suites cannot: that the core answers on plain data with no
+backend at all, and that the module imports without MuJoCo installed - the
+property the Isaac adapter (GH #2123) builds on.
+"""
+
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.motion_primitives_base import (
+    MotionPrimitivesCore,
+)
+
+
+def _error_text(result: dict | None) -> str:
+    assert result is not None and result["status"] == "error", result
+    return result["content"][0]["text"]
+
+
+@pytest.fixture()
+def core() -> MotionPrimitivesCore:
+    return MotionPrimitivesCore()
+
+
+class TestModuleIsBackendFree:
+    def test_imports_without_mujoco(self) -> None:
+        """The core module must import with no MuJoCo anywhere in the process.
+
+        Fresh-interpreter check (immune to ``sys.modules`` pollution from
+        other tests): the Isaac adapter consumes this module on machines
+        without the ``[sim-mujoco]`` extra.
+        """
+        code = (
+            "import sys\n"
+            "sys.modules['mujoco'] = None  # any 'import mujoco' now explodes\n"
+            "import strands_robots.simulation.motion_primitives_base as m\n"
+            "leaked = [k for k, v in sys.modules.items() if k.startswith('mujoco') and v is not None]\n"
+            "assert not leaked, leaked\n"
+            "print('ok')\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+        assert out.stdout.strip() == "ok"
+
+
+class TestMoveToArgValidation:
+    def test_missing_position_is_refused(self, core: MotionPrimitivesCore) -> None:
+        target, quat, steps, err = core._validate_move_to_args(None, None, 0.01, 200)
+        assert (target, quat, steps) == (None, None, 0)
+        assert "requires 'position'" in _error_text(err)
+
+    @pytest.mark.parametrize("position", [[1.0, 2.0], [1.0, 2.0, 3.0, 4.0], "abc", [1.0, float("nan"), 3.0]])
+    def test_malformed_position_is_refused(self, core: MotionPrimitivesCore, position) -> None:
+        _, _, _, err = core._validate_move_to_args(position, None, 0.01, 200)
+        assert err is not None
+        assert "position" in _error_text(err)
+
+    def test_zero_norm_quaternion_is_refused(self, core: MotionPrimitivesCore) -> None:
+        _, _, _, err = core._validate_move_to_args([0.1, 0.2, 0.3], [0.0, 0.0, 0.0, 0.0], 0.01, 200)
+        assert "~zero norm" in _error_text(err)
+
+    @pytest.mark.parametrize("tol", [0.0, -0.01, float("nan"), float("inf"), "0.01", True])
+    def test_off_domain_tol_is_refused(self, core: MotionPrimitivesCore, tol) -> None:
+        _, _, _, err = core._validate_move_to_args([0.1, 0.2, 0.3], None, tol, 200)
+        assert "'tol' must be a positive number" in _error_text(err)
+
+    def test_valid_args_coerce_to_arrays(self, core: MotionPrimitivesCore) -> None:
+        target, quat, max_steps, err = core._validate_move_to_args([0.1, 0.2, 0.3], [1, 0, 0, 0], 0.01, 200)
+        assert err is None
+        assert target is not None and quat is not None
+        np.testing.assert_allclose(target, np.array([0.1, 0.2, 0.3]))
+        np.testing.assert_allclose(quat, np.array([1.0, 0.0, 0.0, 0.0]))
+        assert target.dtype == np.float64 and quat.dtype == np.float64
+        assert max_steps == 200
+
+    def test_orientation_is_optional(self, core: MotionPrimitivesCore) -> None:
+        target, quat, _, err = core._validate_move_to_args([0.1, 0.2, 0.3], None, 0.01, 200)
+        assert err is None and target is not None and quat is None
+
+
+class TestStepBudgetCap:
+    @pytest.mark.parametrize("value", [0, -1, 10_001, 1.5, "200", None, True])
+    def test_off_domain_budget_is_refused(self, core: MotionPrimitivesCore, value) -> None:
+        err = core._validate_step_budget("move_to", "max_steps", value)
+        assert err is not None
+        text = _error_text(err)
+        assert "max_steps" in text and "move_to" in text
+
+    @pytest.mark.parametrize("value", [1, 200, 10_000])
+    def test_in_domain_budget_passes(self, core: MotionPrimitivesCore, value) -> None:
+        assert core._validate_step_budget("move_to", "max_steps", value) is None
+
+    def test_cap_is_named_in_the_refusal(self, core: MotionPrimitivesCore) -> None:
+        err = core._validate_step_budget("set_gripper", "steps", 10_001)
+        assert "between 1 and 10000" in _error_text(err)
+
+
+class TestSetGripperArgValidation:
+    @pytest.mark.parametrize("state", [None, "opened", "CLOSE", 1])
+    def test_off_domain_state_is_refused(self, core: MotionPrimitivesCore, state) -> None:
+        steps, err = core._validate_set_gripper_args(state, 12)
+        assert steps == 0
+        assert '"open" or "close"' in _error_text(err)
+
+    @pytest.mark.parametrize("state", ["open", "close"])
+    def test_valid_state_passes(self, core: MotionPrimitivesCore, state) -> None:
+        steps, err = core._validate_set_gripper_args(state, 12)
+        assert (steps, err) == (12, None)
+
+
+class TestRotateWristArgValidation:
+    def test_missing_target_yaw_is_refused(self, core: MotionPrimitivesCore) -> None:
+        _, _, err = core._validate_rotate_wrist_args(None, 0.02, 200)
+        assert "requires 'target_yaw'" in _error_text(err)
+
+    @pytest.mark.parametrize("target_yaw", [float("nan"), float("inf"), "0.5", True])
+    def test_non_finite_target_yaw_is_refused(self, core: MotionPrimitivesCore, target_yaw) -> None:
+        _, _, err = core._validate_rotate_wrist_args(target_yaw, 0.02, 200)
+        assert "'target_yaw' must be a finite number" in _error_text(err)
+
+    def test_valid_args_pass(self, core: MotionPrimitivesCore) -> None:
+        target_yaw, max_steps, err = core._validate_rotate_wrist_args(0.5, 0.02, 200)
+        assert (target_yaw, max_steps, err) == (0.5, 200, None)
+
+
+class TestWorkspaceSanity:
+    def test_far_target_is_refused_naming_the_distance(self, core: MotionPrimitivesCore) -> None:
+        err = core._workspace_sanity_error("arm", np.array([10.0, 0.0, 0.0]), np.zeros(3))
+        text = _error_text(err)
+        assert "10.00 m" in text and "workspace" in text and "arm" in text
+
+    def test_near_target_passes(self, core: MotionPrimitivesCore) -> None:
+        assert core._workspace_sanity_error("arm", np.array([0.3, 0.2, 0.1]), np.zeros(3)) is None
+
+    def test_distance_is_measured_from_the_base(self, core: MotionPrimitivesCore) -> None:
+        base = np.array([10.0, 0.0, 0.0])
+        assert core._workspace_sanity_error("arm", np.array([10.3, 0.0, 0.2]), base) is None
+
+
+class _RegistryCore(MotionPrimitivesCore):
+    """Core wired to a registry-shaped dict instead of the shipped robots.json."""
+
+    def __init__(self, registry: dict) -> None:
+        self._registry = registry
+
+    def _get_registry_robot(self, data_config: str) -> dict | None:  # type: ignore[override]
+        return self._registry.get(data_config)
+
+
+class TestRegistryGripperMetadata:
+    def _robot(self, data_config: str | None = "so101") -> SimpleNamespace:
+        return SimpleNamespace(name="arm", data_config=data_config)
+
+    def test_well_formed_block_resolves(self) -> None:
+        core = _RegistryCore({"so101": {"gripper": {"actuators": ["Jaw"], "closed": "low", "open": "high"}}})
+        meta, reason = core._registry_gripper_metadata(self._robot())
+        assert reason is None
+        assert meta == {"actuators": ["Jaw"], "closed": "low", "open": "high"}
+
+    def test_no_data_config_means_heuristic_fallback(self) -> None:
+        core = _RegistryCore({})
+        assert core._registry_gripper_metadata(self._robot(data_config=None)) == (None, None)
+
+    def test_unknown_robot_means_heuristic_fallback(self) -> None:
+        core = _RegistryCore({})
+        assert core._registry_gripper_metadata(self._robot()) == (None, None)
+
+    def test_entry_without_gripper_block_means_heuristic_fallback(self) -> None:
+        core = _RegistryCore({"so101": {"hardware": {}}})
+        assert core._registry_gripper_metadata(self._robot()) == (None, None)
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"actuators": [], "closed": "low", "open": "high"},  # empty actuator list
+            {"actuators": ["Jaw", 3], "closed": "low", "open": "high"},  # non-str actuator
+            {"actuators": ["Jaw"], "closed": "low", "open": "low"},  # closed == open
+            {"actuators": ["Jaw"], "closed": "mid", "open": "high"},  # off-domain end
+            "jaw",  # not a dict at all
+        ],
+    )
+    def test_malformed_block_is_a_loud_reason_not_a_fallback(self, block) -> None:
+        core = _RegistryCore({"so101": {"gripper": block}})
+        meta, reason = core._registry_gripper_metadata(self._robot())
+        assert meta is None
+        assert reason is not None and "malformed" in reason
+
+    def test_state_end_mapping_defaults_and_metadata_override(self) -> None:
+        core = MotionPrimitivesCore()
+        # Convention with no metadata: open=HIGH / close=LOW.
+        assert core._gripper_state_end("open", None) == "high"
+        assert core._gripper_state_end("close", None) == "low"
+        # Metadata overrides the convention (the inverted-gripper sign trap).
+        meta = {"actuators": ["Jaw"], "closed": "high", "open": "low"}
+        assert core._gripper_state_end("open", meta) == "low"
+        assert core._gripper_state_end("close", meta) == "high"

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -657,8 +657,14 @@ def _scan_placement_methods(root: pathlib.Path) -> tuple[set[tuple[str, str]], l
                     found.add((backend, fn.name))
                     routed = any(
                         isinstance(node, ast.Call)
-                        and isinstance(node.func, ast.Name)
-                        and node.func.id == "coerce_pose_vector"
+                        and (
+                            (isinstance(node.func, ast.Name) and node.func.id == "coerce_pose_vector")
+                            # Routing through the backend-agnostic core counts:
+                            # MotionPrimitivesCore._validate_move_to_args wraps
+                            # coerce_pose_vector (pinned non-vacuously by
+                            # test_the_shared_core_validator_uses_the_shared_helper).
+                            or (isinstance(node.func, ast.Attribute) and node.func.attr == "_validate_move_to_args")
+                        )
                         for node in ast.walk(fn)
                     )
                     if not routed:
@@ -695,6 +701,21 @@ class TestNoPlacementMethodDrifts:
         assert found == {("newton", "place")}
         assert len(unguarded) == 1
         assert "Engine.place" in unguarded[0]
+
+    def test_the_shared_core_validator_uses_the_shared_helper(self):
+        """The indirection the scan accepts must end at ``coerce_pose_vector``.
+
+        ``move_to`` routes its pose parameters through
+        ``MotionPrimitivesCore._validate_move_to_args`` (the backend-agnostic
+        core extracted in #2153), so the scan accepts that call as routed.
+        That acceptance is only sound while the core validator itself calls
+        the shared helper - this pins the second hop, so the chain cannot be
+        broken by editing the module the scan does not walk.
+        """
+        from strands_robots.simulation.motion_primitives_base import MotionPrimitivesCore
+
+        source = inspect.getsource(MotionPrimitivesCore._validate_move_to_args)
+        assert "coerce_pose_vector" in source
 
     def test_a_module_level_spec_helper_is_out_of_scope_by_construction(self):
         """``reposition_body_in_scene`` is not a public method and takes no envelope.

--- a/tests/test_registry_integrity.py
+++ b/tests/test_registry_integrity.py
@@ -197,7 +197,7 @@ def test_rebot_b601_family_is_drivable_real(registry: dict) -> None:
 
 # Valid values for gripper.closed / gripper.open: which END of the gripper's
 # set-point range the state maps to. Kept in sync with
-# strands_robots/simulation/mujoco/motion_primitives.py::_CTRLRANGE_ENDS.
+# strands_robots/simulation/motion_primitives_base.py::_CTRLRANGE_ENDS.
 _GRIPPER_ENDS = {"low", "high"}
 
 


### PR DESCRIPTION
Extracts the backend-agnostic half of the motion primitives (`move_to` / `set_gripper` / `rotate_wrist`) out of the MuJoCo-only `MotionPrimitivesMixin` into a new shared `strands_robots/simulation/motion_primitives_base.py`, with zero behavior change on MuJoCo. Step 1 of the Isaac motion-primitives parity work (#2123); later children add an Isaac adapter on top of the extracted core. No Isaac code in this PR.

Closes #2153

## What moved into `MotionPrimitivesCore`

- Module helpers `_is_finite_real` / `_err`, and the shared constants `_GRIPPER_HINTS`, `_CTRLRANGE_ENDS`, `_WRIST_HINTS`, `_MAX_PRIMITIVE_STEPS`, `_WORKSPACE_SANITY_RADIUS_M`, `_IK_RESTART_SEEDS`.
- Input validation for the three primitives' args, previously inlined at the top of each: pose coercion via `strands_robots.utils.coerce_pose_vector`, step-budget validation against `_MAX_PRIMITIVE_STEPS`, gripper-state and wrist-angle validation (`_validate_move_to_args` / `_validate_set_gripper_args` / `_validate_rotate_wrist_args` / `_validate_step_budget`).
- Workspace sanity check (`_workspace_sanity_error`).
- Registry gripper-metadata resolution: `_registry_gripper_metadata` (shape check of `robots.json -> <robot>.gripper`) and the `closed`/`open` -> `low`/`high` state-end mapping (`_gripper_state_end`).
- Result/abort shaping: the success/timeout envelopes shared by all three primitives (`_move_to_result` / `_set_gripper_result` / `_rotate_wrist_result`), residual on IK failure included.

## What stayed in MuJoCo

Actuator-map resolution, the actuator-name half of `_resolve_gripper_actuators`, `data.ctrl` writes, the `mj_step` tick loop, `_require_no_running_policy` / `self._lock` interplay, and `_SUBSTEPS_PER_TICK` (a MuJoCo physics-substep detail, deliberately not in the core). `_IK_RESTART_SEEDS` usage (the discrete-solve restart loop) also stays MuJoCo-side; the constant lives in the core per the issue's scope list.

`MotionPrimitivesMixin` now inherits from `MotionPrimitivesCore`; the moved logic is deleted, not copied. The historical patch point `strands_robots.simulation.mujoco.motion_primitives.get_robot` keeps working: the core resolves the registry through a `_get_registry_robot` seam the mixin overrides to read its own module global (pinned by the existing monkeypatch-based tests, which pass untouched).

## Constraints honored

- **No behavior change**: `tests/simulation/mujoco/test_motion_primitives.py`, `test_motion_primitive_numeric_domains.py`, `test_set_gripper_setpoint_range_sources.py`, `test_gripper_action_key_equivalence.py` all pass **unedited** (199 tests including the sibling primitive suites).
- **Imports without MuJoCo**: no `import mujoco` anywhere in the new module; pinned by a fresh-interpreter test that plants `sys.modules['mujoco'] = None` before importing it.
- Public API and docstring semantics identical; no `_`-prefixed names in any `__all__`; no `__init__.py` changes.

## Structural drift scans

Two repo-wide structural guards (not in the do-not-edit list) learned the new indirection, each keeping its non-vacuity:

- `test_pose_vector_domain_across_backends.py`: the placement-method sweep accepts routing through `_validate_move_to_args`, and a new test pins the second hop - the core validator itself must call `coerce_pose_vector` - so the chain cannot be silently broken in the module the scan does not walk.
- `test_input_validators_refuse_a_boolean.py`: `_workspace_sanity_error` (newly discovered as a function; previously inline) is listed in `_NOT_AN_INPUT_DOMAIN` with a reason - its inputs are an already-coerced target and engine-owned base state, so a boolean cannot reach its `float()`.
- `test_registry_integrity.py`: a comment naming `_CTRLRANGE_ENDS`'s home updated to the new path.

## Acceptance checklist

- [x] `strands_robots/simulation/motion_primitives_base.py` exists; `MotionPrimitivesMixin` consumes it; duplicated logic deleted, not copied
- [x] New unit suite `tests/simulation/test_motion_primitives_base.py` (51 tests): arg-validation rejections, step-budget cap, gripper-metadata resolution from a registry-shaped dict, import without `mujoco`
- [x] `hatch run format && hatch run lint && hatch run test` green: 28228 passed, 262 skipped, coverage 95.36% (full suite run with `MUJOCO_GL=egl` on a GPU box; a software-GL run aborts in an unrelated LIBERO rendering test regardless of this diff)
- [x] Changelog fragment `changelog.d/2153-motion-primitives-core.md` (fragment named by issue number per `changelog.d/README.md`; `CHANGELOG.md` untouched)

## Test surface

- 51 new tests exercising the core directly with no engine
- 199 existing MuJoCo primitive tests pass untouched
- Full suite: 28228 passed / 262 skipped

## Out of scope / follow-ups

- The Isaac adapter itself and any Isaac-side wiring: subsequent children of #2123.

Project board: this issue should move to "In review".
