### PR TITLE
fix(policies/groot): apply a server-side episode seed to every RNG or to none

### DIFF
--- a/changelog.d/2283-groot-server-seed-partial-reseed.md
+++ b/changelog.d/2283-groot-server-seed-partial-reseed.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **policies/groot**: the determinism wrapper's per-episode reseed now applies a
+  seed to every RNG or to none of them. It seeds Python `random`, then NumPy's
+  legacy global RNG, then torch, and only the second bounded the value - so any
+  seed NumPy refuses (negative, non-integral, or above `2**32 - 1`) left the
+  server part-way reseeded, with Python `random` moved, NumPy and torch
+  untouched, and the upstream `reset` never reached. The client swallows a
+  failed reset at `INFO`, so an episode drew part of its randomness from a fresh
+  stream and part from the previous episode's while reporting that no reseed had
+  happened. The seed is now checked before the first applier runs, against the
+  domain `randomization_seed_error` already enforces for a rollout seed. A
+  refused per-episode request falls back to the already-validated configured
+  seed with the reason printed, so the episode still gets one whole reseed and
+  still reaches the upstream `reset`; `bool`, numeric strings and floats are
+  refused rather than read or coerced into a seed the caller never named; and an
+  unusable `STRANDS_GR00T_SERVER_SEED` is refused at startup naming the variable
+  and the domain instead of raising out of NumPy with the interpreter's RNG
+  already moved.

--- a/strands_robots/policies/groot/server_wrapper.py
+++ b/strands_robots/policies/groot/server_wrapper.py
@@ -33,7 +33,11 @@ The supported way to run it is the ``gr00t_inference`` tool's
 Environment variables (read inside the container):
 
 - ``STRANDS_GR00T_SERVER_SEED``: default seed applied at server start and on
-  ``reset`` calls that carry no seed (default: 42).
+  ``reset`` calls that carry no seed (default: 42). Must be an integer in
+  ``[0, 2**32 - 1]`` - the range every RNG below can be seeded with. A value
+  outside it is refused at startup, because a server that could not apply the
+  seed it was configured with cannot deliver the determinism it was started
+  for.
 - ``STRANDS_GR00T_STRICT_DETERMINISTIC=1``: additionally enable
   ``torch.use_deterministic_algorithms(True, warn_only=True)``. Strict mode
   can force slower kernels whose numerics differ slightly from the default,
@@ -45,6 +49,52 @@ Environment variables (read inside the container):
 from __future__ import annotations
 
 import os
+
+#: Largest seed this wrapper can apply to every RNG it reseeds.
+#:
+#: The three appliers do not share a domain. Python ``random.seed`` and
+#: ``torch.manual_seed`` take far wider values - including negatives, which
+#: ``manual_seed`` reduces modulo ``2**64`` - while NumPy's legacy global
+#: seeder (``numpy.random.seed``) refuses anything negative, non-integral or
+#: above ``2**32 - 1``. The narrowest applier therefore decides what a seed can
+#: be, and it has to be checked *before the first* applier runs: the three
+#: mutate process-wide state in sequence, so a value only NumPy refuses left
+#: Python ``random`` reseeded with NumPy and torch untouched - an episode drawing
+#: half its randomness from a fresh stream and half from the previous episode's.
+#:
+#: This restates the ceiling ``strands_robots.simulation.base.MAX_EVAL_SEED``
+#: carries for the same destination rather than importing it: this module is
+#: mounted into the GR00T container, where ``strands-robots`` is not installed,
+#: so it can depend on the standard library only. The two are pinned in
+#: agreement, so the duplication cannot drift into a disagreement about which
+#: seeds a rollout may use.
+_MAX_SEED = 2**32 - 1
+
+
+def _seed_error(value: object, source: str) -> str | None:
+    """Return why *value* cannot seed every RNG this wrapper reseeds.
+
+    Args:
+        value: Candidate seed, exactly as it arrived from *source*.
+        source: Where the value came from, named in the message so an operator
+            can tell a misconfigured environment variable from a per-episode
+            ``reset`` option.
+
+    Returns:
+        The reason the value is unusable, or ``None`` when it can be applied to
+        all of Python ``random``, NumPy and torch.
+    """
+    if isinstance(value, bool):
+        # bool is an int subclass, so a bare range test reads True as a seed of
+        # 1 - a seed the caller never named, applied under a success report.
+        return f"{source}: seed must be an integer, not a bool (got {value!r})"
+    if not isinstance(value, int):
+        # No coercion: int("42") and int(3.7) would accept a value NumPy itself
+        # refuses, the second one by silently truncating it to a different seed.
+        return f"{source}: seed must be an integer in [0, {_MAX_SEED}], got {value!r}"
+    if not 0 <= value <= _MAX_SEED:
+        return f"{source}: seed must be in [0, {_MAX_SEED}], got {value!r}"
+    return None
 
 
 def main() -> None:
@@ -80,9 +130,34 @@ def main() -> None:
     )
     print(f"[srv_wrap] CUBLAS_WORKSPACE_CONFIG={os.environ.get('CUBLAS_WORKSPACE_CONFIG')}", flush=True)
 
-    default_seed = int(os.environ.get("STRANDS_GR00T_SERVER_SEED", "42"))
+    configured_seed = os.environ.get("STRANDS_GR00T_SERVER_SEED", "42")
+    try:
+        default_seed = int(configured_seed)
+    except ValueError:
+        raise ValueError(
+            f"STRANDS_GR00T_SERVER_SEED: seed must be an integer in [0, {_MAX_SEED}], got {configured_seed!r}"
+        ) from None
 
-    def _seed_all(seed: int) -> None:
+    def _seed_all(seed: int, source: str) -> None:
+        """Reseed Python, NumPy and torch - all of them, or none of them.
+
+        The single point at which an unusable seed is refused, so the
+        all-or-nothing property belongs to the applier rather than to each
+        caller remembering to check first.
+
+        Args:
+            seed: The seed to apply to every RNG.
+            source: Where the seed came from, named in the refusal.
+
+        Raises:
+            ValueError: If *seed* is outside the domain every applier shares.
+                Checked, and both modules imported, before the first applier
+                runs, so a refused seed and a missing NumPy both leave every
+                RNG exactly as it was rather than part-way reseeded.
+        """
+        if error := _seed_error(seed, source):
+            raise ValueError(error)
+
         import random as _random
 
         import numpy as _np
@@ -95,7 +170,7 @@ def main() -> None:
 
     # Apply once at server start (covers any startup-time module state that
     # isn't otherwise touched by reset).
-    _seed_all(default_seed)
+    _seed_all(default_seed, "STRANDS_GR00T_SERVER_SEED")
     print(f"[srv_wrap] initial seed applied: {default_seed}", flush=True)
 
     # Monkey-patch Gr00tPolicy.reset so the client can trigger a re-seed
@@ -108,15 +183,15 @@ def main() -> None:
     def _seeded_reset(self, options=None):
         seed = default_seed
         if isinstance(options, dict) and "seed" in options:
-            try:
-                seed = int(options["seed"])
-            except (TypeError, ValueError):
-                print(
-                    f"[srv_wrap] warning: bad seed in reset options: {options['seed']!r}; using {default_seed}",
-                    flush=True,
-                )
-                seed = default_seed
-        _seed_all(seed)
+            requested = options["seed"]
+            if error := _seed_error(requested, "reset options['seed']"):
+                # The configured default is already known-good, so the episode
+                # still gets a complete reseed - just not the requested one,
+                # and the reason says which value was dropped and why.
+                print(f"[srv_wrap] warning: {error}; using {default_seed}", flush=True)
+            else:
+                seed = requested
+        _seed_all(seed, "reset options['seed']")
         print(f"[srv_wrap] reset: re-seeded to {seed}", flush=True)
         return original_reset(self, options)
 

--- a/tests/policies/groot/test_server_wrapper_seed_domain.py
+++ b/tests/policies/groot/test_server_wrapper_seed_domain.py
@@ -1,0 +1,367 @@
+"""The server-side reseed accepts exactly the seeds it can apply to every RNG.
+
+:mod:`strands_robots.policies.groot.server_wrapper` is the container-side half
+of the #187 per-episode reproducibility contract: it patches
+``Gr00tPolicy.reset`` so a seed the client forwards in ``options`` reseeds the
+server's RNGs before the episode's first diffusion sample. Its reseed applies
+Python ``random``, then NumPy's legacy global RNG, then torch - three appliers
+with three different accepted domains, run in sequence against process-wide
+state.
+
+Only the second of them bounds the value. Before the guard under test, every
+seed NumPy refuses - anything negative, non-integral, or above ``2**32 - 1`` -
+left the server *half* reseeded: Python ``random`` moved, NumPy and torch
+untouched, and the upstream ``reset`` never reached at all because the NumPy
+refusal raised out of the patched method first. The client swallows a failed
+reset at ``INFO`` and reports "continuing without per-episode server-side
+reseed", so the one thing nothing observed was that the server's RNGs had in
+fact been moved, inconsistently. The episode then drew part of its randomness
+from a fresh stream and part from the previous episode's.
+
+What is pinned here:
+
+* a seed no applier can honor is refused *before the first one runs*, so no RNG
+  moves - at startup for ``STRANDS_GR00T_SERVER_SEED`` and per episode for
+  ``reset``;
+* a ``reset`` carrying an unusable seed still completes a whole reseed, on the
+  already-validated configured default, and still reaches the upstream
+  ``reset`` - a refused *request* is not a refused *episode*;
+* ``bool`` is refused rather than read as a seed of 1, and a numeric string or
+  float is refused rather than coerced into a different seed than the one
+  asked for;
+* the accepted domain is the one
+  :func:`~strands_robots.simulation.base.randomization_seed_error` already
+  enforces for a rollout seed, value for value. The wrapper restates that
+  domain instead of importing it because it runs where ``strands-robots`` is
+  not installed, so the agreement is asserted rather than assumed;
+* the determinism configuration the wrapper exists to apply - cuDNN flags,
+  ``CUBLAS_WORKSPACE_CONFIG``, the optional strict mode, the ``reset`` patch,
+  and the hand-off to the unmodified server entrypoint.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import sys
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.groot import server_wrapper
+from strands_robots.policies.groot.server_wrapper import _MAX_SEED, _seed_error
+from strands_robots.simulation.base import MAX_EVAL_SEED, randomization_seed_error
+
+#: Seeds this path cannot apply, each refused by NumPy's legacy global RNG -
+#: the narrowest of the three appliers. Python ``random`` accepts most of them,
+#: which is exactly why they used to leave the server half reseeded.
+UNUSABLE_SEEDS: list[Any] = [
+    -1,
+    -5,
+    2.5,
+    3.0,
+    True,
+    False,
+    "42",
+    [7],
+    math.nan,
+    math.inf,
+    _MAX_SEED + 1,
+    2**64,
+]
+
+#: Seeds every applier honors, including both endpoints - ``0`` is a seed, not
+#: the absence of one.
+USABLE_SEEDS: list[int] = [0, 1, 7, 12345, _MAX_SEED]
+
+#: State the RNGs are put into before each measurement. Kept out of the lists
+#: above so "the state changed" is never true by coincidence.
+BASELINE_SEED = 999
+
+
+def _stub_module(name: str) -> Any:
+    """Return a module stand-in whose attributes the caller assigns freely.
+
+    Typed ``Any`` so a checked test body can populate it: the wrapper reaches
+    these through ``sys.modules``, which is what lets a host without the GR00T
+    image drive :func:`~strands_robots.policies.groot.server_wrapper.main`.
+    """
+    return types.ModuleType(name)
+
+
+class _StubPolicy:
+    """Stand-in for the upstream ``Gr00tPolicy`` whose ``reset`` is patched."""
+
+    upstream_calls: list[Any] = []
+
+    def reset(self, options: Any = None) -> str:
+        type(self).upstream_calls.append(options)
+        return "upstream-reset"
+
+
+class _Container:
+    """The container-side modules :func:`main` imports, captured for assertions."""
+
+    def __init__(self) -> None:
+        self.torch = _stub_module("torch")
+        self.seeded: list[int] = []
+        self.cuda_seeded: list[int] = []
+        self.strict_calls: list[tuple[Any, ...]] = []
+        self.cuda_available = False
+        self.strict_raises: Exception | None = None
+
+        self.torch.manual_seed = self.seeded.append
+        self.torch.cuda = types.SimpleNamespace(
+            is_available=lambda: self.cuda_available,
+            manual_seed_all=self.cuda_seeded.append,
+        )
+        self.torch.backends = types.SimpleNamespace(cudnn=types.SimpleNamespace(deterministic=False, benchmark=True))
+
+        def _strict(*args: Any, **kwargs: Any) -> None:
+            self.strict_calls.append(args)
+            if self.strict_raises is not None:
+                raise self.strict_raises
+
+        self.torch.use_deterministic_algorithms = _strict
+
+        self.policy_cls: Any = type("Gr00tPolicy", (_StubPolicy,), {"upstream_calls": []})
+        self.server_config_cls: Any = type("ServerConfig", (), {})
+        self.server_configs: list[Any] = []
+        self.cli_targets: list[Any] = []
+
+    @property
+    def cudnn(self) -> Any:
+        return self.torch.backends.cudnn
+
+    @property
+    def patched_reset(self) -> Any:
+        """The ``reset`` implementation :func:`main` installed on the policy."""
+        return self.policy_cls.reset
+
+
+@pytest.fixture
+def container(monkeypatch: pytest.MonkeyPatch) -> _Container:
+    """Install stubs for the modules that only exist inside the GR00T image.
+
+    The wrapper imports ``torch`` / ``gr00t`` / ``tyro`` inside :func:`main`
+    precisely so it stays importable on a host without them, which is what
+    makes it drivable here.
+    """
+    stub = _Container()
+    monkeypatch.setitem(sys.modules, "torch", stub.torch)
+
+    for name in ("gr00t", "gr00t.policy", "gr00t.eval"):
+        monkeypatch.setitem(sys.modules, name, _stub_module(name))
+
+    policy_mod = _stub_module("gr00t.policy.gr00t_policy")
+    policy_mod.Gr00tPolicy = stub.policy_cls
+    monkeypatch.setitem(sys.modules, "gr00t.policy.gr00t_policy", policy_mod)
+
+    server_mod = _stub_module("gr00t.eval.run_gr00t_server")
+    server_mod.ServerConfig = stub.server_config_cls
+    server_mod.main = stub.server_configs.append
+    monkeypatch.setitem(sys.modules, "gr00t.eval.run_gr00t_server", server_mod)
+
+    tyro = _stub_module("tyro")
+
+    def _cli(target: Any) -> str:
+        stub.cli_targets.append(target)
+        return "parsed-config"
+
+    tyro.cli = _cli
+    monkeypatch.setitem(sys.modules, "tyro", tyro)
+
+    monkeypatch.delenv("CUBLAS_WORKSPACE_CONFIG", raising=False)
+    monkeypatch.delenv("STRANDS_GR00T_STRICT_DETERMINISTIC", raising=False)
+    monkeypatch.setenv("STRANDS_GR00T_SERVER_SEED", str(BASELINE_SEED))
+    return stub
+
+
+def _rng_state() -> tuple[Any, Any]:
+    """Snapshot both RNGs the wrapper mutates before torch is reached."""
+    return random.getstate(), np.random.get_state()
+
+
+def _baseline() -> tuple[Any, Any]:
+    """Seed both RNGs to a known value and return that state."""
+    random.seed(BASELINE_SEED)
+    np.random.seed(BASELINE_SEED)
+    return _rng_state()
+
+
+def _states_equal(left: tuple[Any, Any], right: tuple[Any, Any]) -> bool:
+    py_ok = left[0] == right[0]
+    np_ok = all(np.array_equal(a, b) for a, b in zip(left[1], right[1], strict=True))
+    return py_ok and np_ok
+
+
+class TestTheStartupSeedIsAppliedOrRefusedWhole:
+    """``STRANDS_GR00T_SERVER_SEED`` is applied to every RNG, or to none."""
+
+    def test_the_configured_seed_reaches_every_rng_and_the_server_starts(self, container: _Container) -> None:
+        container.cuda_available = True
+        server_wrapper.main()
+
+        assert container.seeded == [BASELINE_SEED], "torch must be seeded with the configured seed"
+        assert container.cuda_seeded == [BASELINE_SEED], "CUDA generators must be seeded when CUDA reports available"
+        assert container.cudnn.deterministic is True, "cuDNN must be pinned deterministic"
+        assert container.cudnn.benchmark is False, "the cuDNN autotuner must be off for determinism"
+        assert server_wrapper.os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":4096:8", (
+            "cuBLAS determinism requires the workspace config, set before torch loads"
+        )
+        assert container.cli_targets == [container.server_config_cls], (
+            "the wrapper must parse the unmodified server's own config"
+        )
+        assert container.server_configs == ["parsed-config"], "the unmodified server entrypoint must run"
+
+    def test_a_preset_workspace_config_is_left_alone(self, container: _Container, monkeypatch) -> None:
+        monkeypatch.setenv("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+        server_wrapper.main()
+        assert server_wrapper.os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8", (
+            "an operator-supplied workspace config must win over the default"
+        )
+
+    def test_cuda_generators_are_left_alone_when_cuda_is_absent(self, container: _Container) -> None:
+        container.cuda_available = False
+        server_wrapper.main()
+        assert container.seeded == [BASELINE_SEED]
+        assert container.cuda_seeded == [], "there are no CUDA generators to seed on a CPU-only host"
+
+    @pytest.mark.parametrize("value", ["4294967296", "-1", "abc", "3.5", "", "true"])
+    def test_an_unusable_configured_seed_moves_no_rng(self, container: _Container, monkeypatch, value: str) -> None:
+        """The refusal must land before the first applier, and name the variable.
+
+        Pre-fix, ``"4294967296"`` and ``"-1"`` parsed as ints, reseeded Python
+        ``random``, and only then raised out of NumPy - so the server failed to
+        start *and* left the interpreter's RNG moved, with a message naming
+        NumPy's range rather than the variable that carried the value.
+        """
+        monkeypatch.setenv("STRANDS_GR00T_SERVER_SEED", value)
+        before = _baseline()
+
+        with pytest.raises(ValueError, match="STRANDS_GR00T_SERVER_SEED"):
+            server_wrapper.main()
+
+        assert _states_equal(before, _rng_state()), "a refused startup seed must leave every RNG untouched"
+        assert container.seeded == [], "torch must not be seeded when the configured seed was refused"
+
+    def test_the_refusal_states_the_domain_it_enforces(self, container: _Container, monkeypatch) -> None:
+        monkeypatch.setenv("STRANDS_GR00T_SERVER_SEED", "-7")
+        with pytest.raises(ValueError) as excinfo:
+            server_wrapper.main()
+        assert str(_MAX_SEED) in str(excinfo.value), "the reason must state the ceiling, not just that it was exceeded"
+        assert "-7" in str(excinfo.value), "the reason must quote the value it refused"
+
+
+class TestStrictDeterminismIsOptIn:
+    """The slower strict mode is applied only when asked for, and never fatal."""
+
+    def test_strict_mode_is_off_by_default(self, container: _Container) -> None:
+        server_wrapper.main()
+        assert container.strict_calls == [], "strict algorithms must not be forced without the opt-in"
+
+    def test_the_opt_in_enables_deterministic_algorithms(self, container: _Container, monkeypatch) -> None:
+        monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        server_wrapper.main()
+        assert container.strict_calls == [(True,)], "the opt-in must reach torch.use_deterministic_algorithms"
+
+    def test_a_strict_mode_failure_does_not_stop_the_server(self, container: _Container, monkeypatch) -> None:
+        monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        container.strict_raises = RuntimeError("no deterministic kernel")
+        server_wrapper.main()
+        assert container.server_configs == ["parsed-config"], (
+            "strict mode is a tightening, so losing it must degrade rather than kill the server"
+        )
+
+
+class TestAResetSeedIsAppliedWholeOrNotAtAll:
+    """The patched ``reset`` never leaves the server part-way reseeded."""
+
+    @pytest.mark.parametrize("seed", USABLE_SEEDS)
+    def test_an_accepted_seed_reaches_every_rng(self, container: _Container, seed: int) -> None:
+        container.cuda_available = True
+        server_wrapper.main()
+        container.seeded.clear()
+        container.cuda_seeded.clear()
+
+        expected = (random.Random(seed).getstate(), None)
+        result = container.patched_reset(container.policy_cls(), {"seed": seed})
+
+        assert random.getstate() == expected[0], "Python random must be reseeded with the requested seed"
+        assert container.seeded == [seed], "torch must be reseeded with the requested seed"
+        assert container.cuda_seeded == [seed], "CUDA generators must be reseeded with the requested seed"
+        assert container.policy_cls.upstream_calls == [{"seed": seed}], "the upstream reset must still run"
+        assert result == "upstream-reset", "the patch must return what the upstream reset returned"
+
+    @pytest.mark.parametrize("seed", UNUSABLE_SEEDS)
+    def test_an_unusable_seed_still_leaves_a_whole_reseed(self, container: _Container, seed: Any) -> None:
+        """A refused request must not raise, and must not half-apply.
+
+        Pre-fix this split three ways, none of them a whole reseed: a value only
+        NumPy refuses raised out of ``reset`` with Python ``random`` already
+        moved, ``True`` was read as a seed of 1, and ``"42"`` was coerced to 42
+        - two of the three reporting success for a seed the caller never asked
+        for.
+        """
+        server_wrapper.main()
+        container.seeded.clear()
+        container.policy_cls.upstream_calls.clear()
+        _baseline()
+
+        result = container.patched_reset(container.policy_cls(), {"seed": seed})
+
+        assert random.getstate() == random.Random(BASELINE_SEED).getstate(), (
+            "the episode must be reseeded on the validated configured seed, not left part-way"
+        )
+        assert container.seeded == [BASELINE_SEED], "torch must be reseeded too, so all three streams agree"
+        assert container.policy_cls.upstream_calls == [{"seed": seed}], (
+            "a refused seed is not a refused episode - the upstream reset must still run"
+        )
+        assert result == "upstream-reset"
+
+    def test_a_reset_without_a_seed_uses_the_configured_default(self, container: _Container) -> None:
+        server_wrapper.main()
+        container.seeded.clear()
+        container.patched_reset(container.policy_cls(), None)
+        assert container.seeded == [BASELINE_SEED], "a seedless reset must still reseed, on the configured default"
+
+    def test_the_warning_names_the_dropped_value_and_the_fallback(
+        self, container: _Container, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        server_wrapper.main()
+        capsys.readouterr()
+        container.patched_reset(container.policy_cls(), {"seed": -1})
+        out = capsys.readouterr().out
+        assert "-1" in out, "the operator must be told which value was dropped"
+        assert str(BASELINE_SEED) in out, "and which seed the episode actually ran with"
+
+
+class TestTheDomainMatchesTheSharedRolloutDomain:
+    """The restated domain must not drift from the one it restates."""
+
+    def test_the_ceiling_is_the_shared_rollout_ceiling(self) -> None:
+        assert _MAX_SEED == MAX_EVAL_SEED, (
+            "the wrapper reseeds the same legacy NumPy global RNG a rollout seed reaches, so it can "
+            "honor exactly the same seeds; a divergence is a defect in whichever moved"
+        )
+
+    @pytest.mark.parametrize("seed", [*UNUSABLE_SEEDS, *USABLE_SEEDS, None])
+    def test_every_value_gets_the_same_verdict_from_both(self, seed: Any) -> None:
+        shared = randomization_seed_error(seed, "rollout", max_seed=MAX_EVAL_SEED, allow_none=False)
+        assert (_seed_error(seed, "reset") is None) == (shared is None), (
+            f"the wrapper and the shared rollout domain disagree about {seed!r}"
+        )
+
+    def test_the_wrapper_stays_importable_without_the_container(self) -> None:
+        """The domain has to be reachable on a host, which is why it is restated.
+
+        The wrapper is mounted into an image where ``strands-robots`` is absent,
+        so importing the shared helper is not an option - this asserts the
+        replacement is a module-level constant rather than something only the
+        container can evaluate.
+        """
+        assert isinstance(_MAX_SEED, int)
+        assert _seed_error(1, "probe") is None
+        assert _seed_error(-1, "probe") is not None


### PR DESCRIPTION
## Problem

The determinism wrapper (`strands_robots/policies/groot/server_wrapper.py`) patches `Gr00tPolicy.reset` so a seed the client forwards in `options` reseeds the server's RNGs before an episode's first diffusion sample. Its reseed applies Python `random`, then NumPy's legacy global RNG, then torch - three appliers against process-wide state, run in sequence.

Only the second of them bounds the value. So every seed NumPy refuses - anything negative, non-integral, or above `2**32 - 1` - left the server **part-way reseeded**: Python `random` moved, NumPy and torch untouched, and the upstream `reset` never reached at all, because the NumPy refusal raised out of the patched method first.

That state is worse than a refusal because nothing reports it. The client swallows a failed reset at `INFO` and logs "continuing without per-episode server-side reseed", so the one thing no observer had was the fact that the server's RNGs *had* moved, inconsistently. The episode then drew part of its randomness from a fresh stream and part from the previous episode's - a reproducibility gap presenting as a reset that did nothing.

Measured on real `random` / `numpy` / `torch`, driving `main()` with `STRANDS_GR00T_SERVER_SEED=999`, the RNGs left on seed 7 by a previous episode, and `reset(options={"seed": 2**32})`:

| RNG | stream it is left on, before | after |
| --- | --- | --- |
| Python `random` | the requested `2**32` | the configured default |
| NumPy (legacy global) | the previous episode's 7 | the configured default |
| torch | the previous episode's 7 | the configured default |
| outcome | `reset` raised `ValueError` | `reset` returned normally |

![server RNG state after a refused episode seed](https://raw.githubusercontent.com/cagataycali/robots/media-groot-server-seed/seed_partial_reseed.png)

Two neighbouring values were accepted rather than refused, both under a success report: `True` was read as a seed of **1** through `int()` (`bool` is an `int` subclass), and a numeric string or float was coerced to a different seed than the one asked for (`"42"` -> 42, `3.7` -> 3).

At startup the same ordering applied: `STRANDS_GR00T_SERVER_SEED=4294967296` reseeded Python `random`, then raised out of NumPy, so the server failed to start *and* left the interpreter's RNG moved - with a message naming NumPy's range rather than the variable that carried the value.

## Change

Check the seed **before the first applier runs**, in `_seed_all`, which is now the single point that refuses one - so the all-or-nothing property belongs to the applier rather than to each caller remembering to check first.

The domain is the one `randomization_seed_error` already enforces for a rollout seed, down to the `MAX_EVAL_SEED` ceiling it carries for this exact destination: both reseed the same legacy NumPy global RNG, so both can honor exactly the same seeds. The wrapper restates that ceiling instead of importing it because it is mounted into the GR00T image, where `strands-robots` is not installed and it must stay stdlib-only (a property `tests/tools/test_gr00t_deterministic.py` already pins). The two are therefore pinned in agreement value for value, so the duplication cannot drift into a disagreement about which seeds a rollout may use.

Behaviour at each of the three seed sources:

- **`reset` with an unusable seed** falls back to the already-validated configured seed with the reason printed, so the episode still gets one whole reseed and still reaches the upstream `reset`. A refused *request* is not a refused *episode*, and this generalises the file's existing documented fallback for a bad seed to the values that used to corrupt state instead.
- **`bool`, numeric strings and floats** are refused rather than coerced, so a seed the caller never named is never installed.
- **`STRANDS_GR00T_SERVER_SEED`** is refused at startup naming the variable and the domain, before any RNG moves. An unusable value was already fatal, so this changes the message and the ordering, not the outcome.

## Tests

New `tests/policies/groot/test_server_wrapper_seed_domain.py` (52 tests). The wrapper defers its `torch` / `gr00t` / `tyro` imports into `main()` precisely so it stays importable without the container, which is what makes it drivable here; `random` and NumPy are real, so "no RNG moved" is measured rather than mocked.

On the pre-fix wrapper, **18 of them fail**, spanning all three observables:

- 7 in `TestTheStartupSeedIsAppliedOrRefusedWhole` - the refusal neither names the variable nor leaves the RNGs untouched;
- 11 in `TestAResetSeedIsAppliedWholeOrNotAtAll` - `-1` / `2**32` / `2**64` raise out of `reset`, while `True`, `"42"`, `2.5` and `3.0` are accepted as a different seed.

`TestTheDomainMatchesTheSharedRolloutDomain` asserts the ceiling equals `MAX_EVAL_SEED` and that both surfaces return the same verdict for all 18 probe values, so the restated domain cannot drift from the one it restates.

Coverage of `server_wrapper.py` goes from **8% to 98%** (the remaining line is the `__main__` guard). Full suite: 29543 passed, no new failures against the pre-change baseline on the same tree.

Closes nothing; found while covering the module.