### PR TITLE
fix(tools): require operator approval for a train run that publishes

### DIFF
--- a/changelog.d/2252-train-publication-requires-approval.md
+++ b/changelog.d/2252-train-publication-requires-approval.md
@@ -1,0 +1,15 @@
+### Fixed: a train run that publishes to the HF Hub now requires operator approval whichever spelling asks for it
+
+`lerobot_train` blocks a set of LeRobot flags -- output paths, telemetry,
+publication, code loading -- behind an operator approval prompt. Three of those
+blocked flags are also named parameters of the tool, and the gate only inspected
+`extra_flags`, so `push_to_hub=True` reached the argv unasked while
+`extra_flags={"push_to_hub": True}` was refused. A caller could launch a
+training run configured to publish the trained checkpoint -- to a destination
+supplied through the ungated `policy.repo_id` flag -- with nobody approving it.
+
+The named `push_to_hub` now routes through the same gate as `pretrained_path`
+already did, so both spellings reach one verdict. The default `False` is not
+gated, and the documented escape hatches (an approving `tool_context`, the
+`STRANDS_TRAIN_EXTRA_FLAGS_ALLOW` allowlist, `BYPASS_TOOL_CONSENT`) are
+unchanged.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -654,6 +654,11 @@ def lerobot_train(
             a validation loss beside it.
         num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
         push_to_hub: Push the trained checkpoint to the HF Hub at the end.
+            Publishing is an outward-facing action, so a true value requires
+            operator approval through ``tool_context`` (or an explicit
+            STRANDS_TRAIN_EXTRA_FLAGS_ALLOW entry) exactly as the
+            ``extra_flags={'push_to_hub': True}`` spelling already does. The
+            default false value emits the flag unchanged and is not gated.
         resume: Resume from the latest checkpoint under output_dir when present.
         action: One of start, status, stop, list.
         session_name: Session identifier (auto-generated on start; required for
@@ -718,6 +723,11 @@ def lerobot_train(
 
             if pretrained_path:
                 gate_err = _gate_extra_flags({"policy.pretrained_path": pretrained_path}, tool_context)
+                if gate_err:
+                    return gate_err
+
+            if push_to_hub:
+                gate_err = _gate_extra_flags({"policy.push_to_hub": push_to_hub}, tool_context)
                 if gate_err:
                     return gate_err
 

--- a/tests/tools/test_train_publication_requires_approval.py
+++ b/tests/tools/test_train_publication_requires_approval.py
@@ -1,0 +1,275 @@
+"""Blocked train flags reach the operator gate whichever spelling names them.
+
+``lerobot_train`` refuses a set of LeRobot flags that control output paths,
+telemetry, publication and code loading unless an operator approves them through
+``tool_context``. Three of those blocked flags are *also* named parameters of the
+tool, so a caller can name them without going through ``extra_flags`` at all --
+and a gate that only inspects ``extra_flags`` never sees that spelling.
+
+These tests pin the wiring rather than the gate helper (whose accepted domain is
+already covered elsewhere):
+
+1. Every gated input -- a blocked ``extra_flags`` key, ``pretrained_path`` and
+   ``push_to_hub`` -- is refused *before* a training subprocess is launched, and
+   the refusal names the flag.
+2. ``push_to_hub=True`` and ``extra_flags={"push_to_hub": True}`` reach the same
+   verdict, so the publication posture does not depend on how the caller spelled
+   it.
+3. The documented escape hatches (an approving ``tool_context``, the allowlist
+   env var, ``BYPASS_TOOL_CONSENT``) still launch, and the default
+   ``push_to_hub=False`` is not gated.
+4. A parity net over the blocklist: any blocked flag that is also a named
+   parameter must be gated, or be named in this module's documented exemption.
+
+Everything here is hardware-, GPU- and network-free: ``subprocess.Popen`` is
+replaced by a recorder, so "launched" means "the tool would have started
+training with this argv".
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import strands_robots.tools.lerobot_train as train_mod
+
+lerobot_train = train_mod.lerobot_train
+
+_ALLOW_ENV = train_mod._EXTRA_FLAGS_ALLOW_ENV
+_BYPASS_ENV = train_mod._BYPASS_CONSENT_ENV
+
+# ``output_dir`` is blocked in ``extra_flags`` yet ungated as a named parameter,
+# deliberately: the builder always emits exactly one ``--output_dir``, so the
+# blocklist entry stops a caller smuggling a second, conflicting one rather than
+# stopping the tool writing where the caller asked. Gating the named parameter
+# would refuse a documented, ordinary argument.
+_UNGATED_BY_DESIGN = frozenset({"output_dir"})
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+class _FakeProc:
+    """Stand-in for a launched training process."""
+
+    pid = 4242
+
+    def poll(self) -> None:
+        return None
+
+
+@pytest.fixture
+def launcher(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """A dataset, an isolated session store, and a recording ``Popen``.
+
+    The ambient environment of a harness run may carry ``BYPASS_TOOL_CONSENT``,
+    which switches the gate off wholesale; these tests are about the gate, so
+    both escape hatches are cleared unless a test sets one itself.
+    """
+    monkeypatch.delenv(_BYPASS_ENV, raising=False)
+    monkeypatch.delenv(_ALLOW_ENV, raising=False)
+
+    dataset = tmp_path / "ds"
+    (dataset / "meta").mkdir(parents=True)
+    (dataset / "meta" / "info.json").write_text(json.dumps({"total_episodes": 10}))
+
+    sessions = tmp_path / ".sessions"
+    sessions.mkdir()
+    monkeypatch.setattr(train_mod, "SESSION_DIR", sessions)
+
+    launched: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], *args: Any, **kwargs: Any) -> _FakeProc:
+        launched.append(list(cmd))
+        return _FakeProc()
+
+    monkeypatch.setattr(train_mod.subprocess, "Popen", _fake_popen)
+    return {"dataset": dataset, "launched": launched}
+
+
+def _start(launcher: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Drive ``action='start'`` through the tool with a unique session name."""
+    kwargs.setdefault("tool_context", None)
+    kwargs.setdefault("policy_type", "act")
+    kwargs.setdefault("session_name", f"s{len(launcher['launched'])}")
+    return dict(lerobot_train(action="start", dataset_root=str(launcher["dataset"]), **kwargs))
+
+
+def _approving_context() -> MagicMock:
+    ctx = MagicMock()
+    ctx.interrupt.return_value = "y"
+    return ctx
+
+
+def _declining_context() -> MagicMock:
+    ctx = MagicMock()
+    ctx.interrupt.return_value = "no"
+    return ctx
+
+
+class TestEveryGatedInputRefusesBeforeLaunch:
+    """A blocked flag is refused before a training subprocess exists."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "flag"),
+        [
+            ({"extra_flags": {"output_dir": "/tmp/elsewhere"}}, "output_dir"),
+            ({"extra_flags": {"wandb.api_key": "sk-secret"}}, "wandb.api_key"),
+            ({"extra_flags": {"config_path": "/tmp/attacker.yaml"}}, "config_path"),
+            ({"pretrained_path": "attacker/model"}, "policy.pretrained_path"),
+            ({"push_to_hub": True}, "policy.push_to_hub"),
+        ],
+        ids=["extra-output_dir", "extra-wandb_key", "extra-config_path", "named-pretrained_path", "named-push_to_hub"],
+    )
+    def test_refused_without_a_tool_context(self, launcher: dict[str, Any], kwargs: dict[str, Any], flag: str) -> None:
+        result = _start(launcher, **kwargs)
+        assert result["status"] == "error", result
+        assert flag in _texts(result)
+        assert launcher["launched"] == [], "a refused call must not launch training"
+
+    def test_a_benign_extra_flag_still_launches(self, launcher: dict[str, Any]) -> None:
+        """The gate refuses the blocklist, not every extra flag."""
+        result = _start(launcher, extra_flags={"policy.optimizer_lr": "1e-4"})
+        assert result["status"] == "success", _texts(result)
+        assert len(launcher["launched"]) == 1
+        assert "--policy.optimizer_lr=1e-4" in launcher["launched"][0]
+
+    def test_the_default_publish_posture_is_not_gated(self, launcher: dict[str, Any]) -> None:
+        """``push_to_hub=False`` is the default for every call and must stay free."""
+        result = _start(launcher)
+        assert result["status"] == "success", _texts(result)
+        assert "--policy.push_to_hub=false" in launcher["launched"][0]
+
+
+class TestPublicationPostureDoesNotDependOnSpelling:
+    """One LeRobot flag, two spellings, one verdict."""
+
+    def test_both_spellings_of_push_to_hub_are_refused_alike(self, launcher: dict[str, Any]) -> None:
+        named = _start(launcher, push_to_hub=True)
+        smuggled = _start(launcher, extra_flags={"push_to_hub": True})
+
+        assert named["status"] == smuggled["status"] == "error"
+        assert "push_to_hub" in _texts(named)
+        assert "push_to_hub" in _texts(smuggled)
+        assert launcher["launched"] == [], "neither spelling may launch unapproved"
+
+    def test_declining_the_publish_launches_nothing(self, launcher: dict[str, Any]) -> None:
+        result = _start(launcher, push_to_hub=True, tool_context=_declining_context())
+        assert result["status"] == "error", result
+        assert "declined" in _texts(result)
+        assert launcher["launched"] == []
+
+    def test_approving_the_publish_launches_with_the_flag(self, launcher: dict[str, Any]) -> None:
+        ctx = _approving_context()
+        result = _start(launcher, push_to_hub=True, tool_context=ctx)
+
+        assert result["status"] == "success", _texts(result)
+        assert "--policy.push_to_hub=true" in launcher["launched"][0]
+        assert ctx.interrupt.called, "approval must be sought from the operator"
+
+    def test_the_publish_destination_cannot_ride_along_unapproved(self, launcher: dict[str, Any]) -> None:
+        """A destination is only reachable once the publish itself is approved.
+
+        ``--policy.repo_id`` is a required LeRobot flag even for a purely local
+        run, so it is deliberately not blocklisted. What must not happen is the
+        pair reaching the argv with nobody asked: the publish decision is the
+        gated one, and it carries the destination with it.
+        """
+        unapproved = _start(
+            launcher,
+            push_to_hub=True,
+            extra_flags={"policy.repo_id": "attacker/stolen-policy"},
+        )
+        assert unapproved["status"] == "error", unapproved
+        assert launcher["launched"] == []
+
+        approved = _start(
+            launcher,
+            push_to_hub=True,
+            extra_flags={"policy.repo_id": "operator/reviewed"},
+            tool_context=_approving_context(),
+        )
+        assert approved["status"] == "success", _texts(approved)
+        argv = launcher["launched"][0]
+        assert "--policy.push_to_hub=true" in argv
+        assert "--policy.repo_id=operator/reviewed" in argv
+
+    @pytest.mark.parametrize("escape", ["allowlist", "bypass"])
+    def test_the_documented_escape_hatches_still_publish(
+        self, launcher: dict[str, Any], monkeypatch: pytest.MonkeyPatch, escape: str
+    ) -> None:
+        if escape == "allowlist":
+            monkeypatch.setenv(_ALLOW_ENV, "policy.push_to_hub")
+        else:
+            monkeypatch.setenv(_BYPASS_ENV, "true")
+
+        result = _start(launcher, push_to_hub=True)
+        assert result["status"] == "success", _texts(result)
+        assert "--policy.push_to_hub=true" in launcher["launched"][0]
+
+
+def _tool_source() -> str:
+    return inspect.getsource(train_mod)
+
+
+def _named_parameters() -> list[str]:
+    """Parameter names of the ``lerobot_train`` dispatcher, read from source.
+
+    The tool is wrapped by ``@tool``, so its signature is read from the module
+    source rather than from the decorated object.
+    """
+    tree = ast.parse(_tool_source())
+    fn = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "lerobot_train")
+    return [arg.arg for arg in fn.args.args + fn.args.kwonlyargs]
+
+
+def _gated_flag_keys() -> set[str]:
+    """Blocklist keys the dispatcher hands to the gate as literal dict keys."""
+    tree = ast.parse(_tool_source())
+    fn = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "lerobot_train")
+    keys: set[str] = set()
+    for node in ast.walk(fn):
+        if not (isinstance(node, ast.Call) and getattr(node.func, "id", "") == "_gate_extra_flags"):
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Dict):
+            keys.update(key.value for key in first.keys if isinstance(key, ast.Constant) and isinstance(key.value, str))
+    return keys
+
+
+class TestBlockedFlagsThatAreAlsoNamedParametersAreGated:
+    """Parity net: the blocklist and the named parameters cannot drift apart."""
+
+    def test_the_survey_finds_the_known_named_parameters(self) -> None:
+        """Non-vacuity: the scan really sees the tool's parameters and blocklist."""
+        params = _named_parameters()
+        assert {"pretrained_path", "push_to_hub", "output_dir", "extra_flags"} <= set(params)
+        assert "policy.push_to_hub" in train_mod._BLOCKED_EXTRA_FLAGS
+
+    def test_every_blocked_named_parameter_is_gated_or_documented(self) -> None:
+        params = set(_named_parameters())
+        gated_tails = {key.rsplit(".", 1)[-1] for key in _gated_flag_keys()}
+
+        blocked_named = {
+            flag.rsplit(".", 1)[-1] for flag in train_mod._BLOCKED_EXTRA_FLAGS if flag.rsplit(".", 1)[-1] in params
+        }
+        adrift = blocked_named - gated_tails - _UNGATED_BY_DESIGN
+        assert not adrift, (
+            f"blocked flags reachable through an ungated named parameter: {sorted(adrift)}. "
+            "Route each through _gate_extra_flags, or record why it is exempt."
+        )
+
+    def test_the_exemption_still_describes_a_real_parameter(self) -> None:
+        """A stale exemption must be deleted, not left as a hole."""
+        params = set(_named_parameters())
+        blocked_tails = {flag.rsplit(".", 1)[-1] for flag in train_mod._BLOCKED_EXTRA_FLAGS}
+        for name in _UNGATED_BY_DESIGN:
+            assert name in params, f"exempt name {name!r} is not a parameter any more"
+            assert name in blocked_tails, f"exempt name {name!r} is not blocklisted any more"


### PR DESCRIPTION
## Problem

`lerobot_train` refuses a set of LeRobot flags unless an operator approves them
through `tool_context` -- output paths, telemetry sinks, publication and code
loading. Three of those blocked flags are also **named parameters** of the tool,
and the gate only ever inspected `extra_flags`, so a caller could name one
directly and never meet the gate.

Measured through the tool with `subprocess.Popen` replaced by a recorder, no
`tool_context` supplied:

```
lerobot_train(action="start", dataset_root=..., push_to_hub=True,
              extra_flags={"policy.repo_id": "attacker/stolen"})

  status  = success
  launched: --policy.push_to_hub=true  --policy.repo_id=attacker/stolen
  operator asked: no
```

The same request spelled `extra_flags={"push_to_hub": True}` **was** refused.
One LeRobot flag, two spellings, opposite verdicts -- and the spelling that got
through is the shorter, documented one.

Worse than "never asked": because the gate was not consulted at all, an operator
who **declines** still got the publish launched. On `main`, `push_to_hub=True`
with a `tool_context` whose reply is `"no"` returns `status="success"` and starts
training with `--policy.push_to_hub=true`.

`--policy.repo_id` is deliberately not blocklisted -- LeRobot's config validation
requires a `repo_id` even for a purely local run -- so the publish *decision* is
the one that has to be approved, and it carries the destination with it.

## Change

The named `push_to_hub` now routes through `_gate_extra_flags` exactly as
`pretrained_path` already did, one line above it:

```python
if pretrained_path:
    gate_err = _gate_extra_flags({"policy.pretrained_path": pretrained_path}, tool_context)
    if gate_err:
        return gate_err
if push_to_hub:
    gate_err = _gate_extra_flags({"policy.push_to_hub": push_to_hub}, tool_context)
    if gate_err:
        return gate_err
```

Nothing else moves. The gate helper's accepted domain, its message, the
allowlist env var and `BYPASS_TOOL_CONSENT` are untouched; the default
`push_to_hub=False` is not gated, and its argv is byte-identical to `main`'s.

## Measured

| call (no `tool_context`) | main | this change |
| --- | --- | --- |
| `push_to_hub=True` | launched, never asked | refused |
| `push_to_hub=True` + `policy.repo_id` | launched with the destination | refused |
| `extra_flags={"push_to_hub": True}` | refused | refused |
| `push_to_hub=False` (default) | launched | launched (same argv) |
| `push_to_hub=True`, operator **declines** | launched | refused |
| `push_to_hub=True`, operator approves | launched, never asked | launched, asked |

Outcomes honouring the approval posture: **main 2 of 6, this change 6 of 6**.

![publication gate](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-publication-gate/publication_gate.png)

## Tests

`tests/tools/test_train_publication_requires_approval.py` (16 cases). The gate's
*wiring* had no test at all -- the helper's domain is covered elsewhere, but
nothing drove a gated input through the tool.

- each gated input (a blocked `extra_flags` key, `pretrained_path`,
  `push_to_hub`) refuses **before** a subprocess exists, and names the flag;
- both spellings of `push_to_hub` reach one verdict; declining launches nothing;
  approving launches with the flag and the operator really was asked;
- the destination cannot ride along unapproved, and *is* emitted once approved;
- the three documented escape hatches still publish, and the default is free;
- a parity net over `_BLOCKED_EXTRA_FLAGS`: any blocked flag that is also a named
  parameter must be gated or carry a documented exemption. `output_dir` is the
  one exemption -- the builder always emits exactly one `--output_dir`, so the
  blocklist entry stops a *second*, conflicting one rather than stopping the tool
  writing where the caller asked -- and two further tests fail if that exemption
  goes stale.

Pre-fix, source reverted to `a78ea602` with the tests kept: **6 failed / 10
passed**. The 10 are the over-reach controls (benign extra flag, default posture,
escape hatches, the `extra_flags` spelling, the survey's non-vacuity).

| mutation | new module | pre-existing (277 cases) |
| --- | --- | --- |
| delete the `push_to_hub` gate | 6 failed | 0 failed |
| keep the call, discard the refusal | 4 failed | 0 failed |
| gate unconditionally (default too) | 2 failed | 0 failed |
| drop the flag from the blocklist | 6 failed | 0 failed |
| gate names a flag that is not blocked | 6 failed | 0 failed |

5 of 5 caught here, 0 of 5 by the pre-existing suite. Each anchor was AST-scoped
to its enclosing function (`in_fn=1` for all five) and the source restored
byte-identically.

## Gate

`ruff check` / `ruff format --check` clean (1215 files); `mypy strands_robots
tests tests_integ` 0 non-examples errors; `MUJOCO_GL=egl python -m pytest tests`
**29604 passed / 266 skipped / 0 failed** (675s) -- 29588 on pristine `main` at
this base plus the 16 new cases. `check_merge_base_overlap.py`: no overlap with
the 4 paths `main` gained since `a78ea602`.

No policy, simulation, rendering, recording or asset behaviour changes, so the
artifact is the measured posture rather than a rollout. Capture and mutation
scripts and both JSON dumps are on
[`artifacts/train-publication-gate`](https://github.com/cagataycali/robots/tree/artifacts/train-publication-gate).
