### PR TITLE
feat(policies): let a policy declare the body poses it needs

### DIFF
--- a/changelog.d/2271-policy-required-bodies.md
+++ b/changelog.d/2271-policy-required-bodies.md
@@ -1,0 +1,35 @@
+### Feature: a policy can declare the body poses it needs
+
+A whole-body motion-mimic tracker is conditioned on the world orientation of one
+anchor link. On a Unitree G1 that link is `torso_link`, and the observation
+schema could not supply it: per-joint scalars carry no world frame, and the
+floating-base signals (`base_pos` / `base_quat` / `base_lin_vel` /
+`base_ang_vel`) describe the pelvis. The waist's three joints separate the two,
+so a tracker written against `base_quat` reads the wrong frame whenever the
+waist is not neutral -- measured on a G1 sweeping its waist, they diverge by up
+to 42 degrees.
+
+`get_body_state` already answered this on MuJoCo and Isaac, but it is a
+`SimEngine` method and a `Policy` is never handed the engine, so the value was
+reachable from everywhere except the place that needed it.
+
+`Policy.required_bodies` is the declaration, on the same "policy declares,
+runtime supplies" contract as `requires_images`: `PolicyRunner` resolves the
+names once before the rollout and merges each body's pose into every observation
+as `body.<name>.pos` / `.quat` / `.lin_vel` / `.ang_vel`, spelled like the
+`base_*` signals already in the schema so a policy reads one convention for the
+base and for any other link.
+
+Resolution happens up front, so a body the scene does not contain raises there,
+carrying the backend's available-names message, rather than going absent from
+every observation and being read as a zero pose for the whole episode. A bare
+`str` is refused rather than iterated into one entry per character.
+
+The nine `get_observation` reads in `simulation/policy_runner.py` now go through
+one `_observe` helper, so the contract holds identically on the synchronous,
+chunked and async-RTC paths rather than only whichever one was patched.
+
+Declaring nothing -- every policy that exists today -- is unchanged: no extra
+backend call, no new observation keys, and no new dataset columns, since the
+recording schema is an explicit allowlist of scalar joints plus expanded base
+components.

--- a/docs/policies/custom-policies.md
+++ b/docs/policies/custom-policies.md
@@ -65,8 +65,53 @@ Aliases and shorthands are validated on load: each must be unique across provide
 | `set_robot_state_keys(keys)` | yes | - |
 | `provider_name` (property) | yes | - |
 | `requires_images` (property) | no | `True` |
+| `required_bodies` (property) | no | `()` |
 | `reset(seed=None)` | no | no-op |
 | `get_actions_sync(...)` | no | sync wrapper |
+
+## Declaring body poses your policy needs
+
+`get_actions` receives per-joint state plus, for a floating-base robot, the base
+pose (`base_pos`, `base_quat`, `base_lin_vel`, `base_ang_vel`). A whole-body
+**motion-mimic tracker** needs more than that: its network is conditioned on the
+world orientation of one *anchor* link -- `torso_link` on a Unitree G1 -- and
+`base_quat` is the **pelvis**, separated from the torso by the three waist
+joints. Reading `base_quat` as if it were the anchor feeds the network the wrong
+frame whenever the waist is not neutral (measured on a G1 sweeping its waist:
+the two diverge by up to 42 degrees).
+
+Declare the links you need and the runtime supplies them:
+
+```python
+class MyTracker(Policy):
+    @property
+    def required_bodies(self) -> tuple[str, ...]:
+        return ("torso_link",)
+
+    async def get_actions(self, obs, instruction="", **kw):
+        anchor_quat = obs["body.torso_link.quat"]   # world w, x, y, z
+        ...
+```
+
+For each declared body the observation gains four keys:
+
+| Key | Contents |
+|---|---|
+| `body.<name>.pos` | world position x, y, z (m) |
+| `body.<name>.quat` | world orientation w, x, y, z |
+| `body.<name>.lin_vel` | world linear velocity x, y, z (m/s) |
+| `body.<name>.ang_vel` | world angular velocity x, y, z (rad/s) |
+
+Notes:
+
+- Names are resolved once, before the rollout. A body the scene does not contain
+  raises there -- listing what is available -- rather than going missing from
+  every observation and being read as a zero pose.
+- Declaring nothing (the default) leaves the observation exactly as the backend
+  produced it, so policies that do not need a link pay no extra read.
+- In a multi-robot scene MuJoCo body names carry the robot's namespace prefix
+  (`alice/Lower_Arm`), the same spelling `get_body_state` resolves.
+- Requires a backend that implements `get_body_state` (MuJoCo, Isaac).
 
 ## Action value convention
 

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -320,6 +320,43 @@ class Policy(ABC):
         return True
 
     @property
+    def required_bodies(self) -> tuple[str, ...]:
+        """Named rigid bodies whose world pose this policy needs in its observation.
+
+        Default ``()`` - most policies are driven by joint state alone and pay
+        nothing for this. A whole-body **motion-mimic tracker** (ProtoMotions
+        GTP, PHC, OmniH2O and the text-to-motion pipelines built on them) is the
+        motivating case: its network consumes the world orientation of a single
+        *anchor* link - ``torso_link`` on a Unitree G1 - which is NOT derivable
+        from the observation's floating-base signals. ``base_quat`` is the
+        pelvis, and the torso differs from it by the three waist joints, so a
+        tracker written against ``base_quat`` silently feeds the network the
+        wrong frame whenever the waist is not neutral.
+
+        Declaring the bodies here is the same "policy declares, runtime
+        supplies" contract as :attr:`requires_images`: the runtime
+        (:class:`~strands_robots.simulation.policy_runner.PolicyRunner`)
+        resolves the names ONCE before the rollout and merges the pose of each
+        into every observation it hands to :meth:`get_actions`, under the keys
+        documented on
+        :meth:`~strands_robots.simulation.base.SimEngine.get_observation`::
+
+            body.<name>.pos      # world x, y, z (m)
+            body.<name>.quat     # world orientation w, x, y, z
+            body.<name>.lin_vel  # world linear velocity x, y, z (m/s)
+            body.<name>.ang_vel  # world angular velocity x, y, z (rad/s)
+
+        A policy that declares a body the scene does not contain fails at the
+        start of the rollout with the available body names, rather than reading
+        a missing key as a zero pose on every tick.
+
+        Returns:
+            Ordered, de-duplicated body names. Empty (the default) means the
+            observation is left exactly as the backend produced it.
+        """
+        return ()
+
+    @property
     def execution_horizon(self) -> int:
         """Number of actions the SIM consumes from one ``get_actions`` chunk before re-querying.
 

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1102,6 +1102,17 @@ class SimEngine(ABC):
               (w,x,y,z), ``"base_lin_vel"`` and ``"base_ang_vel"``, matching
               :meth:`get_robot_state`'s ``"base"`` entry. Absent for fixed-base
               arms.
+            - ``"body.<name>.pos"`` / ``".quat"`` / ``".lin_vel"`` /
+              ``".ang_vel"`` (list[float]): World pose + twist of a NAMED body,
+              present only when the running policy declared that body in
+              :attr:`~strands_robots.policies.base.Policy.required_bodies`.
+              Backends do not emit these from ``get_observation`` itself - the
+              runtime (:class:`~strands_robots.simulation.policy_runner.PolicyRunner`)
+              merges them in from :meth:`get_body_state` for the declared bodies
+              only, so the default observation is unchanged and nothing pays for
+              a link nobody asked for. Motion-mimic trackers need them because
+              their anchor link (``torso_link`` on a G1) is separated from
+              ``base_quat`` (the pelvis) by the waist joints.
 
         Single-camera rendering is :meth:`render`'s job, not this method's.
         For batched multi-robot observation (future Isaac / Newton), add a

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -818,6 +818,152 @@ class PolicyRunner:
     def __init__(self, sim: SimEngine):
         self.sim = sim
 
+    #: Observation key prefix for a named body's world pose, merged in by
+    #: :meth:`_observe` for every body a policy declares in
+    #: :attr:`~strands_robots.policies.base.Policy.required_bodies`.
+    _BODY_KEY_PREFIX = "body."
+
+    #: ``get_body_state`` json field -> observation key suffix. The backend
+    #: reports a body's pose under its own field names; the observation spells
+    #: them like the floating-base signals already in the schema
+    #: (``base_pos`` / ``base_quat`` / ``base_lin_vel`` / ``base_ang_vel``) so a
+    #: policy reads one convention for the base and for any other link.
+    _BODY_POSE_FIELDS: tuple[tuple[str, str], ...] = (
+        ("position", "pos"),
+        ("quaternion", "quat"),
+        ("linear_velocity", "lin_vel"),
+        ("angular_velocity", "ang_vel"),
+    )
+
+    def _resolve_required_bodies(self, policy: Policy | None) -> tuple[str, ...]:
+        """Validate a policy's declared ``required_bodies`` once, before the rollout.
+
+        Resolving up front is the whole point: a mimic tracker reads its anchor
+        link on EVERY tick, so a name the scene does not contain has to fail
+        here - with the available body names - rather than 300 steps of a
+        silently absent key that the policy reads as a zero pose.
+
+        Args:
+            policy: The policy about to be rolled out. ``None`` (replay) and a
+                policy that declares nothing both resolve to ``()``.
+
+        Returns:
+            Ordered, de-duplicated body names to merge into each observation.
+
+        Raises:
+            TypeError: If ``required_bodies`` is not a sequence of non-empty
+                strings. A bare ``str`` is refused explicitly rather than
+                iterated into one entry per character.
+            RuntimeError: If the backend exposes no ``get_body_state``, or a
+                declared body does not resolve in the current scene. Raised
+                rather than returned for the reason this layer raises
+                everywhere else: ``PolicyRunner`` is drivable directly and a
+                direct caller has no envelope to read a refusal from.
+        """
+        declared = getattr(policy, "required_bodies", ()) or ()
+        if not declared:
+            return ()
+        if isinstance(declared, str):
+            raise TypeError(
+                f"{type(policy).__name__}.required_bodies must be a sequence of body names, "
+                f"not a bare str ({declared!r}) - a str iterates into one entry per character. "
+                f"Use a tuple: ('{declared}',)."
+            )
+        bodies: list[str] = []
+        for name in declared:
+            if not isinstance(name, str) or not name.strip():
+                raise TypeError(
+                    f"{type(policy).__name__}.required_bodies entries must be non-empty "
+                    f"body-name strings, got {name!r}."
+                )
+            if name not in bodies:
+                bodies.append(name)
+
+        probe = getattr(self.sim, "get_body_state", None)
+        if not callable(probe):
+            raise RuntimeError(
+                f"{type(policy).__name__} declares required_bodies={tuple(bodies)}, but backend "
+                f"{type(self.sim).__name__} exposes no get_body_state() to read a named body's "
+                f"pose from. Run this policy on a backend that implements it (MuJoCo, Isaac)."
+            )
+        for name in bodies:
+            result = probe(name)
+            if not isinstance(result, dict) or result.get("status") != "success":
+                detail = ""
+                if isinstance(result, dict):
+                    detail = " ".join(
+                        str(block.get("text", "")) for block in result.get("content", []) if isinstance(block, dict)
+                    ).strip()
+                raise RuntimeError(
+                    f"{type(policy).__name__} declares required_bodies entry {name!r}, which does "
+                    f"not resolve to a body in the current scene. {detail}".rstrip()
+                )
+        return tuple(bodies)
+
+    def _observe(
+        self,
+        robot_name: str | None,
+        *,
+        skip_images: bool,
+        bodies: tuple[str, ...] = (),
+    ) -> dict[str, Any]:
+        """Fetch one observation, merging the world pose of each declared body.
+
+        The single point where every rollout loop in this module reads state, so
+        the ``required_bodies`` contract holds identically on the synchronous,
+        chunked and RTC paths instead of only whichever one was patched.
+
+        Args:
+            robot_name: Robot to observe, forwarded verbatim to the backend.
+            skip_images: Backend's camera-render hint (from ``requires_images``).
+            bodies: Pre-resolved names from :meth:`_resolve_required_bodies`.
+                Empty (the default) returns the backend's dict untouched, so a
+                policy that declares nothing pays no extra backend call.
+
+        Returns:
+            The observation dict, plus ``body.<name>.{pos,quat,lin_vel,ang_vel}``
+            for each requested body.
+        """
+        obs = self.sim.get_observation(robot_name=robot_name, skip_images=skip_images)
+        if not bodies:
+            return obs
+        for name in bodies:
+            state = self._body_pose(name)
+            for field, suffix in self._BODY_POSE_FIELDS:
+                value = state.get(field)
+                if value is not None:
+                    obs[f"{self._BODY_KEY_PREFIX}{name}.{suffix}"] = [float(v) for v in value]
+        return obs
+
+    def _body_pose(self, body_name: str) -> dict[str, Any]:
+        """Read one body's pose json out of the backend's ``get_body_state`` envelope.
+
+        Args:
+            body_name: Body name, already validated by
+                :meth:`_resolve_required_bodies`.
+
+        Returns:
+            The backend's pose json block.
+
+        Raises:
+            RuntimeError: If the body stopped resolving mid-rollout (a scene
+                replace can remove it) or the envelope carries no json block.
+                The pose feeds the policy's network input, so an absent one is
+                fatal - not a key to quietly omit from this tick's observation.
+        """
+        result = self.sim.get_body_state(body_name)  # type: ignore[attr-defined]
+        if isinstance(result, dict) and result.get("status") == "success":
+            for block in result.get("content", []):
+                if not isinstance(block, dict):
+                    continue
+                pose = block.get("json")
+                if isinstance(pose, dict):
+                    return pose
+        raise RuntimeError(
+            f"required body {body_name!r} no longer resolves to a pose in the scene; "
+            f"a policy declaring it via required_bodies cannot be stepped."
+        )
+
     def _control_substeps(self, control_frequency: float, override: int | None = None) -> int:
         """Physics steps per applied action so a position-servo arm tracks the
         full control period (1/control_frequency), not a single physics dt.
@@ -1321,6 +1467,11 @@ class PolicyRunner:
         stop_predicate_fired = False
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Named-body poses the policy declared it needs (mimic trackers read an
+        # anchor link). Resolved once here so an unknown name fails before the
+        # loop instead of being read as a zero pose on every tick; () for the
+        # overwhelming majority of policies, which adds no backend call.
+        _bodies = self._resolve_required_bodies(policy)
         # Open-loop chunk replay consumes H actions from ONE observation. That
         # observation is the correct PRE-action state for the FIRST action only;
         # the sim advances as the chunk drains. When a dataset recording is
@@ -1620,7 +1771,7 @@ class PolicyRunner:
 
                 executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="rtc-prefetch")
                 try:
-                    cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                     cur_chunk = _query_chunk(cur_obs)
                     rtc_chunks_acquired += 1
                     if not cur_chunk:
@@ -1642,7 +1793,7 @@ class PolicyRunner:
                             else:
                                 # Chunk was too short to trigger a prefetch;
                                 # fall back to a synchronous re-query.
-                                cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                                cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                                 cur_chunk = _query_chunk(cur_obs)
                             rtc_chunks_acquired += 1
                             if not cur_chunk:
@@ -1655,7 +1806,7 @@ class PolicyRunner:
                                     "async-RTC chunk arrived empty; falling back to one "
                                     "synchronous re-query before erroring."
                                 )
-                                cur_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                                cur_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                                 cur_chunk = _query_chunk(cur_obs)
                                 rtc_chunks_acquired += 1
                                 if not cur_chunk:
@@ -1670,7 +1821,7 @@ class PolicyRunner:
                         # Fire the next inference once we are ~50% through the
                         # current chunk, on a fresh mid-chunk observation.
                         if prefetch is None and idx >= prefetch_trigger:
-                            prefetch_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                            prefetch_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                             # The prefetched chunk first applies after the
                             # remaining steps of the current chunk drain - a
                             # known integer, independent of how long inference
@@ -1688,7 +1839,7 @@ class PolicyRunner:
                         # unaffected - it already consumed cur_obs to produce
                         # this chunk.
                         if _record_per_step_obs:
-                            step_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                            step_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                         else:
                             step_obs = cur_obs
                         _apply(step_obs, cur_chunk[idx])
@@ -1709,7 +1860,7 @@ class PolicyRunner:
                     executor.shutdown(wait=True)
             else:
                 while step_count < total_steps:
-                    observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    observation = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                     chunk = _query_chunk(observation)
                     for chunk_idx, action_dict in enumerate(chunk):
                         if step_count >= total_steps:
@@ -1722,7 +1873,7 @@ class PolicyRunner:
                         # the freshly-queried observation (no re-render, sim has
                         # not stepped yet). Inference is unaffected.
                         if _record_per_step_obs and chunk_idx > 0:
-                            step_obs = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                            step_obs = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                         else:
                             step_obs = observation
                         _apply(step_obs, action_dict)
@@ -2513,6 +2664,11 @@ class PolicyRunner:
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Named-body poses the policy declared it needs (mimic trackers read an
+        # anchor link). Resolved once here so an unknown name fails before the
+        # loop instead of being read as a zero pose on every tick; () for the
+        # overwhelming majority of policies, which adds no backend call.
+        _bodies = self._resolve_required_bodies(policy)
         # Step physics for the full control period per action, same derivation
         # as run(). The default n_substeps=1 made eval rollouts under-step.
         n_substeps = self._control_substeps(control_frequency, control_substeps)
@@ -2543,7 +2699,7 @@ class PolicyRunner:
         rtc_prefetch_blocks = 0
 
         def _observation_fn() -> dict[str, Any]:
-            return self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+            return self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
 
         def _query_chunk(observation: dict[str, Any], observed_delay: int = 0) -> list[dict[str, Any]]:
             # Tell latency-sensitive (RTC) policies how many control steps
@@ -2861,6 +3017,11 @@ class PolicyRunner:
 
         # T26: skip camera rendering when the policy does not need images.
         _skip_images = not getattr(policy, "requires_images", True)
+        # Named-body poses the policy declared it needs (mimic trackers read an
+        # anchor link). Resolved once here so an unknown name fails before the
+        # loop instead of being read as a zero pose on every tick; () for the
+        # overwhelming majority of policies, which adds no backend call.
+        _bodies = self._resolve_required_bodies(policy)
         # Full control-period substeps per action (see run() / evaluate()).
         n_substeps = self._control_substeps(control_frequency, control_substeps)
         policy.set_control_frequency(control_frequency)
@@ -2998,7 +3159,7 @@ class PolicyRunner:
                 last_info: dict[str, Any] = {}
 
                 for _ in range(max_steps):
-                    observation = self.sim.get_observation(robot_name=robot_name, skip_images=_skip_images)
+                    observation = self._observe(robot_name, skip_images=_skip_images, bodies=_bodies)
                     # Hook: benchmarks may bridge the sim's observation schema
                     # (typically joint-space) to whatever the policy was trained
                     # on (e.g. LIBERO's Cartesian state.x/y/z/roll/pitch/yaw/gripper).

--- a/tests/simulation/test_policy_required_bodies_observation.py
+++ b/tests/simulation/test_policy_required_bodies_observation.py
@@ -1,0 +1,162 @@
+"""A policy's declared ``required_bodies`` reach it as body-pose observation keys.
+
+A whole-body motion-mimic tracker consumes the world orientation of a single
+*anchor* link (``torso_link`` on a Unitree G1). That link is not in the
+observation schema and is not derivable from it: ``base_quat`` is the pelvis, and
+the waist joints separate the two. These tests pin the declaration contract that
+carries such a link to the policy - and pin that a policy declaring nothing still
+sees the untouched backend observation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.policies.mock import MockPolicy
+from strands_robots.simulation.mujoco.simulation import Simulation
+from strands_robots.simulation.policy_runner import PolicyRunner
+
+# A body that exists on the fixture's so100 arm. MuJoCo body names carry the
+# robot's namespace prefix, which is what get_body_state resolves.
+ARM_BODY = "alice/Lower_Arm"
+
+
+class _BodyReadingPolicy(MockPolicy):
+    """MockPolicy that declares bodies and records every observation it is given."""
+
+    def __init__(self, bodies: object, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._declared = bodies
+        self.seen: list[dict] = []
+
+    @property
+    def required_bodies(self):
+        return self._declared
+
+    async def get_actions(self, observation, instruction="", **kwargs):
+        self.seen.append(dict(observation))
+        return await super().get_actions(observation, instruction, **kwargs)
+
+
+@pytest.fixture
+def sim_with_robot():
+    s = Simulation(tool_name="required_bodies_test", mesh=False)
+    s.create_world()
+    s.add_robot(name="alice", data_config="so100")
+    yield s
+    s.cleanup()
+
+
+def _run(sim, policy, **kw):
+    policy.set_robot_state_keys(sim.robot_joint_names("alice"))
+    kw.setdefault("duration", 0.06)
+    return PolicyRunner(sim).run("alice", policy, control_frequency=50, fast_mode=True, **kw)
+
+
+class TestDeclaredBodyReachesThePolicy:
+    def test_declared_body_pose_is_merged_into_every_observation(self, sim_with_robot):
+        """The four pose keys are present on every tick, with the right widths."""
+        policy = _BodyReadingPolicy((ARM_BODY,))
+        result = _run(sim_with_robot, policy)
+
+        assert result["status"] == "success"
+        assert policy.seen, "policy should have been queried at least once"
+        for obs in policy.seen:
+            assert [len(obs[f"body.{ARM_BODY}.{s}"]) for s in ("pos", "quat", "lin_vel", "ang_vel")] == [3, 4, 3, 3]
+
+    def test_merged_pose_matches_the_backend_truth(self, sim_with_robot):
+        """The merged values are the backend's own pose read, not a placeholder.
+
+        Compared at a quiescent state: a rollout keeps stepping physics after
+        the final ``get_actions``, so the policy's last observation is
+        legitimately older than a post-rollout read.
+        """
+        runner = PolicyRunner(sim_with_robot)
+        obs = runner._observe("alice", skip_images=True, bodies=(ARM_BODY,))
+        truth = sim_with_robot.get_body_state(ARM_BODY)["content"][1]["json"]
+
+        assert obs[f"body.{ARM_BODY}.pos"] == pytest.approx(truth["position"], abs=1e-9)
+        assert obs[f"body.{ARM_BODY}.quat"] == pytest.approx(truth["quaternion"], abs=1e-9)
+        assert obs[f"body.{ARM_BODY}.lin_vel"] == pytest.approx(truth["linear_velocity"], abs=1e-9)
+        assert obs[f"body.{ARM_BODY}.ang_vel"] == pytest.approx(truth["angular_velocity"], abs=1e-9)
+
+    def test_pose_is_a_live_reading_not_a_frozen_one(self, sim_with_robot):
+        """A body driven by the policy reports a changing pose across ticks."""
+        policy = _BodyReadingPolicy((ARM_BODY,))
+        _run(sim_with_robot, policy, duration=0.4)
+
+        poses = [tuple(o[f"body.{ARM_BODY}.pos"]) for o in policy.seen]
+        assert len(set(poses)) > 1, "arm body pose never changed across the rollout"
+
+    def test_duplicate_declarations_collapse(self, sim_with_robot):
+        """Declaring a body twice is not an error and yields one key set."""
+        policy = _BodyReadingPolicy((ARM_BODY, ARM_BODY))
+        result = _run(sim_with_robot, policy)
+
+        assert result["status"] == "success"
+        assert f"body.{ARM_BODY}.quat" in policy.seen[0]
+
+
+class TestDeclaringNothingIsFree:
+    def test_no_body_keys_when_nothing_is_declared(self, sim_with_robot):
+        """The default policy sees the backend observation untouched.
+
+        Guards the cost + dataset-schema contract: body poses must not appear
+        for the overwhelming majority of policies that never asked for one.
+        """
+        policy = _BodyReadingPolicy(())
+        result = _run(sim_with_robot, policy)
+
+        assert result["status"] == "success"
+        assert policy.seen
+        for obs in policy.seen:
+            assert [k for k in obs if k.startswith("body.")] == []
+
+    def test_plain_policy_without_the_attribute_still_runs(self, sim_with_robot):
+        """A policy predating the contract is unaffected (getattr default)."""
+        policy = MockPolicy()
+        assert _run(sim_with_robot, policy)["status"] == "success"
+
+
+class TestBadDeclarationsFailBeforeTheRollout:
+    def test_unknown_body_raises_and_never_queries_the_policy(self, sim_with_robot):
+        """An unresolvable name fails up front, not as a zero pose per tick."""
+        policy = _BodyReadingPolicy(("no_such_link",))
+
+        with pytest.raises(RuntimeError, match="no_such_link"):
+            _run(sim_with_robot, policy)
+        assert policy.seen == [], "rollout must not start with an unresolvable body"
+
+    def test_bare_str_declaration_is_refused(self, sim_with_robot):
+        """A str would iterate into one entry per character - refuse it."""
+        policy = _BodyReadingPolicy(ARM_BODY)
+
+        with pytest.raises(TypeError, match="not a bare str"):
+            _run(sim_with_robot, policy)
+
+    def test_non_string_entry_is_refused(self, sim_with_robot):
+        policy = _BodyReadingPolicy((7,))
+
+        with pytest.raises(TypeError, match="non-empty"):
+            _run(sim_with_robot, policy)
+
+
+class TestEvalPathHonoursTheContract:
+    def test_eval_observations_carry_declared_body_poses(self, sim_with_robot):
+        """evaluate() shares the declaration contract with run()."""
+        policy = _BodyReadingPolicy((ARM_BODY,))
+        policy.set_robot_state_keys(sim_with_robot.robot_joint_names("alice"))
+
+        result = PolicyRunner(sim_with_robot).evaluate(
+            robot_name="alice",
+            policy=policy,
+            n_episodes=1,
+            max_steps=3,
+            control_frequency=50,
+        )
+
+        assert result["status"] == "success"
+        assert policy.seen
+        assert f"body.{ARM_BODY}.quat" in policy.seen[0]


### PR DESCRIPTION
## Problem

A whole-body **motion-mimic tracker** (ProtoMotions GTP, PHC, OmniH2O, and the text-to-motion pipelines built on them) is conditioned on the world orientation of one *anchor* link. On a Unitree G1 that link is `torso_link`, and the observation schema cannot supply it:

- per-joint scalars carry no world frame, and
- the floating-base signals (`base_pos` / `base_quat` / `base_lin_vel` / `base_ang_vel`) describe the **pelvis**.

`base_quat` and the torso are separated by the three waist joints, so a tracker written against `base_quat` silently feeds the network the wrong frame whenever the waist is not neutral. Measured on a G1 sweeping its waist, the two diverge by **up to 42.1 deg (mean 26.9 deg)** -- not a small-angle approximation of each other.

`get_body_state` already answers this on MuJoCo and Isaac, but it is a `SimEngine` method and a `Policy` is never handed the engine. The value was reachable from everywhere except the place that needs it.

## Change

`Policy.required_bodies` is the declaration, on the same *policy declares, runtime supplies* contract as `requires_images`:

```python
class MyTracker(Policy):
    @property
    def required_bodies(self) -> tuple[str, ...]:
        return ("torso_link",)

    async def get_actions(self, obs, instruction="", **kw):
        anchor_quat = obs["body.torso_link.quat"]   # world w, x, y, z
```

`PolicyRunner` resolves the names once before the rollout and merges each body's pose into every observation as `body.<name>.{pos,quat,lin_vel,ang_vel}` -- spelled like the `base_*` signals already in the schema, so a policy reads one convention for the base and for any other link.

Details worth review:

- **Resolution is up front.** A body the scene does not contain raises there, carrying the backend's available-names message, instead of going absent from every observation and being read as a zero pose for the whole episode. Raised rather than returned, matching this layer's stated contract (`PolicyRunner` is drivable directly and a direct caller has no envelope to read a refusal from).
- **A bare `str` is refused** rather than iterated into one entry per character.
- **One read path.** The nine `get_observation` reads in this module now go through a single `_observe` helper, so the contract holds identically on the synchronous, chunked and async-RTC paths rather than only whichever one was patched.
- **Declaring nothing is free and unchanged.** No extra backend call, no new observation keys, and no new dataset columns -- the recording schema is an explicit allowlist (scalar joints + expanded base components), so it is unaffected by construction. Pinned by a test.

## Visual artifact

MuJoCo rollout (headless EGL) of a G1 driven by a policy declaring `required_bodies = ("torso_link",)` and reading `body.torso_link.quat` each tick, while sweeping waist and shoulders:

![G1 anchor-body rollout](https://raw.githubusercontent.com/cagataycali/robots/media-required-bodies-artifact/anchor_body_g1.gif)

[Full MP4](https://raw.githubusercontent.com/cagataycali/robots/media-required-bodies-artifact/anchor_body_g1.mp4) (640x480, 250 steps @ 50 Hz)

```
run status: success
anchor observations delivered: 32
torso_link vs base_quat divergence: max=42.1 deg  mean=26.9 deg
```

That divergence is the justification: it is the error a tracker would absorb if it read `base_quat` as its anchor.

## Tests

`tests/simulation/test_policy_required_bodies_observation.py` -- 10 cases, **8 of which fail on pre-fix code** (the 2 that pass both ways are the "declaring nothing changes nothing" pins, which is the point of keeping them):

- declared pose merged into every observation, with the right widths (3/4/3/3)
- merged values equal the backend's own `get_body_state` read to 1e-9
- pose is a live reading, not frozen, across a rollout
- duplicate declarations collapse
- nothing declared -> no `body.*` keys on any tick; a policy predating the contract still runs
- unknown body raises before the rollout and the policy is never queried
- bare `str` and non-string entries are refused
- `evaluate()` honours the same contract as `run()`

## Gate

```
ruff check strands_robots tests tests_integ          All checks passed
ruff format --check strands_robots tests tests_integ 1225 files already formatted
mypy strands_robots tests tests_integ               no issues found in 1222 source files
MUJOCO_GL=egl pytest tests/simulation tests/policies 14223 passed, 168 skipped
```

Docs: `docs/policies/custom-policies.md` gains the ABC-contract row plus a section covering the four keys, the namespace-prefix spelling in multi-robot scenes, and the `get_body_state` backend requirement.