### PR TITLE
fix(simulation): write a bare output filename into the sandbox instead of refusing it

### DIFF
--- a/changelog.d/2227-bare-output-filename-anchors-to-sandbox.md
+++ b/changelog.d/2227-bare-output-filename-anchors-to-sandbox.md
@@ -1,0 +1,10 @@
+### Fixed: a bare output filename is written into the sandbox instead of being refused
+
+`validate_output_path` resolved every relative path against the process CWD, so
+under confinement the most natural call a caller can make -- `render(output_path="frame.png")`
+-- was always refused, and the refusal quoted a CWD-absolute path the caller
+never supplied. A one-component name is now anchored to the sandbox root. The
+rule is narrow and cannot widen the sandbox: it applies only when confinement is
+active and only to a single-component name, `..` is still refused, and the
+symlink probe now inspects the anchored destination. Guards-only mode (the
+historic video/recording contract) is unchanged.

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -927,7 +927,10 @@ class RenderingMixin:
         ``~/.strands_robots/renders``); paths with shell metacharacters,
         backslash separators, ``..`` escapes, or a symlinked target, and PNGs
         larger than ``STRANDS_ROBOTS_RENDER_MAX_BYTES`` (default 50 MB) are
-        rejected with ``status=error``. Set ``STRANDS_ROBOTS_RENDER_ALLOW_ABS=1``
+        rejected with ``status=error``. A bare filename (``"frame.png"``) is
+        written INTO the sandbox rather than resolved against the process CWD,
+        so it needs no directory to succeed. Set
+        ``STRANDS_ROBOTS_RENDER_ALLOW_ABS=1``
         to permit absolute paths outside the sandbox. The write is atomic
         (temp file + ``os.replace``), so a crash mid-write cannot corrupt an
         existing file at the destination.

--- a/strands_robots/simulation/safe_output.py
+++ b/strands_robots/simulation/safe_output.py
@@ -76,6 +76,15 @@ def validate_output_path(
     target. Normalizes ``..`` via ``resolve()``. When ``sandbox_root`` is given
     and ``allow_abs`` is False, the resolved path must live under it.
 
+    A bare filename (one component, no separator, e.g. ``"frame.png"``) is
+    anchored to ``sandbox_root`` rather than the process CWD whenever
+    confinement is active. Without that, the most natural call a caller can
+    make is refused for naming a CWD path it never supplied. The anchoring
+    cannot widen the sandbox: it applies only to a single-component name, and
+    every guard above still runs against the anchored destination. In
+    guards-only mode (``sandbox_root=None`` or ``allow_abs=True``) a relative
+    name stays CWD-relative, preserving the historic video/recording contract.
+
     Args:
         output_path: Caller-supplied destination path.
         sandbox_root: Directory the path must resolve under, or ``None`` to skip
@@ -98,6 +107,17 @@ def validate_output_path(
     # directory, while plain absolute paths without ".." remain permitted.
     if ".." in raw.parts:
         raise ValueError(f"unsafe {label}: path traversal")
+    # A bare filename ("frame.png") names no directory, so resolving it against
+    # the process CWD is a guess - and under confinement it is a guess that
+    # always fails, refusing the call with a CWD-absolute path the caller never
+    # supplied. Anchor it to the sandbox root instead: a one-component name
+    # cannot escape it, and ".." is refused above by a check that scans every
+    # part (so it holds for the joined path too). Done BEFORE the symlink probe
+    # below because that guard must inspect the destination actually opened -
+    # after it, a link planted inside the sandbox would be probed at the CWD
+    # path instead and followed.
+    if sandbox_root is not None and not allow_abs and not raw.is_absolute() and len(raw.parts) == 1:
+        raw = sandbox_root / raw
     # Refuse to follow a symlink planted at the target (arbitrary-write vector).
     if raw.is_symlink():
         raise ValueError(f"{label} {output_path!r} is a symlink - refusing to follow")

--- a/tests/simulation/mujoco/test_render_output_path_roundtrip.py
+++ b/tests/simulation/mujoco/test_render_output_path_roundtrip.py
@@ -95,3 +95,26 @@ def test_render_rejects_unsafe_output_path_without_writing(sandbox) -> None:
         assert not (sandbox.parent / "escape.png").exists()
     finally:
         sim.cleanup()
+
+
+@_requires_mujoco
+def test_render_bare_filename_writes_into_the_sandbox(sandbox) -> None:
+    """``output_path="frame.png"`` persists the PNG without naming a directory.
+
+    A bare name is the most natural call an agent makes. It carries no directory
+    intent, so it is anchored to the render sandbox rather than resolved against
+    the process CWD (which, under confinement, could only be refused).
+    """
+    from strands_robots import Robot
+
+    sim = Robot("so101", mesh=False)
+    try:
+        result = sim.render(camera_name="default", width=64, height=48, output_path="frame.png")
+        assert result["status"] == "success", result
+        saved = _json_block(result)["saved_path"]
+        assert saved == str(sandbox / "frame.png")
+        written = sandbox / "frame.png"
+        assert written.is_file(), f"no file at {written}"
+        assert written.read_bytes() == _png_block(result)
+    finally:
+        sim.cleanup()

--- a/tests/simulation/test_output_path_sandbox.py
+++ b/tests/simulation/test_output_path_sandbox.py
@@ -223,3 +223,96 @@ def test_atomic_write_preserves_existing_on_failure(tmp_path, monkeypatch):
     assert target.read_bytes() == b"ORIGINAL"
     leftovers = [p for p in target.parent.iterdir() if p.name.endswith(".tmp")]
     assert leftovers == []
+
+
+# --- bare filenames anchor to the sandbox instead of the process CWD ---------
+
+
+def test_sandbox_anchors_bare_filename_to_root(tmp_path):
+    """A one-component name lands in the sandbox, not under the process CWD."""
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    resolved = validate_output_path("frame.png", sandbox_root=root, allow_abs=False)
+    assert resolved == (root / "frame.png").resolve()
+
+
+def test_bare_filename_anchoring_ignores_cwd(tmp_path, monkeypatch):
+    """The destination is the sandbox root wherever the process happens to be."""
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    resolved = validate_output_path("frame.png", sandbox_root=root, allow_abs=False)
+    assert resolved == (root / "frame.png").resolve()
+    assert not str(resolved).startswith(str(elsewhere.resolve()))
+
+
+def test_sandbox_still_rejects_relative_path_with_separator(tmp_path, monkeypatch):
+    """Anchoring is narrow: a multi-component relative path is untouched.
+
+    ``sub/frame.png`` names a directory, so it keeps resolving against the CWD
+    and stays subject to confinement. Only a bare name is anchored.
+    """
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="outside the sandbox"):
+        validate_output_path("sub/frame.png", sandbox_root=root, allow_abs=False)
+
+
+def test_sandbox_rejects_bare_dotdot_before_anchoring(tmp_path):
+    """``..`` is one component, so only the traversal guard's position saves it.
+
+    ``Path("..").parts`` is ``("..",)`` - a single component that is not
+    absolute, i.e. exactly the shape the anchoring branch matches. The traversal
+    check runs first, so the escape is refused rather than anchored.
+    """
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    with pytest.raises(ValueError, match="path traversal"):
+        validate_output_path("..", sandbox_root=root, allow_abs=False)
+
+
+def test_sandbox_refuses_symlink_planted_at_anchored_destination(tmp_path):
+    """The symlink probe inspects the anchored path, not the CWD-relative one.
+
+    A symlink planted inside the sandbox at the bare name's destination is an
+    arbitrary-write vector. Anchoring happens before the symlink check so the
+    check sees the path that would actually be opened.
+    """
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"x")
+    (root / "frame.png").symlink_to(outside)
+    # Match the reason, not the word "symlink": pytest derives tmp_path from the
+    # test name, so that word appears in every interpolated path in this test.
+    with pytest.raises(ValueError, match="refusing to follow"):
+        validate_output_path("frame.png", sandbox_root=root, allow_abs=False)
+
+
+def test_anchored_bare_filename_still_rejects_metacharacters(tmp_path):
+    """Anchoring does not bypass the unconditional character guards."""
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    with pytest.raises(ValueError, match="metacharacters"):
+        validate_output_path("frame;rm.png", sandbox_root=root, allow_abs=False)
+
+
+def test_guards_only_leaves_bare_filename_cwd_relative(tmp_path, monkeypatch):
+    """With no sandbox root a bare name stays CWD-relative (historic contract)."""
+    monkeypatch.chdir(tmp_path)
+    resolved = validate_output_path("clip.mp4", sandbox_root=None, allow_abs=True)
+    assert resolved == (tmp_path / "clip.mp4").resolve()
+
+
+def test_allow_abs_leaves_bare_filename_cwd_relative(tmp_path, monkeypatch):
+    """``allow_abs`` opts out of confinement, so anchoring does not apply."""
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    resolved = validate_output_path("clip.mp4", sandbox_root=root, allow_abs=True)
+    assert resolved == (elsewhere / "clip.mp4").resolve()


### PR DESCRIPTION
## Problem

`validate_output_path` is the single owner of the path guards behind
`render(output_path=...)`, `run_policy(video={"path": ...})` and
`start_cameras_recording(output_dir=...)`. It resolved **every** relative path
against the process CWD:

```python
raw = Path(output_path).expanduser()
...
resolved = raw.resolve(strict=False)      # relative -> CWD
if sandbox_root is not None and not allow_abs:
    if not resolved.is_relative_to(sandbox_root):
        raise ValueError(f"{label} {resolved} is outside the sandbox ...")
```

Under confinement that makes a bare filename **impossible to satisfy**: it is
resolved against a directory the sandbox does not contain, so the only reachable
outcome is a refusal — and the refusal quotes a CWD-absolute path the caller
never supplied.

Measured on Thor against `upstream/main` 83cc5272:

| call | main | this change |
|---|---|---|
| `render(output_path="frame.png")` | `status="error"`, no file written | `status="success"`, PNG in the sandbox |
| the reason it gave | `output_path /tmp/robots-mine-.../frame.png is outside the sandbox` | — |

The quoted path is the CWD. A caller who names no directory has expressed no
directory intent, so resolving against the CWD is a guess, and under confinement
it is a guess that can only fail.

## Change

Anchor a one-component relative name to the sandbox root before resolution:

```python
if sandbox_root is not None and not allow_abs and not raw.is_absolute() and len(raw.parts) == 1:
    raw = sandbox_root / raw
```

Four conditions keep it from widening the sandbox:

- `sandbox_root is not None` — guards-only mode (the historic video/recording
  contract) is untouched.
- `not allow_abs` — the documented opt-out still means CWD-relative.
- `not raw.is_absolute()` and `len(raw.parts) == 1` — only a name with no
  directory component. `sub/frame.png` expresses directory intent and keeps
  resolving against the CWD.

It runs **before** the symlink probe, so that guard inspects the destination that
is actually opened. `..` is refused above it by a check that scans every part, so
that check holds for the joined path too.

`render()`'s docstring now states the behaviour in the same paragraph that
documents the sandbox, so a caller reading the constraint also reads that a bare
name needs no directory.

## Every case measured

| input | confinement | main | this change |
|---|---|---|---|
| `frame.png` | sandbox | refused (outside the sandbox) | -> sandbox root |
| `sub/frame.png` | sandbox | refused | refused |
| `..` | sandbox | refused (path traversal) | refused (path traversal) |
| `/tmp/x.png` | sandbox | refused | refused |
| `frame;rm.png` | sandbox | refused (shell metacharacters) | refused (shell metacharacters) |
| `clip.mp4` | guards-only | -> process CWD | -> process CWD |
| `evil.png` -> symlink | sandbox | refused (outside the sandbox) | refused (**is a symlink**) |

One verdict changes. Five are byte-identical. The symlink row refuses on both
trees but for different reasons: on `main` the link is never recognised as a link
(the CWD path is probed, then `resolve()` follows it and confinement catches the
target incidentally); with the anchoring the probe sees the link itself, which is
the accurate reason.

## Tests

9 new cases across the two owners of this contract — the helper's own module and
the render round-trip. Pre-fix (source reverted to `main`, tests kept):
**3 failed / 51 passed**; the 51 passing are the security controls, which is what
stops the new tests being satisfied by removing a guard.

Mutations (5 regressions x 2 arms):

| mutation | new cases | 45 pre-existing |
|---|---|---|
| M1 delete the anchoring | 4 failed | 0 failed |
| M2 anchor before the traversal guard | 0 failed | 0 failed |
| M3 anchor after the symlink probe | 1 failed | 0 failed |
| M4 widen to any relative path | 1 failed | 0 failed |
| M5 anchor even when `allow_abs` opted out | 1 failed | 0 failed |

4 of 5 caught here, 0 of 5 by the pre-existing suite. **M2 is reported rather than
padded**: it is provably unobservable, because the traversal check is
`".." in raw.parts` and scans every component, so joining the sandbox root cannot
hide a `..` — both orders refuse. Writing M3 is what exposed a vacuous assertion
in my own first draft: `pytest.raises(match="symlink")` inside a test whose name
contains "symlink" matched pytest's `tmp_path` in the message rather than the
reason, so it passed under the mutation. It now matches `refusing to follow`.

## Artifact

![bare filename anchors to the sandbox](https://raw.githubusercontent.com/cagataycali/robots/artifacts/bare-filename-sandbox/bare-filename-sandbox.png)

Left: `main` has no file to show — the panel carries the verbatim refusal. Right:
the real 320x240 frame this change writes into the sandbox (98.34% saturated
pixels). Below: every case, and the gate. Capture, compose and mutation scripts
are on [`artifacts/bare-filename-sandbox`](https://github.com/cagataycali/robots/tree/artifacts/bare-filename-sandbox); `compose.py`
asserts each rendered number against the two JSON dumps.

## Gate

- Full suite on Thor, `MUJOCO_GL=egl`, base 83cc5272: **28689 passed / 258
  skipped / 0 failed** in 657s (pristine `main` 28680 + the 9 new cases).
- `ruff check` / `ruff format --check` clean (1190 files).
- `mypy strands_robots tests tests_integ`: **0 errors outside
  `examples/isaac_gs`** (14 there, byte-identical to a pristine-base worktree, so
  environmental).
- `scripts/check_merge_base_overlap.py`: no overlap. The 22 paths `main` gained
  since the divergence are disjoint from the 5 this branch touches, and nothing
  added here scans a directory, so the verdict is not base-dependent.
- Shares `safe_output.py` with my open #2224, whose hunks are at lines 4-28
  (module header) against 76-124 here; `git merge-tree --write-tree` returns 0,
  so both can land in either order.
