### PR TITLE
fix(policies/wbc): drive a WBC policy through a wrapper, and let its arms follow a commanded target

### DIFF
--- a/changelog.d/2282-policy-children-tree.md
+++ b/changelog.d/2282-policy-children-tree.md
@@ -1,0 +1,5 @@
+### Added
+
+- `Policy.children` declares the policies a wrapper delegates to, and
+  `iter_policy_tree` walks that tree, so a runtime capability probe can reach the
+  concrete policy inside a wrapper instead of type-testing the wrapper.

--- a/changelog.d/2282-policy-children-tree.md
+++ b/changelog.d/2282-policy-children-tree.md
@@ -2,4 +2,6 @@
 
 - `Policy.children` declares the policies a wrapper delegates to, and
   `iter_policy_tree` walks that tree, so a runtime capability probe can reach the
-  concrete policy inside a wrapper instead of type-testing the wrapper.
+  concrete policy inside a wrapper instead of type-testing the wrapper. The walk
+  reads `children` with `getattr`, so a duck-typed policy object that does not
+  subclass `Policy` answers a probe as "no match" rather than raising.

--- a/changelog.d/2282-wbc-wrapper-torque-and-arm-targets.md
+++ b/changelog.d/2282-wbc-wrapper-torque-and-arm-targets.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **WBC through a policy wrapper**: `sim.run_policy` now installs the MuJoCo torque
+  shim for a `WBCPolicy` reached through a wrapper - a `CompositePolicy` driving the
+  legs from WBC and the arms from a manipulation policy, or a `PersistentPolicy`
+  holding it warm. The hook resolved the shim with `isinstance(policy, WBCPolicy)`,
+  so a wrapped policy silently drove the stock uniform-gain position servos that
+  override SONIC's tuned per-joint PD. `WBCTorqueController` also runs its light arm
+  PD toward whatever target the action dict names for each arm joint, holding the
+  nominal pose only for joints left unnamed; it previously pinned all 14 arm joints
+  to nominal, so the upper body of a `CompositePolicy` was dropped without a warning
+  while the robot walked correctly.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -298,6 +298,28 @@ joint) is raised, never silently resolved. The merged chunk length is the
 shorter of the two, so a per-tick controller (WBC, `execution_horizon == 1`) is
 never starved by a slower chunk-emitting manipulation policy.
 
+Run the composite the same way as a bare policy - the goal payload goes in
+`policy_kwargs`, and the torque shim
+([In simulation](#in-simulation)) is auto-installed for the
+`WBCPolicy` inside the composite just as it is for a bare one:
+
+```python
+sim.run_policy(
+    robot_name="unitree_g1",
+    policy_object=policy,
+    policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
+    control_frequency=50.0,
+    n_steps=500,
+)
+```
+
+The shim drives the legs+waist with SONIC's PD law and runs a light position PD
+(`kp = 100`, `kd = 0.5`) on each arm joint toward whatever target the upper
+policy commands for it, holding the nominal pose for any arm joint left
+unnamed. The same applies to a `WBCPolicy` held warm by a `PersistentPolicy`:
+the shim follows the policy that drives the joints, not the type of the object
+passed to `run_policy`.
+
 [`examples/wbc/wbc_g1_composite.py`](https://github.com/strands-labs/robots/blob/main/examples/wbc/wbc_g1_composite.py)
 runs the composite in the torque-deploy loop with a zero-dependency scripted
 arm-wave as the upper body (swap in `--upper-port` for a real GR00T server):

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -653,8 +653,18 @@ def iter_policy_tree(policy: Policy) -> Iterator[Policy]:
     yielded at most once, so two wrappers sharing one child do not double-report
     it and a cycle in the graph terminates instead of recursing forever.
 
+    ``children`` is read with :func:`getattr` rather than as an attribute, so a
+    duck-typed policy object that does not subclass :class:`Policy` yields
+    itself instead of raising ``AttributeError``. That input class is one the
+    surrounding call chain deliberately tolerates - ``policy_runner`` probes
+    ``is_chunk_emitting`` the same way "so a duck-typed policy_object that
+    predates is_chunk_emitting() simply stays on the synchronous path" - and
+    the callers of this walk are capability probes whose documented answer for
+    an object declaring no tree is "no match", not a crash.
+
     Args:
-        policy: Root of the tree to walk. A leaf policy yields just itself.
+        policy: Root of the tree to walk. A leaf policy, or any object that
+            declares no ``children``, yields just itself.
 
     Yields:
         Each distinct policy in the tree, root first.
@@ -667,4 +677,4 @@ def iter_policy_tree(policy: Policy) -> Iterator[Policy]:
             continue
         seen.add(id(current))
         yield current
-        stack.extend(reversed(tuple(current.children)))
+        stack.extend(reversed(tuple(getattr(current, "children", ()))))

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -24,7 +24,7 @@ non-VLA reference implementation.
 import asyncio
 import concurrent.futures
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
@@ -357,6 +357,35 @@ class Policy(ABC):
         return ()
 
     @property
+    def children(self) -> tuple["Policy", ...]:
+        """The policies this one delegates to, in the order it consults them.
+
+        Default ``()`` - a leaf policy that runs its own inference. A *wrapper*
+        returns the policies it drives:
+        :class:`~strands_robots.policies.composite.CompositePolicy` its ``lower``
+        and ``upper`` children,
+        :class:`~strands_robots.policies.persistent.PersistentPolicy` the single
+        policy it holds warm.
+
+        This is the same "policy declares, runtime supplies" contract as
+        :attr:`requires_images` and :attr:`required_bodies`, applied to a
+        capability probe rather than an observation. A probe answers about the
+        object it is handed, and a wrapper is a different object than the policy
+        inside it, so an ``isinstance`` test against a wrapper reports the
+        wrapped policy's capability as absent. The MuJoCo backend's WBC torque
+        shim is the motivating case: it is required for a
+        :class:`~strands_robots.policies.wbc.WBCPolicy` to hold a stable gait on
+        a position-servo scene, and the physics does not change when that policy
+        is wrapped - only the type of the object the probe sees does. Declaring
+        the children lets one probe walk to the policy that answers, instead of
+        every probe having to learn the name of every wrapper.
+
+        Returns:
+            The child policies. Empty (the default) means this policy is a leaf.
+        """
+        return ()
+
+    @property
     def execution_horizon(self) -> int:
         """Number of actions the SIM consumes from one ``get_actions`` chunk before re-querying.
 
@@ -614,3 +643,28 @@ def chunk_count_error(value: object, param: str, provider: str) -> str | None:
     if error:
         return f"{error} Omit it to use the provider default."
     return None
+
+
+def iter_policy_tree(policy: Policy) -> Iterator[Policy]:
+    """Yield ``policy`` then every policy reachable through :attr:`Policy.children`.
+
+    Pre-order, so an outer wrapper is visited before the policies it wraps and
+    the outermost policy that answers a capability probe wins. Each object is
+    yielded at most once, so two wrappers sharing one child do not double-report
+    it and a cycle in the graph terminates instead of recursing forever.
+
+    Args:
+        policy: Root of the tree to walk. A leaf policy yields just itself.
+
+    Yields:
+        Each distinct policy in the tree, root first.
+    """
+    seen: set[int] = set()
+    stack = [policy]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+        stack.extend(reversed(tuple(current.children)))

--- a/strands_robots/policies/composite.py
+++ b/strands_robots/policies/composite.py
@@ -31,7 +31,8 @@ Example::
         upper_joints=ARM_JOINTS,                 # both arms
     )
     sim.run_policy(robot_name="unitree_g1", policy_object=policy,
-                   target_velocity=[0.5, 0.0, 0.0])
+                   policy_kwargs={"target_velocity": [0.5, 0.0, 0.0]},
+                   control_frequency=50.0, n_steps=500)
 """
 
 import asyncio
@@ -118,6 +119,15 @@ class CompositePolicy(Policy):
     def upper(self) -> Policy:
         """The upper-body (e.g. manipulation) child policy."""
         return self._upper
+
+    @property
+    def children(self) -> tuple[Policy, ...]:
+        """Both child policies, ``lower`` first - the order they are merged in.
+
+        Lets a runtime capability probe reach the concrete policies inside the
+        composite; see :attr:`Policy.children`.
+        """
+        return (self._lower, self._upper)
 
     @property
     def provider_name(self) -> str:

--- a/strands_robots/policies/persistent.py
+++ b/strands_robots/policies/persistent.py
@@ -170,6 +170,15 @@ class PersistentPolicy(Policy):
         """The wrapped policy instance."""
         return self._inner
 
+    @property
+    def children(self) -> tuple[Policy, ...]:
+        """The single wrapped policy.
+
+        Keeps the wrapper transparent to a runtime capability probe as well as to
+        the delegated :class:`Policy` operations; see :attr:`Policy.children`.
+        """
+        return (self._inner,)
+
     async def get_actions(
         self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any
     ) -> list[dict[str, Any]]:

--- a/strands_robots/policies/wbc/sim_control.py
+++ b/strands_robots/policies/wbc/sim_control.py
@@ -20,8 +20,12 @@ When installed it:
    and advances physics by ``control_decimation`` substeps, recomputing the PD
    torque each substep (``owns_stepping = True``).
 
-The arm joints WBC does not drive are held at their nominal pose with a light PD,
-matching the reference deploy loop. With this controller installed,
+The arm joints WBC does not drive track whatever target the action dict names for
+them, under a light PD, and hold their nominal pose while unnamed - so the same
+controller carries the upper body of a
+:class:`~strands_robots.policies.composite.CompositePolicy` (legs+waist from WBC,
+arms from a manipulation policy) instead of overriding it. With this controller
+installed,
 ``sim.run_policy(robot_name="unitree_g1", policy_object=WBCPolicy(...), ...)``
 produces a real walking / balancing gait on the standard ``Robot("unitree_g1")``
 model - no upstream model swap, no mesh download.
@@ -33,6 +37,7 @@ upright; zero command -> balanced standing (< 0.1 m drift).
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -48,8 +53,9 @@ logger = logging.getLogger(__name__)
 # (50 Hz control). The PD->torque law runs every physics substep.
 _SIM_DT = 0.005
 _CONTROL_DECIMATION = 4
-# Arm joints (not driven by WBC) are held at nominal 0 with a light PD so they
-# do not flail; matches the reference deploy loop's arm hold.
+# Arm joints (not driven by WBC) run a light PD toward their commanded target,
+# defaulting to the nominal 0 hold of the reference deploy loop when nothing
+# commands them.
 _ARM_KP = 100.0
 _ARM_KD = 0.5
 
@@ -111,6 +117,13 @@ class WBCTorqueController:
         self._target_q = np.asarray(policy.default_angles, dtype=np.float64).copy()
         if self._target_q.shape[0] != n:
             self._target_q = np.zeros(n, dtype=np.float64)
+        # Arm targets, in ``arm_actuator_ids`` order. Zero is the nominal hold of
+        # the reference deploy loop, and stays the target for any arm joint no
+        # action dict ever names - so a bare WBC rollout is unchanged.
+        self._arm_target_q = np.zeros(len(self.arm_actuator_ids), dtype=np.float64)
+        # Bare joint names of the held arm joints, positionally aligned with
+        # ``_arm_target_q`` (WBC drives ``num_actions``; the rest are the arms).
+        self._arm_joint_names: tuple[str, ...] = tuple(WBC_G1_ALL_JOINTS[n : n + len(self.arm_actuator_ids)])
 
     # ------------------------------------------------------------------
     # Install / teardown
@@ -291,6 +304,28 @@ class WBCTorqueController:
     # Action-controller hook
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _refresh_targets(
+        action_dict: dict[str, Any],
+        names: Sequence[str],
+        targets: np.ndarray,
+    ) -> None:
+        """Overwrite ``targets`` in place from the values ``action_dict`` names.
+
+        ``names`` is positionally aligned with ``targets``. A name the action
+        dict omits, or whose value is not a number, keeps its previous target:
+        one bad or absent key degrades to a hold rather than aborting the whole
+        control step, and the rest of the action still applies.
+        """
+        for i, name in enumerate(names):
+            v = action_dict.get(name)
+            if v is None:
+                continue
+            try:
+                targets[i] = float(v)
+            except (TypeError, ValueError):
+                continue
+
     def apply(
         self,
         action_dict: dict[str, Any],
@@ -300,12 +335,18 @@ class WBCTorqueController:
     ) -> None:
         """Convert WBC position targets to torques and advance physics.
 
-        ``action_dict`` maps the WBC leg+waist joint names to absolute position
-        targets (the policy's output). We update the held target, then run the
-        SONIC PD law (:meth:`WBCPolicy.compute_torques`) every physics substep
-        for ``physics_substeps_per_control`` steps, recomputing the torque from
-        the integrated state each substep. The arm joints are held at nominal 0
-        with a light PD.
+        ``action_dict`` maps joint names to absolute position targets (the
+        policy's output). We update the held targets, then run the SONIC PD law
+        (:meth:`WBCPolicy.compute_torques`) every physics substep for
+        ``physics_substeps_per_control`` steps, recomputing the torque from the
+        integrated state each substep.
+
+        Arm joints - the ones WBC does not drive - track any target the action
+        dict names for them under a light PD, and hold their previous target
+        (nominal 0 until something commands them) otherwise. That is what lets
+        one :class:`~strands_robots.policies.composite.CompositePolicy` put WBC
+        on the legs and a manipulation policy on the arms: pinning the arms to 0
+        here would discard every upper-body command without a word.
 
         ``owns_stepping = True`` tells the SimEngine not to call ``mj_step``
         after this returns - we have advanced physics by the full control step.
@@ -315,16 +356,10 @@ class WBCTorqueController:
         # Refresh the target from this step's action (bare joint-name keys, in
         # WBC output order). Missing keys keep the previous target.
         driven_names = WBC_G1_ALL_JOINTS[: len(self.leg_waist_actuator_ids)]
-        for i, name in enumerate(driven_names):
-            v = action_dict.get(name)
-            if v is not None:
-                try:
-                    self._target_q[i] = float(v)
-                except (TypeError, ValueError):
-                    # Non-numeric action value for this joint: keep the previous
-                    # target rather than aborting the whole control step (one bad
-                    # key degrades to a hold, the rest of the action still applies).
-                    continue
+        self._refresh_targets(action_dict, driven_names, self._target_q)
+        # Same refresh for the arm joints, so an upper-body policy composed on
+        # top of WBC reaches the actuators instead of being overwritten.
+        self._refresh_targets(action_dict, self._arm_joint_names, self._arm_target_q)
 
         leg_q_adr = np.asarray(self.leg_waist_qpos_addrs, dtype=int)
         leg_d_adr = np.asarray(self.leg_waist_dof_addrs, dtype=int)
@@ -342,7 +377,7 @@ class WBCTorqueController:
             if arm_act:
                 qa = data.qpos[arm_q_adr]
                 dqa = data.qvel[arm_d_adr]
-                arm_tau = -qa * _ARM_KP - dqa * _ARM_KD
+                arm_tau = (self._arm_target_q - qa) * _ARM_KP - dqa * _ARM_KD
                 for ai, t in zip(arm_act, arm_tau, strict=True):
                     data.ctrl[ai] = float(t)
             mj.mj_step(model, data)

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1913,15 +1913,26 @@ class MuJoCoSimEngine(
         :func:`~strands_robots.policies.wbc.install_wbc_torque_control` and
         returns its :meth:`uninstall` so the scene is restored after the run.
 
+        ``policy`` may be the ``WBCPolicy`` itself or any wrapper that declares
+        it through :attr:`~strands_robots.policies.base.Policy.children` - a
+        :class:`~strands_robots.policies.composite.CompositePolicy` driving the
+        legs from WBC and the arms from a manipulation policy, or a
+        :class:`~strands_robots.policies.persistent.PersistentPolicy` holding it
+        warm. The shim is resolved by walking that tree
+        (:func:`~strands_robots.policies.base.iter_policy_tree`), because the
+        physics it corrects is a property of the WBC policy driving the joints,
+        not of the type of object handed to ``run_policy``.
+
         Returns ``None`` (no-op) in five cases, in the order they are checked:
-        ``[wbc]`` is not installed; ``policy`` is not a ``WBCPolicy``; the sim
-        has no compiled world; a controller is already registered (a manual
-        install always wins); or
+        ``[wbc]`` is not installed; no ``WBCPolicy`` appears in ``policy``'s
+        tree; the sim has no compiled world; a controller is already registered
+        (a manual install always wins); or
         :func:`~strands_robots.policies.wbc.wbc_uses_position_servo` finds no
         position-servo actuator, meaning the driven actuators are already torque
         motors or none of the WBC joints resolve in this scene.
         """
         try:
+            from strands_robots.policies.base import iter_policy_tree
             from strands_robots.policies.wbc import (
                 WBCPolicy,
                 install_wbc_torque_control,
@@ -1930,7 +1941,11 @@ class MuJoCoSimEngine(
         except ImportError:
             return None
 
-        if not isinstance(policy, WBCPolicy):
+        # The shim is keyed on the WBC policy actually driving the joints, which
+        # may sit inside a wrapper (composite / persistent) that is not itself a
+        # WBCPolicy. Walk the declared tree instead of type-testing the argument.
+        wbc_policy = next((p for p in iter_policy_tree(policy) if isinstance(p, WBCPolicy)), None)
+        if wbc_policy is None:
             return None
         world = self._world
         if world is None or world._model is None:
@@ -1938,10 +1953,10 @@ class MuJoCoSimEngine(
         backend_state = getattr(world, "_backend_state", None)
         if isinstance(backend_state, dict) and backend_state.get("action_controller") is not None:
             return None  # a manually-installed controller wins
-        if not wbc_uses_position_servo(self, policy, robot_name):
+        if not wbc_uses_position_servo(self, wbc_policy, robot_name):
             return None
 
-        controller = install_wbc_torque_control(self, policy, robot_name)
+        controller = install_wbc_torque_control(self, wbc_policy, robot_name)
         logger.info(
             "run_policy: auto-installed WBC torque control on %r (position-servo "
             "actuators detected). WBC emits joint-position targets the stock servo "

--- a/tests/policies/test_policy_tree_children.py
+++ b/tests/policies/test_policy_tree_children.py
@@ -98,3 +98,45 @@ class TestIterPolicyTree:
 
         loop = _SelfReferencing("loop")
         assert list(iter_policy_tree(loop)) == [loop]
+
+    def test_a_duck_typed_policy_object_yields_itself_instead_of_raising(self) -> None:
+        # `iter_policy_tree` is reached from the default MuJoCo `run_policy`
+        # path (the WBC torque-shim probe runs whenever the [wbc] import
+        # succeeds), and its argument there is typed `Any`. A policy object that
+        # does not subclass Policy therefore arrives with no `children`
+        # attribute at all - the input class `policy_runner` names when it
+        # probes `is_chunk_emitting` via getattr ("a duck-typed test double may
+        # have neither hook"). Reading `.children` directly turned that into an
+        # `AttributeError` from inside a capability probe whose documented
+        # answer is "no match".
+        class _DuckTyped:
+            """A policy-shaped object that predates the `children` declaration."""
+
+        duck = _DuckTyped()
+        assert list(iter_policy_tree(duck)) == [duck]  # type: ignore[arg-type]
+
+    def test_a_duck_typed_policy_object_answers_a_capability_probe_as_no_match(self) -> None:
+        # The probe's shape at the call site: `next((p for p in
+        # iter_policy_tree(policy) if isinstance(p, ...)), None)`. For an object
+        # declaring no tree the answer is None - the documented no-op - rather
+        # than an exception that names nothing about the capability being
+        # probed.
+        class _DuckTyped:
+            pass
+
+        duck = _DuckTyped()
+        found = next((p for p in iter_policy_tree(duck) if isinstance(p, _Leaf)), None)  # type: ignore[arg-type]
+        assert found is None
+
+    def test_a_declared_child_is_still_walked_when_children_is_a_plain_attribute(self) -> None:
+        # The getattr read must not quietly stop walking a duck-typed object
+        # that DOES declare children as an instance attribute rather than a
+        # Policy property.
+        leaf = _Leaf("declared")
+
+        class _DuckTypedWrapper:
+            def __init__(self, child: Policy) -> None:
+                self.children = (child,)
+
+        wrapper = _DuckTypedWrapper(leaf)
+        assert list(iter_policy_tree(wrapper)) == [wrapper, leaf]  # type: ignore[arg-type]

--- a/tests/policies/test_policy_tree_children.py
+++ b/tests/policies/test_policy_tree_children.py
@@ -1,0 +1,100 @@
+"""Tests for the policy-tree seam: ``Policy.children`` + ``iter_policy_tree``.
+
+A runtime capability probe answers about the object it is handed. A *wrapper*
+policy is a different object than the policy inside it, so a probe that
+type-tests its argument reports the wrapped policy's capability as absent -
+which is how a WBC policy inside a
+:class:`~strands_robots.policies.composite.CompositePolicy` lost the MuJoCo
+torque shim it needs, even though the physics the shim corrects is identical.
+
+:attr:`~strands_robots.policies.base.Policy.children` is the declaration that
+fixes that once for every probe, and
+:func:`~strands_robots.policies.base.iter_policy_tree` is the walk over it.
+These tests pin the contract the probes rely on: a leaf declares nothing, both
+shipped wrappers declare what they drive, the walk reaches a policy nested
+several wrappers deep, and a shared child or a cycle terminates instead of
+double-reporting or hanging.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strands_robots.policies import MockPolicy
+from strands_robots.policies.base import Policy, iter_policy_tree
+from strands_robots.policies.composite import CompositePolicy
+from strands_robots.policies.persistent import PersistentPolicy
+
+
+class _Leaf(Policy):
+    """Minimal leaf policy that declares one named joint."""
+
+    def __init__(self, joint: str) -> None:
+        self.joint = joint
+
+    @property
+    def provider_name(self) -> str:
+        return f"leaf-{self.joint}"
+
+    @property
+    def requires_images(self) -> bool:
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        return None
+
+    async def get_actions(self, observation_dict: dict[str, Any], instruction: str, **kwargs: Any) -> list[dict]:
+        return [{self.joint: 0.0}]
+
+
+class TestChildrenDeclaration:
+    def test_a_leaf_policy_declares_no_children(self) -> None:
+        assert MockPolicy().children == ()
+        assert _Leaf("a").children == ()
+
+    def test_composite_declares_both_children_lower_first(self) -> None:
+        lower, upper = _Leaf("lo"), _Leaf("up")
+        composite = CompositePolicy(lower=lower, upper=upper)
+        assert composite.children == (lower, upper)
+
+    def test_persistent_declares_the_policy_it_holds_warm(self) -> None:
+        inner = _Leaf("inner")
+        assert PersistentPolicy("mock", policy_object=inner).children == (inner,)
+
+
+class TestIterPolicyTree:
+    def test_a_leaf_yields_only_itself(self) -> None:
+        leaf = _Leaf("solo")
+        assert list(iter_policy_tree(leaf)) == [leaf]
+
+    def test_the_root_is_yielded_before_its_children(self) -> None:
+        lower, upper = _Leaf("lo"), _Leaf("up")
+        composite = CompositePolicy(lower=lower, upper=upper)
+        assert list(iter_policy_tree(composite)) == [composite, lower, upper]
+
+    def test_a_probe_reaches_a_policy_nested_under_several_wrappers(self) -> None:
+        # The shape that lost the torque shim: the policy a probe is looking for
+        # sits two wrappers down, and neither wrapper is of its type.
+        target = _Leaf("target")
+        nested = PersistentPolicy("mock", policy_object=target)
+        composite = CompositePolicy(lower=nested, upper=_Leaf("other"))
+        found = next((p for p in iter_policy_tree(composite) if isinstance(p, _Leaf) and p.joint == "target"), None)
+        assert found is target
+
+    def test_a_child_shared_by_two_wrappers_is_yielded_once(self) -> None:
+        shared = _Leaf("shared")
+        composite = CompositePolicy(
+            lower=PersistentPolicy("mock", policy_object=shared),
+            upper=PersistentPolicy("mock", policy_object=shared),
+        )
+        walked = list(iter_policy_tree(composite))
+        assert walked.count(shared) == 1
+
+    def test_a_cycle_terminates_instead_of_recursing_forever(self) -> None:
+        class _SelfReferencing(_Leaf):
+            @property
+            def children(self) -> tuple[Policy, ...]:
+                return (self,)
+
+        loop = _SelfReferencing("loop")
+        assert list(iter_policy_tree(loop)) == [loop]

--- a/tests/policies/wbc/test_run_policy_auto_torque.py
+++ b/tests/policies/wbc/test_run_policy_auto_torque.py
@@ -18,6 +18,13 @@ mapping) on the real torque/position-servo G1 model. The end-to-end "does it
 actually WALK" validation needs real weights and lives in the gated
 integration suite.
 
+``TestAutoInstallHookThroughWrappers`` pins that the shim is keyed on the WBC
+policy driving the joints rather than on the type of object handed to
+``run_policy``: the same policy inside a ``CompositePolicy`` (legs from WBC,
+arms from a manipulation policy - the composition WBC's own docs recommend) or a
+``PersistentPolicy`` needs the identical shim, because the position-servo gain
+it corrects is a property of the scene and the policy, not of the wrapper.
+
 ``TestAutoInstallHook`` drives the install path and every no-op condition the
 hook documents: no ``[wbc]`` extra, a non-WBC policy, no compiled world, a
 controller already registered, and ``wbc_uses_position_servo`` reporting no
@@ -333,3 +340,75 @@ class TestEveryNoOpConditionIsDriven:
         actuator. Adding a guard without a test fails here.
         """
         assert _hook_no_op_guards() == 5
+
+
+class TestAutoInstallHookThroughWrappers:
+    """The shim resolves a WBCPolicy declared through ``Policy.children``.
+
+    A wrapper is a different object than the policy it wraps, so the hook's
+    ``isinstance`` test saw no WBCPolicy and skipped the install - leaving the
+    composition WBC's own documentation recommends (legs+waist from WBC, arms
+    from a manipulation policy) driving the stock uniform-gain position servos
+    that override SONIC's tuned per-joint PD. The hook now walks the declared
+    policy tree, so the shim follows the policy rather than the wrapper's type.
+    """
+
+    def _sim(self):  # type: ignore[no-untyped-def]
+        model, data = _build_g1_model()
+        return _mujoco_sim_with_world(model, data)
+
+    def test_composite_wrapping_wbc_gets_the_shim(self) -> None:
+        from strands_robots.policies.composite import CompositePolicy
+
+        sim = self._sim()
+        composite = CompositePolicy(lower=_g1_policy(), upper=MockPolicy())
+        undo = sim._maybe_install_wbc_torque_control(composite, "unitree_g1")
+        assert undo is not None, "a WBCPolicy inside a CompositePolicy still needs the torque shim"
+        assert isinstance(sim._world._backend_state["action_controller"], WBCTorqueController)
+        undo()
+
+    def test_the_shim_is_built_for_the_wbc_child_not_the_wrapper(self) -> None:
+        # The controller runs the child's PD law, so it must hold that child -
+        # a controller built around the wrapper could not compute torques at all.
+        from strands_robots.policies.composite import CompositePolicy
+
+        sim = self._sim()
+        wbc = _g1_policy()
+        composite = CompositePolicy(lower=wbc, upper=MockPolicy())
+        undo = sim._maybe_install_wbc_torque_control(composite, "unitree_g1")
+        assert undo is not None
+        controller = cast(WBCTorqueController, sim._world._backend_state["action_controller"])
+        assert controller.policy is wbc
+        undo()
+
+    def test_persistent_wrapping_wbc_gets_the_shim(self) -> None:
+        from strands_robots.policies.persistent import PersistentPolicy
+
+        sim = self._sim()
+        wbc = _g1_policy()
+        undo = sim._maybe_install_wbc_torque_control(PersistentPolicy("wbc", policy_object=wbc), "unitree_g1")
+        assert undo is not None, "a WBCPolicy held warm by a PersistentPolicy still needs the torque shim"
+        assert cast(WBCTorqueController, sim._world._backend_state["action_controller"]).policy is wbc
+        undo()
+
+    def test_a_wrapper_holding_no_wbc_policy_is_still_a_no_op(self) -> None:
+        # The walk must not turn every wrapped policy into a WBC install: a
+        # composite of two non-WBC policies leaves the scene alone.
+        from strands_robots.policies.composite import CompositePolicy
+
+        sim = self._sim()
+        composite = CompositePolicy(lower=MockPolicy(), upper=MockPolicy())
+        assert sim._maybe_install_wbc_torque_control(composite, "unitree_g1") is None
+        assert "action_controller" not in sim._world._backend_state
+
+    def test_wbc_nested_two_wrappers_deep_is_still_found(self) -> None:
+        from strands_robots.policies.composite import CompositePolicy
+        from strands_robots.policies.persistent import PersistentPolicy
+
+        sim = self._sim()
+        wbc = _g1_policy()
+        nested = CompositePolicy(lower=PersistentPolicy("wbc", policy_object=wbc), upper=MockPolicy())
+        undo = sim._maybe_install_wbc_torque_control(nested, "unitree_g1")
+        assert undo is not None
+        assert cast(WBCTorqueController, sim._world._backend_state["action_controller"]).policy is wbc
+        undo()

--- a/tests/policies/wbc/test_sim_control.py
+++ b/tests/policies/wbc/test_sim_control.py
@@ -9,7 +9,11 @@ Two units are covered, both runnable without real SONIC weights:
   and explicit values always win.
 * ``WBCTorqueController`` - flips the robot's actuators to torque mode (restored
   on uninstall), declares ``owns_stepping``, and on ``apply`` writes PD torques
-  to ``data.ctrl`` and advances physics by the decimation count. ``uninstall``
+  to ``data.ctrl`` and advances physics by the decimation count. The arm joints
+  WBC does not drive track whatever target the action dict names for them and
+  hold nominal while unnamed, so one controller can carry the upper body of a
+  ``CompositePolicy`` (legs from WBC, arms from a manipulation policy) rather
+  than overriding it. ``uninstall``
   releases *both* things ``install_wbc_torque_control`` acquires - the
   registration in ``world._backend_state["action_controller"]`` and the gains -
   so the documented manual install/uninstall pair hands the world back as
@@ -221,6 +225,89 @@ class TestWBCTorqueController:
         # And the step still produced finite torques (no abort / NaN spill).
         ctrls = np.array([float(data.ctrl[ai]) for ai in ctrl.leg_waist_actuator_ids])
         assert np.all(np.isfinite(ctrls))
+
+
+class TestArmJointsFollowTheCommandedTarget:
+    """The arm joints WBC does not drive must honour a commanded target.
+
+    ``CompositePolicy``'s contract is that each joint is driven by exactly one
+    child and a dropped command is an error, never a silent resolution. The
+    canonical composition puts WBC on the legs+waist and a manipulation policy
+    on the arms - and this controller is what reaches the actuators for BOTH,
+    because it owns the control step. An arm PD pinned to nominal would discard
+    every upper-body command without a word: the robot walks correctly and the
+    arms simply never move.
+
+    The nominal hold is still the default, for the arm joints nothing commands -
+    a bare WBC rollout must be unchanged.
+    """
+
+    def _installed(self):  # type: ignore[no-untyped-def]
+        from strands_robots.policies.wbc import install_wbc_torque_control
+
+        model, data = _build_min_g1()
+        sim = _FakeSim(_FakeWorld(model, data, _namespace_for(model)))
+        policy = _g1_policy()
+        ctrl = install_wbc_torque_control(cast(SimEngine, sim), policy, "unitree_g1")
+        if not ctrl.arm_actuator_ids:
+            pytest.skip("scene resolves no arm actuators for WBC to hold")
+        stance = {
+            name: float(policy.default_angles[i])
+            for i, name in enumerate(WBC_G1_ALL_JOINTS[: policy.config.num_actions])
+        }
+        return ctrl, model, data, stance
+
+    def test_a_commanded_arm_joint_is_driven_toward_that_target(self) -> None:
+        ctrl, model, data, stance = self._installed()
+        arm_joint = ctrl.arm_actuator_ids[0]
+        commanded = 0.8
+        action: dict[str, Any] = dict(stance)
+        action[WBC_G1_ALL_JOINTS[len(ctrl.leg_waist_actuator_ids)]] = commanded
+
+        # One step: the torque must push the joint toward the command, not hold
+        # it at nominal (from rest at ~0 a nominal hold produces ~0 torque).
+        ctrl.apply(action, model, data, "unitree_g1")
+        assert float(data.ctrl[arm_joint]) > 1.0
+
+        # And it converges there over the following control steps.
+        for _ in range(30):
+            ctrl.apply(action, model, data, "unitree_g1")
+        reached = float(data.qpos[ctrl.arm_qpos_addrs[0]])
+        assert abs(reached - commanded) < 0.1, f"arm joint reached {reached:.4f}, commanded {commanded}"
+
+    def test_an_uncommanded_arm_joint_holds_its_nominal_pose(self) -> None:
+        # The bare-WBC path: the action dict names only leg+waist joints, so
+        # every arm joint keeps the nominal hold of the reference deploy loop.
+        ctrl, model, data, stance = self._installed()
+        for _ in range(30):
+            ctrl.apply(dict(stance), model, data, "unitree_g1")
+        held = np.array([float(data.qpos[a]) for a in ctrl.arm_qpos_addrs])
+        assert np.all(np.abs(held) < 0.15), f"uncommanded arms drifted to {held}"
+
+    def test_commanding_one_arm_joint_leaves_its_neighbours_nominal(self) -> None:
+        # Routing check: the command must land on the joint it names, so a
+        # partial upper-body action does not disturb the rest of the arm.
+        ctrl, model, data, stance = self._installed()
+        n_legs = len(ctrl.leg_waist_actuator_ids)
+        action: dict[str, Any] = dict(stance)
+        action[WBC_G1_ALL_JOINTS[n_legs]] = 0.8
+        for _ in range(30):
+            ctrl.apply(action, model, data, "unitree_g1")
+        assert abs(float(data.qpos[ctrl.arm_qpos_addrs[0]]) - 0.8) < 0.1
+        others = np.array([float(data.qpos[a]) for a in ctrl.arm_qpos_addrs[1:]])
+        assert np.all(np.abs(others) < 0.15), f"uncommanded neighbours moved to {others}"
+
+    def test_a_non_numeric_arm_command_holds_the_previous_arm_target(self) -> None:
+        # Same degradation the leg joints get: one malformed value holds that
+        # joint's prior target instead of aborting the control step.
+        ctrl, model, data, stance = self._installed()
+        n_legs = len(ctrl.leg_waist_actuator_ids)
+        name = WBC_G1_ALL_JOINTS[n_legs]
+        ctrl.apply({**stance, name: 0.4}, model, data, "unitree_g1")
+        held = float(ctrl._arm_target_q[0])
+        ctrl.apply({**stance, name: "not-a-number"}, model, data, "unitree_g1")
+        assert float(ctrl._arm_target_q[0]) == held
+        assert np.all(np.isfinite([float(data.ctrl[a]) for a in ctrl.arm_actuator_ids]))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The composition `docs/policies/wbc.md` recommends - legs+waist from `WBCPolicy`, arms from a manipulation policy, merged by `CompositePolicy` - cannot be driven correctly through `sim.run_policy` today. Two independent defects break it in opposite directions, so there is no configuration in which it works.

**1. The torque shim never installs for a wrapped WBC policy.** `MuJoCoSimEngine._maybe_install_wbc_torque_control` resolved it with `isinstance(policy, WBCPolicy)`. A `CompositePolicy` is not a `WBCPolicy`, so the shim was skipped and the composite drove the stock uniform-gain (`kp=500`) position servos - which override SONIC's tuned per-joint PD, the exact condition `wbc/sim_control.py` exists to correct. `PersistentPolicy` hides its child the same way.

**2. With the shim installed, every upper-body command was silently discarded.** `WBCTorqueController.apply` pinned all 14 arm joints to nominal with `arm_tau = -qa*kp - dqa*kd`, ignoring the arm entries of the action dict. The robot walks correctly and the arms simply never move - no error, no warning. `CompositePolicy`'s own contract forbids exactly this: "A genuine ownership conflict ... is raised, never silently resolved - a dropped command on a humanoid is a fall, not a warning."

That the second behaviour is wrong is already settled in-repo: `examples/wbc/wbc_g1_composite.py` bypasses `run_policy` and hand-rolls its own control loop, whose arm law is `(arm_target - q_arm) * arm_kp + (0.0 - dq_arm) * arm_kd` with `arm_kp=100.0, arm_kd=0.5` - the same law and the same gains as `_ARM_KP` / `_ARM_KD` in the controller. The example reimplements the loop because the shipped controller could not do it.

## Change

`Policy.children` declares the policies a wrapper delegates to, and `iter_policy_tree` walks it (pre-order, de-duplicated, cycle-safe). This is the same "policy declares, runtime supplies" shape as `requires_images` and `required_bodies`, applied to a capability probe instead of an observation: a probe answers about the object it is handed, and a wrapper is a different object than the policy inside it. Declaring the children lets one probe walk to the policy that answers rather than every probe learning the name of every wrapper. `CompositePolicy` returns `(lower, upper)`; `PersistentPolicy` returns `(inner,)`.

- The auto-install hook resolves the WBC policy through that walk, so the shim follows the policy driving the joints, not the type of object passed to `run_policy`. All five documented no-op conditions are unchanged, including a wrapper that holds no WBC policy.
- The arm PD tracks whatever target the action dict names, and holds the previous target (nominal until something commands it) otherwise. A malformed value degrades to a hold, matching the leg joints.
- `docs/policies/wbc.md` gains the `run_policy` call for the composite, and the goal payload in the `composite.py` docstring is corrected to `policy_kwargs=` - `run_policy` has no `**kwargs`, so the form shown there raised `TypeError`.

The arm default stays zero, so a bare WBC rollout is unaffected.

## Measurements

`Robot("unitree_g1")` in MuJoCo, 400 steps at 50 Hz, `target_velocity=[0.5, 0, 0]` (4.0 m commanded), real GR00T-WBC SONIC weights:

| configuration | forward travel | pelvis z | commanded arm target -1.200 |
|---|---|---|---|
| bare WBC (before and after - unchanged) | 3.115 m | 0.746 | n/a (nominal hold) |
| composite via `run_policy`, before | 1.872 m | 0.772 | tracked (no shim: raw servos) |
| composite with shim, before | 3.115 m | 0.746 | **+0.015 - discarded** |
| composite via `run_policy`, after | 3.031 m | 0.745 | **-1.147 - tracked** |

After the fix the composite reproduces the bare-WBC gait (3.03 m vs 3.12 m) *and* tracks its arm targets. Before, it either lost 40% of its commanded velocity or lost the entire upper body.

## Visual

Both panels are the same scripted arm-wave upper body over WBC legs at `vx=0.4`, rendered headless in MuJoCo; they differ only by the tree under test. Left is `main`: the robot walks while the arms stay pinned at nominal. Right is this branch: the arms track the commanded wave.

![WBC composite arm tracking before and after](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-composite-arms/wbc_composite_arms.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-composite-arms/wbc_composite_arms.mp4) (640x480 per panel, 201 frames). Verified non-static: every frame differs from its predecessor in both panels (mean abs pixel delta 4.20 and 4.48), and the panels differ from each other (mean 10.49).

## Tests

7 new tests fail on `main` and pass here:

- `tests/policies/wbc/test_run_policy_auto_torque.py::TestAutoInstallHookThroughWrappers` - the shim installs for a composite and for a persistent wrapper, is built for the WBC *child* (the controller runs that child's PD law), is found two wrappers deep, and is still a no-op for a wrapper holding no WBC policy.
- `tests/policies/wbc/test_sim_control.py::TestArmJointsFollowTheCommandedTarget` - a commanded arm joint is driven toward its target and converges there, its neighbours stay nominal, an uncommanded arm holds nominal (the bare-WBC control, which passes both before and after), and a non-numeric arm value holds the previous target.
- `tests/policies/test_policy_tree_children.py` - the `children` / `iter_policy_tree` contract, including a shared child yielded once and a cycle terminating.

The two control tests pass before *and* after, which is what shows the bare-WBC path is untouched. Full `tests/` on this branch: no new failures against `main` on the same interpreter. `ruff check` / `ruff format --check` clean; `mypy` reports no new errors (18 pre-existing on both trees).

---

## 13. Round changelog

### Round 1 - `iter_policy_tree` crashed on a policy object declaring no tree

Review feedback: `iter_policy_tree` read `current.children` as an attribute, so a `policy_object` that does not subclass `Policy` raised `AttributeError: '...' object has no attribute 'children'` at the top of `run_policy` - a path where the pre-branch `isinstance(policy, WBCPolicy)` probe had returned False and the hook was the documented no-op. The walk turned that no-op into a crash naming nothing about WBC, on the **default** MuJoCo path (`wbc_install_torque_control=True` whenever the `[wbc]` import succeeds).

Fixed in 46c7624a by reading `getattr(current, "children", ())` inside the walk, rather than short-circuiting at the one call site. The defect is in the walk's own contract: its docstring already promised "a leaf policy yields just itself", and an object declaring no tree is a leaf by that description - so it was raising on an input its own documentation admits. Guarding at the caller would have left the next of the two existing probe sites to rediscover it. This also puts the walk on the same footing as `policy_runner`'s `getattr` probe for `is_chunk_emitting`, so tolerance for a duck-typed policy object is uniform across the chain instead of present at one hop and absent at the next.

Pinned by three tests added to `tests/policies/test_policy_tree_children.py`:

| test | on parent commit |
|---|---|
| a duck-typed policy object yields itself instead of raising | fails, `AttributeError` |
| a duck-typed policy object answers a capability probe as no match | fails, `AttributeError` |
| a declared child is still walked when `children` is a plain attribute | passes (preservation control) |

The third is the control that the `getattr` read cannot silently truncate a tree it should have descended. Changelog fragment updated to state the tolerance. `ruff check` / `ruff format --check` clean; `tests/policies` 3089 passed with no new failures (the 22 remaining are pre-existing missing-optional-dependency errors in `cosmos3` / `lerobot_local` - `msgpack`, `huggingface_hub`, torch stubs - none touching `policies/base.py`).