### PR TITLE
fix(simulation/mujoco): expand the CSR inertia on builds without mju_sym2dense

### DIFF
--- a/changelog.d/2276-csr-inertia-without-sym2dense.md
+++ b/changelog.d/2276-csr-inertia-without-sym2dense.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **simulation/mujoco**: the dense mass matrix is now built on MuJoCo builds that
+  ship the CSR joint-space inertia without the `mju_sym2dense` conversion (3.5
+  through 3.9). The CSR rung of the `get_mass_matrix` path called that symbol
+  unconditionally although MuJoCo exports it only from 3.10, so it raised
+  `AttributeError` inside the declared `mujoco>=3.2.0,<4.0.0` range. MuJoCo's own
+  conversion is still used wherever the binding exports it; where it does not, the
+  stored lower triangle is expanded through the `M_rownnz` / `M_rowadr` /
+  `M_colind` index arrays, bit-exact against `mj_fullM`.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -296,7 +296,11 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     - MuJoCo >= 3.11: ``data.qM`` is removed. The joint-space inertia is kept
       only as the compressed-sparse-row ``data.M``, and ``mju_sym2dense`` is
       the conversion MuJoCo's release notes prescribe for callers that used to
-      pass ``qM`` to ``mj_fullM``.
+      pass ``qM`` to ``mj_fullM``. That helper is only exported from MuJoCo
+      3.10 onwards, while the CSR buffers and their index arrays
+      (``M_rownnz`` / ``M_rowadr`` / ``M_colind``) ship from 3.5, so when the
+      helper is absent the stored lower triangle is expanded through those
+      index arrays instead.
 
     Probe the modern signature first, then the legacy orders - but only on a
     build that still exposes ``qM``, because the CSR ``data.M`` that replaced
@@ -317,7 +321,7 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
     Raises:
         TypeError: If no known ``mj_fullM`` signature accepts the arguments.
         AttributeError: If MjData exposes the joint-space inertia under
-            neither ``qM`` nor ``M``.
+            neither ``qM`` nor ``M`` (MuJoCo < 3.5 predates the CSR buffer).
     """
     nv = model.nv
     dst = np.zeros((nv, nv), dtype=np.float64, order="C")
@@ -340,7 +344,7 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
             mj.mj_fullM(model, dst, qm)
         return dst
     # MuJoCo >= 3.11: no legacy buffer to pass, so convert the CSR inertia
-    # directly. nv is taken from dst's shape by the binding.
+    # directly.
     csr = getattr(data, "M", None)
     if csr is None:
         raise AttributeError(
@@ -348,13 +352,23 @@ def _full_mass_matrix(mj: Any, model: Any, data: Any) -> np.ndarray:
             f"data.qM and data.M) on mujoco {getattr(mj, '__version__', 'unknown')}, "
             "so the dense mass matrix cannot be built."
         )
-    mj.mju_sym2dense(
-        dst,
-        np.ascontiguousarray(csr, dtype=np.float64),
-        model.M_rownnz,
-        model.M_rowadr,
-        model.M_colind,
-    )
+    values = np.ascontiguousarray(csr, dtype=np.float64)
+    sym2dense = getattr(mj, "mju_sym2dense", None)
+    if sym2dense is not None:
+        sym2dense(dst, values, model.M_rownnz, model.M_rowadr, model.M_colind)
+        return dst
+    # MuJoCo 3.5 - 3.9 ship the CSR buffers and their index arrays but not the
+    # conversion, so expand the stored lower triangle through those indices and
+    # mirror it. Same arithmetic mju_sym2dense performs, and it keeps the CSR
+    # rung working across the whole supported MuJoCo range rather than only on
+    # the builds that also export the helper.
+    rownnz, rowadr, colind = model.M_rownnz, model.M_rowadr, model.M_colind
+    for row in range(nv):
+        start = int(rowadr[row])
+        stored = values[start : start + int(rownnz[row])]
+        cols = np.asarray(colind[start : start + int(rownnz[row])], dtype=np.intp)
+        dst[row, cols] = stored
+        dst[cols, row] = stored
     return dst
 
 

--- a/tests/simulation/mujoco/test_physics.py
+++ b/tests/simulation/mujoco/test_physics.py
@@ -313,6 +313,44 @@ class _CsrOnlyMjData:
         return getattr(self._data, attr)
 
 
+class _NoSym2DenseShim:
+    """mujoco proxy of a build with the CSR buffers but no ``mju_sym2dense``.
+
+    MuJoCo exports that conversion only from 3.10, while the CSR inertia and
+    its index arrays ship from 3.5, so every build in between reaches the CSR
+    rung with nothing to call. ``mj_fullM`` is refused too, which is what puts
+    the helper on that rung in the first place.
+    """
+
+    def __getattr__(self, attr):
+        if attr == "mju_sym2dense":
+            raise AttributeError(attr)
+        return getattr(mj, attr)
+
+    @staticmethod
+    def mj_fullM(m, a, b):
+        raise TypeError("mj_fullM unavailable in this binding")
+
+
+class _RecordingSym2DenseShim:
+    """mujoco proxy whose ``mju_sym2dense`` records the call it is handed."""
+
+    def __init__(self, reference, calls):
+        self._reference = reference
+        self._calls = calls
+
+    def __getattr__(self, attr):
+        return getattr(mj, attr)
+
+    @staticmethod
+    def mj_fullM(m, a, b):
+        raise TypeError("mj_fullM unavailable in this binding")
+
+    def mju_sym2dense(self, dst, values, rownnz, rowadr, colind):
+        self._calls.append((dst, values, rownnz, rowadr, colind))
+        dst[...] = self._reference
+
+
 class _NoInertiaMjData:
     """MjData proxy exposing the joint-space inertia under neither name."""
 
@@ -451,6 +489,53 @@ class TestFullMassMatrixSignatureDrift:
         assert M.flags["C_CONTIGUOUS"]
         assert M.dtype == np.float64
 
+    def test_helper_expands_csr_inertia_when_the_conversion_binding_is_absent(self, sim):
+        # MuJoCo exports mju_sym2dense only from 3.10, but the CSR inertia and
+        # its M_rownnz / M_rowadr / M_colind index arrays ship from 3.5. Every
+        # build in between therefore reaches the CSR rung with no conversion to
+        # call, and the package supports mujoco>=3.2.0. The helper must expand
+        # the stored lower triangle through those index arrays rather than
+        # reaching for a symbol that release range does not export.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        reference = _full_mass_matrix(mj, model, data)
+        if not hasattr(data, "M"):
+            pytest.skip("installed mujoco predates the CSR data.M inertia")
+
+        M = _full_mass_matrix(_NoSym2DenseShim(), model, _CsrOnlyMjData(data))
+
+        # The index-array expansion is exact, not an approximation: it must
+        # reproduce mj_fullM bit for bit, both triangles filled.
+        assert np.array_equal(M, reference)
+        assert np.array_equal(M, M.T)
+        assert M.flags["C_CONTIGUOUS"]
+        assert M.dtype == np.float64
+
+    def test_helper_prefers_the_native_conversion_where_the_binding_has_it(self, sim):
+        # Where MuJoCo does export mju_sym2dense it stays the conversion used,
+        # called with the documented argument order (dst, values, rownnz,
+        # rowadr, colind), so the index-array expansion is a fallback for the
+        # builds that lack it rather than a second implementation shadowing it.
+        model, data = sim._world._model, sim._world._data
+        mj.mj_forward(model, data)
+        reference = _full_mass_matrix(mj, model, data)
+        if not hasattr(data, "M"):
+            pytest.skip("installed mujoco predates the CSR data.M inertia")
+        calls: list = []
+
+        M = _full_mass_matrix(_RecordingSym2DenseShim(reference, calls), model, _CsrOnlyMjData(data))
+
+        assert len(calls) == 1
+        dst, values, rownnz, rowadr, colind = calls[0]
+        assert dst.shape == (model.nv, model.nv)
+        assert dst.flags["WRITEABLE"] and dst.flags["C_CONTIGUOUS"]
+        assert values.dtype == np.float64 and values.flags["C_CONTIGUOUS"]
+        assert np.array_equal(values, np.asarray(data.M, dtype=np.float64))
+        assert np.array_equal(np.asarray(rownnz), np.asarray(model.M_rownnz))
+        assert np.array_equal(np.asarray(rowadr), np.asarray(model.M_rowadr))
+        assert np.array_equal(np.asarray(colind), np.asarray(model.M_colind))
+        assert np.array_equal(M, reference)
+
     def test_helper_names_both_buffers_when_neither_exists(self, sim):
         # Nothing left to read: fail with a message naming both spellings and
         # the installed version, rather than an opaque AttributeError raised by
@@ -485,6 +570,56 @@ class TestFullMassMatrixSignatureDrift:
         assert np.allclose(M, reference)
         assert np.allclose(M, M.T)
         assert np.all(np.linalg.eigvalsh(M) > 0)
+
+    def test_csr_expansion_is_exact_on_a_branching_tree(self):
+        # The chained fixture stores a full lower triangle, so its CSR rows are
+        # dense and the index arrays are trivially ordered. A branching tree is
+        # the case the expansion can actually get wrong: two sibling limbs do
+        # not couple, so rows are shorter than their row index and the column
+        # indices skip DoFs. Pin the expansion against mj_fullM there.
+        model = mj.MjModel.from_xml_string(
+            """
+            <mujoco>
+              <worldbody>
+                <body name="trunk">
+                  <freejoint/>
+                  <geom type="box" size="0.1 0.1 0.1"/>
+                  <body name="left" pos="0.1 0 0">
+                    <joint type="hinge" axis="0 1 0"/>
+                    <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2"/>
+                    <body name="left_tip" pos="0 0 0.2">
+                      <joint type="hinge" axis="1 0 0"/>
+                      <geom type="sphere" size="0.04"/>
+                    </body>
+                  </body>
+                  <body name="right" pos="-0.1 0 0">
+                    <joint type="hinge" axis="0 1 0"/>
+                    <geom type="capsule" size="0.03" fromto="0 0 0 0 0 0.2"/>
+                    <body name="right_tip" pos="0 0 0.2">
+                      <joint type="hinge" axis="1 0 0"/>
+                      <geom type="sphere" size="0.04"/>
+                    </body>
+                  </body>
+                </body>
+              </worldbody>
+            </mujoco>
+            """
+        )
+        data = mj.MjData(model)
+        data.qpos[7:] = 0.4
+        mj.mj_forward(model, data)
+        if not hasattr(data, "M"):
+            pytest.skip("installed mujoco predates the CSR data.M inertia")
+        # The tree really is sparse: fewer stored values than a full triangle.
+        assert model.nM < model.nv * (model.nv + 1) // 2
+
+        reference = _full_mass_matrix(mj, model, data)
+        M = _full_mass_matrix(_NoSym2DenseShim(), model, _CsrOnlyMjData(data))
+
+        assert np.array_equal(M, reference)
+        # Sibling limbs share no inertial coupling, so the expansion must leave
+        # those entries zero rather than smear a stored value across the row.
+        assert np.count_nonzero(reference) < reference.size
 
     def test_helper_returns_empty_for_zero_dof(self):
         # A model with no DoFs must return a well-typed (0, 0) array, never


### PR DESCRIPTION
## Problem

The CSR rung of `_full_mass_matrix` (`strands_robots/simulation/mujoco/physics.py`) calls `mj.mju_sym2dense` unconditionally. MuJoCo exports that conversion only from **3.10**, while the CSR inertia `data.M` and its `M_rownnz` / `M_rowadr` / `M_colind` index arrays ship from **3.5**. Every build in between therefore reaches the rung with nothing to call and raises `AttributeError: module 'mujoco' has no attribute 'mju_sym2dense'` - inside a declared support range of `mujoco>=3.2.0,<4.0.0`.

Measured availability, read from the tagged headers:

| MuJoCo | `data.M` + index arrays | `mju_sym2dense` | CSR rung |
|---|---|---|---|
| 3.2 - 3.4 | no | no | refused, naming both buffers (correct) |
| 3.5 - 3.9 | yes | **no** | `AttributeError` on a missing symbol |
| >= 3.10 | yes | yes | works |

It is visible in the suite, not only in theory: on any MuJoCo below 3.10, `tests/simulation/mujoco/test_physics.py` reports 2 failures on `main` (`test_helper_reads_csr_inertia_when_the_legacy_buffer_is_gone`, `test_get_mass_matrix_tool_works_without_the_legacy_buffer`), because their `hasattr(data, "M")` guard names a field every build from 3.5 ships rather than the conversion the rung actually calls. Reproduce with `pip install mujoco==3.9.0`.

## Change

Keep MuJoCo's own conversion where the binding exports it, and expand the stored lower triangle through the index arrays where it does not - one more rung on the capability ladder this function already is (`getattr(data, "qM", None)` is the existing precedent), rather than a version comparison.

```python
sym2dense = getattr(mj, "mju_sym2dense", None)
if sym2dense is not None:
    sym2dense(dst, values, model.M_rownnz, model.M_rowadr, model.M_colind)
    return dst
# MuJoCo 3.5 - 3.9: CSR buffers present, conversion absent.
```

The expansion is the same arithmetic `mju_sym2dense` performs, so no verdict moves on a build that has the binding: it is still the code path taken there, pinned by test.

## Verification

Bit-exact against `mj_fullM` on four registry robots, in a randomly perturbed configuration:

| robot | nv | stored values (nM) | dense density | max &#124;difference&#124; |
|---|---|---|---|---|
| so101 | 6 | 21 | 1.00 | 0.0 |
| panda | 9 | 44 | 0.98 | 0.0 |
| aloha | 16 | 70 | 0.48 | 0.0 |
| unitree_g1 | 35 | 341 | 0.52 | 0.0 |

The two sparse rows matter: a branching tree stores fewer values than a full triangle, so its CSR rows are shorter than their row index and the column indices skip DoFs. That is the case a mirrored expansion can get wrong, and it is pinned by its own test.

`M(q)` for `unitree_g1` (nv=35), computed on the CSR rung with the conversion binding hidden, beside the `mj_fullM` reference. MuJoCo render of the configuration used, headless EGL:

![CSR inertia expansion is bit-exact against mj_fullM](https://raw.githubusercontent.com/cagataycali/robots/media-csr-inertia/csr_mass_matrix.png)

## Tests

Three tests on the CSR rung in `tests/simulation/mujoco/test_physics.py`:

- `test_helper_expands_csr_inertia_when_the_conversion_binding_is_absent` - hides `mju_sym2dense` on a module proxy, so it **fails before this change on every MuJoCo version**, including one that has the binding. This is the regression pin.
- `test_helper_prefers_the_native_conversion_where_the_binding_has_it` - records the call and asserts the documented argument order `(dst, values, rownnz, rowadr, colind)` plus the buffer contract, so the fallback cannot silently shadow the native conversion.
- `test_csr_expansion_is_exact_on_a_branching_tree` - two sibling limbs that do not couple, asserting `nM < nv*(nv+1)/2` so the test provably covers the sparse-row case, and that the uncoupled entries stay zero.

`tests/simulation`: 2 pre-existing failures cleared, no new ones (29 vs 31 on the same interpreter and MuJoCo build; the remainder are unrelated pre-existing MuJoCo-version failures). `ruff check`, `ruff format --check` and `mypy` clean on the changed files.