### PR TITLE
fix(hardware): report a rollout dispatch failure's own cause

### DIFF
--- a/changelog.d/2242-hardware-task-loop-dispatch-cause.md
+++ b/changelog.d/2242-hardware-task-loop-dispatch-cause.md
@@ -1,0 +1,17 @@
+### Fixed: a hardware rollout dispatch failure reports its own cause
+
+`Robot._run_control_loop` chose between running the rollout on this thread and
+running it on a worker thread by wrapping `except RuntimeError` around both the
+`asyncio.get_running_loop()` probe and the nested dispatch. Only the probe's own
+`RuntimeError` means "no loop is running".
+
+`Robot.stream(action="execute")` is an `async def` that calls
+`_execute_task_sync`, so the nested branch is that surface's live path. A
+`RuntimeError` raised there - a thread the pool cannot start, an executor
+already shut down - landed in the same handler, whose `asyncio.run` is invalid
+by construction on exactly that branch. The caller was told
+`asyncio.run() cannot be called from a running event loop` instead of the cause,
+and the `task_runner` coroutine the handler built was left un-awaited.
+
+The probe is now separate from the dispatch, so a dispatch failure propagates
+with its own cause and nothing is retried on a thread that cannot serve it.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1925,18 +1925,34 @@ class Robot(TeleopMixin, AgentTool):
                 n_steps=n_steps,
             )
 
-        # Use asyncio.run only if no loop is running, otherwise run in existing loop
+        # Probe for a running loop separately from dispatching onto one. An
+        # ``except RuntimeError`` wrapped around both answers failures it cannot
+        # serve: ``stream(action="execute")`` reaches this from a running loop,
+        # so the nested branch below is that surface's live path, and a
+        # ``RuntimeError`` from it (a thread the pool cannot start, an executor
+        # already shut down) used to land in the handler - whose own
+        # ``asyncio.run`` is invalid by construction on exactly that branch. The
+        # caller was told "asyncio.run() cannot be called from a running event
+        # loop" instead of the cause, and the ``task_runner`` coroutine the
+        # handler built was left un-awaited. Only the probe's own
+        # ``RuntimeError`` means "no loop is running", so only it is caught.
         try:
-            # Try to get the current event loop
             asyncio.get_running_loop()
-            # If we're already in an event loop, we need to run in a thread
+        except RuntimeError:
+            on_a_running_loop = False
+        else:
+            on_a_running_loop = True
+
+        if on_a_running_loop:
+            # Already on a loop: ``asyncio.run`` would refuse, so the rollout
+            # gets its own loop on a worker thread. A failure here propagates
+            # with its own cause rather than being retried on this thread.
             import concurrent.futures
 
-            with concurrent.futures.ThreadPoolExecutor() as exec:
-                future = exec.submit(lambda: asyncio.run(task_runner()))
-                future.result()  # Wait for completion
-        except RuntimeError:
-            # No event loop running - safe to create one
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                pool.submit(lambda: asyncio.run(task_runner())).result()
+        else:
+            # No event loop running - safe to create one.
             asyncio.run(task_runner())
 
         # Return final status

--- a/tests/test_hardware_task_loop_dispatch.py
+++ b/tests/test_hardware_task_loop_dispatch.py
@@ -1,0 +1,275 @@
+"""Behavior tests for how a hardware rollout is dispatched onto an event loop.
+
+``Robot._run_control_loop`` has to work from two kinds of caller: a synchronous
+one (``run_policy``, ``start_task``'s executor worker) and an asynchronous one.
+``Robot.stream(action="execute")`` is an ``async def`` that calls
+``_execute_task_sync``, so the "already on a running loop" branch is that
+surface's *live* path rather than a hypothetical one.
+
+The branch was chosen by wrapping ``except RuntimeError`` around both the loop
+probe *and* the nested dispatch. Only the probe's own ``RuntimeError`` means "no
+loop is running"; a ``RuntimeError`` raised by the nested dispatch (a thread the
+pool cannot start, an executor already shut down) landed in the same handler,
+whose ``asyncio.run`` is invalid by construction on exactly that branch. The
+caller was told ``asyncio.run() cannot be called from a running event loop``
+instead of the cause, and the ``task_runner`` coroutine the handler built was
+left un-awaited.
+
+These tests pin that:
+
+    - an async caller really does take the nested branch, and a sync caller
+      really does not, so neither assertion below is vacuous;
+    - a dispatch failure propagates *its own* cause, with the asyncio internal
+      absent from the message;
+    - that failure leaks no un-awaited coroutine;
+    - the rollout is driven exactly once on either branch, and not at all when
+      the dispatch fails, so a failed dispatch is never retried on a thread that
+      cannot serve it;
+    - the ``except RuntimeError`` guards the probe alone.
+
+No serial/USB hardware is touched: the driver is an in-memory fake, the connect
+path is a stub, and the policy is the built-in ``mock`` provider.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import concurrent.futures
+import gc
+import inspect
+import threading
+import warnings
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from tests.test_hardware_control_loop_rate_guard import _FakeArm
+
+# duration=0.2 at 50 Hz drives ten applied actions -- long enough that "the
+# rollout ran" is unambiguous, short enough to stay a unit test.
+_DURATION = 0.2
+_EXPECTED_ACTIONS = 10
+
+
+@pytest.fixture
+def hw() -> Iterator[Any]:
+    """A ``Robot`` wired to an in-memory arm and a stubbed connect path."""
+    robot = HwRobot.__new__(HwRobot)
+    robot.tool_name_str = "test_arm"
+    robot.action_horizon = 1
+    robot.data_config = None
+    robot.control_frequency = 50.0
+    robot.action_sleep_time = 1.0 / 50.0
+    robot._task_state = RobotTaskState()
+    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._shutdown_event = threading.Event()
+    robot._stop_requested = threading.Event()
+    robot._task_admission = threading.Lock()
+    robot._task_claimed = False
+    robot.mesh = None
+    robot.peer_id = None
+    robot.robot = _FakeArm()
+
+    async def _connected() -> tuple[bool, str]:
+        return (True, "")
+
+    async def _ready() -> bool:
+        return True
+
+    def _init_policy(policy: Any) -> Any:
+        return _ready()
+
+    def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+        return None
+
+    robot._connect_robot = _connected  # type: ignore[method-assign]
+    robot._initialize_policy = _init_policy  # type: ignore[method-assign]
+    robot._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+    try:
+        yield robot
+    finally:
+        robot._shutdown_event.set()
+        robot._task_state.status = TaskStatus.STOPPED
+        robot._executor.shutdown(wait=False)
+
+
+def _drive(robot: Any) -> dict[str, Any]:
+    """Run one rollout through the real dispatch, as ``stream`` would."""
+    return robot._run_control_loop("pick", 5555, "localhost", "mock", _DURATION)
+
+
+def _pool_spy(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every *nested-dispatch* pool construction.
+
+    Only bare ``ThreadPoolExecutor()`` calls are counted. The rollout itself
+    reaches the arm through ``asyncio.to_thread``, which builds the loop's own
+    default executor with ``thread_name_prefix=...``; counting that too would
+    make "the nested branch was taken" true on both branches.
+    """
+    built: list[int] = []
+    real = concurrent.futures.ThreadPoolExecutor
+
+    class Recording(real):  # type: ignore[misc,valid-type]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            if not args and not kwargs:
+                built.append(1)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", Recording)
+    return built
+
+
+def _refusing_pool(monkeypatch: pytest.MonkeyPatch, message: str) -> None:
+    """Make the nested dispatch's pool construction fail with ``message``."""
+
+    class Refusing:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError(message)
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", Refusing)
+
+
+class TestWhichBranchEachCallerTakes:
+    """Neither branch assertion below is vacuous."""
+
+    def test_an_async_caller_takes_the_nested_branch(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        built = _pool_spy(monkeypatch)
+
+        async def caller() -> dict[str, Any]:
+            return _drive(hw)
+
+        result = asyncio.run(caller())
+        assert built, "an async caller must reach the nested dispatch"
+        assert result["status"] == "success"
+
+    def test_a_sync_caller_does_not(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        built = _pool_spy(monkeypatch)
+        result = _drive(hw)
+        assert built == [], "a sync caller must run the rollout on this thread"
+        assert result["status"] == "success"
+
+    def test_stream_reaches_the_dispatch_from_a_running_loop(self) -> None:
+        """``stream`` is the async surface that makes the nested branch live."""
+        assert inspect.isasyncgenfunction(HwRobot.stream)
+        assert "_execute_task_sync" in (inspect.getsource(HwRobot.stream) or "")
+
+
+class TestADispatchFailureReportsItsOwnCause:
+    """The handler must not answer a failure it cannot serve."""
+
+    def test_the_cause_survives(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _refusing_pool(monkeypatch, "can't start new thread")
+
+        async def caller() -> dict[str, Any]:
+            return _drive(hw)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            asyncio.run(caller())
+        message = str(excinfo.value)
+        assert "can't start new thread" in message
+        assert "cannot be called from a running event loop" not in message
+
+    def test_the_arm_is_not_commanded(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failed dispatch is not retried on a thread that cannot serve it."""
+        _refusing_pool(monkeypatch, "can't start new thread")
+
+        async def caller() -> dict[str, Any]:
+            return _drive(hw)
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(caller())
+        assert hw.robot.sent_actions == []
+
+    def test_no_coroutine_is_left_un_awaited(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        _refusing_pool(monkeypatch, "can't start new thread")
+
+        async def caller() -> dict[str, Any]:
+            return _drive(hw)
+
+        raised = False
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                asyncio.run(caller())
+            except RuntimeError:
+                # Deliberately keep no reference to the exception: its traceback
+                # holds the frame that holds the coroutine, which would postpone
+                # the finalizer (and its warning) past this recording block.
+                raised = True
+            gc.collect()
+        assert raised, "the dispatch failure must still propagate"
+        leaked = [w for w in caught if "was never awaited" in str(w.message)]
+        assert leaked == [], f"the failed dispatch leaked {len(leaked)} un-awaited coroutine(s)"
+
+
+class TestTheRolloutIsDrivenExactlyOnce:
+    """Neither branch may drive the rollout twice."""
+
+    def test_on_the_sync_branch(self, hw: Any) -> None:
+        result = _drive(hw)
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == _EXPECTED_ACTIONS
+
+    def test_on_the_nested_branch(self, hw: Any) -> None:
+        async def caller() -> dict[str, Any]:
+            return _drive(hw)
+
+        result = asyncio.run(caller())
+        assert result["status"] == "success"
+        assert len(hw.robot.sent_actions) == _EXPECTED_ACTIONS
+
+
+class TestTheSyncBranchStillPropagates:
+    """A failure of the sync branch keeps its own cause too."""
+
+    def test_a_runtime_error_from_the_run_is_not_swallowed(self, hw: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        def refusing_run(coro: Any, **kwargs: Any) -> Any:
+            coro.close()
+            raise RuntimeError("Event loop is closed")
+
+        monkeypatch.setattr(asyncio, "run", refusing_run)
+        with pytest.raises(RuntimeError, match="Event loop is closed"):
+            _drive(hw)
+        assert hw.robot.sent_actions == []
+
+
+class TestTheGuardWrapsTheProbeAlone:
+    """Structural: only the loop probe may sit inside the RuntimeError guard."""
+
+    def test_the_guarded_body_is_the_probe(self) -> None:
+        fn = ast.parse(inspect.getsource(HwRobot._run_control_loop).lstrip()).body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        guards = [
+            node
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Try)
+            and any(
+                isinstance(handler.type, ast.Name) and handler.type.id == "RuntimeError" for handler in node.handlers
+            )
+        ]
+        assert len(guards) == 1, f"expected one RuntimeError guard, found {len(guards)}"
+        guard = guards[0]
+        assert len(guard.body) == 1, "the guard must cover the probe alone"
+        probe = ast.unparse(guard.body[0])
+        assert "get_running_loop" in probe
+        assert "asyncio.run" not in probe
+
+    def test_the_handler_does_not_run_the_rollout(self) -> None:
+        fn = ast.parse(inspect.getsource(HwRobot._run_control_loop).lstrip()).body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        guard = next(
+            node
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Try)
+            and any(
+                isinstance(handler.type, ast.Name) and handler.type.id == "RuntimeError" for handler in node.handlers
+            )
+        )
+        handler = "\n".join(ast.unparse(stmt) for stmt in guard.handlers[0].body)
+        assert "task_runner" not in handler
+        assert "asyncio.run" not in handler


### PR DESCRIPTION
## Problem

`Robot._run_control_loop` decides where to run a hardware rollout by wrapping
`except RuntimeError` around **both** the `asyncio.get_running_loop()` probe and
the nested dispatch:

```python
try:
    asyncio.get_running_loop()          # probe: RuntimeError means "no loop"
    import concurrent.futures
    with concurrent.futures.ThreadPoolExecutor() as pool:   # dispatch
        pool.submit(lambda: asyncio.run(task_runner())).result()
except RuntimeError:
    asyncio.run(task_runner())          # only correct for the probe's error
```

Only the probe's own `RuntimeError` means "no loop is running". A `RuntimeError`
raised by the **dispatch** - a thread the pool cannot start under memory or
`RLIMIT_NPROC` pressure, an executor already shut down - lands in the same
handler, whose `asyncio.run` is invalid *by construction* on exactly that
branch. The caller is told the asyncio internal instead of the cause, and the
`task_runner` coroutine the handler built is left un-awaited.

This is not a hypothetical branch. `Robot.stream(action="execute")` is an
`async def` that calls `_execute_task_sync`, so **the nested branch is that
surface's live path** - the streaming interface for a hardware task takes it on
every call.

## Measured

One `RuntimeError("can't start new thread")` injected at the nested dispatch,
driven from an async caller as `stream` does:

| | `main` | this PR |
|---|---|---|
| `RuntimeError` the caller gets | `asyncio.run() cannot be called from a running event loop` | `can't start new thread` |
| names the cause | **no** | yes |
| names an asyncio internal | **yes** | no |
| un-awaited coroutines leaked | **1** | 0 |
| actions commanded | 0 | 0 |

The honored paths are unchanged on both trees: the nested branch drives
30 applied actions and the synchronous branch
30, each `status="success"`.

## The change

Probe separately from dispatching, so only the probe's `RuntimeError` is
answered:

```python
try:
    asyncio.get_running_loop()
except RuntimeError:
    on_a_running_loop = False
else:
    on_a_running_loop = True

if on_a_running_loop:
    import concurrent.futures
    with concurrent.futures.ThreadPoolExecutor() as pool:
        pool.submit(lambda: asyncio.run(task_runner())).result()
else:
    asyncio.run(task_runner())
```

Both branches still build and drive the rollout exactly once. A dispatch failure
now propagates with its own cause and is not retried on a thread that cannot
serve it.

## Scope

The fix is the guard's *extent*, not its behaviour on the paths that already
worked: no accepted value changes and no message on a working path changes.
A rollout failure raised *inside* `task_runner` is still handled where it always
was, by `_execute_task_async`'s own `except Exception`, which reports it through
the result dict; this change does not touch that.

## Tests

`tests/test_hardware_task_loop_dispatch.py`, 11 cases, no serial/USB hardware
(in-memory driver, stubbed connect path, the built-in `mock` provider):

- both branch-selection premises, so neither assertion below is vacuous - an
  async caller reaches the nested dispatch and a sync caller does not. The spy
  counts only bare `ThreadPoolExecutor()` calls, because the rollout's own
  `asyncio.to_thread` builds the loop's default executor with
  `thread_name_prefix=...`, and counting that would make "the nested branch was
  taken" true on both branches;
- `stream` is an async generator function that calls `_execute_task_sync`, which
  is what makes the nested branch live;
- a dispatch failure names its own cause, with the asyncio internal absent;
- that failure leaks no un-awaited coroutine, and commands the arm 0 times;
- the rollout is driven exactly once on each branch;
- a `RuntimeError` from the synchronous branch's own `asyncio.run` still
  propagates, so the change does not start swallowing anything;
- structural: the `except RuntimeError` covers the probe alone, and its handler
  neither runs `asyncio.run` nor mentions `task_runner`.

Pre-fix (source reverted to `main`, tests kept): **4 failed / 7 passed**, with
`assert "can't start new thread" in 'asyncio.run() cannot be called from a running event loop'` and
`the guard must cover the probe alone: assert 3 == 1`. The 7 that pass are the
over-reach controls - both branches still work, the arm is not commanded, the
synchronous branch still propagates - which is what stops these tests being
satisfied by deleting the guard.

## Gate

Base `cdb3472e`. `MUJOCO_GL=egl python -m pytest tests -q`: **29534 passed,
266 skipped, 0 failed** (683.63s). `ruff check` and `ruff format --check` clean
(1211 files); `mypy strands_robots tests tests_integ` reports 0 errors outside
`examples/isaac_gs`, whose 14 are byte-identical to a pristine-base worktree
control. `scripts/check_merge_base_overlap.py` reports no overlap and
`compare/main...head` reports `behind_by=0`, so the tree these numbers describe
is the merge result.

## Artifact

![dispatch cause](https://raw.githubusercontent.com/cagataycali/robots/artifacts/hardware-task-loop-dispatch/artifact.png)

Measured on Thor with the arms unplugged: the driver is an in-memory fake and
the render is headless MuJoCo. The top row is the rollout the nested dispatch
delivers, commanded onto `so101` with the rollout's own final joint targets
(mapped positionally onto its actuators and clamped into their ranges - one
component clamps). It is identical across the two trees at `max|delta| = 1/255`,
with **0** of 516800 pixels differing above a threshold of 8, so the rollout this
change dispatches is untouched; the whole difference is what the caller is told
when the dispatch fails. `capture.py` and `compose.py` are on the artifacts
branch, and `compose.py` asserts every number it draws.
