### PR TITLE
fix(simulation/newton): refuse a solver that cannot drive an articulated robot

### DIFF
--- a/changelog.d/2222-newton-solver-must-drive-a-robot.md
+++ b/changelog.d/2222-newton-solver-must-drive-a-robot.md
@@ -1,0 +1,17 @@
+### Fixed: `create_simulation("newton", solver=...)` refuses a solver that cannot drive a robot
+
+Newton resolves eight solver names and only three of them integrate a rigid
+articulated body. The other five were accepted and then failed in two ways a
+caller could not act on: `vbd`, `style3d` and `mpm` raised from inside Newton
+naming a `ModelBuilder` the caller never touched, while `xpbd` and
+`semi_implicit` built and stepped without moving a joint, so `add_robot`,
+`send_action` and `step` all reported success over a frozen world. Measured
+against a two-hinge arm, a commanded 0.9 rad target moved `featherstone`,
+`kamino` and `mujoco` by 0.899 rad and left `xpbd` and `semi_implicit` at
+0.0 rad, and stepping under gravity alone left them at 0.0 rad as well.
+
+Naming one of the five is now reported where the caller names it, before any
+world, model or solver is built, with the reason and the solvers that can drive
+a robot. `describe()["available_solvers"]` reports the accepted names only, and
+the solver table in `docs/simulation/newton.md` no longer lists two frozen
+solvers as the articulated ones nor a working one as particle-only.

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -55,18 +55,24 @@ sim.destroy()
 
 ## Solvers
 
-Pass `solver=` to `create_simulation("newton", solver=...)`. The rigid-body
-solvers used by articulated robots are:
+Pass `solver=` to `create_simulation("newton", solver=...)`. The solvers that
+integrate a rigid articulated robot are:
 
 | Name | Newton class | Notes |
 |------|--------------|-------|
 | `mujoco` (default) | `SolverMuJoCo` | MuJoCo-Warp; requires `mujoco-warp` |
 | `featherstone` | `SolverFeatherstone` | Reduced-coordinate articulated-body |
-| `xpbd` | `SolverXPBD` | Position-based dynamics |
-| `semi_implicit` | `SolverSemiImplicit` | Explicit semi-implicit integrator |
+| `kamino` | `SolverKamino` | Rigid-body contact solver |
 
-`vbd`, `style3d`, `mpm`, and `kamino` are also resolvable for soft-body /
-particle scenes but are not exercised by rigid robot arms.
+Newton resolves five more names -- `vbd`, `style3d`, `mpm`, `xpbd` and
+`semi_implicit` -- that belong to other physics families and have nothing to
+integrate in a rigid robot scene. Naming one is refused when the engine is
+constructed, with the reason and the list above, because the alternatives are
+worse than a refusal: `vbd`, `style3d` and `mpm` raise from inside Newton
+naming a `ModelBuilder` the caller never touched, and `xpbd` and
+`semi_implicit` build and step without moving a joint, so `add_robot`,
+`send_action` and `step` all report success over a frozen world.
+`describe()["available_solvers"]` reports the accepted names only.
 
 `SolverMuJoCo` requires at least one joint in the model; an empty world (ground
 plane only) defers solver creation until a robot is added, and stepping is a

--- a/strands_robots/simulation/newton/backend.py
+++ b/strands_robots/simulation/newton/backend.py
@@ -53,9 +53,10 @@ def ensure_newton() -> tuple[Any, Any]:
 def solver_registry() -> dict[str, str]:
     """Map friendly solver names to ``newton.solvers`` class names.
 
-    The rigid-body articulation solvers come first; the soft-body / particle
-    solvers (``vbd``, ``style3d``, ``mpm``) are included for completeness but
-    are not exercised by articulated robots.
+    This is the factual name-to-class mapping and includes every solver Newton
+    ships, whether or not it can drive an articulated robot. Only the subset
+    :func:`articulated_solvers` returns integrates rigid articulated bodies;
+    :func:`articulated_solver_error` reports the rest with the reason.
 
     Returns:
         Ordered mapping of solver alias to the ``newton.solvers`` attribute
@@ -91,3 +92,61 @@ def resolve_solver_class(solver: str) -> Any:
     if key not in registry:
         raise ValueError(f"Unknown Newton solver {solver!r}. Available: {sorted(registry)}")
     return getattr(nt.solvers, registry[key])
+
+
+# Newton ships solvers for several physics families, and only some of them
+# integrate rigid articulated bodies. The rest fail in two different ways when
+# handed a robot, neither of which a caller can act on: ``vbd``, ``style3d`` and
+# ``mpm`` raise from inside Newton naming a ``ModelBuilder`` the caller never
+# touched, while ``xpbd`` and ``semi_implicit`` build and step without moving a
+# joint, so every call reports success over a frozen world. Measured on newton
+# 1.5.0 / warp 1.16.0 against a two-hinge arm: a commanded 0.9 rad target moved
+# ``featherstone``, ``kamino`` and ``mujoco`` by 0.899 rad and ``xpbd`` /
+# ``semi_implicit`` by 0.0 rad, and stepping under gravity alone moved them by
+# 0.0 rad as well.
+_NON_ARTICULATED_SOLVERS: dict[str, str] = {
+    "vbd": (
+        "it needs per-body colouring that finalize does not apply, and colouring the "
+        "builder makes it step without moving a joint"
+    ),
+    "style3d": "its cloth custom attributes are absent from a rigid-body model",
+    "mpm": "its constructor requires a config object this backend does not build",
+    "xpbd": "it builds and steps without integrating rigid bodies, leaving the world frozen",
+    "semi_implicit": "it builds and steps without integrating rigid bodies, leaving the world frozen",
+}
+
+
+def articulated_solvers() -> tuple[str, ...]:
+    """Return the solver names that can drive an articulated robot.
+
+    Returns:
+        The subset of :func:`solver_registry` that integrates rigid articulated
+        bodies, in registry order.
+    """
+    return tuple(name for name in solver_registry() if name not in _NON_ARTICULATED_SOLVERS)
+
+
+def articulated_solver_error(solver: str) -> str | None:
+    """Report a known solver that cannot drive an articulated robot.
+
+    This backend builds rigid robots and rigid objects only, so a solver from
+    another physics family has nothing it can integrate. Reporting the name here
+    is what keeps the accepted domain equal to the solvers that work: the
+    alternative outcomes are a Newton-internal error naming a ``ModelBuilder``
+    the caller never touched, or -- for ``xpbd`` and ``semi_implicit`` -- a
+    frozen world behind a successful ``add_robot`` / ``send_action`` / ``step``.
+
+    Args:
+        solver: Friendly solver name, already known to :func:`solver_registry`.
+
+    Returns:
+        A message naming the solver, why it cannot be honoured and the solvers
+        that can, or ``None`` when the solver drives an articulated robot.
+    """
+    reason = _NON_ARTICULATED_SOLVERS.get(solver.lower())
+    if reason is None:
+        return None
+    return (
+        f"Newton solver {solver!r} cannot drive an articulated robot: {reason}. "
+        f"Solvers that can: {list(articulated_solvers())}."
+    )

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -54,7 +54,13 @@ from strands_robots.simulation.models import (
     registered,
     registry_entry,
 )
-from strands_robots.simulation.newton.backend import ensure_newton, resolve_solver_class, solver_registry
+from strands_robots.simulation.newton.backend import (
+    articulated_solver_error,
+    articulated_solvers,
+    ensure_newton,
+    resolve_solver_class,
+    solver_registry,
+)
 from strands_robots.simulation.newton.randomization import DomainRandomizationMixin
 from strands_robots.simulation.newton.recording import NewtonRecordingMixin
 from strands_robots.simulation.terrain import validate_difficulty
@@ -186,7 +192,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         Args:
             solver: Friendly solver name. One of
-                :func:`~strands_robots.simulation.newton.backend.solver_registry`
+                :func:`~strands_robots.simulation.newton.backend.articulated_solvers`
                 (default ``"mujoco"``, i.e. MuJoCo-Warp).
             default_timestep: Physics integration timestep in seconds.
             substeps: Physics substeps per :meth:`step` call.
@@ -221,6 +227,12 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         self._nt, self._wp = ensure_newton()
         if solver.lower() not in solver_registry():
             raise ValueError(f"Unknown Newton solver {solver!r}. Available: {sorted(solver_registry())}")
+        # A solver Newton resolves is not automatically one that can drive a
+        # robot. Reported here, where the caller names it, so the refusal
+        # arrives before any world, model or solver is built rather than as a
+        # Newton-internal error or a frozen world behind a successful add_robot.
+        if solver_error := articulated_solver_error(solver):
+            raise ValueError(solver_error)
         self._solver_name = solver.lower()
         self.default_timestep = default_timestep
         self.substeps = substeps
@@ -2278,7 +2290,8 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         """Return a discovery surface describing this backend's capabilities.
 
         Returns:
-            Dict with the backend name, active solver, available solvers,
+            Dict with the backend name, active solver, the solvers that can
+            drive an articulated robot (the accepted domain of ``solver=``),
             device, and current robot / object counts.
         """
         device = str(self._wp.get_device(self.device)) if self.device else str(self._wp.get_device())
@@ -2286,7 +2299,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         return {
             "backend": "newton",
             "solver": self._solver_name,
-            "available_solvers": sorted(solver_registry()),
+            "available_solvers": sorted(articulated_solvers()),
             "device": device,
             "robots": self.list_robots(),
             "objects": list(self._world.objects) if self._world else [],

--- a/tests/simulation/newton/test_solver_articulation_domain.py
+++ b/tests/simulation/newton/test_solver_articulation_domain.py
@@ -1,0 +1,118 @@
+"""The accepted ``solver=`` domain is the solvers that can drive a robot.
+
+Newton resolves eight solver names, and only three of them integrate a rigid
+articulated body. The other five fail in two different ways when handed a robot,
+and neither is something a caller can act on:
+
+* ``vbd``, ``style3d`` and ``mpm`` raise from inside Newton, naming a
+  ``ModelBuilder`` the caller never touched.
+* ``xpbd`` and ``semi_implicit`` build and step without moving a joint, so
+  ``add_robot`` / ``send_action`` / ``step`` all report success over a frozen
+  world -- the worse of the two, because nothing reports it at all.
+
+The rule is a pure function over the solver *name*, so everything except the
+construction cases below runs with Newton uninstalled: that is the install on
+which a caller most needs the refusal to be the one they read.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from strands_robots.simulation.newton.backend import (
+    articulated_solver_error,
+    articulated_solvers,
+    solver_registry,
+)
+
+_HAS_NEWTON = importlib.util.find_spec("newton") is not None and importlib.util.find_spec("warp") is not None
+
+# Measured on newton 1.5.0 / warp 1.16.0 against a two-hinge arm: a commanded
+# 0.9 rad target moved each of these by 0.899 rad.
+DRIVES_A_ROBOT = ("featherstone", "kamino", "mujoco")
+
+# The same probe left these at 0.0 rad, whether commanded or stepped under
+# gravity alone, or refused the model from inside Newton.
+CANNOT_DRIVE_A_ROBOT = ("mpm", "semi_implicit", "style3d", "vbd", "xpbd")
+
+
+class TestThePartitionCoversTheRegistry:
+    """Every resolvable solver is classified, so a new one cannot slip through."""
+
+    def test_the_two_groups_partition_the_registry(self):
+        assert set(DRIVES_A_ROBOT) | set(CANNOT_DRIVE_A_ROBOT) == set(solver_registry())
+        assert not set(DRIVES_A_ROBOT) & set(CANNOT_DRIVE_A_ROBOT)
+
+    def test_articulated_solvers_is_the_driving_group_in_registry_order(self):
+        assert articulated_solvers() == tuple(n for n in solver_registry() if n in DRIVES_A_ROBOT)
+
+    def test_every_refused_name_is_a_solver_newton_resolves(self):
+        # A typo here would silently disable the refusal for the real name.
+        for name in CANNOT_DRIVE_A_ROBOT:
+            assert name in solver_registry()
+
+
+class TestTheDomainReportsEveryUndrivableSolver:
+    @pytest.mark.parametrize("solver", CANNOT_DRIVE_A_ROBOT)
+    def test_it_names_the_solver_the_reason_and_the_alternatives(self, solver):
+        message = articulated_solver_error(solver)
+        assert message is not None
+        assert repr(solver) in message
+        assert "cannot drive an articulated robot" in message
+        # The caller is told what to use instead, not just what failed.
+        for usable in articulated_solvers():
+            assert usable in message
+
+    @pytest.mark.parametrize("solver", DRIVES_A_ROBOT)
+    def test_a_solver_that_drives_a_robot_is_accepted(self, solver):
+        assert articulated_solver_error(solver) is None
+
+    def test_the_name_is_matched_case_insensitively(self):
+        # __init__ lowercases only after this guard, so it must fold here too.
+        refusal = articulated_solver_error("VBD")
+        assert refusal is not None
+        assert articulated_solver_error("MuJoCo") is None
+        # The refusal quotes the spelling the caller passed, not the folded one,
+        # so they can find it in their own call.
+        assert "'VBD'" in refusal
+
+    @pytest.mark.parametrize("solver", CANNOT_DRIVE_A_ROBOT)
+    def test_the_reason_distinguishes_a_frozen_world_from_a_newton_error(self, solver):
+        message = articulated_solver_error(solver)
+        assert message is not None
+        frozen = solver in ("xpbd", "semi_implicit")
+        assert ("frozen" in message) is frozen
+
+
+@pytest.mark.skipif(not _HAS_NEWTON, reason="newton/warp not installed")
+class TestConstructionRefusesAnUndrivableSolver:
+    @pytest.mark.parametrize("solver", CANNOT_DRIVE_A_ROBOT)
+    def test_the_engine_refuses_it_with_the_shared_verdict(self, solver):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        with pytest.raises(ValueError) as excinfo:
+            NewtonSimEngine(solver=solver)
+        # The engine adds nothing of its own to the shared rule's wording.
+        assert str(excinfo.value) == articulated_solver_error(solver)
+
+    def test_an_unknown_solver_still_reports_that_it_is_unknown(self):
+        # Ordering pin: the membership refusal runs before this domain, so a
+        # misspelling is not reported as an undrivable solver.
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        with pytest.raises(ValueError, match="Unknown Newton solver"):
+            NewtonSimEngine(solver="not_a_solver")
+
+    def test_describe_advertises_only_the_solvers_it_accepts(self):
+        from strands_robots.simulation.newton.simulation import NewtonSimEngine
+
+        sim = NewtonSimEngine(solver="mujoco")
+        try:
+            advertised = sim.describe()["available_solvers"]
+        finally:
+            sim.destroy()
+        assert advertised == sorted(articulated_solvers())
+        for refused in CANNOT_DRIVE_A_ROBOT:
+            assert refused not in advertised


### PR DESCRIPTION
## Problem

`create_simulation("newton", solver=...)` accepts every one of the eight names
Newton resolves, and only three of them integrate a rigid articulated body. The
other five are accepted and then fail in two ways, neither of which a caller can
act on.

Three raise from inside Newton, naming a `ModelBuilder` the caller never touched:

```
sim = create_simulation("newton", solver="vbd")   # or style3d, or mpm
sim.create_world()
sim.add_robot(name="arm", urdf_path=...)
ValueError: model.body_color_groups is empty but rigid bodies are present! When using
the SolverVBD you must call ModelBuilder.color() or ModelBuilder.set_coloring() before
calling ModelBuilder.finalize().
```

The other two are worse, because nothing reports them at all: `xpbd` and
`semi_implicit` build and step without moving a joint, so `add_robot`,
`send_action` and `step` all return `status="success"` over a frozen world.

## Measured

newton 1.5.0 / warp 1.16.0, a two-hinge arm, `send_action({"j1": 0.9, "j2": -0.7})`
followed by `step(120)`:

| solver | joint travel | add_robot / send_action / step | on main |
| --- | --- | --- | --- |
| `mujoco` (default) | 0.899 rad | success / success / success | works |
| `featherstone` | 0.899 rad | success / success / success | works |
| `kamino` | 0.899 rad | success / success / success | works |
| `xpbd` | 0.000 rad | success / success / success | accepted, frozen |
| `semi_implicit` | 0.000 rad | success / success / success | accepted, frozen |
| `vbd` | n/a | `ValueError` from Newton | accepted, then raises |
| `style3d` | n/a | `AttributeError` from Newton | accepted, then raises |
| `mpm` | n/a | `TypeError` from Newton | accepted, then raises |

Stepping under gravity with nothing commanded moved `xpbd` and `semi_implicit` by
0.000 rad as well, and their body poses were unchanged, so they do not integrate
rigid bodies at all rather than merely ignoring the target.

## The remedy Newton's own error names was measured, and rejected

`vbd`'s message asks for `ModelBuilder.set_coloring()` / `color()` before
`finalize()`. Applying it does make the model finalize and the solver construct
and step -- and the arm still does not move:

| vbd variant | finalize | solver built | 120 steps | joint travel |
| --- | --- | --- | --- | --- |
| as shipped | raises | no | n/a | n/a |
| `set_coloring([...])` | ok | ok | ok | 0.000 rad |
| `color()` | ok | ok | ok | 0.000 rad |

So colouring the builder trades the one loud failure for a silent one. That is
the wrong direction, and it is why this change reports the solver instead of
teaching the backend to build a model it cannot drive.

## Change

`articulated_solver_error(solver)` names the solver, why it cannot be honoured
and the solvers that can. `NewtonSimEngine.__init__` reports it immediately after
the existing unknown-solver refusal -- where the caller names the solver, and
before any world, model or solver is built:

```
Newton solver 'xpbd' cannot drive an articulated robot: it builds and steps without integrating rigid bodies, leaving the world frozen. Solvers that can: ['mujoco', 'featherstone', 'kamino'].
```

`solver_registry()` stays the factual name-to-class map; `articulated_solvers()`
is the accepted subset, and `describe()["available_solvers"]` now reports that
subset rather than all eight. The solver table in `docs/simulation/newton.md` was
listing `xpbd` and `semi_implicit` as the rigid-body solvers used by articulated
robots and `kamino` as particle-only -- exactly backwards for those three -- and
now matches what was measured.

## Tests

`tests/simulation/newton/test_solver_articulation_domain.py`, 24 cases. The rule
is a pure function over the solver *name*, so 17 of them run with Newton
uninstalled -- the install on which a caller most needs the refusal to be the one
they read. They pin that the two groups partition the registry (so a solver
Newton adds later cannot slip through unclassified), that every refused name is
one Newton actually resolves, that the message names the solver, the reason and
the alternatives, and that the reason distinguishes a frozen world from a
Newton-internal error. The 7 construction cases assert the engine returns the
shared verdict verbatim, that a misspelling is still reported as unknown rather
than as undrivable, and that `describe()` advertises only what it accepts.

Pre-fix, with `simulation.py` reverted to main and the new module kept, 6 of
those 7 fail (`DID NOT RAISE` five times, plus `describe()` advertising all
eight); the one that passes is the pre-existing unknown-solver refusal. Because
that venv has no pytest, the 7 were additionally executed as a plain script under
the real Newton install: 7 passed on this branch, 1 passed / 6 failed on main.

## Gate

`MUJOCO_GL=egl pytest tests` at `83cc5272`: **28697 passed, 265 skipped, 0
failed** (660s). `ruff check` and `ruff format --check` clean over 1191 files;
`mypy strands_robots tests tests_integ` reports 0 errors. Existing
`tests/simulation/newton` unchanged at 802 passed. Every name in-tree passes
`mujoco` (26 sites) or `featherstone` (2 sites), so no call site changes
behaviour.

## Visual

Same scene, same commanded target, only `solver=` differs. The accepted solver
reaches the pose; the refused one reports success three times and does not move.

![newton solver articulation domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/newton-solver-articulation-domain/newton_solver_domain.png)

Every probe, its recorded facts and the figure scripts are on the
`artifacts/newton-solver-articulation-domain` branch of the fork.

## Scope

Only the accepted domain of `solver=` changes. Newton's solvers are untouched, no
colouring pass is added, and `solver_registry()` still resolves all eight names
for any future non-articulated content path. Whether this backend should ever
grow a soft-body path that can use them is a separate question.
