### PR TITLE
docs(mesh): align discovery prose with the gossip-only multicast-off default

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,8 +971,13 @@ backend's install, usage, config, and `STRANDS_ISAAC_*` env vars.
 </p>
 
 Every `Robot()` and `Simulation()` is automatically a peer on a local Zenoh
-mesh - no setup. Peers on the same LAN discover each other via multicast
-scouting, sharing a single ref-counted `zenoh.Session` per process.
+mesh - no setup. Peers on the same host discover each other out of the box
+(gossip scouting plus a shared local endpoint), sharing a single ref-counted
+`zenoh.Session` per process. Cross-host discovery is deliberately explicit:
+point peers at each other with `ZENOH_CONNECT` (e.g. `tcp/10.0.0.1:7447`).
+Multicast scouting is **off by default** - it lets any device on the LAN
+enumerate and attract the fleet - and is opt-in via
+`STRANDS_MESH_MULTICAST=true`, which logs a loud warning.
 
 ```python
 from strands_robots import Robot
@@ -1097,6 +1102,7 @@ touches ROS 2.
 | `STRANDS_MESH_PORT` | TCP port for the local Zenoh router | `7447` |
 | `ZENOH_CONNECT` | Comma-separated remote Zenoh endpoints to connect to | unset |
 | `ZENOH_LISTEN` | Comma-separated endpoints for the local Zenoh listener | unset |
+| `STRANDS_MESH_MULTICAST` | Opt in to multicast scouting for LAN discovery. Off by default: any device on the LAN can enumerate and attract the fleet, so enabling it logs a WARNING. Prefer explicit `ZENOH_CONNECT` endpoints | `false` |
 | `STRANDS_MESH_AUDIT_DIR` | Directory for the safety audit log (`mesh_audit.jsonl`) | `~/.strands_robots/` |
 | `STRANDS_MESH_CA_PINS` | Additional SHA-256 CA pins (comma-separated 64-char hex) | unset |
 | `STRANDS_MESH_DISABLE_CA_PIN` | Skip CA pin check on download path (break-glass) | `false` |

--- a/changelog.d/2184-mesh-multicast-docs.md
+++ b/changelog.d/2184-mesh-multicast-docs.md
@@ -1,0 +1,10 @@
+### Docs: mesh discovery prose now matches the gossip-only default
+
+`README.md` and the `strands_robots.mesh.session` module docstring both claimed
+peers on the same LAN discover each other via multicast scouting automatically,
+while the config builder deliberately defaults multicast scouting OFF
+(gossip-only) to close the LAN-attacker enrollment surface. Both locations now
+state the actual posture: same-host discovery works out of the box, cross-host
+peers need explicit `ZENOH_CONNECT` endpoints, and multicast is opt-in via
+`STRANDS_MESH_MULTICAST=true` (which logs a warning). `STRANDS_MESH_MULTICAST`
+is also added to the README env-var table. No behavior change.

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -31,6 +31,9 @@ Environment variables
     Local auto-mesh port (default ``7447``).
 ``STRANDS_MESH``
     Set to ``false`` to disable mesh globally.
+``STRANDS_MESH_MULTICAST``
+    ``true`` to opt into LAN multicast scouting (logs a warning).
+    Default ``false``.
 """
 
 from __future__ import annotations

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -15,7 +15,11 @@ Connection strategy (when no explicit endpoint is configured):
    first process the local router.
 2. If the port is already bound, fall back to **client** mode and connect to the
    same endpoint.
-3. Zenoh scouting (multicast) handles LAN discovery automatically.
+3. Zenoh gossip scouting propagates peers reachable through those endpoints.
+   Multicast scouting is **disabled by default** (LAN discovery attack
+   surface); operators on a controlled LAN can opt in with
+   ``STRANDS_MESH_MULTICAST=true``. Cross-host peers otherwise need explicit
+   ``ZENOH_CONNECT`` endpoints.
 
 Environment variables
 ---------------------


### PR DESCRIPTION
## What changed

Two prose locations claimed automatic LAN multicast discovery while the config
builder (`scouting_block()` in `strands_robots/mesh/_zenoh_config.py`)
deliberately defaults multicast scouting OFF (gossip-only) to close the
LAN-attacker-enrollment surface:

- **README.md** ("Mesh networking" intro, formerly line 974): now states that
  same-host discovery works out of the box (gossip scouting + shared local
  endpoint), cross-host peers need explicit `ZENOH_CONNECT` endpoints, and
  multicast is opt-in via `STRANDS_MESH_MULTICAST=true` (which logs a loud
  warning, `mesh/core.py`).
- **`strands_robots/mesh/session.py` module docstring** (connection-strategy
  step 3, formerly line 18): same correction.

Also adds `STRANDS_MESH_MULTICAST` to the README mesh env-var table - the
corrected paragraph now names the flag, and the "document every `STRANDS_*`
env var in README" convention requires a table row.

No behavior change; prose + one changelog fragment only.

## Why

Out of the box, cross-host peers silently fail to discover each other if the
operator trusted the old prose. The config default is the deliberate,
security-reviewed posture, so the docs move to match it, not the other way
around.

## Test surface

- `hatch run lint`: clean (ruff, ruff format, mypy).
- `hatch run test` under EGL: **28530 passed, 262 skipped, 0 failed**,
  coverage 95.53%.
- `python scripts/assemble_changelog.py --check`: fragments OK.
- Docs-only change; the existing pins for the default
  (`tests/mesh/test_zenoh_config.py::test_default_is_multicast_off_gossip_on`,
  `tests/mesh/test_session_config.py::test_multicast_disabled_by_default`,
  `tests/mesh/test_multicast_startup_warning.py`) all pass unchanged.

## Acceptance criteria (from the issue)

- [x] README.md mesh intro aligned with the config default (one paragraph)
- [x] `strands_robots/mesh/session.py` docstring aligned (one paragraph)
- [x] No behavior change

## Out of scope / follow-ups

Other docs that describe multicast scouting in the Device Connect context
(`docs/device-connect.md`, `strands_robots/device_connect/GUIDE.md`,
`examples/lerobot/architecture.svg`) were not named by the issue and are left
untouched; if their D2D claims also need auditing against the Device Connect
config path, that is a separate issue.

Board: issue #2184 asked for Status=Todo, Priority=Low on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2);
please move it to "In review" (or add it with that status if intake never
landed) - the filing account lacks org project write.

Closes #2184
