### PR TITLE
ci: bound every workflow job so a hung step cannot hold a runner silently

### DIFF
--- a/.github/workflows/agent-api-check.yml
+++ b/.github/workflows/agent-api-check.yml
@@ -36,6 +36,7 @@ jobs:
   check-agent-api:
     name: Detect AgentTool API Breaking Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -31,6 +31,7 @@ jobs:
   check-breaking-changes:
     name: Detect Breaking Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout PR

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -68,6 +68,7 @@ jobs:
   fragment:
     name: Refuse a changelog entry that breaks the fragment convention
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # The BASE branch, not the pull request head. This job reads two different

--- a/.github/workflows/closing-reference.yml
+++ b/.github/workflows/closing-reference.yml
@@ -101,6 +101,7 @@ jobs:
   closing-reference:
     name: Refuse a closing keyword that only appears in the title
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # The BASE branch, for the reason changelog-fragment.yml documents at

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ jobs:
   analyze:
     name: Analyze (Python)
     runs-on: ubuntu-latest
+    # 3.8 min median / 4.1 max over the last 49 runs; CodeQL scales with the tree,
+    # so the headroom is deliberate.
+    timeout-minutes: 20
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
   # Build on every PR/push to catch broken nav, links, and config early.
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/last-push-approval.yml
+++ b/.github/workflows/last-push-approval.yml
@@ -96,6 +96,7 @@ jobs:
   last-push-approval:
     name: Report the last-push-approval state
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # The BASE branch, for the reason merge-base-overlap.yml documents at

--- a/.github/workflows/llm-input-safety.yml
+++ b/.github/workflows/llm-input-safety.yml
@@ -21,6 +21,7 @@ jobs:
   scan:
     name: Scan agent-callable code for unvalidated LLM input
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/lockfile-parity.yml
+++ b/.github/workflows/lockfile-parity.yml
@@ -113,6 +113,7 @@ jobs:
   lockfile:
     name: Refuse a lockfile that does not resolve the manifest
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # Default ref: the pull request's merge commit. See "WHY THE MERGE COMMIT

--- a/.github/workflows/merge-base-overlap.yml
+++ b/.github/workflows/merge-base-overlap.yml
@@ -40,6 +40,7 @@ jobs:
   overlap:
     name: Detect an untested overlap with the base branch
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       # The BASE branch, not the pull request head. This job reads two different

--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -20,6 +20,7 @@ jobs:
     needs:
       - call-test-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -11,6 +11,12 @@ jobs:
   test-lint:
     name: Test and Lint
     runs-on: ubuntu-latest
+    # The suite is tightly distributed - 19-27 min over the last 20 successful
+    # runs, max 26.5 - so 45 is ~1.7x the observed ceiling and costs a healthy
+    # run nothing. Without it this job inherits the 6-hour default, which is how
+    # a test that had already printed its verdict at 18 min went on to hold the
+    # runner for another 82 (#2239).
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:

--- a/changelog.d/2239-bound-every-workflow-job.md
+++ b/changelog.d/2239-bound-every-workflow-job.md
@@ -1,0 +1,17 @@
+### Fixed: every workflow job that runs on a runner is bounded, so a hung step cannot hold a runner silently
+
+A GitHub Actions job with no `timeout-minutes` inherits a 6-hour default, and no
+job in this repository set one -- including `Test and Lint`, the required check
+every merge waits on. On #2236 that job read `IN_PROGRESS` for 103 minutes while
+pytest had in fact printed `1 failed, 22095 passed` 18 minutes in and then
+refused to exit; the run ended because a human cancelled it, not because
+anything bounded it. A red verdict presented as "still running", which is the
+one direction that misleads a reviewer into waiting.
+
+Each job now declares a bound sized from observed durations over the last 300
+runs: 45 min for the suite (measured band 19-27, max 26.5 over 20 runs), 20 for
+CodeQL, 10-15 for the gates. Two structural exemptions, both asserted rather
+than assumed: a job that calls a reusable workflow cannot carry the key at all
+(the bound lives in the callee, which is checked to have one), and a job gated
+on a deployment `environment:` can be waiting on a human. Pinned tree-wide by
+`tests/test_workflow_jobs_are_bounded.py`.

--- a/tests/test_workflow_jobs_are_bounded.py
+++ b/tests/test_workflow_jobs_are_bounded.py
@@ -1,0 +1,272 @@
+"""Every workflow job that runs on a runner declares a ``timeout-minutes``.
+
+A GitHub Actions job with no ``timeout-minutes`` inherits a **6-hour** default.
+Nothing in this repository set one: at ``79b1582`` all 17 jobs across 14
+workflow files were unbounded, including ``Test and Lint`` -- the one required
+check every merge waits on.
+
+The cost was measured, not projected.  On #2236 (``APPROVED``, ``MERGEABLE``,
+every other check green) ``call-test-lint`` read ``IN_PROGRESS`` for 103
+minutes.  It was not slow or queued: pytest had already printed its verdict 18
+minutes in and the process then refused to exit.  From the attempt-1 log of run
+``31676048797``::
+
+    07:04:58  step starts
+    07:23:19  ==== 1 failed, 22095 passed, 257 skipped in 1093.27s (0:18:13) ====
+              <-- 81 minutes 57 seconds of absolutely nothing -->
+    08:44:16  ##[error]The operation was canceled.        # a human, not a timeout
+
+The two log lines are adjacent.  Everything a reviewer or a merge queue needed
+was on disk at 07:23:19, and the only thing that ended the run was somebody
+cancelling it; left alone the job would have held the runner until 13:01Z.  See
+#2239 for the full account, including why the hang is *after* the last test
+(pytest-timeout bounds tests, and a ``ThreadPoolExecutor`` worker parked by a
+timed-out future blocks interpreter exit through ``_python_exit``, which
+``shutdown(wait=False)`` does not prevent).
+
+**None of the existing bounds could have caught it.**  ``--timeout=120`` in
+``addopts`` bounds tests, and this hang is outside any test.  The roll-up
+reports ``PENDING``, which is indistinguishable from a healthy long run -- so a
+red verdict was rendered as "still running", the one direction that misleads a
+reviewer into waiting.  A job-level bound is the only mechanism that sits
+outside the interpreter, which is why it fixes the class rather than the one
+test that exposed it.
+
+The bounds themselves are sized from observed durations over the last 300
+workflow runs, not guessed::
+
+    workflow / job                    n    p50 min   max min   bound
+    Test and Lint / test-lint        20      25.2      26.5      45
+    CodeQL / analyze                 49       3.8       4.1      20
+    Agent API Check                   5       0.9       1.1      10
+    every other gate job          6..52      0.1       0.6      10
+
+The suite's band is tight (19-27 min, and zero completed runs over the sampled
+300 exceeded 45), so 45 is ~1.7x the observed ceiling: it costs a healthy run
+nothing while converting a six-hour silent stall into a 45-minute honest
+failure.
+
+Two exemptions, both structural rather than discretionary, and each pinned
+below so it cannot quietly widen into a hole:
+
+* **A job that calls a reusable workflow** (``uses:`` at job level) accepts no
+  ``timeout-minutes`` key -- the bound belongs to the job inside the called
+  workflow.  Both callers here delegate to ``test-lint.yml``, whose own job is
+  bounded, so the exemption costs no coverage.  That delegation is asserted,
+  not assumed.
+* **A job gated on a deployment ``environment:``** can legitimately sit waiting
+  on a human approval, so a wall-clock bound there would encode a guess about
+  reviewer latency instead of a fact about code.  Both such jobs are the
+  ``deploy`` steps of ``docs.yml`` and ``pypi-publish-on-release.yml``.
+
+Parsing is deliberately line-based rather than via ``yaml``: ``tests/`` is
+type-checked under ``ignore_missing_imports = false`` and ``types-PyYAML`` is
+not a dev dependency, so importing it would either fail ``mypy`` or require a
+dependency change and a ``uv.lock`` relock to satisfy the lockfile-parity gate
+-- a disproportionate diff for reading two indent levels.  The existing
+workflow contract pins (``tests/test_codeql_query_filters.py``,
+``tests/test_lockfile_parity_gate.py``) read their YAML the same way.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+#: A bound has to be meaningfully tighter than the 6-hour default to be a bound
+#: at all. Nothing here is near it -- the widest is the 45-minute suite -- so a
+#: value above this ceiling means someone silenced this guard rather than sized
+#: a job.
+_CEILING_MINUTES = 60
+
+#: The suite bound must clear the measured 19-27 minute band with room to spare,
+#: or it converts a healthy run into a red one. The lower edge is ~1.1x the
+#: observed maximum of 26.5.
+_SUITE_FLOOR_MINUTES = 30
+
+_JOBS_KEY = re.compile(r"^jobs:\s*$")
+_TOP_LEVEL_KEY = re.compile(r"^\S")
+_JOB_HEADER = re.compile(r"^ {2}([A-Za-z0-9_-]+):\s*$")
+_JOB_KEY = re.compile(r"^ {4}([A-Za-z0-9_-]+):(.*)$")
+
+
+class Job:
+    """One ``jobs.<job_id>`` block, reduced to the keys this contract reads."""
+
+    def __init__(self, workflow: str, job_id: str, keys: dict[str, str]) -> None:
+        self.workflow = workflow
+        self.job_id = job_id
+        self.keys = keys
+
+    @property
+    def ref(self) -> str:
+        return f"{self.workflow}:{self.job_id}"
+
+    @property
+    def calls_a_reusable_workflow(self) -> bool:
+        """``uses:`` at *job* level, which is the reusable-workflow call form."""
+        return "uses" in self.keys
+
+    @property
+    def is_environment_gated(self) -> bool:
+        return "environment" in self.keys
+
+    @property
+    def timeout_minutes(self) -> int | None:
+        """The declared bound, or ``None`` when absent or not a literal int.
+
+        An expression (``${{ ... }}``) reads as absent on purpose: this guard can
+        only vouch for a value it can compare against the measured band.
+        """
+        raw = self.keys.get("timeout-minutes")
+        if raw is None:
+            return None
+        try:
+            return int(raw.split("#", 1)[0].strip())
+        except ValueError:
+            return None
+
+    def __repr__(self) -> str:  # pragma: no cover - test ids only
+        return self.ref
+
+
+class _ParsedWorkflow(NamedTuple):
+    path: Path
+    jobs: list[Job]
+
+
+def _parse(path: Path) -> _ParsedWorkflow:
+    """Collect ``jobs.<job_id>`` and its 4-space-indented scalar keys."""
+    jobs: list[Job] = []
+    lines = path.read_text().splitlines()
+    in_jobs = False
+    current: Job | None = None
+
+    for line in lines:
+        if _JOBS_KEY.match(line):
+            in_jobs = True
+            current = None
+            continue
+        if not in_jobs:
+            continue
+        if _TOP_LEVEL_KEY.match(line):
+            # A sibling of `jobs:` ends the section.
+            in_jobs = False
+            current = None
+            continue
+
+        header = _JOB_HEADER.match(line)
+        if header:
+            current = Job(path.name, header.group(1), {})
+            jobs.append(current)
+            continue
+
+        key = _JOB_KEY.match(line)
+        if key and current is not None:
+            # First occurrence wins; nested mappings (`environment:` with a
+            # `name:` under it) are recorded by key presence, which is all this
+            # contract asks of them.
+            current.keys.setdefault(key.group(1), key.group(2))
+
+    return _ParsedWorkflow(path, jobs)
+
+
+_PARSED = [_parse(p) for p in sorted(_WORKFLOWS.glob("*.yml"))]
+_ALL_JOBS = [job for parsed in _PARSED for job in parsed.jobs]
+_RUNNER_JOBS = [j for j in _ALL_JOBS if not j.calls_a_reusable_workflow and not j.is_environment_gated]
+
+
+class TestTheParserActuallySeesTheTree:
+    """A structural guard that parses nothing passes vacuously. Pin that it does not."""
+
+    def test_workflows_are_found(self) -> None:
+        assert _WORKFLOWS.is_dir(), f"{_WORKFLOWS} is missing"
+        assert _PARSED, "no workflow files were parsed"
+
+    @pytest.mark.parametrize("parsed", _PARSED, ids=lambda p: p.path.name)
+    def test_every_workflow_yields_at_least_one_job(self, parsed: _ParsedWorkflow) -> None:
+        """Every workflow declares jobs, so an empty list means the parser broke."""
+        assert parsed.jobs, f"{parsed.path.name} parsed to zero jobs"
+
+    def test_the_bounded_set_is_not_empty(self) -> None:
+        assert _RUNNER_JOBS, "every job was classified as exempt, so nothing below is checked"
+
+
+class TestEveryRunnerJobIsBounded:
+    """The contract: a job that executes code on a runner cannot be unbounded."""
+
+    @pytest.mark.parametrize("job", _RUNNER_JOBS, ids=lambda j: j.ref)
+    def test_a_timeout_is_declared(self, job: Job) -> None:
+        assert job.timeout_minutes is not None, (
+            f"{job.ref} declares no literal timeout-minutes, so it inherits the 6-hour "
+            f"default and a hung step holds the runner silently (#2239)"
+        )
+
+    @pytest.mark.parametrize("job", _RUNNER_JOBS, ids=lambda j: j.ref)
+    def test_the_bound_is_tighter_than_the_default(self, job: Job) -> None:
+        """A nominal bound near the 6-hour default is not a bound."""
+        minutes = job.timeout_minutes
+        assert minutes is not None and 0 < minutes <= _CEILING_MINUTES, (
+            f"{job.ref} declares timeout-minutes: {minutes}, outside 1..{_CEILING_MINUTES}; "
+            f"the widest job in this tree is the 45-minute suite"
+        )
+
+
+class TestTheExemptionsAreStructuralNotDiscretionary:
+    """Each exemption is a property of the job, and neither leaves the suite unbounded."""
+
+    @pytest.mark.parametrize("job", [j for j in _ALL_JOBS if j.is_environment_gated], ids=lambda j: j.ref)
+    def test_an_unbounded_job_is_gated_on_a_human_decision(self, job: Job) -> None:
+        """Only a deployment gate earns the exemption -- its wait is not code running."""
+        assert job.is_environment_gated
+        assert not job.calls_a_reusable_workflow, (
+            f"{job.ref} is both a reusable-workflow call and environment-gated, which the "
+            f"exemption reasoning below does not cover"
+        )
+
+    @pytest.mark.parametrize("job", [j for j in _ALL_JOBS if j.calls_a_reusable_workflow], ids=lambda j: j.ref)
+    def test_a_caller_declares_no_bound_of_its_own(self, job: Job) -> None:
+        """``timeout-minutes`` is not a valid key on a reusable-workflow call."""
+        assert job.timeout_minutes is None, (
+            f"{job.ref} calls a reusable workflow and also declares timeout-minutes, which "
+            f"GitHub does not accept there; bound the job inside the called workflow instead"
+        )
+
+    @pytest.mark.parametrize("job", [j for j in _ALL_JOBS if j.calls_a_reusable_workflow], ids=lambda j: j.ref)
+    def test_a_caller_delegates_to_a_workflow_whose_jobs_are_bounded(self, job: Job) -> None:
+        """The exemption costs no coverage only if the callee is bounded. Assert it."""
+        target = job.keys["uses"].split("#", 1)[0].strip()
+        if not target.startswith("./"):
+            pytest.skip(f"{job.ref} calls {target}, which is outside this repository")
+
+        called = _REPO_ROOT / target[2:]
+        assert called.is_file(), f"{job.ref} calls {target}, which does not exist"
+
+        callee_jobs = _parse(called).jobs
+        assert callee_jobs, f"{target} parsed to zero jobs"
+        for callee in callee_jobs:
+            assert callee.timeout_minutes is not None, (
+                f"{job.ref} cannot carry a bound itself, and {target}:{callee.job_id} declares "
+                f"none either, so the required check is unbounded end to end (#2239)"
+            )
+
+
+class TestTheSuiteBoundClearsTheMeasuredBand:
+    """The one required check is the job the incident actually happened on."""
+
+    def test_the_suite_job_is_bounded_above_its_observed_ceiling(self) -> None:
+        suite = [j for j in _ALL_JOBS if j.workflow == "test-lint.yml" and j.job_id == "test-lint"]
+        assert len(suite) == 1, "test-lint.yml:test-lint is the required check and must exist"
+
+        minutes = suite[0].timeout_minutes
+        assert minutes is not None, "the required check is unbounded (#2239)"
+        assert _SUITE_FLOOR_MINUTES <= minutes <= _CEILING_MINUTES, (
+            f"the suite bound is {minutes} min; it must clear the measured 19-27 min band "
+            f"(max 26.5 over 20 runs) without approaching the 6-hour default"
+        )


### PR DESCRIPTION
Part of #2239 (item 1 of its three suggested fixes; items 2 and 3 deliberately left open - see Out of scope).

## What changed

Every workflow job that executes code on a runner now declares `timeout-minutes`. At `79b1582` **none of the 17 jobs across 14 workflow files did**, so each inherited the **6-hour** default - including `Test and Lint`, the one required check every merge waits on.

**No production code changes** - 13 workflow files (one line each, plus two explanatory comments), one new test module, one changelog fragment. 309 insertions, 0 deletions.

## Why this is worth a fix rather than a retry

Measured, from the attempt-1 log of run `31676048797` on #2236 (which was `APPROVED` and `MERGEABLE` at the time):

```
07:04:58  step starts
07:23:19  ==== 1 failed, 22095 passed, 257 skipped in 1093.27s (0:18:13) ====
          <-- 81 minutes 57 seconds of absolutely nothing -->
08:44:16  ##[error]The operation was canceled.        # a human, not a timeout
```

Those two log lines are adjacent in the file. pytest had **already printed its verdict** 18 minutes in and the process then refused to exit. The run ended because somebody cancelled it; left alone the job would have held the runner until 13:01Z.

The failure is silent in the worst direction: a **red** verdict is rendered as **"still running"**, so triage reads it as slow CI rather than a failed test.

**None of the existing bounds could have fired:**

| bound | why not |
|---|---|
| `--timeout=120` in `addopts` | pytest-timeout bounds *tests*; this hang is after the last test, after the summary, outside any test |
| the test's own `timeout=30` | it fired correctly - it is what produced the `TimeoutError`. It bounds the *wait*, not the *work* |
| `timeout-minutes` on the job | **absent**, in every workflow |
| roll-up / `mergeStateStatus` | reports `PENDING`, indistinguishable from a healthy long run |

A job-level bound is the only mechanism that sits **outside the interpreter**, which is why it fixes the class rather than the one test that exposed it.

## The values are measured, not guessed

Per-job durations over the last **300 workflow runs**:

| workflow / job | n | p50 min | max min | bound |
|---|---|---|---|---|
| Test and Lint / `test-lint` | 20 | 25.2 | 26.5 | **45** |
| CodeQL / `analyze` | 49 | 3.8 | 4.1 | **20** |
| Agent API Check | 5 | 0.9 | 1.1 | **10** |
| Docs / `build`, PyPI / `build` | 6 / - | 0.3 | 0.4 | **15** |
| the 8 remaining gate jobs | 6..52 | 0.1 | 0.6 | **10** |

The suite band is tight (19-27 min; **zero** completed runs in the sample exceeded 45), so 45 is ~1.7x the observed ceiling: it costs a healthy run nothing while converting a six-hour silent stall into a 45-minute honest failure.

## Two exemptions, both structural rather than discretionary

17 jobs = 13 bounded + 4 exempt. Each exemption is a property of the job read off the YAML, not a hand-maintained allowlist, and each is asserted so it cannot quietly widen into a hole:

1. **A job that calls a reusable workflow** (`uses:` at job level) accepts no `timeout-minutes` key - the bound belongs to the job inside the callee. Both callers (`pr-and-push.yml`, `pypi-publish-on-release.yml`) delegate to `test-lint.yml`, whose job **is** bounded, so the exemption costs no coverage. `test_a_caller_delegates_to_a_workflow_whose_jobs_are_bounded` resolves the `uses:` path and asserts it, rather than assuming it.
2. **A job gated on a deployment `environment:`** (`docs.yml:deploy`, `pypi-publish-on-release.yml:deploy`) can legitimately sit waiting on a human approval, so a wall-clock bound there would encode a guess about reviewer latency instead of a fact about code.

## The guard

`tests/test_workflow_jobs_are_bounded.py` (49 cases) pins this tree-wide so an unbounded job cannot be reintroduced by omission - the same shape as the `examples/` guard #2236 carried. It also refuses a *nominal* bound: anything over 60 minutes is someone silencing the guard rather than sizing a job, and the suite bound must clear the measured band (30..60) so it cannot be tightened into failing healthy runs.

**Negative controls run, not assumed** - each fails for its own reason with an actionable message:

| mutation | result |
|---|---|
| baseline | **49 passed** |
| suite bound deleted | 5 failed, incl. both caller-delegation cases naming `test-lint.yml:test-lint` |
| a gate given `timeout-minutes: 360` | 1 failed - `outside 1..60` |
| suite bound set to `20` | 1 failed - `must clear the measured 19-27 min band` |
| `timeout-minutes` added to a caller job | 1 failed - `GitHub does not accept it there` |

Parsing is line-based rather than via `yaml`: `tests/` is type-checked under `ignore_missing_imports = false` and `types-PyYAML` is not a dev dependency, so importing it would either fail mypy or require a dependency change **plus a `uv.lock` relock** to satisfy the lockfile-parity gate - a disproportionate diff for reading two indent levels. `tests/test_codeql_query_filters.py` and `tests/test_lockfile_parity_gate.py` read their YAML the same way. The parser's output was **cross-validated against `yaml.safe_load` for all 14 files: identical**.

## Verification

- `ruff check` / `ruff format --check` on the new module - clean.
- `mypy tests/test_workflow_jobs_are_bounded.py` - `Success: no issues found`.
- `pytest tests/test_workflow_jobs_are_bounded.py` - **49 passed in 0.11s**.
- All 14 workflow files re-parsed with `yaml.safe_load` after the edits - all valid.
- The diff is **pure insertions** (309+, 0-). Three workflow files (`dependency-review`, `llm-input-safety`, `pypi-publish-on-release`) plus `test-lint.yml` ship without a trailing newline; that was preserved byte-for-byte rather than silently "fixed", to keep the diff to the one concern.

## Out of scope / follow-ups (#2239 stays open)

- **Item 2, the parked worker.** `tests/test_hardware_policy_port_domain.py` leaves a `ThreadPoolExecutor` worker parked, and `_python_exit` joins it at interpreter shutdown regardless of `shutdown(wait=False)`. I reproduced it standalone (exit 124, both prints landing, no repo code involved), and **16 test files** build a fixture executor the same way - so it is a tree-wide shape, not one bad file, and it deserves its own diff.
- **Item 3, why the work blocked at all.** `[5555]` timed out with `policy_provider="mock"` and `duration=0.2`, a combination that should not touch a socket. Deliberately not diagnosed here. Changing the fixture to a daemon thread before knowing the cause would **mask** whatever wedged it, which is the opposite of what the suite is for.

This PR is the one part of #2239 that is complete on its own terms: it bounds the blast radius of *any* such hang, including the ones not yet found.
