### PR TITLE
docs(agents): the not-mergeable error decides nothing - three of three landed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,25 @@ hatch run format            # ruff check --fix, ruff format
      mutation returned that error and the squash was already on `main`. Confirm
      with `state`/`merged`, or `git log origin/main`, before concluding a merge
      failed and redoing the work.
+
+     Read that error as uninformative rather than rare. #2249 and #2250 were
+     squashed thirty seconds apart, each by a single `mergePullRequest` call
+     carrying `expectedHeadOid` - so a stale oid is ruled out - against a pull
+     request reading `CLEAN` / `MERGEABLE` / `APPROVED` with every required
+     context `SUCCESS`. Both calls returned `Pull Request is not mergeable` beside
+     `mergePullRequest: null`, and both squashes were already on `main`:
+     `926beb9` at 19:24:50 and `07a759d` at 19:25:20. Three for three with
+     #1756's `4bf139c`, and the payload carries no field that separates a refusal
+     from a success, so only the read-back can tell you which one you got.
+
+     The read-back also names the likely cause, in the field the error is worded
+     about: after the merge #2249 reports `mergeStateStatus` and `mergeable` as
+     `UNKNOWN`, consistent with the mutation re-reading a pull request it has just
+     closed. That makes the retry the expensive reflex rather than the safe one -
+     a second call against #2249 after it had merged returned the identical error
+     beside the identical `null`, so retrying manufactures a second confirmation
+     of a failure that never happened. Pinned by
+     tests/test_merge_mutation_error_is_not_a_verdict.py.
    - *And on `main` afterwards.* A rollup of `FAILURE` on a merge commit is not
      evidence that the squash broke anything: a **cancelled** check aggregates
      into `FAILURE`. `pr-and-push.yml` keys its concurrency group on

--- a/changelog.d/2251-merge-mutation-error-is-not-a-verdict.md
+++ b/changelog.d/2251-merge-mutation-error-is-not-a-verdict.md
@@ -1,0 +1,30 @@
+### Docs: a `mergePullRequest` error is not a verdict on whether the squash landed
+
+`AGENTS.md` > PR Workflow step 8 already warned that a `mergePullRequest`
+mutation can report `Pull Request is not mergeable` for a merge that succeeded.
+It read as a rare edge case, so the documented remedy - confirm with
+`state`/`merged` before redoing the work - looked optional, and the reflex it
+competes with is a retry.
+
+The error is uninformative rather than rare. #2249 and #2250 were squashed
+thirty seconds apart, each by a single call carrying `expectedHeadOid` - so a
+stale oid is ruled out - against a pull request reading `CLEAN` / `MERGEABLE` /
+`APPROVED` with every required context `SUCCESS`. Both calls returned
+`Pull Request is not mergeable` beside `mergePullRequest: null`, and both
+squashes were already on `main`: `926beb9` at 19:24:50 and `07a759d` at 19:25:20.
+That is three for three with #1756's `4bf139c`, and the payload carries no field
+separating a refusal from a success, so only the read-back can tell you which one
+you got.
+
+The read-back also names the likely cause, in the field the error is worded
+about: after the merge #2249 reports `mergeStateStatus` and `mergeable` as
+`UNKNOWN`, consistent with the mutation re-reading a pull request it has just
+closed. That makes the retry the expensive reflex rather than the safe one - a
+second call against #2249 after it had merged returned the identical error beside
+the identical `null`, so retrying manufactures a second confirmation of a failure
+that never happened.
+
+`tests/test_merge_mutation_error_is_not_a_verdict.py` derives the wrong verdict
+from each recorded payload, so the arithmetic the guidance forbids is executed
+rather than described, and pins the prose adjacency separately so the correction
+cannot drift away from the instruction it qualifies.

--- a/tests/test_merge_mutation_error_is_not_a_verdict.py
+++ b/tests/test_merge_mutation_error_is_not_a_verdict.py
@@ -141,7 +141,7 @@ _GATE_BEFORE: dict[int, dict[str, Any]] = {
 }
 
 #: The repeat call against #2249 after it had merged, same input as the first.
-_RETRY_ON_MERGED = {
+_RETRY_ON_MERGED: dict[str, Any] = {
     "pull_request": 2249,
     "expected_head_oid": "9decef7e6199d695ba928fd45e89f42f055193e5",
     "errors": [_ERROR],

--- a/tests/test_merge_mutation_error_is_not_a_verdict.py
+++ b/tests/test_merge_mutation_error_is_not_a_verdict.py
@@ -1,0 +1,290 @@
+"""Contract pins for what a ``mergePullRequest`` error does and does not decide.
+
+``AGENTS.md`` > PR Workflow > step 8 covers the read-back a mutation needs on both
+sides, and its *After.* half names the case where the mutation reports the wrong
+thing: ``Pull Request is not mergeable`` returned for a squash that is already on
+``main``. Until now that read as a rare race worth a footnote, evidenced by one
+pull request from 2026-07-30 - #1756, merge commit ``4bf139c``.
+
+It is not rare. Three of three recorded merges returned it, and the two most
+recent were thirty seconds apart:
+
+    pull request  mutation error                  merge commit   merged at
+    #1756         Pull Request is not mergeable   4bf139c        2026-07-30 06:55:29Z
+    #2249         Pull Request is not mergeable   926beb9        2026-08-13 19:24:50Z
+    #2250         Pull Request is not mergeable   07a759d        2026-08-13 19:25:20Z
+
+Every cheap explanation is ruled out by the payload that produced those two rows.
+Each was a single call - no earlier attempt against the same pull request - and
+each carried ``expectedHeadOid``, so a stale oid cannot be the refusal's cause;
+each target read ``mergeStateStatus: CLEAN``, ``mergeable: MERGEABLE``,
+``reviewDecision: APPROVED`` with every required context ``SUCCESS`` moments
+before. There is nothing in the response to key a verdict on either: ``errors[0]``
+is that sentence and ``data.mergePullRequest`` is ``null`` whether the squash
+landed or not.
+
+Which makes the error worse than merely noisy. An agent that believes it does not
+stop at a wrong status line - it re-derives work that is already on ``main``, and
+the natural first move, retrying the mutation, cannot correct the belief: a second
+call against #2249 *after* it had merged returned the identical error beside the
+identical ``null``. Two identical failures read as corroboration, so the retry
+converts one misread into a confident one.
+
+The read-back that step 8 already prescribes is the only thing that separates the
+two outcomes, and it also names the likely mechanism, in the very field the error
+is worded about: once #2249 was merged its ``mergeStateStatus`` and ``mergeable``
+both report ``UNKNOWN``, which is what a mutation re-reading the pull request it
+has just closed would see on its way out.
+
+Three classes:
+
+``TestTheErrorDoesNotSeparateTheOutcomes`` runs both verdicts over the recorded
+observations - one keyed on the mutation response, one on the ``state``/``merged``
+read-back - and asserts the first is wrong on every row while the second is right
+on every row. That is the arithmetic behind the guidance, so the pin says *why*
+the error is uninformative rather than only that the prose mentions it.
+
+``TestARetryCannotCorrectTheMisread`` pins the repeat call: same input, same
+error, same ``null``, against a pull request that by then could not be merged by
+anyone. It is the response an agent would treat as confirmation.
+
+``TestTheGuidanceKeepsTheCorrectionAdjacent`` pins the prose, because the prose is
+the deliverable: an agent reads ``AGENTS.md``, not this module. What is asserted is
+*adjacency* - the recurrence and the retry warning have to stay inside the same
+bullet as the instruction they qualify, since "can report" reads perfectly well
+alone and is exactly what a later tidy-up would leave behind. Same shape as
+``tests/test_timeline_filter_count_is_unfiltered.py``,
+``tests/test_merge_gate_viewer_scope.py`` and
+``tests/test_graphql_node_id_targeting.py`` use for step 8's other reading
+disciplines.
+
+Negative control: with ``origin/main``'s ``AGENTS.md`` restored, 4 of the 5 tests
+in ``TestTheGuidanceKeepsTheCorrectionAdjacent`` fail - the fifth reads the
+read-back instruction, which that tree already carries, and the anchor guard
+locates the bullet on both trees - while all 17 offline tests pass unchanged: the
+API's behaviour is a property of GitHub, not of this change, and only the guidance
+is new.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
+
+#: The error message GitHub returns, verbatim.
+_ERROR = "Pull Request is not mergeable"
+
+#: One ``mergePullRequest`` mutation per row, with the response it returned and
+#: the state a read-back found afterwards. #2249 and #2250 were recorded
+#: 2026-08-13 with ``PAT_TOKEN``; #1756 is the case ``AGENTS.md`` already carried,
+#: its merge commit and timestamp read back from the API.
+_OBSERVED: dict[int, dict[str, Any]] = {
+    1756: {
+        "expected_head_oid_supplied": True,
+        "errors": [_ERROR],
+        "data": {"mergePullRequest": None},
+        "read_back": {
+            "state": "MERGED",
+            "merged": True,
+            "merge_commit": "4bf139cc311ee18ae062519bac8c9cfeebda39b2",
+            "merged_at": "2026-07-30T06:55:29Z",
+        },
+    },
+    2249: {
+        "expected_head_oid_supplied": True,
+        "errors": [_ERROR],
+        "data": {"mergePullRequest": None},
+        "read_back": {
+            "state": "MERGED",
+            "merged": True,
+            "merge_commit": "926beb930e8f68336a8211ee0bbbb11f4665795f",
+            "merged_at": "2026-08-13T19:24:50Z",
+            # Read in the same query as ``state``: the fields the error is worded
+            # about no longer answer, because the pull request is closed.
+            "merge_state_status": "UNKNOWN",
+            "mergeable": "UNKNOWN",
+        },
+    },
+    2250: {
+        "expected_head_oid_supplied": True,
+        "errors": [_ERROR],
+        "data": {"mergePullRequest": None},
+        "read_back": {
+            "state": "MERGED",
+            "merged": True,
+            "merge_commit": "07a759d6491c9a76c6655d2d9454fa00ddc66d4c",
+            "merged_at": "2026-08-13T19:25:20Z",
+        },
+    },
+}
+
+#: The pre-mutation gate read on #2249 and #2250, moments before each call. Every
+#: field step 8 tells you to read said "yes".
+_GATE_BEFORE: dict[int, dict[str, Any]] = {
+    2249: {
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "required_contexts_all_success": True,
+    },
+    2250: {
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "required_contexts_all_success": True,
+    },
+}
+
+#: The repeat call against #2249 after it had merged, same input as the first.
+_RETRY_ON_MERGED = {
+    "pull_request": 2249,
+    "expected_head_oid": "9decef7e6199d695ba928fd45e89f42f055193e5",
+    "errors": [_ERROR],
+    "data": {"mergePullRequest": None},
+}
+
+
+def _verdict_from_mutation_response(observation: dict[str, Any]) -> bool:
+    """Did the merge land, judged only by what the mutation returned?
+
+    This is the derivation step 8 exists to forbid, written out so the pin can
+    show what it gets wrong.
+    """
+    return not observation["errors"] and observation["data"]["mergePullRequest"] is not None
+
+
+def _verdict_from_read_back(observation: dict[str, Any]) -> bool:
+    """Did the merge land, judged by reading the pull request back?"""
+    read_back = observation["read_back"]
+    return read_back["merged"] and read_back["state"] == "MERGED"
+
+
+class TestTheErrorDoesNotSeparateTheOutcomes:
+    """The mutation response is the same on a refusal and on a success."""
+
+    @pytest.mark.parametrize("number", sorted(_OBSERVED))
+    def test_the_merge_landed(self, number: int) -> None:
+        assert _verdict_from_read_back(_OBSERVED[number]), (
+            f"#{number} is recorded here because its squash reached main; a row whose "
+            "merge did not land belongs in a different fixture"
+        )
+
+    @pytest.mark.parametrize("number", sorted(_OBSERVED))
+    def test_the_mutation_response_says_it_did_not(self, number: int) -> None:
+        assert _verdict_from_mutation_response(_OBSERVED[number]) is False, (
+            f"#{number}'s mutation response must read as a failure - that is the whole defect being pinned"
+        )
+
+    def test_the_response_keyed_verdict_is_wrong_on_every_row(self) -> None:
+        wrong = [
+            number
+            for number, observation in _OBSERVED.items()
+            if _verdict_from_mutation_response(observation) != _verdict_from_read_back(observation)
+        ]
+        assert sorted(wrong) == sorted(_OBSERVED), (
+            "the point of the guidance is that the mutation response misleads every time, "
+            f"not occasionally; it agreed with the truth on {sorted(set(_OBSERVED) - set(wrong))}"
+        )
+
+    def test_the_error_text_carries_no_discriminator(self) -> None:
+        assert {tuple(observation["errors"]) for observation in _OBSERVED.values()} == {(_ERROR,)}
+        assert {observation["data"]["mergePullRequest"] for observation in _OBSERVED.values()} == {None}
+
+    @pytest.mark.parametrize("number", sorted(_GATE_BEFORE))
+    def test_the_gate_read_before_the_call_said_yes(self, number: int) -> None:
+        gate = _GATE_BEFORE[number]
+        assert gate == {
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "required_contexts_all_success": True,
+        }, f"#{number} was merged on a fully green gate, so the error cannot be read as the gate having refused"
+
+    @pytest.mark.parametrize("number", sorted(_OBSERVED))
+    def test_a_stale_expected_head_oid_is_ruled_out(self, number: int) -> None:
+        assert _OBSERVED[number]["expected_head_oid_supplied"] is True
+
+    def test_the_fields_the_error_is_worded_about_stop_answering(self) -> None:
+        after = _OBSERVED[2249]["read_back"]
+        assert after["merge_state_status"] == "UNKNOWN"
+        assert after["mergeable"] == "UNKNOWN"
+
+
+class TestARetryCannotCorrectTheMisread:
+    """Retrying returns the same payload, so it reads as corroboration."""
+
+    def test_the_retry_targets_an_already_merged_pull_request(self) -> None:
+        assert _OBSERVED[_RETRY_ON_MERGED["pull_request"]]["read_back"]["merged"] is True
+
+    def test_the_retry_returns_the_identical_response(self) -> None:
+        first = _OBSERVED[_RETRY_ON_MERGED["pull_request"]]
+        assert _RETRY_ON_MERGED["errors"] == first["errors"]
+        assert _RETRY_ON_MERGED["data"] == first["data"]
+
+    def test_the_retry_verdict_is_wrong_in_the_same_direction(self) -> None:
+        assert _verdict_from_mutation_response(_RETRY_ON_MERGED) is False, (
+            "two identical failures read as confirmation, which is what makes the retry "
+            "reflex more expensive than the single misread"
+        )
+
+
+#: Locates step 8's *After.* bullet in ``AGENTS.md``. The heading, not the correction.
+_ANCHOR = "- *After.* A `mergePullRequest` mutation can report `Pull Request is not"
+
+#: The next bullet, which bounds the passage.
+_NEXT_BULLET = "- *And on `main` afterwards.*"
+
+
+@pytest.fixture(scope="module")
+def bullet() -> str:
+    """The whole *After.* bullet, so every prose assertion also asserts adjacency."""
+    text = _AGENTS_PATH.read_text(encoding="utf-8")
+    assert _ANCHOR in text, (
+        f"AGENTS.md no longer contains {_ANCHOR!r}, which this module uses to locate step 8's "
+        "after-the-mutation read. Re-point the anchor at the passage that replaced it rather "
+        "than deleting these tests"
+    )
+    start = text.index(_ANCHOR)
+    end = text.index(_NEXT_BULLET, start)
+    return text[start:end]
+
+
+class TestTheGuidanceKeepsTheCorrectionAdjacent:
+    """The prose is the deliverable. Assert it, and assert it stays in place."""
+
+    def test_it_still_prescribes_the_read_back(self, bullet: str) -> None:
+        assert "`state`/`merged`" in bullet
+        assert "git log origin/main" in bullet
+
+    def test_it_says_the_error_recurs(self, bullet: str) -> None:
+        assert "#2249" in bullet and "#2250" in bullet, (
+            "AGENTS.md must carry the recurrence, because one case from a fortnight earlier "
+            "reads as a race worth ignoring and three in a row do not"
+        )
+        assert "926beb9" in bullet and "07a759d" in bullet, (
+            "name the merge commits: the claim is that the squashes landed, and a commit on "
+            "main is the only evidence a reader can check"
+        )
+
+    def test_it_rules_out_the_cheap_explanation(self, bullet: str) -> None:
+        assert "expectedHeadOid" in bullet, (
+            "a reader's first hypothesis is a stale head oid; the guidance has to close it "
+            "or the recurrence looks like the caller's own bug"
+        )
+
+    def test_it_says_a_retry_is_not_the_remedy(self, bullet: str) -> None:
+        assert "retry" in bullet.lower(), (
+            "the read-back instruction alone does not stop the retry reflex, and the retry is "
+            "what turns one misread into a confident one"
+        )
+
+    def test_it_names_this_pin(self, bullet: str) -> None:
+        assert Path(__file__).name in bullet, (
+            "AGENTS.md names the module that pins each measured claim, so a reader can find "
+            "the payloads behind these numbers"
+        )


### PR DESCRIPTION
## Problem

`AGENTS.md` > PR Workflow > step 8's *After.* bullet says a `mergePullRequest` mutation
*can* report `Pull Request is not mergeable` on a merge that in fact landed, evidenced by
one pull request from 2026-07-30 (#1756). Read as written, that is a rare race worth a
footnote.

It is not rare. Two merges today returned it, thirty seconds apart, and both squashes
were already on `main`:

| pull request | mutation response | merge commit | merged at |
| --- | --- | --- | --- |
| #1756 | `Pull Request is not mergeable`, `data.mergePullRequest: null` | `4bf139c` | 2026-07-30 06:55:29Z |
| #2249 | `Pull Request is not mergeable`, `data.mergePullRequest: null` | `926beb9` | 2026-08-13 19:24:50Z |
| #2250 | `Pull Request is not mergeable`, `data.mergePullRequest: null` | `07a759d` | 2026-08-13 19:25:20Z |

Three for three. The cheap explanations are closed by the payloads that produced the
last two rows: each was a **single** call - no earlier attempt against the same pull
request - and each carried `expectedHeadOid`, so a stale oid cannot be the refusal's
cause; each target read `CLEAN` / `MERGEABLE` / `APPROVED` with every required context
`SUCCESS` moments before. And the response carries nothing to key a verdict on either
way: `errors[0]` is that sentence and `data.mergePullRequest` is `null` whether the
squash landed or not.

## Why the retry is the expensive reflex, not the safe one

The read-back step 8 already prescribes is the only thing that separates the two
outcomes - and it also names the likely mechanism, in the very field the error is worded
about. Once #2249 was merged, `mergeStateStatus` and `mergeable` both report `UNKNOWN`,
which is what a mutation re-reading the pull request it has just closed would see on its
way out.

What the bare instruction does not stop is the retry. Measured rather than assumed: a
second `mergePullRequest` against #2249 **after** it had merged, same input, returned
the identical error beside the identical `null`. Two identical failures read as
corroboration, so retrying converts one misread into a confident one - and the work it
then argues for is re-deriving a change that is already on `main`.

## What changes

- `AGENTS.md`, 19 lines inside the existing *After.* bullet: the recurrence with its
  three merge commits, the stale-oid hypothesis closed explicitly, and the retry named
  as the reflex to skip. Nothing is rewritten - the original instruction and the #1756
  case stay exactly as they were, because what was wrong with them was incompleteness,
  not accuracy.
- `tests/test_merge_mutation_error_is_not_a_verdict.py`, a new offline pin, in the shape
  the same step's other reading disciplines already use
  (`test_timeline_filter_count_is_unfiltered.py`, `test_merge_gate_viewer_scope.py`,
  `test_graphql_node_id_targeting.py`).

## What the pin asserts

**`TestTheErrorDoesNotSeparateTheOutcomes`** (14 cases) runs both derivations over the
recorded payloads - one keyed on the mutation response, one on the `state`/`merged`
read-back - and asserts the first is wrong on **every** row while the second is right on
every row. That is the arithmetic behind the guidance, so the module says *why* the error
is uninformative rather than only that the prose mentions it. It also pins the two
exonerating facts (`expectedHeadOid` supplied; the pre-call gate fully green) and the
post-merge `UNKNOWN` / `UNKNOWN` read.

**`TestARetryCannotCorrectTheMisread`** (3 cases) pins the repeat call: same input, same
error, same `null`, against a pull request that by then nobody could merge.

**`TestTheGuidanceKeepsTheCorrectionAdjacent`** (5 cases) pins the prose, because the
prose is the deliverable - an agent reads `AGENTS.md`, not this module. What is asserted
is **adjacency**: the passage is sliced from the *After.* anchor to the next bullet, so
every sentence has to stay inside the bullet it qualifies. "can report" reads perfectly
well alone and is exactly what a later tidy-up would leave behind.

## Negative control

With `origin/main`'s `AGENTS.md` restored: **4 failed, 18 passed**. The 4 are the prose
assertions that read the new sentences; the 5th prose test (the read-back instruction)
and the anchor guard pass on both trees, and all 17 offline tests pass unchanged - the
API's behaviour is a property of GitHub, not of this branch. Only the guidance is new.

## Gate

- `python3 -m pytest tests/test_merge_mutation_error_is_not_a_verdict.py`: **22 passed**
  in 0.07s. No network, no tokens, no fixtures beyond the recorded payloads.
- Run with step 8's three existing pins together
  (`test_timeline_filter_count_is_unfiltered.py`, `test_merge_gate_viewer_scope.py`,
  `test_graphql_node_id_targeting.py`): **85 passed** - the four modules read the same
  file and none of the existing anchors moved.
- `ruff check strands_robots tests tests_integ`: clean.
  `ruff format --check`: 1220 files already formatted.
- `mypy tests/test_merge_mutation_error_is_not_a_verdict.py`: clean. This bullet
  did not exist when the branch was opened, and its absence is why a type error
  reached `call-test-lint` rather than this description - see round 1.
- The full suite, measured at `80f20770` on a host with `torch`, `mujoco` and EGL:
  `MUJOCO_GL=egl pytest tests` gives **29631 passed, 266 skipped, 0 failed** in 708.73s.
  That is 29609 on the base plus this module's 22 cases. It is the first end-to-end run
  this branch has had: `call-test-lint` runs lint before tests, so while the type error
  stood the test step was *skipped* rather than failed - see round 2.
- `changelog.d/2251-merge-mutation-error-is-not-a-verdict.md` under `### Docs:`. The
  earlier reasoning here was that nothing user-visible changes, and that is true of
  library behaviour but not of the convention: `changelog.d/README.md` is "one file per
  change", and every one of the last fifteen merged pull requests touching `AGENTS.md`
  carries a fragment, including the guidance corrections in #2027 and #2147. The gate
  cannot catch the omission, which is why it went unnoticed - see round 2.


## Review round 1

**`call-test-lint` failed; nothing about the argument changed.**

mypy read `_RETRY_ON_MERGED` as `dict[str, object]` - the value type a heterogeneous
dict literal joins to - so the two lookups keying `_OBSERVED` off
`_RETRY_ON_MERGED["pull_request"]` handed an `object` to a `dict[int, ...]`:

```
tests/test_merge_mutation_error_is_not_a_verdict.py:222: error: Invalid index type
  "object" for "dict[int, dict[str, Any]]"; expected type "int"  [index]
tests/test_merge_mutation_error_is_not_a_verdict.py:225: error: (same)
```

- `43077e5` annotates the constant `dict[str, Any]` - one line, and the annotation
  its two siblings in the same block already carry (`_OBSERVED`, `_GATE_BEFORE`).
  It is also the honest type of a recorded JSON payload.
- No assertion moves and no case is weakened: the key is still read at runtime, so a
  typo stays a `KeyError` the pin catches. 22 passed; 85 passed alongside step 8's
  three existing pins; `ruff check` and `ruff format --check` clean.
- Root cause of the miss, not just the symptom: the Gate section above quoted `ruff`
  and the pytest count but never `mypy`, so the one gate that fails here was the one
  never run locally. The bullet is now in the Gate list.

## Review round 2

**The type error had hidden the whole test step; the fragment was missing.**

- `43077e50` fixes the annotation, and a second harness run independently produced the
  **byte-identical** change - same line, same `dict[str, Any]`, same blob `09a84b52`.
  That copy was abandoned rather than pushed; `80f20770` adds only what was left over.
- `80f20770` adds the changelog fragment the convention requires. The fragment gate is
  blind to a missing one: `check_changelog_fragment.py` refuses a `### ` entry added to
  `[Unreleased]` that no fragment accounts for, so a branch writing neither passes it,
  which is why `Refuse a changelog entry that breaks the fragment convention` was green
  on both earlier heads.
- Measured consequence of the lint failure: on `66ed42c7` the job's step 8 `Run lint` is
  `failure` and step 9 `Run tests` is **`skipped`**, so none of this module's 22 cases had
  ever executed in CI. The full suite above closes that.
- The `FAILURE` rollup on `43077e50` is a **cancelled** check, not a failed one:
  `call-test-lint` there started 20:14:18 and stopped 20:24:30, the moment `80f20770`
  landed, because `pr-and-push.yml` keys its concurrency group on the pull request. Every
  other context on that commit is `success` or `neutral`. Fittingly, it is the same
  reading error this branch documents.
- The push dismissed the approval, so this needs a re-approval. It was unavoidable: the
  branch could not merge with its required check red.

Full measurements in the round-2 comment.
