### PR TITLE
test(mesh): pin the receive side of the teleop stream-replacement contract

### DIFF
--- a/changelog.d/2194-teleop-receive-stream-replacement.md
+++ b/changelog.d/2194-teleop-receive-stream-replacement.md
@@ -1,0 +1,12 @@
+### Quality: pin the receive side of the teleop stream-replacement contract
+
+`Robot.start_teleop_receive` keys its receiver registry on
+`source_peer_id/device_name` and stops whatever is registered under that key
+before installing the replacement. That step had no test: the publish mirror was
+pinned with the rate guard, but the receive side only had its identifier
+refusals, and `test_rejected_receive_leaves_a_live_stream_running`'s
+"the live stream survived" assertion holds equally for a body that tears nothing
+down. Four cases now drive the accepted path -- the superseded receiver is
+stopped and replaced, its subscription is dropped rather than leaked, and the
+compound key scopes the replacement so a second leader under the same
+`device_name` leaves the first stream running. Tests only; no behaviour change.

--- a/tests/mesh/test_teleop_identifier_source_scoping.py
+++ b/tests/mesh/test_teleop_identifier_source_scoping.py
@@ -15,6 +15,14 @@ wire path itself delegates to, and the one a local caller uses - accepted them.
 These tests pin the shared contract: one validator
 (:func:`strands_robots.mesh.security.validate_mesh_identifier`) guards every
 surface, so the accepted domains cannot diverge.
+
+Validation sits ahead of the teardown of any stream already registered under
+that key, so a refused call cannot stop a live one. That guarantee only means
+something next to its mirror - an accepted call *does* stop and replace the
+stream it supersedes - because "the live stream survived" is equally true of an
+implementation that never tears anything down. Both halves are pinned here for
+the receive surface; the publish mirror lives with the rate guard that shares
+its entry point.
 """
 
 from __future__ import annotations
@@ -59,13 +67,14 @@ class _FakeMesh:
         self.peer_id = peer_id
         self.alive = True
         self.subscribed: list[str] = []
+        self.unsubscribed: list[str] = []
 
     def subscribe(self, topic: str, callback: Any = None, name: str | None = None) -> str:
         self.subscribed.append(topic)
         return name or topic
 
     def unsubscribe(self, name: str) -> None:
-        return None
+        self.unsubscribed.append(name)
 
 
 class TestValidatorContract:
@@ -230,3 +239,96 @@ class TestHardwareRobotReportsThroughTheToolEnvelope:
         assert result["status"] == "error"
         assert live.stopped is False
         assert hw._input_publishers == {"leader": live}
+
+
+class TestAnAcceptedCallReplacesTheLiveStream:
+    """A receive that passes validation supersedes the stream it replaces.
+
+    ``start_teleop_receive`` keys its registry on ``source_peer_id/device_name``
+    and stops whatever is registered under that key before installing the new
+    receiver. Nothing drove that step, so the refusal guarantee above stood
+    alone - and it holds just as well for a body with no teardown, where the
+    superseded receiver would keep applying the old leader's frames to the same
+    hardware alongside the new one.
+    """
+
+    def test_an_accepted_receive_stops_and_replaces_the_live_receiver(self, hardware_robot: Any) -> None:
+        """The stream under that key is stopped and the new receiver takes it over."""
+        hw = hardware_robot
+        live = _LiveStream()
+        hw._input_receivers = {"leader-1/leader": live}
+
+        result = hw.start_teleop_receive(source_peer_id="leader-1", device_name="leader")
+
+        assert result["status"] == "success"
+        assert live.stopped is True
+        replacement = hw._input_receivers["leader-1/leader"]
+        assert replacement is not live
+        assert isinstance(replacement, InputReceiver)
+        assert hw.mesh.subscribed == ["strands/leader-1/input/leader"]
+        # One entry per key: the replacement takes the slot, it does not add one.
+        assert sorted(hw._input_receivers) == ["leader-1/leader"]
+
+    def test_a_second_leader_under_the_same_device_name_leaves_the_first_running(self, hardware_robot: Any) -> None:
+        """The key is the pair, so two leaders can drive one follower.
+
+        A registry keyed on ``device_name`` alone would silently stop the first
+        leader's stream here - the follower would end up following whichever
+        leader connected last, with nothing reported.
+        """
+        hw = hardware_robot
+        first = _LiveStream()
+        hw._input_receivers = {"leader-1/leader": first}
+
+        result = hw.start_teleop_receive(source_peer_id="leader-2", device_name="leader")
+
+        assert result["status"] == "success"
+        assert first.stopped is False
+        assert sorted(hw._input_receivers) == ["leader-1/leader", "leader-2/leader"]
+
+    def test_the_refusal_assertion_is_backed_by_a_reachable_teardown(self, hardware_robot: Any) -> None:
+        """One key, both directions: refused leaves it, accepted replaces it.
+
+        ``test_rejected_receive_leaves_a_live_stream_running`` asserts a live
+        receiver is *not* stopped by a refused call. On this surface both
+        refusable arguments are part of the registry key, so a refused value
+        cannot name a registered entry and that assertion holds for either
+        ordering of validation and teardown - and for a body with no teardown
+        at all. Driving both directions on one key is what shows the teardown
+        is reachable, and so what the refusal assertion rules out. (The
+        publish surface differs: ``hz`` is refused while ``device_name`` still
+        names the live stream, so ordering is observable there and is pinned
+        with the rate guard.)
+        """
+        hw = hardware_robot
+        live = _LiveStream()
+        hw._input_receivers = {"leader-1/leader": live}
+
+        refused = hw.start_teleop_receive(source_peer_id="**", device_name="leader")
+        assert refused["status"] == "error"
+        assert live.stopped is False
+
+        accepted = hw.start_teleop_receive(source_peer_id="leader-1", device_name="leader")
+        assert accepted["status"] == "success"
+        assert live.stopped is True
+
+    def test_the_replacement_leaves_exactly_one_live_subscription(self, hardware_robot: Any) -> None:
+        """Replacing a real receiver drops its subscription rather than leaking it.
+
+        Driven with a real :class:`InputReceiver` rather than a stand-in: a
+        superseded receiver that stayed subscribed would keep delivering frames
+        into ``robot.send_action`` from a stream the caller believes is gone.
+        """
+        hw = hardware_robot
+        superseded = InputReceiver(mesh=hw.mesh, robot=object(), source_peer_id="leader-1", device_name="leader")
+        superseded.start()
+        hw._input_receivers = {"leader-1/leader": superseded}
+        assert hw.mesh.unsubscribed == []
+
+        result = hw.start_teleop_receive(source_peer_id="leader-1", device_name="leader")
+
+        assert result["status"] == "success"
+        assert hw.mesh.unsubscribed == ["input:leader-1/leader"]
+        replacement = hw._input_receivers["leader-1/leader"]
+        assert replacement is not superseded
+        assert replacement.topic == superseded.topic


### PR DESCRIPTION
## Problem

`Robot.start_teleop_receive` keys its receiver registry on `source_peer_id/device_name` and stops whatever is registered under that key before installing the replacement:

```python
key = f"{source_peer_id}/{device_name}"
if key in self._input_receivers:
    self._input_receivers[key].stop()
```

That line was never executed by the suite. The publish mirror is pinned with the rate guard that shares its entry point (`test_a_usable_rate_replaces_the_live_publisher`), so the four-cell matrix across the two teleop registration surfaces had exactly one hole:

| surface | refused -> live stream survives | accepted -> live stream replaced |
| --- | --- | --- |
| `start_teleop_publish` | pinned | pinned (`hardware_robot.py:2660`) |
| `start_teleop_receive` | pinned | **not pinned** (`hardware_robot.py:2731`) |

The hole matters because of what the pinned receive cell actually rules out. `test_rejected_receive_leaves_a_live_stream_running` asserts a live receiver is *not* stopped by a refused call - and that assertion is equally true of a body that tears nothing down. On its own it ruled nothing out. A superseded receiver left subscribed keeps delivering frames into `robot.send_action` alongside the new one, from a stream the caller believes is gone.

## Change

Tests only. `git diff --numstat upstream/main...HEAD -- strands_robots/` is **0 lines**.

Four cases drive the accepted path, in the module that already owns the refusal half:

- **the slot is taken over** - the superseded entry is stopped and replaced by a real `InputReceiver` subscribed to `strands/leader-1/input/leader`, with one entry per key rather than two;
- **no leaked subscription** - driven with a *real* started `InputReceiver` rather than a stand-in, so `mesh.unsubscribe` is observed for its subscription name;
- **the compound key scopes the replacement** - a second leader under the same `device_name` leaves the first stream running, which a registry keyed on `device_name` alone would silently stop, leaving the follower following whichever leader connected last;
- **both directions on one key** - which is what shows the teardown is reachable, and therefore what the refusal assertion rules out.

The module's fake mesh now records `unsubscribe` calls alongside the topics it already recorded, and the module docstring states the replacement half of the contract it was already describing.

## Evidence

Because the production code is correct, these cases pass on unmodified `main`; what they fail on is a regression. Five plausible regressions in `start_teleop_receive`, each AST-scoped to that function (`in_fn=1 in_file=1` for every anchor) and restored byte-identically:

| regression | the 4 new cases | the 175 pre-existing cases |
| --- | --- | --- |
| M1 delete the teardown entirely | 3 failed | 0 failed <- blind |
| M2 keep the key lookup, drop the `.stop()` call | 3 failed | 0 failed <- blind |
| M3 tear down before validating the identifiers | 0 failed | 0 failed <- blind |
| M4 key the registry on `device_name` alone | 3 failed | 0 failed <- blind |
| M5 never register the replacement in the slot | 3 failed | 0 failed <- blind |

Caught by the new cases: 4 of 5. Invisible to the pre-existing cases: 5 of 5.

**M3 is recorded rather than papered over.** It is not observable on this surface and cannot be made so: both refusable arguments are part of the registry key, so a refused value can never name a registered entry and the "live stream survived" assertion holds for either ordering. Ordering *is* observable on the publish surface - `hz` is refused while `device_name` still names the live stream - and is pinned there with the rate guard. The new test's docstring states this, so the limit is documented where a reader meets it.

Coverage, same file list with the before-arm deselecting the new class: `strands_robots/hardware_robot.py` L2731 missing -> covered (242 -> 241 missing in that subset). L2660 was already covered in both arms, which is the matrix confirmation rather than a change.

## Artifact

No policy, simulation, rendering, recording or asset behaviour changes - 0 production lines - so the artifact is the measurement rather than a rollout.

![matrix and mutation measurement](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-receive-stream-replacement/teleop_receive_replacement.png)

Capture and compose scripts, and the raw mutation output, are on [`artifacts/teleop-receive-stream-replacement`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-receive-stream-replacement/README.md). Every number rendered in the figure is asserted against the measured JSON before the file is written.

## Gate

- `MUJOCO_GL=egl pytest tests` -> **28539 passed / 257 skipped / 0 failed** (622s). Base at `f5442883` is 28535; 28535 + 4 = 28539.
- `tests/mesh/test_teleop_identifier_source_scoping.py` -> 83 passed in 0.51s (no zenoh, no hardware).
- `ruff check` + `ruff format --check` on `strands_robots tests tests_integ` clean (1185 files).
- `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`, **0 outside**; the error set is byte-identical to a pristine `f5442883` worktree, so it is environmental.
- `scripts/check_merge_base_overlap.py` -> no overlap; branch point `f5442883`, 0 paths changed on `upstream/main` in that span.
