### PR TITLE
fix(policies/groot): honour observation/action mappings in service mode

### DIFF
--- a/changelog.d/2265-groot-service-mapping-discarded.md
+++ b/changelog.d/2265-groot-service-mapping-discarded.md
@@ -1,0 +1,46 @@
+### Fixed: a GR00T service-mode policy now honours the observation and action mappings it accepts
+
+`Gr00tPolicy(observation_mapping=..., action_mapping=...)` is the documented
+escape hatch for a robot whose observation keys do not match the conventional
+patterns automatic inference recognises. Both mappings were stored raw at
+construction and parsed only after a **local** model load, so a service-mode
+policy (`host=`/`port=`) discarded both: the request went to the inference
+server carrying the task string and **no video and no state at all**, and the
+returned action chunk kept the model's bare key names.
+
+Measured against a server whose keys are `video.wrist` / `state.arm` and a robot
+whose own keys are `wrist_cam` / `arm_joints` -- the case the mapping exists for,
+since auto-inference could never bridge those names:
+
+| supplying the mapping | video keys on the wire | state keys on the wire | action keys returned |
+| --- | --- | --- | --- |
+| before | 0 | 0 | `arm` |
+| after | 1 (`wrist`) | 1 (`arm`) | `joints` |
+
+Nothing reported the loss. Construction returned normally, and the two service
+consumers disagreed about the unparsed value in ways that were each individually
+quiet: the observation half fell through to the flat legacy payload builder,
+while the action half was skipped by a truthiness guard rather than an assertion.
+A caller who read the documentation, supplied the mapping correctly and got a
+successful call had no channel that said the observation had been dropped.
+
+Both parsers are pure over the caller's own flat dict -- the video/state split
+and the action renaming come from the `video.` / `state.` / `action.` prefixes of
+its values -- so neither ever needed the model, and both now run in either mode.
+Two consequences follow. A malformed mapping value is refused at construction in
+service mode with the message local mode has always produced, instead of being
+silently ignored. And a local policy whose modality configs cannot be read now
+honours a supplied mapping too, rather than dropping it and failing later on an
+assertion.
+
+What still requires the model is everything that *cross-checks* a mapping
+against it: `validate()`, state-DOF discovery, and the auto-inference used when a
+mapping is omitted. So a service-mode mapping is honoured as written and a key
+the server does not have surfaces as a server-side error rather than a
+constructor refusal, and an omitted mapping deliberately stays unset rather than
+acquiring an inferred mapping that could not be validated -- which is what keeps
+the no-mapping service path behaving exactly as before.
+
+The instruction stays addressed to the key the data config declares, which is the
+key the unmapped service path already sent, so enabling a mapping moves the video
+and state onto the wire without relocating the language input.

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -40,11 +40,11 @@ Gr00tPolicy(
 
 ## Strict key matching
 
-When no explicit `observation_mapping`/`action_mapping` is given, GR00T
-auto-infers the robot<->model key mapping: exact name matches first, then
-positional fallback for any leftover keys (with a log line). On a
-multi-camera or multi-DOF rig, positional fallback can silently bind the
-wrong camera or action column. Pass `strict_keys=True` to raise a
+When no explicit `observation_mapping`/`action_mapping` is given, a
+**local-mode** policy auto-infers the robot<->model key mapping: exact name
+matches first, then positional fallback for any leftover keys (with a log
+line). On a multi-camera or multi-DOF rig, positional fallback can silently
+bind the wrong camera or action column. Pass `strict_keys=True` to raise a
 `ValueError` (listing the unmatched robot keys vs available model keys)
 instead of guessing:
 
@@ -55,6 +55,16 @@ policy = create_policy("groot", data_config="so100_dualcam",
 
 `strict_keys` defaults to `False` (positional fallback preserved) and is a
 no-op when an explicit mapping is supplied.
+
+Auto-inference is local-mode only, because it reads the checkpoint's modality
+configs and service mode cannot introspect the remote server. A service-mode
+policy given no mapping therefore infers nothing and sends the keys its
+`data_config` declares, and `strict_keys` has nothing to be strict about
+there. An *explicit* mapping needs no model metadata - the video/state split
+comes from the `video.` / `state.` prefixes of the caller's own values - so it
+is parsed and honoured in **either** mode. What service mode cannot do is
+cross-check it: a mapping naming a key the server does not have surfaces as a
+server-side error rather than a constructor refusal.
 
 ## Versions
 

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -21,7 +21,7 @@ mappings.  No positional guessing.  One step in, one step out.
 import importlib.util
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import numpy as np
@@ -264,11 +264,17 @@ def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool
 # Parse user-provided flat mapping dicts
 
 
-def _parse_observation_mapping(
-    flat: dict[str, str],
-    modality_configs: dict | None = None,
-) -> ObservationMapping:
-    """Parse ``{robot_key: "video.X" | "state.X"}`` → ObservationMapping."""
+def _parse_observation_mapping(flat: dict[str, str]) -> ObservationMapping:
+    """Parse ``{robot_key: "video.X" | "state.X"}`` → ObservationMapping.
+
+    Splits on the caller's own value prefixes and nothing else, so this needs
+    no model metadata and runs in service mode as well as local.
+    ``language_key`` is deliberately left at its default here: which key the
+    instruction is sent under has more sources than this dict (an explicit
+    override, the model, the data config), and
+    :meth:`Gr00tPolicy._resolve_language_key` is the one place that orders
+    them.
+    """
     video: dict[str, str] = {}
     state: dict[str, str] = {}
 
@@ -280,11 +286,7 @@ def _parse_observation_mapping(
         else:
             raise ValueError(f"Mapping value must start with 'video.' or 'state.', got '{model_key}' for '{robot_key}'")
 
-    lang = "task"
-    if modality_configs is not None:
-        lang = modality_configs["language"].modality_keys[0]
-
-    return ObservationMapping(video=video, state=state, language_key=lang)
+    return ObservationMapping(video=video, state=state)
 
 
 def _parse_action_mapping(flat: dict[str, str]) -> ActionMapping:
@@ -367,9 +369,18 @@ class Gr00tPolicy(Policy):
         groot_version: Force ``"n1.5"`` or ``"n1.6"``.
         strict: Strict input validation.
         api_token: ZMQ auth token. Falls back to ``GROOT_API_TOKEN`` env var if not provided.
-        observation_mapping: ``{robot_key: "video.X" | "state.X"}``.
-        action_mapping: ``{"action.X": "robot_key"}``.
-        language_key: Override the model's language key.
+        observation_mapping: ``{robot_key: "video.X" | "state.X"}``. Honoured in
+            either mode: the video/state split comes from the caller's own value
+            prefixes, so no model metadata is needed. Service mode cannot
+            cross-check it against the server, so a key the server does not have
+            surfaces there as a server-side error rather than a refusal here.
+        action_mapping: ``{"action.X": "robot_key"}``. Honoured in either mode,
+            on the same terms.
+        language_key: Override the key the instruction is sent under. Otherwise
+            the model's own language key is used when a local checkpoint is
+            loaded, and in service mode - where there is no model to ask - the
+            key declared by ``data_config``, falling back to ``"task"`` when it
+            declares none.
         strict_keys: When True, raise (instead of warning + positional fallback)
             if auto-inferred observation/action keys cannot be matched to the
             model by exact name. Defaults to False (positional fallback). Ignored
@@ -436,7 +447,6 @@ class Gr00tPolicy(Policy):
             self._mode = "local"
             logger.info("GR00T local mode, model=%s", model_path)
             self._load_local_policy(model_path, embodiment_tag, device)
-            self._init_mappings()
         else:
             self._mode = "service"
             # ``port`` addresses the inference service this client dials, so a
@@ -452,6 +462,10 @@ class Gr00tPolicy(Policy):
             # Resolve api_token from env var if not provided as parameter
             resolved_token = api_token or os.environ.get("GROOT_API_TOKEN")
             self._client = Gr00tInferenceClient(host=host, port=port, api_token=resolved_token)
+
+        # Runs in BOTH modes: a caller-supplied mapping needs no model
+        # metadata, so service mode must reach it too (#2265).
+        self._init_mappings()
 
         logger.info(
             "GR00T ready [mode=%s, version=%s, config=%s]",
@@ -475,37 +489,82 @@ class Gr00tPolicy(Policy):
 
     # Mapping initialization
 
-    def _init_mappings(self) -> None:
-        """Initialize observation/action mappings after model load."""
-        if self._local_policy is None:
-            return
+    def _resolve_language_key(self, modality_configs: dict | None) -> str:
+        """Language key for the observation payload, most specific source first.
 
-        mmc = self._get_modality_configs()
-        if mmc is None:
+        ``language_key=`` wins outright. Failing that the model's own modality
+        config is authoritative, but only a local checkpoint exposes one; a
+        service-mode policy cannot introspect the remote server, so it falls
+        back to this data config's own declaration - the same key
+        :meth:`_build_service_observation` sends on the unmapped path, which is
+        what keeps the mapped and unmapped service payloads addressed to the
+        same place. The ``"task"`` default is last, for a config declaring no
+        language key at all.
+        """
+        if self._language_key_override:
+            return self._language_key_override
+        if modality_configs is not None:
+            return str(modality_configs["language"].modality_keys[0])
+        if self.data_config.language_keys:
+            return self.data_config.language_keys[0]
+        return "task"
+
+    def _init_mappings(self) -> None:
+        """Parse the caller's mappings, and infer/validate what needs the model.
+
+        Both parsers are pure over the caller's own flat dict - the video/state
+        split and the action renaming come from the ``video.`` / ``state.`` /
+        ``action.`` prefixes of its values - so a supplied mapping is parsed
+        here whether or not a model is loaded. It used to be parsed only after
+        a successful local load, which stranded both mappings as raw dicts
+        nothing read: a service-mode request went out carrying the task string
+        and no observation at all, and the already-written mapped arms in
+        :meth:`_service_get_actions` and :meth:`_unpack_service_actions` were
+        unreachable (#2265).
+
+        What needs the model is everything that *cross-checks* a mapping
+        against it: ``validate()``, :meth:`_discover_model_state_dof`, and the
+        auto-inference used when a mapping is omitted. So without modality
+        configs a supplied mapping is honoured as written - a key the server
+        does not have surfaces as a server-side error rather than a constructor
+        refusal - and an omitted one deliberately stays ``None`` rather than
+        acquiring an inferred mapping that could not be validated. ``None`` is
+        the value both service consumers already treat as "send bare model
+        keys", so omitting a mapping keeps today's behaviour exactly.
+        """
+        # Parsed in either mode. A malformed value raises from here, so service
+        # mode now refuses one at construction as local mode always has.
+        if self._raw_obs_mapping is not None:
+            self._obs_mapping = _parse_observation_mapping(self._raw_obs_mapping)
+        if self._raw_action_mapping is not None:
+            self._action_mapping = _parse_action_mapping(self._raw_action_mapping)
+
+        mmc = self._get_modality_configs() if self._local_policy is not None else None
+        if self._local_policy is not None and mmc is None:
             logger.warning("Could not read model modality configs")
+
+        if mmc is None:
+            if self._obs_mapping is not None:
+                self._obs_mapping = replace(self._obs_mapping, language_key=self._resolve_language_key(None))
+            logger.info(
+                "Mappings [no modality configs, unvalidated]: obs_video=%s, obs_state=%s, actions=%s",
+                self._obs_mapping.video if self._obs_mapping is not None else None,
+                self._obs_mapping.state if self._obs_mapping is not None else None,
+                self._action_mapping.actions if self._action_mapping is not None else None,
+            )
             return
 
         self._discover_model_state_dof(mmc)
 
-        # Observation mapping
-        if self._raw_obs_mapping is not None:
-            self._obs_mapping = _parse_observation_mapping(self._raw_obs_mapping, mmc)
-        else:
+        # Observation mapping - a supplied one is already parsed above.
+        if self._obs_mapping is None:
             self._obs_mapping = _auto_infer_observation_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
-        if self._language_key_override:
-            self._obs_mapping = ObservationMapping(
-                video=self._obs_mapping.video,
-                state=self._obs_mapping.state,
-                language_key=self._language_key_override,
-            )
-
+        self._obs_mapping = replace(self._obs_mapping, language_key=self._resolve_language_key(mmc))
         self._obs_mapping.validate(mmc)
 
-        # Action mapping
-        if self._raw_action_mapping is not None:
-            self._action_mapping = _parse_action_mapping(self._raw_action_mapping)
-        else:
+        # Action mapping - a supplied one is already parsed above.
+        if self._action_mapping is None:
             self._action_mapping = _auto_infer_action_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
         self._action_mapping.validate(mmc)

--- a/tests/policies/groot/test_policy.py
+++ b/tests/policies/groot/test_policy.py
@@ -503,16 +503,21 @@ class TestParsing:
     def test_obs(self):
         m = _parse_observation_mapping(
             {"cam": "video.ego_view_bg_crop_pad_res256_freq20", "j": "state.left_arm"},
-            GR1_MMC,
         )
         assert m.video == {"cam": "ego_view_bg_crop_pad_res256_freq20"}
         assert m.state == {"j": "left_arm"}
-        assert m.language_key == "task"
 
-    def test_obs_default_lang_without_mmc(self):
-        """Without modality_configs, language_key defaults to 'task'."""
+    def test_obs_leaves_the_language_key_at_its_default(self):
+        """The parser does not resolve the language key.
+
+        It has more sources than this dict - an explicit ``language_key=``, the
+        model's modality config, the data config's declaration - so ordering them
+        belongs to ``_resolve_language_key`` and this helper leaves the field at
+        the ``ObservationMapping`` default rather than deciding it a second time.
+        """
         m = _parse_observation_mapping({"c": "video.cam"})
         assert m.language_key == "task"
+        assert m.language_key == ObservationMapping().language_key
 
     def test_bad_prefix(self):
         with pytest.raises(ValueError, match="must start with"):
@@ -1867,3 +1872,233 @@ class TestInitMappings:
         assert p._obs_mapping is None
         assert p._action_mapping is None
         assert "modality configs" in caplog.text
+
+
+# (section)
+# Service mode honours a caller-supplied mapping (#2265)
+# (section)
+
+
+# A robot whose observation keys match none of the conventional patterns, so
+# auto-inference could never bridge them and an explicit mapping is the only
+# route. ``language_keys`` is a realistic non-"task" key, which is what makes
+# the language-addressing assertion below able to fail.
+_NONCONVENTIONAL = Gr00tDataConfig(
+    name="nonconventional",
+    video_keys=["video.wrist"],
+    state_keys=["state.arm"],
+    action_keys=["action.arm"],
+    language_keys=["annotation.human.action.task_description"],
+)
+
+_ROBOT_OBS = {
+    "wrist_cam": np.zeros((8, 8, 3), dtype=np.uint8),
+    "arm_joints": [0.1, 0.2, 0.3],
+}
+_OBS_MAP = {"wrist_cam": "video.wrist", "arm_joints": "state.arm"}
+_ACTION_MAP = {"action.arm": "joints"}
+
+
+def _service_policy(**kwargs):
+    """A real service-mode policy - constructed through ``__init__``.
+
+    Deliberately not the ``__new__`` bypass the local-mode helpers above use:
+    the defect was that ``_init_mappings`` was never *called* on this branch,
+    so a test that hand-sets the resolved mappings, or that calls
+    ``_init_mappings`` itself, cannot observe it. The constructor is the
+    subject here.
+    """
+    return Gr00tPolicy(data_config=_NONCONVENTIONAL, host="localhost", port=19999, **kwargs)
+
+
+def _capture_wire_payload(policy, chunk=None):
+    """Run one service inference, returning ``(wire_payload, actions)``."""
+    captured = {}
+
+    def fake_get_action(obs):
+        captured["obs"] = obs
+        return chunk if chunk is not None else {"action.arm": np.zeros((4, 3), dtype=np.float32)}
+
+    policy._client.get_action = fake_get_action
+    actions = policy._service_get_actions(_ROBOT_OBS, "pick the cube")
+    return captured["obs"], actions
+
+
+class TestServiceModeHonoursSuppliedMappings:
+    """Pin that a mapping supplied to a *service*-mode policy reaches the wire.
+
+    ``observation_mapping`` / ``action_mapping`` were stored raw and parsed only
+    after a successful local model load, so in service mode both were discarded:
+    the request carried the task string and no observation at all, and the
+    already-written mapped arms in ``_service_get_actions`` (video/state) and
+    ``_unpack_service_actions`` (action renaming) were unreachable. Both parsers
+    are pure over the caller's flat dict, so neither ever needed the model.
+
+    Each test below is annotated with what it does on the pre-fix tree. The
+    omitted-mapping and local-mode cases are over-reach controls: they pass
+    either way, and are here to fail if the fix reaches further than the
+    supplied-mapping case it is scoped to.
+    """
+
+    def test_mapped_request_carries_the_mapped_video_and_state_keys(self):
+        """Pre-fix: 0 video and 0 state keys on the wire. The headline defect."""
+        p = _service_policy(observation_mapping=_OBS_MAP)
+        wire, _ = _capture_wire_payload(p)
+
+        assert sorted(wire["video"]) == ["wrist"]
+        assert sorted(wire["state"]) == ["arm"]
+        # The caller's own keys are what got mapped, not coincidentally-named ones.
+        assert p._obs_mapping.video == {"wrist_cam": "wrist"}
+        assert p._obs_mapping.state == {"arm_joints": "arm"}
+
+    def test_mapped_service_actions_are_renamed_to_robot_keys(self):
+        """Pre-fix: the chunk comes back under the bare model key ``arm``.
+
+        The action half fails one layer further on than the observation half:
+        ``_unpack_service_actions`` guards the renaming loop on a truthy
+        ``_action_mapping``, so an unparsed mapping is skipped rather than
+        asserted against.
+        """
+        p = _service_policy(action_mapping=_ACTION_MAP)
+        _, actions = _capture_wire_payload(p)
+
+        assert [sorted(step) for step in actions] == [["joints"]] * 4
+        assert p._action_mapping.actions == {"arm": "joints"}
+
+    def test_malformed_observation_mapping_is_refused_at_construction(self):
+        """Pre-fix: accepted silently in service mode, refused in local mode.
+
+        Parsing on both branches means the refusal is now shared, so the
+        message a service-mode caller gets is the one local mode has always
+        produced.
+        """
+        with pytest.raises(ValueError, match="must start with 'video.' or 'state.'"):
+            _service_policy(observation_mapping={"wrist_cam": "audio.mic"})
+
+    def test_language_is_addressed_to_the_same_key_as_the_unmapped_path(self):
+        """Pre-fix: fails on shape - the unmapped arm emits flat prefixed keys,
+        so there is no ``wire["language"]`` at all.
+
+        Also the pin against the narrower fix of parsing with no language
+        resolution: ``_parse_observation_mapping`` defaults ``language_key`` to
+        ``"task"`` when given no modality config, and this server's config
+        declares ``annotation.human.action.task_description``. That fix would
+        land video and state on the wire and leave the instruction addressed to
+        a key nothing reads - a quieter version of the same defect.
+        """
+        declared = _NONCONVENTIONAL.language_keys[0]
+
+        mapped_wire, _ = _capture_wire_payload(_service_policy(observation_mapping=_OBS_MAP))
+        unmapped_wire, _ = _capture_wire_payload(_service_policy())
+
+        assert sorted(mapped_wire["language"]) == [declared]
+        # The unmapped path is flat, and addresses the instruction identically.
+        assert [k for k in unmapped_wire if k == declared] == [declared]
+
+    def test_mapped_payload_is_the_nested_shape_a_live_server_accepts(self):
+        """Pin the payload *shape* the mapped arm sends, not just its keys.
+
+        The mapped arm routes through ``_prepare_observation``, which emits the
+        model's native nested observation. That is the shape
+        ``tests_integ/groot/test_groot_integration.py`` sends to a **real**
+        ``nvidia/GR00T-N1.6-3B`` server and asserts a usable action chunk back
+        from - nested ``video``/``state``/``language`` dicts, video
+        ``(B=1, T=1, H, W, C)`` uint8, state ``(B=1, T=1, D)`` float32,
+        language ``{key: [[instruction]]}``.
+
+        This is the pin against the alternative fix of applying the mapping
+        inside ``_build_service_observation`` and deleting the mapped arm.
+        That builder documents itself as being for *legacy* servers, and for
+        n1.6 it emits video as ``(B, H, W, C)`` with no time axis - a different
+        rank from the one the live server is pinned against. It is also what
+        makes the #187 LOCAL-vs-SERVICE wire diff meaningful: that diagnostic
+        exists to ``np.allclose`` the two modes' payloads against each other,
+        which is only possible while a mapped service request and a local one
+        agree on shape.
+        """
+        p = _service_policy(observation_mapping=_OBS_MAP)
+        wire, _ = _capture_wire_payload(p)
+
+        assert set(wire) == {"video", "state", "language"}
+
+        video = wire["video"]["wrist"]
+        assert video.shape == (1, 1, 8, 8, 3)
+        assert video.dtype == np.uint8
+
+        state = wire["state"]["arm"]
+        assert state.shape == (1, 1, 3)
+        assert state.dtype == np.float32
+
+        assert wire["language"] == {_NONCONVENTIONAL.language_keys[0]: [["pick the cube"]]}
+
+    def test_language_key_override_wins_in_service_mode(self):
+        """Pre-fix: ``_obs_mapping`` is None, so ``language_key=`` was dropped
+        with the rest of the mapping."""
+        p = _service_policy(observation_mapping=_OBS_MAP, language_key="annotation.custom")
+        wire, _ = _capture_wire_payload(p)
+
+        assert p._obs_mapping.language_key == "annotation.custom"
+        assert sorted(wire["language"]) == ["annotation.custom"]
+
+    def test_task_default_when_the_data_config_declares_no_language_key(self):
+        """The documented ``"task"`` default is the last resort, not the first:
+        it applies only when neither an override nor a declared key exists."""
+        cfg = Gr00tDataConfig(name="nolang", video_keys=["video.wrist"], state_keys=["state.arm"])
+        p = Gr00tPolicy(data_config=cfg, host="localhost", port=19999, observation_mapping=_OBS_MAP)
+
+        assert p._obs_mapping.language_key == "task"
+
+    def test_omitting_the_mapping_leaves_the_service_path_unchanged(self):
+        """Over-reach control: passes pre-fix and post-fix.
+
+        An omitted mapping must stay ``None`` rather than acquiring an inferred
+        one. Auto-inference needs modality configs a service policy cannot read,
+        so an inferred mapping here could never be validated - and ``None`` is
+        already the value both service consumers read as "send bare model keys".
+        """
+        p = _service_policy()
+        wire, actions = _capture_wire_payload(p)
+
+        assert p._obs_mapping is None
+        assert p._action_mapping is None
+        # Still the flat legacy payload, not the nested mapped one.
+        assert "video" not in wire and "state" not in wire
+        assert [sorted(step) for step in actions] == [["arm"]] * 4
+
+    def test_local_mode_still_validates_a_supplied_mapping_against_the_model(self):
+        """Over-reach control: passes pre-fix and post-fix.
+
+        Parsing early must not have moved ``validate()`` earlier with it - a
+        mapping naming a model key the checkpoint does not have is still
+        refused at construction in local mode, which is the cross-check service
+        mode has no model to perform.
+        """
+        p = _mapping_policy(
+            local_policy=_MappingPolicy(direct=SO100_MMC),
+            raw_obs={"cam": "video.no_such_camera"},
+        )
+        with pytest.raises(ValueError, match="model only has"):
+            p._init_mappings()
+
+    def test_supplied_mapping_survives_unreadable_modality_configs(self):
+        """Pre-fix: both mappings dropped to None, and inference then died on
+        ``assert self._obs_mapping is not None``.
+
+        Same defect as the service branch, reached from the other direction: a
+        local policy whose modality configs cannot be read returned before
+        parsing. It is not validated - there is nothing to validate against -
+        so an unusable key surfaces at inference rather than at construction.
+        """
+        p = _mapping_policy(
+            local_policy=_MappingPolicy(),
+            raw_obs={"cam": "video.webcam", "arm": "state.single_arm"},
+            raw_action={"action.single_arm": "arm"},
+        )
+        p._init_mappings()
+
+        assert p._obs_mapping.video == {"cam": "webcam"}
+        assert p._obs_mapping.state == {"arm": "single_arm"}
+        assert p._action_mapping.actions == {"single_arm": "arm"}
+        # No model to read a language key from, so the data config's own
+        # declaration stands.
+        assert p._obs_mapping.language_key == "annotation.human.task_description"


### PR DESCRIPTION
Closes #2265

## What

`observation_mapping` and `action_mapping` were stored raw at construction and parsed **only after a local model load**, so a service-mode policy (`host=`/`port=`) discarded both. The request reached the inference server carrying the task string and **no video and no state at all**, and the returned action chunk kept the model's bare key names.

Measured on a robot whose observation keys are `wrist_cam` / `arm_joints` against a server whose config declares `video.wrist` / `state.arm` -- the case the mapping exists for, since auto-inference could never bridge those names:

| supplying the mapping | video keys on the wire | state keys on the wire | action keys returned |
| --- | --- | --- | --- |
| before | **0** | **0** | `arm` |
| after | 1 (`wrist`) | 1 (`arm`) | `joints` |

Both rows of the "before" measurement are identical to supplying nothing at all: the mapping changed nothing.

## Why it was silent

Construction returned normally, and the two service consumers disagreed about an unparsed mapping in ways that were each individually quiet:

- **Observation half** -- `_service_get_actions` has a mapped arm guarded by `if self._obs_mapping is not None:`, so a `None` mapping fell through to the flat payload builder, which looks each key `data_config` declares up under the model's own name. A robot naming its camera `wrist_cam` matched nothing, and nothing said so.
- **Action half** -- `_unpack_service_actions` guards the renaming loop on a *truthy* `_action_mapping` (`:1003`), where the local path asserts (`:873`). So the caller's actuator names were simply absent from the returned steps rather than raising.

The issue's Scope section said the action mapping was "parsed unconditionally". It is not: that call sits below the same early-out. A fix scoped to observations alone would have left the action half live -- a part-1-of-N split of one defect. Both halves are here.

## The fix

Both parsers are pure over the caller's own flat dict -- the video/state split and the action renaming come from the `video.` / `state.` / `action.` prefixes of its *values* -- so neither ever needed the model. They now run in either mode, and `_init_mappings` is called on both branches instead of only after a local load.

What still requires the model is everything that **cross-checks** a mapping against it: `validate()`, `_discover_model_state_dof`, and the auto-inference used when a mapping is omitted. So an omitted mapping deliberately stays `None` rather than acquiring an inferred mapping that could not be validated -- and `None` is already the value both service consumers read as "send bare model keys", which is what keeps the no-mapping service path byte-identical.

Two consequences fall out of the same rule, both disclosed rather than left to be discovered:

1. A **malformed** mapping value is now refused at construction in service mode, with the message local mode has always produced, instead of being silently ignored.
2. A **local** policy whose modality configs cannot be read now honours a supplied mapping too, rather than dropping it and dying later on `assert self._obs_mapping is not None`. This is the same defect reached from the other direction, and it follows from one rule rather than needing a special case.

### The language key needed settling in the same change

Parsing the mapping with no modality config leaves `language_key` at the documented `"task"` default -- which is what the issue suggested. Measured, that would have been a half-fix:

| | language key sent |
| --- | --- |
| unmapped service path (today, unchanged) | `annotation.human.action.task_description` |
| naive fix (parse, take the `"task"` default) | `task` |
| this change | `annotation.human.action.task_description` |

Video and state would have arrived and the instruction would have been addressed to a key the server's config does not declare -- a quieter version of the same defect. Resolution is now ordered in one place, `_resolve_language_key`: an explicit `language_key=` wins, then the model's own key when a checkpoint is loaded, then the key `data_config` declares, then `"task"` for a config declaring none.

That also removes a second implementation of one precedence rule: `_parse_observation_mapping`'s `modality_configs` parameter existed *only* to pick that key, and after this change has no production caller. It is deleted rather than left alive by a single test -- the shape #2062 is open about.

## Alternative considered, and why the mapped arm is kept

The other available fix is to apply the mapping **inside** `_build_service_observation` and delete the mapped arm in `_service_get_actions` on the grounds that every server reads flat dotted keys. That was rejected on this repository's own evidence:

- `tests_integ/groot/test_groot_integration.py` spawns a **real** `nvidia/GR00T-N1.6-3B` server and sends `_make_gr1_server_observation` -- the **nested** `{"video": {...}, "state": {...}, "language": {...}}` payload with `(B=1, T=1, ...)` axes, which is exactly what `_prepare_observation` produces -- then asserts a usable action chunk back. So the mapped arm's shape is the one pinned against a live server; it was unreachable, not wrong.
- `_build_service_observation` documents itself as being for **legacy** service servers, and for n1.6 it emits video as `(B, H, W, C)` with *no* time axis -- a different rank from the one that live test validates.
- #187's wire-payload diagnostic exists to `np.allclose` the LOCAL and SERVICE payloads for the same rollout to bisect a divergence. That is only possible while a mapped service request and a local one agree on shape.
- It keeps one meaning for one parameter: the mapping is authoritative and unnamed model keys are zero-filled, in both modes. Applying it as an *additive* fallback inside the flat builder would give `observation_mapping` mode-dependent semantics.

`test_mapped_payload_is_the_nested_shape_a_live_server_accepts` pins this rather than leaving it as an argument -- it asserts the nesting, `(1, 1, 8, 8, 3)` uint8 video, `(1, 1, 3)` float32 state and `{key: [[instruction]]}` language, so the claim fails loudly if the payload shape drifts from what the integration test sends.

## Cases

Ten cases in `tests/policies/groot/test_policy.py`, beside the existing `_init_mappings` orchestration tests so they reuse those helpers. Each is annotated in-file with what it does on the pre-fix tree.

| case | pins |
| --- | --- |
| mapped request carries the mapped video and state keys | the headline defect |
| mapped service actions are renamed to robot keys | the action half, one layer further on |
| malformed mapping value refused at construction | the shared refusal |
| mapped payload is the nested shape a live server accepts | the wire shape, vs. the flat-builder alternative |
| language addressed to the same key as the unmapped path | the naive-`"task"` half-fix |
| `language_key=` override wins in service mode | override precedence |
| `"task"` default when the config declares no language key | last-resort fallback |
| omitting the mapping leaves the service path unchanged | **over-reach control** |
| local mode still validates a supplied mapping against the model | **over-reach control** |
| supplied mapping survives unreadable modality configs | the disclosed local-mode consequence |

### Mutation matrix

Each variant run against this file:

| variant | fails |
| --- | --- |
| pre-fix tree (both mappings discarded) | **7 of 10** |
| observation half fixed only | **2 of 10** |
| parsed, but no language resolution (`"task"` default) | **3 of 10** |

The two over-reach controls pass under every variant *and* on the pre-fix tree, which is the point: they fail only if the fix reaches past the supplied-mapping case it is scoped to. The two existing short-circuit tests (`test_no_local_policy_is_noop`, `test_missing_modality_configs_warns_and_returns`) also still pass **unchanged**, because both supply no mapping -- which is independent evidence the change is confined to the supplied-mapping case.

## Docs

`docs/policies/groot.md` said auto-inference happens "when no explicit mapping is given" without qualification, but auto-inference reads the checkpoint's modality configs and has always been local-mode only. This change makes that asymmetry user-visible (a *supplied* mapping now works in both modes; an *omitted* one is inferred only in local mode), so the section now states both halves, and that `strict_keys` has nothing to be strict about in service mode. The constructor docstring gains the mode scope for both mapping parameters and the `language_key` resolution order.

Deliberately **not** touched, to keep this one diff: `strands_robots/benchmarks/libero/adapter.py:382-385` advises disabling `inject_eef_state` and supplying an `observation_mapping` instead. That advice was un-actionable in service mode before this change and becomes correct with it, so it needs no edit -- but its parenthetical conflates renaming a key with producing one, which is a separate wording fix.

## Verification

```
ruff check / ruff format --check    clean on both changed files
mypy strands_robots/policies/groot/policy.py    Success: no issues found
python scripts/assemble_changelog.py --check    changelog fragments OK
```

Suite read as a delta, since this environment lacks `mujoco` and `lerobot`:

| `pytest tests/policies/ --ignore=tests/policies/lerobot_local` | result |
| --- | --- |
| base (`b479b8a1`) | 10 failed, **2609** passed |
| this branch | 10 failed, **2618** passed |

The same 10 pre-existing failures (`ModuleNotFoundError: No module named 'mujoco'`), and **+9 passes** -- the new cases, one of which replaces a renamed existing test. `tests/test_docstring_xref_roles_resolve.py` fails identically on both (`No module named 'serial'`).

Intake check per the PR workflow, re-run immediately before the first push:

```
$ python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --issue 2265
Outcome: unique-claim  (#2265 is claimed by no open pull request)
```

Branch contains `main` (`behind_by=0`), so the tree CI evaluates is the merge result.

News fragment: `changelog.d/2265-groot-service-mapping-discarded.md` (`### Fixed`).

## §13 changelog

- **Round 0** -- initial. Both mappings parsed on either branch; language-key precedence centralised in `_resolve_language_key` and the now-callerless `modality_configs` parameter removed; ten cases with a three-variant mutation matrix; the mapped arm's nested wire shape pinned against the shape the live-server integration test uses; `docs/policies/groot.md` and the constructor docstring corrected for the local-only scope of auto-inference.