### PR TITLE
test(simulation): pin the not-reached half of the motion-primitive result envelopes

### DIFF
--- a/changelog.d/2195-motion-primitive-result-envelopes.md
+++ b/changelog.d/2195-motion-primitive-result-envelopes.md
@@ -1,0 +1,16 @@
+### Quality: pin the not-reached half of the motion-primitive result envelopes
+
+`MotionPrimitivesCore` owns the `move_to` / `set_gripper` / `rotate_wrist` result
+envelopes so every backend answers identically, and its own test module says so -
+but it drove none of the three. The reached half was reached through the MuJoCo
+mixin; the not-reached half of both converging primitives was reached nowhere,
+and that is the half an agent acts on: it decides whether to retry with a larger
+step budget, reading `reached`, `steps`, `position_error_m` and `ik_residual_m`
+from the json block rather than the sentence.
+
+Pinned in the module that owns them, plus the reachability and the remedy on a
+live world - a solvable pose the servo cannot reach inside a two-step budget is
+refused with its residuals, and the identical call with a real budget converges.
+Also pins the default `_get_registry_robot` seam, which every shipped caller
+overrides, so the body a new backend adapter inherits is exercised. Tests only;
+no behaviour change.

--- a/tests/simulation/mujoco/test_motion_primitives.py
+++ b/tests/simulation/mujoco/test_motion_primitives.py
@@ -423,6 +423,35 @@ class TestMoveTo:
         assert "IK bridge unavailable" in result["content"][0]["text"]
         assert "mink" in result["content"][0]["text"]
 
+    def test_servo_timeout_reports_the_residual_and_a_budget_that_fixes_it(self, sim):
+        """A solvable pose the servo cannot reach inside the step budget.
+
+        Distinct from ``test_unreachable_target_...`` above: there the IK cannot
+        solve the pose at all and the pre-flight refuses before a single tick,
+        so there is no measured position error to report. Here the IK residual
+        is small - the pose IS solvable - and the servo simply runs out of
+        steps, which is why the envelope's advice ("the servo may need more
+        steps") is the actionable one. Verified by following it: the identical
+        call with a real budget converges.
+        """
+        pytest.importorskip("mink")
+        short = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.02, max_steps=2)
+        assert short["status"] == "error", short
+        text = short["content"][0]["text"]
+        assert "did not reach" in text, text
+        assert "max_steps=2" in text, text
+        payload = _json_block(short)
+        assert payload["reached"] is False
+        assert payload["steps"] == 2
+        # The two residuals are separate fields precisely so the agent can tell
+        # "needs more steps" from "unreachable": here the IK solved the pose.
+        assert payload["position_error_m"] > 0.02
+        assert payload["ik_residual_m"] <= 0.02
+
+        again = _dispatch(sim, "move_to", robot_name="arm", position=REACHABLE, tol=0.02, max_steps=400)
+        assert again["status"] == "success", again
+        assert _json_block(again)["reached"] is True
+
 
 class TestGraspPreservation:
     """``move_to`` must never command the gripper (review on #1654).
@@ -530,6 +559,29 @@ class TestRotateWrist:
         result = _dispatch(sim, "rotate_wrist", robot_name="arm")
         assert result["status"] == "error"
         assert "target_yaw" in result["content"][0]["text"]
+
+    def test_servo_timeout_reports_the_residual_and_a_budget_that_fixes_it(self, sim):
+        """An in-range yaw the servo cannot settle on inside the step budget.
+
+        Distinct from ``test_out_of_range_target_rejected``: that target is
+        refused up front against the joint range, so no tick runs. Here the
+        target is legal and only the budget is short, so the refusal reports
+        how far off the joint ended and stays retryable - verified by retrying.
+        """
+        short = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.3, tol=0.02, max_steps=1)
+        assert short["status"] == "error", short
+        text = short["content"][0]["text"]
+        assert "did not reach" in text, text
+        assert "max_steps=1" in text, text
+        payload = _json_block(short)
+        assert payload["reached"] is False
+        assert payload["steps"] == 1
+        assert payload["wrist_joint"] == "wrist_roll"
+        assert payload["yaw_error_rad"] > 0.02
+
+        again = _dispatch(sim, "rotate_wrist", robot_name="arm", target_yaw=0.3, tol=0.02, max_steps=300)
+        assert again["status"] == "success", again
+        assert _json_block(again)["reached"] is True
 
 
 class TestGripperRegistryMetadata:

--- a/tests/simulation/test_motion_primitives_base.py
+++ b/tests/simulation/test_motion_primitives_base.py
@@ -11,6 +11,7 @@ backend at all, and that the module imports without MuJoCo installed - the
 property the Isaac adapter (GH #2123) builds on.
 """
 
+import inspect
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -210,3 +211,207 @@ class TestRegistryGripperMetadata:
         meta = {"actuators": ["Jaw"], "closed": "high", "open": "low"}
         assert core._gripper_state_end("open", meta) == "low"
         assert core._gripper_state_end("close", meta) == "high"
+
+
+def _move_to_envelope(**overrides: object) -> dict:
+    """``_move_to_result`` on plain values; each override patches one field.
+
+    Defaults are a real converging run measured on the MuJoCo suite's inline
+    arm (43 ticks, 19.8 mm final error, 1.7 mm IK residual), so the not-reached
+    variants below differ from a genuine success in exactly the field under
+    test.
+    """
+    kwargs: dict = {
+        "reached": True,
+        "steps_used": 43,
+        "position_error": 0.0198,
+        "ik_residual": 0.0017,
+        "ee_pos": [0.19, 0.10, 0.19],
+        "ee_quat": [1.0, 0.0, 0.0, 0.0],
+        "frame_name": "arm/ee_site",
+        "frame_type": "site",
+    }
+    kwargs.update(overrides)
+    return MotionPrimitivesCore._move_to_result("arm", np.array([0.2, 0.1, 0.2]), 0.02, 400, **kwargs)
+
+
+def _rotate_wrist_envelope(**overrides: object) -> dict:
+    """``_rotate_wrist_result`` on plain values; each override patches one field."""
+    kwargs: dict = {
+        "reached": True,
+        "steps_used": 76,
+        "wrist_name": "wrist_roll",
+        "target_yaw": 0.3,
+        "final_yaw": 0.2807,
+        "yaw_error": 0.0193,
+    }
+    kwargs.update(overrides)
+    return MotionPrimitivesCore._rotate_wrist_result("arm", 0.02, 300, **kwargs)
+
+
+def _payload(result: dict) -> dict:
+    """The json details block every envelope carries."""
+    blocks = [b["json"] for b in result["content"] if "json" in b]
+    assert len(blocks) == 1, f"expected exactly one json block, got {result['content']}"
+    return blocks[0]
+
+
+class TestMoveToResultEnvelope:
+    """``_move_to_result`` - both halves of the envelope the backends hand back.
+
+    The module docstring names the result envelopes as part of what the core
+    owns. The reached half is exercised through the MuJoCo mixin by the
+    live-world suites; the not-reached half was exercised nowhere, and it is
+    the half an agent has to act on - it is what decides whether to retry with
+    a larger budget, and that decision reads the json block rather than the
+    sentence.
+    """
+
+    def test_reached_is_a_success_envelope_carrying_the_payload(self) -> None:
+        result = _move_to_envelope()
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "reached" in text and "[0.2, 0.1, 0.2]" in text
+        payload = _payload(result)
+        assert payload["reached"] is True
+        assert payload["steps"] == 43
+        assert payload["frame"] == "arm/ee_site"
+        assert payload["frame_type"] == "site"
+
+    def test_not_reached_is_an_error_naming_the_budget_it_spent(self) -> None:
+        result = _move_to_envelope(reached=False, steps_used=2, position_error=0.1815)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "did not reach" in text
+        assert "tol=0.02" in text and "max_steps=400" in text
+        assert "0.1815" in text and "0.0017" in text
+
+    def test_not_reached_still_carries_the_json_details(self) -> None:
+        """The refusal is what an agent retries from, so it keeps the payload.
+
+        An error whose only content were the sentence would force the caller to
+        parse prose to find out how far off it was.
+        """
+        payload = _payload(_move_to_envelope(reached=False, steps_used=2, position_error=0.1815))
+        assert payload["reached"] is False
+        assert payload["steps"] == 2
+        assert payload["position_error_m"] == 0.1815
+
+    def test_the_two_residuals_stay_separate_fields(self) -> None:
+        """``position_error_m`` and ``ik_residual_m`` answer different questions.
+
+        A small IK residual beside a large position error says the pose is
+        solvable and the servo merely ran out of steps; a large IK residual says
+        the pose is out of reach. Collapsing them would erase that distinction.
+        """
+        payload = _payload(_move_to_envelope(reached=False, position_error=0.1815, ik_residual=0.0017))
+        assert payload["position_error_m"] == 0.1815
+        assert payload["ik_residual_m"] == 0.0017
+
+    def test_both_halves_carry_the_same_payload_keys(self) -> None:
+        """One reader shape for success and failure, so the caller need not branch."""
+        assert sorted(_payload(_move_to_envelope())) == sorted(
+            _payload(_move_to_envelope(reached=False, position_error=0.1815))
+        )
+
+
+class TestRotateWristResultEnvelope:
+    """``_rotate_wrist_result`` - the second converging primitive's envelope."""
+
+    def test_reached_is_a_success_envelope_carrying_the_payload(self) -> None:
+        result = _rotate_wrist_envelope()
+        assert result["status"] == "success"
+        assert "reached" in result["content"][0]["text"]
+        payload = _payload(result)
+        assert payload["reached"] is True
+        assert payload["wrist_joint"] == "wrist_roll"
+        assert payload["steps"] == 76
+
+    def test_not_reached_is_an_error_naming_the_budget_it_spent(self) -> None:
+        result = _rotate_wrist_envelope(reached=False, steps_used=1, final_yaw=0.0016, yaw_error=0.2984)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "did not reach" in text
+        assert "tol=0.02" in text and "max_steps=300" in text
+        assert "0.2984" in text
+        assert "wrist_roll" in text
+
+    def test_not_reached_still_carries_the_json_details(self) -> None:
+        payload = _payload(_rotate_wrist_envelope(reached=False, steps_used=1, yaw_error=0.2984))
+        assert payload["reached"] is False
+        assert payload["steps"] == 1
+        assert payload["yaw_error_rad"] == 0.2984
+
+    def test_both_halves_carry_the_same_payload_keys(self) -> None:
+        assert sorted(_payload(_rotate_wrist_envelope())) == sorted(
+            _payload(_rotate_wrist_envelope(reached=False, yaw_error=0.2984))
+        )
+
+
+class TestSetGripperResultEnvelope:
+    """``_set_gripper_result`` - the third envelope, and the one with no failure half.
+
+    ``set_gripper`` drives the gripper open-loop and measures no convergence,
+    so success is its only outcome. Pinned here so that asymmetry with
+    ``move_to`` / ``rotate_wrist`` is recorded rather than inferred from the
+    absence of a branch.
+    """
+
+    def test_success_envelope_reports_state_actuators_and_ticks(self) -> None:
+        result = MotionPrimitivesCore._set_gripper_result(
+            "arm",
+            "close",
+            5,
+            ["Jaw"],
+            {"Jaw": 0.0},
+            {"Jaw": "ctrlrange-low"},
+            {"jaw": 0.0012},
+        )
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "close" in text and "5 ticks" in text and "Jaw" in text
+        payload = _payload(result)
+        assert payload["state"] == "close"
+        assert payload["actuators"] == ["Jaw"]
+        assert payload["setpoint_sources"] == {"Jaw": "ctrlrange-low"}
+        assert payload["gripper_joint_positions"] == {"jaw": 0.0012}
+
+    def test_there_is_no_not_reached_half(self) -> None:
+        source = inspect.getsource(MotionPrimitivesCore._set_gripper_result)
+        assert "reached" not in source, source
+
+
+class TestRegistryLookupSeamDefault:
+    """``_get_registry_robot`` - the default body a non-overriding backend inherits.
+
+    The seam's own docstring records that an adapter may override it to keep a
+    historical patch point alive, and the MuJoCo mixin does; so does the
+    ``_RegistryCore`` stand-in above, which is how every existing exercise of
+    ``_registry_gripper_metadata`` bypasses the default. That left the default -
+    the one a new backend adapter gets for free - resolving through this
+    module's own ``get_robot`` with nothing checking that it does.
+    """
+
+    @staticmethod
+    def _robot(data_config: str) -> SimpleNamespace:
+        return SimpleNamespace(name="arm", data_config=data_config)
+
+    def test_default_seam_resolves_a_shipped_registry_entry(self) -> None:
+        """so100 ships a gripper block, so the default lookup must find it."""
+        core = MotionPrimitivesCore()
+        meta, reason = core._registry_gripper_metadata(self._robot("so100"))
+        assert reason is None
+        assert meta is not None
+        assert meta["actuators"] == ["Jaw"]
+
+    def test_default_seam_falls_back_for_an_unknown_robot(self) -> None:
+        """An unregistered ``data_config`` is the heuristic's cue, not an error."""
+        core = MotionPrimitivesCore()
+        assert core._registry_gripper_metadata(self._robot("not-a-shipped-robot")) == (None, None)
+
+    def test_the_mujoco_adapter_overrides_the_seam(self) -> None:
+        """Why the default body needs its own test: no shipped backend runs it."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation.mujoco.motion_primitives import MotionPrimitivesMixin
+
+        assert MotionPrimitivesMixin._get_registry_robot is not MotionPrimitivesCore._get_registry_robot


### PR DESCRIPTION
## Problem

`MotionPrimitivesCore` owns the `move_to` / `set_gripper` / `rotate_wrist` result
envelopes so every backend answers identically. Its own test module says exactly that:

> ...owns the parameter domains, the registry gripper-metadata contract, and the shared
> result envelopes for `move_to` / `set_gripper` / `rotate_wrist`.

It drove none of the three. The reached half is reached through the MuJoCo mixin by the
live-world suites; the **not-reached half of both converging primitives was reached
nowhere** — `motion_primitives_base.py` L304 and L380 were unexecuted across the whole
suite — and that is the half an agent has to act on. It is what decides whether to retry
with a larger step budget, and that decision reads `reached`, `steps`, `position_error_m`
and `ik_residual_m` out of the json block, not the sentence.

The one existing `reached is False` assertion
(`test_unreachable_target_returns_structured_error_with_residual`) pins a **different**
branch: the pre-flight unreachable-target refusal, which fires before a single tick and
carries no measured position error at all. Nothing asserted the servo-timeout envelope,
and `grep -rn "did not reach" tests/` finds it only inside a docstring and inside one
`or` clause.

Third gap in the same module: `_get_registry_robot` (L207) is the default registry seam.
Its docstring records that an adapter may override it to keep a historical patch point
alive — the MuJoCo mixin does, and so does the `_RegistryCore` stand-in that every
existing `_registry_gripper_metadata` test goes through. So the body a new backend
adapter inherits for free had never run.

## Change

Tests only. `git diff --numstat upstream/main HEAD -- strands_robots/` is empty, so no
policy, simulation, rendering, recording or asset behaviour can change.

Pinned along the split the module docstring itself draws:

- **envelope shape on plain values** → `tests/simulation/test_motion_primitives_base.py`,
  which is that file's stated job ("pins what those suites cannot: that the core answers
  on plain data with no backend at all"). Both halves of `move_to` and `rotate_wrist`,
  the `set_gripper` envelope (completing the matrix in its owning module, and recording
  that it has no failure half because it commands open-loop), and the default registry
  seam resolving through the module's own `get_robot`.
- **reachability and the remedy on a live world** → two cases in
  `tests/simulation/mujoco/test_motion_primitives.py`, beside the pre-flight test they
  are distinct from.

The live-world cases verify the envelope's own advice rather than its wording: a solvable
pose the servo cannot reach inside a two-step budget is refused with its residuals, and
**the identical call with a real budget converges**.

## Measured

`strands_robots/simulation/motion_primitives_base.py` — 114 statements, **97% → 100%**,
missing `[207, 304, 380]` → `[]`.

| | status | reached | steps | position_error_m | ik_residual_m |
|---|---|---|---|---|---|
| `max_steps=2` | error | False | 2 | 0.1815 | 0.0017 |
| `max_steps=400` | success | True | 41 | 0.0197 | 0.0017 |

A small `ik_residual_m` beside a large `position_error_m` is what tells the caller the
pose is solvable and only the budget was short — the distinction a retry depends on, and
the reason the two stay separate fields.

### Mutation table

Seven plausible regressions, each scoped to its enclosing function by AST line range
(four of the seven anchors appear twice in the file, so the scoping is load-bearing;
`in_fn` / `in_file` counts are printed by the script). Two arms: the cases this change
adds, and the 232 pre-existing cases over the same primitives.

| mutation | new cases | pre-existing |
|---|---|---|
| M1 `move_to` not-reached half regressed to success | 2 failed | 0 failed |
| M2 `move_to` refusal drops the json payload | 4 failed | 0 failed |
| M3 `move_to` the two residuals collapse into one | 3 failed | 1 failed |
| M4 `rotate_wrist` not-reached half regressed to success | 2 failed | 0 failed |
| M5 `rotate_wrist` refusal drops the json payload | 3 failed | 0 failed |
| M6 default registry seam stops resolving | 1 failed | 0 failed |
| M7 `set_gripper` payload drops `setpoint_sources` | 1 failed | 5 failed |

Caught by the new cases **7 of 7**; **5 of 7 invisible** to the pre-existing suite. The
two the existing suite does see are complementary rather than duplicated: M3 and M7 also
perturb the success payload, which `test_reaches_reachable_target` and
`test_set_gripper_setpoint_range_sources.py` already own.

Because the production code is correct, these tests pass on unmodified `main` — what they
fail on is a regression, and the table above is that evidence.

## Visual

![move_to not-reached envelope](https://raw.githubusercontent.com/cagataycali/robots/artifacts/motion-primitive-not-reached-envelope/move_to_not_reached_envelope.png)

Three real MuJoCo headless renders (`MUJOCO_GL=egl`) on the motion-primitive suite's
inline arm: at rest, after the two-step call that is refused, and after the identical
call with a real budget. The refusal is visibly *not* "nothing happened" — the arm got
two ticks in and reported how far off it was. Panel pairs differ on 12.09% / 25.21% /
25.43% of pixels; every number in the figure is asserted against the measurement dump
before it is written. Capture and compose scripts, the raw frames and the mutation
script are on the artifacts branch.

## Scope

`move_to`'s two error payloads are deliberately different shapes — the pre-flight
unreachable refusal carries 5 keys and the servo timeout 8, because the pre-flight ran no
tick and so has no measured position error to report. That asymmetry is a property of the
MuJoCo mixin's pre-flight, not of the shared envelope, and is left alone here.

## Gate

- `MUJOCO_GL=egl pytest tests` at `f5442883`: **28551 passed, 257 skipped, 0 failed**
  (733s). Pristine base is 28535, and 28535 + 16 new cases = 28551.
- `ruff check` clean, `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`, **0
  outside**; error set byte-identical to a pristine-base worktree, so environmental.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD`: no overlap.
- `scripts/assemble_changelog.py --check`: OK.
