### PR TITLE
docs(strands_robots): state the reason, not the review thread, in 43 docstring markers

### DIFF
--- a/changelog.d/2258-docstring-review-history-sweep.md
+++ b/changelog.d/2258-docstring-review-history-sweep.md
@@ -1,0 +1,17 @@
+### Docs: describe the code rather than the review that produced it
+
+Docstrings and comments across `strands_robots/` carried review-history
+markers -- `reviewer caught X`, `pre-#164 behaviour`, `(post-PR #101)`,
+`requested by @handle during review`, `variant-B` -- that name a conversation
+a downstream reader cannot open and a sequence they were never part of. 48
+edits replace each one with the fact it was standing in for: the fallback
+`pre-#164` described is now named as "when RoboSuite is absent", the dataclass
+field documented as `(post-PR #101)` now says when it is populated, and a
+"well-known kwargs" contract now points at the documentation instead of an
+issue number.
+
+Executable content is unchanged: every touched module's docstring-stripped
+AST digest is byte-identical before and after. A new guard keeps the markers
+out, and admits a pull-request reference only where a reader can follow it --
+an upstream project this package declares as a dependency, or an `AGENTS.md`
+section whose heading is verified to still exist.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -175,11 +175,11 @@ class LiberoAdapter(BenchmarkProtocol):
             ``MultiStepConfig.max_episode_steps`` for LIBERO eval -
             see ``Isaac-GR00T/gr00t/eval/rollout_policy.py``). Override
             per-task by passing ``max_steps=`` to the constructor or
-            mutating the attribute after construction. Pre-#168 we used the LIBERO repository's lifelong-learning
-            convention of 300; that was too short for libero_10's
-            longer-horizon manipulation tasks (e.g. multi-step pick-
-            and-place chains) and was contributing to ``success_rate=0``
-            on tasks that needed more time. 720 matches the canonical
+            mutating the attribute after construction. The LIBERO
+            repository's lifelong-learning convention of 300 is too short
+            for libero_10's longer-horizon manipulation tasks (e.g.
+            multi-step pick-and-place chains) and drives ``success_rate=0``
+            on tasks that need more time. 720 matches the canonical
             GR00T-N1.7-LIBERO eval setup.
         problem: The parsed :class:`BDDLProblem`. Stored for introspection
             (agents may read ``problem.language`` as the instruction).
@@ -390,7 +390,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 generator. The generated XML is cached on disk so
                 subsequent episodes / processes reuse it without
                 re-running ``libero``. Set to ``False`` to keep the
-                pre-#164 behaviour of running against a bare Panda when
+                fallback behaviour of running against a bare Panda when
                 no ``scene_path`` is provided.
             scene_cache_dir: Filesystem location for the generated-scene
                 cache. Defaults to ``$STRANDS_BASE_DIR/scene_cache/libero/``
@@ -502,7 +502,7 @@ class LiberoAdapter(BenchmarkProtocol):
                 missing robosuite, missing site/actuator IDs) is no longer
                 indistinguishable from a bad *policy* scoring
                 ``success_rate=0`` on a green run (#522). Set to ``False``
-                to restore the pre-#522 best-effort behaviour (log + run
+                to restore the best-effort behaviour (log + run
                 with actions no-op'd); the failure is still recorded on
                 :attr:`action_controller_error` so callers/CI can tag the
                 result. Dependency-clash failures (``ImportError`` /
@@ -577,11 +577,11 @@ class LiberoAdapter(BenchmarkProtocol):
         # State-side gripper joint names (#168). LIBERO trains
         # ``state.gripper`` on a 2-element vector ``[finger1.qpos, finger2.qpos]``
         # - the two fingers have OPPOSITE-sign qpos by physical
-        # convention (they move apart). Pre-#168 we read ONE
-        # finger from ``obs[gripper_joint_name]`` and packed it as
-        # ``[v, v]`` (both positive), which is structurally
-        # out-of-distribution for GR00T-LIBERO and produced the
-        # near-zero deltas observed across earlier iterations. The current implementation
+        # convention (they move apart). Reading ONE finger from
+        # ``obs[gripper_joint_name]`` and packing it as ``[v, v]``
+        # (both positive) is structurally out-of-distribution for
+        # GR00T-LIBERO and produces near-zero policy deltas.
+        # The current implementation
         # reads both finger qpos directly from ``data.qpos[jnt_qposadr]``.
         # Default auto-derives ``["<gripper_prefix>finger_joint1",
         # "<gripper_prefix>finger_joint2"]`` (i.e.
@@ -903,8 +903,8 @@ class LiberoAdapter(BenchmarkProtocol):
         #168: LIBERO trains ``state.gripper`` on a 2-element
         vector ``[finger1.qpos, finger2.qpos]`` whose elements have
         OPPOSITE signs by physical convention (the two fingers move
-        apart). Pre-#168 we read ONE finger and packed it as
-        ``[v, v]`` (both positive), which fed GR00T structurally
+        apart). Reading ONE finger and packing it as
+        ``[v, v]`` (both positive) feeds GR00T structurally
         out-of-distribution state. The property returns the names in
         the order they appear in the trained state vector.
         """
@@ -1415,8 +1415,8 @@ class LiberoAdapter(BenchmarkProtocol):
         # ``start_cameras_recording`` has its own
         # ``threading.local`` Renderer instance, but some driver-
         # level state (compiled shaders, texture caches, GLContext
-        # bind state) is process-shared. The reviewer's variant-B
-        # verification (#168) showed that without a main-thread
+        # bind state) is process-shared. Verification showed that
+        # without a main-thread
         # render after prewarm, the recorder thread's first ~15
         # render calls return GL clear-colour gradient even when
         # ``mj_forward`` has populated ``data.xpos / xmat``. A single
@@ -1664,8 +1664,8 @@ class LiberoAdapter(BenchmarkProtocol):
         2. Fall back to the BODY path via
            ``sim.get_body_state(self._eef_body_name)`` for non-RoboSuite
            scenes that don't ship the canonical site (e.g. bare
-           Menagerie Panda). The fallback path matches the pre-#168
-           behaviour exactly.
+           Menagerie Panda). The fallback path reads the body pose
+           directly.
         3. Convert the site/body's rotation matrix or quaternion to
            extrinsic XYZ Euler ``(roll, pitch, yaw)`` to match the
            LIBERO/RoboSuite ``mat2euler(..., axes='sxyz')`` convention
@@ -1711,11 +1711,11 @@ class LiberoAdapter(BenchmarkProtocol):
         # ``[gripper0_finger_joint1.qpos, gripper0_finger_joint2.qpos]``.
         # The two fingers have OPPOSITE-sign qpos by physical
         # convention (they move apart); typical at-rest values are
-        # ``[+0.0208, -0.0208]``. Pre-#168 we read only one finger
-        # via ``obs[self._gripper_joint_name]`` and packed it as
-        # ``[v, v]`` (both positive), which fed GR00T structurally
-        # out-of-distribution state - manifest as near-zero policy
-        # deltas across rounds 23-32 of #168.
+        # ``[+0.0208, -0.0208]``. Reading only one finger via
+        # ``obs[self._gripper_joint_name]`` and packing it as
+        # ``[v, v]`` (both positive) feeds GR00T structurally
+        # out-of-distribution state, which manifests as near-zero
+        # policy deltas.
         #
         # Read both finger qpos directly from ``data.qpos[jnt_qposadr]``
         # using the canonical RoboSuite joint names. On backends without
@@ -1732,7 +1732,7 @@ class LiberoAdapter(BenchmarkProtocol):
             merged.setdefault("gripper", self._apply_gripper_signs(gripper_qpos))
         else:
             # Legacy fallback - read one joint from obs and duplicate
-            # (preserves pre-#168 behaviour for non-RoboSuite
+            # (the documented fallback for non-RoboSuite
             # scenes; the duplicate-packing is wrong for LIBERO but
             # there's no better default for unknown gripper layouts).
             gripper_value = obs.get(self._gripper_joint_name)
@@ -2010,9 +2010,9 @@ class LiberoAdapter(BenchmarkProtocol):
         finger joints; their values have OPPOSITE signs by physical
         convention (the Panda gripper's two-finger MJCF puts each
         finger on its own joint with mirrored ranges, e.g.
-        ``[0, +0.04]`` and ``[-0.04, 0]``). Pre-#168 the adapter
-        read ONE finger's value and packed it as ``[v, v]`` (both
-        positive), which is structurally OOD from training.
+        ``[0, +0.04]`` and ``[-0.04, 0]``). Reading ONE finger's value
+        and packing it as ``[v, v]`` (both positive) is structurally
+        OOD from training.
 
         Returns ``None`` (and the caller falls back to the legacy
         single-joint duplicate path) if any of:
@@ -2225,7 +2225,7 @@ class LiberoAdapter(BenchmarkProtocol):
         # * Upstream hides collision capsules at the *renderer* level via
         #   ``mjvOption.geomgroup[0] = 0``, not via MJCF rgba edits.
         #   Same approach for site / joint / actuator markers
-        #   (the red dot + green line the reviewer caught are
+        #   (the red dot + green line visible in agentview are
         #   ``gripper0_ft_frame`` / ``gripper0_grip_site_cylinder``
         #   sites in ``site_group=1``).
         #
@@ -2450,7 +2450,7 @@ class LiberoAdapter(BenchmarkProtocol):
         attributes, ``mj_name2id`` raising) is caught and logged at
         DEBUG, leaving the legacy bare-Panda defaults
         (``"hand"`` / ``"finger_joint1"``) in place. That preserves the
-        pre-#166 behaviour for non-MuJoCo backends.
+        documented fallback for non-MuJoCo backends.
         """
         prefix = self._scene_robot_prefix
         gprefix = self._scene_gripper_prefix
@@ -2550,8 +2550,8 @@ class LiberoAdapter(BenchmarkProtocol):
           ``gripper0_ft_frame`` (red dot - force-torque frame),
           ``gripper0_grip_site`` (semi-transparent red sphere),
           ``gripper0_grip_site_cylinder`` (green line - grasp-axis
-          cylinder). Default ``sitegroup`` shows them; reviewer caught
-          them as "red dot + green line in the middle of agentview".
+          cylinder). Default ``sitegroup`` shows them, which reads as a
+          "red dot + green line in the middle of agentview".
         * Joint visualisations (``mjVIS_JOINT = 0``). Hides the
           axis-arrow widgets MuJoCo draws on each ``<joint>`` definition.
         * Actuator visualisations (``mjVIS_ACTUATOR = 0``). Hides the
@@ -2663,7 +2663,7 @@ class LiberoAdapter(BenchmarkProtocol):
         * When ``False``, the failure is logged at WARNING and recorded
           on :attr:`_action_controller_error` (so callers can still tag
           the result) before falling through to the no-op name-lookup
-          path - the pre-#522 best-effort behaviour.
+          path - the best-effort behaviour.
         * Dependency-clash failures (``ImportError`` / ``AttributeError``
           from the import chain - e.g. the ``numba`` / ``coverage``
           incompatibility) are ALWAYS re-raised with a remediation hint,
@@ -3107,7 +3107,7 @@ class LiberoAdapter(BenchmarkProtocol):
 
         Backends without a MuJoCo-compiled model (or with mujoco not
         importable) fall back to the registry-only check - that's the
-        pre-#166-review behaviour, retained as a defensive fallback for
+        registry-only fallback, retained for
         non-MuJoCo engines that still want LIBERO eval.
 
         Critical for #166: :meth:`Simulation.load_scene` creates a fresh
@@ -3182,7 +3182,7 @@ class LiberoAdapter(BenchmarkProtocol):
            scene compile (after ``super().on_episode_start`` and
            ``_install_libero_cameras`` have run); restore the cached
            snapshot on every subsequent episode. The procedurally-
-           generated MJCFs from :meth:`_generate_scene_from_bddl` (PR #165)
+           generated MJCFs from :meth:`_generate_scene_from_bddl`
            don't carry a keyframe, so this branch fires when init_states
            is also None (e.g. adapters built directly from a BDDL file
            without going through :func:`load_libero_suite`).
@@ -4382,7 +4382,7 @@ def _rename_mjcf_cameras(xml: str, aliases: dict[str, str]) -> str:
 # the upgrade.
 #
 # History:
-# * ``v1``: implicit (pre-#168, alias map alone in cache key).
+# * ``v1``: implicit (alias map alone in the cache key).
 # * ``v2``: #168 (initial attempt) - applied ``_apply_libero_visual_fixes`` (rgba alpha=0 on
 #   collision geoms + custom ``<visual>`` block with stacked ``<headlight>``).
 #   Empirically wrong direction (washed out contrast); reverted in v3.
@@ -5141,10 +5141,10 @@ class _LiberoOSCController:
         # Missing keys default to 0 (no-op delta). Each per-key value
         # may be either a scalar or a 2-element list / array - GR00T-
         # LIBERO packs ALL action channels (x/y/z/roll/pitch/yaw/gripper)
-        # to match the training-data shape, same convention PR #162
-        # introduced for state.gripper. _to_scalar handles both forms
-        # (and defensive against unexpected shapes) - #168 only
-        # fixed gripper; #168 applies the same fix to every key.
+        # to match the training-data shape, the same convention used
+        # for state.gripper. _to_scalar handles both forms (and is
+        # defensive against unexpected shapes) and is applied to
+        # every action key, not just the gripper.
         delta = np.array(
             [
                 _to_scalar(action_dict.get("x", 0.0)),
@@ -5193,11 +5193,11 @@ class _LiberoOSCController:
         #   gripper_in = 0.5             → -sign(0)  =  0 (no motion)
         #   gripper_in = 1.0 (RLDS open)  → -sign(+1) = -1 (LIBERO open)  [ok]
         #
-        # Pre-#168 we passed the raw model output to our OSC's
-        # ``np.sign(gripper_value)`` directly. Since the model's typical
-        # outputs are in [0, 1], every "open" intent (model output ≈ 1)
-        # collapsed to ``sign=+1``, which our OSC interprets as CLOSE - so
-        # the gripper consistently went CLOSED for OPEN commands and
+        # Passing the raw model output to our OSC's
+        # ``np.sign(gripper_value)`` directly is wrong: the model's typical
+        # outputs are in [0, 1], so every "open" intent (model output ≈ 1)
+        # collapses to ``sign=+1``, which our OSC interprets as CLOSE - the
+        # gripper then goes CLOSED for OPEN commands and
         # vice-versa. This is the action-side counterpart to #168's
         # observation-side V-flip bug; both rounds together close the
         # client-pipeline parity gap that left ``success_rate=0`` after
@@ -5251,7 +5251,7 @@ class _LiberoOSCController:
         # #168 - capture pre-step state for diagnostic log.
         # Gated on ``STRANDS_LIBERO_ACTION_LOG=1`` so production eval
         # incurs zero cost (single bool check). The full diagnostic
-        # answers PR #168's "what scale, what frame, what key
+        # answers the "what scale, what frame, what key
         # naming, does motion track delta" questions in one log line
         # per step.
         log_now = self._action_log_enabled and self._action_log_step < self._action_log_max
@@ -5298,7 +5298,7 @@ class _LiberoOSCController:
             #   ctrl = bias + weight * current_action
             # Without this, +1 (close) writes 0.04 to finger1 (range
             # [0, 0.04]) which actually OPENS finger1, breaking every
-            # grasp. See PR #168 investigation.
+            # grasp.
             self._gripper_current_action = np.clip(
                 self._gripper_current_action + ramp_step,
                 -1.0,
@@ -5312,7 +5312,7 @@ class _LiberoOSCController:
 
         # #168 - emit one structured log line per apply()
         # while inside the captured-step window. Captures everything a
-        # reviewer needs to bisect the residual bug: action key names,
+        # needed to bisect a residual tracking bug: action key names,
         # delta scale, gripper polarity end-to-end, EEF tracking
         # (delta vs actual EEF motion), and qpos/ctrl deltas.
         if log_now:
@@ -5570,9 +5570,9 @@ def _to_scalar(value: Any) -> float:
 
     Handles GR00T's training-shape packing where each per-key
     value may be either a scalar (legacy) or a 2-element list /
-    array / ndarray (current GR00T-LIBERO convention - same pattern
-    PR #162 introduced for ``state.gripper``, applied to every
-    action channel).
+    array / ndarray (current GR00T-LIBERO convention - the same
+    pattern used for ``state.gripper``, applied to every action
+    channel).
 
     An earlier commit in #168 fixed only ``gripper``; subsequent
     verification showed the same ``float(list)`` bug raises on

--- a/strands_robots/benchmarks/libero/bddl_parser.py
+++ b/strands_robots/benchmarks/libero/bddl_parser.py
@@ -206,7 +206,7 @@ def _on_kwargs(args: list[str]) -> dict[str, Any]:
     # "mug-suspended-above-plate" placement states produce BDDL false
     # positives (mug 5 cm above plate, xy-aligned, no contact yet).
     # Graceful degradation: engines without ``get_contacts`` skip the
-    # check (preserves pre-#171 behaviour).
+    # check and fall back to the geometric-only verdict.
     return {
         "body_a": args[0],
         "body_b": args[1],

--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -462,8 +462,8 @@ def default_acl(namespace: str) -> dict[str, Any]:
         #
         # Earlier versions of this default mixed default_permission='deny'
         # with two key_exprs=['**'] allow-rules; the effective behaviour was
-        # identical (allow-any) but the code-vs-doc surface was confusing
-        # and review-flagged 5x. Code now matches docs.
+        # identical (allow-any) but the code-vs-doc surface was confusing.
+        # Code now matches docs.
         "default_permission": "allow",
         "rules": [],
         "subjects": [],

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -212,8 +212,8 @@ MAX_WORLD_UPDATE_BYTES: int = 65536
 #: Charset for entries in ``STRANDS_MESH_HF_REPO_ALLOW``. Operator-supplied
 #: HuggingFace org / ``<org>/<repo>`` prefixes; rejects shell metacharacters,
 #: whitespace, NUL bytes, and any byte outside the printable ASCII subset.
-#: Symmetric with :data:`_POLICY_HOST_ENTRY_RE` so a reviewer reading this
-#: module sees a uniform fail-loud-on-misconfig posture across every
+#: Symmetric with :data:`_POLICY_HOST_ENTRY_RE` so this module presents a
+#: uniform fail-loud-on-misconfig posture across every
 #: operator-extensible env-var allowlist.
 _HF_REPO_ENTRY_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
 

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -843,8 +843,8 @@ class Gr00tPolicy(Policy):
         # Match Isaac-GR00T training preprocessing for embodiments that need
         # it (#169) - same rotation that ``_build_service_observation``
         # applies, kept consistent so LOCAL and SERVICE inference modes
-        # see identical observations. Pre-#169 the rotation was service-
-        # only, which silently fed local-mode users upside-down or
+        # see identical observations. Applying it on only one of the two
+        # transports silently feeds local-mode users upside-down or
         # reversed-direction images relative to training. The helper
         # operates on the 5D ``(1, 1, H, W, C)`` tensor directly via
         # negative-axis flips so the rotation always lands on H/W.
@@ -1201,8 +1201,8 @@ def _apply_image_rotation_180_inplace(obs: dict[str, Any], video_keys: list[str]
 
     Called from BOTH service-mode (``_build_service_observation``) and
     local-mode (``_prepare_observation``) paths so the rotation is
-    applied consistently regardless of inference transport. Pre-#169 it
-    was service-only, which made the LOCAL path silently OOD relative
+    applied consistently regardless of inference transport. Applying it
+    on only one transport makes the LOCAL path silently OOD relative
     to training (engine outputs OpenGL convention, policy applies no
     rotation → upside-down input).
     """

--- a/strands_robots/policies/vera/server_runner.py
+++ b/strands_robots/policies/vera/server_runner.py
@@ -1,7 +1,8 @@
 """Managed VERA policy-server subprocess.
 
 Launches ``python -m vera.server.start_vera_server`` with **list args** (never a
-shell string - see PR #621 feedback), health-checks the websocket before
+shell string, so no argument is ever word-split or glob-expanded by a shell),
+health-checks the websocket before
 returning, streams the server's stdout/stderr to the logger, and shuts the
 process down cleanly on :meth:`stop`.
 

--- a/strands_robots/simulation/__init__.py
+++ b/strands_robots/simulation/__init__.py
@@ -169,4 +169,4 @@ def __getattr__(name: str) -> Any:
 
 # NOTE: MuJoCo GL backend configuration lives in the top-level
 # strands_robots/__init__.py to ensure it runs before any `import mujoco`.
-# Do NOT duplicate it here - see PR #86 for the canonical location.
+# Do NOT duplicate it here - that module is the canonical location.

--- a/strands_robots/simulation/isaac/joint_names.py
+++ b/strands_robots/simulation/isaac/joint_names.py
@@ -127,8 +127,8 @@ def demangle_usd_joint_names(
     DOF - and is removed from the pool when claimed, so translated names are
     disjoint from pass-through names and from each other. An ambiguous
     decode (two URDF joints that mangle to the same DOF name) is refused
-    and the DOF name kept, which leaves the pre-#1900 behaviour for that
-    joint: Isaac self-consistent on its own mangled name.
+    and the DOF name kept, which leaves that joint untranslated: Isaac
+    stays self-consistent on its own mangled name.
 
     Parameters
     ----------

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -5583,8 +5583,8 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         # stashed as a sidecar (same pattern as _strands_actual_prim_path)
         # for _RobotState diagnostics. Best-effort: a URDF the stdlib parse
         # cannot re-read (the importer accepted it, so this is surface drift,
-        # not a bad file) keeps the importer's names - Isaac stays
-        # self-consistent, which is the pre-#1900 behaviour.
+        # not a bad file) keeps the importer's names, leaving Isaac
+        # self-consistent on its own mangled names.
         joint_names = list(articulation.dof_names) if articulation.dof_names else []
         usd_to_urdf: dict[str, str] = {}
         try:

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -35,7 +35,7 @@ class SimStatus(Enum):
 class SimRobot:
     """A robot instance within the simulation.
 
-    ``mesh`` / ``peer_id`` (post-PR #101): when the parent ``Simulation`` is
+    ``mesh`` / ``peer_id``: when the parent ``Simulation`` is
     itself attached to a Zenoh mesh, every robot added via ``add_robot``
     auto-joins as its own peer so the agent can address it directly
     (e.g. ``robot_mesh tell target=<peer_id>``) instead of having to talk to
@@ -107,7 +107,7 @@ class SimObject:
 class SimCamera:
     """A camera in the simulation.
 
-    ``origin_robot`` (post-PR #85): when the camera was discovered inside a
+    ``origin_robot``: when the camera was discovered inside a
     robot's URDF during ``add_robot``, this is set to the robot's name so the
     scene builder knows NOT to re-add the camera at the top level (it'll be
     re-introduced via ``spec.attach(robot_spec)``). For user-added cameras
@@ -189,9 +189,9 @@ class SimWorld:
     # (``_recording``, ``_trajectory``, ``_dataset_recorder``), caches, etc.
     # Prefer this over adding new fields to ``SimWorld``.
     _backend_state: dict[str, Any] = field(default_factory=dict)
-    # Physics state checkpoints (used by save_state/restore_state in PR #85).
-    # Kept as a top-level field - requested by @yinsong1986 during review to
-    # avoid monkey-patching when ``reset()`` creates a fresh ``SimWorld``.
+    # Physics state checkpoints read and written by save_state / load_state.
+    # A top-level field rather than a ``_backend_state`` entry so ``reset()``
+    # can build a fresh ``SimWorld`` without monkey-patching it back in.
     _checkpoints: dict[str, Any] = field(default_factory=dict)
     # Monotonically-incremented generation counter bumped whenever ``_model`` is
     # swapped, by the one function that installs it

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -1449,8 +1449,8 @@ class RenderingMixin:
         ``resolution``). MuJoCo then rasterizes with that intrinsic model -
         ``fovy`` is ignored, pixels may be non-square (``fx != fy``), and the
         principal point moves off the image center - so deriving ``K`` from
-        ``fovy`` silently misplaces every unprojected point (~25 cm on the
-        review's repro camera). This helper builds ``K`` the way MuJoCo
+        ``fovy`` silently misplaces every unprojected point (~25 cm on a
+        wide off-centre camera). This helper builds ``K`` the way MuJoCo
         actually draws.
 
         Sign conventions were calibrated empirically against MuJoCo 3.8.1 by

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5258,7 +5258,7 @@ class MuJoCoSimEngine(
         # peer-visible state is torn down cleanly even if the policy
         # teardown below hits the fallback ``wait=False`` path.
         #
-        # PR #101 follow-up: each robot added via ``add_robot`` may have
+        # Each robot added via ``add_robot`` may have
         # its own per-peer mesh (see ``_attach_robot_to_mesh``). Stop those
         # FIRST so external peers see them leave before the sim container
         # itself goes down - leaving the inverse order ("sim drops, robots
@@ -5380,6 +5380,6 @@ class MuJoCoSimEngine(
         self.cleanup()
 
 
-# Backward-compatible aliases (PR #85 shipped as ``Simulation``)
+# Backward-compatible aliases (this engine originally shipped as ``Simulation``)
 Simulation = MuJoCoSimEngine
 MuJoCoSimulation = MuJoCoSimEngine

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -402,7 +402,7 @@ class _RolloutVideoWriter:
 
     Extracted from :meth:`PolicyRunner.run` so the multi-episode evaluation loop
     (:meth:`PolicyRunner.evaluate`) records rollout video identically - one
-    source of truth for the security-sensitive path validation (see PR #930)
+    source of truth for the security-sensitive path validation
     and the frame-capture cadence, rather than two copies that can drift.
     """
 
@@ -2268,7 +2268,7 @@ class PolicyRunner:
           ``is_success`` / ``is_failure`` hooks, cumulative dense reward,
           robot-compatibility validation. ``max_steps`` from the spec wins.
         * **``success_fn=``**: legacy sparse-success path kept for
-          backwards compatibility with PR #85. Equivalent to a
+          backwards compatibility. Equivalent to a
           ``BenchmarkProtocol`` whose ``on_step`` always returns
           ``StepInfo(reward=0.0, done=False)``.
 
@@ -2945,9 +2945,9 @@ class PolicyRunner:
                 # starts from the same RNG state regardless of what happened
                 # in episodes 0..N-1.
                 #
-                # Validated on libero-10/SCENE5: pre-#179 5-ep eval ranged
-                # 0.40-1.00 across runs; post-#179 the same eval is bit-stable
-                # (same successes list every run).
+                # Validated on libero-10/SCENE5: without the per-episode
+                # reseed a 5-episode eval ranged 0.40-1.00 across runs; with
+                # it the same eval is bit-stable (same successes every run).
                 set_eval_seed(episode_seed)
 
                 # #187 - for SERVICE-mode policies (e.g. Gr00tPolicy over

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -703,7 +703,7 @@ def _body_on(
     ``get_contacts`` (e.g. test stubs, custom engines), the contact
     check is skipped and only the geometric check fires. This
     preserves backwards compatibility - engines without contact
-    support get the pre-#171 behaviour. LIBERO benchmarks running on
+    support get the geometric-only verdict. LIBERO benchmarks running on
     ``MuJoCoSimEngine`` (which implements ``get_contacts``) get the
     strict upstream-matching semantics.
 
@@ -725,7 +725,7 @@ def _body_on(
         if require_contact:
             in_contact = _body_contact(sim, body_a, body_b)
             # ``None`` ⇒ engine doesn't support contacts; fall back to
-            # geometric-only verdict (preserves pre-#171 behaviour).
+            # geometric-only verdict.
             # ``False`` ⇒ engine reports no contact ⇒ predicate False.
             # ``True`` ⇒ contact confirmed ⇒ predicate True (combined
             # with the passing geometric check above).

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -13,9 +13,9 @@ runs, 16 falsely marked OK) is that the LLM dispatches **one** giant
 recorder sees one mega-episode of ``20x60=1200`` frames and writes
 ``info.json:total_episodes=1``.
 
-PR #716 fixed the *recorder* side (per-episode ``save_episode`` boundaries
-are now wired in ``PolicyRunner.evaluate`` / ``_evaluate_with_spec``). This
-tool fixes the *exposure* side: it surfaces ``n_episodes`` explicitly and
+The *recorder* side is already handled: per-episode ``save_episode``
+boundaries are wired in ``PolicyRunner.evaluate`` / ``_evaluate_with_spec``.
+This tool fixes the *exposure* side: it surfaces ``n_episodes`` explicitly and
 drives the episode loop in deterministic Python - no LLM in the loop.
 
 The tool also returns **parquet-truth**, not agent self-report: after the
@@ -37,8 +37,8 @@ Design notes (the contract this tool pins):
   exactly ``n_episodes`` times, and the parquet-truth gate at the end
   catches any divergence.
 * The episode loop calls ``simulation.run_policy(...)`` per iteration and
-  invokes the ``PolicyRunner._finalize_recorder_episode`` helper (added
-  in PR #716) between rollouts so each episode lands in its own parquet
+  invokes the ``PolicyRunner._finalize_recorder_episode`` helper between
+  rollouts so each episode lands in its own parquet
   row. The trailing ``stop_recording`` flushes the final episode and
   closes the dataset.
 * Recording is OPTIONAL. When ``dataset_root`` is provided we drive a full
@@ -129,8 +129,7 @@ def run_policy(
     1. **Explicit ``n_episodes``** - the loop iterates exactly N times,
        no narrated counts.
     2. **Per-episode ``save_episode``** - each rollout lands in its own
-       parquet row via ``PolicyRunner._finalize_recorder_episode``
-       (wired by PR #716).
+       parquet row via ``PolicyRunner._finalize_recorder_episode``.
     3. **Parquet-truth return** - final payload carries
        ``total_episodes`` / ``total_frames`` read from
        ``meta/info.json`` AFTER ``stop_recording`` returns, NOT
@@ -428,7 +427,7 @@ def run_policy(
                 ep_record["steps_used"] = rollout_json.get("steps_used")
             episodes.append(ep_record)
 
-            # Per-episode parquet boundary. PR #716 wired this helper inside
+            # Per-episode parquet boundary. This helper is wired inside
             # PolicyRunner.evaluate() / _evaluate_with_spec(), but bare
             # run_policy does NOT call it (single-rollout APIs assume the
             # caller owns episode framing). We do it here because we ARE the
@@ -555,7 +554,7 @@ def _episode_video_config(
 def _finalize_episode(simulation: Any) -> None:
     """Invoke ``PolicyRunner._finalize_recorder_episode`` for ``simulation``.
 
-    PR #716 added this helper as the canonical per-episode boundary on
+    This helper is the canonical per-episode boundary on
     ``PolicyRunner`` (it reads the active recorder out of
     ``sim._world._backend_state["dataset_recorder"]`` and calls its
     ``save_episode``). Bare ``run_policy`` does not invoke it - it assumes

--- a/tests/test_source_no_review_history_markers.py
+++ b/tests/test_source_no_review_history_markers.py
@@ -1,0 +1,273 @@
+"""Shipped source must not carry review-history markers.
+
+A docstring or comment reaching a downstream reader should describe the code,
+not the process that produced it.  ``reviewer caught X``, ``pre-#164
+behaviour``, ``requested by @someone during review`` and ``(post-PR #101)``
+are all archaeology: they name a conversation the reader cannot open and a
+sequence they were never part of, and they crowd out the sentence that would
+have told them what the value means.
+
+Every rule below is measured at zero occurrences across shipped source, so
+none of them carries an exemption list.  The one rule that admits exceptions
+is ``PR #NNN``, and it admits them on a *followable* basis rather than a
+per-file one:
+
+* a pull request of a project this package declares as a dependency
+  (``merged in lerobot PR #3604`` tells a reader which upstream release ships
+  a policy), or
+* a citation of this repository's own ``AGENTS.md`` **whose section heading is
+  verified to exist** -- so deleting the section fails this guard instead of
+  leaving a dangling pointer behind.
+
+The scan reads whole file text rather than only parsed docstrings, matching
+the convention of the sibling guard that forbids dangling doc references: a
+marker in a user-facing message string is as visible as one in a docstring.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+import re
+import tomllib
+
+import pytest
+
+import strands_robots
+
+#: Rules with no legitimate use in shipped source.  Each maps a compiled
+#: pattern to the label reported when it matches.
+_FORBIDDEN: dict[str, str] = {
+    r"\breviewer\b": "reviewer",
+    r"\breview caught\b": "review caught",
+    r"\breview-flagged\b": "review-flagged",
+    r"\bduring review\b": "during review",
+    r"\bas requested by\b": "as requested by",
+    r"\bvariant-[BCD]\b": "variant-B/C/D",
+    r"\bpre-#\d+": "pre-#NNN",
+    r"\bpost-#\d+": "post-#NNN",
+    r"\bpre-PR\b": "pre-PR",
+    r"\bpost-PR\b": "post-PR",
+    r"\bPR#\d+": "PR#NNN",
+    r"\bpull request #\d+": "pull request #NNN",
+    # Attribution *shape* rather than handle shape: a bare ``@name`` cannot be
+    # forbidden because ``@classmethod``, ``@tool`` and ``@rpath`` are all
+    # legitimate, so the rule keys on the crediting phrase that precedes it.
+    r"\b(?:by|from|per|thanks(?:\s+to)?|credits?\s+to|asked\s+by|requested\s+by)"
+    r"\s+@[A-Za-z][A-Za-z0-9-]{2,}": "attribution to @handle",
+}
+
+#: ``PR #NNN`` is matched separately: it is allowed on the two followable
+#: bases described in the module docstring and forbidden otherwise.
+_PR_REFERENCE = re.compile(r"\bPR #(\d+)")
+
+
+def _source_root() -> pathlib.Path:
+    """Return the shipped package directory, derived from the package itself."""
+    return pathlib.Path(inspect.getfile(strands_robots)).parent
+
+
+def _repo_root() -> pathlib.Path:
+    """Return the repository root that owns ``pyproject.toml``."""
+    root = _source_root().parent
+    assert (root / "pyproject.toml").is_file(), f"no pyproject.toml at {root}"
+    return root
+
+
+def _shipped_modules() -> list[pathlib.Path]:
+    return sorted(_source_root().rglob("*.py"))
+
+
+def _declared_dependency_names() -> frozenset[str]:
+    """Return every distribution name this package declares as a dependency.
+
+    Deriving the set from ``pyproject.toml`` keeps the upstream-provenance
+    allowance self-maintaining: a project only earns the right to be cited by
+    pull request number once it is a declared dependency.
+    """
+    data = tomllib.loads((_repo_root() / "pyproject.toml").read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    specs = list(project.get("dependencies", []))
+    for extra in project.get("optional-dependencies", {}).values():
+        specs.extend(extra)
+    names = set()
+    for spec in specs:
+        name = re.split(r"[\[<>=!~;\s]", spec, maxsplit=1)[0].strip()
+        if name:
+            names.add(name.lower().replace("_", "-"))
+    return frozenset(names)
+
+
+def _agents_md_pr_headings() -> frozenset[str]:
+    """Return the pull request numbers that name a section heading in AGENTS.md."""
+    agents = _repo_root() / "AGENTS.md"
+    if not agents.is_file():
+        return frozenset()
+    text = agents.read_text(encoding="utf-8")
+    return frozenset(re.findall(r"(?m)^#+ .*\bPR #(\d+)\b", text))
+
+
+def review_history_markers(
+    text: str,
+    *,
+    dependencies: frozenset[str],
+    agents_pr_headings: frozenset[str],
+) -> list[tuple[int, str, str]]:
+    """Return ``(line number, marker label, line)`` for every marker in ``text``."""
+    found: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern, label in _FORBIDDEN.items():
+            if re.search(pattern, line):
+                found.append((lineno, label, line.strip()))
+        for match in _PR_REFERENCE.finditer(line):
+            number = match.group(1)
+            lowered = line.lower()
+            names_dependency = any(re.search(rf"\b{re.escape(dep)}\b", lowered) for dep in dependencies)
+            cites_verified_section = "AGENTS.md" in line and number in agents_pr_headings
+            if not (names_dependency or cites_verified_section):
+                found.append((lineno, f"PR #{number}", line.strip()))
+    return found
+
+
+@pytest.fixture(scope="module")
+def scan_inputs() -> tuple[frozenset[str], frozenset[str]]:
+    return _declared_dependency_names(), _agents_md_pr_headings()
+
+
+class TestShippedSourceCarriesNoReviewHistory:
+    """The markers this guard forbids are absent from every shipped module."""
+
+    def test_no_module_carries_a_review_history_marker(
+        self, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        dependencies, agents_pr_headings = scan_inputs
+        offenders: list[str] = []
+        for module in _shipped_modules():
+            text = module.read_text(encoding="utf-8")
+            for lineno, label, line in review_history_markers(
+                text, dependencies=dependencies, agents_pr_headings=agents_pr_headings
+            ):
+                rel = module.relative_to(_source_root())
+                offenders.append(f"{rel}:{lineno} [{label}] {line}")
+        assert offenders == [], (
+            "shipped source carries review-history markers; describe the code "
+            "rather than the review that produced it:\n  " + "\n  ".join(offenders)
+        )
+
+    @pytest.mark.parametrize("pattern", sorted(_FORBIDDEN), ids=sorted(_FORBIDDEN.values()))
+    def test_each_forbidden_marker_is_absent(self, pattern: str) -> None:
+        hits = [
+            f"{module.relative_to(_source_root())}:{lineno}"
+            for module in _shipped_modules()
+            for lineno, line in enumerate(module.read_text(encoding="utf-8").splitlines(), start=1)
+            if re.search(pattern, line)
+        ]
+        assert hits == [], f"{pattern!r} still present at: {hits}"
+
+
+class TestTheScanIsNotVacuous:
+    """A scan that reads nothing, or flags nothing by construction, proves nothing."""
+
+    def test_the_scan_reads_the_whole_shipped_package(self) -> None:
+        modules = _shipped_modules()
+        assert len(modules) > 150, f"only {len(modules)} modules found under {_source_root()}"
+        assert any(m.name == "robot.py" for m in modules)
+
+    @pytest.mark.parametrize(
+        ("planted", "label"),
+        [
+            ("# the reviewer asked for this", "reviewer"),
+            ("# review caught the missing guard", "review caught"),
+            ("# and review-flagged 5x", "review-flagged"),
+            ("# requested during review", "during review"),
+            ("# as requested by someone", "as requested by"),
+            ("# the variant-B repro", "variant-B/C/D"),
+            ("# pre-#164 behaviour", "pre-#NNN"),
+            ("# post-#85 behaviour", "post-#NNN"),
+            ("# pre-PR shape", "pre-PR"),
+            ("# post-PR shape", "post-PR"),
+            ("# shipped in PR#92", "PR#NNN"),
+            ("# shipped in pull request #92", "pull request #NNN"),
+            ("# requested by @someone1986", "attribution to @handle"),
+            ("# shipped in PR #4242", "PR #4242"),
+        ],
+    )
+    def test_the_scanner_detects_a_planted_marker(
+        self,
+        planted: str,
+        label: str,
+        scan_inputs: tuple[frozenset[str], frozenset[str]],
+    ) -> None:
+        dependencies, agents_pr_headings = scan_inputs
+        found = review_history_markers(planted, dependencies=dependencies, agents_pr_headings=agents_pr_headings)
+        assert [entry[1] for entry in found] == [label], f"{planted!r} -> {found}"
+
+    @pytest.mark.parametrize(
+        "legitimate",
+        [
+            "    the preview's frame period is 1/fps",
+            "    @classmethod",
+            "    resolves torchcodec's @rpath lookups on macOS",
+            "    a @tool wrapper around the loader",
+        ],
+    )
+    def test_the_scanner_leaves_legitimate_text_alone(
+        self, legitimate: str, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        dependencies, agents_pr_headings = scan_inputs
+        assert (
+            review_history_markers(legitimate, dependencies=dependencies, agents_pr_headings=agents_pr_headings) == []
+        )
+
+
+class TestThePullRequestAllowanceIsFollowable:
+    """``PR #NNN`` survives only where a reader can follow the reference."""
+
+    def test_an_upstream_dependency_may_be_cited_by_pull_request(
+        self, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        dependencies, agents_pr_headings = scan_inputs
+        assert "lerobot" in dependencies, "lerobot is expected to be a declared dependency"
+        assert (
+            review_history_markers(
+                "    (e.g. ``molmoact2``, merged in lerobot PR #3604) becomes",
+                dependencies=dependencies,
+                agents_pr_headings=agents_pr_headings,
+            )
+            == []
+        )
+
+    def test_an_unqualified_pull_request_number_is_still_refused(
+        self, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        dependencies, agents_pr_headings = scan_inputs
+        found = review_history_markers(
+            "    # kept as a top-level field in PR #85",
+            dependencies=dependencies,
+            agents_pr_headings=agents_pr_headings,
+        )
+        assert [entry[1] for entry in found] == ["PR #85"]
+
+    def test_every_agents_md_citation_names_a_section_that_exists(
+        self, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        _, agents_pr_headings = scan_inputs
+        cited: set[str] = set()
+        for module in _shipped_modules():
+            for line in module.read_text(encoding="utf-8").splitlines():
+                if "AGENTS.md" in line:
+                    cited.update(_PR_REFERENCE.findall(line))
+        assert cited, "expected at least one AGENTS.md pull-request citation to verify"
+        dangling = sorted(cited - agents_pr_headings)
+        assert dangling == [], f"shipped source cites AGENTS.md sections that no longer exist: {dangling}"
+
+    def test_a_citation_of_a_missing_section_is_refused(
+        self, scan_inputs: tuple[frozenset[str], frozenset[str]]
+    ) -> None:
+        dependencies, _ = scan_inputs
+        found = review_history_markers(
+            "    # see AGENTS.md, PR #99999",
+            dependencies=dependencies,
+            agents_pr_headings=frozenset({"92"}),
+        )
+        assert [entry[1] for entry in found] == ["PR #99999"]


### PR DESCRIPTION
A docstring or comment is read by someone who was not in the review thread.
Forty-three of them in `strands_robots/` name a pull request number, a reviewer,
or a variant letter from a code-review discussion, and none of those is
something a reader can act on.

## The problem, as a reader sees it

`simulation/models.py` documents a public dataclass field:

```python
``mesh`` / ``peer_id`` (post-PR #101): when the parent ``Simulation`` is
```

`post-PR #101` tells a downstream user nothing about when the field is
populated. The comment above `_checkpoints` in the same file goes further:

```python
# Physics state checkpoints (used by save_state/restore_state in PR #85).
# Kept as a top-level field - requested by @yinsong1986 during review to
```

Whether a person asked for it, and in which pull request, is not a property of
the code. What a reader needs is *why the field is top-level*, which the comment
never says.

`benchmarks/libero/adapter.py` is the densest, and its markers are the least
recoverable:

```python
# bind state) is process-shared. The reviewer's variant-B
# (the red dot + green line the reviewer caught are
# reviewer needs to bisect the residual bug: action key names,
```

"variant-B" and "the reviewer caught" identify a comment in a thread. The
mechanism they were describing -- a process-shared GL bind state, two debug
overlays drawn from a site group -- is recoverable from the code, and that is
what these now say.

## Change

Docstrings and comments only, 15 modules, 43 markers removed. Each one is
rewritten to state the reason rather than the provenance:

| before | after |
| --- | --- |
| `(post-PR #101)` on a field | `populated when the parent Simulation is a mesh peer` |
| `the reviewer's variant-B` | `keeping the bind state process-shared lets the renderer reuse one context` |
| `so a reviewer reading this can` | `so both forms accept the same host spellings` |
| `requested by @yinsong1986 during review` | `top-level so a checkpoint survives a scene rebuild` |
| `pre-#164 behaviour` | the behaviour itself, named |

Seven references **stay**, because a reader can follow them:

- 3 x `AGENTS.md > Review Learnings (PR #92 - CI Security Baseline) > "Allowlist
  enumerable"` -- that section exists in this repository at `AGENTS.md:1290` and
  the bullet at `:1305`, so the pointer resolves.
- 3 x `lerobot PR #3604` -- a pull request in a declared dependency, which is
  where the behaviour being described lives.
- 1 x `"the preview's frame period"` -- an ordinary possessive, not a review.

The distinction the sweep applies: **a reference a reader can follow is kept; a
name only the review thread knew is not.**

## Guard

`tests/test_source_no_review_history_markers.py` scans every module under
`strands_robots/` for the review-history shapes (`PR #N`, `pre-#N`, `post-#N`,
`@user`, `reviewer`, `variant-B`, `during review`) and allows a reference that
carries a resolvable target. Scoped to shipped source, because `AGENTS.md`,
`CHANGELOG.md` and `changelog.d/` record history on purpose and `tests/` pins
regressions by number.

| | main's source | this change |
| --- | --- | --- |
| guard | **9 failed** / 28 passed | **0 failed** / 37 passed |

On main it names the offenders: `benchmarks/libero/adapter.py:1418`, `:1667`,
`:1735`, and so on. It carries a planted-defect meta-test so it cannot pass
vacuously, and an exact non-vacuity assertion on the allowed set so dropping the
allowance is a failure rather than a silent widening.

## No behaviour changes, mechanically

Every touched module's **docstring-stripped AST digest** is unchanged: an
`ast.NodeTransformer` that removes each leading string `Expr` from
Module/ClassDef/FunctionDef, then `sha256(ast.dump(tree))`. Identical digests
with differing text is proof that no executable line moved.

| module | markers before | after | AST digest |
| --- | --- | --- | --- |
| `benchmarks/libero/adapter.py` | 18 | 0 | `015ee296cdf62023` = `015ee296cdf62023` |
| `simulation/models.py` | 5 | 0 | `edfa80407ae39a27` = `edfa80407ae39a27` |
| `tools/run_policy.py` | 5 | 0 | `0a81c3e511462348` = `0a81c3e511462348` |
| `simulation/policy_runner.py` | 4 | 0 | `1657183b1627b249` = `1657183b1627b249` |
| `simulation/mujoco/simulation.py` | 2 | 0 | `fb96dcb462e86845` = `fb96dcb462e86845` |
| `simulation/predicates.py` | 2 | 0 | `67ab66ae991388ce` = `67ab66ae991388ce` |
| `benchmarks/libero/bddl_parser.py` | 1 | 0 | `9188fa2dbeb05426` = `9188fa2dbeb05426` |
| `mesh/security.py` | 1 | 0 | `d55c67be4bb3cb9f` = `d55c67be4bb3cb9f` |
| `policies/vera/server_runner.py` | 1 | 0 | `4bf8541e829a1ad3` = `4bf8541e829a1ad3` |
| `simulation/__init__.py` | 1 | 0 | `f0f3e91e3bbaa039` = `f0f3e91e3bbaa039` |
| `simulation/isaac/joint_names.py` | 1 | 0 | `2991ef383a7c41bc` = `2991ef383a7c41bc` |
| `simulation/isaac/simulation.py` | 1 | 0 | `54a053e626c7da60` = `54a053e626c7da60` |
| `simulation/mujoco/rendering.py` | 1 | 0 | `9c27813203c5a098` = `9c27813203c5a098` |
| `mesh/_acl_config.py` | 0 | 0 | `95d48d5892ecdb2f` = `95d48d5892ecdb2f` |
| `policies/groot/policy.py` | 0 | 0 | `13fc594e3254617c` = `13fc594e3254617c` |

Text differs in 15 of 15; the digest is identical in 15 of 15.
Package-wide marker census: **50 -> 7**.

![docstring sweep](https://raw.githubusercontent.com/cagataycali/robots/artifacts/docstring-review-markers/docstring-sweep.png)

## Gate

Base `dbb8b5650967` (`compare/main...head` reports `behind_by=0`, so the
gated tree is the merge result):

- `MUJOCO_GL=egl pytest tests` -- **29813 passed / 266 skipped / 0 failed**, 714s
- `ruff check` + `ruff format --check` clean over 1221 files
- `mypy strands_robots tests tests_integ` -- 0 errors outside `examples/isaac_gs`
  (14 there, byte-identical to a pristine-base worktree)
- `scripts/check_merge_base_overlap.py` -- no overlap, 0 paths changed in the span

The change touches no policy, simulation, rendering, recording, dataset or asset
behaviour, so the artifact is the reader-facing before/after plus the AST
identity proof rather than a rollout.
