### PR TITLE
feat(policies/kimodo): action-key bridge for lerobot's Unitree G1 driver

### DIFF
--- a/changelog.d/2279-kimodo-hardware-bridge.md
+++ b/changelog.d/2279-kimodo-hardware-bridge.md
@@ -1,0 +1,20 @@
+### Added: Kimodo action-key bridge for lerobot's Unitree G1 driver
+
+`strands_robots.policies.kimodo.hardware` renames Kimodo's URDF-named joint
+targets (`left_hip_pitch_joint`) to the action keys lerobot's `UnitreeG1` driver
+accepts (`kLeftHipPitch.q`), so the same `KimodoPolicy` object can drive sim
+actuators and the real robot's DDS lowcmd path.
+
+* `build_lerobot_g1_action_dict(action, extra_action_keys=None)` — the driver
+  action dict for one control tick.
+* `kimodo_action_to_lerobot_g1(action)` — the rename on its own.
+* `get_joint_map()` — the rename table, for callers renaming in their own loop.
+
+The table pairs joints by name, not by position in the driver enum. The driver
+applies only the action keys it recognises and leaves every other motor on its
+previous command, so a mis-paired or unknown key raises nothing at all. Pairing
+by name means a driver-side reorder cannot move a target, and a driver-side
+rename or DOF change is refused with the unmatched joints named on both sides.
+
+Nothing in the rollout loop applies the rename implicitly; a hardware caller
+renames the action dict before `send_action`. See `docs/policies/kimodo.md`.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -135,6 +135,44 @@ checkpoint, or pass a `motion_agent=` adapter that reads the sampler's own
 output field and returns the `(num_frames, 7+29)` `qpos` array this policy
 expects.
 
+## Driving the real robot
+
+Kimodo names its joint targets the way the URDF does (`left_hip_pitch_joint`);
+lerobot's `UnitreeG1` driver names its action keys after its own joint enum
+(`kLeftHipPitch.q`). The two vocabularies name the same 29 joints, so the
+hardware path is a key rename applied between the policy and the driver:
+
+```python
+from strands_robots.policies.kimodo.hardware import build_lerobot_g1_action_dict
+
+for policy_action in await policy.get_actions(observation, instruction):
+    robot.send_action(build_lerobot_g1_action_dict(policy_action))
+```
+
+`get_joint_map()` returns the table itself (`{"left_hip_pitch_joint":
+"kLeftHipPitch.q", ...}`) if you would rather rename in your own loop. Both are
+lerobot-only helpers: `pip install "strands-robots[lerobot]"`. Commanding the
+physical robot additionally needs Unitree's `unitree_sdk2` runtime, which
+lerobot documents separately for its `unitree_g1` robot.
+
+The table pairs joints by name, never by position in the driver enum. That
+matters because the driver applies only the action keys it recognises and leaves
+every other motor on its previous command, so a key paired with the wrong joint
+— or spelled in a way the driver does not know — raises nothing at all and the
+robot simply moves wrong. Pairing by name means a driver-side reorder cannot
+move a target, and a driver-side rename or DOF change is refused with the
+unmatched joints named on both sides instead of being taken on trust:
+
+```text
+RuntimeError: Unitree G1 joint sets disagree between the policy and lerobot's
+driver. Joints the policy commands that the driver does not name:
+['waist_yaw_joint']. Joints the driver names that the policy does not command:
+['kTorsoYaw.q']. ...
+```
+
+The rename is one-way. The driver's `get_observation()` already reports
+`<motor>.q` keys, so the read path needs no inverse table.
+
 ## Unit testing without weights
 
 Inject a `KimodoMotionAgent` stub — no torch/diffusers/CUDA needed. See

--- a/strands_robots/policies/kimodo/__init__.py
+++ b/strands_robots/policies/kimodo/__init__.py
@@ -34,6 +34,15 @@ See :doc:`docs/policies/kimodo`.
 """
 
 from strands_robots.policies.kimodo.config import KimodoConfig
+
+# Hardware action-key helpers. Importing them does not import lerobot: the
+# joint rename table is built on the first get_joint_map() call, so a pure-sim
+# import path never looks for the driver.
+from strands_robots.policies.kimodo.hardware import (
+    build_lerobot_g1_action_dict,
+    get_joint_map,
+    kimodo_action_to_lerobot_g1,
+)
 from strands_robots.policies.kimodo.policy import (
     KIMODO_G1_JOINTS,
     KimodoMotionAgent,
@@ -45,4 +54,7 @@ __all__ = [
     "KimodoConfig",
     "KimodoMotionAgent",
     "KIMODO_G1_JOINTS",
+    "build_lerobot_g1_action_dict",
+    "get_joint_map",
+    "kimodo_action_to_lerobot_g1",
 ]

--- a/strands_robots/policies/kimodo/hardware.py
+++ b/strands_robots/policies/kimodo/hardware.py
@@ -1,0 +1,220 @@
+"""Action-key bridge between :class:`KimodoPolicy` and lerobot's ``unitree_g1`` driver.
+
+Kimodo emits per-frame joint targets keyed by URDF joint names
+(``left_hip_pitch_joint``, ...). lerobot's ``UnitreeG1`` driver accepts action
+keys named after its ``G1_29_JointIndex`` enum (``kLeftHipPitch.q``, ...). The
+two vocabularies name the SAME 29 joints, so the bridge is a pure key rename:
+no reordering, no scaling, no unit conversion.
+
+The rename table is derived BY NAME, never by position. Each driver enum member
+canonicalises to the URDF spelling of the same joint (``kLeftHipPitch`` ->
+``left_hip_pitch_joint``) and is paired with it. Position is not usable as the
+pairing key here because the driver silently drops an action key it does not
+recognise (``UnitreeG1.publish_lowcmd`` writes only the keys it finds, leaving
+every other motor on its previous command), so a mis-pairing raises nothing at
+all -- the robot simply moves wrong. Two consequences follow from pairing by
+name:
+
+* A driver-side reorder cannot pair a hip target with a waist actuator.
+* A driver-side rename or DOF change is refused, naming the unmatched joints on
+  both sides, instead of being mapped onto whatever now sits at that index.
+
+The map is between the canonical G1 joint names and the driver's action keys, so
+any provider emitting those names (Kimodo, ``wbc``, ``motionbricks``) can use
+it. The rename is one-way (policy -> driver): the driver's ``get_observation``
+already reports ``<motor>.q`` keys, so the read path needs no inverse map.
+
+Nothing in the rollout loop applies this implicitly. A hardware caller renames
+the policy's action dict before handing it to the driver::
+
+    action = build_lerobot_g1_action_dict(policy_action)
+    robot.send_action(action)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+from typing import Protocol
+
+from strands_robots.policies.kimodo.policy import KIMODO_G1_JOINTS
+from strands_robots.utils import require_optional
+
+logger = logging.getLogger(__name__)
+
+#: Dotted path to the module that owns the driver's joint enum.
+_DRIVER_MODULE = "lerobot.robots.unitree_g1.g1_utils"
+
+#: Name of the driver's 29-DOF joint enum inside :data:`_DRIVER_MODULE`.
+_DRIVER_ENUM = "G1_29_JointIndex"
+
+#: The driver names a joint-position action key ``<enum member>.q``.
+_DRIVER_POSITION_SUFFIX = ".q"
+
+#: The driver's enum members are prefixed camel case (``kLeftHipPitch``).
+_DRIVER_NAME_PREFIX = "k"
+
+#: URDF suffix every canonical G1 joint name carries (``left_hip_pitch_joint``).
+_URDF_NAME_SUFFIX = "_joint"
+
+_CAMEL_BOUNDARY = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+class _DriverJoint(Protocol):
+    """The one attribute the bridge reads off a driver enum member."""
+
+    name: str
+
+
+def _canonical_joint_name(driver_name: str) -> str:
+    """Translate a driver enum member name to its canonical G1 joint name.
+
+    ``kLeftHipPitch`` -> ``left_hip_pitch_joint``.
+
+    Args:
+        driver_name: Enum member name as the driver spells it.
+
+    Returns:
+        The URDF spelling of the same joint.
+    """
+    core = driver_name.removeprefix(_DRIVER_NAME_PREFIX)
+    return f"{_CAMEL_BOUNDARY.sub('_', core).lower()}{_URDF_NAME_SUFFIX}"
+
+
+def _build_joint_map(driver_joints: Iterable[_DriverJoint]) -> dict[str, str]:
+    """Pair every canonical G1 joint with the driver action key of the same joint.
+
+    Args:
+        driver_joints: Iterable of driver enum members (each exposing ``name``),
+            normally ``G1_29_JointIndex``.
+
+    Returns:
+        ``{canonical joint name: driver action key}`` in
+        :data:`~strands_robots.policies.kimodo.policy.KIMODO_G1_JOINTS` order.
+
+    Raises:
+        RuntimeError: If two driver joints canonicalise to one name, or if any
+            joint is named on only one side. Either way at least one target
+            would be dropped by the driver without an error, so the mismatch is
+            reported instead of mapped.
+    """
+    by_canonical: dict[str, str] = {}
+    for joint in driver_joints:
+        canonical = _canonical_joint_name(joint.name)
+        if canonical in by_canonical:
+            raise RuntimeError(
+                f"Unitree G1 driver joints {by_canonical[canonical]!r} and "
+                f"{joint.name + _DRIVER_POSITION_SUFFIX!r} both name the joint "
+                f"{canonical!r}. The bridge cannot tell which actuator a "
+                f"{canonical!r} target belongs to; audit the driver's "
+                f"{_DRIVER_ENUM} before driving the robot."
+            )
+        by_canonical[canonical] = f"{joint.name}{_DRIVER_POSITION_SUFFIX}"
+
+    unmapped_policy = [name for name in KIMODO_G1_JOINTS if name not in by_canonical]
+    unmapped_driver = sorted(set(by_canonical) - set(KIMODO_G1_JOINTS))
+    if unmapped_policy or unmapped_driver:
+        raise RuntimeError(
+            "Unitree G1 joint sets disagree between the policy and lerobot's "
+            f"driver. Joints the policy commands that the driver does not name: "
+            f"{unmapped_policy}. Joints the driver names that the policy does "
+            f"not command: {[by_canonical[name] for name in unmapped_driver]}. "
+            "The driver applies only the action keys it recognises and leaves "
+            "every other motor on its previous command, so a partial map would "
+            "move the robot without reporting anything. Audit the joint sets "
+            "before driving the robot."
+        )
+    return {name: by_canonical[name] for name in KIMODO_G1_JOINTS}
+
+
+_joint_map: dict[str, str] | None = None
+
+
+def get_joint_map() -> dict[str, str]:
+    """Return the canonical-to-driver joint rename table, building it on first call.
+
+    Built lazily so a pure-sim import never looks for lerobot, then cached: the
+    table is a property of the two joint vocabularies, not of a rollout.
+
+    Returns:
+        ``{"left_hip_pitch_joint": "kLeftHipPitch.q", ...}``, one entry per
+        joint in :data:`~strands_robots.policies.kimodo.policy.KIMODO_G1_JOINTS`.
+
+    Raises:
+        ImportError: If lerobot is not installed.
+        RuntimeError: If the two joint vocabularies do not name the same 29
+            joints, naming the unmatched joints on both sides.
+    """
+    global _joint_map
+    if _joint_map is None:
+        module = require_optional(
+            _DRIVER_MODULE,
+            extra="lerobot",
+            purpose="the Kimodo action-key bridge for lerobot's Unitree G1 driver",
+        )
+        _joint_map = _build_joint_map(getattr(module, _DRIVER_ENUM))
+        logger.debug("Built Unitree G1 action-key map with %d joints", len(_joint_map))
+    return _joint_map
+
+
+def kimodo_action_to_lerobot_g1(kimodo_action: dict[str, float]) -> dict[str, float]:
+    """Rename a Kimodo joint dict to the lerobot ``UnitreeG1`` action dict.
+
+    Args:
+        kimodo_action: One per-tick dict from :meth:`KimodoPolicy.get_actions`
+            (keys are :data:`~strands_robots.policies.kimodo.policy.KIMODO_G1_JOINTS`,
+            values are radians).
+
+    Returns:
+        A new dict keyed for ``UnitreeG1.send_action`` (``kLeftHipPitch.q``,
+        ...). Keys outside the canonical joint set are dropped rather than
+        forwarded: the driver ignores keys it does not recognise, so forwarding
+        them only hides a naming mistake.
+
+    Raises:
+        KeyError: If any canonical G1 joint is absent from ``kimodo_action``.
+            The driver would hold that motor on its previous command, so a
+            short action dict is refused rather than partially applied.
+    """
+    joint_map = get_joint_map()
+    missing = [name for name in joint_map if name not in kimodo_action]
+    if missing:
+        raise KeyError(
+            f"Kimodo action dict is missing G1 joints: {missing}. "
+            f"KimodoPolicy.get_actions() returns all {len(joint_map)} joints; "
+            f"got keys={sorted(kimodo_action)}."
+        )
+    return {joint_map[name]: float(kimodo_action[name]) for name in joint_map}
+
+
+def build_lerobot_g1_action_dict(
+    kimodo_action: dict[str, float],
+    *,
+    extra_action_keys: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Build the driver-side action dict for one control tick.
+
+    Args:
+        kimodo_action: One per-tick dict from :meth:`KimodoPolicy.get_actions`.
+        extra_action_keys: Optional driver keys merged AFTER the rename, so they
+            win over a renamed joint target (locomotion remote inputs such as
+            ``remote.lx``, and per-joint overrides). Most callers pass ``None``.
+
+    Returns:
+        An action dict ready for ``UnitreeG1.send_action``.
+
+    Raises:
+        KeyError: If ``kimodo_action`` is missing a canonical G1 joint.
+    """
+    action = kimodo_action_to_lerobot_g1(kimodo_action)
+    if extra_action_keys:
+        action.update(extra_action_keys)
+    return action
+
+
+__all__ = [
+    "build_lerobot_g1_action_dict",
+    "get_joint_map",
+    "kimodo_action_to_lerobot_g1",
+]

--- a/tests/policies/kimodo/test_kimodo_hardware.py
+++ b/tests/policies/kimodo/test_kimodo_hardware.py
@@ -1,0 +1,266 @@
+"""Tests for the Kimodo -> lerobot Unitree G1 action-key bridge.
+
+The bridge is a pure key rename between two vocabularies for the same 29
+joints. These tests pin the rename table, the fact that it pairs joints by name
+rather than by position, and its failure surfaces -- without a real robot or the
+unitree_sdk2 runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import IntEnum
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.kimodo.hardware import (
+    _build_joint_map,
+    build_lerobot_g1_action_dict,
+    get_joint_map,
+    kimodo_action_to_lerobot_g1,
+)
+from strands_robots.policies.kimodo.policy import KIMODO_G1_JOINTS
+
+# The driver's own spelling of the 29 G1 joints, in the order lerobot's
+# G1_29_JointIndex declares them today. Held here as data so a test can permute
+# or rename it and drive the map builder without lerobot installed.
+DRIVER_JOINT_NAMES: tuple[str, ...] = (
+    "kLeftHipPitch",
+    "kLeftHipRoll",
+    "kLeftHipYaw",
+    "kLeftKnee",
+    "kLeftAnklePitch",
+    "kLeftAnkleRoll",
+    "kRightHipPitch",
+    "kRightHipRoll",
+    "kRightHipYaw",
+    "kRightKnee",
+    "kRightAnklePitch",
+    "kRightAnkleRoll",
+    "kWaistYaw",
+    "kWaistRoll",
+    "kWaistPitch",
+    "kLeftShoulderPitch",
+    "kLeftShoulderRoll",
+    "kLeftShoulderYaw",
+    "kLeftElbow",
+    "kLeftWristRoll",
+    "kLeftWristPitch",
+    "kLeftWristYaw",
+    "kRightShoulderPitch",
+    "kRightShoulderRoll",
+    "kRightShoulderYaw",
+    "kRightElbow",
+    "kRightWristRoll",
+    "kRightWristPitch",
+    "kRightWristYaw",
+)
+
+
+def _driver_enum(names: Sequence[str]) -> Any:
+    """Build a stand-in for the driver's joint enum from ``names``."""
+    return IntEnum("G1_JointIndex", {name: index for index, name in enumerate(names)})
+
+
+def _make_dummy_kimodo_action() -> dict[str, float]:
+    """Build a Kimodo action-dict with a distinct value per joint."""
+    return {name: 0.01 * i for i, name in enumerate(KIMODO_G1_JOINTS)}
+
+
+def test_joint_map_has_all_29_joints():
+    """The rename table covers every Kimodo joint exactly once."""
+    joint_map = get_joint_map()
+    assert len(joint_map) == 29
+    assert set(joint_map.keys()) == set(KIMODO_G1_JOINTS)
+
+
+def test_joint_map_targets_are_lerobot_q_keys():
+    """Every mapped target has the lerobot ``kJointName.q`` shape."""
+    joint_map = get_joint_map()
+    for src, dst in joint_map.items():
+        assert dst.startswith("k"), f"{dst} not lerobot-enum-shaped"
+        assert dst.endswith(".q"), f"{dst} missing .q suffix"
+
+
+def test_joint_map_is_cached():
+    """The map is built once and returned on subsequent calls."""
+    a = get_joint_map()
+    b = get_joint_map()
+    assert a is b  # identity - same dict object
+
+
+def test_rename_preserves_values():
+    """Values pass through the rename verbatim (radians in, radians out)."""
+    kimodo = _make_dummy_kimodo_action()
+    lerobot = kimodo_action_to_lerobot_g1(kimodo)
+    joint_map = get_joint_map()
+    for src, dst in joint_map.items():
+        assert lerobot[dst] == pytest.approx(kimodo[src])
+
+
+def test_rename_produces_29_keys():
+    """The output has exactly 29 keys, one per G1 joint."""
+    result = kimodo_action_to_lerobot_g1(_make_dummy_kimodo_action())
+    assert len(result) == 29
+
+
+def test_rename_missing_joint_raises_keyerror():
+    """A short input surfaces the missing joints in a clear KeyError."""
+    kimodo = _make_dummy_kimodo_action()
+    del kimodo["left_hip_pitch_joint"]
+    with pytest.raises(KeyError) as exc_info:
+        kimodo_action_to_lerobot_g1(kimodo)
+    assert "left_hip_pitch_joint" in str(exc_info.value)
+
+
+def test_rename_ignores_unknown_input_keys():
+    """Extra input keys (e.g. leftover base-pose entries) are dropped, not forwarded."""
+    kimodo = _make_dummy_kimodo_action()
+    kimodo["floating_base_joint"] = 999.0
+    kimodo["surprise"] = 42.0
+    result = kimodo_action_to_lerobot_g1(kimodo)
+    assert 999.0 not in result.values()
+    assert 42.0 not in result.values()
+    assert "surprise" not in result
+
+
+def test_build_full_action_no_extras():
+    """Without ``extra_action_keys``, the wrapper equals the rename."""
+    kimodo = _make_dummy_kimodo_action()
+    a = build_lerobot_g1_action_dict(kimodo)
+    b = kimodo_action_to_lerobot_g1(kimodo)
+    assert a == b
+
+
+def test_build_full_action_merges_extras():
+    """``extra_action_keys`` is merged after the rename (overrides win)."""
+    kimodo = _make_dummy_kimodo_action()
+    extras = {"remote_axis_lx": 0.5, "remote_axis_ly": -0.5}
+    result = build_lerobot_g1_action_dict(kimodo, extra_action_keys=extras)
+    assert result["remote_axis_lx"] == 0.5
+    assert result["remote_axis_ly"] == -0.5
+    # The 29 joints are still there
+    assert len([k for k in result if k.endswith(".q")]) == 29
+
+
+def test_extras_override_joint_values():
+    """``extra_action_keys`` wins over the rename for shared keys."""
+    kimodo = _make_dummy_kimodo_action()
+    # Overwrite the first joint via extras
+    joint_map = get_joint_map()
+    override_key = joint_map["left_hip_pitch_joint"]
+    result = build_lerobot_g1_action_dict(kimodo, extra_action_keys={override_key: 3.14})
+    assert result[override_key] == 3.14
+
+
+def test_end_to_end_policy_to_hardware_action():
+    """The full KimodoPolicy → hardware-bridge → send_action-ready dict flow.
+
+    Uses a stub motion agent (no diffusers/CUDA/checkpoints) so this test
+    runs in CI on any machine — the point is to prove the shapes line up,
+    not to sample real motion.
+    """
+    import asyncio
+
+    import numpy as np
+
+    from strands_robots.policies.kimodo import KimodoConfig, KimodoPolicy
+
+    class _StubAgent:
+        def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+            n = 7 + len(KIMODO_G1_JOINTS)
+            arr = np.zeros((num_frames, n), dtype=np.float32)
+            arr[:, 6] = 1.0  # identity quat
+            # distinct per-joint value so we can verify the rename
+            for i in range(len(KIMODO_G1_JOINTS)):
+                arr[:, 7 + i] = 0.1 * i
+            return arr
+
+    policy = KimodoPolicy(
+        config=KimodoConfig(num_frames=10, diffusion_steps=5),
+        motion_agent=_StubAgent(),
+    )
+    policy.set_robot_state_keys(list(KIMODO_G1_JOINTS))
+
+    kimodo_actions = asyncio.run(policy.get_actions({}, "walk forward"))
+    assert len(kimodo_actions) == 1
+
+    hw_action = build_lerobot_g1_action_dict(kimodo_actions[0])
+    # 29 lerobot-shaped keys, values passed through
+    assert len(hw_action) == 29
+    joint_map = get_joint_map()
+    for i, kimodo_key in enumerate(KIMODO_G1_JOINTS):
+        lerobot_key = joint_map[kimodo_key]
+        assert hw_action[lerobot_key] == pytest.approx(0.1 * i)
+
+
+class TestTheMapPairsJointsByName:
+    """The pairing key is the joint name, never the position in the driver enum.
+
+    The driver applies only the action keys it recognises and silently leaves
+    every other motor on its previous command, so a mis-paired or unrecognised
+    key raises nothing at all -- the robot just moves wrong. Position is
+    therefore not usable as the pairing key.
+    """
+
+    def test_a_reordered_driver_enum_still_pairs_every_joint_with_itself(self):
+        """Reversing the driver's declaration order must not move a single target."""
+        forward = _build_joint_map(_driver_enum(DRIVER_JOINT_NAMES))
+        reversed_order = _build_joint_map(_driver_enum(tuple(reversed(DRIVER_JOINT_NAMES))))
+        assert reversed_order == forward
+        assert forward["left_hip_pitch_joint"] == "kLeftHipPitch.q"
+        assert reversed_order["left_hip_pitch_joint"] == "kLeftHipPitch.q"
+
+    def test_moving_the_waist_block_does_not_move_the_leg_targets(self):
+        """A block reorder is the realistic drift; leg targets must be unaffected."""
+        names = list(DRIVER_JOINT_NAMES)
+        waist = [name for name in names if "Waist" in name]
+        for name in waist:
+            names.remove(name)
+        reordered = _build_joint_map(_driver_enum(tuple(waist + names)))
+        assert reordered == _build_joint_map(_driver_enum(DRIVER_JOINT_NAMES))
+        assert reordered["right_knee_joint"] == "kRightKnee.q"
+        assert reordered["waist_yaw_joint"] == "kWaistYaw.q"
+
+    def test_a_renamed_driver_joint_is_refused_naming_both_sides(self):
+        """A rename keeps the joint count, so only a name check can see it.
+
+        Refusing is the safe answer: the bridge cannot confirm that the new
+        spelling is the same joint, and naming both spellings is what lets a
+        human decide instead of the map being taken on trust.
+        """
+        renamed = tuple("kTorsoYaw" if name == "kWaistYaw" else name for name in DRIVER_JOINT_NAMES)
+        assert len(renamed) == len(DRIVER_JOINT_NAMES)
+        with pytest.raises(RuntimeError) as exc_info:
+            _build_joint_map(_driver_enum(renamed))
+        message = str(exc_info.value)
+        assert "waist_yaw_joint" in message
+        assert "kTorsoYaw.q" in message
+
+    def test_a_dropped_driver_joint_is_refused_naming_the_joint(self):
+        """A shrunk DOF set must not yield a map that silently omits a joint."""
+        with pytest.raises(RuntimeError) as exc_info:
+            _build_joint_map(_driver_enum(DRIVER_JOINT_NAMES[:-1]))
+        assert "right_wrist_yaw_joint" in str(exc_info.value)
+
+    def test_two_driver_joints_naming_one_joint_are_refused(self):
+        """An ambiguous pairing is reported, not resolved by declaration order."""
+        with pytest.raises(RuntimeError) as exc_info:
+            _build_joint_map(_driver_enum((*DRIVER_JOINT_NAMES, "WaistYaw")))
+        message = str(exc_info.value)
+        assert "waist_yaw_joint" in message
+        assert "kWaistYaw.q" in message
+        assert "WaistYaw.q" in message
+
+
+def test_the_installed_driver_enum_still_names_the_canonical_joint_set():
+    """The live lerobot enum agrees with the joint spellings pinned above.
+
+    A lerobot rename or DOF change surfaces here as a diff against
+    ``DRIVER_JOINT_NAMES`` rather than as a wrong target on a real robot.
+    """
+    g1_utils = pytest.importorskip("lerobot.robots.unitree_g1.g1_utils")
+    installed = tuple(joint.name for joint in g1_utils.G1_29_JointIndex)
+    assert set(installed) == set(DRIVER_JOINT_NAMES)
+    assert get_joint_map() == _build_joint_map(_driver_enum(DRIVER_JOINT_NAMES))


### PR DESCRIPTION
## Problem

`KimodoPolicy` emits joint targets keyed the way the URDF names them (`left_hip_pitch_joint`). lerobot's `UnitreeG1` driver accepts action keys named after its own joint enum (`kLeftHipPitch.q`). The two vocabularies name the same 29 joints, so a hardware caller needs a key rename between the policy and `send_action` - there was none, and no table to build one from.

The rename is also the kind of code that must not be written casually. `UnitreeG1.publish_lowcmd` writes only the action keys it recognises and leaves every other motor on its previous command:

```python
for motor in G1_29_JointIndex:
    key = f"{motor.name}.q"
    if key in action:
        self.msg.motor_cmd[motor.value].q = action[key]
```

So a target paired with the wrong joint, or spelled in a way the driver does not know, raises nothing at all. The robot just moves wrong.

## Change

`strands_robots.policies.kimodo.hardware`:

* `build_lerobot_g1_action_dict(action, extra_action_keys=None)` - the driver action dict for one control tick.
* `kimodo_action_to_lerobot_g1(action)` - the rename on its own.
* `get_joint_map()` - the rename table, for callers renaming in their own loop.

The table pairs joints **by name**: each driver enum member canonicalises to the URDF spelling of the same joint (`kLeftHipPitch` -> `left_hip_pitch_joint`) and is paired with it. Position is not usable as the pairing key given the driver behaviour above. Measured against pairing by index (zip the two lists, verify only that both have 29 entries):

| driver-side change | paired by index | paired by name |
|---|---|---|
| declaration order reversed | 28 of 29 targets land on the wrong actuator, nothing raised | every target unchanged |
| `kWaistYaw` renamed `kTorsoYaw` | new spelling emitted on trust | refused, naming `waist_yaw_joint` and `kTorsoYaw.q` |
| a joint dropped | refused with a bare count mismatch | refused, naming `right_wrist_yaw_joint` |
| two joints naming one joint | refused with a bare count mismatch | refused, naming both driver keys |

Refusing a rename is the safe answer: the bridge cannot confirm that a new spelling is the same joint, and naming both spellings is what lets a human decide instead of the map being taken on trust. `test_the_installed_driver_enum_still_names_the_canonical_joint_set` pins the installed enum against the spellings the suite records, so a lerobot rename surfaces as a test diff long before it reaches a robot.

A short action dict is refused rather than partially applied, for the same reason: a missing key silently holds that motor.

Nothing in the rollout loop applies the rename implicitly - a hardware caller renames the action dict before `send_action`. The table is resolved on first use, so a pure-sim import never looks for lerobot. The map is between the canonical G1 joint names and the driver's action keys, so `wbc` and `motionbricks`, which emit the same names, can use it too.

## Verification

Same Kimodo motion (`nvidia/Kimodo-G1-RP-v1`, prompt "a person walking forward with confident strides", 120 frames at 30 fps) applied to `Robot("g1")` through both pairing rules, replayed kinematically in MuJoCo (headless, EGL). Left: paired by name. Right: paired by index against a reordered driver enum - the driver accepts every key, so nothing reports a problem.

![G1 action-key pairing comparison](https://raw.githubusercontent.com/cagataycali/robots/media-g1-action-key-pairing/g1_pairing.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-g1-action-key-pairing/g1_pairing.mp4) (120 frames, 816x464). Mean absolute pixel difference between the two panels: 4.86; every frame moves (min per-frame delta 0.29).

17 unit tests cover the table, the by-name pairing under a reordered, renamed, shrunk and ambiguous driver enum, and the failure surfaces - no real robot and no `unitree_sdk2` runtime. `ruff check`, `ruff format --check` and `mypy` clean over `strands_robots tests tests_integ`; `tests/policies/kimodo` 51 passed.

Docs: new "Driving the real robot" section in `docs/policies/kimodo.md`.