### PR TITLE
feat(simulation/isaac): joint-space motion primitives - set_gripper / rotate_wrist on IsaacMotionPrimitivesMixin

### DIFF
--- a/changelog.d/2154-isaac-joint-space-primitives.md
+++ b/changelog.d/2154-isaac-joint-space-primitives.md
@@ -1,0 +1,18 @@
+### Added: joint-space motion primitives on the Isaac backend (`set_gripper` / `rotate_wrist`)
+
+`IsaacSimulation` now carries the two joint-space motion primitives on a new
+`IsaacMotionPrimitivesMixin`
+(`strands_robots/simulation/isaac/motion_primitives.py`), built on the shared
+`MotionPrimitivesCore` extracted in #2153: same parameter domains, same
+registry-gripper-metadata-first resolution (`closed`/`open` -> limit-range
+end, stale/malformed metadata a loud error rather than a silent heuristic
+fallback), same `_GRIPPER_HINTS`/`_WRIST_HINTS` name fallbacks, and the same
+structured success/timeout/abort envelopes as the MuJoCo reference
+implementation. Previously the only Isaac motion path was the raw kinematic
+`set_joint_positions` write - no blocking move, no timeout/abort contract, no
+gripper semantics. Resolution happens against the articulation's demangled
+URDF joint vocabulary (#1900), stripped of any robot-namespace path prefix;
+the drive loops run PD position targets on the Kit-owning thread (through
+`run_on_main` when the pump is engaged) and abort with a structured error if
+the world is destroyed or the robot removed mid-run. `move_to` (IK-backed,
+Cartesian) is a follow-up child of #2123.

--- a/strands_robots/simulation/isaac/motion_primitives.py
+++ b/strands_robots/simulation/isaac/motion_primitives.py
@@ -1,0 +1,626 @@
+"""Joint-space motion primitives for the Isaac backend - ``set_gripper`` / ``rotate_wrist``.
+
+The Isaac half of the analytic motion primitives (GH #1645; Isaac parity work
+GH #2123, this module is #2154). Before this module the only motion path on
+Isaac was the raw kinematic ``set_joint_positions`` write - no blocking move,
+no timeout/abort-reason contract, no registry-driven gripper semantics. The
+two joint-space primitives now share their backend-neutral half with the
+MuJoCo reference implementation
+(:mod:`strands_robots.simulation.mujoco.motion_primitives`) through
+:class:`~strands_robots.simulation.motion_primitives_base.MotionPrimitivesCore`:
+parameter domains, registry gripper metadata (``closed``/``open`` ->
+set-point-range end), the ``_GRIPPER_HINTS`` / ``_WRIST_HINTS`` name
+fallbacks, step budgets, and the structured success / timeout envelopes. An
+agent reading a refusal or a result payload sees the same sentence and the
+same json keys whichever backend produced it (AGENTS.md: "Match docstrings to
+semantics").
+
+``move_to`` (IK-backed, Cartesian) is deliberately not here - it lands in a
+follow-up child of #2123.
+
+What this adapter owns (the backend-specific half):
+
+* robot / world resolution against ``IsaacSimulation``'s own state
+  (``_robots`` / ``_world_created``), with this backend's established guard
+  wording;
+* the gripper / wrist DOF resolution against the articulation's ``joint_names``
+  - the demangled URDF vocabulary (#1900), further stripped of any
+  robot-namespace path prefix before the shared hints apply;
+* actuation: PD position targets via
+  ``articulation.apply_action(ArticulationAction(...))`` (the same Isaac Sim
+  6.0 surface ``send_action`` drives - the pre-6.0
+  ``set_joint_position_targets`` does not exist there), ticked by
+  ``world.step``;
+* the threading marshal: Isaac writes must happen on the thread that owns the
+  Kit pump, so the drive loop runs inline on the owning thread or is submitted
+  through :meth:`IsaacSimulation.run_on_main` when the pump is engaged.
+  Unlike :meth:`IsaacSimulation._marshal_main_thread_affine` (whose callers do
+  not all inspect the envelope), a primitive called off-thread with no pump
+  returns a structured error - the primitives' documented never-raises
+  contract.
+
+Contract notes shared with the MuJoCo mixin: errors are structured dicts
+(``{"status": "error", ...}``), never raised through the tool surface, and a
+failure is never reported as a zero-valued/silent-default success. The loops
+take ``self._lock`` per control tick, and if the world is destroyed or the
+robot removed mid-run the loop aborts with a structured error rather than
+stepping a torn-down stage.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from strands_robots.registry.robots import get_robot
+from strands_robots.simulation.models import registered, registry_entry
+from strands_robots.simulation.motion_primitives_base import (
+    _GRIPPER_HINTS,
+    _WRIST_HINTS,
+    MotionPrimitivesCore,
+    _err,
+)
+
+
+class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
+    """Joint-space motion primitives mixed into ``IsaacSimulation``.
+
+    **Coupling** (documentary contract, mirrored from the MuJoCo mixin):
+    reaches into ``self._robots``, ``self._world``, ``self._lock``, the
+    config, and the main-thread marshal helpers. The ``TYPE_CHECKING`` stubs
+    below exist so mypy accepts those lookups.
+    """
+
+    if TYPE_CHECKING:
+        _lock: Any  # threading.RLock from IsaacSimulation
+        _world: Any
+        _world_created: bool
+        _robots: dict[str, Any]  # name -> _RobotState
+        _config: Any  # IsaacConfig
+        _sim_time: float
+        _step_count: int
+        _pump_running: bool
+
+        def _on_main_thread(self) -> bool:
+            """Provided by ``IsaacSimulation``; declared here for type-checkers."""
+            raise NotImplementedError
+
+        def run_on_main(self, fn: Any, timeout: float | None = None) -> Any:
+            """Provided by ``IsaacSimulation``; declared here for type-checkers."""
+            raise NotImplementedError
+
+    # -- registry seam ---------------------------------------------------------
+
+    @staticmethod
+    def _get_registry_robot(data_config: str) -> dict[str, Any] | None:
+        """Registry lookup seam (see ``MotionPrimitivesCore._get_registry_robot``).
+
+        Resolves through this module's ``get_robot`` global so tests and user
+        code have a patch point local to the Isaac adapter
+        (``strands_robots.simulation.isaac.motion_primitives.get_robot``),
+        mirroring the MuJoCo mixin's historical seam.
+        """
+        return get_robot(data_config)
+
+    # -- shared guards / resolution --------------------------------------------
+
+    @staticmethod
+    def _short_joint_name(name: str | None) -> str:
+        """Strip any robot-namespace path prefix for hint / metadata matching.
+
+        Isaac articulations report the demangled URDF vocabulary
+        (:mod:`strands_robots.simulation.isaac.joint_names`, #1900), but a
+        robot loaded under a prim namespace can still report path-qualified
+        names (``so101/wrist_roll``). The shared hints and the registry
+        gripper metadata both speak the bare joint name, so matching happens
+        on the segment after the final ``/`` - the counterpart of the MuJoCo
+        mixin's ``robot.namespace`` strip.
+        """
+        return (name or "").rsplit("/", 1)[-1]
+
+    def _primitive_resolve_robot(self, robot_name: str | None) -> tuple[str | None, Any | None, dict[str, Any] | None]:
+        """Common primitive preamble: world + robot + articulation guards.
+
+        Returns ``(robot_name, robot_state, None)`` on success or
+        ``(None, None, error_dict)``. Callers must hold ``self._lock`` (the
+        checks read shared state). The guard wording is this backend's own
+        (``send_action`` / ``set_joint_positions`` established it) - robot and
+        world resolution is the half of the primitives that stays
+        backend-specific, per the ``MotionPrimitivesCore`` split.
+        """
+        if not self._world_created or self._world is None:
+            return None, None, _err("No world created.")
+        if robot_name is None:
+            if len(self._robots) == 1:
+                robot_name = next(iter(self._robots))
+            elif not self._robots:
+                return None, None, _err("No robots in the world.")
+            else:
+                return (
+                    None,
+                    None,
+                    _err(f"Multiple robots present; specify robot_name. Available: {sorted(self._robots)}"),
+                )
+        if not registered(self._robots, robot_name):
+            return None, None, _err(f"Robot '{robot_name}' not found.")
+        robot = self._robots[robot_name]
+        if robot.articulation is None:
+            return None, None, _err(f"Robot {robot_name!r} not initialized.")
+        return robot_name, robot, None
+
+    def _primitive_abort_reason(self, action: str, robot_name: str) -> dict[str, Any] | None:
+        """Mid-loop cancellation check (call under ``self._lock``).
+
+        The primitive loops release the lock between control ticks, so the
+        world can legitimately be destroyed or the robot removed while a
+        primitive runs. Either aborts the primitive with a structured error -
+        the same abort contract as the MuJoCo mixin - rather than stepping a
+        torn-down stage. (Isaac has no in-place model recompile, and policy
+        rollouts are driven externally by ``PolicyRunner``, so those MuJoCo
+        abort branches have no Isaac counterpart.)
+        """
+        if not self._world_created or self._world is None:
+            return _err(f"{action}: world was destroyed mid-run; aborting.")
+        robot = registry_entry(self._robots, robot_name)
+        if robot is None or robot.articulation is None:
+            return _err(f"{action}: robot '{robot_name}' was removed mid-run; aborting.")
+        return None
+
+    def _run_primitive_on_kit(self, action: str, fn: Any) -> dict[str, Any]:
+        """Run a drive loop on the thread that owns the Kit pump, never raising.
+
+        Isaac Sim only pumps kit updates on the thread that created
+        ``SimulationApp``, so ``world.step`` called from a worker thread blocks
+        forever (see :meth:`IsaacSimulation._marshal_main_thread_affine`). On
+        the owning thread ``fn`` runs inline; off it with the pump engaged it
+        is submitted through :meth:`IsaacSimulation.run_on_main`; off it with
+        no pump the primitive returns a structured error naming the recipe -
+        a raise here would escape the primitives' documented never-raises
+        contract, which is why this does not reuse the raising marshal.
+        """
+        if self._on_main_thread():
+            return fn()
+        if self._pump_running:
+            return self.run_on_main(fn)
+        return _err(
+            f"{action}: called from a worker thread with no main-thread pump running. "
+            "Isaac Sim only pumps kit updates on the thread that created SimulationApp, "
+            "so this call would block forever. Either call it from the owning thread, or "
+            "have the owning thread run `run_pump_forever(stop_event=...)` and submit the "
+            "call from the worker via `run_on_main(lambda: ...)`."
+        )
+
+    # -- articulation readers / writers -----------------------------------------
+
+    @staticmethod
+    def _read_joint_positions(articulation: Any) -> np.ndarray | None:
+        """Current joint positions as a flat float64 array, or ``None``.
+
+        Tolerates the surfaces the rest of this backend already handles: a
+        torch tensor (``.cpu().numpy()``, the pump's joint-cache read does the
+        same) and the exception set a torn-down articulation raises. ``None``
+        means "could not be read" - callers must answer that loudly, never by
+        substituting zeros.
+        """
+        try:
+            q = articulation.get_joint_positions()
+        except (RuntimeError, ValueError, AttributeError, TypeError):
+            return None
+        if q is None:
+            return None
+        arr = q.cpu().numpy() if hasattr(q, "cpu") else np.asarray(q)
+        return np.asarray(arr, dtype=np.float64).reshape(-1)
+
+    @staticmethod
+    def _articulation_dof_limits(articulation: Any, n_dofs: int) -> list[tuple[float, float] | None]:
+        """Per-DOF ``(lower, upper)`` limits, ``None`` where none are usable.
+
+        The Isaac counterpart of the MuJoCo mixin's ``jnt_range`` reads: the
+        articulation's ``dof_properties`` structured array (``lower`` /
+        ``upper``, honoring ``hasLimits`` when the field is present) is
+        authoritative, with the view-shaped ``get_dof_limits()`` as the
+        fallback surface. A DOF whose bounds are absent, non-finite, or
+        degenerate (``upper <= lower``) reports ``None`` - the caller refuses
+        loudly rather than mapping ``open``/``close`` onto a range that does
+        not exist.
+        """
+        lower: np.ndarray | None = None
+        upper: np.ndarray | None = None
+        has_limits: np.ndarray | None = None
+        props = getattr(articulation, "dof_properties", None)
+        if props is not None:
+            try:
+                lower = np.asarray(props["lower"], dtype=np.float64).reshape(-1)
+                upper = np.asarray(props["upper"], dtype=np.float64).reshape(-1)
+            except (KeyError, ValueError, IndexError, TypeError):
+                lower = upper = None
+            else:
+                try:
+                    has_limits = np.asarray(props["hasLimits"], dtype=bool).reshape(-1)
+                except (KeyError, ValueError, IndexError, TypeError):
+                    has_limits = None
+        if lower is None or upper is None:
+            get_limits = getattr(articulation, "get_dof_limits", None)
+            if get_limits is not None:
+                try:
+                    raw = get_limits()
+                    arr = raw.cpu().numpy() if hasattr(raw, "cpu") else np.asarray(raw)
+                    arr = np.asarray(arr, dtype=np.float64).reshape(-1, 2)
+                    lower, upper = arr[:, 0], arr[:, 1]
+                except (RuntimeError, ValueError, AttributeError, TypeError, IndexError):
+                    lower = upper = None
+        out: list[tuple[float, float] | None] = []
+        for dof in range(n_dofs):
+            if lower is None or upper is None or dof >= lower.size or dof >= upper.size:
+                out.append(None)
+                continue
+            if has_limits is not None and dof < has_limits.size and not bool(has_limits[dof]):
+                out.append(None)
+                continue
+            lo, hi = float(lower[dof]), float(upper[dof])
+            if not (math.isfinite(lo) and math.isfinite(hi)) or hi <= lo:
+                out.append(None)
+                continue
+            out.append((lo, hi))
+        return out
+
+    def _apply_position_targets(
+        self, action: str, robot_name: str, articulation: Any, targets: dict[int, float]
+    ) -> dict[str, Any] | None:
+        """Assert PD position targets on a DOF subset, as a structured result.
+
+        The same Isaac Sim 6.0 surface ``send_action`` drives:
+        ``apply_action(ArticulationAction(joint_positions=..., joint_indices=...))``
+        commands ONLY the indexed DOFs and leaves the rest at their current PD
+        targets. Same narrow exception set as ``send_action``'s write:
+        ``RuntimeError`` (torn-down articulation), ``ValueError`` (shape
+        mismatch), ``AttributeError`` (omni surface drift), ``ImportError``
+        (isaacsim runtime not importable). Returns ``None`` on success.
+        """
+        try:
+            from isaacsim.core.utils.types import (  # type: ignore[import-not-found]
+                ArticulationAction,
+            )
+
+            indices = sorted(targets)
+            articulation.apply_action(
+                ArticulationAction(
+                    joint_positions=np.array([targets[i] for i in indices], dtype=np.float32),
+                    joint_indices=np.array(indices, dtype=np.int32),
+                )
+            )
+        except (RuntimeError, ValueError, AttributeError, ImportError) as e:
+            return _err(f"{action}: failed to set joint position targets on '{robot_name}': {e}")
+        return None
+
+    def _primitive_tick(self) -> None:
+        """One control tick: advance physics, keep the clock bookkeeping.
+
+        Must be called under ``self._lock`` on the Kit-owning thread (the
+        drive loops run inside :meth:`_run_primitive_on_kit`). One
+        ``world.step`` per control tick - an Isaac step is a full kit update,
+        so there is no MuJoCo-style substep multiplier here; the budget a
+        caller passes IS the physics-step budget. Renders when the config is
+        not headless, matching ``send_action``.
+        """
+        self._world.step(render=self._config.render_mode != "headless")
+        self._sim_time += self._config.physics_dt
+        self._step_count += 1
+
+    def _resolve_gripper_dofs(self, robot: Any) -> tuple[list[int], dict[str, Any] | None, dict[str, Any] | None]:
+        """Resolve *robot*'s gripper DOF indices (registry first, heuristic fallback).
+
+        The shared classification behind ``set_gripper`` (which commands these
+        DOFs) and ``rotate_wrist`` (which must NOT pick one as the wrist).
+        Resolution order, mirroring the MuJoCo mixin (GH #1658):
+
+        1. Registry ``gripper`` metadata for the robot's ``data_config``, when
+           present (authoritative): a DOF qualifies when its
+           namespace-stripped joint name matches one of ``gripper.actuators``
+           exactly (case-insensitive) - on Isaac the articulation drives
+           joints directly, so the metadata's actuator names resolve against
+           the joint vocabulary. Metadata that matches NO joint is a loud
+           structured error, never a silent heuristic fallback.
+        2. Name heuristic (zero-config fallback): the stripped joint name
+           contains one of
+           :data:`~strands_robots.simulation.motion_primitives_base._GRIPPER_HINTS`.
+
+        Returns ``(dof_indices, metadata, error)`` on the same contract as the
+        MuJoCo mixin's ``_resolve_gripper_actuators``. Callers must hold
+        ``self._lock``.
+        """
+        short_names = [self._short_joint_name(n) for n in robot.joint_names]
+        meta, malformed_reason = self._registry_gripper_metadata(robot)
+        if malformed_reason is not None:
+            return [], None, _err(f"Cannot resolve the gripper for '{robot.name}': {malformed_reason}")
+        if meta is not None:
+            wanted = {str(a).lower() for a in meta["actuators"]}
+            matched = [i for i, short in enumerate(short_names) if short.lower() in wanted]
+            if not matched:
+                return (
+                    [],
+                    None,
+                    _err(
+                        f"Registry gripper metadata for '{robot.name}' (data_config "
+                        f"'{robot.data_config}') names actuators {meta['actuators']} but none "
+                        f"match a joint on the articulation. Articulation joints: {short_names}. "
+                        "The registry entry is stale for this robot; fix it, or drive the "
+                        "gripper directly with action='send_action'."
+                    ),
+                )
+            return matched, meta, None
+        matched = [i for i, short in enumerate(short_names) if any(h in short.lower() for h in _GRIPPER_HINTS)]
+        return matched, None, None
+
+    # -- primitives --------------------------------------------------------------
+
+    def set_gripper(
+        self,
+        robot_name: str | None = None,
+        state: str | None = None,
+        steps: int = 12,
+    ) -> dict[str, Any]:
+        """Drive the gripper to an open/close set-point (atomic primitive).
+
+        Resolves the gripper DOF(s) via :meth:`_resolve_gripper_dofs`
+        (registry ``gripper`` metadata for the robot's ``data_config`` when
+        present, else the ``gripper`` / ``finger`` / ``jaw`` name heuristic on
+        the articulation's joint names) and commands an end-point of the
+        joint's limit range as a PD position target on the Kit loop. With no
+        metadata, ``"open"`` drives to the HIGH end and ``"close"`` to the LOW
+        end - the SO-100/SO-101/Franka convention; registry metadata's
+        ``closed``/``open`` fields override it per robot. Same public API and
+        result semantics as the MuJoCo backend's
+        :meth:`~strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin.set_gripper`.
+
+        Args:
+            robot_name: Robot whose gripper to drive; defaults to the single
+                robot in the world (errors if ambiguous).
+            state: ``"open"`` or ``"close"`` (required).
+            steps: Control ticks to hold the set-point (1..10000); each tick
+                advances one physics step so the fingers actually travel.
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{state, actuators, targets, setpoint_sources,
+            gripper_joint_positions}`` (keyed by the namespace-stripped joint
+            names); structured error when the gripper cannot be resolved
+            (listing the joint names), the registry metadata is
+            stale/malformed, or the resolved joint has no usable limits to map
+            ``open``/``close`` onto. Never raises.
+        """
+        steps, arg_err = self._validate_set_gripper_args(state, steps)
+        if arg_err is not None:
+            return arg_err
+        assert state is not None  # narrowed by the shared validator
+        # Rebound under a plain-``str`` name for the closure below (mypy does
+        # not carry an Optional narrowing across a closure boundary).
+        gripper_state: str = state
+
+        with self._lock:
+            robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+            if error is not None:
+                return error
+            assert robot_name_resolved is not None and robot is not None
+            # Rebound under a plain-``str`` name: the drive closure below
+            # captures it, and mypy does not carry an Optional narrowing
+            # across a closure boundary.
+            name: str = robot_name_resolved
+            short_names = [self._short_joint_name(n) for n in robot.joint_names]
+
+            grip_dofs, grip_meta, grip_err = self._resolve_gripper_dofs(robot)
+            if grip_err is not None:
+                return grip_err
+            if not grip_dofs:
+                return _err(
+                    f"set_gripper: could not resolve a gripper joint for '{name}' - the "
+                    f"registry carries no gripper metadata for this robot and no joint name "
+                    f"contains {list(_GRIPPER_HINTS)}. Joints: {short_names}. "
+                    "Drive it directly with action='send_action' instead."
+                )
+
+            # Which END of the set-point range each state maps to: shared
+            # registry-metadata-first mapping (open=HIGH / close=LOW convention
+            # when no metadata; see MotionPrimitivesCore._gripper_state_end).
+            end = self._gripper_state_end(gripper_state, grip_meta)
+
+            limits = self._articulation_dof_limits(robot.articulation, len(short_names))
+            targets: dict[int, float] = {}
+            setpoint_sources: dict[int, str] = {}
+            for dof in grip_dofs:
+                span = limits[dof]
+                if span is None:
+                    return _err(
+                        f"set_gripper: joint '{short_names[dof]}' has no usable open/close "
+                        "set-points - the articulation reports no finite joint limits for it. "
+                        "Drive it directly with action='send_action'."
+                    )
+                lo, hi = span
+                targets[dof] = hi if end == "high" else lo
+                setpoint_sources[dof] = "articulation dof limits"
+            articulation = robot.articulation
+
+        def _drive() -> dict[str, Any]:
+            for _ in range(steps):
+                with self._lock:
+                    abort = self._primitive_abort_reason("set_gripper", name)
+                    if abort is not None:
+                        return abort
+                    apply_err = self._apply_position_targets("set_gripper", name, articulation, targets)
+                    if apply_err is not None:
+                        return apply_err
+                    self._primitive_tick()
+            with self._lock:
+                q = self._read_joint_positions(articulation)
+            if q is None or q.size < len(short_names):
+                # The drive ran, but the readback the success payload promises
+                # is gone - reporting success with fabricated positions would
+                # be a silent default.
+                return _err(
+                    f"set_gripper: commanded '{name}' {gripper_state} but could not read the "
+                    "gripper joint positions back from the articulation; the final state is "
+                    "unverified."
+                )
+            return self._set_gripper_result(
+                name,
+                gripper_state,
+                steps,
+                [short_names[d] for d in grip_dofs],
+                {short_names[d]: float(targets[d]) for d in grip_dofs},
+                {short_names[d]: setpoint_sources[d] for d in grip_dofs},
+                {short_names[d]: float(q[d]) for d in grip_dofs},
+            )
+
+        return self._run_primitive_on_kit("set_gripper", _drive)
+
+    def rotate_wrist(
+        self,
+        robot_name: str | None = None,
+        target_yaw: float | None = None,
+        tol: float = 0.02,
+        max_steps: int = 200,
+    ) -> dict[str, Any]:
+        """Rotate the wrist joint to a set-point, holding the arm posture.
+
+        Atomic primitive: resolves the wrist joint by name heuristic
+        (``wrist_roll`` / ``wrist_yaw`` / ``wrist_rotate`` / ``wrist``, else
+        the last non-gripper joint - the distal roll joint on most serial
+        arms; gripper DOFs are excluded via the shared registry-metadata-first
+        classification, :meth:`_resolve_gripper_dofs`), commands it to
+        ``target_yaw`` while every other articulated DOF holds its current
+        position as a PD target, and servoes on the Kit loop until the joint
+        is within ``tol`` radians or ``max_steps`` control ticks elapse.
+        Holding the other joints preserves the Cartesian EE position up to
+        servo compliance. Same public API and result semantics as the MuJoCo
+        backend's
+        :meth:`~strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin.rotate_wrist`.
+
+        Args:
+            robot_name: Robot whose wrist to rotate; defaults to the single
+                robot in the world (errors if ambiguous).
+            target_yaw: Wrist joint set-point in radians (required; must lie
+                within the joint's limits when the articulation reports them).
+            tol: Joint-angle convergence tolerance in radians (> 0).
+            max_steps: Max control ticks before returning a not-reached error
+                (1..10000).
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{reached, steps, wrist_joint, target_yaw, final_yaw,
+            yaw_error_rad}``; structured error (with the residual) when the
+            joint cannot be resolved, the registry gripper metadata is
+            stale/malformed (same contract as ``set_gripper``), the target is
+            out of range, or servo convergence times out. Never raises.
+        """
+        target_yaw, max_steps, arg_err = self._validate_rotate_wrist_args(target_yaw, tol, max_steps)
+        if arg_err is not None:
+            return arg_err
+
+        with self._lock:
+            robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+            if error is not None:
+                return error
+            assert robot_name_resolved is not None and robot is not None
+            # Rebound under a plain-``str`` name: the servo closure below
+            # captures it, and mypy does not carry an Optional narrowing
+            # across a closure boundary.
+            name: str = robot_name_resolved
+            short_names = [self._short_joint_name(n) for n in robot.joint_names]
+
+            # Exclude gripper DOFs via the shared registry-first classification
+            # (GH #1661), not a raw name-hint match: on so101 the joints are
+            # named 1..6 with no gripper hint, so the last-joint fallback below
+            # would otherwise pick joint 6 - which IS the jaw. Stale/malformed
+            # registry metadata is the same loud structured error set_gripper
+            # returns, never a silent fallback.
+            grip_dofs, _, grip_err = self._resolve_gripper_dofs(robot)
+            if grip_err is not None:
+                return grip_err
+            grip_set = set(grip_dofs)
+
+            # Candidates are every non-gripper DOF. The MuJoCo mixin narrows to
+            # hinge joints; the Isaac articulation's per-DOF joint-type
+            # reporting is not stable across API generations, so this adapter
+            # relies on the gripper classification alone - the case that bit
+            # (so101's revolute jaw) is excluded by it either way.
+            non_gripper = [i for i in range(len(short_names)) if i not in grip_set]
+            wrist_dof: int | None = None
+            for hint in _WRIST_HINTS:
+                matches = [i for i in non_gripper if hint in short_names[i].lower()]
+                if matches:
+                    wrist_dof = matches[-1]  # most distal on a name tie
+                    break
+            if wrist_dof is None and non_gripper:
+                # Fallback: the last (most distal) non-gripper DOF.
+                wrist_dof = non_gripper[-1]
+            if wrist_dof is None:
+                return _err(
+                    f"rotate_wrist: could not resolve a wrist joint for '{name}'. "
+                    f"Articulation joints: {short_names}. Drive one directly with "
+                    "action='send_action' instead."
+                )
+            # Rebound as a plain ``int`` for the closure below, same reason
+            # as ``name``.
+            wrist_index: int = wrist_dof
+            wrist_name = short_names[wrist_index]
+
+            span = self._articulation_dof_limits(robot.articulation, len(short_names))[wrist_index]
+            if span is not None:
+                lo, hi = span
+                if not (lo <= target_yaw <= hi):
+                    return _err(
+                        f"rotate_wrist: target_yaw={target_yaw} rad is outside joint "
+                        f"'{wrist_name}' range [{lo:.3f}, {hi:.3f}] rad."
+                    )
+
+            q0 = self._read_joint_positions(robot.articulation)
+            if q0 is None or q0.size < len(short_names):
+                return _err(
+                    f"rotate_wrist: could not read joint positions from '{name}' - the "
+                    "articulation did not report a usable joint-position vector."
+                )
+            start_yaw = float(q0[wrist_index])
+            # Hold every other DOF at its CURRENT position; command only the
+            # wrist to the set-point (grasp preservation: a closed gripper's
+            # DOF is held closed, mirroring the MuJoCo mixin).
+            targets = {i: (target_yaw if i == wrist_index else float(q0[i])) for i in range(len(short_names))}
+            articulation = robot.articulation
+
+        def _servo() -> dict[str, Any]:
+            steps_used = 0
+            reached = False
+            yaw_error = math.inf
+            final_yaw = start_yaw
+            for _ in range(max_steps):
+                with self._lock:
+                    abort = self._primitive_abort_reason("rotate_wrist", name)
+                    if abort is not None:
+                        return abort
+                    apply_err = self._apply_position_targets("rotate_wrist", name, articulation, targets)
+                    if apply_err is not None:
+                        return apply_err
+                    self._primitive_tick()
+                    q = self._read_joint_positions(articulation)
+                if q is None or wrist_index >= q.size:
+                    return _err(f"rotate_wrist: could not read joint positions from '{name}' mid-run; aborting.")
+                steps_used += 1
+                final_yaw = float(q[wrist_index])
+                yaw_error = abs(final_yaw - target_yaw)
+                if yaw_error <= float(tol):
+                    reached = True
+                    break
+            return self._rotate_wrist_result(
+                name,
+                float(tol),
+                max_steps,
+                reached=reached,
+                steps_used=steps_used,
+                wrist_name=wrist_name,
+                target_yaw=target_yaw,
+                final_yaw=final_yaw,
+                yaw_error=yaw_error,
+            )
+
+        return self._run_primitive_on_kit("rotate_wrist", _servo)

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -40,6 +40,7 @@ import numpy as np
 from strands_robots.simulation.base import SimEngine, unknown_kwargs_error
 from strands_robots.simulation.isaac.config import IsaacConfig
 from strands_robots.simulation.isaac.joint_names import demangle_usd_joint_names, urdf_joint_names
+from strands_robots.simulation.isaac.motion_primitives import IsaacMotionPrimitivesMixin
 from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.terrain import validate_difficulty
@@ -603,7 +604,7 @@ class _ObjectState:
         self.handle = handle
 
 
-class IsaacSimulation(IsaacRecordingMixin, SimEngine):
+class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine):
     """GPU-native simulation backend built on NVIDIA Isaac Sim.
 
     Implements the ``SimEngine`` ABC. Provides photorealistic rendering,
@@ -611,6 +612,9 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
     LeRobotDataset recording (``start_recording`` / ``save_episode`` /
     ``stop_recording`` / ``stream_dataset``) comes from
     :class:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin`,
+    and the joint-space motion primitives (``set_gripper`` /
+    ``rotate_wrist``) from
+    :class:`~strands_robots.simulation.isaac.motion_primitives.IsaacMotionPrimitivesMixin`,
     matching the MuJoCo and Newton backends.
 
     Parameters
@@ -6264,6 +6268,20 @@ class IsaacSimulation(IsaacRecordingMixin, SimEngine):
                     "# raw per-camera MP4 capture (no lerobot dependency)"
                 ),
                 "stop_cameras_recording": "() -> dict  # finalize the raw MP4 capture",
+                # Joint-space motion primitives (GH #2154, Isaac half of the
+                # GH #1645 vocabulary; shared contract in
+                # strands_robots.simulation.motion_primitives_base).
+                "set_gripper": (
+                    "(robot_name=None, state='open'|'close', steps=12) -> dict  # "
+                    "drive the gripper joint(s) to the open/close set-point "
+                    "(registry gripper metadata when present, else open=HIGH / "
+                    "close=LOW end of the joint's limit range)"
+                ),
+                "rotate_wrist": (
+                    "(robot_name=None, target_yaw, tol=0.02, max_steps=200) -> dict  "
+                    "# rotate the wrist joint to a set-point (radians) while the "
+                    "other joints hold their current positions"
+                ),
             }
         )
         return desc

--- a/tests/simulation/isaac/test_motion_primitives.py
+++ b/tests/simulation/isaac/test_motion_primitives.py
@@ -1,0 +1,512 @@
+"""Joint-space motion primitives on the Isaac backend - ``set_gripper`` / ``rotate_wrist``.
+
+The Isaac adapter (#2154, child of the parity epic #2123) shares its
+backend-neutral half with the MuJoCo reference implementation through
+:class:`~strands_robots.simulation.motion_primitives_base.MotionPrimitivesCore`,
+so the contracts pinned here are cross-backend claims:
+
+  * validation rejections come from the shared core, so their wording is
+    byte-identical to MuJoCo's by construction - pinned by comparing the
+    Isaac surface's envelope against the core's own output;
+  * gripper resolution is registry-metadata-first with the shared name-hint
+    fallback, and stale/malformed metadata is a loud error, never a silent
+    heuristic fallback (the so101 jaw misclassification, GH #1658/#1661);
+  * the drive loops carry the same success / timeout / abort envelope shape.
+
+These tests deliberately do NOT require NVIDIA Isaac Sim (the pattern of
+``tests/simulation/isaac/test_isaac_backend.py`` /
+``test_urdf_joint_name_demangle.py``): the articulation, the world and the
+``ArticulationAction`` type are all faked, so resolution, convergence,
+timeout and abort are all exercised on any host. Real-GPU integration
+coverage is the tests child of #2123 and lives in ``tests_integ/``.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import math
+import sys
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+from strands_robots.simulation.motion_primitives_base import MotionPrimitivesCore, _err
+
+# ---------------------------------------------------------------------------
+# Fakes: articulation with PD-target servo semantics, world whose step()
+# advances the articulation toward its targets, and the one isaacsim type the
+# adapter lazily imports.
+# ---------------------------------------------------------------------------
+
+
+class _FakeArticulationAction:
+    """Stand-in for ``isaacsim.core.utils.types.ArticulationAction``."""
+
+    def __init__(self, joint_positions=None, joint_indices=None):
+        self.joint_positions = joint_positions
+        self.joint_indices = joint_indices
+
+
+class _FakeArticulation:
+    """Articulation with joint limits and a per-step PD-servo model.
+
+    ``apply_action`` records the commanded targets; each ``advance()`` (wired
+    to the fake world's ``step``) moves every targeted DOF toward its target
+    by ``servo_rate`` of the remaining distance. ``servo_rate=0.0`` models an
+    arm that never converges (the timeout path).
+    """
+
+    def __init__(
+        self,
+        joint_names: list[str],
+        limits: list[tuple[float, float] | None],
+        positions: list[float] | None = None,
+        servo_rate: float = 0.5,
+    ):
+        n = len(joint_names)
+        assert len(limits) == n
+        self.positions = np.array(positions if positions is not None else [0.0] * n, dtype=np.float64)
+        self.servo_rate = servo_rate
+        self.applied: list[Any] = []
+        self._targets: dict[int, float] = {}
+        self.dof_properties = np.zeros(n, dtype=[("hasLimits", "?"), ("lower", "f8"), ("upper", "f8")])
+        for i, span in enumerate(limits):
+            if span is None:
+                self.dof_properties["hasLimits"][i] = False
+            else:
+                self.dof_properties["hasLimits"][i] = True
+                self.dof_properties["lower"][i] = span[0]
+                self.dof_properties["upper"][i] = span[1]
+
+    def get_joint_positions(self):
+        return self.positions.copy()
+
+    def apply_action(self, action) -> None:
+        self.applied.append(action)
+        for idx, value in zip(np.asarray(action.joint_indices), np.asarray(action.joint_positions)):
+            self._targets[int(idx)] = float(value)
+
+    def advance(self) -> None:
+        for idx, target in self._targets.items():
+            self.positions[idx] += self.servo_rate * (target - self.positions[idx])
+
+
+class _FakeWorld:
+    """World whose ``step`` drives the articulation servo and an optional hook."""
+
+    def __init__(self, articulation: _FakeArticulation, on_step=None):
+        self.articulation = articulation
+        self.on_step = on_step
+        self.steps = 0
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        self.steps += 1
+        if self.on_step is not None:
+            self.on_step()
+        self.articulation.advance()
+
+
+@pytest.fixture(autouse=True)
+def fake_articulation_action(monkeypatch):
+    """Provide the ``isaacsim.core.utils.types`` module the adapter imports."""
+    names = ("isaacsim", "isaacsim.core", "isaacsim.core.utils", "isaacsim.core.utils.types")
+    mods = {}
+    for name in names:
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    mods["isaacsim.core.utils.types"].ArticulationAction = _FakeArticulationAction
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim.core"].utils = mods["isaacsim.core.utils"]
+    mods["isaacsim.core.utils"].types = mods["isaacsim.core.utils.types"]
+    return mods
+
+
+# A generic hobby-arm vocabulary the name heuristics resolve against.
+ARM_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow", "wrist_roll", "jaw"]
+ARM_LIMITS: list[tuple[float, float] | None] = [
+    (-3.1, 3.1),
+    (-1.8, 1.8),
+    (-2.4, 2.4),
+    (-1.7, 1.7),
+    (-0.2, 1.5),
+]
+
+
+def _make_sim(
+    joint_names: list[str] = ARM_JOINTS,
+    limits: list[tuple[float, float] | None] = ARM_LIMITS,
+    robot_name: str = "arm",
+    data_config: str | None = None,
+    positions: list[float] | None = None,
+    servo_rate: float = 0.5,
+    on_step=None,
+) -> tuple[IsaacSimulation, _FakeArticulation]:
+    sim = IsaacSimulation()
+    art = _FakeArticulation(joint_names, limits, positions=positions, servo_rate=servo_rate)
+    sim._world = _FakeWorld(art, on_step=on_step)
+    sim._world_created = True
+    sim._robots[robot_name] = _RobotState(
+        name=robot_name,
+        prim_path=f"/World/Robots/{robot_name}",
+        joint_names=list(joint_names),
+        articulation=art,
+        data_config=data_config,
+    )
+    return sim, art
+
+
+def _json_block(result: dict) -> dict:
+    blocks = [c["json"] for c in result["content"] if "json" in c]
+    assert blocks, result
+    return blocks[0]
+
+
+# ---------------------------------------------------------------------------
+# Validation: the rejections are the shared core's, byte-identical to MuJoCo.
+# ---------------------------------------------------------------------------
+
+
+class TestValidationReusesTheCore:
+    """A rejected parameter answers with the core's own envelope."""
+
+    def test_invalid_state_matches_core_wording(self):
+        sim, _ = _make_sim()
+        result = sim.set_gripper(robot_name="arm", state="ajar")
+        _, expected = MotionPrimitivesCore()._validate_set_gripper_args("ajar", 12)
+        assert result == expected
+        assert '"open" or "close"' in result["content"][0]["text"]
+
+    def test_missing_state_rejected(self):
+        sim, _ = _make_sim()
+        assert sim.set_gripper(robot_name="arm")["status"] == "error"
+
+    @pytest.mark.parametrize("steps", [0, -1, 10_001, 2.7, True, None, "12"])
+    def test_bad_steps_matches_core_wording(self, steps):
+        sim, art = _make_sim()
+        result = sim.set_gripper(robot_name="arm", state="open", steps=steps)
+        _, expected = MotionPrimitivesCore()._validate_set_gripper_args("open", steps)
+        assert result == expected
+        assert result["status"] == "error"
+        assert art.applied == []  # refused before any write
+
+    def test_missing_target_yaw_matches_core_wording(self):
+        sim, _ = _make_sim()
+        result = sim.rotate_wrist(robot_name="arm")
+        _, _, expected = MotionPrimitivesCore()._validate_rotate_wrist_args(None, 0.02, 200)
+        assert result == expected
+        assert "target_yaw" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("tol", [0.0, -0.1, math.nan, math.inf, True, "0.05"])
+    def test_bad_tol_matches_core_wording(self, tol):
+        sim, art = _make_sim()
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.3, tol=tol)
+        _, _, expected = MotionPrimitivesCore()._validate_rotate_wrist_args(0.3, tol, 200)
+        assert result == expected
+        assert result["status"] == "error"
+        assert art.applied == []
+
+
+class TestGuards:
+    """Backend-owned world / robot resolution, this backend's wording."""
+
+    def test_no_world_errors(self):
+        sim = IsaacSimulation()
+        result = sim.set_gripper(state="open")
+        assert result == _err("No world created.")
+        assert sim.rotate_wrist(target_yaw=0.3) == _err("No world created.")
+
+    def test_unknown_robot_errors(self):
+        sim, _ = _make_sim()
+        result = sim.set_gripper(robot_name="nope", state="open")
+        assert result["status"] == "error"
+        assert "not found" in result["content"][0]["text"]
+
+    def test_single_robot_auto_resolves(self):
+        sim, _ = _make_sim()
+        assert sim.set_gripper(state="close")["status"] == "success"
+
+    def test_multiple_robots_require_a_name(self):
+        sim, _ = _make_sim()
+        art2 = _FakeArticulation(["a", "b_gripper"], [(-1, 1), (0, 1)])
+        sim._robots["other"] = _RobotState(
+            name="other", prim_path="/World/Robots/other", joint_names=["a", "b_gripper"], articulation=art2
+        )
+        result = sim.rotate_wrist(target_yaw=0.1)
+        assert result["status"] == "error"
+        assert "Multiple robots" in result["content"][0]["text"]
+
+    def test_uninitialized_articulation_errors(self):
+        sim, _ = _make_sim()
+        sim._robots["arm"].articulation = None
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        assert "not initialized" in result["content"][0]["text"]
+
+    def test_worker_thread_without_pump_is_a_structured_error(self):
+        # Isaac writes must happen on the Kit-owning thread. Called off it
+        # with no pump, the primitive answers with the recipe instead of the
+        # raising marshal step()/reset() use - never-raises contract.
+        sim, art = _make_sim()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(sim.set_gripper, robot_name="arm", state="open").result()
+        assert result["status"] == "error"
+        assert "run_pump_forever" in result["content"][0]["text"]
+        assert art.applied == []
+
+
+# ---------------------------------------------------------------------------
+# set_gripper: resolution, range-end mapping, payload.
+# ---------------------------------------------------------------------------
+
+
+class TestSetGripper:
+    """Open/close set-point semantics (LOW end = closed, HIGH end = open)."""
+
+    def test_close_drives_toward_low_end(self):
+        sim, art = _make_sim(positions=[0, 0, 0, 0, 1.0], servo_rate=0.9)
+        result = sim.set_gripper(robot_name="arm", state="close", steps=40)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["targets"]["jaw"] == pytest.approx(-0.2)
+        assert payload["setpoint_sources"]["jaw"] == "articulation dof limits"
+        assert art.positions[4] < -0.1  # traveled toward the low (closed) end
+        assert payload["gripper_joint_positions"]["jaw"] == pytest.approx(art.positions[4])
+
+    def test_open_drives_toward_high_end(self):
+        sim, art = _make_sim(positions=[0, 0, 0, 0, -0.2], servo_rate=0.9)
+        result = sim.set_gripper(robot_name="arm", state="open", steps=40)
+        assert result["status"] == "success", result
+        assert _json_block(result)["targets"]["jaw"] == pytest.approx(1.5)
+        assert art.positions[4] > 1.0
+
+    def test_target_reasserted_every_tick(self):
+        sim, art = _make_sim()
+        result = sim.set_gripper(robot_name="arm", state="close", steps=7)
+        assert result["status"] == "success", result
+        assert len(art.applied) == 7
+        # Only the gripper DOF is commanded; the arm stays on its own targets.
+        for action in art.applied:
+            assert list(np.asarray(action.joint_indices)) == [4]
+
+    def test_unresolvable_gripper_lists_joint_names(self):
+        sim, _ = _make_sim(joint_names=["j1", "j2", "j3"], limits=[(-1, 1)] * 3)
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "could not resolve a gripper joint" in text
+        assert "['j1', 'j2', 'j3']" in text
+        assert "send_action" in text
+
+    def test_namespaced_joint_names_resolve_via_stripping(self):
+        sim, _ = _make_sim(
+            joint_names=["arm/shoulder", "arm/jaw"],
+            limits=[(-1.0, 1.0), (-0.2, 1.5)],
+        )
+        result = sim.set_gripper(robot_name="arm", state="open", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["actuators"] == ["jaw"]
+
+    def test_unusable_limits_are_a_loud_error(self):
+        sim, art = _make_sim(limits=[(-3.1, 3.1), (-1.8, 1.8), (-2.4, 2.4), (-1.7, 1.7), None])
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        assert "no usable open/close set-points" in result["content"][0]["text"]
+        assert art.applied == []
+
+
+class TestGripperRegistryMetadata:
+    """Registry gripper metadata beats the name heuristic (GH #1658)."""
+
+    def _patch_registry(self, monkeypatch, meta):
+        monkeypatch.setattr(
+            "strands_robots.simulation.isaac.motion_primitives.get_robot",
+            lambda name: {"gripper": meta} if name == "so101" else None,
+        )
+
+    def test_metadata_resolves_a_hint_less_jaw(self, monkeypatch):
+        # so101-style numeric vocabulary: no name hint matches, only the
+        # registry metadata can say DOF "6" is the jaw.
+        self._patch_registry(monkeypatch, {"actuators": ["6"], "closed": "low", "open": "high"})
+        sim, art = _make_sim(
+            joint_names=["1", "2", "3", "4", "5", "6"],
+            limits=[(-1.9, 1.9)] * 5 + [(-0.2, 1.5)],
+            data_config="so101",
+        )
+        result = sim.set_gripper(robot_name="arm", state="open", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["actuators"] == ["6"]
+        assert list(np.asarray(art.applied[0].joint_indices)) == [5]
+
+    def test_inverted_open_close_convention_honored(self, monkeypatch):
+        self._patch_registry(monkeypatch, {"actuators": ["6"], "closed": "high", "open": "low"})
+        sim, _ = _make_sim(
+            joint_names=["1", "2", "3", "4", "5", "6"],
+            limits=[(-1.9, 1.9)] * 5 + [(-0.2, 1.5)],
+            data_config="so101",
+        )
+        result = sim.set_gripper(robot_name="arm", state="open", steps=5)
+        assert result["status"] == "success", result
+        assert _json_block(result)["targets"]["6"] == pytest.approx(-0.2)  # open = LOW here
+
+    def test_stale_metadata_is_a_loud_error_not_a_heuristic_fallback(self, monkeypatch):
+        # The metadata names a joint the articulation does not have; falling
+        # back to the hints would command whatever the heuristic guesses.
+        self._patch_registry(monkeypatch, {"actuators": ["NoSuchJoint"], "closed": "low", "open": "high"})
+        sim, art = _make_sim(data_config="so101")
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "stale" in text
+        assert "NoSuchJoint" in text
+        assert art.applied == []
+
+    def test_malformed_metadata_is_a_loud_error(self, monkeypatch):
+        self._patch_registry(monkeypatch, {"actuators": [], "closed": "low", "open": "low"})
+        sim, _ = _make_sim(data_config="so101")
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        assert "malformed" in result["content"][0]["text"]
+
+    def test_no_data_config_still_uses_heuristic(self):
+        sim, _ = _make_sim(data_config=None)
+        assert sim.set_gripper(robot_name="arm", state="close")["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# rotate_wrist: resolution, hold semantics, convergence / timeout / abort.
+# ---------------------------------------------------------------------------
+
+
+class TestRotateWrist:
+    """Wrist set-point semantics on a mocked converging articulation."""
+
+    def test_reaches_target_yaw(self):
+        sim, art = _make_sim(servo_rate=0.5)
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.7)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert payload["wrist_joint"] == "wrist_roll"
+        assert payload["final_yaw"] == pytest.approx(0.7, abs=0.03)
+        assert art.positions[3] == pytest.approx(0.7, abs=0.03)
+
+    def test_holds_other_joints_at_their_current_positions(self):
+        start = [0.4, -0.3, 0.9, 0.0, 0.2]
+        sim, art = _make_sim(positions=list(start))
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.5)
+        assert result["status"] == "success", result
+        action = art.applied[0]
+        held = dict(
+            zip(
+                (int(i) for i in np.asarray(action.joint_indices)),
+                (float(v) for v in np.asarray(action.joint_positions)),
+            )
+        )
+        assert held[3] == pytest.approx(0.5)  # the wrist is commanded
+        for dof in (0, 1, 2, 4):  # the rest (jaw included) hold current
+            assert held[dof] == pytest.approx(start[dof])
+        for dof in (0, 1, 2, 4):
+            # Targets ride an ArticulationAction as float32 (parity with
+            # send_action), so "held" is exact only to float32 precision.
+            assert art.positions[dof] == pytest.approx(start[dof], abs=1e-6)
+
+    def test_out_of_range_target_rejected(self):
+        sim, art = _make_sim()
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=10.0)
+        assert result["status"] == "error"
+        assert "outside joint 'wrist_roll' range" in result["content"][0]["text"]
+        assert art.applied == []
+
+    def test_timeout_returns_structured_error_with_residual(self):
+        # servo_rate=0 models an arm that never moves: the primitive must
+        # burn its budget and answer with the shared not-reached envelope.
+        sim, _ = _make_sim(servo_rate=0.0)
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.7, tol=0.01, max_steps=8)
+        assert result["status"] == "error"
+        assert "did not reach" in result["content"][0]["text"]
+        payload = _json_block(result)
+        assert payload["reached"] is False
+        assert payload["steps"] == 8
+        assert payload["yaw_error_rad"] == pytest.approx(0.7)
+
+    def test_jaw_is_never_selected_as_wrist_on_so101_style_model(self, monkeypatch):
+        # Numeric joint names carry no wrist hint, so the fallback picks the
+        # last NON-GRIPPER joint - which must be "5", not the jaw "6" the raw
+        # last-joint heuristic would grab (GH #1661).
+        monkeypatch.setattr(
+            "strands_robots.simulation.isaac.motion_primitives.get_robot",
+            lambda name: (
+                {"gripper": {"actuators": ["6"], "closed": "low", "open": "high"}} if name == "so101" else None
+            ),
+        )
+        sim, _ = _make_sim(
+            joint_names=["1", "2", "3", "4", "5", "6"],
+            limits=[(-1.9, 1.9)] * 6,
+            data_config="so101",
+        )
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.3)
+        assert result["status"] == "success", result
+        assert _json_block(result)["wrist_joint"] == "5"
+
+    def test_no_metadata_fallback_is_last_non_gripper_joint(self):
+        sim, _ = _make_sim(joint_names=["base", "lift", "elbow", "jaw"], limits=[(-2, 2)] * 4)
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.3)
+        assert result["status"] == "success", result
+        assert _json_block(result)["wrist_joint"] == "elbow"
+
+    def test_gripper_only_articulation_cannot_resolve_a_wrist(self):
+        sim, _ = _make_sim(joint_names=["jaw"], limits=[(-0.2, 1.5)])
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.3)
+        assert result["status"] == "error"
+        assert "could not resolve a wrist joint" in result["content"][0]["text"]
+
+    def test_unknown_limits_do_not_block_the_move(self):
+        # An articulation that reports no limits for the wrist cannot range-
+        # check the target, but the move itself is still legitimate.
+        sim, _ = _make_sim(limits=[(-3.1, 3.1), (-1.8, 1.8), (-2.4, 2.4), None, (-0.2, 1.5)])
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.4)
+        assert result["status"] == "success", result
+
+
+class TestMidRunAbort:
+    """The loops release the lock per tick; teardown mid-run aborts loudly."""
+
+    def test_robot_removed_mid_run_aborts(self):
+        sim_box: dict[str, IsaacSimulation] = {}
+
+        def _remove_robot():
+            sim_box["sim"]._robots.pop("arm", None)
+
+        sim, _ = _make_sim(servo_rate=0.0, on_step=_remove_robot)
+        sim_box["sim"] = sim
+        result = sim.rotate_wrist(robot_name="arm", target_yaw=0.7, max_steps=50)
+        assert result == _err("rotate_wrist: robot 'arm' was removed mid-run; aborting.")
+
+    def test_world_destroyed_mid_run_aborts(self):
+        sim_box: dict[str, IsaacSimulation] = {}
+
+        def _destroy_world():
+            sim_box["sim"]._world_created = False
+
+        sim, _ = _make_sim(servo_rate=0.0, on_step=_destroy_world)
+        sim_box["sim"] = sim
+        result = sim.set_gripper(robot_name="arm", state="open", steps=50)
+        assert result == _err("set_gripper: world was destroyed mid-run; aborting.")
+        # One tick ran before the abort became observable, no more.
+        assert sim._world.steps == 1
+
+
+class TestDiscoverySurface:
+    """describe() advertises the primitives like the MuJoCo backend does."""
+
+    def test_describe_advertises_primitives(self):
+        sim = IsaacSimulation()
+        methods = sim.describe()["methods"]
+        assert "set_gripper" in methods
+        assert "rotate_wrist" in methods
+        assert "open" in methods["set_gripper"]
+        assert "target_yaw" in methods["rotate_wrist"]


### PR DESCRIPTION
Closes #2154

Part of the Isaac motion-primitives parity epic #2123. Builds on the `MotionPrimitivesCore` extraction (#2153, merged as #2175).

## What changed

- **New module `strands_robots/simulation/isaac/motion_primitives.py`** with `IsaacMotionPrimitivesMixin(MotionPrimitivesCore)`, mixed into `IsaacSimulation`. The backend-neutral half (parameter domains, registry gripper metadata, `_GRIPPER_HINTS`/`_WRIST_HINTS`, step budgets, success/timeout envelopes) comes from the shared core, so wording and payload shape are byte-identical to MuJoCo by construction.
- **`set_gripper(state, ...)`**: resolves the gripper DOF via registry `gripper` metadata for the robot's `data_config` first (authoritative; stale/malformed metadata is a loud structured error, never a silent heuristic fallback - the #1658/#1661 contract), name-hint fallback on the articulation's joint names second. Maps `open`/`closed` onto the joint's limit-range end (`dof_properties` lower/upper, honoring `hasLimits`; `get_dof_limits()` as the fallback surface) and drives PD position targets via `apply_action(ArticulationAction(...))` - the same Isaac Sim 6.0 surface `send_action` uses. An unresolvable gripper returns the structured error listing the joint names, same as MuJoCo.
- **`rotate_wrist(angle, ...)`**: `_WRIST_HINTS` first, else the last non-gripper DOF - the gripper set comes from the shared registry-first classification, so the so101-style numeric vocabulary never picks the jaw as the wrist. Position-targets the wrist while every other DOF holds its current position (grasp preservation); polls convergence per control tick with the shared timeout envelope.
- **Threading**: the drive loops run on the Kit-owning thread - inline when called there, through `run_on_main` when the pump is engaged, and a worker-thread call with no pump answers with a structured error naming the `run_pump_forever` recipe (the primitives' never-raises contract; deliberately not the raising `_marshal_main_thread_affine` used by `step`/`reset`).
- **Joint naming**: resolution happens against the articulation's demangled URDF vocabulary (#1900), further stripped of any robot-namespace path prefix before the shared hints/metadata match.
- **Mid-run aborts**: world destroyed or robot removed between control ticks aborts with a structured error rather than stepping a torn-down stage. (Isaac has no in-place recompile and policies run externally via `PolicyRunner`, so those MuJoCo abort branches have no counterpart here - documented in the mixin.)
- `describe()` advertises both primitives, matching the MuJoCo discovery surface.

`move_to` (IK-backed, Cartesian) is deliberately out of scope; it lands in a follow-up child of #2123.

## Test surface

`tests/simulation/isaac/test_motion_primitives.py` - 44 tests, no Isaac Kit required (fake articulation/world/`ArticulationAction`, the established pattern of `test_backend_parity.py` / `test_urdf_joint_name_demangle.py`):

- validation rejections compared **against the shared core's own envelopes** (byte-identical to MuJoCo by construction), and pinned to precede any articulation write;
- gripper resolution: heuristic hit, namespaced-name stripping, registry metadata resolving a hint-less jaw, inverted `open`/`closed` convention, stale metadata loud-error, malformed metadata loud-error, unusable limits loud-error, unresolvable-gripper error listing joint names;
- wrist resolution: hint match, last-non-gripper fallback, jaw-never-selected on a so101-style model, gripper-only articulation refused, out-of-range target refused;
- mocked-controller convergence (reached), timeout (not-reached envelope with residual), and both mid-run abort reasons (robot removed / world destroyed);
- worker-thread-without-pump returns a structured error, never raises;
- `describe()` advertises both primitives.

## Acceptance criteria (from #2154)

- [x] Unit tests under `tests/simulation/isaac/`, no GPU needed (same kit-free pattern as the existing Isaac tests); validation rejections reuse the core and match MuJoCo's error text; resolution logic tested against mocked articulation joint lists; mocked convergence/timeout path pinning the abort reason
- [x] MuJoCo suite untouched and green (`tests/simulation/mujoco/test_motion_primitives*.py`: 115 passed, 5 skipped)
- [x] `hatch run format && hatch run lint && hatch run test` green - full suite 28579 passed, 262 skipped, coverage 95.48%
- [x] Changelog fragment `changelog.d/2154-isaac-joint-space-primitives.md`

## Out-of-scope follow-ups (tracked on #2123)

- `move_to` (IK-backed Cartesian primitive) on Isaac
- Real-GPU integration coverage (`tests_integ/`) for the primitives

Project board: please move #2154 to "In review" (or it will follow the automation on merge).
