### PR TITLE
feat(simulation/isaac): merged multi-robot recording for run_multi_policy (one frame per timestep)

### DIFF
--- a/changelog.d/2159-isaac-multi-robot-merged-recording.md
+++ b/changelog.d/2159-isaac-multi-robot-merged-recording.md
@@ -1,0 +1,14 @@
+### Added: Isaac `run_multi_policy` records merged multi-robot frames (one frame per timestep)
+
+The Isaac synchronized multi-robot loop now feeds an active dataset recording
+session instead of refusing to run inside one: each loop iteration emits
+exactly ONE `add_frame` carrying every driven robot's namespaced state/action
+columns (`alice__shoulder_pan` ...) plus all camera images (scene-global,
+read once per step), mirroring the MuJoCo merged-frame semantics - so a
+2-robot Isaac dataset has both arms co-observed in every frame, usable for
+bimanual / multi-agent policy training. LeRobot stores one task per frame, so
+with distinct per-robot instructions the first robot's instruction is recorded
+(the shared normalizer's warning covers the limitation). The loop also gains
+the shared recording-rate guard (`control_frequency` must match the open
+dataset's fps) and MuJoCo's partial-episode discard: a mid-loop failure drops
+the dangling frames so the next episode starts at frame 0.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -3581,10 +3581,18 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         entry point reports it in the tool envelope instead). No lock is
         held across a marshal hop; each hop takes ``self._lock`` itself.
 
-        **Recording is not implemented here yet**: the merged-frame recording
-        path is a follow-up to #2158. A call arriving while a dataset
-        recording is active is refused rather than silently producing an
-        unrecorded rollout the session's frame count would misreport.
+        **Recording**: when a dataset recording session is active
+        (:meth:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin.start_recording`),
+        each loop iteration records exactly ONE merged frame containing every
+        driven robot's prefixed state/action columns (``alice__shoulder_pan``
+        ...) plus all camera images - mirroring the MuJoCo merged-frame
+        semantics (:meth:`strands_robots.simulation.mujoco.simulation.Simulation.run_multi_policy`),
+        so a 2-robot dataset has both arms co-observed in every frame.
+        Cameras are scene-global and read once per step (from the first
+        robot's observation), not once per robot. LeRobot stores one task per
+        frame, so the recorded task is the FIRST robot's instruction; the
+        shared instruction normalizer already warns when distinct per-robot
+        instructions are given.
 
         Args:
             policies: Mapping ``{robot_name: Policy}`` of the robots to drive.
@@ -3612,7 +3620,10 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             RuntimeError: Mid-loop on a policy that returns an empty action
                 chunk or an action that cannot be applied (see
                 :meth:`_apply_lockstep_action`) - never a zero-valued
-                substitute action.
+                substitute action. When recording, the partially-recorded
+                frames of the failed episode are discarded so the next episode
+                starts at frame 0 rather than appending to a dangling
+                half-episode (mirrors the MuJoCo loop).
         """
         from collections import deque
 
@@ -3659,23 +3670,13 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 ],
             }
 
-        # The merged-frame recording path is a follow-up to #2158; refusing is
-        # the alternative to silently running an unrecorded rollout inside an
-        # active session (Key Conventions #5/#6).
-        if self._is_recording():
-            return {
-                "status": "error",
-                "content": [
-                    {
-                        "text": (
-                            "run_multi_policy: a dataset recording is active, but the Isaac "
-                            "synchronized multi-robot loop does not record yet (the merged-frame "
-                            "recording path is a follow-up to #2158). Stop the recording first, or "
-                            "record a multi-robot rollout on the MuJoCo backend."
-                        )
-                    }
-                ],
-            }
+        # Latch the active recording session ONCE (MuJoCo parity): every loop
+        # iteration below records exactly one merged frame into this recorder.
+        # A session started mid-rollout is deliberately not picked up - the
+        # schema probe and the rollout must observe the same scene.
+        rec_state = self._recording_state()
+        recorder = rec_state.get("dataset_recorder") if rec_state is not None else None
+        recording = rec_state is not None and bool(rec_state.get("recording", False)) and recorder is not None
 
         # Thread affinity (#1896): off the owning thread every marshal hop
         # below would block forever without a pump. step()/reset() raise for
@@ -3713,6 +3714,11 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # by it).
         if err := self._validate_positive_frequency(control_frequency, "run_multi_policy"):
             return err
+        # Reject a rollout whose rate the active recording cannot describe
+        # (MuJoCo parity): every frame below is timestamped at the dataset's
+        # fps, so a disagreeing control_frequency would mislabel the episode.
+        if err := self._validate_recording_rate(control_frequency, "run_multi_policy"):
+            return err
         duration, n_steps, horizon_error = self._resolve_horizon(
             n_steps, max_steps, control_frequency, duration, "run_multi_policy"
         )
@@ -3739,10 +3745,36 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             except Exception as exc:  # noqa: BLE001 - non-fatal, mirrors run_policy defensiveness
                 logger.debug("set_robot_state_keys(%s) failed: %s", rname, exc)
 
+        # Merged-frame recording wiring (MuJoCo parity). Namespacing follows
+        # the schema start_recording declared: prefixed ``robot__column`` when
+        # the WORLD holds more than one robot (not merely this call), so the
+        # merged frame always matches the declared columns. Every robot driven
+        # here contributes to the one merged frame, so the merged action owes a
+        # value for each of their actuators - resolved once rather than per
+        # frame, and only when a recorder will consume it (robot_action_keys is
+        # best-effort for unrecorded rollouts; where a recording is attached
+        # the keys are load-bearing, so a raise here correctly fails the call).
+        multi_robot = len(self._robots) > 1
+        merged_required_action_keys = (
+            [f"{rname}__{key}" if multi_robot else key for rname in policies for key in self.robot_action_keys(rname)]
+            if recording
+            else []
+        )
+        # Camera frames ride the observation keyed by RAW camera name; the
+        # schema declared the safe names (``/`` -> ``__``), scoped to
+        # start_recording(cameras=...). Same rename+scope the single-robot
+        # on_frame hook applies.
+        raw_to_safe: dict[str, str] = (
+            {src: safe for src, safe, _w, _h in rec_state.get("recording_cameras", [])}
+            if recording and rec_state is not None
+            else {}
+        )
+
         # Renders are expensive; skip camera readback when no policy needs
-        # images (recording, which would force them on, is refused above).
+        # images AND no recording is active (recorded frames must carry the
+        # camera images the schema declared).
         any_needs_images = any(getattr(p, "requires_images", True) for p in policies.values())
-        skip_images = not any_needs_images
+        skip_images = not (any_needs_images or recording)
         render_on = self._config.render_mode != "headless"
         physics_dt = float(getattr(self._config, "physics_dt", 0.0) or 0.0)
 
@@ -3789,6 +3821,13 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
 
         step_count = 0
         stopped_early = False
+        # Tracks whether the loop finished without an unexpected error. A
+        # normal completion and a cooperative stop both leave a VALID
+        # partial/complete episode the caller will save; any other exception
+        # (e.g. an empty action chunk) leaves a dangling partial episode we
+        # must discard so the next recording starts at frame 0 rather than
+        # appending to a half-episode (MuJoCo parity).
+        completed_cleanly = False
         try:
             while step_count < total_steps:
                 # --- 1. Observe every robot (one main-thread hop). No lock is
@@ -3829,25 +3868,67 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 # (one main-thread hop; the hop takes self._lock itself).
                 self.run_on_main(lambda acts=per_robot_action: _apply_all_and_step(acts))
 
+                # --- 5. Record ONE merged frame (all robots + all cameras),
+                # off the main thread: add_frame writes to LeRobot's
+                # image-writer queue and parquet buffer, never to Kit/USD, and
+                # the consistent state snapshot was already taken inside the
+                # two hops above.
+                if recording and recorder is not None:
+                    merged_obs: dict[str, Any] = {}
+                    merged_act: dict[str, Any] = {}
+                    for rname in policies:
+                        if multi_robot:
+                            for k, v in per_robot_obs[rname].items():
+                                merged_obs[f"{rname}__{k}"] = v
+                            for k, v in per_robot_action[rname].items():
+                                merged_act[f"{rname}__{k}"] = v
+                        else:
+                            merged_obs.update(per_robot_obs[rname])
+                            merged_act.update(per_robot_action[rname])
+                    # Cameras are scene-global: rename raw -> schema-safe and
+                    # drop any outside the start_recording(cameras=...) scope.
+                    for k, v in camera_imgs.items():
+                        safe = raw_to_safe.get(k)
+                        if safe is not None:
+                            merged_obs[safe] = v
+                    # LeRobot stores ONE task per frame: the first robot's
+                    # instruction (the shared normalizer already warned when
+                    # per-robot instructions are distinct).
+                    recorder.add_frame(
+                        observation=merged_obs,
+                        action=merged_act,
+                        task=instr_map[next(iter(policies))],
+                        required_action_keys=merged_required_action_keys,
+                    )
+
                 step_count += 1
                 for rname in policies:
                     self._robots[rname].policy_steps = step_count
 
                 if action_sleep:
                     time.sleep(action_sleep)
+
+            completed_cleanly = True
         except CooperativeStop:
             # A cooperative stop is a normal, user-requested halt.
             stopped_early = True
+            completed_cleanly = True
         finally:
             for rname in policies:
                 if registered(self._robots, rname):
                     self._robots[rname].policy_running = False
+            # Bailed mid-episode on an unexpected error (e.g. empty action
+            # chunk): drop the partially-recorded frames so the next episode
+            # begins at frame 0 instead of appending to a dangling half-episode.
+            if not completed_cleanly and recording and recorder is not None:
+                recorder.clear_episode_buffer()
 
         per_robot_steps = {rname: int(self._robots[rname].policy_steps) for rname in policies}
         text = (
             f"{'stopped early' if stopped_early else 'completed'}: "
             f"run_multi_policy on {len(policies)} robots ({', '.join(policies)}) - "
             f"{step_count} synchronized steps"
+            f"{' (recorded)' if recording else ''}"
         )
         return {
             "status": "success",

--- a/tests/simulation/isaac/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/isaac/test_run_multi_policy_no_recording.py
@@ -7,9 +7,13 @@ its buffered action chunk drains, applies every robot's joint targets, then
 steps physics exactly ONCE. These tests pin that behaviour - plus the loop's
 Isaac-specific contracts: every Kit-touching hop is marshalled through
 ``run_on_main`` (#1896), a worker-thread call with no pump is refused in the
-tool envelope, ``reset_between=True`` is refused citing #1895, and a call
-during an active recording session is refused (the merged-frame recording path
-is a follow-up to #2158).
+tool envelope, ``reset_between=True`` is refused citing #1895, and a rollout
+whose ``control_frequency`` disagrees with an active recording's fps is
+refused up front (the shared rate guard every rollout entry point applies).
+
+The merged-frame recording path (one ``add_frame`` per timestep with every
+robot's namespaced columns, #2159) is pinned separately in
+``test_run_multi_policy_recording.py``.
 
 The engine is a skeleton ``IsaacSimulation`` built with ``__new__`` (the
 established pattern from ``test_dataset_recording.py``) so the loop runs
@@ -406,18 +410,32 @@ def test_run_multi_policy_reset_between_returns_the_1895_error(sim_two_robots):
     assert sim._world.step_calls == 0
 
 
-def test_run_multi_policy_refuses_during_an_active_recording(sim_two_robots):
-    """A call during an active recording session is refused, not silently unrecorded.
+def test_run_multi_policy_refuses_rate_the_recording_cannot_describe(sim_two_robots):
+    """A control_frequency the active recording's fps cannot describe is refused.
 
-    The merged-frame recording path is a follow-up to #2158; running the loop
-    anyway inside an open session would leave a rollout the session's frame
-    count misreports.
+    Replaces the pre-#2159 premise test (a blanket refusal while any recording
+    was active): the loop now records merged frames, so what remains refusable
+    is the shared rate disagreement every rollout entry point guards -
+    LeRobot timestamps frames positionally at the dataset fps, so a differing
+    capture rate cannot be honored, only mislabelled. Refused before any
+    physics advances (the same ``_validate_recording_rate`` contract as
+    ``run_policy`` / MuJoCo's ``run_multi_policy``).
     """
     sim = sim_two_robots
-    sim._recording_state_dict = {"recording": True, "dataset_recorder": object()}
-    r = sim.run_multi_policy(policies={"alpha": MockPolicy(), "beta": MockPolicy()}, n_steps=2)
+
+    class _RecorderAt30:
+        class dataset:  # noqa: N801 - attribute surface of DatasetRecorder
+            fps = 30
+
+    sim._recording_state_dict = {"recording": True, "dataset_recorder": _RecorderAt30()}
+    r = sim.run_multi_policy(
+        policies={"alpha": MockPolicy(), "beta": MockPolicy()},
+        n_steps=2,
+        control_frequency=50.0,
+    )
     assert r["status"] == "error", r
-    assert "recording" in r["content"][0]["text"]
+    msg = r["content"][0]["text"]
+    assert "30" in msg and "50" in msg
     assert sim._world.step_calls == 0
 
 

--- a/tests/simulation/isaac/test_run_multi_policy_recording.py
+++ b/tests/simulation/isaac/test_run_multi_policy_recording.py
@@ -1,0 +1,366 @@
+"""Isaac ``run_multi_policy`` merged multi-robot recording (one frame per timestep).
+
+Multi-robot recording parity for the Isaac synchronized loop (#2159, part of
+the #2122 parity work; the control loop itself landed with #2158): while a
+dataset recording session is active, every loop iteration emits exactly ONE
+``add_frame`` containing all driven robots' namespaced state/action columns
+(``alice__shoulder_pan`` ...) plus all camera images - so a 2-robot dataset has
+both arms co-observed in every frame, mirroring the MuJoCo merged-frame
+semantics pinned by
+``tests/simulation/mujoco/test_recording_paths.py::test_b4_synchronized_multi_robot_recording``.
+
+The engine is a skeleton ``IsaacSimulation`` built with ``__new__`` (the
+established no-Kit pattern from ``test_dataset_recording.py``): physics is a
+stub ``World``, articulations are stubs, cameras are ``_CameraState`` entries
+with fake RGBA handles, ``isaacsim.core.utils.types`` is faked by the shared
+``fake_isaacsim_types`` fixture - and the capture path is the REAL
+``IsaacRecordingMixin`` schema declaration plus the REAL ``run_multi_policy``
+loop writing into a REAL ``DatasetRecorder``. Round-trips reopen the on-disk
+``LeRobotDataset`` (the recording round-trip rule). GPU/real-Kit coverage is a
+separate ``tests_integ/`` follow-up.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.dataset_recorder import has_lerobot_dataset
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import (
+    IsaacSimulation,
+    _CameraState,
+    _RobotState,
+)
+from tests.tool_result_contract import tool_json
+
+from .test_backend_parity import fake_isaacsim_types  # noqa: F401 - fixture
+
+_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow"]
+
+
+class _StubArticulation:
+    """Minimal articulation: accepts targets, reports zero joint positions."""
+
+    def __init__(self, n_joints: int) -> None:
+        self._n = n_joints
+        self.applied: list[Any] = []
+
+    def apply_action(self, action: Any) -> None:
+        self.applied.append(action)
+
+    def get_joint_positions(self) -> np.ndarray:
+        return np.zeros(self._n, dtype=np.float32)
+
+
+class _StubWorld:
+    """Stub Isaac ``World`` counting physics steps."""
+
+    def __init__(self) -> None:
+        self.step_calls = 0
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        self.step_calls += 1
+
+
+class _FakeCameraHandle:
+    """Stub RTX camera handle returning a fixed RGBA buffer."""
+
+    def __init__(self, rgba: np.ndarray) -> None:
+        self.rgba = rgba
+
+    def get_rgba(self) -> np.ndarray:
+        return self.rgba
+
+
+def _robot(name: str) -> _RobotState:
+    return _RobotState(
+        name=name,
+        prim_path=f"/World/Robots/{name}",
+        joint_names=list(_JOINTS),
+        data_config="so100",
+        articulation=_StubArticulation(len(_JOINTS)),
+    )
+
+
+def _camera(name: str, width: int = 64, height: int = 48, fill: int = 7) -> _CameraState:
+    cam = _CameraState(name=name, prim_path=f"/World/Cameras/{name}", width=width, height=height)
+    cam.handle = _FakeCameraHandle(np.full((height, width, 4), fill, dtype=np.uint8))
+    return cam
+
+
+def _make_engine(
+    robots: dict[str, _RobotState],
+    cameras: dict[str, _CameraState] | None = None,
+    render_mode: str = "rtx_realtime",
+) -> IsaacSimulation:
+    """Skeleton IsaacSimulation (no Kit runtime), per the recording-test pattern."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode=render_mode)
+    engine._lock = threading.RLock()
+    engine._world = _StubWorld()
+    engine._world_created = True
+    engine._robots = robots
+    engine._cameras = cameras if cameras is not None else {}
+    engine._objects = {}
+    engine._prim_registry = []
+    engine._cams_rec_state = None
+    engine._recording_state_dict = {}
+    engine._action_controllers = {}
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._replicated = False
+    engine._num_envs_active = 1
+    engine._pump_running = False
+    engine._main_tid = threading.get_ident()
+    engine._main_jobs = queue.Queue()
+    return engine
+
+
+@pytest.fixture
+def sim_two_robots(fake_isaacsim_types) -> IsaacSimulation:  # noqa: F811, ARG001 - fixture injects the fake module
+    """Two stub-articulation robots, headless (proprio-only recording)."""
+    return _make_engine(
+        {"alice": _robot("alice"), "bob": _robot("bob")},
+        render_mode="headless",
+    )
+
+
+if not has_lerobot_dataset():
+    pytest.skip("lerobot not installed", allow_module_level=True)
+
+from pathlib import Path  # noqa: E402
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: E402
+
+from strands_robots.dataset_recorder import read_dataset_episode_indices  # noqa: E402
+
+
+def test_synchronized_two_robot_rollout_records_merged_frames(sim_two_robots, tmp_path) -> None:
+    """The direct Isaac mirror of MuJoCo's B4 pin: a synchronized 2-robot
+    ``run_multi_policy`` rollout records ONE merged frame per timestep, and
+    BOTH robots' action columns are non-zero in EVERY frame.
+
+    Pre-#2159 the loop refused to run inside an active recording session; the
+    merged-frame path is the whole point of a multi-robot dataset (bimanual /
+    multi-agent policy training needs both arms co-observed per frame).
+    """
+    sim = sim_two_robots
+    root = str(tmp_path / "sync")
+    n_steps = 8
+
+    r = sim.start_recording(repo_id="local/isaac_sync_multi", fps=30, root=root, overwrite=True)
+    assert r["status"] == "success", r
+
+    r = sim.run_multi_policy(
+        policies={"alice": MockPolicy(), "bob": MockPolicy()},
+        instructions={"alice": "pour", "bob": "catch"},
+        n_steps=n_steps,
+        control_frequency=30.0,
+    )
+    assert r["status"] == "success", r
+    assert tool_json(r)["steps"] == n_steps
+    assert "(recorded)" in r["content"][0]["text"]
+    stopped = sim.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    ds = LeRobotDataset(repo_id="local/isaac_sync_multi", root=root)
+
+    # Merged schema: 2 robots x 3 joints = 6 prefixed action columns.
+    af = ds.features["action"]
+    names = af["names"] if isinstance(af, dict) else getattr(af, "names", None)
+    assert names is not None
+    assert [n for n in names if n.startswith("alice__")] == [f"alice__{j}" for j in _JOINTS]
+    assert [n for n in names if n.startswith("bob__")] == [f"bob__{j}" for j in _JOINTS]
+
+    # One merged frame per timestep: no interleaving (2N single-robot frames)
+    # and no doubling.
+    assert len(ds) == n_steps
+
+    # Both robots' action columns are non-zero in EVERY frame (B4 mirror):
+    # interleaved single-robot frames would leave the other half zero.
+    half = len(names) // 2
+    both = 0
+    for i in range(len(ds)):
+        ac = np.asarray(ds[i]["action"])
+        a = float(np.abs(ac[:half]).sum())
+        b = float(np.abs(ac[half:]).sum())
+        if a > 1e-6 and b > 1e-6:
+            both += 1
+    assert both == len(ds) and len(ds) > 0, f"only {both}/{len(ds)} frames had both robots co-observed"
+
+    # The state columns are merged and namespaced the same way.
+    sf = ds.features["observation.state"]
+    state_names = sf["names"] if isinstance(sf, dict) else getattr(sf, "names", None)
+    assert state_names is not None
+    assert "alice__shoulder_pan" in state_names
+    assert "bob__elbow" in state_names
+    assert len(state_names) == 2 * len(_JOINTS)
+
+
+def test_round_trip_episode_and_frame_counts(sim_two_robots, tmp_path) -> None:
+    """start_recording -> rollout -> save_episode -> rollout -> stop_recording
+    -> reopen: episode/frame counts come from the on-disk parquet (round-trip
+    rule), with frame count == timestep count per episode.
+    """
+    sim = sim_two_robots
+    root = str(tmp_path / "roundtrip")
+
+    r = sim.start_recording(repo_id="local/isaac_multi_rt", fps=30, root=root, overwrite=True)
+    assert r["status"] == "success", r
+
+    for _ep in range(2):
+        r = sim.run_multi_policy(
+            policies={"alice": MockPolicy(), "bob": MockPolicy()},
+            instructions="handover",
+            n_steps=5,
+            control_frequency=30.0,
+        )
+        assert r["status"] == "success", r
+        saved = sim.save_episode()
+        assert saved["status"] == "success", saved
+
+    stopped = sim.stop_recording()
+    assert stopped["status"] == "success", stopped
+
+    verified = sim.verify_dataset_episodes(2)
+    assert verified["status"] == "success", verified
+
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 2
+    assert sorted(set(info["episode_indices"])) == [0, 1]
+    assert info["total_frames"] == 2 * 5
+
+    # Physics advanced exactly once per timestep across both rollouts.
+    assert sim._world.step_calls == 2 * 5
+
+
+def test_recorded_task_is_first_robots_instruction_with_shared_warning(sim_two_robots, tmp_path, caplog) -> None:
+    """LeRobot stores ONE task per frame: with distinct per-robot instructions
+    the frame records the FIRST robot's instruction, and the shared
+    normalization helper emits the one-task-per-frame warning (same behavior
+    and warning as MuJoCo - not duplicated by the Isaac loop).
+    """
+    import logging
+
+    sim = sim_two_robots
+    root = str(tmp_path / "task")
+
+    r = sim.start_recording(repo_id="local/isaac_multi_task", fps=30, root=root, overwrite=True)
+    assert r["status"] == "success", r
+    with caplog.at_level(logging.WARNING, logger="strands_robots.simulation.isaac.simulation"):
+        r = sim.run_multi_policy(
+            policies={"alice": MockPolicy(), "bob": MockPolicy()},
+            instructions={"alice": "pour", "bob": "catch"},
+            n_steps=3,
+            control_frequency=30.0,
+        )
+    assert r["status"] == "success", r
+    warnings = [rec.message for rec in caplog.records if "distinct per-robot instructions" in rec.message]
+    assert len(warnings) == 1, "the shared helper warns exactly once (not re-warned per frame)"
+    assert sim.stop_recording()["status"] == "success"
+
+    ds = LeRobotDataset(repo_id="local/isaac_multi_task", root=root)
+    # ``meta.tasks`` is indexed by the task strings themselves: the first
+    # robot's instruction is the recorded task and the second's never appears.
+    recorded_tasks = [str(t) for t in ds.meta.tasks.index]
+    assert recorded_tasks == ["pour"], recorded_tasks
+
+
+def test_cameras_recorded_once_per_step_into_the_merged_frame(fake_isaacsim_types, tmp_path) -> None:  # noqa: F811
+    """A registered RTX camera lands ONE image per merged frame (scene-global,
+    read from the first robot's observation), and the round-trip writes a real
+    per-camera MP4 alongside the merged proprio columns.
+    """
+    sim = _make_engine(
+        {"alice": _robot("alice"), "bob": _robot("bob")},
+        cameras={"front": _camera("front")},
+        render_mode="rtx_realtime",
+    )
+    root = str(tmp_path / "cams")
+
+    r = sim.start_recording(repo_id="local/isaac_multi_cam", fps=30, root=root, overwrite=True)
+    assert r["status"] == "success", r
+    recorder = sim._recording_state_dict["dataset_recorder"]
+    assert "observation.images.front" in recorder.dataset.features
+
+    r = sim.run_multi_policy(
+        policies={"alice": MockPolicy(), "bob": MockPolicy()},
+        instructions="look",
+        n_steps=4,
+        control_frequency=30.0,
+    )
+    assert r["status"] == "success", r
+    assert sim.stop_recording()["status"] == "success"
+
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 1
+    assert info["total_frames"] == 4
+    mp4s = sorted(Path(root).glob("videos/**/*.mp4"))
+    assert mp4s, "camera recording must land a per-camera MP4 on disk"
+    assert all(p.stat().st_size > 0 for p in mp4s)
+
+
+def test_failed_rollout_discards_partial_episode(sim_two_robots, tmp_path) -> None:
+    """A mid-loop failure (empty action chunk) discards the partially-recorded
+    frames, so the next episode starts at frame 0 rather than appending to a
+    dangling half-episode (MuJoCo parity).
+    """
+    from strands_robots.policies.base import Policy
+
+    class _EmptyAfter(Policy):
+        """Returns one real chunk, then an empty one mid-rollout."""
+
+        requires_images = False
+
+        def __init__(self) -> None:
+            self.calls = 0
+            self._keys: list[str] = list(_JOINTS)
+
+        def set_robot_state_keys(self, keys):
+            self._keys = list(keys)
+
+        @property
+        def provider_name(self) -> str:
+            return "empty_after"
+
+        async def get_actions(self, obs, instruction=""):
+            self.calls += 1
+            if self.calls > 1:
+                return []
+            return [{k: 0.1 for k in self._keys}]
+
+    sim = sim_two_robots
+    root = str(tmp_path / "partial")
+    r = sim.start_recording(repo_id="local/isaac_multi_partial", fps=30, root=root, overwrite=True)
+    assert r["status"] == "success", r
+
+    with pytest.raises(RuntimeError, match="empty action chunk"):
+        sim.run_multi_policy(
+            policies={"alice": _EmptyAfter(), "bob": _EmptyAfter()},
+            instructions="doomed",
+            n_steps=5,
+            control_frequency=30.0,
+            action_horizon=1,
+        )
+    # The dangling frame from the completed first step was discarded.
+    recorder = sim._recording_state_dict["dataset_recorder"]
+    assert getattr(recorder, "episode_frame_count", 0) == 0
+
+    # A clean rollout afterwards records a well-formed single episode.
+    r = sim.run_multi_policy(
+        policies={"alice": MockPolicy(), "bob": MockPolicy()},
+        instructions="recovered",
+        n_steps=3,
+        control_frequency=30.0,
+    )
+    assert r["status"] == "success", r
+    assert sim.stop_recording()["status"] == "success"
+    info = read_dataset_episode_indices(root)
+    assert info["total_episodes"] == 1
+    assert info["total_frames"] == 3


### PR DESCRIPTION
Closes #2159

Part of #2122 (Isaac `run_multi_policy` parity). Depends-on #2158 landed as #2178 (merged).

## What changed

Multi-robot recording parity for Isaac's `run_multi_policy`: while a dataset recording session is active, each synchronized loop iteration now emits exactly **ONE** `add_frame` containing all driven robots' namespaced state/action columns (`alice__shoulder_pan` ...) plus all camera images — mirroring the MuJoCo merged-frame semantics (`strands_robots/simulation/mujoco/simulation.py::run_multi_policy`, steps 1-4). A 2-robot Isaac dataset therefore has both arms co-observed in every frame, which is the point of a multi-robot dataset (bimanual / multi-agent policy training).

- **Merged frame per timestep** — namespaced obs/action (prefixing keyed off the world's robot count, matching the schema `IsaacRecordingMixin.start_recording` declared), cameras scene-global and consumed once per step from the first robot's observation, renamed raw → schema-safe and scoped to `start_recording(cameras=...)`. `add_frame` runs off the Kit main thread (it writes only to LeRobot's image-writer queue / parquet buffer), same rationale as MuJoCo.
- **One task per frame** — LeRobot stores one task per frame; the recorded task is the FIRST robot's instruction. The shared `_normalize_multi_policy_instructions` helper already emits the one-task-per-frame `logger.warning` for distinct per-robot instructions; the loop does not duplicate it.
- **Shared recording-rate guard** — `_validate_recording_rate(control_frequency, "run_multi_policy")` added, the same guard `run_policy` and MuJoCo's `run_multi_policy` apply, so a rollout whose rate the open dataset's fps cannot describe is refused before any physics advances.
- **Partial-episode discard (MuJoCo parity)** — a mid-loop failure (e.g. an empty action chunk) calls `recorder.clear_episode_buffer()` in the `finally`, so the next episode starts at frame 0 instead of appending to a dangling half-episode.
- The pre-#2159 refusal (a call during an active recording errored out citing the missing recording path) is removed, and the `run_multi_policy` docstring's "Recording is not implemented here yet" paragraph replaced with the recording contract.

## Tests

`tests/simulation/isaac/test_run_multi_policy_recording.py` (new, 5 tests), using the established no-Kit skeleton pattern (`IsaacSimulation.__new__` + stub world/articulations/camera handles, `fake_isaacsim_types` fixture) with the REAL `IsaacRecordingMixin` schema declaration and the REAL `run_multi_policy` loop writing into a REAL `DatasetRecorder`; module-level `pytest.skip` via `has_lerobot_dataset()` when lerobot is missing; every dataset rooted at `tmp_path` (never the shared cache):

- `test_synchronized_two_robot_rollout_records_merged_frames` — direct Isaac mirror of `test_b4_synchronized_multi_robot_recording`: reopened `LeRobotDataset` has the merged prefixed schema and BOTH robots' action columns are non-zero in EVERY frame; frame count == timestep count (no interleaving/doubling).
- `test_round_trip_episode_and_frame_counts` — start → 2 rollouts with `save_episode` boundaries → `stop_recording` → reopen: 2 episodes, 5 frames each, physics stepped exactly once per timestep.
- `test_recorded_task_is_first_robots_instruction_with_shared_warning` — one task per frame, first robot's instruction recorded, shared warning emitted exactly once.
- `test_cameras_recorded_once_per_step_into_the_merged_frame` — one image column per merged frame; per-camera MP4 lands on disk.
- `test_failed_rollout_discards_partial_episode` — mid-loop empty chunk raises, dangling frames discarded, a subsequent clean rollout records a well-formed episode.

`tests/simulation/isaac/test_run_multi_policy_no_recording.py`: the pre-#2159 blanket-refusal premise test is **replaced** (per the AGENTS.md premise-test rule) by `test_run_multi_policy_refuses_rate_the_recording_cannot_describe`, which pins the rate guard that remains refusable; module docstring updated to point at the new recording test file. All other existing recording tests (`test_dataset_recording.py`, MuJoCo `test_recording_paths.py`) are unmodified and green.

## Acceptance criteria (from #2159)

- [x] One merged `add_frame` per loop iteration with all robots' prefixed state/action columns + cameras (rendered once per step, consumed from the first robot's observation)
- [x] One task string per frame (first robot's instruction) + shared warning, not duplicated
- [x] Tests in `tests/simulation/isaac/` using the no-Kit skeleton pattern, `pytest.skip` when lerobot is missing
- [x] Merged-schema + both-robots-non-zero-in-every-frame mirror of `test_b4_synchronized_multi_robot_recording`
- [x] Frame count == timestep count
- [x] Round-trip: start → rollout → `save_episode`/`stop_recording` → reopen `LeRobotDataset` → episode/frame counts
- [x] `hatch run format && hatch run lint && hatch run test` clean — 28680 passed, 263 skipped, 0 failed, coverage 95.5% (run with `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`; without a GL backend the suite aborts in an unrelated MuJoCo rendering test on this box)
- [x] Changelog fragment `changelog.d/2159-isaac-multi-robot-merged-recording.md`
- [x] PR body carries `Closes #2159`

## Out of scope / follow-ups

- Real-Kit GPU coverage is the separate `tests_integ/` child of #2122 (per the issue).
- Non-first robots' `get_observation(skip_images=True)` calls are still flipped back on by the recording-forces-images override — byte-for-byte the same behavior as MuJoCo's loop (its override at `mujoco/simulation.py:491` does the same); the merged frame consumes camera images from the first observation only. If the per-robot RTX refresh cost matters on real Kit, that is an optimization for the GPU-integration child.

Board: please move #2159 to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (noting here per workflow; item edit may need board permissions).
