### PR TITLE
fix(device_connect): report an expired bring-up budget instead of returning None

### DIFF
--- a/changelog.d/2205-device-connect-sync-bringup-timeout.md
+++ b/changelog.d/2205-device-connect-sync-bringup-timeout.md
@@ -1,0 +1,22 @@
+### Fixed: `init_device_connect_sync` reports an expired bring-up budget instead of returning `None`
+
+The wrapper starts `init_device_connect` on a daemon thread and bounds the wait,
+but discarded the answer that bound gave it: `ready.wait(timeout=30.0)` returns
+`False` when the budget expires, and that boolean was the only thing separating
+"the runtime came up" from "it did not". With it dropped, an expired budget fell
+through to `return runtime_holder[0]` and handed the caller `None` -- past a
+declared `-> "DeviceRuntime"` -- after 30 seconds, with nothing logged.
+
+The two failure modes of one function therefore reported differently: a bring-up
+that *raised* was re-raised on the caller's thread, while a bring-up that never
+finished was indistinguishable from success. `Robot(...).run()` wraps this call
+in `except Exception` precisely so a failed bring-up is reported, so the timeout
+was the one failure that channel could not see: it printed `<peer> is online.`
+with `_device_connect_runtime` set to `None`.
+
+The wait's result is now read, and an expired budget raises a `TimeoutError`
+naming the budget and what to check, joining the failure channel its sibling
+already used. The budget moves to a module constant documenting why it exists,
+mirroring `simulation/isaac`'s `_BODY_STATE_MAIN_THREAD_TIMEOUT_S`; a successful
+bring-up is unchanged and still returns the runtime with its loop and thread
+wired.

--- a/strands_robots/device_connect/__init__.py
+++ b/strands_robots/device_connect/__init__.py
@@ -41,6 +41,12 @@ __all__ = [
 
 _INSECURE_TRUE = ("true", "1", "yes")
 
+# ``init_device_connect_sync`` bounds the background bring-up: the awaited half
+# constructs a ``DeviceRuntime``, which can block on a broker, so the wrapper
+# must not hang its caller forever. Expiry is a failed bring-up, not a slow one
+# that later succeeds -- the wrapper has already returned by then.
+_INIT_TIMEOUT_S: float = 30.0
+
 
 def resolve_allow_insecure(
     explicit: bool | None = None,
@@ -213,6 +219,14 @@ def init_device_connect_sync(
     The runtime stays alive as long as the process (daemon thread).
 
     Same parameters as :func:`init_device_connect`.
+
+    Raises:
+        Exception: Whatever :func:`init_device_connect` raised on the
+            background thread, re-raised here so a failed bring-up reaches
+            the caller rather than being confined to a thread it cannot see.
+        TimeoutError: If the bring-up does not finish within the wrapper's
+            budget. The runtime is not returned in that case, so the caller
+            is never handed ``None`` in place of a ``DeviceRuntime``.
     """
     loop = asyncio.new_event_loop()
     ready = threading.Event()
@@ -243,10 +257,19 @@ def init_device_connect_sync(
 
     thread = threading.Thread(target=_run, daemon=True, name="device-connect-runtime")
     thread.start()
-    ready.wait(timeout=30.0)
+    started = ready.wait(timeout=_INIT_TIMEOUT_S)
 
+    # The recorded failure first: ``_start``'s ``finally`` sets the event on both
+    # paths, so a bring-up that failed inside the budget arrives with ``started``
+    # true and its own exception, which names the cause better than the budget.
     if error_holder[0] is not None:
         raise error_holder[0]
+    if not started:
+        raise TimeoutError(
+            f"init_device_connect_sync: the Device Connect runtime did not come up "
+            f"within {_INIT_TIMEOUT_S:g}s. The bring-up is still running on its "
+            f"background thread; check that the messaging URL / broker is reachable."
+        )
 
     runtime = runtime_holder[0]
     if runtime is not None:

--- a/tests/test_device_connect_sync_bringup_outcomes.py
+++ b/tests/test_device_connect_sync_bringup_outcomes.py
@@ -1,0 +1,251 @@
+"""What ``init_device_connect_sync`` tells its caller about a bring-up.
+
+The wrapper starts :func:`strands_robots.device_connect.init_device_connect` on a
+daemon thread and bounds the wait, so the bring-up has exactly three outcomes:
+it completes, it fails, or the budget expires. All three have to be
+distinguishable by the caller -- the return type is a ``DeviceRuntime``, not an
+optional one, and ``strands_robots.robot``'s foreground runner wraps the call in
+``except Exception`` precisely so a failed bring-up is reported rather than
+printing an "is online" line for a runtime that never came up.
+
+The two failure outcomes cross a thread boundary, which is why they are pinned
+here: the recorded exception is re-raised on the caller's thread, and an expired
+budget raises rather than handing back the ``None`` the holder still contains.
+
+Nothing here needs a broker, a Docker stack or the Kit runtime: the awaited half
+is substituted, and the wrapper's budget is a module attribute so the expiry
+arm resolves in milliseconds instead of the shipped 30 seconds.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import pathlib
+import types
+from typing import Any
+
+import pytest
+
+# Import the integration module lazily inside each helper. Sibling modules in
+# this directory substitute ``device_connect_edge`` submodules with mocks at
+# import time, so binding it at collection time would fix whichever version
+# happened to be installed first for every test in the session.
+
+
+def _dc() -> Any:
+    """The Device Connect integration module."""
+    import strands_robots.device_connect as module
+
+    return module
+
+
+def _robot() -> Any:
+    """A stand-in for the object the wrapper adapts; only its name is read."""
+    return types.SimpleNamespace(tool_name_str="arm")
+
+
+async def _completes(*_a: Any, **_k: Any) -> Any:
+    """A bring-up that returns a runtime."""
+    return types.SimpleNamespace(name="runtime")
+
+
+async def _fails(*_a: Any, **_k: Any) -> Any:
+    """A bring-up that fails the way an unreachable broker does."""
+    raise RuntimeError("no broker at tcp://127.0.0.1:7447")
+
+
+async def _never_finishes(*_a: Any, **_k: Any) -> Any:
+    """A bring-up still running when the wrapper's budget expires.
+
+    The thread it runs on is a daemon, which is the shipped design: the runtime
+    is meant to outlive the call, so there is nothing for the test to join.
+    """
+    await asyncio.sleep(300)
+
+
+def _sync(monkeypatch: pytest.MonkeyPatch, bring_up: Any, *, budget: float = 0.05) -> Any:
+    """Call the wrapper with ``bring_up`` substituted and a short budget."""
+    module = _dc()
+    monkeypatch.setattr(module, "init_device_connect", bring_up)
+    monkeypatch.setattr(module, "_INIT_TIMEOUT_S", budget)
+    return module.init_device_connect_sync(_robot(), peer_id="arm-1")
+
+
+class TestEveryBringUpOutcomeReachesTheCaller:
+    """The three outcomes, and the two that cross a thread boundary."""
+
+    def test_a_completed_bring_up_returns_the_runtime_it_built(self, monkeypatch):
+        """The control: a bring-up that finishes hands back its runtime."""
+        runtime = _sync(monkeypatch, _completes)
+
+        assert runtime is not None
+        assert runtime.name == "runtime"
+
+    def test_a_completed_bring_up_wires_the_loop_and_thread_it_runs_on(self, monkeypatch):
+        """The returned runtime carries the loop and thread serving it, so the
+        caller can reach the machinery the wrapper created on its behalf."""
+        runtime = _sync(monkeypatch, _completes)
+
+        assert runtime._loop.is_running()
+        assert runtime._thread.daemon is True
+
+    def test_a_failed_bring_up_re_raises_the_exception_it_recorded(self, monkeypatch):
+        """A failure on the background thread is carried to the caller's thread
+        as the same exception object, so its cause survives the crossing."""
+        marker = RuntimeError("etcd refused the registration")
+
+        async def _raise_marker(*_a: Any, **_k: Any) -> Any:
+            raise marker
+
+        with pytest.raises(RuntimeError) as excinfo:
+            _sync(monkeypatch, _raise_marker)
+
+        assert excinfo.value is marker
+
+    def test_an_expired_budget_raises_rather_than_returning_none(self, monkeypatch):
+        """A bring-up still running when the budget expires is a failed
+        bring-up: the holder is empty, and returning it would hand the caller
+        ``None`` where its own annotation promises a runtime."""
+        with pytest.raises(TimeoutError):
+            _sync(monkeypatch, _never_finishes)
+
+    def test_an_expired_budget_names_the_budget_and_where_to_look(self, monkeypatch):
+        """The refusal has to say how long was waited and what to check, since
+        the caller cannot see the thread the bring-up is still running on."""
+        with pytest.raises(TimeoutError) as excinfo:
+            _sync(monkeypatch, _never_finishes, budget=0.05)
+
+        message = str(excinfo.value)
+        assert "init_device_connect_sync" in message
+        assert "0.05s" in message
+        assert "still running" in message
+        assert "broker" in message
+
+    def test_a_failure_inside_the_budget_reports_its_cause_not_the_budget(self, monkeypatch):
+        """Guard order: the recorded exception is checked first, so a bring-up
+        that failed quickly is never reported as a slow one."""
+        with pytest.raises(RuntimeError) as excinfo:
+            _sync(monkeypatch, _fails, budget=30.0)
+
+        assert "no broker" in str(excinfo.value)
+        assert "did not come up" not in str(excinfo.value)
+
+
+class TestTheForegroundRunnerReportsAFailedBringUp:
+    """``Robot(...).run()`` wraps the wrapper in ``except Exception`` so an
+    operator is told when the runtime did not come up. That only works if the
+    wrapper raises: a returned ``None`` is indistinguishable from success."""
+
+    def _foreground(self, monkeypatch, bring_up: Any, *, budget: float = 0.05) -> list[str]:
+        import strands_robots.robot as robot_module
+
+        module = _dc()
+        monkeypatch.setattr(module, "init_device_connect", bring_up)
+        monkeypatch.setattr(module, "_INIT_TIMEOUT_S", budget)
+
+        instance = types.SimpleNamespace(_peer_id="arm-1", _peer_type="robot", mesh=None, tool_name_str="arm")
+        # The runner sleeps forever and then exits the process; end both.
+        monkeypatch.setattr("time.sleep", lambda _s: (_ for _ in ()).throw(KeyboardInterrupt()))
+        monkeypatch.setattr(robot_module.os, "_exit", lambda _code: None)
+
+        records: list[str] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(f"{record.levelname} {record.getMessage()}")
+
+        handler = _Capture()
+        logger = logging.getLogger("strands_robots.robot")
+        logger.addHandler(handler)
+        try:
+            robot_module._run_device_connect_foreground(instance)
+        finally:
+            logger.removeHandler(handler)
+        return records
+
+    def test_an_expired_budget_is_reported_to_the_operator(self, monkeypatch):
+        """Without a raise this outcome logged nothing at all, leaving the
+        runner's "is online" line as the only thing said about a runtime that
+        never came up."""
+        records = self._foreground(monkeypatch, _never_finishes)
+
+        failures = [r for r in records if "Device Connect init failed" in r]
+        assert failures, records
+        assert "did not come up" in failures[0]
+
+    def test_a_failed_bring_up_is_still_reported_to_the_operator(self, monkeypatch):
+        """The unchanged half: an exception already reached this warning."""
+        records = self._foreground(monkeypatch, _fails, budget=30.0)
+
+        failures = [r for r in records if "Device Connect init failed" in r]
+        assert failures, records
+        assert "no broker" in failures[0]
+
+
+class TestTheBudgetIsReadFromTheModuleRatherThanAnInlineLiteral:
+    """Premises the tests above rest on, pinned so they cannot quietly stop
+    holding: the budget is a module attribute (so an expiry is reachable in a
+    unit test at all) and the return type is not optional (so handing back the
+    empty holder was a defect rather than a documented outcome)."""
+
+    def test_the_budget_is_a_positive_finite_number(self):
+        module = _dc()
+
+        budget = module._INIT_TIMEOUT_S
+        assert isinstance(budget, float)
+        assert 0.0 < budget < float("inf")
+
+    def test_the_wait_is_bounded_by_the_module_budget(self):
+        """The wait must read the module attribute, not an inline number: a
+        re-hardcoded budget would make the expiry arm untestable again."""
+        module = _dc()
+        source = pathlib.Path(module.__file__).read_text()
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "init_device_connect_sync"
+        )
+
+        waits = [
+            call
+            for call in ast.walk(function)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute) and call.func.attr == "wait"
+        ]
+        assert len(waits) == 1, [ast.unparse(w) for w in waits]
+        timeouts = [kw.value for kw in waits[0].keywords if kw.arg == "timeout"]
+        assert len(timeouts) == 1, ast.unparse(waits[0])
+        assert isinstance(timeouts[0], ast.Name), ast.unparse(timeouts[0])
+        assert timeouts[0].id == "_INIT_TIMEOUT_S"
+
+    def test_the_wait_result_decides_whether_the_bring_up_finished(self):
+        """The bound wait's own answer is the only thing separating a completed
+        bring-up from an expired budget, so it must be read rather than dropped."""
+        module = _dc()
+        source = pathlib.Path(module.__file__).read_text()
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "init_device_connect_sync"
+        )
+
+        bound = [
+            node.targets[0].id
+            for node in ast.walk(function)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "wait"
+        ]
+        assert len(bound) == 1, bound
+        tested = {ast.unparse(node.test) for node in ast.walk(function) if isinstance(node, ast.If)}
+        assert f"not {bound[0]}" in tested, tested
+
+    def test_the_wrapper_promises_a_runtime_rather_than_an_optional_one(self):
+        module = _dc()
+
+        assert module.init_device_connect_sync.__annotations__["return"] == "DeviceRuntime"


### PR DESCRIPTION
## Problem

`init_device_connect_sync` starts `init_device_connect` on a daemon thread and bounds
the wait, then discarded the answer that bound gave it:

```python
ready.wait(timeout=30.0)          # returns False when the budget expires

if error_holder[0] is not None:
    raise error_holder[0]
...
return runtime_holder[0]          # None, if the bring-up never finished
```

That boolean was the only thing separating "the runtime came up" from "it did not".
With it dropped, an expired budget fell through to `return runtime_holder[0]` and
handed the caller `None` after 30 seconds -- past a declared `-> "DeviceRuntime"` --
with nothing logged.

So the two failure modes of one function reported differently. A bring-up that
**raised** was carried to the caller's thread and re-raised. A bring-up that
**never finished** was indistinguishable from success.

`Robot(...).run()` wraps this call in `except Exception` precisely so a failed
bring-up is reported rather than silently skipped, which makes the timeout the one
failure that channel could not see. Measured through that shipped runner:

| bring-up outcome | caller receives | operator log | `_device_connect_runtime` |
| --- | --- | --- | --- |
| completes | `returned SimpleNamespace` (0.00s) | - | the runtime |
| fails | `raised RuntimeError` (0.00s) | reported | `UNSET` (assignment skipped) |
| **budget expires** | **`returned None`** (30.00s) | **nothing logged** | **`None`** |

The operator's only line in that third row was the runner's own
`arm-1 is online. Ctrl+C to stop.` -- printed for a runtime that never
came up, with `_device_connect_runtime` set to `None`, so the later
`runtime.stop()` on shutdown had nothing to stop either.

## Change

Read the wait's result, and raise on expiry:

```python
started = ready.wait(timeout=_INIT_TIMEOUT_S)

# The recorded failure first: `_start`'s `finally` sets the event on both paths,
# so a bring-up that failed inside the budget arrives with `started` true and its
# own exception, which names the cause better than the budget.
if error_holder[0] is not None:
    raise error_holder[0]
if not started:
    raise TimeoutError(...)
```

The refusal names the budget and what to check, so the timeout joins the failure
channel its sibling already used:

```
init_device_connect_sync: the Device Connect runtime did not come up within 30s.
The bring-up is still running on its background thread; check that the messaging
URL / broker is reachable.
```

The budget moves to a module constant documenting why it exists, mirroring
`_BODY_STATE_MAIN_THREAD_TIMEOUT_S` in `simulation/isaac`. That also makes the
expiry arm reachable in a unit test at all: with the literal inline, every test of
it had to wait the shipped 30 seconds.

A successful bring-up is unchanged and still returns the runtime with its loop and
thread wired; a bring-up that raises is unchanged and still re-raises the same
exception object.

## Scope

The `Raises:` section is new -- the docstring documented neither the re-raised
exception (which already crossed the thread boundary) nor the expiry.

Not changed: the 30-second value itself, and `_start`'s `finally: ready.set()`,
which is what makes the recorded-error check reachable at all.

## Verification

Pre-fix (source reverted to main, the new tests kept, tolerant budget patch so the
failures are behavioural rather than an `AttributeError` on the new constant):

```
3 failed, 5 passed in 90.51s
FAILED ...::test_an_expired_budget_raises_rather_than_returning_none - Failed: DID NOT RAISE TimeoutError
FAILED ...::test_an_expired_budget_names_the_budget_and_where_to_look - Failed: DID NOT RAISE TimeoutError
FAILED ...::test_an_expired_budget_is_reported_to_the_operator - AssertionError: []
```

The 90 seconds is 3 x the hardcoded 30-second budget. Post-fix the same file is
`12 passed in 0.71s`. The `AssertionError: []` is the empty operator log, with
pytest's captured stdout showing `arm-1 is online. Ctrl+C to stop.` as the only
thing said. The 5 that pass pre-fix are the arms that already worked -- a completed
bring-up, the re-raise, and its operator warning -- so the new tests are not
satisfied by deleting anything.

Mutation table, 5 plausible regressions against two arms:

| mutation | new module (12) | pre-existing (1291) |
| --- | --- | --- |
| M1 timeout arm deleted (returns `None` again) | 4 failed | 0 failed |
| M2 timeout checked before the recorded error | 0 failed | 0 failed |
| M3 budget re-hardcoded at the wait site | 1 failed | 0 failed |
| M4 recorded exception re-wrapped, not re-raised | 1 failed | 0 failed |
| M5 budget omitted from the refusal message | 1 failed | 0 failed |
| *(unmutated control)* | 0 failed | 0 failed |

4 of 5 caught here, all 4 invisible to the 1291 pre-existing `device_connect` and
robot-factory tests. **M2 is unobservable by construction** and I am reporting it
rather than claiming it: `_start` sets the event in a `finally`, so a bring-up that
failed inside the budget always arrives with `started` true, which makes the two
arms mutually exclusive. The ordering is defence in depth and the comment says so.
M3 is caught only by the structural pin, because with the literal restored the
behavioural tests still pass -- 30 seconds later each.

Coverage of `device_connect/__init__.py` over its own suite: 88.1% -> 97.6%
(10 -> 2 missing). The module's three uncovered lines were exactly this contract's
failure arms.

Gate on `55e5416d`: `28631 passed, 257 skipped` in 629.78s (`MUJOCO_GL=egl`),
`ruff check` + `ruff format --check` clean (1186 files), `mypy` 0 errors outside
`examples/isaac_gs` (14 there, error set byte-identical to a pristine-base
worktree, so environmental). `check_merge_base_overlap.py` reports no overlap
against the current tip.

## Note on the gated tree

The gate above ran on `6ce20aff`. The pushed head `8ca67d34` differs from it in one respect only: the changelog fragment was renamed `2204-` -> `2205-` once this PR's number was known. `assemble_changelog.py --check` and both changelog guards were re-run after the rename (30 passed); no source or test line changed.

## Artifact

No policy, simulation, rendering, recording or asset behaviour changes, so the
artifact is the measurement rather than a rollout: the three bring-up outcomes as
a caller and an operator actually see them, driven through the shipped foreground
runner in both trees.

![bring-up outcomes](https://raw.githubusercontent.com/cagataycali/robots/artifacts/device-connect-bringup-outcomes/device-connect-bringup-outcomes.png)

