### PR TITLE
fix(tools): report a teleop auto-accept that could not answer the prompt

### DIFF
--- a/changelog.d/2255-teleop-auto-accept-reports-failure.md
+++ b/changelog.d/2255-teleop-auto-accept-reports-failure.md
@@ -1,0 +1,19 @@
+### Fixed: report a teleop auto-accept that could not answer the calibration prompt
+
+`lerobot_teleoperate(action="start", auto_accept_calibration=True)` answers the
+child process's calibration prompt by writing two newlines into its stdin from a
+background thread. A write that failed - a closed pipe, a child that exited
+first - was swallowed with a bare `pass`, so the two outcomes were
+indistinguishable: the start result read `status="success"` and reported
+"Session Started" either way, the session store reported a live pid either way,
+and nothing was logged. The operator was told the session had started while the
+child sat at an unanswered prompt.
+
+The failure is now reported at WARNING, naming the session, the reason, and where
+to look. A write that *succeeds* stays silent, as the parameter's documented
+posture requires. Every other error handler in this tool already reported its
+failure; this one was the exception.
+
+Also pins the `stop` half of the session-lookup refusal (`status`'s was covered
+and `stop`'s was not, so the two could have drifted apart), and pins that the
+store's pid pruning is what makes the tool's "No PID found" refusal unreachable.

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -887,8 +887,10 @@ def lerobot_teleoperate(
             behalf, by writing two newlines into the process's stdin shortly
             after it starts. Withhold it (``False``) to answer the prompt
             yourself; nothing reports that stdin was written to, so an
-            unintended acceptance is not visible afterwards. Must be a boolean,
-            on the same reasoning as ``background``.
+            unintended acceptance is not visible afterwards. A write that
+            *fails* is reported at WARNING, since by then the start result
+            has already told the caller the session started. Must be a
+            boolean, on the same reasoning as ``background``.
 
         dagger_record_autonomous: Record the autonomous rollout episodes into the
             corrections dataset as well, rather than only the teleoperated
@@ -1016,8 +1018,22 @@ def lerobot_teleoperate(
                             proc.stdin.write("\n")  # Send another ENTER (for robot calibration)
                             proc.stdin.flush()
                             proc.stdin.close()  # Close stdin after sending responses
-                        except Exception:
-                            pass  # Ignore errors if process has already finished
+                        except Exception as exc:
+                            # Report it. The start result above has already told the
+                            # caller the session started, so this record is the only
+                            # signal that the prompt went unanswered. Every other
+                            # handler in this tool reports its failure - one even
+                            # surfaces a log-read failure into the caller's content -
+                            # and the write this guards is the whole job of
+                            # ``auto_accept_calibration``. WARNING rather than DEBUG
+                            # because the visible report is a success.
+                            logger.warning(
+                                "[teleop] session %r: auto-accept did not complete (%s); "
+                                "the calibration prompt may be unanswered - check "
+                                "action='status' and the session log",
+                                session_name,
+                                exc,
+                            )
 
                     threading.Thread(target=auto_respond, daemon=True).start()
                 else:

--- a/tests/tools/test_teleop_auto_accept_reports_failure.py
+++ b/tests/tools/test_teleop_auto_accept_reports_failure.py
@@ -1,0 +1,254 @@
+"""The teleop auto-accept reports a failed write, and the ``stop`` refusals.
+
+``lerobot_teleoperate(action="start", auto_accept_calibration=True)`` answers the
+child's calibration prompt on the operator's behalf by writing two newlines into
+its stdin from a background thread. That write is the whole job of the flag, and
+the start result has already reported ``status="success"`` by the time it runs -
+so if it fails, the record this module pins is the only signal the operator gets
+that the prompt went unanswered.
+
+Every other ``except Exception`` in the tool reports its failure (four return an
+error envelope, one surfaces a log-read failure into the caller's own content,
+one logs); this handler was the only silent one. It went untested because the
+auto-accept runs on a daemon thread that sleeps two seconds first, so a test
+process exits before it executes - hence the synchronous thread stand-in below,
+which makes the outcome deterministic rather than a race.
+
+This module also closes the ``stop`` half of a two-cell refusal matrix: ``stop``
+and ``status`` refuse an unknown session with byte-identical text, and only
+``status``'s was driven. The ``stop`` case is the common one in practice - a
+session whose process has exited is pruned from the store on the next read - and
+the same pruning is what makes the tool's "No PID found" branch unreachable, a
+property pinned here rather than assumed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+
+SessionManager = tele_mod.SessionManager
+lerobot_teleoperate = tele_mod.lerobot_teleoperate
+
+_LOGGER_NAME = "strands_robots.tools.lerobot_teleoperate"
+
+# The store prunes any record whose pid is not a live process on every read, so
+# a fake pid would make the session vanish before a test could read it back.
+# This process's own pid is live for the duration of the test, which is what a
+# real session's pid is too.
+_LIVE_PID = os.getpid()
+
+
+def _texts(result: dict[str, Any]) -> str:
+    """Concatenate all content ``text`` fields from a tool result."""
+    return "\n".join(item.get("text", "") for item in result.get("content", []) if "text" in item)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect the module-level session dir so tests never touch the real store."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+class _SyncThread:
+    """Run the target inline so the auto-accept is observable in-test.
+
+    The tool starts the auto-accept on a daemon thread. Left asynchronous, the
+    test process exits during its first ``time.sleep``, so neither outcome is
+    observable - which is why the handler under test had no coverage. The tool
+    does ``import threading`` inside the function body, so the class is resolved
+    off the module at call time and rebinding the attribute is enough.
+    """
+
+    def __init__(self, target: Any = None, daemon: bool | None = None, **_kw: Any) -> None:
+        self._target = target
+
+    def start(self) -> None:
+        if self._target is not None:
+            self._target()
+
+
+class _Stdin:
+    """Recording stdin whose ``write`` optionally fails, as a closed pipe would."""
+
+    def __init__(self, fail: bool) -> None:
+        self.fail = fail
+        self.writes: list[str] = []
+        self.closed = False
+
+    def write(self, data: str) -> None:
+        if self.fail:
+            raise OSError("Broken pipe")
+        self.writes.append(data)
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CalProc:
+    """``Popen`` stand-in carrying a real stdin, unlike the shared ``_FakeProc``."""
+
+    def __init__(self, pid: int | None = None, fail: bool = False) -> None:
+        self.pid = _LIVE_PID if pid is None else pid
+        self.returncode: int | None = None
+        self.stdin = _Stdin(fail)
+
+    def poll(self) -> int | None:
+        return None
+
+
+def _start_with_auto_accept(monkeypatch: pytest.MonkeyPatch, *, fail: bool) -> tuple[dict[str, Any], _CalProc]:
+    """Drive a background start whose auto-accept write succeeds or fails."""
+    proc = _CalProc(fail=fail)
+    monkeypatch.setattr(threading, "Thread", _SyncThread)
+    monkeypatch.setattr(tele_mod.subprocess, "Popen", lambda *a, **k: proc)
+    monkeypatch.setattr(tele_mod.time, "sleep", lambda s: None)
+    result = lerobot_teleoperate(
+        action="start",
+        session_name="cal",
+        robot_type="so101_follower",
+        teleop_type="so101_leader",
+        auto_accept_calibration=True,
+        background=True,
+    )
+    return result, proc
+
+
+# ---------------------------------------------------------------------------
+# the auto-accept write
+# ---------------------------------------------------------------------------
+def test_a_failed_auto_accept_is_reported(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """A write that fails leaves a record naming the session and the reason.
+
+    Without it the two outcomes are indistinguishable: the start result reads
+    ``success`` either way and the session store reports a live pid either way,
+    so nothing tells the operator the prompt is still waiting.
+    """
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        _result, proc = _start_with_auto_accept(monkeypatch, fail=True)
+
+    assert proc.stdin.writes == [], "the failing pipe must not have accepted a newline"
+    records = [r for r in caplog.records if "auto-accept" in r.getMessage()]
+    assert records, "a failed auto-accept left no record at all"
+    message = records[0].getMessage()
+    assert records[0].levelno >= logging.WARNING, f"reported below WARNING: {records[0].levelname}"
+    assert "cal" in message, f"the record does not name the session: {message}"
+    assert "Broken pipe" in message, f"the record does not carry the reason: {message}"
+
+
+def test_a_failed_auto_accept_points_at_the_prompt_and_the_log(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The record says what is wrong and where to look, not just that it failed."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        _start_with_auto_accept(monkeypatch, fail=True)
+
+    reported = [r.getMessage() for r in caplog.records if "auto-accept" in r.getMessage()]
+    assert reported, "a failed auto-accept left no record to inspect"
+    message = reported[0]
+    assert "prompt" in message, f"the record does not name the unanswered prompt: {message}"
+    assert "status" in message and "log" in message, f"the record offers no next step: {message}"
+
+
+def test_the_start_result_still_reports_success_when_the_auto_accept_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The record is additive: the launch itself succeeded and still says so.
+
+    The child process really did start; only the courtesy write into its stdin
+    failed. Turning that into an error envelope would misreport a running
+    session, so the envelope is deliberately unchanged.
+    """
+    result, _proc = _start_with_auto_accept(monkeypatch, fail=True)
+
+    assert result["status"] == "success"
+    assert "Session Started" in _texts(result)
+    assert SessionManager().get_session("cal") is not None, (
+        "the store must still report the session running - that is what makes the "
+        "silent failure indistinguishable from a healthy start"
+    )
+
+
+def test_a_successful_auto_accept_stays_silent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A write that succeeds reports nothing, as the parameter's docs promise.
+
+    ``auto_accept_calibration``'s documented posture is that nothing reports
+    stdin *was* written to, so an unintended acceptance stays invisible. Only
+    the failure is newly reported; this is the over-reach control for that.
+    """
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        _result, _proc = _start_with_auto_accept(monkeypatch, fail=False)
+
+    assert [r.getMessage() for r in caplog.records if "auto-accept" in r.getMessage()] == []
+
+
+def test_the_happy_path_delivers_two_newlines_and_closes_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-vacuity for the silence above: the auto-accept really did run.
+
+    Without this, a body that wrote nothing at all would satisfy the
+    silence assertion just as well as one that answered the prompt.
+    """
+    _result, proc = _start_with_auto_accept(monkeypatch, fail=False)
+
+    assert proc.stdin.writes == ["\n", "\n"], "the calibration prompt was not answered twice"
+    assert proc.stdin.closed, "stdin was left open after the responses"
+
+
+# ---------------------------------------------------------------------------
+# the stop refusal, and why the "No PID found" branch cannot be reached
+# ---------------------------------------------------------------------------
+def test_stop_refuses_an_absent_session() -> None:
+    """``stop`` on a session the store does not hold refuses, naming it.
+
+    This is the common case in practice rather than a corner: a session whose
+    process has exited is pruned on the next store read, so the operator's
+    ``stop`` arrives after it is already gone.
+    """
+    result = lerobot_teleoperate(action="stop", session_name="gone-forever")
+
+    assert result["status"] == "error"
+    text = _texts(result)
+    assert "gone-forever" in text and "not found" in text
+
+
+def test_stop_and_status_refuse_an_absent_session_identically() -> None:
+    """One session-lookup failure, one wording across both actions.
+
+    ``status``'s refusal was pinned and ``stop``'s was not, which is how the
+    two could have drifted apart without anything failing.
+    """
+    stop = lerobot_teleoperate(action="stop", session_name="ghost-session")
+    status = lerobot_teleoperate(action="status", session_name="ghost-session")
+
+    assert stop["status"] == status["status"] == "error"
+    assert _texts(stop) == _texts(status)
+
+
+def test_a_pidless_session_record_is_pruned_so_the_no_pid_refusal_is_unreachable() -> None:
+    """The store drops any record without a live pid, on every read.
+
+    ``stop`` carries a "No PID found" refusal below the lookup. It cannot be
+    reached through any input, because a record that reaches a caller has
+    already been filtered on ``pid and psutil.pid_exists(pid)``. Pinning the
+    pruning keeps that accounting honest: the day the store stops filtering,
+    this fails and the refusal becomes live code that needs its own test.
+    """
+    manager = SessionManager()
+    manager.add_session("nopid", {"start_time": 0.0, "action": "record"})
+
+    assert manager.get_session("nopid") is None, "a pidless record survived the store's pruning"
+    assert "nopid" not in manager.list_sessions()

--- a/tests/tools/test_teleop_auto_accept_reports_failure.py
+++ b/tests/tools/test_teleop_auto_accept_reports_failure.py
@@ -38,6 +38,11 @@ lerobot_teleoperate = tele_mod.lerobot_teleoperate
 
 _LOGGER_NAME = "strands_robots.tools.lerobot_teleoperate"
 
+#: Session name used by the failure fixtures. Deliberately not a substring of
+#: the record's own prose: ``"cal"`` was, because the record says
+#: ``"calibration"``, which made the "names the session" assertion vacuous.
+_SESSION = "wrist-rig-7"
+
 # The store prunes any record whose pid is not a live process on every read, so
 # a fake pid would make the session vanish before a test could read it back.
 # This process's own pid is live for the duration of the test, which is what a
@@ -117,7 +122,7 @@ def _start_with_auto_accept(monkeypatch: pytest.MonkeyPatch, *, fail: bool) -> t
     monkeypatch.setattr(tele_mod.time, "sleep", lambda s: None)
     result = lerobot_teleoperate(
         action="start",
-        session_name="cal",
+        session_name=_SESSION,
         robot_type="so101_follower",
         teleop_type="so101_leader",
         auto_accept_calibration=True,
@@ -144,7 +149,7 @@ def test_a_failed_auto_accept_is_reported(monkeypatch: pytest.MonkeyPatch, caplo
     assert records, "a failed auto-accept left no record at all"
     message = records[0].getMessage()
     assert records[0].levelno >= logging.WARNING, f"reported below WARNING: {records[0].levelname}"
-    assert "cal" in message, f"the record does not name the session: {message}"
+    assert _SESSION in message, f"the record does not name the session: {message}"
     assert "Broken pipe" in message, f"the record does not carry the reason: {message}"
 
 
@@ -162,6 +167,27 @@ def test_a_failed_auto_accept_points_at_the_prompt_and_the_log(
     assert "status" in message and "log" in message, f"the record offers no next step: {message}"
 
 
+def test_the_session_name_needle_is_not_satisfiable_by_the_prose(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The "names the session" assertion must not be satisfiable by the record's
+    own wording.
+
+    With the name stripped out, the remaining prose must not contain it. A name
+    of ``"cal"`` failed this: the record says ``"calibration"``, so the
+    assertion held whether or not the session was ever named.
+    """
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        _start_with_auto_accept(monkeypatch, fail=True)
+
+    reported = [r.getMessage() for r in caplog.records if "auto-accept" in r.getMessage()]
+    assert reported, "a failed auto-accept left no record to inspect"
+    prose = reported[0].replace(repr(_SESSION), "").replace(_SESSION, "")
+    assert _SESSION not in prose, (
+        f"{_SESSION!r} occurs in the record's own prose, so naming the session proves nothing: {prose}"
+    )
+
+
 def test_the_start_result_still_reports_success_when_the_auto_accept_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -175,7 +201,7 @@ def test_the_start_result_still_reports_success_when_the_auto_accept_fails(
 
     assert result["status"] == "success"
     assert "Session Started" in _texts(result)
-    assert SessionManager().get_session("cal") is not None, (
+    assert SessionManager().get_session(_SESSION) is not None, (
         "the store must still report the session running - that is what makes the "
         "silent failure indistinguishable from a healthy start"
     )
@@ -191,7 +217,7 @@ def test_a_successful_auto_accept_stays_silent(
     the failure is newly reported; this is the over-reach control for that.
     """
     with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
-        _result, _proc = _start_with_auto_accept(monkeypatch, fail=False)
+        _start_with_auto_accept(monkeypatch, fail=False)
 
     assert [r.getMessage() for r in caplog.records if "auto-accept" in r.getMessage()] == []
 


### PR DESCRIPTION
## Problem

`lerobot_teleoperate(action="start", auto_accept_calibration=True)` answers the child
process's calibration prompt on the caller's behalf, by writing two newlines into its
stdin from a background thread. That write was wrapped in a bare swallow:

```python
except Exception:
    pass  # Ignore errors if process has already finished
```

A write that fails - a closed pipe, a child that exited first - was therefore
indistinguishable from one that succeeded. Measured on both outcomes:

| `auto_accept_calibration=True` | newlines delivered | start result | session store | log records |
| --- | --- | --- | --- | --- |
| write succeeds | 2 | `success` "Session Started" | live pid | none |
| write raises `BrokenPipeError` | 0 | `success` "Session Started" | live pid | none |

Every channel a caller can read says the same thing in both rows. The operator is told
the session started while the child sits at an unanswered prompt, and the one thing that
was supposed to happen on their behalf did not.

The swallow was also the only one of its kind in the tool. Every other handler here
reports its failure - one even surfaces a log-read failure into the caller's own
`content` - and this one guards the write that is the entire job of the parameter.

## What changes

The failed write is reported at WARNING, naming the session, the reason, and where to
look next:

```
[teleop] session 'cal': auto-accept did not complete (Broken pipe); the calibration
prompt may be unanswered - check action='status' and the session log
```

WARNING rather than DEBUG because the visible report is a *success*: the start result
has already told the caller the session began, so this record is the only signal that
contradicts it, and it has to be at least as loud as the claim it corrects.

A write that succeeds stays silent. That is deliberate and is the parameter's documented
posture - "nothing reports that stdin was written to, so an unintended acceptance is not
visible afterwards" - so reporting the happy path would change a documented contract
rather than fix a defect. The docstring now records what happens when the write fails.

The start envelope is unchanged. The child really did start; only the courtesy write
failed, so turning this into an error envelope would misreport a running session.

| after the change | newlines delivered | start result | log records |
| --- | --- | --- | --- |
| write succeeds | 2 | `success` "Session Started" | none |
| write raises `BrokenPipeError` | 0 | `success` "Session Started" | 1 WARNING naming session, reason, next step |

## Also pinned

Two neighbouring properties of the same tool that had no coverage:

* The `stop` half of the session-lookup refusal. `status` had a test and `stop` did not,
  and both are expected to answer identically for an absent session - so the two could
  have drifted apart silently. Both now measured to return the same text.
* That the session store's pid pruning is what makes the tool's "No PID found" refusal
  unreachable. `_load_sessions` drops any record whose pid is not a live process, so a
  pidless record never survives to reach that branch. Pinning it means a change to the
  pruning surfaces as a failure here rather than as dead code later.

## Tests

9 new cases in `tests/tools/test_teleop_auto_accept_reports_failure.py`, driven against
a recording stub child process - no lerobot, no hardware, no serial port (0.45s).

Pre-fix, with the source reverted to the base and the new tests kept:

```
3 failed, 6 passed
FAILED test_a_failed_auto_accept_is_reported - a failed auto-accept left no record at all
FAILED test_a_failed_auto_accept_points_at_the_prompt_and_the_log - left no record to inspect
FAILED test_the_session_name_needle_is_not_satisfiable_by_the_prose - left no record to inspect
```

The 6 that pass pre-fix are the over-reach controls: the start envelope still reports
success, a successful write stays silent, the happy path still delivers two newlines and
closes stdin, and the three refusal/pruning properties above. They are what stop the
change being satisfied by reporting unconditionally.

### Mutation table

Seven plausible regressions, each run against the new module and against the 58
pre-existing cases in `tests/tools/test_lerobot_teleoperate.py` (failures per arm):

| mutation | new module | pre-existing |
| --- | --- | --- |
| unmutated control | 0 | 0 |
| M1 revert to a bare swallow | 2 | 0 |
| M2 keep the handler, drop only the record | 2 | 0 |
| M3 downgrade WARNING to DEBUG | 2 | 0 |
| M4 drop the reason from the record | 3 | 0 |
| M5 drop the where-to-look guidance | 1 | 0 |
| M6 also report on success (over-reach) | 1 | 0 |
| M7 reword `stop`'s refusal so it drifts from `status` | 2 | 0 |

Seven of seven caught here, none visible to the pre-existing suite. M2 is the row a
structural "the handler exists" check cannot see, and M3 only fails because the tests
assert the record's level rather than its presence. Each anchor was AST-scoped to its
enclosing function; M7's measured `in_range=1` against `in_file=2`, so that scoping was
load-bearing. The source was restored byte-identically afterwards.

## Verification

Base `c45bd1fa`, head `3a87b561`.

* `MUJOCO_GL=egl pytest tests` - **29746 passed, 266 skipped, 0 failed** (694s). Collected
  30003 on the base and 30012 on the branch, so the 9 new cases are the whole delta.
* `tests/tools` plus the eight repository-wide guards - 2542 passed, 1 skipped (30s).
* `ruff check` clean, `ruff format --check` clean (1218 files), `mypy strands_robots tests
  tests_integ` - 0 errors outside `examples/isaac_gs`, whose 14 are unrelated to this
  change and identical on the base.
* `scripts/assemble_changelog.py --check` OK, and `check_merge_base_overlap.py` reports no
  overlap: the base moved by one commit in this window and neither path it changed is read
  by these tests.

## Artifact

The two outcomes side by side, every value read back from the tool rather than asserted
in prose: the start result, the session store's pid, the newlines actually delivered, and
the log records. The two left-hand columns are what a caller sees on the base - identical
in both rows - and the right-hand column is the record that now distinguishes them.

![teleop auto-accept reporting](https://raw.githubusercontent.com/cagataycali/robots/artifacts/teleop-auto-accept-reports-failure/teleop_auto_accept.png)

Recording and log capture are unchanged by this diff; the figure is the measurement, not
a rollout.

## Round 1 - the two unused-local alerts, and a vacuous assertion they exposed

`py/unused-local-variable` x2 on `test_a_successful_auto_accept_stays_silent`, which bound
the helper's `(result, proc)` tuple into `_result, _proc` and read neither.

Both values are already asserted elsewhere in the same module - the start envelope by
`test_the_start_result_still_reports_success_when_the_auto_accept_fails`, the child's stdin
by `test_the_happy_path_delivers_two_newlines_and_closes_stdin` - so this test only needs
the call's side effect. Dropping the assignment removes the shape rather than renaming it
into one the linter tolerates. A rule mirror validated against the published alerts (both
columns reproduced exactly) reports no findings on the new head, and the PR's
code-scanning alert list is now empty.

Checking the alert's neighbourhood found a second, worse problem. The session name was
`"cal"` and the record's own prose says `"calibration"`, so

```
assert "cal" in message, f"the record does not name the session: {message}"
```

could not fail: it was satisfied by the message's wording whether or not the session was
ever named. The name is now `_SESSION = "wrist-rig-7"`, defined once, plus a case pinning
that the needle is not a substring of the record's prose so the collision cannot return.

Found by mutation, and measured against both arms:

| mutation | new module | pre-existing |
| --- | --- | --- |
| unmutated control | 0 | 0 |
| drop the session name from the record | 1 | 0 |
| revert this round's unused-local fix | 0 (scanner-only) | 0 |

Before this round the first row measured 0 - the module could not see a record that stopped
naming its session. The third row is behaviour-preserving by construction, which is why it
needs the scanner rather than a test, and why the fix is a deletion rather than a rename.

One more thing was corrected while here: the new case indexed `[0]` into the record list
without guarding it, so pre-fix it failed as an `IndexError` rather than an assertion. All
eight of its siblings guard that index; it now does too, and the pre-fix proof above shows
all three failures as self-explaining `AssertionError`s.

Re-approval is needed: the fix had to be pushed to clear the alerts, and a push dismisses
the standing approval.

Verification on `3a87b561` is the Verification section above, re-measured on this head -
full suite 29746 passed / 266 skipped / 0 failed, `ruff check` and `ruff format --check`
clean over 1218 files, and `mypy strands_robots tests tests_integ` with 0 errors outside
`examples/isaac_gs` (whose 14 are byte-identical to the base). No production line changed
in this round; the diff is +30/-5 in the one test module.
