### PR TITLE
feat(simulation/isaac): synchronized multi-robot run_multi_policy control loop (no recording)

### DIFF
--- a/changelog.d/2158-isaac-run-multi-policy-loop.md
+++ b/changelog.d/2158-isaac-run-multi-policy-loop.md
@@ -1,0 +1,17 @@
+### Added: Isaac synchronized multi-robot `run_multi_policy` control loop
+
+`IsaacSimulation.run_multi_policy` now drives multiple robots, each with its
+own policy and instruction, in one lockstep control loop (parity with the
+MuJoCo implementation, #2122): per timestep every robot is observed once, a
+policy is re-queried only when its buffered action chunk drains
+(`resolve_chunk_length`, exactly as the single-policy runner sizes it), every
+robot's joint targets are applied, and physics steps exactly once. All
+Kit-touching work is marshalled through `run_on_main` in two batched hops per
+timestep while policy inference stays off the main thread (#1896); a
+worker-thread call with no pump running is refused in the tool envelope. The
+Isaac override adds a keyword-only `reset_between: bool = False`
+(forward-compat with `run_policy`'s multi-episode semantics); requesting
+`reset_between=True` returns a structured error citing #1895 rather than
+silently skipping the reset. Dataset recording inside this loop is not
+implemented yet - a call during an active recording session is refused; the
+merged-frame recording path is a follow-up to #2158.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -2770,9 +2770,9 @@ class SimEngine(ABC):
         This base implementation is a documented refusal, not a fallback: a
         backend that has no synchronized multi-robot loop must say so rather
         than silently driving robots one at a time (which would interleave
-        frames and break the merged-frame contract above). The MuJoCo backend
-        overrides it with a full implementation; backends that do not yet
-        (Isaac, Newton) inherit this structured error.
+        frames and break the merged-frame contract above). The MuJoCo and
+        Isaac backends override it with full implementations; backends that
+        do not yet (Newton) inherit this structured error.
 
         Args:
             policies: Mapping ``{robot_name: Policy}`` of the robots to drive.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -58,6 +58,7 @@ from strands_robots.utils import (
 )
 
 if TYPE_CHECKING:
+    from strands_robots.policies.base import Policy
     from strands_robots.rendering import CameraParams
 
 logger = logging.getLogger(__name__)
@@ -522,6 +523,17 @@ class _RobotState:
         # ``/World/Robots/arm`` being requested). Used by
         # ``gripper_frame_pose`` to walk the actual robot subtree.
         self.actual_prim_path = actual_prim_path or prim_path
+        # Rollout bookkeeping, mirroring the MuJoCo per-robot record: the
+        # policy-driving loops (:meth:`IsaacSimulation.run_multi_policy`, the
+        # recording hook in
+        # :meth:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin._make_run_policy_hook`)
+        # set these while a rollout drives this robot. ``policy_running`` is
+        # both the busy guard (a robot already driven by one loop must not be
+        # double-stepped by another) and the cooperative-stop flag (flipping
+        # it False ends the loop cleanly).
+        self.policy_running = False
+        self.policy_instruction = ""
+        self.policy_steps = 0
 
 
 def _cameras_recording_option_error(
@@ -3445,6 +3457,397 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
         return {
             "status": "success",
             "content": [{"text": f"Action applied to '{robot_name}', {n_substeps} substeps."}],
+        }
+
+    # --- SimEngine: Synchronized multi-robot rollout -------------------------
+
+    def _apply_lockstep_action(self, robot_name: str, action: dict[str, Any], warned_unresolved: set[str]) -> None:
+        """Apply one robot's action WITHOUT stepping physics (lockstep half of send_action).
+
+        The synchronized loop in :meth:`run_multi_policy` writes every robot's
+        joint targets first and then steps physics ONCE, so it cannot use
+        :meth:`send_action` (whose contract steps physics per call). This is
+        the apply-only half of that method: task-space controller routing
+        (#1812), the shared action-value coercion
+        (:meth:`~strands_robots.simulation.base.SimEngine._coerce_action`), and
+        the named-joints-only ``ArticulationAction`` application.
+
+        Runs inside the loop's apply-and-step main-thread hop with
+        ``self._lock`` held by the caller.
+
+        Raises:
+            RuntimeError: On a controller conversion failure, a refused action
+                value, or an articulation apply failure. Mid-loop failures
+                raise rather than returning an envelope because applying a
+                zero/partial substitute and stepping anyway would advance a
+                trajectory no policy commanded (Key Conventions #5/#6); the
+                loop's ``finally`` clears the running flags.
+        """
+        robot = self._robots[robot_name]
+
+        # Route through an installed task-space controller first, so the
+        # controller's *output* is what clears the value domain (parity with
+        # send_action, #1812).
+        controller = registry_entry(self._action_controllers, robot_name)
+        if controller is not None and isinstance(action, dict):
+            try:
+                action = controller.compute_joint_targets(action)
+            except (RuntimeError, ValueError, TypeError) as e:
+                raise RuntimeError(
+                    f"run_multi_policy: action controller for '{robot_name}' failed to "
+                    f"convert the task-space action: {e}"
+                ) from e
+
+        action_map, coerce_error = self._coerce_action(action, robot_name)
+        if coerce_error is not None:
+            raise RuntimeError(f"run_multi_policy: action for '{robot_name}' refused: {self._first_text(coerce_error)}")
+        assert action_map is not None  # narrow for mypy: no error implies a mapping
+
+        # A key naming no joint is surfaced once per (robot, key) rather than
+        # silently dropped (parity with the MuJoCo loop's warn-once unresolved
+        # reporting) or spammed at the control rate.
+        joint_set = set(robot.joint_names)
+        for key in action_map:
+            if key not in joint_set and (tag := f"{robot_name}:{key}") not in warned_unresolved:
+                warned_unresolved.add(tag)
+                logger.warning(
+                    "run_multi_policy: action key %r resolves to no joint on '%s' and is not applied. Valid keys: %s",
+                    key,
+                    robot_name,
+                    robot.joint_names,
+                )
+
+        # Command ONLY the named joints (see send_action for why a full
+        # zero-filled vector would slam unnamed joints to 0.0).
+        named = [i for i, jname in enumerate(robot.joint_names) if jname in action_map]
+        if robot.articulation is None or not named:
+            return
+        action_array: np.ndarray = np.array(
+            [float(action_map[robot.joint_names[i]]) for i in named],
+            dtype=np.float32,
+        )
+        joint_indices: np.ndarray = np.array(named, dtype=np.int32)
+        try:
+            from isaacsim.core.utils.types import (  # type: ignore[import-not-found]
+                ArticulationAction,
+            )
+
+            robot.articulation.apply_action(
+                ArticulationAction(joint_positions=action_array, joint_indices=joint_indices)
+            )
+        except (RuntimeError, ValueError, AttributeError, ImportError) as e:
+            # Same expected-failure set as send_action's apply path; a failed
+            # apply mid-lockstep must halt the loop, not leave this robot
+            # coasting on stale targets while its siblings advance.
+            raise RuntimeError(f"run_multi_policy: failed to set joint targets on '{robot_name}': {e}") from e
+
+    def run_multi_policy(
+        self,
+        policies: dict[str, Policy],
+        instructions: dict[str, str] | str = "",
+        duration: float = 10.0,
+        control_frequency: float = 50.0,
+        action_horizon: int | dict[str, int] = 8,
+        n_steps: int | None = None,
+        max_steps: int | None = None,
+        *,
+        reset_between: bool = False,
+    ) -> dict[str, Any]:
+        """Drive MULTIPLE robots with their own policies in ONE synchronized control loop.
+
+        The Isaac implementation of the
+        :meth:`~strands_robots.simulation.base.SimEngine.run_multi_policy`
+        contract (#2158, part of the #2122 MuJoCo-parity work), for the fleet
+        topology ``add_robot`` already supports: one stage, one env, multiple
+        articulations. Per loop iteration it (1) observes every robot once,
+        (2) re-queries each robot's policy only when that robot's buffered
+        action chunk drains (chunk length via
+        :func:`~strands_robots.policies.base.resolve_chunk_length`, exactly as
+        the single-policy runner sizes it), (3) applies every robot's joint
+        targets, then (4) steps physics ONCE - so all robots stay
+        phase-aligned regardless of their individual re-query cadence.
+
+        **Threading**: all Kit/USD/physics interaction is marshalled through
+        :meth:`run_on_main` in two batched hops per timestep (observe-all,
+        then apply-all-and-step); policy inference runs between the hops on
+        the calling thread, never on the Kit main thread. Called on the
+        owning thread the hops run inline; called from a worker thread the
+        owning thread must be running :meth:`run_pump_forever` (the #1896
+        contract :meth:`step` / :meth:`reset` enforce by raising - this
+        entry point reports it in the tool envelope instead). No lock is
+        held across a marshal hop; each hop takes ``self._lock`` itself.
+
+        **Recording is not implemented here yet**: the merged-frame recording
+        path is a follow-up to #2158. A call arriving while a dataset
+        recording is active is refused rather than silently producing an
+        unrecorded rollout the session's frame count would misreport.
+
+        Args:
+            policies: Mapping ``{robot_name: Policy}`` of the robots to drive.
+            instructions: Single instruction string for all robots, or a
+                ``{robot_name: instruction}`` mapping.
+            duration: Episode length in seconds (steps = duration x freq).
+                Used only when no ``n_steps`` / ``max_steps`` is given.
+            control_frequency: Target Hz for policy queries / physics steps.
+            action_horizon: Actions consumed from each policy's chunk before
+                re-querying it, as one int or a per-robot mapping.
+            n_steps: Exact step horizon (overrides ``duration`` when set).
+            max_steps: Legacy alias for ``n_steps``.
+            reset_between: Forward-compat with :meth:`run_policy`'s
+                multi-episode semantics. Must be ``False``: on the pip Isaac
+                Sim wheels :meth:`reset` tears down the articulation
+                physics-tensor views (#1895), so a mid-run reset would leave
+                every robot unobservable; requesting one returns a structured
+                error rather than silently skipping the reset.
+
+        Returns:
+            The standard status dict; on success ``content`` carries a text
+            summary plus ``{"json": {"steps": N, "per_robot_steps": {...}}}``.
+
+        Raises:
+            RuntimeError: Mid-loop on a policy that returns an empty action
+                chunk or an action that cannot be applied (see
+                :meth:`_apply_lockstep_action`) - never a zero-valued
+                substitute action.
+        """
+        from collections import deque
+
+        from strands_robots._async_utils import _resolve_coroutine
+        from strands_robots.policies.base import resolve_chunk_length
+        from strands_robots.simulation.policy_runner import CooperativeStop
+
+        if not getattr(self, "_world_created", False) or self._world is None:
+            return {"status": "error", "content": [{"text": "No world created. Use action='create_world' first."}]}
+        if err := self._validate_multi_policies(policies, "run_multi_policy"):
+            return err
+
+        # Validate every robot exists.
+        for rname in policies:
+            if not registered(self._robots, rname):
+                return {"status": "error", "content": [{"text": self._unknown_robot_msg(rname)}]}
+
+        # Reject a robot another loop is already driving (double-stepping
+        # physics on it), mirroring the MuJoCo busy check. Isaac has no
+        # background start_policy futures to prune; ``policy_running`` is the
+        # per-robot flag every Isaac policy-driving loop sets.
+        busy = [r for r in policies if getattr(self._robots[r], "policy_running", False)]
+        if busy:
+            names = ", ".join(f"'{n}'" for n in busy)
+            return {
+                "status": "error",
+                "content": [{"text": f"run_multi_policy: policy already running on {names}. Stop it first."}],
+            }
+
+        if reset_between:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "run_multi_policy: reset_between=True is not supported on the Isaac "
+                            "backend: reset() tears down the articulation physics-tensor views on "
+                            "the pip Isaac Sim wheels (#1895), so a mid-run reset would leave every "
+                            "robot unobservable. Pass reset_between=False (the default) and reset "
+                            "explicitly between calls, or use the MuJoCo backend for multi-episode "
+                            "multi-robot rollouts."
+                        )
+                    }
+                ],
+            }
+
+        # The merged-frame recording path is a follow-up to #2158; refusing is
+        # the alternative to silently running an unrecorded rollout inside an
+        # active session (Key Conventions #5/#6).
+        if self._is_recording():
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "run_multi_policy: a dataset recording is active, but the Isaac "
+                            "synchronized multi-robot loop does not record yet (the merged-frame "
+                            "recording path is a follow-up to #2158). Stop the recording first, or "
+                            "record a multi-robot rollout on the MuJoCo backend."
+                        )
+                    }
+                ],
+            }
+
+        # Thread affinity (#1896): off the owning thread every marshal hop
+        # below would block forever without a pump. step()/reset() raise for
+        # this; a tool-facing driver reports it in the envelope instead.
+        if not self._on_main_thread() and not self._pump_running:
+            return {
+                "status": "error",
+                "content": [
+                    {
+                        "text": (
+                            "run_multi_policy was called from a worker thread with no main-thread "
+                            "pump running. Isaac Sim only pumps kit updates on the thread that "
+                            "created SimulationApp, so the per-step observe/apply hops would block "
+                            "forever. Either call it from the owning thread, or have the owning "
+                            "thread run `run_pump_forever(stop_event=...)` and call this from the "
+                            "worker (the loop marshals each hop via run_on_main itself)."
+                        )
+                    }
+                ],
+            }
+
+        # Normalize instructions through the shared base helper (one refusal
+        # text for every backend), attributing the distinct-instructions
+        # warning to this module's logger.
+        instr_map, err = self._normalize_multi_policy_instructions(
+            policies, instructions, "run_multi_policy", warn_logger=logger
+        )
+        if err is not None:
+            return err
+        assert instr_map is not None  # for the type checker: err is None <=> instr_map is not None
+
+        # Resolve the step horizon through the shared helpers so this loop
+        # guards the same domain as run_policy (n_steps / max_steps override
+        # duration; frequency validated first because _resolve_horizon divides
+        # by it).
+        if err := self._validate_positive_frequency(control_frequency, "run_multi_policy"):
+            return err
+        duration, n_steps, horizon_error = self._resolve_horizon(
+            n_steps, max_steps, control_frequency, duration, "run_multi_policy"
+        )
+        if horizon_error is not None:
+            return horizon_error
+        if n_steps is None:
+            if err := self._validate_duration(duration, "run_multi_policy"):
+                return err
+
+        # Normalize action_horizon to a per-robot mapping on the shared
+        # positive-int domain.
+        horizon_map, err = self._normalize_multi_policy_horizons(
+            policies, action_horizon, "run_multi_policy", default_horizon=8
+        )
+        if err is not None:
+            return err
+        assert horizon_map is not None  # for the type checker: err is None <=> horizon_map is not None
+
+        # Bind each policy's action keys (best-effort, mirrors run_policy).
+        for rname, pol in policies.items():
+            try:
+                pol.set_robot_state_keys(self.robot_action_keys(rname))
+                self.bind_policy_sim_context(pol, rname)
+            except Exception as exc:  # noqa: BLE001 - non-fatal, mirrors run_policy defensiveness
+                logger.debug("set_robot_state_keys(%s) failed: %s", rname, exc)
+
+        # Renders are expensive; skip camera readback when no policy needs
+        # images (recording, which would force them on, is refused above).
+        any_needs_images = any(getattr(p, "requires_images", True) for p in policies.values())
+        skip_images = not any_needs_images
+        render_on = self._config.render_mode != "headless"
+        physics_dt = float(getattr(self._config, "physics_dt", 0.0) or 0.0)
+
+        total_steps = int(duration * control_frequency)
+        action_sleep = 1.0 / control_frequency if control_frequency > 0 else 0.0
+
+        # Mark all robots as running so a cooperative stop can interrupt the
+        # loop, and so a concurrent driver is refused by the busy check above.
+        for rname in policies:
+            r = self._robots[rname]
+            r.policy_running = True
+            r.policy_instruction = instr_map[rname]
+            r.policy_steps = 0
+
+        # Per-robot action queue: actions remaining from the last chunk query.
+        # A policy is only re-queried when its queue is empty, so expensive VLA
+        # inference amortizes over up to ``horizon_map[robot]`` steps.
+        action_queues: dict[str, deque] = {r: deque() for r in policies}
+        warned_unresolved: set[str] = set()
+
+        def _observe_all() -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+            """Main-thread hop 1: observe every robot, read cameras ONCE."""
+            per_obs: dict[str, dict[str, Any]] = {}
+            cams: dict[str, Any] = {}
+            first = True
+            for rname in policies:
+                obs = self.get_observation(robot_name=rname, skip_images=(skip_images or not first))
+                # Split scalars (joints) from ndarrays (camera images);
+                # cameras are scene-global, so one readback serves all robots.
+                per_obs[rname] = {k: v for k, v in obs.items() if not isinstance(v, np.ndarray)}
+                if first:
+                    cams = {k: v for k, v in obs.items() if isinstance(v, np.ndarray)}
+                    first = False
+            return per_obs, cams
+
+        def _apply_all_and_step(per_robot_action: dict[str, dict[str, Any]]) -> None:
+            """Main-thread hop 2: apply EVERY robot's targets, step physics ONCE."""
+            with self._lock:
+                for rname, act in per_robot_action.items():
+                    self._apply_lockstep_action(rname, act, warned_unresolved)
+                self._world.step(render=render_on)
+                self._sim_time += physics_dt
+                self._step_count += 1
+
+        step_count = 0
+        stopped_early = False
+        try:
+            while step_count < total_steps:
+                # --- 1. Observe every robot (one main-thread hop). No lock is
+                # held across the marshal (#1896); get_observation takes it.
+                per_robot_obs, camera_imgs = self.run_on_main(_observe_all)
+
+                # --- 2. Resolve each robot's action for THIS step, off the
+                # main thread. Re-query a policy ONLY when its buffered chunk
+                # drains (open-loop chunk execution).
+                per_robot_action: dict[str, dict[str, Any]] = {}
+                for rname, pol in policies.items():
+                    # Cooperative stop check.
+                    if not self._robots[rname].policy_running:
+                        raise CooperativeStop(f"Policy stopped on '{rname}'")
+                    if not action_queues[rname]:
+                        pol_obs = dict(per_robot_obs[rname])
+                        pol_obs.update(camera_imgs)
+                        coro = pol.get_actions(pol_obs, instr_map[rname])
+                        acts = _resolve_coroutine(coro)
+                        # Size the chunk via the shared ChunkedPolicy rule so a
+                        # chunk-emitting policy keeps its full trained chunk
+                        # here exactly as the single-policy runner does.
+                        _chunk = resolve_chunk_length(pol, horizon_map[rname])
+                        for a in acts[:_chunk]:
+                            action_queues[rname].append(a)
+                    if not action_queues[rname]:
+                        # Emitting a zero-valued substitute here would advance
+                        # a trajectory no policy commanded. Fail loudly
+                        # instead (Key Conventions #6).
+                        raise RuntimeError(
+                            f"Policy for robot '{rname}' returned an empty action chunk; "
+                            "cannot advance the synchronized loop. Check the policy's "
+                            "get_actions() output."
+                        )
+                    per_robot_action[rname] = action_queues[rname].popleft()
+
+                # --- 3+4. Apply ALL robots' targets, then step physics ONCE
+                # (one main-thread hop; the hop takes self._lock itself).
+                self.run_on_main(lambda acts=per_robot_action: _apply_all_and_step(acts))
+
+                step_count += 1
+                for rname in policies:
+                    self._robots[rname].policy_steps = step_count
+
+                if action_sleep:
+                    time.sleep(action_sleep)
+        except CooperativeStop:
+            # A cooperative stop is a normal, user-requested halt.
+            stopped_early = True
+        finally:
+            for rname in policies:
+                if registered(self._robots, rname):
+                    self._robots[rname].policy_running = False
+
+        per_robot_steps = {rname: int(self._robots[rname].policy_steps) for rname in policies}
+        text = (
+            f"{'stopped early' if stopped_early else 'completed'}: "
+            f"run_multi_policy on {len(policies)} robots ({', '.join(policies)}) - "
+            f"{step_count} synchronized steps"
+        )
+        return {
+            "status": "success",
+            "content": [{"text": text}, {"json": {"steps": step_count, "per_robot_steps": per_robot_steps}}],
         }
 
     # --- SimEngine: Rendering -----------------------------------------------

--- a/tests/simulation/isaac/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/isaac/test_run_multi_policy_no_recording.py
@@ -1,0 +1,507 @@
+"""Isaac ``run_multi_policy``: the synchronized multi-robot loop WITHOUT recording.
+
+The Isaac backend drives MULTIPLE robots, each with its own policy and
+instruction, in ONE lockstep control loop (#2158, part of the #2122 parity
+work): every iteration observes each robot once, re-queries a policy only when
+its buffered action chunk drains, applies every robot's joint targets, then
+steps physics exactly ONCE. These tests pin that behaviour - plus the loop's
+Isaac-specific contracts: every Kit-touching hop is marshalled through
+``run_on_main`` (#1896), a worker-thread call with no pump is refused in the
+tool envelope, ``reset_between=True`` is refused citing #1895, and a call
+during an active recording session is refused (the merged-frame recording path
+is a follow-up to #2158).
+
+The engine is a skeleton ``IsaacSimulation`` built with ``__new__`` (the
+established pattern from ``test_dataset_recording.py``) so the loop runs
+without the Isaac Sim Kit runtime: physics is a stub ``World`` counting
+``step()`` calls, articulations are stubs recording ``apply_action`` calls,
+and ``isaacsim.core.utils.types`` is faked by the shared
+``fake_isaacsim_types`` fixture. GPU/real-Kit coverage is a separate
+``tests_integ/`` follow-up.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.base import Policy
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+from tests.tool_result_contract import tool_json
+
+from .test_backend_parity import fake_isaacsim_types  # noqa: F401 - fixture
+
+_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow"]
+
+
+class _StubArticulation:
+    """Records every ``ArticulationAction`` applied, with the applying thread."""
+
+    def __init__(self, n_joints: int) -> None:
+        self._n = n_joints
+        self.applied: list[Any] = []
+        self.apply_threads: set[int] = set()
+
+    def apply_action(self, action: Any) -> None:
+        self.applied.append(action)
+        self.apply_threads.add(threading.get_ident())
+
+    def get_joint_positions(self) -> np.ndarray:
+        return np.zeros(self._n, dtype=np.float32)
+
+
+class _StubWorld:
+    """Stub Isaac ``World`` counting physics steps and the stepping thread."""
+
+    def __init__(self) -> None:
+        self.step_calls = 0
+        self.step_threads: set[int] = set()
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        self.step_calls += 1
+        self.step_threads.add(threading.get_ident())
+
+
+def _make_engine(robots: dict[str, _RobotState]) -> IsaacSimulation:
+    """Skeleton IsaacSimulation (no Kit runtime), per the recording-test pattern."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode="headless")
+    engine._lock = threading.RLock()
+    engine._world = _StubWorld()
+    engine._world_created = True
+    engine._robots = robots
+    engine._cameras = {}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._recording_state_dict = {}
+    engine._action_controllers = {}
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._replicated = False
+    engine._num_envs_active = 1
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    engine._main_jobs = queue.Queue()
+    return engine
+
+
+def _robot(name: str) -> _RobotState:
+    return _RobotState(
+        name=name,
+        prim_path=f"/World/Robots/{name}",
+        joint_names=list(_JOINTS),
+        articulation=_StubArticulation(len(_JOINTS)),
+    )
+
+
+@pytest.fixture
+def sim_two_robots(fake_isaacsim_types) -> IsaacSimulation:  # noqa: F811, ARG001 - fixture injects the fake module
+    """Two stub-articulation robots in one skeleton engine."""
+    return _make_engine({"alpha": _robot("alpha"), "beta": _robot("beta")})
+
+
+class _ChunkCounter(Policy):
+    """Counts inference calls and returns a fixed-length action chunk."""
+
+    requires_images = False
+
+    def __init__(self, chunk: int = 10):
+        self.calls = 0
+        self.chunk = chunk
+        self.call_threads: set[int] = set()
+        self._keys: list[str] | None = None
+
+    def set_robot_state_keys(self, keys):
+        self._keys = list(keys)
+
+    @property
+    def provider_name(self) -> str:
+        return "chunk_counter"
+
+    async def get_actions(self, obs, instruction=""):
+        self.calls += 1
+        self.call_threads.add(threading.get_ident())
+        keys = self._keys or list(_JOINTS)
+        return [{k: 0.05 * (j + 1) for k in keys} for j in range(self.chunk)]
+
+
+# --------------------------------------------------------------------------- #
+# The synchronized loop                                                       #
+# --------------------------------------------------------------------------- #
+def test_run_multi_policy_runs_and_reports_per_robot_steps(sim_two_robots):
+    """The loop completes recorder-free and reports per-robot step counts."""
+    sim = sim_two_robots
+    r = sim.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        n_steps=10,
+        control_frequency=500.0,
+        action_horizon=4,
+    )
+    assert r["status"] == "success", r
+    payload = tool_json(r)
+    assert payload["steps"] == 10
+    assert payload["per_robot_steps"] == {"alpha": 10, "beta": 10}
+    assert "synchronized steps" in r["content"][0]["text"]
+    assert "recorded" not in r["content"][0]["text"]
+    # Both robots advanced together and were released from the running flag.
+    for name in ("alpha", "beta"):
+        robot = sim._robots[name]
+        assert robot.policy_steps == 10
+        assert robot.policy_running is False
+
+
+def test_run_multi_policy_steps_physics_exactly_once_per_timestep(sim_two_robots):
+    """Lockstep: N timesteps with 2 robots = N physics steps, not 2N."""
+    sim = sim_two_robots
+    r = sim.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        n_steps=6,
+        control_frequency=500.0,
+    )
+    assert r["status"] == "success", r
+    assert sim._world.step_calls == 6
+    # Every robot's targets were applied on every timestep (phase-aligned).
+    for name in ("alpha", "beta"):
+        assert len(sim._robots[name].articulation.applied) == 6
+
+
+def test_run_multi_policy_action_horizon_amortizes_inference(sim_two_robots):
+    """A policy is re-queried only when its buffered chunk drains."""
+    pa, pb = _ChunkCounter(chunk=10), _ChunkCounter(chunk=10)
+    r = sim_two_robots.run_multi_policy(
+        policies={"alpha": pa, "beta": pb},
+        n_steps=20,
+        control_frequency=500.0,
+        action_horizon=10,
+    )
+    assert r["status"] == "success", r
+    assert pa.calls == 2
+    assert pb.calls == 2
+
+
+def test_run_multi_policy_per_robot_horizon_mapping(sim_two_robots):
+    """A ``{robot: horizon}`` mapping drives per-robot re-query cadence."""
+    pa, pb = _ChunkCounter(chunk=10), _ChunkCounter(chunk=10)
+    r = sim_two_robots.run_multi_policy(
+        policies={"alpha": pa, "beta": pb},
+        n_steps=20,
+        control_frequency=500.0,
+        action_horizon={"alpha": 1, "beta": 10},
+    )
+    assert r["status"] == "success", r
+    # alpha re-queried every step (horizon clamped to >=1); beta batched.
+    assert pa.calls == 20
+    assert pb.calls == 2
+
+
+def test_run_multi_policy_honors_policy_chunk_length_over_smaller_horizon(sim_two_robots):
+    """A chunk-emitting policy keeps its full trained chunk in the loop.
+
+    With ``actions_per_step=10`` and ``action_horizon=2`` over 20 steps, each
+    policy runs inference exactly twice: the effective chunk is
+    ``max(action_horizon, actions_per_step) == 10`` via the shared
+    ``resolve_chunk_length`` rule, exactly as the single-policy runner sizes
+    it. Truncating to ``action_horizon`` alone would drop the chunk tail and
+    force out-of-distribution re-queries MuJoCo's loop never makes.
+    """
+
+    class _Chunked(_ChunkCounter):
+        def __init__(self, actions_per_step: int = 10):
+            super().__init__(chunk=actions_per_step)
+            self.actions_per_step = actions_per_step
+            self.supports_rtc = False
+
+    pa, pb = _Chunked(actions_per_step=10), _Chunked(actions_per_step=10)
+    r = sim_two_robots.run_multi_policy(
+        policies={"alpha": pa, "beta": pb},
+        n_steps=20,
+        control_frequency=500.0,
+        action_horizon=2,
+    )
+    assert r["status"] == "success", r
+    assert pa.calls == 2
+    assert pb.calls == 2
+
+
+def test_run_multi_policy_max_steps_aliases_n_steps(sim_two_robots):
+    """``max_steps`` is honoured as the legacy alias for ``n_steps``."""
+    r = sim_two_robots.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        max_steps=8,
+        control_frequency=500.0,
+    )
+    assert r["status"] == "success", r
+    assert tool_json(r)["steps"] == 8
+
+
+def test_run_multi_policy_cooperative_stop_ends_early(sim_two_robots):
+    """Flipping a robot's running flag mid-loop ends the loop early but cleanly."""
+    sim = sim_two_robots
+
+    class _StopAfter(Policy):
+        requires_images = False
+
+        def __init__(self, robots, robot_name, stop_at=3):
+            self._robots = robots
+            self._robot_name = robot_name
+            self._stop_at = stop_at
+            self.calls = 0
+            self._keys: list[str] | None = None
+
+        def set_robot_state_keys(self, keys):
+            self._keys = list(keys)
+
+        @property
+        def provider_name(self) -> str:
+            return "stop_after"
+
+        async def get_actions(self, obs, instruction=""):
+            self.calls += 1
+            if self.calls >= self._stop_at:
+                # Cooperative stop: drop the running flag so the loop bails.
+                self._robots[self._robot_name].policy_running = False
+            keys = self._keys or list(_JOINTS)
+            return [{k: 0.0 for k in keys}]
+
+    pa = _StopAfter(sim._robots, "alpha", stop_at=3)
+    r = sim.run_multi_policy(
+        policies={"alpha": pa, "beta": MockPolicy()},
+        n_steps=50,
+        control_frequency=500.0,
+        action_horizon=1,
+    )
+    assert r["status"] == "success", r
+    assert "stopped early" in r["content"][0]["text"]
+    assert tool_json(r)["steps"] < 50
+    # Running flags are cleared on the way out regardless of early stop.
+    for name in ("alpha", "beta"):
+        assert sim._robots[name].policy_running is False
+
+
+def test_run_multi_policy_raises_on_empty_action_chunk(sim_two_robots):
+    """An empty action chunk fails loudly instead of a zero-valued substitute."""
+
+    class _Empty(Policy):
+        requires_images = False
+
+        def set_robot_state_keys(self, keys):
+            pass
+
+        @property
+        def provider_name(self) -> str:
+            return "empty"
+
+        async def get_actions(self, obs, instruction=""):
+            return []
+
+    with pytest.raises(RuntimeError, match="empty action chunk"):
+        sim_two_robots.run_multi_policy(
+            policies={"alpha": _Empty(), "beta": _Empty()},
+            n_steps=5,
+            control_frequency=500.0,
+        )
+    # The failure path still released the running flags.
+    for name in ("alpha", "beta"):
+        assert sim_two_robots._robots[name].policy_running is False
+
+
+def test_run_multi_policy_warns_on_distinct_instructions(sim_two_robots, caplog):
+    """Distinct per-robot instructions warn, attributed to the Isaac module logger."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.isaac.simulation"):
+        r = sim_two_robots.run_multi_policy(
+            policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+            instructions={"alpha": "pour", "beta": "catch"},
+            n_steps=4,
+            control_frequency=500.0,
+        )
+    assert r["status"] == "success", r
+    assert any("distinct per-robot instructions" in rec.message for rec in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Caller-error envelope                                                       #
+# --------------------------------------------------------------------------- #
+def test_run_multi_policy_rejects_empty_policies(sim_two_robots):
+    assert sim_two_robots.run_multi_policy(policies={})["status"] == "error"
+
+
+def test_run_multi_policy_rejects_unknown_robot(sim_two_robots):
+    r = sim_two_robots.run_multi_policy(policies={"ghost": MockPolicy()}, n_steps=2)
+    assert r["status"] == "error"
+    assert "ghost" in r["content"][0]["text"]
+
+
+def test_run_multi_policy_rejects_nonpositive_n_steps(sim_two_robots):
+    r = sim_two_robots.run_multi_policy(
+        policies={"alpha": MockPolicy()},
+        n_steps=0,
+        control_frequency=500.0,
+    )
+    assert r["status"] == "error"
+    assert "n_steps must be a positive integer" in r["content"][0]["text"]
+
+
+def test_run_multi_policy_requires_world():
+    """Without a created world the loop returns a graceful error, not a crash."""
+    engine = _make_engine({})
+    engine._world_created = False
+    engine._world = None
+    r = engine.run_multi_policy(policies={"alpha": MockPolicy()}, n_steps=2)
+    assert r["status"] == "error"
+    assert "world" in r["content"][0]["text"].lower()
+
+
+def test_run_multi_policy_rejects_robot_with_running_policy(sim_two_robots):
+    """A robot already driven by another rollout is refused up front.
+
+    ``run_multi_policy`` advances physics; letting it also drive a robot some
+    other loop is already stepping would double-step that robot. Isaac has no
+    background ``start_policy`` futures to prune (the base ``start_policy`` is
+    a synchronous passthrough), so the guard reads the per-robot
+    ``policy_running`` flag every Isaac policy-driving loop sets - the same
+    flag the recording hook and this loop itself maintain.
+    """
+    sim = sim_two_robots
+    sim._robots["alpha"].policy_running = True
+    r = sim.run_multi_policy(policies={"alpha": MockPolicy(), "beta": MockPolicy()}, n_steps=2)
+    assert r["status"] == "error", r
+    msg = r["content"][0]["text"]
+    assert "already running" in msg
+    assert "alpha" in msg
+    # The refusal touched nothing: no physics step, no targets applied.
+    assert sim._world.step_calls == 0
+    assert sim._robots["beta"].articulation.applied == []
+
+
+def test_run_multi_policy_reset_between_returns_the_1895_error(sim_two_robots):
+    """``reset_between=True`` is a structured refusal citing #1895, not a silent skip.
+
+    Isaac's ``reset()`` tears down the articulation physics-tensor views on
+    the pip wheels (#1895), so a mid-run reset would leave every robot
+    unobservable. The keyword exists for forward-compat with ``run_policy``'s
+    multi-episode semantics; until #1895 is fixed it must refuse loudly (Key
+    Conventions #5/#6).
+    """
+    sim = sim_two_robots
+    r = sim.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        n_steps=4,
+        control_frequency=500.0,
+        reset_between=True,
+    )
+    assert r["status"] == "error", r
+    msg = r["content"][0]["text"]
+    assert "#1895" in msg
+    assert "reset_between" in msg
+    # Refused before any physics advanced.
+    assert sim._world.step_calls == 0
+
+
+def test_run_multi_policy_refuses_during_an_active_recording(sim_two_robots):
+    """A call during an active recording session is refused, not silently unrecorded.
+
+    The merged-frame recording path is a follow-up to #2158; running the loop
+    anyway inside an open session would leave a rollout the session's frame
+    count misreports.
+    """
+    sim = sim_two_robots
+    sim._recording_state_dict = {"recording": True, "dataset_recorder": object()}
+    r = sim.run_multi_policy(policies={"alpha": MockPolicy(), "beta": MockPolicy()}, n_steps=2)
+    assert r["status"] == "error", r
+    assert "recording" in r["content"][0]["text"]
+    assert sim._world.step_calls == 0
+
+
+# --------------------------------------------------------------------------- #
+# Thread affinity (#1896)                                                     #
+# --------------------------------------------------------------------------- #
+def test_run_multi_policy_marshals_hops_through_run_on_main(sim_two_robots):
+    """Every Kit-touching hop goes through ``run_on_main``: two per timestep."""
+    sim = sim_two_robots
+    calls: list[int] = []
+    real_run_on_main = sim.run_on_main
+
+    def _spy(fn, timeout=None):
+        calls.append(threading.get_ident())
+        return real_run_on_main(fn, timeout)
+
+    sim.run_on_main = _spy
+    r = sim.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        n_steps=3,
+        control_frequency=500.0,
+    )
+    assert r["status"] == "success", r
+    # One observe-all hop + one apply-all-and-step hop per timestep.
+    assert len(calls) == 2 * 3
+
+
+def test_run_multi_policy_from_worker_thread_runs_kit_work_on_the_pump_thread(sim_two_robots):
+    """Called off the owning thread, physics/apply run on the pump owner while
+    policy inference stays on the worker (the #1896 split)."""
+    sim = sim_two_robots
+    sim._pump_running = True
+    main_tid = threading.get_ident()
+    policy_a, policy_b = _ChunkCounter(chunk=4), _ChunkCounter(chunk=4)
+    box: dict[str, Any] = {}
+
+    def _worker() -> None:
+        box["tid"] = threading.get_ident()
+        box["result"] = sim.run_multi_policy(
+            policies={"alpha": policy_a, "beta": policy_b},
+            n_steps=4,
+            control_frequency=500.0,
+            action_horizon=4,
+        )
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    # Emulate run_pump_forever: drain the main-jobs queue on this ("main") thread.
+    while t.is_alive():
+        try:
+            job = sim._main_jobs.get(timeout=0.05)
+        except queue.Empty:
+            continue
+        job()
+    t.join(timeout=10.0)
+
+    assert box["result"]["status"] == "success", box["result"]
+    # Kit work (physics step, articulation apply) ran on the pump owner...
+    assert sim._world.step_threads == {main_tid}
+    for name in ("alpha", "beta"):
+        assert sim._robots[name].articulation.apply_threads == {main_tid}
+    # ...while policy inference stayed off the main thread.
+    assert main_tid not in policy_a.call_threads
+    assert main_tid not in policy_b.call_threads
+    assert box["tid"] in policy_a.call_threads
+
+
+def test_run_multi_policy_from_worker_thread_without_a_pump_is_refused(sim_two_robots):
+    """No pump on the owning thread: the call is refused in the tool envelope
+    (the hops would block forever), rather than raising like step()/reset()."""
+    sim = sim_two_robots
+    box: dict[str, Any] = {}
+
+    def _worker() -> None:
+        box["result"] = sim.run_multi_policy(
+            policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+            n_steps=2,
+            control_frequency=500.0,
+        )
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join(timeout=10.0)
+    assert not t.is_alive(), "the worker-thread call must not hang"
+    assert box["result"]["status"] == "error", box["result"]
+    assert "run_pump_forever" in box["result"]["content"][0]["text"]
+    assert sim._world.step_calls == 0

--- a/tests/simulation/test_run_multi_policy_base_contract.py
+++ b/tests/simulation/test_run_multi_policy_base_contract.py
@@ -9,7 +9,7 @@ Promoting ``run_multi_policy`` from a MuJoCo-only method to the
   error naming its own class - never ``AttributeError`` (there was no
   contract), never a silent per-robot fallback (which would interleave
   recording frames and break the merged-frame contract the docstring
-  documents). Isaac and Newton inherit this today; MuJoCo overrides it.
+  documents). Newton inherits this today; MuJoCo and Isaac override it.
 
 * **The validation/normalization is shared, not duplicated.** The
   backend-independent first phase of the MuJoCo loop - empty-``policies``
@@ -54,7 +54,7 @@ def _text(result: dict[str, Any]) -> str:
 class TestTheBaseDefaultRefuses:
     """A backend without the synchronized loop says so in the tool envelope."""
 
-    @pytest.mark.parametrize("engine_cls", [IsaacSimulation, NewtonSimEngine])
+    @pytest.mark.parametrize("engine_cls", [NewtonSimEngine])
     def test_a_backend_without_an_override_returns_the_structured_error(self, engine_cls: type[SimEngine]) -> None:
         """``__new__`` skeleton: the refusal must precede any engine state."""
         engine = engine_cls.__new__(engine_cls)
@@ -70,6 +70,22 @@ class TestTheBaseDefaultRefuses:
         text = _text(engine.run_multi_policy(policies={"alpha": MockPolicy()}))
         assert text.startswith("run_multi_policy: NewtonSimEngine does not implement")
         assert not text.startswith("run_multi_policy: SimEngine ")
+
+    def test_isaac_overrides_the_default(self) -> None:
+        """The Isaac synchronized loop (#2158) must not fall through to the refusal."""
+        assert IsaacSimulation.run_multi_policy is not SimEngine.run_multi_policy
+
+    def test_isaac_signature_extends_the_base_contract(self) -> None:
+        """Isaac keeps the base parameters (names, order, defaults) and adds only
+        the keyword-only ``reset_between`` (its #1895 forward-compat guard)."""
+        base = inspect.signature(SimEngine.run_multi_policy).parameters
+        override = inspect.signature(IsaacSimulation.run_multi_policy).parameters
+        assert list(override)[: len(base)] == list(base)
+        assert {n: p.default for n, p in base.items()} == {n: override[n].default for n in base}
+        extras = {n: p for n, p in override.items() if n not in base}
+        assert list(extras) == ["reset_between"]
+        assert extras["reset_between"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert extras["reset_between"].default is False
 
     def test_mujoco_overrides_the_default(self) -> None:
         """The reference implementation must not fall through to the refusal."""

--- a/tests/simulation/test_step_count_domain_across_backends.py
+++ b/tests/simulation/test_step_count_domain_across_backends.py
@@ -720,6 +720,7 @@ _KNOWN_STEP_COUNT_SURFACES: dict[tuple[str, str], tuple[str, ...]] = {
     ("mujoco", "run_multi_policy"): ("_resolve_horizon",),
     ("newton", "step"): ("non_negative_whole_number_error",),
     ("isaac", "step"): ("non_negative_whole_number_error",),
+    ("isaac", "run_multi_policy"): ("_resolve_horizon",),
 }
 
 #: The surfaces this change owns: every backend's public ``step``.


### PR DESCRIPTION
Closes #2158

Part of #2122 (Isaac `run_multi_policy` parity). Depends on the shared-contract promotion from #2157 (merged as #2164).

## What changed

`IsaacSimulation` now implements `run_multi_policy`: multiple robots, each with its own `Policy` and instruction, driven in ONE synchronized control loop - lockstep physics, one loop iteration per timestep. **Recording is explicitly out of scope** (the merged-frame recording path is a follow-up child); a call arriving during an active recording session is refused rather than silently producing an unrecorded rollout.

Per loop iteration:
1. observe every robot once (cameras read once, shared across robots),
2. re-query a robot's policy only when its buffered action chunk drains - chunk length via the shared `resolve_chunk_length` rule (`max(action_horizon[r], policy.actions_per_step)`, RTC-aware), so a chunk-emitting policy keeps its full trained chunk exactly as the single-policy runner does,
3. apply every robot's joint targets (the apply-only half of `send_action`, factored as `_apply_lockstep_action`: task-space controller routing, shared `_coerce_action` value domain, named-joints-only `ArticulationAction`),
4. step physics ONCE.

### Isaac-specific design

- **Threading (#1896)**: all Kit/USD/physics work is marshalled through `run_on_main` in two batched hops per timestep (observe-all, then apply-all-and-step). Policy inference runs between the hops on the calling thread, never on the Kit main thread. No lock is held across a marshal - each hop takes `self._lock` itself. A worker-thread call with no pump running is refused in the tool envelope (this is a tool-facing entry point, unlike `step()`/`reset()` which raise by documented design).
- **Topology**: single stage, `num_envs=1`, multiple articulations - the fleet case `add_robot` already supports. Not vectorized envs.
- **Reset semantics (#1895)**: the Isaac override adds a keyword-only `reset_between: bool = False` (forward-compat with `run_policy`'s multi-episode semantics). `reset_between=True` returns a structured error citing #1895 - never a silent skip (AGENTS.md rules 5/6) - with its own regression test.
- **Busy guard**: a robot already driven by another rollout is refused up front via the per-robot `policy_running` flag (Isaac has no `start_policy` futures to prune - the base `start_policy` is a synchronous passthrough - so the flag every Isaac policy-driving loop sets is the guard). `_RobotState` now initialises the rollout bookkeeping (`policy_running` / `policy_instruction` / `policy_steps`) that the recording hook previously set dynamically.
- **Validation** comes from the shared base helpers introduced by #2157/#2164 (`_validate_multi_policies`, `_normalize_multi_policy_instructions` with this module's logger, `_normalize_multi_policy_horizons`, `_resolve_horizon`, frequency/duration validators) - nothing duplicated.
- **Error contract**: caller errors return `{"status": "error", "content": [...]}`; mid-loop failures (empty action chunk, refused action value, failed apply) raise `RuntimeError` rather than substituting zero-valued actions, mirroring MuJoCo's loop.

### Also in this diff

- `strands_robots/simulation/base.py`: the base-refusal docstring no longer names Isaac as a non-implementer.
- `tests/simulation/test_run_multi_policy_base_contract.py`: Isaac moves from the inherits-the-refusal parametrize to an overrides-the-default pin, plus a signature test asserting Isaac keeps the base parameters and adds only keyword-only `reset_between=False`.
- `tests/simulation/test_step_count_domain_across_backends.py`: the structural `n_steps`-surface registry gains `("isaac", "run_multi_policy")` (the scanner correctly detected the new surface routing through `_resolve_horizon`).
- Changelog fragment `changelog.d/2158-isaac-run-multi-policy-loop.md`.

## Test surface

New `tests/simulation/isaac/test_run_multi_policy_no_recording.py` (17 tests) runs **without the Kit runtime** via the established `IsaacSimulation.__new__` skeleton + stubbed `_RobotState`/articulation/world pattern (`test_dataset_recording.py`) and the shared `fake_isaacsim_types` fixture, mirroring the MuJoCo non-recording suite where it applies:

- runs N steps with `MockPolicy` per robot; reports per-robot step counts (in the JSON payload and on the robot state)
- physics stepped exactly once per timestep with 2 robots (the lockstep property, asserted on the stubbed step counter)
- `action_horizon` amortizes inference (policy queried steps/horizon times); per-robot horizon mapping honored; chunk-emitting policy keeps its full chunk over a smaller horizon
- `max_steps` aliases `n_steps`
- rejects: empty `policies`, unknown robot, non-positive `n_steps`, no world, robot with a running policy, active recording session
- `reset_between=True` returns the structured #1895 error (regression test)
- distinct per-robot instructions warn via the Isaac module logger
- empty action chunk raises `RuntimeError`; cooperative stop ends the loop early and cleanly; running flags cleared on every exit path
- marshaling: two `run_on_main` hops per timestep (spy); a worker-thread call with a pump runs physics/apply on the pump-owner thread while inference stays on the worker (recorded thread ids); a worker-thread call with no pump is refused in the envelope without hanging

## Acceptance criteria (from #2158)

- [x] `hatch run format && hatch run lint && hatch run test` clean - full suite `28465 passed, 262 skipped` (with `MUJOCO_GL=egl`; without it two MuJoCo GL renderer tests abort the interpreter on this dev box, reproduced identically on clean `main`, i.e. pre-existing/environmental)
- [x] Changelog fragment `changelog.d/2158-isaac-run-multi-policy-loop.md`
- [x] PR body carries `Closes #2158`
- [x] Unit tests run without the Isaac Sim Kit runtime
- [x] GPU/real-Kit coverage deliberately NOT added here (separate `tests_integ/` child)

## Out-of-scope follow-ups (children of #2122)

- Merged-frame dataset recording inside the Isaac loop (the refusal in this PR points there)
- `tests_integ/` GPU/real-Kit coverage

Board: please move #2158 to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (installation-token board writes are unreliable per AGENTS.md step 6).
