### PR TITLE
fix(policies/groot): apply the service-mode key mappings instead of discarding them

### DIFF
--- a/changelog.d/2265-groot-service-mapping-discarded.md
+++ b/changelog.d/2265-groot-service-mapping-discarded.md
@@ -1,0 +1,34 @@
+### Fixed: a GR00T service-mode key mapping is applied instead of discarded
+
+`Gr00tPolicy` accepts `observation_mapping` and `action_mapping` on both
+transports, and they are the only way to drive a model whose channel names
+differ from the robot's. Resolving them ran only after a local model loaded, so
+on the service transport both were stored and never parsed -- and neither
+consumer of an unparsed mapping reported anything.
+
+The observation half is the damaging one. The flat wire builder looked every
+channel `data_config` declares up under the model's own name, so a robot naming
+its camera `wrist_cam` for `video.wrist` matched nothing: measured on a service
+policy carrying both mappings, the payload sent to the server was the
+instruction alone -- no video and no state, under a successful call, with the
+policy reporting an action chunk built from whatever the server does with an
+empty observation. The action half fails one layer on: `_unpack_service_actions`
+skips renaming on a falsy mapping, so the caller's requested actuator names were
+absent from the returned steps and the bare model keys were returned in their
+place.
+
+Both mappings are now parsed on either transport, since each is a rename over a
+flat dict and needs no model to read. What service mode still cannot do is
+*infer* a mapping it was not given, or cross-check one against the model's
+declared channels -- both read `modality_configs`, which only a loaded local
+policy exposes -- so an omitted mapping stays unresolved rather than acquiring an
+inferred mapping that nothing could validate, and a caller who passed none sends
+and receives exactly what they did before.
+
+The mapping is applied inside the flat wire builder rather than by switching
+which builder runs. The nested `{"video": ..., "state": ...}` observation is what
+the in-process Isaac-GR00T policy takes; every server version this client dials
+reads the flat dotted keys, so selecting a robot key must not also decide the
+payload's shape. A mapping that names only some channels adds those and leaves
+the rest resolving by name, so no channel that reaches the server without a
+mapping stops reaching it because one was supplied.

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -436,7 +436,6 @@ class Gr00tPolicy(Policy):
             self._mode = "local"
             logger.info("GR00T local mode, model=%s", model_path)
             self._load_local_policy(model_path, embodiment_tag, device)
-            self._init_mappings()
         else:
             self._mode = "service"
             # ``port`` addresses the inference service this client dials, so a
@@ -452,6 +451,10 @@ class Gr00tPolicy(Policy):
             # Resolve api_token from env var if not provided as parameter
             resolved_token = api_token or os.environ.get("GROOT_API_TOKEN")
             self._client = Gr00tInferenceClient(host=host, port=port, api_token=resolved_token)
+
+        # Both transports resolve the caller's mappings. Parsing one needs no
+        # model - see :meth:`_init_mappings` for what service mode cannot do.
+        self._init_mappings()
 
         logger.info(
             "GR00T ready [mode=%s, version=%s, config=%s]",
@@ -476,8 +479,19 @@ class Gr00tPolicy(Policy):
     # Mapping initialization
 
     def _init_mappings(self) -> None:
-        """Initialize observation/action mappings after model load."""
+        """Resolve the observation/action mappings on either transport.
+
+        A mapping the caller supplied is a rename over flat dicts, so it is
+        parsed whether or not a model is loaded. What service mode cannot do
+        is *infer* a mapping it was not given, or cross-check one against the
+        model's declared channels: both read ``modality_configs``, which only
+        a loaded local policy exposes. So service mode resolves exactly what
+        the caller declared and nothing more, and an absent mapping stays
+        ``None`` there rather than acquiring an inferred one it could not
+        validate.
+        """
         if self._local_policy is None:
+            self._init_service_mappings()
             return
 
         mmc = self._get_modality_configs()
@@ -516,6 +530,42 @@ class Gr00tPolicy(Policy):
             self._obs_mapping.state,
             self._action_mapping.actions,
         )
+
+    def _init_service_mappings(self) -> None:
+        """Parse the caller's mappings with no model to validate against.
+
+        Only the parsers run here. Both are pure over the flat dict the
+        caller passed, so neither needs the model's declared channels -
+        whereas ``_auto_infer_observation_mapping`` and
+        ``_auto_infer_action_mapping`` do, which is why an omitted mapping
+        stays ``None`` instead of being inferred. A ``None`` mapping is the
+        signal both service consumers read to mean "send and return the
+        channels ``data_config`` declares, under their own names", so
+        leaving it unset is what keeps an unmapped caller unaffected.
+        """
+        if self._raw_obs_mapping is not None:
+            parsed = _parse_observation_mapping(self._raw_obs_mapping)
+            # ``_parse_observation_mapping`` falls back to ``"task"`` for the
+            # language key when it cannot read the model's. ``data_config``
+            # declares the key for the embodiment the caller named, and it is
+            # already the key the flat wire builder sends the instruction
+            # under, so prefer it over that fallback and keep an explicit
+            # ``language_key=`` above both.
+            lang = self._language_key_override or (
+                self.data_config.language_keys[0] if self.data_config.language_keys else parsed.language_key
+            )
+            self._obs_mapping = ObservationMapping(video=parsed.video, state=parsed.state, language_key=lang)
+
+        if self._raw_action_mapping is not None:
+            self._action_mapping = _parse_action_mapping(self._raw_action_mapping)
+
+        if self._obs_mapping is not None or self._action_mapping is not None:
+            logger.info(
+                "Service mappings (unvalidated - no model to check against): obs_video=%s, obs_state=%s, actions=%s",
+                self._obs_mapping.video if self._obs_mapping else None,
+                self._obs_mapping.state if self._obs_mapping else None,
+                self._action_mapping.actions if self._action_mapping else None,
+            )
 
     def _get_modality_configs(self) -> dict | None:
         """Get the model's per-embodiment modality configs.
@@ -892,12 +942,15 @@ class Gr00tPolicy(Policy):
     def _service_get_actions(self, robot_obs: dict[str, Any], instruction: str) -> list[dict[str, Any]]:
         """Service mode: build observation, call server, unpack."""
         assert self._client is not None, "Service client not initialized"
-        if self._obs_mapping is not None:
-            wire_obs = self._prepare_observation(robot_obs, instruction)
-            action_chunk = self._client.get_action(wire_obs)
-        else:
-            wire_obs = self._build_service_observation(robot_obs, instruction)
-            action_chunk = self._client.get_action(wire_obs)
+        # One builder, whether or not a mapping was supplied.
+        # :meth:`_prepare_observation` produces the nested
+        # ``{"video": {...}, "state": {...}}`` observation the in-process
+        # Isaac-GR00T policy takes; every server version this client dials
+        # expects the flat dotted keys :meth:`_build_service_observation`
+        # emits, so the mapping is applied inside that builder rather than by
+        # switching transports' payload shape.
+        wire_obs = self._build_service_observation(robot_obs, instruction)
+        action_chunk = self._client.get_action(wire_obs)
 
         # #187 wire-payload diagnostic: capture (wire_obs, action_chunk)
         # for offline diff against the LOCAL path. Zero overhead when
@@ -907,6 +960,48 @@ class Gr00tPolicy(Policy):
         self._maybe_dump_wire_payload("service", wire_obs, action_chunk)
 
         return self._unpack_service_actions(action_chunk)
+
+    def _wire_sources(self, prefix: str, declared: list[str]) -> dict[str, str]:
+        """Resolve ``{wire key: robot observation key}`` for one modality.
+
+        The service wire format is flat and dotted (``video.image``), so an
+        ``observation_mapping`` is honoured by naming the robot key each wire
+        key draws from - not by nesting, which is what
+        :meth:`_prepare_observation` does for the local transport. Two
+        sources, in precedence order:
+
+        1. The caller's mapping, which is authoritative and is the only way
+           to reach a wire key whose robot-side name differs from the model's.
+        2. ``data_config``'s declared keys, under the identity assumption that
+           the robot names a channel exactly as the model does.
+
+        The identity pass is a fallback rather than a replacement, so a
+        mapping that names only some channels *adds* those and leaves the
+        rest resolving as they did: no channel that reaches the server
+        without a mapping stops reaching it because one was supplied. That
+        differs deliberately from the local transport, which sends only what
+        the mapping names and zero-fills the remaining declared channels -
+        zero-filling needs the model's per-key DOF, which this transport
+        cannot read, and sending the robot's real value beats inventing one.
+
+        Args:
+            prefix: The modality's wire-key prefix, ``"video."`` or
+                ``"state."``.
+            declared: ``data_config``'s wire keys for that modality.
+
+        Returns:
+            Wire key to robot observation key. Keys the observation does not
+            carry are included; the caller skips them.
+        """
+        mapping = self._obs_mapping
+        sources: dict[str, str] = {}
+        if mapping is not None:
+            mapped = mapping.video if prefix == "video." else mapping.state
+            for robot_key, model_key in mapped.items():
+                sources[f"{prefix}{model_key}"] = robot_key
+        for wire_key in declared:
+            sources.setdefault(wire_key, wire_key.removeprefix(prefix))
+        return sources
 
     def _build_service_observation(self, robot_obs: dict[str, Any], instruction: str) -> dict:
         """Build flat-key observation for legacy service servers.
@@ -939,10 +1034,9 @@ class Gr00tPolicy(Policy):
         video_keys: list[str] = []
         state_keys: list[str] = []
 
-        for vk in self.data_config.video_keys:
-            bare = vk.removeprefix("video.")
-            if bare in robot_obs:
-                obs[vk] = robot_obs[bare]
+        for vk, robot_key in self._wire_sources("video.", self.data_config.video_keys).items():
+            if robot_key in robot_obs:
+                obs[vk] = robot_obs[robot_key]
                 video_keys.append(vk)
         # Match Isaac-GR00T training preprocessing for embodiments that need
         # it - see :func:`_apply_image_rotation_180_inplace` for the algebra.
@@ -951,10 +1045,9 @@ class Gr00tPolicy(Policy):
         # local-mode inference applies the same rotation.
         if self.data_config.image_rotation_180:
             _apply_image_rotation_180_inplace(obs, video_keys)
-        for sk in self.data_config.state_keys:
-            bare = sk.removeprefix("state.")
-            if bare in robot_obs:
-                arr = np.asarray(robot_obs[bare], dtype=np.float32)
+        for sk, robot_key in self._wire_sources("state.", self.data_config.state_keys).items():
+            if robot_key in robot_obs:
+                arr = np.asarray(robot_obs[robot_key], dtype=np.float32)
                 # Scalars (joint readings, gripper pose components, …)
                 # arrive as 0-D arrays. Promote to (D=1,) so the newaxis
                 # loop below produces the canonical (B, [T,] D) shape
@@ -984,7 +1077,16 @@ class Gr00tPolicy(Policy):
         """Unpack service response into per-timestep dicts.
 
         Applies ``_action_mapping`` if available (consistent with local mode),
-        otherwise returns bare model keys.
+        otherwise returns bare model keys. The falsy branch is reached by a
+        caller who supplied no ``action_mapping``: on this transport an
+        omitted mapping is not inferred, because inferring one needs the
+        model's declared channels. A mapping that *was* supplied is applied
+        here without that cross-check - ``ActionMapping.validate`` reads the
+        same modality configs, so service mode honours the rename it was
+        given and cannot tell the caller that a target channel is misspelled.
+        A key the mapping does not name is returned under
+        ``unmapped.<key>`` rather than dropped, so a partial or wrong mapping
+        is visible in the result instead of silently losing actuators.
         """
         normalized: dict = {}
         for key, value in action_chunk.items():

--- a/tests/policies/groot/test_service_mapping_is_applied.py
+++ b/tests/policies/groot/test_service_mapping_is_applied.py
@@ -1,0 +1,282 @@
+"""A GR00T service-mode caller's key mappings are honoured, not discarded.
+
+``Gr00tPolicy`` accepts ``observation_mapping`` and ``action_mapping`` on both
+transports, and they are the only way to drive a model whose channel names
+differ from the robot's. Resolving them was reached only after a local model
+loaded, so on the service transport both were stored and never parsed - and
+neither consumer of an unparsed mapping reports anything:
+
+* the flat wire builder looked every declared channel up under the model's own
+  name, so a robot naming its camera ``wrist_cam`` for ``video.wrist`` matched
+  nothing and the payload carried the instruction alone - a server receiving no
+  video and no state at all, under a successful call;
+* the action unpacker skips renaming on a falsy mapping, so the caller's
+  requested actuator names were absent from the returned steps.
+
+Both halves are silent, which is what these cases pin. The mapped-channel
+assertions are the load-bearing ones; the unmapped-caller cases are controls
+against the opposite error, resolving *more* than the caller declared.
+
+Nothing here needs the ``groot-service`` extra: the client is replaced with a
+recorder before construction, so the real ``__init__`` runs - which is where
+mapping resolution is wired - without a ZMQ socket. Routing these through the
+extra would skip them exactly where a service-mode user is most likely to be.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.groot import policy as policy_mod
+from strands_robots.policies.groot.policy import Gr00tPolicy
+
+#: ``so100`` declares one camera and two state channels, none of which the
+#: mapped observations below name - so an ignored mapping resolves nothing and
+#: an honoured one resolves exactly what it declares.
+_DECLARED_VIDEO = "video.webcam"
+_DECLARED_STATE = ("state.single_arm", "state.gripper")
+_DECLARED_LANG = "annotation.human.task_description"
+
+_MAPPING_OBS = {"wrist_cam": "video.wrist", "arm_joints": "state.arm"}
+_MAPPING_ACTION = {"action.arm": "joints"}
+
+
+class _RecordingClient:
+    """Stands in for ``Gr00tInferenceClient``; records the payload sent."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.sent: list[dict] = []
+
+    def get_action(self, observations: dict) -> dict:
+        self.sent.append(observations)
+        return {"action.arm": np.zeros((1, 2, 3), dtype=np.float32)}
+
+
+@pytest.fixture
+def service_policy(monkeypatch):
+    """Build a service-mode policy whose client records instead of dialling."""
+
+    def _build(**kwargs) -> Gr00tPolicy:
+        monkeypatch.setattr(policy_mod, "Gr00tInferenceClient", _RecordingClient)
+        return Gr00tPolicy(data_config="so100", host="localhost", port=19999, **kwargs)
+
+    return _build
+
+
+def _mapped_observation() -> dict[str, Any]:
+    """Robot-side names from ``_MAPPING_OBS``, none of them model names."""
+    return {
+        "wrist_cam": np.zeros((8, 8, 3), dtype=np.uint8),
+        "arm_joints": [0.1, 0.2, 0.3],
+    }
+
+
+def _identity_observation() -> dict[str, Any]:
+    """Robot names each channel exactly as ``so100`` declares it."""
+    return {
+        "webcam": np.zeros((8, 8, 3), dtype=np.uint8),
+        "single_arm": [0.0, 0.1, 0.2, 0.3, 0.4],
+        "gripper": 0.5,
+    }
+
+
+class TestASuppliedMappingIsResolved:
+    """Service mode parses what the caller declared."""
+
+    def test_a_supplied_observation_mapping_is_parsed(self, service_policy):
+        p = service_policy(observation_mapping=_MAPPING_OBS)
+
+        assert p._obs_mapping is not None, "the observation mapping was stored and never parsed"
+        assert p._obs_mapping.video == {"wrist_cam": "wrist"}
+        assert p._obs_mapping.state == {"arm_joints": "arm"}
+
+    def test_a_supplied_action_mapping_is_parsed(self, service_policy):
+        p = service_policy(action_mapping=_MAPPING_ACTION)
+
+        assert p._action_mapping is not None, "the action mapping was stored and never parsed"
+        assert p._action_mapping.actions == {"arm": "joints"}
+
+    def test_the_language_key_is_the_embodiment_key(self, service_policy):
+        """Not the parser's ``"task"`` fallback, which no ``so100`` server reads.
+
+        The fallback exists for a caller whose model declares the key, which is
+        unreadable here. ``data_config`` names it for the embodiment the caller
+        asked for, and it is already the key the instruction is sent under.
+        """
+        p = service_policy(observation_mapping=_MAPPING_OBS)
+
+        assert p._obs_mapping is not None
+        assert p._obs_mapping.language_key == _DECLARED_LANG
+
+    def test_an_explicit_language_key_outranks_the_embodiment_key(self, service_policy):
+        p = service_policy(observation_mapping=_MAPPING_OBS, language_key="instruction")
+
+        assert p._obs_mapping is not None
+        assert p._obs_mapping.language_key == "instruction"
+
+
+class TestTheMappedChannelsReachTheServer:
+    """The payload carries the robot's data under the model's names."""
+
+    def test_mapped_video_and_state_are_sent(self, service_policy):
+        p = service_policy(observation_mapping=_MAPPING_OBS)
+
+        wire = p._build_service_observation(_mapped_observation(), "pick the cube")
+
+        assert "video.wrist" in wire, "mapped camera never reached the wire"
+        assert "state.arm" in wire, "mapped state never reached the wire"
+        np.testing.assert_allclose(np.asarray(wire["state.arm"]).ravel(), [0.1, 0.2, 0.3])
+
+    def test_the_payload_is_more_than_the_instruction(self, service_policy):
+        """Non-vacuity: the discarded-mapping payload was the language key alone.
+
+        Asserted as the whole key set rather than a count, so a payload that
+        regains a key by some other route does not satisfy it.
+        """
+        p = service_policy(observation_mapping=_MAPPING_OBS)
+
+        wire = p._build_service_observation(_mapped_observation(), "pick the cube")
+
+        assert set(wire) == {"video.wrist", "state.arm", _DECLARED_LANG}
+
+    def test_a_mapped_state_channel_is_float32_with_a_component_axis(self, service_policy):
+        """The mapped path applies the same coercions the identity path does.
+
+        A server rejects ``float64`` state, and a scalar reading must carry a
+        component axis, so a mapping that reached the wire without these would
+        be honoured into a payload the server refuses.
+        """
+        p = service_policy(observation_mapping={"grip": "state.gripper"})
+
+        wire = p._build_service_observation({"grip": 0.5}, "t")
+
+        assert wire["state.gripper"].dtype == np.float32
+        assert wire["state.gripper"].shape == (1, 1)
+
+    def test_the_mapping_does_not_change_the_payload_shape(self, service_policy):
+        """A mapped payload is flat and dotted, like an unmapped one.
+
+        The nested ``{"video": {...}, "state": {...}}`` observation is what the
+        in-process Isaac-GR00T policy takes; every server version this client
+        dials reads the flat form. A mapping selects *which* robot key feeds a
+        wire key, so it must not decide the payload's shape - a nested payload
+        would leave a mapped caller as unable to reach the model as an ignored
+        mapping did.
+        """
+        p = service_policy(observation_mapping=_MAPPING_OBS)
+
+        p._service_get_actions(_mapped_observation(), "pick the cube")
+
+        assert isinstance(p._client, _RecordingClient)
+        sent = p._client.sent[0]
+        assert "video" not in sent and "state" not in sent, "the nested local-transport payload was sent"
+        assert "video.wrist" in sent
+
+
+class TestASuppliedActionMappingRenamesTheResult:
+    """The returned steps use the caller's actuator names."""
+
+    def test_the_mapped_actuator_name_is_returned(self, service_policy):
+        p = service_policy(action_mapping=_MAPPING_ACTION)
+
+        steps = p._unpack_service_actions({"action.arm": np.zeros((1, 2, 3), dtype=np.float32)})
+
+        assert steps, "no steps unpacked"
+        assert "joints" in steps[0], "the caller's actuator name is absent from the step"
+        assert "arm" not in steps[0], "the bare model key was returned alongside the mapped one"
+
+    def test_a_channel_the_mapping_omits_is_named_unmapped(self, service_policy):
+        """A partial mapping loses no actuator; the surplus is visible.
+
+        Returning the omitted channel under its bare name would make a wrong
+        mapping indistinguishable from a right one at the call site.
+        """
+        p = service_policy(action_mapping=_MAPPING_ACTION)
+
+        steps = p._unpack_service_actions(
+            {
+                "action.arm": np.zeros((1, 2, 3), dtype=np.float32),
+                "action.gripper": np.zeros((1, 2, 1), dtype=np.float32),
+            }
+        )
+
+        assert "joints" in steps[0]
+        assert "unmapped.gripper" in steps[0]
+
+
+class TestAnUnmappedCallerIsUnaffected:
+    """Controls against resolving more than the caller declared."""
+
+    def test_an_omitted_mapping_is_not_inferred(self, service_policy):
+        """Inference reads the model's declared channels, which are unreadable.
+
+        A mapping guessed here could not be validated against anything, and
+        ``None`` is the signal both consumers read to mean "use the names
+        ``data_config`` declares" - so acquiring one would change an unmapped
+        caller's payload rather than leave it alone.
+        """
+        p = service_policy()
+
+        assert p._obs_mapping is None
+        assert p._action_mapping is None
+
+    def test_the_declared_channels_still_resolve_by_name(self, service_policy):
+        p = service_policy()
+
+        wire = p._build_service_observation(_identity_observation(), "pick the cube")
+
+        assert set(wire) == {_DECLARED_VIDEO, *_DECLARED_STATE, _DECLARED_LANG}
+
+    def test_an_unmapped_action_chunk_returns_bare_model_keys(self, service_policy):
+        p = service_policy()
+
+        steps = p._unpack_service_actions({"action.arm": np.zeros((1, 2, 3), dtype=np.float32)})
+
+        assert "arm" in steps[0]
+
+    def test_a_partial_mapping_leaves_the_other_channels_resolving(self, service_policy):
+        """The mapping adds the channels it names; it does not replace the set.
+
+        The local transport sends only what the mapping names and zero-fills
+        the rest, which needs the model's per-key DOF. This transport cannot
+        read it, so an omitted channel keeps resolving by name rather than
+        being dropped or invented: a caller who renames one channel does not
+        lose the others for it.
+
+        The mapping here is partial *within* the state modality, not merely
+        across the two. A mapping that replaced its own modality's declared
+        set would still leave the untouched modality resolving, so a case
+        that renames only a camera cannot observe the difference: with one
+        state channel renamed and its sibling not, dropping the sibling is
+        what the replacing behaviour costs.
+        """
+        p = service_policy(observation_mapping={"arm_joints": "state.single_arm"})
+
+        wire = p._build_service_observation(
+            {
+                "arm_joints": [0.0, 0.1, 0.2, 0.3, 0.4],
+                "gripper": 0.5,
+                "webcam": np.zeros((8, 8, 3), dtype=np.uint8),
+            },
+            "pick the cube",
+        )
+
+        assert set(wire) == {_DECLARED_VIDEO, *_DECLARED_STATE, _DECLARED_LANG}
+
+    def test_the_mapping_outranks_the_identity_name_for_one_wire_key(self, service_policy):
+        """When both could feed a wire key, the declared mapping wins.
+
+        Otherwise a caller could not override a channel the robot happens to
+        name as the model does, and which of the two was sent would depend on
+        iteration order rather than on what was asked for.
+        """
+        p = service_policy(observation_mapping={"wrist_cam": "video.webcam"})
+
+        mapped = np.full((8, 8, 3), 7, dtype=np.uint8)
+        decoy = np.zeros((8, 8, 3), dtype=np.uint8)
+        wire = p._build_service_observation({"wrist_cam": mapped, "webcam": decoy}, "t")
+
+        np.testing.assert_array_equal(np.asarray(wire[_DECLARED_VIDEO]).squeeze(), mapped)


### PR DESCRIPTION
> **Superseded and closed in favour of #2267, and one premise below is measurably wrong. Read this note before reusing anything here.**
>
> This description argues that the nested-payload branch in `_service_get_actions` was not merely unreachable but *wrong*, on the grounds that "every server version this client dials reads flat dotted keys". **That is false, and the counter-evidence was already in the tree.** `tests_integ/groot/test_groot_integration.py::_make_gr1_server_observation` sends the nested `{"video": {...}, "state": {...}, "language": {...}}` payload at `(B=1, T=1, ...)` to a live `nvidia/GR00T-N1.6-3B` server and asserts a usable action chunk back, and `_build_service_observation` documents itself as being for *legacy* service servers. So the nested shape is a format a live server accepts, the branch was **unreachable rather than wrong**, and deleting it was the wrong call. #2267 keeps it and pins the shape instead.
>
> Everything else here reproduced as written and was independently confirmed in review: the defect, the measurement that a mapped service request sent the instruction alone, the discarded action half, the 15 pins with 12 failing pre-fix, and the six mutations. #2267 reaches the same diagnosis and the same treatment of inference and `validate()`, and additionally pins two properties this branch did not: a malformed mapping refused at construction, and a supplied mapping surviving unreadable modality configs.
>
> The one gap #2267 leaves -- a renamed channel has no working combination with a legacy flat-key server, which the `_wire_sources` helper below is a reasonable shape for -- is now tracked as **#2269** rather than left in a comment on a closed pull request. The branch (`dd43f789`) is left in place for it.
>
> Not reopened: the direction was reconsidered on evidence, and the claim was mine to correct.

---

Closes #2265

## What

`Gr00tPolicy` accepts `observation_mapping` and `action_mapping` on both transports, and they are the only way to drive a model whose channel names differ from the robot's. Resolving them ran only after a local model loaded, so on the service transport **both were stored and never parsed** -- and neither consumer of an unparsed mapping reports anything.

```python
# strands_robots/policies/groot/policy.py, _init_mappings
if self._local_policy is None:
    return                      # <- service mode left here; both parsers sit below
```

Measured on a service policy carrying both mappings, before this change:

| attribute | value |
| --- | --- |
| `_raw_obs_mapping` | `{'wrist_cam': 'video.wrist', 'arm_joints': 'state.arm'}` |
| `_raw_action_mapping` | `{'action.arm': 'joints'}` |
| `_obs_mapping` | **None** |
| `_action_mapping` | **None** |
| wire payload keys | **`['annotation.human.task_description']`** |
| unpacked step 0 | `{'arm': [0.0, 0.0, 0.0]}` |

The payload is the instruction **alone**: no video, no state, under a successful call. The flat wire builder looked every channel `data_config` declares up under the model's own name, so a robot naming its camera `wrist_cam` for `video.wrist` matched nothing and the loop wrote no key. The action half fails one layer on -- `_unpack_service_actions` skips renaming on a falsy mapping, so the caller's `joints` is absent and the bare model key `arm` is returned in its place.

After, same policy and same observation:

| | before | after |
| --- | --- | --- |
| wire payload keys | `annotation.human.task_description` | `video.wrist`, `state.arm`, `annotation.human.task_description` |
| unpacked step 0 | `{'arm': ...}` | `{'joints': ...}` |

## The issue understated the scope by half

The issue proposed moving the parse above the early-out. That is necessary and not sufficient.

**The action mapping is discarded too.** `_parse_action_mapping` is called *below* the same early-out, so it never runs in service mode either. Both raw dicts are stored, neither is parsed. The two consumers of a `None` also disagree: the local path asserts (`assert self._action_mapping is not None`), the service path guards on truthiness and silently skips the renaming loop.

**On the second direction this section originally argued -- that parsing alone activates a wrong-shaped payload -- see the correction at the top.** The branch was unreachable, and no test in `tests/` or `tests_integ/` calls `_service_get_actions`, but it was not wrong: a live N1.6 server accepts the nested shape.

## Shape of the change

- `_init_mappings` runs on both transports (one call site, moved below the mode branch). It dispatches to `_init_service_mappings` when no local policy is loaded.
- `_init_service_mappings` runs **only the two parsers**. Both are pure over the flat dict the caller passed. `_auto_infer_observation_mapping` / `_auto_infer_action_mapping` and both `validate` calls are *not* lifted: they read `modality_configs`, which only a loaded local policy exposes. So an omitted mapping stays `None` rather than acquiring an inferred one nothing could validate, and a caller who passed none is byte-for-byte unaffected.
- `_wire_sources(prefix, declared)` resolves `{wire key: robot observation key}` from two sources -- the caller's mapping (authoritative), then `data_config`'s declared keys under the identity assumption. Both the video and state loops read it, so the mapped path inherits the existing `float32` cast and 0-D component-axis promotion rather than needing its own. **This helper is the part worth salvaging, and #2269 tracks it.**
- `_unpack_service_actions` needed no code change; its docstring now states what the falsy branch means and that a supplied mapping is honoured **without** the modality-config cross-check.

### The identity pass is a fallback, not a replacement

A mapping that names only some channels *adds* those and leaves the rest resolving by name, so no channel that reaches the server without a mapping stops reaching it because one was supplied. This differs deliberately from the local transport, which sends only what the mapping names and zero-fills the remaining declared channels: zero-filling needs the model's per-key DOF, which the flat transport cannot read. Recorded in `_wire_sources`' docstring.

## Verification

15 cases in `tests/policies/groot/test_service_mapping_is_applied.py`. **12 fail on pre-fix source**; the 3 that pass are the no-over-reach controls, which must pass on both sides. Independently reproduced in review at `dd43f789`.

Nothing in the file needs the `groot-service` extra: the client is replaced with a recorder before construction, so the real `__init__` runs -- which is where mapping resolution is wired -- with no ZMQ socket.

### What the pins catch

| mutation | this module |
| --- | --- |
| service mode never resolves (revert the `__init__` call) | **12 of 15 fail** |
| identity outranks the mapping (precedence flipped) | **3 of 15 fail** |
| nested local payload sent over the wire | **1 of 15 fails** |
| mapping replaces the declared set (identity fallback dropped) | **1 of 15 fails** |
| service mode infers a mapping it was not given | **1 of 15 fails** |
| language key left at the parser's `"task"` fallback | **1 of 15 fails** |

The replaces-the-set row needed a second attempt, and the first version of the suite **missed it entirely -- 15 of 15 passed**. `_wire_sources` is called once per modality, so a mapping naming only a camera leaves the state modality unmapped, where the identity pass still runs: partial *across* modalities cannot observe the difference. The case now renames one state channel and leaves its sibling unmapped.

### Suite

```
ruff format --check / ruff check   clean on both touched files
mypy                              no findings in either touched file
python scripts/assemble_changelog.py --check    changelog fragments OK
```

Read as a delta, since this environment has no `mujoco`, `torch`, `strands` or Isaac:

| run | result |
| --- | --- |
| whole `tests/` on this branch | 333 failed, **16366 passed**, 1290 skipped, 765 errors |
| whole `tests/` on the unmerged base | 333 failed, **16351 passed**, 1290 skipped, 765 errors |

Identical failure, skip and error counts; `+15 passed` is exactly the new pins.

## Intake

```
$ python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --issue 2265
Outcome: unique-claim  (#2265 is claimed by no open pull request)
```

Asked twice -- at intake and again immediately before the first push -- and `unique-claim` both times. #2267 opened inside the window between the last read and the push, which is the residual interval #2031 describes and the fourth measured instance of it on this account.

News fragment: `changelog.d/2265-groot-service-mapping-discarded.md` (`### Fixed`).

## §13 changelog

- **Round 0** -- initial. Both mappings parsed on either transport; the flat wire builder honours the observation mapping via `_wire_sources`; the nested-payload branch in `_service_get_actions` removed; `_unpack_service_actions` docstring states the missing cross-check. 15 pins, 12 failing pre-fix, 6 mutations measured.
- **Round 1** -- closed as the duplicate half of a two-PR claim on #2265. Description corrected at the top: the premise that every server reads flat dotted keys is false, refuted by the live-server integration test already in the tree, so removing the nested branch was wrong and #2267's direction is better founded. Salvage recorded as #2269 rather than left in a comment on a closed pull request. No code pushed.
