### PR TITLE
test(hardware): an abandoned fixture work item must not hang the run

### DIFF
--- a/changelog.d/2239-abandoned-fixture-work-item-hangs-exit.md
+++ b/changelog.d/2239-abandoned-fixture-work-item-hangs-exit.md
@@ -1,0 +1,19 @@
+### Quality: a fixture work item a test gives up on no longer hangs the run
+
+`Robot.start_task` submits the rollout to `Robot._executor`, and the fixtures
+that build that executor for a `Robot` assembled via `__new__` wait for the
+submitted work with `future.result(timeout=...)`. When that wait gave up, the
+work item was still running on a **non-daemon** `ThreadPoolExecutor` worker, and
+`ThreadPoolExecutor` registers an interpreter-exit hook that joins every worker
+it started -- `shutdown(wait=False)` does not detach one already running. So the
+process could not exit: pytest printed the verdict and the job then hung,
+delivering a red test as a hung job rather than a failed one. Measured on that
+shape, pytest reported `1 failed in 2.03s` and a 45s wall clock had to kill the
+process.
+
+The three test modules that build such an executor and can abandon its work
+item now use `tests._daemon_executor.DaemonThreadExecutor`, which keeps
+`ThreadPoolExecutor(max_workers=1)` semantics -- one worker, submissions
+serialized, a real `Future`, `shutdown(wait=True)` draining -- with a daemon
+worker the interpreter does not join. The verdict is unchanged; only the hang is
+gone. A structural check keeps a new abandoning fixture from reintroducing it.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -26,7 +26,7 @@ import shutil
 import threading
 import time
 from collections.abc import AsyncGenerator, Mapping
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -530,7 +530,10 @@ class Robot(TeleopMixin, AgentTool):
 
         # Task execution state
         self._task_state = RobotTaskState()
-        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"{tool_name}_executor")
+        # Annotated with the base class rather than the concrete pool: the two
+        # uses below are ``submit`` and ``shutdown``, so a caller substituting a
+        # different Executor is honouring the contract, not evading it.
+        self._executor: Executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"{tool_name}_executor")
         self._shutdown_event = threading.Event()
         # A stop request that arrived for the current task. An Event rather
         # than a task-state field because ``stop_task`` is called from the

--- a/tests/_daemon_executor.py
+++ b/tests/_daemon_executor.py
@@ -1,0 +1,154 @@
+"""A single-worker executor for fixtures whose work item can be abandoned.
+
+A fixture that hands :attr:`strands_robots.hardware_robot.Robot._executor` a
+``ThreadPoolExecutor`` and then lets a test give up on the work item --
+``future.result(timeout=...)`` raising ``TimeoutError`` -- leaves that work item
+still running on a **non-daemon** worker. ``ThreadPoolExecutor`` registers an
+interpreter-exit hook (``threading._register_atexit``) that joins every worker
+it started, and ``shutdown(wait=False)`` does not detach one that is already
+running. The process therefore cannot exit while the work item is wedged:
+pytest prints the verdict and the job then hangs, so a red test is delivered as
+a hung job rather than a failed one.
+
+Measured on this shape -- a one-worker pool, a wedged work item, a wait that
+gives up after 2s, and ``shutdown(wait=False)`` in teardown -- pytest reported
+``1 failed in 2.03s`` and the process was still alive when a 45s wall clock
+killed it (exit 124).
+
+This executor keeps the semantics the fixtures rely on -- one worker,
+submissions serialized in submit order, ``submit`` returning a real
+:class:`concurrent.futures.Future`, ``shutdown(wait=True)`` draining -- while
+running that worker as a **daemon** thread, which the interpreter does not join
+at exit. An abandoned work item then costs the test its own verdict, reported at
+the ``timeout=`` the test chose, and nothing more.
+
+It does not hide the failure it makes survivable: the wait still raises
+``TimeoutError`` and the test still fails. Only the hang goes away.
+
+One deliberate difference from ``ThreadPoolExecutor``: a work item raising a
+``BaseException`` that is not an ``Exception`` (``KeyboardInterrupt``,
+``SystemExit``) is not captured into the future. ``ThreadPoolExecutor`` captures
+it; here it is allowed to propagate and end the daemon worker, because turning
+an interpreter-level interrupt into a future result is exactly the swallow that
+makes an interrupted run look like a completed one.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from concurrent.futures import Executor, Future
+from typing import Any, ParamSpec, TypeVar
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
+_SHUTDOWN = object()
+"""Sentinel queued by :meth:`DaemonThreadExecutor.shutdown` to end the worker."""
+
+
+class DaemonThreadExecutor(Executor):
+    """``ThreadPoolExecutor(max_workers=1)`` with a daemon worker.
+
+    Only the two members the hardware task path uses are implemented --
+    ``submit`` (``Robot.start_task``) and ``shutdown`` (``Robot.cleanup``) --
+    because those are the only two a fixture hands to production code.
+    """
+
+    def __init__(self, max_workers: int = 1, thread_name_prefix: str = "daemon_executor") -> None:
+        """Build the executor.
+
+        Args:
+            max_workers: Must be ``1``. The queue below serializes work on a
+                single worker, which is what the fixtures using this helper
+                already asked ``ThreadPoolExecutor`` for; a larger pool would
+                need a different implementation rather than a different number.
+            thread_name_prefix: Prefix for the worker thread name, so a stuck
+                worker is identifiable in a thread dump.
+
+        Raises:
+            ValueError: If ``max_workers`` is not ``1``.
+        """
+        if max_workers != 1:
+            raise ValueError(
+                f"DaemonThreadExecutor serializes on one worker; max_workers must be 1, got {max_workers!r}"
+            )
+        self._queue: queue.Queue[Any] = queue.Queue()
+        self._thread_name_prefix = thread_name_prefix
+        self._worker: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._shutdown = False
+
+    @property
+    def worker(self) -> threading.Thread | None:
+        """The worker thread, or ``None`` before the first :meth:`submit`."""
+        return self._worker
+
+    def submit(self, fn: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs) -> Future[_T]:
+        """Queue ``fn`` for the worker and return its future.
+
+        Args:
+            fn: Callable to run on the worker.
+            *args: Positional arguments for ``fn``.
+            **kwargs: Keyword arguments for ``fn``.
+
+        Returns:
+            A future completed by the worker.
+
+        Raises:
+            RuntimeError: If :meth:`shutdown` has already been called, matching
+                ``ThreadPoolExecutor``.
+        """
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            if self._worker is None:
+                self._worker = threading.Thread(target=self._serve, name=f"{self._thread_name_prefix}_0", daemon=True)
+                self._worker.start()
+            future: Future[_T] = Future()
+            self._queue.put((future, fn, args, kwargs))
+            return future
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        """Stop accepting work and end the worker.
+
+        Args:
+            wait: Join the worker before returning. A wedged work item makes
+                this block, exactly as ``ThreadPoolExecutor`` does -- inside the
+                caller, where a test timeout can bound it, rather than at
+                interpreter exit where nothing can.
+            cancel_futures: Cancel work that is queued but not yet started.
+        """
+        with self._lock:
+            first = not self._shutdown
+            self._shutdown = True
+            worker = self._worker
+        if cancel_futures:
+            while True:
+                try:
+                    item = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if item is not _SHUTDOWN:
+                    item[0].cancel()
+        if first:
+            self._queue.put(_SHUTDOWN)
+        if wait and worker is not None:
+            worker.join()
+
+    def _serve(self) -> None:
+        """Run queued work items in order until the shutdown sentinel arrives."""
+        while True:
+            item = self._queue.get()
+            if item is _SHUTDOWN:
+                return
+            future, fn, args, kwargs = item
+            if not future.set_running_or_notify_cancel():
+                continue
+            try:
+                result = fn(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - delivered to the caller via the future
+                future.set_exception(exc)
+            else:
+                future.set_result(result)

--- a/tests/test_abandoned_work_item_cannot_hang_exit.py
+++ b/tests/test_abandoned_work_item_cannot_hang_exit.py
@@ -1,0 +1,351 @@
+"""An abandoned fixture work item must not turn a red test into a hung job.
+
+``Robot.start_task`` submits the rollout to ``Robot._executor``, and the
+fixtures that build that executor for a ``Robot`` assembled via ``__new__``
+sometimes wait for the submitted work with ``future.result(timeout=...)``. When
+that wait gives up, the work item is still running. A ``ThreadPoolExecutor``
+worker is **not** a daemon thread and the class registers an interpreter-exit
+hook that joins every worker it started, so the process cannot exit while the
+work item is wedged: pytest prints the verdict and the job then hangs.
+
+Measured on that shape -- one worker, a wedged item, a wait that gives up after
+2s, ``shutdown(wait=False)`` in teardown -- pytest reported ``1 failed in
+2.03s`` and a 45s wall clock had to kill the process (exit 124). A failing test
+was delivered as a hung job.
+
+:mod:`tests._daemon_executor` keeps the semantics those fixtures asked for and
+runs the worker as a daemon, which the interpreter does not join. This module
+pins both halves: that the helper really does let the process exit, and that the
+``ThreadPoolExecutor`` shape really does not -- so the helper cannot be reverted
+to the shape it replaced without a test saying so.
+
+The verdict itself is untouched. Every test here asserts the wait still fails;
+only the hang goes away.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from strands_robots.hardware_robot import Robot as HwRobot
+from tests._daemon_executor import DaemonThreadExecutor
+
+_TESTS_DIR = pathlib.Path(inspect.getfile(DaemonThreadExecutor)).resolve().parent
+_ROOT = _TESTS_DIR.parent
+
+# Derived from the helper module rather than written as a path literal, so a
+# move of the test tree cannot silently point the scan somewhere empty.
+assert (_ROOT / "pyproject.toml").is_file(), f"repository root not found at {_ROOT}"
+
+_CHILD = """
+import sys, threading
+sys.path.insert(0, {root!r})
+{import_line}
+ex = {ctor}
+wedged = threading.Event()
+fut = ex.submit(wedged.wait)
+try:
+    fut.result(timeout=0.3)
+except TimeoutError:
+    print("VERDICT: the wait gave up", flush=True)
+ex.shutdown(wait=False)
+"""
+
+
+def _child(import_line: str, ctor: str, budget: float) -> tuple[bool, str]:
+    """Run the abandon-a-work-item shape in a child interpreter.
+
+    Args:
+        import_line: Import statement for the executor under test.
+        ctor: Constructor expression for the executor.
+        budget: Seconds to allow the child before declaring it stuck.
+
+    Returns:
+        ``(exited, stdout)`` where ``exited`` is whether the interpreter
+        terminated on its own inside ``budget``.
+    """
+    code = _CHILD.format(root=str(_ROOT), import_line=import_line, ctor=ctor)
+    try:
+        done = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            [sys.executable, "-c", code],
+            cwd=_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=budget,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as expired:
+        return False, (expired.stdout or b"").decode() if isinstance(expired.stdout, bytes) else (expired.stdout or "")
+    return True, done.stdout
+
+
+class TestTheWorkerCannotOutliveTheInterpreter:
+    """The one property that makes exit possible: the worker is a daemon."""
+
+    def test_the_helper_worker_is_a_daemon_thread(self) -> None:
+        executor = DaemonThreadExecutor(max_workers=1, thread_name_prefix="probe")
+        try:
+            started = threading.Event()
+            executor.submit(started.set).result(timeout=5)
+            worker = executor.worker
+            assert worker is not None, "submit did not start a worker"
+            assert worker.daemon is True, "the worker would be joined at interpreter exit"
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_a_thread_pool_worker_is_not_a_daemon(self) -> None:
+        """The premise: the shape this helper replaces is joined at exit."""
+        pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="premise")
+        try:
+            pool.submit(lambda: None).result(timeout=5)
+            workers = [t for t in threading.enumerate() if t.name.startswith("premise")]
+            assert workers, "no worker to inspect"
+            assert all(not t.daemon for t in workers), (
+                "ThreadPoolExecutor workers are non-daemon; if that changed the helper is redundant"
+            )
+        finally:
+            pool.shutdown(wait=True)
+
+
+class TestAnAbandonedWorkItemDoesNotBlockInterpreterExit:
+    """End to end, in a child interpreter, for both executor shapes."""
+
+    def test_the_helper_lets_the_interpreter_exit(self) -> None:
+        exited, out = _child(
+            "from tests._daemon_executor import DaemonThreadExecutor",
+            "DaemonThreadExecutor(max_workers=1)",
+            budget=20.0,
+        )
+        assert "VERDICT" in out, f"the wait did not give up: {out!r}"
+        assert exited, "the interpreter did not exit while a work item was wedged"
+
+    def test_the_thread_pool_shape_does_not(self) -> None:
+        """Why the helper exists. Reverting to a pool reinstates the hang."""
+        exited, out = _child(
+            "from concurrent.futures import ThreadPoolExecutor",
+            "ThreadPoolExecutor(max_workers=1)",
+            budget=5.0,
+        )
+        assert "VERDICT" in out, f"the wait did not give up: {out!r}"
+        assert not exited, (
+            "ThreadPoolExecutor no longer joins a running worker at exit; if that is now true the helper can be retired"
+        )
+
+
+class TestPytestDeliversTheVerdictAndThenExits:
+    """The incident shape: a failing test must cost a failure, not a hung job."""
+
+    def test_a_failing_wait_is_reported_and_the_run_ends(self, tmp_path: pathlib.Path) -> None:
+        generated = tmp_path / "test_generated_abandon.py"
+        generated.write_text(
+            "import threading\n"
+            "from typing import Any\n"
+            "import pytest\n"
+            "from tests._daemon_executor import DaemonThreadExecutor\n"
+            "\n"
+            "@pytest.fixture\n"
+            "def pool() -> Any:\n"
+            "    ex = DaemonThreadExecutor(max_workers=1)\n"
+            "    try:\n"
+            "        yield ex\n"
+            "    finally:\n"
+            "        ex.shutdown(wait=False)\n"
+            "\n"
+            "def test_the_wait_gives_up(pool: Any) -> None:\n"
+            "    wedged = threading.Event()\n"
+            "    pool.submit(wedged.wait).result(timeout=0.3)\n"
+        )
+        try:
+            done = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                [sys.executable, "-m", "pytest", str(generated), "-q", "--no-cov", "-p", "no:cacheprovider"],
+                cwd=_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:  # pragma: no cover - the defect this pins
+            pytest.fail("the child pytest run never exited after the failing wait")
+        assert done.returncode != 0, "the abandoned wait should still fail the test"
+        assert "1 failed" in done.stdout, done.stdout[-2000:]
+
+
+class TestTheDropInContractHolds:
+    """The helper stands in for ``ThreadPoolExecutor(max_workers=1)``."""
+
+    def test_a_result_is_returned(self) -> None:
+        executor = DaemonThreadExecutor()
+        try:
+            assert executor.submit(lambda: "chunk").result(timeout=5) == "chunk"
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_an_exception_reaches_the_caller(self) -> None:
+        executor = DaemonThreadExecutor()
+
+        def _boom() -> None:
+            raise ValueError("from the worker")
+
+        try:
+            with pytest.raises(ValueError, match="from the worker"):
+                executor.submit(_boom).result(timeout=5)
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_work_runs_in_submit_order_on_one_worker(self) -> None:
+        executor = DaemonThreadExecutor()
+        seen: list[int] = []
+        try:
+            futures = [executor.submit(seen.append, i) for i in range(5)]
+            for future in futures:
+                future.result(timeout=5)
+            assert seen == [0, 1, 2, 3, 4]
+        finally:
+            executor.shutdown(wait=True)
+
+    def test_submit_after_shutdown_is_refused(self) -> None:
+        executor = DaemonThreadExecutor()
+        executor.shutdown(wait=True)
+        with pytest.raises(RuntimeError, match="after shutdown"):
+            executor.submit(lambda: None)
+
+    def test_shutdown_waiting_joins_the_worker(self) -> None:
+        executor = DaemonThreadExecutor()
+        executor.submit(lambda: None).result(timeout=5)
+        worker = executor.worker
+        assert worker is not None
+        executor.shutdown(wait=True)
+        assert worker.is_alive() is False
+
+    def test_cancel_futures_cancels_queued_work(self) -> None:
+        executor = DaemonThreadExecutor()
+        release = threading.Event()
+        running = threading.Event()
+
+        def _hold() -> None:
+            running.set()
+            release.wait()
+
+        # Wait until the holder is actually running, so the second submission is
+        # the one still queued when the drain happens.
+        holder = executor.submit(_hold)
+        assert running.wait(5), "the worker never picked up the first item"
+        queued = executor.submit(lambda: None)
+        executor.shutdown(wait=False, cancel_futures=True)
+        assert queued.cancelled() is True
+        release.set()
+        holder.result(timeout=5)
+
+    def test_more_than_one_worker_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="max_workers must be 1"):
+            DaemonThreadExecutor(max_workers=2)
+
+    def test_robot_cleanup_drains_the_executor_it_is_handed(self) -> None:
+        """The production call the helper must honour (``shutdown(wait=True)``)."""
+        source = inspect.getsource(HwRobot.cleanup)
+        assert "_executor.shutdown(wait=True)" in source, (
+            "Robot.cleanup no longer drains the executor; the helper's shutdown contract was written against that call"
+        )
+
+
+def _executor_constructors(tree: ast.AST) -> list[tuple[int, str]]:
+    """Return ``(line, constructor)`` for each ``*._executor = <Call>``."""
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Attribute) and target.attr == "_executor":
+                func = node.value.func
+                name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+                found.append((node.lineno, name))
+    return found
+
+
+def _abandons_a_work_item(tree: ast.AST) -> bool:
+    """Whether the module gives up on a future via ``result(timeout=...)``."""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "result"
+        and any(keyword.arg == "timeout" for keyword in node.keywords)
+        for node in ast.walk(tree)
+    )
+
+
+def _unsafe_modules(files: list[pathlib.Path]) -> dict[str, list[int]]:
+    """Modules that abandon a work item on a non-daemon fixture executor."""
+    offenders: dict[str, list[int]] = {}
+    for path in files:
+        tree = ast.parse(path.read_text())
+        constructors = _executor_constructors(tree)
+        if not constructors or not _abandons_a_work_item(tree):
+            continue
+        bad = [line for line, name in constructors if name != "DaemonThreadExecutor"]
+        if bad:
+            offenders[path.name] = bad
+    return offenders
+
+
+class TestEveryAbandoningFixtureUsesTheDaemonExecutor:
+    """A fixture whose work item a test may abandon must use the helper.
+
+    Scoped to executors assigned to ``*._executor`` -- the attribute
+    ``Robot.start_task`` submits to -- so a pool a test builds and drains inside
+    its own ``with`` block is out of scope by construction rather than by an
+    exemption. The scan does not verify *ordering*: a module that drains through
+    ``Robot.cleanup`` before its wait is safe today and would still be safe with
+    the helper, so demanding the helper costs nothing and removes the dependence
+    on that ordering. Fixtures that never abandon a work item are a wider class
+    and are deliberately left alone.
+    """
+
+    def test_no_module_abandons_work_on_a_non_daemon_executor(self) -> None:
+        offenders = _unsafe_modules(sorted(_TESTS_DIR.rglob("test_*.py")))
+        assert offenders == {}, (
+            "these fixtures leave a running work item for interpreter exit; "
+            f"use tests._daemon_executor.DaemonThreadExecutor: {offenders}"
+        )
+
+    def test_the_scan_covers_the_modules_that_abandon_work(self) -> None:
+        """Non-vacuity: the known abandoning modules are the ones scanned."""
+        abandoning = {
+            path.name
+            for path in sorted(_TESTS_DIR.rglob("test_*.py"))
+            if _executor_constructors(tree := ast.parse(path.read_text())) and _abandons_a_work_item(tree)
+        }
+        assert abandoning == {
+            "test_hardware_cleanup_disconnects.py",
+            "test_hardware_policy_port_domain.py",
+            "test_hardware_robot_lifecycle.py",
+        }, abandoning
+
+    def test_the_scan_reports_a_planted_thread_pool_fixture(self, tmp_path: pathlib.Path) -> None:
+        planted = tmp_path / "test_planted_pool.py"
+        planted.write_text(
+            "from concurrent.futures import ThreadPoolExecutor\n"
+            "def _make(hw):\n"
+            "    hw._executor = ThreadPoolExecutor(max_workers=1)\n"
+            "def test_x(hw):\n"
+            "    hw._task_state.task_future.result(timeout=5)\n"
+        )
+        assert _unsafe_modules([planted]) == {"test_planted_pool.py": [3]}
+
+    def test_the_scan_passes_a_planted_daemon_fixture(self, tmp_path: pathlib.Path) -> None:
+        planted = tmp_path / "test_planted_daemon.py"
+        planted.write_text(
+            "from tests._daemon_executor import DaemonThreadExecutor\n"
+            "def _make(hw):\n"
+            "    hw._executor = DaemonThreadExecutor(max_workers=1)\n"
+            "def test_x(hw):\n"
+            "    hw._task_state.task_future.result(timeout=5)\n"
+        )
+        assert _unsafe_modules([planted]) == {}

--- a/tests/test_hardware_cleanup_disconnects.py
+++ b/tests/test_hardware_cleanup_disconnects.py
@@ -59,7 +59,6 @@ import asyncio
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pytest
@@ -67,6 +66,7 @@ from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnected
 
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState
+from tests._daemon_executor import DaemonThreadExecutor
 
 #: Upper bound on any wait, so a broken contract fails instead of hanging.
 DEADLINE = 10.0
@@ -233,7 +233,7 @@ def _make_robot(driver: Any) -> HwRobot:
     hw.control_frequency = 1000.0
     hw.action_sleep_time = 0.001
     hw._task_state = RobotTaskState()
-    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw._executor = DaemonThreadExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
     hw._stop_requested = threading.Event()
     hw.mesh = None

--- a/tests/test_hardware_policy_port_domain.py
+++ b/tests/test_hardware_policy_port_domain.py
@@ -39,7 +39,6 @@ import ast
 import inspect
 import pathlib
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import numpy as np
@@ -49,6 +48,7 @@ import strands_robots.hardware_robot as hardware_robot
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from strands_robots.utils import tcp_port_error
+from tests._daemon_executor import DaemonThreadExecutor
 from tests.test_hardware_control_loop_rate_guard import _FakeArm
 
 # Ports no policy can be built from. ``0`` asks the kernel for an ephemeral port
@@ -111,7 +111,7 @@ def hw() -> Any:
     robot.control_frequency = 50.0
     robot.action_sleep_time = 1.0 / 50.0
     robot._task_state = RobotTaskState()
-    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._executor = DaemonThreadExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     robot._shutdown_event = threading.Event()
     robot._stop_requested = threading.Event()
     robot._task_admission = threading.Lock()

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -19,7 +19,6 @@ import pkgutil
 import sys
 import threading
 import types
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pytest
@@ -27,6 +26,7 @@ import pytest
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from strands_robots.policies.base import Policy
+from tests._daemon_executor import DaemonThreadExecutor
 from tests.tool_result_contract import tool_json
 
 
@@ -98,7 +98,7 @@ def _make_robot(fake: _FakeLeRobot | None = None, control_frequency: float = 100
     hw.control_frequency = control_frequency
     hw.action_sleep_time = 1.0 / control_frequency
     hw._task_state = RobotTaskState()
-    hw._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
+    hw._executor = DaemonThreadExecutor(max_workers=1, thread_name_prefix="test_arm_executor")
     hw._shutdown_event = threading.Event()
     hw._stop_requested = threading.Event()
     hw._task_admission = threading.Lock()


### PR DESCRIPTION
## Problem

`Robot.start_task` submits the rollout to `Robot._executor`. The fixtures that build that executor for a `Robot` assembled via `__new__` wait for the submitted work with `future.result(timeout=...)`, and a test that gives up on that wait leaves the work item running.

That work item was running on a **non-daemon** `ThreadPoolExecutor` worker. `ThreadPoolExecutor` registers an interpreter-exit hook that joins every worker it started, and `shutdown(wait=False)` does not detach one that is already running -- it only declines to wait *here*. So the process could not exit.

Measured on the real `start_task` path (bring-up wedged, the test waits 2s and gives up, teardown calls `shutdown(wait=False)`):

| | main | this PR |
|---|---|---|
| executor the fixture builds | `ThreadPoolExecutor` | `DaemonThreadExecutor` |
| `start_task` | `success` | `success` |
| the wait | `TimeoutError` after 2.0s | `TimeoutError` after 2.0s |
| non-daemon threads left | `['test_arm_executor_0']` | none |
| interpreter exited | **no -- killed at 45s** | yes, exit 0 |
| wall clock | 45.06s | 2.78s |

The verdict is identical on both trees. The difference is entirely whether the run ends: a red test is delivered as a *hung job* rather than a failed one, so the log ends after the summary line and the failure it just printed is the last thing anyone sees.

Three modules build such an executor and can abandon its work item:

| module | line | it can give up on |
|---|---|---|
| `tests/test_hardware_policy_port_domain.py` | 114 | `task_future.result(timeout=...)` |
| `tests/test_hardware_robot_lifecycle.py` | 101 | `task_future.result(timeout=...)` |
| `tests/test_hardware_cleanup_disconnects.py` | 236 | a `start_task` rollout it later stops |

## Change

`tests/_daemon_executor.py` -- a `concurrent.futures.Executor` that keeps the semantics those fixtures asked for by writing `ThreadPoolExecutor(max_workers=1)`:

- one worker, so submissions are serialized in submit order;
- a real `concurrent.futures.Future`, so `result(timeout=...)`, exceptions and cancellation behave as before;
- `shutdown(wait=True)` drains and joins, `cancel_futures=True` cancels what is still queued;
- `submit` after shutdown raises `RuntimeError`;

with a daemon worker, which the interpreter does not join. The three modules above now build that. Nothing about the verdict changes -- the wait still raises and the test still fails at the same instant.

`Robot._executor` was *inferred* as `ThreadPoolExecutor` from its assignment, while the only two uses are `submit` (hardware_robot.py:2031) and `shutdown` (hardware_robot.py:2442). It is now annotated with the base class it actually depends on. That is an annotation change with no runtime effect, and it is what makes the substitution type-legal rather than three `# type: ignore[assignment]`.

## Scope

The check is scoped to a pool assigned to `*._executor` and asserts it is not a bare `ThreadPoolExecutor`. That is the shape that outlives the test, because the object under test keeps the reference and the test hands the future back to itself. A pool a test builds and drains inside its own `with` block never reaches that state, so it is out of scope by construction rather than by an exemption list.

Fixtures that build such an executor and always join their work item are not touched. They are correct today; the hazard is specific to giving up on the wait.

`#2241` bounds a hung job from the CI side. This removes the cause of this particular hang; the two are complementary.

## Artifact

![measured](https://raw.githubusercontent.com/cagataycali/robots/artifacts/abandoned-fixture-work-item-hangs-exit/abandoned-fixture-work-item-hangs-exit.png)

Capture, compose, the mutation script and the raw facts: [`artifacts/abandoned-fixture-work-item-hangs-exit`](https://github.com/cagataycali/robots/tree/artifacts/abandoned-fixture-work-item-hangs-exit). `compose.py` asserts every number drawn against `facts.json` before saving.

## Verification

Pre-fix -- the three fixtures reverted to `144b000e`, the helper and the new module kept:

```
1 failed, 16 passed in 15.38s
```

The failure names all three modules with their line numbers. The 16 that pass are the helper's own drop-in contract and the two child-interpreter proofs, which are new coverage rather than a fix.

Mutation table -- 7 plausible regressions x 2 arms:

| mutation | new module | 201 pre-existing |
|---|---|---|
| (unmutated control) | 0 failed / 17 | 0 failed / 201 |
| M1 `port_domain` fixture back to `ThreadPoolExecutor` | 1 failed / 16 | 0 failed / 201 |
| M2 `lifecycle` fixture back to `ThreadPoolExecutor` | 1 failed / 16 | 0 failed / 201 |
| M3 `cleanup_disconnects` back to `ThreadPoolExecutor` | 1 failed / 16 | 0 failed / 201 |
| M4 helper worker is not a daemon | 3 failed / 14 | 0 failed / 201 |
| M5 `shutdown(wait=True)` does not join | 1 failed / 16 | 1 failed / 200 |
| M6 `submit` after shutdown allowed | 1 failed / 16 | 0 failed / 201 |
| M7 worker swallows the exception | 1 failed / 16 | 0 failed / 201 |

7 of 7 caught here, 6 of 7 invisible to the 201 pre-existing cases. M5 is caught by both, and that is the informative row: `test_hardware_cleanup_disconnects.py` asserts ordering around production's own `shutdown(wait=True)`, so that half of the drop-in contract is already load-bearing for an existing test. Every file restored byte-identically.

Gate at `144b000e` (rebased onto it, so this is the tree that merges):

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` -> **29551 passed, 266 skipped, 0 failed** in 698.80s. That reconciles: 29523 at `cdb3472e` + 11 from `#2242` + the 17 new cases here.
- `ruff check` / `ruff format --check strands_robots tests tests_integ` -> clean, 1213 files.
- `mypy strands_robots tests tests_integ` -> **0 errors outside `examples/`**; the 14 in `examples/isaac_gs` are byte-identical to a pristine `144b000e` worktree.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` -> `No overlap` (0 paths changed in that span).
- The 8 repo-wide root guards and `tests/tools/test_docstring_module_xrefs.py` pass; `assemble_changelog.py --check` -> OK.

Closes #2239
