### PR TITLE
fix(simulation/mujoco): floor joint damping on either MuJoCo layout of that field

### DIFF
--- a/changelog.d/2272-joint-damping-floor-mujoco-layouts.md
+++ b/changelog.d/2272-joint-damping-floor-mujoco-layouts.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `actuate_robot` no longer refuses every URDF-loaded arm on MuJoCo builds where
+  `MjsJoint.damping` is a plain float rather than a per-DOF sequence. Both
+  layouts occur across the declared `mujoco>=3.2.0,<4.0.0` range; writing the
+  damping floor through the wrong one raised `TypeError`, which was reported as
+  a refused spec surgery, leaving the arm actuator-less and undrivable by
+  `send_action` / `run_policy`.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -75,6 +75,37 @@ def _sync_cached_xml(world: SimWorld, spec: Any) -> None:
         logger.debug("spec.to_xml() failed; cached XML left stale: %s", xml_err)
 
 
+def _raise_spec_joint_damping(joint: Any, floor: float) -> None:
+    """Floor a spec joint's damping, on either MuJoCo layout of that field.
+
+    ``MjsJoint.damping`` is a per-DOF sequence on MuJoCo builds from 3.10 and a
+    plain ``float`` on the older builds this package still supports
+    (``mujoco>=3.2.0``). Reading or writing through the wrong one of those two
+    layouts raises ``TypeError``, which
+    :func:`actuate_robot_in_scene` reports as a refused spec surgery - so a
+    robot that needs a damping floor cannot be actuated at all. Both layouts are
+    handled here, once, rather than at the call site.
+
+    Existing damping larger than ``floor`` is kept, which is the floor contract
+    :meth:`strands_robots.simulation.mujoco.manipulation.ManipulationMixin.actuate_robot`
+    documents for its ``damping`` argument.
+
+    Args:
+        joint: The ``MjsJoint`` (or any object exposing a ``damping`` field in
+            one of the two layouts) to floor in place.
+        floor: Minimum damping to leave on the joint.
+    """
+    current = joint.damping
+    try:
+        first = float(current[0])
+    except TypeError:
+        # Scalar layout (mujoco < 3.10): assign the field itself.
+        joint.damping = max(float(current), floor)
+    else:
+        # Per-DOF layout: write element 0, leaving any further DOFs alone.
+        joint.damping[0] = max(first, floor)
+
+
 def _snapshot_spec(spec: Any, *, context: str) -> Any | None:
     """Deep-copy ``spec`` so a refused mutation can be rolled back losslessly.
 
@@ -1363,7 +1394,7 @@ def actuate_robot_in_scene(
             short = joint_name[len(pfx) :]
             if short not in kp_by_joint:
                 continue
-            joint.damping[0] = max(float(joint.damping[0]), damping)
+            _raise_spec_joint_damping(joint, damping)
             joint.armature = max(float(joint.armature), armature)
 
         for short, kp in kp_by_joint.items():

--- a/tests/simulation/mujoco/test_joint_damping_floor_layouts.py
+++ b/tests/simulation/mujoco/test_joint_damping_floor_layouts.py
@@ -1,0 +1,140 @@
+"""The joint damping floor must land on either MuJoCo layout of that field.
+
+``actuate_robot`` converts an actuator-less (URDF-loaded) arm into a
+position-servo arm, and part of that surgery is flooring each driven joint's
+``damping``: bare URDFs ship none, and stiff position servos on an undamped
+chain diverge. The floor is written onto the ``MjSpec``, through
+``MjsJoint.damping``.
+
+That field has two layouts across the MuJoCo range this package declares
+(``mujoco>=3.2.0,<4.0.0``):
+
+* a **per-DOF sequence** on builds from 3.10, where the floor is written to
+  element 0,
+* a plain **float** on the older builds, where the field itself is assigned.
+
+Reading or writing through the wrong one raises ``TypeError``. That exception is
+caught by :func:`strands_robots.simulation.mujoco.scene_ops.actuate_robot_in_scene`
+as a refused spec surgery, so the whole actuation is rolled back and
+``actuate_robot`` reports ``status="error"`` - i.e. on the layout the code does
+not handle, no URDF arm can be actuated at all, and the failure surfaces as a
+generic refusal that names neither ``damping`` nor MuJoCo.
+
+:func:`strands_robots.simulation.mujoco.scene_ops._raise_spec_joint_damping` owns
+both layouts. The tests below drive it with each layout explicitly rather than
+only through the installed build, because the installed build exercises exactly
+one of the two - a test that only used the real spec would pass on whichever
+layout happens to be installed and pin nothing about the other, which is the
+coupling this file exists to prevent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.scene_ops import _raise_spec_joint_damping  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_actuate_robot import MINI_ARM_URDF  # noqa: E402
+
+
+class _PerDofDampingJoint:
+    """A spec joint whose ``damping`` is a per-DOF sequence (mujoco >= 3.10)."""
+
+    def __init__(self, *dofs: float) -> None:
+        self.damping = np.array(dofs, dtype=np.float64)
+
+
+class _ScalarDampingJoint:
+    """A spec joint whose ``damping`` is a plain float (mujoco < 3.10)."""
+
+    def __init__(self, damping: float) -> None:
+        self.damping = float(damping)
+
+
+def _damping_of(joint: Any) -> float:
+    value = joint.damping
+    try:
+        return float(value[0])
+    except TypeError:
+        return float(value)
+
+
+class TestTheFloorIsAppliedOnBothLayouts:
+    """A joint below the floor is raised to it, whichever layout it uses."""
+
+    def test_a_per_dof_joint_below_the_floor_is_raised(self) -> None:
+        joint = _PerDofDampingJoint(0.0)
+        _raise_spec_joint_damping(joint, 2.0)
+        assert _damping_of(joint) == pytest.approx(2.0)
+
+    def test_a_scalar_joint_below_the_floor_is_raised(self) -> None:
+        joint = _ScalarDampingJoint(0.0)
+        _raise_spec_joint_damping(joint, 2.0)
+        assert _damping_of(joint) == pytest.approx(2.0)
+
+
+class TestAStifferJointKeepsItsOwnDamping:
+    """It is a floor, not an assignment: a larger existing value survives."""
+
+    def test_a_per_dof_joint_above_the_floor_is_left_alone(self) -> None:
+        joint = _PerDofDampingJoint(7.5)
+        _raise_spec_joint_damping(joint, 2.0)
+        assert _damping_of(joint) == pytest.approx(7.5)
+
+    def test_a_scalar_joint_above_the_floor_is_left_alone(self) -> None:
+        joint = _ScalarDampingJoint(7.5)
+        _raise_spec_joint_damping(joint, 2.0)
+        assert _damping_of(joint) == pytest.approx(7.5)
+
+
+class TestFurtherDofsAreNotTouched:
+    """Only DOF 0 is floored, matching the pre-existing per-DOF behaviour.
+
+    A ball or free joint carries several DOFs in the same field. Flooring all of
+    them would be a silent behaviour change for those joints, so the sequence
+    layout keeps writing element 0 only.
+    """
+
+    def test_the_remaining_dofs_keep_their_values(self) -> None:
+        joint = _PerDofDampingJoint(0.0, 0.25, 0.5)
+        _raise_spec_joint_damping(joint, 2.0)
+        assert joint.damping.tolist() == pytest.approx([2.0, 0.25, 0.5])
+
+
+class TestActuationSucceedsOnTheInstalledBuild:
+    """End to end: the arm actuates and its joints carry the requested floor.
+
+    This is the surface the layout bug actually broke - ``actuate_robot``
+    returning ``status="error"`` for every URDF arm - so it is asserted through
+    the public facade on whatever MuJoCo is installed.
+    """
+
+    def test_actuate_robot_applies_the_damping_floor(self, tmp_path) -> None:
+        urdf = tmp_path / "mini_arm.urdf"
+        urdf.write_text(MINI_ARM_URDF)
+        sim = Simulation(backend="mujoco")
+        try:
+            sim.create_world(timestep=0.002, gravity=[0, 0, -9.81], ground_plane=True)
+            assert sim.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+
+            result = sim.actuate_robot("arm", kp=300.0, damping=3.5)
+            assert result["status"] == "success", result
+
+            world = sim._world
+            assert world is not None and world._model is not None
+            model = world._model
+            driven = [
+                int(model.jnt_dofadr[j])
+                for j in range(model.njnt)
+                if (mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, j) or "").startswith("arm/")
+            ]
+            assert driven
+            assert all(float(model.dof_damping[adr]) >= 3.5 for adr in driven)
+        finally:
+            sim.cleanup()


### PR DESCRIPTION
## Problem

`actuate_robot` turns an actuator-less (URDF-loaded) arm into a position-servo arm. Part of that spec surgery is flooring each driven joint's damping - bare URDFs ship none, and stiff position servos on an undamped chain diverge. The floor is written onto the `MjSpec` through `MjsJoint.damping`.

That field has two layouts across the MuJoCo range this package declares (`mujoco>=3.2.0,<4.0.0`):

* a **per-DOF sequence** on builds from 3.10,
* a plain **float** on the older builds.

`scene_ops.actuate_robot_in_scene` only handled the sequence layout:

```python
joint.damping[0] = max(float(joint.damping[0]), damping)
```

On a scalar-layout build that subscript raises `TypeError`, which the surrounding `except (ValueError, RuntimeError, TypeError)` catches as a refused spec surgery. The snapshot is restored and the whole actuation is rolled back, so **no URDF-loaded arm can be actuated at all** on those builds - `send_action` / `run_policy` cannot drive one - and the caller gets a refusal naming neither `damping` nor MuJoCo:

```
actuate_robot: spec recompile failed for 'arm' (spec restored, see logs).
status=error
```

Measured on `mujoco 3.5.0`, which the declared floor admits: **12 pinned tests** across `test_actuate_robot.py`, `test_actuator_ownership_by_transmission.py` and `test_spec_snapshot_refusal.py` fail on this, all with `'float' object is not subscriptable` from `scene_ops.py`.

## Change

`_raise_spec_joint_damping` owns both layouts in one place instead of at the call site. It follows the drift-tolerant-helper pattern already used for `mj_fullM` by `physics._full_mass_matrix`.

The sequence layout keeps writing element 0 only, so a ball or free joint carrying several DOFs in the same field is unchanged - flooring all of them would be a silent behaviour change for those joints.

The floor semantics documented for `actuate_robot`'s `damping` argument ("existing larger values are kept") are preserved on both layouts.

## Tests

`tests/simulation/mujoco/test_joint_damping_floor_layouts.py` drives **each layout explicitly** rather than only through the installed build. That matters: the installed MuJoCo exercises exactly one of the two, so a test using only the real spec passes on whichever layout happens to be installed and pins nothing about the other - the same reasoning `TestFullMassMatrixSignatureDrift` states for emulating both `mj_fullM` signatures.

Against the pre-fix subscript-only logic, 3 of the 6 new tests fail (both scalar-layout cases plus the end-to-end actuation); 2 of those 3 are layout-independent, so they fail on a sequence-layout build too rather than only where the bug reproduces.

Full `tests/` run, before -> after on `mujoco 3.5.0`:

| | failures | passes |
|---|---|---|
| before | 126 | 29428 |
| after | 115 | 29445 |

The 12 target failures are gone and the set difference introduces none. Remaining failures are pre-existing and unrelated (missing optional extras, plus a separate `mju_sym2dense` drift in `_full_mass_matrix`). `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Rollout in MuJoCo sim (headless)

A real 6-DOF SO-101 **URDF** arm - the case this breaks - loaded with `nu=0`, actuated, then driven through a scripted joint sweep by `run_policy`. Pre-fix, `actuate_robot` returns `status=error` here and the arm stays undrivable.

```
add_robot:      success        nu before: 0
actuate_robot:  success        nu after:  6
run_policy:     success        240 frames @30fps, 640x480
```

![URDF arm actuated and driven in MuJoCo](https://raw.githubusercontent.com/cagataycali/robots/media-urdf-damping-floor/urdf_arm_actuated.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-urdf-damping-floor/urdf_arm_actuated.mp4) - every one of the 239 frame transitions changes (per-frame mean abs pixel delta min 0.105, mean 0.583), so the servos are tracking rather than the scene being static.