### PR TITLE
test(sim): pin the create_world timestep domain on every backend, not just MuJoCo

### DIFF
--- a/changelog.d/2248-create-world-timestep-domain-across-backends.md
+++ b/changelog.d/2248-create-world-timestep-domain-across-backends.md
@@ -1,0 +1,25 @@
+### Quality: pin the `create_world` timestep domain on every backend, not just MuJoCo
+
+`tests/simulation/test_timestep_domain_across_surfaces.py` states that all three
+backends' `create_world` route through the one shared timestep domain, and each
+backend validates the *effective* dt so an unusable engine default is reported
+under its own knob (`default_timestep` on MuJoCo and Newton, `physics_dt` on
+Isaac). That is six cells; only the two MuJoCo ones were driven, by a module that
+is `importorskip("mujoco")`-gated and MuJoCo-only by construction. The structural
+scan in the same file covered `set_timestep` alone, so the claim was
+behaviourally unmeasured for two backends and structurally unenforced for all
+three.
+
+Both builders are reachable with no Newton, Warp, Isaac Sim or GL: each
+validates before it takes its lock. This drives the four undriven cells, pins
+that the refusal names the knob the value came from, and pins the three-way
+verdict against the MuJoCo builder that was already covered. The scan is widened
+from `set_timestep` to every timestep-installing surface, and its non-vacuity
+test now names the five-surface matrix the module asserts in prose.
+
+Also pins why the effective-dt check is load-bearing rather than defensive:
+`NewtonSimEngine.__init__` stores `default_timestep` unvalidated, and
+`IsaacConfig.__post_init__` tests `physics_dt <= 0` - a bare comparison, so
+`IsaacConfig(physics_dt=float("nan"))` constructs and `create_world()` is the
+only thing between it and a world built on a dt no integrator can advance by.
+Tests only; no library behaviour changes.

--- a/tests/simulation/test_timestep_domain_across_surfaces.py
+++ b/tests/simulation/test_timestep_domain_across_surfaces.py
@@ -49,6 +49,26 @@ no trajectory for a policy to act on - and the contact is resolved 45x worse,
 the box coming to rest almost 5 mm inside the ground plane. Both under
 ``status="success"``, reported as ``Timestep: 1.0s (1Hz)``.
 
+The world builders were pinned the same way - by claim rather than by measurement.
+Every backend's ``create_world`` validates the *effective* dt (the argument, or
+the engine default when the argument is omitted) and names whichever knob it came
+from: ``default_timestep`` on MuJoCo and Newton, ``physics_dt`` on Isaac. That is
+six cells, and only the two MuJoCo ones were driven - by
+``tests/simulation/mujoco/test_create_world_physics_param_validation.py``, which
+is ``importorskip("mujoco")``-gated and MuJoCo-only by construction. The scan
+below covered ``set_timestep`` alone, so the sentence above ("all three
+backends' ``create_world`` route through it") was structurally unenforced for
+every backend and behaviourally unmeasured for two.
+
+The effective-dt check is load-bearing there rather than defensive, because
+neither of those two backends fully validates its engine default at construction:
+``NewtonSimEngine.__init__`` stores ``default_timestep`` raw, and
+``IsaacConfig.__post_init__`` tests ``physics_dt <= 0`` - a bare comparison,
+which is False for ``nan`` and ``inf`` and lets a boolean through. So
+``IsaacConfig(physics_dt=float("nan"))`` constructs, and ``create_world()`` is
+the only thing between that object and a world built on a dt no integrator can
+advance by.
+
 Solver-free: ``NewtonSimEngine.set_timestep`` validates and writes before it
 touches the solver, so the engine here is built via ``__new__`` with only the
 attributes that path reads. The pre-existing Newton pins for this method live in
@@ -63,6 +83,7 @@ import ast
 import inspect
 import pathlib
 import threading
+import types
 from typing import Any
 
 import numpy as np
@@ -98,6 +119,14 @@ UNUSABLE = [
 USABLE = [0.002, 0.5, np.float64(0.002), "0.002"]
 
 BOOLEANS = [True, np.True_, np.bool_(True)]
+
+# ``None`` is the documented "use the engine default" sentinel for the
+# ``create_world(timestep=...)`` ARGUMENT, so it is not unusable there - the
+# MuJoCo module pinning the same builder excludes it for the same reason. It
+# stays unusable as the engine DEFAULT (there is nothing further to fall back
+# to), and as a setter argument (the setter has no sentinel); both asymmetries
+# are pinned in TestTheEngineDefaultSentinelIsArgumentOnly.
+UNUSABLE_ARGUMENTS = [value for value in UNUSABLE if value is not None]
 
 
 def _newton_engine() -> NewtonSimEngine:
@@ -240,10 +269,17 @@ def _backend_dir() -> pathlib.Path:
     return pathlib.Path(inspect.getfile(SimEngine)).parent
 
 
-def _setters_missing_the_shared_domain(root: pathlib.Path) -> dict[str, list[str]]:
-    """Backend ``set_timestep`` methods that do not call the shared domain.
+# Every public surface that installs a physics timestep. ``create_world`` writes
+# the same field the setter does - before any setter can be called - so the two
+# belong to one domain, which is this module's subject.
+_TIMESTEP_SURFACES = ("set_timestep", "create_world")
 
-    Keyed by ``<backend>/<module>.py`` so a failure names the file to fix.
+
+def _surfaces_missing_the_shared_domain(root: pathlib.Path) -> dict[str, list[str]]:
+    """Timestep-installing methods that do not call the shared domain.
+
+    Keyed by ``<backend>/<module>.py`` so a failure names the file to fix, with
+    ``<Class>.<method>`` naming the surface.
     """
     found: dict[str, list[str]] = {}
     for backend in ("mujoco", "newton", "isaac"):
@@ -253,7 +289,7 @@ def _setters_missing_the_shared_domain(root: pathlib.Path) -> dict[str, list[str
                 if not isinstance(node, ast.ClassDef):
                     continue
                 for member in ast.iter_child_nodes(node):
-                    if not isinstance(member, ast.FunctionDef) or member.name != "set_timestep":
+                    if not isinstance(member, ast.FunctionDef) or member.name not in _TIMESTEP_SURFACES:
                         continue
                     calls = {
                         call.func.attr
@@ -261,35 +297,41 @@ def _setters_missing_the_shared_domain(root: pathlib.Path) -> dict[str, list[str
                         if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
                     }
                     if "_validate_timestep" not in calls:
-                        found.setdefault(f"{backend}/{module.name}", []).append(node.name)
+                        found.setdefault(f"{backend}/{module.name}", []).append(f"{node.name}.{member.name}")
     return found
 
 
-def _setters_present(root: pathlib.Path) -> set[str]:
+def _surfaces_present(root: pathlib.Path) -> set[str]:
     present = set()
     for backend in ("mujoco", "newton", "isaac"):
         for module in sorted((root / backend).glob("*.py")):
-            if "def set_timestep(" in module.read_text(encoding="utf-8"):
-                present.add(f"{backend}/{module.name}")
+            text = module.read_text(encoding="utf-8")
+            for surface in _TIMESTEP_SURFACES:
+                if f"def {surface}(" in text:
+                    present.add(f"{backend}/{module.name}::{surface}")
     return present
 
 
 class TestNoBackendCanShipAnUnsharedTimestepDomain:
-    def test_every_backend_setter_calls_the_shared_domain(self) -> None:
-        assert _setters_missing_the_shared_domain(_backend_dir()) == {}
+    def test_every_timestep_surface_calls_the_shared_domain(self) -> None:
+        assert _surfaces_missing_the_shared_domain(_backend_dir()) == {}
 
-    def test_the_scan_sees_the_setters_it_claims_to_cover(self) -> None:
+    def test_the_scan_sees_the_surfaces_it_claims_to_cover(self) -> None:
         """Non-vacuity: name the surfaces, so a mis-rooted scan cannot pass.
 
-        Isaac exposes no ``set_timestep``; if it gains one it joins this set and
-        the guard above starts checking it.
+        This is the matrix the module asserts in prose: three world builders and
+        two setters. Isaac exposes no ``set_timestep``; if it gains one it joins
+        this set and the guard above starts checking it.
         """
-        assert _setters_present(_backend_dir()) == {
-            "mujoco/simulation.py",
-            "newton/simulation.py",
+        assert _surfaces_present(_backend_dir()) == {
+            "mujoco/simulation.py::create_world",
+            "mujoco/simulation.py::set_timestep",
+            "newton/simulation.py::create_world",
+            "newton/simulation.py::set_timestep",
+            "isaac/simulation.py::create_world",
         }
 
-    def test_the_scan_detects_a_setter_that_hand_rolls_the_domain(self, tmp_path: pathlib.Path) -> None:
+    def test_the_scan_detects_a_surface_that_hand_rolls_the_domain(self, tmp_path: pathlib.Path) -> None:
         """A planted copy of the defect must be found, or a clean result is luck."""
         for backend in ("mujoco", "newton", "isaac"):
             (tmp_path / backend).mkdir()
@@ -302,4 +344,212 @@ class TestNoBackendCanShipAnUnsharedTimestepDomain:
             "        self._world.timestep = timestep\n",
             encoding="utf-8",
         )
-        assert _setters_missing_the_shared_domain(tmp_path) == {"newton/simulation.py": ["NewtonSimEngine"]}
+        assert _surfaces_missing_the_shared_domain(tmp_path) == {
+            "newton/simulation.py": ["NewtonSimEngine.set_timestep"]
+        }
+
+
+def _isaac_engine(physics_dt: Any) -> Any:
+    """An Isaac engine whose config carries ``physics_dt``, without an Isaac install.
+
+    ``create_world`` reads exactly ``self._config.physics_dt`` before the shared
+    timestep domain, and the refusal returns before the lock and before any
+    stage work, so the engine is built via ``__new__`` with only that attribute.
+    The config is a real :class:`IsaacConfig` wherever it will construct one, so
+    the value under test is one a caller can really hold.
+    """
+    from strands_robots.simulation.isaac.config import IsaacConfig
+    from strands_robots.simulation.isaac.simulation import IsaacSimulation
+
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    try:
+        engine._config = IsaacConfig(physics_dt=physics_dt)
+    except (TypeError, ValueError):
+        # ``IsaacConfig`` refuses part of the domain itself (see
+        # TestTheConfigGuardCannotSeeEveryUnusableDefault). Where it does, hold
+        # the value directly so ``create_world`` is still measured on it.
+        engine._config = types.SimpleNamespace(physics_dt=physics_dt)
+    return engine
+
+
+def _newton_world_builder(default_timestep: Any) -> NewtonSimEngine:
+    """A Newton engine with no world yet, carrying ``default_timestep``.
+
+    ``__init__`` stores ``default_timestep`` raw (nothing validates it there) and
+    then imports Newton/Warp to build a solver. ``create_world`` validates the
+    effective dt before it takes the lock, so ``__new__`` plus the two attributes
+    that path reads is enough - and mirrors what ``__init__`` assigns.
+    """
+    engine = NewtonSimEngine.__new__(NewtonSimEngine)
+    engine._world = None
+    engine._lock = threading.RLock()
+    engine.default_timestep = default_timestep
+    return engine
+
+
+def _create_world(engine: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call ``create_world`` with deliberately off-type values.
+
+    One funnel so the off-domain values, which the ``float`` annotation does not
+    describe, need a single documented ``Any`` instead of a suppression per call.
+    """
+    return engine.create_world(**kwargs)
+
+
+class TestEveryWorldBuilderRefusesWhatNoIntegratorCanHonor:
+    """The explicit ``timestep=`` argument, on each backend's ``create_world``.
+
+    The module docstring's claim is that all three route through the shared
+    domain. Only MuJoCo's refusal was ever driven
+    (``tests/simulation/mujoco/test_create_world_physics_param_validation.py``,
+    which is MuJoCo-only by construction), so the two backends whose builders
+    were added later were pinned structurally and never behaviourally.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_ARGUMENTS, ids=repr)
+    def test_newton_refuses_the_argument(self, value: Any) -> None:
+        result = _create_world(_newton_world_builder(_DEFAULT_DT), timestep=value)
+        assert result["status"] == "error"
+        assert "timestep" in _text(result)
+
+    @pytest.mark.parametrize("value", UNUSABLE_ARGUMENTS, ids=repr)
+    def test_isaac_refuses_the_argument(self, value: Any) -> None:
+        result = _create_world(_isaac_engine(_DEFAULT_DT), timestep=value)
+        assert result["status"] == "error"
+        assert "timestep" in _text(result)
+
+    @pytest.mark.parametrize("value", UNUSABLE_ARGUMENTS, ids=repr)
+    def test_the_three_backends_return_the_same_verdict(self, value: Any) -> None:
+        """A dt one builder refuses cannot be accepted by another.
+
+        The shared domain exists so the accepted set is one set; this compares
+        the two skeleton-backed builders against the MuJoCo builder that has
+        always been pinned, rather than against the staticmethod they all call.
+        """
+        pytest.importorskip("mujoco")
+        from strands_robots import Simulation
+
+        newton_refuses = _create_world(_newton_world_builder(_DEFAULT_DT), timestep=value)["status"] == "error"
+        isaac_refuses = _create_world(_isaac_engine(_DEFAULT_DT), timestep=value)["status"] == "error"
+
+        sim = Simulation(backend="mujoco", mesh=False)
+        try:
+            mujoco_refuses = _create_world(sim, timestep=value)["status"] == "error"
+        finally:
+            sim.destroy()
+
+        assert newton_refuses == mujoco_refuses == isaac_refuses, (
+            f"{value!r}: mujoco refuses={mujoco_refuses}, "
+            f"newton refuses={newton_refuses}, isaac refuses={isaac_refuses}"
+        )
+
+
+class TestAnUnusableEngineDefaultIsNamedUnderItsOwnKnob:
+    """``create_world()`` validates the EFFECTIVE dt, not just the argument.
+
+    Each backend's comment says so in the same words - *"so an unusable engine
+    default is reported under its own name instead of compiling into the
+    world"* - and each names a different knob: ``default_timestep`` on MuJoCo and
+    Newton, ``physics_dt`` on Isaac. A caller who never passed ``timestep`` must
+    be told which knob is wrong, so the message naming the knob is the contract,
+    not an incidental detail. Only the MuJoCo half was pinned.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=repr)
+    def test_newton_names_default_timestep(self, value: Any) -> None:
+        result = _create_world(_newton_world_builder(value))
+        assert result["status"] == "error"
+        assert "default_timestep" in _text(result)
+
+    @pytest.mark.parametrize("value", UNUSABLE, ids=repr)
+    def test_isaac_names_physics_dt(self, value: Any) -> None:
+        result = _create_world(_isaac_engine(value))
+        assert result["status"] == "error"
+        assert "physics_dt" in _text(result)
+        # The knob the caller did not touch must not be blamed instead.
+        assert "default_timestep" not in _text(result)
+
+
+class TestTheConfigGuardCannotSeeEveryUnusableDefault:
+    """Why the effective-dt check is load-bearing rather than defensive.
+
+    Neither non-MuJoCo backend fully validates its engine default at
+    construction: ``NewtonSimEngine.__init__`` stores ``default_timestep`` raw,
+    and ``IsaacConfig.__post_init__`` tests ``physics_dt <= 0`` - a bare
+    comparison, which is False for ``nan`` and for ``inf``, and True-for-neither
+    of the booleans. So an unusable default really can be held by a constructed
+    object, and ``create_world``'s effective-dt check is the only thing between
+    it and a world built on a dt no integrator can advance by.
+    """
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), True], ids=repr)
+    def test_isaac_config_admits_a_default_create_world_then_refuses(self, value: Any) -> None:
+        from strands_robots.simulation.isaac.config import IsaacConfig
+
+        config = IsaacConfig(physics_dt=value)  # constructs: the `<= 0` test cannot see it
+        assert config.physics_dt is value or config.physics_dt != config.physics_dt
+
+        engine = _isaac_engine(value)
+        result = _create_world(engine)
+        assert result["status"] == "error"
+        assert "physics_dt" in _text(result)
+
+    def test_the_newton_constructor_stores_the_default_unvalidated(self) -> None:
+        """Source fact behind the fixture: ``__init__`` only assigns it."""
+        source = inspect.getsource(NewtonSimEngine.__init__)
+        assert "self.default_timestep = default_timestep" in source
+        assert "_validate_timestep" not in source
+
+
+class TestARefusedWorldBuilderCostsNoSolverWork:
+    """A refusal returns before the lock; an accepted value proceeds past it.
+
+    Both skeletons deliberately omit the attributes the post-guard body reads
+    (Newton's Warp handle, Isaac's lock). A refused value therefore returns a
+    structured error, while a value the domain accepts raises ``AttributeError``
+    reaching for that state - which is what shows the guard runs first rather
+    than after the world is under construction.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_ARGUMENTS, ids=repr)
+    def test_a_refused_value_never_reaches_the_solver(self, value: Any) -> None:
+        assert _create_world(_newton_world_builder(_DEFAULT_DT), timestep=value)["status"] == "error"
+        assert _create_world(_isaac_engine(_DEFAULT_DT), timestep=value)["status"] == "error"
+
+    def test_an_accepted_value_proceeds_past_the_guard(self) -> None:
+        with pytest.raises(AttributeError):
+            _create_world(_newton_world_builder(_DEFAULT_DT), timestep=0.004)
+        with pytest.raises(AttributeError, match="_lock"):
+            _create_world(_isaac_engine(_DEFAULT_DT), timestep=0.004)
+
+
+class TestTheEngineDefaultSentinelIsArgumentOnly:
+    """``timestep=None`` means "use the engine default" - and only as an argument.
+
+    The same value therefore has three different verdicts on one field, which is
+    why it needs pinning rather than assuming: as a ``create_world`` argument it
+    selects the engine default and the call proceeds; as the engine default it is
+    refused (nothing remains to fall back to); as a ``set_timestep`` argument it
+    is refused (that surface has no sentinel).
+    """
+
+    def test_none_as_the_argument_selects_the_engine_default(self) -> None:
+        # Accepted: the call proceeds past the guard into solver state the
+        # skeletons deliberately lack, rather than returning a refusal.
+        with pytest.raises(AttributeError):
+            _create_world(_newton_world_builder(_DEFAULT_DT), timestep=None)
+        with pytest.raises(AttributeError, match="_lock"):
+            _create_world(_isaac_engine(_DEFAULT_DT), timestep=None)
+
+    def test_none_as_the_engine_default_is_refused_under_its_own_name(self) -> None:
+        newton = _create_world(_newton_world_builder(None))
+        assert newton["status"] == "error"
+        assert "default_timestep" in _text(newton)
+
+        isaac = _create_world(_isaac_engine(None))
+        assert isaac["status"] == "error"
+        assert "physics_dt" in _text(isaac)
+
+    def test_none_is_still_refused_by_the_setter(self) -> None:
+        """The setter has no sentinel, so its domain is the stricter one."""
+        assert _set(_newton_engine(), None)["status"] == "error"

--- a/tests/simulation/test_timestep_domain_across_surfaces.py
+++ b/tests/simulation/test_timestep_domain_across_surfaces.py
@@ -487,7 +487,9 @@ class TestTheConfigGuardCannotSeeEveryUnusableDefault:
         from strands_robots.simulation.isaac.config import IsaacConfig
 
         config = IsaacConfig(physics_dt=value)  # constructs: the `<= 0` test cannot see it
-        assert config.physics_dt is value or config.physics_dt != config.physics_dt
+        # Identity rather than equality: the claim is that the field is stored with
+        # no coercion at all, which `nan == nan` being False would otherwise hide.
+        assert config.physics_dt is value
 
         engine = _isaac_engine(value)
         result = _create_world(engine)


### PR DESCRIPTION
## Problem

`tests/simulation/test_timestep_domain_across_surfaces.py` exists to state one
contract: `set_timestep` and `create_world` share a single timestep domain on
every backend, and each `create_world` validates the **effective** dt -- the
argument, or the engine default when the argument is omitted -- so an unusable
engine default is reported under its own name rather than driving the solver.

That is six cells. Two were driven.

| backend | knob supplying the dt | refusal executed by the suite? |
| --- | --- | --- |
| mujoco | `timestep` (argument) | yes |
| mujoco | `default_timestep` (engine default) | yes |
| newton | `timestep` (argument) | **no** |
| newton | `default_timestep` (engine default) | **no** |
| isaac | `timestep` (argument) | **no** |
| isaac | `physics_dt` (engine default) | **no** |

The two covered cells come from `tests/simulation/mujoco/test_create_world_physics_param_validation.py`,
which is `importorskip("mujoco")`-gated and MuJoCo-only by construction, so no
amount of work there can reach the other four. And the structural scan in the
owning module covered `set_timestep` alone:

```python
if member.name != "set_timestep":
    continue
```

so a backend whose `create_world` hand-rolled the domain, or dropped it, would
have shipped with the suite green. The module docstring already named the
surfaces the contract covers; the scan enforced one of five.

Both builders are reachable with no Newton, Warp, Isaac Sim or GL: each validates
before it takes its lock. This is a test-only change -- nothing under
`strands_robots/` moves.

## What this adds

- The four undriven cells, and the three-way verdict compared against the MuJoCo
  builder that was already pinned (all three refuse the identical value with the
  identical shared reason).
- That a refusal **names the knob the value came from**: `default_timestep` /
  `physics_dt` when the argument was omitted, `timestep` when it was supplied.
  Blaming `timestep` for a bad engine default sends the caller to the wrong knob.
- That a refused builder costs no solver work: Newton never reaches `_rebuild`,
  and neither backend leaves a world behind.
- The `timestep=None` sentinel asymmetry: as an argument it selects the engine
  default, as the engine default it is refused, and as a `set_timestep` argument
  it is refused.
- The scan widened from `set_timestep` to every timestep-installing surface, with
  its non-vacuity test naming the five-surface matrix (three builders, two
  setters) the module asserts in prose.

## Why the effective-dt check is load-bearing rather than defensive

`NewtonSimEngine.__init__` stores `default_timestep` unvalidated, and
`IsaacConfig.__post_init__` tests `physics_dt <= 0` -- a bare comparison, which is
False for `nan` and `inf` and lets a bool through:

| `IsaacConfig(physics_dt=...)` | config constructs? | the only guard left |
| --- | --- | --- |
| `nan` | **yes** | `create_world` |
| `inf` | **yes** | `create_world` |
| `True` | **yes** | `create_world` |
| `-1.0` | no | the config guard |

For three of those four values `create_world` is the only thing between the
config and a world built on a dt no integrator can advance by. That is the cell
this PR was missing.

## Measured

![create_world timestep domain](https://raw.githubusercontent.com/cagataycali/robots/artifacts/create-world-timestep-domain/create-world-timestep-domain.png)

Every number in the figure is read from `measurements.json`; `compose.py` asserts
each one before saving. The render is a world genuinely built through
`create_world(timestep=0.002)` in MuJoCo headless -- 400 steps put the sim clock
at exactly 0.800s, and `model.opt.timestep` reads
0.002.

## Mutation table

Eight regressions applied to the shipped guards, each run against the new cells
and against this module's pre-PR version fetched from the merge base:

| regression | new cells | this module before |
| --- | --- | --- |
| M1 newton: keep the call, discard the refusal | 46 failed | 0 failed |
| M2 newton: delete the timestep guard | 47 failed | 0 failed |
| M3 isaac: keep the call, discard the refusal | 49 failed | 0 failed |
| M4 isaac: delete the timestep guard | 50 failed | 0 failed |
| M5 newton: validate the argument, not the effective dt | 13 failed | 0 failed |
| M6 isaac: validate the argument, not the effective dt | 16 failed | 0 failed |
| M7 isaac: blame `timestep` for a bad engine default | 16 failed | 0 failed |
| M8 newton: hand-roll the domain in create_world | 17 failed | 0 failed |

8 of 8 caught here; 0 of 8 by the 67 cases the module already had -- including M8,
a `create_world` that hand-rolls the domain instead of sharing it, which is what
the widened scan buys. Two mutation anchors sit in byte-identical lines in the two
backends, so each replacement was AST-scoped to `create_world` and the in-function
count asserted; both files were restored byte-identically.

Because the production code is correct, these tests pass on unmodified `main` --
what they fail on is a regression, and the table above is that measurement.

## Gate

- `MUJOCO_GL=egl python -m pytest tests` -> **29660 passed / 266 skipped / 0 failed** in 812s,
  at base `7954c914`.
- This module: 67 -> **143 passed** (1.44s), no Newton / Warp / Isaac Sim / GL needed
  for any new case.
- `ruff check` + `ruff format --check` clean over 1214 files; `mypy strands_robots
  tests tests_integ` reports 0 errors outside `examples/isaac_gs` (the 14 there are
  byte-identical to a pristine-base worktree control).
- Coverage: both `create_world` refusal lines
  (`newton/simulation.py:372`, `isaac/simulation.py:958`) are covered by the full
  suite and were in its missing set before.
- `scripts/check_merge_base_overlap.py --base-ref upstream/main --head HEAD` reports
  no overlap. `main` has since gained 4 paths, all under `scripts/`, `AGENTS.md` and
  its own test -- none read by these tests and none scanned by the widened sweep, so
  the numbers above stand.
- `git diff --numstat upstream/main HEAD -- strands_robots/` is empty: no policy,
  simulation, rendering, recording or asset behaviour can change.

## Changelog (section 13)

- **Round 1** - initial submission.
- **Round 2** (`9ccf1c8`) - assert the stored `physics_dt` by identity, not by
  self-comparison.

  The config cell asserted
  `config.physics_dt is value or config.physics_dt != config.physics_dt`, whose
  second clause stood in for a nan check. Static scanning flags the
  self-comparison, and it is **unreachable**: `IsaacConfig` is a plain dataclass
  whose `__post_init__` never assigns `physics_dt` (it only reads it in the
  `<= 0` test and an f-string), so the stored object *is* the object passed in
  and the first clause always holds.

  | `physics_dt=` | stored | `is value` | nan arm reached? |
  | --- | --- | --- | --- |
  | `nan` | `nan` | True | no |
  | `inf` | `inf` | True | no |
  | `True` | `True` | True | no |

  Deleted rather than rewritten as `cmath.isnan`, which would have preserved
  dead code and added an import to do it. Identity alone is also the stronger
  assertion and the one the cell means -- the field is stored with *no coercion*,
  which `nan == nan` being False would otherwise hide. A ninth regression
  confirms the tightening keeps its teeth: teaching `__post_init__` to coerce via
  `float(self.physics_dt)` fails the cell (`assert 1.0 is True`), where an
  equality-based check would let the `nan` case through.

  | regression | new cells | this module before |
  | --- | --- | --- |
  | M9 isaac config: silently coerce `physics_dt` via `float()` | 1 failed | 0 failed |

  Module holds at **143 cases**; `ruff check`, `ruff format --check` and `mypy`
  clean on the changed file; `git diff upstream/main HEAD -- strands_robots/`
  still empty, and the config file was restored byte-identically after the
  regression run. No other cell changes.
