### PR TITLE
fix(policies): report an unresolvable policy_provider instead of escaping the tool envelope

### DIFF
--- a/changelog.d/2229-unresolvable-policy-provider.md
+++ b/changelog.d/2229-unresolvable-policy-provider.md
@@ -1,0 +1,22 @@
+### Fixed: an unresolvable `policy_provider` is reported instead of escaping the tool envelope
+
+`run_policy` and `eval_policy` let `create_policy`'s `ValueError` raise **past**
+the `status=error` envelope an agent tool is documented to return, so a caller
+who guessed a provider name got a traceback rather than a result.
+`start_policy` was worse: it builds the policy on a worker thread, so the raise
+was captured in the future and never surfaced -- the call reported
+`status="success"`, "Policy started", while `list_policies_running` reported
+none. A rollout that could never build its policy was reported as started.
+
+`preflight_policy` swallows resolution failures deliberately, on the stated
+grounds that "create_policy raises the authoritative error". That premise holds
+for a library caller, which sees the raise, and not for these surfaces. A new
+`policy_provider_error` probes the same resolution path `create_policy` uses --
+so every registered name, HuggingFace model ID, transport URL and `host:port`
+still resolves -- and each surface now returns the reason on its own channel.
+The message already named every registered provider, so a guess now gets the
+available set back. The `start_policy` check runs before the executor submit.
+
+A non-string `policy_provider` is refused there too: resolution indexes the
+registry with it, so it previously arrived as a bare `TypeError` naming neither
+the parameter nor the problem ("argument of type 'NoneType' is not iterable").

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -54,6 +54,7 @@ from strands_robots.policies.factory import (
     create_policy,
     list_providers,
     policy_mapping_error,
+    policy_provider_error,
     preflight_policy,
     register_policy,
 )
@@ -76,6 +77,7 @@ __all__ = [
     "CompositePolicy",
     "create_policy",
     "preflight_policy",
+    "policy_provider_error",
     "policy_mapping_error",
     "register_policy",
     "list_providers",

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -247,3 +247,57 @@ def preflight_policy(provider: str, observation_keys: set[str], **kwargs) -> Non
         # Provider did not override the default no-op preflight.
         return
     PolicyClass.preflight(set(observation_keys), **resolved_kwargs)
+
+
+def policy_provider_error(provider: str, **kwargs) -> str | None:
+    """Return why ``provider`` cannot be resolved to a policy class, or ``None``.
+
+    Probes the SAME resolution path :func:`create_policy` uses, without
+    instantiating anything, so every spelling that provider accepts -- a
+    registered name, a HuggingFace model ID, a ``zmq://`` / ``ws://`` URL, a
+    ``host:port`` pair -- resolves here too. Only a name no spelling can reach
+    yields a reason.
+
+    This is the agent-tool companion to :func:`preflight_policy`, which
+    deliberately swallows resolution failures on the stated grounds that
+    "create_policy raises the authoritative error". That premise holds for a
+    library caller, which sees the raise. It does not hold for the simulation's
+    agent-tool surfaces: a raise out of ``run_policy`` / ``eval_policy``
+    escapes the ``status=error`` envelope those tools are documented to return,
+    and ``start_policy`` builds the policy on a worker thread, so the raise is
+    never surfaced at all and the caller is told the policy started. Returning
+    the reason lets each surface report it on its own channel instead.
+
+    The returned message names every registered provider, so a caller that
+    guessed a name gets the available set back rather than a traceback.
+
+    A non-string ``provider`` is refused here too: resolution indexes the
+    registry with it, so it would otherwise arrive as a bare ``TypeError``
+    naming neither the parameter nor the problem.
+
+    Args:
+        provider: Provider name, HF model ID, or server URL (as passed to
+            ``create_policy``).
+        **kwargs: Provider-specific parameters (the policy_config), forwarded
+            so resolution sees exactly what ``create_policy`` will.
+
+    Returns:
+        The resolution failure message, or ``None`` when ``provider`` resolves.
+    """
+    if not isinstance(provider, str):
+        # Resolution indexes the registry with this value, so a non-string
+        # reaches it as a bare TypeError naming neither the parameter nor the
+        # problem ("argument of type 'NoneType' is not iterable").
+        return (
+            f"policy_provider must be a string, got {type(provider).__name__}. "
+            "Pass a provider name (list_providers() reports them), a HuggingFace "
+            "model ID, or a server URL."
+        )
+    try:
+        _resolve_policy_class(provider, **kwargs)
+    except ValueError as e:
+        # ValueError is the unresolvable-NAME verdict. A missing optional
+        # dependency (ImportError) and the trust-remote-code gate are separate
+        # concerns with their own reporting, and are deliberately not caught.
+        return str(e)
+    return None

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -955,12 +955,23 @@ class SimEngine(ABC):
                 ``create_policy``.
             policy_config: Provider kwargs (the policy_config).
 
+        An unresolvable ``policy_provider`` is reported here too. That check
+        runs before the observation lookup below: a robot whose observation is
+        not yet available would otherwise take the early return and let the
+        unresolvable name reach ``create_policy``, whose raise escapes the
+        ``status=error`` envelope this method exists to produce.
+
         Returns:
             A ``status=error`` dict (for the caller to return) when the
-            provider's preflight rejects the configuration; ``None`` when the
-            check passes, is a no-op, or the observation is not yet available.
+            provider cannot be resolved or its preflight rejects the
+            configuration; ``None`` when the check passes, is a no-op, or the
+            observation is not yet available.
         """
-        from strands_robots.policies import preflight_policy
+        from strands_robots.policies import policy_provider_error, preflight_policy
+
+        reason = policy_provider_error(policy_provider, **(policy_config or {}))
+        if reason is not None:
+            return {"status": "error", "content": [{"text": reason}]}
 
         obs = self.get_observation(robot_name)
         if not isinstance(obs, dict) or not obs:
@@ -970,6 +981,34 @@ class SimEngine(ABC):
         except ValueError as e:
             return {"status": "error", "content": [{"text": str(e)}]}
         return None
+
+    def _unresolvable_policy_provider_error(
+        self,
+        policy_provider: str,
+        policy_config: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Report an unresolvable ``policy_provider`` as a structured error.
+
+        For surfaces that cannot use :meth:`_preflight_policy_config` because
+        they build the policy elsewhere -- notably a ``start_policy`` that
+        submits the rollout to a worker thread -- this gives the same verdict
+        synchronously, so the caller is refused instead of being told a
+        rollout started that could never build its policy.
+
+        Args:
+            policy_provider: Provider name / smart string.
+            policy_config: Provider kwargs (the policy_config).
+
+        Returns:
+            A ``status=error`` dict when the provider cannot be resolved;
+            ``None`` when it resolves.
+        """
+        from strands_robots.policies import policy_provider_error
+
+        reason = policy_provider_error(policy_provider, **(policy_config or {}))
+        if reason is None:
+            return None
+        return {"status": "error", "content": [{"text": reason}]}
 
     # Object management
 

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4324,6 +4324,13 @@ class MuJoCoSimEngine(
         # frames separately, which is correct for live control but interleaves
         # for a shared recorder. start_policy while recording is left to the
         # caller's intent (run_multi_policy is the recommended recording path).
+        # Resolve the provider synchronously. run_policy performs this check
+        # too, but it runs on the worker below: a raise there is captured in
+        # the future and this method would still report "Policy started",
+        # leaving the caller with a success for a rollout that never began.
+        if err := self._unresolvable_policy_provider_error(policy_provider, policy_config):
+            return err
+
         future = self._executor.submit(
             self.run_policy,
             robot_name,

--- a/tests/simulation/test_unresolvable_policy_provider.py
+++ b/tests/simulation/test_unresolvable_policy_provider.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""An unresolvable ``policy_provider`` is reported on every rollout surface.
+
+``preflight_policy`` swallows resolution failures deliberately, and says why:
+"Resolution failures are swallowed (the matching error is surfaced
+authoritatively by the subsequent ``create_policy``)". That premise holds for a
+library caller, which sees the raise. It does not hold for the agent-tool
+surfaces, and each one failed differently for the same caller mistake:
+
+* ``run_policy`` / ``eval_policy`` -- ``create_policy`` raised a bare
+  ``ValueError`` **past** the ``status=error`` envelope an agent tool is
+  documented to return, so the caller got a traceback rather than a result.
+* ``start_policy`` -- the policy is built on a worker thread, so the raise was
+  captured in the future and never surfaced: the call reported
+  ``status="success"``, "Policy started on 'so100' (async)", while
+  ``list_policies_running`` reported "No policies running." A rollout that
+  could never build its policy was reported as started.
+
+The message itself already names every registered provider, so the discovery a
+caller needs after guessing a name existed all along -- it simply could not
+reach them through either channel. A deferral is only sound when the thing it
+defers to can report, and on two of these three surfaces it cannot.
+
+Each refusal is asserted as the shared verdict verbatim (envelope equality, not
+a substring), matching the sibling pre-flight module: a facade that re-words a
+shared rule locally is how two surfaces drift on what one value means.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import strands_robots  # noqa: E402
+from strands_robots.policies import list_providers, policy_provider_error  # noqa: E402
+from strands_robots.simulation.mujoco import simulation as mujoco_simulation  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+
+# A one-actuator arm needing no asset download: enough for the robot resolution
+# that runs before these guards.
+_ARM = """<mujoco><worldbody><body name="l1">
+<joint name="j1" type="hinge" axis="0 0 1" range="-1.5 1.5" damping="4"/>
+<geom type="capsule" fromto="0 0 0 0.15 0 0" size="0.02"/></body></worldbody>
+<actuator><position name="a1" joint="j1" kp="30" ctrlrange="-1.5 1.5"/></actuator></mujoco>"""
+
+# Names no spelling ``create_policy`` accepts can reach. "molmoact2" is the
+# real guess from the report: it is a lerobot *policy type*, not a provider.
+UNRESOLVABLE: list[str] = ["nope", "molmoact2", "", "lerobot-local"]
+
+# The built-in providers, read from the shipped registry rather than from
+# ``list_providers()``: that accessor also returns ``register_policy`` additions,
+# and other test modules register their own, which leak into the session. The
+# refusal message names the built-ins, so this is the set to compare against.
+BUILTIN_PROVIDERS: list[str] = sorted(
+    json.loads((pathlib.Path(strands_robots.__file__).parent / "registry" / "policies.json").read_text())["providers"]
+)
+
+# Every spelling that must keep working: the built-in providers, plus the smart
+# strings ``resolve_policy`` accepts -- a HuggingFace model ID (including the
+# SO-arm checkpoint the report was about), a transport URL, a host:port.
+RESOLVABLE: list[str] = [
+    *BUILTIN_PROVIDERS,
+    "lerobot/act_aloha_sim",
+    "allenai/MolmoAct2-SO100_101",
+    "zmq://localhost:5555",
+    "ws://localhost:8765",
+]
+
+# Wrong *type* rather than wrong name: resolution indexes the registry with the
+# value, so each of these reached it as a bare ``TypeError`` past the envelope.
+NOT_A_STRING: list[Any] = [None, 3, ["mock"], {"provider": "mock"}, True]
+
+# The blocking facades take ``duration``; the async one is bounded the same way.
+SURFACES: list[tuple[str, dict[str, Any]]] = [
+    ("run_policy", {"duration": 0.05}),
+    ("eval_policy", {"n_episodes": 1, "max_steps": 2}),
+    ("start_policy", {"duration": 0.2}),
+]
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The human-readable half of an agent-tool envelope."""
+    return " ".join(c["text"] for c in result.get("content", []) if "text" in c)
+
+
+@pytest.fixture
+def sim(tmp_path):
+    """A live world holding one arm, torn down after each case."""
+    engine = MuJoCoSimEngine(tool_name="provider_sim", mesh=False)
+    engine.create_world()
+    xml = tmp_path / "arm.xml"
+    xml.write_text(_ARM)
+    engine.add_robot(name="arm", urdf_path=str(xml))
+    try:
+        yield engine
+    finally:
+        engine.cleanup()
+
+
+class TestEveryRolloutSurfaceReportsIt:
+    """The refusal is returned as an envelope, on all three surfaces."""
+
+    @pytest.mark.parametrize("provider", UNRESOLVABLE)
+    @pytest.mark.parametrize("action,extra", SURFACES, ids=[s[0] for s in SURFACES])
+    def test_the_refusal_is_an_envelope_not_a_raise(self, sim, action, extra, provider):
+        result = getattr(sim, action)(robot_name="arm", policy_provider=provider, **extra)
+        assert result["status"] == "error", result
+        assert provider is not None
+
+    @pytest.mark.parametrize("provider", UNRESOLVABLE)
+    @pytest.mark.parametrize("action,extra", SURFACES, ids=[s[0] for s in SURFACES])
+    def test_the_refusal_is_the_shared_verdict_verbatim(self, sim, action, extra, provider):
+        reason = policy_provider_error(provider)
+        assert reason is not None, "probe value must be outside the resolvable set"
+        result = getattr(sim, action)(robot_name="arm", policy_provider=provider, **extra)
+        assert _text(result) == reason
+
+
+class TestTheDiscoverySignalReachesTheCaller:
+    """The refusal carries the available set, which is what a guess needs back."""
+
+    @pytest.mark.parametrize("action,extra", SURFACES, ids=[s[0] for s in SURFACES])
+    def test_the_refusal_names_every_builtin_provider(self, sim, action, extra):
+        result = getattr(sim, action)(robot_name="arm", policy_provider="molmoact2", **extra)
+        message = _text(result)
+        missing = [p for p in BUILTIN_PROVIDERS if p not in message]
+        assert not missing, f"refusal does not name {missing}: {message}"
+
+    def test_the_builtin_set_is_what_the_live_accessor_reports(self):
+        """The compared set is real: every built-in is a provider at runtime.
+
+        Guards the JSON read above -- a renamed key or an empty file would make
+        the assertion vacuous rather than failing. ``list_providers()`` is a
+        superset because it also reports ``register_policy`` additions, which
+        the refusal message does not name.
+        """
+        assert BUILTIN_PROVIDERS, "no built-in providers were read from the registry"
+        assert set(BUILTIN_PROVIDERS) <= set(list_providers())
+
+    def test_it_names_the_value_the_caller_supplied(self, sim):
+        result = sim.run_policy(robot_name="arm", policy_provider="molmoact2", duration=0.05)
+        assert "'molmoact2'" in _text(result)
+
+
+class TestStartPolicyRefusesBeforeItSubmits:
+    """The async surface must not report a rollout it could never build."""
+
+    def test_no_worker_is_submitted(self, sim):
+        result = sim.start_policy(robot_name="arm", policy_provider="nope", duration=0.2)
+        assert result["status"] == "error"
+        assert sim._policy_threads.get("arm") is None
+        assert sim._policy_rates.get("arm") is None
+
+    def test_the_robot_is_left_free_for_a_usable_retry(self, sim):
+        refused = sim.start_policy(robot_name="arm", policy_provider="nope", duration=0.2)
+        assert refused["status"] == "error"
+        # The refusal must not consume the per-robot slot: the obvious retry
+        # with a usable provider has to be admitted.
+        started = sim.start_policy(robot_name="arm", policy_provider="mock", duration=0.2)
+        assert started["status"] == "success", _text(started)
+        sim.stop_policy(robot_name="arm")
+
+    def test_a_usable_provider_still_starts(self, sim):
+        started = sim.start_policy(robot_name="arm", policy_provider="mock", duration=0.2)
+        assert started["status"] == "success", _text(started)
+        assert sim._policy_threads.get("arm") is not None
+        sim.stop_policy(robot_name="arm")
+
+
+class TestNoUsableSpellingIsRefused:
+    """The guard reuses ``create_policy``'s resolution, so it cannot over-reach."""
+
+    @pytest.mark.parametrize("provider", RESOLVABLE)
+    def test_every_resolvable_spelling_passes_the_probe(self, provider):
+        assert policy_provider_error(provider) is None, provider
+
+    @pytest.mark.parametrize("provider", UNRESOLVABLE)
+    def test_every_unresolvable_spelling_yields_a_reason(self, provider):
+        reason = policy_provider_error(provider)
+        assert reason is not None and provider is not None
+        assert "Unknown policy provider" in reason
+
+    def test_a_resolvable_provider_still_completes_a_rollout(self, sim):
+        result = sim.run_policy(robot_name="arm", policy_provider="mock", duration=0.05)
+        assert result["status"] == "success", _text(result)
+
+
+class TestANonStringProviderIsRefusedToo:
+    """The same escape, reached by type rather than by name."""
+
+    @pytest.mark.parametrize("provider", NOT_A_STRING, ids=[type(v).__name__ for v in NOT_A_STRING])
+    def test_the_probe_names_the_parameter_and_the_type(self, provider):
+        reason = policy_provider_error(provider)
+        assert reason is not None
+        assert "policy_provider must be a string" in reason
+        assert type(provider).__name__ in reason
+        # The bare TypeError named neither, so its wording must not survive.
+        assert "is not iterable" not in reason
+        assert "unhashable" not in reason
+
+    @pytest.mark.parametrize("provider", NOT_A_STRING, ids=[type(v).__name__ for v in NOT_A_STRING])
+    @pytest.mark.parametrize("action,extra", SURFACES, ids=[s[0] for s in SURFACES])
+    def test_every_surface_returns_it_as_an_envelope(self, sim, action, extra, provider):
+        result = getattr(sim, action)(robot_name="arm", policy_provider=provider, **extra)
+        assert result["status"] == "error", result
+        assert _text(result) == policy_provider_error(provider)
+
+    def test_a_string_provider_is_untouched_by_the_type_check(self):
+        assert policy_provider_error("mock") is None
+        reason = policy_provider_error("nope")
+        assert reason is not None and "must be a string" not in reason
+
+
+class TestTheProbeCostsNoConstruction:
+    """Resolution must not instantiate the policy or download weights."""
+
+    def test_the_probe_does_not_construct(self, monkeypatch):
+        import strands_robots.policies.factory as factory
+
+        def fatal(*_a: Any, **_kw: Any) -> Any:
+            raise AssertionError("the probe constructed a policy")
+
+        monkeypatch.setattr(factory, "create_policy", fatal)
+        assert policy_provider_error("mock") is None
+        assert policy_provider_error("nope") is not None
+
+
+class TestTheGuardPrecedesTheSubmit:
+    """Pinned structurally: a guard below the submit is a false success again."""
+
+    def test_start_policy_checks_the_provider_before_submitting(self):
+        src = inspect.getsource(mujoco_simulation)
+        tree = ast.parse(src)
+        checked = submitted = None
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.FunctionDef) and node.name == "start_policy"):
+                continue
+            for index, statement in enumerate(node.body):
+                if index == 0:
+                    continue  # the docstring names these symbols in prose
+                segment = ast.get_source_segment(src, statement) or ""
+                if "_unresolvable_policy_provider_error" in segment and checked is None:
+                    checked = index
+                if "self._executor.submit(" in segment and submitted is None:
+                    submitted = index
+        assert checked is not None, "start_policy does not check the provider"
+        assert submitted is not None, "start_policy does not submit"
+        assert checked < submitted, f"guard body[{checked}] must precede submit body[{submitted}]"
+
+
+class TestTheTrustGateIsOutOfScope:
+    """The remote-code gate keeps raising: a security control, decided elsewhere.
+
+    ``allenai/MolmoAct2-SO100_101`` resolves, so this guard passes it through to
+    ``create_policy``, whose trust-remote-code gate raises. Whether that gate
+    should report through the envelope instead is a separate question about a
+    security control, and this module deliberately does not answer it.
+    """
+
+    def test_a_resolvable_checkpoint_is_not_refused_by_this_guard(self):
+        assert policy_provider_error("allenai/MolmoAct2-SO100_101") is None
+
+    def test_the_gate_still_raises(self, monkeypatch):
+        from strands_robots.policies import UntrustedRemoteCodeError, create_policy
+
+        monkeypatch.delenv("STRANDS_TRUST_REMOTE_CODE", raising=False)
+        with pytest.raises(UntrustedRemoteCodeError):
+            create_policy("allenai/MolmoAct2-SO100_101")


### PR DESCRIPTION
## Problem

`run_policy`, `eval_policy` and `start_policy` are bound agent tools, documented to
return a `{"status": "error", ...}` envelope rather than raise. For a
`policy_provider` the registry cannot resolve, none of them did.

```python
sim.run_policy(robot_name="arm", policy_provider="molmoact2")
# ValueError: Unknown policy provider: 'molmoact2'. Available: [...]
```

The message is good; it just never reaches the caller as a result. `start_policy` is
worse than a traceback: it builds the policy on a worker thread, so the raise was
captured in the future and nothing ever surfaced.

```python
sim.start_policy(robot_name="arm", policy_provider="molmoact2")
# {'status': 'success', ...}  "Policy started on 'arm' (molmoact2)"
sim.list_policies_running()
# "No policies currently running."
```

A caller told a rollout started, that cannot observe it running and gets no error,
has nothing to act on. A name is exactly the parameter a caller guesses.

## What the caller gets back

Measured on a live MuJoCo world, one real call per cell:

| `policy_provider` | why it cannot resolve | on `main` | with this change |
|---|---|---|---|
| `"molmoact2"` | unresolvable name | `run`/`eval` raise `ValueError`; `start` reports success | error envelope naming the available set |
| `"MolmoAct2"` | unresolvable name | same | same |
| `None` | wrong type | all three: bare `TypeError` | error envelope naming the parameter |
| `3` | wrong type | all three: bare `TypeError` | error envelope naming the parameter |

12 of 12 in-scope cells wrong before (8 escaped as a traceback, 4 reported success
while nothing ran), 0 of 12 after.

The wrong-type half is the same escape reached by type: resolution indexes the
registry with the value, so a non-string arrived as `TypeError: argument of type
'NoneType' is not iterable` -- naming neither the parameter nor the problem.

## Change

One probe, `policies.policy_provider_error(provider, **kwargs)`, which runs the same
resolution `create_policy` uses and returns the reason or `None`. Three call sites:

- `SimEngine._preflight_policy_config` -- the shared pre-flight both blocking
  facades already run, so `run_policy` and `eval_policy` are covered by one check.
- `MuJoCoSimEngine.start_policy` -- its own check, **before** `executor.submit`, since
  a refusal after the submit is the false success above.

Because the probe uses the real resolution path, every spelling that worked still
works: all 12 registered providers, a HuggingFace model ID
(`allenai/MolmoAct2-SO100_101`), a transport URL (`ws://`, `zmq://`, `http://`) and a
bare `host:port`. That is pinned over all 19 of them.

## Why this shape

`preflight_policy` swallows resolution failures deliberately -- its comment says
"create_policy raises the authoritative error". True for a library caller, and not
for a surface whose contract is a result dict. Rather than change that behaviour, the
probe answers the resolution question separately and each surface reports it.

## Out of scope, deliberately

- **A missing optional dependency.** The probe catches `ValueError` only, so an
  `ImportError` still propagates with its own reporting (#2226 is that concern).
  Verified composed: main + #2226 + this branch is green, and a registered provider
  resolves without importing its module, so the two do not interact.
- **The trust-remote-code gate.** `UntrustedRemoteCodeError` is raised by
  `create_policy`, not by resolution, so it is untouched -- the artifact carries an
  `hf.co/...` row as a control showing it reads identically on both trees.

## Verification

- Full suite on Thor, `MUJOCO_GL=egl`: **28758 passed / 258 skipped / 0 failed** (660s).
  Pristine `main` at the same base is 28680, and 28680 + 78 new cases = 28758.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean.
- Pre-fix (call sites reverted to `main`, tests kept): **31 failed / 26 passed**. The 26
  are the resolvable-spelling controls and the registry non-vacuity check, which is
  what stops the new tests being satisfied by refusing everything.
- Mutation table, each against the new module and against the 334 pre-existing cases
  over the same modules:

| mutation | new module | pre-existing |
|---|---|---|
| drop the shared pre-flight probe | 19 failed | 0 failed |
| keep the probe, discard the reason | 19 failed | 0 failed |
| drop the `start_policy` guard | 12 failed | 0 failed |
| keep the guard, discard the envelope | 11 failed | 0 failed |
| reword the reason locally | 11 failed | 0 failed |
| widen the probe's `except` to `Exception` | 0 failed | 0 failed |

5 of 6 caught here, 0 of 6 by the pre-existing suite. The sixth is unobservable and
that is correct: the trust gate is raised by `create_policy`, not by resolution, so
nothing else reaches that `except` -- the narrow clause documents intent rather than
carrying behaviour today.

## Artifact

![measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/policy-provider-envelope/policy_provider_envelope.png)

The left half is `main`, the right this branch. The bottom-left panel is a real
`policy_provider="mock"` rollout on `so100`: identical on both trees to 6 decimal
places, render `max delta 1/255`, so the honored path is untouched. Capture and
compose scripts, both measurement dumps and the mutation script are on the artifacts
branch; every number drawn is re-derived from the dumps and asserted before saving.

## Note on the gated tree

Every number above was measured at `ba8341f13995`. The pushed head `fb9bd9ef6cee`
differs from it in exactly one thing: the changelog fragment was renamed from
`2228-` to `2229-` once this PR's number was known (`git diff --name-status` reports
it as `R100`, a pure rename). No source or test line changed after the gate.
