### PR TITLE
test(isaac): pin the recording camera-scoping matrix to MuJoCo/Newton parity

### DIFF
--- a/changelog.d/2254-isaac-camera-scoping-parity.md
+++ b/changelog.d/2254-isaac-camera-scoping-parity.md
@@ -1,0 +1,9 @@
+### Quality: pin the Isaac recording camera-scoping matrix to MuJoCo/Newton parity
+
+`IsaacSimulation.start_recording` documents `cameras=` names as either raw
+(`arm0/wrist`) or already schema-safe (`arm0__wrist`), and its source comment
+claims "parity with MuJoCo/Newton". Both siblings pin the schema-safe spelling;
+Isaac pinned only the raw and unknown-name cells, leaving the alias branch
+unexecuted. Adds the alias cell, the raw-equals-safe equivalence assertion that
+MuJoCo already carries, and the first pin anywhere for the both-spellings
+dedup. Tests only; no library behaviour changes.

--- a/tests/simulation/isaac/test_dataset_recording.py
+++ b/tests/simulation/isaac/test_dataset_recording.py
@@ -473,3 +473,105 @@ def test_multi_robot_namespaced_schema(tmp_path) -> None:
     assert stopped["status"] == "success", stopped
     info = read_dataset_episode_indices(root)
     assert info["total_episodes"] == 2
+
+
+def _namespaced_camera_engine(fill: int = 11) -> IsaacSimulation:
+    """Engine whose cameras include a namespaced one, so raw != schema-safe.
+
+    ``arm0/wrist`` sanitizes to ``arm0__wrist``, which is what makes the two
+    request spellings distinguishable; ``overview`` is the unscoped sibling
+    that must be excluded when the namespaced one is selected.
+    """
+    return _make_engine(
+        robots={"so100": _robot()},
+        cameras={
+            "arm0/wrist": _camera("arm0/wrist", fill=fill),
+            "overview": _camera("overview", fill=fill + 1),
+        },
+    )
+
+
+def test_start_recording_accepts_schema_safe_camera_name(tmp_path) -> None:
+    """A namespaced camera can be scoped by its schema-safe ``__`` form.
+
+    ``start_recording`` documents ``cameras=`` names as either raw
+    (``arm0/wrist``) or already schema-safe (``arm0__wrist``), "parity with
+    MuJoCo/Newton". Both siblings pin the alias spelling; this pins it here.
+    Driving one hook step is what makes the alias branch's *raw* resolution
+    load-bearing: the per-step capture maps observation keys through the raw
+    source name, so an alias that kept the schema-safe spelling as its source
+    would declare the column and then never fill it.
+    """
+    root = str(tmp_path / "isaac_safe_name")
+    engine = _namespaced_camera_engine()
+    assert "arm0/wrist".replace("/", "__") != "arm0/wrist", "fixture must make the two spellings differ"
+
+    started = engine.start_recording(
+        repo_id="local/isaac_safe_name", root=root, fps=30, overwrite=True, cameras=["arm0__wrist"]
+    )
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    image_feats = {k for k in recorder.dataset.features if k.startswith("observation.images.")}
+    assert image_feats == {"observation.images.arm0__wrist"}, image_feats
+    # The hook renders the RAW scene camera and writes the schema-safe column.
+    assert engine._recording_state_dict["recording_cameras"] == [("arm0/wrist", "arm0__wrist", 64, 48)]
+
+    _drive_episode(engine, "so100", "alias", 1)
+    assert recorder.frame_count == 1, "the aliased column must actually receive frames"
+
+
+def test_start_recording_raw_and_schema_safe_names_are_equivalent(tmp_path) -> None:
+    """Scoping by raw or schema-safe name yields the same schema and sources.
+
+    Mirrors the MuJoCo equivalence pin: the two spellings are aliases of one
+    camera, so neither the declared columns nor the rendered source set may
+    depend on which one the caller wrote.
+    """
+    outcomes = []
+    for label, requested in (("raw", "arm0/wrist"), ("safe", "arm0__wrist")):
+        engine = _namespaced_camera_engine()
+        started = engine.start_recording(
+            repo_id=f"local/isaac_equiv_{label}",
+            root=str(tmp_path / label),
+            fps=30,
+            overwrite=True,
+            cameras=[requested],
+        )
+        assert started["status"] == "success", (label, started)
+        recorder = engine._recording_state_dict["dataset_recorder"]
+        outcomes.append(
+            (
+                frozenset(k for k in recorder.dataset.features if k.startswith("observation.images.")),
+                tuple(engine._recording_state_dict["recording_cameras"]),
+            )
+        )
+
+    assert outcomes[0] == outcomes[1], outcomes
+    assert outcomes[0][0] == frozenset({"observation.images.arm0__wrist"}), outcomes[0]
+
+
+def test_start_recording_dedupes_both_spellings_of_one_camera(tmp_path) -> None:
+    """Requesting a camera by BOTH spellings records it once, not twice.
+
+    The two names resolve to one scene camera, so the schema must carry a
+    single column: a per-spelling column would declare a duplicate feature
+    that the capture hook can only fill once.
+    """
+    root = str(tmp_path / "isaac_dedup")
+    engine = _namespaced_camera_engine()
+
+    started = engine.start_recording(
+        repo_id="local/isaac_dedup",
+        root=root,
+        fps=30,
+        overwrite=True,
+        cameras=["arm0/wrist", "arm0__wrist"],
+    )
+    assert started["status"] == "success", started
+
+    recorder = engine._recording_state_dict["dataset_recorder"]
+    image_feats = [k for k in recorder.dataset.features if k.startswith("observation.images.")]
+    assert image_feats == ["observation.images.arm0__wrist"], image_feats
+    assert engine._recording_state_dict["recording_cameras"] == [("arm0/wrist", "arm0__wrist", 64, 48)]
+    assert "2 cameras" not in started["content"][0]["text"], started["content"][0]["text"]


### PR DESCRIPTION
## Problem

`IsaacSimulation.start_recording(cameras=...)` accepts a camera by either its raw scene name
(`arm0/wrist`) or the schema-safe key it gets in the dataset (`arm0__wrist`), and the source
comment above that branch says it exists "for parity with the MuJoCo and Newton backends".

Measured, `strands_robots/simulation/isaac/recording.py:338` -- the whole alias branch -- was
never executed. The module that owns Isaac recording drives the raw name, an unknown name and
the default, and never the alias. So the parity that comment asserts was unverified on the
backend whose scene names most often carry a `/`, which is exactly what makes the alias
necessary there.

## What each spelling produces (measured on this branch)

| `cameras=` | status | dataset columns | rendered from |
| --- | --- | --- | --- |
| `['arm0__wrist']` (schema-safe) | success | `['arm0__wrist']` | `['arm0/wrist']` |
| `['arm0/wrist']` (raw) | success | `['arm0__wrist']` | `['arm0/wrist']` |
| `['arm0/wrist', 'arm0__wrist']` | success | `['arm0__wrist']` | `['arm0/wrist']` |
| `['nope']` | error, lists `['arm0/wrist', 'overview']` | none | none |
| omitted | success | `['arm0__wrist', 'overview']` | both |

The alias and the raw name are indistinguishable -- identical columns **and** identical render
sources -- and naming both spellings of one camera records it once rather than twice. Neither
property had a test on this backend.

## Cross-backend cells pinned by a test

| cell | MuJoCo | Newton | Isaac before | Isaac now |
| --- | --- | --- | --- | --- |
| raw scene name accepted | pinned | pinned | pinned | pinned |
| schema-safe alias accepted | pinned | pinned | no test | pinned |
| raw and alias equivalent | pinned | no test | no test | pinned |
| both spellings dedup to one column | no test | no test | no test | pinned |
| unknown name refused | pinned | pinned | pinned | pinned |
| omitted records every camera | pinned | pinned | pinned | pinned |

3 of 6 on Isaac before, 6 of 6 now. The dedup row is the first pin of that branch on any
backend.

## Tests

Three cases in the module that already owns this contract, plus one helper building a
`__new__` skeleton whose only camera has a namespaced name:

- the schema-safe spelling is accepted and declares the column under that key;
- the raw and schema-safe spellings produce byte-identical columns and render sources -- the
  equivalence assertion MuJoCo already carries;
- naming both spellings of one camera records one column rendered from one source.

## Plausible regressions in that branch

| mutation | 3 new cases | 18 pre-existing |
| --- | --- | --- |
| drop the schema-safe alias arm entirely | 3 failed | 0 failed |
| resolve the alias to the wrong source camera | 2 failed | 0 failed |
| let the alias declare a column under the raw name | 2 failed | 0 failed |
| stop deduping the two spellings | 1 failed | 0 failed |
| accept an unknown name as a schema-safe alias | 1 failed | 0 failed |

All five caught here, all five invisible to the 18 cases the module already had. Every anchor
was AST-scoped to its enclosing function (`in_fn=1` for each) and the source restored
byte-identically afterwards.

## Scope

Tests only. `git diff --numstat` over `strands_robots/` is empty, so no policy, simulation,
rendering, recording or asset behaviour can change. The uncovered line this closes is exactly
`recording.py:338`; `isaac/recording.py` over `tests/simulation/isaac` goes 96.36% to 96.97%
(11 to 10 missing).

Because production is correct, the new cases pass on unmodified `main` -- what they fail on is
a regression, and the mutation table is that evidence.

## Verification

Gate at base `c45bd1fa`: **29739 passed, 266 skipped** in 677s
(`MUJOCO_GL=egl pytest tests`), `ruff check` and `ruff format --check` clean over 1217 files,
`mypy strands_robots tests tests_integ` with 0 errors outside `examples/isaac_gs`.

One unrelated failure in that run,
`tests/training/test_reward_model_parity.py::test_strands_discovery_matches_lerobot_source`,
is an external-tree flake and not attributable to this change: it AST-scans the installed
lerobot checkout on disk, the assertion failed as `<= set()` (an empty scan), that directory's
mtime lands inside the suite window, its git reflog holds a single `clone:` entry, the file
passes 18 of 18 on re-run, and this diff touches nothing it reads.

## Artifact

![Isaac schema-safe camera alias parity](https://raw.githubusercontent.com/cagataycali/robots/artifacts/isaac-camera-scoping-parity/isaac_camera_scoping_parity.png)

Top left is frame 3 decoded back out of the dataset's own MP4 at
`videos/observation.images.arm0__wrist/chunk-000/file-000.mp4` -- the schema-safe key in the
path, the frames rendered from `arm0/wrist`, so the alias carries image data rather than only
naming a column. Capture, compose, the census view that found this slice and the mutation
script are on that branch; all of it runs with no Isaac Sim Kit, no GPU and no MuJoCo.
