### PR TITLE
test(simulation): drive the failure arms of get_world_point's camera-params read

### DIFF
--- a/changelog.d/2199-get-world-point-camera-params-arms.md
+++ b/changelog.d/2199-get-world-point-camera-params-arms.md
@@ -1,0 +1,23 @@
+### Quality: pin the failure arms of `get_world_point`'s camera-params read
+
+`SimEngine.get_world_point` makes two backend reads -- `get_frame`, then
+`get_camera_params` -- and answers for each independently so the method can
+keep its documented never-raises envelope. Only the first read's failure was
+ever driven: both handlers behind the second one, and the base class's own
+`get_frame` / `get_camera_params` defaults behind them, were unexecuted
+anywhere in the suite.
+
+The second read can fail on input the call has already accepted and a frame it
+has already rendered. MuJoCo's orthographic free camera is the reachable
+instance: it rasterizes normally, so `get_frame` returns a full RGB + depth
+pair, but an orthographic projection has no pinhole `K`, so
+`get_camera_params` refuses. `get_world_point`'s `Returns:` enumerated its
+failure causes and named neither backend read, so a caller had no way to
+anticipate a refusal that arrives after a successful render.
+
+Adds behaviour tests for both arms -- every member of the handled exception
+tuple, the missing-path report, that the backend's reason survives into the
+envelope, and that the two reads stay distinguishable -- plus the orthographic
+case end to end against a real MuJoCo render with a perspective control on the
+same scene. The `Returns:` enumeration now names both reads and the
+orthographic cause. No executable line changes.

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -4340,8 +4340,16 @@ class SimEngine(ABC):
             samples and ``points`` is aligned with the input ``pixels``
             (``None`` where the pixel had no valid depth). Backends without a
             metric-depth path (Newton), all-invalid pixel sets, out-of-bounds
-            pixels, and malformed input all return
-            ``{"status": "error", "content": [{"text": ...}]}``.
+            pixels, malformed input, and a failed frame render or
+            camera-params read all return
+            ``{"status": "error", "content": [{"text": ...}]}``, with the
+            two backend reads reporting distinguishable text so a caller
+            knows which one failed. The camera-params read can fail on input
+            this call already accepted and a frame it already rendered --
+            most notably a camera whose projection no pinhole ``K`` can
+            represent, such as MuJoCo's orthographic free camera, which
+            renders normally but has no intrinsics. So check ``status``
+            rather than inferring success from a valid pixel set.
         """
         # numpy stays TYPE_CHECKING-only at this module's top level; import at
         # use time like the backends' render paths do.

--- a/tests/simulation/mujoco/test_get_world_point.py
+++ b/tests/simulation/mujoco/test_get_world_point.py
@@ -290,6 +290,81 @@ def test_world_point_correct_on_explicit_intrinsics_camera(tmp_path) -> None:
         sim.destroy()
 
 
+# A scene whose FREE camera is orthographic. MuJoCo rasterizes it normally --
+# ``get_frame`` returns a full RGB + depth pair -- but an orthographic
+# projection has no pinhole ``K``, so ``get_camera_params`` refuses. That makes
+# it the reachable real-world instance of a failure that arrives AFTER a
+# successful render, on pixels ``get_world_point`` has already accepted.
+_ORTHOGRAPHIC_SCENE = """
+<mujoco model="orthographic_free_camera">
+  <visual><global orthographic="true" fovy="0.35"/></visual>
+  <worldbody>
+    <light pos="0.4 -0.6 1.2" dir="-0.2 0.4 -1"/>
+    <body name="cube" pos="0.4 0 0.05">
+      <geom name="cube_g" type="box" size="0.1 0.1 0.05" rgba="0.9 0.4 0.1 1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _load_scene_sim(tmp_path, scene_xml: str, name: str):
+    """Fresh sim with *scene_xml* loaded, mirroring the intrinsics fixture."""
+    from strands_robots.simulation import Simulation
+
+    scene = tmp_path / name
+    scene.write_text(scene_xml)
+    sim = Simulation(mesh=False)
+    assert sim.create_world(ground_plane=False)["status"] == "success"
+    assert sim.load_scene(str(scene))["status"] == "success", "load_scene failed"
+    return sim
+
+
+@requires_gl
+def test_orthographic_free_camera_renders_but_reports_unreadable_intrinsics(tmp_path) -> None:
+    """The camera-params read fails on a frame that rendered fine.
+
+    ``get_world_point`` makes two backend reads. This pins the second one
+    failing while the first succeeded, through a documented MJCF option rather
+    than a mock: the pixels are valid, the depth buffer is real, and the call
+    still has to report -- never raise, and never return a point derived from
+    intrinsics it could not read. The reported text has to carry MuJoCo's own
+    actionable reason, because nothing else in the result names the cause.
+    """
+    sim = _load_scene_sim(tmp_path, _ORTHOGRAPHIC_SCENE, "orthographic.xml")
+    try:
+        # The frame read succeeds: this is not a rendering failure.
+        rgb, depth = sim.get_frame("default")
+        assert depth is not None and depth.shape[:2] == rgb.shape[:2]
+
+        result = sim.get_world_point("default", pixels=[[320, 240]])
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "camera parameters" in text, text
+        assert "orthographic" in text, text
+        # The remedy has to survive into the envelope, not just the exception.
+        assert "add_camera" in text, text
+        # ... and it must be the params read being reported, not the render.
+        assert "render camera frame" not in text, text
+    finally:
+        sim.destroy()
+
+
+@requires_gl
+def test_a_perspective_free_camera_on_the_same_scene_still_grounds(tmp_path) -> None:
+    """Control for the case above: the identical scene, camera and pixel
+    ground successfully once the projection is perspective, so the refusal is
+    the projection and not the fixture."""
+    perspective = _ORTHOGRAPHIC_SCENE.replace('orthographic="true" fovy="0.35"', 'fovy="45"')
+    sim = _load_scene_sim(tmp_path, perspective, "perspective.xml")
+    try:
+        data = _json_block(sim.get_world_point("default", pixels=[[320, 240]]))
+        assert data["n_valid"] == 1
+        assert len(data["point"]) == 3
+    finally:
+        sim.destroy()
+
+
 # ----- Tool surface (no GL required) ----- #
 
 

--- a/tests/simulation/test_get_world_point_math.py
+++ b/tests/simulation/test_get_world_point_math.py
@@ -3,9 +3,13 @@
 """Backend-agnostic ``SimEngine.get_world_point`` contract (issue #1647).
 
 ``get_world_point`` is pure math over ``get_frame`` + ``get_camera_params``,
-so its unprojection, median robustness, invalid-pixel handling, and input
-validation are all pinned here against a pure-Python stub engine -- no MuJoCo,
-no GL, no GPU. Backend-specific accuracy lives in
+so its unprojection, median robustness, invalid-pixel handling, input
+validation, and the failure arms of BOTH backend reads are all pinned here
+against a pure-Python stub engine -- no MuJoCo, no GL, no GPU. The two reads
+fail independently: ``get_camera_params`` is called after a frame has already
+rendered, so its failure is not reachable by making ``get_frame`` fail, and
+the two must stay distinguishable in the reported text. Backend-specific
+accuracy lives in
 ``tests/simulation/mujoco/test_get_world_point.py`` (regression against a box
 at a known pose) and the gated Isaac GPU test.
 """
@@ -191,6 +195,99 @@ def test_base_facade_without_raw_frames_is_a_structured_error() -> None:
     result = _NoFrames(_flat_depth()).get_world_point("default", pixels=[[1, 1]])
     assert result["status"] == "error"
     assert "get_frame" in result["content"][0]["text"]
+
+
+def test_base_facade_without_camera_params_is_a_structured_error() -> None:
+    """The mirror of the ``get_frame`` case one backend read later: an engine
+    that renders frames but never implemented ``get_camera_params`` gets a
+    clear error dict naming the missing path, not a ``NotImplementedError``
+    out of a method documented never to raise.
+
+    ``NotImplementedError`` subclasses ``RuntimeError``, so the handled tuple
+    below this arm would catch it too and still return an envelope. The
+    dedicated arm therefore earns its place on the WORDING -- "this backend
+    has no camera-params path" instead of a generic read failure carrying the
+    exception text -- which is what these assertions pin. Checking only
+    ``status``, or only that the method name appears somewhere in the text,
+    passes either way.
+    """
+
+    class _NoParams(_StubSim):
+        def get_camera_params(self, camera_name="default", width=None, height=None):
+            raise NotImplementedError("get_camera_params not implemented by this backend")
+
+    result = _NoParams(_flat_depth()).get_world_point("default", pixels=[[1, 1]])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "has no camera-params path" in text, text
+    assert "get_camera_params" in text, text
+    # Only the dedicated arm produces the wording above; the tuple arm would
+    # report a generic read failure instead.
+    assert "failed to read camera parameters" not in text, text
+    # The frame read succeeded, so a test that only checked ``status`` could
+    # be satisfied by the WRONG read being reported. Pin that it was not.
+    assert "get_frame" not in text
+    assert "render camera frame" not in text
+
+
+def test_the_missing_path_stubs_reproduce_the_base_defaults() -> None:
+    """Premise for the two missing-path cases above: :class:`SimEngine`'s own
+    defaults raise exactly what those stubs raise, so they exercise the arm
+    rather than an invented exception."""
+    naked = _StubSim.__new__(_StubSim)
+    for method in ("get_frame", "get_camera_params"):
+        with pytest.raises(NotImplementedError, match=method):
+            getattr(SimEngine, method)(naked)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        KeyError("camera 'front' not found"),
+        ValueError("no pinhole K for an orthographic projection"),
+        RuntimeError("renderer went away between the two reads"),
+        TypeError("camera name must be a string"),
+    ],
+    ids=["KeyError", "ValueError", "RuntimeError", "TypeError"],
+)
+def test_a_failed_camera_params_read_reports_its_reason(exc: Exception) -> None:
+    """Every member of the handled tuple is reported, with the backend's own
+    reason carried through -- the caller cannot act on "it failed" alone, and
+    the render already succeeded so nothing else names the cause."""
+
+    class _ParamsRaise(_StubSim):
+        def get_camera_params(self, camera_name="default", width=None, height=None):
+            raise exc
+
+    result = _ParamsRaise(_flat_depth()).get_world_point("default", pixels=[[1, 1]])
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "camera parameters" in text
+    assert str(exc.args[0]) in text
+
+
+def test_the_two_backend_reads_are_distinguishable() -> None:
+    """One failure per read, same exception type, different text: a caller
+    that has to fix the camera must be able to tell a bad render from
+    unreadable intrinsics. The success control shares the fixture, so the
+    difference is the failing read and nothing else."""
+    boom = RuntimeError("backend went away")
+
+    class _FrameRaise(_StubSim):
+        def get_frame(self, camera_name="default", width=None, height=None):
+            raise boom
+
+    class _ParamsRaise(_StubSim):
+        def get_camera_params(self, camera_name="default", width=None, height=None):
+            raise boom
+
+    depth = _flat_depth()
+    assert _StubSim(depth).get_world_point("default", pixels=[[1, 1]])["status"] == "success"
+    frame_text = _FrameRaise(depth).get_world_point("default", pixels=[[1, 1]])["content"][0]["text"]
+    params_text = _ParamsRaise(depth).get_world_point("default", pixels=[[1, 1]])["content"][0]["text"]
+    assert frame_text != params_text
+    assert "render camera frame" in frame_text and "camera parameters" not in frame_text
+    assert "camera parameters" in params_text and "render camera frame" not in params_text
 
 
 # ----- Input validation ----- #


### PR DESCRIPTION
## Problem

`SimEngine.get_world_point` makes two backend reads and answers for each
independently, so the method can keep the never-raises envelope its own
docstring promises:

```python
try:
    _rgb, depth = self.get_frame(camera_name, width=width, height=height)
except NotImplementedError: ...
except (KeyError, ValueError, RuntimeError, TypeError) as e: ...
...
try:
    cam = self.get_camera_params(camera_name, width=w, height=h)
except NotImplementedError: ...                                  # never reached
except (KeyError, ValueError, RuntimeError, TypeError) as e: ...  # never reached
```

Only the first read's failure was ever driven. Both handlers behind the second
read, and the `SimEngine` defaults behind them, were unexecuted anywhere in the
suite -- the camera-params read had never raised at all:

| backend read | failure arm | on main |
| --- | --- | --- |
| `get_frame` | `NotImplementedError` | covered |
| `get_frame` | `KeyError` / `ValueError` / `RuntimeError` / `TypeError` | covered |
| `get_camera_params` | `NotImplementedError` | **not covered** |
| `get_camera_params` | `KeyError` / `ValueError` / `RuntimeError` / `TypeError` | **not covered** |
| `SimEngine.get_frame` | base default `raise` | **not covered** |
| `SimEngine.get_camera_params` | base default `raise` | **not covered** |

`tests/simulation/test_get_world_point_math.py` already scopes itself to "pure
math over `get_frame` **+ `get_camera_params`**" and pins the `get_frame` half
with `test_base_facade_without_raw_frames_is_a_structured_error`. There was no
`get_camera_params` counterpart.

That second read is not reachable by making the first one fail: it runs after a
frame has already rendered, on pixels this call has already bounds-checked. The
reachable instance needs no mock -- MuJoCo's orthographic free camera
rasterizes normally but has no pinhole `K`:

| | orthographic free camera | perspective, same scene |
| --- | --- | --- |
| `get_frame` | ok, 640x480 rgb + depth (26.1% of pixels carry geometry) | ok, 640x480 (26.4%) |
| `get_camera_params` | `ValueError: The free camera is orthographic ...` | ok, `fx=579.41` |
| `get_world_point` | `status=error`, reports the reason | `status=success`, point `[0.3997, -0.0641, 0.1002]` m |

## Change

Tests only, in the two modules that already own this contract, plus one
docstring correction.

`tests/simulation/test_get_world_point_math.py` (backend-agnostic, no MuJoCo/GL):

- both missing-path reports, pinned on the **dedicated arm's own wording**.
  `NotImplementedError` subclasses `RuntimeError`, so the handled tuple below
  would catch it too and still return an envelope -- the dedicated arm earns
  its place on the wording, and asserting only `status`, or only that the
  method name appears somewhere in the text, passes either way.
- every member of the handled tuple, with the backend's own reason carried
  through; at that point nothing else in the result names the cause.
- that the two reads stay **distinguishable**: same exception, different text,
  with the success control sharing the fixture.
- a premise test that the stubs reproduce `SimEngine`'s own defaults, so they
  exercise the arm rather than an invented exception.

`tests/simulation/mujoco/test_get_world_point.py` (GL-gated, real render):

- the orthographic case end to end -- the frame renders, the params read
  refuses, the envelope carries `orthographic` and the `add_camera` remedy --
  with a perspective control on the identical scene, camera and pixel.

`strands_robots/simulation/base.py`: `get_world_point`'s `Returns:` enumerated
its failure causes (`Newton`, all-invalid pixels, out-of-bounds, malformed
input) and named neither backend read, so a caller had no way to anticipate a
refusal that arrives after a successful render. It now names both reads and the
orthographic cause. **Docstring only** -- the docstring-stripped AST digest of
`base.py` is `cef58c812ca3008d` on both trees, and `git diff --numstat` reports
`10 2 strands_robots/simulation/base.py`.

## Fails pre-fix

The production code is correct, so the new tests pass on unmodified `main`;
what they fail on is a regression. Six plausible ones, each run against the new
cases and against the pre-existing cases in the same two files:

| regression introduced | new cases | pre-existing cases |
| --- | --- | --- |
| M1 dedicated `NotImplementedError` arm no longer catches | 1 failed | 0 failed |
| M2 that arm's report drops the method name | 1 failed | 0 failed |
| M3 handled tuple narrowed to `KeyError` | 5 failed | 0 failed |
| M4 params report drops the backend's reason | 5 failed | 0 failed |
| M5 params report copies the frame wording | 6 failed | 0 failed |
| M6 base default stops naming the method | 1 failed | 0 failed |

6 of 6 caught here, 0 of 6 by the pre-existing cases. M1 is the interesting
one: because `NotImplementedError` is a `RuntimeError` subclass it was
initially **invisible** to this PR's own test, which asserted only that the
method name appeared in the text -- true of the catch-all's message too. The
assertions now pin the dedicated arm's wording, and the docstring records why.

Each mutation anchor is scoped to its enclosing function by AST (`in_fn=1` for
all six; `except NotImplementedError:` alone occurs twice in `get_world_point`),
and the source is restored byte-identically.

## Coverage

`strands_robots/simulation/base.py`, lines closed by the new cases:
`4235`, `4269` (the two `SimEngine` defaults) and `4435`, `4436`, `4439`, `4440`
(the two camera-params arms). Nothing newly missing.

## Gate

Thor, MuJoCo 3.11.0, `MUJOCO_GL=egl`, base `f5442883`, head `4283b275`:

- `MUJOCO_GL=egl python3 -m pytest tests -q --no-cov -p no:randomly` ->
  **28544 passed, 257 skipped, 0 failed** in 621.68s. Pristine `main` at the
  same commit is 28535 passed / 257 skipped, and 28535 + 9 new cases = 28544.
- `ruff check strands_robots tests tests_integ` -> clean;
  `ruff format --check` -> 1185 files already formatted.
- `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/`**.
  The 14 `examples/isaac_gs` errors are byte-identical to a pristine-base
  worktree control, i.e. environmental.
- `scripts/assemble_changelog.py --check` -> OK (329 pending); the seven
  repo-wide root guards -> 422 passed.

## Artifact

Both frames below render successfully. The orthographic scene still cannot be
grounded, and nothing in the suite drove that path. The figure's left panel is
the frame the new MuJoCo test renders; the matrix and the mutation table are
read from the capture's `facts.json` and re-asserted by the compose step.

![get_world_point camera-params failure arms](https://raw.githubusercontent.com/cagataycali/robots/artifacts/get-world-point-camera-params-arms/get_world_point_camera_params_arms.png)

Capture, compose and mutation scripts: [`artifacts/get-world-point-camera-params-arms`](https://github.com/cagataycali/robots/tree/artifacts/get-world-point-camera-params-arms).

## Scope

No policy, simulation, rendering, recording or asset behaviour changes -- the
only non-test edit is a docstring, proven by the unchanged AST digest above.
Isaac's own `get_frame` / `get_camera_params` size contracts agree with each
other (both require the camera's native resolution), so `get_world_point`
cannot trip them by passing the returned frame's size back; that is unchanged
and out of scope here.
