### PR TITLE
test(tools): drive the service-name and publish-argument refusals in use_rosbridge

### DIFF
--- a/changelog.d/2214-rosbridge-name-and-publish-argument-refusals.md
+++ b/changelog.d/2214-rosbridge-name-and-publish-argument-refusals.md
@@ -1,0 +1,19 @@
+### Quality: drive the two `use_rosbridge` refusals nothing reached
+
+`use_rosbridge` refuses a mistyped name for `topic` and for `service` from one
+`_NAME_RE`, and refuses each action that is missing a required argument. Two
+members of those families were never driven: the `service` name refusal, and the
+`publish` refusal for a missing topic or interface type - the one action in that
+family that writes to the robot. Their siblings were pinned, so both looked
+covered.
+
+Fifteen cases close them and take the module to 100%: the service name refused
+for exactly the spellings its topic sibling is (compared, not restated, so the
+two cannot drift apart on one rule), that refusal landing before the bridge is
+dialed rather than after a client is cached, and an incomplete `publish`
+advertising no publisher - asserted against a complete publish on the same
+connection, so an empty topic list means "refused before advertising" rather
+than "never advertises".
+
+The `type` parameter is now documented as required for `publish`, and each name
+parameter records that it shares one rule with the other.

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -313,10 +313,13 @@ def use_rosbridge(
             ``echo``, ``publish``, ``service_call``.
         host: rosbridge server hostname or IP.
         port: rosbridge WebSocket port (default 9090).
-        topic: Topic name (``echo``, ``publish``).
-        service: Service name (``service_call``).
+        topic: Topic name (``echo``, ``publish``). Held to the same name rule
+            as ``service``.
+        service: Service name (``service_call``). Held to the same name rule
+            as ``topic``.
         type: ROS1 two-segment interface type, e.g. ``geometry_msgs/Twist``.
-            Auto-resolved for ``echo`` when omitted.
+            Required for ``publish`` - a message cannot be built without it -
+            and auto-resolved for ``echo`` when omitted.
         fields: JSON field dict (``publish`` message / ``service_call`` request).
         timeout: Seconds for the WebSocket dial, sample collection, or a
             service call. A positive finite number of seconds; every action

--- a/tests/tools/test_use_rosbridge.py
+++ b/tests/tools/test_use_rosbridge.py
@@ -152,6 +152,57 @@ def test_invalid_topic_rejected(bad: str) -> None:
     assert "invalid topic" in _texts(result)
 
 
+@pytest.mark.parametrize("bad", ["/cmd vel", "/x|y", "../etc", "/a$(x)"])
+def test_invalid_service_rejected(bad: str) -> None:
+    """A mistyped service name is refused, naming the parameter that is wrong.
+
+    ``service`` is matched against the same ``_NAME_RE`` as ``topic``, so the
+    correcting error a mistyped topic already gets is owed to a mistyped service
+    too. Without it the name is carried into a rosbridge service call that
+    cannot resolve it, and the caller reads a transport failure instead of the
+    spelling mistake that caused it.
+    """
+    result = use_rosbridge(action="service_call", service=bad, type="std_srvs/Empty")
+    assert result["status"] == "error"
+    assert "invalid service name" in _texts(result)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["/cmd vel", "/x|y", "../etc", "/a$(x)", "/gazebo/reset_world", "~private"],
+)
+def test_topic_and_service_are_held_to_one_name_rule(name: str, fake_roslibpy: _types.ModuleType) -> None:
+    """The two name parameters cannot drift apart on what a name may contain.
+
+    Comparing the two verdicts rather than restating the pattern is what makes
+    this survive a change to ``_NAME_RE``: whatever the rule becomes, both
+    parameters must still answer alike. A name neither refuses goes on to fail
+    for an unrelated reason, which is the same outcome on both sides.
+    """
+    topic_result = use_rosbridge(action="echo", topic=name)
+    service_result = use_rosbridge(action="service_call", service=name, type="std_srvs/Empty")
+
+    topic_refused = "invalid topic name" in _texts(topic_result)
+    service_refused = "invalid service name" in _texts(service_result)
+    assert topic_refused == service_refused, f"{name!r}: topic and service disagree on one name rule"
+
+
+def test_an_invalid_service_name_is_refused_before_the_bridge_is_dialed(
+    fake_roslibpy: _types.ModuleType,
+) -> None:
+    """The name checks run ahead of the backend probe, so nothing is opened.
+
+    This tool caches one client per ``(host, port)``, so dialing on the way to a
+    refusal would leave a connection registered for a call that never ran.
+    """
+    result = use_rosbridge(action="service_call", service="/bad name", type="std_srvs/Empty")
+
+    assert result["status"] == "error"
+    assert "invalid service name" in _texts(result)
+    assert fake_roslibpy.Ros.instances == []  # type: ignore[attr-defined]
+    assert rb_mod._backend._connections == {}
+
+
 def test_ros1_two_segment_type_enforced() -> None:
     # ROS1 types are pkg/Name; a ROS2-style pkg/msg/Name must be rejected so
     # agents get a correcting error instead of a silent rosbridge failure.
@@ -462,3 +513,42 @@ def test_publish_rejects_nonpositive_count(fake_roslibpy: _types.ModuleType) -> 
     result = use_rosbridge(action="publish", topic="/cmd_vel", type="geometry_msgs/Twist", count=0)
     assert result["status"] == "error"
     assert "count" in _texts(result)
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        pytest.param({"topic": "/cmd_vel"}, id="type-missing"),
+        pytest.param({"type": "geometry_msgs/Twist"}, id="topic-missing"),
+        pytest.param({}, id="both-missing"),
+    ],
+)
+def test_publish_requires_topic_and_type(fake_roslibpy: _types.ModuleType, supplied: dict[str, Any]) -> None:
+    """A publish missing either half of its address is refused, not attempted.
+
+    ``publish`` is the one action in this family that writes to the robot, and a
+    message cannot be built without both the topic to advertise and the
+    interface type to build it from.
+    """
+    result = use_rosbridge(action="publish", **supplied)
+    assert result["status"] == "error"
+    assert "publish requires topic and type" in _texts(result)
+
+
+def test_an_incomplete_publish_advertises_no_publisher(fake_roslibpy: _types.ModuleType) -> None:
+    """The refusal lands before the publisher is advertised.
+
+    An advertisement is state on the bridge rather than a local call, so a
+    publisher advertised on the way to a refusal outlives the call that never
+    published and leaves the bridge carrying a topic this tool has no message
+    type for. The complete publish that follows is what makes the empty topic
+    list mean "refused before advertising" rather than "never advertises".
+    """
+    refused = use_rosbridge(action="publish", topic="/cmd_vel")
+    assert refused["status"] == "error"
+    ros = fake_roslibpy.Ros.instances[0]  # type: ignore[attr-defined]
+    assert ros.topics == []
+
+    honored = use_rosbridge(action="publish", topic="/cmd_vel", type="geometry_msgs/Twist", count=1)
+    assert honored["status"] == "success"
+    assert [(t.name, t.advertised, t.unadvertised) for t in ros.topics] == [("/cmd_vel", True, True)]


### PR DESCRIPTION
## Problem

`use_rosbridge` refuses a mistyped name for `topic` and for `service` against
the same `_NAME_RE`, one line apart, and refuses each action that is missing a
required argument. Two members of those families were never driven:

| | refusal | driven before this PR |
|---|---|---|
| `topic` name | `invalid topic name: ...` | yes - `test_invalid_topic_rejected`, over 4 spellings |
| `service` name | `invalid service name: ...` | **no** |
| `echo` / `service_call` / `list_*` required args | each refusal | yes |
| `publish` required args | `publish requires topic and type` | **no** |

Both had a pinned sibling, so both looked covered. `publish` is the one action
in that family that writes to the robot.

The module comments the property those refusals carry:

> `# Name and required-argument checks run before the WebSocket is dialed and before a publisher is advertised.`

Measured on the roslibpy double, that is exactly what happens, and nothing
asserted it:

| call | clients dialed | publishers advertised | outcome |
|---|---|---|---|
| `service_call(service="/bad name", type=...)` | 0 | 0 | refused, `invalid service name` |
| `publish(topic="/cmd_vel")` (no `type`) | 1 | 0 | refused, `publish requires topic and type` |
| the same `publish`, complete | 1 | 1 | advertised, published, unadvertised |

## What this adds

15 cases in the module that already owns this contract, next to the siblings
they complete:

- **the service name refusal**, over the same 4 spellings its topic twin uses.
- **one name rule for two parameters** - the topic and service verdicts are
  *compared* rather than the pattern restated, over 6 spellings (4 refused, 2
  carried past the name check). Whatever `_NAME_RE` becomes, the two parameters
  must still answer alike; a test that re-spelled the pattern would not say that.
- **the refusal lands before the bridge is dialed.** This tool caches one client
  per `(host, port)`, so dialing on the way to a refusal would leave a
  connection registered for a call that never ran.
- **`publish` refused for a missing topic, a missing type, and neither.**
- **an incomplete `publish` advertises no publisher**, asserted against a
  complete publish *on the same connection* - so an empty topic list means
  "refused before advertising" rather than "never advertises". An advertisement
  is state on the bridge, not a local call.

`tools/use_rosbridge.py`: **2 missing / 99% -> 0 missing / 100%**
over its own suite (82 cases -> 97).

## Would a regression be caught?

Each mutation run against the 15 new cases and, separately, against the 82
pre-existing ones:

| mutation | these 15 cases | the 82 pre-existing |
|---|---|---|
| M1 delete the service name guard | 9 failed | 0 failed **(blind)** |
| M2 service check evaluated, refusal discarded | 9 failed | 0 failed **(blind)** |
| M3 service checked with the interface-type rule | 2 failed | 3 failed (also caught) |
| M4 delete the publish required-argument guard | 4 failed | 0 failed **(blind)** |
| M5 publish refused only when BOTH are missing | 3 failed | 0 failed **(blind)** |
| M6 publish refusal reworded locally | 3 failed | 0 failed **(blind)** |
| *(unmutated control)* | 0 failed | 0 failed |

6 of 6 caught here, **5 of 6 invisible to the suite as it stands**.
M3 is caught by both, because applying the interface-type rule to a service name
also refuses a valid one - reporting that honestly is what makes the other five
rows worth reading. M2 is the shape a structural "the guard is called" pin is
blind to by construction: the check still runs, only its verdict is dropped.

Because the production code is correct, these cases pass on unmodified `main`.
What they fail on is a regression, and the table above is that evidence.

## Docs

`type` is now documented as required for `publish` - its entry said
"auto-resolved for `echo` when omitted" and never said `publish` cannot proceed
without it - and each name parameter records that it shares one rule with the
other. Those descriptions are what an agent reads out of the tool schema.

No executable line changes: the docstring-stripped AST digest of
`use_rosbridge.py` is `2cd51ef54807b823` before and after. The three-line
docstring insert shifts later line numbers, which is why the refusals that were
missing at 345 and 408 on `main` read as 348 and 411 here.

## Out of scope

`echo`'s empty-result disclosure, the type-resolution failures and the numeric
option domains are already pinned in the same module; this PR adds only the two
refusals that had none.

## Verification

Full suite on the merge base, `MUJOCO_GL=egl`:

- `28695 passed, 258 skipped, 0 failed` in 626s (pristine `83cc5272` is 28680 + these 15).
- `ruff check` clean, `ruff format --check` clean (1190 files).
- `mypy strands_robots tests tests_integ`: 14 errors, all in `examples/isaac_gs`,
  0 elsewhere - byte-identical to the error set at pristine `83cc5272`.
- `scripts/check_merge_base_overlap.py`: no overlap, 0 paths changed on
  `upstream/main` since the two diverged.
- The 7 repo-wide root guards plus the tools xref guard: 404 passed.

## Artifact

![the two refusals nothing reached](https://raw.githubusercontent.com/cagataycali/robots/artifacts/rosbridge-refusals/rosbridge-refusals.png)

Every number is read from one measurement dump, and the generator asserts each
one before saving. Capture, compose and the dump are on
[`artifacts/rosbridge-refusals`](https://github.com/cagataycali/robots/tree/artifacts/rosbridge-refusals).
This is a tools-layer change with no policy, simulation, rendering, recording or
asset behaviour, so the artifact is the coverage, wire-trace and mutation
measurement rather than a rollout.
