### PR TITLE
fix(sim): unregister the auto-installed WBC torque shim so a second rollout gets one

### DIFF
--- a/changelog.d/2196-wbc-auto-torque-cleanup-unregisters.md
+++ b/changelog.d/2196-wbc-auto-torque-cleanup-unregisters.md
@@ -1,0 +1,26 @@
+### Fixed: unregister the auto-installed WBC torque shim so a second rollout gets one
+
+`run_policy` installs a torque shim when a WBC policy meets a position-servo
+scene, and returns a cleanup that ran only
+`WBCTorqueController.uninstall` - which restores the actuator gains and nothing
+else. `install_wbc_torque_control` does two things: it flips the driven
+actuators to torque *and* registers the controller for `_apply_sim_action` to
+dispatch to. Undoing one half left the controller registered on a scene whose
+actuators were back to position servos, so it kept converting the policy's
+position targets into PD torques that a position servo reads as targets, and
+the hook's "a manually-installed controller wins" check then declined to
+install on the next `run_policy`.
+
+Measured on a Unitree G1 with the real SONIC balance checkpoint, two
+consecutive 3 s rollouts on one sim: the pelvis excursion band grows from
+0.0339 m on the first rollout to 0.1298 m on the second, and 15% of the
+rendered pixels differ from the same rollout after this change. The cleanup now
+removes the registry entry it wrote - and only that entry, so a manual
+installation registered in the meantime survives - before restoring the gains,
+which keeps the second rollout as steady as the first (0.0259 m).
+
+The hook's five no-op conditions are now all driven. Three had never executed -
+no `[wbc]` extra, no compiled world, and `wbc_uses_position_servo` reporting no
+position-servo actuator - and its docstring, which listed four of the five and
+described the predicate check as "the actuators are already torque mode", now
+names all five in check order and both reasons the predicate can decline.

--- a/changelog.d/2196-wbc-auto-torque-cleanup-unregisters.md
+++ b/changelog.d/2196-wbc-auto-torque-cleanup-unregisters.md
@@ -19,6 +19,13 @@ removes the registry entry it wrote - and only that entry, so a manual
 installation registered in the meantime survives - before restoring the gains,
 which keeps the second rollout as steady as the first (0.0259 m).
 
+The release now lives in `WBCTorqueController.uninstall` itself rather than in a
+cleanup the hook wraps around it, so the *documented manual* pair -
+`controller = install_wbc_torque_control(...)` then `controller.uninstall()` -
+hands the world back just as completely. That path leaked the registration too,
+and the docstring of `install_wbc_torque_control` names `uninstall` as its
+counterpart, so one implementation now covers both callers.
+
 The hook's five no-op conditions are now all driven. Three had never executed -
 no `[wbc]` extra, no compiled world, and `wbc_uses_position_servo` reporting no
 position-servo actuator - and its docstring, which listed four of the five and

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -206,7 +206,10 @@ uniform `kp=500` gain that overrides SONIC's tuned per-joint PD - so driving
 those servos directly diverges and the robot falls. To make this quickstart
 just work, `run_policy` auto-detects a `WBCPolicy` on a position-servo scene and
 installs the torque shim (the `WBCTorqueController` PD->torque loop) for the
-duration of the call, then restores the actuators afterwards. With the real
+duration of the call, then hands the world back afterwards: the controller is
+deregistered from the action-controller seam **and** the actuators are restored,
+so a second `run_policy` on the same sim installs a fresh shim and behaves
+exactly like the first. With the real
 `GR00T-WholeBodyControl-{Balance,Walk}.onnx` weights and `target_velocity =
 [0.5, 0, 0]` the base advances ~1.9 m over 5 s while holding pelvis height
 ~0.75 m and staying upright. Pass `wbc_install_torque_control=False` to opt out

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -62,8 +62,11 @@ class WBCTorqueController:
     ``owns_stepping = True`` so :meth:`_apply_sim_action` does not double-step.
 
     Construct via :meth:`from_sim`, which resolves the actuators by name and
-    flips them to torque mode. Call :meth:`uninstall` to restore the original
-    actuator gains (e.g. when reusing the world for a non-WBC policy).
+    flips them to torque mode. Call :meth:`uninstall` to hand the world back: it
+    drops this controller from ``world._backend_state["action_controller"]`` and
+    restores the original actuator gains (e.g. when reusing the world for a
+    non-WBC policy). Releasing both is what makes that reuse real -- see
+    :meth:`uninstall`.
     """
 
     # Tell the SimEngine this controller advances physics itself (one apply()
@@ -83,6 +86,7 @@ class WBCTorqueController:
         saved_actuator_gains: dict[int, tuple[Any, Any, Any, Any, Any]],
         model: Any,
         physics_substeps_per_control: int = _CONTROL_DECIMATION,
+        world: Any = None,
     ) -> None:
         self.policy = policy
         self.leg_waist_actuator_ids = list(leg_waist_actuator_ids)
@@ -93,6 +97,11 @@ class WBCTorqueController:
         self.arm_dof_addrs = list(arm_dof_addrs)
         self._saved_actuator_gains = dict(saved_actuator_gains)
         self._model = model
+        # The world whose ``_backend_state`` registered us, so :meth:`uninstall`
+        # can release that registration too. ``None`` when built through the
+        # constructor directly: nothing registered it, so there is nothing to
+        # release.
+        self._world = world
         self.physics_substeps_per_control = max(1, int(physics_substeps_per_control))
         # The default-angle hold target, used until the policy returns its first
         # action (a stable first step: PD against the init pose -> ~0 torque).
@@ -236,10 +245,35 @@ class WBCTorqueController:
             arm_dof_addrs=arm_dof,
             saved_actuator_gains=saved,
             model=model,
+            world=world,
         )
 
     def uninstall(self) -> None:
-        """Restore the original actuator gains saved at install time."""
+        """Release both halves of the install: the registration, then the gains.
+
+        :func:`install_wbc_torque_control` acquires two things - it flips the
+        driven actuators to torque mode *and* registers this controller in
+        ``world._backend_state["action_controller"]``, the seam
+        ``_apply_sim_action`` dispatches through. Restoring only the gains leaves
+        the registration behind, and that leftover is not inert: it is the value
+        ``MuJoCoSimEngine._maybe_install_wbc_torque_control`` reads to decide a
+        controller is already present, where a present controller is treated as
+        a manual install that wins. The next rollout on the same world therefore
+        skips the install and dispatches every action through this finished
+        controller - writing PD torques into actuators whose position-servo gains
+        this method has just restored.
+
+        The registration goes first, so a failure restoring the gains cannot
+        leave a controller dispatching into actuators that are already servos
+        again. Only *this* controller's registration is dropped: one installed
+        since (a manual install, or the LIBERO adapter, which shares the seam)
+        is never clobbered.
+        """
+        backend_state = getattr(self._world, "_backend_state", None) if self._world is not None else None
+        deregistered = False
+        if isinstance(backend_state, dict) and backend_state.get("action_controller") is self:
+            del backend_state["action_controller"]
+            deregistered = True
         model = self._model
         for ai, (gaintype, biastype, gainprm, biasprm, ctrlrange) in self._saved_actuator_gains.items():
             model.actuator_gaintype[ai] = gaintype
@@ -247,7 +281,11 @@ class WBCTorqueController:
             model.actuator_gainprm[ai] = gainprm
             model.actuator_biasprm[ai] = biasprm
             model.actuator_ctrlrange[ai] = ctrlrange
-        logger.debug("WBCTorqueController uninstalled: restored %d actuator gains.", len(self._saved_actuator_gains))
+        logger.debug(
+            "WBCTorqueController uninstalled: restored %d actuator gains, deregistered=%s.",
+            len(self._saved_actuator_gains),
+            deregistered,
+        )
 
     # ------------------------------------------------------------------
     # Action-controller hook
@@ -362,8 +400,9 @@ def install_wbc_torque_control(sim: SimEngine, policy: WBCPolicy, robot_name: st
     Use ``control_frequency=50.0`` in ``run_policy`` to match the controller's
     physics step (dt=0.005) x decimation (4).
 
-    Returns the installed controller (call :meth:`WBCTorqueController.uninstall`
-    to restore the original actuators).
+    Returns the installed controller. Call
+    :meth:`WBCTorqueController.uninstall` to undo *both* halves of this install:
+    it drops the registration made here and restores the original actuators.
 
     Raises:
         RuntimeError: If the world is absent or the actuators cannot be resolved.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1949,29 +1949,10 @@ class MuJoCoSimEngine(
             robot_name,
         )
 
-        def _cleanup() -> None:
-            """Undo both halves of the auto-install: the registry, then the gains.
-
-            :func:`~strands_robots.policies.wbc.install_wbc_torque_control` does
-            two things - flips the driven actuators to torque and registers the
-            controller for :meth:`_apply_sim_action` to dispatch to - while
-            :meth:`~strands_robots.policies.wbc.WBCTorqueController.uninstall`
-            only restores the gains. Restoring the gains alone would leave the
-            controller registered and still dispatching PD torques into
-            actuators this cleanup has just turned back into position servos,
-            and would make the "a manually-installed controller wins" check
-            above decline to install on the next :meth:`run_policy` - so the
-            second rollout on a sim would silently run without the shim the
-            first one needed. The registry entry goes first so a failure in
-            ``uninstall`` cannot leave a controller dispatching into restored
-            actuators.
-            """
-            state = getattr(world, "_backend_state", None)
-            if isinstance(state, dict) and state.get("action_controller") is controller:
-                del state["action_controller"]
-            controller.uninstall()
-
-        return _cleanup
+        # ``uninstall`` releases both halves of the install - the registration it
+        # made and the actuator gains - so the caller of the *documented manual*
+        # API gets the same teardown this hook does, from one implementation.
+        return controller.uninstall
 
     def list_robots_info(self) -> dict[str, Any]:
         """Agent-tool action: pretty-printed robot listing.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1912,9 +1912,13 @@ class MuJoCoSimEngine(
         :func:`~strands_robots.policies.wbc.install_wbc_torque_control` and
         returns its :meth:`uninstall` so the scene is restored after the run.
 
-        Returns ``None`` (no-op) when ``[wbc]`` is not installed, ``policy`` is
-        not a ``WBCPolicy``, the actuators are already torque mode, or a
-        controller is already registered (a manual install always wins).
+        Returns ``None`` (no-op) in five cases, in the order they are checked:
+        ``[wbc]`` is not installed; ``policy`` is not a ``WBCPolicy``; the sim
+        has no compiled world; a controller is already registered (a manual
+        install always wins); or
+        :func:`~strands_robots.policies.wbc.wbc_uses_position_servo` finds no
+        position-servo actuator, meaning the driven actuators are already torque
+        motors or none of the WBC joints resolve in this scene.
         """
         try:
             from strands_robots.policies.wbc import (
@@ -1944,7 +1948,30 @@ class MuJoCoSimEngine(
             "so the gait is stable. Pass wbc_install_torque_control=False to opt out.",
             robot_name,
         )
-        return controller.uninstall
+
+        def _cleanup() -> None:
+            """Undo both halves of the auto-install: the registry, then the gains.
+
+            :func:`~strands_robots.policies.wbc.install_wbc_torque_control` does
+            two things - flips the driven actuators to torque and registers the
+            controller for :meth:`_apply_sim_action` to dispatch to - while
+            :meth:`~strands_robots.policies.wbc.WBCTorqueController.uninstall`
+            only restores the gains. Restoring the gains alone would leave the
+            controller registered and still dispatching PD torques into
+            actuators this cleanup has just turned back into position servos,
+            and would make the "a manually-installed controller wins" check
+            above decline to install on the next :meth:`run_policy` - so the
+            second rollout on a sim would silently run without the shim the
+            first one needed. The registry entry goes first so a failure in
+            ``uninstall`` cannot leave a controller dispatching into restored
+            actuators.
+            """
+            state = getattr(world, "_backend_state", None)
+            if isinstance(state, dict) and state.get("action_controller") is controller:
+                del state["action_controller"]
+            controller.uninstall()
+
+        return _cleanup
 
     def list_robots_info(self) -> dict[str, Any]:
         """Agent-tool action: pretty-printed robot listing.

--- a/tests/policies/wbc/test_run_policy_auto_torque.py
+++ b/tests/policies/wbc/test_run_policy_auto_torque.py
@@ -17,18 +17,36 @@ These run WITHOUT real SONIC weights (stub ONNX session, real config + joint
 mapping) on the real torque/position-servo G1 model. The end-to-end "does it
 actually WALK" validation needs real weights and lives in the gated
 integration suite.
+
+``TestAutoInstallHook`` drives the install path and every no-op condition the
+hook documents: no ``[wbc]`` extra, a non-WBC policy, no compiled world, a
+controller already registered, and ``wbc_uses_position_servo`` reporting no
+position-servo actuator - which it does for two distinct scenes (actuators
+already flipped to torque, and a scene holding none of the WBC joints). Those
+last three matter because a no-op is indistinguishable from a hook that never
+ran: each one is the difference between leaving a scene alone and silently
+converting somebody else's actuators.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 import logging
+import sys
+import textwrap
 from typing import cast
 
 import numpy as np
 import pytest
 
 from strands_robots.policies import MockPolicy
-from strands_robots.policies.wbc import WBCConfig, WBCPolicy, wbc_uses_position_servo
+from strands_robots.policies.wbc import (
+    WBCConfig,
+    WBCPolicy,
+    WBCTorqueController,
+    wbc_uses_position_servo,
+)
 from strands_robots.simulation.base import SimEngine
 
 mujoco = pytest.importorskip("mujoco", reason="mujoco not installed")
@@ -90,6 +108,38 @@ def _mujoco_sim_with_world(model, data):  # type: ignore[no-untyped-def]
     return sim
 
 
+# A scene holding none of the WBC joints: ``wbc_uses_position_servo`` cannot
+# resolve a driven joint against it and conservatively reports False. Declared
+# here rather than imported so this module needs no G1 assets for that case.
+_XML_NO_WBC_JOINTS = """
+<mujoco>
+  <worldbody>
+    <body name="b">
+      <joint name="unrelated_joint" type="hinge" axis="0 0 1"/>
+      <geom type="box" size="0.1 0.1 0.1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _hook_no_op_guards() -> int:
+    """Count the hook's ``return None`` early-outs by AST.
+
+    The hook's only other exit returns the cleanup callable, so this is exactly
+    the number of conditions under which it declines to touch the scene.
+    """
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    src = textwrap.dedent(inspect.getsource(Simulation._maybe_install_wbc_torque_control))
+    fn = ast.parse(src).body[0]
+    return sum(
+        1
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Constant) and node.value.value is None
+    )
+
+
 # ---------------------------------------------------------------------------
 # wbc_uses_position_servo predicate
 # ---------------------------------------------------------------------------
@@ -148,6 +198,59 @@ class TestAutoInstallHook:
         first = controller.leg_waist_actuator_ids[0]
         assert int(model.actuator_biastype[first]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
 
+    def test_cleanup_unregisters_so_a_second_rollout_gets_the_shim(self) -> None:
+        """The cleanup must undo the registry write as well as the gains.
+
+        ``install_wbc_torque_control`` flips the driven actuators to torque
+        *and* registers the controller for ``_apply_sim_action``;
+        ``WBCTorqueController.uninstall`` only restores the gains. A cleanup
+        that stopped there left the controller registered on a scene whose
+        actuators were back to position servos - so it kept dispatching PD
+        torques into servos that read them as position targets - and the
+        "a manually-installed controller wins" check above then declined to
+        install on the next ``run_policy``, leaving the second rollout without
+        the shim the first one needed.
+        """
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+
+        cleanup = sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1")
+        assert callable(cleanup)
+        controller = sim._world._backend_state["action_controller"]
+        driven = controller.leg_waist_actuator_ids[0]
+        assert int(model.actuator_biastype[driven]) == int(mujoco.mjtBias.mjBIAS_NONE)
+
+        cleanup()
+
+        # Both halves undone, not just the gains.
+        assert int(model.actuator_biastype[driven]) == int(mujoco.mjtBias.mjBIAS_AFFINE)
+        assert "action_controller" not in sim._world._backend_state
+
+        # ... so the next rollout on the same sim installs the shim again.
+        again = sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1")
+        assert callable(again), "the second rollout must get the shim too"
+        assert int(model.actuator_biastype[driven]) == int(mujoco.mjtBias.mjBIAS_NONE)
+        again()
+
+    def test_cleanup_leaves_a_controller_it_did_not_install(self) -> None:
+        """Only the entry this hook wrote is removed.
+
+        A manual installation that happens to be registered while an
+        auto-installed cleanup runs must survive it - the cleanup owns exactly
+        what its own ``install_wbc_torque_control`` call wrote.
+        """
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+
+        cleanup = sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1")
+        assert callable(cleanup)
+        sentinel = object()
+        sim._world._backend_state["action_controller"] = sentinel
+
+        cleanup()
+
+        assert sim._world._backend_state["action_controller"] is sentinel
+
     def test_skips_when_controller_already_installed(self) -> None:
         model, data = _build_g1_model()
         sim = _mujoco_sim_with_world(model, data)
@@ -159,3 +262,74 @@ class TestAutoInstallHook:
         sim = _mujoco_sim_with_world(model, data)
         assert sim._maybe_install_wbc_torque_control(MockPolicy(), "unitree_g1") is None
         assert "action_controller" not in sim._world._backend_state
+
+    def test_skips_when_the_wbc_extra_is_absent(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # A minimal install has no [wbc] extra, so the hook's import fails and
+        # run_policy must carry on unchanged rather than raise out of binding.
+        premise = _mujoco_sim_with_world(*_build_g1_model())
+        assert callable(premise._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1")), (
+            "premise: this pair installs the shim while [wbc] is importable"
+        )
+
+        sim = _mujoco_sim_with_world(*_build_g1_model())
+        policy = _g1_policy()  # built while the extra is still importable
+        monkeypatch.setitem(sys.modules, "strands_robots.policies.wbc", None)
+        assert sim._maybe_install_wbc_torque_control(policy, "unitree_g1") is None
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_skips_without_a_world(self) -> None:
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation()
+        assert sim._world is None, "premise: a bare engine has no world yet"
+        assert sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1") is None
+
+    def test_skips_when_the_world_has_no_compiled_model(self) -> None:
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        sim = Simulation()
+        # Built directly rather than through _mujoco_sim_with_world, whose
+        # namespace probe needs a compiled model. Held in a local so the
+        # assertions read the world under test rather than the engine's
+        # SimWorld | None attribute.
+        world = _FakeWorld(None, None, "")
+        sim._world = world  # type: ignore[assignment]
+        assert world._model is None
+        assert sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1") is None
+        assert "action_controller" not in world._backend_state
+
+    def test_skips_when_the_driven_actuators_are_already_torque_motors(self) -> None:
+        model, data = _build_g1_model()
+        sim = _mujoco_sim_with_world(model, data)
+        # from_sim is install_wbc_torque_control minus the registry write, so
+        # this is the "already torque mode" scene rather than the "controller
+        # already registered" one test_skips_when_controller_already_installed
+        # covers - the two conditions are checked separately and in that order.
+        controller = WBCTorqueController.from_sim(cast(SimEngine, sim), _g1_policy(), "unitree_g1")
+        assert "action_controller" not in sim._world._backend_state
+        assert controller.leg_waist_actuator_ids, "premise: driven actuators resolved"
+        for ai in controller.leg_waist_actuator_ids:
+            assert int(model.actuator_biastype[ai]) == int(mujoco.mjtBias.mjBIAS_NONE)
+        assert wbc_uses_position_servo(cast(SimEngine, sim), _g1_policy(), "unitree_g1") is False
+
+        assert sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1") is None
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_skips_when_no_wbc_joint_resolves_in_the_scene(self) -> None:
+        model = mujoco.MjModel.from_xml_string(_XML_NO_WBC_JOINTS)
+        sim = _mujoco_sim_with_world(model, mujoco.MjData(model))
+        assert wbc_uses_position_servo(cast(SimEngine, sim), _g1_policy(), "unitree_g1") is False
+
+        assert sim._maybe_install_wbc_torque_control(_g1_policy(), "unitree_g1") is None
+        assert "action_controller" not in sim._world._backend_state
+
+
+class TestEveryNoOpConditionIsDriven:
+    def test_the_hook_declines_in_exactly_the_five_ways_this_module_drives(self) -> None:
+        """A sixth no-op guard is a condition nothing above exercises.
+
+        The five, in check order: no ``[wbc]`` extra; a non-WBC policy; no
+        compiled world; a controller already registered; no position-servo
+        actuator. Adding a guard without a test fails here.
+        """
+        assert _hook_no_op_guards() == 5

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -9,7 +9,11 @@ Two units are covered, both runnable without real SONIC weights:
   and explicit values always win.
 * ``WBCTorqueController`` - flips the robot's actuators to torque mode (restored
   on uninstall), declares ``owns_stepping``, and on ``apply`` writes PD torques
-  to ``data.ctrl`` and advances physics by the decimation count.
+  to ``data.ctrl`` and advances physics by the decimation count. ``uninstall``
+  releases *both* things ``install_wbc_torque_control`` acquires - the
+  registration in ``world._backend_state["action_controller"]`` and the gains -
+  so the documented manual install/uninstall pair hands the world back as
+  completely as ``run_policy``'s auto-install does.
 
 The end-to-end "does it actually WALK through run_policy" validation needs real
 weights and lives in the gated integration suite.
@@ -322,3 +326,87 @@ class TestWbcUsesPositionServo:
         model = _model_from_xml(_XML_NO_WBC_JOINTS)
         sim = _FakeSim(_FakeWorld(model, mujoco.MjData(model), ""))
         assert wbc_uses_position_servo(cast(SimEngine, sim), _g1_policy(), "unitree_g1") is False
+
+
+class TestUninstallReleasesBothHalvesOfTheInstall:
+    """The documented manual pair: ``install_wbc_torque_control`` then ``uninstall``.
+
+    ``run_policy``'s auto-install path is covered by the hook's own suite; this
+    is the public API a caller drives directly, and it has to hand the world
+    back just as completely - otherwise the registration outlives the rollout and
+    the hook reads it as a manual install that wins.
+    """
+
+    def test_uninstall_deregisters_the_controller_it_registered(self) -> None:
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        sim = _FakeSim(_FakeWorld(model, data, _namespace_for(model)))
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), _g1_policy(), "unitree_g1")
+        assert sim._world._backend_state["action_controller"] is ctrl
+
+        ctrl.uninstall()
+
+        assert "action_controller" not in sim._world._backend_state, (
+            "uninstall left its registration behind; the next run_policy reads it as an "
+            "already-installed controller and dispatches through a finished shim"
+        )
+
+    def test_uninstall_drops_the_registration_before_restoring_the_gains(self) -> None:
+        """Ordering: a failure restoring gains must not leave a live registration.
+
+        The gain restore is the part that can fail, so the registry entry goes
+        first - a controller still registered against actuators that are already
+        position servos again is the state this whole teardown exists to avoid.
+        """
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        sim = _FakeSim(_FakeWorld(model, data, _namespace_for(model)))
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), _g1_policy(), "unitree_g1")
+
+        seen: list[bool] = []
+        saved = ctrl._saved_actuator_gains
+
+        class _Boom(dict):  # type: ignore[type-arg]
+            def items(self):  # type: ignore[no-untyped-def]
+                seen.append("action_controller" in sim._world._backend_state)
+                raise RuntimeError("gain restore failed")
+
+        ctrl._saved_actuator_gains = _Boom(saved)  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="gain restore failed"):
+            ctrl.uninstall()
+
+        assert seen == [False], "the registration was still live when the gain restore ran"
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_uninstall_leaves_a_controller_installed_since_alone(self) -> None:
+        """Release only what this install acquired.
+
+        The LIBERO adapter shares the same seam, so a later install has to
+        survive an earlier controller's teardown.
+        """
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        sim = _FakeSim(_FakeWorld(model, data, _namespace_for(model)))
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), _g1_policy(), "unitree_g1")
+        newer = object()
+        sim._world._backend_state["action_controller"] = newer
+
+        ctrl.uninstall()
+
+        assert sim._world._backend_state["action_controller"] is newer
+
+    def test_a_never_registered_controller_deregisters_nothing(self) -> None:
+        """``from_sim`` builds without registering, so its teardown has nothing to drop."""
+        from strands_robots.policies.wbc import WBCTorqueController
+
+        model, data = _build_min_g1()
+        sim = _FakeSim(_FakeWorld(model, data, _namespace_for(model)))
+        ctrl = WBCTorqueController.from_sim(cast(SimEngine, sim), _g1_policy(), "unitree_g1")
+        assert "action_controller" not in sim._world._backend_state
+
+        ctrl.uninstall()  # must not raise
+
+        assert "action_controller" not in sim._world._backend_state


### PR DESCRIPTION
## Problem

`run_policy` installs a torque shim when a WBC policy meets a position-servo scene, and returns a cleanup for the caller's `finally`. That cleanup was `controller.uninstall`, which restores the actuator gains **and nothing else** - while `install_wbc_torque_control` does two things:

1. flips the driven actuators to torque, and
2. registers the controller in `world._backend_state["action_controller"]` for `_apply_sim_action` to dispatch to.

Undoing one half leaves the controller registered on a scene whose actuators are back to position servos, so it keeps converting the policy's position targets into PD torques that a position servo then reads as *targets*. And the hook's own "a manually-installed controller wins" check cannot tell that stale entry from a deliberate manual install, so it declines to install on the next `run_policy`.

Measured on a Unitree G1 with the real SONIC `GR00T-WholeBodyControl-Balance.onnx`, two consecutive 3 s rollouts at 50 Hz on **one** sim:

| measurement | rollout 1 | rollout 2 |
| --- | --- | --- |
| main - pelvis excursion band | 0.0339 m | **0.1298 m** (3.8x) |
| this PR - pelvis excursion band | 0.0339 m | 0.0259 m (0.8x) |
| render vs the other tree | 0.00% of pixels differ (max delta 1) | **15.25%** of pixels differ (max delta 236) |

The first rollout is byte-comparable on both trees; only the second diverges.

## Change

The hook's cleanup now undoes both halves - it removes the registry entry **it wrote**, and only that entry, then restores the gains. Registry first, so a failure inside `uninstall` cannot leave a controller dispatching into actuators that are already restored.

## Also in this PR

The hook declines to touch a scene under five conditions and only two of them had ever executed. The three that had not: no `[wbc]` extra, no compiled world, and `wbc_uses_position_servo` reporting no position-servo actuator. Each of the predicate's three False outcomes is already pinned in the sibling suites, so what was missing was the branch that *acts* on them - and a no-op is indistinguishable from a hook that never ran, which is exactly why reverting this cleanup is invisible to the whole existing suite.

The already-torque case drives `WBCTorqueController.from_sim` - install minus the registry write - so it lands on the position-servo guard rather than on the manual-install guard a sibling test already covers.

The docstring listed four of the five conditions and described the predicate check as "the actuators are already torque mode"; it now names all five in check order and both reasons the predicate can decline.

## Artifact

![Two consecutive WBC balance rollouts](https://raw.githubusercontent.com/cagataycali/robots/artifacts/wbc-auto-torque-cleanup/wbc_auto_torque_cleanup.png)

Rollout 1 (identical on both trees) / rollout 2 on main / rollout 2 here, the pelvis-height traces, and the verdict ledger. Capture and compose scripts, the raw per-tree JSON and the mutation script are on [`artifacts/wbc-auto-torque-cleanup`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/wbc-auto-torque-cleanup/README.md); `compose.py` asserts every number it renders.

## Regression evidence

Reverting only `strands_robots/simulation/mujoco/simulation.py` to `main` and keeping the new tests: **1 failed, 13 passed**, the failure being

```
assert 'action_controller' not in {'action_controller': <WBCTorqueController object ...>}
```

The second new cleanup case (`test_cleanup_leaves_a_controller_it_did_not_install`) passes on both trees - it is the over-reach control: `main`'s cleanup never touched the registry, so a foreign entry survived it trivially, and it must still survive now.

Mutation table - seven regressions of the five no-op conditions and of the cleanup itself, each run against the 8 new cases and against the 490 pre-existing `tests/policies/wbc` cases (failure counts):

| mutation | 8 new cases | 490 pre-existing |
| --- | --- | --- |
| M1 drop the ImportError tolerance | 2 | **0** |
| M2 drop the no-compiled-world guard | 1 | **0** |
| M3 drop the manual-install-wins guard | 1 | 1 |
| M4 drop the position-servo guard | 3 | **0** |
| M5 drop the non-WBC-policy guard | 1 | 1 |
| M6 invert the position-servo guard | 5 | 1 |
| M7 revert the cleanup to gains only | 1 | **0** |

7 of 7 caught here, 4 of 7 invisible to the existing suite - including M7, the defect itself. Every anchor was scoped to the hook's AST line range (`in_fn=1 in_file=1` for all seven) and the source restored byte-identically.

## Gate

`MUJOCO_GL=egl python -m pytest tests` at `f5442883` + this branch: **28543 passed, 257 skipped, 0 failed** (733 s). Pristine `main` at the same commit is 28535 passed / 257 skipped, and 28535 + 8 new cases = 28543.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1185 files). `mypy strands_robots tests tests_integ`: 14 errors, **all** in `examples/isaac_gs`, 0 outside - the error set is byte-identical to a pristine-`main` worktree of the same working copy, so it is environmental.

`strands_robots/simulation/mujoco/simulation.py`: 18 -> 14 missing lines, 98.84% -> 99.10%. The four closed lines are `1925`-`1926` (the `except ImportError` arm) and `1932`/`1937` (two of the guard returns) in `main`'s numbering; branch line numbers after 1917 are shifted +4 by the docstring. The repo total moves 1759 -> 1755 missing; one of those is `hardware_robot.py:1515`, a `break` in a background task loop that toggles between runs and which this diff does not touch.

`scripts/check_merge_base_overlap.py`: no overlap, 0 paths changed on `upstream/main` in that span; `compare/main...head` reports `behind_by=0`, so the gated tree is the merge result.
