### PR TITLE
fix(ci): the open-set sweep reads a rename's old name and keeps a large head side in the pairwise mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -904,15 +904,26 @@ hatch run format            # ruff check --fix, ruff format
    `strands_robots/mesh/ros_bridge.py`), neither of which any per-branch signal
    was reporting - both read `mergeStateStatus: CLEAN`.
 
-   Two properties of that sweep are worth knowing before leaning on it. A
-   truncated path set is named as unevaluated rather than intersected: the compare
-   endpoint caps `files` at 300, a capped list is indistinguishable from a
-   complete one in the payload, and this check's failure mode is a *missed*
-   overlap, so quietly intersecting a truncated set is how one goes missing.
+   Three properties of that sweep are worth knowing before leaning on it. A
+   truncated path set is named as unevaluated rather than intersected: a capped
+   list is indistinguishable from a complete one in the payload, and this check's
+   failure mode is a *missed* overlap, so quietly intersecting a truncated set is
+   how one goes missing. The two sides differ in how far away that is - the head
+   side is read from the paginated `pulls/{n}/files` endpoint and stops at 3000
+   entries, while the base side has no paginated equivalent and keeps the compare
+   endpoint's 300 - and the head side is the input to the pairwise mode, so it is
+   the one that must not drop a large diff.
    And the two path sets skip apart: the base-side set is the one that grows
-   without bound, so it is the one that hits that cap - #1035 was 265 commits
+   without bound, so it is the one that hits its cap - #1035 was 265 commits
    behind - and dropping the whole pull request for it would discard the pairwise
    finding this mode exists to make.
+
+   Both sides collect `previous_filename` alongside `filename`, so a rename
+   intersects a sibling still editing the old name. Without it the two share no
+   path, while git - which does detect the rename - applies the sibling's edit to
+   the new name and merges with no conflict marker, which is the exact silence
+   this sweep exists to break. That is what keeps the two modes agreeing: the
+   single-branch one reaches the same set with `--no-renames` (#2246).
 
    A file carrying a `strict=True` xfail is the highest-value overlap candidate
    there is, because its whole purpose is to fail when a sibling change lands: it

--- a/changelog.d/2246-sweep-rename-and-head-side-ceiling.md
+++ b/changelog.d/2246-sweep-rename-and-head-side-ceiling.md
@@ -1,0 +1,40 @@
+### Fixed: the open-set sweep reads a rename's old name, and a large head side no longer drops out of the pairwise comparison
+
+`check_merge_base_overlap.py --all-open` reported two inputs as sharing no path
+when they share one, both in the false-negative direction its own docstring names
+as the one that matters.
+
+A rename was invisible. Both file-carrying endpoints report a rename as a single
+entry whose `filename` is the new path and whose `previous_filename` is the old
+one, and the sweep collected only the first. So a branch renaming `foo.py` and a
+branch editing `foo.py` intersected on nothing, while git -- which does detect the
+rename -- applies the second branch's edit to the new name with no conflict marker
+to report. That is precisely the silent composition this check exists to find,
+arriving in the one shape it could not see. The single-branch mode never had the
+defect: it passes `--no-renames` for this reason, so the two modes disagreed about
+what an overlap is, which is the divergence that makes one of them wrong without
+either looking it. Taking both names can only widen the reported set, which is the
+safe direction here. Measured: 0 renames across the 7 open pull requests, so
+nothing was being missed today, but merged #2057 renamed
+`tests/simulation/test_args_docstring_completeness.py` and a sibling still editing
+the old path would have been invisible while both were open.
+
+A head side at the compare endpoint's 300-entry file cap dropped the pull request
+from *both* modes. For the base side that is correct and unchanged -- it has no
+paginated equivalent, and it is the side that grows without bound, so it is the
+side that reaches the cap. The head side does have one: `pulls/{n}/files` is
+paginated to 3000 entries and returns the same set below the cap, measured
+identical both ways on #1035 (7 files), #1722 (10) and #1667 (153, the largest
+pull request in this repository's history), and byte-identical across the whole
+open queue. Reading it there raises the head-side ceiling tenfold and changes no
+verdict. The compare call remains, for `merge_base_commit` and `behind_by`, and no
+longer enforces a cap on a `files` list it does not read -- because the mode a
+300-file branch was being dropped from is the pairwise one, which is the mode that
+finds defects, and a large diff is the most likely thing on a queue to collide with
+something. Reaching the paginated ceiling is still reported as unevaluated, for the
+reason the cap was: an endpoint that stops without saying so manufactures a missed
+overlap.
+
+Neither input is reachable on today's queue; both are reachable in this
+repository's history. Who runs the sweep and what a finding costs remains
+undecided (#2245) and is untouched here.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -48,7 +48,17 @@ both invisible to every per-branch signal:
 computes the same intersection twice per pull request -- once against each
 sibling's ``M..head``, once against what has landed on the base since its own
 ``M`` -- reusing the path-set helpers the single-branch mode uses, so the two
-modes cannot disagree about what counts as an overlap or as prose.
+modes cannot disagree about what counts as an overlap or as prose. That parity
+includes renames: git reports one as its delete plus its add under
+``--no-renames``, and the API side takes ``previous_filename`` alongside
+``filename`` to reach the same set, because a branch that renames a file and a
+branch that edits its old name compose without a conflict marker.
+
+The two sides come from different endpoints, and so have different ceilings. The
+head side -- the input to the pairwise mode -- is read from the paginated
+pull-request files endpoint, which carries ten times what the compare endpoint's
+``files`` does. The base side has no paginated equivalent and keeps the compare
+cap, reported as unevaluated for that mode alone.
 
 A file carrying a ``strict=True`` xfail is the highest-value overlap candidate
 there is: its whole purpose is to fail when a sibling change lands, so it breaks
@@ -248,8 +258,21 @@ _MAX_PAGES = 20
 #: truncated list is indistinguishable from a complete one in the payload, so a
 #: path set that reaches the cap is reported as unevaluated rather than as not
 #: overlapping. This check's failure mode is a *missed* overlap, and quietly
-#: intersecting a truncated set is exactly how one goes missing.
+#: intersecting a truncated set is exactly how one goes missing. Only the
+#: base-side set is read from this endpoint; the head side has a paginated one.
 _COMPARE_FILE_CAP = 300
+
+#: The pull-request files endpoint is paginated and stops at this many entries,
+#: ten times the compare cap. Reaching it carries the same ambiguity a capped
+#: compare does and is reported the same way -- but it is ten times further
+#: away, and the head-side set is the input to the pairwise mode, which is the
+#: mode that finds defects. The largest pull request in this repository's history
+#: is 153 files (#1667, closed unmerged); the largest open one today is 10.
+_PULL_FILE_CAP = 3000
+
+#: Page size for that endpoint. ``_PULL_FILE_CAP`` must stay a whole multiple of
+#: it, because the loop bound below is the quotient.
+_PULL_FILE_PAGE = 100
 
 
 class ApiError(RuntimeError):
@@ -265,6 +288,11 @@ class ApiError(RuntimeError):
 @dataclasses.dataclass(frozen=True)
 class OpenPullRequest:
     """One open pull request's path sets, both taken from its own merge base.
+
+    ``edits`` comes from the paginated pull-request files endpoint and
+    ``landed_since`` from the compare endpoint, so the two sides have different
+    ceilings: the base side has no paginated equivalent and keeps
+    ``_COMPARE_FILE_CAP``.
 
     ``landed_since`` is ``None`` when that side could not be read. It is an input
     to the stale-base mode only, so an unreadable one excludes the pull request
@@ -321,15 +349,45 @@ def resolve_open_pull_requests(repo: str, token: str) -> list[tuple[int, str]]:
     return sorted(found)
 
 
-def compare_paths(repo: str, base: str, head: str, token: str) -> tuple[frozenset[str], str, int]:
-    """Return ``(paths, merge_base_sha, behind_by)`` for a three-dot ``base...head``.
+def paths_from_entries(entries: Iterable[object]) -> frozenset[str]:
+    """Return every path a file-list entry names, a rename's old name included.
+
+    Both file-carrying endpoints report a rename as a single entry whose
+    ``filename`` is the new path and whose ``previous_filename`` is the old one.
+    Reading only the first is a false negative in the direction that matters: a
+    branch renaming ``foo.py`` and a branch editing ``foo.py`` then share no
+    path, while git -- which does detect the rename -- applies the second
+    branch's edit to the new name with no conflict to report. That is exactly
+    the composition this file exists to find, arriving invisibly.
+
+    This is the API counterpart of ``changed_paths``'s ``--no-renames``, and it
+    is what keeps the two modes agreeing about what an overlap is. Taking both
+    names can only widen the reported set, which is the safe direction for a
+    check whose failure mode is a missed overlap.
+    """
+    return frozenset(
+        str(value)
+        for entry in entries
+        if isinstance(entry, dict)
+        for key in ("filename", "previous_filename")
+        if (value := entry.get(key))
+    )
+
+
+def _compare_payload(repo: str, base: str, head: str, token: str) -> tuple[list[object], str, int]:
+    """Fetch a three-dot ``base...head`` and return ``(file entries, merge_base_sha, behind_by)``.
 
     The three-dot form is what makes this the same question the single-branch
     mode asks with git: the ``files`` it reports are the diff from
     ``merge_base(base, head)`` to ``head``, i.e. ``M..head``. Swapping the
     operands therefore yields ``M..base`` from the same endpoint, which is how
-    the sweep obtains both sides without resolving a merge base itself or
+    the sweep obtains the base side without resolving a merge base itself or
     fetching a single commit.
+
+    ``_COMPARE_FILE_CAP`` is deliberately not enforced here. Whether a truncated
+    ``files`` list is a problem depends on whether the caller reads it, and the
+    two callers differ: one wants the paths, the other wants only the two fields
+    the paginated endpoint does not carry.
     """
     url = f"{API_ROOT}/repos/{repo}/compare/{base}...{head}"
     payload = _get(url, token)
@@ -337,16 +395,69 @@ def compare_paths(repo: str, base: str, head: str, token: str) -> tuple[frozense
         raise ApiError(f"{url}: expected an object, got {type(payload).__name__}")
     entries = payload.get("files")
     entries = entries if isinstance(entries, list) else []
-    if len(entries) >= _COMPARE_FILE_CAP:
-        raise ApiError(
-            f"{url}: the file list reached the {_COMPARE_FILE_CAP}-entry cap, so the path set is "
-            + "incomplete and an overlap computed from it could be a false negative"
-        )
-    paths = frozenset(str(entry["filename"]) for entry in entries if isinstance(entry, dict) and entry.get("filename"))
     commit = payload.get("merge_base_commit")
     merge_base_sha = str((commit or {}).get("sha") or "") if isinstance(commit, dict) else ""
     behind_by = payload.get("behind_by")
-    return paths, merge_base_sha, behind_by if isinstance(behind_by, int) else 0
+    return entries, merge_base_sha, behind_by if isinstance(behind_by, int) else 0
+
+
+def compare_paths(repo: str, base: str, head: str, token: str) -> tuple[frozenset[str], str, int]:
+    """Return ``(paths, merge_base_sha, behind_by)`` for a three-dot ``base...head``.
+
+    Enforces the compare endpoint's file cap: a path set that reached it is
+    incomplete, and intersecting it would report "no overlap" while meaning "did
+    not look". Used for the base side, which has no paginated equivalent.
+    """
+    entries, merge_base_sha, behind_by = _compare_payload(repo, base, head, token)
+    if len(entries) >= _COMPARE_FILE_CAP:
+        raise ApiError(
+            f"{API_ROOT}/repos/{repo}/compare/{base}...{head}: the file list reached the "
+            + f"{_COMPARE_FILE_CAP}-entry cap, so the path set is incomplete and an overlap "
+            + "computed from it could be a false negative"
+        )
+    return paths_from_entries(entries), merge_base_sha, behind_by
+
+
+def compare_fork_point(repo: str, base: str, head: str, token: str) -> tuple[str, int]:
+    """Return ``(merge_base_sha, behind_by)`` for ``base...head``, ignoring ``files``.
+
+    The head side takes its paths from ``pull_request_paths``, so this call is
+    needed only for the two fields that endpoint does not carry -- and it must
+    not fail on a capped ``files`` list it never reads. It once did, via
+    ``compare_paths``, which removed a large pull request from the *pairwise*
+    comparison as well: the one mode where a 300-file branch is the most likely
+    thing on the queue to collide with something.
+    """
+    _, merge_base_sha, behind_by = _compare_payload(repo, base, head, token)
+    return merge_base_sha, behind_by
+
+
+def pull_request_paths(repo: str, number: int, token: str) -> frozenset[str]:
+    """Return the paths pull request ``number`` edits, from the paginated endpoint.
+
+    Below the compare cap this is the same set ``base...head`` reports -- measured
+    on this repository at 7, 10 and 153 files (#1035, #1722, #1667), identical
+    both ways, and byte-identical across the whole open queue -- so no verdict
+    changes. What changes is the ceiling: paginating raises the head side's from
+    ``_COMPARE_FILE_CAP`` to ``_PULL_FILE_CAP``.
+
+    Reaching that ceiling is reported like a capped compare, for the same reason:
+    the endpoint stops there without saying so, and a silently short path set is
+    how a missed overlap is manufactured.
+    """
+    collected: list[object] = []
+    for page in range(1, _PULL_FILE_CAP // _PULL_FILE_PAGE + 1):
+        url = f"{API_ROOT}/repos/{repo}/pulls/{number}/files?per_page={_PULL_FILE_PAGE}&page={page}"
+        payload = _get(url, token)
+        rows = payload if isinstance(payload, list) else []
+        collected.extend(rows)
+        if len(rows) < _PULL_FILE_PAGE:
+            return paths_from_entries(collected)
+    raise ApiError(
+        f"{API_ROOT}/repos/{repo}/pulls/{number}/files: the file list reached the "
+        + f"{_PULL_FILE_CAP}-entry ceiling, so the path set is incomplete and an overlap "
+        + "computed from it could be a false negative"
+    )
 
 
 def collect_open_pull_requests(
@@ -366,7 +477,8 @@ def collect_open_pull_requests(
     lookup_failures = (ApiError, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError)
     for number, head_sha in resolve_open_pull_requests(repo, token):
         try:
-            edits, fork_point, behind_by = compare_paths(repo, base_ref, head_sha, token)
+            fork_point, behind_by = compare_fork_point(repo, base_ref, head_sha, token)
+            edits = pull_request_paths(repo, number, token)
         except lookup_failures as error:
             unevaluated.append((number, f"not evaluated in either mode - own path set unreadable: {error}"))
             continue

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -31,6 +31,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
+from typing import cast
 
 import pytest
 
@@ -425,29 +426,76 @@ def test_the_workflow_reads_the_script_from_the_base_and_names_the_head() -> Non
 # seam, so faking that is faking the network and nothing else.
 
 
-def _compare(files: list[str], *, merge_base: str = "aaaa1111", behind_by: int = 0) -> dict[str, object]:
+def _files(names: list[str], renamed: dict[str, str] | None = None) -> list[dict[str, object]]:
+    """Build a file list in the shape both file-carrying endpoints return.
+
+    ``renamed`` maps a new path to the path it was renamed from, which the API
+    reports as ``previous_filename`` on that same entry rather than as a second
+    entry -- so a rename is one row naming two paths, and reading only one of
+    them is invisible in the payload.
+    """
+    previous = renamed or {}
+    rows: list[dict[str, object]] = []
+    for name in names:
+        row: dict[str, object] = {"filename": name}
+        if name in previous:
+            row["previous_filename"] = previous[name]
+        rows.append(row)
+    return rows
+
+
+def _compare(
+    files: list[str],
+    *,
+    merge_base: str = "aaaa1111",
+    behind_by: int = 0,
+    renamed: dict[str, str] | None = None,
+) -> dict[str, object]:
     """Build one ``compare`` payload in the shape the endpoint returns."""
     return {
         "merge_base_commit": {"sha": merge_base},
         "behind_by": behind_by,
-        "files": [{"filename": name} for name in files],
+        "files": _files(files, renamed),
     }
 
 
 def _api(
     pulls: list[dict[str, object]],
     compares: dict[str, object],
+    pull_files: dict[int, list[dict[str, object]]] | None = None,
+    base: str = "main",
 ) -> Callable[[str, str], object]:
-    """Return a ``_get`` stand-in serving a recorded open set and compare payloads.
+    """Return a ``_get`` stand-in serving the open set, compares, and head file lists.
 
     A compare with no recorded payload raises, which is deliberate: an unrecorded
     lookup is a test that has not said what it means, and silently returning an
     empty path set would make it pass as "no overlap".
+
+    ``pull_files`` records a pull request's own paginated file list. A number with
+    no entry is served, paginated, from that pull request's ``base...head``
+    compare recording -- sound below the compare cap because the two endpoints
+    return the same set there, measured on #1035 (7 files), #1722 (10) and #1667
+    (153), identical both ways. The tests where the two must differ record the
+    divergence explicitly, which is the only place the distinction carries
+    meaning.
     """
+    heads = {int(cast(int, row["number"])): str(cast(dict[str, object], row["head"])["sha"]) for row in pulls}
+    recorded = dict(pull_files or {})
 
     def get(url: str, token: str) -> object:
         if "/pulls?" in url:
             return pulls if url.endswith("page=1") else []
+        if "/files?" in url:
+            number = int(url.split("/pulls/", 1)[1].split("/files", 1)[0])
+            entries = recorded.get(number)
+            if entries is None:
+                key = f"{base}...{heads[number]}"
+                if key not in compares:
+                    raise check.ApiError(f"no recorded file list for #{number}")
+                entries = cast(list[dict[str, object]], cast(dict[str, object], compares[key])["files"])
+            page = int(url.rsplit("page=", 1)[1])
+            start = (page - 1) * check._PULL_FILE_PAGE
+            return entries[start : start + check._PULL_FILE_PAGE]
         key = url.split("/compare/", 1)[1]
         if key not in compares:
             raise check.ApiError(f"no recorded compare for {key}")
@@ -616,20 +664,22 @@ def test_a_pull_request_level_with_its_base_is_not_a_stale_base_finding(
     assert "base moved under a path" not in capsys.readouterr().out
 
 
-def test_a_truncated_path_set_is_named_rather_than_read_as_no_overlap(
+def test_a_truncated_head_side_path_set_is_named_rather_than_read_as_no_overlap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The compare endpoint caps ``files``, and a capped list looks complete.
+    """A file list that stopped at its ceiling looks complete in the payload.
 
     This check's failure mode is a *missed* overlap, so a path set that reached
-    the cap is named as unevaluated. Quietly intersecting a truncated set is
+    the ceiling is named as unevaluated. Quietly intersecting a truncated set is
     exactly how one goes missing, and the report would say "clean" while meaning
-    "did not look".
+    "did not look". The ceiling that applies to the head side is the paginated
+    endpoint's, ten times the compare cap.
     """
-    capped = [f"strands_robots/f{index}.py" for index in range(check._COMPARE_FILE_CAP)]
+    at_ceiling = _files([f"strands_robots/f{index}.py" for index in range(check._PULL_FILE_CAP)])
     get = _api(
         [_pull(10, "head10")],
-        {"main...head10": _compare(capped), "head10...main": _compare([])},
+        {"main...head10": _compare([]), "head10...main": _compare([])},
+        pull_files={10: at_ceiling},
     )
 
     assert _sweep(monkeypatch, get, tmp_path) == 0
@@ -637,8 +687,113 @@ def test_a_truncated_path_set_is_named_rather_than_read_as_no_overlap(
     report = capsys.readouterr().out
     assert "Unevaluated (1)" in report
     assert "#10: not evaluated in either mode" in report
-    assert f"{check._COMPARE_FILE_CAP}-entry cap" in report
+    assert f"{check._PULL_FILE_CAP}-entry ceiling" in report
     assert "0 open non-draft pull request(s)" in report
+
+
+def test_a_head_side_at_the_compare_cap_stays_in_the_pairwise_comparison(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The compare cap must not remove a pull request from the mode that finds defects.
+
+    The compare call survives for ``merge_base_commit`` and ``behind_by``, which
+    the paginated endpoint does not carry, and its ``files`` list is not read --
+    so a head side at the 300-entry cap is not a reason to drop the pull request.
+    It used to be, and a large diff is the most likely thing on a queue to collide
+    with something, so the old behaviour discarded findings in proportion to how
+    much they were worth.
+    """
+    capped = [f"strands_robots/f{index}.py" for index in range(check._COMPARE_FILE_CAP)]
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare(capped),
+            "head10...main": _compare([]),
+            "main...head20": _compare([_SHARED]),
+            "head20...main": _compare([]),
+        },
+        pull_files={10: _files([_SHARED, "strands_robots/private.py"])},
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #20" in report, "a capped compare must not drop the pull request from the pairwise mode"
+    assert "Unevaluated" not in report
+    assert "2 open non-draft pull request(s)" in report
+
+
+def test_a_head_side_path_set_spanning_several_pages_is_read_whole(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The pagination is the point, so a set larger than one page must be followed.
+
+    A read that stopped after the first page would raise the ceiling on paper and
+    lower it in fact: the overlap here sits on the last page, past two full ones.
+    """
+    filler = [f"strands_robots/f{index}.py" for index in range(2 * check._PULL_FILE_PAGE)]
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([]),
+            "head10...main": _compare([]),
+            "main...head20": _compare([_SHARED]),
+            "head20...main": _compare([]),
+        },
+        pull_files={10: _files([*filler, _SHARED])},
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #20" in report
+    assert _SHARED in report
+
+
+def test_a_renamed_path_overlaps_a_sibling_editing_the_old_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A rename and an edit of the old name compose with no conflict marker.
+
+    The API reports a rename as one entry carrying both names, so collecting only
+    ``filename`` leaves the two branches sharing no path -- while git, which does
+    detect the rename, applies the edit to the new name and merges cleanly. That
+    is the silent composition the sweep exists to report, so it must not be the
+    one shape the sweep cannot see. Merged #2057 renamed a test file, and a
+    sibling still editing the old path would have been invisible.
+    """
+    renamed_to = "tests/test_args_docstring_completeness.py"
+    old_name = "tests/simulation/test_args_docstring_completeness.py"
+    get = _api(
+        [_pull(10, "head10"), _pull(20, "head20")],
+        {
+            "main...head10": _compare([renamed_to], renamed={renamed_to: old_name}),
+            "head10...main": _compare([]),
+            "main...head20": _compare([old_name]),
+            "head20...main": _compare([]),
+        },
+    )
+
+    assert _sweep(monkeypatch, get, tmp_path) == 1
+
+    report = capsys.readouterr().out
+    assert "#10 + #20" in report
+    assert old_name in report
+
+
+def test_the_two_modes_agree_about_a_rename() -> None:
+    """``--no-renames`` and ``previous_filename`` must reach the same path set.
+
+    ``test_a_rename_on_the_base_still_overlaps_the_old_path`` pins the git side of
+    this from real commits. The two modes reading a rename differently is the
+    class of divergence that makes one of them wrong without either looking it,
+    so the equality is asserted rather than inferred from two separate verdicts.
+    """
+    renamed_to = "strands_robots/b.py"
+    old_name = "strands_robots/a.py"
+    entries = _files([renamed_to], renamed={renamed_to: old_name})
+
+    assert check.paths_from_entries(entries) == frozenset({renamed_to, old_name})
 
 
 def test_a_truncated_base_side_set_still_leaves_the_pair_comparison(
@@ -649,7 +804,9 @@ def test_a_truncated_base_side_set_still_leaves_the_pair_comparison(
     Measured on the live queue: the base-side set is the one that grows without
     bound, so it is the one that reaches the cap -- on #1035, 265 commits behind.
     Dropping the whole pull request for it would have discarded the pairwise
-    finding against #1722, which is the finding this mode exists to make.
+    finding against #1722, which is the finding this mode exists to make. The base
+    side is also the only side still read from the capped endpoint: it has no
+    paginated equivalent, so this is the one cap the sweep cannot route around.
     """
     capped = [f"strands_robots/f{index}.py" for index in range(check._COMPARE_FILE_CAP)]
     get = _api(


### PR DESCRIPTION
Fixes #2246

## What was wrong

`check_merge_base_overlap.py --all-open` landed in #2244 and reported the pair it was written to find. Two inputs still read as "no shared path" when they share one, both in the **false-negative** direction the script's own docstring names as the one that matters.

### 1. A renamed path was not intersected

Both file-carrying endpoints report a rename as a **single entry** whose `filename` is the new path and whose `previous_filename` is the old one. The sweep collected only the first:

| | pull request A | pull request B |
|---|---|---|
| does | renames `foo.py` -> `bar.py` | edits `foo.py` |
| path set before | `{bar.py}` | `{foo.py}` |
| intersection | empty - reported clean | |
| path set after | `{bar.py, foo.py}` | `{foo.py}` |
| intersection | `foo.py` - reported | |

git *does* detect the rename and applies B's edit to `bar.py` without a conflict, so this is exactly the shape the sweep exists for: two branches composing silently into a tree neither compiled.

The single-branch mode never had this defect - `changed_paths` passes `--no-renames` for precisely this reason, and says so in its docstring. So the two modes disagreed about what an overlap *is*, which is the divergence that makes one of them wrong without either one looking it. That parity is now asserted directly rather than inferred from two separate verdicts.

### 2. A head side at the 300-entry compare cap dropped the pull request from **both** modes

`compare_paths` raised at the cap and `collect_open_pull_requests` named the pull request unevaluated and continued. For the **base** side that is correct and unchanged: it has no paginated equivalent, and it is the side that grows without bound, so it is the side that actually reaches the cap - measured now, #1035 and #1087 are both capped there, and keeping them in the pairwise mode is what makes the #1035 + #1722 finding reachable at all.

For the **head** side the same raise removed the pull request from the pairwise comparison, which is the mode that finds defects - and a large diff is the most likely thing on a queue to collide with something, so the old behaviour discarded findings in proportion to how much they were worth.

The head side now reads `pulls/{n}/files`, paginated, ceiling 3000. Measured identical to the compare set both ways:

| pull request | `compare/main...head` `.files` | `pulls/N/files` paginated | identical |
|---|---|---|---|
| #1035 | 7 | 7 | yes |
| #1722 | 10 | 10 | yes |
| #1667 | 153 | 153 | yes |

The compare call remains - `merge_base_commit` and `behind_by` live only there - and no longer enforces a cap on a `files` list it does not read.

## Evidence this changes no verdict today

The sweep run against the live queue, before and after, is **byte-identical**, both exiting 1:

```
`strands-labs/robots`, base `main`: 7 open non-draft pull request(s), 21 pair(s) compared.
| #1035 + #1722 | `strands_robots/mesh/__init__.py`, `tests/mesh/test_drive_command_numeric_domains.py` |
| #1722 | 66 | `strands_robots/mesh/ros_bridge.py`, `tests/mesh/test_ros_bridge.py` |
Unevaluated (2) - #1035, #1087: stale-base mode only - base-side path set unreadable (300-entry cap)
```

So this is a pure widening: 0 renames across the 7 open pull requests and the largest open head side is 10 files, so neither input is reachable on the current queue. Both are reachable in this repository's history - merged #2057 renamed `tests/simulation/test_args_docstring_completeness.py`, and a sibling still editing the old path would have been invisible while both were open.

## Correction to the issue

#2246 described #1667 as "the largest **merged** one". It is not: #1667 is `state: closed, merged: false, merged_at: null, changed_files: 153`. It is the largest pull request in this repository's *history*, merged or not. The docstring and changelog fragment say that instead, rather than propagating the claim.

## Mutation table

Every pin fails without its fix, and only the intended pins fail:

| mutation | tests that fail |
|---|---|
| `for key in ("filename",)` - drop `previous_filename` | `test_a_renamed_path_overlaps_a_sibling_editing_the_old_name`, `test_the_two_modes_agree_about_a_rename` |
| `compare_fork_point` enforces the compare cap again (old behaviour) | `test_a_head_side_at_the_compare_cap_stays_in_the_pairwise_comparison` |
| `pull_request_paths` returns after page 1 | `test_a_truncated_head_side_path_set_is_named_rather_than_read_as_no_overlap`, `test_a_head_side_path_set_spanning_several_pages_is_read_whole` |

47 passed in `tests/test_merge_base_overlap.py`; ruff check, ruff format and mypy clean.

`test_a_truncated_path_set_is_named_rather_than_read_as_no_overlap` is **rewritten, not deleted**: its intent - a truncated set is named rather than read as clean - is preserved and moved to the ceiling that now applies to the head side. The base-side equivalent (`test_a_truncated_base_side_set_still_leaves_the_pair_comparison`) is unchanged, because the base side's cap is unchanged.

## Scope

Wiring the sweep to a workflow is **not** here. #2244 stated why the exit status a queue-wide check should carry is a separate decision, #2245 is that decision, and nothing above changes it. The computation's other properties - the prose/behaviour partition, the capped-base-side handling - are also untouched.

Doc drift: the AGENTS.md passage describing the sweep's cap behaviour is updated in the same commit, since it stated the 300-entry cap applied to both sides.

## Changelog (section 13)

- **Round 1** - initial submission.