### PR TITLE
fix(simulation/ik): resolve a tool site over the end-effector body that shares its name

### DIFF
--- a/changelog.d/2273-ee-frame-tool-site-precedence.md
+++ b/changelog.d/2273-ee-frame-tool-site-precedence.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Simulation / IK**: `discover_ee_frame` now resolves a tool-point site over the
+  end-effector body that shares its name. Its site rung only searched TCP-specific
+  spellings (`attachment_site` / `grasp` / `tcp` / ...) while the body rung matched a
+  wider end-effector vocabulary (`gripper` / `hand` / `tool` / ...), so a model
+  publishing its tool point as a site named for the end effector was answered with a
+  link origin instead - `so101` (98.4 mm behind its own fingertips), `aloha` (130.0 mm)
+  and `toddlerbot_2xc`/`toddlerbot_2xm` (60.8 mm). Because `move_to` measures the
+  residual it reports at the discovered frame, the offset was invisible: on `so101` it
+  reported 18.1 mm convergence while the fingertips were 100.5 mm from the commanded
+  target. The site rung now searches its own spellings first and then the body rung's,
+  so a site wins whenever one names the end effector. 58 of the 62 loadable registry
+  robots resolve unchanged, and a site-less model still resolves to its end-effector
+  body.

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -297,10 +297,23 @@ class MinkIKBridge:
 #      ``wrist`` / ...).
 #   3. The **leaf body** of the robot's kinematic chain (the descendant of the
 #      robot's joints with no child body) - the last link, where a tool mounts.
+#
+# Rung 1 searches the end-effector vocabulary of rung 2 as well, after its own
+# TCP-specific names. The two rungs describe the same physical part of the robot
+# in different words, so a token that identifies the end effector as a body
+# identifies it as a site too - and a site is the more precise frame, because it
+# is placed at the tool point while the body origin sits at the link's mount.
+# Searching sites for TCP names only made a model that publishes its tool point
+# as a site lose to the link of the same name: ``so101`` names both ``gripper``
+# and resolved to the body, 98 mm behind its own fingertips.
 # --------------------------------------------------------------------------
 
 _SITE_HINTS = ("attachment_site", "attachment", "grasp", "pinch", "tcp", "ee_site", "ee", "flange")
 _BODY_HINTS = ("hand", "gripper", "tool", "tcp", "ee", "wrist", "flange", "end_effector", "eef")
+# Rung 1's search order: TCP-specific site names first, then the end-effector
+# names rung 2 matches on bodies. Order-preserving dedupe, because the two
+# tuples share tokens and the first occurrence is the one that decides.
+_SITE_SEARCH_HINTS = tuple(dict.fromkeys((*_SITE_HINTS, *_BODY_HINTS)))
 
 
 def _names_of(model: Any, obj_type: Any) -> list[tuple[int, str]]:
@@ -336,6 +349,12 @@ def _basename(name: str, namespace: str | None) -> str:
 def discover_ee_frame(model: Any, namespace: str | None = None) -> tuple[str, str] | None:
     """Discover an IK end-effector frame ``(name, type)`` for a robot.
 
+    Resolution is first-match-wins over three rungs: a site whose name denotes
+    the tool point or the end effector, else a body whose name denotes the end
+    effector, else the leaf body of the namespace's kinematic chain. A site
+    outranks a body even when both carry the same name, because a site is placed
+    at the tool point while the body origin sits at the link's mount.
+
     Args:
         model: The compiled ``mujoco.MjModel`` (the shared world model).
         namespace: The robot's body/site namespace prefix (e.g. ``"panda/"``).
@@ -351,9 +370,9 @@ def discover_ee_frame(model: Any, namespace: str | None = None) -> tuple[str, st
         logger.debug("mujoco not importable; cannot auto-discover ee-frame")
         return None
 
-    # 1) Prefer a TCP-like SITE.
+    # 1) Prefer a SITE: a TCP-like name first, then an end-effector name.
     sites = [(i, n) for i, n in _names_of(model, _site_obj()) if _scoped(n, namespace)]
-    for hint in _SITE_HINTS:
+    for hint in _SITE_SEARCH_HINTS:
         for _i, name in sites:
             if hint in _basename(name, namespace).lower():
                 logger.info("ee-frame: site %r (hint %r)", name, hint)

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -419,9 +419,12 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
         elapse (each tick advances a few physics substeps).
 
         The end-effector frame is auto-discovered per robot namespace
-        (:func:`strands_robots.simulation.ik.discover_ee_frame`: TCP-like site,
-        else hand/tool body, else the chain's leaf body) - the same heuristic
-        eef-delta policies use, so multi-robot scenes resolve the right arm.
+        (:func:`strands_robots.simulation.ik.discover_ee_frame`: a site naming
+        the tool point or the end effector, else a body naming the end effector,
+        else the chain's leaf body) - the same heuristic eef-delta policies use,
+        so multi-robot scenes resolve the right arm. A site outranks a body of
+        the same name: it is placed at the tool point, while the body origin
+        sits at the link's mount.
 
         GRASP PRESERVATION (contract): gripper actuators (resolved by the same
         registry-metadata-first classification ``set_gripper`` uses, see

--- a/tests/policies/vera/test_ee_frame_discovery.py
+++ b/tests/policies/vera/test_ee_frame_discovery.py
@@ -5,9 +5,15 @@ namespace-aware heuristic that resolves an IK target frame from a compiled
 ``mujoco.MjModel`` so eef-delta / cartesian-delta embodiments stay zero-config.
 
 The heuristic is a first-match-wins ladder:
-  1. a TCP-like *site* (``attachment_site`` / ``grasp`` / ``tcp`` / ...),
+  1. a *site* named for the tool point (``attachment_site`` / ``grasp`` /
+     ``tcp`` / ...) or for the end effector itself (``gripper`` / ``hand`` /
+     ``tool`` / ...),
   2. otherwise a hand/tool *body* (``gripper`` / ``hand`` / ``wrist`` / ...),
   3. otherwise the *leaf body* of the robot's kinematic chain.
+
+Rung 1 covers rung 2's vocabulary after its own, so a site wins over a body of
+the same name; that ordering is pinned in
+``tests/simulation/test_ee_frame_site_outranks_same_named_body.py``.
 
 Discovery is scoped to a body/site namespace prefix so multi-robot worlds
 resolve the right arm, and hint matching runs on the namespace-stripped

--- a/tests/simulation/test_ee_frame_site_outranks_same_named_body.py
+++ b/tests/simulation/test_ee_frame_site_outranks_same_named_body.py
@@ -1,0 +1,132 @@
+"""A tool-point site outranks the end-effector body, including a same-named one.
+
+:func:`strands_robots.simulation.ik.discover_ee_frame` resolves the Cartesian IK
+target frame that ``move_to`` servos and that eef-delta policies decode against.
+Its ladder is documented site-first - "a TCP-like site, else a hand/tool body,
+else the chain's leaf body" - because a site is placed at the tool point while a
+body origin sits at the link's mount, several centimetres behind it.
+
+Rung 1 only searched TCP-specific spellings (``attachment_site`` / ``grasp`` /
+``tcp`` / ...), while rung 2 matched a wider end-effector vocabulary on bodies
+(``gripper`` / ``hand`` / ``tool`` / ...). A model that publishes its tool point
+as a site named for the end effector therefore skipped rung 1 and was answered
+from rung 2 with a link origin - silently, and with the correct frame present in
+the same model. Shipped models do exactly this: ``so101`` names both its tool
+site and its jaw body ``gripper`` (98 mm apart), ``aloha`` pairs the ``gripper``
+site with the ``gripper_link`` body (130 mm), and ``toddlerbot`` pairs the
+``left_hand_center`` site with the ``left_hand`` body (61 mm). Nothing reported
+the substitution, so a solved ``move_to`` left the fingertips short of the
+target by that offset.
+
+Rung 1 now searches the TCP spellings first and then rung 2's vocabulary, so a
+site wins whenever one names the end effector - the same-name case included.
+Pinned on the frame's resolved world position, not only on its name, because the
+offset is the whole defect.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.ik import discover_ee_frame  # noqa: E402
+
+# A jaw body and its tool site share the bare name ``gripper``, as ``so101``
+# ships it. The site sits 98 mm out along the link, matching that model's
+# measured site-to-body-origin offset.
+_TOOL_OFFSET_M = 0.098
+
+_SAME_NAME_ARM = f"""
+<mujoco><worldbody>
+  <body name="arm/base">
+    <joint name="arm/j0" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+    <body name="arm/gripper" pos="0 0 .2">
+      <joint name="arm/j1" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+      <site name="arm/gripper" pos="0 0 {_TOOL_OFFSET_M}"/>
+    </body>
+  </body>
+</worldbody></mujoco>
+"""
+
+
+def _framed(xml: str, namespace: str) -> tuple[tuple[str, str], np.ndarray]:
+    """Resolve the ee-frame and return it with its world position."""
+    model = mujoco.MjModel.from_xml_string(xml)
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    frame = discover_ee_frame(model, namespace)
+    assert frame is not None
+    name, kind = frame
+    obj = mujoco.mjtObj.mjOBJ_SITE if kind == "site" else mujoco.mjtObj.mjOBJ_BODY
+    index = mujoco.mj_name2id(model, obj, name)
+    position = data.site_xpos[index] if kind == "site" else data.xpos[index]
+    return frame, np.asarray(position, dtype=float).copy()
+
+
+def test_tool_site_wins_over_the_body_that_shares_its_name() -> None:
+    """The site is chosen, and the frame lands at the tool point not the mount."""
+    frame, position = _framed(_SAME_NAME_ARM, "arm/")
+
+    assert frame == ("arm/gripper", "site")
+    # The jaw body origin is at z=0.2; the tool point is _TOOL_OFFSET_M beyond it.
+    assert position[2] == pytest.approx(0.2 + _TOOL_OFFSET_M, abs=1e-9)
+
+
+def test_end_effector_named_site_wins_over_a_differently_named_body() -> None:
+    """A site named for the hand outranks the hand body (the toddlerbot shape)."""
+    xml = """
+    <mujoco><worldbody>
+      <body name="bot/torso">
+        <joint name="bot/j0" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+        <body name="bot/left_hand" pos="0 0 .3">
+          <joint name="bot/j1" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+          <site name="bot/left_hand_center" pos="0 0 .061"/>
+        </body>
+      </body>
+    </worldbody></mujoco>
+    """
+    frame, position = _framed(xml, "bot/")
+
+    assert frame == ("bot/left_hand_center", "site")
+    assert position[2] == pytest.approx(0.361, abs=1e-9)
+
+
+def test_a_tcp_named_site_still_outranks_an_end_effector_named_site() -> None:
+    """Rung 1 keeps its own spellings ahead of rung 2's vocabulary.
+
+    A model carrying both a purpose-built TCP site and a site named for the hand
+    must resolve the TCP one, whichever order they are declared in.
+    """
+    xml = """
+    <mujoco><worldbody>
+      <body name="a/l0">
+        <joint name="a/j0" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+        <site name="a/gripper" pos="0 0 .1"/>
+        <site name="a/grasp_point" pos="0 0 .2"/>
+      </body>
+    </worldbody></mujoco>
+    """
+    assert discover_ee_frame(mujoco.MjModel.from_xml_string(xml), "a/") == (
+        "a/grasp_point",
+        "site",
+    )
+
+
+def test_a_site_less_model_still_resolves_to_the_end_effector_body() -> None:
+    """Rung 2 stays reachable: widening rung 1 must not strand a site-less model."""
+    xml = """
+    <mujoco><worldbody>
+      <body name="arm/base">
+        <joint name="arm/j0" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+        <body name="arm/gripper" pos="0 0 .2">
+          <joint name="arm/j1" type="hinge"/><geom type="box" size=".05 .05 .05"/>
+        </body>
+      </body>
+    </worldbody></mujoco>
+    """
+    assert discover_ee_frame(mujoco.MjModel.from_xml_string(xml), "arm/") == (
+        "arm/gripper",
+        "body",
+    )


### PR DESCRIPTION
## Problem

`discover_ee_frame` resolves the Cartesian IK target frame that `move_to` servos and that eef-delta policies decode against. Its ladder is documented site-first - "a TCP-like site, else a hand/tool body, else the chain's leaf body" - because a site is placed at the tool point while a body origin sits at the link's mount.

Rung 1 only searched TCP-specific spellings, while rung 2 matched a wider end-effector vocabulary on bodies:

```python
_SITE_HINTS = ("attachment_site", "attachment", "grasp", "pinch", "tcp", "ee_site", "ee", "flange")
_BODY_HINTS = ("hand", "gripper", "tool", "tcp", "ee", "wrist", "flange", "end_effector", "eef")
```

So a model that publishes its tool point as a site named for the end effector skips rung 1 and is answered from rung 2 with a link origin - with the correct frame present in the same model, and nothing reporting the substitution.

## Measured

Three shipped models do exactly this. Sweeping all 72 registry entries on `main` at `a3f899cc` (mujoco 3.5.0, `MUJOCO_GL=egl`), 62 load and **58 resolve unchanged**; these 4 were answered with a link origin:

| robot | resolved frame | its own tool site | offset |
|---|---|---|---|
| `so101` | `gripper` **body** | `gripper` **site** | **98.4 mm** |
| `aloha` | `left/gripper_link` **body** | `left/gripper` **site** | **130.0 mm** |
| `toddlerbot_2xc` | `left_hand` **body** | `left_hand_center` **site** | **60.8 mm** |
| `toddlerbot_2xm` | `left_hand` **body** | `left_hand_center` **site** | **60.8 mm** |

`so101` names both its tool site and its jaw body `gripper`; `aloha`'s site is menagerie's `<site name="left/gripper" pos="0.13 0 -.003"/>`, matching the measured 130.0 mm.

`move_to` measures the convergence it reports **at the discovered frame**, so the offset does not merely shift the target - it hides itself. Driving `so101` to `[0.03, -0.26, 0.16]` (`tol=0.005`):

| | discovered frame | `move_to` reports | actual tool-site to target |
|---|---|---|---|
| before | `arm/gripper` **body** | `position_error_m` 18.1 mm | **100.5 mm** |
| after | `arm/gripper` **site** | `position_error_m` 10.1 mm | **10.1 mm** |

Before the change the reported residual understates the real fingertip error by 82 mm; after it, the reported number *is* the fingertip error.

## Rollout in MuJoCo sim (headless)

Same target, same tolerance, same trajectory budget. Left: the frame resolved before this change - the jaw stops short of the red target marker while reporting convergence at 18.1 mm. Right: after - the fingertips arrive at the marker.

![so101 move_to end-effector frame comparison](https://raw.githubusercontent.com/cagataycali/robots/media-ee-frame-tool-site/so101_ee_frame.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-ee-frame-tool-site/so101_ee_frame.mp4)

## Change

Rung 1 now searches its own TCP spellings first and then rung 2's vocabulary, so a site wins whenever one names the end effector - the same-name case included:

```python
_SITE_SEARCH_HINTS = tuple(dict.fromkeys((*_SITE_HINTS, *_BODY_HINTS)))
```

The two rungs describe the same physical part of the robot in different words, so a token that identifies the end effector as a body identifies it as a site too - and the site is the more precise frame. Order-preserving dedupe, because the tuples share tokens and the first occurrence decides. Rung 2 is untouched and stays reachable for site-less models (`panda` ships zero sites and still resolves to its `hand` body).

No new parameter, no registry metadata, no per-model special case - the existing ladder is applied consistently.

## Tests

`tests/simulation/test_ee_frame_site_outranks_same_named_body.py`, pinned on the frame's resolved **world position** rather than only its name, because the offset is the whole defect:

- a site and body sharing the bare name `gripper` resolve to the site, and the frame lands at the tool point not the mount - **fails pre-fix** (`'arm/gripper', 'body'`)
- an end-effector-named site outranks a differently-named body (the `toddlerbot` shape) - **fails pre-fix** (`'bot/left_hand', 'body'`)
- a TCP-named site still outranks an end-effector-named site (rung 1 keeps its own ordering) - passes both ways, guards the widening
- a site-less model still resolves to the end-effector body (rung 2 reachable) - passes both ways, guards the widening

The existing exhaustive pin (`tests/policies/vera/test_ee_frame_discovery.py`) needed no assertion changes - every case that reaches rung 2 or 3 there uses a site-less model - and its ladder description is updated to match.

## Verification

- `ruff check` / `ruff format --check` / `mypy` clean on `strands_robots tests tests_integ`.
- Full `tests/` run diffed against a pristine `upstream/main` worktree on the same interpreter: **identical failure sets, zero regressions** (the local deltas are environmental - mujoco 3.5.0 API drift and absent optional extras - and reproduce on the base commit).
- `tests/simulation tests/policies/vera tests/registry`: 11913 passed on this branch vs 11909 on base, the +4 being the new tests.