### PR TITLE
fix(policies/composite): refuse a merge that discards a child policy's entire output

### DIFF
--- a/changelog.d/2285-composite-refuse-shadowed-child.md
+++ b/changelog.d/2285-composite-refuse-shadowed-child.md
@@ -1,0 +1,20 @@
+### Fixed
+
+`CompositePolicy` now refuses a merge in which routing discards a child policy's
+entire output, instead of silently returning the other child's commands. Two
+children that drive the same joints (a whole-body kinematic generator such as
+`KimodoPolicy` / `MotionBricksPolicy`, both keyed on all 29 `WBC_G1_ALL_JOINTS`,
+paired with `WBCPolicy`, which drives 15 of them) left one child contributing
+nothing while the rollout reported success. The error names the shadowed child,
+the joints the other child already drives and the remedy. Partial shadowing --
+lower precedence on a shared name with the upper child still contributing its own
+names -- is the documented default and is unchanged.
+
+Generator docstrings and `docs/policies/{kimodo,motionbricks}.md` no longer
+present physics tracking as a `CompositePolicy` layer: a controller that tracks a
+reference consumes the generator's targets as its input, so the two run in series
+over the same joints, and `WBCPolicy` has no reference-pose input at all.
+`docs/policies/kimodo.md` and `examples/kimodo/kimodo_g1_walking.py` also
+documented a `policy_config={"layers": [...]}` composite configuration that does
+not exist -- `create_policy("composite", layers=[...])` raises `TypeError` -- so
+the example's tracker path could never run.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -6,10 +6,10 @@ full-body `qpos` sequences for the Unitree G1 in a single diffusion pass, then
 streams them one frame per tick as G1 joint targets.
 
 Kimodo sits in the same seat as [`MotionBricksPolicy`](./motionbricks.md) — it
-is a *kinematic motion generator* that emits motion targets, not torques. A
-tracking controller (WBC / PD) turns those into physics — see
-[`WBC`](./wbc.md) or compose via `policy_provider="composite"` (see
-[Custom Policies](./custom-policies.md)).
+is a *kinematic motion generator* that emits motion targets, not torques — a
+whole-body reference over all 29 leg + waist + arm joints. Applying that
+reference under physics needs a controller that *tracks* it; see
+[Tracking the reference under physics](#tracking-the-reference-under-physics).
 
 ## When to use
 
@@ -63,24 +63,36 @@ sim.run_policy(
 )
 ```
 
-## Composing with a physics tracker
+## Tracking the reference under physics
 
-Kimodo is kinematic. To close the loop through physics, compose it with WBC:
+Kimodo is kinematic: it emits joint *targets* for all 29 DOFs, not torques. Run
+standalone (the example above) those targets are applied directly, which is the
+faithful visualisation of the generated motion.
 
-```python
-sim.run_policy(
-    robot_name="g1",
-    policy_provider="composite",
-    policy_config={
-        "layers": [
-            {"provider": "kimodo", "config": {"diffusion_steps": 100}},
-            {"provider": "wbc"},
-        ],
-    },
-    instruction="walking forward",
-    n_steps=500,
-)
+Making the robot follow that motion under physics requires a controller that
+**tracks the reference** — the 29 targets are the tracker's input. Generator and
+tracker therefore run in **series over the same joints**:
+
+```text
+prompt -> Kimodo -> 29 joint targets -> reference tracker -> torques -> robot
 ```
+
+That is a cascade, and `CompositePolicy` does not express it.
+[`CompositePolicy`](./custom-policies.md) merges two policies over **disjoint**
+joint groups (locomotion legs+waist plus manipulation arms, each joint owned by
+exactly one child); handing it a whole-body generator and a whole-body controller
+gives both children the same joints, so one child's output is discarded entirely.
+That configuration is refused with an error naming the shadowed joints rather
+than silently returning one child's commands.
+
+[`WBCPolicy`](./wbc.md) in particular is **not** a reference tracker: its only
+command input is a target base velocity (`target_velocity`, plus optional
+orientation and height), it has no reference-pose input, and it drives 15 of the
+same 29 joints Kimodo drives. Composing the two cannot track a Kimodo motion.
+
+`strands_robots` does not currently ship a whole-body reference tracker. A
+tracker matched to the generator's motion distribution (an RL tracker trained on
+it, or a tuned PD law) is required, and is out of scope for this provider.
 
 ## Config reference
 

--- a/docs/policies/motionbricks.md
+++ b/docs/policies/motionbricks.md
@@ -46,11 +46,18 @@ WBCPolicy / GEAR-SONIC  <- tracks the targets: joint torques / position targets
 robot (sim or hardware)
 ```
 
-The two compose through
-[`CompositePolicy`](https://github.com/strands-labs/robots/blob/main/strands_robots/policies/composite.py):
-MotionBricks emits the joint references, WBC tracks them. The 29 joints are
-keyed by the **same canonical ordering as WBC** (`MOTIONBRICKS_G1_JOINTS` is
-`WBC_G1_ALL_JOINTS`), so the two name the same joints without a remapping table.
+The two stages run in **series**: MotionBricks emits the joint references and a
+tracker consumes them as its input. The 29 joints are keyed by the **same
+canonical ordering as WBC** (`MOTIONBRICKS_G1_JOINTS` is `WBC_G1_ALL_JOINTS`), so
+the tracker names the same joints without a remapping table.
+
+That cascade is *not*
+[`CompositePolicy`](https://github.com/strands-labs/robots/blob/main/strands_robots/policies/composite.py),
+which merges two policies over **disjoint** joint groups. A whole-body generator
+and a whole-body tracker claim the same joints, so composing them discards one
+child's output entirely — a configuration `CompositePolicy` refuses. Note also
+that `WBCPolicy` is a velocity-commanded locomotion controller with no
+reference-pose input, so it cannot track a MotionBricks reference.
 
 Standalone, the policy's output is a kinematic reference - the faithful way to
 visualise a kinematic generator is to set the synthesised `qpos`

--- a/examples/kimodo/kimodo_g1_walking.py
+++ b/examples/kimodo/kimodo_g1_walking.py
@@ -1,16 +1,29 @@
-"""Kimodo + MuJoCo end-to-end example: text prompt -> G1 walking in sim.
+"""Kimodo + MuJoCo example: text prompt -> Unitree G1 motion in sim -> MP4.
 
-The full text-to-motion-to-physics pipeline:
-  text prompt -> Kimodo diffusion -> qpos frames -> SLERP upsample ->
-  ProtoMotions GTP ONNX tracker -> G1 physics @ 1kHz -> rendered MP4
+The pipeline this script runs:
+  text prompt -> Kimodo diffusion -> 29-DOF qpos frames -> SLERP upsample to the
+  control rate -> applied as G1 joint targets -> rendered MP4
+
+Kimodo is a *kinematic* whole-body generator: it emits joint targets for all 29
+leg + waist + arm DOFs, not torques. Applied directly, as here, the result is the
+faithful visualisation of the generated motion.
+
+Making the robot FOLLOW that motion under physics is a separate stage - a
+controller that tracks the reference, with Kimodo's 29 targets as its input:
+
+    prompt -> Kimodo -> 29 joint targets -> reference tracker -> torques -> robot
+
+Generator and tracker are in series over the same joints, which is a cascade, not
+a composition. ``CompositePolicy`` merges two policies over DISJOINT joint groups
+(locomotion legs+waist plus manipulation arms) and cannot express it; handing it a
+whole-body generator plus a whole-body controller gives both children the same
+joints and discards one child's output entirely. ``WBCPolicy`` in particular is
+not a reference tracker at all - its only command input is a target base velocity
+and it has no reference-pose input. See ``docs/policies/kimodo.md``.
 
 Run:
   STRANDS_TRUST_REMOTE_CODE=1 python examples/kimodo/kimodo_g1_walking.py \
       --prompt "a person walking forward with confident strides"
-
-The tracker layer is composed via CompositePolicy: Kimodo emits motion targets,
-WBC/PD tracks them. If you don't have the tracker installed, run WITHOUT
---tracker to visualise the kinematic reference directly (sets qpos each tick).
 """
 
 from __future__ import annotations
@@ -33,11 +46,6 @@ def main() -> int:
     parser.add_argument("--n-steps", type=int, default=200)
     parser.add_argument("--control-hz", type=int, default=50)
     parser.add_argument(
-        "--tracker",
-        action="store_true",
-        help="Compose with WBC tracker (requires [wbc] extra + weights)",
-    )
-    parser.add_argument(
         "--out",
         default="kimodo_g1_walking.mp4",
         help="Output MP4 path (rendered from the sim's front camera)",
@@ -52,32 +60,16 @@ def main() -> int:
     sim = Robot("g1", mesh=False)
     sim.add_camera(name="front", position=[3.0, 0.0, 1.2], target=[0.0, 0.0, 0.8])
 
-    policy_config = {
-        "diffusion_steps": args.diffusion_steps,
-        "guidance_scale": args.guidance_scale,
-        "num_frames": args.num_frames,
-        "device": "cuda",
-        "dtype": "fp16",
-    }
-
-    provider = "kimodo"
-    if args.tracker:
-        # Composite: Kimodo emits targets, WBC tracks them.
-        provider = "composite"
-        policy_config = {
-            "layers": [
-                {
-                    "provider": "kimodo",
-                    "config": policy_config,
-                },
-                {"provider": "wbc"},
-            ]
-        }
-
     result = sim.run_policy(
         robot_name="g1",
-        policy_provider=provider,
-        policy_config=policy_config,
+        policy_provider="kimodo",
+        policy_config={
+            "diffusion_steps": args.diffusion_steps,
+            "guidance_scale": args.guidance_scale,
+            "num_frames": args.num_frames,
+            "device": "cuda",
+            "dtype": "fp16",
+        },
         instruction=args.prompt,
         n_steps=args.n_steps,
         control_frequency=args.control_hz,

--- a/strands_robots/policies/composite.py
+++ b/strands_robots/policies/composite.py
@@ -14,7 +14,16 @@ rest. Ownership is explicit (``lower_joints`` / ``upper_joints``) or, when left
 default, the lower policy takes precedence on any name it emits and the upper
 policy contributes the remaining names. A genuine ownership conflict (both
 children emit a value for a name each claims) is raised, never silently
-resolved - a dropped command on a humanoid is a fall, not a warning.
+resolved - a dropped command on a humanoid is a fall, not a warning. By the same
+rule, a child whose ENTIRE action dict is discarded by routing is refused: a
+composite in which one child reaches no actuator is the other child alone.
+
+This class composes joint groups in PARALLEL; it is not a cascade. A whole-body
+kinematic generator (Kimodo / MotionBricks) and a controller that tracks its
+reference drive the SAME joints and run in SERIES - the generator's targets are
+the controller's input, not a disjoint half of one action dict. No composite
+expresses that: a reference tracker has to consume the reference through its own
+interface.
 
 Example::
 
@@ -56,6 +65,10 @@ class CompositePolicy(Policy):
     * ``upper`` contributes the names in ``upper_joints`` (or, when ``None``,
       every name it emits that the lower policy did not already claim - lower
       precedence).
+
+    Routing that discards a child's ENTIRE action dict raises: the composite
+    would otherwise silently be the surviving child alone. Two children that
+    drive the same joint set cannot be composed, only cascaded (module docstring).
 
     The merged chunk length is the shorter of the two children's chunks, so the
     more frequently re-querying child sets the re-query cadence
@@ -183,8 +196,10 @@ class CompositePolicy(Policy):
             child that owns that name.
 
         Raises:
-            ValueError: If either child returns an empty chunk, or if the routed
-                lower and upper action dicts both assign the same joint name.
+            ValueError: If either child returns an empty chunk, if routing
+                discards a child's entire action dict (the composite would be
+                the other child alone), or if the routed lower and upper action
+                dicts both assign the same joint name.
         """
         lower_obs = self._filter_obs(observation_dict, self._lower_obs_keys)
         upper_obs = self._filter_obs(observation_dict, self._upper_obs_keys)
@@ -212,6 +227,8 @@ class CompositePolicy(Policy):
         lo = self._route(lower_action, self._lower_joints)
         # Upper default: every name not already claimed by the routed lower dict.
         up = self._route(upper_action, self._upper_joints, exclude=None if self._upper_joints else set(lo))
+        self._reject_discarded_child("lower", self._lower, lower_action, lo, self._lower_joints, set())
+        self._reject_discarded_child("upper", self._upper, upper_action, up, self._upper_joints, set(lo))
         collision = set(lo) & set(up)
         if collision:
             raise ValueError(
@@ -221,6 +238,59 @@ class CompositePolicy(Policy):
             )
         lo.update(up)
         return lo
+
+    def _reject_discarded_child(
+        self,
+        role: str,
+        child: Policy,
+        emitted: dict[str, Any],
+        routed: dict[str, Any],
+        group: set[str] | None,
+        claimed_by_lower: set[str],
+    ) -> None:
+        """Refuse a tick in which routing discarded everything ``child`` commanded.
+
+        A child whose whole action dict is dropped reaches no actuator, so the
+        composite commands exactly what the other child alone would - a no-op
+        wearing the shape of a composition. That is the same dropped command this
+        class raises on elsewhere, so name the child, the joints it commanded and
+        the reason instead of returning a tick the caller will read as composed.
+
+        Args:
+            role: The seat ``child`` occupies - ``"lower"`` or ``"upper"``.
+            child: The child policy whose routed output is being checked.
+            emitted: The action dict ``child`` returned for this tick.
+            routed: What survived routing for ``child``.
+            group: ``child``'s explicit joint group, or ``None`` when defaulted.
+            claimed_by_lower: Names the routed lower dict already claims. Empty
+                for the lower seat, which is routed first and claims freely.
+
+        Raises:
+            ValueError: If ``child`` commanded at least one joint and none of them
+                survived routing. A child that commanded nothing is left alone -
+                there is no command to drop.
+        """
+        if routed or not emitted:
+            return
+        names = sorted(emitted)
+        head = (
+            f"CompositePolicy: the {role} policy '{child.provider_name}' commanded "
+            f"{len(names)} joint(s) and none of them reached the merged action"
+        )
+        if group is not None:
+            raise ValueError(
+                f"{head} - the {role}_joints group {sorted(group)} shares no name with the "
+                f"joints it emits {names}. Set {role}_joints to names this policy emits."
+            )
+        lower_name = self._lower.provider_name
+        raise ValueError(
+            f"{head} - the lower policy '{lower_name}' already drives every one of "
+            f"{sorted(set(names) & claimed_by_lower)}, so this composite commands exactly what "
+            f"'{lower_name}' alone would. CompositePolicy merges DISJOINT joint groups (e.g. "
+            "locomotion legs+waist plus manipulation arms); it does not feed one policy's targets "
+            "into another policy. Give each joint exactly one owner via lower_joints / "
+            "upper_joints, or drive the whole body with a single policy."
+        )
 
     @staticmethod
     def _route(action: dict[str, Any], joints: set[str] | None, *, exclude: set[str] | None = None) -> dict[str, Any]:

--- a/strands_robots/policies/kimodo/__init__.py
+++ b/strands_robots/policies/kimodo/__init__.py
@@ -12,11 +12,12 @@ Where it sits (the same seat as :class:`~strands_robots.policies.motionbricks.Mo
 * ``get_actions`` reads the goal from the well-known ``**kwargs`` keys
   (``text_prompt`` / ``instruction``, ``diffusion_steps``, ``guidance_scale``).
 * The output is the G1's 29 leg+waist+arm joint targets, keyed by the
-  canonical WBC joint ordering, so it composes with
-  :class:`~strands_robots.policies.wbc.WBCPolicy` (Kimodo emits motion
-  targets, WBC tracks them) via
-  :class:`~strands_robots.policies.composite.CompositePolicy` and (in the sim)
-  a PD tracker at 1kHz physics / 50Hz control.
+  canonical WBC joint ordering, so a downstream tracker names the same joints
+  without a remapping table. Tracking is a cascade (the 29 targets are the
+  tracker's input), NOT a
+  :class:`~strands_robots.policies.composite.CompositePolicy` layer - that
+  class merges disjoint joint groups. Standalone in sim the targets are applied
+  directly, which is the faithful kinematic reference.
 
 Kimodo differs from MotionBricks in ONE dimension: Kimodo is **prompt-driven
 generative** (any English motion description, one-shot diffusion sample),

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -10,12 +10,21 @@ per-tick action-dict contract the rest of ``strands_robots`` expects.
 Where it sits in the stack (identical seat to
 :class:`~strands_robots.policies.motionbricks.MotionBricksPolicy`):
 
-* Kimodo emits **motion targets** (kinematic ``qpos``).
-* A tracking controller (WBC / PD) turns those targets into joint torques
-  under physics via :class:`~strands_robots.policies.composite.CompositePolicy`.
-* Standalone, calling the policy in a MuJoCo sim without a tracker sets
-  ``qpos`` directly - this is the faithful visualisation of a kinematic
-  generator.
+* Kimodo emits **motion targets** (kinematic ``qpos``) for all 29 leg + waist +
+  arm joints - a whole-body reference, not a joint subset.
+* Standalone, calling the policy in a MuJoCo sim without a tracker sets those
+  targets directly - the faithful visualisation of a kinematic generator, and
+  what this provider supports today.
+* Closing the loop through physics needs a controller that TRACKS this
+  reference: the 29 targets are its input, so generator and tracker run in
+  series over the same joints. That is a cascade, not a composition, and
+  :class:`~strands_robots.policies.composite.CompositePolicy` does not express
+  it - it merges two policies over DISJOINT joint groups (see its module
+  docstring). Composing Kimodo with
+  :class:`~strands_robots.policies.wbc.WBCPolicy` in particular cannot track a
+  reference at all: WBC's only command input is a target base velocity, it has
+  no reference-pose input, and it drives 15 of the 29 joints Kimodo already
+  drives.
 
 Contract:
 

--- a/strands_robots/policies/motionbricks/__init__.py
+++ b/strands_robots/policies/motionbricks/__init__.py
@@ -12,10 +12,11 @@ movement/facing command, and like the rest of the non-VLA family:
 * ``get_actions`` reads the goal from the well-known ``**kwargs`` keys
   (``style`` / ``mode``, ``target_velocity``, ``target_heading``).
 * The output is the G1's 29 leg+waist+arm joint targets, keyed by
-  :data:`MOTIONBRICKS_G1_JOINTS` (the canonical WBC joint ordering), so it
-  composes with :class:`~strands_robots.policies.wbc.WBCPolicy` (MotionBricks
-  emits motion targets, WBC tracks them) via
-  :class:`~strands_robots.policies.composite.CompositePolicy`.
+  :data:`MOTIONBRICKS_G1_JOINTS` (the canonical WBC joint ordering), so a
+  downstream tracker names the same joints without a remapping table. Tracking
+  is a cascade (the 29 targets are the tracker's input), NOT a
+  :class:`~strands_robots.policies.composite.CompositePolicy` layer - that class
+  merges disjoint joint groups.
 
 Requires the ``[motionbricks]`` extra and the upstream checkpoints (git-LFS,
 NVIDIA Open Model License); no weights are bundled. See ``docs/policies/motionbricks.md``.

--- a/strands_robots/policies/motionbricks/policy.py
+++ b/strands_robots/policies/motionbricks/policy.py
@@ -9,14 +9,17 @@ command it synthesises per-frame full-body ``qpos`` for the G1, faster than
 real time. Upstream reference runner:
 ``motionbricks/scripts/interactive_demo_g1.py``.
 
-Where it sits in the stack (issue #466 series): MotionBricks emits the per-frame
-**motion targets**; a tracking controller (the existing
-:class:`~strands_robots.policies.wbc.WBCPolicy`) turns those into joint torques
-under physics. The two compose via
-:class:`~strands_robots.policies.composite.CompositePolicy` - MotionBricks does
-not replace WBC, it sits above it. Standalone, the policy's output is a
-kinematic reference (set ``qpos`` + forward kinematics), which is the faithful
-way to visualise a kinematic generator.
+Where it sits in the stack: MotionBricks emits the per-frame **motion targets**
+for all 29 leg + waist + arm joints - a whole-body reference. Standalone, that
+output is a kinematic reference (set ``qpos`` + forward kinematics), which is the
+faithful way to visualise a kinematic generator and what this provider supports
+today. Closing the loop through physics needs a controller that TRACKS the
+reference, taking the 29 targets as its input: generator and tracker run in
+series over the same joints. That is a cascade, not a composition, so
+:class:`~strands_robots.policies.composite.CompositePolicy` (which merges
+DISJOINT joint groups) does not express it, and
+:class:`~strands_robots.policies.wbc.WBCPolicy` cannot serve as the tracker -
+its only command input is a target base velocity, with no reference-pose input.
 
 This is a non-VLA member of the policy family (like ``wbc`` / cuRobo / MoveIt2):
 

--- a/tests/policies/test_composite.py
+++ b/tests/policies/test_composite.py
@@ -156,6 +156,105 @@ class TestErrorPaths:
         with pytest.raises(ValueError, match="upper policy"):
             _run(c)
 
+    def test_upper_fully_shadowed_by_lower_raises(self):
+        # Both children drive the SAME joints, so lower precedence leaves the
+        # upper policy contributing nothing: the composite commands exactly what
+        # the lower policy alone would. Silently returning that reads as
+        # "composed" while half the pipeline has no effect.
+        lower = StubPolicy([{j: 1.0 for j in LEG_JOINTS}], name="generator")
+        upper = StubPolicy([{j: 2.0 for j in LEG_JOINTS}], name="tracker")
+        c = CompositePolicy(lower, upper)
+        with pytest.raises(ValueError) as excinfo:
+            _run(c)
+        message = str(excinfo.value)
+        # The refusal names the shadowed child, the count, and every joint the
+        # lower policy already drives, so the caller can fix the ownership.
+        assert "upper policy 'tracker'" in message
+        assert "none of them reached the merged action" in message
+        assert "lower policy 'generator'" in message
+        for joint in LEG_JOINTS:
+            assert joint in message
+        assert "lower_joints" in message and "upper_joints" in message
+
+    def test_partially_shadowed_upper_still_merges(self):
+        # The refusal is scoped to a child that contributes NOTHING. Lower
+        # precedence on a shared name, with the upper still contributing its own,
+        # is the documented default and must keep working.
+        lower = StubPolicy([{"hip": 1.0, "shared": 1.0}])
+        upper = StubPolicy([{"shared": 99.0, "shoulder": 2.0}])
+        assert _run(CompositePolicy(lower, upper))[0] == {"hip": 1.0, "shared": 1.0, "shoulder": 2.0}
+
+    def test_child_commanding_nothing_is_not_a_dropped_command(self):
+        # An empty action DICT (not an empty chunk) is a child commanding no
+        # joint this tick. There is no command to drop, so it is not refused.
+        lower = StubPolicy([{"hip": 1.0}])
+        upper = StubPolicy([{}])
+        assert _run(CompositePolicy(lower, upper))[0] == {"hip": 1.0}
+
+    @pytest.mark.parametrize("role", ["lower", "upper"])
+    def test_joint_group_matching_no_emitted_name_raises(self, role):
+        # A group whose names do not exist in the child's output silently routed
+        # that child to nothing. Name the mismatch instead of dropping it.
+        emitted = {"hip": 1.0} if role == "lower" else {"shoulder": 2.0}
+        groups = {f"{role}_joints": ["typo_joint"]}
+        if role == "upper":
+            groups["lower_joints"] = ["hip"]
+        c = CompositePolicy(
+            StubPolicy([{"hip": 1.0}], name="lo"),
+            StubPolicy([emitted], name="up"),
+            **groups,
+        )
+        with pytest.raises(ValueError, match=f"{role}_joints group"):
+            _run(c)
+
+
+class TestWholeBodyGeneratorIsNotComposable:
+    """A whole-body generator and a whole-body controller cannot be composed.
+
+    ``KimodoPolicy`` / ``MotionBricksPolicy`` emit joint targets for ALL 29 G1
+    leg+waist+arm joints, and ``WBCPolicy`` drives 15 of those same joints. The
+    two therefore claim overlapping joints rather than disjoint groups, so a
+    composite of the pair is one child alone - the generator's reference is never
+    tracked, or the controller is never consulted. Refusing that configuration is
+    what keeps the mistake from looking like a working pipeline.
+    """
+
+    def test_generator_over_locomotion_controller_is_refused(self):
+        from strands_robots.policies.kimodo.policy import KIMODO_G1_JOINTS
+        from strands_robots.policies.wbc.policy import WBC_G1_LEG_WAIST_JOINTS
+
+        # Every joint the controller drives is also driven by the generator.
+        assert set(WBC_G1_LEG_WAIST_JOINTS) <= set(KIMODO_G1_JOINTS)
+
+        generator = StubPolicy([{j: 0.5 for j in KIMODO_G1_JOINTS}], name="kimodo")
+        controller = StubPolicy([{j: -0.9 for j in WBC_G1_LEG_WAIST_JOINTS}], name="wbc")
+
+        with pytest.raises(ValueError) as excinfo:
+            _run(CompositePolicy(generator, controller))
+        message = str(excinfo.value)
+        assert f"commanded {len(WBC_G1_LEG_WAIST_JOINTS)} joint(s)" in message
+        assert "DISJOINT joint groups" in message
+
+    def test_disjoint_groups_on_the_same_robot_still_compose(self):
+        # The pattern CompositePolicy exists for: locomotion owns legs+waist,
+        # manipulation owns the arms, each joint owned exactly once.
+        from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS
+
+        arm_joints = WBC_G1_ALL_JOINTS[len(WBC_G1_LEG_WAIST_JOINTS) :]
+        lower = StubPolicy([{j: -0.9 for j in WBC_G1_LEG_WAIST_JOINTS}], name="wbc")
+        upper = StubPolicy([{j: 0.3 for j in arm_joints}], name="manipulation")
+        c = CompositePolicy(
+            lower,
+            upper,
+            lower_joints=WBC_G1_LEG_WAIST_JOINTS,
+            upper_joints=arm_joints,
+        )
+
+        merged = _run(c)[0]
+        assert set(merged) == set(WBC_G1_ALL_JOINTS)
+        assert all(merged[j] == -0.9 for j in WBC_G1_LEG_WAIST_JOINTS)
+        assert all(merged[j] == 0.3 for j in arm_joints)
+
 
 class TestForwarding:
     """The composite forwards lifecycle calls and obs subsets to both children."""

--- a/tests/policies/test_composite_run_policy_integration.py
+++ b/tests/policies/test_composite_run_policy_integration.py
@@ -102,10 +102,20 @@ def test_run_policy_names_composite_children_by_actuator_keys(sim):
     and ``CompositePolicy`` forwards those keys to both children so their
     emitted action dicts key on the same names the group filter uses. A child
     left unnamed emits placeholder keys that never resolve -> a failed rollout.
+
+    The groups are split explicitly: two children named with the same actuator
+    keys emit the same names, and a composite in which one child owns none of
+    them is refused (it would command what the other child alone commands).
     """
+    keys = list(sim.robot_action_keys("so100"))
     lower = create_policy("mock")
     upper = create_policy("mock")
-    comp = CompositePolicy(lower=lower, upper=upper)
+    comp = CompositePolicy(
+        lower=lower,
+        upper=upper,
+        lower_joints=keys[: len(keys) // 2],
+        upper_joints=keys[len(keys) // 2 :],
+    )
 
     run = sim.run_policy(
         robot_name="so100",


### PR DESCRIPTION
## Problem

`CompositePolicy` merges two policies over **disjoint** joint groups. Left default, the lower child takes precedence on any name it emits and the upper child fills the rest. When both children drive the *same* joints, that default leaves the upper child contributing **nothing**: the merged action equals the lower child alone, and the rollout reports success.

That is exactly the whole-body case, and both whole-body generators document it as the way to track their output under physics:

```python
KIMODO_G1_JOINTS: tuple[str, ...] = WBC_G1_ALL_JOINTS        # 29 joints
MOTIONBRICKS_G1_JOINTS: tuple[str, ...] = WBC_G1_ALL_JOINTS  # 29 joints
```

`WBCPolicy` drives 15 of those same 29 joints, so composing a generator with the controller discards one child entirely. Measured with a real Kimodo diffusion sample over 180 control ticks on `unitree_g1`:

| | value |
|---|---|
| ticks where the composite differed from the generator alone | **0 / 180** |
| controller joint commands that survived the merge | **0 / 2700** |
| merged action size | 29 joints (all from the generator) |
| rollout status | `success` |

Reversing the seats does not help, it only changes which child is silently overridden (the controller's 15 win, 15 of the generator's 29 are dropped). There is no arrangement that works, because the two stages are not parallel: a controller that *tracks* a reference takes the generator's 29 targets as its **input**. Generator and tracker run in **series over the same joints** — a cascade, which this class does not express.

`WBCPolicy` additionally cannot serve as the tracker in any arrangement: its only command input is a target base velocity (`target_velocity`, plus optional orientation and height). It has no reference-pose input, so it cannot follow a generated motion even in principle.

Separately, `docs/policies/kimodo.md` and `examples/kimodo/kimodo_g1_walking.py` documented a composite configuration that does not exist:

```python
create_policy("composite", layers=[{"provider": "kimodo"}, {"provider": "wbc"}])
# TypeError: CompositePolicy.__init__() got an unexpected keyword argument 'layers'
```

`CompositePolicy` takes `lower` / `upper` **Policy objects**; there is no `layers` key and no `composite` entry in `policies.json`. The example's documented `--tracker` path could never run.

## Change

`_merge_tick` refuses a tick in which routing discarded everything a child commanded, naming the child, the joints and the remedy:

```
ValueError: CompositePolicy: the upper policy 'leg_waist_controller' commanded 15 joint(s)
and none of them reached the merged action - the lower policy 'kimodo' already drives every
one of ['left_ankle_pitch_joint', ..., 'waist_yaw_joint'], so this composite commands exactly
what 'kimodo' alone would. CompositePolicy merges DISJOINT joint groups (e.g. locomotion
legs+waist plus manipulation arms); it does not feed one policy's targets into another policy.
Give each joint exactly one owner via lower_joints / upper_joints, or drive the whole body
with a single policy.
```

The refusal is deliberately narrow, so no working configuration changes:

- **Partial** shadowing is untouched. Lower precedence on a shared name, with the upper child still contributing its own names, is the documented default and keeps working (pinned).
- A child that commanded **no** joint this tick is left alone — there is no command to drop (pinned).
- A `lower_joints` / `upper_joints` group matching **none** of its child's emitted names is refused the same way, with a message naming the mismatch: it also routes that child to nothing, and it is a name typo rather than an ownership clash.
- Explicit disjoint groups — the pattern the class exists for — are unaffected (pinned).

The guidance that led here is corrected in the same change: the `kimodo` / `motionbricks` module docstrings and `docs/policies/{kimodo,motionbricks}.md` now describe tracking as a cascade rather than a `CompositePolicy` layer, state that `WBCPolicy` is not a reference tracker, and note that no whole-body reference tracker currently ships. `docs/policies/wbc.md`'s composite section is untouched — WBC legs+waist plus a manipulation upper body is the correct disjoint use. The example now runs the generator as the kinematic reference it is, and the dead `--tracker` flag is gone.

One existing test changed: `test_run_policy_names_composite_children_by_actuator_keys` composed two `mock` policies named with the *same* actuator keys and asserted `status == "success"` — a rollout in which one child had no effect. Its intent is state-key forwarding, so it now splits the keys into explicit disjoint groups; the assertions it makes are unchanged.

## Tests

Added to `tests/policies/test_composite.py`. On pre-fix code **4 fail, 29 pass**; after the fix **33 pass**:

```
FAILED TestErrorPaths::test_upper_fully_shadowed_by_lower_raises - DID NOT RAISE
FAILED TestErrorPaths::test_joint_group_matching_no_emitted_name_raises[lower] - DID NOT RAISE
FAILED TestErrorPaths::test_joint_group_matching_no_emitted_name_raises[upper] - DID NOT RAISE
FAILED TestWholeBodyGeneratorIsNotComposable::test_generator_over_locomotion_controller_is_refused - DID NOT RAISE
```

The passing 29 are the control: they pin partial shadowing, an empty action dict, explicit disjoint groups and the real `WBC_G1_LEG_WAIST_JOINTS` + arm split, all unchanged by this PR. `TestWholeBodyGeneratorIsNotComposable` drives the real `KIMODO_G1_JOINTS` and `WBC_G1_LEG_WAIST_JOINTS` constants, so it fails if a future edit ever makes the two joint sets disjoint without revisiting this contract.

Full suite on `unitree_g1` / MuJoCo: **29447 passed**, and an ID-level diff against `upstream/main` over the whole `tests/` tree shows **0 new failures** (361 pre-existing failures/errors on the branch vs 364 on main; the 3 deltas are the known wall-clock-sensitive RTC latency tests). `ruff check`, `ruff format --check` and `mypy` over `strands_robots tests tests_integ` are clean (the 18 remaining mypy errors are pre-existing and all outside the changed files).

## Rollout artifact

Unitree G1 in MuJoCo (headless EGL), driven by one genuine Kimodo diffusion sample for the prompt *"a person walking forward with confident strides"* (120 frames at 30 Hz, SLERP-upsampled to 50 Hz control). Left: the generator alone. Middle: `CompositePolicy(generator, controller)` on pre-fix code. Right: what the controller alone commands — a deep crouch that never reached an actuator.

![CompositePolicy silently discards the shadowed child](https://raw.githubusercontent.com/cagataycali/robots/media-composite-shadowed-child/composite_shadowed_child.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-composite-shadowed-child/composite_shadowed_child.mp4) · [still frame](https://raw.githubusercontent.com/cagataycali/robots/media-composite-shadowed-child/composite_shadowed_child.png)

The first two panels are the same motion because the composite commanded the same 29 values on all 180 ticks. After this change that middle rollout returns `status="error"` with the message above instead of a video of half a pipeline.