### PR TITLE
feat(simulation/isaac): IK-backed move_to via the shared MinkIKBridge

### DIFF
--- a/changelog.d/2155-isaac-move-to.md
+++ b/changelog.d/2155-isaac-move-to.md
@@ -1,0 +1,23 @@
+### Added: IK-backed `move_to` on the Isaac backend via the shared MinkIKBridge
+
+The Isaac backend gains the third motion primitive, `move_to` (GH #2155, child
+of the parity epic #2123): blocking Cartesian end-effector transport with the
+same signature, defaults, structured result/abort envelopes and never-raises
+contract as the MuJoCo reference. The solve reuses the shared
+damped-least-squares bridge (`strands_robots.simulation.ik.MinkIKBridge`) on
+the MuJoCo model the robot's `data_config` resolves to - Isaac registry robots
+carry MJCF sources - seeded from the articulation's live joint positions, with
+the same deterministic restart schedule, position-only solve when no
+orientation is given (5-DOF arms), workspace sanity rejection, and unreachable
+targets answered with the IK residual in a structured error.
+
+The MJCF-side solution is reconciled with the Isaac articulation through an
+explicit name-keyed joint map (MJCF joint name -> articulation DOF index): a
+solved joint with no articulation counterpart is a structured refusal, never a
+positional/flat-index write, so an articulation whose DOF order differs from
+the MJCF converges identically. The world-frame target is mapped through the
+articulation's live base pose, convergence is measured by FK of the live joint
+readback through the same bridge frame the solver optimized, gripper DOFs are
+held at their live position for the whole descent (grasp preservation), and a
+policy running on the robot (`policy_running`) refuses the primitive up front
+and aborts it mid-run.

--- a/strands_robots/simulation/isaac/motion_primitives.py
+++ b/strands_robots/simulation/isaac/motion_primitives.py
@@ -1,11 +1,11 @@
-"""Joint-space motion primitives for the Isaac backend - ``set_gripper`` / ``rotate_wrist``.
+"""Motion primitives for the Isaac backend - ``move_to`` / ``set_gripper`` / ``rotate_wrist``.
 
 The Isaac half of the analytic motion primitives (GH #1645; Isaac parity work
-GH #2123, this module is #2154). Before this module the only motion path on
-Isaac was the raw kinematic ``set_joint_positions`` write - no blocking move,
-no timeout/abort-reason contract, no registry-driven gripper semantics. The
-two joint-space primitives now share their backend-neutral half with the
-MuJoCo reference implementation
+GH #2123: the joint-space pair is #2154, the IK-backed ``move_to`` is #2155).
+Before this module the only motion path on Isaac was the raw kinematic
+``set_joint_positions`` write - no blocking move, no timeout/abort-reason
+contract, no registry-driven gripper semantics. The primitives share their
+backend-neutral half with the MuJoCo reference implementation
 (:mod:`strands_robots.simulation.mujoco.motion_primitives`) through
 :class:`~strands_robots.simulation.motion_primitives_base.MotionPrimitivesCore`:
 parameter domains, registry gripper metadata (``closed``/``open`` ->
@@ -15,8 +15,15 @@ agent reading a refusal or a result payload sees the same sentence and the
 same json keys whichever backend produced it (AGENTS.md: "Match docstrings to
 semantics").
 
-``move_to`` (IK-backed, Cartesian) is deliberately not here - it lands in a
-follow-up child of #2123.
+``move_to`` reuses the shared damped-least-squares IK bridge
+(:class:`strands_robots.simulation.ik.MinkIKBridge`), which operates on the
+MuJoCo model of the robot: Isaac registry robots carry MJCF sources, so the
+kinematic model the solve runs on is resolved from the robot's
+``data_config``. The Isaac articulation's joint ordering/namespacing is
+reconciled with the MJCF-side solution through an explicit NAME-KEYED map
+(MJCF joint name -> articulation DOF index); a solved joint that cannot be
+mapped is a structured refusal, never a positional/flat-index write
+(AGENTS.md: "Per-name state copy, not flat index").
 
 What this adapter owns (the backend-specific half):
 
@@ -55,9 +62,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
+from strands_robots.simulation.model_registry import resolve_model
 from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.motion_primitives_base import (
     _GRIPPER_HINTS,
+    _IK_RESTART_SEEDS,
     _WRIST_HINTS,
     MotionPrimitivesCore,
     _err,
@@ -354,7 +363,512 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         matched = [i for i, short in enumerate(short_names) if any(h in short.lower() for h in _GRIPPER_HINTS)]
         return matched, None, None
 
+    # -- move_to kinematics plumbing ---------------------------------------------
+
+    @staticmethod
+    def _articulation_base_pose(articulation: Any) -> tuple[np.ndarray, np.ndarray] | None:
+        """World pose of the articulation base: ``(position (3,), quat wxyz (4,))`` or ``None``.
+
+        Reads ``articulation.get_world_pose()`` - the read counterpart of the
+        write :meth:`IsaacSimulation.set_robot_pose` drives - tolerating torch
+        tensors and the exception set a torn-down articulation raises.
+        ``None`` means "could not be read"; callers must answer that loudly,
+        never by substituting an origin base (a wrong base makes every
+        world-frame target silently wrong). The returned quaternion is
+        normalized.
+        """
+        try:
+            pose = articulation.get_world_pose()
+        except (RuntimeError, ValueError, AttributeError, TypeError):
+            return None
+        if pose is None:
+            return None
+        try:
+            pos_raw, quat_raw = pose
+        except (TypeError, ValueError):
+            return None
+        if pos_raw is None or quat_raw is None:
+            return None
+        pos_arr = pos_raw.cpu().numpy() if hasattr(pos_raw, "cpu") else pos_raw
+        quat_arr = quat_raw.cpu().numpy() if hasattr(quat_raw, "cpu") else quat_raw
+        pos = np.asarray(pos_arr, dtype=np.float64).reshape(-1)
+        quat = np.asarray(quat_arr, dtype=np.float64).reshape(-1)
+        if pos.size != 3 or quat.size != 4:
+            return None
+        if not (np.all(np.isfinite(pos)) and np.all(np.isfinite(quat))):
+            return None
+        norm = float(np.linalg.norm(quat))
+        if norm < 1e-8:
+            return None
+        return pos, quat / norm
+
+    def _load_ik_mjcf(self, robot: Any) -> tuple[Any, Any, dict[str, Any] | None]:
+        """Compile the MuJoCo model the IK solve runs on: ``(mujoco, model, None)`` or an error.
+
+        The shared IK bridge (:class:`strands_robots.simulation.ik.MinkIKBridge`)
+        operates on a compiled ``mujoco.MjModel``; Isaac registry robots carry
+        MJCF sources, so the kinematic model is resolved from the robot's
+        ``data_config`` through the same
+        :func:`~strands_robots.simulation.model_registry.resolve_model` lookup
+        the MuJoCo backend's ``add_robot`` uses (this module's ``resolve_model``
+        global is the patch point for tests). Every failure - no
+        ``data_config``, nothing resolves, ``mujoco`` not importable, the file
+        does not compile - is a structured error naming the remedy, never a
+        raise or a silent identity model.
+        """
+        data_config = getattr(robot, "data_config", None)
+        if not data_config:
+            return (
+                None,
+                None,
+                _err(
+                    f"move_to: robot '{robot.name}' has no data_config, so the registry MJCF the "
+                    "IK solve runs on cannot be resolved. Re-add the robot with data_config=..., "
+                    "or drive the joints directly with action='send_action'."
+                ),
+            )
+        path = resolve_model(data_config)
+        if path is None:
+            return (
+                None,
+                None,
+                _err(
+                    f"move_to: no MJCF/URDF model resolves for data_config '{data_config}', so "
+                    "there is no kinematic model for the IK solve. Register one "
+                    "(strands_robots.simulation.model_registry.register_urdf), or drive the "
+                    "joints directly with action='send_action'."
+                ),
+            )
+        try:
+            import mujoco as mj
+        except ImportError:
+            return (
+                None,
+                None,
+                _err(
+                    "move_to: the IK solve runs on the MuJoCo model of the robot and needs the "
+                    "'mujoco' + 'mink' stack, which is not importable. Install the sim extra: "
+                    "uv pip install 'strands-robots[sim-mujoco]'."
+                ),
+            )
+        try:
+            model = mj.MjModel.from_xml_path(path)
+        except (ValueError, OSError, RuntimeError, mj.FatalError) as e:
+            return (
+                None,
+                None,
+                _err(f"move_to: could not compile the IK model for data_config '{data_config}' from {path}: {e}"),
+            )
+        return mj, model, None
+
+    def _mjcf_articulation_joint_map(
+        self, mj: Any, model: Any, robot: Any
+    ) -> tuple[dict[int, int], dict[int, int], dict[str, Any] | None]:
+        """Name-keyed map from MJCF joints onto articulation DOF indices.
+
+        The key risk of running the IK on the MJCF while writing targets to
+        the Isaac articulation is joint ORDER (#2123): the URDF importer and
+        the MJCF compiler need not agree on DOF ordering, so the solved
+        configuration is reconciled per NAME - MJCF joint name (namespace
+        stripped on both sides, see :meth:`_short_joint_name`) -> articulation
+        DOF index - and a solved joint that cannot be mapped is a structured
+        refusal, never a positional/flat-index write (AGENTS.md: "Per-name
+        state copy, not flat index").
+
+        Returns ``(arm_map, grip_map, error)``: ``arm_map`` / ``grip_map`` map
+        MJCF joint id -> articulation DOF index for the hinge/slide joints,
+        split by the shared registry-metadata-first gripper classification
+        (same vocabulary on both sides, so the split cannot disagree with
+        :meth:`_resolve_gripper_dofs`). Every ARM joint must map - the solve
+        commands them all; a gripper joint with no counterpart merely stays at
+        the model default in the FK reads (it is held on the articulation
+        side, not commanded from the solve). Callers must hold ``self._lock``.
+        """
+        short_names = [self._short_joint_name(n) for n in robot.joint_names]
+        dof_by_name: dict[str, int] = {}
+        for i, short in enumerate(short_names):
+            dof_by_name.setdefault(short, i)
+
+        meta, malformed_reason = self._registry_gripper_metadata(robot)
+        if malformed_reason is not None:
+            return {}, {}, _err(f"Cannot resolve the gripper for '{robot.name}': {malformed_reason}")
+        wanted = {str(a).lower() for a in meta["actuators"]} if meta is not None else None
+
+        def _is_gripper(short: str) -> bool:
+            if wanted is not None:
+                return short.lower() in wanted
+            return any(h in short.lower() for h in _GRIPPER_HINTS)
+
+        settable = {int(mj.mjtJoint.mjJNT_HINGE), int(mj.mjtJoint.mjJNT_SLIDE)}
+        arm_map: dict[int, int] = {}
+        grip_map: dict[int, int] = {}
+        unmapped: list[str] = []
+        for jnt_id in range(int(model.njnt)):
+            if int(model.jnt_type[jnt_id]) not in settable:
+                continue
+            jname = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jnt_id) or ""
+            short = self._short_joint_name(jname)
+            dof = dof_by_name.get(short)
+            if _is_gripper(short):
+                if dof is not None:
+                    grip_map[jnt_id] = dof
+                continue
+            if dof is None:
+                unmapped.append(short or f"<unnamed joint {jnt_id}>")
+                continue
+            arm_map[jnt_id] = dof
+        if unmapped:
+            return (
+                {},
+                {},
+                _err(
+                    f"move_to: the IK model for '{robot.name}' (data_config '{robot.data_config}') "
+                    f"has joints {unmapped} with no articulation counterpart. Joint targets are "
+                    "written per NAME, never by flat index, so a solved joint that cannot be "
+                    f"mapped is refused. Articulation joints: {short_names}."
+                ),
+            )
+        if not arm_map:
+            return (
+                {},
+                {},
+                _err(
+                    f"move_to: the IK model for '{robot.name}' (data_config '{robot.data_config}') "
+                    "has no non-gripper hinge/slide joints to solve - nothing can move the "
+                    "end-effector."
+                ),
+            )
+        return arm_map, grip_map, None
+
+    @staticmethod
+    def _quat_wxyz_to_mat(mj: Any, quat: np.ndarray) -> np.ndarray:
+        """``(3, 3)`` rotation matrix for a wxyz quaternion (MuJoCo convention)."""
+        rot = np.zeros(9, dtype=np.float64)
+        mj.mju_quat2Mat(rot, np.asarray(quat, dtype=np.float64))
+        return rot.reshape(3, 3)
+
     # -- primitives --------------------------------------------------------------
+
+    def move_to(
+        self,
+        robot_name: str | None = None,
+        position: list[float] | None = None,
+        orientation: list[float] | None = None,
+        tol: float = 0.01,
+        max_steps: int = 200,
+    ) -> dict[str, Any]:
+        """Move the end-effector to a world-frame Cartesian target via IK.
+
+        Composite analytic primitive (the staging/transport verb), same public
+        API and result semantics as the MuJoCo backend's
+        :meth:`~strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin.move_to`:
+        solves inverse kinematics to the target with the shared mink
+        damped-least-squares bridge
+        (:class:`strands_robots.simulation.ik.MinkIKBridge`; position-only
+        when no orientation is given - important for 5-DOF arms like SO-101),
+        then drives PD position targets on the Kit loop until the
+        end-effector is within ``tol`` meters of the target or ``max_steps``
+        control ticks elapse. Deterministic restart seeds
+        (:data:`~strands_robots.simulation.motion_primitives_base._IK_RESTART_SEEDS`)
+        retry a stalled direct solve; an unreachable target returns the IK
+        residual in a structured error, never a raise.
+
+        The bridge operates on the MuJoCo model of the robot, resolved from
+        the robot's ``data_config`` (Isaac registry robots carry MJCF
+        sources; see :meth:`_load_ik_mjcf`). The solve is seeded from the
+        articulation's CURRENT joint positions and its result is reconciled
+        with the articulation through an explicit NAME-KEYED joint map
+        (:meth:`_mjcf_articulation_joint_map`) - a solved joint that cannot
+        be mapped by name is a structured refusal, never a positional write.
+        The world-frame target is mapped into the model frame through the
+        articulation's live base pose (``get_world_pose``), which is read
+        once at setup: the arm's base is assumed fixed for the duration of
+        the move.
+
+        CONVERGENCE MEASUREMENT: the EE pose is computed per tick by forward
+        kinematics of the live joint readback through the SAME bridge frame
+        the solver optimized (then mapped back to world through the base
+        pose). Measuring a different frame (e.g. the USD gripper-link
+        heuristic) could leave the solver and the convergence check watching
+        points that never agree - the same trap the MuJoCo mixin's
+        ``_frame_world_pose`` documents.
+
+        GRASP PRESERVATION (contract): gripper DOFs (resolved by the same
+        registry-metadata-first classification ``set_gripper`` uses, see
+        :meth:`_resolve_gripper_dofs`) are excluded from the IK solve and its
+        restart seeding, and are HELD at their live position for the whole
+        servo descent - ``set_gripper("close") -> move_to(...)`` carries the
+        held object rather than releasing it.
+
+        REFUSES WHILE A POLICY RUNS on the same robot: ``policy_running`` is
+        the per-robot flag every Isaac policy-driving loop sets
+        (:meth:`IsaacSimulation.run_multi_policy`, the recording rollout
+        hook), so it is this backend's counterpart of the MuJoCo
+        ``_require_no_running_policy`` guard - checked up front and per
+        control tick (a policy starting mid-run aborts the primitive).
+
+        NOT collision-aware: the straight servo descent can sweep through
+        obstacles - the same contract as the MuJoCo backend, which
+        deliberately hides the solver so a collision-aware upgrade cannot
+        change this surface.
+
+        Args:
+            robot_name: Robot to move; defaults to the single robot in the
+                world (errors if ambiguous).
+            position: World-frame target ``[x, y, z]`` in meters (required).
+                Validated by the same rule the scene-construction calls use
+                (:func:`strands_robots.utils.coerce_pose_vector`): three finite
+                real components, a NumPy array accepted, a ``bool`` refused.
+            orientation: Optional target orientation quaternion ``[w, x, y, z]``
+                in the world frame, validated the same way and normalized
+                before it enters the solve. When omitted the solve is
+                position-only - the right choice for arms with fewer than
+                6 DOF (e.g. SO-100/SO-101).
+            tol: Position convergence tolerance in meters (> 0).
+            max_steps: Max control ticks before returning a not-reached error
+                (1..10000).
+
+        Returns:
+            ``{"status": "success", ...}`` with a json block
+            ``{reached, steps, position_error_m, ik_residual_m, ee_position,
+            ee_orientation_wxyz, frame, frame_type}`` on arrival;
+            ``{"status": "error", ...}`` with the same json block (including
+            the residual) when the target is unreachable (IK residual > tol)
+            or servo convergence times out. Never raises.
+        """
+        # ---- parameter validation (before touching the world) ----
+        # Shared with the MuJoCo adapter (motion_primitives_base): same
+        # pose-vector rule the scene-construction calls use, same tol /
+        # max_steps domains, same wording.
+        target, target_quat, max_steps, arg_err = self._validate_move_to_args(position, orientation, tol, max_steps)
+        if arg_err is not None:
+            return arg_err
+        assert target is not None  # no error implies a coerced target
+        # Rebound under a plain-ndarray name for the closure below (mypy does
+        # not carry an Optional narrowing across a closure boundary).
+        target_world: np.ndarray = target
+
+        def _move() -> dict[str, Any]:
+            # ---- setup under the lock: guards, IK model, joint map, solve ----
+            # Runs on the Kit-owning thread (see _run_primitive_on_kit), so the
+            # articulation reads that seed the solve happen on the Kit loop.
+            with self._lock:
+                robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+                if error is not None:
+                    return error
+                assert robot_name_resolved is not None and robot is not None
+                name: str = robot_name_resolved
+                if robot.policy_running:
+                    return _err(
+                        f"Cannot 'move_to' on '{name}' while its policy is running - a primitive "
+                        "and the policy loop would race on the articulation's PD targets. Wait "
+                        "for the rollout to finish (Isaac policy loops clear the flag on exit)."
+                    )
+                articulation = robot.articulation
+                short_names = [self._short_joint_name(n) for n in robot.joint_names]
+
+                base = self._articulation_base_pose(articulation)
+                if base is None:
+                    return _err(
+                        f"move_to: could not read the articulation base pose for '{name}', so the "
+                        "world-frame target cannot be mapped into the robot's model frame."
+                    )
+                base_pos, base_quat = base
+                sanity_err = self._workspace_sanity_error(name, target_world, base_pos)
+                if sanity_err is not None:
+                    return sanity_err
+
+                mj, model, load_err = self._load_ik_mjcf(robot)
+                if load_err is not None:
+                    return load_err
+
+                from strands_robots.simulation.ik import discover_ee_frame
+
+                # The registry MJCF is a standalone robot model, so discovery
+                # runs un-namespaced (unlike the MuJoCo backend's shared
+                # multi-robot world model).
+                frame = discover_ee_frame(model, None)
+                if frame is None:
+                    return _err(
+                        f"move_to: could not auto-discover an end-effector frame in the IK model "
+                        f"for '{name}' (data_config '{robot.data_config}'). The model has no "
+                        "TCP-like site or hand/tool body to track."
+                    )
+                frame_name, frame_type = frame
+
+                arm_map, grip_map, map_err = self._mjcf_articulation_joint_map(mj, model, robot)
+                if map_err is not None:
+                    return map_err
+                full_map = {**arm_map, **grip_map}
+
+                # Articulation-side gripper DOFs, HELD at their live position
+                # below (grasp preservation). Same shared classification as
+                # the MJCF-side split, so the two cannot disagree.
+                grip_dofs, _, grip_err = self._resolve_gripper_dofs(robot)
+                if grip_err is not None:
+                    return grip_err
+
+                q_live = self._read_joint_positions(articulation)
+                if q_live is None or q_live.size < len(short_names):
+                    return _err(
+                        f"move_to: could not read joint positions from '{name}' - the "
+                        "articulation did not report a usable joint-position vector."
+                    )
+
+                try:
+                    from strands_robots.simulation.ik import MinkIKBridge
+
+                    # max_iters is raised well above the bridge default (20)
+                    # for the same reason as the MuJoCo mixin: move_to jumps
+                    # from the current pose to an arbitrary workspace point in
+                    # one solve and needs the extra integration budget.
+                    bridge = MinkIKBridge(
+                        model,
+                        frame_name,
+                        frame_type,
+                        orientation_cost=1.0 if target_quat is not None else 0.0,
+                        max_iters=200,
+                    )
+                except (ImportError, RuntimeError, ValueError) as e:
+                    return _err(f"move_to: IK bridge unavailable: {e}")
+
+                # World -> model-frame transform through the live base pose.
+                base_rot = self._quat_wxyz_to_mat(mj, base_quat)
+                target_local = base_rot.T @ (target_world - base_pos)
+
+                # Seed the MJCF configuration from the LIVE articulation
+                # state, scattered per NAME (never flat-index).
+                q0 = np.array(model.qpos0, dtype=np.float64).reshape(-1).copy()
+                for jnt_id, dof in full_map.items():
+                    q0[int(model.jnt_qposadr[jnt_id])] = float(q_live[dof])
+
+                target_pose = np.eye(4, dtype=np.float64)
+                target_pose[:3, 3] = target_local
+                if target_quat is not None:
+                    quat = target_quat / np.linalg.norm(target_quat)
+                    # The requested orientation is world-frame; express it in
+                    # the model frame the bridge solves in.
+                    target_pose[:3, :3] = base_rot.T @ self._quat_wxyz_to_mat(mj, quat)
+                else:
+                    # Position-only: keep the current EE orientation in the
+                    # target pose (the zero orientation cost makes it a soft
+                    # no-op).
+                    target_pose[:3, :3] = bridge.ee_pose(q0)[:3, :3]
+
+                q_star = bridge.solve(target_pose, q0)
+                ik_residual = float(np.linalg.norm(bridge.ee_pose(q_star)[:3, 3] - target_local))
+
+                # Damped-least-squares IK is a local method: from a distant
+                # seed it can stall in a joint-limit / elbow-branch local
+                # minimum even for a reachable target. Same deterministic
+                # restart schedule as the MuJoCo mixin: the model's home
+                # keyframe first when one exists, then uniform draws over the
+                # ARM joints' ranges from a per-call fixed-seed RNG (identical
+                # calls draw identical seeds - reproducibility, not a bug).
+                # Gripper DOFs and everything else stay at the live state.
+                if ik_residual > float(tol):
+                    rng = np.random.default_rng(0)
+                    settable_qadr = [int(model.jnt_qposadr[jnt_id]) for jnt_id in arm_map]
+                    ranges = [
+                        (float(model.jnt_range[jnt_id][0]), float(model.jnt_range[jnt_id][1]))
+                        if bool(model.jnt_limited[jnt_id])
+                        else (-np.pi, np.pi)
+                        for jnt_id in arm_map
+                    ]
+                    for restart in range(_IK_RESTART_SEEDS):
+                        q_seed = q0.copy()
+                        if restart == 0 and int(model.nkey) > 0:
+                            for qadr in settable_qadr:
+                                q_seed[qadr] = float(model.key_qpos[0][qadr])
+                        else:
+                            for qadr, (lo, hi) in zip(settable_qadr, ranges, strict=True):
+                                q_seed[qadr] = rng.uniform(lo, hi)
+                        q_try = bridge.solve(target_pose, q_seed)
+                        residual_try = float(np.linalg.norm(bridge.ee_pose(q_try)[:3, 3] - target_local))
+                        if residual_try < ik_residual:
+                            q_star, ik_residual = q_try, residual_try
+                        if ik_residual <= float(tol):
+                            break
+
+                if ik_residual > float(tol):
+                    return _err(
+                        f"move_to: target {target_world.tolist()} is unreachable for '{name}' "
+                        f"within tol={float(tol)} m - best IK solution leaves a residual of "
+                        f"{ik_residual:.4f} m. Choose a closer target or loosen tol.",
+                        {
+                            "reached": False,
+                            "steps": 0,
+                            "ik_residual_m": ik_residual,
+                            "frame": frame_name,
+                            "frame_type": frame_type,
+                        },
+                    )
+
+                # Command ARM DOFs to the solve, per name; HOLD gripper DOFs
+                # at their live position (grasp preservation - and every
+                # commanded channel is re-asserted per tick, mirroring the
+                # MuJoCo mixin).
+                targets: dict[int, float] = {
+                    dof: float(q_star[int(model.jnt_qposadr[jnt_id])]) for jnt_id, dof in arm_map.items()
+                }
+                for dof in grip_dofs:
+                    targets[dof] = float(q_live[dof])
+
+            # ---- servo loop: self-locking per control tick ----
+            steps_used = 0
+            reached = False
+            position_error = math.inf
+            ee_pos_world: np.ndarray = np.array(target_world, dtype=np.float64, copy=True)
+            ee_quat_world = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+            q_fk = q0.copy()
+            for _ in range(max_steps):
+                with self._lock:
+                    abort = self._primitive_abort_reason("move_to", name)
+                    if abort is not None:
+                        return abort
+                    live = registry_entry(self._robots, name)
+                    if live is not None and live.policy_running:
+                        return _err(f"move_to: a policy started on '{name}' mid-run; aborting.")
+                    apply_err = self._apply_position_targets("move_to", name, articulation, targets)
+                    if apply_err is not None:
+                        return apply_err
+                    self._primitive_tick()
+                    q = self._read_joint_positions(articulation)
+                if q is None or q.size < len(short_names):
+                    return _err(f"move_to: could not read joint positions from '{name}' mid-run; aborting.")
+                steps_used += 1
+                # FK of the live joint readback through the SAME bridge frame
+                # the solver optimized, scattered per NAME, mapped to world
+                # through the base pose (see the docstring's convergence-
+                # measurement contract).
+                for jnt_id, dof in full_map.items():
+                    q_fk[int(model.jnt_qposadr[jnt_id])] = float(q[dof])
+                ee_local = bridge.ee_pose(q_fk)
+                ee_pos_world = base_pos + base_rot @ ee_local[:3, 3]
+                quat_out = np.zeros(4, dtype=np.float64)
+                mj.mju_mat2Quat(quat_out, np.ascontiguousarray(base_rot @ ee_local[:3, :3]).reshape(9))
+                ee_quat_world = quat_out
+                position_error = float(np.linalg.norm(ee_pos_world - target_world))
+                if position_error <= float(tol):
+                    reached = True
+                    break
+
+            return self._move_to_result(
+                name,
+                target_world,
+                float(tol),
+                max_steps,
+                reached=reached,
+                steps_used=steps_used,
+                position_error=position_error,
+                ik_residual=ik_residual,
+                ee_pos=ee_pos_world,
+                ee_quat=ee_quat_world,
+                frame_name=frame_name,
+                frame_type=frame_type,
+            )
+
+        return self._run_primitive_on_kit("move_to", _move)
 
     def set_gripper(
         self,

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -624,7 +624,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
     LeRobotDataset recording (``start_recording`` / ``save_episode`` /
     ``stop_recording`` / ``stream_dataset``) comes from
     :class:`~strands_robots.simulation.isaac.recording.IsaacRecordingMixin`,
-    and the joint-space motion primitives (``set_gripper`` /
+    and the motion primitives (``move_to`` / ``set_gripper`` /
     ``rotate_wrist``) from
     :class:`~strands_robots.simulation.isaac.motion_primitives.IsaacMotionPrimitivesMixin`,
     matching the MuJoCo and Newton backends.
@@ -6671,9 +6671,15 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     "# raw per-camera MP4 capture (no lerobot dependency)"
                 ),
                 "stop_cameras_recording": "() -> dict  # finalize the raw MP4 capture",
-                # Joint-space motion primitives (GH #2154, Isaac half of the
-                # GH #1645 vocabulary; shared contract in
-                # strands_robots.simulation.motion_primitives_base).
+                # Motion primitives (GH #2154 joint-space pair + GH #2155
+                # move_to, Isaac half of the GH #1645 vocabulary; shared
+                # contract in strands_robots.simulation.motion_primitives_base).
+                "move_to": (
+                    "(robot_name=None, position=[x,y,z], orientation=None, tol=0.01, "
+                    "max_steps=200) -> dict  # IK-solve (shared mink bridge on the "
+                    "registry MJCF) then servo the end-effector to a world-frame "
+                    "Cartesian target; position-only when orientation is omitted"
+                ),
                 "set_gripper": (
                     "(robot_name=None, state='open'|'close', steps=12) -> dict  # "
                     "drive the gripper joint(s) to the open/close set-point "

--- a/tests/simulation/isaac/test_move_to_ik.py
+++ b/tests/simulation/isaac/test_move_to_ik.py
@@ -1,0 +1,560 @@
+"""IK-backed ``move_to`` on the Isaac backend (GH #2155, child of #2123).
+
+The Isaac ``move_to`` reuses the shared mink damped-least-squares bridge
+(:class:`strands_robots.simulation.ik.MinkIKBridge`) on the MuJoCo model the
+robot's ``data_config`` resolves to, then drives PD position targets on the
+articulation. The contracts pinned here:
+
+* validation rejections come from the shared core
+  (:class:`~strands_robots.simulation.motion_primitives_base.MotionPrimitivesCore`),
+  so their wording is byte-identical to MuJoCo's by construction;
+* the workspace sanity box refuses a unit-mistake target up front;
+* the MJCF-side solution is reconciled with the articulation through an
+  explicit NAME-KEYED joint map - a solved joint with no articulation
+  counterpart is a structured refusal, never a positional/flat-index write
+  (AGENTS.md "Per-name state copy, not flat index"), and an articulation
+  whose DOF ORDER differs from the MJCF still converges (the mapping, not
+  the index, carries the write);
+* convergence / timeout / unreachable / mid-run-abort answer with the same
+  envelopes as the MuJoCo reference, and a policy running on the robot
+  refuses the primitive (``policy_running`` is the per-robot flag every
+  Isaac policy-driving loop sets).
+
+These tests deliberately do NOT require NVIDIA Isaac Sim (the pattern of
+``tests/simulation/isaac/test_motion_primitives.py``): the articulation and
+the world are faked, and the IK side runs on a real inline MJCF arm.
+Guard/validation tests run anywhere; joint-map tests ``importorskip`` on
+``mujoco``; convergence tests ``importorskip`` on ``mink`` (the dev env
+ships both; a clean base install skips them). Real-GPU integration coverage
+is the tests child of #2123 and lives in ``tests_integ/``.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import math
+import sys
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _RobotState
+from strands_robots.simulation.motion_primitives_base import MotionPrimitivesCore
+
+# ---------------------------------------------------------------------------
+# Fakes: articulation with PD-target servo semantics + a world pose, world
+# whose step() advances the articulation, and the one isaacsim type the
+# adapter lazily imports. Same shape as test_motion_primitives.py, extended
+# with ``get_world_pose`` (move_to maps the world-frame target through the
+# articulation's base pose).
+# ---------------------------------------------------------------------------
+
+
+class _FakeArticulationAction:
+    """Stand-in for ``isaacsim.core.utils.types.ArticulationAction``."""
+
+    def __init__(self, joint_positions=None, joint_indices=None):
+        self.joint_positions = joint_positions
+        self.joint_indices = joint_indices
+
+
+class _FakeArticulation:
+    """Articulation with a per-step PD-servo model and a world base pose.
+
+    ``apply_action`` records the commanded targets; each ``advance()`` (wired
+    to the fake world's ``step``) moves every targeted DOF toward its target
+    by ``servo_rate`` of the remaining distance. ``servo_rate=0.0`` models an
+    arm that never converges (the timeout path).
+    """
+
+    def __init__(
+        self,
+        joint_names: list[str],
+        positions: list[float] | None = None,
+        servo_rate: float = 0.5,
+        base_pos: list[float] | None = None,
+        base_quat: list[float] | None = None,
+    ):
+        n = len(joint_names)
+        self.positions = np.array(positions if positions is not None else [0.0] * n, dtype=np.float64)
+        self.servo_rate = servo_rate
+        self.applied: list[Any] = []
+        self._targets: dict[int, float] = {}
+        self._base_pos = np.array(base_pos if base_pos is not None else [0.0, 0.0, 0.0], dtype=np.float64)
+        self._base_quat = np.array(base_quat if base_quat is not None else [1.0, 0.0, 0.0, 0.0], dtype=np.float64)
+
+    def get_joint_positions(self):
+        return self.positions.copy()
+
+    def get_world_pose(self):
+        return self._base_pos.copy(), self._base_quat.copy()
+
+    def apply_action(self, action) -> None:
+        self.applied.append(action)
+        for idx, value in zip(np.asarray(action.joint_indices), np.asarray(action.joint_positions)):
+            self._targets[int(idx)] = float(value)
+
+    def advance(self) -> None:
+        for idx, target in self._targets.items():
+            self.positions[idx] += self.servo_rate * (target - self.positions[idx])
+
+
+class _FakeWorld:
+    """World whose ``step`` drives the articulation servo and an optional hook."""
+
+    def __init__(self, articulation: _FakeArticulation, on_step=None):
+        self.articulation = articulation
+        self.on_step = on_step
+        self.steps = 0
+
+    def step(self, render: bool = False) -> None:  # noqa: ARG002 - signature parity
+        self.steps += 1
+        if self.on_step is not None:
+            self.on_step()
+        self.articulation.advance()
+
+
+@pytest.fixture(autouse=True)
+def fake_articulation_action(monkeypatch):
+    """Provide the ``isaacsim.core.utils.types`` module the adapter imports."""
+    names = ("isaacsim", "isaacsim.core", "isaacsim.core.utils", "isaacsim.core.utils.types")
+    mods = {}
+    for name in names:
+        mod = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, mod)
+        mods[name] = mod
+    mods["isaacsim.core.utils.types"].ArticulationAction = _FakeArticulationAction
+    mods["isaacsim"].core = mods["isaacsim.core"]
+    mods["isaacsim.core"].utils = mods["isaacsim.core.utils"]
+    mods["isaacsim.core.utils"].types = mods["isaacsim.core.utils.types"]
+    return mods
+
+
+# The same stable 4-DOF positioner + jaw the MuJoCo move_to tests solve on
+# (tests/simulation/mujoco/test_motion_primitives.py): an ``ee_site`` TCP
+# site (EE-frame discovery), conventional joint names, and a ``jaw`` gripper.
+# Here it is the IK MODEL only - the "articulation" the targets land on is
+# the fake above.
+ARM_XML = """
+<mujoco model="prim_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02"/>
+        <body name="link2" pos="0 0 0.2">
+          <joint name="shoulder_lift" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/>
+          <body name="link3" pos="0.15 0 0">
+            <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+            <geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.018"/>
+            <body name="link4" pos="0.15 0 0">
+              <joint name="wrist_roll" type="hinge" axis="1 0 0" range="-3.0 3.0"/>
+              <geom type="capsule" fromto="0 0 0 0.05 0 0" size="0.015"/>
+              <site name="ee_site" pos="0.05 0 0"/>
+              <body name="jaw_body" pos="0.05 0 0">
+                <joint name="jaw" type="hinge" axis="0 0 1" range="-0.2 1.5"/>
+                <geom type="box" size="0.01 0.01 0.02" contype="0" conaffinity="0"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+MJCF_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow", "wrist_roll", "jaw"]
+
+# Reachable for the arm above in its OWN (model) frame; same point the MuJoCo
+# suite verified against the real solver. UNREACHABLE is inside the sanity
+# box but outside the workspace.
+REACHABLE_LOCAL = [0.2, 0.1, 0.2]
+UNREACHABLE_LOCAL = [1.5, 0.0, 0.2]
+
+
+@pytest.fixture()
+def arm_xml_path(tmp_path, monkeypatch):
+    """Write the IK model and point the adapter's ``resolve_model`` at it."""
+    path = tmp_path / "prim_arm.xml"
+    path.write_text(ARM_XML)
+    monkeypatch.setattr(
+        "strands_robots.simulation.isaac.motion_primitives.resolve_model",
+        lambda name: str(path) if name == "prim_arm" else None,
+    )
+    return str(path)
+
+
+def _make_sim(
+    joint_names: list[str] = MJCF_JOINTS,
+    robot_name: str = "arm",
+    data_config: str | None = "prim_arm",
+    positions: list[float] | None = None,
+    servo_rate: float = 0.5,
+    base_pos: list[float] | None = None,
+    base_quat: list[float] | None = None,
+    on_step=None,
+) -> tuple[IsaacSimulation, _FakeArticulation]:
+    sim = IsaacSimulation()
+    art = _FakeArticulation(
+        joint_names,
+        positions=positions,
+        servo_rate=servo_rate,
+        base_pos=base_pos,
+        base_quat=base_quat,
+    )
+    sim._world = _FakeWorld(art, on_step=on_step)
+    sim._world_created = True
+    sim._robots[robot_name] = _RobotState(
+        name=robot_name,
+        prim_path=f"/World/Robots/{robot_name}",
+        joint_names=list(joint_names),
+        articulation=art,
+        data_config=data_config,
+    )
+    return sim, art
+
+
+def _json_block(result: dict) -> dict:
+    blocks = [c["json"] for c in result["content"] if "json" in c]
+    assert blocks, result
+    return blocks[0]
+
+
+def _text(result: dict) -> str:
+    return result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Validation: the rejections are the shared core's, byte-identical to MuJoCo.
+# No IK stack required - these refuse before any engine or model is touched.
+# ---------------------------------------------------------------------------
+
+
+class TestValidationReusesTheCore:
+    """A rejected parameter answers with the core's own envelope."""
+
+    def test_missing_position_matches_core_wording(self):
+        sim, art = _make_sim()
+        result = sim.move_to(robot_name="arm")
+        _, _, _, expected = MotionPrimitivesCore()._validate_move_to_args(None, None, 0.01, 200)
+        assert result == expected
+        assert "position" in _text(result)
+        assert art.applied == []
+
+    @pytest.mark.parametrize("position", [[0.1, 0.2], [0.1, 0.2, 0.3, 0.4], 0.3, True, [0.1, math.nan, 0.2]])
+    def test_bad_position_shape_matches_core_wording(self, position):
+        sim, art = _make_sim()
+        result = sim.move_to(robot_name="arm", position=position)
+        _, _, _, expected = MotionPrimitivesCore()._validate_move_to_args(position, None, 0.01, 200)
+        assert result == expected
+        assert result["status"] == "error"
+        assert art.applied == []
+
+    def test_zero_norm_orientation_matches_core_wording(self):
+        sim, _ = _make_sim()
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, orientation=[0.0, 0.0, 0.0, 0.0])
+        _, _, _, expected = MotionPrimitivesCore()._validate_move_to_args(
+            REACHABLE_LOCAL, [0.0, 0.0, 0.0, 0.0], 0.01, 200
+        )
+        assert result == expected
+
+    @pytest.mark.parametrize("tol", [0.0, -0.1, math.nan, math.inf, True, "0.05"])
+    def test_bad_tol_matches_core_wording(self, tol):
+        sim, art = _make_sim()
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=tol)
+        _, _, _, expected = MotionPrimitivesCore()._validate_move_to_args(REACHABLE_LOCAL, None, tol, 200)
+        assert result == expected
+        assert art.applied == []
+
+    @pytest.mark.parametrize("max_steps", [0, -1, 10_001, 2.7, True, None])
+    def test_bad_max_steps_matches_core_wording(self, max_steps):
+        sim, art = _make_sim()
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, max_steps=max_steps)
+        _, _, _, expected = MotionPrimitivesCore()._validate_move_to_args(REACHABLE_LOCAL, None, 0.01, max_steps)
+        assert result == expected
+        assert art.applied == []
+
+
+# ---------------------------------------------------------------------------
+# Guards: backend-owned world / robot / policy / kinematic-model resolution.
+# ---------------------------------------------------------------------------
+
+
+class TestGuards:
+    def test_no_world_errors(self):
+        sim = IsaacSimulation()
+        result = sim.move_to(position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "No world created." in _text(result)
+
+    def test_unknown_robot_errors(self):
+        sim, _ = _make_sim()
+        result = sim.move_to(robot_name="nope", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+    def test_running_policy_refuses_up_front(self):
+        sim, art = _make_sim()
+        sim._robots["arm"].policy_running = True
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "while its policy is running" in _text(result)
+        assert art.applied == []
+
+    def test_workspace_sanity_box_rejects_far_target(self):
+        # 10 m from the base: a unit mistake (mm vs m), refused before the IK
+        # model is even resolved.
+        sim, art = _make_sim(data_config=None)  # no model needed - sanity fires first
+        result = sim.move_to(robot_name="arm", position=[10.0, 0.0, 0.2])
+        assert result["status"] == "error"
+        assert "sanity box" in _text(result)
+        assert art.applied == []
+
+    def test_sanity_box_is_relative_to_the_base_pose(self):
+        # The same world point is fine for a robot whose base sits next to it.
+        sim, _ = _make_sim(data_config=None, base_pos=[10.0, 0.0, 0.0])
+        result = sim.move_to(robot_name="arm", position=[10.0, 0.0, 0.2])
+        # Passes the sanity box, then fails on the missing data_config - which
+        # proves the sanity check measured from the base, not the origin.
+        assert result["status"] == "error"
+        assert "data_config" in _text(result)
+
+    def test_unreadable_base_pose_is_a_loud_error(self):
+        sim, art = _make_sim()
+        art.get_world_pose = lambda: None  # type: ignore[method-assign]
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "base pose" in _text(result)
+
+    def test_no_data_config_is_a_loud_error(self):
+        sim, _ = _make_sim(data_config=None)
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "data_config" in _text(result)
+        assert "send_action" in _text(result)
+
+    def test_unresolvable_model_is_a_loud_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "strands_robots.simulation.isaac.motion_primitives.resolve_model",
+            lambda name: None,
+        )
+        sim, _ = _make_sim(data_config="prim_arm")
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "no MJCF/URDF model resolves" in _text(result)
+
+    def test_worker_thread_without_pump_is_a_structured_error(self):
+        sim, art = _make_sim()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            result = pool.submit(sim.move_to, robot_name="arm", position=REACHABLE_LOCAL).result()
+        assert result["status"] == "error"
+        assert "run_pump_forever" in _text(result)
+        assert art.applied == []
+
+    def test_missing_mink_degrades_to_structured_error(self, arm_xml_path, monkeypatch):
+        """A missing IK stack is a structured error through the tool surface, not a raise."""
+        pytest.importorskip("mujoco")
+        monkeypatch.setitem(sys.modules, "mink", None)  # forces `import mink` to ImportError
+        sim, _ = _make_sim()
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        assert "IK bridge unavailable" in _text(result)
+        assert "mink" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# Joint-name reconciliation: the MJCF-side solution is written to the
+# articulation per NAME, and an unmappable solved joint is a refusal.
+# ---------------------------------------------------------------------------
+
+
+class TestJointNameReconciliation:
+    def test_unmappable_arm_joint_is_a_structured_error(self, arm_xml_path):
+        # The articulation is missing 'elbow': the solve would command a joint
+        # the robot cannot name, so the primitive refuses - a flat-index write
+        # is forbidden (AGENTS.md "Per-name state copy, not flat index").
+        pytest.importorskip("mujoco")
+        sim, art = _make_sim(joint_names=["shoulder_pan", "shoulder_lift", "wrist_roll", "jaw"])
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "elbow" in text
+        assert "no articulation counterpart" in text
+        assert "flat index" in text
+        assert art.applied == []
+
+    def test_namespaced_articulation_names_map_via_stripping(self, arm_xml_path):
+        pytest.importorskip("mink")
+        sim, _ = _make_sim(joint_names=[f"arm/{n}" for n in MJCF_JOINTS])
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02)
+        assert result["status"] == "success", result
+
+    def test_reordered_articulation_dofs_still_converge(self, arm_xml_path):
+        # The articulation reports its DOFs in REVERSE of the MJCF order. A
+        # positional write would command the wrong joints and never converge;
+        # the name-keyed map must not care about order.
+        pytest.importorskip("mink")
+        sim, art = _make_sim(joint_names=list(reversed(MJCF_JOINTS)))
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        # The pan joint lives at articulation index 4 under the reversed
+        # order; the commanded targets must have followed the names there.
+        commanded = {int(i) for a in art.applied for i in np.asarray(a.joint_indices)}
+        assert commanded == {0, 1, 2, 3, 4}
+
+    def test_unmappable_gripper_joint_does_not_refuse(self, arm_xml_path):
+        # The MJCF 'jaw' is a gripper joint; the articulation names its jaw
+        # differently ('gripper'). The gripper is never commanded from the
+        # solve, so the move itself is still legitimate - the articulation
+        # jaw is simply held by the articulation-side classification.
+        pytest.importorskip("mink")
+        sim, _ = _make_sim(joint_names=["shoulder_pan", "shoulder_lift", "elbow", "wrist_roll", "gripper"])
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02)
+        assert result["status"] == "success", result
+
+
+# ---------------------------------------------------------------------------
+# Semantics: convergence, base-frame transform, grasp preservation,
+# unreachable / timeout / abort envelopes (real mink solver, fake servo).
+# ---------------------------------------------------------------------------
+
+
+class TestMoveTo:
+    def test_reaches_reachable_target(self, arm_xml_path):
+        pytest.importorskip("mink")
+        sim, _ = _make_sim()
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert payload["position_error_m"] <= 0.02
+        assert payload["frame"] == "ee_site"
+        assert payload["frame_type"] == "site"
+        assert np.linalg.norm(np.array(payload["ee_position"]) - np.array(REACHABLE_LOCAL)) <= 0.02
+
+    def test_world_frame_target_respects_a_translated_base(self, arm_xml_path):
+        # The robot's base sits away from the origin: the world-frame target
+        # must be mapped through the base pose, not solved as-is.
+        pytest.importorskip("mink")
+        base = [1.0, -0.5, 0.0]
+        target = list(np.array(base) + np.array(REACHABLE_LOCAL))
+        sim, _ = _make_sim(base_pos=base)
+        result = sim.move_to(robot_name="arm", position=target, tol=0.02)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert np.linalg.norm(np.array(payload["ee_position"]) - np.array(target)) <= 0.02
+
+    def test_world_frame_target_respects_a_rotated_base(self, arm_xml_path):
+        # Base yawed 90 degrees about z: the local-frame reachable point lands
+        # at a rotated world position, which is where the target is given.
+        pytest.importorskip("mink")
+        half = math.pi / 4.0
+        quat = [math.cos(half), 0.0, 0.0, math.sin(half)]
+        rot = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        target = list(rot @ np.array(REACHABLE_LOCAL))
+        sim, _ = _make_sim(base_quat=quat)
+        result = sim.move_to(robot_name="arm", position=target, tol=0.02)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert np.linalg.norm(np.array(payload["ee_position"]) - np.array(target)) <= 0.02
+
+    def test_gripper_is_held_not_commanded(self, arm_xml_path):
+        # Grasp preservation: the jaw DOF (index 4) is written every tick with
+        # its LIVE position, never a solver output.
+        pytest.importorskip("mink")
+        jaw_before = 0.9
+        sim, art = _make_sim(positions=[0.0, 0.0, 0.0, 0.0, jaw_before])
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02)
+        assert result["status"] == "success", result
+        for action in art.applied:
+            held = dict(
+                zip(
+                    (int(i) for i in np.asarray(action.joint_indices)),
+                    (float(v) for v in np.asarray(action.joint_positions)),
+                )
+            )
+            assert held[4] == pytest.approx(jaw_before, abs=1e-6)
+        assert art.positions[4] == pytest.approx(jaw_before, abs=1e-6)
+
+    def test_unreachable_target_returns_structured_error_with_residual(self, arm_xml_path):
+        pytest.importorskip("mink")
+        sim, art = _make_sim()
+        result = sim.move_to(robot_name="arm", position=UNREACHABLE_LOCAL, tol=0.01)
+        assert result["status"] == "error", result
+        assert "unreachable" in _text(result)
+        payload = _json_block(result)
+        assert payload["reached"] is False
+        assert payload["ik_residual_m"] > 0.01
+        assert art.applied == []  # refused before a single tick
+
+    def test_servo_timeout_reports_the_residual_and_a_budget_that_fixes_it(self, arm_xml_path):
+        # A solvable pose the (deliberately slow) servo cannot reach inside
+        # the budget: the envelope separates "needs more steps" (small IK
+        # residual, large position error) from "unreachable".
+        pytest.importorskip("mink")
+        sim, _ = _make_sim(servo_rate=0.05)
+        short = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02, max_steps=2)
+        assert short["status"] == "error", short
+        text = _text(short)
+        assert "did not reach" in text
+        assert "max_steps=2" in text
+        payload = _json_block(short)
+        assert payload["reached"] is False
+        assert payload["steps"] == 2
+        assert payload["position_error_m"] > 0.02
+        assert payload["ik_residual_m"] <= 0.02
+
+        again = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, tol=0.02, max_steps=400)
+        assert again["status"] == "success", again
+        assert _json_block(again)["reached"] is True
+
+
+class TestMidRunAbort:
+    """The loop releases the lock per tick; teardown / a policy start aborts loudly."""
+
+    def test_world_destroyed_mid_run_aborts(self, arm_xml_path):
+        pytest.importorskip("mink")
+        sim_box: dict[str, IsaacSimulation] = {}
+
+        def _destroy_world():
+            sim_box["sim"]._world_created = False
+
+        sim, _ = _make_sim(servo_rate=0.0, on_step=_destroy_world)
+        sim_box["sim"] = sim
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, max_steps=50)
+        assert result["status"] == "error"
+        assert "world was destroyed mid-run" in _text(result)
+
+    def test_policy_started_mid_run_aborts(self, arm_xml_path):
+        pytest.importorskip("mink")
+        sim_box: dict[str, IsaacSimulation] = {}
+
+        def _start_policy():
+            sim_box["sim"]._robots["arm"].policy_running = True
+
+        sim, _ = _make_sim(servo_rate=0.0, on_step=_start_policy)
+        sim_box["sim"] = sim
+        result = sim.move_to(robot_name="arm", position=REACHABLE_LOCAL, max_steps=50)
+        assert result["status"] == "error"
+        assert "a policy started on 'arm' mid-run" in _text(result)
+
+
+class TestDiscoverySurface:
+    """describe() advertises move_to like the MuJoCo backend does."""
+
+    def test_describe_advertises_move_to(self):
+        sim = IsaacSimulation()
+        methods = sim.describe()["methods"]
+        assert "move_to" in methods
+        assert "world-frame" in methods["move_to"]

--- a/tests/simulation/test_pose_vector_domain_across_backends.py
+++ b/tests/simulation/test_pose_vector_domain_across_backends.py
@@ -652,6 +652,7 @@ _KNOWN_PLACEMENT_METHODS = {
     ("isaac", "add_object"),
     ("isaac", "add_robot"),
     ("isaac", "move_object"),
+    ("isaac", "move_to"),
     ("isaac", "set_robot_pose"),
 }
 


### PR DESCRIPTION
Implements `move_to` (blocking Cartesian end-effector transport) on the Isaac backend, reusing the shared `MinkIKBridge` and the `IsaacMotionPrimitivesMixin` introduced by the joint-space child (#2154, merged as #2200).

Closes #2155

Part of #2123.

## What changed

- **`strands_robots/simulation/isaac/motion_primitives.py`** - `IsaacMotionPrimitivesMixin.move_to(robot_name=None, position=None, orientation=None, tol=0.01, max_steps=200)` with the same signature, defaults, docstring semantics and structured result/abort dicts as MuJoCo's reference implementation, plus the plumbing it needs:
  - `_load_ik_mjcf`: resolves the MuJoCo model the solve runs on from the robot's `data_config` via the same `resolve_model` lookup the MuJoCo backend's `add_robot` uses (Isaac registry robots carry MJCF sources). Every failure - no `data_config`, nothing resolves, `mujoco` not importable, the file does not compile - is a structured error, never a raise.
  - `_mjcf_articulation_joint_map`: the #2123 key risk, verified rather than assumed - an explicit **name-keyed** map (MJCF joint name -> articulation DOF index, namespace-stripped on both sides per the #1900 demangled vocabulary). A solved joint with no articulation counterpart is a structured refusal; a positional/flat-index write is forbidden (AGENTS.md "Per-name state copy, not flat index").
  - `_articulation_base_pose`: the world-frame target is mapped into the model frame through the articulation's live base pose (`get_world_pose`, the read counterpart of `set_robot_pose`); an unreadable base is a loud error, never a silently-assumed origin.
  - The solve is seeded from the articulation's **current** joint positions read on the Kit loop (the whole body runs through `_run_primitive_on_kit`), uses the shared deterministic restart schedule (`_IK_RESTART_SEEDS`, home keyframe first), is position-only when no orientation is given (5-DOF arms like SO-101), rejects targets outside the workspace sanity box up front, and answers an unreachable target with the IK residual in a structured error.
  - Convergence is measured per tick by FK of the live joint readback through the **same** bridge frame the solver optimized (then mapped to world through the base pose), so the solver and the convergence check cannot watch different points - the trap the MuJoCo `_frame_world_pose` docstring documents.
  - Grasp preservation: gripper DOFs (shared registry-metadata-first classification) are excluded from the solve/seeding and HELD at their live position every tick.
  - Running-policy guard: `policy_running` is the per-robot flag every Isaac policy-driving loop sets (`run_multi_policy`, the recording rollout hook), so it is this backend's counterpart of MuJoCo's `_require_no_running_policy` - checked up front and per control tick (a policy starting mid-run aborts the primitive), alongside the world-destroyed / robot-removed aborts.
- **`strands_robots/simulation/isaac/simulation.py`** - `describe()` advertises `move_to`; class docstring updated.
- **`tests/simulation/test_pose_vector_domain_across_backends.py`** - the cross-backend placement-method roster gains `('isaac', 'move_to')` (the scan found the new method and requires it routed through the shared pose-vector rule, which it is via `_validate_move_to_args`).
- **`changelog.d/2155-isaac-move-to.md`** - news fragment.

## Test surface

`tests/simulation/isaac/test_move_to_ik.py` (42 tests, GPU-skipped: faked articulation/world, real `mujoco`+`mink` on an inline MJCF arm - the same pattern and arm as the MuJoCo `move_to` suite):

- **Joint-name reconciliation**: mapping built by name; an unmappable solved joint (`elbow` missing from the articulation) is a structured error naming both vocabularies with zero writes; an articulation whose DOF order is the **reverse** of the MJCF still converges (a flat-index write could not); namespaced articulation names map via stripping; an unmappable *gripper* joint does not refuse (it is held, not commanded).
- **Validation parity with MuJoCo**: missing/bad-shape/non-finite position, zero-norm orientation, bad `tol`/`max_steps` all compared byte-for-byte against `MotionPrimitivesCore`'s own envelopes; workspace sanity rejection, including that the box is measured from the base pose, not the origin.
- **Mocked convergence / abort reasons**: reachable target converges (payload `reached`/`frame`/`ee_position`); translated and rotated (90 deg yaw) base poses; unreachable -> structured error with `ik_residual_m` and zero writes; servo timeout separates "needs more steps" from "unreachable" and the identical call with a real budget converges; world destroyed mid-run and policy started mid-run abort loudly; running policy refuses up front; worker thread with no pump is a structured error; missing `mink` degrades to a structured error; `describe()` advertises the primitive.

## Acceptance criteria (from #2155)

- [x] Depends on #2154 - merged (`1995e2df`, PR #2200); `IsaacMotionPrimitivesMixin` exists on `main`.
- [x] `move_to` with the same signature, defaults, docstring semantics, and structured result/abort dicts as MuJoCo's.
- [x] MJCF loaded/derived from the robot's `data_config` for `MinkIKBridge`; solve seeded from the articulation's current joint positions on the Kit loop (`run_on_main` via `_run_primitive_on_kit`).
- [x] Convergence loop applies position targets through the articulation controller, polls EE pose per tick on the Kit loop, succeeds within `tol`, aborts with the same reasons as MuJoCo on timeout / world destroyed / policy started mid-run (the running-policy guard reuses `policy_running`, the per-robot flag every Isaac policy-driving loop sets).
- [x] Explicit name-keyed mapping MJCF joint name -> articulation joint index; structured refusal when a solved joint cannot be mapped; no positional/flat-index writes.
- [x] Unit tests under `tests/simulation/isaac/` (GPU-skipped): joint-name reconciliation, validation parity, mocked convergence/timeout abort reasons.
- [x] MuJoCo suite untouched and green; `hatch run format && hatch run lint && hatch run test` green - full suite: **28718 passed, 263 skipped** (with `MUJOCO_GL=egl`; without EGL two MuJoCo-rendering test files abort identically on unmodified `main` - environmental, no X11/GLX on the dev box).
- [x] Changelog fragment `changelog.d/2155-isaac-move-to.md`.

## Out of scope / follow-ups

- Real-GPU integration coverage is the tests child of #2123 (`tests_integ/`).
- The joint-space siblings (`set_gripper` / `rotate_wrist`, #2154) do not carry the mid-run `policy_running` abort this PR gives `move_to`; their `_primitive_abort_reason` docstring says why they skipped it, but the same race argument applies - worth its own small follow-up rather than a behavior change smuggled into this PR.

Project board: please move #2155 to "In review" (or I'll note it below).
