### PR TITLE
fix(mesh): record a Zenoh session close the teardown could not finish

### DIFF
--- a/changelog.d/2186-session-close-failure-recorded.md
+++ b/changelog.d/2186-session-close-failure-recorded.md
@@ -1,0 +1,18 @@
+### Fixed: a failed Zenoh session close is recorded instead of reported as a clean one
+
+`release_session()` and `_atexit_cleanup()` are the only two `close()` calls in
+the module that defines `zenoh_error_types()` -- whose docstring names `close`
+among the operations it covers, and excludes programmer errors so they "surface
+loudly instead of being swallowed by a best-effort cleanup path". Both caught
+bare `Exception` and recorded nothing, so a close that failed was
+indistinguishable from one that succeeded: `release_session()` emitted only
+`INFO Zenoh mesh session closed`, byte-identical to the healthy path, and
+`_atexit_cleanup()` emitted nothing at all. A `TypeError` / `AttributeError`
+from a mis-shaped session object was swallowed there too.
+
+Both now catch the module's own `zenoh_error_types()` and log the failure --
+WARNING in `release_session()`, where the success line would otherwise
+contradict the record, and DEBUG at exit, where there is no claim to contradict.
+The "session closed" line is emitted only when the close completed. A failure
+outside the documented transport surface propagates, matching how
+`Mesh.stop()` already treats its `undeclare` calls.

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -828,6 +828,16 @@ def release_session() -> None:
 
     Delegates to the transport factory when the active backend is
     ``iot`` / ``bridge``; otherwise falls back to the legacy Zenoh refcount.
+
+    On the Zenoh path the final release closes the session. That close is
+    fail-soft over the surface :func:`zenoh_error_types` documents - a broker
+    drop or socket teardown race is logged at WARNING and the reference is
+    still dropped, because nothing can retry a close once the only handle to
+    the session is gone. A failure outside that surface (a ``TypeError`` or
+    ``AttributeError``, i.e. a bug rather than a transport fault) propagates,
+    matching how :meth:`strands_robots.mesh.core.Mesh.stop` treats its
+    ``undeclare`` calls. The "session closed" INFO line is emitted only when
+    the close actually completed.
     """
     global _SESSION, _SESSION_REFS  # noqa: PLW0603
 
@@ -842,13 +852,25 @@ def release_session() -> None:
             return
         _SESSION_REFS -= 1
         if _SESSION_REFS <= 0 and _SESSION is not None:
+            closed = True
             try:
                 _SESSION.close()
-            except Exception:
-                pass
+            except zenoh_error_types() as exc:
+                # Narrow surface per :func:`zenoh_error_types`, whose docstring
+                # names ``close`` among the operations it covers and excludes
+                # programmer errors so they surface loudly instead of being
+                # swallowed by a best-effort teardown. The session reference is
+                # dropped below either way, so nothing can retry the close and
+                # this record is the only evidence it did not complete -
+                # WARNING (not the DEBUG a per-entity cleanup uses) because the
+                # INFO line below otherwise reports a clean close, and a record
+                # must be at least as loud as the claim it contradicts.
+                closed = False
+                logger.warning("Zenoh mesh session close failed: %s", exc)
             _SESSION = None
             _SESSION_REFS = 0
-            logger.info("Zenoh mesh session closed")
+            if closed:
+                logger.info("Zenoh mesh session closed")
 
 
 def session_alive() -> bool:
@@ -899,14 +921,24 @@ def put(key: str, data: dict[str, Any]) -> None:
 
 
 def _atexit_cleanup() -> None:
-    """Best-effort session teardown on process exit."""
+    """Best-effort session teardown on process exit.
+
+    Same close contract as :func:`release_session`, logged at DEBUG: this path
+    reports nothing on success, so there is no claim for the record to
+    contradict. A programmer error still propagates rather than being swallowed
+    at interpreter shutdown.
+    """
     global _SESSION, _SESSION_REFS  # noqa: PLW0603
     with _SESSION_LOCK:
         if _SESSION is not None:
             try:
                 _SESSION.close()
-            except Exception:
-                pass
+            except zenoh_error_types() as exc:
+                # Same narrow surface as :func:`release_session`. DEBUG here
+                # because this path makes no success claim to contradict and
+                # runs during interpreter shutdown, matching the level
+                # ``BridgeTransport.close`` uses for its per-backend close.
+                logger.debug("Zenoh mesh session close failed at exit: %s", exc)
             _SESSION = None
             _SESSION_REFS = 0
 

--- a/tests/mesh/test_zenoh_lifecycle_error_classification.py
+++ b/tests/mesh/test_zenoh_lifecycle_error_classification.py
@@ -6,22 +6,26 @@ so a transport-side failure cannot escape partial-failure cleanup or
 ``Mesh.stop()``. The native ``zenoh.ZError`` subclasses ``Exception`` directly
 - NOT ``RuntimeError`` - so it has to be named explicitly in the ``except``
 tuple. :func:`strands_robots.mesh.session.zenoh_error_types` centralises that
-tuple; these tests pin the contract and the fail-soft teardown behaviour.
+tuple; these tests pin the contract and the fail-soft teardown behaviour on
+both surfaces that consume it - ``Mesh.stop()``'s ``undeclare`` calls and the
+session's own ``close`` calls in ``release_session`` / ``_atexit_cleanup``.
 """
 
 from __future__ import annotations
 
+import logging
+import sys
 import threading
 from unittest.mock import MagicMock
 
 import pytest
 
+import strands_robots.mesh.session as session_mod
 from strands_robots.mesh.core import Mesh
-from strands_robots.mesh.session import zenoh_error_types
 
 
 def test_error_tuple_always_includes_transport_builtins():
-    types = zenoh_error_types()
+    types = session_mod.zenoh_error_types()
     assert isinstance(types, tuple)
     for builtin in (RuntimeError, OSError, ConnectionError):
         assert builtin in types
@@ -38,7 +42,7 @@ def test_error_tuple_names_zenoh_zerror_explicitly():
     # The whole reason ZError is named explicitly: it is an Exception subclass,
     # NOT a RuntimeError, so (RuntimeError, OSError) alone would let it escape.
     assert not issubclass(zerr, RuntimeError)
-    assert zerr in zenoh_error_types()
+    assert zerr in session_mod.zenoh_error_types()
 
 
 def _bare_mesh_for_stop(subs=None, safety_publishers=None):
@@ -66,14 +70,19 @@ def _bare_mesh_for_stop(subs=None, safety_publishers=None):
     return mesh
 
 
-def _zerror_raiser():
-    """A publisher/subscriber whose ``undeclare`` raises a real ``zenoh.ZError``."""
+def _zerror(message: str) -> BaseException:
+    """A real ``zenoh.ZError`` instance, or skip when zenoh is unavailable."""
     zenoh = pytest.importorskip("zenoh")
     zerr = getattr(zenoh, "ZError", None)
     if not isinstance(zerr, type):
         pytest.skip("zenoh.ZError is not a real class in this environment")
+    return zerr(message)
+
+
+def _zerror_raiser():
+    """A publisher/subscriber whose ``undeclare`` raises a real ``zenoh.ZError``."""
     obj = MagicMock()
-    obj.undeclare.side_effect = zerr("simulated broker drop during teardown")
+    obj.undeclare.side_effect = _zerror("simulated broker drop during teardown")
     return obj
 
 
@@ -108,3 +117,172 @@ def test_stop_does_not_swallow_programmer_error_from_undeclare():
 
     with pytest.raises(TypeError):
         mesh.stop()
+
+
+# ---------------------------------------------------------------------------
+# The session's own ``close`` paths.
+#
+# :func:`zenoh_error_types` names ``close`` among the operations it covers, and
+# ``release_session`` / ``_atexit_cleanup`` are the only two ``close`` calls in
+# the module that defines it. Both swallowed bare ``Exception`` and neither
+# recorded anything, so a failed close was indistinguishable from a clean one -
+# ``release_session``'s only visible line said the session had closed - and the
+# programmer errors the tuple's docstring excludes were swallowed here too.
+# ---------------------------------------------------------------------------
+
+_SESSION_LOGGER = "strands_robots.mesh.session"
+
+# The transport-failure surface the tuple documents. ``ZError`` is added by the
+# fixture below when a real ``zenoh`` is importable.
+_TRANSPORT_ERRORS = [RuntimeError, ConnectionError, OSError]
+
+# Bugs, not transport faults: the tuple's docstring excludes these so they
+# surface loudly instead of being swallowed by a best-effort teardown.
+_PROGRAMMER_ERRORS = [TypeError, AttributeError]
+
+
+@pytest.fixture
+def failing_session():
+    """Install a module session whose ``close`` raises, and reset after.
+
+    Yields a factory taking the exception to raise; the caller drives
+    ``release_session`` / ``_atexit_cleanup`` against it. The module globals are
+    restored unconditionally so a propagating error cannot leak a session into
+    the next test.
+    """
+
+    def install(exc: BaseException):
+        session = MagicMock()
+        session.close.side_effect = exc
+        with session_mod._SESSION_LOCK:
+            session_mod._SESSION = session
+            session_mod._SESSION_REFS = 1
+        return session
+
+    try:
+        yield install
+    finally:
+        with session_mod._SESSION_LOCK:
+            session_mod._SESSION = None
+            session_mod._SESSION_REFS = 0
+
+
+@pytest.mark.parametrize("exc_type", _TRANSPORT_ERRORS, ids=lambda t: t.__name__)
+def test_release_session_records_a_transport_close_failure(failing_session, caplog, exc_type):
+    session = failing_session(exc_type("broker drop racing with close"))
+
+    with caplog.at_level(logging.WARNING, logger=_SESSION_LOGGER):
+        session_mod.release_session()  # fail-soft: a close fault is not the caller's problem
+
+    session.close.assert_called_once()
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a close failure left no record at all"
+    assert "close failed" in warnings[0].message
+    assert "broker drop racing with close" in warnings[0].message
+    # The reference is dropped either way, so nothing can retry the close.
+    assert session_mod._SESSION is None
+    assert session_mod._SESSION_REFS == 0
+
+
+def test_release_session_records_a_zerror_close_failure(failing_session, caplog):
+    # The whole reason the tuple names ZError: it subclasses Exception directly,
+    # so (RuntimeError, OSError, ConnectionError) alone would let it escape.
+    session = failing_session(_zerror("simulated broker drop during teardown"))
+
+    with caplog.at_level(logging.WARNING, logger=_SESSION_LOGGER):
+        session_mod.release_session()
+
+    session.close.assert_called_once()
+    assert any("close failed" in r.message for r in caplog.records if r.levelno >= logging.WARNING)
+    assert session_mod._SESSION is None
+
+
+def test_release_session_does_not_report_a_close_it_could_not_complete(failing_session, caplog):
+    """A failed close must not still be reported as a clean one.
+
+    This is what made the swallow silent rather than merely quiet: the success
+    line was emitted unconditionally, so it was the only thing an operator saw
+    and it contradicted what had happened.
+    """
+    failing_session(OSError("socket already closed"))
+
+    with caplog.at_level(logging.DEBUG, logger=_SESSION_LOGGER):
+        session_mod.release_session()
+
+    assert not any("mesh session closed" in r.message for r in caplog.records)
+
+
+def test_release_session_still_reports_a_clean_close(caplog):
+    """The success line survives for the close that did complete."""
+    session = MagicMock()
+    with session_mod._SESSION_LOCK:
+        session_mod._SESSION = session
+        session_mod._SESSION_REFS = 1
+    try:
+        with caplog.at_level(logging.INFO, logger=_SESSION_LOGGER):
+            session_mod.release_session()
+    finally:
+        with session_mod._SESSION_LOCK:
+            session_mod._SESSION = None
+            session_mod._SESSION_REFS = 0
+
+    session.close.assert_called_once()
+    assert any("mesh session closed" in r.message for r in caplog.records)
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+@pytest.mark.parametrize("exc_type", _PROGRAMMER_ERRORS, ids=lambda t: t.__name__)
+def test_release_session_does_not_swallow_a_programmer_error_from_close(failing_session, exc_type):
+    failing_session(exc_type("close() takes no arguments"))
+
+    with pytest.raises(exc_type):
+        session_mod.release_session()
+
+
+@pytest.mark.parametrize("exc_type", _TRANSPORT_ERRORS, ids=lambda t: t.__name__)
+def test_atexit_cleanup_records_a_transport_close_failure(failing_session, caplog, exc_type):
+    session = failing_session(exc_type("broker drop racing with exit"))
+
+    with caplog.at_level(logging.DEBUG, logger=_SESSION_LOGGER):
+        session_mod._atexit_cleanup()
+
+    session.close.assert_called_once()
+    records = [r for r in caplog.records if "close failed at exit" in r.message]
+    assert records, "the exit-time close failure left no record at all"
+    # DEBUG: this path makes no success claim to contradict.
+    assert records[0].levelno == logging.DEBUG
+    assert session_mod._SESSION is None
+    assert session_mod._SESSION_REFS == 0
+
+
+def test_atexit_cleanup_records_a_zerror_close_failure(failing_session, caplog):
+    session = failing_session(_zerror("simulated broker drop at exit"))
+
+    with caplog.at_level(logging.DEBUG, logger=_SESSION_LOGGER):
+        session_mod._atexit_cleanup()
+
+    session.close.assert_called_once()
+    assert any("close failed at exit" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize("exc_type", _PROGRAMMER_ERRORS, ids=lambda t: t.__name__)
+def test_atexit_cleanup_does_not_swallow_a_programmer_error_from_close(failing_session, exc_type):
+    failing_session(exc_type("close() takes no arguments"))
+
+    with pytest.raises(exc_type):
+        session_mod._atexit_cleanup()
+
+
+def test_error_tuple_falls_back_to_the_builtins_without_zenoh(monkeypatch):
+    """Without an importable ``zenoh`` the tuple is still usable.
+
+    Both ``close`` sites evaluate the tuple when an exception arrives, so a
+    partially provisioned install must still get a narrow, non-empty surface
+    rather than an import error from the handler itself.
+    """
+    monkeypatch.setitem(sys.modules, "zenoh", None)  # makes ``import zenoh`` raise
+
+    types = session_mod.zenoh_error_types()
+
+    assert types == (RuntimeError, OSError, ConnectionError)
+    assert all(issubclass(t, BaseException) for t in types)


### PR DESCRIPTION
## Problem

`strands_robots/mesh/session.py` defines `zenoh_error_types()`, the module's centralised
exception tuple for best-effort Zenoh lifecycle work. Its docstring names the operations it
covers -- "`open` / `declare_subscriber` / `declare_publisher` / `undeclare` / **`close`**
failures" -- and states what it deliberately leaves out:

> Programmer errors (`TypeError` / `AttributeError` / `MemoryError`) are deliberately excluded
> so they surface loudly instead of being swallowed by a best-effort cleanup path.

Six sites in the session-open paths use that tuple and log. The module's only two `close()`
calls -- `release_session()` and `_atexit_cleanup()` -- caught bare `Exception` and did
`pass`.

Measured in-process with a session whose `close()` raises (no broker needed; zenoh installed,
so `ZError` is the real class):

| teardown | `close()` raises | upstream/main | this PR |
| --- | --- | --- | --- |
| `release_session()` | `ZError` | `INFO Zenoh mesh session closed` | `WARNING ... close failed: ...` |
| `release_session()` | `OSError` | `INFO Zenoh mesh session closed` | `WARNING ... close failed: ...` |
| `release_session()` | `TypeError` | `INFO Zenoh mesh session closed` | propagates |
| `release_session()` | `AttributeError` | `INFO Zenoh mesh session closed` | propagates |
| `_atexit_cleanup()` | `ZError` | *(nothing logged)* | `DEBUG ... close failed at exit: ...` |
| `_atexit_cleanup()` | `OSError` | *(nothing logged)* | `DEBUG ... close failed at exit: ...` |
| `_atexit_cleanup()` | `TypeError` | *(nothing logged)* | propagates |
| `_atexit_cleanup()` | `AttributeError` | *(nothing logged)* | propagates |

Three things followed from that:

1. **A failed close was reported as a clean one.** `release_session()`'s only visible line was
   `INFO Zenoh mesh session closed`, emitted unconditionally after the swallow -- byte-identical
   to the healthy path. 4 of 8 failure cases reported a clean close; the other 4 said nothing
   at all.
2. **The reference was dropped either way**, so nothing could retry the close -- which is why
   the record matters: it is the only remaining evidence.
3. **Programmer errors were swallowed here too**, contradicting the tuple's own docstring.
   `Mesh.stop()` already lets a `TypeError` from `undeclare` propagate, pinned by
   `test_stop_does_not_swallow_programmer_error_from_undeclare`; the `close` half did not.

## Change

Both `close()` sites now catch `zenoh_error_types()` -- the tuple this module defines and whose
docstring already named `close` -- and record the failure:

- `release_session()` logs at **WARNING**, because the `INFO` line otherwise reports a clean
  close and a record must be at least as loud as the claim it contradicts. That line is now
  emitted only when the close completed.
- `_atexit_cleanup()` logs at **DEBUG**: this path makes no success claim to contradict, and it
  runs at interpreter shutdown. Same level `BridgeTransport.close()` uses for its per-backend
  close, whose docstring makes the same narrow-surface argument.

A failure outside the documented transport surface propagates. Both docstrings now state the
contract.

## Scope

`release_session()` and `_atexit_cleanup()` are the only two `_SESSION.close()` calls in this
module, so this is the module's whole `close` surface. The package carries 54 bare
`except Exception: pass` sites; a sweep of those would be over-reach and is not attempted --
the unit here is the module that defines the policy these two ignored.

`BridgeTransport.close()` on the transport path already had this contract, pinned by
`TestBridgeCloseFailSoft` (swallows the documented surface, propagates a `ValueError`). This
brings the legacy Zenoh session's close to the same footing.

## Tests

Extends `tests/mesh/test_zenoh_lifecycle_error_classification.py`, which already owns this
contract and whose module docstring already named `close` among the operations it pins. +15
cases (5 -> 20):

- each documented transport error, and a real `zenoh.ZError`, is swallowed **and recorded**, on
  both teardowns, at the level each path uses;
- a failed close does **not** emit the "session closed" line, and a clean close still does
  (the over-reach control);
- `TypeError` / `AttributeError` propagate from both teardowns;
- `zenoh_error_types()` still returns a narrow, non-empty tuple when `zenoh` is not importable --
  both handlers evaluate it when an exception arrives, so a partially provisioned install must
  not get an import error from the handler itself.

Pre-fix (source reverted to `main`, tests kept): **13 failed / 7 passed**, e.g.
`AssertionError: the exit-time close failure left no record at all` and
`Failed: DID NOT RAISE TypeError`. The 7 that pass are the 5 pre-existing cases plus the two
over-reach controls (a clean close still reports, and the tuple fallback), which is what stops
the new tests being satisfied by deleting the handler.

**Mutation table** -- 6 plausible regressions, run against this PR's tests and against
upstream's own copy of the same module:

| regression | this PR | pre-existing tests |
| --- | --- | --- |
| M1 `release_session`: revert to a bare swallow | 7 failed | 0 failed |
| M2 `release_session`: keep the narrow catch, drop the record | 4 failed | 0 failed |
| M3 `release_session`: report the close unconditionally again | 1 failed | 0 failed |
| M4 `_atexit_cleanup`: revert to a bare swallow | 6 failed | 0 failed |
| M5 `_atexit_cleanup`: keep the narrow catch, drop the record | 4 failed | 0 failed |
| M6 `release_session`: downgrade the record to DEBUG | 4 failed | 0 failed |

6 of 6 caught here, 0 of 6 by the tests as they stand. M2/M5 are the ones a structural "the
guard is called" pin cannot see by construction -- they keep the call and drop only the record.

`mesh/session.py`: 6 missing lines -> 0.

## Measurement

![session close reporting](https://raw.githubusercontent.com/cagataycali/robots/artifacts/session-close-report/session_close_report.png)

No policy, simulation, rendering, recording or asset behaviour changes -- this is transport
teardown reporting, so the artifact is the measurement rather than a rollout. Every cell is
read from two probe runs (one per tree, each printing the tree it imported from) and the
figure generator asserts each rendered number before saving. Scripts on
`artifacts/session-close-report`.

## Gate

- `MUJOCO_GL=egl pytest tests`: **28463 passed / 257 skipped / 0 failed** (618s) == 28448 on
  `main` + the 15 new cases.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`: clean. mypy
  reports 14 errors, all in `examples/isaac_gs`, 0 outside it, and the error set is
  byte-identical to a pristine checkout of the same base -- environmental, not from this change.
- `scripts/check_merge_base_overlap.py`: no overlap; `changelog.d` fragment added.
