### PR TITLE
test(tools): pin both deferrals on pose_tool's incremental-move delta domain

### DIFF
--- a/changelog.d/2215-pose-delta-deferrals.md
+++ b/changelog.d/2215-pose-delta-deferrals.md
@@ -1,0 +1,27 @@
+### Quality: pin both deferrals on `pose_tool`'s incremental-move delta domain
+
+`_joint_delta_error` returns `None` for a motor absent from
+`_DEFAULT_MOTOR_CONFIGS`, because there is no configured travel to bound a
+displacement against. That branch was unexecuted by the whole suite, leaving
+`strands_robots/tools/pose_tool.py` at 99% on its one remaining statement. A
+deferral is only sound if the thing it defers TO refuses, and nothing asserted
+that half: a change making an unconfigured motor commandable through the delta
+path would have left every test green.
+
+The helper now documents the deferral its sibling `_joint_target_error` already
+documents, and `tests/tools/test_pose_tool_target_domain.py` measures both
+deferrals on that path -- an unknown motor, refused by the action's own position
+read with no `Goal_Position` written, and a displacement inside the full travel
+whose computed absolute target leaves the range, bounded by
+`degrees_to_position`'s clamp.
+
+The second measurement corrects a claim in the same test module, which said the
+clamp "is unreachable from `move_motor` / `move_multiple` / `incremental_move`
+now". It is unreachable from the first two, whose targets are absolute and are
+held to the joint's endpoints, but not from `incremental_move`: a +300 deg
+displacement is inside the 360 deg travel this domain checks, and from a joint
+parked at +169.89 deg it computes +469.89 deg, which the clamp turns into
+`Goal_Position` 4095 while the caller is told the move happened.
+
+No library behaviour changes -- the only production edit is a docstring, and the
+docstring-stripped AST digest of `pose_tool.py` is unchanged at `48bd01cc3adc195f`.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -308,6 +308,14 @@ def _joint_delta_error(action: str, motor_name: str | None, delta: Any) -> str |
     remains the last resort for a target computed from a live position reading
     rather than supplied by the caller.
 
+    A motor absent from :data:`_DEFAULT_MOTOR_CONFIGS` has no travel to bound a
+    displacement against, so this domain defers exactly as
+    :func:`_joint_target_error` does. What it defers to is the action itself:
+    ``incremental_move`` needs a current position before it can compute anything,
+    and neither ``read_motor_position`` nor ``move_motor`` can address a motor
+    absent from that table, so the move is refused before any ``Goal_Position``
+    is written.
+
     Args:
         action: The requested action, used as the message prefix.
         motor_name: The motor the displacement is for.

--- a/tests/tools/test_pose_tool_target_domain.py
+++ b/tests/tools/test_pose_tool_target_domain.py
@@ -21,6 +21,12 @@ conversion instead of only asserting on them:
   ``"Moved shoulder_pan to nan deg"`` for a move to +180. That is the property
   ``TestTheBusIsNotTouched`` pins: a refused target produces no write at all.
 
+The two deferrals on the ``delta`` path are pinned here as well, because each is
+only sound if the thing it defers TO refuses. An unknown motor has no travel to
+bound a displacement against, and ``incremental_move``'s own position read is
+what refuses it; a displacement *inside* the travel can still compute an absolute
+target outside the range, and ``degrees_to_position``'s clamp is what bounds that.
+
 The domain itself is delegated to :func:`~strands_robots.utils.finite_number_error`
 so an off-type or non-finite target is reported in the words every other surface
 uses; only the per-joint bounds are decided in this module, because they are a
@@ -40,15 +46,20 @@ import math
 from typing import Any
 
 import pytest
+import serial
 
 from strands_robots.tools.pose_tool import (
     _DEFAULT_MOTOR_CONFIGS,
     _TARGET_OPTION_BY_ACTION,
     MotorController,
+    _joint_delta_error,
+    _joint_target_error,
     _pose_target_error,
     pose_tool,
 )
 from strands_robots.utils import finite_number_error
+
+from .conftest import FakeSerial
 
 _PORT = "/dev/fake-pose-target"
 
@@ -329,10 +340,12 @@ class TestNeighbouringTargetProducersStayOutOfScope:
       carries ``safety_bounds``;
     * ``reset_to_home`` supplies its own literal targets, which are in range.
 
-    ``degrees_to_position`` therefore keeps its clamp: it is unreachable from
-    ``move_motor`` / ``move_multiple`` / ``incremental_move`` now, and removing
-    it would turn those other two paths into raises, which is a separate
-    concern.
+    ``degrees_to_position`` therefore keeps its clamp. It is unreachable from
+    ``move_motor`` / ``move_multiple``, whose targets are absolute and are held
+    to the joint's endpoints - but NOT from ``incremental_move``, whose delta is
+    held to the full travel instead, so a displacement inside that travel can
+    still compute an absolute target outside the range.
+    ``TestTheComputedTargetDeferralHolds`` measures that path.
     """
 
     def test_the_clamp_is_still_present_for_the_paths_that_rely_on_it(self):
@@ -355,3 +368,140 @@ class TestNeighbouringTargetProducersStayOutOfScope:
             _pose_target_error("move_motor", motor_name="no_such_joint", position=math.nan, delta=None, positions=None)
             is not None
         )
+
+
+def _position_packet(raw: int) -> bytes:
+    """A Feetech read response encoding ``raw`` at bytes 5/6."""
+    return bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
+
+
+# A joint parked near the upper end of its travel, and a displacement inside the
+# full span but *larger than either endpoint*. That is the value only the travel
+# rule accepts, so it distinguishes this domain from one written against the
+# endpoints; together they also compute an absolute target outside the range,
+# which is the case the delta domain deliberately does not bound.
+_NEAR_UPPER_RAW = 3980
+_INSIDE_TRAVEL_DELTA = 300
+
+
+class _ReadingSerial(FakeSerial):
+    """A ``FakeSerial`` that always answers a read with a decodable position.
+
+    ``incremental_move`` reads the current position before commanding anything,
+    so a source that never answers refuses every motor - configured or not - and
+    an assertion that an unknown motor reached no servo would hold for the wrong
+    reason.
+    """
+
+    def read(self, n: int = 1) -> bytes:
+        return _position_packet(_NEAR_UPPER_RAW)
+
+
+@pytest.fixture
+def reading_serial(monkeypatch: pytest.MonkeyPatch) -> list[_ReadingSerial]:
+    """Patch ``serial.Serial`` with an always-answering position source."""
+    instances: list[_ReadingSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _ReadingSerial:
+        fs = _ReadingSerial(port, baudrate, timeout)
+        instances.append(fs)
+        return fs
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return instances
+
+
+def _goal_positions(instances: list[_ReadingSerial]) -> list[int]:
+    """Every ``Goal_Position`` value that reached the bus, decoded from the packets.
+
+    A goal write is ``INST_WRITE`` (``0x03``) whose first parameter is the
+    ``Goal_Position`` address (``0x2A``), with the value little-endian after it.
+    Reads share the bus, so the payload is what distinguishes a command from a
+    query.
+
+    Args:
+        instances: The recording serial stand-ins the fixture handed out.
+
+    Returns:
+        The commanded goal positions, in the order they were written.
+    """
+    goals: list[int] = []
+    for fake in instances:
+        for packet in fake.writes:
+            if len(packet) >= 9 and packet[4] == 0x03 and packet[5] == 0x2A:
+                goals.append(packet[6] | (packet[7] << 8))
+    return goals
+
+
+class TestTheUnknownMotorDeferralHolds:
+    """A displacement for a motor with no configured travel, and what refuses it.
+
+    :func:`_joint_delta_error` returns ``None`` for a motor absent from
+    ``_DEFAULT_MOTOR_CONFIGS``: there is no travel to bound a displacement
+    against, so it has nothing to say and defers - exactly as its sibling
+    :func:`_joint_target_error` does for an absolute target.
+
+    A deferral is only sound if the thing it defers TO refuses, and that half
+    was unasserted. The branch itself was unexecuted by the whole suite, so a
+    change making an unconfigured motor commandable through the delta path would
+    have left every test green.
+    """
+
+    def test_an_unknown_motor_has_no_travel_to_bound_the_delta_against(self):
+        """The domain defers rather than inventing a bound it cannot know."""
+        assert _joint_delta_error("incremental_move", "no_such_joint", 5000) is None
+
+    def test_both_helpers_defer_for_the_same_absent_configuration(self):
+        """Whatever the domain does here it does for the absolute target too."""
+        assert _joint_target_error("move_motor", "position", "no_such_joint", 5000) is None
+        assert _joint_delta_error("incremental_move", "no_such_joint", 5000) is None
+
+    def test_finiteness_still_applies_without_a_configured_range(self):
+        """Only the per-joint bound needs a configuration; the shared domain does not."""
+        assert _joint_delta_error("incremental_move", "no_such_joint", math.nan) is not None
+
+    def test_the_action_refuses_the_unknown_motor_without_commanding_it(self, reading_serial, cwd_tmp):
+        """The deferral's target: a read that cannot address an unconfigured motor."""
+        result = _call(action="incremental_move", motor_name="no_such_joint", delta=5000, port=_PORT)
+        assert result["status"] == "error"
+        assert "no_such_joint" in _texts(result)
+        assert _goal_positions(reading_serial) == []
+
+    def test_a_configured_motor_takes_the_same_call_to_the_servo(self, reading_serial, cwd_tmp):
+        """The refusal above is about the motor, not about the reading source."""
+        result = _call(action="incremental_move", motor_name=_JOINT, delta=-90, port=_PORT)
+        assert result["status"] == "success"
+        assert _goal_positions(reading_serial) != []
+
+
+class TestTheComputedTargetDeferralHolds:
+    """A displacement inside the travel can still compute a target outside the range.
+
+    The delta is bounded by the joint's *full travel* rather than by its
+    endpoints, because a displacement is relative and the endpoints are not. So
+    ``current + delta`` can leave the configured range for a delta this domain
+    accepts, and ``degrees_to_position``'s clamp is what bounds it - making
+    ``incremental_move`` the one caller-driven path from which that clamp is
+    still reachable.
+    """
+
+    def test_a_displacement_inside_the_full_travel_is_accepted(self):
+        """The premise: this delta is one the domain has no reason to refuse."""
+        span = _JOINT_RANGE[1] - _JOINT_RANGE[0]
+        assert abs(_INSIDE_TRAVEL_DELTA) < span
+        # And larger than either endpoint, so a domain written against those
+        # would refuse it: this is what makes the travel rule observable.
+        assert abs(_INSIDE_TRAVEL_DELTA) > _JOINT_RANGE[1]
+        assert _joint_delta_error("incremental_move", _JOINT, _INSIDE_TRAVEL_DELTA) is None
+
+    def test_the_computed_absolute_target_leaves_the_configured_range(self):
+        """And the premise for the clamp: the sum is outside the endpoints."""
+        start = MotorController(_PORT).position_to_degrees(_JOINT, _NEAR_UPPER_RAW)
+        assert start + _INSIDE_TRAVEL_DELTA > _JOINT_RANGE[1]
+
+    def test_the_clamp_bounds_it_while_the_caller_is_told_it_moved(self, reading_serial, cwd_tmp):
+        """So the end stop is commanded, and the text still echoes the request."""
+        result = _call(action="incremental_move", motor_name=_JOINT, delta=_INSIDE_TRAVEL_DELTA, port=_PORT)
+        assert result["status"] == "success"
+        assert _goal_positions(reading_serial) == [_goal_position(_JOINT, _JOINT_RANGE[1])]
+        assert f"+{_INSIDE_TRAVEL_DELTA}" in _texts(result)


### PR DESCRIPTION
## Problem

`_joint_delta_error` bounds `incremental_move`'s `delta` by the joint's **full travel** rather than by its endpoints, because a displacement is relative and the endpoints are not. That leaves it two deliberate deferrals, and neither was measured:

1. **A motor absent from `_DEFAULT_MOTOR_CONFIGS`** has no travel to bound a displacement against, so the domain returns `None` and defers - exactly as its sibling `_joint_target_error` does for an absolute target. That branch was the **one remaining unexecuted statement** in `strands_robots/tools/pose_tool.py` (418 statements, 99%).
2. **A displacement inside the travel** can still compute an absolute target outside the range, which `degrees_to_position`'s clamp bounds.

A deferral is only sound if the thing it defers **to** refuses, and nothing asserted that half. A change making an unconfigured motor commandable through the delta path would have left every test in the tree green.

## Measured

Joint `shoulder_pan` parked at **+169.89 deg** (raw 3980), range `(-180, 180)`, full travel 360 deg. `Goal_Position` values are what the tool wrote to the bus.

| call | domain | action | `Goal_Position` |
| --- | --- | --- | --- |
| `'no_such_joint'`, `delta=+5000` | defers | `error` - `"Failed to move no_such_joint"` | `[]` - nothing commanded |
| `'shoulder_pan'`, `delta=-90` | defers | `success` | `[2956]` - commanded |
| `'shoulder_pan'`, `delta=+300` | defers | `success` - `"Moved shoulder_pan by +300 deg"` | `[4095]` - the end stop |

The third row is deferral 2: `+300` is inside the 360 deg travel the domain checks, so it is accepted, and `169.89 + 300 = 469.89` deg leaves the range. An unclamped scale would have produced 5117, past the 12-bit register.

## A claim this corrects

`TestNeighbouringTargetProducersStayOutOfScope` said the clamp "is unreachable from `move_motor` / `move_multiple` / `incremental_move` now". It is unreachable from the first two, whose targets are absolute and are held to the joint's endpoints - but **not** from `incremental_move`, as the row above shows. `_joint_delta_error`'s own docstring already said the clamp "remains the last resort for a target computed from a live position reading", so the two docstrings disagreed about the same path. The measurement settles it in favour of the helper, and a test now says so.

## Tests

`tests/tools/test_pose_tool_target_domain.py` gains two classes (8 cases, 75 -> 83 collected):

- **`TestTheUnknownMotorDeferralHolds`** - the domain defers, both helpers defer for the same absent configuration, finiteness still applies without one, and the action refuses with **zero** `Goal_Position` writes. That last assertion is made against an always-answering position source, and paired with a configured motor taking the same call to the servo - otherwise "no servo was commanded" would hold for the fixture rather than for the motor.
- **`TestTheComputedTargetDeferralHolds`** - the delta is inside the travel **and larger than either endpoint** (so a domain written against the endpoints would refuse it, which is what makes the travel rule observable), the computed target leaves the range, and the clamp commands the end stop while the caller is told the move happened.

## Plausible regressions, two arms

| regression | new (8) | pre-existing (249) |
| --- | --- | --- |
| M1 remove the unknown-motor deferral | caught (3) | **BLIND** |
| M2 the read tolerates an unconfigured motor | missed | caught (5) |
| M3 `incremental_move` tolerates a missing reading | missed | caught (1) |
| M4 bound the delta by the endpoints, not the travel | caught (2) | **BLIND** |
| M5 drop the clamp the computed target relies on | caught (1) | caught (10) |

The two regressions no test in the tree sees are exactly the two these classes pin. M2 and M3 are the pre-existing suite's own cells, and that is correct division of labour: the property asserted here - an unconfigured motor is not commanded - is held by **two** defences (neither `read_motor_position` nor `move_motor` can address it), so the new tests deliberately do not pin which one fires.

Each mutation is AST-scoped to its enclosing function. M1's anchor is `in_fn=1 in_file=2` (both helpers carry that branch), so the scoping is load-bearing; the source is restored byte-identically in a `finally`.

## Out of scope

- The clamp itself stays. Removing it would turn the stored-pose and `reset_to_home` paths into raises, and it is still the only bound on a target computed from a live reading.
- Which of the two defences refuses an unconfigured motor is not pinned, for the reason above.

## Gate

Full suite on an NVIDIA Jetson AGX Thor at `83cc5272` (`MUJOCO_GL=egl python -m pytest tests`): **28688 passed / 258 skipped / 0 failed** in 626s - 28680 pristine + the 8 new cases. `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean (mypy reports 14 errors, all in `examples/isaac_gs`, byte-identical to a pristine-base worktree control and outside CI's scope). The 8 repo-wide root guards: 430 passed.

`strands_robots/tools/pose_tool.py` over its own suite: **1 missing (99%) -> 0 missing (100%)**.

`scripts/check_merge_base_overlap.py` reports no overlap (0 paths changed on `upstream/main` in the span).

## Artifact

The only production edit is a docstring, and the docstring-stripped AST digest of `pose_tool.py` is **unchanged at `48bd01cc3adc195f`** - no executable line moved - so there is no rollout to show. The artifact is the measurement: the commanded `Goal_Position` across a delta sweep, the deferral ledger, and the mutation matrix.

![delta domain deferrals](https://raw.githubusercontent.com/cagataycali/robots/artifacts/pose-delta-deferrals/pose_delta_deferrals.png)

Scripts and raw JSON: [`artifacts/pose-delta-deferrals`](https://github.com/cagataycali/robots/tree/artifacts/pose-delta-deferrals).
