### PR TITLE
test(mesh): pin the inbound-command listener's parse-and-dispatch contract

### DIFF
--- a/changelog.d/2261-mesh-command-dispatch-isolation.md
+++ b/changelog.d/2261-mesh-command-dispatch-isolation.md
@@ -1,0 +1,25 @@
+### Quality: pin the mesh inbound-command listener's parse-and-dispatch contract
+
+`Mesh._on_cmd` is the callback every remote command arrives on, and it answers by
+returning -- a refused sample and a dispatched one are indistinguishable to the
+caller, so the whole listener was invisible to the suite. The cases around it
+drove `_exec_cmd` (the dispatch body) and the wire validator on either side
+instead, leaving three properties of the listener itself unpinned.
+
+3 test functions (6 cases) in `tests/mesh/test_mesh_rpc.py` now drive it with
+a raw sample the way a subscription would. They pin that valid JSON which is not
+an object -- an array, a string, a number, `null` -- is dropped before any field
+is read and leaves neither a dispatch nor a response behind; that a well-formed
+command from another peer reaches `_exec_cmd` with the decoded payload and
+answers on the requester's turn-scoped key; and that the dispatch runs on its own
+daemon thread named after the peer, so one wedged command can neither stall the
+subscription nor hold interpreter exit open.
+
+Five plausible regressions were applied to the listener and run against both
+arms. Four are caught here and are invisible to all 41 pre-existing cases in
+that module: dropping the non-mapping guard, making the dispatch thread
+non-daemon, dispatching synchronously on the callback thread, and dropping the
+peer scope from the thread name. The fifth, the self-echo guard, is already held
+by the pre-existing cases, which is why these deliberately do not restate it.
+
+No library behaviour changes.

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -642,3 +642,97 @@ class TestCommandDispatchErrorAudit:
         payload = next(d for k, d in captured_puts if k == "strands/alice/response/me/t4")
         assert payload["type"] == "error"
         assert payload["error"] == "dispatch error"
+
+
+def _spy_exec(m: Mesh) -> tuple[list[dict[str, Any]], list[threading.Thread], threading.Event]:
+    """Wrap ``_exec_cmd`` so a dispatch is observable without replacing it.
+
+    The spy records the payload it was handed and the thread it ran on, then
+    delegates -- so the accept arm still publishes its response while the
+    reject arms can be asserted against an empty record.  The event lets a
+    test wait for the dispatch thread deterministically instead of sleeping
+    for a fixed span, and capturing ``current_thread()`` from inside the
+    target avoids patching the stdlib ``threading`` module, which would also
+    intercept thread creation unrelated to this dispatch.
+    """
+    seen: list[dict[str, Any]] = []
+    threads: list[threading.Thread] = []
+    done = threading.Event()
+    real = m._exec_cmd
+
+    def _wrapped(data: dict[str, Any]) -> None:
+        seen.append(data)
+        threads.append(threading.current_thread())
+        try:
+            real(data)
+        finally:
+            done.set()
+
+    m._exec_cmd = _wrapped  # type: ignore[method-assign]
+    return seen, threads, done
+
+
+def test_on_cmd_dispatches_a_foreign_command_to_exec(
+    started_mesh: Mesh, captured_puts: list[tuple[str, dict[str, Any]]]
+) -> None:
+    """A well-formed command from another peer reaches ``_exec_cmd`` and answers.
+
+    The two neighbouring ``_on_cmd`` cases pin the arms that DROP a sample
+    (a self echo, an undecodable payload).  This pins the arm that accepts
+    one, driven through the wire seam rather than by calling ``_exec_cmd``
+    directly: a regression that stopped dispatching would leave the mesh
+    silently deaf to every inbound command while the direct-drive cases
+    still passed.
+    """
+    seen, _, done = _spy_exec(started_mesh)
+    payload = {"sender_id": "peer-b", "turn_id": "t1", "command": {"action": "status"}}
+    started_mesh._on_cmd(_make_sample(payload))
+
+    assert done.wait(timeout=5.0), "the inbound command was never dispatched"
+    assert seen == [payload], "the dispatched payload is not the decoded sample"
+    responses = [k for k, _ in captured_puts if k == "strands/peer-b/response/peer-a/t1"]
+    assert responses, f"no response on the requester's turn-scoped key: {captured_puts}"
+
+
+@pytest.mark.parametrize(
+    "decoded",
+    [[1, 2, 3], "hello", 42, None],
+    ids=["json-array", "json-string", "json-number", "json-null"],
+)
+def test_on_cmd_drops_a_non_mapping_payload(
+    started_mesh: Mesh, captured_puts: list[tuple[str, dict[str, Any]]], decoded: Any
+) -> None:
+    """Valid JSON that is not an object is dropped rather than dispatched.
+
+    ``json.loads`` accepts arrays, strings, numbers and ``null``, so decoding
+    successfully does not make a sample a command.  Without the mapping check
+    the payload would reach ``.get("sender_id")`` and raise inside the Zenoh
+    callback thread, where nothing can report it.
+    """
+    seen, _, _ = _spy_exec(started_mesh)
+    started_mesh._on_cmd(_make_sample(decoded))
+    # Give a wrongly-spawned dispatch thread time to run before asserting.
+    time.sleep(0.05)
+
+    assert seen == [], f"a non-mapping payload was dispatched as a command: {seen}"
+    assert [k for k, _ in captured_puts if "response" in k] == []
+
+
+def test_on_cmd_dispatch_thread_is_a_daemon(started_mesh: Mesh) -> None:
+    """The per-command dispatch thread cannot hold the interpreter at exit.
+
+    Each inbound command runs on its own thread.  A non-daemon thread wedged
+    in a long-running command would be joined by the interpreter's exit hook,
+    so a single peer could keep this process alive by sending one command.
+    The thread is also named after the peer, so a stack dump attributes a
+    wedged command to the mesh that accepted it.
+    """
+    _, threads, done = _spy_exec(started_mesh)
+    started_mesh._on_cmd(_make_sample({"sender_id": "peer-b", "turn_id": "t1", "command": {"action": "status"}}))
+
+    assert done.wait(timeout=5.0), "the inbound command was never dispatched"
+    assert len(threads) == 1, f"expected one dispatch thread, got {len(threads)}"
+    thread = threads[0]
+    assert thread is not threading.main_thread(), "the command ran on the callback thread, not its own"
+    assert thread.daemon is True, "a wedged inbound command would block interpreter exit"
+    assert started_mesh.peer_id in thread.name, f"dispatch thread is not peer-scoped: {thread.name!r}"


### PR DESCRIPTION
## Problem

`Mesh._on_cmd` is the callback every remote command arrives on. It answers by
**returning** -- a refused sample and a dispatched one are indistinguishable to
the subscription that called it -- so the listener itself was invisible to the
suite. The cases around it drive `_exec_cmd` (the dispatch body) and
`validate_command` (the wire validator) on either side, which left three
properties of the listener unpinned.

`_on_cmd` is where a command stops being bytes and becomes work, so those three
properties are the ones that decide whether a malformed sample can be read as a
command, whether a wedged command can stall the subscription, and whether a
response reaches the peer that asked.

## What this pins

3 test functions (6 cases) in `tests/mesh/test_mesh_rpc.py`, driven with a raw
sample the way a live subscription would deliver one:

| Property | Case |
| --- | --- |
| Valid JSON that is not an object is dropped before any field is read | `test_on_cmd_drops_a_non_mapping_payload` (4 cases: array, string, number, `null`) |
| A well-formed foreign command reaches `_exec_cmd` with the decoded payload, and answers on the requester's turn-scoped key | `test_on_cmd_dispatches_a_foreign_command_to_exec` |
| The dispatch runs on its own daemon thread named after the sending peer | `test_on_cmd_dispatch_thread_is_a_daemon` |

The non-mapping case asserts the absence of **both** effects, not just the
absence of a raise: no dispatch is recorded and no response is published. A
listener that returned early without dispatching, but had already published, would
pass a status-only assertion.

## Mutation table

Five plausible regressions applied to `_on_cmd`, each run against the new cases
and against the 41 pre-existing cases in the same module. Anchors were scoped to
the enclosing function by AST line range (`in_fn=1` for all five) and the source
restored byte-identically afterwards.

| # | Regression | New cases | 41 pre-existing |
| --- | --- | --- | --- |
| M1 | Drop the non-mapping guard | 4 failed | 0 failed |
| M2 | Make the dispatch thread non-daemon | 1 failed | 0 failed |
| M3 | Dispatch synchronously on the callback thread | 1 failed | 0 failed |
| M4 | Drop the peer scope from the thread name | 1 failed | 0 failed |
| M5 | Drop the self-echo guard | 1 failed | 3 failed |

M5 is already held by the pre-existing cases, which is why these deliberately do
not restate it -- reporting that row is what makes the other four credible. M2 and
M3 are the two a structural check cannot see: both keep the dispatch call, and
only its **threading** changes.

M2 is the one worth reading twice. A non-daemon dispatch thread means a single
wedged command holds interpreter exit open, which is the shape that turns a red
test into a hung job rather than a failure.

## Gate

Run on an aarch64 Jetson Thor node, `MUJOCO_GL=egl`, against merge-base
`03a6759f`, which is also the current `upstream/main` -- so the gated tree is the
merge result. `behind_by` is 0 and the overlap check reports no overlap.

| Check | Result |
| --- | --- |
| `pytest tests` | 29824 passed, 266 skipped, 0 failed (683s) |
| Collected-count delta | 30084 to 30090, exactly the 6 new cases |
| `tests/mesh` | 3153 passed, 0 failed |
| Repo-wide guards + this module | 479 passed |
| `ruff check` / `ruff format --check` | clean, 1221 files |
| `mypy strands_robots tests tests_integ` | 0 errors outside `examples/isaac_gs` |
| `scripts/assemble_changelog.py --check` | OK |

The suite total reconciles arithmetically: 29824 passed plus 266 skipped is
30090, the branch collected count, and the base's own 29818 plus 6 is 29824.

The 14 `examples/isaac_gs` mypy errors are environmental on this node -- the error
set is byte-identical to a pristine worktree at the same base, so none is
introduced here.

## Scope

Tests and a changelog fragment only. `git diff --numstat upstream/main HEAD --
strands_robots/` is empty, so no policy, simulation, rendering, recording,
dataset or asset behaviour changes and there is nothing to show in a rollout.

Because the production code is correct, these cases pass on unmodified `main`.
What they fail on is a regression, and the mutation table is that evidence.

Not in scope: `_exec_cmd`'s own dispatch body and `validate_command`'s domain,
both already covered by the cases around this listener.
