### PR TITLE
feat(examples/fleet): 01_skill_dispatch_multi_vendor - capability-based dispatch across heterogeneous robots

### DIFF
--- a/changelog.d/2180-fleet-skill-dispatch-multi-vendor.md
+++ b/changelog.d/2180-fleet-skill-dispatch-multi-vendor.md
@@ -1,0 +1,16 @@
+### Added: fleet suite scaffold + capability-based skill dispatch across heterogeneous robots
+
+`examples/fleet/01_skill_dispatch_multi_vendor.py` (issue #2180, epic #2179):
+one MuJoCo world hosts an SO-101 arm, a LeKiwi wheeled base and a Unitree Go2
+quadruped via repeated `add_robot`. A skills table maps skill names to
+capability requirements over registry metadata (category, joint count,
+gripper) and to execution bindings (`create_policy` provider or `move_to`
+motion primitive); manifests derive from that metadata alone, so the dispatch
+path contains no per-embodiment branching. Matching runs through the suite's
+shared `capabilities.py` hard-constraint filter - a task no robot can serve
+is rejected with a per-robot machine-readable reason, never dropped - and
+every dispatch passes a HITL gate (`STRANDS_MESH_HITL_ACTIONS=none` is the CI
+posture). Execution is one synchronized `run_multi_policy` batch plus
+`move_to` on MuJoCo; `--backend isaac` runs the identical dispatch layer with
+a sequential per-robot `run_policy` fallback marking the portability boundary
+(#2122, #2123). Ships the `examples/fleet/` scaffold and README.

--- a/examples/fleet/01_skill_dispatch_multi_vendor.py
+++ b/examples/fleet/01_skill_dispatch_multi_vendor.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Capability-based skill dispatch across heterogeneous robots.
+
+Goal: One MuJoCo world hosts three robots from three vendors (an SO-101 arm,
+a LeKiwi wheeled base, a Unitree Go2 quadruped - repeated ``add_robot`` on the
+same world). A skills table maps each skill name to capability requirements
+over REGISTRY METADATA (category, joint count, gripper) and to an execution
+binding (a ``create_policy`` provider or a motion primitive). Each robot's
+capability manifest is derived from that metadata alone, so the dispatch path
+contains no per-embodiment branching anywhere: swapping a vendor is a one-line
+fleet edit, and the dispatcher never learns robot names beyond the manifests.
+Matching runs through the suite's shared ``capabilities.py`` hard-constraint
+filter; a task no robot can serve is rejected with a machine-readable,
+per-robot reason - never silently dropped. Every dispatch passes a
+human-in-the-loop gate before anything executes.
+
+Dependencies: pip install "strands-robots[sim-mujoco]"
+              (--dry-run needs only the base package: no simulator)
+Expected output: two tasks with distinct capability requirements land on the
+                 correct robots (the staging task on the arm, the transport on
+                 a mobile base), one infeasible task is rejected naming each
+                 robot's failing constraint, and the approved work executes -
+                 concurrently via run_multi_policy plus a move_to primitive on
+                 MuJoCo; sequentially via per-robot run_policy elsewhere.
+Runtime: ~2 seconds with --dry-run; under ~90 seconds live (cached assets).
+
+Note: Set STRANDS_MESH_HITL_ACTIONS=none to auto-approve dispatches (CI /
+      smoke mode; logged loudly) - the default is an interactive prompt per
+      dispatch. --view opens the passive MuJoCo viewer (needs a display).
+      --backend isaac runs the identical dispatch layer on Isaac Sim.
+
+Part of the fleet suite (epic #2179); the shared manifest schema lives in
+``capabilities.py`` (also consumed by example 05, #2185).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import random
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+_FLEET_DIR = Path(__file__).resolve().parent
+if str(_FLEET_DIR) not in sys.path:
+    # examples/ is not an installed package; the shared schema module lives
+    # next to this script.
+    sys.path.insert(0, str(_FLEET_DIR))
+
+from capabilities import (  # noqa: E402
+    CapabilityManifest,
+    Skill,
+    StepRequirement,
+    feasible_robots,
+)
+
+from strands_robots.registry import get_robot  # noqa: E402
+
+SITE = "cell-a"
+
+# The fleet: instance name -> registry embodiment, maximally heterogeneous on
+# purpose (three vendors, three morphologies). Swapping a vendor is this one
+# line - nothing below reads these names except to address the sim.
+FLEET: dict[str, str] = {"so101": "so101", "lekiwi": "lekiwi", "go2": "unitree_go2"}
+FLEET_POSITION: dict[str, list[float]] = {"so101": [0.0, 0.0, 0.0], "lekiwi": [1.0, 0.0, 0.0], "go2": [0.0, 1.2, 0.0]}
+
+# The skills table: skill name -> capability requirements (over registry
+# metadata: category, joint count, gripper) -> execution binding (a
+# create_policy provider, or a motion primitive). A robot OFFERS a skill iff
+# its registry metadata satisfies the requirements - so dispatch is a
+# capability match by construction, never an embodiment switch.
+SKILLS: dict[str, dict[str, Any]] = {
+    "stage_part": {
+        "requires": {"category": "arm", "min_joints": 5, "gripper": True},
+        "offer": {"payload_kg": 0.5, "fixture": "smif_pod", "zones": ("bench",)},
+        "binding": {"execute": "move_to", "position": [0.2, 0.0, 0.15]},
+    },
+    "transport_tote": {
+        "requires": {"category": "mobile", "min_joints": 3, "gripper": False},
+        "offer": {"payload_kg": 5.0, "fixture": "tote_clamp", "zones": ("bench", "stock")},
+        "binding": {"execute": "policy", "policy_provider": "mock"},
+    },
+}
+
+# The work: two tasks with distinct capability requirements plus one no robot
+# can serve (40 kg exceeds every offer), so the explicit-rejection path is
+# exercised on every run.
+TASKS: list[dict[str, Any]] = [
+    {"task_id": "T-01", "skill": "stage_part", "payload_kg": 0.2, "zones": ("bench",)},
+    {"task_id": "T-02", "skill": "transport_tote", "payload_kg": 4.0, "zones": ("bench", "stock")},
+    {"task_id": "T-03", "skill": "transport_tote", "payload_kg": 40.0, "zones": ("bench", "stock")},
+]
+
+
+def robot_capability_metadata(embodiment: str) -> dict[str, Any]:
+    """Read one embodiment's capability-relevant metadata from the registry.
+
+    Raises ValueError for an unknown embodiment - a robot whose capabilities
+    cannot be read must never be dispatched to.
+    """
+    meta = get_robot(embodiment)
+    if meta is None:
+        raise ValueError(f"unknown embodiment {embodiment!r}: not in the robot registry")
+    return {"category": meta.get("category"), "joints": meta.get("joints", 0), "gripper": "gripper" in meta}
+
+
+def _meets(meta: dict[str, Any], requires: dict[str, Any]) -> bool:
+    return (
+        meta["category"] == requires["category"]
+        and meta["joints"] >= requires["min_joints"]
+        and (meta["gripper"] or not requires["gripper"])
+    )
+
+
+def build_manifests(fleet: dict[str, str]) -> list[CapabilityManifest]:
+    """Derive one capability manifest per robot from registry metadata alone."""
+    manifests = []
+    for name, embodiment in fleet.items():
+        meta = robot_capability_metadata(embodiment)
+        offered = tuple(
+            Skill(name=skill, **spec["offer"]) for skill, spec in SKILLS.items() if _meets(meta, spec["requires"])
+        )
+        manifests.append(CapabilityManifest(robot=name, site=SITE, skills=offered))
+    return manifests
+
+
+def _task_requirement(task: dict[str, Any]) -> StepRequirement:
+    return StepRequirement(
+        skill=task["skill"],
+        site=SITE,
+        payload_kg=task["payload_kg"],
+        fixture=SKILLS[task["skill"]]["offer"]["fixture"],
+        zones=tuple(task["zones"]),
+    )
+
+
+def _task_instruction(task: dict[str, Any]) -> str:
+    return f"task {task['task_id']}: {task['skill']} {task['payload_kg']} kg in {'/'.join((SITE, *task['zones']))}"
+
+
+def match_skill_for_task(
+    manifests: Sequence[CapabilityManifest], task: dict[str, Any]
+) -> tuple[list[CapabilityManifest], list[dict[str, Any]]]:
+    """Run the shared hard-constraint filter for one task.
+
+    Returns ``(feasible, rejections)`` - the same shape as
+    :func:`capabilities.feasible_robots`: feasible sorted by robot name, one
+    machine-readable rejection per excluded robot.
+    """
+    return feasible_robots(list(manifests), _task_requirement(task))
+
+
+def dispatch_tasks(
+    tasks: Sequence[dict[str, Any]],
+    manifests: Sequence[CapabilityManifest],
+    approve: Callable[[str, str, str], bool],
+    execute: Callable[[list[dict[str, Any]]], dict[str, dict[str, Any]]],
+) -> dict[str, Any]:
+    """Match every task, gate each dispatch on approval, then execute the batch.
+
+    ``approve(action, robot, instruction)`` is the HITL seam;
+    ``execute(assignments)`` is the execution seam (run_multi_policy +
+    move_to on MuJoCo, sequential run_policy elsewhere, a loopback in
+    --dry-run and the smoke test). Every task ends in exactly one of
+    ``dispatched`` / ``rejected`` / ``declined`` - no outcome is silent.
+    """
+    summary: dict[str, Any] = {"dispatched": [], "rejected": [], "declined": []}
+    assignments: list[dict[str, Any]] = []
+    for task in tasks:
+        feasible, rejections = match_skill_for_task(manifests, task)
+        if not feasible:
+            reason = {"task_id": task["task_id"], "code": "no_capable_robot", "rejections": rejections}
+            summary["rejected"].append(reason)
+            print(f"  REJECT {task['task_id']}: no capable robot")
+            for r in rejections:
+                print(f"    {r['robot']}: fails {r['constraint']} (required {r['required']!r}, has {r['actual']!r})")
+            continue
+        robot = feasible[0].robot  # deterministic: feasible is sorted by name
+        instruction = _task_instruction(task)
+        if not approve("dispatch", robot, instruction):
+            summary["declined"].append({"task_id": task["task_id"], "robot": robot, "code": "hitl_declined"})
+            print(f"  DECLINED {task['task_id']}: operator declined dispatch to {robot}")
+            continue
+        assignments.append(
+            {
+                "task_id": task["task_id"],
+                "robot": robot,
+                "skill": task["skill"],
+                "instruction": instruction,
+                "binding": SKILLS[task["skill"]]["binding"],
+            }
+        )
+        print(f"  MATCH {task['task_id']}: {task['skill']} -> {robot} (of {[m.robot for m in feasible]})")
+    results = execute(assignments)
+    for assignment in assignments:
+        result = results.get(assignment["task_id"], {"status": "error", "detail": "executor returned no result"})
+        if result.get("status") != "success":
+            raise RuntimeError(f"execution failed for {assignment['task_id']} on {assignment['robot']}: {result}")
+        summary["dispatched"].append({k: assignment[k] for k in ("task_id", "robot", "skill")})
+        print(f"  DONE {assignment['task_id']} ({assignment['robot']})")
+    return summary
+
+
+def make_hitl_gate() -> Callable[[str, str, str], bool]:
+    """Human-in-the-loop gate applied BEFORE any command reaches a robot.
+
+    Interactive by default; ``STRANDS_MESH_HITL_ACTIONS=none`` opts out for
+    CI/smoke runs (same env contract as the robot_mesh tool, and just as loud
+    about it). A decline is a normal outcome, not an error: the task is
+    recorded as declined and nothing executes.
+    """
+    if os.environ.get("STRANDS_MESH_HITL_ACTIONS", "").strip().lower() == "none":
+
+        def auto_approve(action: str, robot: str, instruction: str) -> bool:
+            print(f"  [HITL] auto-approved {action} -> {robot} (STRANDS_MESH_HITL_ACTIONS=none): {instruction!r}")
+            return True
+
+        return auto_approve
+
+    def prompt_operator(action: str, robot: str, instruction: str) -> bool:
+        answer = input(f"  [HITL] approve {action} -> {robot}: {instruction!r} [y/N] ")
+        return answer.strip().lower() in {"y", "yes", "approve", "approved"}
+
+    return prompt_operator
+
+
+def make_loopback_executor() -> Callable[[list[dict[str, Any]]], dict[str, dict[str, Any]]]:
+    """Dry-run execution seam: prints each assignment and reports success."""
+
+    def execute(assignments: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        results = {}
+        for a in assignments:
+            print(f"  [dry-run] {a['robot']} <- {a['instruction']!r} via {a['binding']['execute']}")
+            results[a["task_id"]] = {"status": "success", "detail": "dry-run loopback"}
+        return results
+
+    return execute
+
+
+def make_synchronized_executor(sim: Any, n_steps: int) -> Callable[[list[dict[str, Any]]], dict[str, dict[str, Any]]]:
+    """MuJoCo execution seam: move_to primitives, then ONE run_multi_policy.
+
+    Motion-primitive bindings run first (move_to is a synchronous IK servo);
+    every policy binding then executes in a single synchronized multi-robot
+    loop - one physics step per tick for all robots, per the
+    :meth:`run_multi_policy` contract.
+    """
+    from strands_robots.policies import create_policy
+
+    def execute(assignments: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        results: dict[str, dict[str, Any]] = {}
+        policy_batch = [a for a in assignments if a["binding"]["execute"] == "policy"]
+        for a in assignments:
+            if a["binding"]["execute"] == "move_to":
+                results[a["task_id"]] = sim.move_to(robot_name=a["robot"], position=a["binding"]["position"])
+        if policy_batch:
+            reply = sim.run_multi_policy(
+                policies={a["robot"]: create_policy(a["binding"]["policy_provider"]) for a in policy_batch},
+                instructions={a["robot"]: a["instruction"] for a in policy_batch},
+                n_steps=n_steps,
+            )
+            for a in policy_batch:
+                results[a["task_id"]] = reply
+        return results
+
+    return execute
+
+
+def make_sequential_executor(
+    sim: Any, n_steps: int, seed: int
+) -> Callable[[list[dict[str, Any]]], dict[str, dict[str, Any]]]:
+    """Portability-fallback execution seam for non-MuJoCo backends (epic D8).
+
+    ``run_multi_policy`` and the motion primitives are MuJoCo-only today
+    (#2122 tracks run_multi_policy parity on Isaac, #2123 the motion
+    primitives), so every binding here - including move_to-bound skills -
+    executes as a sequential per-robot ``run_policy``, the base-ABC contract
+    (strands_robots.simulation.base) every backend implements. The dispatch
+    layer above runs unchanged; this executor is the entire portability
+    boundary.
+    """
+
+    def execute(assignments: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        results = {}
+        for a in assignments:
+            results[a["task_id"]] = sim.run_policy(
+                robot_name=a["robot"],
+                policy_provider=a["binding"].get("policy_provider", "mock"),
+                instruction=a["instruction"],
+                n_steps=n_steps,
+                seed=seed,
+            )
+        return results
+
+    return execute
+
+
+def make_dispatcher_tools(
+    manifests: Sequence[CapabilityManifest],
+    approve: Callable[[str, str, str], bool],
+    execute: Callable[[list[dict[str, Any]]], dict[str, dict[str, Any]]],
+) -> list[Any]:
+    """The dispatcher agent's toolbox: list_robots, match_skill, dispatch.
+
+    Each tool wraps the same deterministic functions the scripted path calls,
+    so an LLM dispatcher can choose WHEN to match and dispatch but can never
+    bypass the capability filter or the HITL gate.
+    """
+    from strands import tool
+
+    tasks_by_id = {t["task_id"]: t for t in TASKS}
+
+    @tool
+    def list_robots() -> dict[str, Any]:
+        """List every robot in the fleet with its site and offered skills."""
+        return {
+            m.robot: {"site": m.site, "skills": [{"name": s.name, "zones": list(s.zones)} for s in m.skills]}
+            for m in manifests
+        }
+
+    @tool
+    def match_skill(task_id: str) -> dict[str, Any]:
+        """Run the capability filter for one task and report the verdict.
+
+        Args:
+            task_id: The id of the task to match (e.g. ``"T-01"``).
+        """
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            return {"error": f"unknown task_id {task_id!r}; known: {sorted(tasks_by_id)}"}
+        feasible, rejections = match_skill_for_task(manifests, task)
+        return {"feasible": [m.robot for m in feasible], "rejections": rejections}
+
+    @tool
+    def dispatch(task_id: str) -> dict[str, Any]:
+        """Dispatch one task through the HITL gate to its matched robot.
+
+        Args:
+            task_id: The id of the task to dispatch (e.g. ``"T-01"``).
+        """
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            return {"error": f"unknown task_id {task_id!r}; known: {sorted(tasks_by_id)}"}
+        return dispatch_tasks([task], manifests, approve, execute)
+
+    return [list_robots, match_skill, dispatch]
+
+
+def _build_sim(backend: str, seed: int, view: bool) -> Any:
+    """One world, three heterogeneous robots via repeated add_robot."""
+    from strands_robots.simulation import create_simulation
+
+    random.seed(seed)
+    sim = create_simulation(backend)
+    result = sim.create_world()
+    if result.get("status") != "success":
+        sim.destroy()
+        raise RuntimeError(f"create_world failed: {result}")
+    try:
+        for name, embodiment in FLEET.items():
+            result = sim.add_robot(name=name, data_config=embodiment, position=FLEET_POSITION[name])
+            if result.get("status") != "success":
+                raise RuntimeError(f"add_robot({name}) failed: {result}")
+        if view:
+            result = sim.open_viewer()  # passive viewer; needs a local display
+            if result.get("status") != "success":
+                raise RuntimeError(f"--view requested but the viewer failed: {result}")
+    except BaseException:
+        sim.destroy()
+        raise
+    return sim
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--backend", default="mujoco", help="simulation backend (mujoco is the acceptance target)")
+    parser.add_argument("--seed", type=int, default=42, help="seed for the run")
+    parser.add_argument("--n-steps", type=int, default=50, help="policy steps per dispatched skill")
+    parser.add_argument("--view", action="store_true", help="open the passive viewer (needs a local display)")
+    parser.add_argument("--dry-run", action="store_true", help="no simulator: loopback execution seam")
+    parser.add_argument(
+        "--agent",
+        action="store_true",
+        help="drive dispatch through a Strands Agent holding [list_robots, match_skill, dispatch]",
+    )
+    args = parser.parse_args(argv)
+
+    manifests = build_manifests(FLEET)
+    for m in manifests:
+        print(f"fleet: {m.robot}@{m.site} offers {[s.name for s in m.skills]}")
+
+    sim = None
+    if args.dry_run:
+        execute = make_loopback_executor()
+    else:
+        sim = _build_sim(args.backend, args.seed, args.view)
+        if args.backend == "mujoco":
+            execute = make_synchronized_executor(sim, args.n_steps)
+        else:
+            execute = make_sequential_executor(sim, args.n_steps, args.seed)
+
+    approve = make_hitl_gate()
+    try:
+        if args.agent:
+            from strands import Agent
+
+            agent = Agent(
+                tools=make_dispatcher_tools(manifests, approve, execute),
+                system_prompt=(
+                    "You dispatch tasks to a robot fleet. For every task id, call match_skill, "
+                    "then dispatch it only if a feasible robot exists. Report rejected tasks verbatim."
+                ),
+            )
+            agent(f"Dispatch these tasks in order: {[t['task_id'] for t in TASKS]}")
+            return 0
+        summary = dispatch_tasks(TASKS, manifests, approve, execute)
+    finally:
+        if sim is not None:
+            sim.destroy()
+
+    print(f"\nsummary: {summary}")
+    if not summary["rejected"]:
+        raise RuntimeError("expected the infeasible task to be rejected with an explicit reason")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -1,0 +1,74 @@
+# Fleet orchestration examples
+
+Multi-robot orchestration on top of the pieces the rest of `examples/`
+introduces one at a time: multi-robot worlds, the Zenoh mesh with its safety
+protocol, capability-based dispatch, and the signed audit log. Tracked by epic
+[#2179](https://github.com/strands-labs/robots/issues/2179).
+
+| # | Example | Status |
+|---|---|---|
+| 01 | [`01_skill_dispatch_multi_vendor.py`](01_skill_dispatch_multi_vendor.py) - capability-based dispatch across heterogeneous robots | here |
+| 02 | `02_cross_zone_transport.py` + read-only Rerun fleet dashboard | tracked by [#2181](https://github.com/strands-labs/robots/issues/2181) |
+| 03 | `03_failover_and_degraded_ops.py` - peer-loss reassignment + dispatcher-down safety | tracked by [#2182](https://github.com/strands-labs/robots/issues/2182) |
+| 04 | `04_emergency_evacuation.py` - three-phase evacuate protocol, benchmark-scored | tracked by [#2183](https://github.com/strands-labs/robots/issues/2183) |
+| 05 | `05_work_order_dispatch.py` - structured task ingress mapped onto per-site capability manifests | tracked by [#2185](https://github.com/strands-labs/robots/issues/2185) |
+
+Shared across the suite:
+
+- [`capabilities.py`](capabilities.py) - the per-robot, per-site capability
+  manifest schema (`{robot, site, skills: [{name, payload_kg, fixture,
+  zones}]}`) plus the deterministic hard-constraint filter. Consumed by
+  examples 01 and 05.
+
+Air-gap acceptance (epic decision D1): every example here passes with the
+network fully off, given a pre-populated asset cache (`HF_HUB_OFFLINE=1` +
+cached robot assets). The first live run downloads robot models from GitHub /
+robot_descriptions; after that, no network is required anywhere in the suite.
+
+## 01 - skill dispatch across vendors
+
+One MuJoCo world, three robots from three vendors (SO-101 arm, LeKiwi wheeled
+base, Unitree Go2 quadruped - repeated `add_robot` on the same world). A
+skills table maps each skill name to capability requirements over registry
+metadata (category, joint count, gripper) and to an execution binding
+(`create_policy` provider or motion primitive); each robot's capability
+manifest is derived from that metadata alone, so nothing in the dispatch path
+branches on an embodiment. Matching runs through the shared `capabilities.py`
+filter: a task no robot can serve is rejected with a per-robot,
+machine-readable reason - never silently dropped. Every dispatch passes a
+human-in-the-loop gate first.
+
+Execution on MuJoCo is a `move_to` motion primitive for the staging skill
+plus ONE synchronized `run_multi_policy` loop for every policy-bound skill.
+`--backend isaac` runs the identical dispatch layer with execution falling
+back to sequential per-robot `run_policy` (the base-ABC contract every
+backend implements) - the fallback deliberately shows where the portability
+boundary sits today ([#2122](https://github.com/strands-labs/robots/issues/2122)
+tracks `run_multi_policy` parity, [#2123](https://github.com/strands-labs/robots/issues/2123)
+the motion primitives).
+
+```bash
+# No simulator - match, gate, and reject with a loopback execution seam:
+STRANDS_MESH_HITL_ACTIONS=none python examples/fleet/01_skill_dispatch_multi_vendor.py --dry-run
+
+# Live: one MuJoCo world (so101 + lekiwi + unitree_go2), interactive HITL
+# approval per dispatch:
+python examples/fleet/01_skill_dispatch_multi_vendor.py
+
+# Watch it (needs a local display):
+python examples/fleet/01_skill_dispatch_multi_vendor.py --view
+
+# Same dispatch layer, Isaac execution fallback (needs Isaac Sim):
+python examples/fleet/01_skill_dispatch_multi_vendor.py --backend isaac
+
+# Let a Strands Agent drive the [list_robots, match_skill, dispatch] tools
+# (needs model-provider credentials; the scripted path needs none):
+STRANDS_MESH_HITL_ACTIONS=none python examples/fleet/01_skill_dispatch_multi_vendor.py --dry-run --agent
+```
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `STRANDS_MESH_HITL_ACTIONS=none` | Auto-approve dispatches (CI/smoke mode; logged loudly). The default is an interactive prompt per dispatch. |
+| `MUJOCO_GL` | GL backend for headless rendering (the examples default it to `egl`). |

--- a/examples/fleet/capabilities.py
+++ b/examples/fleet/capabilities.py
@@ -1,0 +1,197 @@
+"""Shared capability-manifest schema for the fleet examples.
+
+A capability manifest is a per-robot, per-site declaration of what a robot can
+physically do. It is the boundary between business vocabulary (work orders:
+material, operation, qty) and robot vocabulary (skills, payload, fixtures,
+zones). One manifest per robot per site:
+
+    {"robot": "lekiwi-a1", "site": "site-a",
+     "skills": [{"name": "transport", "payload_kg": 8.0,
+                 "fixture": "tote_clamp", "zones": ["litho", "etch"]}]}
+
+Matching is deterministic hard-constraint filtering only: site equality, skill
+name equality, payload threshold, fixture equality, zone coverage. There is no
+model in the loop. An LLM agent may choose AMONG the robots this filter admits
+(see ``05_work_order_dispatch.py``); it can never add one.
+
+Consumed by example 01 (skill dispatch, #2180) and example 05 (work-order
+dispatch, #2185). Part of the fleet suite (epic #2179).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# Robot / site / skill / fixture / zone identifiers share one conservative
+# charset: they cross the mesh wire (``robot_name`` allows ``[A-Za-z0-9_.-]+``)
+# and appear in audit payloads, so nothing fancier is accepted here.
+_IDENT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class Skill:
+    """One capability a robot offers at its site.
+
+    Attributes:
+        name: Skill identifier (e.g. ``"transport"``, ``"handle"``).
+        payload_kg: Maximum payload this skill can carry, in kilograms.
+        fixture: The single fixture type this skill can hold (e.g.
+            ``"smif_pod"``). A robot with several fixtures declares one
+            skill entry per fixture.
+        zones: Zones (within the robot's site) this skill can serve.
+    """
+
+    name: str
+    payload_kg: float
+    fixture: str
+    zones: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CapabilityManifest:
+    """Everything one robot can do at one site."""
+
+    robot: str
+    site: str
+    skills: tuple[Skill, ...]
+
+
+@dataclass(frozen=True)
+class StepRequirement:
+    """The hard constraints one work-order step places on a robot.
+
+    Produced by the deterministic order-to-steps translation in example 05;
+    consumed by :func:`feasible_robots`.
+    """
+
+    skill: str
+    site: str
+    payload_kg: float
+    fixture: str
+    zones: tuple[str, ...]
+
+
+def _require_ident(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not _IDENT_RE.match(value):
+        raise ValueError(f"{field} must be a non-empty string matching [A-Za-z0-9][A-Za-z0-9_.-]* (got {value!r})")
+    return value
+
+
+def skill_from_dict(raw: Any) -> Skill:
+    """Validate one skill dict and return a :class:`Skill`.
+
+    Raises ValueError naming the offending field; a manifest that cannot be
+    validated must never silently shrink to the fields that happened to parse.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"skill must be an object (got {type(raw).__name__})")
+    unknown = set(raw) - {"name", "payload_kg", "fixture", "zones"}
+    if unknown:
+        raise ValueError(f"skill has unknown fields {sorted(unknown)}")
+    name = _require_ident(raw.get("name"), "skill.name")
+    payload = raw.get("payload_kg")
+    if isinstance(payload, bool) or not isinstance(payload, int | float) or not payload > 0:
+        raise ValueError(f"skill.payload_kg must be a positive number (got {payload!r})")
+    fixture = _require_ident(raw.get("fixture"), "skill.fixture")
+    zones = raw.get("zones")
+    if not isinstance(zones, list | tuple) or not zones:
+        raise ValueError(f"skill.zones must be a non-empty list (got {zones!r})")
+    return Skill(
+        name=name,
+        payload_kg=float(payload),
+        fixture=fixture,
+        zones=tuple(_require_ident(z, "skill.zones[]") for z in zones),
+    )
+
+
+def manifest_from_dict(raw: Any) -> CapabilityManifest:
+    """Validate one manifest dict and return a :class:`CapabilityManifest`."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"manifest must be an object (got {type(raw).__name__})")
+    unknown = set(raw) - {"robot", "site", "skills"}
+    if unknown:
+        raise ValueError(f"manifest has unknown fields {sorted(unknown)}")
+    robot = _require_ident(raw.get("robot"), "manifest.robot")
+    site = _require_ident(raw.get("site"), "manifest.site")
+    skills = raw.get("skills")
+    if not isinstance(skills, list | tuple) or not skills:
+        raise ValueError(f"manifest.skills must be a non-empty list (got {skills!r})")
+    return CapabilityManifest(robot=robot, site=site, skills=tuple(skill_from_dict(s) for s in skills))
+
+
+def _reject_reason(manifest: CapabilityManifest, req: StepRequirement) -> dict[str, Any] | None:
+    """Why this manifest cannot serve this step, or None if it can.
+
+    The reason is machine-readable: it names the first failing constraint in a
+    fixed check order (site, skill, fixture, payload_kg, zones) together with
+    the required and actual values, so a NACK consumer can act on it without
+    parsing prose.
+    """
+    if manifest.site != req.site:
+        return {"robot": manifest.robot, "constraint": "site", "required": req.site, "actual": manifest.site}
+    named = [s for s in manifest.skills if s.name == req.skill]
+    if not named:
+        return {
+            "robot": manifest.robot,
+            "constraint": "skill",
+            "required": req.skill,
+            "actual": sorted({s.name for s in manifest.skills}),
+        }
+    # A skill entry serves the step only if every remaining constraint holds.
+    # When several entries share the name, report the failure of the entry
+    # that got FURTHEST through the checks (fixture, then payload, then
+    # zones): "your tote_clamp skill is 4 kg short" is actionable where
+    # "your smif_pod skill is the wrong fixture" is noise.
+    _DEPTH = {"fixture": 0, "payload_kg": 1, "zones": 2}
+    best_failure: dict[str, Any] | None = None
+    for skill in named:
+        if skill.fixture != req.fixture:
+            failure = {
+                "robot": manifest.robot,
+                "constraint": "fixture",
+                "required": req.fixture,
+                "actual": skill.fixture,
+            }
+        elif skill.payload_kg < req.payload_kg:
+            failure = {
+                "robot": manifest.robot,
+                "constraint": "payload_kg",
+                "required": req.payload_kg,
+                "actual": skill.payload_kg,
+            }
+        elif not set(req.zones) <= set(skill.zones):
+            failure = {
+                "robot": manifest.robot,
+                "constraint": "zones",
+                "required": sorted(req.zones),
+                "actual": sorted(skill.zones),
+            }
+        else:
+            return None  # this skill entry satisfies every constraint
+        if best_failure is None or _DEPTH[failure["constraint"]] > _DEPTH[best_failure["constraint"]]:
+            best_failure = failure
+    return best_failure
+
+
+def feasible_robots(
+    manifests: list[CapabilityManifest] | tuple[CapabilityManifest, ...],
+    req: StepRequirement,
+) -> tuple[list[CapabilityManifest], list[dict[str, Any]]]:
+    """Deterministic hard-constraint filter: stage one of the translation.
+
+    Returns ``(feasible, rejections)`` where ``feasible`` is sorted by robot
+    name (so the result is stable across runs) and ``rejections`` carries one
+    machine-readable reason per excluded robot. An empty ``feasible`` list is
+    the caller's cue to NACK the order - never to guess.
+    """
+    feasible: list[CapabilityManifest] = []
+    rejections: list[dict[str, Any]] = []
+    for manifest in sorted(manifests, key=lambda m: m.robot):
+        reason = _reject_reason(manifest, req)
+        if reason is None:
+            feasible.append(manifest)
+        else:
+            rejections.append(reason)
+    return feasible, rejections

--- a/tests/test_fleet_skill_dispatch_multi_vendor.py
+++ b/tests/test_fleet_skill_dispatch_multi_vendor.py
@@ -1,0 +1,234 @@
+"""Smoke test for examples/fleet/01_skill_dispatch_multi_vendor.py (issue #2180).
+
+The dispatch layer is exercised end to end with no simulator and no network:
+capability manifests are derived from the real robot registry's metadata
+(category, joint count, gripper), matching runs through the suite's shared
+``capabilities.py`` hard-constraint filter, the HITL gate is driven in both
+its CI (auto-approve) and declined postures, and execution goes through stub
+seams that record what would have run. The executor-construction tests pin
+the two execution shapes the example ships: one synchronized
+``run_multi_policy`` batch plus ``move_to`` primitives on MuJoCo, and the
+sequential per-robot ``run_policy`` portability fallback (epic D8) elsewhere.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_FLEET_DIR = Path(__file__).resolve().parent.parent / "examples" / "fleet"
+_EXAMPLE_PATH = _FLEET_DIR / "01_skill_dispatch_multi_vendor.py"
+
+# Loaded under a distinctive module name: "capabilities" (its sibling import)
+# is generic enough to collide, so both are evicted between loads.
+_MODULE_NAME = "fleet_skill_dispatch_multi_vendor_example"
+
+
+@pytest.fixture
+def example(monkeypatch):
+    """Load the example module fresh, with its sibling schema importable."""
+    monkeypatch.syspath_prepend(str(_FLEET_DIR))
+    for name in (_MODULE_NAME, "capabilities"):
+        sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _EXAMPLE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    for name in (_MODULE_NAME, "capabilities"):
+        sys.modules.pop(name, None)
+
+
+def _approve_all(action: str, robot: str, instruction: str) -> bool:
+    return True
+
+
+class _RecordingExecutor:
+    """Execution seam stub: records assignments, reports success."""
+
+    def __init__(self):
+        self.assignments: list[dict[str, Any]] = []
+
+    def __call__(self, assignments: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        self.assignments.extend(assignments)
+        return {a["task_id"]: {"status": "success"} for a in assignments}
+
+
+def test_manifests_derive_from_registry_metadata_not_names(example):
+    """Offered skills follow category/joints/gripper metadata, not robot names.
+
+    The arm (and only the arm) offers the staging skill because only its
+    registry entry is category ``arm`` with a gripper; both mobile robots -
+    a wheeled base and a quadruped from different vendors - offer transport
+    because their metadata satisfies that skill's requirements.
+    """
+    manifests = {m.robot: m for m in example.build_manifests(example.FLEET)}
+    assert [s.name for s in manifests["so101"].skills] == ["stage_part"]
+    assert [s.name for s in manifests["lekiwi"].skills] == ["transport_tote"]
+    assert [s.name for s in manifests["go2"].skills] == ["transport_tote"]
+
+
+def test_unknown_embodiment_is_refused_not_dispatched(example):
+    """A robot whose capabilities cannot be read is never given a manifest."""
+    with pytest.raises(ValueError, match="not in the robot registry"):
+        example.build_manifests({"ghost": "no_such_embodiment_zz"})
+
+
+def test_dispatch_selects_the_correct_robot_for_two_distinct_tasks(example):
+    """Two tasks with distinct capability requirements land on distinct robots.
+
+    T-01 (stage_part: arm + gripper) can only go to the arm; T-02
+    (transport_tote: mobile) goes to a mobile robot chosen deterministically
+    from the sorted feasible set. No per-embodiment branching exists to make
+    this happen - the verdicts are the capability filter's alone.
+    """
+    manifests = example.build_manifests(example.FLEET)
+    executor = _RecordingExecutor()
+
+    summary = example.dispatch_tasks(example.TASKS, manifests, _approve_all, executor)
+
+    dispatched = {d["task_id"]: d["robot"] for d in summary["dispatched"]}
+    assert dispatched["T-01"] == "so101"
+    assert dispatched["T-02"] == "go2"  # first of the sorted feasible mobiles
+    assert [a["task_id"] for a in executor.assignments] == ["T-01", "T-02"]
+
+
+def test_infeasible_task_is_rejected_with_a_per_robot_reason(example):
+    """A task no robot can serve is rejected explicitly, never silently.
+
+    T-03's 40 kg payload exceeds every transport offer; the arm does not
+    offer the skill at all. The rejection carries one machine-readable
+    reason per robot naming the failing constraint, and the executor never
+    sees the task.
+    """
+    manifests = example.build_manifests(example.FLEET)
+    executor = _RecordingExecutor()
+
+    summary = example.dispatch_tasks(example.TASKS, manifests, _approve_all, executor)
+
+    assert [r["task_id"] for r in summary["rejected"]] == ["T-03"]
+    reasons = {r["robot"]: r for r in summary["rejected"][0]["rejections"]}
+    assert reasons["lekiwi"]["constraint"] == "payload_kg"
+    assert reasons["go2"]["constraint"] == "payload_kg"
+    assert reasons["so101"]["constraint"] == "skill"
+    assert all(a["task_id"] != "T-03" for a in executor.assignments)
+
+
+def test_hitl_decline_is_a_structured_outcome_and_nothing_executes(example):
+    """A declined approval records the task as declined; no work reaches a robot."""
+    manifests = example.build_manifests(example.FLEET)
+    executor = _RecordingExecutor()
+
+    summary = example.dispatch_tasks(example.TASKS, manifests, lambda action, robot, instruction: False, executor)
+
+    assert summary["dispatched"] == []
+    assert executor.assignments == []
+    assert {d["task_id"] for d in summary["declined"]} == {"T-01", "T-02"}
+    assert all(d["code"] == "hitl_declined" for d in summary["declined"])
+
+
+def test_hitl_gate_auto_approves_only_in_ci_mode(example, monkeypatch):
+    """STRANDS_MESH_HITL_ACTIONS=none is the CI posture (epic D4)."""
+    monkeypatch.setenv("STRANDS_MESH_HITL_ACTIONS", "none")
+    assert example.make_hitl_gate()("dispatch", "so101", "task T-01") is True
+
+    monkeypatch.delenv("STRANDS_MESH_HITL_ACTIONS")
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+    assert example.make_hitl_gate()("dispatch", "so101", "task T-01") is False
+    monkeypatch.setattr("builtins.input", lambda prompt: "y")
+    assert example.make_hitl_gate()("dispatch", "so101", "task T-01") is True
+
+
+class _StubSim:
+    """Sim stub recording the execution calls the two executors make."""
+
+    def __init__(self):
+        self.move_to_calls: list[dict[str, Any]] = []
+        self.multi_policy_calls: list[dict[str, Any]] = []
+        self.run_policy_calls: list[dict[str, Any]] = []
+
+    def move_to(self, robot_name, position):
+        self.move_to_calls.append({"robot_name": robot_name, "position": position})
+        return {"status": "success"}
+
+    def run_multi_policy(self, policies, instructions, n_steps):
+        self.multi_policy_calls.append({"policies": policies, "instructions": instructions, "n_steps": n_steps})
+        return {"status": "success"}
+
+    def run_policy(self, **kwargs):
+        self.run_policy_calls.append(kwargs)
+        return {"status": "success"}
+
+
+def _matched_assignments(example):
+    manifests = example.build_manifests(example.FLEET)
+    assignments = []
+    for task in example.TASKS:
+        feasible, _rejections = example.match_skill_for_task(manifests, task)
+        if feasible:
+            assignments.append(
+                {
+                    "task_id": task["task_id"],
+                    "robot": feasible[0].robot,
+                    "skill": task["skill"],
+                    "instruction": example._task_instruction(task),
+                    "binding": example.SKILLS[task["skill"]]["binding"],
+                }
+            )
+    return assignments
+
+
+def test_synchronized_executor_batches_policies_into_one_run_multi_policy(example):
+    """MuJoCo execution: move_to for the primitive binding, ONE multi-policy batch.
+
+    The policy-bound dispatches share a single synchronized ``run_multi_policy``
+    call (one physics step per tick for all robots), and the primitive-bound
+    staging skill goes through ``move_to`` - never a per-robot policy loop.
+    """
+    sim = _StubSim()
+    execute = example.make_synchronized_executor(sim, n_steps=7)
+
+    results = execute(_matched_assignments(example))
+
+    assert [c["robot_name"] for c in sim.move_to_calls] == ["so101"]
+    assert len(sim.multi_policy_calls) == 1
+    batch = sim.multi_policy_calls[0]
+    assert set(batch["policies"]) == {"go2"}
+    assert batch["n_steps"] == 7
+    assert sim.run_policy_calls == []
+    assert results["T-01"]["status"] == "success"
+    assert results["T-02"]["status"] == "success"
+
+
+def test_sequential_fallback_executes_every_binding_via_run_policy(example):
+    """The D8 portability fallback: per-robot run_policy, dispatch unchanged.
+
+    On a backend without run_multi_policy / motion primitives (#2122, #2123),
+    every assignment - including the move_to-bound one - executes through the
+    base-ABC ``run_policy``, seeded, one robot at a time.
+    """
+    sim = _StubSim()
+    execute = example.make_sequential_executor(sim, n_steps=7, seed=42)
+
+    results = execute(_matched_assignments(example))
+
+    assert sim.multi_policy_calls == [] and sim.move_to_calls == []
+    assert [c["robot_name"] for c in sim.run_policy_calls] == ["so101", "go2"]
+    assert all(c["n_steps"] == 7 and c["seed"] == 42 for c in sim.run_policy_calls)
+    assert all(results[t]["status"] == "success" for t in ("T-01", "T-02"))
+
+
+def test_executor_failure_raises_instead_of_reporting_success(example):
+    """A failed execution is fatal - the summary never absorbs an error."""
+    manifests = example.build_manifests(example.FLEET)
+
+    def broken_executor(assignments):
+        return {a["task_id"]: {"status": "error", "detail": "actuator fault"} for a in assignments}
+
+    with pytest.raises(RuntimeError, match="execution failed for T-01"):
+        example.dispatch_tasks(example.TASKS, manifests, _approve_all, broken_executor)


### PR DESCRIPTION
# feat(examples/fleet): 01_skill_dispatch_multi_vendor - capability-based dispatch across heterogeneous robots

Closes #2180

Part of epic #2179 (PR1 of 5, plus the suite scaffold + README).

## What changed

- **`examples/fleet/01_skill_dispatch_multi_vendor.py`** - one MuJoCo world,
  three heterogeneous robots via repeated `add_robot` (`so101` arm + `lekiwi`
  wheeled base + `unitree_go2` quadruped). A skills table maps each skill name
  to capability requirements over **registry metadata** (category, joint
  count, gripper) and to an execution binding (`create_policy` provider or
  `move_to` motion primitive). Each robot's capability manifest is derived
  from that metadata alone, so the dispatch path contains **no per-embodiment
  branching anywhere**: swapping a vendor is a one-line fleet edit. Matching
  runs through the suite's shared `capabilities.py` hard-constraint filter; a
  task no robot can serve is rejected with a per-robot machine-readable reason
  (never silently dropped). Every dispatch passes a HITL gate first
  (`STRANDS_MESH_HITL_ACTIONS=none` is the CI posture, epic D4).
- **Dispatcher agent toolbox** - `make_dispatcher_tools` builds the
  `[list_robots, match_skill, dispatch]` `@tool` set; each tool wraps the same
  deterministic functions the scripted path calls, so an LLM dispatcher can
  choose *when* to match and dispatch but can never bypass the capability
  filter or the HITL gate. `--agent` drives it; the scripted default needs no
  credentials, keeping the acceptance path air-gapped (epic D1).
- **Execution** - on MuJoCo: `move_to` for the primitive-bound staging skill
  plus **one** synchronized `run_multi_policy` batch for every policy-bound
  skill. `--backend isaac` (epic D8) runs the identical dispatch layer with
  execution falling back to sequential per-robot `run_policy` (the base-ABC
  contract), documented inline with pointers to #2122 / #2123 - the fallback
  deliberately shows where the portability boundary sits.
- **`--view`** - opens the existing passive viewer (`open_viewer`); an
  explicitly requested viewer that fails is a raise, not a warn-and-continue.
- **`examples/fleet/` scaffold + `README.md` skeleton** - suite table, shared
  `capabilities.py` section, and the air-gap acceptance documented per epic D1.
- **`examples/fleet/capabilities.py`** - the shared manifest schema +
  deterministic filter, **byte-identical** to the copies carried by the open
  sibling PRs #2191 (example 03) and #2188 (example 05), so any merge order is
  conflict-free on that file. (The suite `README.md` will need a mechanical
  add/add resolution against whichever sibling lands adjacent - the structure
  is kept identical to minimize it.)
- **`tests/test_fleet_skill_dispatch_multi_vendor.py`** - 9 smoke tests, no
  simulator, no network (details below).
- **`changelog.d/2180-fleet-skill-dispatch-multi-vendor.md`** - news fragment.

## Acceptance criteria (from #2180)

- [x] Runs CPU-only, headless, seeded, well under ~90 s: measured **~3 s**
  live (`--n-steps 25`, cached assets) and ~1 s `--dry-run`
- [x] Passes with the network off given cached assets: verified with
  `HF_HUB_OFFLINE=1` and the live sim path, exit 0
- [x] Smoke test; HITL CI mode per epic D4 (`STRANDS_MESH_HITL_ACTIONS=none`
  auto-approves loudly; the decline posture is also pinned)
- [x] Dispatch selects the correct robot for two tasks with distinct
  capability requirements: `stage_part` (arm + gripper) -> `so101`;
  `transport_tote` (mobile) -> first of the sorted feasible mobiles
- [x] A task with no capable robot is rejected with an explicit reason: the
  40 kg transport is rejected naming each robot's failing constraint
  (`payload_kg` for both mobiles, `skill` for the arm) - and the smoke test
  asserts the executor never sees it
- [x] LOC: the dispatch core is ~150 LOC; the file lands at 433 including the
  module docstring, the three executors, the agent toolbox, and CLI wiring
  (in line with the sibling fleet examples)

## Test surface

`hatch run lint` clean; `hatch run test` with CI's `MUJOCO_GL=osmesa`:
**28542 passed, 263 skipped, 0 failed** (the 9 new tests included).

New tests pin: manifests derive from registry metadata (not names); an
unknown embodiment is refused, never dispatched to; correct robot per
distinct-requirement task; explicit per-robot rejection with no silent drop;
HITL decline is a structured outcome with nothing executing; the D4 CI
posture; the MuJoCo executor batches all policy bindings into **one**
`run_multi_policy` call (and routes the primitive binding to `move_to`); the
D8 fallback executes every binding via seeded per-robot `run_policy`; and a
failed execution raises rather than being absorbed into the summary.

Environmental note: without `MUJOCO_GL` preset, a full local suite run aborts
inside `mujoco`'s classic renderer on a headless box (first collected module
locks `glfw`); reproduced identically with this branch's test excluded, i.e.
pre-existing and unrelated.

## Out of scope / follow-ups

- Examples 02/04 of the suite: #2181, #2183 (open); 03/05 are in review as
  #2191 / #2188
- Isaac parity for `run_multi_policy` / motion primitives: #2122, #2123 (the
  example's inline comments point at both)
- `examples/README.md` index row for the fleet suite: already added by #2188;
  deliberately not duplicated here to avoid a cross-PR conflict

## Board

Please move #2180 to "In review" on the
[Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2)
(filing account lacks org project write).
