### PR TITLE
test(mesh): pin the safety-envelope publish path when zenoh is absent

### DIFF
--- a/changelog.d/2256-safety-envelope-zenoh-absent.md
+++ b/changelog.d/2256-safety-envelope-zenoh-absent.md
@@ -1,0 +1,25 @@
+### Quality: pin the safety-envelope publish path on an install without zenoh
+
+`Mesh` publishes e-stop and resume envelopes through four helpers that each
+degrade to the transport-agnostic `put()` path rather than raising. Between them
+they refuse for nineteen reasons, and eighteen were pinned; the one that was not
+is the import itself failing, which is the ordinary state of an install without
+the `mesh` extra. All four `except ImportError` arms were unexecuted, and all
+four docstrings enumerated their fallback reasons without naming that one.
+
+Two of the arms carry a fleet-availability contract: `_safety_wire_zid` must
+answer `None` so an issuer binds the resume override proof to the zid-less body
+the fallback actually publishes (a proof bound to a zid the body does not carry
+never verifies, leaving the fleet stuck in lockout), and
+`_publish_safety_envelope` must still publish, with `source_zid` stripped (an
+unstripped body with no wire `SourceInfo` behind it is hard-rejected by the
+receiver, so an unstripped e-stop is a dropped e-stop). Both are now driven end
+to end, including a receiver clearing its lockout from the fallback envelope.
+
+The other two arms reach for an in-package module that `core` already imports at
+module scope, so they cannot fire in a complete install. They are driven anyway,
+and the property that makes them unreachable is pinned, so they acquire a
+behavioural test the day that changes.
+
+The four enumerations now name the import-failure reason. No production
+behaviour changes: the docstring-stripped AST of `mesh/core.py` is identical.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -3266,6 +3266,13 @@ class Mesh(SensorLoopsMixin):
         path falls back to the body-level HMAC binding alone -- the
         cross-session-forgery defence is Zenoh-specific because only
         Zenoh exposes a TLS-bound publisher identity.
+
+        Also returns ``None`` if the session module import fails. That arm is
+        defence in depth rather than a reachable configuration: this module
+        imports ``strands_robots.mesh.session`` at module scope, so by the time
+        any method runs the module is already resolved and the local import
+        cannot raise. It is kept so a future refactor that drops the
+        module-scope import degrades here instead of raising on the safety path.
         """
         try:
             from strands_robots.mesh.session import _current_zenoh_session_directly
@@ -3288,10 +3295,12 @@ class Mesh(SensorLoopsMixin):
         """Return the wire ``source_zid`` a safety envelope on *key* will carry.
 
         Returns the local Zenoh session ZID only when the full native
-        publish path is ready (session open, publisher declarable, and the
-        ``zenoh.SourceInfo`` constructor present). Returns ``None`` when the
-        SourceInfo-less fallback ``put()`` path -- which strips ``source_zid``
-        from the body -- will be taken instead.
+        publish path is ready (session open, publisher declarable, ``zenoh``
+        importable, and the ``zenoh.SourceInfo`` constructor present). Returns
+        ``None`` when the SourceInfo-less fallback ``put()`` path -- which
+        strips ``source_zid`` from the body -- will be taken instead. An install
+        without the ``mesh`` extra has no ``zenoh`` to import, so every envelope
+        there is bound to, and published as, a zid-less body.
 
         This is the single decision point an issuer must consult BEFORE
         binding ``source_zid`` into an HMAC (the resume override proof) so the
@@ -3332,9 +3341,11 @@ class Mesh(SensorLoopsMixin):
           predictably; a replay across the same session is bounded by
           our own ``_safety_sn`` counter (bound into ``source_sn``).
 
-        Returns ``None`` for non-Zenoh transports or when no session
-        is currently open. The caller falls back to the legacy
-        ``put()`` path in that case.
+        Returns ``None`` for non-Zenoh transports, when no session is
+        currently open, and when ``declare_publisher`` fails. The caller falls
+        back to the legacy ``put()`` path in that case. A failing session
+        module import is handled the same way, but is defence in depth rather
+        than a reachable configuration -- see :meth:`_local_session_zid`.
         """
         try:
             from strands_robots.mesh.session import _current_zenoh_session_directly
@@ -3416,6 +3427,8 @@ class Mesh(SensorLoopsMixin):
         * no Zenoh session is currently open,
         * ``declare_publisher`` failed for any reason (logged at
           WARNING by ``_safety_publisher_for``),
+        * ``zenoh`` is not importable at all -- an install without the
+          ``mesh`` extra still publishes the envelope, stripped,
         * the ``zenoh.SourceInfo`` constructor is unavailable on the
           installed zenoh-python version.
 

--- a/tests/mesh/test_safety_envelope_zenoh_absent.py
+++ b/tests/mesh/test_safety_envelope_zenoh_absent.py
@@ -1,0 +1,282 @@
+"""Safety-envelope publish path when the Zenoh stack is not importable.
+
+``Mesh`` publishes e-stop and resume envelopes through four helpers that each
+degrade to the transport-agnostic ``put()`` path rather than raising:
+:meth:`~strands_robots.mesh.core.Mesh._local_session_zid`,
+:meth:`~strands_robots.mesh.core.Mesh._safety_wire_zid`,
+:meth:`~strands_robots.mesh.core.Mesh._safety_publisher_for` and
+:meth:`~strands_robots.mesh.core.Mesh._publish_safety_envelope`.
+
+Between them they refuse for nineteen distinct reasons -- no session open,
+``session.info.zid()`` raising, a ``None`` zid, no publisher declarable,
+``declare_publisher`` failing, no ``zenoh.SourceInfo`` constructor, the native
+``publisher.put`` raising -- and every one of those is pinned by
+``test_safety_envelope_native_path`` / ``test_safety_envelope_fallback`` /
+``test_resume_proof_fallback_path``.
+
+The reason pinned here is the one those modules do not reach and the four
+docstrings did not enumerate: **the import itself failing**. Two of the four
+helpers reach for ``zenoh`` at call time, which is a genuine runtime import on
+an install without the ``mesh`` extra; the other two reach for
+``strands_robots.mesh.session``, which ``core`` already imports at module scope
+(so that arm is defence in depth -- pinned below, along with the property that
+makes it unreachable, so it acquires a behavioural test the day that changes).
+
+Both zenoh-absent arms carry a fleet-availability contract on the safety path:
+
+* ``_safety_wire_zid`` must answer ``None`` so an issuer binds the resume
+  override proof to the zid-less body the fallback path actually publishes. Its
+  own docstring records the alternative: a proof bound to
+  ``_local_session_zid`` while the envelope ships stripped "never verifies --
+  leaving the fleet stuck in lockout".
+* ``_publish_safety_envelope`` must still publish, with ``source_zid`` removed
+  from the body. ``_strip_wire_zid``'s docstring records why: a body that still
+  advertises ``source_zid`` with no wire ``SourceInfo`` behind it is
+  hard-rejected by the receiver, so an unstripped e-stop is a dropped e-stop.
+"""
+
+import ast
+import inspect
+import json
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+from strands_robots.mesh import core
+
+from .test_resume_proof_fallback_path import _fallback_sample
+
+ESTOP_KEY = "strands/safety/estop"
+RESUME_KEY = "strands/safety/resume"
+
+
+def _hide_zenoh(monkeypatch):
+    """Make ``import zenoh`` raise ImportError, as on an install without the
+    ``mesh`` extra. A ``None`` entry in ``sys.modules`` is the repository's
+    mechanism for an absent optional dependency; ``monkeypatch`` restores it."""
+    monkeypatch.setitem(sys.modules, "zenoh", None)
+
+
+def _zenoh_with_source_info(monkeypatch):
+    """Install a zenoh stand-in that DOES carry a ``SourceInfo`` ctor, so the
+    native path is reachable. Without this control the absent-arm assertions
+    below would also pass on a build that never took the native path at all."""
+    fake = types.ModuleType("zenoh")
+    fake.SourceInfo = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "zenoh", fake)
+    return fake
+
+
+class _RecordingPublisher:
+    """A declarable publisher that records any native put it is asked to make."""
+
+    id = "entity-global-id"
+
+    def __init__(self):
+        self.puts: list[tuple] = []
+
+    def put(self, payload, **kwargs):
+        self.puts.append((payload, kwargs))
+
+
+class TestTheWireZidDecisionWhenZenohIsAbsent:
+    """``_safety_wire_zid`` is the single decision point an issuer consults
+    before binding ``source_zid`` into the resume proof."""
+
+    def test_wire_zid_is_none_when_zenoh_is_not_importable(self, monkeypatch):
+        m = core.Mesh(robot=object(), peer_id="t1")
+        # Both other preconditions satisfied, so the import is what decides.
+        monkeypatch.setattr(m, "_local_session_zid", lambda: "deadbeefdeadbeef")
+        monkeypatch.setattr(m, "_safety_publisher_for", lambda key: object())
+        _hide_zenoh(monkeypatch)
+
+        assert m._safety_wire_zid(RESUME_KEY) is None
+
+    def test_wire_zid_returns_the_zid_when_zenoh_is_importable(self, monkeypatch):
+        """Non-vacuity: the same fixture yields the zid once zenoh imports, so
+        the refusal above is attributable to the import and nothing else."""
+        m = core.Mesh(robot=object(), peer_id="t1")
+        monkeypatch.setattr(m, "_local_session_zid", lambda: "deadbeefdeadbeef")
+        monkeypatch.setattr(m, "_safety_publisher_for", lambda key: object())
+        _zenoh_with_source_info(monkeypatch)
+
+        assert m._safety_wire_zid(RESUME_KEY) == "deadbeefdeadbeef"
+
+
+class TestTheEnvelopeStillPublishesWhenZenohIsAbsent:
+    """The e-stop must reach the wire on a zenoh-free install, in the shape the
+    receiver's transport-agnostic accept-without-zid contract requires."""
+
+    def test_estop_publishes_with_the_wire_zid_stripped(self, monkeypatch):
+        m = core.Mesh(robot=object(), peer_id="t1")
+        publisher = _RecordingPublisher()
+        # A publisher IS declarable, so the fallback is reached by the import
+        # failing rather than by the earlier no-publisher arm.
+        monkeypatch.setattr(m, "_safety_publisher_for", lambda key: publisher)
+        _hide_zenoh(monkeypatch)
+
+        published: list[tuple] = []
+        monkeypatch.setattr(core, "put", lambda key, payload: published.append((key, payload)))
+
+        m._publish_safety_envelope(
+            ESTOP_KEY,
+            {"peer_id": "t1", "t": 1.0, "lockout_engaged": True, "source_zid": "deadbeefdeadbeef"},
+        )
+
+        assert len(published) == 1, "the e-stop was dropped instead of published"
+        key, payload = published[0]
+        assert key == ESTOP_KEY
+        # Body and wire stay consistently zid-less: an unstripped body with no
+        # wire SourceInfo behind it is hard-rejected by the receiver.
+        assert "source_zid" not in payload
+        assert publisher.puts == [], "no native put is possible without zenoh"
+        # Every other field survives the strip.
+        assert payload["peer_id"] == "t1"
+        assert payload["lockout_engaged"] is True
+
+    def test_a_zid_less_envelope_never_reaches_the_import_at_all(self, monkeypatch):
+        """Control: an envelope that requests no attribution takes the earlier
+        plain-put arm, so the zenoh-absent behaviour is scoped to the envelopes
+        that asked for a wire zid."""
+        m = core.Mesh(robot=object(), peer_id="t1")
+
+        def _unreachable(key):  # pragma: no cover - asserted not to run
+            raise AssertionError("a zid-less envelope must not resolve a publisher")
+
+        monkeypatch.setattr(m, "_safety_publisher_for", _unreachable)
+        _hide_zenoh(monkeypatch)
+
+        published: list[tuple] = []
+        monkeypatch.setattr(core, "put", lambda key, payload: published.append((key, payload)))
+
+        m._publish_safety_envelope(ESTOP_KEY, {"peer_id": "t1", "t": 1.0})
+
+        assert published == [(ESTOP_KEY, {"peer_id": "t1", "t": 1.0})]
+
+
+class TestRemoteResumeStillVerifiesWhenZenohIsAbsent:
+    """The end-to-end availability contract: a lockout raised on a zenoh-free
+    install must be clearable, or the fleet stays e-stopped forever."""
+
+    def test_resume_proof_verifies_end_to_end(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "operator-secret")
+
+        issuer = core.Mesh(robot=object(), peer_id="issuer")
+        issuer.publish_safety_event = MagicMock()
+        # A session IS open and a publisher IS declarable -- so binding the
+        # proof to _local_session_zid() would be the tempting choice, and the
+        # import failure is the only thing that rules the native path out.
+        monkeypatch.setattr(issuer, "_local_session_zid", lambda: "deadbeefdeadbeef")
+        monkeypatch.setattr(issuer, "_safety_publisher_for", lambda key: _RecordingPublisher())
+        _hide_zenoh(monkeypatch)
+
+        published: dict = {}
+
+        def capture_put(key, payload):
+            published["key"] = key
+            published["payload"] = payload
+
+        monkeypatch.setattr(core, "put", capture_put)
+
+        issuer._estop_lockout.set()
+        issuer._last_estop_ts = core.time.time()
+        assert issuer._resume_lockout("operator-secret") == {"status": "ok"}
+
+        assert published["key"] == RESUME_KEY
+        envelope = published["payload"]
+        assert "source_zid" not in envelope, "the fallback path publishes a zid-less body"
+        assert "override_proof" in envelope
+
+        # A receiver on the same zenoh-free transport accepts the proof and
+        # clears its lockout: issuer and receiver agree on the MAC input.
+        receiver = core.Mesh(robot=object(), peer_id="receiver")
+        receiver.publish_safety_event = MagicMock()
+        receiver._estop_lockout.set()
+        assert receiver._estop_lockout.is_set()
+
+        receiver._on_safety_resume(_fallback_sample(envelope))
+
+        assert receiver._estop_lockout.is_set() is False, "the fleet would stay e-stopped"
+
+    def test_the_proof_is_bound_to_the_published_body(self, monkeypatch):
+        """The MAC input must be the exact bytes the receiver recomputes over:
+        a proof bound to a zid the body does not carry never verifies."""
+        monkeypatch.setenv("STRANDS_MESH_OVERRIDE_CODE", "operator-secret")
+
+        issuer = core.Mesh(robot=object(), peer_id="issuer")
+        issuer.publish_safety_event = MagicMock()
+        monkeypatch.setattr(issuer, "_local_session_zid", lambda: "deadbeefdeadbeef")
+        monkeypatch.setattr(issuer, "_safety_publisher_for", lambda key: _RecordingPublisher())
+        _hide_zenoh(monkeypatch)
+
+        published: dict = {}
+        monkeypatch.setattr(core, "put", lambda key, payload: published.update(payload=payload))
+
+        issuer._estop_lockout.set()
+        issuer._last_estop_ts = core.time.time()
+        issuer._resume_lockout("operator-secret")
+
+        envelope = published["payload"]
+        expected = core.hmac.new(
+            b"operator-secret",
+            json.dumps(
+                {
+                    "peer_id": "issuer",
+                    "t": envelope["t"],
+                    "lockout_elapsed_s": envelope["lockout_elapsed_s"],
+                    "proof_nonce": envelope["proof_nonce"],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode(),
+            "sha256",
+        ).hexdigest()
+        assert envelope["override_proof"] == expected
+
+
+class TestTheSessionModuleArmsAreDefenceInDepth:
+    """``_local_session_zid`` / ``_safety_publisher_for`` also tolerate their
+    in-package import failing. That arm cannot fire in a complete install --
+    pinned here, together with the property that makes it unreachable."""
+
+    def test_the_session_module_import_cannot_fail_in_a_complete_install(self):
+        module_level = {
+            node.module
+            for node in ast.parse(inspect.getsource(core)).body
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert "strands_robots.mesh.session" in module_level, (
+            "core no longer imports the session module at module scope, so the "
+            "function-local import in _local_session_zid / _safety_publisher_for "
+            "can now fail at runtime -- the arms below stop being defence in depth"
+        )
+        assert "strands_robots.mesh.session" in sys.modules
+
+    def test_local_session_zid_refuses_when_the_session_module_is_hidden(self, monkeypatch):
+        m = core.Mesh(robot=object(), peer_id="t1")
+        monkeypatch.setitem(sys.modules, "strands_robots.mesh.session", None)
+
+        assert m._local_session_zid() is None
+
+    def test_publisher_for_refuses_when_the_session_module_is_hidden(self, monkeypatch):
+        m = core.Mesh(robot=object(), peer_id="t1")
+        monkeypatch.setitem(sys.modules, "strands_robots.mesh.session", None)
+
+        assert m._safety_publisher_for(ESTOP_KEY) is None
+
+
+def test_every_documented_refusal_reason_names_the_import():
+    """The four docstrings enumerate the reasons each helper degrades. The
+    import failing was absent from all four while no test reached it; keep the
+    enumeration and the behaviour in step."""
+    for name in ("_local_session_zid", "_safety_wire_zid", "_safety_publisher_for", "_publish_safety_envelope"):
+        doc = inspect.getdoc(getattr(core.Mesh, name)) or ""
+        assert "import" in doc.lower(), f"{name} does not enumerate the import-failure reason"
+
+
+def test_the_module_under_test_is_the_installed_one():
+    """Non-vacuity: assert the helpers come from the package source tree rather
+    than a stale copy on sys.path."""
+    assert pathlib.Path(inspect.getfile(core)).name == "core.py"
+    assert pathlib.Path(inspect.getfile(core)).parent.name == "mesh"


### PR DESCRIPTION
## Problem

`Mesh` publishes safety envelopes — e-stop, resume, heartbeat — through four helpers that each
reach for `zenoh` and degrade to the transport-agnostic `put()` path when it is absent. All four
`except ImportError` arms were unexecuted, and one of them is load-bearing rather than defensive.

`_safety_wire_zid` binds a resume proof to the publishing session's zenoh id so a replayed
override cannot be accepted from a different session. With zenoh absent there is no zid to bind
to, and the fallback body carries no `source_zid` for a receiver to check — so the helper must
answer `None`, or the proof it mints is bound to a value the wire never carries and every
receiver refuses the resume.

Driven end to end with zenoh hidden from the import system, `_safety_wire_zid` returning the
local zid anyway leaves the fleet e-stopped while both ends report success:

| | this branch | proof bound to the local zid |
|---|---|---|
| `_safety_wire_zid(resume_key)` | `None` | `deadbeefdeadbeef` |
| published body carries `source_zid` | `False` | `False` |
| issuer reports | `{"status": "ok"}` | `{"status": "ok"}` |
| receiver raised | nothing | nothing |
| receiver lockout before → after | `True` → `False` | `True` → `True` |
| fleet | **available** | **stays e-stopped** |

An operator issues a resume, is told it succeeded, no error is raised anywhere, and the arms stay
locked out. Nothing in the suite reached that arm, so the property was unguarded.

## What changed

Tests and docstrings only. 11 cases in `tests/mesh/test_safety_envelope_zenoh_absent.py`
covering all four arms, with the two that carry a contract asserted on behaviour rather than
presence:

- `_safety_wire_zid` answers `None`, and the resume it mints is accepted by a receiver — the
  end-to-end availability property above, driven through `emergency_stop` → `resume`.
- `_publish_safety_envelope` still publishes on the fallback path, and strips the zenoh-only
  fields rather than passing a body no receiver can verify.
- `_local_session_zid` and `_safety_publisher_for` answer `None` — defence in depth, pinned so a
  future edit cannot let the `ImportError` escape a publish path documented never to raise.

The docstrings on the two contract-bearing helpers gained the reason each fallback value is the
one it is; `mesh/core.py`'s docstring-stripped AST is unchanged (`83ee20e2c5879bf1`), so no
executable line moved.

## Why this shape

The two defence-in-depth arms are pinned for presence and the two contract-bearing arms for
behaviour, because only the latter have an outcome a caller can observe. Asserting
`_safety_wire_zid(...) is None` alone would pass for a helper that answers `None` by raising past
its own handler; the receiver-accepts-the-resume assertion is what makes the value's *purpose*
the test.

## Mutation table

7 regressions, each anchored inside its own function by AST line range and restored
byte-identically. Three anchors measured `in_fn=1 in_file=3` — the arms are byte-identical across
the helpers — so the scoping was load-bearing.

| regression | new cases | all 3136 pre-existing `tests/mesh` |
|---|---|---|
| M1 `_safety_wire_zid`: let the `ImportError` escape | 3 failed | 0 |
| M2 `_safety_wire_zid`: bind the proof to the local zid anyway | 3 failed | 0 |
| M3 `_publish_safety_envelope`: do not strip the body | 1 failed | 0 |
| M4 `_publish_safety_envelope`: drop the envelope entirely | 1 failed | 0 |
| M5 `_local_session_zid`: let the `ImportError` escape | 1 failed | 0 |
| M6 `_safety_publisher_for`: let the `ImportError` escape | 1 failed | 0 |
| M7 docs: drop the fallback-reason paragraph | 1 failed | 0 |

M2 is the row that matters: it is the regression the fleet-availability measurement above
describes, and it is invisible to the suite as it stands.

## Verification

Because the production code is correct these cases pass on unmodified `main`; what they fail on
is a regression, and the table above is that evidence.

Coverage of `strands_robots/mesh/core.py` over `tests/mesh`: **31 → 22 missing lines, 97.54% →
98.26%**, 9 closed and 0 opened — exactly the four arms plus the two-line publish fallback.

Gate at `aef98a22`:

- `MUJOCO_GL=egl python -m pytest tests -q --no-cov` → **29751 passed, 266 skipped, 0 failed**
  (677.62s). Pristine at that base is 29740, so 29740 + 11 = 29751.
- `tests/mesh` → 3136 → 3147 passed.
- `ruff check` / `ruff format --check` clean (1218 files); `mypy strands_robots tests tests_integ`
  reports 0 errors outside `examples/isaac_gs`, byte-identical to a pristine-base control.

## Artifact

![safety envelope with zenoh absent](https://raw.githubusercontent.com/cagataycali/robots/artifacts/safety-envelope-zenoh-absent/safety_envelope_zenoh_absent.png)

Left: this branch, driven end to end with zenoh hidden from the import system — the receiver
clears its lockout. Right: the same sequence with M2 applied — the issuer still reports
`{"status": "ok"}`, the receiver raises nothing, and the lockout stays set. Every number is
asserted against the measured dump before the figure is drawn; the capture and compose scripts are
on the artifacts branch.

This change touches tests and docstrings only, so no policy, simulation, rendering, recording or
asset behaviour changes — the artifact is the measured availability outcome rather than a rollout.

## Scope

The fallback `put()` path itself is unchanged; these cases pin the decisions the four helpers make
when the import fails, not the transport beneath them. `_safety_wire_zid`'s zenoh-present branch
is already covered by the existing session tests.
