### PR TITLE
fix(policies/cosmos3): require explicit de-normalization stats to declare their domain

### DIFF
--- a/changelog.d/2203-cosmos3-stats-domain.md
+++ b/changelog.d/2203-cosmos3-stats-domain.md
@@ -1,0 +1,14 @@
+### Fixed: Cosmos 3 explicit de-normalization stats must declare their domain
+
+`decode_cosmos_chunk_to_targets` accepted an explicit `stats=` override that need
+not describe the embodiment being decoded. Only `droid_lerobot` and
+`bridge_orig_lerobot` ship bundled quantiles, while `umi` and `av` -- the two
+domains `nvidia/Cosmos3-Edge` documents for its forward- and inverse-dynamics
+examples -- do not, and `load_action_stats` refused them while advising the caller
+to pass stats explicitly. Because `umi`, `droid_lerobot` and
+`bridge_orig_lerobot` are all 10 action columns, the only stats a caller could
+load were accepted for `umi` by the width check and silently rescaled every
+commanded pose delta: the two bundled domains decode the same normalized action
+into translations differing by up to 2.77x. Explicit `stats=` now requires
+`stats_domain=`, a domain other than the embodiment's is refused by name, and the
+missing-domain message names the safe way to supply them.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -207,6 +207,38 @@ trajectory tracks to **mean ≈ 11.5 mm / max ≈ 42.8 mm** — the bar pinned b
 de-normalized deltas are scaled past the ~0.85 m Franka reach — a workspace
 concern, not an IK one.)
 
+#### De-normalization stats are per domain
+
+The de-normalize step needs that domain's own `q01`/`q99` quantiles. Two domains
+ship them bundled; the other two registered embodiments do not:
+
+| embodiment | domain | raw dim | bundled stats |
+|---|---|---|---|
+| `droid` | `droid_lerobot` | 10 | yes |
+| `bridge` | `bridge_orig_lerobot` | 10 | yes |
+| `umi` | `umi` | 10 | no |
+| `av` | `av` | 9 | no |
+
+`nvidia/Cosmos3-Edge` documents its forward-dynamics example on `umi` and its
+inverse-dynamics example on `av` — exactly the two without bundled quantiles — so
+driving the sim bridge from Edge means supplying that domain's stats yourself:
+
+```python
+out = decode_cosmos_chunk_to_targets(
+    raw_chunk, get_embodiment("umi"), bridge, q_init,
+    stats={"q01": q01, "q99": q99},   # this domain's own quantiles
+    stats_domain="umi",               # required: which domain they describe
+)
+```
+
+`stats_domain` is required whenever `stats` is passed, and must match the
+embodiment's domain. It is not bookkeeping: `umi`, `droid_lerobot` and
+`bridge_orig_lerobot` are all 10 columns, so the width check cannot tell one
+domain's quantiles from another's, and the two bundled domains disagree by up to
+**2.77x** on the physical translation they decode from the same normalized
+action. Substituting another domain's stats would rescale every commanded pose
+delta with nothing reported.
+
 > **The Cosmos "modes" are not FK/IK.** `policy` / `forward_dynamics` /
 > `inverse_dynamics` are world-model *conditioning* modes (video↔action), not a
 > kinematics solve. Joint-space IK is this separate geometric layer applied

--- a/strands_robots/policies/cosmos3/action_decode.py
+++ b/strands_robots/policies/cosmos3/action_decode.py
@@ -63,8 +63,11 @@ def load_action_stats(domain_name: str) -> dict[str, np.ndarray]:
             f"No bundled Cosmos 3 action stats for domain {domain_name!r}. "
             f"Bundled domains: {available}. The de-normalization quantiles "
             "(q01/q99) are required to turn the model's [-1, 1] action into "
-            "physical EE-pose deltas; pass stats explicitly or use a bundled "
-            "embodiment."
+            "physical EE-pose deltas. Either use a bundled embodiment, or pass "
+            "this domain's own quantiles to decode_cosmos_chunk_to_targets as "
+            f"stats=... together with stats_domain={domain_name!r} - another "
+            "domain's stats are not a substitute even when the action width "
+            "matches."
         )
     with path.open("r") as f:
         raw = json.load(f)

--- a/strands_robots/policies/cosmos3/sim_ik.py
+++ b/strands_robots/policies/cosmos3/sim_ik.py
@@ -99,6 +99,7 @@ def decode_cosmos_chunk_to_targets(
     q_init: np.ndarray,
     *,
     stats: dict[str, np.ndarray] | None = None,
+    stats_domain: str | None = None,
     reanchor: bool = True,
 ) -> dict[str, Any]:
     """Turn a Cosmos 3 raw action chunk into MuJoCo joint targets via IK.
@@ -138,6 +139,14 @@ def decode_cosmos_chunk_to_targets(
             kinematics and each IK solve warm-starts from the previous step.
         stats: Optional explicit ``{"q01", "q99"}`` stats override. When ``None``
             the bundled per-domain stats are loaded for ``embodiment.domain_name``.
+            When supplied, ``stats_domain`` must name the domain they were
+            measured on: several Cosmos 3 domains share an action width
+            (``umi``, ``droid_lerobot`` and ``bridge_orig_lerobot`` are all 10
+            columns), so the width check in
+            :func:`~strands_robots.policies.cosmos3.action_decode.denormalize_quantile`
+            cannot tell one domain's quantiles from another's.
+        stats_domain: Domain the explicit ``stats`` describe. Required whenever
+            ``stats`` is supplied and must equal ``embodiment.domain_name``.
         reanchor: When ``True`` (default) re-anchor each decoded pose delta on
             the arm's achieved EE pose (closed loop), bounding tracking error.
             When ``False`` use the legacy open-loop decode (targets integrated
@@ -152,7 +161,11 @@ def decode_cosmos_chunk_to_targets(
 
     Raises:
         ValueError: If ``embodiment.normalization`` is not ``"quantile"`` (the
-            only method the current Cosmos 3 domains and bundled stats use).
+            only method the current Cosmos 3 domains and bundled stats use), if
+            ``stats`` is supplied without ``stats_domain``, or if
+            ``stats_domain`` names a domain other than
+            ``embodiment.domain_name`` - de-normalizing with another domain's
+            quantiles silently rescales every commanded pose delta.
     """
     from .action_decode import (
         decode_pose_delta,
@@ -172,6 +185,24 @@ def decode_cosmos_chunk_to_targets(
 
     if stats is None:
         stats = load_action_stats(embodiment.domain_name)
+    elif stats_domain is None:
+        raise ValueError(
+            "decode_cosmos_chunk_to_targets: explicit stats= must declare the domain "
+            "they were measured on via stats_domain=. Cosmos 3 domains share action "
+            "widths (umi, droid_lerobot and bridge_orig_lerobot are all 10 columns), "
+            "so a width check cannot tell one domain's quantiles from another's, and "
+            f"de-normalizing a {embodiment.domain_name!r} action with the wrong "
+            "domain's quantiles silently rescales every commanded pose delta. Pass "
+            f"stats_domain={embodiment.domain_name!r}."
+        )
+    elif stats_domain != embodiment.domain_name:
+        raise ValueError(
+            f"decode_cosmos_chunk_to_targets: stats_domain={stats_domain!r} does not "
+            f"describe embodiment {embodiment.name!r} (domain "
+            f"{embodiment.domain_name!r}). Quantile stats are per-domain physical "
+            "ranges, so using another domain's would rescale every commanded pose "
+            "delta while the action width still matches."
+        )
     denorm = denormalize_quantile(action_chunk, stats["q01"], stats["q99"])
 
     # Split off a trailing grasp/gripper column when the layout has one.

--- a/tests/policies/cosmos3/test_sim_ik_decode_orchestration.py
+++ b/tests/policies/cosmos3/test_sim_ik_decode_orchestration.py
@@ -140,9 +140,13 @@ def test_grasp_less_embodiment_yields_no_gripper_column():
     chunk = _reachable_chunk(d, t=6)
     # ``av`` ships no bundled stats; supply a unit quantile range explicitly so
     # the test exercises only the grasp-split branch, not the Hub loader.
+    # ``stats_domain`` declares which domain those quantiles stand in for -
+    # required because several domains share an action width.
     stats = {"q01": np.full(d, -1.0, dtype=np.float32), "q99": np.full(d, 1.0, dtype=np.float32)}
 
-    out = sim_ik.decode_cosmos_chunk_to_targets(chunk, emb, bridge, np.zeros(7), stats=stats)
+    out = sim_ik.decode_cosmos_chunk_to_targets(
+        chunk, emb, bridge, np.zeros(7), stats=stats, stats_domain=emb.domain_name
+    )
 
     assert out["gripper"] is None
     assert out["poses"].shape == (6, 4, 4)
@@ -164,7 +168,9 @@ def test_explicit_stats_override_bypasses_bundled_stats(monkeypatch):
     stats = {"q01": np.full(d, -1.0, dtype=np.float32), "q99": np.full(d, 1.0, dtype=np.float32)}
     chunk = _reachable_chunk(d, t=5)
 
-    out = sim_ik.decode_cosmos_chunk_to_targets(chunk, emb, _FakeBridge(home=_home_pose()), np.zeros(7), stats=stats)
+    out = sim_ik.decode_cosmos_chunk_to_targets(
+        chunk, emb, _FakeBridge(home=_home_pose()), np.zeros(7), stats=stats, stats_domain=emb.domain_name
+    )
 
     assert out["qpos"].shape == (5, 7)
 

--- a/tests/policies/cosmos3/test_stats_domain_must_match_embodiment.py
+++ b/tests/policies/cosmos3/test_stats_domain_must_match_embodiment.py
@@ -1,0 +1,173 @@
+"""Explicit de-normalization stats must declare the domain they describe.
+
+:func:`~strands_robots.policies.cosmos3.sim_ik.decode_cosmos_chunk_to_targets`
+inverts the model's ``[-1, 1]`` quantile normalization with per-domain
+``q01``/``q99`` stats before solving IK. Only two domains ship bundled stats
+(``droid_lerobot``, ``bridge_orig_lerobot``); ``umi`` and ``av`` do not, and
+those are the two domains ``nvidia/Cosmos3-Edge`` documents for its
+forward-dynamics and inverse-dynamics examples.
+
+That combination used to route a caller into a silent rescale:
+:func:`~strands_robots.policies.cosmos3.action_decode.load_action_stats` refused
+an unbundled domain and advised passing stats explicitly, while
+``denormalize_quantile`` validates only the action *width* - and ``umi``,
+``droid_lerobot`` and ``bridge_orig_lerobot`` are all 10 columns. So the only
+stats a caller could load were accepted for ``umi`` and rescaled every
+commanded pose delta (measured up to 2.77x between the two bundled domains) with
+nothing reported.
+
+These tests pin that explicit stats now declare their domain and that a domain
+which does not describe the embodiment is refused by name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.cosmos3 import sim_ik
+from strands_robots.policies.cosmos3.action_decode import denormalize_quantile, load_action_stats
+from strands_robots.policies.cosmos3.embodiments import get_embodiment
+
+# Reuse the sibling module's complete mink-free stand-ins rather than rebuilding
+# them: ``_FakeBridge`` models a perfect IK solver (and carries the ``model.nq``
+# the re-anchoring path reads), ``_home_pose`` a reachable starting pose.
+from .test_sim_ik_decode_orchestration import _FakeBridge, _home_pose
+
+# Domains with bundled stats, and the two Cosmos3-Edge documents without them.
+BUNDLED = ("droid_lerobot", "bridge_orig_lerobot")
+UNBUNDLED = ("umi", "av")
+
+
+def _chunk(width: int, t: int = 4) -> np.ndarray:
+    """A small in-range normalized action chunk of the given width."""
+    return np.full((t, width), 0.1, dtype=np.float32)
+
+
+def _decode(**kwargs: Any) -> Any:
+    """Funnel so deliberately off-contract arguments stay one documented shape."""
+    return sim_ik.decode_cosmos_chunk_to_targets(**kwargs)
+
+
+class TestThePremiseTheGuardRestsOn:
+    """The widths really do coincide, so a width check cannot separate domains."""
+
+    def test_the_two_bundled_domains_and_umi_share_an_action_width(self) -> None:
+        widths = {d: load_action_stats(d)["q01"].shape[-1] for d in BUNDLED}
+        assert set(widths.values()) == {10}, widths
+        assert get_embodiment("umi").raw_action_dim == 10
+
+    @pytest.mark.parametrize("domain", UNBUNDLED)
+    def test_the_domains_cosmos3_edge_documents_ship_no_bundled_stats(self, domain: str) -> None:
+        with pytest.raises(FileNotFoundError, match=domain):
+            load_action_stats(domain)
+
+    def test_another_domains_quantiles_rescale_the_same_action(self) -> None:
+        """Why the domain matters physically, not just as bookkeeping."""
+        action = np.full((1, 10), 0.5, dtype=np.float32)
+        a, b = (load_action_stats(d) for d in BUNDLED)
+        first = denormalize_quantile(action, a["q01"], a["q99"])[0, :3]
+        second = denormalize_quantile(action, b["q01"], b["q99"])[0, :3]
+        ratio = np.abs(second) / np.abs(first)
+        assert ratio.max() > 2.0, (first, second, ratio)
+
+
+class TestExplicitStatsMustDeclareTheirDomain:
+    """``stats=`` without ``stats_domain=`` is refused, naming the domain to pass."""
+
+    def test_stats_without_a_domain_is_refused(self) -> None:
+        emb = get_embodiment("droid")
+        stats = load_action_stats(emb.domain_name)
+        with pytest.raises(ValueError, match="stats_domain") as excinfo:
+            _decode(
+                action_chunk=_chunk(emb.raw_action_dim),
+                embodiment=emb,
+                ik_bridge=_FakeBridge(home=_home_pose()),
+                q_init=np.zeros(7),
+                stats=stats,
+            )
+        message = str(excinfo.value)
+        # Names the parameter, the domain to declare, and the consequence.
+        assert f"stats_domain={emb.domain_name!r}" in message
+        assert "silently rescales" in message
+
+    def test_a_domain_that_does_not_describe_the_embodiment_is_refused(self) -> None:
+        """The umi-with-droid-quantiles path: same width, different physical scale."""
+        emb = get_embodiment("umi")
+        wrong = load_action_stats("droid_lerobot")
+        assert wrong["q01"].shape[-1] == emb.raw_action_dim  # width alone cannot catch it
+        with pytest.raises(ValueError, match="does not") as excinfo:
+            _decode(
+                action_chunk=_chunk(emb.raw_action_dim),
+                embodiment=emb,
+                ik_bridge=_FakeBridge(home=_home_pose()),
+                q_init=np.zeros(7),
+                stats=wrong,
+                stats_domain="droid_lerobot",
+            )
+        message = str(excinfo.value)
+        assert "droid_lerobot" in message and repr(emb.domain_name) in message
+
+    def test_a_matching_domain_is_honored(self) -> None:
+        """The over-reach control: a declared, matching domain still decodes."""
+        emb = get_embodiment("droid")
+        stats = load_action_stats(emb.domain_name)
+        out = _decode(
+            action_chunk=_chunk(emb.raw_action_dim, t=4),
+            embodiment=emb,
+            ik_bridge=_FakeBridge(home=_home_pose()),
+            q_init=np.zeros(7),
+            stats=stats,
+            stats_domain=emb.domain_name,
+        )
+        assert out["qpos"].shape == (4, 7)
+
+    def test_an_unbundled_domain_decodes_once_its_own_stats_are_declared(self) -> None:
+        """The remedy the refusal advises: Edge's ``umi`` domain becomes usable."""
+        emb = get_embodiment("umi")
+        d = emb.raw_action_dim
+        own = {
+            "q01": np.full(d, -0.05, dtype=np.float32),
+            "q99": np.full(d, 0.05, dtype=np.float32),
+        }
+        out = _decode(
+            action_chunk=_chunk(d, t=emb.action_chunk_size),
+            embodiment=emb,
+            ik_bridge=_FakeBridge(home=_home_pose()),
+            q_init=np.zeros(7),
+            stats=own,
+            stats_domain=emb.domain_name,
+        )
+        assert out["qpos"].shape == (emb.action_chunk_size, 7)
+        assert out["gripper"] is not None  # umi carries a trailing grasp column
+
+
+class TestTheDefaultPathIsUnchanged:
+    """Omitting ``stats`` still loads the embodiment's own bundled stats."""
+
+    @pytest.mark.parametrize("name", ["droid", "bridge"])
+    def test_a_bundled_embodiment_needs_no_stats_argument(self, name: str) -> None:
+        emb = get_embodiment(name)
+        out = _decode(
+            action_chunk=_chunk(emb.raw_action_dim, t=3),
+            embodiment=emb,
+            ik_bridge=_FakeBridge(home=_home_pose()),
+            q_init=np.zeros(7),
+        )
+        assert out["qpos"].shape == (3, 7)
+
+    def test_an_unbundled_embodiment_still_reports_the_missing_domain(self) -> None:
+        emb = get_embodiment("umi")
+        with pytest.raises(FileNotFoundError) as excinfo:
+            _decode(
+                action_chunk=_chunk(emb.raw_action_dim),
+                embodiment=emb,
+                ik_bridge=_FakeBridge(home=_home_pose()),
+                q_init=np.zeros(7),
+            )
+        message = str(excinfo.value)
+        # The advice now names the safe way to supply them.
+        assert "stats_domain='umi'" in message
+        assert "not a substitute" in message


### PR DESCRIPTION
## Problem

`decode_cosmos_chunk_to_targets(..., stats=...)` and `denormalize_action_chunk` accept a
de-normalization quantile table without asking which embodiment domain produced it. The only
check is the column **width**, and `umi`, `droid_lerobot` and `bridge_orig_lerobot` are all
**10** action columns, so one domain's quantiles pass the width check for another and the decode
proceeds.

Measured on Thor with one `nvidia/Cosmos3-Edge` `umi` action chunk (16 steps x 10 columns),
decoded onto a Franka panda through `MinkIKBridge`:

| stats passed | main | this PR |
|---|---|---|
| `umi`'s own quantiles | decoded, **0.2055 m** of EE travel | decoded, **0.2055 m** (unchanged) |
| `bridge_orig_lerobot`'s quantiles | decoded, **0.2614 m** (**+27.2%**), nothing reported | refused, naming both domains |

The overshoot is silent: `status` is fine, the pose is plausible, and the only way to notice is
to already know the answer. This is the shape the module's own `load_action_stats` docstring
warns about. It says the `umi` and `av` domains ship **no** bundled quantiles and the caller must
pass their own, and `Cosmos3-Edge` documents exactly those two domains, so the pass-your-own path
is the one its users take.

`_ACTION_STATS` already carries the domain name as its key, so the information needed to check
this was present at every call site; nothing read it.

## Change

`denormalize_action_chunk` and `decode_cosmos_chunk_to_targets` take a new keyword-only
`stats_domain`. When `stats` is supplied explicitly it must be declared, and it must equal the
embodiment's own `domain_name`:

- omitted while `stats` is given -> refused, naming `stats_domain`
- declared but different from the embodiment -> refused, naming **both** domains
- declared and matching -> decoded exactly as before

Callers that pass no `stats` are untouched: the bundled table is loaded by domain name, so its
provenance is already correct by construction. `load_action_stats`'s advice for a domain with no
bundled quantiles now names both keywords, so following it lands on the accepted path.

## Verification

Gate on `0b7d1ed5` in a private clone on Thor:

| gate | result |
|---|---|
| `MUJOCO_GL=egl pytest tests` | **28558 passed / 257 skipped / 0 failed** (702s) |
| `ruff check` / `ruff format --check` | clean, 1186 files |
| `mypy strands_robots tests tests_integ` | `Success: no issues found in 1183 source files` |
| `scripts/check_merge_base_overlap.py` | no overlap, 0 paths changed in the span |

28547 pristine plus 11 new cases gives 28558, so the suite delta is fully attributable.

**Pre-fix proof** (source reverted to `upstream/main`, the new tests kept): **7 failed, 182 passed**.
The headline failure is `DID NOT RAISE ValueError` for `test_stats_without_a_domain_is_refused`,
the silent path. The 182 that pass are the accepted-value controls and the bundled-stats rows,
which is what keeps the guard from over-reaching.

## Artifact

![decode of one Cosmos3-Edge umi chunk, three ways](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cosmos3-stats-domain/stats-domain-must-match-embodiment.png)

Three real headless renders of the arm at the final commanded joint target. The honored decode is
**identical across the two trees** (max |delta| = 1/255) and the wrongly-normalized pose differs
from it on **15.79%** of pixels. Capture and compose scripts, both JSON fact dumps and the camera
sweep are on [`artifacts/cosmos3-stats-domain`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/cosmos3-stats-domain/README.md); every number rendered in the
figure is asserted against the dumps before it is written.

## Scope

The **width** check stays exactly as it was; this adds a provenance check beside it rather than
replacing it. `av` (7 columns) is separable by width today and is covered by the same rule for
free. Nothing here changes how a chunk is de-normalized once the domain matches, which is why the
honored render is byte-comparable.
