### PR TITLE
fix(policies/kimodo): re-sample when a sampler input changes, so a per-episode seed reaches the sampler

### DIFF
--- a/changelog.d/2284-kimodo-episode-seed-resample.md
+++ b/changelog.d/2284-kimodo-episode-seed-resample.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **policies/kimodo**: a per-episode seed now reaches the sampler. `KimodoPolicy`
+  re-entered the sampler only when the prompt changed, so `reset(seed=...)` - the
+  call `PolicyRunner.evaluate` makes once per episode - recorded the seed without
+  ever applying it, and every episode after the first replayed episode 0's motion.
+  The `diffusion_steps` and `guidance_scale` per-call overrides were dropped the
+  same way. The buffered motion is now identified by every input that produced it,
+  so a changed prompt, knob or seed re-samples while a repeated seed still replays
+  the buffer and `reset()` without a seed still only rewinds.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -115,6 +115,32 @@ merged value is re-validated by `KimodoConfig`, so `diffusion_steps=0` is
 refused whichever way it arrives. There is no `**kwargs`: a misspelled knob
 raises `TypeError` at construction instead of being silently ignored.
 
+## When the sampler runs again
+
+One `sample()` call produces a motion buffer that `get_actions` then drains one
+frame per control tick, holding the last frame once the buffer is exhausted. The
+buffer is identified by the four inputs that determine it - the prompt plus
+`diffusion_steps`, `guidance_scale` and `seed` - so the sampler runs again as
+soon as any of them differs from the values that produced the buffer in hand,
+and otherwise the buffered frames are reused:
+
+```python
+await policy.get_actions({}, "walking forward")                     # samples
+await policy.get_actions({}, "walking forward")                     # drains
+await policy.get_actions({}, "waving")                              # samples
+await policy.get_actions({}, "waving", diffusion_steps=25)          # samples
+policy.reset()                                                      # rewinds
+policy.reset(seed=7); await policy.get_actions({}, "waving")        # samples
+```
+
+This is what makes a multi-episode `eval_policy` meaningful for a stochastic
+policy. `PolicyRunner.evaluate` derives a distinct seed per episode and forwards
+it to `policy.reset(seed=...)`, so each episode samples its own motion while the
+whole run stays reproducible: re-running at the same master `seed=` replays the
+same per-episode motions. Repeating a seed replays the buffered motion rather
+than re-running the sampler for identical frames, and `reset()` without a seed
+only rewinds - neither pays for a diffusion run.
+
 ## When the checkpoint is not a Kimodo checkpoint
 
 `model_id` is accepted verbatim so an alternate Kimodo revision can be pinned,

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -229,7 +229,10 @@ class KimodoPolicy(Policy):
         self._motion_agent: KimodoMotionAgent | None = motion_agent
 
         # Streaming state - filled by _synthesise() and drained by get_actions().
-        self._current_prompt: str | None = None
+        # The buffer caches ONE sampler run; _buffer_key records the inputs that
+        # produced it so a changed prompt/knob/seed re-enters the sampler instead
+        # of draining a buffer those inputs never generated.
+        self._buffer_key: tuple[str, int, float, int | None] | None = None
         self._motion_buffer: NDArray[np.float32] | None = None
         self._frame_cursor: int = 0
         self._joint_names: tuple[str, ...] = KIMODO_G1_JOINTS
@@ -284,7 +287,11 @@ class KimodoPolicy(Policy):
                 calls, the sampler re-runs and the frame cursor resets.
             **kwargs: Optional overrides for this call:
                 ``text_prompt`` (alias for ``instruction``),
-                ``diffusion_steps``, ``guidance_scale``, ``seed``.
+                ``diffusion_steps``, ``guidance_scale``, ``seed``. Each is an
+                input to the sampler, so supplying one that differs from the
+                value that produced the buffered motion re-samples; supplying
+                the same values drains the existing buffer rather than paying
+                for a run that would return identical frames.
 
         Returns:
             A single-element list containing a dict mapping each of
@@ -300,13 +307,18 @@ class KimodoPolicy(Policy):
                 "(natural-language motion description)."
             )
 
-        # (Re)sample if prompt changed or first call.
-        if self._motion_buffer is None or prompt != self._current_prompt:
+        # (Re)sample on the first call, or whenever any input that determines
+        # the motion differs from the one that produced the buffer we hold.
+        diffusion_steps = int(kwargs.get("diffusion_steps", self.config.diffusion_steps))
+        guidance_scale = float(kwargs.get("guidance_scale", self.config.guidance_scale))
+        seed = kwargs.get("seed", self.config.seed)
+        key = self._sample_key(prompt, diffusion_steps, guidance_scale, seed)
+        if self._motion_buffer is None or key != self._buffer_key:
             self._synthesise(
                 prompt=prompt,
-                diffusion_steps=int(kwargs.get("diffusion_steps", self.config.diffusion_steps)),
-                guidance_scale=float(kwargs.get("guidance_scale", self.config.guidance_scale)),
-                seed=kwargs.get("seed", self.config.seed),
+                diffusion_steps=diffusion_steps,
+                guidance_scale=guidance_scale,
+                seed=seed,
             )
 
         assert self._motion_buffer is not None  # narrowed by _synthesise
@@ -319,7 +331,22 @@ class KimodoPolicy(Policy):
         return [action]
 
     def reset(self, seed: int | None = None) -> None:
-        """Reset the frame cursor. ``seed`` is stored for the next resample."""
+        """Rewind to the first frame, and re-seed the sampler when given a seed.
+
+        ``PolicyRunner.evaluate`` derives a distinct seed per episode and
+        forwards it here so a stochastic policy samples afresh each episode
+        while staying reproducible across re-runs at the same master seed. A
+        diffusion sample IS this policy's per-episode state, so a new seed has
+        to reach the sampler: it is recorded on the config and the next
+        :meth:`get_actions` re-samples, because the seed is part of the key
+        identifying the buffered motion.
+
+        Args:
+            seed: Sampling seed for the next episode. ``None`` rewinds only,
+                replaying the motion already held. A seed equal to the one that
+                produced the current buffer also replays it rather than
+                re-running the sampler for identical frames.
+        """
         self._frame_cursor = 0
         if seed is not None:
             # Store on config-shadow so next _synthesise picks it up.
@@ -328,6 +355,36 @@ class KimodoPolicy(Policy):
     # -----------------------------------------------------------------
     # Internals
     # -----------------------------------------------------------------
+    @staticmethod
+    def _sample_key(
+        prompt: str,
+        diffusion_steps: int,
+        guidance_scale: float,
+        seed: int | None,
+    ) -> tuple[str, int, float, int | None]:
+        """Identify a sampler run by every input that determines its output.
+
+        The buffered motion is a cache of one sampler run, and this is its cache
+        key. Comparing the full key - rather than the prompt alone - is what
+        makes ``diffusion_steps`` / ``guidance_scale`` / ``seed`` behave as the
+        per-call overrides :meth:`get_actions` documents, and what lets
+        :meth:`reset` re-seed an episode.
+
+        Both the producer (:meth:`_synthesise`) and the consumer
+        (:meth:`get_actions`) build the key here, so the two cannot disagree
+        about which inputs identify a motion.
+
+        Args:
+            prompt: Text prompt the motion was sampled for.
+            diffusion_steps: Denoising steps used.
+            guidance_scale: Classifier-free-guidance weight used.
+            seed: Sampling seed, or ``None`` for an unseeded sample.
+
+        Returns:
+            A hashable tuple identifying the run.
+        """
+        return (prompt, diffusion_steps, guidance_scale, None if seed is None else int(seed))
+
     def _synthesise(
         self,
         prompt: str,
@@ -355,7 +412,7 @@ class KimodoPolicy(Policy):
             native_fps=self.config.native_fps,
             target_fps=self.config.tracker_fps,
         )
-        self._current_prompt = prompt
+        self._buffer_key = self._sample_key(prompt, diffusion_steps, guidance_scale, seed)
         self._frame_cursor = 0
         # The prompt is caller-supplied, so it is identified by digest rather
         # than echoed: interpolating the text would let a prompt containing a

--- a/tests/policies/kimodo/test_kimodo_policy.py
+++ b/tests/policies/kimodo/test_kimodo_policy.py
@@ -9,6 +9,7 @@ is covered by an integration test gated on the ``[kimodo]`` extra + HF access.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 
 import numpy as np
 import pytest
@@ -295,3 +296,120 @@ def test_the_prompt_is_logged_by_digest_and_never_echoed(caplog):
 
     digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
     assert any(digest in message for message in logged), "the digest identifies the prompt"
+
+
+class _SeedAwareAgent:
+    """Stub whose frames depend on every sampler input, and which records them.
+
+    The real sampler is stochastic in ``seed`` and sensitive to
+    ``diffusion_steps`` / ``guidance_scale``; a stub that ignores them cannot
+    show whether an override reached it, so this one derives its frames from all
+    of them.
+    """
+
+    def __init__(self, num_joints: int = 29) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.num_joints = num_joints
+
+    def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "diffusion_steps": diffusion_steps,
+                "guidance_scale": guidance_scale,
+                "seed": seed,
+            }
+        )
+        # A stable digest, not builtin hash(): PYTHONHASHSEED salts str hashing
+        # per process, which would make the reproducibility assertion below hold
+        # only within a single interpreter run.
+        material = repr((prompt, diffusion_steps, round(float(guidance_scale), 6), seed)).encode("utf-8")
+        rng = np.random.default_rng(int.from_bytes(hashlib.sha256(material).digest()[:4], "big"))
+        out = np.zeros((num_frames, 7 + self.num_joints), dtype=np.float32)
+        out[:, 6] = 1.0  # identity quaternion
+        out[:, 7:] = rng.uniform(-1.0, 1.0, size=(num_frames, self.num_joints)).astype(np.float32)
+        return out
+
+
+def _seeded_policy(**cfg_kwargs):
+    agent = _SeedAwareAgent()
+    return KimodoPolicy(config=KimodoConfig(**cfg_kwargs), motion_agent=agent), agent
+
+
+def test_a_new_episode_seed_re_samples_the_motion():
+    """``reset(seed=...)`` must reach the sampler, not just rewind the cursor.
+
+    ``PolicyRunner.evaluate`` derives one seed per episode and forwards it here;
+    a seed that is recorded but never sampled leaves every episode replaying the
+    first episode's motion.
+    """
+    policy, agent = _seeded_policy(num_frames=8, native_fps=30, tracker_fps=30)
+    first = _first_action(policy, "walk forward")
+
+    policy.reset(seed=1234)
+    after = _first_action(policy, "walk forward")
+
+    assert [call["seed"] for call in agent.calls] == [None, 1234]
+    assert any(first[joint] != after[joint] for joint in KIMODO_G1_JOINTS)
+
+
+def test_reset_without_a_seed_replays_the_motion_without_re_sampling():
+    """A plain rewind must stay cheap - no seed means no new sampler run."""
+    policy, agent = _seeded_policy(num_frames=8, native_fps=30, tracker_fps=30)
+    first = _first_action(policy, "walk forward")
+    _first_action(policy, "walk forward")
+
+    policy.reset()
+    again = _first_action(policy, "walk forward")
+
+    assert len(agent.calls) == 1
+    assert again == first
+
+
+def test_repeating_an_episode_seed_replays_instead_of_re_running_the_sampler():
+    """The same inputs identify the same motion, so the buffer is reused."""
+    policy, agent = _seeded_policy(num_frames=8, native_fps=30, tracker_fps=30)
+    policy.reset(seed=99)
+    first = _first_action(policy, "walk forward")
+
+    policy.reset(seed=99)
+    again = _first_action(policy, "walk forward")
+
+    assert len(agent.calls) == 1
+    assert again == first
+
+
+def test_each_episode_of_a_seeded_eval_samples_at_its_own_seed():
+    """Distinct per-episode seeds give distinct motions, reproducibly.
+
+    Mirrors the per-episode ``set_eval_seed`` + ``policy.reset(seed=...)`` loop
+    in ``PolicyRunner.evaluate``: episode N must not inherit episode N-1's
+    motion, and re-running the same seed sequence must reproduce it.
+    """
+    episode_seeds = [11, 22, 33]
+
+    def run_episodes():
+        policy, agent = _seeded_policy(num_frames=6, native_fps=30, tracker_fps=30)
+        motions = []
+        for episode_seed in episode_seeds:
+            policy.reset(seed=episode_seed)
+            motions.append(tuple(_first_action(policy, "walk forward")[j] for j in KIMODO_G1_JOINTS))
+        return motions, agent
+
+    motions, agent = run_episodes()
+
+    assert [call["seed"] for call in agent.calls] == episode_seeds
+    assert len(set(motions)) == len(episode_seeds), "an episode replayed another episode's motion"
+    assert run_episodes()[0] == motions, "the same seed sequence did not reproduce"
+
+
+def test_a_changed_sampler_knob_is_honoured_after_the_first_call():
+    """``diffusion_steps`` / ``guidance_scale`` are documented per-call overrides."""
+    policy, agent = _seeded_policy(num_frames=6, native_fps=30, tracker_fps=30)
+    _first_action(policy, "walk forward")
+
+    _first_action(policy, "walk forward", diffusion_steps=25)
+    _first_action(policy, "walk forward", guidance_scale=2.5)
+
+    assert [call["diffusion_steps"] for call in agent.calls] == [100, 25, 100]
+    assert [call["guidance_scale"] for call in agent.calls] == [7.5, 7.5, 2.5]


### PR DESCRIPTION
## Problem

`KimodoPolicy` samples a motion once and drains it one frame per control tick. That buffer was re-entered only when the prompt changed:

```python
if self._motion_buffer is None or prompt != self._current_prompt:
    self._synthesise(
        prompt=prompt,
        diffusion_steps=int(kwargs.get("diffusion_steps", self.config.diffusion_steps)),
        guidance_scale=float(kwargs.get("guidance_scale", self.config.guidance_scale)),
        seed=kwargs.get("seed", self.config.seed),
    )
```

The other three values are read only on the call that happens to sample. Once a buffer exists they are recorded and never applied, so the sampler never sees them.

The consequence lands on the eval path. `PolicyRunner.evaluate` derives a distinct seed per episode and forwards it to `policy.reset(seed=...)` specifically so a stochastic policy samples afresh each episode while staying reproducible across re-runs at the same master seed. `KimodoPolicy.reset` stored that seed on the config, but `get_actions` never re-sampled, so **every episode after the first replayed episode 0's motion** and the per-episode seeds were inert. A diffusion sample is precisely the "per-episode state" `Policy.reset` documents.

Measured with a recording agent, in sim on the registry `unitree_g1`:

```
eval_policy(robot_name="g1", policy_object=<KimodoPolicy>, n_episodes=3, seed=7)

                 sample() calls   seeds reaching the sampler
  before               1          [1390851128]
  after                3          [1390851128, 647892279, 1695753998]
```

Episode 0's seed is identical in both trees, so an already-reproducible single-episode rollout is byte-identical. The same silence covered `diffusion_steps` and `guidance_scale`, which `get_actions` documents as "optional overrides for this call".

## Change

The buffered motion is a cache of one sampler run, so it is now identified by every input that determines that run - prompt, `diffusion_steps`, `guidance_scale`, `seed` - through one `_sample_key` helper that both the producer (`_synthesise`) and the consumer (`get_actions`) build. The two cannot disagree about what identifies a motion, and the fix is one comparison rather than a new branch per knob.

What deliberately does not change:

- `reset()` with no seed still only rewinds and replays the buffered motion.
- Repeating a seed replays the buffer instead of re-running the sampler for frames that would be identical.

So no diffusion run is added to any path that did not ask for a different sample.

## Rollout in MuJoCo sim (headless)

Three episodes of a seeded eval, one row per episode, same camera and tick count. The injected agent returns a real `nvidia/Kimodo-G1-RP-v1` motion pre-sampled at the seed it is asked for, so the frames are genuine model output for each seed.

![per-episode seed rollout](https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-episode-seed/kimodo-episode-seed.png)

Top half is `main`: only seed 11 reached the sampler, and episodes 1 and 2 are **pixel-identical** to episode 0 - mean absolute pixel delta exactly `0.000` against episode 0 for both. Bottom half is this change: all three seeds reach the sampler and the episodes differ (`0.762` and `1.186`). The three pre-sampled motions differ from each other by `0.127` to `0.225` mean absolute qpos, so there was a visible difference available for `main` to show and it showed none.

## Tests

Five tests in `tests/policies/kimodo/test_kimodo_policy.py`, driven by a stub whose frames depend on every sampler input (a stub that ignores `seed` cannot show whether the seed arrived). Against `main`:

| test | on `main` |
|---|---|
| `test_a_new_episode_seed_re_samples_the_motion` | fails - `assert [None] == [None, 1234]` |
| `test_each_episode_of_a_seeded_eval_samples_at_its_own_seed` | fails - `assert [11] == [11, 22, 33]` |
| `test_a_changed_sampler_knob_is_honoured_after_the_first_call` | fails - `assert [100] == [100, 25, 100]` |
| `test_reset_without_a_seed_replays_the_motion_without_re_sampling` | passes |
| `test_repeating_an_episode_seed_replays_instead_of_re_running_the_sampler` | passes |

The last two pass on both trees by design: they are what pins that `reset` did not become unconditionally expensive. `tests/policies/kimodo/` is 27 passed here, 3 failed / 24 passed on `main`.

Also verified: `ruff check` / `ruff format --check` clean, and `mypy strands_robots tests tests_integ` reports the same 18 pre-existing errors as `main` (zero new).

## Docs

`docs/policies/kimodo.md` gains a "When the sampler runs again" section stating which inputs identify a buffer, and how that makes a multi-episode `eval_policy` meaningful for this policy.