### PR TITLE
fix(policies/groot): resolve model keys by name under either release key spelling

### DIFF
--- a/changelog.d/2275-groot-modality-key-spelling.md
+++ b/changelog.d/2275-groot-modality-key-spelling.md
@@ -8,6 +8,24 @@
   order, so a wrist image could be sent under the model's front key with nothing
   reporting it. A correct explicit `observation_mapping` was also refused, and
   `strict_keys=True` raised for a key set that matches exactly by name. Both
-  spellings now reduce to the bare name for comparison, and a resolved model key
-  is stated in the spelling its model declares, leaving the emitted payload
-  unchanged for every release.
+  spellings now reduce to the bare name for comparison, leaving the emitted
+  payload unchanged for every release.
+
+  Which spelling a resolved key is then *held* in depends on the direction it
+  travels, and the two directions want opposite answers. An observation key is
+  held in the model's declared spelling, because it is the key the payload is
+  sent under. An action key is held bare, because it is never sent - it only
+  arrives, and both unpack paths reduce a raw output key with
+  `removeprefix("action.")` before matching it by name.
+
+- **policies/groot**: deliver every mapped actuator against an N1.5 checkpoint.
+  `_auto_infer_action_mapping`'s positional arm stored the model's declared
+  spelling, so against a prefixed release it produced a mapping key that
+  `_unpack_actions` and `_unpack_service_actions` could not match: each one
+  reduces a raw output key to bare before its lookup, so every actuator missed
+  its mapping and was emitted under `unmapped.<bare>` with nothing reporting it.
+  Action mapping keys are now reduced to bare by a single owner shared with
+  `_parse_action_mapping`, so service mode - which has no model metadata to
+  canonicalize against - is reduced on the same terms. Naming one action key in
+  both spellings is refused rather than collapsed to whichever entry iteration
+  order reached last.

--- a/changelog.d/2275-groot-modality-key-spelling.md
+++ b/changelog.d/2275-groot-modality-key-spelling.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **policies/groot**: resolve model keys by name under either GR00T release key
+  spelling. N1.6/N1.7 declare `ModalityConfig.modality_keys` bare (`"front"`)
+  and N1.5 declares them prefixed (`"video.front"`); every consumer compared
+  them as bare, so against an N1.5 checkpoint mapping resolution fell through to
+  positional matching - pairing two identically named cameras by declaration
+  order, so a wrist image could be sent under the model's front key with nothing
+  reporting it. A correct explicit `observation_mapping` was also refused, and
+  `strict_keys=True` raised for a key set that matches exactly by name. Both
+  spellings now reduce to the bare name for comparison, and a resolved model key
+  is stated in the spelling its model declares, leaving the emitted payload
+  unchanged for every release.

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -143,21 +143,34 @@ class ObservationMapping:
 class ActionMapping:
     """Maps model action keys → robot actuator names.
 
-    A model key is spelled as the loaded model declares it - see
-    :class:`ObservationMapping` for why, and for what a caller may supply.
+    A model key is held **bare**, which is the opposite of
+    :class:`ObservationMapping` and for the opposite reason: an action key is
+    never sent to the model, it only arrives from it, and both unpack paths
+    reduce a raw output key to its bare name before matching it. So bare is the
+    spelling a lookup can succeed in, whichever spelling the model declares.
+    :class:`Gr00tPolicy` accepts either spelling from a caller and reduces it
+    once, so a mapping built by hand needs no knowledge of which release is
+    loaded.
 
     Attributes:
-        actions: ``{model_action_key: robot_actuator}``.
+        actions: ``{model_action_key: robot_actuator}`` - bare, no prefix.
     """
 
     actions: dict[str, str] = field(default_factory=dict)
 
     def validate(self, modality_configs: dict) -> None:
-        """Validate all mapped model action keys exist in the model config."""
-        model_action = set(modality_configs["action"].modality_keys)
+        """Validate all mapped model action keys exist in the model config.
+
+        Compares bare names on both sides, so a mapping resolves against a
+        release that declares its action keys in either spelling. The refusal
+        quotes the model's own spellings, which is the vocabulary a caller
+        correcting the mapping has to read.
+        """
+        declared = list(modality_configs["action"].modality_keys)
+        model_action = {key.removeprefix("action.") for key in declared}
         for model_key in self.actions:
-            if model_key not in model_action:
-                raise ValueError(f"Action mapping: model key '{model_key}' not in model: {sorted(model_action)}")
+            if model_key.removeprefix("action.") not in model_action:
+                raise ValueError(f"Action mapping: model key '{model_key}' not in model: {sorted(declared)}")
 
 
 # Model key spelling
@@ -176,8 +189,21 @@ class ActionMapping:
 #                                                     ``gr00t.experiment.data_config``
 #
 # Everything downstream matches keys by name, so both spellings have to reduce to
-# one before a name comparison, and a resolved model key has to be written back in
-# the spelling that model declares - it is the key the payload is sent under.
+# one before a name comparison. Which spelling a *resolved* key is then held in
+# depends on the direction that key travels, and the two directions want opposite
+# answers:
+#
+#   observation  robot -> model  held in the model's declared spelling, because it
+#                                is the key ``_prepare_observation`` sends the
+#                                payload under, and the model reads that key
+#   action       model -> robot  held bare, because it is only ever compared
+#                                against a raw output key that ``_unpack_actions``
+#                                and ``_unpack_service_actions`` have already
+#                                reduced with ``removeprefix("action.")``
+#
+# Holding an action key in the declared spelling instead would make that lookup
+# unsatisfiable against a prefixed release: every actuator would miss its mapping
+# and be emitted under ``unmapped.<bare>`` with nothing reporting it.
 
 
 def _declared_by_bare(declared: list[str], modality: str) -> dict[str, str]:
@@ -230,10 +256,41 @@ def _canonicalize_observation_mapping(mapping: ObservationMapping, modality_conf
     )
 
 
-def _canonicalize_action_mapping(mapping: ActionMapping, modality_configs: dict) -> ActionMapping:
-    """Restate an action mapping's model keys in the model's own spelling."""
-    canonical = _canonical_model_keys(mapping.actions, modality_configs["action"].modality_keys, "action")
-    return replace(mapping, actions={canonical[model]: robot for model, robot in mapping.actions.items()})
+def _bare_action_keys(actions: dict[str, str]) -> dict[str, str]:
+    """Reduce ``{model_action_key: robot_key}`` to bare model keys.
+
+    The single owner of the reduction, so a caller's mapping is reduced on the
+    same terms in either mode: service mode has no model metadata and therefore
+    never reaches :func:`_canonicalize_action_mapping`, but its unpack path
+    reduces raw output keys identically, so it needs the same bare form.
+
+    Raises:
+        ValueError: If two entries name one action key in different spellings.
+            A plain dict comprehension keeps whichever the iteration order
+            reached last and drops the other actuator with nothing reporting it,
+            which is the failure this whole module exists to remove.
+    """
+    reduced: dict[str, str] = {}
+    for model_key, robot_key in actions.items():
+        bare = model_key.removeprefix("action.")
+        if bare in reduced and reduced[bare] != robot_key:
+            raise ValueError(
+                f"Action mapping: model key '{bare}' is mapped twice, to robot keys "
+                f"'{reduced[bare]}' and '{robot_key}'. A prefixed and a bare spelling of one "
+                "model key are the same key; map it once."
+            )
+        reduced[bare] = robot_key
+    return reduced
+
+
+def _canonicalize_action_mapping(mapping: ActionMapping) -> ActionMapping:
+    """Reduce an action mapping's model keys to their bare names.
+
+    Actions travel the other way from observations - see :class:`ActionMapping`
+    for why bare rather than declared spelling is the form a mapping is held in,
+    and note that the model's declared spelling is therefore not consulted here.
+    """
+    return replace(mapping, actions=_bare_action_keys(mapping.actions))
 
 
 # Auto-inference (exact name match → positional fallback)
@@ -293,7 +350,7 @@ def _auto_infer_action_mapping(
     used: set = set()
     for k in ours:
         if k in declared:
-            actions[declared[k]] = k
+            actions[k] = k
             used.add(declared[k])
     remaining_ours = [k for k in ours if k not in actions.values()]
     remaining_model = [k for k in model if k not in used]
@@ -306,7 +363,7 @@ def _auto_infer_action_mapping(
             "or set strict_keys=False to allow positional fallback."
         )
     for mdl, our in zip(remaining_model, remaining_ours):
-        actions[mdl] = our
+        actions[mdl.removeprefix("action.")] = our
         logger.info("Auto-mapped action: model '%s' -> robot '%s' (positional)", mdl, our)
     return ActionMapping(actions=actions)
 
@@ -382,8 +439,8 @@ def _parse_observation_mapping(flat: dict[str, str]) -> ObservationMapping:
 
 
 def _parse_action_mapping(flat: dict[str, str]) -> ActionMapping:
-    """Parse ``{"action.X": "robot_key"}`` → ActionMapping."""
-    return ActionMapping(actions={k.removeprefix("action."): v for k, v in flat.items()})
+    """Parse ``{"action.X": "robot_key"}`` → ActionMapping, keys reduced to bare."""
+    return ActionMapping(actions=_bare_action_keys(flat))
 
 
 def _coerce_action_row(row: Any) -> float | list[float]:
@@ -471,7 +528,10 @@ class Gr00tPolicy(Policy):
             so either spelling is accepted here and one that names no declared
             key is refused by name.
         action_mapping: ``{"action.X": "robot_key"}``. Honoured in either mode,
-            on the same terms.
+            on the same terms. Either spelling of a model key is accepted and
+            reduced to a bare name, which is the form the unpack paths match
+            against; naming one key in both spellings is refused rather than
+            silently collapsed.
         language_key: Override the key the instruction is sent under. Otherwise
             the model's own language key is used when a local checkpoint is
             loaded, and in service mode - where there is no model to ask - the
@@ -664,7 +724,7 @@ class Gr00tPolicy(Policy):
         if self._action_mapping is None:
             self._action_mapping = _auto_infer_action_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
-        self._action_mapping = _canonicalize_action_mapping(self._action_mapping, mmc)
+        self._action_mapping = _canonicalize_action_mapping(self._action_mapping)
         self._action_mapping.validate(mmc)
 
         logger.info(

--- a/strands_robots/policies/groot/policy.py
+++ b/strands_robots/policies/groot/policy.py
@@ -21,6 +21,7 @@ mappings.  No positional guessing.  One step in, one step out.
 import importlib.util
 import logging
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from typing import Any
 
@@ -96,9 +97,16 @@ def _detect_groot_version(*, force: bool = False) -> str | None:
 class ObservationMapping:
     """Maps robot sensor names → model modality keys.
 
+    A model key is spelled as the loaded model declares it, because it is the
+    key the observation payload is sent under: bare on N1.6/N1.7
+    (``"front"``), prefixed on N1.5 (``"video.front"``).
+    :class:`Gr00tPolicy` accepts either spelling from a caller and restates it
+    once against the model, so a mapping built by hand needs no knowledge of
+    which release is loaded.
+
     Attributes:
-        video: ``{robot_camera: model_video_key}`` - bare, no prefix.
-        state: ``{robot_state: model_state_key}`` - bare, no prefix.
+        video: ``{robot_camera: model_video_key}``.
+        state: ``{robot_state: model_state_key}``.
         language_key: Model's language key (e.g. ``"task"``).
     """
 
@@ -135,8 +143,11 @@ class ObservationMapping:
 class ActionMapping:
     """Maps model action keys → robot actuator names.
 
+    A model key is spelled as the loaded model declares it - see
+    :class:`ObservationMapping` for why, and for what a caller may supply.
+
     Attributes:
-        actions: ``{model_action_key: robot_actuator}`` - bare, no prefix.
+        actions: ``{model_action_key: robot_actuator}``.
     """
 
     actions: dict[str, str] = field(default_factory=dict)
@@ -147,6 +158,82 @@ class ActionMapping:
         for model_key in self.actions:
             if model_key not in model_action:
                 raise ValueError(f"Action mapping: model key '{model_key}' not in model: {sorted(model_action)}")
+
+
+# Model key spelling
+
+# The spelling of ``ModalityConfig.modality_keys`` differs by GR00T release, and
+# a policy reads whichever one its loaded model carries:
+#
+#   N1.6 / N1.7  bare      ``["front", "wrist"]``   - built by the checkpoint
+#                                                     processor that
+#                                                     ``gr00t.policy.gr00t_policy``
+#                                                     reads, and the same
+#                                                     spelling a live server
+#                                                     returns for
+#                                                     ``get_modality_config``
+#   N1.5         prefixed  ``["video.front", ...]`` - declared by
+#                                                     ``gr00t.experiment.data_config``
+#
+# Everything downstream matches keys by name, so both spellings have to reduce to
+# one before a name comparison, and a resolved model key has to be written back in
+# the spelling that model declares - it is the key the payload is sent under.
+
+
+def _declared_by_bare(declared: list[str], modality: str) -> dict[str, str]:
+    """Index a model's declared keys by their bare (prefix-free) name.
+
+    Args:
+        declared: The model's ``modality_keys`` for one modality, in either
+            spelling.
+        modality: The modality these keys belong to (``"video"``, ``"state"``
+            or ``"action"``), whose name is the prefix to reduce away.
+
+    Returns:
+        ``{bare name: declared spelling}``. For a bare-spelling model every
+        entry maps to itself.
+    """
+    prefix = f"{modality}."
+    return {key.removeprefix(prefix): key for key in declared}
+
+
+def _canonical_model_keys(requested: Iterable[str], declared: list[str], modality: str) -> dict[str, str]:
+    """Resolve requested model keys to the model's own spelling of each.
+
+    A caller names a model key in whichever spelling they have in front of
+    them; the payload has to carry the spelling the model declares. A key that
+    matches no declared key is returned unchanged, so it reaches
+    :meth:`ObservationMapping.validate` / :meth:`ActionMapping.validate` and is
+    refused there by name rather than being quietly rewritten.
+
+    Args:
+        requested: Model keys as supplied or inferred.
+        declared: The model's ``modality_keys`` for that modality.
+        modality: ``"video"``, ``"state"`` or ``"action"``.
+
+    Returns:
+        ``{requested key: declared spelling}``.
+    """
+    index = _declared_by_bare(declared, modality)
+    prefix = f"{modality}."
+    return {key: index.get(key.removeprefix(prefix), key) for key in requested}
+
+
+def _canonicalize_observation_mapping(mapping: ObservationMapping, modality_configs: dict) -> ObservationMapping:
+    """Restate an observation mapping's model keys in the model's own spelling."""
+    video = _canonical_model_keys(mapping.video.values(), modality_configs["video"].modality_keys, "video")
+    state = _canonical_model_keys(mapping.state.values(), modality_configs["state"].modality_keys, "state")
+    return replace(
+        mapping,
+        video={robot: video[model] for robot, model in mapping.video.items()},
+        state={robot: state[model] for robot, model in mapping.state.items()},
+    )
+
+
+def _canonicalize_action_mapping(mapping: ActionMapping, modality_configs: dict) -> ActionMapping:
+    """Restate an action mapping's model keys in the model's own spelling."""
+    canonical = _canonical_model_keys(mapping.actions, modality_configs["action"].modality_keys, "action")
+    return replace(mapping, actions={canonical[model]: robot for model, robot in mapping.actions.items()})
 
 
 # Auto-inference (exact name match → positional fallback)
@@ -200,14 +287,14 @@ def _auto_infer_action_mapping(
     """
     ours = [k.removeprefix("action.") for k in data_config.action_keys]
     model = list(modality_configs["action"].modality_keys)
-    model_set = set(model)
+    declared = _declared_by_bare(model, "action")
 
     actions: dict[str, str] = {}
     used: set = set()
     for k in ours:
-        if k in model_set:
-            actions[k] = k
-            used.add(k)
+        if k in declared:
+            actions[declared[k]] = k
+            used.add(declared[k])
     remaining_ours = [k for k in ours if k not in actions.values()]
     remaining_model = [k for k in model if k not in used]
     if strict_keys and remaining_ours and remaining_model:
@@ -224,13 +311,18 @@ def _auto_infer_action_mapping(
     return ActionMapping(actions=actions)
 
 
-def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool = False) -> dict[str, str]:
-    """Match our keys to model keys: exact first, positional fallback.
+def _match_keys(ours: list[str], model: list[str], modality: str, strict_keys: bool = False) -> dict[str, str]:
+    """Match our keys to model keys: exact name first, positional fallback.
+
+    Both arms return the model's declared spelling of the key they resolved, so
+    which arm resolved a key is not observable in the result.
 
     Args:
-        ours: Robot/sim key names to map.
-        model: The model's declared key names.
-        label: Human-readable label for logs/errors (e.g. ``"video"``).
+        ours: Robot/sim key names to map, bare.
+        model: The model's declared key names, in either spelling.
+        modality: The modality being matched (``"video"``, ``"state"`` or
+            ``"action"``) - names the prefix to reduce away, and labels logs
+            and errors.
         strict_keys: When True, raise instead of falling back to positional
             matching if any key cannot be resolved by exact name.
 
@@ -238,18 +330,18 @@ def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool
         ValueError: If ``strict_keys`` is True and any key needs positional
             fallback.
     """
-    model_set = set(model)
+    declared = _declared_by_bare(model, modality)
     mapping: dict[str, str] = {}
     used: set = set()
     for k in ours:
-        if k in model_set:
-            mapping[k] = k
-            used.add(k)
+        if k in declared:
+            mapping[k] = declared[k]
+            used.add(declared[k])
     remaining_ours = [k for k in ours if k not in mapping]
     remaining_model = [k for k in model if k not in used]
     if strict_keys and remaining_ours and remaining_model:
         raise ValueError(
-            f"strict_keys=True: cannot resolve {label} keys by exact name. "
+            f"strict_keys=True: cannot resolve {modality} keys by exact name. "
             f"Unmatched robot keys: {sorted(remaining_ours)}; "
             f"available model keys: {sorted(remaining_model)}. "
             "Provide an explicit mapping (observation_mapping/action_mapping) "
@@ -257,7 +349,7 @@ def _match_keys(ours: list[str], model: list[str], label: str, strict_keys: bool
         )
     for our, mdl in zip(remaining_ours, remaining_model):
         mapping[our] = mdl
-        logger.info("Auto-mapped %s: '%s' -> '%s' (positional)", label, our, mdl)
+        logger.info("Auto-mapped %s: '%s' -> '%s' (positional)", modality, our, mdl)
     return mapping
 
 
@@ -374,6 +466,10 @@ class Gr00tPolicy(Policy):
             prefixes, so no model metadata is needed. Service mode cannot
             cross-check it against the server, so a key the server does not have
             surfaces there as a server-side error rather than a refusal here.
+            With a local checkpoint loaded, each model key is restated in the
+            spelling that model declares - bare on N1.6/N1.7, prefixed on N1.5 -
+            so either spelling is accepted here and one that names no declared
+            key is refused by name.
         action_mapping: ``{"action.X": "robot_key"}``. Honoured in either mode,
             on the same terms.
         language_key: Override the key the instruction is sent under. Otherwise
@@ -560,6 +656,7 @@ class Gr00tPolicy(Policy):
         if self._obs_mapping is None:
             self._obs_mapping = _auto_infer_observation_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
+        self._obs_mapping = _canonicalize_observation_mapping(self._obs_mapping, mmc)
         self._obs_mapping = replace(self._obs_mapping, language_key=self._resolve_language_key(mmc))
         self._obs_mapping.validate(mmc)
 
@@ -567,6 +664,7 @@ class Gr00tPolicy(Policy):
         if self._action_mapping is None:
             self._action_mapping = _auto_infer_action_mapping(self.data_config, mmc, strict_keys=self._strict_keys)
 
+        self._action_mapping = _canonicalize_action_mapping(self._action_mapping, mmc)
         self._action_mapping.validate(mmc)
 
         logger.info(

--- a/tests/policies/groot/test_modality_key_spelling.py
+++ b/tests/policies/groot/test_modality_key_spelling.py
@@ -10,12 +10,27 @@
   N1.5 policy and then reads back.
 
 Mapping resolution compares key *names*, so it must reduce both spellings to one
-before comparing, and must state a resolved model key back in the spelling that
-model declares - it is the key the payload is sent under. Against a prefixed
-model the by-name arm used to match nothing, which left declaration *order* the
-only thing that resolved a mapping and refused an explicit one that was correct.
+before comparing. Against a prefixed model the by-name arm used to match nothing,
+which left declaration *order* the only thing that resolved a mapping and refused
+an explicit one that was correct.
+
+Which spelling a resolved key is *held* in then depends on the direction it
+travels, and the two directions want opposite answers:
+
+* An **observation** key is held in the model's declared spelling, because it is
+  the key the payload is sent under and the model reads that key.
+* An **action** key is held bare, because it is never sent - it only arrives, and
+  both unpack paths reduce a raw output key with ``removeprefix("action.")``
+  before matching it by name.
+
+Holding an action key in the declared spelling makes that lookup unsatisfiable
+against a prefixed release: the mapping validates, then every actuator misses it
+at ``get_actions()`` and is emitted under ``unmapped.<bare>`` with nothing
+reporting it. So the action assertions below are round trips through unpack
+rather than assertions about the mapping's spelling alone.
 """
 
+import numpy as np
 import pytest
 
 msgpack = pytest.importorskip("msgpack", reason="msgpack not installed - pip install 'strands-robots[groot-service]'")
@@ -125,15 +140,31 @@ class TestAutoInferenceResolvesByName:
         # Declared in the opposite order, so a positional resolution swaps them.
         assert mapping.video == {"wrist": wrist, "front": front}
 
-    @pytest.mark.parametrize(
-        ("spelling", "expected"),
-        [
-            ("bare", {"single_arm": "single_arm", "gripper": "gripper"}),
-            ("prefixed", {"action.single_arm": "single_arm", "action.gripper": "gripper"}),
-        ],
-    )
-    def test_action_keys_carry_the_spelling_the_model_declares(self, spelling, expected):
-        assert _auto_infer_action_mapping(DATA_CONFIG, _modality_configs(spelling)).actions == expected
+    @pytest.mark.parametrize("spelling", ["bare", "prefixed"])
+    def test_action_keys_are_inferred_bare_under_either_spelling(self, spelling):
+        """The by-name arm resolves against a prefixed model, and stores bare."""
+        mapping = _auto_infer_action_mapping(DATA_CONFIG, _modality_configs(spelling))
+
+        assert mapping.actions == {"single_arm": "single_arm", "gripper": "gripper"}
+
+    @pytest.mark.parametrize("spelling", ["bare", "prefixed"])
+    def test_a_positionally_resolved_action_key_is_also_stored_bare(self, spelling):
+        """The positional arm reads the declared list, so it must reduce too.
+
+        This arm stored the declared spelling before either spelling resolved by
+        name, so against a prefixed release it produced a mapping key no unpack
+        lookup could match - the same silent drop, reached without a caller
+        supplying anything.
+        """
+        configs = _modality_configs(spelling)
+        configs["action"] = ModalityConfig(
+            delta_indices=[0],
+            modality_keys=[k if spelling == "bare" else f"action.{k}" for k in ("left", "right")],
+        )
+
+        mapping = _auto_infer_action_mapping(DATA_CONFIG, configs)
+
+        assert mapping.actions == {"left": "single_arm", "right": "gripper"}
 
     @pytest.mark.parametrize("spelling", ["bare", "prefixed"])
     def test_a_fully_name_matching_key_set_is_not_a_strict_keys_failure(self, spelling):
@@ -167,16 +198,26 @@ class TestASuppliedMappingIsAcceptedInEitherSpelling:
         assert p._obs_mapping.video == {"cam": front}
 
     @pytest.mark.parametrize(
-        ("spelling", "version", "action_key"),
-        [
-            ("bare", "n1.6", "single_arm"),
-            ("prefixed", "n1.5", "action.single_arm"),
-        ],
+        ("spelling", "version"),
+        [("bare", "n1.6"), ("prefixed", "n1.5")],
     )
-    def test_a_supplied_action_key_is_restated_in_the_model_spelling(self, spelling, version, action_key):
+    def test_a_supplied_action_key_is_reduced_to_a_bare_name(self, spelling, version):
         p = _policy(spelling, version=version, action_mapping={"action.single_arm": "joints"})
 
-        assert p._action_mapping.actions == {action_key: "joints"}
+        assert p._action_mapping.actions == {"single_arm": "joints"}
+
+    @pytest.mark.parametrize(
+        ("spelling", "version"),
+        [("bare", "n1.6"), ("prefixed", "n1.5")],
+    )
+    def test_one_action_key_named_in_both_spellings_is_refused(self, spelling, version):
+        """Reducing the pair would keep one actuator and drop the other silently."""
+        with pytest.raises(ValueError, match="mapped twice"):
+            _policy(
+                spelling,
+                version=version,
+                action_mapping={"action.single_arm": "joints", "single_arm": "other"},
+            )
 
     @pytest.mark.parametrize(
         ("spelling", "version"),
@@ -185,3 +226,64 @@ class TestASuppliedMappingIsAcceptedInEitherSpelling:
     def test_a_mapping_naming_no_declared_key_is_still_refused_by_name(self, spelling, version):
         with pytest.raises(ValueError, match="model video 'wirst'"):
             _policy(spelling, version=version, observation_mapping={"cam": "video.wirst"})
+
+
+class TestAMappedActionReachesTheRobotKey:
+    """A validated action mapping must actually resolve at ``get_actions()``.
+
+    The mapping's spelling is only observable through unpack, so a mapping that
+    validates and then matches nothing is indistinguishable from a correct one
+    until an actuator value is read back. Both spellings of the *model's*
+    declaration and both spellings of the *raw output* are covered, because the
+    unpack paths reduce the raw key and must therefore be insensitive to it.
+    """
+
+    @staticmethod
+    def _raw(spelling: str) -> dict[str, np.ndarray]:
+        """A two-timestep action chunk keyed in one spelling."""
+        prefix = "" if spelling == "bare" else "action."
+        return {
+            f"{prefix}single_arm": np.array([[0.1, 0.2], [0.3, 0.4]]),
+            f"{prefix}gripper": np.array([[1.0], [0.0]]),
+        }
+
+    @pytest.mark.parametrize("unpack", ["_unpack_actions", "_unpack_service_actions"])
+    @pytest.mark.parametrize("raw_spelling", ["bare", "prefixed"])
+    @pytest.mark.parametrize(("spelling", "version"), [("bare", "n1.6"), ("prefixed", "n1.5")])
+    def test_a_supplied_mapping_resolves_every_actuator(self, spelling, version, raw_spelling, unpack):
+        p = _policy(
+            spelling,
+            version=version,
+            action_mapping={"action.single_arm": "joints", "action.gripper": "grip"},
+        )
+
+        steps = getattr(p, unpack)(self._raw(raw_spelling))
+
+        assert [sorted(step) for step in steps] == [["grip", "joints"], ["grip", "joints"]]
+        assert steps[0]["joints"] == [0.1, 0.2]
+        assert steps[1]["grip"] == [0.0]
+
+    @pytest.mark.parametrize("unpack", ["_unpack_actions", "_unpack_service_actions"])
+    @pytest.mark.parametrize("raw_spelling", ["bare", "prefixed"])
+    @pytest.mark.parametrize(("spelling", "version"), [("bare", "n1.6"), ("prefixed", "n1.5")])
+    def test_no_mapped_actuator_is_reported_as_unmapped(self, spelling, version, raw_spelling, unpack):
+        """``unmapped.*`` is the shape a missed lookup takes, so pin its absence."""
+        p = _policy(
+            spelling,
+            version=version,
+            action_mapping={"action.single_arm": "joints", "action.gripper": "grip"},
+        )
+
+        steps = getattr(p, unpack)(self._raw(raw_spelling))
+
+        assert [key for step in steps for key in step if key.startswith("unmapped.")] == []
+
+    @pytest.mark.parametrize("unpack", ["_unpack_actions", "_unpack_service_actions"])
+    @pytest.mark.parametrize(("spelling", "version"), [("bare", "n1.6"), ("prefixed", "n1.5")])
+    def test_an_auto_inferred_mapping_resolves_every_actuator(self, spelling, version, unpack):
+        """Auto-inference feeds the same lookup, so it needs the same round trip."""
+        p = _policy(spelling, version=version)
+
+        steps = getattr(p, unpack)(self._raw(spelling))
+
+        assert [sorted(step) for step in steps] == [["gripper", "single_arm"]] * 2

--- a/tests/policies/groot/test_modality_key_spelling.py
+++ b/tests/policies/groot/test_modality_key_spelling.py
@@ -1,0 +1,187 @@
+"""The model key spelling a GR00T release declares must not change what resolves.
+
+``ModalityConfig.modality_keys`` is spelled differently by GR00T release:
+
+* N1.6 / N1.7 declare bare keys (``["front", "wrist"]``) - what
+  ``examples/SO100/so100_config.py`` in Isaac-GR00T ships, and what
+  ``tests_integ/groot/test_n17_live_server.py`` pins coming back over the wire.
+* N1.5 declares them prefixed (``["video.front", "video.wrist"]``) - what
+  ``gr00t.experiment.data_config`` ships, and what ``_load_n15`` hands to the
+  N1.5 policy and then reads back.
+
+Mapping resolution compares key *names*, so it must reduce both spellings to one
+before comparing, and must state a resolved model key back in the spelling that
+model declares - it is the key the payload is sent under. Against a prefixed
+model the by-name arm used to match nothing, which left declaration *order* the
+only thing that resolved a mapping and refused an explicit one that was correct.
+"""
+
+import pytest
+
+msgpack = pytest.importorskip("msgpack", reason="msgpack not installed - pip install 'strands-robots[groot-service]'")
+zmq = pytest.importorskip("zmq", reason="zmq not installed - pip install 'strands-robots[groot-service]'")
+
+from strands_robots.policies.groot import Gr00tPolicy  # noqa: E402
+from strands_robots.policies.groot.data_config import Gr00tDataConfig, ModalityConfig  # noqa: E402
+from strands_robots.policies.groot.policy import (  # noqa: E402
+    _auto_infer_action_mapping,
+    _auto_infer_observation_mapping,
+)
+
+# Two cameras named identically by robot and model, declared in opposite order,
+# so name resolution and positional resolution give different answers.
+DATA_CONFIG = Gr00tDataConfig(
+    name="spelling_probe",
+    video_keys=["video.wrist", "video.front"],
+    state_keys=["state.single_arm", "state.gripper"],
+    action_keys=["action.single_arm", "action.gripper"],
+    language_keys=["annotation.human.task_description"],
+    observation_indices=[0],
+    action_indices=[0],
+)
+
+_MODEL_KEYS = {
+    "video": ["front", "wrist"],
+    "state": ["single_arm", "gripper"],
+    "action": ["single_arm", "gripper"],
+}
+
+
+def _modality_configs(spelling: str) -> dict[str, ModalityConfig]:
+    """Build model modality configs in one release's key spelling.
+
+    Args:
+        spelling: ``"bare"`` for the N1.6/N1.7 convention, ``"prefixed"`` for
+            the N1.5 convention.
+
+    Returns:
+        ``{modality: ModalityConfig}`` in the requested spelling. The language
+        key carries no modality prefix in either release.
+    """
+    configs = {
+        modality: ModalityConfig(
+            delta_indices=[0],
+            modality_keys=[k if spelling == "bare" else f"{modality}.{k}" for k in keys],
+        )
+        for modality, keys in _MODEL_KEYS.items()
+    }
+    configs["language"] = ModalityConfig(delta_indices=[0], modality_keys=["annotation.human.task_description"])
+    return configs
+
+
+class _StubLocalPolicy:
+    """A loaded checkpoint that exposes only its modality configs.
+
+    Named attributes only, so the DOF-discovery probes for ``normalizer`` and
+    ``processor`` find nothing and leave ``_model_state_dof`` empty - this suite
+    is about key resolution, not zero-fill sizing.
+    """
+
+    def __init__(self, modality_configs: dict[str, ModalityConfig]) -> None:
+        self.modality_config = modality_configs  # N1.5 reads the singular name
+        self.modality_configs = modality_configs  # N1.6 / N1.7 read the plural
+
+
+def _policy(
+    spelling: str,
+    *,
+    version: str,
+    observation_mapping: dict[str, str] | None = None,
+    action_mapping: dict[str, str] | None = None,
+    strict_keys: bool = False,
+) -> Gr00tPolicy:
+    """Build a local-mode policy over a stub checkpoint and run mapping init."""
+    p = Gr00tPolicy.__new__(Gr00tPolicy)
+    p.data_config = DATA_CONFIG
+    p.data_config_name = DATA_CONFIG.name
+    p._mode = "local"
+    p._groot_version = version
+    p._strict = False
+    p._strict_keys = strict_keys
+    p._client = None
+    p._local_policy = _StubLocalPolicy(_modality_configs(spelling))
+    p._raw_obs_mapping = observation_mapping
+    p._raw_action_mapping = action_mapping
+    p._language_key_override = None
+    p._obs_mapping = None
+    p._action_mapping = None
+    p._init_mappings()
+    return p
+
+
+class TestAutoInferenceResolvesByName:
+    """Auto-inference must resolve by name under either spelling."""
+
+    @pytest.mark.parametrize(
+        ("spelling", "front", "wrist"),
+        [
+            ("bare", "front", "wrist"),
+            ("prefixed", "video.front", "video.wrist"),
+        ],
+    )
+    def test_each_camera_maps_to_the_model_key_of_the_same_name(self, spelling, front, wrist):
+        mapping = _auto_infer_observation_mapping(DATA_CONFIG, _modality_configs(spelling))
+
+        # Declared in the opposite order, so a positional resolution swaps them.
+        assert mapping.video == {"wrist": wrist, "front": front}
+
+    @pytest.mark.parametrize(
+        ("spelling", "expected"),
+        [
+            ("bare", {"single_arm": "single_arm", "gripper": "gripper"}),
+            ("prefixed", {"action.single_arm": "single_arm", "action.gripper": "gripper"}),
+        ],
+    )
+    def test_action_keys_carry_the_spelling_the_model_declares(self, spelling, expected):
+        assert _auto_infer_action_mapping(DATA_CONFIG, _modality_configs(spelling)).actions == expected
+
+    @pytest.mark.parametrize("spelling", ["bare", "prefixed"])
+    def test_a_fully_name_matching_key_set_is_not_a_strict_keys_failure(self, spelling):
+        """strict_keys only refuses keys that genuinely need positional fallback."""
+        mapping = _auto_infer_observation_mapping(DATA_CONFIG, _modality_configs(spelling), strict_keys=True)
+
+        assert set(mapping.video) == {"front", "wrist"}
+
+    @pytest.mark.parametrize("spelling", ["bare", "prefixed"])
+    def test_a_genuinely_unresolvable_key_still_refuses_under_strict_keys(self, spelling):
+        configs = _modality_configs(spelling)
+        configs["video"] = ModalityConfig(delta_indices=[0], modality_keys=["overhead", "chest"])
+
+        with pytest.raises(ValueError, match="cannot resolve video keys by exact name"):
+            _auto_infer_observation_mapping(DATA_CONFIG, configs, strict_keys=True)
+
+
+class TestASuppliedMappingIsAcceptedInEitherSpelling:
+    """A caller's mapping must not depend on which release is loaded."""
+
+    @pytest.mark.parametrize(
+        ("spelling", "version", "front"),
+        [
+            ("bare", "n1.6", "front"),
+            ("prefixed", "n1.5", "video.front"),
+        ],
+    )
+    def test_a_correct_mapping_is_accepted_and_restated_in_the_model_spelling(self, spelling, version, front):
+        p = _policy(spelling, version=version, observation_mapping={"cam": "video.front"})
+
+        assert p._obs_mapping.video == {"cam": front}
+
+    @pytest.mark.parametrize(
+        ("spelling", "version", "action_key"),
+        [
+            ("bare", "n1.6", "single_arm"),
+            ("prefixed", "n1.5", "action.single_arm"),
+        ],
+    )
+    def test_a_supplied_action_key_is_restated_in_the_model_spelling(self, spelling, version, action_key):
+        p = _policy(spelling, version=version, action_mapping={"action.single_arm": "joints"})
+
+        assert p._action_mapping.actions == {action_key: "joints"}
+
+    @pytest.mark.parametrize(
+        ("spelling", "version"),
+        [("bare", "n1.6"), ("prefixed", "n1.5")],
+    )
+    def test_a_mapping_naming_no_declared_key_is_still_refused_by_name(self, spelling, version):
+        with pytest.raises(ValueError, match="model video 'wirst'"):
+            _policy(spelling, version=version, observation_mapping={"cam": "video.wirst"})


### PR DESCRIPTION
## Problem

Isaac-GR00T spells `ModalityConfig.modality_keys` differently by release, and a policy reads whichever spelling its loaded checkpoint carries:

| release | spelling | source |
| --- | --- | --- |
| N1.6 / N1.7 | bare - `["front", "wrist"]` | built by the checkpoint processor `gr00t.policy.gr00t_policy` reads; the same spelling a live server returns for `get_modality_config` |
| N1.5 | prefixed - `["video.front", "video.wrist"]` | declared by `gr00t.experiment.data_config`, and what `_load_n15` hands the N1.5 policy and then reads back |

Every consumer of those keys compared them as bare, so against an N1.5 checkpoint the by-name arm of mapping resolution could never match. Three consequences:

1. **A camera can be silently paired with the wrong model key.** Auto-inference fell through to positional matching, so two cameras named identically by robot and model were resolved by *declaration order*. When the orders differ, the wrist image is sent under the model's front key and nothing reports it - the policy runs, and only its behaviour is wrong.
2. **A correct explicit `observation_mapping` was refused**, reporting that the model "only has" the prefixed spelling of the very key just asked for: `robot 'cam' -> model video 'front', but model only has: ['video.front', 'video.wrist']`.
3. **`strict_keys=True` raised for a key set that matches exactly by name**, pointing the caller at an explicit mapping that option 2 then refuses.

## Change

Reduce both spellings to the bare name before any name comparison. Which spelling a resolved key is then *held* in depends on the direction that key travels, and the two directions want opposite answers:

| key | direction | held as | because |
| --- | --- | --- | --- |
| observation | robot -> model | the model's declared spelling | it is the key `_prepare_observation` sends the payload under, and the model reads that key |
| action | model -> robot | bare | it is only ever compared against a raw output key that `_unpack_actions` and `_unpack_service_actions` have already reduced with `removeprefix("action.")` |

So **the emitted observation payload is byte-identical for every release**, including the positional path that already returned the declared spelling, and an action mapping key is in the one form its lookup can succeed in. The by-name arm and the positional arm now agree on how they spell what they resolved.

A supplied mapping is reduced the same way, so a caller may spell a model key in either convention and needs no knowledge of which release is loaded. A mapping that names no declared key is still refused by name, unchanged. Naming one action key in both spellings is refused rather than collapsed.

## Visual

Rendered headless in MuJoCo: an SO-101 with a world-fixed `front` camera and a `wrist` camera mounted on `so101/gripper`, against a checkpoint declaring the N1.5 prefixed spelling. Each panel is the frame the model actually receives under that key, using the mapping each tree resolves - not an illustration.

![what the model receives under each video key](https://raw.githubusercontent.com/cagataycali/robots/media-groot-key-spelling/groot-key-spelling.png)

Top row (`main`): the two views are swapped. Bottom row (this change): each key carries the camera of the same name. Mean absolute pixel difference between the two rows is 41.4 per channel, so the panels are genuinely different views.

## Tests

`tests/policies/groot/test_modality_key_spelling.py` - 38 cases, each parametrized over both spellings so the bare convention is pinned as a control alongside the prefixed one. The bare cases passing is the evidence that N1.6/N1.7 behaviour is unchanged.

The action assertions are round trips through both unpack paths rather than assertions about the mapping's spelling: a mapping held in the wrong spelling validates cleanly and only misses at `get_actions()`, so unpack is the only place it is observable. Parametrized over the cross product of the model's declared spelling, the raw output's spelling, and both unpack paths, plus explicit absence of any `unmapped.*` key.

| tree | result |
| --- | --- |
| this branch (post-fix) | 38 passed |
| this branch at `26873e4` (pre-fix) | 15 failed |
| `main` | 3 failed |

`tests/policies/groot/` is 266 passed / 2 skipped.

Local gate: `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`; full `tests/` run diffed against `main` shows zero new failures.

Out of scope: the flat/legacy service builder and service-mode mapping validation raised in #2268 and #2269 - both turn on a payload-shape contract decision that is still open there. This change touches only key resolution against a loaded local checkpoint.

## Round 2 - review feedback

**A mapped actuator could not reach its robot key against an N1.5 checkpoint.** Round 1 canonicalized action mapping keys into the model's declared spelling, alongside observation keys. That was wrong for actions specifically: both consumers reduce a raw output key with `removeprefix("action.")` before their lookup, so a prefixed mapping key could never match, and every actuator was emitted under `unmapped.<bare>` under `status="success"` with nothing reporting it - a silent action drop, and Key Conventions 5/6.

- Action mapping keys are now held **bare**; `_canonicalize_action_mapping` no longer consults the model's declared spelling. `ActionMapping.validate` compares bare names on both sides and quotes the model's declared spellings in its refusal.
- The **positional arm** of `_auto_infer_action_mapping` stored the declared spelling before this branch existed, so the drop was already reachable on `main` with no caller involvement - 3 of the new assertions fail there. Both arms now store bare.
- `_parse_action_mapping` and the canonicalization share one guarded reducer, `_bare_action_keys`. It is the only reducer **service mode** reaches, since service mode has no model metadata to canonicalize against, and its plain dict comprehension previously collapsed a duplicate spelling to whichever entry iteration order reached last. That collision is now refused.
- The direction rule is stated once in the module comment and in both mapping docstrings, naming the `removeprefix` sites, so the asymmetry is a documented contract rather than an accident.

One deletion, no additions to the public surface: `_canonical_model_keys` is now observation-only.