### PR TITLE
fix(policies): a provider whose optional dependency is missing names the remedy

### DIFF
--- a/changelog.d/2226-provider-import-error-names-its-remedy.md
+++ b/changelog.d/2226-provider-import-error-names-its-remedy.md
@@ -1,0 +1,25 @@
+### Fixed: a policy provider whose optional dependency is missing now names the remedy instead of raising a bare ModuleNotFoundError
+
+`create_policy("lerobot_local", ...)` on an install without `torch` raised
+`ModuleNotFoundError: No module named 'torch'` -- an error naming neither the
+provider the caller asked for nor the way to fix it. Every other provider defers
+its heavy import and reports through `require_optional` / `require_optionals`,
+which name the extra that ships the dependency; `lerobot_local` imports `torch`
+at module level, so the failure happened while importing the provider's module,
+before any provider machinery could run.
+
+`import_policy_class` -- the single funnel every provider class is imported
+through -- now translates a failed provider import into an error naming the
+provider, the missing module and the install command, using the `extra` the
+provider declares in `policies.json`. The remedy therefore no longer depends on
+WHERE a provider happens to import its dependency.
+
+The auto-discovery branch swallowed the same `ImportError` and reported
+`Unknown policy provider`, sending a caller whose provider name was correct to go
+and check the name; a module that exists but cannot satisfy its dependency now
+reports the dependency. An unknown provider is still reported as an unknown
+provider.
+
+No provider has ever been substituted for another when its dependency was
+missing, and that is now pinned: a failed import reports rather than returning a
+different provider's policy whose action space happens to fit.

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -55,6 +55,7 @@
       "module": "strands_robots.policies.lerobot_local",
       "class": "LerobotLocalPolicy",
       "description": "Direct HuggingFace inference (no server)",
+      "extra": "lerobot",
       "requires": [],
       "config_keys": [
         "pretrained_name_or_path",

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -182,6 +182,46 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
     return "lerobot_local", kwargs
 
 
+def _provider_import_error(provider: str, exc: ImportError, extra: str | None) -> ImportError:
+    """Translate a failed provider-module import into an actionable error.
+
+    A policy provider's module may import an optional dependency at import time
+    (e.g. ``lerobot_local`` imports ``torch``). When that dependency is absent
+    the import machinery raises a bare ``ModuleNotFoundError: No module named
+    'torch'`` which names neither the provider the caller asked for nor the way
+    to fix it -- so a caller who asked for one provider is left holding an error
+    about a package they never mentioned.
+
+    Every other provider defers its heavy import and reports the remedy through
+    :func:`~strands_robots.utils.require_optional` /
+    :func:`~strands_robots.utils.require_optionals`, which name the extra that
+    ships the dependency. This is the same report for the providers whose
+    dependency is needed to import the module at all, so the remedy does not
+    depend on WHERE a provider happens to import its dependency.
+
+    Args:
+        provider: Canonical provider name the caller asked for.
+        exc: The ``ImportError`` raised while importing the provider's module.
+        extra: ``pyproject.toml`` extras group that ships the dependency, as
+            declared by the provider's ``extra`` field in ``policies.json``.
+            ``None`` when the provider declares none, in which case the missing
+            module is named without an install command for a specific extra.
+
+    Returns:
+        An ``ImportError`` naming the provider, the missing module and the
+        remedy. The caller should ``raise ... from exc`` to keep the original
+        traceback.
+    """
+    missing = getattr(exc, "name", None) or "an optional dependency"
+    if extra:
+        remedy = f"Install the extra that ships it:\n  uv pip install 'strands-robots[{extra}]'"
+    else:
+        remedy = f"Install {missing!r} (or the strands-robots extra that ships it) and retry."
+    return ImportError(
+        f"Policy provider {provider!r} needs an optional dependency that is not installed:\n  {exc}\n\n{remedy}"
+    )
+
+
 def import_policy_class(provider: str) -> type:
     """Dynamically import and return the Policy class for a provider.
 
@@ -195,8 +235,12 @@ def import_policy_class(provider: str) -> type:
         The Policy subclass.
 
     Raises:
-        ValueError: If provider not found.
-        ImportError: If the module can't be imported.
+        ValueError: If the provider does not exist.
+        ImportError: If the provider exists but its module cannot be imported,
+            naming the provider, the missing module and the remedy (see
+            :func:`_provider_import_error`). A provider whose module is present
+            but whose optional dependency is missing reports that rather than
+            being misreported as an unknown provider.
     """
     config = get_policy_provider(provider)
     if config:
@@ -206,7 +250,14 @@ def import_policy_class(provider: str) -> type:
         canonical = alias_map.get(provider, provider)
         config = reg.get("providers", {}).get(canonical, config)
 
-        mod = importlib.import_module(config["module"])
+        try:
+            mod = importlib.import_module(config["module"])
+        except ImportError as exc:
+            # A provider whose module needs an optional dependency at import
+            # time (lerobot_local imports torch) otherwise raises a bare
+            # "No module named 'torch'" naming neither this provider nor the
+            # remedy - the dead end _provider_import_error exists to close.
+            raise _provider_import_error(canonical, exc, config.get("extra")) from exc
         return getattr(mod, config["class"])
 
     # Auto-discovery fallback
@@ -221,8 +272,13 @@ def import_policy_class(provider: str) -> type:
             attr = getattr(mod, attr_name)
             if isinstance(attr, type) and issubclass(attr, Policy) and attr is not Policy:
                 return attr
-    except ImportError:
-        pass
+    except ImportError as exc:
+        # Distinguish "this provider does not exist" from "it exists but its
+        # optional dependency is missing". Only the former is an unknown
+        # provider; reporting the latter that way sends the caller to check a
+        # name that was correct.
+        if getattr(exc, "name", None) != f"strands_robots.policies.{provider}":
+            raise _provider_import_error(provider, exc, None) from exc
 
     raise ValueError(f"Unknown policy provider: '{provider}'. Available: {list_policy_providers()}")
 

--- a/tests/registry/test_provider_import_error_names_its_remedy.py
+++ b/tests/registry/test_provider_import_error_names_its_remedy.py
@@ -42,6 +42,9 @@ from strands_robots.policies import create_policy
 #: Extra that ships ``lerobot_local``'s dependency, as declared in policies.json.
 _LEROBOT_EXTRA = "lerobot"
 
+#: Providers whose module needs an optional dependency, so a substitution could hide there.
+_SUBSTITUTION_CANDIDATES = ("lerobot_local", "groot", "cosmos3", "wbc")
+
 
 def _absent(module: str) -> Any:
     """Build an import_module stand-in that reports ``module`` as not installed.
@@ -122,7 +125,7 @@ class TestNoProviderIsSubstituted:
     is indistinguishable from the requested one at the call site.
     """
 
-    @pytest.mark.parametrize("provider", ["lerobot_local", "groot", "cosmos3", "wbc"])
+    @pytest.mark.parametrize("provider", _SUBSTITUTION_CANDIDATES)
     def test_a_missing_dependency_raises_rather_than_substituting(
         self, provider: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -131,7 +134,10 @@ class TestNoProviderIsSubstituted:
             policies_mod.import_policy_class(provider)
         assert "mock" not in str(excinfo.value).lower()
 
-    def test_the_funnel_never_falls_back_to_the_mock_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize("provider", _SUBSTITUTION_CANDIDATES)
+    def test_the_funnel_never_falls_back_to_the_mock_provider(
+        self, provider: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Nothing the funnel returns on the failure path is a policy at all."""
         monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
         returned: list[Any] = []
@@ -140,8 +146,8 @@ class TestNoProviderIsSubstituted:
         # required -- a tree that stopped raising would still have to append nothing
         # for this to pass, which is the substitution being ruled out.
         with contextlib.suppress(ImportError):
-            returned.append(policies_mod.import_policy_class("lerobot_local"))
-        assert returned == [], f"the funnel returned {returned!r} instead of reporting"
+            returned.append(policies_mod.import_policy_class(provider))
+        assert returned == [], f"the funnel returned {returned!r} for {provider!r} instead of reporting"
 
 
 class TestAnUnknownProviderIsStillUnknown:

--- a/tests/registry/test_provider_import_error_names_its_remedy.py
+++ b/tests/registry/test_provider_import_error_names_its_remedy.py
@@ -1,0 +1,200 @@
+"""A provider whose optional dependency is missing reports its own remedy.
+
+Every policy provider except one defers its heavy import and reports a missing
+dependency through :func:`~strands_robots.utils.require_optional` /
+:func:`~strands_robots.utils.require_optionals`, which name the extra that ships
+it. ``lerobot_local`` imports ``torch`` at module level, so the failure happens
+while importing the provider's module - before any provider machinery runs - and
+the bare ``ModuleNotFoundError: No module named 'torch'`` that escaped named
+neither the provider the caller asked for nor the way to fix it.
+
+:func:`~strands_robots.registry.policies.import_policy_class` is the single
+funnel every provider class is imported through, so the translation lives there
+and the remedy no longer depends on WHERE a provider imports its dependency.
+
+Two further contracts are pinned here because both were reported as defects and
+neither existed:
+
+* No provider is ever SUBSTITUTED for another when its dependency is missing.
+  A silent swap to ``mock`` was reported; the factory has never done it, and
+  this pins that it cannot start.
+* A provider whose module exists but whose dependency is missing is not
+  misreported as an unknown provider. The auto-discovery branch swallowed the
+  ``ImportError`` and raised ``Unknown policy provider``, sending a caller who
+  had the name right to go and check the name.
+
+The absent dependency is emulated by making the import the funnel performs raise
+the exact ``ModuleNotFoundError`` the real import system raises (``name`` set),
+so the production path runs unchanged and the tests need no minimal install.
+"""
+
+import json
+import pathlib
+import tomllib
+from typing import Any
+
+import pytest
+
+import strands_robots.registry.policies as policies_mod
+from strands_robots.policies import create_policy
+
+#: Extra that ships ``lerobot_local``'s dependency, as declared in policies.json.
+_LEROBOT_EXTRA = "lerobot"
+
+
+def _absent(module: str) -> Any:
+    """Build an import_module stand-in that reports ``module`` as not installed.
+
+    Args:
+        module: Top-level module name to report absent.
+
+    Returns:
+        A callable raising the same ``ModuleNotFoundError`` (with ``name`` set)
+        that the import system raises for a package that is not installed.
+    """
+
+    def _import(name: str, *args: Any, **kwargs: Any) -> Any:
+        raise ModuleNotFoundError(f"No module named {module!r}", name=module)
+
+    return _import
+
+
+def _repo_root() -> pathlib.Path:
+    """Return the repository root, derived from the package under test.
+
+    ``policies.py`` sits at ``<root>/strands_robots/registry/``, so the root is
+    two parents up from the package directory. Derived from the module rather
+    than from a path literal so the guard follows the package.
+    """
+    root = pathlib.Path(policies_mod.__file__).resolve().parents[2]
+    assert (root / "pyproject.toml").is_file(), f"repo root not resolved: {root}"
+    return root
+
+
+class TestAMissingDependencyReportsItsRemedy:
+    """The translated error names the provider, the module and the fix."""
+
+    def test_it_names_the_provider_the_missing_module_and_the_install_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
+        with pytest.raises(ImportError) as excinfo:
+            policies_mod.import_policy_class("lerobot_local")
+        message = str(excinfo.value)
+        assert "lerobot_local" in message, message
+        assert "torch" in message, message
+        assert f"strands-robots[{_LEROBOT_EXTRA}]" in message, message
+
+    def test_the_original_import_error_is_kept_as_the_cause(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
+        with pytest.raises(ImportError) as excinfo:
+            policies_mod.import_policy_class("lerobot_local")
+        cause = excinfo.value.__cause__
+        assert isinstance(cause, ModuleNotFoundError), cause
+        assert getattr(cause, "name", None) == "torch"
+
+    def test_create_policy_propagates_the_actionable_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The report reaches the caller through the public entry point."""
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
+        with pytest.raises(ImportError) as excinfo:
+            create_policy("lerobot_local", pretrained_name_or_path="allenai/MolmoAct2-SO100_101")
+        message = str(excinfo.value)
+        assert f"strands-robots[{_LEROBOT_EXTRA}]" in message, message
+
+    def test_a_provider_declaring_no_extra_still_names_the_missing_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a declared extra the module is still named, not swallowed."""
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("pyzmq_stand_in"))
+        with pytest.raises(ImportError) as excinfo:
+            policies_mod.import_policy_class("groot")
+        message = str(excinfo.value)
+        assert "groot" in message, message
+        assert "pyzmq_stand_in" in message, message
+
+
+class TestNoProviderIsSubstituted:
+    """A missing dependency never yields a different provider's policy.
+
+    Reported as a silent swap to ``mock``; the factory has never done it. Pinned
+    so it cannot begin to - a swapped provider whose action space happens to fit
+    is indistinguishable from the requested one at the call site.
+    """
+
+    @pytest.mark.parametrize("provider", ["lerobot_local", "groot", "cosmos3", "wbc"])
+    def test_a_missing_dependency_raises_rather_than_substituting(
+        self, provider: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
+        with pytest.raises(ImportError) as excinfo:
+            policies_mod.import_policy_class(provider)
+        assert "mock" not in str(excinfo.value).lower()
+
+    def test_the_funnel_never_falls_back_to_the_mock_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nothing the funnel returns on the failure path is a policy at all."""
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
+        returned: list[Any] = []
+        try:
+            returned.append(policies_mod.import_policy_class("lerobot_local"))
+        except ImportError:
+            pass
+        assert returned == [], f"the funnel returned {returned!r} instead of reporting"
+
+
+class TestAnUnknownProviderIsStillUnknown:
+    """The translation does not swallow the unknown-provider report.
+
+    Over-reach control: the two failures are distinct and must stay distinct.
+    """
+
+    def test_an_unknown_name_is_a_value_error_naming_the_available_providers(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            policies_mod.import_policy_class("no_such_provider_at_all")
+        message = str(excinfo.value)
+        assert "no_such_provider_at_all" in message, message
+        assert "Available" in message, message
+
+    def test_an_existing_module_with_a_missing_dependency_is_not_reported_as_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The auto-discovery branch must not blame the provider name.
+
+        A module that imports but cannot satisfy its dependency reports the
+        dependency. Reported as an unknown provider it sent a caller whose name
+        was correct to go and check the name.
+        """
+        monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("some_missing_dep"))
+        with pytest.raises(ImportError) as excinfo:
+            policies_mod.import_policy_class("not_in_the_registry")
+        message = str(excinfo.value)
+        assert "some_missing_dep" in message, message
+        assert "Unknown policy provider" not in message, message
+
+
+class TestTheDeclaredExtrasAreReal:
+    """Every extra a provider names must be installable.
+
+    A remedy naming an extra that does not exist is a dead end wearing the
+    clothes of an instruction: ``pip`` exits 0 for an unknown extra and
+    installs nothing.
+    """
+
+    def test_every_provider_extra_is_declared_in_pyproject(self) -> None:
+        registry = json.loads(
+            (pathlib.Path(policies_mod.__file__).parent / "policies.json").read_text(encoding="utf-8")
+        )
+        pyproject = tomllib.loads((_repo_root() / "pyproject.toml").read_text(encoding="utf-8"))
+        declared = set(pyproject["project"]["optional-dependencies"])
+        named = {name: cfg["extra"] for name, cfg in registry["providers"].items() if cfg.get("extra") is not None}
+        assert named, "no provider declares an extra - this guard would pass vacuously"
+        assert named.get("lerobot_local") == _LEROBOT_EXTRA
+        undeclared = {p: e for p, e in named.items() if e not in declared}
+        assert not undeclared, f"providers naming an undeclared extra: {undeclared}"
+
+
+class TestAUsableProviderStillImports:
+    """Over-reach control: the translation only fires on a failed import."""
+
+    def test_a_provider_with_no_optional_dependency_imports_unchanged(self) -> None:
+        cls = policies_mod.import_policy_class("mock")
+        assert cls.__name__ == "MockPolicy"

--- a/tests/registry/test_provider_import_error_names_its_remedy.py
+++ b/tests/registry/test_provider_import_error_names_its_remedy.py
@@ -28,6 +28,7 @@ the exact ``ModuleNotFoundError`` the real import system raises (``name`` set),
 so the production path runs unchanged and the tests need no minimal install.
 """
 
+import contextlib
 import json
 import pathlib
 import tomllib
@@ -134,10 +135,12 @@ class TestNoProviderIsSubstituted:
         """Nothing the funnel returns on the failure path is a policy at all."""
         monkeypatch.setattr(policies_mod.importlib, "import_module", _absent("torch"))
         returned: list[Any] = []
-        try:
+        # The refusal itself is asserted by the cases above; this one is only about
+        # what the funnel RETURNS, so the ImportError is suppressed rather than
+        # required -- a tree that stopped raising would still have to append nothing
+        # for this to pass, which is the substitution being ruled out.
+        with contextlib.suppress(ImportError):
             returned.append(policies_mod.import_policy_class("lerobot_local"))
-        except ImportError:
-            pass
         assert returned == [], f"the funnel returned {returned!r} instead of reporting"
 
 


### PR DESCRIPTION
## Problem

`create_policy("lerobot_local", ...)` on an install without `torch` raised:

```
ModuleNotFoundError: No module named 'torch'
```

That error names neither the provider the caller asked for nor the way to fix it. Every
other policy provider defers its heavy import and reports a missing dependency through
`require_optional` / `require_optionals`, which name the extra that ships it -- 9 provider
modules do exactly that. `lerobot_local` imports `torch` at **module level**
(`policies/lerobot_local/policy.py:21`), so the failure happens while importing the
provider's module, before any provider machinery can run, and the bare import error escapes.

A second instance of the same gap sat in the auto-discovery branch, which caught the same
`ImportError` and `pass`ed, so the caller was told:

```
ValueError: Unknown policy provider: 'some_provider'. Available: [...]
```

A provider whose module exists but cannot import its dependency was reported as an unknown
provider -- sending a caller whose name was correct to go and check the name.

## Change

`import_policy_class` is the single funnel every provider class is imported through, so the
translation lives there. A failed provider import now reports the provider, the missing
module and the install command, taking the extra from the provider's new `extra` field in
`policies.json`:

```
ImportError: Policy provider 'lerobot_local' needs an optional dependency that is not installed:
  No module named 'torch'

Install the extra that ships it:
  uv pip install 'strands-robots[lerobot]'
```

The remedy therefore no longer depends on WHERE a provider happens to import its dependency.
The auto-discovery branch now distinguishes the two failures: a module that exists but cannot
satisfy its dependency reports the dependency, and an unknown provider is still reported as an
unknown provider. The original exception is kept as `__cause__`.

## Measured

`torch` is reported absent exactly as the import system reports it (`ModuleNotFoundError`,
`name` set), so the production path runs unchanged.

| surface | upstream/main | this PR |
| --- | --- | --- |
| names the provider | no | yes |
| names the missing module | yes | yes |
| names the install command | no | yes |
| module present, dependency absent | `ValueError: Unknown policy provider` | reports the dependency |
| substituted another provider | no | no |

The last row was reported as a silent swap to `mock`. It does not happen and never has --
but nothing pinned it, so this PR pins it: a failed import reports rather than returning a
different provider's policy whose action space happens to fit.

## Scope

Deferring `lerobot_local`'s `torch` import was measured and rejected as a separate change: the
module has no `from __future__ import annotations` and 6 signature annotations reference
`torch`, so they are evaluated at import time. Making the import lazy means the future import,
those 6 sites and 33 runtime uses across a 3147-line module on the hot policy path -- a
refactor with its own risk, and unnecessary once the funnel reports the remedy.

`start_recording` was also reported as silently degrading to raw MP4. Measured on both trees it
returns `status="error"`, names lerobot's dataset stack and points at `start_cameras_recording`
as the explicit alternative; `degraded_to_mp4` is `false`. The report is byte-identical on both
trees, asserted in the artifact generator, and is not changed here.

## Tests

`tests/registry/test_provider_import_error_names_its_remedy.py`, 16 cases. With the source
reverted to `upstream/main` and the tests kept: **6 failed / 10 passed**. The 10 that pass are the
over-reach controls -- the no-substitution cases, the unknown-provider `ValueError`, and a
provider with no optional dependency still importing -- which is what stops the tests being
satisfied by deleting anything.

One guard is self-maintaining: every `extra` a provider declares must be a really declared
`pyproject.toml` extra. `pip` exits 0 for an unknown extra and installs nothing, so a remedy
naming one that does not exist is a dead end wearing the clothes of an instruction.

Mutation table, 6 plausible regressions x 2 arms (anchors AST-scoped to their enclosing
function, `in_fn` printed, byte-identical restore):

| mutation | new tests | pre-existing (708) |
| --- | --- | --- |
| no translation (raw error escapes) | 4 failed | 0 failed |
| call the translator, discard the verdict | 4 failed | 0 failed |
| swallow the `ImportError` again | 1 failed | 0 failed |
| ignore the declared extra | 2 failed | 0 failed |
| substitute `mock` on a failed import | 9 failed | 0 failed |
| drop the extra from the registry | 3 failed | 0 failed |

6 of 6 caught here; 6 of 6 invisible to the 708 pre-existing registry tests. The
`substitute mock` row is the reported defect: it fails 12 of 16, so it cannot begin.

## Gate

On Thor at `83cc5272`:

* `MUJOCO_GL=egl pytest tests` -- **28696 passed / 258 skipped / 0 failed** (10:29) at head `bb9cc178`.
  Pristine main at the same commit is 28680 passed / 258 skipped, so the delta is exactly the 16 new cases.
* `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` -- clean, 0 errors.
* `scripts/check_merge_base_overlap.py` -- no overlap; 0 paths changed on `upstream/main` since
  the branch point, so the numbers above describe the tree that merges.

## Artifact

![measured verdict](https://raw.githubusercontent.com/cagataycali/robots/artifacts/provider-import-remedy/provider-import-remedy.png)

A diagnostic change: no policy inference, simulation, rendering, recording or asset behaviour
moves, so the artifact is the measurement rather than a rollout. Every value in it is read from
two capture runs -- one in a worktree at `upstream/main`, one on this branch -- and the generator
asserts each rendered value against those dumps, that the two arms measured different trees, and
that the recording report is byte-identical across them. Capture, compose and mutation scripts
are published alongside it.

## Note on the gated tree

The gate above ran at `c985806`. The pushed head `fea1a1cb` differs from it only in the
changelog fragment's filename: it was written as `2222-` before this PR had a number and
renamed to `2226-` once it did. No source or test line differs; `assemble_changelog.py --check`
and both changelog guards were re-run after the rename.

## Review rounds

**Round 1** -- `8fe3655`. One CodeQL "Empty except" alert on the return-path case
(`test_the_funnel_never_falls_back_to_the_mock_provider`): it caught `ImportError` with a
bare `pass` and no statement of intent, which is indistinguishable from a swallowed
failure at a glance -- and in a module whose whole subject is an `ImportError` that used
to be swallowed, that shape is the wrong thing to leave in the tests.

Fixed structurally rather than annotated: `contextlib.suppress(ImportError)` states the
same intent in the language, so the shape is gone instead of carrying an exemption
comment. The accompanying comment records why the refusal is *not* asserted in this one
case -- the four cases above already pin that it raises, and this case exists to pin what
the funnel **returns** on the failure path, so a tree that stopped raising altogether
would still have to append nothing for it to pass. That is the substitution being ruled
out, and suppressing rather than requiring the exception is what keeps the case measuring
it.

No assertion, case count or provider behaviour changed: still 13 cases, and
`strands_robots/` is untouched by this round.

*Measured this round* -- narrower than the Gate above, which stands for the source change:

* The branch composed with `main` at `ca70639` -- `main` moved 6 commits since the Gate --
  merges cleanly, and the 13 cases plus both repo-wide guards that landed in the meantime
  and now scan this file (#2208's implicit-string-concatenation-in-lists over `tests/`,
  #2211's `__all__`-statically-defined scan) report **40 passed**.
* `ruff check` and `ruff format --check` on the changed file: clean.

The two guards are the reason the composition was run rather than the file alone: both are
merge-blocking, both are new since this branch's Gate, and both scan `tests/` -- so neither
had ever been evaluated against this test module.

**Round 2** -- `bb9cc178`. Keeps Round 1's `contextlib.suppress` shape and comment, which are
the better answer than the `_resolve_outcome` helper I had written for the same alert, and adds
only the widening Round 1 left on the table.

The two cases in `TestNoProviderIsSubstituted` ask the same question from the two sides a call
can answer on: one asserts the raise, the other asserts that nothing comes back. The raise side
already covered four providers and the return side covered one, so a substitution reachable only
through `groot`, `cosmos3` or `wbc` was pinned in the control-flow framing and not in the data
framing. Both decorators now read one `_SUBSTITUTION_CANDIDATES` tuple, so the pair cannot drift.

*Measured this round:*

| module version | py/empty-except findings | failures under the `MockPolicy` mutation |
|---|---|---|
| as first pushed | `[(139, 9, 28)]` | 9 |
| Round 1 `8fe3655f` | `[]` | 9 |
| Round 2 `bb9cc178` | `[]` | **12** |

The findings column is a mirror of the rule validated against this alert's own reported location,
which it reproduces at exactly `139:9-28`. The unmutated control is 0 failures on all three
shapes. 13 cases -> 16, and the whole-PR pre-fix proof re-derived at this head is
`6 failed / 10 passed`: the failing count is unchanged and the entire delta is in the passing
count, which is the three new cases. `strands_robots/` is untouched by this round, so the Gate
above was
re-run rather than narrowed: `28696 passed / 258 skipped / 0 failed`, lint triple clean, and
`check_merge_base_overlap.py` reports no overlap with the 22 paths `main` gained since the branch
point (Isaac, `pose_tool`, CI -- none of which this test reads).

