### PR TITLE
fix(ros_telemetry): report an unreadable joint_command position instead of raising

### DIFF
--- a/changelog.d/2228-malformed-joint-command-costs-one-message.md
+++ b/changelog.d/2228-malformed-joint-command-costs-one-message.md
@@ -1,0 +1,19 @@
+### Fixed: a malformed `joint_command` position no longer discards the commands queued behind it
+
+`RosTelemetryBase._command_action` promises an action dict or `None`, but a
+position `float()` could not read escaped as `ValueError`/`TypeError`. What that
+cost depended on the transport: rclpy delivers one callback per `spin_once`, so
+the raise cost that one message, while the cyclonedds `_poll_loop` calls
+`take(N=10)` and has therefore already consumed a batch - the raise aborted the
+dispatch loop, so every sample *behind* the malformed one was dropped with it.
+Measured on a three-sample batch, one of two valid commands was applied.
+
+The parser now reports the offending joint and value and returns `None`,
+rejecting the message whole exactly as it already did for a length mismatch and
+an out-of-range joint, so the failure costs itself on either transport.
+Finiteness is unchanged: a `nan` position is a readable number that
+`send_action` already refuses naming the joint.
+
+Also drives the three cyclonedds poll-loop contracts its rclpy sibling has
+pinned all along - a taken sample is dispatched, a reader failure costs only
+that tick, and a second start spawns no second thread.

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -248,7 +248,10 @@ class RosTelemetryBase:
         empty sample (a DDS dispose / keep-alive, which is not a real actuation
         request) is dropped silently; an empty or length-mismatched message is
         otherwise rejected with a warning rather than partially applied, so a
-        malformed command never drives the arm to a surprising pose.
+        malformed command never drives the arm to a surprising pose. A position
+        that is not a readable number rejects the message the same way - it is
+        reported and returns ``None`` rather than raising, so the failure costs
+        exactly the one message on either transport.
 
         When ``joint_limits`` is supplied (``{motor: (min, max)}``), the command
         is range-checked against the declared bounds: if ANY commanded joint
@@ -275,7 +278,29 @@ class RosTelemetryBase:
                 len(positions),
             )
             return None
-        action = {name: float(pos) for name, pos in zip(names, positions)}
+        action: dict[str, float] = {}
+        for name, pos in zip(names, positions):
+            try:
+                action[name] = float(pos)
+            except (TypeError, ValueError):
+                # A position this cannot read is a malformed command, not a
+                # reason to raise: this method's contract is an action dict or
+                # None. Refusing the message WHOLE matches the length-mismatch
+                # and out-of-range branches - no partial application - and it
+                # keeps the failure inside the parser, where it costs exactly
+                # the one message. Escaping instead reached each transport's
+                # loop tolerance, and the cyclonedds loop has already taken a
+                # batch by then, so the samples behind this one were dropped
+                # with it. Finiteness is deliberately not checked here: a nan
+                # position is a readable number that ``send_action`` refuses
+                # naming the joint.
+                logger.warning(
+                    "%s: ignoring joint_command with a non-numeric position for %r: %r",
+                    type(self).__name__,
+                    name,
+                    pos,
+                )
+                return None
         if joint_limits:
             for name, pos in action.items():
                 bounds = joint_limits.get(name)

--- a/tests/test_hardware_rtps_bridge.py
+++ b/tests/test_hardware_rtps_bridge.py
@@ -419,3 +419,20 @@ def test_invalid_joint_limits_raise_at_construction(fake_cyclonedds: dict[str, A
         _bridge(_FakeRobot(), joint_limits={"a": (1.0, -1.0)})
     with pytest.raises(ValueError, match="must be a"):
         _bridge(_FakeRobot(), joint_limits={"a": 5.0})  # type: ignore[dict-item]
+
+
+def test_start_poll_is_idempotent(fake_cyclonedds: dict[str, Any]) -> None:
+    """A second start while the poll thread is alive spawns no second thread.
+
+    The cyclonedds mirror of ``test_start_spin_is_idempotent``: two threads on
+    one reader would each ``take()`` and split the command stream between them.
+    """
+    b = _bridge(_FakeRobot())  # enable_commands default -> poll thread started
+    first = b._poll_thread
+    assert first is not None and first.is_alive()
+
+    b._start_poll()
+    assert b._poll_thread is first
+
+    b.shutdown()
+    assert b._poll_thread is None

--- a/tests/test_inbound_command_costs_one_message.py
+++ b/tests/test_inbound_command_costs_one_message.py
@@ -1,0 +1,196 @@
+"""One failure on the inbound command path costs exactly one message.
+
+Both hardware bridges deliver ``/<robot>/joint_command`` into
+:meth:`~strands_robots.ros_telemetry.RosTelemetryBase._command_action`, whose
+contract is an action dict or ``None`` - never an exception. A position it could
+not read used to escape as ``ValueError``/``TypeError``, and what that cost
+depended on the transport:
+
+* rclpy delivers one subscription callback per ``spin_once``, so the raise was
+  absorbed by ``_spin_loop``'s tolerance and cost that one message.
+* cyclonedds has no executor: ``_poll_loop`` calls ``take(N=10)``, which has
+  already consumed the batch by the time a sample is parsed. The raise aborted
+  the ``for``, so every sample *behind* the malformed one was discarded with it -
+  valid commands that had already arrived, dropped with a DEBUG line.
+
+The parser now reports the position and returns ``None``, so a malformed command
+costs itself on either transport. The classes below pin that, the values that
+were always readable (including ``nan``, whose finiteness ``send_action`` owns),
+and the three contracts of the cyclonedds poll loop that its rclpy sibling has
+pinned all along in ``test_hardware_ros_bridge.py``: a sample taken by the loop
+is dispatched, a reader failure costs only that tick, and a second start spawns
+no second thread (that last one lives beside its siblings in
+``test_hardware_rtps_bridge.py``).
+
+The loop is driven synchronously against a recording stop event: the command
+thread is a background daemon coverage cannot trace, which is the same reason
+the rclpy module gives for driving ``_spin_loop`` in the test thread.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_ros_bridge import HardwareRosBridge
+from strands_robots.hardware_rtps_bridge import HardwareRtpsBridge
+from strands_robots.ros_telemetry import RosTelemetryBase
+from tests.test_hardware_rtps_bridge import _FakeReader, _FakeRobot, _JointState
+from tests.test_wait_budget_domain import _RecordingStop
+
+_LOGGER = "strands_robots.ros_telemetry"
+
+#: Positions ``float()`` cannot read. Exactly the set that used to raise.
+_UNREADABLE = [
+    pytest.param("not-a-number", id="non-numeric-string"),
+    pytest.param(None, id="None"),
+    pytest.param([0.1], id="list"),
+    pytest.param({"j": 0.1}, id="dict"),
+    pytest.param(object(), id="object"),
+]
+
+#: Positions that were readable before this change and must stay readable.
+_READABLE = [
+    pytest.param(0.5, 0.5, id="float"),
+    pytest.param(1, 1.0, id="int"),
+    pytest.param("0.5", 0.5, id="numeric-string"),
+    pytest.param(True, 1.0, id="bool"),
+]
+
+
+def _poll_skeleton(reader: Any, robot: Any, *, iterations: int) -> Any:
+    """A bridge whose poll loop can be driven in the traced test thread.
+
+    ``__new__`` skips ``__init__``, so no DDS participant is built and no poll
+    thread is started; the loop body then runs synchronously with no race
+    against a live daemon. Typed ``Any`` because the skeleton is deliberately
+    partial - only what ``_poll_loop`` reads is wired.
+    """
+    bridge: Any = HardwareRtpsBridge.__new__(HardwareRtpsBridge)
+    bridge._robot = robot
+    bridge._command_reader = reader
+    bridge._poll_period = 0.001
+    bridge._joint_limits = None
+    bridge._stop = _RecordingStop(iterations)
+    return bridge
+
+
+class TestAPositionThatCannotBeReadRejectsTheMessage:
+    """The parser reports it and returns ``None`` - it does not raise."""
+
+    @pytest.mark.parametrize("position", _UNREADABLE)
+    def test_an_unreadable_position_returns_none(self, position: Any) -> None:
+        base = RosTelemetryBase()
+        assert base._command_action(_JointState(name=["j0"], position=[position])) is None
+
+    @pytest.mark.parametrize("position", _UNREADABLE)
+    def test_an_unreadable_position_is_reported(self, position: Any, caplog: pytest.LogCaptureFixture) -> None:
+        base = RosTelemetryBase()
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            base._command_action(_JointState(name=["j0"], position=[position]))
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING], "the refusal was not reported at all"
+        assert any("non-numeric position" in r.getMessage() for r in caplog.records)
+
+    def test_the_report_names_the_joint_and_the_value(self, caplog: pytest.LogCaptureFixture) -> None:
+        base = RosTelemetryBase()
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            base._command_action(_JointState(name=["ok", "wrist"], position=[0.5, "spin"]))
+        assert caplog.records, "the refusal was not reported at all"
+        message = caplog.records[-1].getMessage()
+        assert "'wrist'" in message, message
+        assert "'spin'" in message, message
+
+    def test_the_whole_command_is_rejected_not_partially_applied(self) -> None:
+        # The readable joint precedes the unreadable one, so a parser that
+        # applied what it could would move "ok" and leave "wrist" behind.
+        robot = _FakeRobot()
+        RosTelemetryBase()._drive_from_command(robot, _JointState(name=["ok", "wrist"], position=[0.5, "spin"]))
+        assert robot.sent_actions == []
+
+
+class TestEveryReadablePositionStaysReadable:
+    """The refused set is exactly what used to raise - nothing wider."""
+
+    @pytest.mark.parametrize(("position", "expected"), _READABLE)
+    def test_a_readable_position_is_still_accepted(self, position: Any, expected: float) -> None:
+        base = RosTelemetryBase()
+        assert base._command_action(_JointState(name=["j0"], position=[position])) == {"j0": expected}
+
+    def test_a_nan_position_is_still_read(self) -> None:
+        """Finiteness is not this parser's job.
+
+        ``nan`` is a readable number, and ``send_action`` already refuses a
+        non-finite action value naming the joint - so checking it here would
+        move that report away from the surface that owns it.
+        """
+        base = RosTelemetryBase()
+        action = base._command_action(_JointState(name=["j0"], position=[float("nan")]))
+        assert action is not None
+        assert action["j0"] != action["j0"]  # nan
+
+
+class TestBothTransportsGetTheSameRefusal:
+    """The parser is one inherited function, so neither transport can drift."""
+
+    def test_the_parser_is_shared_by_both_bridges(self) -> None:
+        assert HardwareRosBridge._command_action is RosTelemetryBase._command_action
+        assert HardwareRtpsBridge._command_action is RosTelemetryBase._command_action
+
+    @pytest.mark.parametrize("bridge_cls", [HardwareRosBridge, HardwareRtpsBridge])
+    def test_each_bridge_refuses_the_same_message(self, bridge_cls: Any) -> None:
+        # ``Any`` so ``__new__`` is reachable: skipping ``__init__`` is the point
+        # here - the parser reads only ``type(self).__name__``.
+        bridge: Any = bridge_cls.__new__(bridge_cls)
+        assert bridge._command_action(_JointState(name=["j0"], position=["nope"])) is None
+
+
+class TestTheCyclonedddsLoopKeepsTheRestOfTheBatch:
+    """``take(N=10)`` consumes a batch, so one bad sample must not cost the rest."""
+
+    def test_the_samples_behind_an_unreadable_one_are_still_applied(self) -> None:
+        robot = _FakeRobot()
+        reader = _FakeReader("/arm/joint_command")
+        reader.feed(_JointState(name=["j0"], position=[0.1]))
+        reader.feed(_JointState(name=["j1"], position=["not-a-number"]))
+        reader.feed(_JointState(name=["j2"], position=[0.3]))
+
+        _poll_skeleton(reader, robot, iterations=1)._poll_loop()
+
+        # Both valid commands land; only the malformed one is dropped.
+        assert robot.sent_actions == [{"j0": 0.1}, {"j2": 0.3}]
+
+    def test_the_loop_dispatches_every_sample_of_a_batch(self) -> None:
+        robot = _FakeRobot()
+        reader = _FakeReader("/arm/joint_command")
+        for i in range(3):
+            reader.feed(_JointState(name=[f"j{i}"], position=[float(i)]))
+
+        _poll_skeleton(reader, robot, iterations=1)._poll_loop()
+
+        assert robot.sent_actions == [{"j0": 0.0}, {"j1": 1.0}, {"j2": 2.0}]
+
+
+class TestAReaderFailureCostsOnlyThatTick:
+    """The cyclonedds mirror of ``test_command_spin_loop_survives_a_transient_spin_once_failure``."""
+
+    def test_a_take_that_raises_does_not_kill_the_loop(self) -> None:
+        class _FlakyReader:
+            def __init__(self) -> None:
+                self.takes = 0
+
+            def take(self, N: int = 10) -> list[Any]:
+                self.takes += 1
+                if self.takes == 1:
+                    raise RuntimeError("cyclonedds take failed")
+                # Reached only if the loop survived the failure above.
+                return [_JointState(name=["j0"], position=[0.75])]
+
+        robot = _FakeRobot()
+        reader = _FlakyReader()
+
+        _poll_skeleton(reader, robot, iterations=2)._poll_loop()  # must not propagate
+
+        assert reader.takes == 2, "the loop stopped at the failing tick"
+        assert robot.sent_actions == [{"j0": 0.75}]


### PR DESCRIPTION
## Problem

`RosTelemetryBase._command_action` parses every inbound `/<robot>/joint_command`
for both hardware bridges. Its docstring states the contract:

> Returns: The action mapping, or `None` if the message is unusable.

It built the dict with a bare `float(pos)`, so a position it could not read
escaped as `ValueError`/`TypeError`. **What that cost depended on the transport.**

rclpy delivers one subscription callback per `spin_once`, so the raise was
absorbed by `_spin_loop`'s tolerance and cost that one message. cyclonedds has
no executor: `_poll_loop` calls `take(N=10)`, which has **already consumed the
batch** by the time a sample is parsed, and the raise aborted the `for` - so
every sample *behind* the malformed one was discarded with it. Valid commands
that had already arrived, dropped with a DEBUG line.

Measured on a three-sample batch `(valid pose, malformed position, final pose)`
driven through the real poll loop with a MuJoCo so101 behind it:

| | commands applied | final pose |
| --- | --- | --- |
| `main` | 1 of 2 valid | stranded at the intermediate pose |
| this PR | 2 of 2 valid | the commanded pose, joint for joint |

The lost command left one joint **2.2359 rad (128 deg)** from where it was told
to go, and the operator's only signal was `DEBUG ... command poll error`.

## Why this is a defect rather than a documented outcome

Three things in the file already say so:

- `_command_action`'s own `Returns:` promises an action dict or `None`.
- It already rejects an **empty** message and a **length mismatch** by returning
  `None`, and rejects an out-of-range joint whole - "so one out-of-range joint
  can never drive part of the arm while the rest holds". An unreadable position
  was the one malformed input it raised on instead.
- `_poll_loop`'s tolerance is documented for "one bad sample" and
  `_spin_loop`'s comment says a failure "must not kill the command path". On
  cyclonedds a raise mid-batch is not one bad sample.

## The fix

Read each position under `try` and, on failure, report the offending joint and
value and return `None` - the same all-or-nothing rejection the length mismatch
and the range check already use, so the failure costs itself on either transport.

## Scope

- **Finiteness is unchanged.** `nan` is a readable number and `send_action`
  already refuses a non-finite action value naming the joint; checking it here
  would move that report away from the surface that owns it.
- **The refused set is exactly what used to raise.** A numeric string still
  reads; `bool` and `int` still read.
- **`_poll_loop`'s outer tolerance stays.** A reader failure (`take()` raising)
  is a DDS-layer failure, not a parse failure, and is still absorbed per tick.
- **No docs page changes.** No `docs/*.md` enumerates the malformed-message
  reasons - the two that discuss rejecting a command whole are about
  `joint_limits`, a guard the caller threads through `Robot()`. The contract
  lives on `_command_action`, whose docstring this PR updates.

## Tests

`tests/test_inbound_command_costs_one_message.py` (23 cases) plus one
sibling-mirroring case in `tests/test_hardware_rtps_bridge.py`:

- the parser returns `None` and reports the joint and value for five unreadable
  value classes, and the whole command is rejected rather than partially applied;
- every readable position still reads, `nan` included (the over-reach control);
- the parser is one inherited function, so neither transport can drift;
- **the samples behind a malformed one are still applied** - the batch-integrity
  contract, the case that fails on `main`;
- the three cyclonedds poll-loop contracts its rclpy sibling has pinned all
  along: a taken sample is dispatched, a reader failure costs only that tick,
  and a second `_start_poll` spawns no second thread.

**Pre-fix proof** (source reverted to `upstream/main`, tests kept):
`15 failed / 30 passed`. The decisive line is the defect itself -
`assert [{'j0': 0.1}] == [{'j0': 0.1}, {'j2': 0.3}]` - and twelve of the fifteen
are bare `ValueError`/`TypeError` escaping at `ros_telemetry.py:278`. The 30 that
pass are the over-reach controls and the contracts that already held.

**Mutation table** - 7 plausible regressions, each against the 24 new cases and
against the 202 pre-existing cases in the five neighbouring modules:

| regression | new (24) | pre-existing (202) |
| --- | --- | --- |
| M1 revert the fix (raise again) | 15 failed | 0 failed |
| M2 partially apply instead of rejecting whole | 9 failed | 0 failed |
| M3 refuse but say nothing | 6 failed | 0 failed |
| M4 narrow the `except` to `ValueError` only | 8 failed | 0 failed |
| M5 reword the refusal locally | 6 failed | 0 failed |
| M6 poll loop: no reader tolerance | 1 failed | 0 failed |
| M7 `_start_poll` not idempotent | 1 failed | 0 failed |

Every regression - including reverting the fix itself - is invisible to all 202
pre-existing cases.

## Gate

`MUJOCO_GL=egl python -m pytest tests` at `0ae8600d`:
**28765 passed / 258 skipped / 0 failed** (655s), zero existing-test churn.
`ruff check` and `ruff format --check` clean over 1193 files;
`mypy strands_robots tests tests_integ` has **0 errors outside `examples/isaac_gs`**
(the 14 there are byte-identical to a pristine-base worktree control).
`scripts/check_merge_base_overlap.py` reports no overlap, and none of the 20
paths `main` gained since the branch point is read by these tests.

## Artifact

![measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/malformed-joint-command/artifact.png)

Three real headless MuJoCo renders of a so101 driven **through the bridge's own
poll loop** (`_on_command` calls `robot.send_action`, so a shim forwarding to a
live sim makes the loop really move the arm): what the operator commanded,
`main`'s outcome with a malformed sample in the batch, and this PR's. The
intended pose renders identically on both trees (max delta 1/255) and this PR
reaches it joint for joint; `main`'s panel differs from it on 13.54% of pixels.
Capture, compose and mutation scripts are on the artifact branch.
