### PR TITLE
fix(simulation/mujoco): validate export_xml's LLM-supplied output_path

### DIFF
--- a/changelog.d/2224-export-xml-path-validation.md
+++ b/changelog.d/2224-export-xml-path-validation.md
@@ -1,0 +1,29 @@
+### Fixed: `export_xml(output_path=...)` validates its LLM-supplied destination
+
+`export_xml` is one of the MuJoCo simulation's agent-callable actions, so its
+`output_path` arrives from a tool call exactly as `render`'s does, but it wrote
+that path straight to `open(output_path, "w")`. A `..` segment escaped the
+requested directory, a symlinked target was followed and overwrote whatever it
+pointed at, and shell metacharacters and backslash separators were accepted,
+each reporting `status=success`. `strands_robots.simulation.safe_output` exists
+for this class of sink and its module docstring enumerates them; `export_xml`
+was absent from that list in prose and in behaviour.
+
+The write also sat outside the method's `try`, so an `OSError` from the
+caller's path escaped the result envelope entirely: a missing parent directory
+raised `FileNotFoundError` and a directory destination raised
+`IsADirectoryError`, past a method documented to return a result dict.
+
+`output_path` now routes through the shared `validate_output_path` guard before
+writing, the write is atomic so a crash mid-export cannot truncate an existing
+file at the destination, and an `OSError` at the sink is reported through the
+envelope (a missing parent is created; the message names the destination rather
+than the internal temp filename). Confinement is guards-only: an absolute
+destination is still accepted, preserving this sink's historic contract, because
+`safe_output` documents `render`'s sandbox as applying to a "newer,
+sandboxed-by-design feature". The success text now reports the resolved path
+rather than the raw argument, which could name a file that was not written.
+
+The `output_path` description in the agent tool schema said "Trajectory/video
+export path", naming neither `render` nor `export_xml`; it now states each
+sink's destination and the guards that apply to all of them.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -36,6 +36,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
 )
+from strands_robots.simulation.safe_output import atomic_write_bytes, validate_output_path
 from strands_robots.utils import BOOLEAN_VECTOR_REASON, coerce_rgba, is_boolean
 
 logger = logging.getLogger(__name__)
@@ -2338,6 +2339,14 @@ class PhysicsMixin:
         ``replace_scene_mjcf`` / ``patch_scene_mjcf`` / the ``inject_*``
         helpers all do this). The serialised XML reflects any runtime
         mutation, so no extra caching or round-tripping is needed.
+
+        ``output_path`` is treated as untrusted (LLM-callable tool): a ``..``
+        traversal segment, a symlinked target, shell metacharacters, and
+        backslash separators are rejected with ``status=error``. An absolute
+        destination is accepted (the historic contract for this sink). The
+        write is atomic and the success text reports the RESOLVED path. A
+        destination the filesystem cannot accept (a directory, an unwritable
+        parent) is reported the same way; a missing parent is created.
         """
         if self._world is None or self._world._model is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -2364,9 +2373,32 @@ class PhysicsMixin:
             return {"status": "error", "content": [{"text": f"spec.to_xml() failed: {e}"}]}
 
         if output_path:
-            with open(output_path, "w") as f:
-                f.write(xml)
-            return {"status": "success", "content": [{"text": f"Model exported to {output_path}"}]}
+            # output_path is LLM-supplied (export_xml is an agent-callable
+            # action): reject traversal, a symlinked target, and shell
+            # metacharacters before writing. Guards-only (no sandbox root) keeps
+            # the historic contract that an absolute destination is accepted -
+            # unlike render(), whose output_path is documented as a newer,
+            # sandboxed-by-design feature. The write is atomic so a crash
+            # mid-export cannot truncate an existing file at the destination.
+            try:
+                safe = validate_output_path(output_path, sandbox_root=None, allow_abs=True)
+            except ValueError as e:
+                return {"status": "error", "content": [{"text": f"export_xml: {e}"}]}
+            try:
+                atomic_write_bytes(safe, xml.encode("utf-8"))
+            except OSError as e:
+                # A destination the caller supplied but the filesystem cannot
+                # accept (a directory, an unwritable parent) is the same class
+                # of caller error as an unsafe path, so it is reported through
+                # the envelope rather than raised past it. strerror keeps the
+                # internal temp filename out of the message.
+                return {
+                    "status": "error",
+                    "content": [{"text": f"export_xml: cannot write {safe}: {e.strerror or e}"}],
+                }
+            # Report the RESOLVED path: the raw argument can normalize to a
+            # different location, so echoing it would name a file we did not write.
+            return {"status": "success", "content": [{"text": f"Model exported to {safe}"}]}
 
         return {
             "status": "success",

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -255,7 +255,7 @@
     },
     "output_path": {
       "type": "string",
-      "description": "Trajectory/video export path"
+      "description": "Destination file path. render: PNG still, confined to the render sandbox (~/.strands_robots/renders, or STRANDS_ROBOTS_RENDER_ROOT); set STRANDS_ROBOTS_RENDER_ALLOW_ABS=1 to write outside it. export_xml: MJCF scene, any absolute path accepted. run_policy/start_policy/eval_policy/evaluate_benchmark: rollout MP4. Every sink rejects '..' traversal, a symlinked target, backslash separators and shell metacharacters."
     },
     "fps": {
       "type": "integer",

--- a/strands_robots/simulation/safe_output.py
+++ b/strands_robots/simulation/safe_output.py
@@ -4,6 +4,7 @@ Several simulation entry points persist an artifact to a caller-chosen
 filesystem path that originates from an untrusted (LLM tool-call) source:
 
 * ``render(output_path=...)`` - a PNG still,
+* ``export_xml(output_path=...)`` - the scene as canonical MJCF,
 * ``run_policy(video={"path": ...})`` - a rollout MP4,
 * ``start_cameras_recording(output_dir=..., name=...)`` - per-camera MP4s.
 
@@ -19,7 +20,8 @@ Two confinement policies are supported, selected per sink:
   (used by ``render``, whose ``output_path`` is a newer, sandboxed-by-design
   feature). Pass a non-``None`` ``sandbox_root`` with ``allow_abs=False``.
 * **Guards-only (opt-in sandbox)** - absolute paths are permitted (the historic
-  video/recording contract) but the metacharacter, backslash, symlink, and
+  video/recording contract, and ``export_xml``'s) but the metacharacter,
+  backslash, symlink, and
   name-traversal guards still apply. Pass ``sandbox_root=None`` (or
   ``allow_abs=True``); callers opt in to confinement by supplying a root.
 """

--- a/tests/simulation/mujoco/test_export_xml_path_safety.py
+++ b/tests/simulation/mujoco/test_export_xml_path_safety.py
@@ -1,0 +1,257 @@
+"""``export_xml(output_path=...)`` treats its destination as untrusted input.
+
+``export_xml`` is one of the 77 actions the MuJoCo simulation exposes as an
+agent tool, so ``output_path`` arrives from an LLM tool call exactly as
+``render``'s does. :mod:`strands_robots.simulation.safe_output` exists for that
+class of sink and its module docstring enumerates them; this module pins that
+``export_xml`` is one of the enumerated sinks in behaviour and not only in prose.
+
+Two halves, because a guard that refuses everything is as wrong as one that
+refuses nothing:
+
+* the arbitrary-write vectors (``..`` traversal, a symlinked target, shell
+  metacharacters, backslash separators) are refused through the tool envelope
+  and leave nothing on disk, and
+* an ordinary absolute destination still exports. Confinement here is
+  guards-only: unlike ``render``, whose ``output_path`` ``safe_output`` documents
+  as "a newer, sandboxed-by-design feature", this sink has always accepted an
+  absolute path and a sandbox would be a breaking change.
+
+The structural test at the end is the drift net: it asserts no function in the
+agent-callable simulation tree writes a caller-supplied path parameter directly
+rather than the validated derivative, which is exactly the shape this fixed.
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Path parameters that reach a filesystem sink from an agent tool call.
+_PATH_PARAMS = frozenset({"output_path", "output_dir", "path", "root", "spec_path", "scene_path"})
+# Calls that write. The validated derivative is what these must receive.
+_WRITE_CALLS = frozenset({"open", "write_text", "write_bytes"})
+# Helpers that mean "this function routed its path through the shared guard".
+_GUARDS = ("validate_output_path", "_validate_render_output_path", "atomic_write_bytes")
+
+
+@pytest.fixture
+def sim():
+    """A live world whose ``_backend_state["spec"]`` export_xml serialises."""
+    s = Simulation(tool_name="export_path_safety", mesh=False)
+    s.create_world()
+    yield s
+    s.cleanup()
+
+
+def _text(result):
+    """First text block of an agent-tool envelope."""
+    for block in result.get("content", []):
+        if "text" in block:
+            return block["text"]
+    return ""
+
+
+class TestArbitraryWriteVectorsAreRefused:
+    """Each vector is reported through the envelope and writes nothing."""
+
+    def test_a_traversal_segment_is_refused(self, sim, tmp_path):
+        escaped = tmp_path.parent / "escaped-by-traversal.xml"
+        assert not escaped.exists(), "fixture: the escape target must not pre-exist"
+
+        result = sim.export_xml(output_path=str(tmp_path / ".." / escaped.name))
+
+        assert result["status"] == "error"
+        assert "path traversal" in _text(result)
+        assert not escaped.exists(), "a refused export still escaped the requested directory"
+
+    def test_a_symlinked_target_is_not_followed(self, sim, tmp_path):
+        victim = tmp_path / "victim.xml"
+        victim.write_text("ORIGINAL")
+        link = tmp_path / "link.xml"
+        link.symlink_to(victim)
+
+        result = sim.export_xml(output_path=str(link))
+
+        assert result["status"] == "error"
+        assert "symlink" in _text(result)
+        assert victim.read_text() == "ORIGINAL", "the export followed a symlink and overwrote the target"
+
+    @pytest.mark.parametrize("bad", [";", "|", "$", "`", ">", "<"])
+    def test_shell_metacharacters_are_refused(self, sim, tmp_path, bad):
+        target = tmp_path / f"a{bad}b.xml"
+
+        result = sim.export_xml(output_path=str(target))
+
+        assert result["status"] == "error"
+        assert "shell metacharacters" in _text(result)
+        assert not target.exists()
+
+    def test_backslash_separators_are_refused(self, sim, tmp_path):
+        result = sim.export_xml(output_path=str(tmp_path) + "\\nested\\scene.xml")
+
+        assert result["status"] == "error"
+        assert "backslash" in _text(result)
+
+    def test_a_refusal_names_the_method(self, sim, tmp_path):
+        """The envelope says which action refused, not just what was wrong."""
+        result = sim.export_xml(output_path=str(tmp_path / ".." / "x.xml"))
+
+        assert result["status"] == "error"
+        assert _text(result).startswith("export_xml: ")
+
+
+class TestTheHistoricContractStillHolds:
+    """Over-reach controls: an ordinary destination must still export."""
+
+    def test_an_absolute_destination_still_exports(self, sim, tmp_path):
+        target = tmp_path / "exported.xml"
+
+        result = sim.export_xml(output_path=str(target))
+
+        assert result["status"] == "success"
+        assert target.exists()
+        assert "<mujoco" in target.read_text()
+
+    def test_the_success_text_reports_the_resolved_path(self, sim, tmp_path):
+        """The raw argument can name a different file than the one written."""
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        # No ".." segment, but a symlinked *directory* still resolves elsewhere.
+        alias = tmp_path / "alias"
+        alias.symlink_to(nested, target_is_directory=True)
+        target = alias / "scene.xml"
+
+        result = sim.export_xml(output_path=str(target))
+
+        assert result["status"] == "success"
+        written = nested / "scene.xml"
+        assert written.exists(), "the export did not land in the resolved directory"
+        assert str(written) in _text(result), (
+            f"the text names the raw argument rather than the file written: {_text(result)!r}"
+        )
+
+    def test_inline_export_is_unaffected(self, sim):
+        """Omitting output_path keeps returning the XML inline."""
+        result = sim.export_xml()
+
+        assert result["status"] == "success"
+        assert "mujoco" in _text(result).lower()
+
+
+class TestTheWriteIsAtomic:
+    def test_an_existing_file_is_replaced_without_temp_residue(self, sim, tmp_path):
+        target = tmp_path / "scene.xml"
+        target.write_text("STALE")
+
+        result = sim.export_xml(output_path=str(target))
+
+        assert result["status"] == "success"
+        assert "<mujoco" in target.read_text()
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == [], f"atomic write left temp residue: {leftovers}"
+
+
+class TestTheWriteNeverRaisesPastTheEnvelope:
+    """``export_xml`` returns a result dict; a bad destination must not escape it.
+
+    The write used to sit outside the method's ``try``, so any ``OSError`` from
+    the caller's path - a missing parent, a directory, an unwritable parent -
+    propagated to the caller as a raw exception rather than as a result.
+    """
+
+    def test_a_missing_parent_directory_is_created(self, sim, tmp_path):
+        target = tmp_path / "does" / "not" / "exist" / "scene.xml"
+
+        result = sim.export_xml(output_path=str(target))
+
+        assert result["status"] == "success"
+        assert target.exists()
+        assert oct(target.parent.stat().st_mode & 0o777) == "0o700", "a created parent must be owner-only"
+
+    def test_a_destination_the_filesystem_rejects_is_reported_not_raised(self, sim, tmp_path):
+        # A directory can never be written as a file.
+        result = sim.export_xml(output_path=str(tmp_path))
+
+        assert result["status"] == "error"
+        text = _text(result)
+        assert str(tmp_path) in text, f"the report does not name the destination: {text!r}"
+        assert ".tmp" not in text, f"the report leaks the internal temp filename: {text!r}"
+
+
+class TestNoAgentCallableSinkWritesAnUnvalidatedPath:
+    """Drift net for the shape this module fixed.
+
+    A well-behaved sink validates first and writes the *validated* path, so its
+    write call never names the raw parameter. A write whose target expression
+    names a caller-supplied path parameter directly is therefore the defect,
+    and this scan needs no exemption list.
+    """
+
+    @staticmethod
+    def _offenders():
+        import strands_robots.simulation as sim_pkg
+
+        root = pathlib.Path(inspect.getfile(sim_pkg)).parent
+        found = []
+        for py in sorted(root.rglob("*.py")):
+            text = py.read_text()
+            for fn in ast.walk(ast.parse(text)):
+                if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                params = {a.arg for a in fn.args.args + fn.args.kwonlyargs} & _PATH_PARAMS
+                if not params:
+                    continue
+                fn_src = ast.get_source_segment(text, fn) or ""
+                if any(g in fn_src for g in _GUARDS):
+                    continue
+                for node in ast.walk(fn):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+                    if name not in _WRITE_CALLS:
+                        continue
+                    seg = ast.get_source_segment(text, node) or ""
+                    if any(p in seg for p in params):
+                        found.append(f"{py.name}::{fn.name} line {node.lineno} -> {name}()")
+        return found, root
+
+    def test_every_path_sink_routes_through_the_shared_guard(self):
+        offenders, _ = self._offenders()
+        assert offenders == [], (
+            "these functions write a caller-supplied path without routing it through "
+            f"strands_robots.simulation.safe_output: {offenders}"
+        )
+
+    def test_the_scan_reaches_the_simulation_tree(self):
+        """Non-vacuity: an empty result must mean clean sources, not an empty scan."""
+        _, root = self._offenders()
+        modules = list(root.rglob("*.py"))
+        assert len(modules) > 20, f"scan root {root} looks wrong: {len(modules)} modules"
+        assert (root / "mujoco" / "physics.py").exists(), f"scan root {root} misses physics.py"
+
+    def test_the_scan_detects_a_planted_offender(self, tmp_path, monkeypatch):
+        """A planted raw write must be reported, or the scan proves nothing."""
+        planted = tmp_path / "planted.py"
+        planted.write_text('def save(output_path):\n    with open(output_path, "w") as f:\n        f.write("x")\n')
+
+        text = planted.read_text()
+        hits = []
+        for fn in ast.walk(ast.parse(text)):
+            if not isinstance(fn, ast.FunctionDef):
+                continue
+            params = {a.arg for a in fn.args.args} & _PATH_PARAMS
+            fn_src = ast.get_source_segment(text, fn) or ""
+            if not params or any(g in fn_src for g in _GUARDS):
+                continue
+            for node in ast.walk(fn):
+                if isinstance(node, ast.Call) and getattr(node.func, "id", None) in _WRITE_CALLS:
+                    seg = ast.get_source_segment(text, node) or ""
+                    if any(p in seg for p in params):
+                        hits.append(fn.name)
+        assert hits == ["save"], f"the scan predicate missed a planted raw write: {hits}"


### PR DESCRIPTION
## Problem

`export_xml` is one of the MuJoCo simulation's agent-callable actions (it is in the
`action` enum in `tool_spec.json`), so its `output_path` arrives from an LLM tool call
exactly as `render`'s does. It wrote that path straight to `open(output_path, "w")`.

`strands_robots.simulation.safe_output` exists for this class of sink. Its module
docstring enumerates them - "`render(output_path=...)` writes a PNG, the plain-MP4
recorders write clips, `export_xml` writes an MJCF" - and `export_xml` was the one
name on that list whose behaviour did not match it. Measured through the public tool
envelope on `so101`, every destination shape below reported `status=success`:

| `output_path` the agent supplied | main | what actually happened |
| --- | --- | --- |
| a symlink to `important-notes.txt` | `success` | the target file was overwritten: 41 bytes of the caller's notes became 13,488 bytes of MJCF |
| `<dir>/sub/../escaped.xml` | `success` | written outside the requested directory |
| `a;rm -rf ~;b.xml` | `success` | shell metacharacters accepted into the reported path |
| `<dir>\nested\scene.xml` | `success` | backslash separators accepted |

The write also sat outside the method's `try`, so an `OSError` from the caller's path
escaped the result envelope entirely, past a method documented to return a result dict:

| `output_path` | main | this PR |
| --- | --- | --- |
| missing parent directory | `RAISED FileNotFoundError` | `success` (the parent is created, `0o700`) |
| destination is a directory | `RAISED IsADirectoryError` | `error` naming the destination |

Six destination shapes, six outcomes that do not honour the sink's contract.

`export_xml` was also the only function in the agent-callable simulation tree that
wrote a caller-supplied path parameter directly rather than a validated derivative -
`render`, the plain-MP4 recorders and the dataset recorder all write a path the guard
returned.

## Change

`output_path` now routes through the shared `validate_output_path` guard before
writing, and the write goes through `atomic_write_bytes`, so a crash mid-export
cannot truncate an existing file at the destination. An `OSError` at the sink is
reported through the envelope; the message names the destination rather than the
internal temp filename.

Confinement is guards-only (`sandbox_root=None`): an absolute destination is still
accepted, preserving this sink's historic contract. `safe_output`'s own docstring is
the reason - it documents `render`'s sandbox as applying to a "newer,
sandboxed-by-design feature", so retro-sandboxing an established sink would be a
separate decision rather than part of a path-safety fix. Refused now: traversal,
symlinks, shell metacharacters, backslash separators, NUL bytes and control
characters.

Two reporting corrections fall out of it. The success text now reports the RESOLVED
path (it previously echoed the raw argument, which could name a file that was not
written - `.../sub/../escaped.xml`). And the tool schema's `output_path` description
said "Trajectory/video export path", naming neither `render` nor `export_xml`; since
this change narrows what the parameter accepts, it now states each sink's destination
and the guards common to all of them.

`safe_output`'s module docstring listed `export_xml` among the sinks it covers, which
was true of the list and not of the code; it now says so explicitly.

## Tests

`tests/simulation/mujoco/test_export_xml_path_safety.py`, 19 cases:

- the four arbitrary-write vectors, each asserting the escape did not happen (the
  symlink target is byte-identical afterwards, the traversal destination does not
  exist) rather than only that the status is `error`
- the two envelope escapes, including that the report does not leak the internal
  temp filename
- over-reach controls: an absolute destination inside a legitimate directory still
  works, and `export_xml()` with no `output_path` still returns the MJCF inline
- the resolved-path report, and atomicity (an existing file at the destination
  survives intact when the export is refused)
- a structural drift net asserting that no function in the agent-callable simulation
  tree writes a caller-supplied path parameter directly, with a planted-defect
  meta-test so it cannot pass vacuously

Pre-fix (source reverted to the base, tests kept): **14 failed / 5 passed**. The five
that pass are the over-reach controls and the inline-return contract, which is what
keeps the guard from reaching further than the vectors.

## Visual artifact

![export_xml output_path validation](https://raw.githubusercontent.com/cagataycali/robots/artifacts/export-xml-path-validation/export_xml_path_validation.png)

Left: the real MuJoCo scene being exported (headless EGL), byte-comparable across the
two trees (max delta 2/255, 0 pixels differ above a threshold of 8) - the export
itself is unchanged, and it really wrote 13,488 bytes of MJCF. Right: the file the
caller never named, before and after, on each tree. Below: every vector and every
envelope escape, measured through the public tool call.

Every number in the figure is asserted against the two measured JSON dumps by the
compose script, including that the two dumps came from different trees. The
measurement scripts and raw dumps are on the `artifacts/export-xml-path-validation`
branch.

## Gate on Thor

- `MUJOCO_GL=egl python -m pytest tests -q` - **28699 passed / 258 skipped / 0
  failed** (626s). Base `83cc5272` measures 28680 passed / 258 skipped, and 28680 +
  19 = 28699.
- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`:
  clean, 1191 files.
- `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`,
  whose 14 are byte-identical to a pristine-base worktree control (an environmental
  artifact of the editable install root, not introduced here).
- `scripts/check_merge_base_overlap.py`: no overlap; 0 paths changed on
  `upstream/main` since the branch point.
- Zero existing tests changed.

### Note on the gated tree

The gate above was measured at `2fa0c374`. The head is now `c0cecb92`, which differs
from it only by renaming the changelog fragment from the predicted number to this PR's
(`git diff 2fa0c374 c0cecb92` is the rename alone: 1 file changed, 0 insertions, 0
deletions). No source or test line moved after the gate.

