### PR TITLE
fix(ci): the closing-reference report cancels its own in-flight run, so a head that satisfies it keeps a permanent red context

### DIFF
--- a/.github/workflows/closing-reference.yml
+++ b/.github/workflows/closing-reference.yml
@@ -56,11 +56,38 @@ on:
     # name, so an edit starts no run in that group and cancels nothing. Both
     # halves of that premise are pinned there, so this exemption cannot outlive
     # its justification.
+    #
+    # That premise is checked against the wrong concurrency group, and #2216
+    # measured what it costs. It asks whether an edit can cancel the *required*
+    # check, which it cannot. It never asks whether an edit can cancel *this*
+    # workflow's own in-flight run, which it can: that run shares a workflow name
+    # and a pull request number with the one already going, so a group keyed on
+    # either holds both. Being exempt is what makes it reachable -- an exempt
+    # workflow is the only kind that can be started twice on one head sha -- so
+    # the cancelled context lands on the live head instead of a superseded one.
+    # Measured on #1722 and #2205: each head carried this check as `SUCCESS` and
+    # `CANCELLED` together, every other context `SUCCESS`, and #2205's roll-up
+    # read SUCCESS, then FAILURE, then SUCCESS across three reads of one
+    # unchanged sha. That is why this file now carries no `concurrency` block.
     types: [opened, synchronize, reopened, edited]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# No `concurrency` block, deliberately, and this is the one workflow here for
+# which that is the right spelling (#2216).
+#
+# Cancelling is a saving only when a newer head supersedes an older run, and in
+# that case the cancelled context attaches to a sha that is no longer the head,
+# where nobody reads it. Every other `pull_request` workflow in this repository
+# takes GitHub's default activity types, so a superseded head is the only case any
+# of them can produce and `cancel-in-progress: true` is correct in all of them.
+# This one also subscribes to `edited`, so two of its runs can share one head, and
+# cancelling either leaves a red context on a pull request that satisfies the
+# check -- unclearable without a push, which is the one thing a self-clearing
+# report must not require.
+#
+# What is given up is seconds of runner time: a checkout, a `setup-python`, and
+# one standard-library script with nothing to install. Overlapping runs are
+# idempotent, because neither reads the tree and neither is handed the title (see
+# the step below), so both resolve the same verdict from the API.
 
 permissions:
   contents: read
@@ -100,11 +127,22 @@ jobs:
 
       # Standard library only, so there is nothing to install.
       #
-      # The title goes through the environment rather than into the command line,
-      # because it is author-controlled text and `${{ }}` interpolation of it
-      # would be a shell-injection seam in a job that holds a token. The script
-      # reads PR_TITLE itself; it also falls back to the API's copy of the title,
-      # so a workflow that stopped setting it would still check the right string.
+      # The title is deliberately not passed in, and that is load-bearing for the
+      # absent `concurrency` block above rather than a tidy-up. `main()` resolves
+      # `title = args.title or api_title`, so a `PR_TITLE` taken from the event
+      # payload outranks `resolve_pull_request`'s copy for the whole life of that
+      # run. Once runs are no longer cancelled, a run started by `synchronize` can
+      # still be going when an `edited` run passes, and with the payload's title it
+      # would report the pre-edit verdict afterwards -- stranding a red context on
+      # a head that had already cleared, which is the same harm #2216 removed by
+      # one route arriving by another. Reading the title from the API is what makes
+      # two runs on one head agree.
+      #
+      # It also retires an injection seam instead of documenting one. The payload
+      # title is author-controlled text, and the reason it travelled through the
+      # environment at all was that `${{ }}` interpolation of it into a shell in a
+      # job holding a token is a risk. Not interpolating it anywhere is stronger
+      # than interpolating it carefully.
       #
       # The absence guard is the residual case #1791 could not cover. Checking out
       # the base fixes a head that predates the script; it cannot fix a *base*
@@ -129,7 +167,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [ ! -f scripts/check_closing_reference.py ]; then
             echo "::notice title=No closing-reference rule on this base::The base branch carries no scripts/check_closing_reference.py, so there is no rule here to enforce."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1013,9 +1013,14 @@ hatch run format            # ruff check --fix, ruff format
    lands in the step summary and in a `Needs an approver who did not push the
    head` annotation, because a red X drags `statusCheckRollup.state` to
    `FAILURE`, where it cannot be told apart from the branch's own tests failing -
-   measured on #1722, whose rollup read `FAILURE` with every required context
-   `SUCCESS` and this check as the only non-`SUCCESS` context, and misread as a
-   broken diff four times. Red on that job now means the check itself could not
+   measured on #1722 at head `3a32a14`, whose rollup read `FAILURE` with every
+   required context `SUCCESS` and this check as the only non-`SUCCESS` context,
+   and misread as a broken diff four times. Cite that head, because the citation
+   no longer reproduces from the pull request: on `741f4057` this job reads
+   `SUCCESS` under its present name, and #1722's rollup is still `FAILURE` for an
+   unrelated producer - a cancelled duplicate of the closing-reference check
+   (#2216). The decision rests on the `3a32a14` measurement; re-deriving it from
+   #1722 today finds this job green and the reasoning apparently unfounded. Red on that job now means the check itself could not
    compute an answer. The check row is named `Report the last-push-approval
    state` for the same reason: green must not assert the absence of a finding. The point of automating it is not that the check is clever - it is
    that the state it reports is *invisible*: `REVIEW_REQUIRED` / `BLOCKED` is

--- a/changelog.d/2216-closing-reference-self-cancellation.md
+++ b/changelog.d/2216-closing-reference-self-cancellation.md
@@ -1,0 +1,21 @@
+### Fixed: the closing-reference check no longer leaves a red context on a pull request that satisfies it
+
+`closing-reference.yml` is the one workflow subscribed to a `pull_request`
+activity type that cannot change the head sha (`edited`, which its own remedy
+produces), so it is the one workflow that can be started twice on a single head.
+Its concurrency group was keyed on the pull request number with
+`cancel-in-progress: true`, so when those two runs overlapped one was cancelled -
+and a cancelled check run is permanent, attaches to the live head, and aggregates
+into `statusCheckRollup.state == FAILURE` from behind a same-named `SUCCESS`.
+
+Measured on #1722 and #2205: every context on both heads was `SUCCESS` except a
+cancelled duplicate of this check, and #2205's roll-up read `SUCCESS`, then
+`FAILURE`, then `SUCCESS` across three reads of one unchanged sha. Whether it
+happened was a race - #2204's two runs are 40s apart and both completed.
+
+The workflow now carries no concurrency block, and no longer passes `PR_TITLE`:
+with cancellation gone, two runs can overlap, and the payload's title outranks the
+API's copy for the life of a run, so a `synchronize` run handed it would report a
+pre-edit verdict after an `edited` run had already passed. Reading the title from
+the API makes concurrent runs agree, and removes the interpolation seam that
+passing author-controlled text existed to work around.

--- a/tests/test_closing_reference_gate.py
+++ b/tests/test_closing_reference_gate.py
@@ -416,11 +416,47 @@ def test_the_gate_passes_when_the_base_carries_no_copy_of_the_check() -> None:
     assert _SCRIPT.exists()
 
 
-def test_the_title_reaches_the_script_through_the_environment() -> None:
-    """Author-controlled text interpolated into a shell would be an injection seam."""
+def test_the_title_is_not_handed_to_the_script_by_the_workflow() -> None:
+    """#2216: the payload's title outranks the API's, and would go stale.
+
+    ``main()`` resolves ``title = args.title or api_title``, so a ``PR_TITLE``
+    from the event payload wins for the life of the run that received it. The
+    workflow cancels nothing (it carries no ``concurrency`` block, pinned by
+    ``test_the_gate_does_not_cancel_its_own_run``), so a run started by
+    ``synchronize`` can still be going when an ``edited`` run passes; handed the
+    payload title it would report the pre-edit verdict afterwards and strand a red
+    context on a head that had already cleared.
+
+    Not passing it makes ``resolve_pull_request``'s copy authoritative, so any run
+    on a pull request computes the current verdict and two runs on one head agree.
+    The script keeps reading ``PR_TITLE`` and ``--title`` for the command line,
+    which is what the tests above exercise; this pin is about the workflow.
+    """
     workflow = _workflow()
-    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in workflow
+    setters = [
+        line.strip()
+        for line in workflow.splitlines()
+        if not line.lstrip().startswith("#") and re.match(r"^\s*PR_TITLE\s*:", line)
+    ]
+    assert not setters, f"the workflow still hands the script a title: {setters}"
 
     invocation = [line for line in workflow.splitlines() if "check_closing_reference.py" in line]
     assert invocation
     assert all("${{" not in line for line in invocation)
+
+
+def test_the_gate_does_not_cancel_its_own_run() -> None:
+    """The premise the pin above leans on, and #2216's own finding.
+
+    This workflow is the only one here started by an activity type that cannot
+    change the head sha, so it is the only one that can have two runs on one head
+    -- and a concurrency group keyed on the pull request number would hold both.
+    Cancelling one leaves a permanent ``CANCELLED`` context on a head that
+    satisfies the check, which is unclearable without a push and so defeats the
+    self-clearing property ``test_the_gate_reruns_when_the_title_or_body_is_edited``
+    exists to protect. The fleet-wide form of this rule is
+    ``test_an_exempt_workflow_cannot_cancel_its_own_run``.
+    """
+    workflow = _workflow()
+    assert not re.search(r"^concurrency:", workflow, re.MULTILINE)
+    assert not re.search(r"^\s*cancel-in-progress:", workflow, re.MULTILINE)

--- a/tests/test_pull_request_trigger_types.py
+++ b/tests/test_pull_request_trigger_types.py
@@ -64,12 +64,32 @@ event that changes either. It is also the event that check's own remedy produces
 moving a closing keyword out of the title and into the body changes no sha, so
 without ``edited`` the report would ask for a fix it could never observe.
 
-The measured harm cannot follow from it either, and that is a premise rather than
-an assurance: cancellation is per concurrency group, ``pr-and-push.yml`` keys its
-group on its own ``github.workflow`` name and does not subscribe to ``edited``,
-so an edit starts no run in that group. Both halves are read back by
-``test_an_exempt_workflow_cannot_cancel_the_required_check``, so an exemption
-cannot outlive the reasoning that admitted it.
+The measured harm cannot reach the *required check* from it either, and that is a
+premise rather than an assurance: cancellation is per concurrency group,
+``pr-and-push.yml`` keys its group on its own ``github.workflow`` name and does
+not subscribe to ``edited``, so an edit starts no run in that group. Both halves
+are read back by ``test_an_exempt_workflow_cannot_cancel_the_required_check``, so
+an exemption cannot outlive the reasoning that admitted it.
+
+That premise is true and it was the wrong group to check. The run an exempt event
+cancels first is the exempt workflow's **own**, which shares both a workflow name
+and a pull request number with the run already in flight. Being exempt is exactly
+what makes this reachable -- an exempt workflow is the only kind that can be
+started twice on one head sha -- so unlike the ``main`` case above the cancelled
+context lands on the *live* head. #2216 measured it on #1722 and #2205: each head
+carried ``Refuse a closing keyword that only appears in the title`` as ``SUCCESS``
+and ``CANCELLED`` together, with every other context ``SUCCESS``, and #2205's
+roll-up read ``SUCCESS``, then ``FAILURE``, then ``SUCCESS`` across three reads of
+one unchanged sha -- the same instability this module records for #1901 and #1902,
+reintroduced by the exemption it granted. Whether it happens is a race and the
+inter-arrival gap does not predict it: #2204's two runs are 40 s apart and both
+completed, #2205's are 71 s apart and one was cancelled.
+
+So an exemption needs a second premise, read back by
+``test_an_exempt_workflow_cannot_cancel_its_own_run``: an exempt workflow must not
+cancel in progress at all. It is the same conclusion this module already reaches
+for the required check -- remove the producer rather than read around it --
+applied to the workflow the exemption is granted to.
 
 ``test_no_workflow_gates_on_draft_status`` is the premise behind dropping
 ``ready_for_review`` specifically: nothing in the fleet skips a draft pull
@@ -289,4 +309,46 @@ def test_no_workflow_gates_on_draft_status() -> None:
     assert not gating, (
         f"these workflows mention 'draft': {gating}. If one now skips draft pull requests, "
         "re-derive whether ready_for_review must start it"
+    )
+
+
+def test_an_exempt_workflow_cannot_cancel_its_own_run() -> None:
+    """The second premise every entry in :data:`_INPUT_IS_NOT_THE_TREE` rests on.
+
+    ``test_an_exempt_workflow_cannot_cancel_the_required_check`` establishes that
+    an exempt event cannot reach ``pr-and-push.yml``'s concurrency group. That is
+    necessary and not sufficient: the run an exempt event cancels first is the
+    exempt workflow's own, which shares a workflow name and a pull request number
+    with the run already in flight, so a group keyed on either holds both.
+
+    Being exempt is what makes it reachable -- an exempt workflow is the only kind
+    that can be started twice on one head sha -- and the cancelled context then
+    sits on the live head rather than on a superseded one, where the roll-up reads
+    it. Measured on #1722 and #2205 (#2216), each carrying its check as
+    ``SUCCESS`` and ``CANCELLED`` at once with every other context ``SUCCESS``.
+
+    Asserted of the table rather than of the single file in it, so a future
+    exemption inherits the requirement instead of rediscovering it the same way.
+    """
+    assert _INPUT_IS_NOT_THE_TREE, "the exemption table is empty; this pin has nothing to check"
+
+    offenders: dict[str, list[str]] = {}
+    for name in _INPUT_IS_NOT_THE_TREE:
+        path = _WORKFLOW_DIR / name
+        assert path.exists(), f"{name} is exempt but does not exist"
+        cancelling = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#") and line.strip().startswith("cancel-in-progress:")
+        ]
+        if cancelling:
+            offenders[name] = cancelling
+
+    assert not offenders, (
+        f"these workflows are exempted for a sha-invariant activity type and still cancel in "
+        f"progress: {offenders}. An exempt workflow can be started twice on one head sha, so its "
+        "own in-flight run is what it cancels, and the cancelled check run is permanent, sits on "
+        "the live head and drags statusCheckRollup.state to FAILURE from behind a same-named "
+        "SUCCESS. Drop the concurrency block: a superseded head is the only case cancelling helps "
+        "with, and a sha-invariant trigger does not produce one."
     )


### PR DESCRIPTION
Closes #2216.

## What this is

`closing-reference.yml` is the only workflow here subscribed to a `pull_request` activity type that cannot change the head sha -- `edited`, which is the event its own remedy produces. That makes it the only workflow that can be started twice on one head. It also carried `cancel-in-progress: true` on a group keyed on the pull request **number**, so when two of its runs overlapped one was cancelled, and a cancelled check run is permanent, attaches to the **live** head, and aggregates into `statusCheckRollup.state == FAILURE` from behind a same-named `SUCCESS`.

That is the producer `tests/test_pull_request_trigger_types.py` removed from the required check in #1914, reintroduced on the exempt workflow's own check by the exemption #1914 granted.

## Why the existing premise did not catch it

The exemption is not undefended. It ships with an argument that cancellation cannot reach the required check, pinned by `test_an_exempt_workflow_cannot_cancel_the_required_check`:

> `pr-and-push.yml` does not subscribe to `edited` and keys its concurrency group on its own workflow name, so an edit starts no run in that group and cancels nothing.

Every clause of that is true. It is the wrong concurrency group. The run an exempt event cancels first is the exempt workflow's **own** -- it shares a workflow name *and* a pull request number with the run already in flight, so a group keyed on either holds both. Being exempt is precisely what makes it reachable, and unlike the `main`-branch case the module already documents as wanted, the cancelled context lands on a live head rather than a superseded one.

## Measured, open population, 2026-08-12 ~23:30 UTC

Five of 18 open heads ran this workflow twice on one sha. Two raced into a cancellation:

| pull request | head | contexts named `Refuse a closing keyword that only appears in the title` |
|---|---|---|
| #1722 | `741f4057` | **`SUCCESS` + `CANCELLED`** |
| #2205 | `8ca67d34` | **`SUCCESS` + `CANCELLED`** |
| #2204 | `9e626421` | `SUCCESS` + `SUCCESS` |
| #2207 | `fe856c49` | `SUCCESS` + `SUCCESS` |
| #2213 | `f958666b` | `SUCCESS` + `SUCCESS` |

On #1722 and #2205 every other context is `SUCCESS`/`SKIPPED`/`NEUTRAL`, the required `call-test-lint / Test and Lint` included; the cancelled duplicate is the only non-`SUCCESS` context on either head.

**It is a race, and the inter-arrival gap does not predict it:** #2204's runs are 40 s apart and both completed, #2205's are 71 s apart and one was cancelled. The direction is not fixed either -- on #2205 the newer run cancelled the older, while on #1722 both runs are attempt 2 (re-runs) and the *newer* is the cancelled one.

Three reads of #2205's rollup on the unchanged head `8ca67d34`, inside ~20 minutes with no new run: `SUCCESS` -> `FAILURE` -> `SUCCESS`. That is the same instability the module records for #1901/#1902, and the reason it concludes that for a pull request the producer should be removed rather than read around.

## The change

Two deletions, and they are coupled rather than two cleanups:

1. **The `concurrency` block goes.** Cancelling is a saving only when a newer head supersedes an older run, and then the cancelled context sits on a sha that is no longer the head, where nobody reads it. Keyed on the pull request number it also cancels runs on the *same* head, where nothing is superseded. What is given up is seconds: a checkout, a `setup-python`, and one standard-library script with nothing to install.

2. **`PR_TITLE` goes with it.** This is required *by* (1). `main()` resolves `title = args.title or api_title`, so the payload's copy outranks `resolve_pull_request`'s for the life of the run that received it. Once runs can overlap, a `synchronize` run handed the payload title would report the pre-edit verdict after an `edited` run had already passed -- stranding a red context on a head that had just cleared, which is the same harm arriving by another route. Reading the title from the API makes two runs on one head agree. The file's header already sanctioned this ("a workflow that stopped setting it would still check the right string"), and it retires the `${{ }}` interpolation seam that passing author-controlled text existed to work around instead of documenting it.

## Pins

Three, and each one fails against `main`'s workflow and passes against this branch (verified by reverting only the workflow file and re-running):

- `test_an_exempt_workflow_cannot_cancel_its_own_run` -- the fleet-wide form, asserted of the `_INPUT_IS_NOT_THE_TREE` **table** rather than of the one file in it, so a future exemption inherits the requirement instead of rediscovering it the same way.
- `test_the_gate_does_not_cancel_its_own_run` -- the local form, next to the self-clearing property it protects.
- `test_the_title_is_not_handed_to_the_script_by_the_workflow` -- forbids the assignment rather than the mention, so the explanatory comment does not satisfy or break it. Keeps the original assertion that nothing `${{ }}`-interpolated reaches the invocation line.

The module docstrings are corrected in place rather than annotated, since the old premise paragraph is what a reader would otherwise re-derive the exemption from.

## One documentation correction, in AGENTS.md

AGENTS.md justifies `last-push-approval.yml` reporting rather than failing by citing #1722, "whose rollup read `FAILURE` with every required context `SUCCESS` and this check as the only non-`SUCCESS` context". That was true of head `3a32a14`. On today's head `741f4057` that job reads `SUCCESS` under its present name, and #1722's rollup is still `FAILURE` for this bug instead. The decision is unchanged and correct; the citation no longer reproduces from the pull request, so it now names the head it was measured on and says what the rollup is red for today. Anyone re-deriving that paragraph from #1722 would otherwise find the named check green and conclude the reasoning was unfounded.

## Out of scope, deliberately

- **The other five `cancel-in-progress: true` workflows** (`changelog-fragment`, `lockfile-parity`, `merge-base-overlap`, `pr-and-push`, `last-push-approval`). None subscribes to a sha-invariant type, so no event can start two of their runs on one head, and their cancellations land on superseded shas where they are invisible. Correct as they stand, and the new pin deliberately does not touch them.
- **The re-run path.** #1722's pair are both attempt 2, and #1087's head carries a duplicate of *every* workflow, so re-running a completed run also produces two runs on one head for workflows that subscribe to nothing unusual. That reaches the whole fleet, is initiated by a human action rather than a trigger list, and needs its own decision about whether a re-run replaces or accumulates contexts. Recorded in #2216, not addressed here.
- **Merge exposure.** The `default` ruleset requires exactly one context (`call-test-lint / Test and Lint`), so a cancelled advisory context costs triage attention, not mergeability. Not claimed as a merge fix. #1087's head does carry the required name twice as `FAILURE` + `CANCELLED`, but it has a genuine failure too, so it is not a clean case and is offered only as grounds for not assuming the required name cannot be duplicated.

## Verification

```
pytest tests/test_pull_request_trigger_types.py tests/test_closing_reference_gate.py  ->  78 passed
ruff check / ruff format --check on both modules                                     ->  clean
yaml.safe_load(closing-reference.yml)  ->  parses; 'concurrency' absent; types unchanged;
                                           step env is GITHUB_TOKEN + PR_NUMBER only
the three new pins against main's workflow  ->  3 failed (they are not vacuous)
```

The trigger list is untouched: `edited` stays, for the reason the file and `test_the_gate_reruns_when_the_title_or_body_is_edited` both give. This makes the exemption safe rather than withdrawing it.

## 13. Round changelog

**Round 1** -- initial submission. Found while sweeping the open queue: the sweep had recorded #2205 as `CI SUCCESS` in its own opening pass, because it read the rollup during a `SUCCESS` phase of the instability described above.
