### PR TITLE
fix(tools): name the allowlist key that actually clears push_to_hub

### DIFF
--- a/changelog.d/2259-train-publish-allowlist-key.md
+++ b/changelog.d/2259-train-publish-allowlist-key.md
@@ -1,0 +1,16 @@
+### Fixed: `lerobot_train`'s `push_to_hub` description named an allowlist key that does not clear it
+
+`push_to_hub` is the one blocked flag `_BLOCKED_EXTRA_FLAGS` names twice, bare
+and `policy.`-prefixed, and the two entries are not interchangeable: the named
+parameter is gated under `policy.push_to_hub` (the only spelling LeRobot accepts,
+since `push_to_hub` is a field of its policy config rather than of the train
+config), while the bare key covers the raw
+`extra_flags={"push_to_hub": True}` passthrough. The parameter's agent-facing
+description said the approval could be pre-approved "exactly as the
+`extra_flags={'push_to_hub': True}` spelling already does", which reads as one
+shared opt-out -- so a headless run that set
+`STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=push_to_hub` still hit the approval prompt with
+nobody there to answer it, and the description was the only place that env var is
+documented at all. The description now names `policy.push_to_hub` and says which
+spelling each entry clears, and the blocklist carries a comment recording why the
+pair is not a duplicate.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -108,6 +108,10 @@ _BLOCKED_EXTRA_FLAGS = frozenset(
         "wandb.api_key",
         "dataset.root",
         "policy.pretrained_path",
+        # Blocked in both spellings, and the pair is not a duplicate: the named
+        # push_to_hub parameter is gated under the policy.-prefixed key (the only
+        # one LeRobot accepts), while the bare key covers the raw extra_flags
+        # passthrough. The allowlist entry that clears one does not clear the other.
         "push_to_hub",
         "policy.push_to_hub",
         "hub_repo_id",
@@ -655,9 +659,14 @@ def lerobot_train(
         num_gpus: Number of GPUs; >1 launches via accelerate --multi_gpu.
         push_to_hub: Push the trained checkpoint to the HF Hub at the end.
             Publishing is an outward-facing action, so a true value requires
-            operator approval through ``tool_context`` (or an explicit
-            STRANDS_TRAIN_EXTRA_FLAGS_ALLOW entry) exactly as the
-            ``extra_flags={'push_to_hub': True}`` spelling already does. The
+            operator approval through ``tool_context``. A headless run
+            pre-approves it with
+            ``STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=policy.push_to_hub``: this
+            parameter is gated under the ``policy.``-prefixed key, the only
+            spelling LeRobot accepts (``push_to_hub`` is a field of its policy
+            config, not of the train config). The bare ``push_to_hub``
+            allowlist entry clears the raw ``extra_flags={'push_to_hub': True}``
+            passthrough instead -- one flag, two spellings, two entries. The
             default false value emits the flag unchanged and is not gated.
         resume: Resume from the latest checkpoint under output_dir when present.
         action: One of start, status, stop, list.

--- a/tests/tools/test_train_publication_requires_approval.py
+++ b/tests/tools/test_train_publication_requires_approval.py
@@ -20,6 +20,10 @@ already covered elsewhere):
    ``push_to_hub=False`` is not gated.
 4. A parity net over the blocklist: any blocked flag that is also a named
    parameter must be gated, or be named in this module's documented exemption.
+5. Which allowlist entry clears which spelling: push_to_hub is the one
+   blocked flag named twice in the blocklist, so a headless run's
+   STRANDS_TRAIN_EXTRA_FLAGS_ALLOW value has to match the spelling the call
+   used -- and the description an agent reads has to say which.
 
 Everything here is hardware-, GPU- and network-free: ``subprocess.Popen`` is
 replaced by a recorder, so "launched" means "the tool would have started
@@ -31,6 +35,7 @@ from __future__ import annotations
 import ast
 import inspect
 import json
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -273,3 +278,101 @@ class TestBlockedFlagsThatAreAlsoNamedParametersAreGated:
         for name in _UNGATED_BY_DESIGN:
             assert name in params, f"exempt name {name!r} is not a parameter any more"
             assert name in blocked_tails, f"exempt name {name!r} is not blocklisted any more"
+
+
+def _push_to_hub_description() -> str:
+    """The ``push_to_hub`` description an agent reads, from the tool's own schema."""
+    props = lerobot_train.tool_spec["inputSchema"]["json"]["properties"]
+    return str(props["push_to_hub"]["description"])
+
+
+def _allow_key_from_schema() -> str:
+    """The allowlist entry the schema tells a headless caller to set."""
+    match = re.search(r"STRANDS_TRAIN_EXTRA_FLAGS_ALLOW=([A-Za-z0-9_.]+)", _push_to_hub_description())
+    assert match, "the description must name the allowlist entry that clears this parameter"
+    return match.group(1)
+
+
+class TestWhichAllowlistEntryClearsWhichSpelling:
+    """One flag, two spellings, two allowlist entries -- and the schema says which.
+
+    ``push_to_hub`` is the only blocked flag the blocklist names twice, bare and
+    ``policy.``-prefixed. The named parameter is gated under the prefixed key
+    because that is the only spelling LeRobot accepts; the bare key covers the raw
+    ``extra_flags`` passthrough. So the ``STRANDS_TRAIN_EXTRA_FLAGS_ALLOW`` value a
+    headless run needs depends on how the call named the publish, and the
+    description an agent reads has to say which one -- an unattended run that
+    pre-approves the wrong spelling gets an approval prompt with nobody there to
+    answer it.
+    """
+
+    @pytest.mark.parametrize(
+        ("allow", "parameter_publishes", "expected_flag"),
+        [
+            ("policy.push_to_hub", True, "--policy.push_to_hub=true"),
+            # The passthrough echoes the caller's own literal, hence the capital T:
+            # the named parameter lowercases the bool, ``extra_flags`` does not.
+            ("push_to_hub", False, "--push_to_hub=True"),
+        ],
+        ids=["prefixed-entry-clears-the-parameter", "bare-entry-clears-the-passthrough"],
+    )
+    def test_an_allowlist_entry_clears_only_its_own_spelling(
+        self,
+        launcher: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+        allow: str,
+        parameter_publishes: bool,
+        expected_flag: str,
+    ) -> None:
+        monkeypatch.setenv(_ALLOW_ENV, allow)
+
+        named = _start(launcher, session_name="named", push_to_hub=True)
+        smuggled = _start(launcher, session_name="smuggled", extra_flags={"push_to_hub": True})
+
+        assert (named["status"] == "success") is parameter_publishes, _texts(named)
+        assert (smuggled["status"] == "success") is (not parameter_publishes), _texts(smuggled)
+
+        assert len(launcher["launched"]) == 1, "one entry clears exactly one spelling"
+        assert expected_flag in launcher["launched"][0]
+
+    def test_following_the_schema_pre_approves_the_named_parameter(
+        self, launcher: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The key the agent-facing description names really clears this parameter.
+
+        This is the remedy the description prescribes, executed rather than
+        restated: it fails if the description ever names a key the gate does not
+        honour, whatever the wording around it.
+        """
+        monkeypatch.setenv(_ALLOW_ENV, _allow_key_from_schema())
+
+        result = _start(launcher, push_to_hub=True)
+
+        assert result["status"] == "success", _texts(result)
+        assert "--policy.push_to_hub=true" in launcher["launched"][0]
+
+    def test_the_description_does_not_claim_the_spellings_share_an_opt_out(self) -> None:
+        """The two spellings share the approval prompt, not the allowlist entry."""
+        description = _push_to_hub_description()
+        assert "policy.push_to_hub" in description, "the description must name the key it is gated under"
+        assert "exactly as" not in description, (
+            "the parameter and the extra_flags passthrough are gated under different keys, "
+            "so the description must not claim one opt-out covers both"
+        )
+
+    def test_only_the_prefixed_spelling_is_a_lerobot_flag(self) -> None:
+        """``push_to_hub`` is a policy-config field, so ``--policy.`` is the only spelling.
+
+        This is what makes the asymmetry correct rather than accidental: the named
+        parameter has to synthesize the prefixed key because a bare
+        ``--push_to_hub`` is not a flag LeRobot's parser knows, which leaves the
+        bare blocklist entry covering the raw passthrough alone.
+        """
+        pytest.importorskip("lerobot")
+        import dataclasses
+
+        from lerobot.configs.policies import PreTrainedConfig
+        from lerobot.configs.train import TrainPipelineConfig
+
+        assert "push_to_hub" not in {field.name for field in dataclasses.fields(TrainPipelineConfig)}
+        assert "push_to_hub" in {field.name for field in dataclasses.fields(PreTrainedConfig)}


### PR DESCRIPTION
## Problem

`lerobot_train` gates a publishing train run behind operator approval, and its
`push_to_hub` parameter documents how a headless run pre-approves it:

> a true value requires operator approval through `tool_context` (or an explicit
> STRANDS_TRAIN_EXTRA_FLAGS_ALLOW entry) exactly as the
> `extra_flags={'push_to_hub': True}` spelling already does

Following that sentence does not work. The gate keys the named parameter on
`policy.push_to_hub` and the raw passthrough on `push_to_hub`, so the entry the
description points at clears the *other* spelling. Measured by driving the real
tool with a recorded `subprocess.Popen`, one allowlist entry at a time:

| STRANDS_TRAIN_EXTRA_FLAGS_ALLOW | `push_to_hub=True` (the named parameter) | `extra_flags={"push_to_hub": True}` (raw) |
| --- | --- | --- |
| (unset) | asked, refused | asked, refused |
| `push_to_hub` | asked, refused | **published, never asked** |
| `policy.push_to_hub` | **published, never asked** | refused |

So an operator who follows the description gets `status='error'`
and no upload, and an operator who guesses `policy.push_to_hub` gets a silent
publish they were never asked about. Both halves of the sentence are wrong for the
parameter it documents.

## Why the description is the fix rather than the gate

Issue #2257 lists three options and marks one premise unverified: whether LeRobot
honours the bare `--push_to_hub=` spelling at all. It does not. Read from the
installed dataclasses:

| field | on `TrainPipelineConfig` | on `PreTrainedConfig` |
| --- | --- | --- |
| `push_to_hub` | no | yes |

`push_to_hub` is a field of the *policy* config, so `--policy.push_to_hub=` is the
only spelling the train CLI parses. That rules out option (1) - gating the named
parameter under the bare key would pre-approve a token LeRobot cannot read, and
would silently pre-approve the raw passthrough at the same time. Option (2) is a
breaking rename the issue itself does not want. What is left is option (3), the
issue's own inclination: keep both entries and say which is which.

The two blocklist entries are load-bearing and stay: `policy.push_to_hub` stops a
caller re-adding the prefixed flag through `extra_flags`, and `push_to_hub` stops
the bare one reaching the argv even though LeRobot would ignore it. A comment now
records that asymmetry beside them.

## Change

- `push_to_hub`'s parameter description names `policy.push_to_hub` as its
  pre-approval entry, says why (the field lives on the policy config), and states
  that the bare entry clears the raw passthrough instead. This is the text the
  model reads out of the tool schema, so the wrong spelling was being advertised.
- A comment on the blocklist pair records that the two keys clear two different
  spellings of one flag.
- No behaviour change: the gate, the blocklist and the emitted argv are untouched.

## Tests

`tests/tools/test_train_publication_requires_approval.py` grows 5 cases:

- each spelling is pre-approved by its own entry and refused by the other one
- following the description's own entry really does pre-approve the parameter
- the description names `policy.push_to_hub` and does not name the bare key as
  this parameter's entry
- `push_to_hub` is a `PreTrainedConfig` field and not a `TrainPipelineConfig`
  field, so the prefixed spelling is the only flag LeRobot parses

Mutation table, each anchor AST-scoped to its enclosing function (`in_fn=1`
printed per anchor) and restored byte-identically:

| mutation | new cases | 16 pre-existing |
| --- | --- | --- |
| revert the description to main's wording | 2 failed | 0 |
| gate the named parameter under the bare key | 3 failed | 2 failed |
| drop `policy.push_to_hub` from the blocklist | 1 failed | 6 failed |
| drop `push_to_hub` from the blocklist | 1 failed | 1 failed |
| description names the bare key instead | 2 failed | 0 |
| remove the blocklist pair's comment | 0 | 0 |

5 of 6 caught, 2 of them invisible to the pre-existing cases - both the docs
regressions, which is the half that had no pin. The 6th deletes a comment and is
prose rather than behaviour, so nothing asserts it and I have not invented a pin
for it.

## Gate

Measured on the rebased head, whose base **is** `upstream/main`:

- `MUJOCO_GL=egl pytest tests` -> **29781 passed / 266 skipped / 0 failed** (684s).
  That reconciles arithmetically with the pre-rebase run (29772 + the 9 cases
  #2255 brought in), which independently confirms both numbers.
- Collected cases **30042 -> 30047** against a worktree at the base, so the 5 new
  cases are the whole delta.
- `ruff check` and `ruff format --check` clean over 1220 files; `mypy` 0 errors
  outside `examples/isaac_gs`.
- `check_merge_base_overlap.py` reports no overlap and `behind_by` is 0.

An earlier pre-rebase run hit 8 failures, all lerobot imports from a shared
source tree a sibling process re-cloned mid-suite (a lone `clone:` reflog entry,
directory mtime inside the window). They do not reproduce and none of the 8 reads
any file in this diff; the run above is clean.

## Artifact

![allowlist key](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-publish-allowlist-key/push_to_hub_allowlist.png)

The figure is the measured matrix, the before/after description and the mutation
table; every drawn number is asserted against the two dumps, which record their
own trees. No policy, simulation, rendering, recording or asset behaviour
changes, so the artifact is a verdict table rather than a rollout. Capture and
compose scripts plus the raw dumps are on
[`artifacts/train-publish-allowlist-key`](https://raw.githubusercontent.com/cagataycali/robots/artifacts/train-publish-allowlist-key/README.md).

Closes #2257

## Note on the gated tree

The gate above ran at `3a02cee0`. The pushed head `bb878f3b` differs from it only
by the changelog fragment's filename (`2258-` -> `2259-`, renamed once this PR had
a number; `git diff --name-status` reports `R100`, so no source line changed).

