### PR TITLE
fix(examples/fleet): the incident report attests the records it shows, not the whole audit log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,25 @@ hatch run format            # ruff check --fix, ruff format
     the call site. `tests_integ/` records real datasets and is out of scope.
     Pinned by tests/test_recording_root_is_not_the_shared_cache.py.
 
+16. **An example attests the records it shows, not the whole audit log** -
+    `verify_audit_integrity()` with no argument re-reads the entire log, and an
+    example's log is the developer's real `~/.strands_robots/mesh_audit.jsonl`,
+    because examples deliberately do not redirect `STRANDS_MESH_AUDIT_DIR`. So
+    an example that scopes its read to the run (`read_audit_log(since=...)`)
+    and then attests everything prints one document describing two record sets.
+    Measured on `e4fe2f9` with 4000 records of prior history in the log,
+    `examples/fleet/04_emergency_evacuation.py` rendered
+    `Audit integrity: ok=False (signed=5/4005)` above a five-row timeline. The
+    `ok` value is the worse half: history written before a PSK was configured is
+    unsigned, and an unsigned record is a forgery by definition once a PSK is
+    set at verification time, so a completely successful run reports tamper
+    evidence. Scoped to the records shown the same run reports
+    `ok=True (signed=5/5)`. Pass the records (`verify_audit_integrity(records)`),
+    or have the report pair them itself so the caller cannot get it wrong.
+    `tests/` is exempt mechanically rather than by trust - a test redirects the
+    audit dir to `tmp_path`, so there the whole log *is* the record set it
+    means. Pinned by tests/test_examples_attest_only_what_they_report.py.
+
 ## PR Workflow
 
 1. Create the feature branch **on your fork**. Branch creation in the base

--- a/changelog.d/2236-incident-report-attests-what-it-shows.md
+++ b/changelog.d/2236-incident-report-attests-what-it-shows.md
@@ -1,0 +1,21 @@
+### Fixed: the fleet evacuation incident report attests the records it shows
+
+`examples/fleet/04_emergency_evacuation.py` scoped its audit read to the run
+(`read_audit_log(since=run_start - 1.0)`) and then called
+`verify_audit_integrity()` with no argument, which re-reads the whole log. For
+an example that log is the developer's real
+`~/.strands_robots/mesh_audit.jsonl`, because examples deliberately do not
+redirect `STRANDS_MESH_AUDIT_DIR`, so the report's header and its timeline
+described different record sets. Measured with 4000 records of prior history in
+the log and 5 events from the run, the rendered report read
+`Audit integrity: ok=False (signed=5/4005)` above a five-row table. The `ok`
+value is the worse half: history written before `STRANDS_MESH_AUDIT_PSK` was
+configured is unsigned, and an unsigned record is a forgery by definition once a
+PSK is set at verification time, so a completely successful evacuation reported
+tamper evidence. Scoped to the records shown, the same run reports
+`ok=True (signed=5/5)`.
+
+`build_incident_report` now pairs them itself - `integrity` defaults to a
+verdict over the records it was handed - so the unscoped call is gone from the
+file rather than merely given an argument, and a caller cannot reintroduce the
+mismatch by omission. The explicit two-argument form still works.

--- a/examples/fleet/04_emergency_evacuation.py
+++ b/examples/fleet/04_emergency_evacuation.py
@@ -350,13 +350,28 @@ def score_evacuation(
     return verdict
 
 
-def build_incident_report(records: list[dict[str, Any]], integrity: dict[str, Any]) -> str:
+def build_incident_report(records: list[dict[str, Any]], integrity: dict[str, Any] | None = None) -> str:
     """Deterministic incident report from the signed audit trail.
 
     Structured post-event reconstruction - the LLM stays outside the safety
     path; pass the result to an agent for a narrative if you want one
     (``--agent-report``), but the record of what happened is this.
+
+    The integrity verdict attests exactly ``records``, because the header and
+    the timeline below it have to describe the same records to be read
+    together. Leave ``integrity`` unset and this pairs them for you; pass a
+    verdict computed over some other record set and the report says two
+    different things. ``verify_audit_integrity()`` with no argument is that
+    other set - it re-reads the whole log, which on any machine that has run
+    the mesh before is mostly other runs.
+
+    Args:
+        records: The audit records to report on, already scoped to this run.
+        integrity: Optional pre-computed verdict for ``records``. Defaults to
+            attesting ``records`` themselves.
     """
+    if integrity is None:
+        integrity = verify_audit_integrity(records)
     lines = [
         "# Evacuation incident report",
         "",
@@ -946,7 +961,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"clearances at muster: {summary['clearances']}")
 
     records = read_audit_log(since=run_start - 1.0)
-    report = build_incident_report(records, verify_audit_integrity())
+    report = build_incident_report(records)
     print("\n" + report)
     if args.agent_report:
         # Post-event narration only - the LLM never touches the safety path.

--- a/tests/test_examples_attest_only_what_they_report.py
+++ b/tests/test_examples_attest_only_what_they_report.py
@@ -1,0 +1,160 @@
+"""No example computes an audit-integrity verdict over the developer's whole log.
+
+An example that prints a scoped audit trail and an integrity verdict is
+printing one document, so both halves have to describe the same records.
+:func:`~strands_robots.mesh.audit.verify_audit_integrity` called with no
+argument does not: it re-reads the entire log, which unlike a test's log is the
+developer's real ``~/.strands_robots/mesh_audit.jsonl`` -- examples do not
+redirect ``STRANDS_MESH_AUDIT_DIR``, and are not supposed to, because their
+point is to write where the mesh really writes.
+
+Measured on ``e4fe2f9``, before the call site this module guards was paired.
+``examples/fleet/04_emergency_evacuation.py`` scoped its read to the run
+(``read_audit_log(since=run_start - 1.0)``) and then attested everything::
+
+    report = build_incident_report(records, verify_audit_integrity())
+
+With 4000 records of prior history in the log and 5 events from the run, the
+rendered incident report read::
+
+    Audit integrity: ok=False (signed=5/4005)
+
+    | t | peer | event | detail |
+    |---|---|---|---|
+    | +0.00s | evac-coordinator | evacuation_alarm | ... |     <- 5 rows
+    ...
+
+A header counting 4005 records above a table showing 5, in a forensic artifact
+whose whole purpose is to say what happened during one incident. The ``ok``
+value is the worse half: the planted history is unsigned, which is what a log
+written before ``STRANDS_MESH_AUDIT_PSK`` was configured looks like, and with a
+PSK set at verification time an unsigned record is a forgery by definition. So
+the verdict is not merely wide -- a completely successful evacuation reports
+``ok=False``, which reads as tamper evidence. The same run with the verdict
+scoped to the records shown reports ``ok=True (signed=5/5)``.
+
+Why the rule is keyed on the *call site* rather than on the resolved path:
+
+- The hazard is not that the shared log is read. It is that a verdict about one
+  record set is printed as a verdict about another, and only the call site knows
+  which records the surrounding code is reporting. A path-level rule would have
+  to model that, and would also have to forbid the read outright -- which would
+  break a forensic example whose subject genuinely *is* the whole log.
+- ``tests/`` is deliberately out of scope, and the difference is mechanical
+  rather than a matter of trust: a test redirects ``STRANDS_MESH_AUDIT_DIR`` to
+  ``tmp_path`` (see ``tests/test_fleet_emergency_evacuation.py``), so a
+  no-argument call there reads a log containing only what that test wrote, which
+  is exactly the whole log it means. The same call in an example reads whatever
+  the developer's machine has accumulated. The two are the same expression with
+  different meanings, so the scope is the rule.
+- ``records`` is accepted positionally or by keyword and the two are the same
+  pairing, so both forms satisfy this module. What it refuses is the argument
+  being absent.
+
+The behavioural half of this pair lives in
+``tests/test_fleet_emergency_evacuation.py::test_the_report_attests_the_records_it_shows_and_not_the_whole_log``,
+which pins the verdict a correctly paired report renders. That test cannot pin
+this: it calls ``build_incident_report`` directly, so a call site that went back
+to computing its own unscoped verdict would leave it green. This module is the
+half that reads the call sites.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+_GUARDED_FUNCTION = "verify_audit_integrity"
+
+# The whole-log read is the point of these, so a no-argument call is correct.
+# Empty today; an entry here needs a comment saying why the whole log is the
+# record set the example reports on.
+_WHOLE_LOG_IS_THE_SUBJECT: frozenset[str] = frozenset()
+
+
+def _called_function_name(node: ast.Call) -> str | None:
+    """The bare name of a call target, through an attribute access if needed.
+
+    Both ``verify_audit_integrity(...)`` and ``audit.verify_audit_integrity(...)``
+    reach the same function and are the same exposure.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _integrity_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _called_function_name(node) == _GUARDED_FUNCTION
+    ]
+
+
+def _attests_a_record_set(call: ast.Call) -> bool:
+    """True when the call names the records it is a verdict about."""
+    if call.args:
+        return True
+    return any(keyword.arg == "records" for keyword in call.keywords)
+
+
+def _example_sources() -> list[tuple[Path, ast.AST]]:
+    sources = []
+    for path in sorted(_EXAMPLES_DIR.rglob("*.py")):
+        if path.relative_to(_REPO_ROOT).as_posix() in _WHOLE_LOG_IS_THE_SUBJECT:
+            continue
+        sources.append((path, ast.parse(path.read_text(encoding="utf-8"), filename=str(path))))
+    return sources
+
+
+def test_no_example_attests_a_record_set_it_does_not_name() -> None:
+    """Every ``verify_audit_integrity`` call in ``examples/`` names its records."""
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT).as_posix()}:{call.lineno}"
+        for path, tree in _example_sources()
+        for call in _integrity_calls(tree)
+        if not _attests_a_record_set(call)
+    ]
+    assert not offenders, (
+        "verify_audit_integrity() with no argument re-reads the developer's whole "
+        "audit log, so its verdict describes records the example is not showing. "
+        "Pass the records being reported on: " + ", ".join(offenders)
+    )
+
+
+def test_the_scan_reaches_the_calls_it_is_meant_to_check() -> None:
+    """Non-vacuity: an example really does call the guarded function.
+
+    Without this, a scan that resolved no call sites -- a renamed function, a
+    moved ``examples/`` directory, a parse that silently yielded nothing --
+    would satisfy the assertion above by finding nothing to reject.
+    """
+    calls = [(path, call) for path, tree in _example_sources() for call in _integrity_calls(tree)]
+    assert calls, f"no {_GUARDED_FUNCTION} call found under {_EXAMPLES_DIR}; the scan is not reaching the examples"
+
+
+def test_the_guard_detects_an_unscoped_call() -> None:
+    """Planted positive: the predicate rejects what it claims to reject.
+
+    Both spellings of the correct form are accepted, so the rule cannot be
+    satisfied merely by importing the function differently.
+    """
+    tree = ast.parse(
+        "\n".join(
+            (
+                "verify_audit_integrity()",  # offender: no record set
+                "audit.verify_audit_integrity()",  # offender through an attribute
+                "verify_audit_integrity(records)",  # positional
+                "audit.verify_audit_integrity(records=records)",  # keyword
+            )
+        )
+    )
+    calls = _integrity_calls(tree)
+    assert len(calls) == 4, "the walker missed a call spelling"
+    assert [_attests_a_record_set(call) for call in calls] == [False, False, True, True]

--- a/tests/test_examples_attest_only_what_they_report.py
+++ b/tests/test_examples_attest_only_what_they_report.py
@@ -105,7 +105,10 @@ def _attests_a_record_set(call: ast.Call) -> bool:
 
 
 def _example_sources() -> list[tuple[Path, ast.AST]]:
-    sources = []
+    # Annotated because ``ast.parse`` returns ``Module``: an inferred
+    # ``list[tuple[Path, Module]]`` is not a ``list[tuple[Path, AST]]``, since
+    # ``list`` is invariant.
+    sources: list[tuple[Path, ast.AST]] = []
     for path in sorted(_EXAMPLES_DIR.rglob("*.py")):
         if path.relative_to(_REPO_ROOT).as_posix() in _WHOLE_LOG_IS_THE_SUBJECT:
             continue

--- a/tests/test_fleet_emergency_evacuation.py
+++ b/tests/test_fleet_emergency_evacuation.py
@@ -253,6 +253,57 @@ def test_incident_report_is_a_deterministic_timeline_with_integrity(example):
     assert "dropped" not in report  # an unreadable timestamp row is skipped, not guessed
 
 
+def test_the_report_attests_the_records_it_shows_and_not_the_whole_log(example):
+    """The header and the timeline must describe one record set.
+
+    ``main`` scopes its read to this run (``read_audit_log(since=...)``) and
+    renders those records as the timeline. The integrity verdict has to be
+    about the same records, or the report states two things at once: a header
+    counting the developer's entire history above a table showing one run.
+
+    The prior-run records planted here are unsigned, which is what a log
+    written before ``STRANDS_MESH_AUDIT_PSK`` was configured looks like. With
+    a PSK set at verification time an unsigned record is a forgery by
+    definition, so an unscoped verdict does not merely inflate ``total`` - it
+    reports ``ok=False`` on a run in which nothing went wrong.
+    """
+    import time
+
+    from strands_robots.mesh.audit import audit_log_path, log_safety_event, read_audit_log, verify_audit_integrity
+
+    # A machine that has used the mesh before, from runs this report is not about.
+    log_file = Path(audit_log_path())
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with log_file.open("a") as handle:
+        for i in range(120):
+            handle.write(
+                json.dumps(
+                    {"ts": 1000.0 + i, "event": "some_earlier_run", "peer_id": "prior-run", "seq": i + 1, "payload": {}}
+                )
+                + "\n"
+            )
+
+    run_start = time.time()
+    for event in ("evacuation_alarm", "evacuation_path_clear", "evacuation_scored"):
+        log_safety_event(event, example.COORDINATOR_ID, {"phase": event})
+
+    records = read_audit_log(since=run_start - 1.0)
+    report = example.build_incident_report(records)
+
+    # The header counts exactly the rows below it.
+    rows = [line for line in report.splitlines() if line.startswith("| +")]
+    assert len(rows) == len(records)
+    assert f"(signed={len(records)}/{len(records)})" in report
+    assert "Audit integrity: ok=True" in report
+
+    # Non-vacuity: the planted history is really in the log, and an unscoped
+    # verdict really would have reported on it. Without this the assertions
+    # above would also hold on a log that happened to contain only this run.
+    unscoped = verify_audit_integrity()
+    assert unscoped["total"] > len(records)
+    assert unscoped["ok"] is False
+
+
 # Phase 3 -- lockout + HMAC resume, asserted through the real safety handlers.
 
 


### PR DESCRIPTION
## The finding

`examples/fleet/04_emergency_evacuation.py` scoped its audit read to the run and then attested everything:

```python
records = read_audit_log(since=run_start - 1.0)
report = build_incident_report(records, verify_audit_integrity())   # line 949
```

`verify_audit_integrity()` with no argument re-reads the entire log. For an example that is the developer's real `~/.strands_robots/mesh_audit.jsonl`, because examples deliberately do **not** redirect `STRANDS_MESH_AUDIT_DIR` - writing where the mesh really writes is the point. So the two halves of one document described different record sets.

Measured with 4000 records of prior history in the log and 5 events from the run, this is the artifact that was printed:

```
# Evacuation incident report

Audit integrity: ok=False (signed=5/4005)

| t | peer | event | detail |
|---|---|---|---|
| +0.00s | evac-coordinator | evacuation_alarm | ... |
| +0.00s | evac-coordinator | evacuation_abort_complete | ... |
| +0.00s | evac-coordinator | evacuation_retreat_order | ... |
| +0.00s | evac-coordinator | evacuation_path_clear | ... |
| +0.01s | evac-coordinator | evacuation_scored | ... |
```

A header counting 4005 records above a table showing 5, in a forensic artifact whose entire purpose is to say what happened during one incident.

**`ok=False` is the worse half.** History written before `STRANDS_MESH_AUDIT_PSK` was configured is unsigned, and an unsigned record is a forgery by definition once a PSK is set at verification time. So a completely successful evacuation reported tamper evidence. Same run, verdict scoped to the records shown:

| | ok | signed | total |
|---|---|---|---|
| as shipped | **False** | 5 | 4005 |
| this PR | True | 5 | 5 |

The example's own module docstring says the PSK signs "the audit trail **the incident report is built from**". The header was not describing that trail.

## Why the report pairs them rather than the call site passing an argument

The one-token fix is `verify_audit_integrity(records)`. Instead `integrity` became optional and defaults to a verdict over the records the function was handed:

```python
if integrity is None:
    integrity = verify_audit_integrity(records)
```

Three reasons, in order of weight:

1. **The unscoped call is now absent from the file** rather than given an argument. There is no longer a site to get wrong.
2. **A caller cannot reintroduce the mismatch by omission.** These are examples; they are copied. The correct pairing being the default is the difference between teaching the pattern and documenting it.
3. **The explicit two-argument form still works**, which is what the existing rendering test uses - it passes a literal `{"ok": True, "signed": 2, "total": 2}` to keep the timeline assertions deterministic. That test is untouched.

This mirrors `verify_audit_integrity(records=None)`'s own shape in the audit module, so the convention is consistent rather than new.

## Pinned twice, because the halves catch different regressions

Neither test subsumes the other, and each was verified against a planted mutant.

**Behavioural** - `tests/test_fleet_emergency_evacuation.py`. Plants 120 unsigned prior-run records, writes this run's events through the real signing writer, and asserts the header counts exactly the rows below it. It carries its own non-vacuity assertion - that an unscoped verdict over the same log really does report `total > len(records)` and `ok=False` - so it cannot pass on a log that happens to hold only this run.

| tree | result |
|---|---|
| this PR | 15 passed |
| default restored to `verify_audit_integrity()` | **1 failed** - `assert '(signed=3/3)' in ... 'ok=False (signed=3/123)'` |

**Structural** - `tests/test_examples_attest_only_what_they_report.py`. Reads the call sites across `examples/`, which the behavioural test cannot: it calls `build_incident_report` directly, so a call site that went back to computing its own unscoped verdict would leave it green.

| tree | result |
|---|---|
| this PR | 3 passed |
| old call site restored | **1 failed**, naming `examples/fleet/04_emergency_evacuation.py:964` |

It carries a non-vacuity test (the scan must actually reach a call, or a renamed function would satisfy it by finding nothing) and a planted-positive meta-test over all four call spellings - bare and attribute access, positional and `records=` keyword.

`tests/` is out of scope for the guard **mechanically rather than by trust**: a test redirects the audit dir to `tmp_path`, so a no-argument call there reads a log holding only what that test wrote, which is the whole log it means. The same expression has different meanings in the two trees, so the scope is the rule. An allowlist constant exists, empty, for a future example whose subject genuinely *is* the whole log.

## Interaction with the three open fleet PRs, measured

The guard is tree-wide over `examples/`, so it must not ambush anyone. Composed this branch with each open fleet PR:

| composition | merge | guard |
|---|---|---|
| + #2198 | clean | **3 passed** |
| + #2191 | clean | 1 failed - `03_failover_and_degraded_ops.py:592` |
| + #2188 | conflict, `examples/fleet/README.md` | not reached |

Two things worth stating plainly:

- The offender in #2191, and the equivalent one in #2188, is **the change already requested on both** in review. The guard does not introduce a new demand; it makes an existing one mechanical, which is why it is here rather than in a third round of the same comment on a third PR.
- **#2188's conflict is not mine.** `main` alone conflicts with #2188 on the same file (that PR reads `CONFLICTING` today). This branch touches no file any of the three touch except the already-merged example 04, whose only overlap is the two lines this PR changes.

I deliberately did **not** touch `examples/fleet/README.md`, whose env-var table also spells `verify_audit_integrity()`. All three open PRs rewrite that file, and editing it here would add exactly the add/add conflict class this batch has already paid for four times. The guard scans `*.py` only, so the doc line is unaffected either way.

## Gate

- `tests/test_examples_attest_only_what_they_report.py` + `tests/test_fleet_emergency_evacuation.py`: **18 passed**
- Fleet + every audit/verify test in `tests/mesh/`: **192 passed, 5 skipped**
- `ruff check`, `ruff format --check` and `mypy` clean on all four changed files
- Regression check by delta rather than by absolute, since this host lacks several optional deps: ran every tree-scanning guard test in `tests/` (41 modules, the population that could react to a new test file or an `AGENTS.md` edit) on base `main` and on this branch. Failing node ids **184 on both sides, identical sets** - zero introduced, zero fixed. All 184 are `ModuleNotFoundError` on optional extras and pre-exist on `main`.

## Scope

One defect, its fix, two pins, and the convention. `AGENTS.md` gains convention 16 next to convention 15, which is the same class one layer over - a unit test that resolves the developer's shared dataset cache instead of naming its own root. No production file changes; nothing outside `examples/fleet/04_emergency_evacuation.py` and its tests moves.

### §13 round changelog

- **Round 1** - initial submission.
- **Round 2** - `call-test-lint` red on one `mypy` error, in this branch's new guard module only: `ast.parse` returns `Module`, so the accumulator inferred as `list[tuple[Path, Module]]`, which `list` invariance makes incompatible with the declared `list[tuple[Path, AST]]`. Annotated the local at its declaration (mypy's own suggestion), keeping the declared return type since `_integrity_calls` takes an `ast.AST` and nothing depends on the element being a module. `ruff` was already clean and the test phase never ran, mypy preceding it, so that one error was the whole of the red. No behaviour, no test assertion and no example line changed.