### PR TITLE
fix(simulation/mujoco): let the finalizer finish its teardown at shutdown

### DIFF
--- a/changelog.d/2223-finalizer-teardown-needs-no-import.md
+++ b/changelog.d/2223-finalizer-teardown-needs-no-import.md
@@ -1,0 +1,18 @@
+### Fixed: the MuJoCo finalizer completes its teardown at interpreter shutdown
+
+`MuJoCoSimEngine.cleanup()` opened with a function-local `import contextlib`.
+A finalizer calls it during interpreter shutdown, where the import system is
+already gone, so that first statement raised before any of the nine teardown
+steps below it: `SimEngine.__del__`'s safety net released nothing - not the ROS
+bridge, not the renderers, not the executor - and the only thing the operator
+was told was a warning naming the interpreter (`sys.meta_path is None, Python
+is likely shutting down`) rather than anything actionable. A script that called
+`cleanup()` explicitly got the same warning per engine, reporting a failure on
+the path where everything had succeeded.
+
+`contextlib` is now imported at module scope, matching the nine other modules
+in the package that do so - including `simulation/base.py`, which declares the
+`cleanup`/`__del__` contract, and `mujoco/backend.py` beside it. A structural
+test refuses a standard-library import inside any `cleanup`, `destroy` or
+`__del__` in the package, and the behavioural half drives a child interpreter
+to real shutdown and asserts the teardown steps are reached.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -41,6 +41,7 @@ dedup).
 So: the split is honest about being for file-size, not for decoupling.
 """
 
+import contextlib
 import inspect
 import json
 import logging
@@ -5234,6 +5235,14 @@ class MuJoCoSimEngine(
                 stale-pointer window step 2 exists to close, so the safe budget
                 is the honest reading of "no usable preference". Teardown always
                 completes; see :func:`_resolve_policy_stop_timeout`.
+
+        Note:
+            Every name this method needs is bound at module scope. A
+            finalizer calls this during interpreter shutdown, where the
+            import system is already gone, so a function-local import here
+            raises before the first teardown step and the ``__del__`` safety
+            net releases nothing at all - reported only as a warning naming
+            the interpreter rather than anything the caller can act on.
         """
         # Detach from the mesh network first (if attached). A truthy
         # ``self.mesh`` is any object exposing ``.stop()``; falsy values
@@ -5252,12 +5261,10 @@ class MuJoCoSimEngine(
         # (TeleopMixin) before mesh teardown. Best-effort.
         # Tear down the ROS 2 telemetry bridge (if any) before other teardown
         # so external subscribers see the node leave cleanly.
-        import contextlib as _cl
-
-        with _cl.suppress(Exception):
+        with contextlib.suppress(Exception):
             self._shutdown_ros_bridge()
         if getattr(self, "_teleop_running", False) or getattr(self, "_teleops", None):
-            with _cl.suppress(Exception):
+            with contextlib.suppress(Exception):
                 self.stop_teleoperate()
         if self._world is not None:
             for r in list(self._world.robots.values()):

--- a/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
+++ b/tests/simulation/test_finalizer_reports_only_real_cleanup_failures.py
@@ -30,9 +30,13 @@ from __future__ import annotations
 
 import ast
 import gc
+import importlib.util
 import inspect
 import logging
+import os
 import pathlib
+import subprocess
+import sys
 from typing import Any
 
 import pytest
@@ -43,6 +47,7 @@ from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
 
 _BASE_LOGGER = "strands_robots.simulation.base"
 _CLEANUP_WARNING = "Cleanup error during __del__"
+_MUJOCO_SPEC = importlib.util.find_spec("mujoco")
 
 
 def _cleanup_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
@@ -383,3 +388,215 @@ class TestEveryBackendDeclaresConstructionComplete:
             "        self._init_complete = True\n"
         )
         assert _engines_missing_the_sentinel(compliant) == []
+
+
+# The finalizer runs during interpreter shutdown, where imports no longer work.
+
+_SHUTDOWN_PROBE = """\
+import os
+import sys
+
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+fd = os.open(sys.argv[1], os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+
+# ``os.write`` and the descriptor are bound as default arguments so the wrapper
+# needs neither a module global nor an import once the interpreter has started
+# clearing module dictionaries - the window the finalizer runs in.
+_real = MuJoCoSimEngine._close_main_thread_renderers
+
+
+def _traced(self, *a, _r=_real, _w=os.write, _fd=fd, **k):
+    _w(_fd, b"renderers\\n")
+    return _r(self, *a, **k)
+
+
+MuJoCoSimEngine._close_main_thread_renderers = _traced
+
+engine = MuJoCoSimEngine(tool_name="finalizer_shutdown_probe")
+if len(sys.argv) > 2 and sys.argv[2] == "explicit":
+    engine.cleanup()
+# Fall off the end holding a reference: CPython finalizes it during shutdown.
+"""
+
+
+def _run_at_shutdown(tmp_path: pathlib.Path, *, explicit_cleanup: bool = False) -> tuple[int, list[str]]:
+    """Build an engine in a child interpreter and let shutdown finalize it.
+
+    Real shutdown cannot be emulated in-process: setting ``sys.meta_path`` to
+    ``None`` is not enough, because a module already in ``sys.modules`` needs no
+    finder. Only a genuine exit clears the module dictionaries the import
+    machinery reads, so the child process is the instrument.
+
+    ``PYTHONPATH`` is pinned to the tree this test was imported from, so the
+    child measures the same working copy rather than whichever installation
+    happens to be first on the default path.
+
+    Args:
+        tmp_path: Per-test directory for the script and its trace file.
+        explicit_cleanup: Call ``cleanup()`` before exiting, modelling a caller
+            who released everything correctly.
+
+    Returns:
+        ``(cleanup_warning_count, teardown_steps_reached)``.
+    """
+    script = tmp_path / "shutdown_probe.py"
+    script.write_text(_SHUTDOWN_PROBE, encoding="utf-8")
+    trace = tmp_path / "trace.txt"
+    tree = pathlib.Path(inspect.getfile(SimEngine)).parents[2]
+    argv = [sys.executable, str(script), str(trace)]
+    if explicit_cleanup:
+        argv.append("explicit")
+    completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={**os.environ, "PYTHONPATH": str(tree)},
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    steps = trace.read_text(encoding="utf-8").split() if trace.exists() else []
+    return completed.stderr.count(_CLEANUP_WARNING), steps
+
+
+@pytest.mark.skipif(_MUJOCO_SPEC is None, reason="mujoco is not installed")
+class TestTheFinalizerCompletesAtInterpreterShutdown:
+    """The third direction of this module's contract: the ordinary exit path.
+
+    The two halves above cover an engine that never acquired anything and one
+    whose ``cleanup`` raises. Neither covers a fully constructed engine being
+    finalized by interpreter shutdown - which is what happens to every engine a
+    script does not explicitly release, and where the report was least true:
+    ``cleanup()`` opened with a function-local ``import contextlib``, so the
+    import raised before the first teardown step and the safety net released
+    nothing while reporting a failure that named the interpreter.
+    """
+
+    def test_the_teardown_steps_are_reached(self, tmp_path: pathlib.Path) -> None:
+        """A statement that runs before the teardown must not be able to skip it."""
+        _warnings, steps = _run_at_shutdown(tmp_path)
+        assert steps == ["renderers"], (
+            "the finalizer did not reach the renderer teardown, so nothing it guards was released at exit"
+        )
+
+    def test_no_cleanup_failure_is_reported(self, tmp_path: pathlib.Path) -> None:
+        count, _steps = _run_at_shutdown(tmp_path)
+        assert count == 0, f"{count} spurious cleanup warning(s) on a teardown that succeeded"
+
+    def test_a_caller_who_released_everything_is_told_nothing_failed(self, tmp_path: pathlib.Path) -> None:
+        """The correct path must be silent.
+
+        ``cleanup()`` is idempotent, so the finalizer runs it a second time on
+        an engine the caller already released. That second run has nothing left
+        to do and must therefore report nothing - one warning per engine here
+        would accuse the caller who did exactly the right thing.
+        """
+        count, _steps = _run_at_shutdown(tmp_path, explicit_cleanup=True)
+        assert count == 0, f"{count} cleanup warning(s) after an explicit cleanup()"
+
+
+# Structural: nothing a finalizer calls may need the import system.
+
+_FINALIZER_METHODS = frozenset({"cleanup", "destroy", "__del__"})
+
+
+def _teardown_stdlib_imports(source: str, label: str = "<source>") -> list[str]:
+    """Function-local standard-library imports inside finalizer-reachable methods.
+
+    ``SimEngine.__del__`` calls ``cleanup()``, which calls ``destroy()``, so
+    these three names are the methods CPython can run while it is dismantling
+    the interpreter. An import there is unserviceable at that point: the failure
+    is reported as a cleanup error and every step below it is skipped.
+
+    Only the standard library is flagged. An *optional dependency* is imported
+    lazily on purpose - ``IsaacSimulation.destroy`` reaches for ``omni.usd``
+    inside a guarded block so the module stays importable without Isaac Sim -
+    and that import is not what a finalizer needs to release local resources.
+    A stdlib module has no such reason and belongs at module scope, where the
+    name is already bound.
+    """
+    offenders: list[str] = []
+    for class_node in (n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.ClassDef)):
+        for method in class_node.body:
+            if not isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if method.name not in _FINALIZER_METHODS:
+                continue
+            for node in ast.walk(method):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or ""]
+                else:
+                    continue
+                for name in names:
+                    top = name.split(".")[0]
+                    if top in sys.stdlib_module_names:
+                        offenders.append(f"{label}:{node.lineno} {class_node.name}.{method.name} imports {top!r}")
+    return offenders
+
+
+def _package_sources() -> dict[str, str]:
+    """Every module of the installed package, keyed by its path relative to it."""
+    root = pathlib.Path(inspect.getfile(SimEngine)).parents[1]
+    return {str(p.relative_to(root)): p.read_text(encoding="utf-8") for p in sorted(root.rglob("*.py"))}
+
+
+class TestNoFinalizerReachableTeardownNeedsTheImportSystem:
+    def test_the_scan_covers_the_package(self) -> None:
+        """An empty scan would pass the check below vacuously."""
+        sources = _package_sources()
+        assert len(sources) > 100, len(sources)
+        assert "simulation/base.py" in sources
+        assert "simulation/mujoco/simulation.py" in sources
+
+    def test_the_known_teardown_methods_are_found(self) -> None:
+        """The scan is worthless if its method filter matches nothing."""
+        found = {
+            f"{c.name}.{m.name}"
+            for source in _package_sources().values()
+            for c in (n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.ClassDef))
+            for m in c.body
+            if isinstance(m, ast.FunctionDef | ast.AsyncFunctionDef) and m.name in _FINALIZER_METHODS
+        }
+        assert {
+            "SimEngine.__del__",
+            "SimEngine.cleanup",
+            "SimEngine.destroy",
+            "MuJoCoSimEngine.cleanup",
+            "MuJoCoSimEngine.destroy",
+        } <= found, sorted(found)
+
+    @pytest.mark.parametrize("relative_path", sorted(_package_sources()))
+    def test_no_teardown_method_imports_a_stdlib_module(self, relative_path: str) -> None:
+        offenders = _teardown_stdlib_imports(_package_sources()[relative_path], relative_path)
+        assert offenders == [], (
+            f"{offenders} - move the import to module scope. A finalizer runs "
+            f"these methods during interpreter shutdown, where the import fails "
+            f"and every teardown step below it is skipped"
+        )
+
+    def test_the_scan_detects_a_planted_import(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        plain = "class Broken:\n    def cleanup(self):\n        import contextlib\n        return contextlib\n"
+        from_form = "class AlsoBroken:\n    def __del__(self):\n        from json import dumps\n        return dumps\n"
+        assert [o.split()[1] for o in _teardown_stdlib_imports(plain)] == ["Broken.cleanup"]
+        assert [o.split()[1] for o in _teardown_stdlib_imports(from_form)] == ["AlsoBroken.__del__"]
+
+    def test_a_lazy_optional_dependency_is_not_flagged(self) -> None:
+        """Importing an absent third-party stack lazily is the documented idiom."""
+        optional = (
+            "class Fine:\n"
+            "    def destroy(self):\n"
+            "        try:\n"
+            "            import omni.usd\n"
+            "        except ImportError:\n"
+            "            return None\n"
+            "        return omni.usd\n"
+        )
+        assert _teardown_stdlib_imports(optional) == []
+
+    def test_a_module_scope_import_is_not_flagged(self) -> None:
+        compliant = "import contextlib\n\n\nclass Fine:\n    def cleanup(self):\n        return contextlib\n"
+        assert _teardown_stdlib_imports(compliant) == []


### PR DESCRIPTION
`MuJoCoSimEngine.cleanup()` opened with a function-local `import contextlib`.
A finalizer calls it during interpreter shutdown, where the import system is
already gone, so that first statement raised before any of the nine teardown
steps below it.

Traced through the real finalizer, `cleanup()` on `main` gets exactly two lines
in and stops:

| | `main` | this PR |
|---|---|---|
| finalizer trace at real shutdown | `enter -> raised:ImportError` | `enter -> _shutdown_ros_bridge -> _close_main_thread_renderers -> returned` |
| ROS bridge released at exit | no | yes |
| renderers released at exit | no | yes |

So `SimEngine.__del__`'s safety net - the one that exists for a caller who never
called `cleanup()` - released nothing, and the only thing the operator was told
was a warning naming the interpreter:

```
Cleanup error during __del__: sys.meta_path is None, Python is likely shutting down
```

That message names neither the engine nor anything the reader can act on. Three
engines in one process print it three times. And a caller who *did* release
everything correctly gets it too, once per engine: `cleanup()` is idempotent, so
the finalizer runs it again, the import fails again, and the report accuses the
path that had succeeded.

| the reported scenario | `main` | this PR |
|---|---|---|
| 3 sims, `cleanup()` never called | 3 warnings | 0 |
| 3 sims, `cleanup()` called on each | 3 warnings | 0 |

## Change

`import contextlib` moves to module scope - one line, plus the nine
`contextlib.suppress` call sites losing their local alias.

That is what the rest of the package already does: nine modules import
`contextlib` at module scope and this was the only function-local one. Two of
those nine are the ones that matter here - `simulation/base.py`, which declares
the `cleanup`/`__del__` contract and calls it from the finalizer, and
`mujoco/backend.py` beside it.

The method's docstring gains a `Note:` recording why, since the constraint is
not visible from the body.

## Tests

In `test_finalizer_reports_only_real_cleanup_failures.py`, whose title is this
contract. It already pinned two directions - nothing is reported for an engine
that never acquired anything, everything is reported for one whose `cleanup`
raises - and its `TestMuJoCoUsesTheSharedFinalizer` class exists specifically to
check that the default backend obeys the base class's guarantees. Neither half
covered a fully constructed engine being finalized by interpreter shutdown,
which is what happens to every engine a script does not explicitly release, and
where the report was least true.

* **Behavioural** - a child interpreter builds an engine and falls off the end,
  so shutdown finalizes it. Real shutdown cannot be emulated in-process: setting
  `sys.meta_path = None` is not enough, because a module already in
  `sys.modules` needs no finder. Only a genuine exit clears the module
  dictionaries the import machinery reads. The steps reached are recorded
  through a raw file descriptor, since a finalizer cannot rely on buffered I/O.
* **Structural** - a standard-library import inside any `cleanup`, `destroy` or
  `__del__` in the package fails the scan, parametrized per module so the
  failure names the file and line. An *optional dependency* stays lazy on
  purpose (`IsaacSimulation.destroy` reaches for `omni.usd` in a guarded block
  so the module imports without Isaac Sim) and is deliberately not flagged; a
  stdlib module has no such reason.

Pre-fix, with the source reverted to `upstream/main` and the tests kept:
**4 failed / 232 passed**. The structural half names it exactly -
`simulation/mujoco/simulation.py:5255 MuJoCoSimEngine.cleanup imports 'contextlib'`.

Three of four plausible regressions are caught here and all three are invisible
to the 19 cases already in the module. The fourth deletes the docstring
paragraph explaining the constraint: prose, so it is not pinned - the scan
enforces the behaviour itself.

## Scope

Only the import moves. The nine teardown steps, their order and their
per-step tolerance are untouched, which is why all three robots in the reported
scenario render identically on both trees (`max|delta| = 1/255`, renderer
noise).

Two things the report mentions are **not** addressed here. The raw
`EGLError(EGL_NOT_INITIALIZED)` tracebacks did not reproduce on this host - 0 on
both trees across the 3-sim scenario - so whatever produces those is separate
from this and I have not measured it. And `robot_joint_names()` requiring an
explicit `robot_name` is a different surface (per-robot introspection
ergonomics across several methods, with its own choice about what to do when the
world holds none or many); it deserves its own change rather than riding along.

![finalizer teardown at interpreter shutdown](https://raw.githubusercontent.com/cagataycali/robots/artifacts/finalizer-teardown-shutdown/finalizer-teardown.png)

Top row is the reported three-sim scenario rendered headless on both trees, to
show the simulation path is untouched. Middle is the measured report and the
teardown actually reached. Bottom is the mutation table. Every number in the
figure is asserted against the two measurement dumps before it is drawn;
`capture.py`, `compose.py` and `mutations.py` are on the artifact branch.

## Gate

Thor, `MUJOCO_GL=egl`, base `83cc5272`.

* `MUJOCO_GL=egl python -m pytest tests` - **28897 passed / 258 skipped / 0 failed** (685s).
  `main` is 28680; the module goes from 19 collected cases to 236, so +217.
* `ruff check` clean (1190 files), `ruff format --check` clean, `mypy strands_robots tests tests_integ`
  0 errors outside `examples/isaac_gs` (14 there, byte-identical to a pristine
  `upstream/main` worktree - pre-existing and environmental).
* `scripts/check_merge_base_overlap.py` - no overlap; 0 paths changed on
  `upstream/main` since the branch point.

* No code change after the gate: the tree measured above (`0b574e2d`) differs from
  the pushed head (`462b14eb`) only in the changelog fragment's filename, renamed
  from `2222-` to `2223-` once this PR had a number.

