### PR TITLE
test(mesh): cover the IoT routes that decide broker delivery

### DIFF
--- a/changelog.d/2249-iot-broker-delivery-routes.md
+++ b/changelog.d/2249-iot-broker-delivery-routes.md
@@ -1,0 +1,13 @@
+### Quality: cover the IoT transport routes that decide whether a message reaches the broker
+
+`strands_robots/mesh/transport/iot_transport.py` had five unexecuted lines, all on
+the path a message or a subscription has to survive to reach the broker. Three are
+reachable and now pinned: the explicit `DROP` short-circuit in `put()` (not
+redundant with `_should_drop`, which requires a trailing `camera/` segment, so a
+bare `strands/<peer>/camera` passes it and the `qos < 0` branch is the only thing
+that stops the publish), `_unsubscribe` with a handler that is already gone, and
+`_unsubscribe` reaching the broker step after a failed reconnect left the client
+`None` with the handler map still populated. The fourth and fifth are one
+`DROP` branch that is unreachable by construction, and it is now pinned as such:
+no policy entry a top-level topic layout can reach carries the `DROP` sentinel,
+so the pin fails the day one does. Tests only; no library behaviour changes.

--- a/tests/mesh/test_iot_broker_delivery_routes.py
+++ b/tests/mesh/test_iot_broker_delivery_routes.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Routes that decide whether an IoT MQTT message reaches the broker at all.
+
+``tests/mesh/test_iot_transport_session.py`` pins the common publish/subscribe
+path and the ``camera/<name>`` never-bridge prefix. This module covers the
+remaining bookkeeping routes on that path -- the ones a message has to survive
+to be published, and the ones a subscription has to survive to be torn down:
+
+  - the explicit ``DROP`` short-circuit in :meth:`put`. It is *not* redundant
+    with ``_should_drop``: that prefix test requires a trailing ``camera/``
+    segment, so a bare ``strands/<peer>/camera`` passes it and the ``qos < 0``
+    branch is the only thing that stops the publish.
+  - ``_unsubscribe`` with a handler that is already gone, which must not
+    disturb the subscribers that remain.
+  - ``_unsubscribe`` reaching the broker step after a *failed reconnect* left
+    the client ``None`` while the handler map was still populated. Only
+    ``close()`` clears that map, so this is reachable from the public API. The
+    broad ``except`` around the broker call would swallow the resulting
+    ``AttributeError``, so what the guard actually buys is silence: without it
+    an ordinary teardown logs an internal ``NoneType`` error against a session
+    the caller already knows is down.
+
+One layout-(a) ``DROP`` branch is unreachable by construction rather than
+untested; :class:`TestDropPolicyReachability` pins the property that makes it so.
+
+The AWS IoT SDK is never reached over the network: ``mtls_from_path`` is patched
+to hand back the session module's ``_FakeMqtt5Client``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.transport.iot_transport import (
+    _TOPIC_POLICY,
+    _qos_and_retain_for,
+    _should_drop,
+)
+
+from .test_iot_transport_session import _connect, _FakeMqtt5Client
+
+_STATE_FILTER = "strands/+/state"
+
+
+@pytest.fixture
+def builder(monkeypatch):
+    """Patch ``mtls_from_path`` to return a captured fake client.
+
+    ``build_exc_after`` makes the *n*-th build raise, which is how a reconnect
+    is failed: :meth:`connect` nulls the stale client before rebuilding, so a
+    build that raises leaves ``_client`` ``None`` with the handler map intact.
+    """
+    import awsiot.mqtt5_client_builder as awsiot_builder
+
+    holder: dict[str, Any] = {
+        "client": None,
+        "auto_connack": True,
+        "subscribe_exc": None,
+        "build_calls": 0,
+        "build_exc_after": None,
+    }
+
+    def fake_mtls_from_path(**kwargs):
+        holder["build_calls"] += 1
+        if holder["build_exc_after"] is not None and holder["build_calls"] > holder["build_exc_after"]:
+            raise RuntimeError("simulated corrupt PEM on reconnect")
+        client = _FakeMqtt5Client(holder=holder, **kwargs)
+        holder["client"] = client
+        return client
+
+    monkeypatch.setattr(awsiot_builder, "mtls_from_path", fake_mtls_from_path)
+    return holder
+
+
+class TestExplicitDropShortCircuit:
+    """A ``DROP`` policy entry stops the publish even when the prefix test does not."""
+
+    def test_bare_camera_topic_is_not_caught_by_the_prefix_test(self):
+        # Premise for the test below: _should_drop matches on a trailing
+        # 'camera/' segment, so the bare kind slips past it entirely.
+        assert _should_drop("strands/thor-arm/camera") is False
+        assert _should_drop("strands/thor-arm/camera/wrist") is True
+
+    def test_bare_camera_topic_resolves_to_the_drop_sentinel(self):
+        assert _qos_and_retain_for("strands/thor-arm/camera") == (-1, False)
+
+    def test_bare_camera_topic_is_never_published(self, tmp_path, builder):
+        # The only route that stops this one: the prefix test above passes it.
+        t = _connect(tmp_path)
+        t.connect()
+        t.put("strands/thor-arm/camera", {"jpeg": "x" * 64})
+        assert builder["client"].published == []
+
+    def test_a_usable_topic_on_the_same_session_still_publishes(self, tmp_path, builder):
+        # Over-reach control: the short-circuit is scoped to DROP topics.
+        t = _connect(tmp_path)
+        t.connect()
+        t.put("strands/thor-arm/camera", {"jpeg": "x"})
+        t.put("strands/thor-arm/state", {"x": 1})
+        assert [p.topic for p in builder["client"].published] == ["strands/thor-arm/state"]
+
+    def test_camera_reference_metadata_is_exempt_from_both_routes(self, tmp_path, builder):
+        # The /ref pointer is small and cloud-relevant, so neither route drops it.
+        t = _connect(tmp_path)
+        t.connect()
+        t.put("strands/thor-arm/camera/wrist/ref", {"key": "s3://b/k"})
+        assert [p.topic for p in builder["client"].published] == ["strands/thor-arm/camera/wrist/ref"]
+
+
+class TestUnsubscribeBookkeeping:
+    """Removing a handler twice, or after the client is gone, stays quiet."""
+
+    def test_removing_an_already_gone_handler_keeps_the_live_subscriber(self, tmp_path, builder):
+        t = _connect(tmp_path)
+        t.connect()
+        seen: list[Any] = []
+        first = lambda sample: None  # noqa: E731 - identity is what is removed
+        t.declare_subscriber(_STATE_FILTER, first)
+        t.declare_subscriber(_STATE_FILTER, lambda sample: seen.append(sample))
+
+        t._unsubscribe(_STATE_FILTER, first)
+        t._unsubscribe(_STATE_FILTER, first)  # already gone: must not raise
+
+        # The surviving subscriber still receives, and the broker subscription
+        # was never torn down.
+        builder["client"].fire_inbound("strands/thor-arm/state", b"{}")
+        assert len(seen) == 1
+        assert builder["client"].unsubscribed == []
+
+    def test_undeclare_after_a_failed_reconnect_is_quiet(self, tmp_path, builder, caplog):
+        t = _connect(tmp_path)
+        t.connect()
+        handle = t.declare_subscriber(_STATE_FILTER, lambda sample: None)
+        client = builder["client"]
+
+        # Broker drops, then a caller-driven reconnect fails while building the
+        # replacement client: _client is None and the handler map is untouched
+        # (only close() clears it).
+        client.fire_disconnect()
+        builder["build_exc_after"] = 1
+        assert t.connect() is False
+
+        with caplog.at_level(logging.DEBUG, logger="strands_robots.mesh.transport.iot_transport"):
+            handle.undeclare()  # no client to unsubscribe against
+
+        # The broker call is never attempted, so the teardown records nothing:
+        # reaching it would log an internal NoneType error against a session the
+        # caller already knows is down.
+        assert client.unsubscribed == []
+        assert [r.getMessage() for r in caplog.records if "unsubscribe error" in r.getMessage()] == []
+        assert t.is_alive() is False
+
+    def test_undeclare_with_a_live_client_still_unsubscribes(self, tmp_path, builder):
+        # Over-reach control for the route above: the guard is about a missing
+        # client, not about skipping the broker step in general.
+        t = _connect(tmp_path)
+        t.connect()
+        handle = t.declare_subscriber(_STATE_FILTER, lambda sample: None)
+        handle.undeclare()
+        assert [p.topic_filters for p in builder["client"].unsubscribed] == [[_STATE_FILTER]]
+
+
+class TestDropPolicyReachability:
+    """Why the layout-(a) ``DROP`` branch is unreachable rather than untested.
+
+    ``_qos_and_retain_for`` resolves two topic layouts. Layout (a) is entered
+    only when the first segment is a reserved top-level kind, and every
+    candidate it builds therefore starts with that kind -- so a ``DROP`` entry
+    can only be reached from layout (b). This pin fails the day a top-level
+    kind gains a ``DROP`` entry, which is the point at which that branch needs
+    a behavioural test of its own.
+    """
+
+    def test_no_drop_entry_is_reachable_from_a_top_level_layout(self):
+        top_level_kinds = {"broadcast", "safety"}
+        drop_keys = [key for key, (qos, _retain) in _TOPIC_POLICY.items() if qos == "DROP"]
+        assert drop_keys, "non-vacuity: the policy table must declare at least one DROP entry"
+        for key in drop_keys:
+            assert key.split("/")[0] not in top_level_kinds, (
+                f"policy DROP entry {key!r} is now reachable from the top-level layout; "
+                "cover that branch in TestExplicitDropShortCircuit"
+            )
+
+    def test_a_top_level_kind_with_no_entry_falls_through_rather_than_dropping(self):
+        # The fall-through returns the safe default, never the DROP sentinel.
+        assert _qos_and_retain_for("strands/safety/unknown-kind") == (0, False)


### PR DESCRIPTION
## Problem

`strands_robots/mesh/transport/iot_transport.py` carried five unexecuted lines
(257 statements, 98.05%), and all five sit on the path a message or a
subscription has to survive to reach the broker: lines [238, 539, 607, 608, 617]. Nothing in
the suite drove any of them, so the module's own delivery decisions -- which payloads
never traverse MQTT, and what happens to a subscription whose broker went away -- were
unverified.

Three are reachable from the public API. One is not, and this PR proves which is which
rather than leaving the reader to guess.

## The reachable routes

**`put()`'s explicit `DROP` sentinel is not redundant with the prefix test.**
`_should_drop` splits on `/` and tests the suffix against `_NEVER_BRIDGE_PREFIXES`,
whose camera entry is `camera/` **with a trailing separator**. So a bare
`strands/<peer>/camera` -- a peer publishing frames without a per-camera segment --
passes it, and the `qos < 0` branch is the only thing standing between that payload
and the broker:

| topic | `_should_drop` | policy qos | published? | stopped by |
| --- | --- | --- | --- | --- |
| `strands/thor-arm/camera` | `False` | `-1` | no | **the `DROP` sentinel -- the only route** |
| `strands/thor-arm/camera/wrist` | `True` | `-1` | no | the prefix test |
| `strands/thor-arm/camera/wrist/ref` | `False` | `0` | yes | nothing (published) |
| `strands/thor-arm/state` | `False` | `0` | yes | nothing (published) |

**`_unsubscribe` with a handler already gone.** A duplicate `undeclare()` must leave
the subscribers that remain registered, and the topic filter must stay subscribed while
another handler still wants it.

**`_unsubscribe` reaching the broker step with no client.** A broker drop followed by a
failed reconnect leaves `_client` as `None` while the handler map is still populated --
only `close()` clears that map -- so this is reachable from the public API. The broad
`except` around the broker call would swallow the resulting `AttributeError`, so what
the guard actually buys is *silence*: without it an ordinary teardown logs an internal
`NoneType` error against a session the caller already knows is down. The test asserts
the silence, not just the absence of a raise. (Found by the mutation table: reverting
that guard failed nothing until the log assertion was added.)

## The unreachable one, pinned as unreachable

`_qos_and_retain_for` walks two candidates -- `kind/sub` then the top-level `kind` --
and returns the `DROP` marker if either matches an entry carrying it. The top-level
branch is dead by construction: the only policy entry with the sentinel is
`['camera']`, and every candidate that branch can build starts with a reserved
top-level kind, none of which carries one. Rather than leave a line looking merely
untested, the module pins the property -- if a reserved kind ever gains a `DROP` entry
the pin fails, and the branch acquires a behavioural test on the day it becomes
reachable.

## Mutation table

Six regressions of these routes, against the new module and against the
470 pre-existing cases in `tests/mesh/test_iot*.py` +
`test_transport.py`. Every anchor is AST-scoped to its enclosing function (asserted to
occur exactly once inside it) and the source is restored byte-identically.

| regression introduced | new module | pre-existing |
| --- | --- | --- |
| (unmutated control) | 0 failed | 0 failed |
| `M1 put(): drop the explicit-DROP short-circuit` | 2 failed | 0 failed **blind** |
| `M2 _should_drop(): match a bare kind too (make qos<0 redundant)` | 1 failed | 0 failed **blind** |
| `M3 _unsubscribe(): re-raise instead of tolerating a gone handler` | 1 failed | 0 failed **blind** |
| `M4 _unsubscribe(): drop the missing-client guard` | 1 failed | 0 failed **blind** |
| `M5 _is_camera_ref(): stop exempting the /ref pointer` | 1 failed | 4 failed (also owned by `test_iot_camera_ref_delivery.py`) |
| `M6 _TOPIC_POLICY: add a DROP entry under a top-level kind` | 1 failed | 0 failed **blind** |

6 of 6 caught here; 5 of 6 invisible to the suite as it stands. M5 is the honest
exception -- the `/ref` exemption is already owned by `test_iot_camera_ref_delivery.py`,
so that row is complementary rather than new coverage.

The new tests necessarily pass on unmodified `main`: the production code is correct and
this PR adds no library line. What they fail on is a regression, and the table above is
that evidence.

## Coverage

`strands_robots/mesh/transport/iot_transport.py`: 98.05% -> 99.61% over `tests/mesh`
(5 -> 1 missing, the remaining line being the one proved unreachable).
Subset 3126 -> 3136 passed.

## Gate

- `MUJOCO_GL=egl python3 -m pytest tests -q`: **29588 + 10 = 29598 passed, 266 skipped, 0 failed** (673.59s)
- `ruff check` / `ruff format --check strands_robots tests tests_integ`: clean (1215 files)
- `mypy strands_robots tests tests_integ`: 0 errors outside `examples/isaac_gs`
- `scripts/check_merge_base_overlap.py`: no overlap, `behind_by=0`
- The new module needs no broker and no network: it drives the real
  `IotMqttTransport` against the fake mqtt5 client `test_iot_transport_session.py`
  already exports. 10 cases in 0.49s.

## Artifact

Tests only, so no policy, simulation, rendering, recording or asset behaviour changes
-- the artifact is the coverage, mechanism and mutation measurement rather than a
rollout. Every number in it is asserted against `facts.json` by `compose.py`.

![broker delivery routes](https://raw.githubusercontent.com/cagataycali/robots/artifacts/iot-broker-delivery-routes/broker_delivery_routes.png)

Scripts and raw measurements: [`artifacts/iot-broker-delivery-routes`](https://github.com/cagataycali/robots/tree/artifacts/iot-broker-delivery-routes)
