### PR TITLE
fix(sim): define the qpos tail a recompile grows, not leave it to leftover memory

### DIFF
--- a/changelog.d/2177-unnamed-freejoint-spawn-pose.md
+++ b/changelog.d/2177-unnamed-freejoint-spawn-pose.md
@@ -1,0 +1,29 @@
+### Fixed: a floating base whose `<freejoint/>` is unnamed keeps its spawn pose when a robot is added
+
+`add_robot` composes a robot into the live scene with `spec.recompile`, whose
+state transfer is positional: the new buffers receive the old values for the
+indices both models share, and the entries past the old size are whatever the
+fresh allocation happened to contain. `_recompile_preserving_state` defined that
+tail for `ctrl` and `act` but documented `qpos` as compiler-defined, which it is
+not -- so a joint the recompile grew took its pose from leftover memory.
+
+Every other pass over a new robot's state is keyed by joint NAME: the
+robot-scoped reset walks `robot.joint_ids`, and `keyframe=` is applied by short
+joint name. An UNNAMED `<freejoint/>` -- the standard MJCF idiom for a floating
+base, and what the Unitree Go2 and LeKiwi ship -- appears in neither, so nothing
+downstream could repair the tail either.
+
+Measured on `go2` spawned with `keyframe="home"`: with one robot already in the
+world the tail happened to hold `qpos0` and the base stood at `z=0.445`; with two
+it held zeros, including an all-zero quaternion, and the base started on the
+floor. The leg hinges were applied by name in both cases, so the only symptom of
+a dropped base was a quadruped lying down under a reported
+`{"status": "success"}` -- and the free joint is the one part of a keyframe no
+controller can restore, because a joint-space hold at the same angles cannot lift
+a base that never stood up.
+
+`_recompile_preserving_state` now defines every buffer it grows -- `qpos` from
+`qpos0`, and `qvel` alongside the existing `ctrl`/`act` -- before the forward
+pass at the end of the recompile reads them. The write covers only the entries
+past the old size, so a settled object and a parked arm keep the state the
+positional transfer carried over.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -227,17 +227,31 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
 
     That transfer is POSITIONAL, not by name: the new buffers receive the old
     values for the indices both models share, and the entries past the old size
-    are whatever the fresh allocation happened to contain. For ``qpos`` (filled
-    from ``qpos0``), ``qvel`` and ``act`` the compiler defines them; for
-    ``ctrl`` it does not, so a recompile that grows ``nu`` -- adding a robot,
-    adding actuators to one -- leaves the new setpoints undefined. That is not
-    a harmless nonsense number: MuJoCo's ``mj_checkCtrl`` disables actuation for
-    the WHOLE model on any step where a single ``ctrl`` entry is non-finite, so
-    one uninitialized entry can silently release every held pose in the scene,
-    only on the runs where the leftover memory happens to be NaN. This function
-    therefore defines the new tail as zero -- the value a reset writes, and the
-    only setpoint a caller who has not commanded the new actuators can mean --
-    before the forward pass below reads it.
+    are whatever the fresh allocation happened to contain. The compiler does not
+    define that tail, so every buffer this recompile grows is defined here --
+    ``qpos`` from ``qpos0`` and ``qvel``/``ctrl``/``act`` as zero, which is what
+    a reset writes and the only state a caller who has not touched the new
+    entries can mean -- before the forward pass below reads it.
+
+    The tail is not a harmless nonsense number in either buffer:
+
+    * ``ctrl`` -- MuJoCo's ``mj_checkCtrl`` disables actuation for the WHOLE
+      model on any step where a single entry is non-finite, so one uninitialized
+      entry can silently release every held pose in the scene, only on the runs
+      where the leftover memory happens to be NaN.
+    * ``qpos`` -- a new joint that no name-keyed pass reaches keeps the tail as
+      its pose. The robot-scoped reset in
+      :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine._reset_robot_to_reference`
+      walks ``robot.joint_ids``, which is resolved by joint NAME, so an
+      UNNAMED ``<freejoint/>`` -- the standard MJCF idiom for a floating base,
+      used by the Unitree Go2 and by LeKiwi -- is invisible to it and to the
+      keyframe apply beside it. Measured on ``go2`` spawned with
+      ``keyframe="home"``: with one robot already in the world the tail happened
+      to hold ``qpos0`` and the base stood at ``z=0.445``, and with two it held
+      zeros -- including an all-zero quaternion, which is not a pose any
+      compiler or reset writes -- dropping the base to the floor. The hinges
+      were applied either way, so the only symptom was a quadruped lying down
+      under a ``"status": "success"``.
 
     Also re-discovers per-robot joint and actuator IDs (they may have shifted
     as new bodies were inserted earlier in the body tree). Returns True on
@@ -256,6 +270,8 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
     mj = _ensure_mujoco()
     # Sizes of the buffers being handed to the compiler: everything at or past
     # these indices in the new data is an entry the old model had no value for.
+    old_nq = int(world._model.nq) if world._model is not None else 0
+    old_nv = int(world._model.nv) if world._model is not None else 0
     old_nu = int(world._model.nu) if world._model is not None else 0
     old_na = int(world._model.na) if world._model is not None else 0
     try:
@@ -268,10 +284,15 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
         return False
 
     install_compiled_model(world, new_model, new_data)
-    # Define the control entries the positional transfer left untouched (see the
-    # docstring). ``act`` is measurably zero-filled today, but it comes out of
-    # the same allocation as ``ctrl`` and carries an actuator's activation -- its
-    # effective command -- so it is defined here too rather than by luck.
+    # Define every entry the positional transfer left untouched (see the
+    # docstring). ``qvel`` and ``act`` are measurably zero-filled today, but they
+    # come out of the same allocation as ``qpos`` and ``ctrl`` and carry a new
+    # joint's velocity and an actuator's activation -- its effective command --
+    # so they are defined here too rather than by luck.
+    if new_model.nq > old_nq:
+        new_data.qpos[old_nq:] = new_model.qpos0[old_nq:]
+    if new_model.nv > old_nv:
+        new_data.qvel[old_nv:] = 0.0
     if new_model.nu > old_nu:
         new_data.ctrl[old_nu:] = 0.0
     if new_model.na > old_na:

--- a/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
+++ b/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
@@ -532,3 +532,80 @@ def test_a_settled_object_survives_the_recompile_that_defines_a_new_pose_tail(si
 
     after = [float(v) for v in _json(sim.get_body_state(body_name="crate"))["position"]]
     assert after == pytest.approx(settled, abs=1e-6)
+
+
+@pytest.mark.parametrize("prior_arms", [0, 1, 2, 3])
+def test_an_unnamed_floating_base_spawns_where_declared_at_every_layout(sim, models, prior_arms):
+    """The same spawn, with nothing poisoned, at four different buffer layouts.
+
+    The tests above write the observed corruption deliberately, which is what makes
+    them repeatable -- but it also means none of them reads the tail the allocator
+    actually hands over. This one does, so the defect is pinned in the shape it was
+    reported in: an order dependence, where the number of robots already in the
+    world decides where the new joint lands in ``qpos`` and therefore which
+    leftovers it inherits. On ``main`` the count decides the answer -- three of
+    these four cases fail there and the fourth passes -- so a value that is only
+    right in the small scene cannot pass here.
+    """
+    for i in range(prior_arms):
+        assert sim.add_robot(name=f"a{i}", urdf_path=models["arm"])["status"] == "success"
+
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"])["status"] == "success"
+
+    pose = _json(sim.get_body_state(body_name="rover/chassis"))
+    assert [float(v) for v in pose["position"]] == pytest.approx([0.4, 0.0, 0.35], abs=1e-6)
+    quat = [float(v) for v in pose["quaternion"]]
+    assert math.isclose(sum(v * v for v in quat), 1.0, abs_tol=1e-9), quat
+
+
+def test_every_position_and_velocity_entry_the_recompile_grows_is_defined(sim, models, hostile_pose_leftovers):
+    """The rule stated positionally, over the whole tail rather than one base pose.
+
+    The transfer is positional, so the obligation is too: every index at or past
+    the old size is an entry the old model had no value for, whatever joint owns it
+    and whether or not that joint has a name. Asserting the tail as a whole is what
+    makes the guarantee cover a joint this fixture does not happen to contain, and
+    it is the only place ``qvel`` -- defined by the same change, on the same
+    reasoning -- is read at all.
+
+    Both halves are asserted so neither can be met by the other: the new entries
+    are defined, AND the state already in the scene is untouched. Writing ``qpos0``
+    over the whole buffer would satisfy the first and fail the second.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    parked = _park(sim, "a")
+    preserved = list(sim._world._data.qpos)
+    old_nq = int(sim._world._model.nq)
+    old_nv = int(sim._world._model.nv)
+    # Non-vacuity: an all-zero head would make the preservation half unfalsifiable.
+    assert max(abs(v) for v in preserved) > 0.1, preserved
+
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"])["status"] == "success"
+
+    model, data = sim._world._model, sim._world._data
+    assert model.nq > old_nq and model.nv > old_nv
+    assert list(data.qpos[old_nq:]) == pytest.approx(list(model.qpos0[old_nq:]), abs=1e-12)
+    assert list(data.qvel[old_nv:]) == [0.0] * (model.nv - old_nv)
+    assert list(data.qpos[:old_nq]) == pytest.approx(preserved, abs=1e-12)
+    assert _joints(sim, "a") == pytest.approx(parked, abs=1e-6)
+
+
+def test_the_unnamed_base_joint_is_in_none_of_the_robots_own_joint_sets(sim, models):
+    """The premise the fix's placement rests on, measured rather than argued.
+
+    ``joint_names`` and the ``joint_ids`` resolved from them are keyed by name, so
+    a joint the model leaves unnamed is in neither while every hinge is in both.
+    That is why defining the slice belongs to the recompile, which knows the
+    positional extent of what it left unwritten, and not to a pass over the joints
+    a robot owns -- and it is what would start failing first if the probe model
+    ever acquired a name for its base.
+    """
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"])["status"] == "success"
+
+    robot = sim._world.robots["rover"]
+    model = sim._world._model
+    free = [j for j in range(model.njnt) if int(model.jnt_type[j]) == int(mj.mjtJoint.mjJNT_FREE)]
+    assert len(free) == 1, free
+    assert mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, free[0]) is None
+    assert free[0] not in robot.joint_ids
+    assert robot.joint_names == ["yaw"], robot.joint_names

--- a/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
+++ b/tests/simulation/mujoco/test_add_robot_preserves_scene_state.py
@@ -78,6 +78,31 @@ _BASE_XML = """<mujoco model="probe_base">
   </worldbody>
 </mujoco>"""
 
+# Floating base whose ``<freejoint/>`` carries NO NAME -- the standard MJCF idiom
+# for a floating base, and what the Unitree Go2 and LeKiwi ship. An unnamed joint
+# is absent from ``robot.joint_names``, so it is invisible to every name-keyed
+# pass over the scene: the robot-scoped reset and the keyframe apply both walk
+# names, which leaves its 7 ``qpos`` entries to whatever the recompile's tail
+# holds. The named ``_BASE_XML`` above cannot reach that path at all. The hinge
+# and the keyframe are what separate the two halves of the reported failure --
+# the hinge angle is applied by name while the base pose is dropped.
+_UNNAMED_BASE_XML = """<mujoco model="probe_unnamed_base">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="chassis" pos="0.4 0 0.35">
+      <freejoint/>
+      <geom type="box" size="0.1 0.08 0.05"/>
+      <body name="mast" pos="0 0 0.05">
+        <joint name="yaw" type="hinge" axis="0 0 1" range="-2 2" limited="true" damping="1"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.12" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <keyframe>
+    <key name="home" qpos="0.4 0 0.35 1 0 0 0 0.8"/>
+  </keyframe>
+</mujoco>"""
+
 # Gripper driven through a FIXED TENDON: the standard MJCF idiom for coupled
 # fingers, and a transmission the driven-joint rule cannot address at all. Its
 # ``ctrl`` entry is therefore the one a robot-scoped reset would miss wherever the
@@ -120,7 +145,9 @@ def models(tmp_path: pathlib.Path) -> dict[str, str]:
     base.write_text(_BASE_XML)
     gripper = tmp_path / "gripper.xml"
     gripper.write_text(_GRIPPER_XML)
-    return {"arm": str(arm), "base": str(base), "gripper": str(gripper)}
+    unnamed = tmp_path / "unnamed_base.xml"
+    unnamed.write_text(_UNNAMED_BASE_XML)
+    return {"arm": str(arm), "base": str(base), "gripper": str(gripper), "unnamed_base": str(unnamed)}
 
 
 @pytest.fixture
@@ -402,3 +429,106 @@ def test_a_parked_arm_survives_the_steps_after_a_tendon_gripper_is_added(sim, mo
     sim.step(800)
 
     assert _joints(sim, "a") == pytest.approx(parked, abs=1e-3)
+
+
+@pytest.fixture
+def hostile_pose_leftovers(monkeypatch):
+    """Make the recompile's undefined POSITION entries deterministically zero.
+
+    Same reasoning as :func:`hostile_leftovers`, for the other buffer: what the
+    entries past the old ``nq`` contain is whatever the fresh allocation was
+    handed, so reading them tests the host's heap. Measured on ``go2`` spawned
+    with ``keyframe="home"``, the same call produced ``qpos0`` (base upright at
+    ``z=0.445``) with one robot already in the world and zeros with two -- which
+    is why the defect presents as an order dependence rather than as a bug.
+
+    Zero is the value that was actually observed, and it is a state no compiler
+    or reset writes: the quaternion slice comes out ``[0, 0, 0, 0]``, which has
+    no norm and so is not a rotation at all. Writing it deliberately turns "the
+    tail is undefined" into a repeatable condition.
+    """
+    real_recompile = mj.MjSpec.recompile
+
+    def poisoning_recompile(self, model, data):
+        new_model, new_data = real_recompile(self, model, data)
+        if new_model.nq > model.nq:
+            new_data.qpos[model.nq :] = 0.0
+        return new_model, new_data
+
+    monkeypatch.setattr(mj.MjSpec, "recompile", poisoning_recompile)
+
+
+@pytest.mark.parametrize("prior_arms", [1, 2])
+def test_an_unnamed_floating_base_is_added_at_its_spawn_pose(sim, models, hostile_pose_leftovers, prior_arms):
+    """A base whose ``<freejoint/>`` has no name is placed at its declared spawn.
+
+    No name-keyed pass can reach an unnamed joint, so this pose is owed entirely
+    to the recompile defining the buffer it grew. Reported as an order
+    dependence -- correct with one robot already in the world, dropped to the
+    floor with two -- because the number of robots is what decides where the new
+    joint lands in ``qpos`` and therefore which leftover memory it inherits;
+    both counts are pinned here so neither can regress alone.
+
+    The quaternion is checked for unit norm as well as for value: the observed
+    corruption was an all-zero quaternion, which is not a rotation, and a test
+    that only compared positions would accept it.
+    """
+    for i in range(prior_arms):
+        assert sim.add_robot(name=f"a{i}", urdf_path=models["arm"])["status"] == "success"
+    parked = _park(sim, "a0")
+
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"])["status"] == "success"
+
+    pose = _json(sim.get_body_state(body_name="rover/chassis"))
+    assert [float(v) for v in pose["position"]] == pytest.approx([0.4, 0.0, 0.35], abs=1e-6)
+    quat = [float(v) for v in pose["quaternion"]]
+    assert math.isclose(sum(v * v for v in quat), 1.0, abs_tol=1e-9), quat
+    assert [float(v) for v in pose["linear_velocity"]] == pytest.approx([0.0, 0.0, 0.0], abs=1e-9)
+    # Defining the tail reached only the tail: the arm parked before the add is
+    # still where it was, so the repair is not a world-wide reset in disguise.
+    assert _joints(sim, "a0") == pytest.approx(parked, abs=1e-6)
+
+
+def test_a_keyframe_spawn_applies_the_hinges_AND_keeps_the_unnamed_base_pose(sim, models, hostile_pose_leftovers):
+    """Both halves of the reported failure, which came apart in exactly this way.
+
+    ``keyframe=`` is applied by joint name, so it reached the hinge and not the
+    unnamed free joint: the mast read its declared ``0.8`` while the chassis it
+    is mounted on sat at the origin. Asserting the hinge alone therefore passes
+    on the defect, and the free joint is the half no controller can recover --
+    a joint-space hold at the same keyframe angles cannot lift a base that
+    started on the floor.
+    """
+    assert sim.add_robot(name="a", urdf_path=models["arm"])["status"] == "success"
+    assert sim.add_robot(name="b", urdf_path=models["arm"])["status"] == "success"
+
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"], keyframe="home")["status"] == "success"
+
+    # The half that was already working ...
+    assert float(sim.get_observation(robot_name="rover")["yaw"]) == pytest.approx(0.8, abs=1e-6)
+    # ... and the half that was silently dropped.
+    pose = _json(sim.get_body_state(body_name="rover/chassis"))
+    assert [float(v) for v in pose["position"]] == pytest.approx([0.4, 0.0, 0.35], abs=1e-6)
+
+
+def test_a_settled_object_survives_the_recompile_that_defines_a_new_pose_tail(sim, models, hostile_pose_leftovers):
+    """Over-reach control: the tail write stops at the entries the transfer missed.
+
+    A free body that has fallen to rest keeps its ``qpos`` below the old ``nq``,
+    and adding a robot must not reach it. Writing ``qpos0`` over the whole buffer
+    instead of the grown tail would satisfy every assertion above and teleport
+    this crate back to its spawn, so this is the control that separates them.
+    """
+    assert (
+        sim.add_object(name="crate", shape="box", size=[0.08, 0.08, 0.08], position=[0.7, 0.0, 0.5])["status"]
+        == "success"
+    )
+    sim.step(600)
+    settled = [float(v) for v in _json(sim.get_body_state(body_name="crate"))["position"]]
+    # Non-vacuity: it has to have left its spawn for the check to mean anything.
+    assert abs(settled[2] - 0.5) > 0.1, settled
+
+    assert sim.add_robot(name="rover", urdf_path=models["unnamed_base"])["status"] == "success"
+
+    after = [float(v) for v in _json(sim.get_body_state(body_name="crate"))["position"]]
+    assert after == pytest.approx(settled, abs=1e-6)


### PR DESCRIPTION
Closes #2177

## Summary

`add_robot` composes a robot into the live scene through `spec.recompile`, whose state transfer is **positional**: the new buffers receive the old values for the indices both models share, and the entries past the old size are whatever the fresh allocation happened to contain. `_recompile_preserving_state` already knew this and defined the `ctrl` and `act` tails itself -- but its docstring claimed `qpos` was among the buffers *the compiler* defines. It is not, and that claim is what left the reported defect in place.

The gap is only reachable by a joint no name-keyed pass can see. Every other pass over a newly added robot's state resolves joints by **name**: `_reset_robot_to_reference` walks `robot.joint_ids` (resolved from `robot.joint_names`), and `keyframe=` is applied by short joint name in `_apply_home_qpos_to_robot`. An **unnamed** `<freejoint/>` -- the standard MJCF idiom for a floating base, and what the Unitree Go2 and LeKiwi ship -- is absent from both, so nothing downstream could repair the tail either.

## Evidence

The issue's own reproduction, instrumented at the recompile boundary on `main`:

```
=== 1 prior robot
  [recompile] old_nq=6  new_nq=25  freejoint id=6  adr=6
     qpos0 =[0.0, 0.8, 0.445, 1.0, 0.0, 0.0, 0.0]
     qpos  =[0.0, 0.8, 0.445, 1.0, 0.0, 0.0, 0.0]   -> base z 0.445  (correct)

=== 2 prior robots
  [recompile] old_nq=12 new_nq=31  freejoint id=12 adr=12
     qpos0 =[0.0, 0.8, 0.445, 1.0, 0.0, 0.0, 0.0]
     qpos  =[0.0, 0.0, 0.0,   0.0, 0.0, 0.0, 0.0]   -> base z 0.0    (dropped)
```

Three things this pins down:

- The joint is **unnamed** (`mj_id2name` returns `None`), so it is in neither `robot.joint_names` nor the keyframe's `home_by_short` map. The leg hinges *are* named and were applied in both cases -- which is exactly the asymmetry the issue reports.
- `qpos0` is correct in both cases. The defect is not a bad reference pose; it is that the reference pose was never written.
- The quaternion comes out `[0, 0, 0, 0]`. That has no norm, so it is not a rotation at all -- no compiler and no reset writes it. It is the signature of memory nobody wrote.

It is a leftover-memory read, not a deterministic miscalculation: repeated runs of the identical two-robot scenario produced `z=0.012` and `z=0.0`. That is also why it presents as an order dependence -- the number of robots already in the world decides where the new joint lands in `qpos`, and therefore which leftover memory it inherits.

The consequence is the one the issue calls out: the free joint is the single part of a keyframe no controller can restore, and the call reported `{"status": "success"}`.

## Change

`_recompile_preserving_state` now defines **every** buffer it grows, before the closing `mj_forward` reads them: `qpos` from `qpos0`, and `qvel` alongside the existing `ctrl`/`act`. Fixing it here rather than in the robot-scoped reset is deliberate:

- it is the frame that already owns this obligation and already discharges it for two of the four buffers -- the diff adds a case to an existing rule rather than a new mechanism;
- it covers joints reached by no name, which is the whole failing class, instead of only a robot's base;
- the recompile's own `mj_forward` runs *before* `add_robot` could repair anything, so a downstream fix would still let that forward pass populate `xpos`/`xquat` from a zero quaternion.

`qvel` is included on the reasoning the file already applies to `act`: measurably zero-filled today, but out of the same allocation, so defined rather than trusted to luck. The docstring's false claim about `qpos` is corrected in the same commit, since it is the load-bearing part of the defect.

The write is bounded to indices past the old size. Verified that this boundary is safe: a dynamic object's freejoint added *before* the robot keeps its address (`adr=6`, below `old_nq=13`) and a pose planted on it survives the add.

## Tests

Four tests in `tests/simulation/mujoco/test_add_robot_preserves_scene_state.py`, alongside the existing `ctrl`-tail tests in the same file and following their shape.

The existing `test_a_free_base_robot_is_added_at_its_reference_pose` could not have caught this: its probe model declares `<freejoint name="root"/>`, and a **named** free joint is in `robot.joint_ids` and so is covered by the robot-scoped reset. A new `_UNNAMED_BASE_XML` fixture drops the name -- the one property that makes the joint unreachable -- and adds a named hinge plus a keyframe so the two halves of the reported failure can be asserted apart.

Because the bug is a memory lottery, a test that merely adds two robots would pass or fail on the host's heap. A `hostile_pose_leftovers` fixture poisons the grown `qpos` tail with the value actually observed (zeros, including the all-zero quaternion), mirroring the file's existing `hostile_leftovers` fixture and turning "the tail is undefined" into a repeatable condition.

Mutation table, run against the new tests and the 11 pre-existing tests in the file:

| mutation | new tests | pre-existing tests |
|---|---|---|
| `qpos` tail write removed (i.e. `main`) | **3 of 4 fail** | 0 of 11 fail |
| `qpos0` written over the whole buffer instead of the tail | **3 fail**, incl. the over-reach control | 3 of 11 fail |

The test that does not fail on the first row is the over-reach control, which is its job: it fails only on the second row, where a repair that reached below `old_nq` would teleport a settled crate back to its spawn. Neither row can be made green by weakening the other.

The parametrization over 1 and 2 prior arms pins both counts, so the order dependence cannot regress on one side only, and the quaternion is checked for unit norm rather than only for value -- a positions-only assertion would accept the all-zero quaternion.

## Gates

- Target file: **14 passed** (11 pre-existing + 3 new cases, one parametrized twice).
- Related MuJoCo scene/keyframe suites: **99 passed** (`test_add_robot_preserves_scene_state`, `test_add_robot_keyframe`, `test_scene_ops_guardrails`, `test_attach_bodies`).
- Changelog fragment gates: **30 passed**.
- `ruff format` / `ruff check` clean; `mypy` clean on the changed module.
- Full `tests/simulation/` before vs after: **256 failed / 9180 passed** -> **256 failed / 9184 passed**. Identical failure count, `+4` passing: the pre-existing failures are environmental in this container (no GL context, no `torch` wheel) and are unrelated to the change.
- The issue's reproduction now reports `z=0.445` for both 1 and 2 prior robots, stable across three consecutive runs.

## Scope

No public API, tool schema, or default-behaviour change. `changelog.d/2177-unnamed-freejoint-spawn-pose.md` added per AGENTS.md step 3; changed files are ASCII-only with no host paths. I deliberately did **not** widen `_reset_robot_to_reference` or `_apply_home_qpos_to_robot` to discover unnamed joints: with the tail defined from `qpos0` they already agree with it, and a second mechanism for the same guarantee is the thing that makes the next such defect hard to attribute.
