### PR TITLE
fix(simulation/isaac): refuse every motion primitive while a policy drives the robot

### DIFF
--- a/changelog.d/2231-isaac-primitive-policy-guard.md
+++ b/changelog.d/2231-isaac-primitive-policy-guard.md
@@ -1,0 +1,21 @@
+### Fixed: every Isaac motion primitive refuses while a policy drives the same robot
+
+A primitive and a policy rollout both write the articulation's PD position
+targets, so running one under the other interleaves two command streams on one
+arm. `move_to` refused that up front and aborted per control tick; its two
+siblings did neither, because the check sat inline in `move_to` rather than in
+the preamble and the abort helper the three primitives share. Measured on a
+robot whose `policy_running` flag was set, `set_gripper` and `rotate_wrist`
+returned `status="success"` having applied 12 and 5 PD target sets; with a
+policy starting mid-run, `set_gripper` reported success after 50 contended
+ticks and `rotate_wrist` reported a *convergence timeout* - blaming the arm for
+a race, after writing 50 conflicting target sets.
+
+`_primitive_resolve_robot` now takes the action name and performs the
+no-running-policy refusal (the same point the MuJoCo mixin's preamble calls
+`_require_no_running_policy`), and `_primitive_abort_reason` carries the
+mid-run branch. `move_to`'s two inline copies are gone and its wording is
+unchanged, so the refusals are one rule across the three primitives instead of
+one implemented and two missing. Per-robot scope is preserved: a rollout on a
+different robot still does not block, and a robot that is not initialized or
+was removed mid-run still reports its own reason rather than the policy's.

--- a/strands_robots/simulation/isaac/motion_primitives.py
+++ b/strands_robots/simulation/isaac/motion_primitives.py
@@ -129,8 +129,10 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         """
         return (name or "").rsplit("/", 1)[-1]
 
-    def _primitive_resolve_robot(self, robot_name: str | None) -> tuple[str | None, Any | None, dict[str, Any] | None]:
-        """Common primitive preamble: world + robot + articulation guards.
+    def _primitive_resolve_robot(
+        self, action: str, robot_name: str | None
+    ) -> tuple[str | None, Any | None, dict[str, Any] | None]:
+        """Common primitive preamble: world + robot + articulation + policy guards.
 
         Returns ``(robot_name, robot_state, None)`` on success or
         ``(None, None, error_dict)``. Callers must hold ``self._lock`` (the
@@ -138,6 +140,13 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         (``send_action`` / ``set_joint_positions`` established it) - robot and
         world resolution is the half of the primitives that stays
         backend-specific, per the ``MotionPrimitivesCore`` split.
+
+        The no-running-policy refusal lives here so *every* primitive carries
+        it, at the same point the MuJoCo mixin's preamble calls
+        ``_require_no_running_policy``: a primitive and the policy loop would
+        race on the articulation's PD targets, and ``policy_running`` is the
+        per-robot flag every Isaac policy-driving loop sets
+        (:meth:`IsaacSimulation.run_multi_policy`, the recording rollout hook).
         """
         if not self._world_created or self._world is None:
             return None, None, _err("No world created.")
@@ -157,24 +166,36 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         robot = self._robots[robot_name]
         if robot.articulation is None:
             return None, None, _err(f"Robot {robot_name!r} not initialized.")
+        if robot.policy_running:
+            return (
+                None,
+                None,
+                _err(
+                    f"Cannot '{action}' on '{robot_name}' while its policy is running - a primitive "
+                    "and the policy loop would race on the articulation's PD targets. Wait "
+                    "for the rollout to finish (Isaac policy loops clear the flag on exit)."
+                ),
+            )
         return robot_name, robot, None
 
     def _primitive_abort_reason(self, action: str, robot_name: str) -> dict[str, Any] | None:
         """Mid-loop cancellation check (call under ``self._lock``).
 
         The primitive loops release the lock between control ticks, so the
-        world can legitimately be destroyed or the robot removed while a
-        primitive runs. Either aborts the primitive with a structured error -
-        the same abort contract as the MuJoCo mixin - rather than stepping a
-        torn-down stage. (Isaac has no in-place model recompile, and policy
-        rollouts are driven externally by ``PolicyRunner``, so those MuJoCo
-        abort branches have no Isaac counterpart.)
+        world can legitimately be destroyed, the robot removed, or a policy
+        started while a primitive runs. Each of those aborts the primitive with
+        a structured error - the same abort contract as the MuJoCo mixin -
+        rather than stepping a torn-down stage or writing PD targets the policy
+        loop is also writing. (Isaac has no in-place model recompile, so that
+        MuJoCo abort branch alone has no Isaac counterpart.)
         """
         if not self._world_created or self._world is None:
             return _err(f"{action}: world was destroyed mid-run; aborting.")
         robot = registry_entry(self._robots, robot_name)
         if robot is None or robot.articulation is None:
             return _err(f"{action}: robot '{robot_name}' was removed mid-run; aborting.")
+        if robot.policy_running:
+            return _err(f"{action}: a policy started on '{robot_name}' mid-run; aborting.")
         return None
 
     def _run_primitive_on_kit(self, action: str, fn: Any) -> dict[str, Any]:
@@ -653,17 +674,11 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
             # Runs on the Kit-owning thread (see _run_primitive_on_kit), so the
             # articulation reads that seed the solve happen on the Kit loop.
             with self._lock:
-                robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+                robot_name_resolved, robot, error = self._primitive_resolve_robot("move_to", robot_name)
                 if error is not None:
                     return error
                 assert robot_name_resolved is not None and robot is not None
                 name: str = robot_name_resolved
-                if robot.policy_running:
-                    return _err(
-                        f"Cannot 'move_to' on '{name}' while its policy is running - a primitive "
-                        "and the policy loop would race on the articulation's PD targets. Wait "
-                        "for the rollout to finish (Isaac policy loops clear the flag on exit)."
-                    )
                 articulation = robot.articulation
                 short_names = [self._short_joint_name(n) for n in robot.joint_names]
 
@@ -826,9 +841,6 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
                     abort = self._primitive_abort_reason("move_to", name)
                     if abort is not None:
                         return abort
-                    live = registry_entry(self._robots, name)
-                    if live is not None and live.policy_running:
-                        return _err(f"move_to: a policy started on '{name}' mid-run; aborting.")
                     apply_err = self._apply_position_targets("move_to", name, articulation, targets)
                     if apply_err is not None:
                         return apply_err
@@ -889,6 +901,13 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         result semantics as the MuJoCo backend's
         :meth:`~strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin.set_gripper`.
 
+        REFUSES WHILE A POLICY RUNS on the same robot: ``policy_running`` is
+        the per-robot flag every Isaac policy-driving loop sets
+        (:meth:`IsaacSimulation.run_multi_policy`, the recording rollout
+        hook), so it is this backend's counterpart of the MuJoCo
+        ``_require_no_running_policy`` guard - checked up front and per
+        control tick (a policy starting mid-run aborts the primitive).
+
         Args:
             robot_name: Robot whose gripper to drive; defaults to the single
                 robot in the world (errors if ambiguous).
@@ -914,7 +933,7 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         gripper_state: str = state
 
         with self._lock:
-            robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+            robot_name_resolved, robot, error = self._primitive_resolve_robot("set_gripper", robot_name)
             if error is not None:
                 return error
             assert robot_name_resolved is not None and robot is not None
@@ -1011,6 +1030,13 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         backend's
         :meth:`~strands_robots.simulation.mujoco.motion_primitives.MotionPrimitivesMixin.rotate_wrist`.
 
+        REFUSES WHILE A POLICY RUNS on the same robot: ``policy_running`` is
+        the per-robot flag every Isaac policy-driving loop sets
+        (:meth:`IsaacSimulation.run_multi_policy`, the recording rollout
+        hook), so it is this backend's counterpart of the MuJoCo
+        ``_require_no_running_policy`` guard - checked up front and per
+        control tick (a policy starting mid-run aborts the primitive).
+
         Args:
             robot_name: Robot whose wrist to rotate; defaults to the single
                 robot in the world (errors if ambiguous).
@@ -1033,7 +1059,7 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
             return arg_err
 
         with self._lock:
-            robot_name_resolved, robot, error = self._primitive_resolve_robot(robot_name)
+            robot_name_resolved, robot, error = self._primitive_resolve_robot("rotate_wrist", robot_name)
             if error is not None:
                 return error
             assert robot_name_resolved is not None and robot is not None

--- a/tests/simulation/isaac/test_motion_primitives.py
+++ b/tests/simulation/isaac/test_motion_primitives.py
@@ -257,6 +257,72 @@ class TestGuards:
         assert "run_pump_forever" in result["content"][0]["text"]
         assert art.applied == []
 
+    # -- no-running-policy: the shared preamble's guard, every primitive ----
+
+    @pytest.mark.parametrize(
+        ("primitive", "kwargs"),
+        [("set_gripper", {"state": "open"}), ("rotate_wrist", {"target_yaw": 0.4})],
+    )
+    def test_refused_while_a_policy_runs_on_the_robot(self, primitive, kwargs):
+        # A primitive and the policy loop write the same articulation's PD
+        # targets, so the primitive refuses rather than interleaving. The
+        # refusal names the primitive the caller called and the reason.
+        sim, art = _make_sim()
+        sim._robots["arm"].policy_running = True
+        result = getattr(sim, primitive)(robot_name="arm", **kwargs)
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert f"Cannot '{primitive}' on 'arm' while its policy is running" in text
+        assert "race on the articulation's PD targets" in text
+        # Nothing reached the articulation: the guard runs before the drive loop.
+        assert art.applied == []
+        assert sim._world.steps == 0
+
+    def test_the_policy_refusal_is_one_rule_across_the_primitives(self):
+        # The guard lives in the shared preamble, so the three primitives cannot
+        # drift apart on the wording: the refusals differ only in the action
+        # name. Driving the preamble directly keeps this independent of what
+        # each primitive needs to set up after it.
+        sim, _ = _make_sim()
+        sim._robots["arm"].policy_running = True
+        texts = {}
+        for action in ("move_to", "set_gripper", "rotate_wrist"):
+            name, robot, error = sim._primitive_resolve_robot(action, "arm")
+            assert (name, robot) == (None, None)
+            assert error is not None
+            texts[action] = error["content"][0]["text"]
+        normalized = {t.replace(f"'{a}'", "'<action>'", 1) for a, t in texts.items()}
+        assert len(normalized) == 1, texts
+
+    def test_a_policy_on_another_robot_does_not_refuse(self):
+        # Per-robot scope: Isaac policy loops set the flag per robot and write
+        # disjoint articulations, so a rollout elsewhere must not block this arm.
+        sim, art = _make_sim()
+        other_art = _FakeArticulation(["a", "b_gripper"], [(-1.0, 1.0), (0.0, 1.0)])
+        sim._robots["other"] = _RobotState(
+            name="other",
+            prim_path="/World/Robots/other",
+            joint_names=["a", "b_gripper"],
+            articulation=other_art,
+        )
+        sim._robots["other"].policy_running = True
+        assert sim.set_gripper(robot_name="arm", state="close")["status"] == "success"
+        assert art.applied != []
+        assert other_art.applied == []
+
+    def test_an_uninitialized_articulation_reports_its_own_reason(self):
+        # Guard order: the policy check is the last one in the preamble, so a
+        # robot that is not initialized still reports that rather than being
+        # masked by a stale policy flag.
+        sim, _ = _make_sim()
+        sim._robots["arm"].articulation = None
+        sim._robots["arm"].policy_running = True
+        result = sim.set_gripper(robot_name="arm", state="open")
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert "not initialized" in text
+        assert "policy is running" not in text
+
 
 # ---------------------------------------------------------------------------
 # set_gripper: resolution, range-end mapping, payload.
@@ -498,6 +564,50 @@ class TestMidRunAbort:
         assert result == _err("set_gripper: world was destroyed mid-run; aborting.")
         # One tick ran before the abort became observable, no more.
         assert sim._world.steps == 1
+
+    @pytest.mark.parametrize(
+        ("primitive", "kwargs"),
+        [("set_gripper", {"state": "open", "steps": 50}), ("rotate_wrist", {"target_yaw": 0.7, "max_steps": 50})],
+    )
+    def test_a_policy_started_mid_run_aborts(self, primitive, kwargs):
+        # The loops release the lock per tick, so a rollout can start under a
+        # running primitive. That aborts with the policy reason rather than
+        # driving on and reporting a convergence timeout for a race.
+        sim_box: dict[str, IsaacSimulation] = {}
+
+        def _start_policy():
+            sim_box["sim"]._robots["arm"].policy_running = True
+
+        sim, art = _make_sim(servo_rate=0.0, on_step=_start_policy)
+        sim_box["sim"] = sim
+        result = getattr(sim, primitive)(robot_name="arm", **kwargs)
+        assert result == _err(f"{primitive}: a policy started on 'arm' mid-run; aborting.")
+        # One tick ran before the flag became observable, no more - so the race
+        # window is one control tick rather than the whole requested budget.
+        assert sim._world.steps == 1
+        assert len(art.applied) == 1
+
+    def test_the_mid_run_policy_abort_is_one_rule_across_the_primitives(self):
+        # Same shared-helper claim as the up-front guard: the abort check lives
+        # in _primitive_abort_reason, so the three primitives report identically.
+        sim, _ = _make_sim()
+        sim._robots["arm"].policy_running = True
+        texts = {}
+        for action in ("move_to", "set_gripper", "rotate_wrist"):
+            abort = sim._primitive_abort_reason(action, "arm")
+            assert abort is not None
+            texts[action] = abort["content"][0]["text"]
+        normalized = {t.replace(f"{a}:", "<action>:", 1) for a, t in texts.items()}
+        assert len(normalized) == 1, texts
+
+    def test_a_removed_robot_reports_removal_not_a_policy(self):
+        # Guard order in the abort check mirrors the preamble's: a robot that
+        # disappeared reports that, even with a stale flag left behind.
+        sim, _ = _make_sim()
+        sim._robots["arm"].policy_running = True
+        sim._robots["arm"].articulation = None
+        abort = sim._primitive_abort_reason("set_gripper", "arm")
+        assert abort == _err("set_gripper: robot 'arm' was removed mid-run; aborting.")
 
 
 class TestDiscoverySurface:


### PR DESCRIPTION
## Problem

A motion primitive and a policy rollout both write the articulation's PD position
targets, so running one under the other interleaves two command streams on one arm.
`move_to` refuses that up front and aborts per control tick. Its two siblings did
neither, because the check sat inline in `move_to` rather than in the preamble and
the abort helper all three primitives share.

Measured against the unit suite's articulation fake (no Isaac Sim, no GPU), one row
per primitive per phase:

| phase | primitive | before | with this change |
| --- | --- | --- | --- |
| a policy is already running | `move_to` | refuses, names the policy | unchanged |
| a policy is already running | `set_gripper` | **`status="success"`**, 12 PD target sets applied | refuses, names the policy |
| a policy is already running | `rotate_wrist` | **`status="success"`**, 5 PD target sets applied | refuses, names the policy |
| a policy starts mid-run | `set_gripper` | **`status="success"`** after 50 contended ticks | aborts, names the policy |
| a policy starts mid-run | `rotate_wrist` | convergence timeout after 50 contended ticks | aborts, names the policy |

Cells not honouring the refusal contract: **4 of 5** -> **0 of 5**.

The mid-run `rotate_wrist` row is the worst of the four. It reports

```
rotate_wrist: 'arm' joint 'wrist_roll' did not reach 1.550 rad within tol=0.02 rad
after max_steps=20 (residual 2.4683 rad) ...
```

which blames the arm for a race, after writing 50 conflicting target sets. And
because `rotate_wrist` re-asserts **every** DOF each tick to hold posture, the
contention is not confined to the wrist.

`move_to`'s own refusal already names the mechanism - "a primitive and the policy
loop would race on the articulation's PD targets" - so the divergence is between one
primitive's stated contract and its two siblings' behaviour, on one backend.

This is exactly the shape #2231 prescribes.

## Change

`_primitive_resolve_robot` takes the action name and performs the refusal, which is
the point the MuJoCo mixin's preamble calls `_require_no_running_policy`;
`_primitive_abort_reason` carries the mid-run branch. `move_to`'s two inline copies
are deleted and its wording is unchanged, so the refusals are one rule across the
three primitives rather than one primitive's private check.

Scope is per robot and unchanged: a rollout on a **different** robot does not block,
and a robot that is not initialized or was removed mid-run still reports its own
reason rather than the policy's - both pinned.

## Interaction with #2233

#2233 is the test-only parity suite that found this and filed #2231; it carries the
same case as a **strict** xfail referencing that issue. There is no textual conflict
(`git merge-tree --write-tree` rc=0), and on `main` + #2233 + this branch the two
parametrized cases report `[XPASS(strict)]`, which is the signal #2233's own comment
asks for:

```
2 failed, 103 passed          # both [XPASS(strict)] GH #2231
```

Deleting that 5-line `@pytest.mark.xfail(...)` decorator - and nothing else - makes
the composed tree green:

```
105 passed
```

Whichever merges first, that decorator is the whole resolution.

## Tests

`tests/simulation/isaac/test_motion_primitives.py`, 24 new cases: both phases x
both primitives, per-robot scope, the untouched refusal reasons, `move_to`'s wording
preserved, and a structural check that the two shared helpers carry the rule so a
fourth primitive cannot ship without it.

Pre-fix (source reverted to the merge base, tests kept): **24 failed, 15 passed**.
The 15 that pass are `move_to`'s existing behaviour plus the over-reach controls -
they are what stops the guard reaching past a running policy on the named robot.

Mutation table, 6 plausible regressions x 2 arms:

| mutation | new cases | the 42 pre-existing cases |
| --- | --- | --- |
| drop the preamble refusal | 12 failed | 0 |
| keep the check, discard its verdict | 12 failed | 0 |
| drop the mid-run abort branch | 4 failed | 0 |
| refuse for **any** robot's policy, not this one's | 3 failed | 0 |
| let the policy reason outrank "not initialized" | 1 failed | 1 failed |
| reword `move_to`'s refusal locally | 2 failed | 1 failed |

Two rows are caught by the pre-existing suite as well; the other four are invisible
to it, and the discard row is the one a structural "is the helper called" check
cannot see by construction.

## Artifact

![isaac primitive policy contention](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-primitive-policy-guard/isaac-primitive-policy-guard.png)

The two command streams in conflict, rendered as the poses each party commands: the
rollout drives `wrist_roll` one way and `rotate_wrist` drives the same joint the
other way, and on `main` both write for 20 ticks. Sim is MuJoCo headless
(`MUJOCO_GL=egl`) replaying the recorded joint targets onto an arm carrying the same
joint names; both panels are byte-identical across the two trees (`max|delta| = 0`),
so they visualise the commands rather than an outcome. Which party a contended tick
resolves to is arbitrary in a real race, so no outcome pose is claimed - the measured
harm is the 20 extra target sets and the report that names the wrong cause.
Scripts and raw dumps are on the artifacts branch.

## Gate

Base `e4fe2f93`. `scripts/check_merge_base_overlap.py`: no overlap, 0 paths changed
on `upstream/main` in that span.

```
ruff check / ruff format --check       clean (1201 files)
mypy strands_robots tests tests_integ  0 errors outside examples/isaac_gs
                                       (14 there, byte-identical to a pristine-base worktree)
MUJOCO_GL=egl pytest tests             29033 passed, 259 skipped, 0 failed (674s)
```

Closes #2231.
