### PR TITLE
feat(examples/fleet): 04_emergency_evacuation - three-phase evacuate protocol, benchmark-scored

### DIFF
--- a/changelog.d/2183-fleet-emergency-evacuation.md
+++ b/changelog.d/2183-fleet-emergency-evacuation.md
@@ -1,0 +1,18 @@
+### Added: fleet emergency-evacuation example (three-phase protocol, benchmark-scored)
+
+`examples/fleet/04_emergency_evacuation.py` drills the evacuation protocol a
+plain e-stop cannot provide - a frozen robot in a corridor is itself the
+blocking hazard. Phase 1: an injected alarm broadcast aborts every rollout
+fleet-wide, rate-limited and audited. Phase 2: each robot runs a pre-validated
+deterministic retreat (scripted base/joint setpoints behind the
+`EvacuationWorld` seam, so the Isaac adapter drops in later) to muster, ordered
+by corridor distance - closest to the path first, never an LLM decision.
+Phase 3: mesh lockout engages only after the path is asserted clear, and
+resume goes through the HMAC override protocol with operator approval - a
+wrong-code or declined resume leaves the lockout engaged. A
+`DeclarativeBenchmark` scores the run: any robot re-entering the
+clearance-inflated corridor fails it, and it passes only when the personnel
+proxy reaches the exit unimpeded and the abort met its deadline. The incident
+report is built deterministically from the signed audit log, and the mesh ACL
+template gains a read-only `dashboard` role (observe presence/health/safety/
+camera; no command-plane grants). (#2183, epic #2179)

--- a/examples/fleet/04_emergency_evacuation.py
+++ b/examples/fleet/04_emergency_evacuation.py
@@ -513,7 +513,7 @@ class ScriptedEvacuationWorld:
         self._proxy = [x, y]
 
     def settle(self, n: int) -> None:
-        del n  # kinematic world: nothing integrates
+        """No-op: a kinematic world integrates nothing, so a tick advances nothing."""
 
     # Benchmark engine surface (plain non-envelope payloads).
     def get_body_state(self, body_name: str) -> dict[str, Any]:

--- a/examples/fleet/04_emergency_evacuation.py
+++ b/examples/fleet/04_emergency_evacuation.py
@@ -1,0 +1,961 @@
+#!/usr/bin/env python3
+"""Three-phase emergency evacuation protocol for a robot fleet, benchmark-scored.
+
+Goal: During an emergency, robots must immediately clear the evacuation path
+and never block personnel. A plain e-stop is NOT sufficient - a frozen robot
+in a corridor is itself the blocking hazard, and mesh lockout refuses every
+action except ``status``/``resume`` (strands_robots.mesh.core). So the
+protocol layers three phases on the primitives that already exist, with the
+LLM outside the safety path at every step:
+
+- **Phase 1 - abort**: an injected alarm broadcast (a mesh event, not a
+  simulated sensor) stops every policy rollout fleet-wide. Rate-limited (an
+  alarm flood cannot re-trigger the protocol) and audited.
+- **Phase 2 - clear path**: each robot runs a pre-validated deterministic
+  retreat - scripted base/joint setpoints, never a learned policy - to its
+  muster pose. Priority conflicts resolve by deterministic corridor-distance
+  ordering: closest to the path moves first, the others hold. Explicitly not
+  an LLM decision.
+- **Phase 3 - lockout + HITL resume**: mesh lockout engages only AFTER the
+  path is clear (lockout first would freeze the hazard in place). Resume goes
+  through the existing HMAC override protocol with operator approval, and a
+  declined resume leaves the lockout engaged.
+
+Scored, not narrated: a ``DeclarativeBenchmark`` (predicate DSL) fails the run
+if any robot re-enters the inflated corridor (clearance margin) at any tick
+after the path is declared clear, and succeeds only when the personnel proxy
+reaches the exit unimpeded AND the fleet-wide abort finished inside its
+deadline.
+
+Dependencies: pip install "strands-robots[sim-mujoco,mesh]"
+              (--dry-run needs only the base package: no simulator, no Zenoh)
+Expected output: alarm -> abort (timed) -> ordered retreat with live corridor
+                 clearances -> lockout engaged at muster -> a wrong-code
+                 resume refused with the lockout intact -> benchmark verdict
+                 as the proxy traverses -> incident report from the signed
+                 audit log -> HITL-approved resume.
+Runtime: ~5 seconds with --dry-run; under ~90 seconds live.
+
+Note: The live lockout drill needs `STRANDS_MESH_OVERRIDE_CODE`; when unset,
+      the example generates a single-run code and says so loudly. Interactive
+      operator approval is the default; set `STRANDS_MESH_HITL_ACTIONS=none`
+      for unattended runs (CI posture). Set STRANDS_MESH_AUDIT_PSK to sign the
+      audit trail the incident report is built from.
+
+Part of the fleet suite (epic #2179). The retreat sits behind the small
+``EvacuationWorld`` seam so the Isaac adapter (#2123) drops in later; the
+read-only Rerun fleet dashboard (#2181) attaches to the same mesh and shows
+the safety events live once it lands.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("STRANDS_MESH_LOCAL_DEV", "1")
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import argparse
+import secrets
+import time
+from collections.abc import Callable
+from typing import Any
+
+from strands_robots.mesh.audit import log_safety_event, read_audit_log, verify_audit_integrity
+from strands_robots.simulation.benchmark_spec import DeclarativeBenchmark
+from strands_robots.simulation.predicates import PREDICATE_REGISTRY, BoolPredicate, register_predicate
+
+COORDINATOR_ID = "evac-coordinator"
+FLEET_PEER_ID = "evac-fleet-sim"
+ALARM_TOPIC = "strands/safety/alarm"
+PROXY_BODY = "evac-proxy"
+
+# The corridor is the evacuation path: an axis-aligned rectangle in the world
+# XY plane. CLEARANCE_M is the margin every robot must keep from it after the
+# path is declared clear; the benchmark checks it as an INFLATED rectangle
+# (per-axis inflation is stricter than Euclidean distance near the corners,
+# i.e. conservative in the safe direction).
+CORRIDOR = {"x_min": -3.0, "x_max": 3.0, "y_min": -0.7, "y_max": 0.7}
+CLEARANCE_M = 0.8
+ABORT_DEADLINE_S = 10.0
+
+# The personnel proxy traverses the corridor centerline toward the exit. It
+# advances only while the next stretch of path is clear of robots - a blocked
+# proxy waits, never teleports through, so "reaches the exit" is honest.
+PROXY_START_XY = (-2.8, 0.0)
+PROXY_STEP_M = 0.15
+PROXY_STANDOFF_M = 0.6
+EXIT_REGION = {"min": [2.4, -0.7, -2.0], "max": [3.6, 0.7, 3.0]}
+
+RETREAT_STEP_M = 0.12  # scripted base setpoint advance per retreat tick
+MUSTER_TOL_M = 0.05
+
+# The fleet (epic D3 cast): two mobile robots mid-task inside the corridor and
+# one arm whose reach overhangs it. ``muster`` is a pre-validated pose OUTSIDE
+# the inflated corridor; the arm musters by folding (its base cannot move), so
+# its tracked point is the wrist, not the base.
+FLEET: list[dict[str, Any]] = [
+    {"robot": "lekiwi-1", "data_config": "lekiwi", "kind": "mobile", "spawn": [0.4, 0.35, 0.0], "muster": [0.4, 2.2]},
+    {
+        "robot": "go2-1",
+        "data_config": "unitree_go2",
+        "kind": "mobile",
+        "spawn": [-1.2, -0.4, 0.0],
+        "muster": [-1.2, -2.2],
+    },
+    {"robot": "arm-1", "data_config": "so101", "kind": "arm", "spawn": [1.6, 1.7, 0.0], "muster": [1.6, 1.75]},
+]
+
+# Folded muster joint setpoints for the arm (radians), applied to the arm's
+# joints in kinematic order (base rotation first) and clamped to each joint's
+# range at discovery time. Pre-validated: rotates the reach away from the
+# corridor and tucks it over the base.
+ARM_MUSTER_SETPOINTS = [1.5, -1.5, 1.4, 1.0, 0.0, 0.0]
+ARM_RETREAT_TICKS = 20
+
+
+def corridor_distance(x: float, y: float, corridor: dict[str, float] | None = None) -> float:
+    """Euclidean distance from a world XY point to the corridor rectangle.
+
+    Zero inside the corridor. This is the live clearance telemetry; the
+    benchmark's pass/fail uses the (stricter) inflated-rectangle form via the
+    built-in ``inside_region`` predicate.
+    """
+    c = CORRIDOR if corridor is None else corridor
+    dx = max(c["x_min"] - x, 0.0, x - c["x_max"])
+    dy = max(c["y_min"] - y, 0.0, y - c["y_max"])
+    return float((dx * dx + dy * dy) ** 0.5)
+
+
+def _centerline_distance(x: float, y: float) -> float:
+    """Distance to the corridor centerline (y = mid): the retreat priority key."""
+    return abs(y - (CORRIDOR["y_min"] + CORRIDOR["y_max"]) / 2.0)
+
+
+def retreat_order(positions: dict[str, tuple[float, float]]) -> list[str]:
+    """Deterministic priority ordering: closest to the path moves first.
+
+    Sorted by distance to the corridor centerline ascending, name-tiebroken.
+    Explicitly not an LLM decision - the safety layer is deterministic code.
+    """
+    return sorted(positions, key=lambda name: (_centerline_distance(*positions[name]), name))
+
+
+class AlarmGate:
+    """Rate limiter for alarm handling: an alarm flood must not re-trigger the
+    protocol back to back. Mirrors the robot_mesh tool's emergency_stop cap
+    (3 per rolling 60 s); a suppressed alarm is audited, never silently dropped.
+    """
+
+    def __init__(self, max_alarms: int = 3, window_s: float = 60.0, clock: Callable[[], float] = time.monotonic):
+        self._max = max_alarms
+        self._window = window_s
+        self._clock = clock
+        self._admitted: list[float] = []
+
+    def admit(self, alarm_id: str) -> bool:
+        now = self._clock()
+        self._admitted = [t for t in self._admitted if now - t < self._window]
+        if len(self._admitted) >= self._max:
+            _audit("evacuation_alarm_suppressed", {"alarm_id": alarm_id, "window_s": self._window})
+            return False
+        self._admitted.append(now)
+        return True
+
+
+def _audit(event: str, payload: dict[str, Any]) -> None:
+    log_safety_event(event, COORDINATOR_ID, payload)
+
+
+def _evacuation_abort_within(deadline_s: float) -> BoolPredicate:
+    """True when the recorded fleet-wide abort finished within ``deadline_s``.
+
+    Reads ``sim.evacuation_abort_elapsed_s``, stamped by phase 1. Stateless by
+    design (no closure over run state), so the guarded re-registration below
+    is safe across reloads.
+    """
+
+    def check(sim: Any) -> bool:
+        elapsed = getattr(sim, "evacuation_abort_elapsed_s", None)
+        if isinstance(elapsed, bool) or not isinstance(elapsed, (int, float)):
+            return False
+        return 0.0 <= float(elapsed) <= float(deadline_s)
+
+    return check
+
+
+def register_evacuation_predicates() -> None:
+    """Register the custom abort-deadline predicate (idempotent)."""
+    if "evacuation_abort_within" not in PREDICATE_REGISTRY:
+        register_predicate("evacuation_abort_within", _evacuation_abort_within)
+
+
+def build_benchmark_spec(tracked_bodies: dict[str, str], abort_deadline_s: float = ABORT_DEADLINE_S) -> dict[str, Any]:
+    """The evacuation scorecard as a declarative predicate-DSL spec.
+
+    Failure at ANY scored tick: a tracked robot body inside the corridor
+    inflated by the clearance margin - that is "min distance to the corridor
+    stayed above X for all t after T_clear", expressed without a NOT.
+    Success: the proxy inside the exit region AND the abort inside deadline.
+    A proxy that a lingering robot blocks simply never reaches the exit, so
+    the run fails on the step budget - unimpeded is asserted, not narrated.
+    """
+    inflated = {
+        "min": [CORRIDOR["x_min"] - CLEARANCE_M, CORRIDOR["y_min"] - CLEARANCE_M, -2.0],
+        "max": [CORRIDOR["x_max"] + CLEARANCE_M, CORRIDOR["y_max"] + CLEARANCE_M, 3.0],
+    }
+    return {
+        "name": "emergency-evacuation-corridor-clear",
+        "max_steps": 120,
+        "default_robot": "lekiwi",
+        "success": {
+            "all": [
+                {"predicate": "inside_region", "body": PROXY_BODY, **EXIT_REGION},
+                {"predicate": "evacuation_abort_within", "deadline_s": abort_deadline_s},
+            ]
+        },
+        "failure": {
+            "any": [{"predicate": "inside_region", "body": body, **inflated} for body in tracked_bodies.values()]
+        },
+    }
+
+
+# The evacuation-world seam. The protocol core talks to this surface only, so
+# the Isaac adapter (#2123) is one more implementation, not a protocol change.
+# Implementations: MujocoEvacuationWorld (live) and ScriptedEvacuationWorld
+# (--dry-run and the smoke test). The contract:
+#
+#   robot_names            ordered fleet names
+#   tracked_body(name)     body name the benchmark watches for that robot
+#   tracked_xy(name)       that body's current world XY
+#   tasks_running()        names still running a policy rollout
+#   stop_all_tasks()       fleet-wide abort (mesh broadcast on the live path)
+#   retreat_tick(name)     ONE deterministic setpoint tick toward muster;
+#                          returns True once mustered
+#   proxy_xy()/set_proxy_xy(x, y)   the personnel proxy
+#   settle(n)              advance physics/time n ticks
+#   sim                    the object benchmark predicates read
+
+
+def run_evacuation(
+    world: Any,
+    *,
+    abort_deadline_s: float = ABORT_DEADLINE_S,
+    abort_poll_s: float = 0.2,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+    on_tick: Callable[[str, float, float], None] | None = None,
+) -> dict[str, Any]:
+    """Phases 1 and 2: fleet-wide abort, then the ordered deterministic retreat.
+
+    Returns ``{"abort_elapsed_s", "order", "clearances"}`` and stamps
+    ``world.sim.evacuation_abort_elapsed_s`` for the benchmark's deadline
+    predicate. Raises if the abort misses its deadline or a robot fails to
+    muster clear of the corridor - the path being clear is asserted, never
+    assumed, before phase 3 may engage the lockout.
+
+    The stop is delivered at-least-once: it is re-issued on every poll until
+    the fleet reports quiet. A single stop can race a rollout that is still
+    warming up (its running flag is raised only once its control loop starts),
+    and a stop that lands inside that window would be silently overwritten -
+    re-issuing the idempotent stop closes the race without trusting any
+    single acknowledgement.
+    """
+    print("\nphase 1 - abort: stopping every rollout fleet-wide")
+    t0 = clock()
+    while True:
+        world.stop_all_tasks()
+        if not world.tasks_running():
+            break
+        if clock() - t0 > abort_deadline_s:
+            still = world.tasks_running()
+            _audit("evacuation_abort_timeout", {"deadline_s": abort_deadline_s, "still_running": still})
+            raise RuntimeError(f"abort missed its {abort_deadline_s:.0f}s deadline; still running: {still}")
+        sleep(abort_poll_s)
+    abort_elapsed = clock() - t0
+    world.sim.evacuation_abort_elapsed_s = abort_elapsed
+    _audit("evacuation_abort_complete", {"elapsed_s": round(abort_elapsed, 3), "robots": list(world.robot_names)})
+    print(f"  all rollouts stopped in {abort_elapsed:.2f}s (deadline {abort_deadline_s:.0f}s)")
+
+    print("\nphase 2 - clear path: deterministic retreat, closest to the path first")
+    positions = {name: world.tracked_xy(name) for name in world.robot_names}
+    order = retreat_order(positions)
+    _audit("evacuation_retreat_order", {"order": order})
+    print(f"  order: {' -> '.join(order)} (corridor-distance priority; the others hold)")
+    clearances: dict[str, float] = {}
+    tick = 0
+    for name in order:
+        budget = 400  # deterministic setpoints converge; a diverging retreat is a fault, not a wait
+        while not world.retreat_tick(name):
+            tick += 1
+            budget -= 1
+            if budget <= 0:
+                _audit("evacuation_retreat_stuck", {"robot": name})
+                raise RuntimeError(f"{name}: retreat did not converge; refusing to engage lockout")
+            if on_tick is not None:
+                for robot in world.robot_names:
+                    on_tick(robot, float(tick), corridor_distance(*world.tracked_xy(robot)))
+        clearance = corridor_distance(*world.tracked_xy(name))
+        clearances[name] = round(clearance, 3)
+        _audit("evacuation_robot_mustered", {"robot": name, "clearance_m": clearances[name]})
+        print(f"  {name}: mustered, corridor clearance {clearance:.2f} m")
+
+    breaching = {n: c for n, c in clearances.items() if c <= CLEARANCE_M}
+    if breaching:
+        _audit("evacuation_clear_failed", {"breaching": breaching, "required_m": CLEARANCE_M})
+        raise RuntimeError(f"path not clear: {breaching} (required > {CLEARANCE_M} m); refusing to engage lockout")
+    _audit("evacuation_path_clear", {"clearances": clearances, "required_m": CLEARANCE_M})
+    print(f"  path clear: every clearance > {CLEARANCE_M} m")
+    return {"abort_elapsed_s": abort_elapsed, "order": order, "clearances": clearances}
+
+
+def score_evacuation(
+    world: Any,
+    benchmark: DeclarativeBenchmark,
+    *,
+    on_tick: Callable[[str, float, float], None] | None = None,
+) -> dict[str, Any]:
+    """Score the cleared path with the declarative benchmark, tick by tick.
+
+    The proxy advances along the corridor only while the stretch ahead is
+    clear of robots; every tick the benchmark's failure clause (a robot back
+    inside the inflated corridor) and success clause (proxy at the exit,
+    abort inside deadline) are evaluated. Deterministic: scripted setpoints,
+    fixed step sizes, no randomness.
+    """
+    for step in range(benchmark.max_steps):
+        px, py = world.proxy_xy()
+        ahead = (px + PROXY_STEP_M, py)
+        blocked = any(
+            ((world.tracked_xy(n)[0] - ahead[0]) ** 2 + (world.tracked_xy(n)[1] - ahead[1]) ** 2) ** 0.5
+            < PROXY_STANDOFF_M
+            for n in world.robot_names
+        )
+        if not blocked:
+            world.set_proxy_xy(*ahead)
+        world.settle(1)
+        if on_tick is not None:
+            for robot in world.robot_names:
+                on_tick(robot, float(step), corridor_distance(*world.tracked_xy(robot)))
+        if benchmark.is_failure(world.sim):
+            verdict = {"passed": False, "reason": "corridor clearance breached", "steps": step + 1}
+            _audit("evacuation_scored", verdict)
+            return verdict
+        if benchmark.is_success(world.sim):
+            verdict = {"passed": True, "reason": "proxy reached the exit unimpeded", "steps": step + 1}
+            _audit("evacuation_scored", verdict)
+            return verdict
+    verdict = {"passed": False, "reason": "proxy never reached the exit", "steps": benchmark.max_steps}
+    _audit("evacuation_scored", verdict)
+    return verdict
+
+
+def build_incident_report(records: list[dict[str, Any]], integrity: dict[str, Any]) -> str:
+    """Deterministic incident report from the signed audit trail.
+
+    Structured post-event reconstruction - the LLM stays outside the safety
+    path; pass the result to an agent for a narrative if you want one
+    (``--agent-report``), but the record of what happened is this.
+    """
+    lines = [
+        "# Evacuation incident report",
+        "",
+        f"Audit integrity: ok={integrity['ok']} (signed={integrity['signed']}/{integrity['total']})",
+        "",
+        "| t | peer | event | detail |",
+        "|---|---|---|---|",
+    ]
+    t0: float | None = None
+    for record in records:
+        event = record.get("event")
+        ts = record.get("ts")
+        if not isinstance(event, str) or isinstance(ts, bool) or not isinstance(ts, (int, float)):
+            continue
+        if t0 is None:
+            t0 = float(ts)
+        payload = record.get("payload")
+        detail = ""
+        if isinstance(payload, dict):
+            detail = ", ".join(
+                f"{k}={payload[k]}" for k in sorted(payload) if isinstance(payload[k], (str, int, float))
+            )
+        lines.append(f"| +{float(ts) - t0:.2f}s | {record.get('peer_id', '?')} | {event} | {detail[:120]} |")
+    return "\n".join(lines)
+
+
+class EvacuationTrace:
+    """Optional visualization: live corridor-clearance plot, camera tiles and
+    a saved ``.rrd`` replay artifact via Rerun; a GIF of the retreat via
+    imageio. Both degrade loudly to no-ops when unavailable - visualization
+    must never gate the safety path.
+    """
+
+    def __init__(self, rrd_path: str | None = None, gif_path: str | None = None, camera: str = "default"):
+        self._rr: Any | None = None
+        self._gif_path = gif_path
+        self._camera = camera
+        self._frames: list[Any] = []
+        self._seq: dict[str, int] = {}
+        if rrd_path:
+            try:
+                from strands_robots.utils import require_optional
+
+                rr = require_optional("rerun", pip_install="rerun-sdk", purpose="the evacuation replay artifact")
+                rr.init("strands-fleet-evacuation")
+                rr.save(rrd_path)
+                self._rr = rr
+                print(f"  rerun replay -> {rrd_path}")
+            except ImportError as exc:
+                print(f"  rerun unavailable ({exc}); continuing without the .rrd artifact")
+
+    def clearance(self, robot: str, tick: float, clearance_m: float) -> None:
+        del tick  # phases restart their tick counters; the plot wants one monotonic axis
+        if self._rr is None:
+            return
+        seq = self._seq[robot] = self._seq.get(robot, 0) + 1
+        set_time = getattr(self._rr, "set_time_sequence", None)
+        if set_time is not None:
+            set_time("tick", seq)
+        scalar_type = getattr(self._rr, "Scalars", None) or getattr(self._rr, "Scalar", None)
+        if scalar_type is not None:
+            self._rr.log(f"corridor/clearance/{robot}", scalar_type(clearance_m))
+
+    def frame(self, world: Any) -> None:
+        """Capture one camera tile (live worlds only; scripted worlds have none)."""
+        get_frame = getattr(world.sim, "get_frame", None)
+        if get_frame is None:
+            return
+        try:
+            rgb, _depth = get_frame(camera_name=self._camera, width=480, height=360)
+        except Exception as exc:  # noqa: BLE001 - visualization must never break the drill
+            print(f"  frame capture failed ({exc}); continuing")
+            return
+        if self._gif_path is not None:
+            self._frames.append(rgb)
+        if self._rr is not None:
+            image_type = getattr(self._rr, "Image", None)
+            if image_type is not None:
+                self._rr.log(f"corridor/camera/{self._camera}", image_type(rgb))
+
+    def close(self) -> None:
+        if self._gif_path and self._frames:
+            try:
+                import imageio.v2 as imageio
+
+                imageio.mimsave(self._gif_path, self._frames, duration=0.08)
+                print(f"  retreat GIF -> {self._gif_path} ({len(self._frames)} frames)")
+            except ImportError as exc:
+                print(f"  imageio unavailable ({exc}); skipping the GIF artifact")
+
+
+class ScriptedEvacuationWorld:
+    """Kinematic evacuation world: no simulator, no Zenoh, fully deterministic.
+
+    Doubles as the benchmark's engine: ``get_body_state`` serves scripted
+    positions in the plain (non-envelope) shape the predicate helpers accept,
+    so the REAL ``DeclarativeBenchmark`` scores the dry run too.
+    """
+
+    def __init__(self, fleet: list[dict[str, Any]] | None = None):
+        self._fleet = {entry["robot"]: dict(entry) for entry in (FLEET if fleet is None else fleet)}
+        self.robot_names = list(self._fleet)
+        self._xy: dict[str, list[float]] = {}
+        self._arm_ticks: dict[str, int] = {}
+        for name, entry in self._fleet.items():
+            if entry["kind"] == "arm":
+                # The arm's tracked point is its reach, which overhangs the
+                # corridor edge until the fold pulls it back over the base.
+                self._xy[name] = [entry["spawn"][0], CORRIDOR["y_max"] + 0.35]
+                self._arm_ticks[name] = 0
+            else:
+                self._xy[name] = [entry["spawn"][0], entry["spawn"][1]]
+        self._proxy = list(PROXY_START_XY)
+        self._running = set(self.robot_names)
+        self.sim = self  # benchmark predicates read this object directly
+
+    def tracked_body(self, name: str) -> str:
+        return f"{name}/tracked"
+
+    def tracked_xy(self, name: str) -> tuple[float, float]:
+        return (self._xy[name][0], self._xy[name][1])
+
+    def tasks_running(self) -> list[str]:
+        return sorted(self._running)
+
+    def stop_all_tasks(self) -> None:
+        for name in self.tasks_running():
+            print(f"  [scripted] {name}: rollout stopped")
+        self._running.clear()
+
+    def retreat_tick(self, name: str) -> bool:
+        entry = self._fleet[name]
+        if entry["kind"] == "arm":
+            ticks = self._arm_ticks[name] = self._arm_ticks[name] + 1
+            frac = min(1.0, ticks / ARM_RETREAT_TICKS)
+            start_y = CORRIDOR["y_max"] + 0.35
+            self._xy[name][1] = start_y + frac * (entry["muster"][1] - start_y)
+            self._xy[name][0] = entry["muster"][0]
+            return frac >= 1.0
+        x, y = self._xy[name]
+        tx, ty = entry["muster"]
+        dx, dy = tx - x, ty - y
+        dist = (dx * dx + dy * dy) ** 0.5
+        if dist <= MUSTER_TOL_M:
+            return True
+        step = min(RETREAT_STEP_M, dist)
+        self._xy[name] = [x + dx / dist * step, y + dy / dist * step]
+        return dist - step <= MUSTER_TOL_M
+
+    def proxy_xy(self) -> tuple[float, float]:
+        return (self._proxy[0], self._proxy[1])
+
+    def set_proxy_xy(self, x: float, y: float) -> None:
+        self._proxy = [x, y]
+
+    def settle(self, n: int) -> None:
+        del n  # kinematic world: nothing integrates
+
+    # Benchmark engine surface (plain non-envelope payloads).
+    def get_body_state(self, body_name: str) -> dict[str, Any]:
+        if body_name == PROXY_BODY:
+            return {"status": "success", "position": [self._proxy[0], self._proxy[1], 0.1]}
+        for name in self.robot_names:
+            if body_name == self.tracked_body(name):
+                x, y = self.tracked_xy(name)
+                return {"status": "success", "position": [x, y, 0.2]}
+        return {"status": "error", "content": [{"text": f"unknown body '{body_name}'"}]}
+
+
+class MujocoEvacuationWorld:
+    """Live evacuation world: one MuJoCo scene holding the whole fleet.
+
+    The retreat writes base qpos directly (the documented teleport pattern:
+    write qpos, run forward kinematics) under the sim lock - deterministic
+    scripted setpoints, exactly what phase 2 promises. Joint-space folds go
+    through the public ``set_joint_positions``.
+    """
+
+    def __init__(self, sim: Any, mesh: Any | None = None):
+        self.sim = sim
+        self.mesh = mesh  # coordinator peer; None = stop locally
+        self.robot_names = [entry["robot"] for entry in FLEET]
+        self._fleet = {entry["robot"]: dict(entry) for entry in FLEET}
+        self._arm_ticks: dict[str, int] = {}
+        # name -> (qpos adr, dof adr, tracked body); adr < 0 marks a fixed base.
+        self._base: dict[str, tuple[int, int, str]] = {}
+        self._arm_joints: dict[str, dict[str, tuple[float, float]]] = {}  # name -> joint -> (start, target)
+        self._discover()
+
+    def _discover(self) -> None:
+        import mujoco as mj
+
+        # Direct model access is required here: MuJoCo has no public
+        # base-teleport API (Isaac's set_robot_pose is the #2123 seam), and
+        # the free joint / wrist body of each robot is model metadata.
+        model, data = self.sim._world._model, self.sim._world._data
+        for name, entry in self._fleet.items():
+            robot = self.sim._world.robots[name]
+            if entry["kind"] == "arm":
+                joints: dict[str, tuple[float, float]] = {}
+                for rel, target in zip(robot.joint_names, ARM_MUSTER_SETPOINTS, strict=False):
+                    jname = f"{robot.namespace}{rel}"
+                    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, jname)
+                    if jid < 0:
+                        continue
+                    clamped = float(target)
+                    if model.jnt_limited[jid]:
+                        lo, hi = float(model.jnt_range[jid][0]), float(model.jnt_range[jid][1])
+                        clamped = min(max(clamped, lo), hi)
+                    joints[jname] = (float(data.qpos[model.jnt_qposadr[jid]]), clamped)
+                if not joints:
+                    raise RuntimeError(f"{name}: no muster joints resolved; cannot script the arm retreat")
+                self._arm_joints[name] = joints
+                last_jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, next(reversed(joints)))
+                wrist = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, model.jnt_bodyid[last_jid])
+                self._base[name] = (-1, -1, wrist)
+                self._arm_ticks[name] = 0
+                continue
+            # The library's shared free-joint detection: a NAMED free joint
+            # first, then the kinematic-tree walk that finds an unnamed
+            # <freejoint> (LeKiwi's base). A fixed-base arm returns -1.
+            jid = self.sim._robot_free_base_joint_id(model, robot)
+            if jid < 0:
+                raise RuntimeError(f"{name}: no free base joint found; cannot script the base retreat")
+            adr = int(model.jnt_qposadr[jid])
+            dadr = int(model.jnt_dofadr[jid])
+            body = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, model.jnt_bodyid[jid])
+            self._base[name] = (adr, dadr, body)
+
+    def tracked_body(self, name: str) -> str:
+        return self._base[name][2]
+
+    def tracked_xy(self, name: str) -> tuple[float, float]:
+        adr, _dadr, body = self._base[name]
+        if adr >= 0:
+            data = self.sim._world._data
+            return (float(data.qpos[adr]), float(data.qpos[adr + 1]))
+        result = self.sim.get_body_state(body_name=body)
+        payload = next((c["json"] for c in result.get("content", []) if isinstance(c, dict) and "json" in c), {})
+        pos = payload.get("position", [0.0, 0.0, 0.0])
+        return (float(pos[0]), float(pos[1]))
+
+    def tasks_running(self) -> list[str]:
+        result = self.sim.list_policies_running()
+        text = result["content"][0]["text"]
+        if text.startswith("No policies"):
+            return []
+        return [line.strip("- ").strip() for line in text.splitlines()[1:]]
+
+    def stop_all_tasks(self) -> None:
+        if self.mesh is not None:
+            # The fleet-wide abort is a mesh broadcast, answered by the sim
+            # peer's stop_task (see _FleetSimPeer); a peer that cannot stop
+            # answers ok=False and is surfaced, never assumed halted. The ack
+            # window is short on purpose: run_evacuation re-issues the stop
+            # until the fleet is quiet (at-least-once delivery), so waiting
+            # out a long collection window per attempt would spend the abort
+            # deadline on acks instead of on stopping.
+            responses = self.mesh.broadcast({"action": "stop"}, timeout=1.5)
+            not_stopped = [
+                r
+                for r in responses
+                if isinstance(r, dict)
+                and isinstance(r.get("result", r), dict)
+                and (r.get("result", r).get("ok") is False or r.get("result", r).get("status") == "error")
+            ]
+            if not_stopped:
+                raise RuntimeError(f"fleet abort: peers refused to stop: {not_stopped}")
+            return
+        for name in self.robot_names:
+            self.sim.stop_policy(robot_name=name)
+
+    def retreat_tick(self, name: str) -> bool:
+        import mujoco as mj
+
+        entry = self._fleet[name]
+        if entry["kind"] == "arm":
+            ticks = self._arm_ticks[name] = self._arm_ticks[name] + 1
+            frac = min(1.0, ticks / ARM_RETREAT_TICKS)
+            setpoints = {j: s + frac * (t - s) for j, (s, t) in self._arm_joints[name].items()}
+            result = self.sim.set_joint_positions(positions=setpoints)
+            if result.get("status") != "success":
+                raise RuntimeError(f"{name}: scripted joint setpoint refused: {result}")
+            self.sim.step(2)
+            return frac >= 1.0
+        adr, dadr, _body = self._base[name]
+        model, data = self.sim._world._model, self.sim._world._data
+        x, y = float(data.qpos[adr]), float(data.qpos[adr + 1])
+        tx, ty = entry["muster"]
+        dx, dy = tx - x, ty - y
+        dist = (dx * dx + dy * dy) ** 0.5
+        if dist <= MUSTER_TOL_M:
+            return True
+        step = min(RETREAT_STEP_M, dist)
+        with self.sim._lock:
+            data.qpos[adr] = x + dx / dist * step
+            data.qpos[adr + 1] = y + dy / dist * step
+            # Zero the base twist so the teleported setpoint holds.
+            data.qvel[dadr : dadr + 6] = 0.0
+            mj.mj_forward(model, data)
+        self.sim.step(2)
+        return dist - step <= MUSTER_TOL_M
+
+    def proxy_xy(self) -> tuple[float, float]:
+        result = self.sim.get_body_state(body_name=PROXY_BODY)
+        payload = next((c["json"] for c in result.get("content", []) if isinstance(c, dict) and "json" in c), {})
+        pos = payload.get("position", list(PROXY_START_XY) + [0.0])
+        return (float(pos[0]), float(pos[1]))
+
+    def set_proxy_xy(self, x: float, y: float) -> None:
+        result = self.sim.move_object(PROXY_BODY, position=[x, y, 0.12])
+        if result.get("status") != "success":
+            raise RuntimeError(f"proxy move refused: {result}")
+
+    def settle(self, n: int) -> None:
+        self.sim.step(max(1, n))
+
+
+class _FleetSimPeer:
+    """Mesh owner for the sim peer: makes the whole sim fleet stoppable.
+
+    ``Simulation`` exposes no ``stop_task``, so a bare sim peer honestly
+    answers a fleet stop with ok=False; this adapter is the stop surface -
+    one call stops every robot's rollout and reports it.
+    """
+
+    def __init__(self, sim: Any, robot_names: list[str]):
+        self._sim = sim
+        self._robot_names = robot_names
+
+    def stop_task(self) -> dict[str, Any]:
+        stopped = []
+        for name in self._robot_names:
+            result = self._sim.stop_policy(robot_name=name)
+            if result.get("status") != "success":
+                return {"ok": False, "error": f"stop_policy({name}) failed: {result}"}
+            stopped.append(name)
+        return {"ok": True, "status": "stopped", "robots": stopped}
+
+
+def _operator_approves(prompt: str) -> bool:
+    """HITL gate for the resume. Interactive by default; the CI/smoke posture
+    is STRANDS_MESH_HITL_ACTIONS=none (epic D4), which auto-approves here the
+    way the robot_mesh tool skips its interrupt. A decline is a first-class
+    outcome: nothing is sent, the lockout stays.
+    """
+    if os.getenv("STRANDS_MESH_HITL_ACTIONS", "").strip().lower() == "none":
+        print(f"  [HITL] {prompt} -> auto-approved (STRANDS_MESH_HITL_ACTIONS=none)")
+        return True
+    reply = input(f"  [HITL] {prompt} [y/N]: ").strip().lower()
+    return reply in ("y", "yes", "approve")
+
+
+def _run_lockout_drill(coordinator: Any, target_peer: str) -> None:
+    """Phase 3 live: engage the lockout at muster, prove a bad resume holds it,
+    then resume through the HMAC override protocol with operator approval."""
+    print("\nphase 3 - lockout at muster + HITL resume")
+    coordinator.emergency_stop()
+    probe = coordinator.send(
+        target_peer,
+        {"action": "execute", "instruction": "probe: must be refused", "policy_provider": "mock", "n_steps": 1},
+        timeout=10.0,
+    )
+    if not (isinstance(probe, dict) and probe.get("type") == "error"):
+        raise RuntimeError(f"lockout did not engage: execute was not refused: {probe!r}")
+    print(f"  {target_peer}: lockout engaged (execute refused, status/resume only)")
+
+    denied = coordinator.send(target_peer, {"action": "resume", "override_code": "not-the-code"}, timeout=10.0)
+    denied_result = denied.get("result") if isinstance(denied, dict) else None
+    if not (isinstance(denied_result, dict) and denied_result.get("status") == "error"):
+        raise RuntimeError(f"the wrong-code resume was not refused: {denied!r}")
+    probe = coordinator.send(target_peer, {"action": "status"}, timeout=10.0)
+    if not isinstance(probe, dict) or probe.get("type") != "response":
+        raise RuntimeError(f"{target_peer} stopped answering status during lockout: {probe!r}")
+    still_refused = coordinator.send(
+        target_peer,
+        {"action": "execute", "instruction": "probe: must be refused", "policy_provider": "mock", "n_steps": 1},
+        timeout=10.0,
+    )
+    if not (isinstance(still_refused, dict) and still_refused.get("type") == "error"):
+        raise RuntimeError(f"a rejected resume cleared the lockout: {still_refused!r}")
+    print(f"  wrong-code resume refused ({denied_result.get('error', 'resume rejected')!s}); lockout intact")
+
+    if not _operator_approves(f"resume {target_peer} out of lockout with the override code?"):
+        print("  resume declined by the operator; the lockout stays engaged. Rerun to resume.")
+        return
+    resumed = coordinator.send(
+        target_peer,
+        {"action": "resume", "override_code": os.environ["STRANDS_MESH_OVERRIDE_CODE"]},
+        timeout=10.0,
+    )
+    resumed_result = resumed.get("result") if isinstance(resumed, dict) else None
+    if not (isinstance(resumed_result, dict) and resumed_result.get("status") == "ok"):
+        raise RuntimeError(f"approved resume was rejected: {resumed!r}")
+    print(f"  {target_peer}: resumed via HMAC override (operator approved)")
+
+
+def _build_live_world() -> tuple[MujocoEvacuationWorld, Any, Callable[[], None]]:
+    """Corridor scene + fleet + proxy + mesh peers. Returns (world, coordinator, cleanup)."""
+    from strands_robots.mesh import init_mesh
+    from strands_robots.simulation import Simulation
+
+    sim = Simulation()
+    coordinator: Any | None = None
+    sim_mesh: Any | None = None
+
+    def cleanup() -> None:
+        if coordinator is not None and coordinator.alive:
+            coordinator.stop()
+        if sim_mesh is not None and sim_mesh.alive:
+            sim_mesh.stop()
+        sim.destroy()
+
+    try:
+        steps: list[Callable[[], dict[str, Any]]] = [
+            lambda: sim.create_world(),
+            # Visual corridor walls (static) and the exit marker.
+            lambda: sim.add_object(
+                "corridor-wall-north",
+                shape="box",
+                position=[0.0, CORRIDOR["y_max"] + 0.05, 0.05],
+                size=[CORRIDOR["x_max"] - CORRIDOR["x_min"], 0.05, 0.1],
+                color=[0.9, 0.6, 0.1, 1.0],
+                is_static=True,
+            ),
+            lambda: sim.add_object(
+                "corridor-wall-south",
+                shape="box",
+                position=[0.0, CORRIDOR["y_min"] - 0.05, 0.05],
+                size=[CORRIDOR["x_max"] - CORRIDOR["x_min"], 0.05, 0.1],
+                color=[0.9, 0.6, 0.1, 1.0],
+                is_static=True,
+            ),
+            lambda: sim.add_object(
+                "corridor-exit",
+                shape="box",
+                position=[3.0, 0.0, 0.01],
+                size=[0.6, 1.2, 0.02],
+                color=[0.1, 0.8, 0.2, 1.0],
+                is_static=True,
+            ),
+            lambda: sim.add_object(
+                PROXY_BODY,
+                shape="cylinder",
+                position=[PROXY_START_XY[0], PROXY_START_XY[1], 0.12],
+                size=[0.18, 0.18, 0.24],
+                color=[0.2, 0.4, 0.9, 1.0],
+                mass=1.0,
+            ),
+            lambda: sim.add_camera(
+                "corridor-cam", position=[0.0, -4.5, 4.0], target=[0.0, 0.0, 0.0], width=480, height=360
+            ),
+        ]
+        steps.extend(
+            lambda e=entry: sim.add_robot(name=e["robot"], data_config=e["data_config"], position=e["spawn"])
+            for entry in FLEET
+        )
+        for build in steps:
+            result = build()
+            if result.get("status") != "success":
+                raise RuntimeError(f"world construction failed: {result}")
+
+        # The fleet is mid-task when the alarm lands.
+        for entry in FLEET:
+            result = sim.start_policy(
+                robot_name=entry["robot"], policy_provider="mock", instruction="routine task", duration=60.0
+            )
+            if result.get("status") != "success":
+                raise RuntimeError(f"start_policy({entry['robot']}) failed: {result}")
+
+        sim_mesh = init_mesh(_FleetSimPeer(sim, [e["robot"] for e in FLEET]), peer_id=FLEET_PEER_ID, peer_type="sim")
+        coordinator = init_mesh(_Coordinator(), peer_id=COORDINATOR_ID)
+        if sim_mesh is None or coordinator is None:
+            raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+    except BaseException:
+        cleanup()
+        raise
+    return MujocoEvacuationWorld(sim, mesh=coordinator), coordinator, cleanup
+
+
+class _Coordinator:
+    """Minimal mesh owner for the coordinator peer (it only sends)."""
+
+    tool_name_str = COORDINATOR_ID
+
+
+def _wait_for(predicate: Callable[[], bool], *, timeout_s: float, what: str, poll_s: float = 0.5) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(poll_s)
+    raise RuntimeError(f"timed out after {timeout_s:.0f}s waiting for {what}")
+
+
+def _run_live(trace: EvacuationTrace) -> dict[str, Any]:
+    if not os.getenv("STRANDS_MESH_OVERRIDE_CODE", "").strip():
+        code = secrets.token_urlsafe(9)
+        os.environ["STRANDS_MESH_OVERRIDE_CODE"] = code
+        print(f"STRANDS_MESH_OVERRIDE_CODE was unset; using a single-run code for this demo: {code}")
+
+    world, coordinator, cleanup = _build_live_world()
+    try:
+        _wait_for(
+            lambda: FLEET_PEER_ID in coordinator.peers_by_id,
+            timeout_s=15.0,
+            what="presence discovery of the fleet sim peer",
+        )
+
+        # The alarm is an injected mesh broadcast event (epic D5), observed by
+        # the coordinator's own subscriber - coordination, not perception.
+        alarms: list[dict[str, Any]] = []
+        coordinator.subscribe(ALARM_TOPIC, callback=lambda _t, payload: alarms.append(payload), name="alarm")
+        gate = AlarmGate()
+        print("\ninjecting the alarm broadcast")
+        coordinator.publish(ALARM_TOPIC, {"alarm_id": "drill-1", "peer_id": COORDINATOR_ID, "t": time.time()})
+        _wait_for(lambda: bool(alarms), timeout_s=10.0, what="the alarm to arrive on the safety topic")
+        alarm = alarms[0]
+        if not gate.admit(str(alarm.get("alarm_id", "?"))):
+            raise RuntimeError("the first alarm of the run was rate-limited; gate state is wrong")
+        _audit("evacuation_alarm", {"alarm_id": alarm.get("alarm_id"), "source": alarm.get("peer_id")})
+
+        def on_tick(robot: str, tick: float, clearance: float) -> None:
+            trace.clearance(robot, tick, clearance)
+            if int(tick) % 5 == 0 and robot == world.robot_names[0]:
+                trace.frame(world)
+
+        summary = run_evacuation(world, on_tick=on_tick)
+
+        _run_lockout_drill(coordinator, FLEET_PEER_ID)
+
+        print("\nscoring: proxy traversal against the declarative benchmark")
+        register_evacuation_predicates()
+        tracked = {name: world.tracked_body(name) for name in world.robot_names}
+        benchmark = DeclarativeBenchmark.from_dict(build_benchmark_spec(tracked))
+        verdict = score_evacuation(world, benchmark, on_tick=on_tick)
+        summary["verdict"] = verdict
+        return summary
+    finally:
+        cleanup()
+
+
+def _run_dry(trace: EvacuationTrace) -> dict[str, Any]:
+    """Scripted kinematics; the protocol core, ordering, benchmark and report
+    are all real. The lockout/resume drill needs a live mesh (the smoke test
+    asserts it through the real safety handlers)."""
+    world = ScriptedEvacuationWorld()
+    gate = AlarmGate()
+    print("\ninjecting the alarm (scripted; the live path publishes on the mesh)")
+    if not gate.admit("drill-1"):
+        raise RuntimeError("the first alarm of the run was rate-limited; gate state is wrong")
+    _audit("evacuation_alarm", {"alarm_id": "drill-1", "source": COORDINATOR_ID})
+
+    summary = run_evacuation(world, sleep=lambda _s: None, on_tick=trace.clearance)
+
+    print("\nphase 3 - lockout + HITL resume: live-mode only (see the smoke test)")
+
+    print("\nscoring: proxy traversal against the declarative benchmark")
+    register_evacuation_predicates()
+    tracked = {name: world.tracked_body(name) for name in world.robot_names}
+    benchmark = DeclarativeBenchmark.from_dict(build_benchmark_spec(tracked))
+    verdict = score_evacuation(world, benchmark, on_tick=trace.clearance)
+    summary["verdict"] = verdict
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true", help="no simulator, no mesh: scripted kinematics")
+    parser.add_argument("--rrd", default="", help="save a Rerun .rrd replay artifact to this path")
+    parser.add_argument("--gif", default="", help="save a retreat GIF to this path (live mode)")
+    parser.add_argument("--agent-report", action="store_true", help="narrate the incident report with an agent")
+    args = parser.parse_args(argv)
+
+    run_start = time.time()
+    trace = EvacuationTrace(rrd_path=args.rrd or None, gif_path=args.gif or None, camera="corridor-cam")
+    try:
+        summary = _run_dry(trace) if args.dry_run else _run_live(trace)
+    finally:
+        trace.close()
+
+    verdict = summary["verdict"]
+    print(
+        f"\nbenchmark verdict: {'PASS' if verdict['passed'] else 'FAIL'} - {verdict['reason']} ({verdict['steps']} ticks)"
+    )
+    print(f"abort: {summary['abort_elapsed_s']:.2f}s; retreat order: {' -> '.join(summary['order'])}")
+    print(f"clearances at muster: {summary['clearances']}")
+
+    records = read_audit_log(since=run_start - 1.0)
+    report = build_incident_report(records, verify_audit_integrity())
+    print("\n" + report)
+    if args.agent_report:
+        # Post-event narration only - the LLM never touches the safety path.
+        from strands import Agent
+
+        agent = Agent()
+        agent(f"Write a three-sentence operator summary of this evacuation incident report:\n\n{report}")
+    return 0 if verdict["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -1,0 +1,87 @@
+# Fleet orchestration examples
+
+Multi-robot orchestration on top of the pieces the rest of `examples/`
+introduces one at a time: multi-robot worlds, the Zenoh mesh with its safety
+protocol, capability-based dispatch, and the signed audit log. Tracked by epic
+[#2179](https://github.com/strands-labs/robots/issues/2179).
+
+| # | Example | Status |
+|---|---|---|
+| 01 | `01_skill_dispatch_multi_vendor.py` - capability-based dispatch across heterogeneous robots | tracked by [#2180](https://github.com/strands-labs/robots/issues/2180) |
+| 02 | `02_cross_zone_transport.py` + read-only Rerun fleet dashboard | tracked by [#2181](https://github.com/strands-labs/robots/issues/2181) |
+| 03 | `03_failover_and_degraded_ops.py` - peer-loss reassignment + dispatcher-down safety | tracked by [#2182](https://github.com/strands-labs/robots/issues/2182) |
+| 04 | [`04_emergency_evacuation.py`](04_emergency_evacuation.py) - three-phase evacuate protocol, benchmark-scored | here |
+| 05 | `05_work_order_dispatch.py` - structured task ingress mapped onto per-site capability manifests | tracked by [#2185](https://github.com/strands-labs/robots/issues/2185) |
+
+Shared across the suite (each lands with its sibling PR): `capabilities.py`,
+the per-robot capability manifest schema consumed by 01/03/05, and
+`dashboard.py`, the read-only Rerun fleet dashboard (#2181) that attaches to
+the MESH, not a simulator, so it serves every example here unchanged.
+
+## 04 - emergency evacuation
+
+During an emergency, robots must clear the evacuation path and never block
+personnel. A plain e-stop is NOT sufficient - a frozen robot in a corridor is
+itself the blocking hazard, and mesh lockout refuses everything except
+`status`/`resume`. So the protocol is three phases on existing primitives,
+with the LLM outside the safety path (epic decisions D2/D5/D7):
+
+1. **Abort**: an injected alarm broadcast (a mesh event, not a simulated
+   sensor) stops every policy rollout fleet-wide - rate-limited, so an alarm
+   flood cannot re-trigger the protocol, and audited either way.
+2. **Clear path**: each robot runs a pre-validated deterministic retreat -
+   scripted base/joint setpoints, never a learned policy - to its muster
+   pose. Priority conflicts resolve by deterministic corridor-distance
+   ordering: closest to the path moves first, the others hold. The retreat
+   sits behind the small `EvacuationWorld` seam so the Isaac adapter
+   ([#2123](https://github.com/strands-labs/robots/issues/2123)) drops in
+   later.
+3. **Lockout + HITL resume**: mesh lockout engages only AFTER the path is
+   asserted clear (D7 - lockout first would freeze the hazard in place).
+   Resume goes through the existing HMAC override protocol with operator
+   approval; a wrong-code or declined resume leaves the lockout engaged, and
+   the example proves it with a live probe.
+
+Scored, not narrated: a `DeclarativeBenchmark` (predicate DSL) fails the run
+if any robot re-enters the clearance-inflated corridor at any tick after the
+path is declared clear, and succeeds only when the personnel proxy reaches
+the exit unimpeded (a blocked proxy waits - it never teleports through) AND
+the fleet-wide abort met its deadline. Post-event, an incident report is
+built deterministically from the signed audit log.
+
+```bash
+# No simulator, no mesh - scripted kinematics through the same protocol core:
+python examples/fleet/04_emergency_evacuation.py --dry-run
+
+# Live: one MuJoCo corridor world (lekiwi + go2 mid-task in the corridor,
+# so101 overhanging it), mesh alarm -> abort -> retreat -> lockout -> resume:
+STRANDS_MESH_HITL_ACTIONS=none python examples/fleet/04_emergency_evacuation.py
+
+# Artifacts: Rerun replay (.rrd: clearance plot + camera tiles) and a GIF of
+# the robots vacating the corridor; signed audit trail for the report:
+STRANDS_MESH_AUDIT_PSK=demo-psk python examples/fleet/04_emergency_evacuation.py \
+  --rrd evacuation.rrd --gif evacuation.gif
+```
+
+Interactive operator approval is the documented default for the resume; the
+CI/smoke posture is `STRANDS_MESH_HITL_ACTIONS=none` (epic D4). A declined
+approval sends nothing - the lockout stays engaged, and (same property the
+`robot_mesh` tool pins) a decline consumes no rate-limit slot anywhere, so
+nuisance prompts can never lock the fleet out of a genuine emergency action.
+
+The mesh ACL template ([`examples/mesh/mesh_acl_example.json5`](../mesh/mesh_acl_example.json5))
+now ships a read-only `dashboard` role for the fleet dashboard: subscribe to
+presence/health/safety/camera plus its own presence announcement, and no
+`cmd`/`broadcast`/`safety` publish grant - a compromised dashboard cert can
+watch, not actuate.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `STRANDS_MESH_AUDIT_PSK` | HMAC-sign every audit record; `verify_audit_integrity()` then attests the trail. |
+| `STRANDS_MESH_AUDIT_DIR` | Relocate the audit log (default `~/.strands_robots/`). |
+| `STRANDS_MESH_OVERRIDE_CODE` | Operator override code required to resume a peer out of estop lockout. |
+| `STRANDS_MESH_HITL_ACTIONS` | `none` = unattended approvals (CI posture); unset = interactive prompts. |
+| `STRANDS_MESH_LOCAL_DEV=1` | Skip TLS for local development (defaulted by the examples). |
+| `STRANDS_MESH=0` | Disable the mesh entirely; use `--dry-run` in that posture. |

--- a/examples/mesh/mesh_acl_example.json5
+++ b/examples/mesh/mesh_acl_example.json5
@@ -125,6 +125,43 @@
       permission: "allow",
       key_exprs: ["**"],
     },
+    {
+      // Dashboard subscribe is OBSERVE-ONLY: presence, health, safety
+      // events, camera frames, state and rollout streams - everything a
+      // read-only fleet dashboard (examples/fleet/dashboard.py, epic
+      // #2179) renders. It deliberately does NOT include `**/cmd`,
+      // `**/broadcast` or `**/response/**`: a dashboard has no
+      // operational need to observe the command/RPC plane, and this
+      // role must never be a quiet path to it.
+      id: "dashboard_subscribe_observe",
+      messages: ["declare_subscriber"],
+      flows: ["egress"],
+      permission: "allow",
+      key_exprs: [
+        "**/presence",
+        "**/health",
+        "**/safety/**",
+        "**/camera/**",
+        "**/state/**",
+        "**/stream",
+        "**/pose",
+      ],
+    },
+    {
+      // The dashboard's ONLY publish grant: announcing its own presence
+      // so operators can see it on the mesh. Zenoh 1.x key_exprs cannot
+      // interpolate the peer's cert CN (see the header), so this is the
+      // presence topic CLASS - the role still cannot publish commands,
+      // broadcasts or safety traffic, which is the boundary that makes
+      // it read-only where it matters.
+      id: "dashboard_publish_presence",
+      messages: ["put"],
+      flows: ["ingress"],
+      permission: "allow",
+      key_exprs: [
+        "**/presence",
+      ],
+    },
   ],
 
   subjects: [
@@ -145,6 +182,14 @@
         // Add more operators...
       ],
     },
+    {
+      id: "dashboard_peer",
+      // Read-only observers: fleet dashboards, wall displays, replay
+      // recorders. ENUMERATE each one's exact cert CN.
+      cert_common_names: [
+        "dashboard-1",
+      ],
+    },
   ],
 
   policies: [
@@ -157,6 +202,13 @@
       // Operators: publish commands + broad observe (intentional).
       rules: ["operator_publish_cmds", "operator_subscribe_all"],
       subjects: ["operator_peer"],
+    },
+    {
+      // Dashboards: observe-only. May watch the fleet and announce their
+      // own presence; may NOT publish commands, broadcasts or safety
+      // traffic - a compromised dashboard cert can watch, not actuate.
+      rules: ["dashboard_subscribe_observe", "dashboard_publish_presence"],
+      subjects: ["dashboard_peer"],
     },
   ],
 }

--- a/tests/test_fleet_emergency_evacuation.py
+++ b/tests/test_fleet_emergency_evacuation.py
@@ -1,0 +1,389 @@
+"""Smoke test for examples/fleet/04_emergency_evacuation.py (issue #2183).
+
+Phases 1-2 (abort + deterministic retreat) and the benchmark scoring drive
+the shipped protocol core through the scripted evacuation world: no
+simulator, no Zenoh session, no network. The corridor-distance ordering, the
+clear-path-before-lockout gate, and the benchmark's three claims (clearance
+held for all scored ticks, proxy reached the exit unimpeded, abort inside
+deadline) are asserted on outputs, not narrated.
+
+Phase 3 (lockout + HITL resume) is asserted through the REAL mesh safety
+handlers, the same pattern the failover example's test uses: a real ``Mesh``
+peer minus the Zenoh transport receives the real estop envelope captured from
+the issuer's own publish path, refuses everything but ``status``/``resume``
+while locked, refuses a wrong-code resume WITHOUT clearing the lockout - the
+acceptance criterion this issue names - and resumes only on the real HMAC
+override compare.
+
+The audit log is redirected to ``tmp_path`` (never the developer's real
+``~/.strands_robots/mesh_audit.jsonl``) and signed with a test PSK so
+``verify_audit_integrity`` attests the trail end to end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from strands_robots.mesh import core as mesh_core
+from strands_robots.mesh import security as mesh_security
+
+_FLEET_DIR = Path(__file__).resolve().parent.parent / "examples" / "fleet"
+_EXAMPLE_PATH = _FLEET_DIR / "04_emergency_evacuation.py"
+_MODULE_NAME = "fleet_emergency_evacuation_example"
+
+
+@pytest.fixture
+def example(monkeypatch, tmp_path):
+    """Load the example with the audit log confined to tmp_path and signed."""
+    from strands_robots.mesh import audit
+
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_PSK", "smoke-test-psk")
+    # Reset the process-global audit state (same isolation as
+    # tests/mesh/test_audit_integrity.py): the PSK fingerprint and sequence
+    # counters are one-shot per process, so records written by earlier tests
+    # in the suite would otherwise poison this test's fresh, signed log.
+    audit._SEQ_COUNTERS.clear()
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._AUDIT_STATE.psk_fingerprint = None
+    sys.modules.pop(_MODULE_NAME, None)
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _EXAMPLE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop(_MODULE_NAME, None)
+    audit._SEQ_COUNTERS.clear()
+    audit._AUDIT_STATE.seq_loaded = False
+    audit._AUDIT_STATE.audit_log_seeded = False
+    audit._AUDIT_STATE.psk_fingerprint = None
+
+
+def _coordinator_events(example):
+    from strands_robots.mesh.audit import read_audit_log
+
+    return [r["event"] for r in read_audit_log() if r.get("peer_id") == example.COORDINATOR_ID]
+
+
+def _mustered_world(example, fleet=None):
+    """A scripted world driven to muster through the shipped retreat ticks."""
+    world = example.ScriptedEvacuationWorld(fleet)
+    world.stop_all_tasks()
+    for name in world.robot_names:
+        budget = 400
+        while not world.retreat_tick(name):
+            budget -= 1
+            assert budget > 0, f"{name}: scripted retreat did not converge"
+    return world
+
+
+def test_corridor_distance_is_zero_inside_and_euclidean_outside(example):
+    assert example.corridor_distance(0.0, 0.0) == 0.0
+    assert example.corridor_distance(example.CORRIDOR["x_max"], example.CORRIDOR["y_max"]) == 0.0
+    assert example.corridor_distance(0.0, example.CORRIDOR["y_max"] + 1.5) == pytest.approx(1.5)
+    # Off a corner the distance is Euclidean, not per-axis.
+    assert example.corridor_distance(example.CORRIDOR["x_max"] + 3.0, example.CORRIDOR["y_max"] + 4.0) == pytest.approx(
+        5.0
+    )
+
+
+def test_retreat_order_is_corridor_distance_ascending_with_name_tiebreak(example):
+    positions = {"far": (0.0, 2.0), "near": (0.0, 0.1), "mid": (0.0, -1.0)}
+    assert example.retreat_order(positions) == ["near", "mid", "far"]
+    # Equidistant robots order by name - deterministic, never arrival order.
+    tied = {"b-robot": (1.0, 0.5), "a-robot": (-1.0, -0.5)}
+    assert example.retreat_order(tied) == ["a-robot", "b-robot"]
+
+
+def test_alarm_gate_rate_limits_a_flood_and_audits_the_suppression(example):
+    clock = {"now": 0.0}
+    gate = example.AlarmGate(max_alarms=3, window_s=60.0, clock=lambda: clock["now"])
+    assert [gate.admit(f"a{i}") for i in range(3)] == [True, True, True]
+    # The fourth alarm inside the window is suppressed - and audited, never
+    # silently dropped.
+    assert gate.admit("a3") is False
+    assert "evacuation_alarm_suppressed" in _coordinator_events(example)
+    # Outside the rolling window the gate admits again.
+    clock["now"] = 61.0
+    assert gate.admit("a4") is True
+
+
+def test_dry_run_protocol_orders_phases_and_signs_the_trail(example):
+    """Abort completes, the retreat runs closest-first, the path-clear claim
+    precedes everything phase 3 would do, and the benchmark passes - all read
+    from outputs and the signed audit chain."""
+    from strands_robots.mesh.audit import verify_audit_integrity
+
+    world = example.ScriptedEvacuationWorld()
+    summary = example.run_evacuation(world, sleep=lambda _s: None)
+
+    assert summary["order"] == ["lekiwi-1", "go2-1", "arm-1"]
+    assert all(c > example.CLEARANCE_M for c in summary["clearances"].values())
+    assert world.sim.evacuation_abort_elapsed_s == summary["abort_elapsed_s"]
+
+    example.register_evacuation_predicates()
+    tracked = {name: world.tracked_body(name) for name in world.robot_names}
+    benchmark = example.DeclarativeBenchmark.from_dict(example.build_benchmark_spec(tracked))
+    verdict = example.score_evacuation(world, benchmark)
+    assert verdict["passed"] is True
+    assert verdict["reason"] == "proxy reached the exit unimpeded"
+
+    events = _coordinator_events(example)
+    assert events.index("evacuation_abort_complete") < events.index("evacuation_retreat_order")
+    assert events.index("evacuation_retreat_order") < events.index("evacuation_path_clear")
+    assert events.index("evacuation_path_clear") < events.index("evacuation_scored")
+    integrity = verify_audit_integrity()
+    assert integrity["ok"] is True
+    assert integrity["signed"] == integrity["total"]
+
+
+def test_a_robot_that_cannot_clear_the_path_blocks_lockout_engagement(example):
+    """Epic D7: phase 2 must complete BEFORE lockout. A muster pose still
+    inside the clearance margin is a structured refusal, never a lockout on
+    top of a blocked corridor."""
+    fleet = [dict(entry) for entry in example.FLEET]
+    for entry in fleet:
+        if entry["robot"] == "go2-1":
+            entry["muster"] = [-1.2, -1.0]  # clearance 0.3 m < the 0.8 m margin
+    world = example.ScriptedEvacuationWorld(fleet)
+
+    with pytest.raises(RuntimeError, match="refusing to engage lockout"):
+        example.run_evacuation(world, sleep=lambda _s: None)
+
+    events = _coordinator_events(example)
+    assert "evacuation_clear_failed" in events
+    assert "evacuation_path_clear" not in events
+
+
+def test_benchmark_fails_the_run_when_a_robot_reenters_the_corridor(example):
+    """The clearance claim holds for ALL scored ticks: a robot drifting back
+    into the inflated corridor mid-traversal fails the benchmark at that tick."""
+
+    class _DriftingWorld(example.ScriptedEvacuationWorld):
+        def __init__(self):
+            super().__init__()
+            self._ticks = 0
+
+        def settle(self, n):
+            self._ticks += n
+            if self._ticks == 5:
+                self._xy["go2-1"] = [-1.2, -1.0]  # back inside the margin
+
+    world = _mustered_world(example)
+    drifting = _DriftingWorld()
+    drifting._xy = dict(world._xy)
+    drifting.sim.evacuation_abort_elapsed_s = 0.1
+
+    example.register_evacuation_predicates()
+    tracked = {name: drifting.tracked_body(name) for name in drifting.robot_names}
+    benchmark = example.DeclarativeBenchmark.from_dict(example.build_benchmark_spec(tracked))
+    verdict = example.score_evacuation(drifting, benchmark)
+    assert verdict["passed"] is False
+    assert verdict["reason"] == "corridor clearance breached"
+    assert verdict["steps"] == 5
+
+
+def test_a_blocked_proxy_waits_and_the_run_fails_on_the_step_budget(example):
+    """Unimpeded is asserted, not narrated: the proxy never advances through
+    an obstruction on the path, so a blocker parks the run into a failure."""
+    fleet = [dict(entry) for entry in example.FLEET] + [
+        {
+            "robot": "blocker-1",
+            "data_config": "lekiwi",
+            "kind": "mobile",
+            "spawn": [2.0, 0.2, 0.0],
+            "muster": [2.0, 0.2],
+        }
+    ]
+    world = _mustered_world(example, fleet)
+    world.sim.evacuation_abort_elapsed_s = 0.1
+
+    example.register_evacuation_predicates()
+    # The blocker is deliberately untracked: the failure being asserted is the
+    # proxy's, not a clearance breach.
+    tracked = {name: world.tracked_body(name) for name in world.robot_names if name != "blocker-1"}
+    benchmark = example.DeclarativeBenchmark.from_dict(example.build_benchmark_spec(tracked))
+    verdict = example.score_evacuation(world, benchmark)
+    assert verdict["passed"] is False
+    assert verdict["reason"] == "proxy never reached the exit"
+    # The proxy stopped short of the blocker rather than teleporting past it.
+    assert world.proxy_xy()[0] < 2.0 - example.PROXY_STANDOFF_M + example.PROXY_STEP_M
+
+
+def test_benchmark_requires_the_abort_deadline_not_just_the_traversal(example):
+    """An abort that missed its deadline fails the benchmark even though the
+    corridor is clear and the proxy walks out."""
+    world = _mustered_world(example)
+    world.sim.evacuation_abort_elapsed_s = example.ABORT_DEADLINE_S + 5.0
+
+    example.register_evacuation_predicates()
+    tracked = {name: world.tracked_body(name) for name in world.robot_names}
+    benchmark = example.DeclarativeBenchmark.from_dict(example.build_benchmark_spec(tracked))
+    verdict = example.score_evacuation(world, benchmark)
+    assert verdict["passed"] is False
+
+    # The predicate itself: missing, malformed and boolean stamps all read as
+    # NOT within deadline - a deadline that cannot be read is never met.
+    check = example._evacuation_abort_within(5.0)
+    assert check(SimpleNamespace()) is False
+    assert check(SimpleNamespace(evacuation_abort_elapsed_s=True)) is False
+    assert check(SimpleNamespace(evacuation_abort_elapsed_s=7.0)) is False
+    assert check(SimpleNamespace(evacuation_abort_elapsed_s=3.0)) is True
+
+
+def test_incident_report_is_a_deterministic_timeline_with_integrity(example):
+    records = [
+        {"ts": 100.0, "event": "evacuation_alarm", "peer_id": "evac-coordinator", "payload": {"alarm_id": "a1"}},
+        {"ts": 101.5, "event": "evacuation_path_clear", "peer_id": "evac-coordinator", "payload": {"required_m": 0.8}},
+        {"ts": "bogus", "event": "dropped", "peer_id": "x", "payload": {}},
+    ]
+    report = example.build_incident_report(records, {"ok": True, "signed": 2, "total": 2})
+    lines = report.splitlines()
+    assert "Audit integrity: ok=True (signed=2/2)" in report
+    assert any("+0.00s" in line and "evacuation_alarm" in line for line in lines)
+    assert any("+1.50s" in line and "evacuation_path_clear" in line for line in lines)
+    assert "dropped" not in report  # an unreadable timestamp row is skipped, not guessed
+
+
+# Phase 3 -- lockout + HMAC resume, asserted through the real safety handlers.
+
+
+class _StoppableRobot:
+    """Mesh owner whose stop_task records the stop (so the broadcast is honest)."""
+
+    def __init__(self):
+        self.stopped = False
+
+    def stop_task(self):
+        self.stopped = True
+        return {"ok": True, "status": "stopped"}
+
+
+def _capturing_bus(monkeypatch):
+    """Capture every payload the mesh publishes, keyed by topic."""
+    published = []
+    monkeypatch.setattr(mesh_core, "put", lambda key, payload: published.append((key, payload)))
+    return published
+
+
+def _as_sample(payload: dict) -> SimpleNamespace:
+    """Wrap a published body the way the Zenoh subscriber hands it over."""
+    raw = json.dumps(payload).encode()
+    return SimpleNamespace(payload=SimpleNamespace(to_bytes=lambda r=raw: r))
+
+
+def _live_unstarted_mesh(peer_id: str) -> mesh_core.Mesh:
+    """A real Mesh peer minus the Zenoh transport (see the failover test)."""
+    mesh = mesh_core.Mesh(_StoppableRobot(), peer_id=peer_id, peer_type="robot")
+    mesh._running = True
+    mesh._stop_event.set()
+    return mesh
+
+
+def test_declined_resume_does_not_clear_the_lockout(example, monkeypatch):
+    """The acceptance criterion, end to end through the real handlers: the
+    estop envelope engages a receiving peer's lockout; a wrong-code resume is
+    refused and every non-status/resume action stays refused; only the real
+    HMAC override compare clears it."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "drill-override-code")
+    published = _capturing_bus(monkeypatch)
+    issuer = _live_unstarted_mesh(example.COORDINATOR_ID)
+    receiver = _live_unstarted_mesh(example.FLEET_PEER_ID)
+
+    issuer.emergency_stop()
+    envelope = next(payload for key, payload in published if key == "strands/safety/estop")
+    receiver._on_safety_estop(_as_sample(envelope))
+
+    # Locked out: status still answers, everything else is refused.
+    assert isinstance(receiver._dispatch({"action": "status"}), dict)
+    with pytest.raises(mesh_security.LockoutError):
+        receiver._dispatch({"action": "stop"})
+
+    # The declined resume: refused, and the lockout is INTACT afterwards.
+    denied = receiver._dispatch({"action": "resume", "override_code": "not-the-code"})
+    assert denied == {"status": "error", "error": "resume rejected"}
+    with pytest.raises(mesh_security.LockoutError):
+        receiver._dispatch({"action": "stop"})
+
+    # The audit trail names the denial with a structured local reason.
+    from strands_robots.mesh.audit import read_audit_log
+
+    denials = [r for r in read_audit_log() if r.get("event") == "resume_denied"]
+    assert denials, "a refused resume must leave a resume_denied audit record"
+
+    # Only the correct override code clears it - and then the fleet stop that
+    # was refused a moment ago executes.
+    resumed = receiver._dispatch({"action": "resume", "override_code": "drill-override-code"})
+    assert resumed == {"status": "ok"}
+    assert receiver._dispatch({"action": "stop"}) == {"ok": True, "status": "stopped"}
+
+
+def test_resume_success_publishes_a_proof_other_peers_verify(example, monkeypatch):
+    """Fleet-wide resume is second-factor gated: the resume envelope carries
+    an HMAC override proof, and a second locked peer clears only on it."""
+    monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "drill-override-code")
+    published = _capturing_bus(monkeypatch)
+    issuer = _live_unstarted_mesh(example.COORDINATOR_ID)
+    peer_a = _live_unstarted_mesh("evac-peer-a")
+    peer_b = _live_unstarted_mesh("evac-peer-b")
+
+    issuer.emergency_stop()
+    estop = next(payload for key, payload in published if key == "strands/safety/estop")
+    peer_a._on_safety_estop(_as_sample(estop))
+    peer_b._on_safety_estop(_as_sample(estop))
+
+    assert peer_a._dispatch({"action": "resume", "override_code": "drill-override-code"}) == {"status": "ok"}
+    resume = next(payload for key, payload in published if key == "strands/safety/resume")
+    assert "override_proof" in resume
+    peer_b._on_safety_resume(_as_sample(resume))
+    # peer_b never saw the code itself - only the verified proof - and is out
+    # of lockout.
+    assert peer_b._dispatch({"action": "stop"}) == {"ok": True, "status": "stopped"}
+
+
+def test_benchmark_spec_tracks_every_robot_and_compiles_in_the_dsl(example):
+    example.register_evacuation_predicates()
+    tracked = {"r1": "r1/base", "r2": "r2/base"}
+    spec = example.build_benchmark_spec(tracked)
+    failure_bodies = {clause["body"] for clause in spec["failure"]["any"]}
+    assert failure_bodies == {"r1/base", "r2/base"}
+    success_predicates = {clause["predicate"] for clause in spec["success"]["all"]}
+    assert success_predicates == {"inside_region", "evacuation_abort_within"}
+    benchmark = example.DeclarativeBenchmark.from_dict(spec)
+    assert benchmark.name == "emergency-evacuation-corridor-clear"
+
+
+def test_abort_that_misses_its_deadline_is_a_structured_failure(example):
+    """A fleet that cannot stop is a refusal with an audit record, never a
+    retreat over still-running rollouts."""
+
+    class _StuckWorld(example.ScriptedEvacuationWorld):
+        def stop_all_tasks(self):
+            pass  # nothing stops; the deadline must trip
+
+    world = _StuckWorld()
+    clock = {"now": 0.0}
+
+    def fake_sleep(s):
+        clock["now"] += s
+
+    with pytest.raises(RuntimeError, match="missed its"):
+        example.run_evacuation(world, clock=lambda: clock["now"], sleep=fake_sleep, abort_deadline_s=2.0)
+    assert "evacuation_abort_timeout" in _coordinator_events(example)
+
+
+def test_registering_the_custom_predicate_twice_is_idempotent(example):
+    example.register_evacuation_predicates()
+    example.register_evacuation_predicates()  # a reload must not raise
+    from strands_robots.simulation.predicates import make_predicate
+
+    check = make_predicate("evacuation_abort_within", deadline_s=5.0)
+    assert check(SimpleNamespace(evacuation_abort_elapsed_s=1.0)) is True


### PR DESCRIPTION
Closes #2183 (epic #2179, PR4 of 5).

## What changed

`examples/fleet/04_emergency_evacuation.py` - the three-phase evacuation protocol the issue specifies. Built standalone (per the epic's D6/D7 notes; it consumes nothing from `capabilities.py`); #2197 merged mid-flight and `main` has been merged back in, resolving the expected `README.md` add/add conflict.

- **Phase 1 - abort.** An injected alarm broadcast (a mesh event, epic D5) stops every rollout fleet-wide over `mesh.broadcast({"action": "stop"})`, answered by the sim peer's `stop_task` adapter. Delivery is **at-least-once**: the idempotent stop is re-issued until the fleet reports quiet, because a single stop can race a rollout still warming up (its running flag is raised only once its control loop starts) and be silently overwritten - observed live before the fix, ~3s abort after. Alarm handling is rate-limited (`AlarmGate`, mirrors the `robot_mesh` tool's e-stop cap) and every admit/suppress/complete/timeout is audited.
- **Phase 2 - clear path.** Each robot runs a pre-validated deterministic retreat - scripted base-qpos / joint setpoints, never a learned policy (epic D2) - to a muster pose, ordered by corridor-centerline distance: closest to the path moves first, the others hold, name-tiebroken. Explicitly not an LLM decision. The retreat sits behind the small `EvacuationWorld` seam (contract documented in-file) so the Isaac adapter (#2123) drops in as one more implementation; `MujocoEvacuationWorld` uses the library's shared free-joint detection so LeKiwi's unnamed `<freejoint>` and go2's named one resolve the same way.
- **Phase 3 - lockout + HITL resume.** Lockout engages only AFTER the path is asserted clear (epic D7) - a robot that cannot clear the margin is a structured refusal that never reaches lockout. Resume goes through the existing HMAC override protocol with operator approval (interactive by default; `STRANDS_MESH_HITL_ACTIONS=none` for CI, epic D4). The live drill proves a wrong-code resume is refused **with the lockout intact** before the approved resume clears it.

**Scored, not narrated**: a `DeclarativeBenchmark` (predicate DSL) fails the run if any tracked robot re-enters the clearance-inflated corridor at ANY scored tick (the "min distance > X for all t after T_clear" claim, expressed via `inside_region` on an inflated rectangle - per-axis inflation is stricter than Euclidean near corners, conservative in the safe direction), and passes only when the personnel proxy reaches the exit unimpeded AND the fleet abort met its deadline (a registered custom predicate, `evacuation_abort_within`). A blocked proxy waits - it never teleports through - so "unimpeded" fails on the step budget rather than being narrated.

Also in this PR:

- **Read-only `dashboard` role** in `examples/mesh/mesh_acl_example.json5`: observe-only subscribe (presence/health/safety/camera/state/stream/pose) plus a single own-presence publish grant; deliberately no `**/cmd`, `**/broadcast` or `**/safety/**` publish - a compromised dashboard cert can watch, not actuate. Validated against `_validate_acl_shape`; the existing ACL tests pass.
- **Visualization**: `--rrd` saves a Rerun replay (live corridor-clearance plot per robot + camera tiles; the repo's first `rr.save` artifact), `--gif` saves the retreat GIF. Both degrade loudly to no-ops when the optional dep is missing - visualization never gates the safety path.
- **Incident report**: built deterministically from the signed audit log post-event (`verify_audit_integrity` attested); `--agent-report` optionally narrates it with an agent, keeping the LLM outside the safety path.
- `examples/fleet/README.md` (04 section; will need a trivial merge with the sibling fleet PRs, same as they need with each other) and a changelog fragment.

## Test surface

`tests/test_fleet_emergency_evacuation.py` - 14 tests, no simulator, no Zenoh session, no network; audit log confined to `tmp_path` and PSK-signed:

- corridor geometry + deterministic retreat ordering (distance then name)
- alarm-flood rate limiting with audited suppression
- full dry-run protocol: phase ordering read from the signed audit chain, benchmark PASS
- **D7 pinned**: a robot that cannot clear the margin raises and `evacuation_path_clear` is never audited
- benchmark verdicts: re-entry fails at the breach tick; a blocked proxy fails on the budget with the proxy provably short of the blocker; a missed abort deadline fails despite a clear corridor
- **acceptance criterion pinned end-to-end through the real mesh safety handlers** (same pattern as the failover example's test): estop envelope engages the receiver's lockout; a wrong-code resume returns the generic refusal and every non-status/resume action stays refused; only the real HMAC compare clears it; the resume envelope's `override_proof` clears a second peer that never saw the code
- benchmark spec compiles in the DSL and tracks every robot; custom predicate registration is reload-idempotent

## Validation

- `hatch run lint` clean (ruff + ruff format + mypy); example formatted with the repo's ruff config
- `hatch run test`: **28557 passed, 263 skipped** (run with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`; without EGL this dev box aborts in a pre-existing GL-init crash in `tests/benchmarks/libero/test_libero_camera_config_domain.py`, reproduced identically on a clean `upstream/main` checkout - environmental, not from this change)
- Live run end to end on MuJoCo (headless EGL): alarm -> abort 3.2s -> retreat (go2/lekiwi/arm all mustered > 0.8 m) -> lockout -> wrong-code resume refused, lockout intact -> HITL resume -> benchmark PASS (35 ticks) -> signed incident report (integrity ok, 23/23 signed); `.rrd` (1.7 MB) and an 18-frame GIF showing the robots vacating the corridor produced
- `--dry-run` passes with the base package only

## Acceptance criteria from #2183

- [x] Benchmark passes deterministically (scripted setpoints, fixed step sizes, no randomness; dry-run and live both PASS)
- [x] GIF artifact shows robots visibly vacating the corridor (`--gif`, verified 18 frames, 480x360)
- [x] Lockout/resume exercised end-to-end, including: a declined resume does not clear the lockout (live drill + `test_declined_resume_does_not_clear_the_lockout`)
- [x] Alarm is an injected mesh broadcast (D5); clear-path completes BEFORE lockout (D7, pinned by test); retreat behind a seam for the Isaac adapter (D8/#2123)
- [x] Read-only `dashboard` role added to the `examples/mesh/` ACL template
- [x] Changelog fragment; suite-wide criteria (headless, seeded-deterministic, <90s live, ASCII only, no host paths)

## Out of scope / follow-ups

- Isaac backend for the retreat: #2122 / #2123 (stretch per the epic, not blockers; the seam is in place)
- `examples/fleet/README.md` will conflict trivially with the remaining sibling PRs (#2198/#2191/#2188) on the suite table - each carries the same file; whichever lands last rebases the table markers (the #2197 conflict is already resolved here)
- No library change was needed for the D7 sequencing (the epic reserved a separate PR for that case; it did not arise)

Board routing: please move #2183 to "In review" on the [project board](https://github.com/orgs/strands-labs/projects/2) (filing account lacks org project write).
