### PR TITLE
fix(tests): latch the MuJoCo GL probe so a cleared cache cannot re-run the renderer construction

### DIFF
--- a/changelog.d/2237-gl-probe-latch-is-a-safety-invariant.md
+++ b/changelog.d/2237-gl-probe-latch-is-a-safety-invariant.md
@@ -31,3 +31,11 @@ Pinned on a GL host as well as a headless one: a `mujoco.Renderer` stand-in that
 fails if it is ever constructed proves a cleared cache reaches no second
 construction, and a stand-in that fails on its *first* call proves a graceful
 failure is latched rather than retried. No production behaviour changes.
+
+The cases hold with `ROBOT_TEST_MUJOCO=0` already in the environment as well as
+without it -- the configuration the skip reason points an operator at on a
+known-bad runner, which is the host class this gating exists for. An autouse
+fixture gives every case the unforced environment its assertions assume and
+primes an unset latch rather than probing it, since that setting exists to keep
+such a host from attempting GL at all. A child pytest run over the module pins
+that configuration.

--- a/changelog.d/2237-gl-probe-latch-is-a-safety-invariant.md
+++ b/changelog.d/2237-gl-probe-latch-is-a-safety-invariant.md
@@ -1,0 +1,33 @@
+### Quality: the GL probe builds its renderer at most once per process, latched outside the cache
+
+`tests/simulation/mujoco/_gl_probe.gl_available()` decides whether a MuJoCo
+render test can run by constructing a 1x1 offscreen renderer and reporting
+whether it worked. On a headless host that construction fails gracefully and
+reports `False`, which is the whole point of the probe -- but a *second*
+construction in the same process does not fail gracefully. It aborts the
+interpreter uncatchably:
+
+```
+libc++abi: __cxa_guard_acquire detected recursive initialization: do you have a
+function-local static variable whose initialization depends on that function?
+Aborted (core dumped)
+```
+
+The answer lived only in the `functools.cache` on `gl_available`, and the
+probe's own contract test clears that cache to exercise the
+`ROBOT_TEST_MUJOCO=0` force-skip. Clearing it re-armed the hardware probe, so
+the next caller re-ran the construction and took the process with it -- and the
+abort surfaced in whichever test called `gl_available()` next, not in the test
+that cleared the cache. `except Exception` cannot see an abort, so nothing
+reported it as a GL problem at all.
+
+The hardware answer is now latched in a module-level sentinel the cache cannot
+reset, written *before* the construction is attempted so a graceful failure
+cannot be handed a retry. `gl_available` still re-reads `ROBOT_TEST_MUJOCO` on a
+cleared cache -- the force-skip contract is unchanged, and the force-skip no
+longer consumes or poisons the latch either.
+
+Pinned on a GL host as well as a headless one: a `mujoco.Renderer` stand-in that
+fails if it is ever constructed proves a cleared cache reaches no second
+construction, and a stand-in that fails on its *first* call proves a graceful
+failure is latched rather than retried. No production behaviour changes.

--- a/tests/simulation/mujoco/_gl_probe.py
+++ b/tests/simulation/mujoco/_gl_probe.py
@@ -70,18 +70,18 @@ def _probe_gl_once() -> bool:
     try:
         import mujoco as mj
     except ImportError:
-        return False
+        return _HARDWARE_PROBE_RESULT
     try:
         model = mj.MjModel.from_xml_string("<mujoco><worldbody/></mujoco>")
         renderer = mj.Renderer(model, height=1, width=1)
     except Exception:
         # Any failure (no EGL/OSMesa, no display, driver error) means the host
         # cannot render offscreen; the dependent tests must skip cleanly.
-        return False
+        return _HARDWARE_PROBE_RESULT
     else:
         del renderer
         _HARDWARE_PROBE_RESULT = True
-        return True
+        return _HARDWARE_PROBE_RESULT
 
 
 @functools.cache

--- a/tests/simulation/mujoco/_gl_probe.py
+++ b/tests/simulation/mujoco/_gl_probe.py
@@ -9,10 +9,27 @@ capture) went unverified anywhere ``CI`` was set unless a human remembered to
 export ``ROBOT_TEST_MUJOCO=1``.
 
 Instead, probe once whether a tiny offscreen render actually succeeds under the
-ambient ``MUJOCO_GL`` backend and skip only when it genuinely fails. The probe
-result is cached so the cost is a single 1x1 renderer construction per session.
-Setting ``ROBOT_TEST_MUJOCO=0`` forces the skip (e.g. to keep a known-bad
-runner from attempting GL at all).
+ambient ``MUJOCO_GL`` backend and skip only when it genuinely fails. Setting
+``ROBOT_TEST_MUJOCO=0`` forces the skip (e.g. to keep a known-bad runner from
+attempting GL at all).
+
+Constructing that probe renderer at most once per process is a **safety**
+invariant, not a cost saving. On a host where the first attempt fails - the
+headless case this probe exists for - the failure is graceful and reports
+``False``, but a *second* construction in the same process does not raise: it
+aborts the interpreter uncatchably, because the GL loader re-enters a
+function-local static guard whose own initialisation already failed::
+
+    libc++abi: __cxa_guard_acquire detected recursive initialization
+    Aborted (core dumped)
+
+``except Exception`` cannot see that, and the abort surfaces in whichever test
+called :func:`gl_available` next rather than in the caller that re-armed the
+probe. So the hardware answer is latched in a module-level sentinel that the
+``functools.cache`` on the public entry point cannot reset. Clearing that cache
+is a reasonable thing for a test to do - it is how the ``ROBOT_TEST_MUJOCO=0``
+contract is exercised - and it re-reads the environment, but it can never
+re-run the renderer construction.
 
 Usage::
 
@@ -29,16 +46,27 @@ import os
 
 import pytest
 
+#: Latched answer from the one probe-renderer construction this process allows.
+#: ``None`` means "not probed yet". Deliberately kept *outside* the
+#: ``functools.cache`` on :func:`gl_available` so that clearing that cache
+#: cannot re-arm the probe; a second construction on a host whose first attempt
+#: failed aborts the interpreter (see the module docstring).
+_HARDWARE_PROBE_RESULT: bool | None = None
 
-@functools.cache
-def gl_available() -> bool:
-    """Return True when a minimal offscreen MuJoCo render context can be built.
 
-    Cached: the underlying 1x1 renderer construction runs at most once per test
-    session. ``ROBOT_TEST_MUJOCO=0`` forces a negative result without probing.
+def _probe_gl_once() -> bool:
+    """Return whether an offscreen render works, constructing at most one renderer.
+
+    The construction runs on the first call in the process and never again, even
+    if :func:`gl_available` has had its cache cleared in between.
     """
-    if os.environ.get("ROBOT_TEST_MUJOCO") == "0":
-        return False
+    global _HARDWARE_PROBE_RESULT
+    if _HARDWARE_PROBE_RESULT is not None:
+        return _HARDWARE_PROBE_RESULT
+    # Latch the negative *before* attempting the construction: a host whose
+    # attempt fails gracefully must not be handed a second one, and the latch
+    # has to already be in place when that retry would otherwise happen.
+    _HARDWARE_PROBE_RESULT = False
     try:
         import mujoco as mj
     except ImportError:
@@ -52,7 +80,22 @@ def gl_available() -> bool:
         return False
     else:
         del renderer
+        _HARDWARE_PROBE_RESULT = True
         return True
+
+
+@functools.cache
+def gl_available() -> bool:
+    """Return True when a minimal offscreen MuJoCo render context can be built.
+
+    ``ROBOT_TEST_MUJOCO=0`` forces a negative result without probing. The
+    hardware answer comes from :func:`_probe_gl_once`, which runs the underlying
+    1x1 renderer construction at most once per process - including across a
+    ``cache_clear()`` on this function.
+    """
+    if os.environ.get("ROBOT_TEST_MUJOCO") == "0":
+        return False
+    return _probe_gl_once()
 
 
 requires_gl = pytest.mark.skipif(

--- a/tests/simulation/mujoco/test_gl_probe.py
+++ b/tests/simulation/mujoco/test_gl_probe.py
@@ -16,6 +16,7 @@ headless host.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import os
 import pathlib
@@ -44,10 +45,19 @@ def _unforced_probe_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[Non
     ahead of the probe. Left ambient it means the latch is never primed, so the
     cases below would assert about a probe that never ran. The cases that
     exercise the force-skip set the variable themselves.
+
+    An unset latch is *primed* rather than probed. That setting exists to keep a
+    known-bad runner from attempting GL at all, so calling the probe here would
+    attempt it on exactly the host that opted out - measured as one offscreen
+    renderer constructed under ``ROBOT_TEST_MUJOCO=0``, against none when the
+    value is primed. ``monkeypatch`` also restores it, so a case that latches a
+    swallowed failure cannot leave that as the process-wide answer for every
+    later caller.
     """
     monkeypatch.delenv("ROBOT_TEST_MUJOCO", raising=False)
+    if _gl_probe._HARDWARE_PROBE_RESULT is None:
+        monkeypatch.setattr(_gl_probe, "_HARDWARE_PROBE_RESULT", False)
     _gl_probe.gl_available.cache_clear()
-    _gl_probe._probe_gl_once()
     yield
     _gl_probe.gl_available.cache_clear()
 
@@ -74,11 +84,14 @@ def test_requires_gl_is_a_skip_marker() -> None:
     assert requires_gl.name == "skipif"
 
 
-def test_the_hardware_answer_is_latched_at_import_time() -> None:
-    """Importing the module already ran the one probe this process allows.
+def test_a_hardware_answer_is_latched_before_any_case_runs() -> None:
+    """An answer is on the latch by the time a case runs, so it is never retried.
 
     Non-vacuity for the tests below: "no second renderer was constructed" only
-    means something if a first construction has already happened.
+    means something if the process already holds an answer. On a host that
+    exports the force-skip the import-time probe never ran, and the fixture
+    primes the latch rather than probing - which is why this asserts that an
+    answer is present rather than where it came from.
     """
     assert _gl_probe._HARDWARE_PROBE_RESULT is not None
 
@@ -193,3 +206,59 @@ def test_the_force_skip_avoids_the_probe_construction_entirely() -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert "answer=False built=0" in proc.stdout, proc.stdout
+
+
+def test_every_probe_exit_returns_the_latch() -> None:
+    """``_probe_gl_once`` reports the latched value rather than a literal.
+
+    The value reported and the value remembered have to be the same one: a
+    literal return can be changed without the latch beside it, leaving the
+    process answering one thing and remembering another for every later caller.
+    Pinned structurally because the two agree today, so no input distinguishes
+    them - the divergence this forbids is a future edit, not current behaviour.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_gl_probe._probe_gl_once)))
+    returns = [n for n in ast.walk(tree) if isinstance(n, ast.Return)]
+    assert len(returns) == 4, f"expected four exits, found {len(returns)}"
+    for node in returns:
+        assert isinstance(node.value, ast.Name) and node.value.id == "_HARDWARE_PROBE_RESULT", (
+            f"exit on line {node.lineno} returns "
+            f"{ast.unparse(node.value) if node.value else 'None'} instead of the latch"
+        )
+
+
+def test_this_module_is_green_under_the_force_skip() -> None:
+    """Every case here holds with ``ROBOT_TEST_MUJOCO=0`` in the environment.
+
+    That is the configuration the skip reason points an operator at on a
+    known-bad runner - the host class this gating exists for - so these cases
+    must not depend on the ambient value. With the force-skip set before the
+    module is imported the import-time probe never runs and the latch stays
+    unset, and an assertion written against a latched answer fails there with
+    text (``assert None is not None``) that reads as the safety latch being
+    broken rather than as an environment sensitivity. A child pytest over this
+    file pins it, deselecting this case so the recursion is one level deep.
+    """
+    here = pathlib.Path(__file__).resolve()
+    root = here.parents[3]
+    assert (root / "pyproject.toml").is_file(), root
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(here),
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:randomly",
+            "-k",
+            "not is_green_under_the_force_skip",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=root,
+        env={**os.environ, "ROBOT_TEST_MUJOCO": "0"},
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stdout[-4000:] + proc.stderr[-2000:]

--- a/tests/simulation/mujoco/test_gl_probe.py
+++ b/tests/simulation/mujoco/test_gl_probe.py
@@ -22,6 +22,7 @@ import pathlib
 import subprocess
 import sys
 import textwrap
+from collections.abc import Iterator
 
 import pytest
 
@@ -32,6 +33,23 @@ from tests.simulation.mujoco._gl_probe import gl_available, requires_gl
 def _refuse_to_construct(*args: object, **kwargs: object) -> None:
     """Stand in for ``mujoco.Renderer`` and fail if anything tries to build one."""
     raise AssertionError("the probe renderer was constructed a second time")
+
+
+@pytest.fixture(autouse=True)
+def _unforced_probe_environment(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Give every case the unforced environment its assertions assume.
+
+    ``ROBOT_TEST_MUJOCO=0`` is a supported host setting - this module documents
+    it for "a known-bad runner" - and it short-circuits :func:`gl_available`
+    ahead of the probe. Left ambient it means the latch is never primed, so the
+    cases below would assert about a probe that never ran. The cases that
+    exercise the force-skip set the variable themselves.
+    """
+    monkeypatch.delenv("ROBOT_TEST_MUJOCO", raising=False)
+    _gl_probe.gl_available.cache_clear()
+    _gl_probe._probe_gl_once()
+    yield
+    _gl_probe.gl_available.cache_clear()
 
 
 def test_gl_available_returns_bool() -> None:

--- a/tests/simulation/mujoco/test_gl_probe.py
+++ b/tests/simulation/mujoco/test_gl_probe.py
@@ -1,17 +1,37 @@
 """Contract tests for the shared MuJoCo GL-availability probe.
 
-These pin the behaviour that the render-test gating relies on: the probe
-reports a boolean, honours the ``ROBOT_TEST_MUJOCO=0`` force-skip escape hatch,
-and exposes a reusable ``requires_gl`` skip marker. They run without a GL
-context (the force-skip and marker-shape assertions never touch a renderer).
+These pin the behaviour that the render-test gating relies on: the probe reports
+a boolean, honours the ``ROBOT_TEST_MUJOCO=0`` force-skip escape hatch, exposes
+a reusable ``requires_gl`` skip marker, and - the safety half - constructs the
+probe renderer at most once per process however often the cache on the public
+entry point is cleared. On a host whose first attempt failed, a second
+construction aborts the interpreter uncatchably and takes the rest of the
+session with it, so a cleared cache must not be able to reach one.
+
+They run without a GL context: the force-skip, marker-shape and
+build-at-most-once assertions never construct a renderer, and the one that
+exercises a *failing* probe supplies its own failure rather than needing a
+headless host.
 """
 
 from __future__ import annotations
+
+import inspect
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
 from tests.simulation.mujoco import _gl_probe
 from tests.simulation.mujoco._gl_probe import gl_available, requires_gl
+
+
+def _refuse_to_construct(*args: object, **kwargs: object) -> None:
+    """Stand in for ``mujoco.Renderer`` and fail if anything tries to build one."""
+    raise AssertionError("the probe renderer was constructed a second time")
 
 
 def test_gl_available_returns_bool() -> None:
@@ -34,3 +54,124 @@ def test_requires_gl_is_a_skip_marker() -> None:
     """requires_gl is a usable skipif MarkDecorator (applies cleanly to tests)."""
     assert isinstance(requires_gl, pytest.MarkDecorator)
     assert requires_gl.name == "skipif"
+
+
+def test_the_hardware_answer_is_latched_at_import_time() -> None:
+    """Importing the module already ran the one probe this process allows.
+
+    Non-vacuity for the tests below: "no second renderer was constructed" only
+    means something if a first construction has already happened.
+    """
+    assert _gl_probe._HARDWARE_PROBE_RESULT is not None
+
+
+def test_gl_available_reports_the_latched_hardware_answer() -> None:
+    """The cached entry point answers from the latch rather than re-probing."""
+    assert gl_available() is _gl_probe._HARDWARE_PROBE_RESULT
+
+
+def test_a_cleared_cache_cannot_reprobe_the_hardware(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cache_clear() re-reads the environment but never re-runs the construction.
+
+    On a host whose first probe failed, a second renderer construction aborts
+    the interpreter uncatchably, so the cleared cache must not be able to reach
+    one. A renderer that refuses to be built proves nothing tries: this holds on
+    a GL host and on a headless one, so the pin lives where CI can see it.
+    """
+    mj = pytest.importorskip("mujoco")
+    monkeypatch.setattr(mj, "Renderer", _refuse_to_construct)
+    latched = _gl_probe._HARDWARE_PROBE_RESULT
+    _gl_probe.gl_available.cache_clear()
+    try:
+        assert gl_available() is latched
+    finally:
+        _gl_probe.gl_available.cache_clear()
+
+
+def test_a_first_probe_failure_is_latched_and_never_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A graceful first failure is remembered; the retry that would abort never runs.
+
+    This is the headless host's own path, driven on a host that does have GL by
+    resetting the latch and making the construction fail.
+    """
+    mj = pytest.importorskip("mujoco")
+    attempts: list[str] = []
+
+    def _failing(*args: object, **kwargs: object) -> None:
+        attempts.append("constructed")
+        raise RuntimeError("X11: The DISPLAY environment variable is missing")
+
+    monkeypatch.setattr(mj, "Renderer", _failing)
+    monkeypatch.setattr(_gl_probe, "_HARDWARE_PROBE_RESULT", None)
+
+    assert _gl_probe._probe_gl_once() is False
+    assert _gl_probe._probe_gl_once() is False
+    assert attempts == ["constructed"], "the failed probe was retried"
+
+
+def test_the_force_skip_leaves_the_hardware_latch_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ROBOT_TEST_MUJOCO=0 forces the skip without consuming or poisoning the latch.
+
+    The force-skip short-circuits ahead of the probe, so the real hardware
+    answer survives it and comes back unprobed once the variable is gone.
+    """
+    mj = pytest.importorskip("mujoco")
+    monkeypatch.setattr(mj, "Renderer", _refuse_to_construct)
+    latched = _gl_probe._HARDWARE_PROBE_RESULT
+
+    monkeypatch.setenv("ROBOT_TEST_MUJOCO", "0")
+    _gl_probe.gl_available.cache_clear()
+    try:
+        assert gl_available() is False
+        assert _gl_probe._HARDWARE_PROBE_RESULT is latched
+    finally:
+        _gl_probe.gl_available.cache_clear()
+
+    monkeypatch.delenv("ROBOT_TEST_MUJOCO", raising=False)
+    _gl_probe.gl_available.cache_clear()
+    try:
+        assert gl_available() is latched
+    finally:
+        _gl_probe.gl_available.cache_clear()
+
+
+def test_the_force_skip_avoids_the_probe_construction_entirely() -> None:
+    """``ROBOT_TEST_MUJOCO=0`` answers without building a renderer at all.
+
+    The latch makes this unobservable inside a process that has already probed:
+    by the time any test runs, the import-time probe has answered and a second
+    call constructs nothing either way. So it runs in a child interpreter where
+    the force-skip is set before the module is first imported, which is the only
+    place the ordering between the force-skip and the probe is visible.
+    """
+    pytest.importorskip("mujoco")
+    root = pathlib.Path(inspect.getfile(_gl_probe)).resolve().parents[3]
+    assert (root / "pyproject.toml").is_file(), root
+    code = textwrap.dedent(
+        """
+        import mujoco
+
+        built = []
+        real = mujoco.Renderer
+
+        def counting(*args, **kwargs):
+            built.append(1)
+            return real(*args, **kwargs)
+
+        mujoco.Renderer = counting
+
+        from tests.simulation.mujoco._gl_probe import gl_available
+
+        print(f"answer={gl_available()} built={len(built)}")
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=root,
+        env={**os.environ, "ROBOT_TEST_MUJOCO": "0", "PYTHONPATH": str(root)},
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "answer=False built=0" in proc.stdout, proc.stdout


### PR DESCRIPTION
## Problem

`tests/simulation/mujoco/_gl_probe.py` decides whether the ~660 `requires_gl`-gated render
tests can run, by building a 1x1 `mujoco.Renderer` once and caching the answer on
`gl_available()` with `functools.cache`. Its own module docstring already stated the
constraint the cache could not carry:

> Constructing a renderer is the only reliable way to detect a working offscreen
> context, and on a host where that fails **the second attempt aborts the process**
> rather than raising.

`functools.cache` is clearable, and the module's own test cleared it
(`gl_available.cache_clear()` in the `ROBOT_TEST_MUJOCO=0` case, and again in a fixture
teardown). On a host with no usable GL that re-arms the probe, and the next caller of
`gl_available()` builds a second renderer -- which aborts the interpreter uncatchably and
takes the rest of the session with it. The abort does not land in the probe's own test: it
lands in whichever later test asks the question next.

Measured over the whole directory with `MUJOCO_GL=glfw` and no display (3122 tests collected):

| | on main | with this change |
|---|---|---|
| probe renderers built | 2 | 1 |
| interpreter aborts | 1 | 0 |
| progress reached before the abort | 39% | 91% |
| tests never reached | ~1900 | 0 from this cause |
| first victim | `test_load_scene_interaction.py::test_load_scene_render_returns_real_geometry_immediately` | -- |

The abort, verbatim:

```
tests/simulation/mujoco/test_load_scene_interaction.py ..........
Fatal Python error: Aborted

Current thread 0x... (most recent call first):
  File ".../test_load_scene_interaction.py", line 350 in test_load_scene_render_returns_real_geometry_immediately
timeout: the monitored command dumped core
```

Nothing on the host is broken there -- the gating is meant to skip those tests cleanly, and
it does on main until the cache is cleared.

## Measured

One `gl_available()` after a `cache_clear()`, counted in-process by wrapping
`mujoco.Renderer`:

| tree | latch symbol | renderers constructed | outcome |
|---|---|---|---|
| main | absent | 1 | the hardware is probed a second time |
| this branch | present | 0 | the latched answer is returned |

On this host (working EGL) the second construction succeeds, so main is not broken here --
the abort needs a host whose *first* attempt failed. That is exactly the CI/container host
the gating exists for, which is why the emulation above runs under `MUJOCO_GL=glfw`.

## Change

The hardware answer moves to a module-level latch outside the cache:

- `_HARDWARE_PROBE_RESULT: bool | None` -- `None` means "not probed yet".
- `_probe_gl_once()` returns the latch when it is set, and otherwise **latches the negative
  before attempting the construction**, so a host whose attempt fails gracefully is never
  handed a second one; only a success promotes it to `True`.
- `gl_available()` keeps its cache and its `ROBOT_TEST_MUJOCO=0` escape hatch, and now
  answers from `_probe_gl_once()`. Clearing the cache re-runs the wrapper, never the probe.

Ordering inside `gl_available()` is unchanged: the force-skip is still honoured before the
probe, so `ROBOT_TEST_MUJOCO=0` touches no GL at all.

## Tests

6 new cases in `tests/simulation/mujoco/test_gl_probe.py`, none needing a GL context except
the last:

- the hardware answer is latched by import time, and `gl_available()` reports it;
- a cleared cache constructs nothing -- with `mujoco.Renderer` replaced by a stand-in that
  raises if anything tries;
- a *failing* first probe is latched and never retried (the test supplies its own failure,
  so it does not need a host that cannot render);
- the force-skip leaves the hardware latch untouched, so it cannot poison the answer for a
  later caller;
- the force-skip builds no renderer at all -- in a child interpreter, because with the latch
  already primed the ordering is unobservable in-process.

Pre-fix proof, public surface only, with `_gl_probe.py` reverted to main's version:

```
on main's source   E  AssertionError: the cleared cache re-ran the renderer construction: ['constructed']
on this branch     1 passed in 0.29s
```

## Mutation matrix

5 plausible regressions x 2 arms:

| mutation | new tests | 3 pre-existing |
|---|---|---|
| (unmutated control) | 0 bad / 6 pass | 0 bad / 3 pass |
| M1 drop the early-out (the original defect) | 2 bad | 0 bad -- blind |
| M2 latch only on success (retry a graceful failure) | 1 bad | 0 bad -- blind |
| M3 the force-skip poisons the hardware latch | 1 bad | 0 bad -- blind |
| M4 probe before honouring the force-skip | 1 bad | 0 bad -- blind |
| M5 drop the `global` so the latch never persists | 1 bad | 1 bad |

5 of 5 caught here, 4 of 5 invisible to the pre-existing cases. M5 is the one both catch:
the latch write becomes local, so the module fails at import.

M4 was invisible to the first version of these tests, and adding the child-interpreter case
is what closed it -- with the latch already primed, calling the probe before the force-skip
constructs nothing, so the reordering has no in-process effect. Worth stating rather than
padding the table.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` -> **29457 passed / 266 skipped / 0 failed** (11m).
  Pristine main at this base is 29456, so the delta is exactly the new cases.
- `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ` clean
  (0 errors outside `examples/isaac_gs`, byte-identical to a pristine-base worktree).
- The changed file passes under `MUJOCO_GL=egl` **and** `MUJOCO_GL=glfw` (9 passed each).
- `scripts/check_merge_base_overlap.py` reports no overlap; the 2 paths main gained in that
  span are an Isaac GPU integration test and its fragment, neither read by these tests.

## Artifact

![GL-probe latch](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-probe-latch/gl-probe-latch.png)

`0` lines under `strands_robots/` change, so no policy, simulation, rendering, recording or
asset behaviour can move -- the render in the artifact is byte-identical across the two
trees (`max|delta| = 0/255`) and is there to show what the tests past the abort actually
verify. Scripts: [capture.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-probe-latch/capture.py), [compose.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-probe-latch/compose.py),
[mutations.py](https://raw.githubusercontent.com/cagataycali/robots/artifacts/gl-probe-latch/mutations.py).

## Out of scope

The `cache_clear()` calls in the tests are left in place. They are the right thing for a
test that varies `ROBOT_TEST_MUJOCO`, and removing them would trade one caller's discipline
for the invariant; the latch makes the call safe for every caller instead.

Closes #2237

## Round 2 -- review fixes (f9ae1a43)

All three threads on the first head are addressed.

**[MUST FIX] the new cases failed under an ambient `ROBOT_TEST_MUJOCO=0`.** That
variable short-circuits `gl_available()` ahead of the probe, so on a runner that
exports it -- the known-bad-host configuration this module's own skip reason names --
import leaves the latch at `None` and four cases asserted about a probe that never
ran. `main` passes 3/3 in that mode, so the regression was introduced here, which is
the wrong way round for a PR whose purpose is making headless hosts safe.

| host mode | before | after |
|---|---|---|
| `MUJOCO_GL=egl` | 9 passed | 9 passed |
| `MUJOCO_GL=glfw`, no display | 9 passed | 9 passed |
| `MUJOCO_GL=egl` + `ROBOT_TEST_MUJOCO=0` | **4 failed**, 5 passed | 9 passed |
| `MUJOCO_GL=glfw`, no display + `ROBOT_TEST_MUJOCO=0` | **4 failed**, 5 passed | 9 passed |

An autouse fixture gives every case the unforced environment its assertions assume;
the two cases that exercise the force-skip set the variable themselves, so their
meaning is unchanged. Priming through `_probe_gl_once()` is safe by the invariant
this PR adds -- it is the one-construction-per-process entry point.

**Both CodeQL `py/unused-global-variable` reports** were the latch writes: each was
followed by a literal `return`, so the value written was never read on that path.
`_probe_gl_once()` now returns the latch it just set -- same behaviour, and a
clearer statement that the answer *is* the latch. No literal `return True` /
`return False` survives in the function.

Re-verified on this head: the headless abort trigger is still 19 passed / 1 skipped,
the full suite is **29457 passed / 266 skipped / 0 failed** (11m, `MUJOCO_GL=egl`),
and `ruff check` / `ruff format --check` / `mypy strands_robots tests tests_integ`
are clean. `scripts/check_merge_base_overlap.py` reports no overlap against today's
`upstream/main` (27 paths changed in that span, none read by these tests).

## Round 3 -- prime the unset latch, and pin both properties (dcfcd3a2)

The round-2 fixture primed the latch by calling `_probe_gl_once()`. That attempts
GL on exactly the host the setting exists for: this module's docstring says
`ROBOT_TEST_MUJOCO=0` is there "to keep a known-bad runner from attempting GL at
all". Counting `mujoco.Renderer` constructions over the module with the force-skip
exported:

| fixture primes the unset latch by | offscreen renderers constructed |
| --- | --- |
| calling `_probe_gl_once()` | 1 |
| `monkeypatch.setattr` | **0** |

One construction is safe by the latch, so this was not a new abort risk -- but it
is the operation the operator opted out of. The unset latch is now primed through
`monkeypatch`, which also restores it, so
`test_the_force_skip_leaves_the_hardware_latch_untouched` cannot leave the `False`
it latches through the refusing renderer as the process-wide answer for every
later caller. `test_the_hardware_answer_is_latched_at_import_time` is renamed to
`test_a_hardware_answer_is_latched_before_any_case_runs`, because on that host the
value is present due to the fixture rather than to import.

Two cases added, both closing a gap the round-2 shape leaves:

| case | what it catches | visible to the other 9 cases? |
| --- | --- | --- |
| a child pytest over this file with `ROBOT_TEST_MUJOCO=0` set before import | a reintroduction of this sensitivity, in CI rather than only on a runner that exports the variable | no -- on the 9 cases as first pushed it reports `1 failed, 9 passed` in the default environment |
| every exit of `_probe_gl_once` returns the latch (structural) | a later edit reverting one exit to a literal, so the value reported and the value remembered drift apart | no -- 0 failures, because reporting `True` while latching `True` is the same behaviour today |

`4` is the exit count that case pins, not `3`: the fast-path `return` when the
latch is already set is an exit too.

Gate on `dcfcd3a2`: **11 passed in all four host modes** (egl/glfw x
forced/unforced), **0** renderers constructed under the force-skip, full suite
**29459 passed / 266 skipped / 0 failed** (10m54s, `MUJOCO_GL=egl`) -- which
reconciles as round 2's 29457 plus these two cases -- and `ruff check` /
`ruff format --check` / `mypy strands_robots tests tests_integ` clean, with 0
errors outside the pre-existing `examples/isaac_gs` set (byte-identical to a
worktree control at the same base).
