### PR TITLE
fix(utils): report a vector whose length cannot be read

### DIFF
--- a/changelog.d/2201-finite-vector-unreadable-length.md
+++ b/changelog.d/2201-finite-vector-unreadable-length.md
@@ -1,0 +1,25 @@
+### Fixed: `finite_vector_error` reports a vector whose length cannot be read
+
+`finite_vector_error` is the verdict half of the shared component read: it
+returns a message rather than the floats, so a caller counts the components
+itself, by reading the value again. It documented deferring that count, and
+deferring it is what makes a *readable* length part of the verdict - a value with
+no length cannot be read twice, because the read behind the verdict consumes it.
+
+It was the one guard in the family not asking. `coerce_size_vector` (its own
+coercing sibling over the same read), `coerce_rgba` and `_read_pose_vector` all
+refuse an unreadable length, the middle one with a comment naming this exact
+value class. The verdict half accepted it, and both of its live call sites then
+read the consumed value: `add_object(size=<generator of three edge lengths>)`
+reported `box needs 3 'size' component(s) ... got 0 (size=[])` - describing a
+caller who passed nothing - and `patch_scene_mjcf`'s `size` field carried `object
+of type 'generator' has no len()` into its envelope, naming neither the field nor
+the op while `pos`, `quat` and `rgba` on that same op named both.
+
+The probe now runs after the component read, which is the order
+`coerce_size_vector` uses and the reason every refusal this guard already gave is
+unchanged: a value whose `__iter__` raises, or whose read fails part-way, has no
+readable length either, and those verdicts describe what happened instead of
+claiming a domain check that never ran. Four value classes move from accepted to
+refused - a generator, an iterator, a `map` and an iterable whose `__len__`
+raises - each in the words its sibling coercion already used.

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1735,8 +1735,39 @@ def finite_vector_error(method: str, param_name: str, vec: Any) -> str | None:
     The read itself is :func:`_read_finite_vector`, which returns the floats it
     built alongside this verdict; this is the verdict half, for the callers that
     want only a message. Both are one read of ``vec`` (#1906).
+
+    Deferring the count is what makes a *readable* length part of this verdict.
+    A caller holding only a message counts the components by reading ``vec``
+    again, and a value with no readable length cannot be read twice - the read
+    behind this verdict consumes it, so the caller's own count sees nothing. That
+    is a different question from the count itself ("how many components is this?"
+    versus "is that answerable at all"), and it is the one
+    :func:`sequence_length` owns and cannot raise answering (#1888). Refusing it
+    is the rule :func:`coerce_size_vector` - this function's own sibling over the
+    same read - :func:`coerce_rgba` and :func:`_read_pose_vector` already apply,
+    in the same words and for the same reason. Without it a generator of finite
+    numbers passed this verdict and then reached the caller's count as an empty
+    vector, so ``add_object`` reported a three-component extent as ``got 0
+    (size=[])`` and ``patch_scene_mjcf`` raised ``object of type 'generator' has
+    no len()`` into its envelope, naming neither the field nor the method while
+    the sibling fields of that same op named both.
+
+    The probe runs *after* the component read rather than before it, which is the
+    order :func:`coerce_size_vector` uses and the reason every refusal this guard
+    already gave is unchanged: a value whose ``__iter__`` raises, or whose read
+    fails part-way, has no readable length either, and those verdicts say what
+    actually happened instead of reporting a domain check that never ran (#1875,
+    #1878).
     """
-    return _read_finite_vector(method, param_name, vec)[1]
+    err = _read_finite_vector(method, param_name, vec)[1]
+    if err is not None:
+        return err
+    if sequence_length(vec) is None:
+        # The components were read and were finite; what the value cannot supply
+        # is a length for the caller to count. Same words as the sibling
+        # coercions, because it is the same verdict about the same value.
+        return f"{method}: '{param_name}' must be a list/tuple of numbers, got {_refusal_container_repr(vec)}"
+    return None
 
 
 def _read_pose_vector(method: str, param_name: str, vec: Any, expected_len: int) -> tuple[list[float], str | None]:

--- a/tests/test_container_refusals_render_elementwise.py
+++ b/tests/test_container_refusals_render_elementwise.py
@@ -992,6 +992,25 @@ class TestTheIterationIsAnsweredNotEscaped:
         assert _refusal_container_repr(HostileIteration()) == "<unrepresentable HostileIteration>"
 
 
+class LazySizedVector:
+    """A legacy sequence: a readable ``__len__`` and components read one at a time.
+
+    ``GetItemOnly`` below is the failing counterpart. This one succeeds, so it is
+    what shows the element loop accepting a complete lazy read - the property a
+    generator used to carry here before an unreadable length became part of the
+    verdict (#2200).
+    """
+
+    def __init__(self, *values: float) -> None:
+        self._values = values
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, index: int) -> float:
+        return self._values[index]
+
+
 class GetItemOnly:
     """A sequence by the legacy protocol: ``__getitem__``, no ``__iter__``.
 
@@ -1169,12 +1188,19 @@ class TestElementProductionIsAnsweredNotEscaped:
     def test_an_acceptable_lazy_vector_is_still_accepted(self) -> None:
         """The rewritten loop must not refuse what the ``for`` accepted.
 
-        A generator of finite numbers, and an empty one - the ``StopIteration``
-        that ends the read is the read finishing, not a failure.
+        The ``StopIteration`` that ends the read is the read finishing, not a
+        failure, and this is the property that pins it. The vehicle is a legacy
+        sequence rather than a generator because the two are not the same claim: a
+        generator also has no readable length, and the guard refuses that
+        separately - its callers count the components by reading the value again,
+        which a consumed value cannot answer (#2200). ``LazySizedVector`` is read
+        one component at a time through ``__getitem__``, so it exercises the same
+        loop and the same ``StopIteration`` while leaving that second question
+        answerable. An empty one is here for the same reason it was before: zero
+        components is a complete read.
         """
-        assert finite_vector_error("raycast", "origin", (v for v in (0.1, 0.2, 0.3))) is None
-        empty: tuple[float, ...] = ()
-        assert finite_vector_error("raycast", "origin", (v for v in empty)) is None
+        assert finite_vector_error("raycast", "origin", LazySizedVector(0.1, 0.2, 0.3)) is None
+        assert finite_vector_error("raycast", "origin", LazySizedVector()) is None
 
     def test_the_index_is_a_position_and_not_a_constant(self) -> None:
         """Non-vacuity of the index: three values, three different positions.

--- a/tests/test_unsized_value_is_refused_not_raised.py
+++ b/tests/test_unsized_value_is_refused_not_raised.py
@@ -38,6 +38,20 @@ raising nothing at all and its ``__len__`` returning an ordinary ``int``. And
 carried the same gap. Every unreadable length now reports as ``None`` from one
 probe, which is what the guards' callers document, and the tests below pin that
 domain at the owner rather than at each of its readers.
+
+"Every surface that reads a caller-supplied length" turned out to exclude the one
+that reads no length at all. :func:`~strands_robots.utils.finite_vector_error` is
+the verdict half of the shared component read - it returns a message rather than
+the floats, so its callers count the components themselves, by reading the value
+again. A value with no readable length cannot be read twice, and the read behind
+the verdict consumes it, so the caller's own count saw an empty vector. The guard
+asked nothing, and both of its live call sites reported the consequence instead
+of the cause: ``add_object`` described a three-component extent as ``got 0
+(size=[])`` and ``patch_scene_mjcf`` carried ``object of type 'generator' has no
+len()`` into its envelope. The last two classes below pin that probe and the two
+surfaces, and their values are the other shape of "unreadable" - a value that
+reads cleanly and only then cannot be counted, rather than one the read never
+reaches.
 """
 
 from __future__ import annotations
@@ -45,7 +59,9 @@ from __future__ import annotations
 import ast
 import asyncio
 import inspect
+import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -56,7 +72,13 @@ from strands_robots.policies.mock import MockPolicy
 from strands_robots.policies.wbc.policy import WBCPolicy
 from strands_robots.rendering.video import mjpeg_frames
 from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
-from strands_robots.utils import coerce_rgba, pose_vector_error, sequence_length
+from strands_robots.utils import (
+    coerce_rgba,
+    coerce_size_vector,
+    finite_vector_error,
+    pose_vector_error,
+    sequence_length,
+)
 
 # A 0-d array: declares ``__len__``, raises from it, holds exactly one scalar.
 UNSIZED = np.array(0.5)
@@ -689,3 +711,230 @@ class TestTheLengthRuleHasOneOwner:
             "def guard(value: Any) -> str:\n    missing = [value]\n    return 'is' if len(missing) == 1 else 'are'\n"
         )
         assert _own_length_probes(planted) == []
+
+
+# --------------------------------------------------------------------------- #
+# The other half of "unreadable": a value that reads cleanly and then has no
+# length. Every row of UNREADABLE_LENGTHS above is a value the component read
+# never reaches - a 0-d array is not iterable at all, and the three hostile
+# ``__len__`` rows are legacy sequences whose ``__getitem__`` never stops, so
+# they are refused before any component is produced. A generator is the opposite
+# shape: it yields finite components and only then cannot say how many there
+# were. Factories, because each of these is one-shot - a generator handed to two
+# guards is already empty for the second (#1906's reason, applied to the fixture).
+# --------------------------------------------------------------------------- #
+class _RefusingLengthIterable:
+    """Iterates cleanly to completion and refuses to report a length.
+
+    The unsized-iterable counterpart of :class:`_RefusingLength`: that one is
+    read through ``__getitem__`` and never terminates, this one is a genuine
+    iterable whose read finishes normally, so it reaches the point where the
+    length matters.
+    """
+
+    def __iter__(self) -> Iterator[float]:
+        return iter((0.1, 0.2, 0.3))
+
+    def __len__(self) -> int:
+        raise RuntimeError("length unavailable")
+
+
+class _LazySizedVector:
+    """A legacy sequence: readable ``__len__``, components produced one at a time.
+
+    The over-reach control for the rule below. Laziness is not what makes a value
+    unusable here - being unable to answer "how many components?" is - so a value
+    that is read a component at a time and *can* answer must keep working.
+    """
+
+    def __len__(self) -> int:
+        return 3
+
+    def __getitem__(self, index: int) -> float:
+        if index >= 3:
+            raise IndexError(index)
+        return 0.1 * (index + 1)
+
+
+def _without_object_ids(message: str) -> str:
+    """Mask CPython object addresses so two verdicts can be compared byte for byte.
+
+    These values are one-shot, so each guard is handed its own instance and the
+    ``repr`` the refusal quotes carries a different address. The addresses are the
+    only part that may differ; masking them is what lets the comparison below be
+    an equality rather than a substring.
+    """
+    return re.sub(r"0x[0-9a-fA-F]+", "0xADDR", message)
+
+
+UNSIZED_ITERABLES: list[Any] = [
+    pytest.param(lambda: (component for component in (0.1, 0.2, 0.3)), id="generator"),
+    pytest.param(lambda: iter([0.1, 0.2, 0.3]), id="list_iterator"),
+    pytest.param(lambda: map(float, (1, 2, 3)), id="map"),
+    pytest.param(_RefusingLengthIterable, id="refusing_len_iterable"),
+]
+
+# Values whose components read as finite and whose length *is* readable. The
+# accepted side of the same rule, so a guard cannot satisfy it by refusing
+# everything lazy.
+SIZED_VECTORS: list[Any] = [
+    pytest.param(lambda: [0.1, 0.2, 0.3], id="list"),
+    pytest.param(lambda: (0.1, 0.2, 0.3), id="tuple"),
+    pytest.param(lambda: np.array([0.1, 0.2, 0.3]), id="np_array"),
+    pytest.param(lambda: range(3), id="range"),
+    pytest.param(_LazySizedVector, id="lazy_sized_sequence"),
+]
+
+
+class TestTheVerdictHalfAnswersAnUnreadableLength:
+    """The two guards over the shared read, and what their callers do next.
+
+    :func:`~strands_robots.utils.finite_vector_error` is the verdict half: it
+    returns a message and not the floats, so a caller holding one counts the
+    components by reading the value a second time. It documents deferring that
+    count, and deferring it is exactly what makes a *readable* length part of the
+    verdict - a value with no length cannot be read twice, because the read
+    behind the verdict consumed it.
+
+    It was the one guard in the family not asking. Its own coercing sibling over
+    the same read (:func:`~strands_robots.utils.coerce_size_vector`),
+    :func:`~strands_robots.utils.coerce_rgba` and
+    :func:`~strands_robots.utils.pose_vector_error` all refuse an unreadable
+    length, the middle one with a comment naming this precise value class - "it
+    is what refuses a generator, whose components a read would consume before
+    anything could count them". The verdict half accepted it, and both of its
+    real call sites then read the consumed value: ``add_object`` reported a
+    three-component extent as ``got 0 (size=[])``, and ``patch_scene_mjcf``
+    raised ``object of type 'generator' has no len()`` into its envelope - naming
+    neither the field nor the method, while the sibling fields of that same op
+    named both.
+    """
+
+    @pytest.mark.parametrize("make_value", UNSIZED_ITERABLES)
+    def test_the_verdict_half_reports_an_unreadable_length(self, make_value: Any) -> None:
+        """A message naming the parameter, not ``None`` and not a raise."""
+        message = finite_vector_error("add_object", "size", make_value())
+        assert message is not None, "a value with no readable length passed the verdict"
+        assert "add_object: 'size' must be a list/tuple of numbers" in message
+
+    @pytest.mark.parametrize("make_value", UNSIZED_ITERABLES)
+    def test_the_coercing_half_reports_it_in_the_same_words(self, make_value: Any) -> None:
+        """One value, one verdict: the two guards over one read must not disagree.
+
+        Byte equality rather than a substring, because the point is that neither
+        guard states the rule in its own words - a second wording is how two
+        halves of one contract drift apart.
+        """
+        verdict = finite_vector_error("add_object", "size", make_value())
+        _floats, coerced = coerce_size_vector("add_object", "size", make_value())
+        assert verdict is not None and coerced is not None
+        assert _without_object_ids(verdict) == _without_object_ids(coerced)
+
+    @pytest.mark.parametrize("make_value", SIZED_VECTORS)
+    def test_a_lazily_read_value_with_a_readable_length_is_still_accepted(self, make_value: Any) -> None:
+        """Over-reach control: laziness is not the defect, an unanswerable count is.
+
+        ``_LazySizedVector`` is read one component at a time through the legacy
+        protocol and reports its length, so it must keep passing - otherwise the
+        rule would be "refuse anything not already a list", which is not the rule
+        the sibling guards apply.
+        """
+        assert finite_vector_error("add_object", "size", make_value()) is None
+        floats, reason = coerce_size_vector("add_object", "size", make_value())
+        assert reason is None
+        assert floats is not None and len(floats) == 3
+
+    def test_every_refusal_this_guard_already_gave_is_unchanged(self) -> None:
+        """Non-regression, stated as the exact texts rather than as prose.
+
+        A value whose ``__iter__`` raises, or whose read fails part-way, has no
+        readable length either. Those verdicts describe what actually happened,
+        and reporting them as "not a list/tuple" would claim a domain check that
+        never ran (#1875, #1878) - which is why the length probe runs after the
+        component read and not before it.
+        """
+
+        def fails_part_way() -> Iterator[float]:
+            yield 0.1
+            raise RuntimeError("stream truncated")
+
+        class HostileIter:
+            def __iter__(self) -> Iterator[float]:
+                raise RuntimeError("no iteration for you")
+
+        part_way = finite_vector_error("raycast", "origin", fails_part_way())
+        never_started = finite_vector_error("raycast", "origin", HostileIter())
+        assert part_way is not None and "'origin[1]' could not be read" in part_way
+        assert never_started is not None and "'origin' could not be iterated" in never_started
+        for message in (part_way, never_started):
+            assert "must be a list/tuple of numbers" not in message
+        # The plain non-iterable and the non-numeric element are untouched too.
+        assert finite_vector_error("m", "size", 0.5) == "m: 'size' must be a list/tuple of numbers, got 0.5"
+        assert finite_vector_error("m", "size", ["a"]) == "m: 'size' elements must be numbers, got ['a']"
+        assert finite_vector_error("m", "size", [0.1, float("nan")]) == (
+            "m: 'size' must contain finite numbers (no nan/inf), got [0.1, nan]"
+        )
+
+
+class TestTheCallersThatCountByReadingAgain:
+    """End to end: the two live surfaces that hold only the verdict.
+
+    Both take the message, then count the components themselves - the one thing a
+    consumed value cannot answer. These pin what each reported instead, so a
+    guard that stops asking about the length is caught at the surface a caller
+    actually touches and not only at the helper.
+    """
+
+    def test_add_object_reports_the_extent_it_was_given(self) -> None:
+        """It must not report a supplied extent as an omitted one.
+
+        ``add_object`` counts ``size`` against the shape after the verdict, by
+        reading it again. For a consumed value that count is zero, so the refusal
+        said ``got 0 (size=[])`` - describing a caller who passed nothing, about a
+        caller who passed three components.
+        """
+        engine = MuJoCoSimEngine(tool_name="unsized_size_add_object", mesh=False)
+        assert engine.create_world()["status"] == "success"
+        # Bound through ``Any`` rather than suppressed: ``size`` is declared
+        # ``list[float] | None`` and the measurement is what the runtime does with a
+        # value outside that declaration, which is the caller mistake this guards.
+        unsized: Any = (edge for edge in (0.3, 0.3, 0.3))
+        result = engine.add_object(name="crate", shape="box", size=unsized, position=[0.0, 0.0, 0.4])
+        assert result["status"] == "error"
+        message = _text(result)
+        assert "'size' must be a list/tuple of numbers" in message
+        assert "got 0" not in message, "a supplied extent was reported as an empty one"
+        assert "size=[]" not in message
+
+    def test_a_patch_op_size_field_answers_like_its_sibling_fields(self) -> None:
+        """The op's four numeric fields must not answer in two different ways.
+
+        ``size`` is the only field in the patch-op domain table held by the
+        verdict half; ``pos``, ``quat`` and ``rgba`` are held by guards that
+        already refuse an unreadable length. Without the probe, ``size`` reached
+        the compiler's own ``len()`` and the envelope carried ``object of type
+        'generator' has no len()`` - a message naming neither the field nor the op,
+        beside a sibling field naming both.
+        """
+        engine = MuJoCoSimEngine(tool_name="unsized_size_patch_op", mesh=False)
+        assert engine.create_world()["status"] == "success"
+
+        def op(field: str, value: Any) -> dict[str, Any]:
+            base: dict[str, Any] = {
+                "op": "add_geom",
+                "body": "world",
+                "name": f"patched_{field}",
+                "type": "box",
+                "size": [0.2, 0.2, 0.2],
+                "pos": [1.0, 0.0, 0.3],
+            }
+            base[field] = value
+            return base
+
+        size_result = engine.patch_scene_mjcf(ops=[op("size", (edge for edge in (0.25, 0.25, 0.25)))])
+        pos_result = engine.patch_scene_mjcf(ops=[op("pos", (axis for axis in (1.5, 0.0, 0.3)))])
+        size_message, pos_message = _text(size_result), _text(pos_result)
+        assert size_result["status"] == "error" and pos_result["status"] == "error"
+        assert "has no len()" not in size_message, "the compiler's own TypeError reached the envelope"
+        for field, message in (("size", size_message), ("pos", pos_message)):
+            assert f"add_geom: '{field}' must be a list/tuple of" in message, message


### PR DESCRIPTION
## Problem

`finite_vector_error` is the **verdict half** of the shared component read: it returns a message rather than the floats, so a caller holding one counts the components itself, **by reading the value again**. Its docstring says so, and defers the count:

> Length is NOT checked here (size is shape-dependent, so its count is checked against the shape afterwards).

Deferring the count is exactly what makes a *readable* length part of that verdict. A value with no readable length cannot be read twice — the read behind the verdict consumes it — so the caller's own count sees an empty vector.

It was the one guard in the family not asking. Its own coercing sibling over the same read refuses an unreadable length, and `coerce_rgba`'s probe carries the reason in the source:

> Asked only as "is this a sized sequence at all", the question this probe owns and cannot raise answering (#1888). **It is what refuses a generator, whose components a read would consume before anything could count them.**

`_read_pose_vector` and `coerce_size_vector` both apply that rule. `finite_vector_error` did not, and **both** of its live call sites then read the consumed value.

### Measured on a real MuJoCo world

| call (three edge lengths, produced lazily) | `main` | this PR |
|---|---|---|
| `add_object(size=…)` | `add_object: box needs 3 'size' component(s) [x, y, z] full edge lengths, got 0 (size=[]). 'size' is the full extent in meters along each axis (not MuJ` | `add_object: 'size' must be a list/tuple of numbers, got <generator object <genexpr> at 0x…>` |
| `patch_scene_mjcf(add_geom, size=…)` | `MJCF patch failed: patch op #1 failed: object of type 'generator' has no len()` | `MJCF patch failed: patch op #1 failed: add_geom: 'size' must be a list/tuple of numbers, got <generator object <genexpr> at 0x…>` |
| `patch_scene_mjcf(add_geom, pos=…)` — sibling field | `MJCF patch failed: patch op #1 failed: add_geom: 'pos' must be a list/tuple of 3 numbers, got <generator object <genexpr> at 0x…>` | unchanged |

Two things a caller cannot act on:

- `add_object` reported a **three-component extent as `got 0 (size=[])`** — describing a caller who passed nothing — and then advised "pass every component the shape consumes rather than a partial vector", which the caller had already done.
- `patch_scene_mjcf`'s `size` field carried the compiler's own `TypeError` into the envelope, **naming neither the field nor the op**, beside `pos` on that same op naming both. `size` is the only one of the op's four numeric fields held by the verdict half.

A third consumer, `predicates._kwarg_domain_error`, judges every `list[float]`-annotated predicate kwarg through the same guard.

## Change

Four lines in `strands_robots/utils.py`. After the component read succeeds, ask the shared owner whether the value has a readable length, and refuse in the words the sibling coercion already uses.

**The probe runs *after* the read, not before it** — the order `coerce_size_vector` uses. A value whose `__iter__` raises, or whose read fails part-way, has no readable length either, and those verdicts describe what happened rather than claiming a domain check that never ran (#1875, #1878). Moving the probe ahead of the read **fails 11 pre-existing tests**, which is what pins the placement.

## Blast radius: 4 of 16 probe rows

One script, run in a worktree at `upstream/main` and in the branch. Exactly four value classes move from accepted to refused, each to the message `coerce_size_vector` already gave:

| value | `sequence_length` | `finite_vector_error` before | after |
|---|---|---|---|
| generator / iterator / `map` / iterable whose `__len__` raises | `None` | **accepted** | refused (sibling's wording) |
| 0-d array, `np.float64`, plain float | `None` | refused | byte-identical |
| `str`, `dict`, element `nan` | 3 / 1 / 2 | refused | byte-identical |
| list, tuple, 1-d array, `range`, `set`, `[]` | 3 / 3 / 3 / 3 / 2 / 0 | accepted | byte-identical |

## Tests

+16 cases, in the module that already owns this rule — whose own class is named `TestEveryUnreadableLengthAnswersTheSameWay` and pins `pose_vector_error`, `coerce_rgba` and the router envelope, omitting the two guards over this read.

- both guards refuse each of the four classes, and the two verdicts are compared **byte for byte** (addresses masked), because a second wording is how two halves of one contract drift apart
- a lazily-read value **with** a readable length is still accepted — laziness is not the defect, an unanswerable count is
- every refusal this guard already gave, asserted as its exact text
- the two live call sites, end to end on a real world

One existing pin moved: `test_an_acceptable_lazy_vector_is_still_accepted` used a generator as the vehicle for "the `StopIteration` that ends the read is the read finishing, not a failure". That property is unchanged; its vehicle is now a legacy sized sequence, which exercises the same loop while leaving the length answerable. Its docstring records why.

### Mutation table

Two arms: the new cases, and the 233 pre-existing cases in the two files.

| mutation | new cases | pre-existing |
|---|---|---|
| M1 revert the fix (delete the probe) | 10 failed | 0 failed ← **blind** |
| M2 probe BEFORE the component read | 1 failed | 11 failed |
| M3 reword the verdict locally | 1 failed | 0 failed ← **blind** |
| M4 own narrow len() probe instead of the shared owner | 2 failed | 1 failed |
| M5 keep the probe, discard its verdict | 10 failed | 0 failed ← **blind** |
| unmutated control | 0 failed | 0 failed |

**5 of 5 caught by the new cases; 3 of 5 invisible to the pre-existing ones.** M2 is the informative row the other way: probing *before* the read fails 11 pre-existing tests, so the existing suite already protects the placement. M3 (rewording the verdict locally) is caught only by the byte-equality parity test.

## Scope

`_read_finite_vector` is untouched, so its callers that use the returned floats are unaffected and its three documented verdicts keep their wording.

Out of scope, measured and unchanged by this PR: a legacy sequence whose `__getitem__` never raises `IndexError` reads unboundedly through this guard **on both trees** (`_NegativeLength` in the test module is such a value). That is a different question — an unbounded read rather than an unreadable length — and it is filed separately rather than folded in.

## Artifact

![finite_vector_error reports a vector whose length cannot be read](https://raw.githubusercontent.com/cagataycali/robots/artifacts/finite-vector-unreadable-length/finite-vector-unreadable-length.png)

Three real headless renders. Panel A is the crate the caller asked for, spelled as a list; B and C are the same call with the three edge lengths produced lazily, on `main` and here. **B and C are byte-comparable (`max|delta| = 1/255`)** — the scene is untouched either way, and the whole difference is what the caller is told. A differs from C on **28.53%** of pixels, so the reference call really does build the crate. Capture and compose scripts, both fact dumps and the mutation table are on the artifact branch; `compose.py` asserts every number it renders and that the two arms measured different trees.

## Gate

`upstream/main` `0b7d1ed5` (rebased onto it after #2196 merged, because that PR changed `mujoco/simulation.py`, which the new end-to-end test drives; its hunks are at 1912/1944 and the guard call is at 2840).

- `MUJOCO_GL=egl pytest tests` — **28563 passed / 257 skipped / 0 failed** (633s). Pristine at this base is 28547, and 28547 + 16 = 28563.
- pre-fix (source reverted to `upstream/main`, tests kept) — **10 failed / 233 passed**, identical at both bases. The 6 new cases that pass are the over-reach controls and the unchanged-refusal pins.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` — clean, 0 errors outside `examples/isaac_gs`.
- the 8 repo-wide root guards — 424 passed.
- `check_merge_base_overlap.py` — no overlap, 0 paths changed in that span.
