### PR TITLE
test(simulation/isaac): drive run_multi_policy's four shared knob refusals

### DIFF
--- a/changelog.d/2250-isaac-run-multi-policy-shared-knob-refusals.md
+++ b/changelog.d/2250-isaac-run-multi-policy-shared-knob-refusals.md
@@ -1,0 +1,17 @@
+### Quality: pin Isaac `run_multi_policy`'s four shared caller-knob refusals
+
+`IsaacSimulation.run_multi_policy` routes `control_frequency`, `duration`,
+`instructions` and `action_horizon` through base helpers shared with the MuJoCo
+backend, and its own comments state that intent four times ("one refusal text
+for every backend", "guards the same domain as `run_policy`", "MuJoCo parity",
+"the shared positive-int domain"). The helpers are unit-tested on the base, and
+the behavioural coverage the base-contract module delegates to an entry point
+runs on `create_simulation()` - the default backend - so no test drove those
+four refusals through the Isaac loop: five refusal lines were unexecuted,
+including the whole `if n_steps is None` duration arm.
+
+Each is now driven through the Isaac entry point and asserted to return the
+shared helper's envelope **verbatim**, so "cannot drift from MuJoCo's refusal
+texts" is a checked property rather than an intention, and each refusal is
+asserted to advance no physics, apply no joint targets and leave no
+`policy_running` flag set. Tests only - no library behaviour changes.

--- a/tests/simulation/isaac/test_run_multi_policy_no_recording.py
+++ b/tests/simulation/isaac/test_run_multi_policy_no_recording.py
@@ -11,6 +11,14 @@ tool envelope, ``reset_between=True`` is refused citing #1895, and a rollout
 whose ``control_frequency`` disagrees with an active recording's fps is
 refused up front (the shared rate guard every rollout entry point applies).
 
+The four caller knobs the pre-flight block routes through base helpers
+shared with MuJoCo - ``control_frequency``, ``duration``, ``instructions``
+and ``action_horizon`` - are driven through THIS entry point below, each
+asserted to return the shared helper's envelope verbatim. The helpers
+themselves are unit-tested on the base; the behavioural coverage that
+module delegates to an entry point runs on the default backend, so these
+are what make Isaac's delegation to them a checked property.
+
 The merged-frame recording path (one ``add_frame`` per timestep with every
 robot's namespaced columns, #2159) is pinned separately in
 ``test_run_multi_policy_recording.py``.
@@ -352,6 +360,120 @@ def test_run_multi_policy_rejects_nonpositive_n_steps(sim_two_robots):
     )
     assert r["status"] == "error"
     assert "n_steps must be a positive integer" in r["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# The four shared knob domains, driven through THIS entry point               #
+# --------------------------------------------------------------------------- #
+# The pre-flight block above the loop routes four caller knobs -
+# ``control_frequency``, ``duration``, ``instructions`` and ``action_horizon`` -
+# through base helpers shared with MuJoCo, and its own comments state the
+# intent four times ("one refusal text for every backend", "guards the same
+# domain as run_policy", "MuJoCo parity", "the shared positive-int domain").
+# Those helpers are unit-tested on the base in
+# ``tests/simulation/test_run_multi_policy_base_contract.py``, and the
+# behavioural coverage that module delegates to an entry point runs on
+# ``create_simulation()`` - the default backend - so no test drove these four
+# refusals through the Isaac loop. Each one is asserted here to return the
+# shared helper's own envelope verbatim, which is what makes "cannot drift
+# from MuJoCo's refusal texts" a checked property rather than an intention,
+# and needs neither MuJoCo nor a Kit runtime to state.
+
+
+def _both() -> dict[str, Any]:
+    """The two-robot policy mapping the fixture's engine drives."""
+    return {"alpha": MockPolicy(), "beta": MockPolicy()}
+
+
+def _cost_nothing(sim: IsaacSimulation) -> None:
+    """Assert a refusal advanced no physics and applied no joint targets."""
+    assert sim._world.step_calls == 0
+    for name, robot in sim._robots.items():
+        assert robot.articulation.applied == [], name
+        assert getattr(robot, "policy_running", False) is False, name
+
+
+@pytest.mark.parametrize("bad", [0.0, -5.0, float("nan")], ids=["zero", "negative", "nan"])
+def test_run_multi_policy_rejects_a_frequency_it_cannot_divide_by(sim_two_robots, bad: float) -> None:
+    """``control_frequency`` is refused with the shared helper's own envelope.
+
+    It is validated before ``_resolve_horizon`` because that helper divides by
+    it. The assertion is envelope EQUALITY rather than a substring: it pins
+    that the loop returns the shared verdict, not a locally re-worded copy
+    that could drift from the sibling backends.
+    """
+    sim = sim_two_robots
+    result = sim.run_multi_policy(policies=_both(), n_steps=4, control_frequency=bad)
+
+    assert result == IsaacSimulation._validate_positive_frequency(bad, "run_multi_policy")
+    assert result["status"] == "error"
+    _cost_nothing(sim)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, True], ids=["zero", "negative", "bool"])
+def test_run_multi_policy_rejects_a_duration_it_cannot_honor(sim_two_robots, bad: Any) -> None:
+    """``duration`` - the horizon when no step count is given - is refused too."""
+    sim = sim_two_robots
+    result = sim.run_multi_policy(policies=_both(), duration=bad, control_frequency=500.0)
+
+    assert result == IsaacSimulation._validate_duration(bad, "run_multi_policy")
+    assert result["status"] == "error"
+    _cost_nothing(sim)
+
+
+def test_run_multi_policy_checks_duration_only_when_it_is_the_effective_horizon(sim_two_robots) -> None:
+    """A step count supersedes ``duration``, so an unusable one stays inert.
+
+    The mirror of the test above. ``_resolve_horizon`` REBINDS ``duration`` to
+    ``n_steps / control_frequency`` (measured: 0.0 in, 0.008 out), so the
+    caller's unusable value never reaches ``_validate_duration`` and the
+    ``if n_steps is None`` gate above it is belt-and-braces rather than the
+    thing that makes this pass - removing that gate is behaviour-preserving.
+    What this pins is the caller-visible contract, that an ignored knob is not
+    a refusal, which is what breaks if a later change validates the ARGUMENT
+    instead of the resolved horizon.
+    """
+    sim = sim_two_robots
+    result = sim.run_multi_policy(policies=_both(), n_steps=4, duration=0.0, control_frequency=500.0)
+
+    assert result["status"] == "success", result
+    assert sim._world.step_calls == 4
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [{"nosuch": "pick the cube"}, ["pick", "hold"]],
+    ids=["undriven-robot", "non-mapping"],
+)
+def test_run_multi_policy_rejects_instructions_the_shared_helper_refuses(sim_two_robots, bad: Any) -> None:
+    """``instructions`` normalization refuses with the shared helper's envelope."""
+    sim = sim_two_robots
+    policies = _both()
+    _, expected = IsaacSimulation._normalize_multi_policy_instructions(policies, bad, "run_multi_policy")
+    assert expected is not None, "probe value must be outside the shared domain"
+
+    result = sim.run_multi_policy(policies=policies, instructions=bad, n_steps=4)
+
+    assert result == expected
+    _cost_nothing(sim)
+
+
+@pytest.mark.parametrize("bad", [0, {"nosuch": 4}], ids=["nonpositive-scalar", "undriven-robot"])
+def test_run_multi_policy_rejects_an_action_horizon_the_shared_helper_refuses(sim_two_robots, bad: Any) -> None:
+    """``action_horizon`` normalization refuses with the shared helper's envelope.
+
+    ``default_horizon=8`` mirrors the value the loop passes, so the expected
+    envelope is the one the production call really produces.
+    """
+    sim = sim_two_robots
+    policies = _both()
+    _, expected = IsaacSimulation._normalize_multi_policy_horizons(policies, bad, "run_multi_policy", default_horizon=8)
+    assert expected is not None, "probe value must be outside the shared domain"
+
+    result = sim.run_multi_policy(policies=policies, action_horizon=bad, n_steps=4)
+
+    assert result == expected
+    _cost_nothing(sim)
 
 
 def test_run_multi_policy_requires_world():


### PR DESCRIPTION
## Problem

`IsaacSimulation.run_multi_policy` routes four caller knobs through base helpers shared
with the MuJoCo backend, and the source says so four times inside one block: "one refusal
text for every backend", "guards the same domain as `run_policy`", "MuJoCo parity", "the
shared positive-int domain".

Nothing drove any of those four refusals through this entry point. The helpers are
unit-tested on the base, and `tests/simulation/test_run_multi_policy_base_contract.py` --
which does exercise the behaviour -- builds its engine with `create_simulation()`, the
**default** backend, so its coverage lands on MuJoCo. Five lines in the Isaac loop were
unexecuted, including the whole `if n_steps is None` duration arm, whose condition was
never even evaluated.

| knob | shared helper | refusal line | driven before | what the caller is told |
| --- | --- | --- | --- | --- |
| `control_frequency` | `_validate_positive_frequency` | 3716 | never run | `run_multi_policy: control_frequency must be > 0, got 0.0.` |
| `duration` | `_validate_duration` | 3729 | never run | `run_multi_policy: duration must be > 0, got 0.0.` |
| `instructions` | `_normalize_multi_policy_instructions` | 3708 | never run | `run_multi_policy: instructions names a robot not driven by this ...` |
| `action_horizon` | `_normalize_multi_policy_horizons` | 3737 | never run | `run_multi_policy: action_horizon must be a positive integer, got...` |

## What this pins

Each knob is now driven through the Isaac entry point, and each refusal is asserted to
equal the shared helper's envelope **verbatim** (`result == IsaacSimulation._validate_positive_frequency(...)`,
and likewise for the other three). That is what turns "cannot drift from MuJoCo's refusal
texts" from an intention into a checked property: a locally re-worded copy, or a
copy-pasted method name in the prefix, fails.

Each refusal is also asserted to cost nothing -- no physics step, no applied joint
targets, no `policy_running` flag left set -- and a mirror case pins that a step count
supersedes `duration`, so an ignored knob is not a refusal.

## Mutation table

| mutation | new cases | the 19 pre-existing cases |
| --- | --- | --- |
| M1 frequency guard deleted | 3 failed | 0 failed |
| M2 frequency verdict discarded | 3 failed | 0 failed |
| M3 duration guard deleted | 3 failed | 0 failed |
| M4 duration gate removed (behaviour-preserving) | -- | -- |
| M5 instructions verdict discarded | 2 failed | 0 failed |
| M6 action_horizon verdict discarded | 2 failed | 0 failed |
| M8 caller argument validated instead of resolved horizon | 1 failed | 0 failed |
| M7 message re-worded locally (wrong method name) | 3 failed | 0 failed |

7 of 8 caught here; 7 of 8 invisible to
the cases the file already had. Every anchor was scoped to `run_multi_policy`'s own AST line
range, reporting one match inside the function for all eight, and the source restored
byte-identically. The "verdict discarded" rows are what a structural "the guard is called"
check cannot see.

**M4 is measured-unobservable, not a gap.** `_resolve_horizon` *rebinds* `duration` to
`n_steps / control_frequency` (measured: `0.0` in, `0.008` out), so the caller's unusable
value never reaches `_validate_duration` and removing the `if n_steps is None` gate is
behaviour-preserving. The mirror case pins the caller-visible contract instead, and M8 --
validating the argument rather than the resolved horizon -- is the regression it catches.

## Out of scope

`run_multi_policy`'s remaining uncovered lines are the rollout body itself (the per-tick
policy loop, the reset-between-episodes arm), which needs an Isaac Sim Kit runtime. Only
the pre-flight refusals are reachable without one, and those are what this covers.

## Gate

`MUJOCO_GL=egl python -m pytest tests` -> **29599 passed / 266 skipped /
0 failed** in 684s at upstream `a78ea602`
(pristine 29588 + 11 new cases = 29599).
`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`;
`mypy` reports 0 errors outside `examples/isaac_gs`, whose 14 are byte-identical to a
pristine-base worktree.

`tests/simulation/isaac/test_run_multi_policy_no_recording.py`: 19 ->
30 cases, and `isaac/simulation.py` over `tests/simulation/isaac` goes
921 -> 916 missing (53.30% -> 53.55%),
closing [3708, 3716, 3728, 3729, 3737].

`git diff --numstat upstream/main...HEAD -- strands_robots/` -> **0 lines**.
Tests only, so no policy, simulation, rendering, recording or asset behaviour can change.
No Isaac Sim Kit runtime, no GPU and no MuJoCo are needed for any new case.

## Measurement

![Isaac run_multi_policy shared knob refusals](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-run-multi-policy-knob-refusals/isaac_run_multi_policy_knob_refusals.png)

The figure is the coverage and mutation measurement rather than a rollout, for the reason
above. Capture, mutation and compose scripts, plus the measured payload, are on
`artifacts/isaac-run-multi-policy-knob-refusals`; `compose.py` asserts every drawn number
against `facts.json`.
