### PR TITLE
fix(examples): release the mesh session so the peer-discovery example exits

### DIFF
--- a/changelog.d/2204-mesh-example-releases-the-session.md
+++ b/changelog.d/2204-mesh-example-releases-the-session.md
@@ -1,0 +1,16 @@
+### Fixed: the mesh peer-discovery example now terminates
+
+`examples/04_mesh_peer_discovery.py` released its Zenoh session through
+`getattr(sim, "_mesh", None)`, but the `Robot` factory assigns the public
+`sim.mesh` (`strands_robots/robot.py`), and the SDK's own teardown reads
+`getattr(instance, "mesh", None)` before calling `stop()`. `_mesh` never
+exists, so the read returned `None`, the `if mesh:` guard skipped, and the
+session stayed open on non-daemon threads: the example whose docstring
+promised "~3 seconds" ran until it was interrupted (measured: killed at 40s
+versus exit 0 in 1s once the session is released). Only the default
+mesh-enabled path was affected -- `STRANDS_MESH=0` already exited.
+
+Because the name was read through `getattr` with a default, nothing raised.
+A new guard derives the attribute the factory actually assigns and refuses any
+example that reaches for a mesh attribute nothing assigns, while leaving a
+module's own `self._mesh` private state alone.

--- a/examples/04_mesh_peer_discovery.py
+++ b/examples/04_mesh_peer_discovery.py
@@ -7,7 +7,7 @@ no config server, no manual IP lists.
 
 Dependencies: pip install "strands-robots[sim-mujoco,mesh]"
 Expected output: Prints local robot info and discovered peer list.
-Runtime: ~3 seconds.
+Runtime: ~3 seconds (the script exits; it releases the mesh session).
 
 Note: Set STRANDS_MESH_LOCAL_DEV=1 to skip TLS for local development.
       Set STRANDS_MESH=0 to disable mesh entirely (the example still runs
@@ -39,7 +39,10 @@ print(f"Discovered mesh peers: {len(peers)}")
 for peer in peers:
     print(f"  {peer.get('peer_id', '?')}: type={peer.get('peer_type', '?')}")
 
-# Cleanup
-mesh = getattr(sim, "_mesh", None)
+# Cleanup. Release the Zenoh session through the attribute the Robot factory
+# assigns (`sim.mesh`) - the same one strands_robots.robot's own teardown reads.
+# The session runs on non-daemon threads, so a cleanup that silently reads a
+# name the SDK never sets leaves this script running forever.
+mesh = getattr(sim, "mesh", None)
 if mesh:
     mesh.stop()

--- a/tests/test_examples_release_the_mesh.py
+++ b/tests/test_examples_release_the_mesh.py
@@ -1,0 +1,199 @@
+"""Mesh examples must release the Zenoh session through the attribute the SDK sets.
+
+A mesh-enabled ``Robot`` holds a Zenoh session whose Rust runtime callbacks run
+on **non-daemon** threads (six ``pyo3-closure`` threads on this build). Releasing
+it is therefore not tidiness: an example that fails to call ``Mesh.stop()`` never
+terminates, and the user has to interrupt it.
+
+The observed defect: ``examples/04_mesh_peer_discovery.py`` cleaned up with
+``getattr(sim, "_mesh", None)``, but :func:`strands_robots.robot.Robot` assigns
+the *public* ``sim.mesh`` (and ``strands_robots.robot``'s own teardown reads
+``getattr(instance, "mesh", None)`` before calling ``stop()``). ``_mesh`` never
+exists, so ``getattr`` returned ``None``, the ``if mesh:`` guard skipped, and the
+script whose docstring promised "~3 seconds" ran until it was killed. Because the
+name was read through ``getattr`` with a default, nothing raised - the cleanup
+silently did nothing.
+
+Two rules, both derived from the SDK rather than hand-listed so they track a
+rename instead of drifting from it:
+
+1. No example may reach for a mesh attribute that nothing assigns - neither the
+   factory nor the module itself. (A module that sets its own ``self._mesh`` and
+   reads it back holds ordinary private state and is not affected.)
+2. The peer-discovery example must actually stop the session it opened, so
+   deleting the cleanup cannot pass rule 1 by having nothing to check.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+_ROBOT_PY = _REPO_ROOT / "strands_robots" / "robot.py"
+
+# Attribute names that plausibly hold the live Mesh: "mesh", "_mesh", "__mesh".
+# Deliberately tight - it must not match unrelated names such as ``skip_mesh``.
+_MESH_ATTR_RE = re.compile(r"^_*mesh$")
+
+
+def _factory_mesh_attributes() -> set[str]:
+    """Instance attributes the Robot factory assigns the live ``Mesh`` to.
+
+    Derived from ``strands_robots/robot.py``: find the locals bound from
+    ``init_mesh(...)`` (``sim_mesh`` / ``hw_mesh``), then the attributes those
+    locals are assigned to (``sim.mesh`` / ``hw.mesh``). Reading the factory
+    means a rename updates this rule automatically.
+    """
+    tree = ast.parse(_ROBOT_PY.read_text(encoding="utf-8"))
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            called = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if called == "init_mesh":
+                bound |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+
+    attrs: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Name) and node.value.id in bound:
+            attrs |= {t.attr for t in node.targets if isinstance(t, ast.Attribute)}
+    return attrs
+
+
+def _locally_assigned_mesh_attributes(tree: ast.AST) -> set[str]:
+    """Mesh-ish attributes this module assigns on its own objects.
+
+    A module that writes ``self._mesh = mesh`` in its own ``__init__`` and then
+    reads it back is holding ordinary private state - not reaching for an
+    attribute the SDK was expected to provide. Those names are legitimate, so
+    they are excluded from the rule below.
+    """
+    assigned: set[str] = set()
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign | ast.AugAssign):
+            targets = [node.target]
+        for target in targets:
+            if isinstance(target, ast.Attribute) and _MESH_ATTR_RE.match(target.attr):
+                assigned.add(target.attr)
+    return assigned
+
+
+def _unknown_mesh_reads(source: str, known: set[str]) -> list[str]:
+    """Mesh-ish attribute reads in ``source`` that nothing ever assigns.
+
+    Flags a read only when the name is neither (a) the attribute the Robot
+    factory assigns nor (b) one this module assigns itself. That is exactly the
+    silent-no-op case: the value can only ever be the ``getattr`` default.
+    """
+    found: list[str] = []
+    tree = ast.parse(source)
+    known = known | _locally_assigned_mesh_attributes(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and _MESH_ATTR_RE.match(node.attr) and node.attr not in known:
+            found.append(f"line {node.lineno}: .{node.attr}")
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+            and _MESH_ATTR_RE.match(node.args[1].value)
+            and node.args[1].value not in known
+        ):
+            found.append(f'line {node.lineno}: getattr(..., "{node.args[1].value}")')
+    return found
+
+
+def _example_scripts() -> list[Path]:
+    return sorted(_EXAMPLES_DIR.rglob("*.py")) if _EXAMPLES_DIR.is_dir() else []
+
+
+def test_the_factory_assigns_exactly_one_public_mesh_attribute():
+    """Non-vacuity: the derived rule must name the real attribute.
+
+    An empty or renamed result would make the per-example scan below pass
+    trivially, so the expected value is pinned here.
+    """
+    assert _factory_mesh_attributes() == {"mesh"}
+
+
+@pytest.mark.parametrize("script", _example_scripts(), ids=[p.name for p in _example_scripts()])
+def test_examples_only_read_the_mesh_attribute_the_factory_sets(script: Path):
+    """An example must not read a mesh attribute the SDK never assigns."""
+    known = _factory_mesh_attributes()
+    offenders = _unknown_mesh_reads(script.read_text(encoding="utf-8"), known)
+    assert not offenders, (
+        f"{script.relative_to(_REPO_ROOT)} reads a mesh attribute the Robot factory "
+        f"never assigns: {offenders}. The factory sets {sorted(known)} (see "
+        f"strands_robots/robot.py), so this read returns None and any "
+        f"`if mesh:` cleanup silently does nothing - leaving the Zenoh session's "
+        f"non-daemon threads running and the example unable to exit."
+    )
+
+
+def test_the_peer_discovery_example_stops_the_session_it_opened():
+    """The mesh example must call ``stop()`` on the attribute it read.
+
+    Without this, deleting the cleanup entirely would satisfy the scan above
+    while reintroducing the hang.
+    """
+    example = _EXAMPLES_DIR / "04_mesh_peer_discovery.py"
+    source = example.read_text(encoding="utf-8")
+    attr = sorted(_factory_mesh_attributes())[0]
+    assert f'getattr(sim, "{attr}"' in source, (
+        f"{example.name} must read the live mesh via getattr(sim, {attr!r}, None)."
+    )
+    stops = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "stop"
+    ]
+    assert stops, (
+        f"{example.name} never calls .stop(); the Zenoh session runs on "
+        f"non-daemon threads, so the script would not terminate."
+    )
+
+
+@pytest.mark.parametrize(
+    "planted",
+    [
+        'mesh = getattr(sim, "_mesh", None)\nif mesh:\n    mesh.stop()\n',
+        "sim._mesh.stop()\n",
+    ],
+    ids=["getattr-private-name", "direct-private-attribute"],
+)
+def test_the_scan_detects_a_planted_private_mesh_read(planted: str):
+    """Meta: an empty result must mean clean examples, not a blind scanner."""
+    assert _unknown_mesh_reads(planted, {"mesh"})
+
+
+@pytest.mark.parametrize(
+    "clean",
+    [
+        'mesh = getattr(sim, "mesh", None)\nif mesh:\n    mesh.stop()\n',
+        "if args.skip_mesh:\n    pass\n",
+        'sim = Robot("so100", mesh=True)\n',
+        # Own private state: assigned here, then read back. Not a missing SDK
+        # attribute, so the rule must leave it alone (examples/fleet/dashboard.py).
+        "class D:\n    def __init__(self, mesh):\n        self._mesh = mesh\n"
+        "    def go(self):\n        return self._mesh.peers\n",
+    ],
+    ids=[
+        "public-getattr",
+        "unrelated-skip_mesh",
+        "mesh-keyword-argument",
+        "own-private-attribute-round-trip",
+    ],
+)
+def test_the_scan_does_not_flag_correct_or_unrelated_code(clean: str):
+    """The rule must not fire on the public form or on names merely containing 'mesh'."""
+    assert _unknown_mesh_reads(clean, {"mesh"}) == []

--- a/tests/test_examples_release_the_mesh.py
+++ b/tests/test_examples_release_the_mesh.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import ast
 import re
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -176,16 +177,29 @@ def test_the_scan_detects_a_planted_private_mesh_read(planted: str):
     assert _unknown_mesh_reads(planted, {"mesh"})
 
 
+# Own private state: assigned in ``__init__``, then read back. Not a missing SDK
+# attribute, so the rule must leave it alone (examples/fleet/dashboard.py does
+# exactly this). Kept as a named constant rather than adjacent string literals so
+# that a dropped comma in the list below cannot silently merge two cases into one.
+_OWN_PRIVATE_MESH_ROUND_TRIP = textwrap.dedent(
+    """\
+    class D:
+        def __init__(self, mesh):
+            self._mesh = mesh
+
+        def go(self):
+            return self._mesh.peers
+    """
+)
+
+
 @pytest.mark.parametrize(
     "clean",
     [
         'mesh = getattr(sim, "mesh", None)\nif mesh:\n    mesh.stop()\n',
         "if args.skip_mesh:\n    pass\n",
         'sim = Robot("so100", mesh=True)\n',
-        # Own private state: assigned here, then read back. Not a missing SDK
-        # attribute, so the rule must leave it alone (examples/fleet/dashboard.py).
-        "class D:\n    def __init__(self, mesh):\n        self._mesh = mesh\n"
-        "    def go(self):\n        return self._mesh.peers\n",
+        _OWN_PRIVATE_MESH_ROUND_TRIP,
     ],
     ids=[
         "public-getattr",


### PR DESCRIPTION
## Problem

`examples/04_mesh_peer_discovery.py` releases its Zenoh session with

```python
mesh = getattr(sim, "_mesh", None)
if mesh:
    mesh.stop()
```

but the `Robot` factory assigns the **public** `sim.mesh` (`strands_robots/robot.py:392`),
and the SDK's own teardown reads `getattr(instance, "mesh", None)` before calling
`stop()` 76 lines below that (`robot.py:468`). `_mesh` never exists, so the read
returns `None`, the `if mesh:` guard skips, and the session stays open.

The session's Rust callbacks run on **non-daemon** threads, so this is not
tidiness -- the interpreter cannot exit. Measured on Thor:

| measured property | upstream/main | this PR |
|---|---|---|
| script terminates | **no** -- SIGKILL at 30.1s | yes, **exit 0 in 1.5s** |
| attribute the example reads | `"_mesh"` | `"mesh"` |
| that read returns `None` | **yes** (cleanup silently skipped) | no |
| `Mesh.stop()` actually called | **no** | yes |
| surviving non-daemon threads | **6** (`pyo3-closure`) | **0** |

The script's own docstring promises "Runtime: ~3 seconds". Because the name was
read through `getattr` with a default, nothing raised -- the cleanup silently did
nothing. Only the default mesh-enabled path is affected: `STRANDS_MESH=0` already
exited in 0s, so the broken path is the one a reader runs first.

Notebook `examples/notebooks/06_*.ipynb` already documents the public form
(`sim.mesh, sim.peer_id = sim_mesh, sim_mesh.peer_id`), so the example was the
outlier rather than the convention.

## Change

Read the attribute the SDK sets, and correct the runtime claim.

A guard **derives** the attribute name from `strands_robots/robot.py` (the
`init_mesh(...)` -> `sim.mesh` / `hw.mesh` assignment chain) rather than
hard-coding it, so a rename tracks the rule instead of drifting from it. It
refuses an example that reads a mesh attribute **nothing assigns** -- neither the
factory nor the module itself -- which is exactly the silent-no-op case where the
value can only ever be the `getattr` default. A second rule pins that the example
still calls `stop()`, so deleting the cleanup cannot pass by having nothing left
to check.

**Precision.** The first version of that rule over-reached, and running it against
open PR #2198 is what caught it: `examples/fleet/dashboard.py` writes
`self._mesh = mesh` in its own `__init__` and reads it back -- ordinary private
state, not a missing SDK attribute. Excluding names the module assigns itself
makes `dashboard.py` pass while still naming `line 43: getattr(..., "_mesh")` in
the example. No exemption list.

## Artifact

![mesh teardown](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-example-teardown/mesh-teardown.png)

Left panel is a real headless MuJoCo render of the world the example builds,
**byte-comparable on both trees (`max|delta| = 1/255`)** -- this PR changes
teardown only, so nothing in simulation, policy or rendering behaviour moves.
`capture.py`, `compose.py` and the two `facts-*.json` are on the
[artifacts branch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/mesh-example-teardown/README.md); `compose.py` asserts every number it draws
against those dumps, including that the two arms measured different trees.

## Verification

- **Pre-fix** (example reverted to `upstream/main`, guard kept): **2 failed / 84 passed**.
  The failure reads `examples/04_mesh_peer_discovery.py reads a mesh attribute the
  Robot factory never assigns: ['line 43: getattr(..., "_mesh")']` and explains the
  consequence. **Post-fix: 86 passed.**
- **End to end**, on the committed tree: `python3 examples/04_mesh_peer_discovery.py`
  exits 0 in 1-2s across two namespaces, reporting
  `Local robots in this process: ['example-arm-01']`.
- **Composed with current `main`** (which has since added two `examples/fleet/*.py`
  files this guard scans): **88 passed**.
- **Full suite** at `0b7d1ed5`: **28633 passed / 257 skipped / 0 failed** (672s,
  `MUJOCO_GL=egl`) = 28547 pristine + 86 new cases. `ruff check` and
  `ruff format --check` clean (1186 files); `mypy strands_robots tests tests_integ`
  has 0 errors outside `examples/isaac_gs`, byte-identical to the pristine base.
- `scripts/check_merge_base_overlap.py`: no overlap (30 paths changed on `main` in
  that span, none of them a file this change edits).

## Scope

- The pre-existing `Cleanup error during __del__: sys.meta_path is None` line is
  interpreter-shutdown noise from `__del__` running after the module system is torn
  down. It appears on `main` and on the `STRANDS_MESH=0` path too, and is left alone.
- The guard scans `examples/**/*.py`; notebooks are JSON and are out of scope.
- A runnable multi-peer Docker demo for `examples/mesh/` is a separate, larger
  deliverable (new directory, image, compose topology) and is filed separately
  rather than bundled here.

## Round 1 changelog

`9e62642` -- **implicit string concatenation in the `clean` parametrize list.**

The own-private-state case was built from two adjacent string literals. Inside a
list of test cases that shape is a hazard rather than a style nit: a dropped
comma between two neighbouring cases concatenates them into a single case, so one
case silently leaves coverage while the suite still reports green. Hoisted the
source into a named `textwrap.dedent` constant, so the list now holds one element
per line and no implicit concatenation remains.

Behaviour is unchanged, and I checked that the case did not become vacuous in the
process:

| property | before | after |
|---|---|---|
| constant parses as valid Python | yes | yes |
| precise rule result (must be empty) | `[]` | `[]` |
| over-reaching rule result (must be non-empty) | 2 reads | `['line 3: ._mesh', 'line 6: ._mesh']` |
| cases collected in this file | 86 | **86** |

The last two rows are the ones that matter: the case still discriminates the
precise rule from an over-reaching one, so it continues to guard the regression
that motivated it, and no case was lost to the merge it was protecting against.
`ruff check` and `ruff format --check` clean on the file; `pytest
tests/test_examples_release_the_mesh.py` **86 passed**.
