### PR TITLE
feat(ci): sweep the open pull request set for untested compositions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -878,6 +878,49 @@ hatch run format            # ruff check --fix, ruff format
    code does not separate them. Qualify first, then read a `404` on the
    *qualified* form as the uncomparable one.
 
+   **Both readings above are per-branch, and neither can see the open set.**
+   `M..base` is empty by construction whenever `M` is the base the branch was
+   evaluated against, which is every run, so two pull requests that are both
+   still open are invisible to each other: the intersection contains neither, the
+   overlap check reports clean on both, and the first tree in which the two are
+   compiled together is `main`. That is the #1763/#1766 topology arriving from the
+   open set rather than from a merged base. It also does not clear itself over
+   time - stale *approvals* are dismissed on push, a stale *pass* has no
+   equivalent, and a pull request idle in review never re-runs - so the exposure
+   runs until that branch's next push rather than until the sibling merges.
+   `--all-open` is the caller for both, exactly as for the sweep in step 12:
+
+   ```
+   python3 scripts/check_merge_base_overlap.py --github-repo <owner/name> --all-open
+   ```
+
+   Run it when reporting repository health. It reads the open set from the API and
+   computes the same intersection twice per pull request - once against each
+   sibling's `M..head`, once against what has landed on the base since its own
+   `M` - so the two modes cannot disagree about what counts as an overlap or as
+   prose. Measured on the queue the day it was added: 10 open non-draft pull
+   requests, 45 pairs, one pair sharing a behaviour-bearing path (#1035 + #1722 on
+   `strands_robots/mesh/__init__.py`) and one stale base 62 commits deep (#1722 on
+   `strands_robots/mesh/ros_bridge.py`), neither of which any per-branch signal
+   was reporting - both read `mergeStateStatus: CLEAN`.
+
+   Two properties of that sweep are worth knowing before leaning on it. A
+   truncated path set is named as unevaluated rather than intersected: the compare
+   endpoint caps `files` at 300, a capped list is indistinguishable from a
+   complete one in the payload, and this check's failure mode is a *missed*
+   overlap, so quietly intersecting a truncated set is how one goes missing.
+   And the two path sets skip apart: the base-side set is the one that grows
+   without bound, so it is the one that hits that cap - #1035 was 265 commits
+   behind - and dropping the whole pull request for it would discard the pairwise
+   finding this mode exists to make.
+
+   A file carrying a `strict=True` xfail is the highest-value overlap candidate
+   there is, because its whole purpose is to fail when a sibling change lands: it
+   breaks a composition that git merges without a single conflict marker. #2233
+   pinned a defect that way and #2235 fixed it; composed, the tree was red with
+   nothing to resolve, which is why `mergeStateStatus: CLEAN` is not merely
+   unhelpful here but actively reassuring.
+
    Read that run as a **delta, not an absolute**. The environment you verify in
    is almost never the one CI uses, and a partial one fails tests for reasons
    that have nothing to do with the merge. Composing #1786 and #1804 - both

--- a/changelog.d/2244-sweep-the-open-set-for-untested-compositions.md
+++ b/changelog.d/2244-sweep-the-open-set-for-untested-compositions.md
@@ -1,0 +1,27 @@
+### Added: `check_merge_base_overlap.py --all-open` sweeps the open set for untested compositions
+
+The overlap check could only ever read one branch, and `M..base` is empty by
+construction whenever `M` is the base that branch was evaluated against. So two
+pull requests that both edit one file while both are still open are invisible to
+each other -- the intersection contains neither, both read clean, and the first
+tree in which the two are compiled together is `main`. Nothing clears that over
+time either: stale approvals are dismissed on push, a stale pass has no
+equivalent, and a pull request idle in review never re-runs.
+
+`--all-open` reads the open set from the API and computes the same intersection
+twice per pull request -- once against each sibling 's head, once against what
+has landed on the base since its own merge base -- reusing the path-set helpers
+the single-branch mode uses, so the two cannot disagree about what counts as an
+overlap or as prose. A path set that reached the compare endpoint 's 300-entry
+file cap is named as unevaluated rather than intersected, because this check 's
+failure mode is a missed overlap. The two sets skip independently: the base-side
+one is what grows without bound and so what hits the cap, and dropping the whole
+pull request for it would discard the pairwise finding the mode exists to make.
+
+Adding a second inferring script joins the scope of the guard that pins #2030's
+defect, so that guard moves from a `len(...) == 3` literal to a set equality against
+a declared mapping of the flag each script spells the repository with and the argv
+marker that makes naming it required. It is per invocation rather than per script
+because this script's own `--repo` is a local checkout path and its single-branch
+mode never reaches the API, so a blanket rule would read a correctly-named
+invocation as an inferred one and would false-reject the local-git mode.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -23,6 +23,40 @@ which predates #1766, so the first evaluation of the two changes *together* was
 **text** -- git had no conflicting hunks to report, and it is not git's job to
 know that one branch's assertion describes the other branch's bug.
 
+What one branch cannot see
+--------------------------
+``M..base`` is empty **by construction** whenever ``M`` is the base the branch
+was evaluated against, which is every run: the check clears itself not after
+wall-clock time but when the pull request is *re-evaluated*. Two consequences,
+both invisible to every per-branch signal:
+
+- For two pull requests that are both still **open**, ``M..base`` contains
+  neither of them, so the intersection is empty and the check reports clean on
+  both. The first evaluation of the two changes together is ``main``. That is the
+  #1763/#1766 topology arriving from the open set rather than from the merged
+  base, and it is a property of the *set*, which is the same reason the
+  duplicate-claim check had to exist (#2017) -- every other check here reads one
+  pull request at a time. This one keys on the file rather than the issue, so two
+  pull requests claiming different issues are silent to that check by design.
+- Once the sibling merges, nothing invalidates the second pull request's green.
+  Stale *approvals* are dismissed on push; a stale *pass* has no equivalent, and
+  a pull request idle in review never re-runs. So the exposure is not the interval
+  between two merges: it is the interval until the second one's next push, which
+  is unbounded for anything sitting in a review queue.
+
+``--all-open`` is the caller for both. It reads the open set from the API and
+computes the same intersection twice per pull request -- once against each
+sibling's ``M..head``, once against what has landed on the base since its own
+``M`` -- reusing the path-set helpers the single-branch mode uses, so the two
+modes cannot disagree about what counts as an overlap or as prose.
+
+A file carrying a ``strict=True`` xfail is the highest-value overlap candidate
+there is: its whole purpose is to fail when a sibling change lands, so it breaks
+a composition that git merges without a single conflict marker. #2233 pinned a
+defect that way and #2235 fixed it; composed, the tree was red with no conflict
+to resolve, which is why ``mergeStateStatus: CLEAN`` is not merely unhelpful
+here but actively reassuring.
+
 What this computes
 ------------------
 The overlap between two path sets, both taken from the branch's merge base ``M``
@@ -78,15 +112,37 @@ Usage
                 never from the working tree.
 ``--repo``      repository root (default: the current working directory).
 
-Exit status is ``1`` when a behaviour-bearing path overlaps, else ``0``.
+``--all-open``  Sweep the open set instead of one branch (see above). Mutually
+                exclusive with ``--head``, which names one commit.
+``--github-repo``
+                ``owner/name`` for ``--all-open`` (default:
+                ``$GITHUB_REPOSITORY``). Deliberately not ``--repo``: in this
+                script ``--repo`` is already a local checkout path, and one flag
+                that means a filesystem path in one mode and a slug in the other
+                is the kind of ambiguity a caller discovers by getting a wrong
+                answer.
+``--token``     API token for ``--all-open`` (default: ``$GITHUB_TOKEN``). Needs
+                ``pull-requests: read``.
+
+Exit status is ``1`` when a behaviour-bearing path overlaps, else ``0``. That is a
+blocking result for one branch, and a report for ``--all-open``: the sweep's
+remedy is a decision about merge order plus possibly one composition run, which
+no push by either author turns green, so it is deliberately absent from the
+required set. A gate a branch cannot clear by doing anything is a report,
+whatever it is wired to.
 """
 
 from __future__ import annotations
 
 import argparse
+import dataclasses
+import itertools
+import json
 import os
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
@@ -179,6 +235,324 @@ def overlapping_paths(pr_paths: Iterable[str], base_paths: Iterable[str]) -> tup
     return tuple(sorted(frozenset(pr_paths) & frozenset(base_paths)))
 
 
+API_ROOT = "https://api.github.com"
+
+#: Pagination ceiling for the open-pull-request listing, mirroring the sibling
+#: sweep in ``scripts/check_last_push_approval.py``. A repository holding more
+#: open pull requests than this at once has a different problem, and an unbounded
+#: loop over a paginated endpoint is how a transient API shape change becomes a
+#: hang rather than an error.
+_MAX_PAGES = 20
+
+#: GitHub's compare endpoint returns at most this many entries in ``files``. A
+#: truncated list is indistinguishable from a complete one in the payload, so a
+#: path set that reaches the cap is reported as unevaluated rather than as not
+#: overlapping. This check's failure mode is a *missed* overlap, and quietly
+#: intersecting a truncated set is exactly how one goes missing.
+_COMPARE_FILE_CAP = 300
+
+
+class ApiError(RuntimeError):
+    """A GitHub API call the sweep depends on did not succeed.
+
+    Separate from ``GitError`` because the two modes have disjoint inputs: the
+    single-branch check reads the object database and never the network, and the
+    sweep reads the network and never a checkout. One shared exception would let
+    a report offer a remedy that cannot apply to the mode that produced it.
+    """
+
+
+@dataclasses.dataclass(frozen=True)
+class OpenPullRequest:
+    """One open pull request's path sets, both taken from its own merge base.
+
+    ``landed_since`` is ``None`` when that side could not be read. It is an input
+    to the stale-base mode only, so an unreadable one excludes the pull request
+    from that mode while leaving it in the pairwise comparison -- which matters:
+    the base-side set is the one that grows without bound and so the one that
+    hits the file cap, and dropping the whole pull request for it would discard a
+    pairwise finding this check exists to make.
+    """
+
+    number: int
+    head_sha: str
+    merge_base: str
+    behind_by: int
+    edits: frozenset[str]
+    landed_since: frozenset[str] | None
+
+
+def _get(url: str, token: str) -> object:
+    """Fetch and decode one API response."""
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "check-merge-base-overlap",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        return json.load(response)
+
+
+def resolve_open_pull_requests(repo: str, token: str) -> list[tuple[int, str]]:
+    """Return ``(number, head_sha)`` for every open non-draft pull request, sorted.
+
+    Drafts are excluded for the reason the sibling sweep gives: a draft cannot
+    merge whatever else is true of it, so a finding on one does not mean what a
+    finding here means. Sorting keeps a diff of two reports about changed
+    verdicts rather than reordered rows.
+    """
+    found: list[tuple[int, str]] = []
+    for page in range(1, _MAX_PAGES + 1):
+        payload = _get(f"{API_ROOT}/repos/{repo}/pulls?state=open&per_page=100&page={page}", token)
+        rows = payload if isinstance(payload, list) else []
+        for row in rows:
+            if not isinstance(row, dict) or row.get("draft"):
+                continue
+            number = row.get("number")
+            head = ((row.get("head") or {}).get("sha")) or ""
+            if isinstance(number, int) and head:
+                found.append((number, str(head)))
+        if len(rows) < 100:
+            break
+    return sorted(found)
+
+
+def compare_paths(repo: str, base: str, head: str, token: str) -> tuple[frozenset[str], str, int]:
+    """Return ``(paths, merge_base_sha, behind_by)`` for a three-dot ``base...head``.
+
+    The three-dot form is what makes this the same question the single-branch
+    mode asks with git: the ``files`` it reports are the diff from
+    ``merge_base(base, head)`` to ``head``, i.e. ``M..head``. Swapping the
+    operands therefore yields ``M..base`` from the same endpoint, which is how
+    the sweep obtains both sides without resolving a merge base itself or
+    fetching a single commit.
+    """
+    url = f"{API_ROOT}/repos/{repo}/compare/{base}...{head}"
+    payload = _get(url, token)
+    if not isinstance(payload, dict):
+        raise ApiError(f"{url}: expected an object, got {type(payload).__name__}")
+    entries = payload.get("files")
+    entries = entries if isinstance(entries, list) else []
+    if len(entries) >= _COMPARE_FILE_CAP:
+        raise ApiError(
+            f"{url}: the file list reached the {_COMPARE_FILE_CAP}-entry cap, so the path set is "
+            + "incomplete and an overlap computed from it could be a false negative"
+        )
+    paths = frozenset(str(entry["filename"]) for entry in entries if isinstance(entry, dict) and entry.get("filename"))
+    commit = payload.get("merge_base_commit")
+    merge_base_sha = str((commit or {}).get("sha") or "") if isinstance(commit, dict) else ""
+    behind_by = payload.get("behind_by")
+    return paths, merge_base_sha, behind_by if isinstance(behind_by, int) else 0
+
+
+def collect_open_pull_requests(
+    repo: str, base_ref: str, token: str
+) -> tuple[list[OpenPullRequest], list[tuple[int, str]]]:
+    """Read both path sets for every open pull request.
+
+    Returns the rows it could evaluate and ``(number, reason)`` for every side it
+    could not. A failure on one pull request is named and skipped rather than
+    raised: the sweep exists to surface findings across the standing population,
+    and one unreachable pull request must not take the rest of the report with
+    it. Naming the skips is the same requirement -- an unevaluated pull request
+    that says nothing is the failure mode this whole file is written against.
+    """
+    rows: list[OpenPullRequest] = []
+    unevaluated: list[tuple[int, str]] = []
+    lookup_failures = (ApiError, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError)
+    for number, head_sha in resolve_open_pull_requests(repo, token):
+        try:
+            edits, fork_point, behind_by = compare_paths(repo, base_ref, head_sha, token)
+        except lookup_failures as error:
+            unevaluated.append((number, f"not evaluated in either mode - own path set unreadable: {error}"))
+            continue
+        landed_since: frozenset[str] | None
+        try:
+            landed_since, _, _ = compare_paths(repo, head_sha, base_ref, token)
+        except lookup_failures as error:
+            landed_since = None
+            unevaluated.append((number, f"stale-base mode only - base-side path set unreadable: {error}"))
+        rows.append(
+            OpenPullRequest(
+                number=number,
+                head_sha=head_sha,
+                merge_base=fork_point,
+                behind_by=behind_by,
+                edits=edits,
+                landed_since=landed_since,
+            )
+        )
+    return rows, unevaluated
+
+
+def pair_overlaps(
+    pull_requests: Iterable[OpenPullRequest],
+) -> list[tuple[int, int, tuple[str, ...], tuple[str, ...]]]:
+    """Return ``(left, right, blocking, prose)`` for every pair sharing a path."""
+    ordered = sorted(pull_requests, key=lambda row: row.number)
+    found: list[tuple[int, int, tuple[str, ...], tuple[str, ...]]] = []
+    for left, right in itertools.combinations(ordered, 2):
+        blocking, prose = partition_overlap(overlapping_paths(left.edits, right.edits))
+        if blocking or prose:
+            found.append((left.number, right.number, blocking, prose))
+    return found
+
+
+def stale_base_overlaps(
+    pull_requests: Iterable[OpenPullRequest],
+) -> list[tuple[int, int, tuple[str, ...], tuple[str, ...]]]:
+    """Return ``(number, behind_by, blocking, prose)`` for every stale-base overlap.
+
+    This is the single-branch computation applied to the population: the same
+    intersection, with the base branch substituted for a sibling's head. A pull
+    request level with its base has nothing to compare, so it is skipped rather
+    than reported as clean.
+    """
+    found: list[tuple[int, int, tuple[str, ...], tuple[str, ...]]] = []
+    for row in sorted(pull_requests, key=lambda row: row.number):
+        if row.landed_since is None or row.behind_by == 0:
+            continue
+        blocking, prose = partition_overlap(overlapping_paths(row.edits, row.landed_since))
+        if blocking or prose:
+            found.append((row.number, row.behind_by, blocking, prose))
+    return found
+
+
+def render_sweep(
+    *,
+    repo: str,
+    base_ref: str,
+    pull_requests: Sequence[OpenPullRequest],
+    pairs: Sequence[tuple[int, int, tuple[str, ...], tuple[str, ...]]],
+    stale: Sequence[tuple[int, int, tuple[str, ...], tuple[str, ...]]],
+    unevaluated: Sequence[tuple[int, str]],
+) -> str:
+    """Render the sweep report.
+
+    Every multi-line paragraph is a named local joined with explicit ``+``, for
+    the reason ``render_report`` gives: implicit concatenation inside a list of
+    report lines is indistinguishable from a forgotten comma.
+    """
+    pair_count = len(pull_requests) * (len(pull_requests) - 1) // 2
+    lines = ["## Merge-base overlap check - open set", ""]
+    header = (
+        f"`{repo}`, base `{base_ref}`: {len(pull_requests)} open non-draft pull request(s), "
+        + f"{pair_count} pair(s) compared."
+    )
+    lines.append(header)
+    lines.append("")
+
+    blocking_pairs = [row for row in pairs if row[2]]
+    prose_pairs = [row for row in pairs if not row[2]]
+    blocking_stale = [row for row in stale if row[2]]
+
+    if not blocking_pairs and not blocking_stale:
+        lines.append("No untested composition in the open set. Nothing here needs a merge-order decision.")
+        lines.append("")
+    if blocking_pairs:
+        pair_heading = f"### Pairs editing the same behaviour-bearing path ({len(blocking_pairs)})"
+        pair_why = (
+            "Neither pull request's checks have compiled the other's changes, and neither can: "
+            + "each ran against a base that contains neither. Whichever merges second inherits a "
+            + "green result about a tree that no longer exists."
+        )
+        lines.append(pair_heading)
+        lines.append("")
+        lines.append(pair_why)
+        lines.append("")
+        lines.append("| pull requests | shared path(s) |")
+        lines.append("|---|---|")
+        for left, right, paths, _ in blocking_pairs:
+            rendered = ", ".join(f"`{path}`" for path in paths)
+            lines.append(f"| #{left} + #{right} | {rendered} |")
+        lines.append("")
+    if blocking_stale:
+        stale_heading = f"### Pull requests whose base moved under a path they edit ({len(blocking_stale)})"
+        stale_why = (
+            "The single-branch check would report each of these today, and reported none of them "
+            + "when it ran: it reads the base as of that run, and the commits below landed after. "
+            + "Nothing re-runs a pull request idle in review, so the green stands until its next push."
+        )
+        lines.append(stale_heading)
+        lines.append("")
+        lines.append(stale_why)
+        lines.append("")
+        lines.append(f"| pull request | behind `{base_ref}` by | path(s) also changed on `{base_ref}` |")
+        lines.append("|---|---|---|")
+        for number, behind_by, paths, _ in blocking_stale:
+            rendered = ", ".join(f"`{path}`" for path in paths)
+            lines.append(f"| #{number} | {behind_by} | {rendered} |")
+        lines.append("")
+    if prose_pairs:
+        prose_heading = (
+            f"Also sharing a path, not reported ({len(prose_pairs)} prose-only pair(s)) - prose "
+            + "cannot change what the suite or the package does, and a genuine collision inside one "
+            + "surfaces as a merge conflict:"
+        )
+        lines.append(prose_heading)
+        lines.append("")
+        for left, right, _, paths in prose_pairs:
+            rendered = ", ".join(f"`{path}`" for path in paths)
+            lines.append(f"- #{left} + #{right}: {rendered}")
+        lines.append("")
+    if unevaluated:
+        unevaluated_heading = (
+            f"Unevaluated ({len(unevaluated)}) - named rather than counted as clean, because a "
+            + "pull request this check could not read is not a pull request it cleared:"
+        )
+        lines.append(unevaluated_heading)
+        lines.append("")
+        for number, reason in unevaluated:
+            lines.append(f"- #{number}: {reason}")
+        lines.append("")
+
+    remedy = (
+        "**To clear a row above:** decide the merge order, run the tests covering the shared "
+        + "paths against the composition once, and merge. This is a report, not a required check: "
+        + "no push by either author makes a *pair* green."
+    )
+    lines.append(remedy)
+    return "\n".join(lines) + "\n"
+
+
+def _emit(report: str) -> None:
+    """Print the report and append it to the CI job summary when there is one."""
+    print(report, end="")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report)
+
+
+def _run_sweep(repo: str, base_ref: str, token: str) -> int:
+    """Sweep the open set. Exit 1 when a behaviour-bearing composition is untested."""
+    try:
+        pull_requests, unevaluated = collect_open_pull_requests(repo, base_ref, token)
+    except (ApiError, urllib.error.URLError, urllib.error.HTTPError, ValueError) as error:
+        # Listing the pull requests is the one lookup with no partial result to
+        # fall back on: without it there is no population to sweep.
+        print(f"::error::merge-base overlap sweep could not list open pull requests: {error}", file=sys.stderr)
+        return 1
+
+    pairs = pair_overlaps(pull_requests)
+    stale = stale_base_overlaps(pull_requests)
+    _emit(
+        render_sweep(
+            repo=repo,
+            base_ref=base_ref,
+            pull_requests=pull_requests,
+            pairs=pairs,
+            stale=stale,
+            unevaluated=unevaluated,
+        )
+    )
+    return 1 if any(row[2] for row in pairs) or any(row[2] for row in stale) else 0
+
+
 def render_report(
     *,
     base_ref: str,
@@ -256,16 +630,48 @@ def main(argv: Sequence[str] | None = None) -> int:
         description="Report files a pull request edits that its base also changed since it branched.",
     )
     parser.add_argument("--base-ref", default="main", help="branch being merged into (default: main)")
-    parser.add_argument("--head", default="HEAD", help="commit under test (default: HEAD)")
+    parser.add_argument(
+        "--head",
+        default=None,
+        help="commit under test (default: HEAD); one branch only, not --all-open",
+    )
     parser.add_argument("--repo", default=None, help="repository root (default: current directory)")
+    parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="sweep the open set from the API instead of checking one branch",
+    )
+    parser.add_argument(
+        "--github-repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="owner/name for --all-open (default: $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="API token for --all-open (default: $GITHUB_TOKEN)",
+    )
     args = parser.parse_args(argv)
 
+    # Mutually exclusive rather than ignored: --head names one commit and the
+    # sweep reads none, so honouring both would answer a question the caller did
+    # not ask while looking like it had.
+    if args.all_open and args.head is not None:
+        parser.error("--all-open sweeps the open set and reads no local commit; --head names one branch")
+    if args.all_open:
+        if not args.github_repo:
+            parser.error("--all-open needs --github-repo owner/name (or $GITHUB_REPOSITORY)")
+        if not args.token:
+            parser.error("--all-open needs --token (or $GITHUB_TOKEN)")
+        return _run_sweep(args.github_repo, args.base_ref, args.token)
+
+    head = args.head if args.head is not None else "HEAD"
     repo = Path(args.repo) if args.repo is not None else None
 
     try:
         base = resolve_base_ref(args.base_ref, repo=repo)
-        fork_point = merge_base(base, args.head, repo=repo)
-        pr_paths = changed_paths(fork_point, args.head, repo=repo)
+        fork_point = merge_base(base, head, repo=repo)
+        pr_paths = changed_paths(fork_point, head, repo=repo)
         base_paths = changed_paths(fork_point, base, repo=repo)
     except GitError as error:
         # Loud and non-zero: a check that cannot compute its answer must not

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -76,6 +76,22 @@ _INFERS_REPOSITORY: tuple[str, ...] = tuple(
     )
 )
 
+#: The flag that names the API repository, and the argv marker that makes naming it
+#: required, for each script that can infer one from ``GITHUB_REPOSITORY``.
+#:
+#: ``check_merge_base_overlap.py`` differs on both axes and is why this is a mapping
+#: rather than a blanket ``--repo`` test. Its own ``--repo`` is the local checkout
+#: path, so the API repository needs a distinct spelling; and only ``--all-open``
+#: reaches the API at all, its single-branch mode being local git with nothing to
+#: infer. Requiring the flag of that mode would be the same false rejection this
+#: scope exists to avoid.
+_NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
+    "check_closing_reference.py": ("--repo", None),
+    "check_duplicate_claim.py": ("--repo", None),
+    "check_last_push_approval.py": ("--repo", None),
+    "check_merge_base_overlap.py": ("--github-repo", "--all-open"),
+}
+
 
 def _documented_intake_argv(issue: int) -> list[str]:
     """Return the intake command step 1 prints, as an ``argv`` list."""
@@ -638,17 +654,31 @@ class TestNoDocumentedInvocationLeavesTheRepositoryInferred:
     it with no arguments, where the environment is correct by construction. Scoped to
     the scripts that can *infer* a repository, since the local-git checks have nothing
     to infer and requiring a flag of them would be a false rejection.
+
+    The scope is per *invocation*, not per script: :data:`_NAMES_REPOSITORY` carries
+    both the flag each script spells the repository with and the argv marker that makes
+    naming it required, because one script's ``--repo`` means a local checkout path and
+    one of its two modes never reaches the API.
     """
 
     def test_the_inferring_scripts_are_the_ones_measured(self) -> None:
         """Non-vacuity: the scope is a real set, and this script is in it."""
         assert "check_duplicate_claim.py" in _INFERS_REPOSITORY, _INFERS_REPOSITORY
-        assert len(_INFERS_REPOSITORY) == 3, _INFERS_REPOSITORY
+        assert set(_INFERS_REPOSITORY) == set(_NAMES_REPOSITORY), (
+            "a script that can infer the repository must declare how it names one",
+            _INFERS_REPOSITORY,
+            sorted(_NAMES_REPOSITORY),
+        )
 
     def test_every_documented_invocation_names_the_repository(self) -> None:
         invocations = _documented_check_invocations()
         assert len(invocations) >= 3, invocations
-        inferring = [(script, rest) for script, rest in invocations if script in _INFERS_REPOSITORY]
+        inferring = [(script, rest) for script, rest in invocations if script in _NAMES_REPOSITORY]
         assert inferring, invocations
-        missing = [f"{script}{rest}" for script, rest in inferring if "--repo" not in rest]
+        missing = [
+            f"{script}{rest}"
+            for script, rest in inferring
+            for flag, marker in (_NAMES_REPOSITORY[script],)
+            if (marker is None or marker in rest) and flag not in rest
+        ]
         assert not missing, missing

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import importlib.util
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 
@@ -412,3 +413,339 @@ def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> Non
     )
     assert "HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
     assert '--head "$HEAD_SHA"' in workflow, "the commit under test is named, not checked out"
+
+
+# --- the open set ---------------------------------------------------------------
+#
+# ``--all-open`` answers a question no per-branch run can: ``M..base`` is empty by
+# construction whenever ``M`` is the base a branch was evaluated against, so two
+# pull requests that are both still open are invisible to each other, and a
+# sibling merging afterwards invalidates nothing. These pins are API-shaped rather
+# than git-shaped because the sweep reads no checkout -- ``_get`` is its single
+# seam, so faking that is faking the network and nothing else.
+
+
+def _compare(files: list[str], *, merge_base: str = "aaaa1111", behind_by: int = 0) -> dict[str, object]:
+    """Build one ``compare`` payload in the shape the endpoint returns."""
+    return {
+        "merge_base_commit": {"sha": merge_base},
+        "behind_by": behind_by,
+        "files": [{"filename": name} for name in files],
+    }
+
+
+def _api(
+    pulls: list[dict[str, object]],
+    compares: dict[str, object],
+) -> Callable[[str, str], object]:
+    """Return a ``_get`` stand-in serving a recorded open set and compare payloads.
+
+    A compare with no recorded payload raises, which is deliberate: an unrecorded
+    lookup is a test that has not said what it means, and silently returning an
+    empty path set would make it pass as "no overlap".
+    """
+
+    def get(url: str, token: str) -> object:
+        if "/pulls?" in url:
+            return pulls if url.endswith("page=1") else []
+        key = url.split("/compare/", 1)[1]
+        if key not in compares:
+            raise check.ApiError(f"no recorded compare for {key}")
+        return compares[key]
+
+    return get
+
+
+def _pull(number: int, head: str, *, draft: bool = False) -> dict[str, object]:
+    return {"number": number, "head": {"sha": head}, "draft": draft}
+
+
+def _sweep(monkeypatch: pytest.MonkeyPatch, get: Callable[[str, str], object], tmp_path: Path) -> int:
+    """Run the sweep from a directory that is not a repository at all.
+
+    Every sweep test runs from ``tmp_path`` rather than the checkout, which pins
+    the property the mode depends on: the open set comes from the API, so a caller
+    reporting repository health needs no clone and no fetch of ten pull request
+    heads.
+    """
+    monkeypatch.setattr(check, "_get", get)
+    monkeypatch.chdir(tmp_path)
+    return int(check.main(["--all-open", "--github-repo", "owner/name", "--token", "t"]))
+
+
+def test_a_pair_of_open_pull_requests_editing_one_path_is_reported(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The finding the single-branch mode cannot make: two open branches, one file.
+
+    This is the #1763/#1766 topology before either has merged. Each pull request's
+    checks ran against a base holding neither change, so both read clean and the
+    first tree in which the two are compiled together is ``main``.
+    """
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([_SHARED, "tests/a_test.py"]),
+            "head10...main": _compare([]),
+            "main...head20": _compare([_SHARED, "tests/b_test.py"]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #20" in report
+    assert _SHARED in report
+    # Only the shared path is named: the two private files are not the finding.
+    assert "tests/a_test.py" not in report
+    assert "tests/b_test.py" not in report
+
+
+def test_a_prose_only_pair_is_listed_but_does_not_set_the_exit_status(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Same suppression the single-branch mode applies, and for the same reason.
+
+    Reported so a reader can see it was considered, not blocking because prose
+    cannot change what the package or the suite does -- and a genuine collision
+    inside one paragraph arrives as a merge conflict, which is a signal already.
+    """
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare(["docs/guide.md"]),
+            "head10...main": _compare([]),
+            "main...head20": _compare(["docs/guide.md"]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 0
+
+    report = capsys.readouterr().out
+    assert "prose-only" in report
+    assert "#10 + #20: `docs/guide.md`" in report
+    assert "behaviour-bearing path" not in report
+
+
+def test_disjoint_open_pull_requests_report_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without this, the pins above are satisfied by a sweep that flags everything."""
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare(["strands_robots/one.py"]),
+            "head10...main": _compare([]),
+            "main...head20": _compare(["strands_robots/two.py"]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 0
+    assert "No untested composition" in capsys.readouterr().out
+
+
+def test_a_draft_pull_request_is_excluded_from_the_sweep(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A draft cannot merge whatever else is true of it.
+
+    So a pair involving one does not mean what a pair of ready pull requests
+    means, and reporting it would spend a merge-order decision on a change nobody
+    has offered yet. The excluded pull request's compares are deliberately absent
+    from the recorded set: reaching for them at all would raise.
+    """
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20", draft=True)],
+        {"main...head10": _compare([_SHARED]), "head10...main": _compare([])},
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 0
+
+    report = capsys.readouterr().out
+    assert "1 open non-draft pull request(s)" in report
+    assert "#20" not in report
+
+
+def test_a_stale_base_overlap_is_reported_with_its_distance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The second mode: the single-branch computation, applied to the population.
+
+    Nothing invalidates a pull request's pass when its sibling merges. Stale
+    approvals are dismissed on push; a stale pass has no equivalent, and a pull
+    request idle in review never re-runs -- so the exposure runs until its next
+    push, not until the next merge.
+    """
+    get = _api(
+        [_pull(10, "head10")],
+        {
+            "main...head10": _compare([_SHARED], behind_by=7),
+            "head10...main": _compare([_SHARED, "strands_robots/other.py"]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "base moved under a path they edit" in report
+    assert "| #10 | 7 |" in report
+    assert _SHARED in report
+    assert "strands_robots/other.py" not in report
+
+
+def test_a_pull_request_level_with_its_base_is_not_a_stale_base_finding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``behind_by == 0`` is the state the single-branch check already cleared.
+
+    Reporting it would re-report every green pull request in the repository, which
+    is how a sweep becomes noise nobody reads.
+    """
+    get = _api(
+        [_pull(10, "head10")],
+        {
+            "main...head10": _compare([_SHARED], behind_by=0),
+            "head10...main": _compare([_SHARED]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 0
+    assert "base moved under a path" not in capsys.readouterr().out
+
+
+def test_a_truncated_path_set_is_named_rather_than_read_as_no_overlap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The compare endpoint caps ``files``, and a capped list looks complete.
+
+    This check's failure mode is a *missed* overlap, so a path set that reached
+    the cap is named as unevaluated. Quietly intersecting a truncated set is
+    exactly how one goes missing, and the report would say "clean" while meaning
+    "did not look".
+    """
+    capped = [f"strands_robots/f{index}.py" for index in range(check._COMPARE_FILE_CAP)]
+    get = _api(
+        [_pull(10, "head10")],
+        {"main...head10": _compare(capped), "head10...main": _compare([])},
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 0
+
+    report = capsys.readouterr().out
+    assert "Unevaluated (1)" in report
+    assert "#10: not evaluated in either mode" in report
+    assert f"{check._COMPARE_FILE_CAP}-entry cap" in report
+    assert "0 open non-draft pull request(s)" in report
+
+
+def test_a_truncated_base_side_set_still_leaves_the_pair_comparison(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The two path sets are inputs to two independent modes, so they skip apart.
+
+    Measured on the live queue: the base-side set is the one that grows without
+    bound, so it is the one that reaches the cap -- on #1035, 265 commits behind.
+    Dropping the whole pull request for it would have discarded the pairwise
+    finding against #1722, which is the finding this mode exists to make.
+    """
+    capped = [f"strands_robots/f{index}.py" for index in range(check._COMPARE_FILE_CAP)]
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([_SHARED], behind_by=265),
+            "head10...main": _compare(capped),
+            "main...head20": _compare([_SHARED]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #20" in report, "the pair comparison must survive an unreadable base side"
+    assert "stale-base mode only" in report
+    assert "base moved under a path they edit" not in report
+
+
+def test_one_unreadable_pull_request_does_not_suppress_the_others(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A sweep exists to report across a population, so one failure is not fatal.
+
+    The unreadable pull request is named rather than counted as clean: one this
+    check could not read is not one it cleared, which is the failure mode the
+    whole file is written against.
+    """
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20"), _pull(30, "head30")],
+        {
+            "main...head10": _compare([_SHARED]),
+            "head10...main": _compare([]),
+            "main...head30": _compare([_SHARED]),
+            "head30...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #30" in report
+    assert "#20: not evaluated in either mode" in report
+
+
+def test_the_sweep_and_the_single_branch_mode_share_one_prose_rule(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Both modes call ``partition_overlap``, so they cannot disagree about prose.
+
+    Pinned by construction rather than by comparing two reports: narrowing
+    ``PROSE_SUFFIXES`` moves both verdicts together, which is the point of the
+    sweep reusing the path-set helpers instead of carrying its own copy.
+    """
+    monkeypatch.setattr(check, "PROSE_SUFFIXES", frozenset())
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare(["docs/guide.md"]),
+            "head10...main": _compare([]),
+            "main...head20": _compare(["docs/guide.md"]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    # The same prose-only pair the test above cleared now blocks, because the one
+    # classification both modes read has changed.
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+
+def test_all_open_and_head_are_mutually_exclusive(tmp_path: Path) -> None:
+    """``--head`` names one commit and the sweep reads none.
+
+    Ignoring it would answer a question the caller did not ask while looking like
+    it had, which is the same reasoning the sibling sweep gives for refusing
+    ``--all-open --pr``.
+    """
+    with pytest.raises(SystemExit) as raised:
+        check.main(["--all-open", "--head", "abc123", "--github-repo", "owner/name", "--token", "t"])
+    assert raised.value.code == 2
+
+
+@pytest.mark.parametrize("missing", ["--github-repo", "--token"])
+def test_the_sweep_refuses_to_run_without_its_own_inputs(monkeypatch: pytest.MonkeyPatch, missing: str) -> None:
+    """Neither input has a local fallback, so a missing one is refused, not guessed.
+
+    ``--repo`` is not consulted for either: in this script it is a checkout path,
+    and the sweep reads no checkout.
+    """
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    argv = ["--all-open", "--github-repo", "owner/name", "--token", "t"]
+    argv.remove(missing)
+    argv.remove("owner/name" if missing == "--github-repo" else "t")
+
+    with pytest.raises(SystemExit) as raised:
+        check.main(argv)
+    assert raised.value.code == 2


### PR DESCRIPTION
## Problem

`scripts/check_merge_base_overlap.py` answers one question about one branch: which
files does this pull request edit that its base also changed since it branched. That
computation is `merge-base(head, base)..base` intersected with `merge-base..head`, so
the only tree it ever compares a branch against is the base branch. It never compares
two branches against each other.

Two consequences follow, and both are reachable today:

1. A pull request pair that edits the same file is invisible to every per-branch
   signal. `git` reports no conflict when the hunks are disjoint, `mergeable` reads
   `MERGEABLE`, and each branch's own overlap run is computed against the base rather
   than against the sibling. The first tree in which the two changes meet is `main`.
2. A branch far behind its base is only checked when someone runs the check on it. The
   workflow runs it per pull request, so a branch that has not been pushed since it
   fell behind carries a verdict computed against a base that has since moved.

Both are the topology that produced #1766: two pull requests, individually green, each
editing a file the other also edited, composed for the first time on `main`.

Measured live on the current queue: 8 open non-draft pull requests,
28 pairs.

| | #1035 | #1722 |
|---|---|---|
| own merge base | `c1acf21d` (267 behind) | `04fd6680` (64 behind) |
| `mergeable` / state | MERGEABLE / BLOCKED | CONFLICTING / DIRTY |
| its own single-branch run | No overlap | overlap on 3 other paths |
| names either shared path | no | no |

The two share `strands_robots/mesh/__init__.py` and
`tests/mesh/test_drive_command_numeric_domains.py`, plus
`docs/ros2-integration.md` as prose. Neither branch's own run names either
of them: #1035's is empty, and #1722's reports three unrelated paths. #1722's `DIRTY`
state is a conflict with `main` on `strands_robots/mesh/ros_bridge.py`, not with #1035.

## What this changes

`--all-open` sweeps the population instead of one branch. For each open non-draft pull
request it takes the same two path sets from that pull request's own merge base, then
reports two things the per-branch run cannot see:

- every pair sharing a path, compared head to head
- every branch whose own stale base overlaps its edits, which is the existing
  computation applied to the population rather than waiting for a push

`--all-open` and `--head` are mutually exclusive and the parser says so, because
`--head` names one commit and the sweep reads none: honouring both would answer a
question the caller did not ask while looking as though it had.

## The decisions this makes, and why

**Prose is reported, not blocking.** Three of the four pairs found share only
`examples/fleet/README.md`. A shared markdown file is worth knowing about and is not a
reason to hold a merge, so `partition_overlap` splits behaviour-bearing paths from prose
and only the former sets the exit status. Without the split the sweep would report four
findings where one matters, and a check that cries wolf gets muted.

**A capped base-side path set excludes a pull request from the stale-base mode only.**
The compare API caps its file list at 300 entries, and a truncated set can only produce
a false negative. Such a pull request is listed as unevaluated with that reason rather
than reported clean. It stays in the pairwise comparison, and that decision is what made
this run's finding reachable: #1035's base side is capped, and #1035 is exactly the pull
request that produced the one blocking pair. Measured:
`capped_but_still_paired = [1035]`.

**Drafts are excluded.** A draft is not asking to merge, so pairing it against the
reviewable set reports a composition nobody has proposed.

## Verification

| check | result |
|---|---|
| `MUJOCO_GL=egl pytest tests` | 29547 passed / 266 skipped / 0 failed (652s) |
| the same suite on the base | 29534 passed / 266 skipped |
| `ruff check` + `ruff format --check` | clean, 1211 files |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/`; the 14 in `examples/isaac_gs` are byte-identical to a pristine-base worktree |
| single-branch mode on this branch | No overlap |

Collected cases: `tests/test_merge_base_overlap.py` 30 -> 43.

## Mutation table

Five regressions, each against the new cases and against the 30 that were already there:

| regression | new (43) | pre-existing (30) |
|---|---|---|
| the pairwise comparison is dropped | 3 failed | 0 failed |
| prose and code are not partitioned | 4 failed | 0 failed |
| the stale-base mode is dropped | 2 failed | 0 failed |
| a capped base side drops the whole pull request | 2 failed | 0 failed |
| drafts are swept as if reviewable | 1 failed | 0 failed |

All five are invisible to the pre-existing cases, which is expected: they pin the
single-branch computation, and none of them reads more than one branch.

## The guard this joins

`tests/test_duplicate_claim_check.py` pins #2030's defect, that a script able to infer
the repository from the environment must not leave a documented local invocation
inferring it. This script becomes the second such script, so that guard moves from a
`len(...) == 3` literal to a set equality against a declared mapping of the flag each
script spells the repository with and the argv marker that makes naming it required. The
rule is per invocation rather than per script: this script's `--repo` is a local checkout
path and its single-branch mode reaches no API, so a blanket per-script rule would read a
correctly-named invocation as an inferred one and would refuse the local-git mode. A
sixth script that starts reading the environment now fails that guard until it declares
how it names one.

## Artifact

![sweep](https://raw.githubusercontent.com/cagataycali/robots/artifacts/sweep-open-set/sweep-open-set.png)

The pair matrix, what each reported branch's own signals said, the design decision that
made the finding reachable, and the mutation table. Every number is read from a live
capture; `capture.py` asserts the mechanism it claims, that neither reported pull request
names either shared path, and `compose.py` asserts every drawn number against that
capture. Scripts and raw JSON are on the `artifacts/sweep-open-set` branch.

This changes a repository check and its tests only. No policy, simulation, rendering,
recording or asset behaviour changes, so the artifact is the measurement rather than a
rollout.

## Out of scope

The sweep is not wired to a workflow. Adding a scheduled job needs a `.github/workflows`
change, and the exit status a queue-wide check should carry is a separate decision: a
pairwise finding is a sequencing cost rather than a defect in either branch, so failing
both is the wrong default. The script is usable now from a checkout and prints a step
summary when one is available.
