### PR TITLE
feat(policies): ProtoMotionsPolicy — native ONNX GTP tracker for Unitree G1

### DIFF
--- a/changelog.d/2287-protomotions-motion-file-loader.md
+++ b/changelog.d/2287-protomotions-motion-file-loader.md
@@ -1,0 +1,10 @@
+### Security
+
+- `policies/protomotions`: a raw `.pt` reference motion is now read with
+  `torch.load(..., weights_only=True)`. A motion file is an artifact that
+  travels between machines, and the unrestricted unpickler executes whatever
+  `__reduce__` the file names while reading it, so loading a third-party clip
+  was enough to run code on the host. The documented payload is tensors plus two
+  scalars, which the restricted unpickler reads, so no supported motion stops
+  loading; one it refuses is reported with the `save_cache_npz` conversion route
+  instead of a bare `UnpicklingError`.

--- a/changelog.d/2287-protomotions-tracker.md
+++ b/changelog.d/2287-protomotions-tracker.md
@@ -1,0 +1,16 @@
+### Added
+
+- `ProtoMotionsPolicy` (`protomotions`, shorthands `gtp` / `gtp_g1` /
+  `protomotions_g1`): a ProtoMotions Generalist Tracking Policy provider that
+  tracks a reference motion clip on the Unitree G1 and emits balanced PD joint
+  targets. Runs an ONNX export in-process, so no GPU is required. It is the
+  tracking half of the two-stage pipeline whose kinematic half is
+  `KimodoPolicy` or `MotionBricksPolicy`: `qpos_to_motion_data` bridges a
+  generated `qpos` clip into the tracker's reference cache via MuJoCo forward
+  kinematics. The policy declares `required_bodies = ("torso_link",)` so the
+  runtime supplies the anchor link's world orientation, which is not derivable
+  from the observation's floating-base signals - `base_quat` is the pelvis, and
+  on a G1 sweeping its waist the two frames diverge by up to 42 degrees.
+  `ProtoMotionsSession` injects a stub tracker for tests, so the observation to
+  action mapping is exercised without onnxruntime, weights or CUDA. New
+  `[protomotions]` extra; see `docs/policies/protomotions.md`.

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -1,5 +1,5 @@
 ---
-description: The Policy ABC and every provider that ships - mock, groot, lerobot_local, lerobot_async, cosmos3, vera, remote, curobo, moveit2, wbc, wbc_gait, motionbricks, kimodo.
+description: The Policy ABC and every provider that ships - mock, groot, lerobot_local, lerobot_async, cosmos3, vera, remote, curobo, moveit2, wbc, wbc_gait, motionbricks, kimodo, protomotions.
 ---
 
 # Policy providers
@@ -9,7 +9,7 @@ truth - list every provider that `create_policy("<name>")` accepts with:
 
 ```bash
 python -c 'from strands_robots.policies import list_providers; print(list_providers())'
-# ['cosmos3', 'curobo', 'groot', 'kimodo', 'lerobot_async', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'remote', 'vera', 'wbc', 'wbc_gait']
+# ['cosmos3', 'curobo', 'groot', 'kimodo', 'lerobot_async', 'lerobot_local', 'mock', 'motionbricks', 'moveit2', 'protomotions', 'remote', 'vera', 'wbc', 'wbc_gait']
 ```
 
 ```python
@@ -46,6 +46,7 @@ is kept in sync with `list_providers()` by a regression test
 | [`wbc_gait`](wbc_gait.md) | `WBCGaitPolicy` | `wbc` | WBC gait-clock variant: single ONNX policy, 95-dim obs + bipedal phase clock (non-VLA) |
 | [`motionbricks`](motionbricks.md) | `MotionBricksPolicy` | `motionbricks` | Generative kinematic Unitree G1 motion (style-driven: walk/stealth_walk/...), in-process torch (non-VLA) |
 | [`kimodo`](kimodo.md) | `KimodoPolicy` | `kimodo` | Text-to-motion diffusion for the Unitree G1 (free-form prompt -> kinematic qpos), in-process torch (non-VLA) |
+| [`protomotions`](protomotions.md) | `ProtoMotionsPolicy` | `protomotions` | ProtoMotions Generalist Tracking Policy: tracks a reference motion clip on the Unitree G1, in-process ONNX (non-VLA) |
 
 ## Policy ABC
 
@@ -115,4 +116,5 @@ structured error naming the parameter, before any policy is created.
 - [WBC gait-clock variant](wbc_gait.md) - single-ONNX gait-clock G1 controller (non-VLA).
 - [MotionBricks](motionbricks.md) - generative kinematic G1 motion (non-VLA, in-process torch).
 - [Kimodo](kimodo.md) - text-to-motion diffusion for the G1 (non-VLA, in-process torch).
+- [ProtoMotions](protomotions.md) - GTP reference-motion tracker for the G1 (non-VLA, in-process ONNX).
 - [Custom policies](custom-policies.md) - implement the ABC.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -112,6 +112,19 @@ cache["num_frames"], cache["control_dt"]
 `MotionPlayer` accepts that dict, an `.npz` written by
 `MotionPlayer.save_cache_npz`, or a raw ProtoMotions `.pt`.
 
+### Motion files are read with a restricted unpickler
+
+An `.npz` cache is read by NumPy and needs no torch. A raw `.pt` is read with
+`torch.load(..., weights_only=True)`, which accepts tensors and plain scalars -
+the documented payload above - and refuses anything else.
+
+That restriction matters because a motion file travels: clips get downloaded,
+shared between machines and committed to dataset repos. The unrestricted
+unpickler runs whatever `__reduce__` a file names *while reading it*, so
+accepting one would make playing a third-party motion enough to execute code on
+the machine that plays it. If a `.pt` is refused, re-save it as a dict of
+tensors, or convert it once with `save_cache_npz` and load the `.npz`.
+
 ## Per-episode reset
 
 `reset(seed=...)` rewinds the playhead and clears the historical-action buffer.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -1,0 +1,152 @@
+# ProtoMotions — reference-motion tracking for the Unitree G1
+
+`ProtoMotionsPolicy` wraps a ProtoMotions **Generalist Tracking Policy** (GTP)
+ONNX export. Given a reference motion clip it emits balanced PD joint targets
+for the Unitree G1's 29 actuators, tracking that clip while keeping the robot
+upright.
+
+It is the tracking half of a two-stage pipeline. A *kinematic* generator such as
+[`KimodoPolicy`](./kimodo.md) (text-to-motion diffusion) or
+[`MotionBricksPolicy`](./motionbricks.md) produces a `qpos` sequence with no
+notion of balance; the tracker turns that sequence into physics. Compare
+[`WBC`](./wbc.md), which takes a velocity/height *command* rather than a
+reference clip and so cannot follow a whole-body pose trajectory.
+
+## Install
+
+```bash
+pip install "strands-robots[protomotions]"
+```
+
+That pulls `onnxruntime` (runs the graph), `pyyaml` (reads the
+`unified_pipeline.yaml` sidecar) and `huggingface_hub` (fetches a checkpoint from
+a model id). Weights are not bundled. Building a reference clip from `qpos` with
+[`qpos_to_motion_data`](#bridging-a-qpos-clip) additionally needs MuJoCo, which
+ships in `strands-robots[sim-mujoco]`.
+
+## Run a clip in simulation
+
+```python
+from strands_robots import Robot
+from strands_robots.policies.protomotions import (
+    ProtoMotionsPolicy,
+    qpos_to_motion_data,
+)
+
+sim = Robot("unitree_g1", mode="sim")
+
+motion = qpos_to_motion_data(qpos, fps=30, proto_mjcf_path=mjcf)
+policy = ProtoMotionsPolicy(
+    onnx_path="unified_pipeline.onnx",
+    yaml_path="unified_pipeline.yaml",
+    motion=motion,
+)
+
+sim.run_policy(
+    robot_name="unitree_g1",
+    policy_object=policy,
+    n_steps=1000,
+    control_frequency=50.0,
+)
+```
+
+## The observation contract
+
+The tracker consumes four inputs per tick. Three are ordinary proprioception —
+joint positions, joint velocities, and the floating base's angular velocity —
+and the runtime already publishes all three (`<joint>`, `<joint>.vel` and
+`base_ang_vel`, which is the base freejoint's `qvel[3:6]` and so is already in
+the body frame the network wants).
+
+The fourth is the **world orientation of the anchor link**, `torso_link` on the
+G1. This one is not derivable from the observation's floating-base signals:
+`base_quat` is the *pelvis*, and the torso differs from it by the three waist
+joints. On a G1 sweeping its waist through 0.6 rad the two frames diverge by up
+to 42 degrees, so substituting the base would feed the network a wrong frame
+rather than an approximation of the right one.
+
+The policy therefore declares the link it needs:
+
+```python
+policy.required_bodies        # ('torso_link',)
+```
+
+and the runtime resolves that name once per rollout and merges
+`body.torso_link.quat` into every observation it hands to `get_actions`. Nothing
+is required of the caller — this is the same "policy declares, runtime supplies"
+contract as [`requires_images`](./overview.md).
+
+A caller assembling observations by hand (a hardware loop reading an IMU, for
+instance) can pass the signals directly instead:
+
+```python
+await policy.get_actions(
+    obs,
+    "",
+    anchor_rot_xyzw=[x, y, z, w],   # anchor link, world frame
+    root_ang_vel_local=[wx, wy, wz],
+)
+```
+
+If neither the declared body pose nor an explicit override is present the policy
+raises, naming the key it wanted. It will not fall back to `base_quat` unless
+the config's anchor body *is* the floating base, in which case the two are the
+same frame by definition.
+
+Joint velocities are treated the same way: an absent `<joint>.vel` is refused
+rather than substituted with zero. Velocity is tracker feedback, and zeros are a
+plausible-looking value that quietly degrades tracking.
+
+## Bridging a qpos clip
+
+`qpos_to_motion_data` turns a `[T, 7 + 29]` MuJoCo `qpos` sequence into the
+cache the tracker plays. It runs forward kinematics through the ProtoMotions
+MJCF to recover per-body world poses, finite-differences velocities at the
+source rate, and resamples onto the tracker's `control_dt` (0.02 s):
+
+```python
+cache = qpos_to_motion_data(qpos, fps=30, proto_mjcf_path=mjcf)
+cache["num_frames"], cache["control_dt"]
+```
+
+`MotionPlayer` accepts that dict, an `.npz` written by
+`MotionPlayer.save_cache_npz`, or a raw ProtoMotions `.pt`.
+
+## Per-episode reset
+
+`reset(seed=...)` rewinds the playhead and clears the historical-action buffer.
+The runtime calls it once per episode, so a multi-episode `eval_policy` run
+replays the clip from frame 0 each time. The seed is accepted for interface
+parity and ignored: given a reference clip and an observation the tracker is
+deterministic, holding no RNG state.
+
+## Configuration
+
+`ProtoMotionsConfig` is a frozen dataclass mirroring the checkpoint's
+`unified_pipeline.yaml`: the 29 joint names in ONNX action order, the 33 body
+names, the anchor and root body indices, per-joint PD gains, timing, and the
+lookahead offsets for the future-reference window. Pass `yaml_path=` to load a
+sidecar; omit it to use the defaults, which match the shipped export.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `joint_names` | 29 G1 joints | ONNX action order |
+| `anchor_body_index` | `16` (`torso_link`) | Link whose world rotation the network reads |
+| `root_body_index` | `0` (`pelvis`) | Floating base |
+| `control_dt` | `0.02` | Seconds per control tick (50 Hz) |
+| `future_step_indices` | `(1, 2, 4, 8)` | Lookahead offsets, in control steps |
+
+## Testing without weights
+
+`session=` injects anything satisfying the `ProtoMotionsSession` protocol
+(`run(output_names, inputs) -> list[np.ndarray]`), so the observation to action
+mapping can be exercised with no onnxruntime, no weights and no GPU:
+
+```python
+policy = ProtoMotionsPolicy(session=stub, motion=cache)
+```
+
+Outputs are paired to the names in `config.onnx_out_names` rather than read
+positionally, so an export that declares them in another order still feeds
+`joint_pos_targets` to the PD loop; an export missing that output is refused by
+name.

--- a/examples/kimodo/kimodo_g1_dataset_headcam.py
+++ b/examples/kimodo/kimodo_g1_dataset_headcam.py
@@ -1,0 +1,210 @@
+"""Kimodo + G1 head-cam dataset recording — end-to-end.
+
+Text prompt → Kimodo motion diffusion → G1 MuJoCo sim with a **head-mounted
+camera** → recorded LeRobot v3 dataset with per-episode MP4 video tracks and
+parquet joint/action tables.
+
+The head-cam is the sensor cagatay asked for: it rides on the G1 as it moves
+so the recorded video is a first-person, from-the-robot view — the same shape
+next-gen VLA datasets need.
+
+Note on the mount: the 29-DoF G1 URDF has no ``head_link`` body (bodies stop
+at ``torso_link``). We mount the camera on ``g1/torso_link`` with an offset
+that approximates head position (~35 cm up, ~8 cm forward). Once the MJCF
+asset ships a canonical ``head`` site this file will use ``parent_body="g1/head"``
+directly.
+
+Run (stub motion — no CUDA/weights needed, useful for CI/dev):
+
+    MUJOCO_GL=egl python examples/kimodo/kimodo_g1_dataset_headcam.py --stub
+
+Run with real Kimodo (needs the ``[kimodo]`` extra + CUDA):
+
+    MUJOCO_GL=egl STRANDS_TRUST_REMOTE_CODE=1 \\
+        python examples/kimodo/kimodo_g1_dataset_headcam.py \\
+        --prompt "a person walking forward with confident strides"
+
+The script prints parquet-truth verification at the end and exits non-zero if
+the dataset was not built with N distinct episodes — same contract the
+autonomous harness uses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def _positive_int(v: str) -> int:
+    n = int(v)
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be positive, got {n}")
+    return n
+
+
+def _make_stub_motion_agent():
+    """Return a lightweight motion agent that emits a gentle arm-sway motion.
+
+    Avoids downloading Kimodo weights so this example runs on a CPU-only
+    machine and in CI. Same protocol as the real agent (see
+    ``strands_robots.policies.kimodo.KimodoMotionAgent``).
+    """
+    import numpy as np
+
+    class _StubKimodoAgent:
+        def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+            qpos = np.zeros((num_frames, 7 + 29), dtype=np.float32)
+            qpos[:, 2] = 0.75  # standing z
+            qpos[:, 6] = 1.0   # quat w
+            t = np.linspace(0.0, 4.0 * np.pi, num_frames, dtype=np.float32)
+            # left/right shoulder pitch — indices matched to KIMODO_G1_JOINTS
+            qpos[:, 7 + 15] = 0.5 * np.sin(t)
+            qpos[:, 7 + 22] = 0.5 * np.sin(t + np.pi)
+            return qpos
+
+    return _StubKimodoAgent()
+
+
+def _verify_parquet_truth(dataset_root: Path, n_episodes: int) -> None:
+    """Parquet-truth verification — matches the autonomous harness contract."""
+    import pyarrow.parquet as pq
+
+    info = json.loads((dataset_root / "meta" / "info.json").read_text())
+    total_episodes = info.get("total_episodes")
+    if total_episodes != n_episodes:
+        raise SystemExit(
+            f"parquet truth FAIL: info.total_episodes={total_episodes}, expected {n_episodes}"
+        )
+
+    ep_tab = pq.read_table(
+        dataset_root / "meta" / "episodes" / "chunk-000" / "file-000.parquet"
+    )
+    if ep_tab.num_rows != n_episodes:
+        raise SystemExit(
+            f"parquet truth FAIL: meta/episodes rows={ep_tab.num_rows}, expected {n_episodes}"
+        )
+
+    data_tab = pq.read_table(
+        dataset_root / "data" / "chunk-000" / "file-000.parquet"
+    )
+    ep_col = data_tab.column("episode_index").to_pylist()
+    unique = sorted(set(ep_col))
+    if unique != list(range(n_episodes)):
+        raise SystemExit(
+            f"parquet truth FAIL: unique episode_index={unique}, expected {list(range(n_episodes))}"
+        )
+
+    features = list(info.get("features", {}).keys())
+    for expected in ("observation.images.head", "observation.images.front"):
+        if expected not in features:
+            raise SystemExit(f"parquet truth FAIL: missing feature {expected}")
+
+    print(
+        f"✓ parquet truth PASS: {total_episodes} eps, "
+        f"{info.get('total_frames')} frames, features={features}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Kimodo → G1 head-cam dataset")
+    parser.add_argument("--prompt", default="a person walking forward")
+    parser.add_argument("--n-episodes", type=_positive_int, default=3)
+    parser.add_argument("--n-steps", type=_positive_int, default=100)
+    parser.add_argument("--control-hz", type=_positive_int, default=25)
+    parser.add_argument("--num-frames", type=_positive_int, default=180,
+                        help="Kimodo motion length in native frames (<=196)")
+    parser.add_argument(
+        "--stub",
+        action="store_true",
+        help="Use a stub motion agent (no CUDA/weights needed).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("/tmp/kimodo_g1_headcam_dataset"),
+        help="Dataset root directory (LeRobot v3 layout).",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default="cagataydev/g1-kimodo-headcam-example",
+        help="Dataset repo_id for the LeRobot recorder.",
+    )
+    args = parser.parse_args()
+
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    # Trust gate fires on provider name even in --stub mode (stub loads no code).
+    # Ack unconditionally — real code path is protected by the stub agent path.
+    os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
+
+    from strands_robots import Robot
+
+    sim = Robot("g1", mesh=False)
+
+    # Head-cam: mounted on torso_link with head-position offset.
+    # When the G1 asset ships a canonical head site this becomes
+    # parent_body="g1/head" with zero offset.
+    sim.add_camera(
+        name="head",
+        parent_body="g1/torso_link",
+        position=[0.08, 0.0, 0.35],
+        target=[1.5, 0.0, 0.15],
+        fov=70.0,
+        width=640,
+        height=480,
+    )
+    sim.add_camera(
+        name="front",
+        position=[3.0, 0.0, 1.2],
+        target=[0.0, 0.0, 0.8],
+        width=640,
+        height=480,
+    )
+    print(f"cameras: {sim.list_cameras()}")
+
+    if args.out.exists():
+        shutil.rmtree(args.out)
+
+    sim.start_recording(
+        repo_id=args.repo_id,
+        root=str(args.out),
+        fps=args.control_hz,
+        overwrite=True,
+        task=f"Kimodo motion: {args.prompt}",
+        cameras=["front", "head"],  # skip the implicit 'default' overview cam
+    )
+
+    policy_config = {
+        "num_frames": args.num_frames,
+        "device": "cpu" if args.stub else "cuda",
+    }
+    if args.stub:
+        policy_config["motion_agent"] = _make_stub_motion_agent()
+
+    result = sim.run_policy(
+        robot_name="g1",
+        policy_provider="kimodo",
+        policy_config=policy_config,
+        instruction=args.prompt,
+        n_steps=args.n_steps,
+        control_frequency=args.control_hz,
+        n_episodes=args.n_episodes,
+        reset_between=True,
+        video={"path": str(args.out.parent / "kimodo_headcam.mp4"),
+               "fps": args.control_hz, "camera": "head"},
+    )
+    status = result.get("status") if isinstance(result, dict) else str(result)
+    print(f"run_policy status: {status}")
+
+    sim.stop_recording()
+
+    _verify_parquet_truth(args.out, args.n_episodes)
+    print(f"dataset root: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - WBC Gait-Clock Variant: policies/wbc_gait.md
   - MotionBricks (G1 generative motion): policies/motionbricks.md
   - Kimodo (G1 text-to-motion diffusion): policies/kimodo.md
+  - ProtoMotions (G1 motion tracker): policies/protomotions.md
   - LeRobot Local: policies/lerobot-local.md
   - LeRobot Async (gRPC inference): policies/lerobot-async.md
   - MolmoAct2 (SO-100/101): policies/molmoact2.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,22 @@ kimodo = [
     "accelerate>=0.30.0",
     "scipy>=1.10.0",
 ]
+protomotions = [
+    # ProtoMotions Generalist Tracking Policy (GTP) - the ONNX whole-body
+    # motion tracker that turns a kinematic reference clip (e.g. one Kimodo
+    # samples) into balanced joint targets for the Unitree G1. Same three
+    # support libraries as [wbc], for the same three reasons: onnxruntime runs
+    # the exported graph, pyyaml reads the `unified_pipeline.yaml` sidecar next
+    # to it, and huggingface_hub fetches the checkpoint from a model id. Weights
+    # are NOT bundled. See strands_robots/policies/protomotions/ and
+    # docs/policies/protomotions.md.
+    "onnxruntime>=1.17.0,<2.0.0",
+    "pyyaml>=5.1,<7.0.0",
+    # Same >=1.5 floor and MAJOR-only cap as [wbc]: the documented bucket-sync
+    # guidance needs the `hf buckets`/`hf sync` CLI subcommands, which first
+    # ship in huggingface_hub 1.5.0. See the [wbc] comment for the full reason.
+    "huggingface_hub>=1.5,<2.0.0",
+]
 lerobot = [
     # [dataset] bundles the read-back stack the streaming data loop needs:
     # datasets + pandas + pyarrow (parquet streaming) + av + torchcodec
@@ -440,6 +456,7 @@ all = [
     "strands-robots[wbc]",
     "strands-robots[motionbricks]",
     "strands-robots[kimodo]",
+    "strands-robots[protomotions]",
     "strands-robots[molmoact2]",
     "strands-robots[ollama]",
     "strands-robots[inference]",

--- a/strands_robots/policies/protomotions/__init__.py
+++ b/strands_robots/policies/protomotions/__init__.py
@@ -1,0 +1,80 @@
+"""ProtoMotions Generalist Tracking Policy - native provider.
+
+The ONNX Generalist Tracking Policy (GTP) from NVIDIA GEAR's ProtoMotions
+framework, adapted as a first-class :class:`~strands_robots.policies.base.Policy`
+provider. Consumes a per-tick observation (root/anchor rotation + joint pos/vel)
+plus a future-reference window from a :class:`MotionPlayer`, and emits PD joint
+targets for the Unitree G1's 29 leg+waist+arm actuators.
+
+Two entry points:
+
+* Direct construction with a ``.pt`` / ``.npz`` motion cache:
+  ``ProtoMotionsPolicy(onnx_path=..., yaml_path=..., motion_path=...)``.
+* Chained after :class:`~strands_robots.policies.kimodo.KimodoPolicy` - Kimodo
+  samples a qpos trajectory, :func:`~strands_robots.policies.protomotions.
+  bridge.qpos_to_motion_data` converts it to a MotionPlayer cache, this policy
+  tracks it under physics. See :issue:`279` for why this is the correct
+  pairing for a whole-body kinematic generator (WBC would overwrite Kimodo's
+  leg+waist reference).
+
+The pretrained artifact lives on HuggingFace at
+``cagataydev/protomotions-gtp-unitree-g1`` (``unified_pipeline.onnx`` +
+``unified_pipeline.yaml``). BeyondMimic-trained (arXiv:2408.07295) on
+NVIDIA GEAR's ProtoMotions.
+"""
+
+from __future__ import annotations
+
+from strands_robots.policies.protomotions.bridge import qpos_to_motion_data
+from strands_robots.policies.protomotions.config import (
+    GTP_G1_ANCHOR_BODY_INDEX,
+    GTP_G1_BODY_NAMES,
+    GTP_G1_CONTROL_DT,
+    GTP_G1_DEFAULT_LOOKAHEAD_STEPS,
+    GTP_G1_JOINT_NAMES,
+    GTP_G1_ROOT_BODY_INDEX,
+    ProtoMotionsConfig,
+    load_config_from_yaml,
+)
+from strands_robots.policies.protomotions.motion_utils import MotionPlayer, lerp, slerp
+from strands_robots.policies.protomotions.policy import (
+    ProtoMotionsPolicy,
+    ProtoMotionsSession,
+)
+from strands_robots.policies.protomotions.state_utils import (
+    apply_heading_offset,
+    compute_anchor_rot,
+    compute_root_local_ang_vel,
+    compute_yaw_offset,
+    extract_yaw_quat,
+    mujoco_wxyz_to_xyzw,
+    quat_conjugate,
+    quat_mul,
+    quat_rotate_inverse,
+)
+
+__all__ = [
+    "ProtoMotionsPolicy",
+    "ProtoMotionsSession",
+    "ProtoMotionsConfig",
+    "MotionPlayer",
+    "load_config_from_yaml",
+    "qpos_to_motion_data",
+    "GTP_G1_JOINT_NAMES",
+    "GTP_G1_BODY_NAMES",
+    "GTP_G1_ANCHOR_BODY_INDEX",
+    "GTP_G1_ROOT_BODY_INDEX",
+    "GTP_G1_DEFAULT_LOOKAHEAD_STEPS",
+    "GTP_G1_CONTROL_DT",
+    "lerp",
+    "slerp",
+    "mujoco_wxyz_to_xyzw",
+    "quat_rotate_inverse",
+    "quat_mul",
+    "quat_conjugate",
+    "compute_anchor_rot",
+    "compute_root_local_ang_vel",
+    "extract_yaw_quat",
+    "compute_yaw_offset",
+    "apply_heading_offset",
+]

--- a/strands_robots/policies/protomotions/bridge.py
+++ b/strands_robots/policies/protomotions/bridge.py
@@ -1,0 +1,295 @@
+"""Bridge from Kimodo qpos output to a ProtoMotions MotionPlayer cache.
+
+Kimodo emits a full-body qpos trajectory of shape ``[T, 36]``: three root xyz
+translations, four ``wxyz`` root quaternion elements, then twenty-nine G1 joint
+positions in the canonical WBC joint order (which is the same as
+:data:`~strands_robots.policies.protomotions.config.GTP_G1_JOINT_NAMES`, so no
+per-joint reordering is needed).
+
+The ProtoMotions Generalist Tracking Policy consumes a
+:class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer` - a
+dict of per-frame joint states AND per-body rigid-body states (position,
+rotation, linear velocity, angular velocity). This module builds that dict by
+running MuJoCo forward-kinematics on the same G1 MJCF the tracker was trained
+on, then finite-differencing to fill the velocity channels.
+
+Runs entirely in numpy + mujoco. Reused at policy build time (a one-off cost
+in the tens of milliseconds per motion) - never on the hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import numpy as np
+
+from strands_robots.utils import require_optional
+
+from .motion_utils import lerp, slerp
+from .state_utils import mujoco_wxyz_to_xyzw
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["qpos_to_motion_data"]
+
+
+# ---------------------------------------------------------------------------
+# MJCF patching
+# ---------------------------------------------------------------------------
+
+
+def _patch_and_load_mjcf(mjcf_path: Path):
+    """Load MJCF with a floor geom + no sensors - required for FK."""
+    mujoco = require_optional(
+        "mujoco",
+        extra="sim-mujoco",
+        purpose="forward kinematics for the reference-motion bridge",
+    )
+
+    tree = ET.parse(str(mjcf_path))
+    root = tree.getroot()
+
+    # Sensors add DOFs - strip so qpos indexing stays canonical.
+    for sensor_elem in list(root.findall("sensor")):
+        root.remove(sensor_elem)
+
+    worldbody = root.find("worldbody")
+    if worldbody is not None:
+        has_ground = any(
+            "floor" in g.get("name", "").lower()
+            or "ground" in g.get("name", "").lower()
+            or g.get("type", "").lower() == "plane"
+            for g in worldbody.findall("geom")
+        )
+        if not has_ground:
+            floor = ET.SubElement(worldbody, "geom")
+            floor.set("name", "floor")
+            floor.set("type", "plane")
+            floor.set("size", "0 0 0.05")
+            floor.set("rgba", "0.7 0.7 0.7 1")
+
+    xml_str = ET.tostring(root, encoding="unicode")
+
+    # Write the patched XML back into the SAME directory so MJCF asset paths
+    # (mesh files, textures) resolve relative to the original location.
+    asset_dir = str(mjcf_path.parent)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", dir=asset_dir, delete=False) as f:
+        f.write(xml_str)
+        tmp_path = f.name
+
+    try:
+        model = mujoco.MjModel.from_xml_path(tmp_path)  # type: ignore[attr-defined]
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:  # pragma: no cover - best-effort cleanup
+            pass
+
+    data = mujoco.MjData(model)  # type: ignore[attr-defined]
+    return mujoco, model, data
+
+
+# ---------------------------------------------------------------------------
+# Angular velocity via quaternion finite diff
+# ---------------------------------------------------------------------------
+
+
+def _quat_finite_diff_ang_vel(quats_xyzw: np.ndarray, dt: float) -> np.ndarray:
+    """Approximate body angular velocities from an ``xyzw`` quaternion trajectory.
+
+    Uses ``omega ~ 2 * (q_{t+1} - q_t) * q_t^-1 / dt`` (small-angle diff),
+    then keeps the vector part. Output copies the last frame from the
+    second-to-last so shapes match the input trajectory.
+
+    Args:
+        quats_xyzw: Shape ``[T, num_bodies, 4]`` xyzw quaternions.
+        dt: Source period, seconds.
+
+    Returns:
+        Shape ``[T, num_bodies, 3]`` local-frame angular velocities.
+    """
+    T = quats_xyzw.shape[0]
+    if T < 2:
+        return np.zeros(quats_xyzw.shape[:-1] + (3,), dtype=np.float32)
+
+    q0 = quats_xyzw[:-1]
+    q1 = quats_xyzw[1:]
+    # Conjugate q0.
+    q0_conj = q0.copy()
+    q0_conj[..., :3] *= -1.0
+
+    # Hamilton product q1 * q0^-1 -> element-wise (broadcast-safe).
+    ax, ay, az, aw = q1[..., 0], q1[..., 1], q1[..., 2], q1[..., 3]
+    bx, by, bz, bw = q0_conj[..., 0], q0_conj[..., 1], q0_conj[..., 2], q0_conj[..., 3]
+    dq = np.stack(
+        [
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+            aw * bw - ax * bx - ay * by - az * bz,
+        ],
+        axis=-1,
+    )
+    ang_vel = 2.0 * dq[..., :3] / max(dt, 1e-8)
+    # Repeat last frame so output has same T.
+    out = np.zeros(quats_xyzw.shape[:-1] + (3,), dtype=np.float32)
+    out[:-1] = ang_vel.astype(np.float32)
+    out[-1] = out[-2]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def qpos_to_motion_data(
+    qpos: np.ndarray,
+    fps: float,
+    proto_mjcf_path: str | Path,
+    control_dt: float = 0.02,
+) -> dict:
+    """Convert a Kimodo-style G1 ``qpos`` trajectory to a MotionPlayer cache.
+
+    Steps:
+    1. Load the ProtoMotions G1 MJCF and its FK data buffer.
+    2. For each source frame: set ``qpos``, call ``mj_forward``, read body
+       xpos + xquat.
+    3. Finite-difference for joint + body linear + body angular velocities.
+    4. Resample onto ``control_dt`` with SLERP + LERP.
+
+    Args:
+        qpos: Shape ``[T, 36]`` - ``root_xyz(3) + root_quat_wxyz(4) +
+            joints(29)``. Anything wider than 36 is truncated on the joint end
+            with a warning (some Kimodo variants emit trailing padding).
+        fps: Source frame rate in Hz (Kimodo default is 30).
+        proto_mjcf_path: Path to the ProtoMotions G1 MJCF (the caller supplies
+            it; this module ships no asset bundle).
+        control_dt: Target control period, seconds (default 0.02 = 50Hz).
+
+    Returns:
+        A dict with the keys :class:`~strands_robots.policies.protomotions.
+        motion_utils.MotionPlayer` accepts.
+
+    Raises:
+        FileNotFoundError: If ``proto_mjcf_path`` does not exist.
+        ValueError: If ``qpos.shape[1]`` is not exactly 36 (after truncation).
+        RuntimeError: If MuJoCo is not installed.
+    """
+    proto_mjcf_path = Path(proto_mjcf_path)
+    if not proto_mjcf_path.exists():
+        raise FileNotFoundError(
+            f"ProtoMotions G1 MJCF not found: {proto_mjcf_path}. Supply the "
+            f"path via `proto_mjcf_path=...` - no asset is bundled."
+        )
+
+    qpos = np.asarray(qpos, dtype=np.float64)
+    if qpos.ndim != 2:
+        raise ValueError(f"qpos must be 2-D [T, 36], got shape {qpos.shape}.")
+    if qpos.shape[1] < 36:
+        raise ValueError(f"qpos must have at least 36 columns (root_xyz + root_quat + 29 joints), got {qpos.shape[1]}.")
+    if qpos.shape[1] > 36:
+        logger.warning(
+            "qpos has %d columns (>36) - truncating trailing padding.",
+            qpos.shape[1],
+        )
+        qpos = qpos[:, :36]
+
+    T = qpos.shape[0]
+    mujoco, model, data = _patch_and_load_mjcf(proto_mjcf_path)
+
+    num_bodies = model.nbody - 1  # skip world body at index 0
+    num_dofs = model.nq - 7
+
+    logger.info(
+        "qpos_to_motion_data: MJCF has %d bodies, %d dofs. Processing %d frames @ %.1f Hz.",
+        num_bodies,
+        num_dofs,
+        T,
+        fps,
+    )
+
+    body_pos = np.zeros((T, num_bodies, 3), dtype=np.float32)
+    body_rot_xyzw = np.zeros((T, num_bodies, 4), dtype=np.float32)
+    dof_pos = np.zeros((T, num_dofs), dtype=np.float32)
+
+    for t in range(T):
+        data.qpos[:] = qpos[t]
+        data.qvel[:] = 0.0
+        mujoco.mj_forward(model, data)  # type: ignore[attr-defined]
+        body_pos[t] = data.xpos[1:].astype(np.float32)
+        body_rot_xyzw[t] = mujoco_wxyz_to_xyzw(data.xquat[1:]).astype(np.float32)
+        # Root body's rot is the canonical freejoint quaternion from qpos.
+        body_rot_xyzw[t, 0] = mujoco_wxyz_to_xyzw(data.qpos[3:7].astype(np.float32))
+        dof_pos[t] = data.qpos[7:].astype(np.float32)
+
+    dt_src = 1.0 / max(fps, 1e-6)
+    dof_vel = np.zeros_like(dof_pos)
+    body_vel = np.zeros_like(body_pos)
+    body_ang_vel = _quat_finite_diff_ang_vel(body_rot_xyzw, dt_src)
+    if T > 1:
+        dof_vel[:-1] = (dof_pos[1:] - dof_pos[:-1]) / dt_src
+        dof_vel[-1] = dof_vel[-2]
+        body_vel[:-1] = (body_pos[1:] - body_pos[:-1]) / dt_src
+        body_vel[-1] = body_vel[-2]
+
+    target_fps = 1.0 / control_dt
+    if abs(fps - target_fps) < 0.5:
+        return {
+            "dof_pos": dof_pos,
+            "dof_vel": dof_vel,
+            "body_rot": body_rot_xyzw,
+            "body_pos": body_pos,
+            "body_vel": body_vel,
+            "body_ang_vel": body_ang_vel,
+            "control_dt": control_dt,
+            "num_frames": T,
+        }
+
+    # SLERP / LERP resample onto control_dt.
+    motion_length = dt_src * (T - 1)
+    num_ctrl_frames = max(1, int(round(motion_length / control_dt)) + 1)
+
+    body_pos_ctrl = np.zeros((num_ctrl_frames, num_bodies, 3), dtype=np.float32)
+    body_rot_ctrl = np.zeros((num_ctrl_frames, num_bodies, 4), dtype=np.float32)
+    body_vel_ctrl = np.zeros((num_ctrl_frames, num_bodies, 3), dtype=np.float32)
+    body_ang_vel_ctrl = np.zeros((num_ctrl_frames, num_bodies, 3), dtype=np.float32)
+    dof_pos_ctrl = np.zeros((num_ctrl_frames, num_dofs), dtype=np.float32)
+    dof_vel_ctrl = np.zeros((num_ctrl_frames, num_dofs), dtype=np.float32)
+
+    for i in range(num_ctrl_frames):
+        time_s = i * control_dt
+        phase = min(max(time_s / max(motion_length, 1e-8), 0.0), 1.0)
+        frame_f = phase * (T - 1)
+        f0 = int(frame_f)
+        f1 = min(f0 + 1, T - 1)
+        blend = np.float32(frame_f - f0)
+        body_pos_ctrl[i] = lerp(body_pos[f0], body_pos[f1], blend)
+        body_rot_ctrl[i] = slerp(body_rot_xyzw[f0], body_rot_xyzw[f1], blend)
+        body_vel_ctrl[i] = lerp(body_vel[f0], body_vel[f1], blend)
+        body_ang_vel_ctrl[i] = lerp(body_ang_vel[f0], body_ang_vel[f1], blend)
+        dof_pos_ctrl[i] = lerp(dof_pos[f0], dof_pos[f1], blend)
+        dof_vel_ctrl[i] = lerp(dof_vel[f0], dof_vel[f1], blend)
+
+    logger.info(
+        "qpos_to_motion_data: resampled %d frames @ %.1f Hz -> %d frames @ %.0f Hz.",
+        T,
+        fps,
+        num_ctrl_frames,
+        target_fps,
+    )
+
+    return {
+        "dof_pos": dof_pos_ctrl,
+        "dof_vel": dof_vel_ctrl,
+        "body_rot": body_rot_ctrl,
+        "body_pos": body_pos_ctrl,
+        "body_vel": body_vel_ctrl,
+        "body_ang_vel": body_ang_vel_ctrl,
+        "control_dt": control_dt,
+        "num_frames": num_ctrl_frames,
+    }

--- a/strands_robots/policies/protomotions/config.py
+++ b/strands_robots/policies/protomotions/config.py
@@ -1,0 +1,410 @@
+"""Configuration + YAML loader for the ProtoMotions Generalist Tracking Policy.
+
+The upstream ONNX artifact
+(``cagataydev/protomotions-gtp-unitree-g1/unified_pipeline.onnx``) ships with a
+YAML sidecar (``unified_pipeline.yaml``) that pins:
+
+* The 29 joint names in the ONNX action order.
+* The 33 body names + anchor index (``torso_link`` = 16) + root index
+  (``pelvis`` = 0).
+* Per-joint stiffness + damping.
+* Timing: ``control_dt = 0.02s`` (50Hz), ``physics_dt = 0.001s`` (1kHz),
+  ``decimation = 20``.
+* The future-reference lookahead schedule ``[1, 2, 4, 8]`` control steps.
+
+:class:`ProtoMotionsConfig` is the typed dataclass representation of that
+sidecar. Loading it once at construction (rather than reading the YAML on every
+tick) means the hot path never touches disk, and a dimension or joint-count
+error surfaces at policy build time with a clean message.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from strands_robots.utils import require_optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ProtoMotionsConfig",
+    "load_config_from_yaml",
+    "GTP_G1_JOINT_NAMES",
+    "GTP_G1_BODY_NAMES",
+    "GTP_G1_ANCHOR_BODY_INDEX",
+    "GTP_G1_ROOT_BODY_INDEX",
+    "GTP_G1_DEFAULT_LOOKAHEAD_STEPS",
+    "GTP_G1_CONTROL_DT",
+]
+
+# ---------------------------------------------------------------------------
+# Canonical constants - pinned from unified_pipeline.yaml (2026-08-14 upload)
+# ---------------------------------------------------------------------------
+
+# The 29 joint names in the order the ONNX policy emits them, matching the
+# yaml `joint_names` field (id001). Order matters - ONNX output index i drives
+# GTP_G1_JOINT_NAMES[i]. Kept identical to :data:`strands_robots.policies.
+# kimodo.KIMODO_G1_JOINTS` so a Kimodo qpos plugs straight into a ProtoMotions
+# tracker without any per-joint reordering.
+GTP_G1_JOINT_NAMES: tuple[str, ...] = (
+    "left_hip_pitch_joint",
+    "left_hip_roll_joint",
+    "left_hip_yaw_joint",
+    "left_knee_joint",
+    "left_ankle_pitch_joint",
+    "left_ankle_roll_joint",
+    "right_hip_pitch_joint",
+    "right_hip_roll_joint",
+    "right_hip_yaw_joint",
+    "right_knee_joint",
+    "right_ankle_pitch_joint",
+    "right_ankle_roll_joint",
+    "waist_yaw_joint",
+    "waist_roll_joint",
+    "waist_pitch_joint",
+    "left_shoulder_pitch_joint",
+    "left_shoulder_roll_joint",
+    "left_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "left_wrist_roll_joint",
+    "left_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+    "right_shoulder_pitch_joint",
+    "right_shoulder_roll_joint",
+    "right_shoulder_yaw_joint",
+    "right_elbow_joint",
+    "right_wrist_roll_joint",
+    "right_wrist_pitch_joint",
+    "right_wrist_yaw_joint",
+)
+
+# The 33 body names in the model's body order (yaml `body_names` id002).
+# Index 0 = pelvis (root), 16 = torso_link (anchor). ``rubber_hand`` bodies are
+# placeholders on the ``g1_29dof_rev_1_0`` URDF that ships fingerless - a real
+# manipulation URDF would substitute finger links here without changing the
+# tracker's input contract.
+GTP_G1_BODY_NAMES: tuple[str, ...] = (
+    "pelvis",
+    "head",
+    "left_hip_pitch_link",
+    "left_hip_roll_link",
+    "left_hip_yaw_link",
+    "left_knee_link",
+    "left_ankle_pitch_link",
+    "left_ankle_roll_link",
+    "right_hip_pitch_link",
+    "right_hip_roll_link",
+    "right_hip_yaw_link",
+    "right_knee_link",
+    "right_ankle_pitch_link",
+    "right_ankle_roll_link",
+    "waist_yaw_link",
+    "waist_roll_link",
+    "torso_link",
+    "left_shoulder_pitch_link",
+    "left_shoulder_roll_link",
+    "left_shoulder_yaw_link",
+    "left_elbow_link",
+    "left_wrist_roll_link",
+    "left_wrist_pitch_link",
+    "left_wrist_yaw_link",
+    "left_rubber_hand",
+    "right_shoulder_pitch_link",
+    "right_shoulder_roll_link",
+    "right_shoulder_yaw_link",
+    "right_elbow_link",
+    "right_wrist_roll_link",
+    "right_wrist_pitch_link",
+    "right_wrist_yaw_link",
+    "right_rubber_hand",
+)
+
+GTP_G1_ANCHOR_BODY_INDEX = 16  # torso_link
+GTP_G1_ROOT_BODY_INDEX = 0  # pelvis
+
+# The four future-step offsets the ONNX consumes at each tick (yaml
+# ``motion.future_step_indices``). Kept as a tuple so it hashes and cannot be
+# mutated across policy instances.
+GTP_G1_DEFAULT_LOOKAHEAD_STEPS: tuple[int, ...] = (1, 2, 4, 8)
+
+GTP_G1_CONTROL_DT: float = 0.02  # seconds - 50Hz outer control loop
+
+# Upstream per-joint SONIC PD gains from the yaml sidecar. Order matches
+# :data:`GTP_G1_JOINT_NAMES` (id003 stiffness, id004 damping).
+_G1_STIFFNESS: tuple[float, ...] = (
+    40.17923847137318,
+    99.09842777666113,
+    40.17923847137318,
+    99.09842777666113,
+    28.50124619574858,
+    28.50124619574858,
+    40.17923847137318,
+    99.09842777666113,
+    40.17923847137318,
+    99.09842777666113,
+    28.50124619574858,
+    28.50124619574858,
+    40.17923847137318,
+    28.50124619574858,
+    28.50124619574858,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    16.77832748089279,
+    16.77832748089279,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    14.25062309787429,
+    16.77832748089279,
+    16.77832748089279,
+)
+_G1_DAMPING: tuple[float, ...] = (
+    2.5578897650279457,
+    6.3088018534966395,
+    2.5578897650279457,
+    6.3088018534966395,
+    1.814445686584846,
+    1.814445686584846,
+    2.5578897650279457,
+    6.3088018534966395,
+    2.5578897650279457,
+    6.3088018534966395,
+    1.814445686584846,
+    1.814445686584846,
+    2.5578897650279457,
+    1.814445686584846,
+    1.814445686584846,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    1.06814150219,
+    1.06814150219,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    0.907222843292423,
+    1.06814150219,
+    1.06814150219,
+)
+
+
+@dataclass(frozen=True)
+class ProtoMotionsConfig:
+    """Frozen typed view of the ONNX ``unified_pipeline.yaml`` sidecar.
+
+    All fields have upstream-verified defaults matching the shipped
+    ``cagataydev/protomotions-gtp-unitree-g1`` weights. A caller that points at
+    a different checkpoint should always pair it with a matching config.
+
+    Attributes:
+        joint_names: 29 joint names in ONNX action order.
+        body_names: 33 body names in the model's rigid-body order.
+        anchor_body_index: Row index of the anchor body inside ``body_names``.
+        root_body_index: Row index of the root body inside ``body_names``.
+        stiffness: Per-joint kp used by the deployed PD loop.
+        damping: Per-joint kd used by the deployed PD loop.
+        control_dt: Seconds per outer control tick.
+        physics_dt: Seconds per inner physics substep.
+        decimation: Physics substeps per control tick (``control_dt /
+            physics_dt``).
+        future_step_indices: Future-reference lookahead offsets in control
+            steps.
+        action_ema_alpha: Optional exponential-moving-average smoothing on the
+            joint target output (``1.0`` = passthrough, upstream default).
+    """
+
+    joint_names: tuple[str, ...] = GTP_G1_JOINT_NAMES
+    body_names: tuple[str, ...] = GTP_G1_BODY_NAMES
+    anchor_body_index: int = GTP_G1_ANCHOR_BODY_INDEX
+    root_body_index: int = GTP_G1_ROOT_BODY_INDEX
+    stiffness: tuple[float, ...] = _G1_STIFFNESS
+    damping: tuple[float, ...] = _G1_DAMPING
+    control_dt: float = GTP_G1_CONTROL_DT
+    physics_dt: float = 0.001
+    decimation: int = 20
+    future_step_indices: tuple[int, ...] = GTP_G1_DEFAULT_LOOKAHEAD_STEPS
+    action_ema_alpha: float = 1.0
+    # ONNX I/O names - kept as tuples so the ordering is stable and the ONNX
+    # session's ``get_inputs()`` order can be validated against it at load.
+    onnx_in_names: tuple[str, ...] = (
+        "current_anchor_rot",
+        "current_dof_pos",
+        "current_dof_vel",
+        "current_root_local_ang_vel",
+        "historical_processed_actions",
+        "mimic_future_anchor_rot",
+        "mimic_future_dof_pos",
+        "mimic_future_dof_vel",
+    )
+    onnx_out_names: tuple[str, ...] = (
+        "actions",
+        "joint_pos_targets",
+        "stiffness_targets",
+        "damping_targets",
+    )
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Derived properties - computed on read, never stored, so a frozen
+    # dataclass with a single source of truth for each field stays that way.
+    # ------------------------------------------------------------------
+
+    @property
+    def num_dofs(self) -> int:
+        """Length of :attr:`joint_names` (also the ONNX action width)."""
+        return len(self.joint_names)
+
+    @property
+    def num_bodies(self) -> int:
+        """Length of :attr:`body_names`."""
+        return len(self.body_names)
+
+    @property
+    def num_future_steps(self) -> int:
+        """Length of :attr:`future_step_indices`."""
+        return len(self.future_step_indices)
+
+    @property
+    def anchor_body_name(self) -> str:
+        """Name of the anchor body (``torso_link`` on the shipped G1 config).
+
+        The tracker consumes this body's WORLD orientation, not the floating
+        base's. Resolving the name here keeps
+        :attr:`~strands_robots.policies.base.Policy.required_bodies` and the
+        observation lookup reading one source of truth.
+
+        Raises:
+            IndexError: If :attr:`anchor_body_index` is out of range for
+                :attr:`body_names`.
+        """
+        return self.body_names[self.anchor_body_index]
+
+    @property
+    def root_body_name(self) -> str:
+        """Name of the root (floating-base) body - ``pelvis`` on the G1.
+
+        Raises:
+            IndexError: If :attr:`root_body_index` is out of range for
+                :attr:`body_names`.
+        """
+        return self.body_names[self.root_body_index]
+
+    @property
+    def anchor_is_root(self) -> bool:
+        """Whether the anchor body IS the floating base.
+
+        Only when this holds is the observation's ``base_quat`` the anchor
+        orientation. On the G1 it is ``False``: the torso differs from the
+        pelvis by the three waist joints, so substituting ``base_quat`` would
+        feed the tracker a silently wrong frame.
+        """
+        return self.anchor_body_index == self.root_body_index
+
+
+def load_config_from_yaml(path: str | Path) -> ProtoMotionsConfig:
+    """Parse a ``unified_pipeline.yaml`` sidecar into a typed config.
+
+    The yaml is the artifact's source of truth. Fields absent from the yaml
+    fall back to the dataclass defaults (which are themselves pinned to the
+    shipped weights, so a missing block is not an error).
+
+    Args:
+        path: Path to the yaml file.
+
+    Returns:
+        A :class:`ProtoMotionsConfig` - validated for consistent dimensions.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ImportError: If ``pyyaml`` is not installed.
+        ValueError: If the yaml contains an inconsistent dimension (e.g.
+            ``stiffness`` length != number of joints).
+    """
+    yaml = require_optional(
+        "yaml",
+        pip_install="pyyaml",
+        extra="protomotions",
+        purpose="reading the unified_pipeline.yaml checkpoint sidecar",
+    )
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"ProtoMotions yaml not found: {path}")
+
+    with open(path) as f:
+        data = yaml.safe_load(f)  # type: ignore[attr-defined]
+
+    joint_names = tuple(data.get("joint_names", GTP_G1_JOINT_NAMES))
+    body_names = tuple(data.get("body_names", GTP_G1_BODY_NAMES))
+
+    robot = data.get("robot", {})
+    anchor_idx = int(robot.get("anchor_body_index", GTP_G1_ANCHOR_BODY_INDEX))
+    root_idx = int(robot.get("root_body_index", GTP_G1_ROOT_BODY_INDEX))
+
+    control = data.get("control", {})
+    stiffness = tuple(control.get("stiffness", data.get("default_joint_stiffness", _G1_STIFFNESS)))
+    damping = tuple(control.get("damping", data.get("default_joint_damping", _G1_DAMPING)))
+    ema = float(control.get("action_ema_alpha", 1.0))
+
+    timing = data.get("timing", {})
+    control_dt = float(timing.get("control_dt", GTP_G1_CONTROL_DT))
+    physics_dt = float(timing.get("physics_dt", 0.001))
+    decimation = int(timing.get("decimation", 20))
+
+    motion = data.get("motion", {})
+    future_steps = tuple(int(x) for x in motion.get("future_step_indices", GTP_G1_DEFAULT_LOOKAHEAD_STEPS))
+
+    runtime = data.get("_runtime", {})
+    onnx_in_names = tuple(
+        runtime.get(
+            "onnx_in_names",
+            ProtoMotionsConfig.__dataclass_fields__["onnx_in_names"].default,
+        )
+    )
+    onnx_out_names = tuple(
+        runtime.get(
+            "onnx_out_names",
+            ProtoMotionsConfig.__dataclass_fields__["onnx_out_names"].default,
+        )
+    )
+
+    if len(stiffness) != len(joint_names):
+        raise ValueError(f"stiffness length ({len(stiffness)}) != joint count ({len(joint_names)}) in {path}.")
+    if len(damping) != len(joint_names):
+        raise ValueError(f"damping length ({len(damping)}) != joint count ({len(joint_names)}) in {path}.")
+
+    cfg = ProtoMotionsConfig(
+        joint_names=joint_names,
+        body_names=body_names,
+        anchor_body_index=anchor_idx,
+        root_body_index=root_idx,
+        stiffness=stiffness,
+        damping=damping,
+        control_dt=control_dt,
+        physics_dt=physics_dt,
+        decimation=decimation,
+        future_step_indices=future_steps,
+        action_ema_alpha=ema,
+        onnx_in_names=onnx_in_names,
+        onnx_out_names=onnx_out_names,
+        metadata=data.get("metadata", {}),
+    )
+    logger.info(
+        "ProtoMotionsConfig loaded from %s: %d joints, %d bodies, %d future steps @ %.0f Hz",
+        path.name,
+        cfg.num_dofs,
+        cfg.num_bodies,
+        cfg.num_future_steps,
+        1.0 / cfg.control_dt,
+    )
+    return cfg

--- a/strands_robots/policies/protomotions/motion_utils.py
+++ b/strands_robots/policies/protomotions/motion_utils.py
@@ -32,6 +32,7 @@ Clean-room from ProtoMotions (Apache 2.0) deployment/motion_utils.py.
 from __future__ import annotations
 
 import logging
+import pickle
 from typing import Any
 
 import numpy as np
@@ -300,9 +301,25 @@ class MotionPlayer:
             purpose="unpickling a raw ProtoMotions .pt motion (a cache dict or .npz needs no torch)",
         )
 
-        data = torch.load(  # type: ignore[attr-defined]
-            path, map_location="cpu", weights_only=False
-        )
+        # A motion file travels: it gets downloaded, shared between machines and
+        # committed to dataset repos. The unrestricted unpickler runs whatever
+        # __reduce__ the file names while reading it, so accepting one would make
+        # playing a motion enough to execute code on this host. The documented
+        # payload is tensors plus two scalars (see the cache format above), which
+        # weights_only=True reads, so the restriction costs nothing. Same loader
+        # as the checkpoint read in strands_robots.training.rl.base_algo.
+        try:
+            data = torch.load(  # type: ignore[attr-defined]
+                path, map_location="cpu", weights_only=True
+            )
+        except pickle.UnpicklingError as e:
+            raise ValueError(
+                f"{path} carries more than tensors and plain scalars, so only "
+                "the unrestricted unpickler could read it - and that executes "
+                "arbitrary code from the file while loading. Re-save the motion "
+                "as a dict of tensors, or convert it once with "
+                "MotionPlayer.save_cache_npz and load the .npz instead."
+            ) from e
         if "control_dt" in data and "body_rot" in data:
             # A .pt that is already a cache.
             self._load_cache({k: np.asarray(v) for k, v in data.items()})

--- a/strands_robots/policies/protomotions/motion_utils.py
+++ b/strands_robots/policies/protomotions/motion_utils.py
@@ -1,0 +1,382 @@
+"""MotionPlayer - a fixed-rate reference-motion window for the ProtoMotions tracker.
+
+The ONNX Generalist Tracking Policy (GTP) that :class:`~strands_robots.policies.
+protomotions.policy.ProtoMotionsPolicy` wraps expects, each control tick, a
+window of FUTURE reference frames: joint pos + joint vel + anchor rotation at a
+handful of step-offsets ahead (default ``[1, 2, 4, 8]`` control steps). This
+module is the source of that window.
+
+Two input modes:
+
+1. A pre-resampled cache dict (from
+   :func:`~strands_robots.policies.protomotions.bridge.qpos_to_motion_data` or
+   from an on-disk ``.npz`` produced by this module) - fast, no torch.
+2. A raw motion library or single-motion ``.pt`` file in the ProtoMotions
+   format. Handled lazily so a caller with only a cache dict never imports
+   torch or scipy.
+
+Cache format (dict-of-numpy):
+
+* ``dof_pos``       - ``[num_frames, num_dofs]``   float32
+* ``dof_vel``       - ``[num_frames, num_dofs]``   float32
+* ``body_rot``      - ``[num_frames, num_bodies, 4]``  float32 (xyzw)
+* ``body_pos``      - ``[num_frames, num_bodies, 3]``  float32
+* ``body_vel``      - ``[num_frames, num_bodies, 3]``  float32
+* ``body_ang_vel``  - ``[num_frames, num_bodies, 3]``  float32
+* ``control_dt``    - python float, seconds per control tick
+* ``num_frames``    - python int
+
+Clean-room from ProtoMotions (Apache 2.0) deployment/motion_utils.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from strands_robots.utils import require_optional
+
+__all__ = ["MotionPlayer", "slerp", "lerp"]
+
+logger = logging.getLogger(__name__)
+
+# The keys a full motion state carries. Kept as a module constant so a caller
+# a stubs one for a test can round-trip identical field names.
+_STATE_KEYS = ("dof_pos", "dof_vel", "body_rot", "body_pos", "body_vel", "body_ang_vel")
+
+
+# ---------------------------------------------------------------------------
+# Vendored quaternion + scalar interpolation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_quat(q: np.ndarray) -> np.ndarray:
+    """Unit-normalise along the last axis with a soft floor."""
+    norm = np.linalg.norm(q, axis=-1, keepdims=True)
+    return q / np.maximum(norm, 1e-8)
+
+
+def slerp(q0: np.ndarray, q1: np.ndarray, t: np.ndarray | np.floating[Any] | float) -> np.ndarray:
+    """Spherical linear interpolation between two ``xyzw`` quaternions.
+
+    Falls back to linear interpolation on near-parallel pairs so the result is
+    stable when ``sin(theta) -> 0``.
+
+    Args:
+        q0: Shape ``[..., 4]`` start quaternion.
+        q1: Shape ``[..., 4]`` end quaternion.
+        t: Interpolation factor in ``[0, 1]`` - a python float, a numpy
+            scalar, or an array broadcastable against ``q0``.
+
+    Returns:
+        Shape ``[..., 4]`` interpolated, unit-normalised.
+    """
+    q0 = _normalize_quat(q0)
+    q1 = _normalize_quat(q1)
+
+    dot = np.sum(q0 * q1, axis=-1, keepdims=True)
+    q1 = np.where(dot < 0, -q1, q1)  # ensure shortest path
+    dot = np.abs(dot).clip(-1.0, 1.0)
+
+    if np.ndim(t) < np.ndim(dot):
+        t = np.asarray(t)[..., np.newaxis]
+
+    theta = np.arccos(dot)
+    sin_theta = np.sin(theta)
+
+    s0 = np.sin((1.0 - t) * theta) / np.maximum(sin_theta, 1e-8)
+    s1 = np.sin(t * theta) / np.maximum(sin_theta, 1e-8)
+    result = s0 * q0 + s1 * q1
+
+    # Linear-blend fallback where sin(theta) ~ 0 (parallel quats).
+    linear_result = (1.0 - t) * q0 + t * q1
+    use_linear = np.abs(sin_theta) < 1e-6
+    result = np.where(use_linear, linear_result, result)
+    return _normalize_quat(result)
+
+
+def lerp(a: np.ndarray, b: np.ndarray, t: np.ndarray | np.floating[Any] | float) -> np.ndarray:
+    """Linear interpolation ``a + t * (b - a)`` with sensible broadcasting.
+
+    Args:
+        a: Any-shape array.
+        b: Same shape as ``a``.
+        t: Scalar or broadcast-compatible factor.
+
+    Returns:
+        Interpolated array, same shape as ``a``.
+    """
+    if np.ndim(t) < np.ndim(a):
+        t = np.asarray(t)[..., np.newaxis]
+    return a + t * (b - a)
+
+
+def _calc_frame_blend(time_s: float, motion_length_s: float, num_frames: int, src_dt: float) -> tuple[int, int, float]:
+    """Map a query time onto ``(f0, f1, blend)`` inside a fixed-step motion.
+
+    Args:
+        time_s: Query time, seconds since the start.
+        motion_length_s: Total motion duration in seconds.
+        num_frames: Number of source frames.
+        src_dt: Source period ``1/fps``. Currently informational - kept in the
+            signature so an at-a-glance reader can verify the frame count and
+            duration are consistent.
+
+    Returns:
+        ``(f0, f1, blend)`` - the two frames to interpolate between and the
+        blend factor in ``[0, 1)``.
+    """
+    del src_dt  # informational only; motion_length + num_frames define the rate
+    phase = max(0.0, min(time_s / max(motion_length_s, 1e-8), 1.0))
+    frame_f = phase * (num_frames - 1)
+    f0 = int(frame_f)
+    f1 = min(f0 + 1, num_frames - 1)
+    blend = frame_f - f0
+    return f0, f1, blend
+
+
+# ---------------------------------------------------------------------------
+# MotionPlayer
+# ---------------------------------------------------------------------------
+
+
+class MotionPlayer:
+    """Playhead over a pre-resampled reference motion for a single clip.
+
+    Args:
+        source: Either a cache dict (see module docstring) or a path to a
+            ProtoMotions ``.pt`` file. String paths are loaded lazily - no
+            torch import when only a dict is passed.
+        control_dt: Target control period in seconds (default ``0.02s`` =
+            50Hz). Only used when ``source`` is a raw ``.pt`` that needs
+            resampling; a cache dict carries its own ``control_dt``.
+        motion_index: For a packaged multi-motion ``.pt`` library, which entry
+            to play.
+    """
+
+    def __init__(
+        self,
+        source: dict[str, Any] | str,
+        control_dt: float = 0.02,
+        motion_index: int = 0,
+    ) -> None:
+        self._control_dt = float(control_dt)
+        if isinstance(source, dict):
+            self._load_cache(source)
+        elif isinstance(source, str):
+            self._load_file(source, motion_index)
+        else:
+            raise TypeError(f"MotionPlayer source must be a cache dict or a .pt path, got {type(source).__name__}.")
+
+    # ---- Public API --------------------------------------------------------
+
+    @property
+    def total_frames(self) -> int:
+        """Number of pre-resampled frames in the loaded clip."""
+        return int(self._num_frames)
+
+    @property
+    def num_bodies(self) -> int:
+        """Number of rigid bodies in the loaded clip's rotation tensor."""
+        return int(self._body_rot.shape[1])
+
+    @property
+    def num_dofs(self) -> int:
+        """Number of joint DOFs in the loaded clip's joint tensor."""
+        return int(self._dof_pos.shape[1])
+
+    @property
+    def control_dt(self) -> float:
+        """Control period, seconds. Matches the ONNX tracker's ``control_dt``."""
+        return float(self._control_dt)
+
+    def get_state_at_frame(self, frame_idx: int) -> dict[str, np.ndarray]:
+        """Return a single-frame state, index-clamped to the valid range."""
+        idx = int(np.clip(frame_idx, 0, self._num_frames - 1))
+        return {
+            "dof_pos": self._dof_pos[idx],
+            "dof_vel": self._dof_vel[idx],
+            "body_rot": self._body_rot[idx],
+            "body_pos": self._body_pos[idx],
+            "body_vel": self._body_vel[idx],
+            "body_ang_vel": self._body_ang_vel[idx],
+        }
+
+    def get_future_references(self, frame_idx: int, step_indices: list[int]) -> dict[str, np.ndarray]:
+        """Stack N future frames at the given step offsets.
+
+        Args:
+            frame_idx: Current playhead frame.
+            step_indices: Positive integer offsets in control steps (e.g. the
+                GTP tracker's ``[1, 2, 4, 8]``).
+
+        Returns:
+            Dict with each state key stacked along a new leading axis of size
+            ``len(step_indices)``.
+        """
+        future_states = [self.get_state_at_frame(frame_idx + s) for s in step_indices]
+        return {key: np.stack([s[key] for s in future_states], axis=0) for key in _STATE_KEYS}
+
+    def as_cache(self) -> dict[str, Any]:
+        """Return the loaded state as a plain dict (for saving or re-loading)."""
+        return {
+            "dof_pos": self._dof_pos,
+            "dof_vel": self._dof_vel,
+            "body_rot": self._body_rot,
+            "body_pos": self._body_pos,
+            "body_vel": self._body_vel,
+            "body_ang_vel": self._body_ang_vel,
+            "control_dt": self._control_dt,
+            "num_frames": self._num_frames,
+        }
+
+    def save_cache_npz(self, path: str) -> None:
+        """Write the loaded state to an ``.npz`` file for later re-use."""
+        np.savez(
+            path,
+            dof_pos=self._dof_pos,
+            dof_vel=self._dof_vel,
+            body_rot=self._body_rot,
+            body_pos=self._body_pos,
+            body_vel=self._body_vel,
+            body_ang_vel=self._body_ang_vel,
+            control_dt=np.float32(self._control_dt),
+            num_frames=np.int64(self._num_frames),
+        )
+        logger.info(
+            "MotionPlayer cached %d frames @ %.0f Hz -> %s",
+            self._num_frames,
+            1.0 / self._control_dt,
+            path,
+        )
+
+    # ---- Private loaders ---------------------------------------------------
+
+    def _load_cache(self, data: dict[str, Any]) -> None:
+        """Bind a pre-resampled cache dict in-place."""
+        missing = [k for k in _STATE_KEYS if k not in data]
+        if missing:
+            raise KeyError(f"MotionPlayer cache is missing required keys: {missing!r}.")
+        self._dof_pos = np.asarray(data["dof_pos"], dtype=np.float32)
+        self._dof_vel = np.asarray(data["dof_vel"], dtype=np.float32)
+        self._body_rot = np.asarray(data["body_rot"], dtype=np.float32)
+        self._body_pos = np.asarray(data["body_pos"], dtype=np.float32)
+        self._body_vel = np.asarray(data["body_vel"], dtype=np.float32)
+        self._body_ang_vel = np.asarray(data["body_ang_vel"], dtype=np.float32)
+        self._control_dt = float(data.get("control_dt", self._control_dt))
+        self._num_frames = int(data.get("num_frames", self._dof_pos.shape[0]))
+        logger.info(
+            "MotionPlayer loaded cache: %d frames @ %.0f Hz",
+            self._num_frames,
+            1.0 / self._control_dt,
+        )
+
+    def _load_file(self, path: str, motion_index: int) -> None:
+        """Load an ``.npz`` cache or a raw ProtoMotions ``.pt`` file."""
+        if path.endswith(".npz"):
+            data = dict(np.load(path))
+            self._load_cache(
+                {
+                    "dof_pos": data["dof_pos"],
+                    "dof_vel": data["dof_vel"],
+                    "body_rot": data["body_rot"],
+                    "body_pos": data["body_pos"],
+                    "body_vel": data["body_vel"],
+                    "body_ang_vel": data["body_ang_vel"],
+                    "control_dt": float(data["control_dt"]),
+                    "num_frames": int(data["num_frames"]),
+                }
+            )
+            return
+
+        # .pt raw ProtoMotions format - needs torch to unpickle. torch is not
+        # part of [protomotions]: the tracker itself runs on onnxruntime, and a
+        # caller with a cache dict or .npz never needs it.
+        torch = require_optional(
+            "torch",
+            extra="kimodo",
+            purpose="unpickling a raw ProtoMotions .pt motion (a cache dict or .npz needs no torch)",
+        )
+
+        data = torch.load(  # type: ignore[attr-defined]
+            path, map_location="cpu", weights_only=False
+        )
+        if "control_dt" in data and "body_rot" in data:
+            # A .pt that is already a cache.
+            self._load_cache({k: np.asarray(v) for k, v in data.items()})
+            return
+        self._resample_raw(data, motion_index)
+
+    def _resample_raw(self, data: dict[str, Any], motion_index: int) -> None:
+        """Resample raw ProtoMotions motion data onto ``control_dt``."""
+        if "length_starts" in data:
+            length_starts = data["length_starts"]
+            motion_num_frames = data["motion_num_frames"]
+            motion_dt_all = data["motion_dt"]
+
+            start = int(length_starts[motion_index].item())
+            nf = int(motion_num_frames[motion_index].item())
+            end = start + nf
+            src_dt = float(motion_dt_all[motion_index].item())
+
+            gts = np.asarray(data["gts"][start:end], dtype=np.float32)
+            grs = np.asarray(data["grs"][start:end], dtype=np.float32)
+            gvs = np.asarray(data["gvs"][start:end], dtype=np.float32)
+            gavs = np.asarray(data["gavs"][start:end], dtype=np.float32)
+            dps = np.asarray(data["dps"][start:end], dtype=np.float32)
+            dvs = np.asarray(data["dvs"][start:end], dtype=np.float32)
+        elif "rigid_body_pos" in data:
+            fps = float(data["fps"])
+            src_dt = 1.0 / fps
+            gts = np.asarray(data["rigid_body_pos"], dtype=np.float32)
+            grs = np.asarray(data["rigid_body_rot"], dtype=np.float32)
+            gvs = np.asarray(data["rigid_body_vel"], dtype=np.float32)
+            gavs = np.asarray(data["rigid_body_ang_vel"], dtype=np.float32)
+            dps = np.asarray(data["dof_pos"], dtype=np.float32)
+            dvs = np.asarray(data["dof_vel"], dtype=np.float32)
+            nf = gts.shape[0]
+        else:
+            raise ValueError(
+                "Unrecognised raw motion format. Expected either "
+                "'length_starts' (packed library) or 'rigid_body_pos' "
+                "(single motion)."
+            )
+
+        motion_length = src_dt * (nf - 1)
+        num_ctrl_frames = max(1, int(round(motion_length / self._control_dt)) + 1)
+
+        body_pos_list: list[np.ndarray] = []
+        body_rot_list: list[np.ndarray] = []
+        body_vel_list: list[np.ndarray] = []
+        body_ang_vel_list: list[np.ndarray] = []
+        dof_pos_list: list[np.ndarray] = []
+        dof_vel_list: list[np.ndarray] = []
+
+        for i in range(num_ctrl_frames):
+            t = i * self._control_dt
+            f0, f1, blend = _calc_frame_blend(t, motion_length, nf, src_dt)
+            bl = np.float32(blend)
+            body_pos_list.append(lerp(gts[f0], gts[f1], bl))
+            body_rot_list.append(slerp(grs[f0], grs[f1], bl))
+            body_vel_list.append(lerp(gvs[f0], gvs[f1], bl))
+            body_ang_vel_list.append(lerp(gavs[f0], gavs[f1], bl))
+            dof_pos_list.append(lerp(dps[f0], dps[f1], bl))
+            dof_vel_list.append(lerp(dvs[f0], dvs[f1], bl))
+
+        self._body_pos = np.stack(body_pos_list).astype(np.float32)
+        self._body_rot = np.stack(body_rot_list).astype(np.float32)
+        self._body_vel = np.stack(body_vel_list).astype(np.float32)
+        self._body_ang_vel = np.stack(body_ang_vel_list).astype(np.float32)
+        self._dof_pos = np.stack(dof_pos_list).astype(np.float32)
+        self._dof_vel = np.stack(dof_vel_list).astype(np.float32)
+        self._num_frames = num_ctrl_frames
+
+        logger.info(
+            "MotionPlayer resampled: %d @ %.1f Hz -> %d @ %.0f Hz",
+            nf,
+            1.0 / src_dt,
+            num_ctrl_frames,
+            1.0 / self._control_dt,
+        )

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -1,0 +1,576 @@
+"""ProtoMotionsPolicy - ONNX Generalist Tracking Policy provider.
+
+Wraps ``cagataydev/protomotions-gtp-unitree-g1``'s ``unified_pipeline.onnx``
+into the :class:`~strands_robots.policies.base.Policy` interface. Given a
+reference :class:`~strands_robots.policies.protomotions.motion_utils.
+MotionPlayer` and a per-tick observation dict, emits PD joint targets for the
+G1's 29 actuators.
+
+Contract:
+
+* ``requires_images = False`` - the tracker reads root/anchor rotation and
+  joint pos/vel only, never an image.
+* ``get_actions(obs, instruction, **kwargs)`` reads:
+
+  - ``observation.state`` (well-known key) OR the joint names in
+    :data:`~strands_robots.policies.protomotions.config.GTP_G1_JOINT_NAMES`
+    directly on the obs dict - either shape works.
+  - Optional per-call knobs on ``kwargs``:
+
+    * ``motion``: A new :class:`MotionPlayer`, cache dict, or ``.pt`` /
+      ``.npz`` path to swap in without re-instantiating the policy.
+    * ``anchor_rot_xyzw`` / ``root_ang_vel_local``: If the caller already
+      derived these (e.g. from an IMU on hardware), pass them directly; else
+      the policy computes them from ``observation_dict``.
+
+* Output is a per-frame dict ``{joint_name: target_radians, ...}`` in the
+  action-value convention (``float`` per DOF, never ``np.ndarray``).
+
+Injection seam: pass ``session=`` implementing :class:`ProtoMotionsSession`
+to unit-test the observation -> future-window -> action-dict mapping without
+onnxruntime, weights, or CUDA.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from strands_robots.policies.base import Policy
+from strands_robots.utils import require_optional
+
+from .config import (
+    ProtoMotionsConfig,
+    load_config_from_yaml,
+)
+from .motion_utils import MotionPlayer
+from .state_utils import (
+    compute_anchor_rot,
+    compute_root_local_ang_vel,
+    mujoco_wxyz_to_xyzw,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ProtoMotionsPolicy", "ProtoMotionsSession"]
+
+
+@runtime_checkable
+class ProtoMotionsSession(Protocol):
+    """Injection seam for the ONNX tracker session.
+
+    A caller stubs this for tests to avoid importing onnxruntime,
+    downloading weights, or needing a CUDA runtime. The real session (``onnxruntime.
+    InferenceSession``) satisfies this shape via a thin adapter built in
+    :meth:`ProtoMotionsPolicy._build_onnx_session`.
+    """
+
+    def run(self, output_names: list[str] | None, inputs: dict[str, np.ndarray]) -> list[np.ndarray]:
+        """Run the tracker on a single input batch.
+
+        Args:
+            output_names: Names of outputs to return (or ``None`` for all,
+                in the order the session declares).
+            inputs: Named input arrays. Shapes documented in
+                :attr:`ProtoMotionsConfig.onnx_in_names`.
+
+        Returns:
+            A list of output arrays in the requested order.
+        """
+        ...
+
+
+class ProtoMotionsPolicy(Policy):
+    """ONNX Generalist Tracking Policy for the Unitree G1.
+
+    See the module docstring for the full contract. All fields the registry
+    advertises are explicit constructor parameters - no ``**kwargs`` - so a
+    typo raises ``TypeError`` at build time rather than being swallowed.
+
+    Args:
+        onnx_path: Path to the ONNX artifact (``unified_pipeline.onnx`` or an
+            equivalent GTP export). Required unless ``session=`` is passed.
+        yaml_path: Path to the sidecar YAML (``unified_pipeline.yaml``).
+            Falls back to the pinned :class:`ProtoMotionsConfig` defaults if
+            omitted, which matches the shipped weights.
+        motion: Initial reference motion. One of:
+            - :class:`MotionPlayer` instance,
+            - cache dict (from :func:`qpos_to_motion_data` or ``as_cache()``),
+            - ``.npz`` / ``.pt`` path (loaded lazily).
+            May be ``None`` at build time and set later via
+            ``get_actions(motion=...)`` or :meth:`load_motion`.
+        session: Injected ONNX-like session (see :class:`ProtoMotionsSession`).
+            Used for tests / non-CUDA hosts.
+        providers: Ordered list of onnxruntime execution providers. Defaults to
+            ``["CUDAExecutionProvider", "CPUExecutionProvider"]`` if
+            ``onnxruntime`` is installed.
+        history_length: Length of the historical-actions rolling buffer that
+            feeds the ``historical_processed_actions`` ONNX input. The upstream
+            checkpoint uses ``1`` (single previous action). Larger values pad
+            with zeros until the buffer fills.
+    """
+
+    #: Non-VLA - the tracker is proprioceptive, no cameras.
+    requires_images = False
+
+    def __init__(
+        self,
+        *,
+        onnx_path: str | Path | None = None,
+        yaml_path: str | Path | None = None,
+        motion: MotionPlayer | dict[str, Any] | str | Path | None = None,
+        session: ProtoMotionsSession | None = None,
+        providers: list[str] | None = None,
+        history_length: int = 1,
+    ) -> None:
+        if session is None and onnx_path is None:
+            raise ValueError(
+                "ProtoMotionsPolicy requires either `onnx_path` (real weights) "
+                "or `session` (injected for tests). Neither was supplied."
+            )
+        if history_length < 1:
+            raise ValueError(f"history_length must be >= 1, got {history_length}.")
+
+        self._config: ProtoMotionsConfig = (
+            load_config_from_yaml(yaml_path) if yaml_path is not None else ProtoMotionsConfig()
+        )
+
+        self._session: ProtoMotionsSession | None = session
+        self._onnx_path: Path | None = Path(onnx_path) if onnx_path else None
+        self._providers = providers or [
+            "CUDAExecutionProvider",
+            "CPUExecutionProvider",
+        ]
+
+        # Rolling history buffer, shape [history_length, num_dofs].
+        # Initialised BEFORE load_motion so its reset path can zero it in-place.
+        self._history_length = int(history_length)
+        self._action_history: NDArray[np.float32] = np.zeros(
+            (self._history_length, self._config.num_dofs), dtype=np.float32
+        )
+
+        # Per-episode playhead - advances on each get_actions() call, unless the
+        # caller passes a new motion (which resets it).
+        self._frame_cursor: int = 0
+
+        self._motion_player: MotionPlayer | None = None
+        if motion is not None:
+            self.load_motion(motion)
+
+        # Cache of joint names -> their index inside a caller-supplied
+        # ``observation.state`` (list-of-values). Recomputed lazily whenever
+        # the robot's state-key list changes.
+        self._state_index_cache: dict[str, int] | None = None
+        self._robot_state_keys: list[str] = list(self._config.joint_names)
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    @property
+    def provider_name(self) -> str:
+        """Registry key for this provider (``"protomotions"``)."""
+        return "protomotions"
+
+    @property
+    def config(self) -> ProtoMotionsConfig:
+        """The pinned typed config in force for this instance."""
+        return self._config
+
+    @property
+    def required_bodies(self) -> tuple[str, ...]:
+        """The anchor link whose world orientation the tracker consumes.
+
+        ``torso_link`` on the shipped G1 config. Declaring it here is what
+        makes the policy runnable through the standard runtime: the observation
+        feed carries the floating base only (``base_quat`` is the PELVIS), and
+        the anchor differs from it by the three waist joints, so the tracker
+        cannot derive this signal itself. The runtime resolves the name once
+        per rollout and merges ``body.<name>.quat`` into every observation.
+        """
+        return (self._config.anchor_body_name,)
+
+    @property
+    def num_dofs(self) -> int:
+        """Number of joint DOFs the tracker drives (29 for the G1 GTP)."""
+        return self._config.num_dofs
+
+    def set_robot_state_keys(self, robot_state_keys: list[str]) -> None:
+        """Resolve the 29 GTP joint names by NAME in the robot's key list.
+
+        The tracker's ONNX input is dof-index-based, so we build a lookup from
+        joint name -> the caller's ``observation.state`` index and cache it.
+        Resolving by name means the tracker's output aligns with the robot's
+        actuators regardless of sim-specific joint ordering or namespacing.
+
+        Args:
+            robot_state_keys: The robot's own joint-name list (as reported by
+                the runtime's observation feed).
+
+        Raises:
+            ValueError: If any of the 29 expected G1 joint names is absent
+                from ``robot_state_keys``.
+        """
+        keys = list(robot_state_keys)
+        key_set = set(keys)
+        missing = [n for n in self._config.joint_names if n not in key_set]
+        if missing:
+            raise ValueError(
+                "ProtoMotionsPolicy: robot's joint list is missing expected G1 "
+                f"joints: {missing}.\n"
+                f"  expected: {list(self._config.joint_names)}\n"
+                f"  robot provided: {keys}\n"
+                "The GTP tracker drives the 29-DOF G1; load unitree_g1."
+            )
+        self._robot_state_keys = keys
+        self._state_index_cache = {name: keys.index(name) for name in keys}
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    def load_motion(self, motion: MotionPlayer | dict[str, Any] | str | Path) -> None:
+        """Swap in a new reference motion and reset the playhead.
+
+        Args:
+            motion: Same union as the constructor. A string / Path is loaded
+                lazily by :class:`MotionPlayer` (``.npz`` fast path or ``.pt``
+                via torch).
+        """
+        if isinstance(motion, MotionPlayer):
+            self._motion_player = motion
+        elif isinstance(motion, dict):
+            self._motion_player = MotionPlayer(motion, control_dt=self._config.control_dt)
+        elif isinstance(motion, (str, Path)):
+            self._motion_player = MotionPlayer(str(motion), control_dt=self._config.control_dt)
+        else:
+            raise TypeError(f"motion must be a MotionPlayer, cache dict, or path, got {type(motion).__name__}.")
+
+        # New clip -> reset playhead and history.
+        self._frame_cursor = 0
+        self._action_history[:] = 0.0
+        logger.info(
+            "ProtoMotionsPolicy loaded motion: %d frames @ %.0f Hz",
+            self._motion_player.total_frames,
+            1.0 / self._motion_player.control_dt,
+        )
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset the playhead and action history at the start of an episode.
+
+        The signature matches :meth:`Policy.reset`, which the runtime calls as
+        ``policy.reset(seed=...)`` once per episode. A narrower override would
+        raise ``TypeError`` there; the runtime catches it and continues, so the
+        playhead would silently carry over and every episode after the first
+        would replay from wherever the previous one stopped.
+
+        Args:
+            seed: Accepted for interface parity and ignored - the tracker is
+                deterministic given its reference motion and observation, so it
+                holds no RNG state to reseed.
+        """
+        del seed  # deterministic tracker: no RNG state to reseed
+        self._frame_cursor = 0
+        self._action_history[:] = 0.0
+
+    # ------------------------------------------------------------------
+    # get_actions
+    # ------------------------------------------------------------------
+
+    async def get_actions(
+        self,
+        observation_dict: dict[str, Any],
+        instruction: str,  # unused - tracker is not VLA
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Return the next per-frame G1 joint targets from the ONNX tracker.
+
+        Args:
+            observation_dict: Per-tick observation. Must supply the current
+                anchor rotation, root angular velocity, joint positions and
+                joint velocities. Two shapes are accepted:
+
+                1. A canonical ``observation.state`` list plus explicit
+                   ``anchor_rot_xyzw`` / ``root_ang_vel_local`` on ``kwargs``.
+                2. Per-joint entries under the GTP joint names (with ``.vel``
+                   suffix for velocities), plus ``anchor_rot_xyzw`` /
+                   ``root_ang_vel_local`` on the obs dict itself.
+
+            instruction: Ignored - the tracker follows the loaded motion, not
+                a text prompt.
+            **kwargs: Optional per-call knobs:
+
+                * ``motion``: Swap in a new reference on this call
+                  (see :meth:`load_motion`).
+                * ``anchor_rot_xyzw``: Shape ``[4]`` (xyzw) explicit override.
+                * ``root_ang_vel_local``: Shape ``[3]`` explicit override.
+                * ``dof_pos`` / ``dof_vel``: Shape ``[num_dofs]`` explicit
+                  overrides. When present, they win over ``observation_dict``.
+
+        Returns:
+            A single-frame list ``[{joint_name: target_radians, ...}]``
+            matching the base ``Policy.get_actions`` list-of-dicts contract.
+
+        Raises:
+            RuntimeError: If no motion has been loaded yet.
+            KeyError: If a required piece of state is absent from both the
+                obs dict and ``kwargs``.
+        """
+        if "motion" in kwargs and kwargs["motion"] is not None:
+            self.load_motion(kwargs["motion"])
+
+        if self._motion_player is None:
+            raise RuntimeError(
+                "ProtoMotionsPolicy.get_actions: no reference motion loaded. "
+                "Pass `motion=` to the constructor, call load_motion(), or "
+                "pass `motion=...` on get_actions()."
+            )
+
+        # 1. Build the future-reference window from the MotionPlayer.
+        future = self._motion_player.get_future_references(self._frame_cursor, list(self._config.future_step_indices))
+        num_future = self._config.num_future_steps
+
+        mimic_future_anchor_rot = (
+            future["body_rot"][:, self._config.anchor_body_index, :].reshape(1, num_future, 4).astype(np.float32)
+        )
+        mimic_future_dof_pos = future["dof_pos"].reshape(1, num_future, self._config.num_dofs).astype(np.float32)
+        mimic_future_dof_vel = future["dof_vel"].reshape(1, num_future, self._config.num_dofs).astype(np.float32)
+
+        # 2. Derive the current-state inputs from the observation.
+        current_anchor_rot = self._extract_anchor_rot(observation_dict, kwargs)
+        current_root_local_ang_vel = self._extract_root_local_ang_vel(observation_dict, kwargs)
+        current_dof_pos = self._extract_dof_pos(observation_dict, kwargs)
+        current_dof_vel = self._extract_dof_vel(observation_dict, kwargs)
+
+        # 3. Historical actions buffer (shape [1, history_length, num_dofs]).
+        historical = self._action_history.reshape(1, self._history_length, self._config.num_dofs).astype(np.float32)
+
+        inputs = {
+            "current_anchor_rot": current_anchor_rot.reshape(1, 4).astype(np.float32),
+            "current_dof_pos": current_dof_pos.reshape(1, self._config.num_dofs).astype(np.float32),
+            "current_dof_vel": current_dof_vel.reshape(1, self._config.num_dofs).astype(np.float32),
+            "current_root_local_ang_vel": current_root_local_ang_vel.reshape(1, 3).astype(np.float32),
+            "historical_processed_actions": historical,
+            "mimic_future_anchor_rot": mimic_future_anchor_rot,
+            "mimic_future_dof_pos": mimic_future_dof_pos,
+            "mimic_future_dof_vel": mimic_future_dof_vel,
+        }
+
+        session = self._get_session()
+        requested = list(self._config.onnx_out_names)
+        outputs = session.run(requested, inputs)
+        # Pair outputs to names via the list we asked for, so a config that
+        # declares the checkpoint's outputs in a different order still reads
+        # the right tensor. Positional indexing would silently feed the PD
+        # loop `stiffness_targets` after such a reorder.
+        by_name = dict(zip(requested, outputs, strict=False))
+        missing = [name for name in ("actions", "joint_pos_targets") if name not in by_name]
+        if missing:
+            raise RuntimeError(
+                "ProtoMotionsPolicy: the tracker session returned no "
+                f"{missing} output. config.onnx_out_names declares "
+                f"{requested}; the session answered with "
+                f"{len(outputs)} array(s). The GTP export must expose "
+                "`actions` (fed back into the history buffer) and "
+                "`joint_pos_targets` (sent to the robot's PD loop)."
+            )
+        actions_out = by_name["actions"].reshape(-1)[: self._config.num_dofs]
+        joint_pos_targets = by_name["joint_pos_targets"].reshape(-1)[: self._config.num_dofs]
+
+        # 4. Update history + advance the playhead.
+        self._action_history = np.roll(self._action_history, shift=-1, axis=0)
+        self._action_history[-1] = actions_out.astype(np.float32)
+        self._frame_cursor += 1
+
+        # 5. Wrap as the per-joint action-dict expected by the runtime.
+        action_dict: dict[str, float] = {
+            name: float(joint_pos_targets[i]) for i, name in enumerate(self._config.joint_names)
+        }
+        return [action_dict]
+
+    # ------------------------------------------------------------------
+    # ONNX session lifecycle
+    # ------------------------------------------------------------------
+
+    def _get_session(self) -> ProtoMotionsSession:
+        """Return the cached session, building it from ``onnx_path`` on first call."""
+        if self._session is not None:
+            return self._session
+        assert self._onnx_path is not None  # validated in __init__
+        self._session = self._build_onnx_session(self._onnx_path, self._providers)
+        return self._session
+
+    @staticmethod
+    def _build_onnx_session(onnx_path: Path, providers: list[str]) -> ProtoMotionsSession:
+        """Build a real onnxruntime session - deferred so tests don't import ORT."""
+        ort = require_optional(
+            "onnxruntime",
+            extra="protomotions",
+            purpose="running the GTP tracker graph (pass `session=` to inject a stub instead)",
+        )
+
+        if not onnx_path.exists():
+            raise FileNotFoundError(
+                f"ONNX artifact not found: {onnx_path}. Download from "
+                f"cagataydev/protomotions-gtp-unitree-g1 on HuggingFace."
+            )
+
+        sess = ort.InferenceSession(  # type: ignore[attr-defined]
+            str(onnx_path), providers=providers
+        )
+        logger.info(
+            "ProtoMotions ONNX session ready: %s (providers=%s)",
+            onnx_path.name,
+            sess.get_providers(),
+        )
+        return sess  # onnxruntime.InferenceSession already satisfies the Protocol
+
+    # ------------------------------------------------------------------
+    # Observation extraction helpers
+    # ------------------------------------------------------------------
+
+    def _extract_anchor_rot(self, obs: dict[str, Any], kwargs: dict[str, Any]) -> np.ndarray:
+        """Pull the anchor-body ``xyzw`` rotation from obs or an explicit kwarg."""
+        if "anchor_rot_xyzw" in kwargs and kwargs["anchor_rot_xyzw"] is not None:
+            return np.asarray(kwargs["anchor_rot_xyzw"], dtype=np.float32)
+        # The runtime's answer to `required_bodies`: body.<anchor>.quat, wxyz.
+        anchor_key = f"body.{self._config.anchor_body_name}.quat"
+        if anchor_key in obs:
+            return mujoco_wxyz_to_xyzw(np.asarray(obs[anchor_key], dtype=np.float32))
+        # Try well-known observation keys.
+        for key in ("anchor_rot_xyzw", "observation.anchor_rot"):
+            if key in obs:
+                return np.asarray(obs[key], dtype=np.float32)
+        # Fallback: derive from a full body-rotation batch.
+        if "body_rot_xyzw" in obs:
+            arr = np.asarray(obs["body_rot_xyzw"], dtype=np.float32)
+            return compute_anchor_rot(arr, self._config.anchor_body_index)
+        # The floating-base quaternion is the ROOT. It is the anchor rotation
+        # only when the config anchors on the root itself; on the G1 the torso
+        # differs from the pelvis by the waist joints, so substituting it would
+        # silently feed the tracker the wrong frame.
+        if self._config.anchor_is_root:
+            for key in ("base_quat", "root_quat_wxyz"):
+                if key in obs:
+                    return mujoco_wxyz_to_xyzw(np.asarray(obs[key], dtype=np.float32))
+        raise KeyError(
+            "ProtoMotionsPolicy: could not resolve the anchor rotation. The "
+            f"tracker anchors on {self._config.anchor_body_name!r}, so it needs "
+            f"{anchor_key!r} in the observation. Through a simulation rollout "
+            "the runtime supplies that key from this policy's "
+            "`required_bodies`; a caller assembling observations by hand can "
+            "instead pass `anchor_rot_xyzw=[x,y,z,w]` via kwargs or supply "
+            "`body_rot_xyzw`. Note that `base_quat` is the floating base "
+            f"({self._config.root_body_name!r}), NOT the anchor."
+        )
+
+    def _extract_root_local_ang_vel(self, obs: dict[str, Any], kwargs: dict[str, Any]) -> np.ndarray:
+        """Pull the root-body local-frame angular velocity."""
+        if "root_ang_vel_local" in kwargs and kwargs["root_ang_vel_local"] is not None:
+            return np.asarray(kwargs["root_ang_vel_local"], dtype=np.float32)
+        for key in ("root_ang_vel_local", "observation.root_ang_vel_local"):
+            if key in obs:
+                return np.asarray(obs[key], dtype=np.float32)
+        # Derive from full body-rot + world-frame body-angvel arrays.
+        if "body_rot_xyzw" in obs and "body_ang_vel_world" in obs:
+            rots = np.asarray(obs["body_rot_xyzw"], dtype=np.float32)
+            avels = np.asarray(obs["body_ang_vel_world"], dtype=np.float32)
+            return compute_root_local_ang_vel(rots, avels, self._config.root_body_index)
+        # The runtime's floating-base angular velocity is the root freejoint's
+        # qvel[3:6], which MuJoCo already reports in the BODY frame - exactly
+        # the local-frame quantity this input wants.
+        for key in ("base_ang_vel", "root_ang_vel_body"):
+            if key in obs:
+                return np.asarray(obs[key], dtype=np.float32)
+        raise KeyError(
+            "ProtoMotionsPolicy: could not resolve the root angular velocity "
+            "in the root's local frame. A simulation rollout supplies it as "
+            "`base_ang_vel` (the floating base's body-frame qvel); a caller "
+            "assembling observations by hand can pass "
+            "`root_ang_vel_local=[wx,wy,wz]` via kwargs or supply "
+            "`body_rot_xyzw`+`body_ang_vel_world`."
+        )
+
+    def _extract_dof_pos(self, obs: dict[str, Any], kwargs: dict[str, Any]) -> np.ndarray:
+        """Pull the 29 joint positions in :attr:`config.joint_names` order."""
+        if "dof_pos" in kwargs and kwargs["dof_pos"] is not None:
+            return np.asarray(kwargs["dof_pos"], dtype=np.float32)
+        return self._pack_by_name(obs, suffix="")
+
+    def _extract_dof_vel(self, obs: dict[str, Any], kwargs: dict[str, Any]) -> np.ndarray:
+        """Pull the 29 joint velocities in :attr:`config.joint_names` order."""
+        if "dof_vel" in kwargs and kwargs["dof_vel"] is not None:
+            return np.asarray(kwargs["dof_vel"], dtype=np.float32)
+        return self._pack_by_name(obs, suffix=".vel")
+
+    def _pack_by_name(self, obs: dict[str, Any], suffix: str, fill: float | None = None) -> np.ndarray:
+        """Pack per-joint values from the obs dict in canonical joint order.
+
+        Tries three obs conventions in order:
+        1. ``observation.state`` as a flat array + a matching ``state_keys``.
+        2. Per-joint keys ``<name><suffix>`` directly on ``obs``.
+        3. A single ``observation.state`` array whose ordering matches
+           ``self._robot_state_keys`` (set via :meth:`set_robot_state_keys`).
+        """
+        # 1. observation.state + explicit joint-key list on obs.
+        state_arr = obs.get("observation.state")
+        keys_list = obs.get("state_keys")
+        if state_arr is not None and keys_list is not None:
+            state_arr = np.asarray(state_arr, dtype=np.float32)
+            out = np.zeros(self._config.num_dofs, dtype=np.float32)
+            for i, name in enumerate(self._config.joint_names):
+                key = name + suffix
+                if key in keys_list:
+                    out[i] = float(state_arr[list(keys_list).index(key)])
+                elif fill is None:
+                    raise KeyError(f"ProtoMotionsPolicy: joint {key!r} missing from observation.state's state_keys.")
+                else:
+                    out[i] = fill
+            return out
+
+        # 2. Per-joint keys directly on the obs dict.
+        direct_hits = sum(1 for name in self._config.joint_names if (name + suffix) in obs)
+        if direct_hits > 0:
+            out = np.zeros(self._config.num_dofs, dtype=np.float32)
+            for i, name in enumerate(self._config.joint_names):
+                key = name + suffix
+                if key in obs:
+                    out[i] = float(obs[key])
+                elif fill is None:
+                    raise KeyError(
+                        f"ProtoMotionsPolicy: joint {key!r} missing from obs "
+                        f"(found {direct_hits}/{self._config.num_dofs})."
+                    )
+                else:
+                    out[i] = fill
+            return out
+
+        # 3. observation.state matches self._robot_state_keys order.
+        if state_arr is not None and self._robot_state_keys:
+            state_arr = np.asarray(state_arr, dtype=np.float32).reshape(-1)
+            out = np.zeros(self._config.num_dofs, dtype=np.float32)
+            for i, name in enumerate(self._config.joint_names):
+                key = name + suffix
+                if key in self._robot_state_keys:
+                    out[i] = float(state_arr[self._robot_state_keys.index(key)])
+                elif fill is None:
+                    raise KeyError(
+                        f"ProtoMotionsPolicy: joint {key!r} missing from "
+                        f"self._robot_state_keys (call set_robot_state_keys)."
+                    )
+                else:
+                    out[i] = fill
+            return out
+
+        # Nothing matched.
+        if fill is None:
+            raise KeyError(
+                f"ProtoMotionsPolicy: could not resolve dof values with suffix "
+                f"{suffix!r}. Provide `observation.state`+`state_keys`, "
+                f"per-joint keys, or explicit `dof_pos`/`dof_vel` kwargs."
+            )
+        return np.full(self._config.num_dofs, fill, dtype=np.float32)

--- a/strands_robots/policies/protomotions/state_utils.py
+++ b/strands_robots/policies/protomotions/state_utils.py
@@ -1,0 +1,210 @@
+"""Pure-numpy quaternion + state derivation utilities for ProtoMotions tracking.
+
+Clean-room from ProtoMotions (Apache 2.0) deployment/state_utils.py.
+No torch, no PyTorch tensors - a caller a strands-robots policy can invoke
+without a GPU or a heavy tensor stack.
+
+Quaternion convention throughout: ``xyzw`` (ProtoMotions common format).
+MuJoCo's own quaternions are ``wxyz`` - :func:`mujoco_wxyz_to_xyzw` bridges
+the two at the read boundary so the rest of this module a caller mixes with
+MuJoCo state can stay in one convention.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "mujoco_wxyz_to_xyzw",
+    "quat_rotate_inverse",
+    "compute_anchor_rot",
+    "compute_root_local_ang_vel",
+    "extract_yaw_quat",
+    "quat_mul",
+    "quat_conjugate",
+    "compute_yaw_offset",
+    "apply_heading_offset",
+]
+
+
+# ---------------------------------------------------------------------------
+# Convention conversion
+# ---------------------------------------------------------------------------
+
+
+def mujoco_wxyz_to_xyzw(wxyz: np.ndarray) -> np.ndarray:
+    """Convert a MuJoCo ``wxyz`` quaternion (or array of them) to ``xyzw``.
+
+    Args:
+        wxyz: Shape ``[..., 4]`` in MuJoCo's ``wxyz`` order.
+
+    Returns:
+        Same shape, reordered to ``xyzw``.
+    """
+    return wxyz[..., [1, 2, 3, 0]]
+
+
+# ---------------------------------------------------------------------------
+# Quaternion math
+# ---------------------------------------------------------------------------
+
+
+def _normalize_quat(q: np.ndarray) -> np.ndarray:
+    """Unit-normalise ``q`` along the last axis with a soft floor."""
+    norm = np.linalg.norm(q, axis=-1, keepdims=True)
+    return q / np.maximum(norm, 1e-8)
+
+
+def quat_rotate_inverse(q_xyzw: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Rotate vector ``v`` by the INVERSE of a unit quaternion ``q``.
+
+    Args:
+        q_xyzw: Shape ``[4]`` (xyzw).
+        v: Shape ``[3]`` world-frame vector.
+
+    Returns:
+        Shape ``[3]`` local-frame vector.
+    """
+    q_w = q_xyzw[3]
+    q_vec = q_xyzw[:3]
+    a = v * (2.0 * q_w * q_w - 1.0)
+    b = np.cross(q_vec, v) * q_w * 2.0
+    c = q_vec * np.dot(q_vec, v) * 2.0
+    return a - b + c
+
+
+def quat_mul(a_xyzw: np.ndarray, b_xyzw: np.ndarray) -> np.ndarray:
+    """Hamilton product of two ``xyzw`` quaternions.
+
+    Args:
+        a_xyzw: Shape ``[..., 4]``.
+        b_xyzw: Shape ``[..., 4]`` (broadcastable with ``a``).
+
+    Returns:
+        Product ``a * b``, shape ``[..., 4]``.
+    """
+    ax, ay, az, aw = a_xyzw[..., 0], a_xyzw[..., 1], a_xyzw[..., 2], a_xyzw[..., 3]
+    bx, by, bz, bw = b_xyzw[..., 0], b_xyzw[..., 1], b_xyzw[..., 2], b_xyzw[..., 3]
+    return np.stack(
+        [
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+            aw * bw - ax * bx - ay * by - az * bz,
+        ],
+        axis=-1,
+    ).astype(np.float32)
+
+
+def quat_conjugate(q_xyzw: np.ndarray) -> np.ndarray:
+    """Conjugate (inverse, for unit quats) of an ``xyzw`` quaternion."""
+    result = q_xyzw.copy()
+    result[..., :3] *= -1.0
+    return result
+
+
+# ---------------------------------------------------------------------------
+# State derivation on a full body-rotation array
+# ---------------------------------------------------------------------------
+
+
+def compute_anchor_rot(rigid_body_rot: np.ndarray, anchor_body_index: int) -> np.ndarray:
+    """Slice a single anchor-body orientation out of a full body-rotation array.
+
+    Args:
+        rigid_body_rot: Shape ``[num_bodies, 4]`` (xyzw).
+        anchor_body_index: Row index (e.g. ``16`` for ``torso_link`` on the G1).
+
+    Returns:
+        Shape ``[4]`` xyzw anchor orientation.
+    """
+    return rigid_body_rot[anchor_body_index]
+
+
+def compute_root_local_ang_vel(
+    rigid_body_rot: np.ndarray,
+    rigid_body_ang_vel: np.ndarray,
+    root_body_index: int = 0,
+) -> np.ndarray:
+    """Rotate a root-body world-frame angular velocity into the local frame.
+
+    Use ONLY when the source is a WORLD-frame angular velocity (e.g.
+    ``data.cvel[root_body, :3]`` from MuJoCo, which is a world-frame twist).
+    Do NOT use for a source that is already local (``data.qvel[3:6]`` on a
+    freejoint or a real-robot IMU gyro reading is a body-frame quantity - pass
+    it straight through).
+
+    Args:
+        rigid_body_rot: Shape ``[num_bodies, 4]`` (xyzw).
+        rigid_body_ang_vel: Shape ``[num_bodies, 3]`` (world frame).
+        root_body_index: Row index of the root (default ``0``).
+
+    Returns:
+        Shape ``[3]`` local-frame angular velocity of the root body.
+    """
+    root_rot = rigid_body_rot[root_body_index]
+    root_ang_vel = rigid_body_ang_vel[root_body_index]
+    return quat_rotate_inverse(root_rot, root_ang_vel)
+
+
+# ---------------------------------------------------------------------------
+# Heading alignment
+# ---------------------------------------------------------------------------
+
+
+def extract_yaw_quat(q_xyzw: np.ndarray) -> np.ndarray:
+    """Extract a yaw-only unit quaternion from a full orientation ``q_xyzw``.
+
+    Discards pitch and roll - the residual is a rotation about the world Z axis
+    only, which is the natural way to align a motion clip's ground-plane
+    heading with the robot's own heading without touching torso lean.
+
+    Args:
+        q_xyzw: Shape ``[4]``.
+
+    Returns:
+        Shape ``[4]`` yaw-only quaternion ``(0, 0, sin(yaw/2), cos(yaw/2))``.
+    """
+    x, y, z, w = q_xyzw[0], q_xyzw[1], q_xyzw[2], q_xyzw[3]
+    yaw = np.arctan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+    half = yaw * 0.5
+    return np.array([0.0, 0.0, np.sin(half), np.cos(half)], dtype=np.float32)
+
+
+def compute_yaw_offset(robot_quat_xyzw: np.ndarray, motion_quat_xyzw: np.ndarray) -> np.ndarray:
+    """Compute the yaw-only offset that maps ``motion`` heading onto ``robot``.
+
+    Both inputs are extracted to yaw-only quaternions first (so torso lean does
+    not contaminate the alignment), then the offset is ``robot_yaw *
+    motion_yaw^-1`` in Hamilton convention.
+
+    Args:
+        robot_quat_xyzw: Shape ``[4]`` - robot's current anchor orientation.
+        motion_quat_xyzw: Shape ``[4]`` - motion clip's first-frame anchor
+            orientation (a caller uses the same anchor body on both sides).
+
+    Returns:
+        Shape ``[4]`` yaw-only quaternion offset - apply with
+        :func:`apply_heading_offset` to align a motion body-rot batch.
+    """
+    robot_yaw = extract_yaw_quat(robot_quat_xyzw)
+    motion_yaw = extract_yaw_quat(motion_quat_xyzw)
+    return quat_mul(robot_yaw, quat_conjugate(motion_yaw))
+
+
+def apply_heading_offset(offset_quat_xyzw: np.ndarray, body_rots_xyzw: np.ndarray) -> np.ndarray:
+    """Apply a single yaw offset to a batch of body rotations.
+
+    Args:
+        offset_quat_xyzw: Shape ``[4]``.
+        body_rots_xyzw: Shape ``[..., 4]``.
+
+    Returns:
+        Same shape as ``body_rots_xyzw``, each row multiplied on the left by
+        ``offset_quat_xyzw``.
+    """
+    original_shape = body_rots_xyzw.shape
+    flat = body_rots_xyzw.reshape(-1, 4)
+    offset_broadcast = np.broadcast_to(offset_quat_xyzw, flat.shape)
+    aligned = quat_mul(offset_broadcast, flat)
+    return aligned.reshape(original_shape)

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -326,6 +326,26 @@
         "text2motion"
       ]
     },
+    "protomotions": {
+      "module": "strands_robots.policies.protomotions",
+      "class": "ProtoMotionsPolicy",
+      "description": "ProtoMotions Generalist Tracking Policy (ONNX, BeyondMimic-trained) for the Unitree G1 — consumes a MotionPlayer reference and emits PD joint targets",
+      "requires": [],
+      "config_keys": [
+        "onnx_path",
+        "yaml_path",
+        "motion",
+        "session",
+        "providers",
+        "history_length"
+      ],
+      "shorthands": [
+        "protomotions",
+        "gtp",
+        "gtp_g1",
+        "protomotions_g1"
+      ]
+    },
     "remote": {
       "module": "strands_robots.inference.client",
       "class": "RemotePolicy",

--- a/tests/policies/protomotions/test_motion_file_loading.py
+++ b/tests/policies/protomotions/test_motion_file_loading.py
@@ -1,0 +1,125 @@
+"""MotionPlayer reads a ``.pt`` motion without executing code out of the file.
+
+``MotionPlayer`` accepts a reference motion as a path, and a motion file is an
+artifact that travels: checkpoints and motion libraries get downloaded, shared
+between machines, and committed to dataset repos. Reading one with the legacy
+unpickler runs whatever ``__reduce__`` the file names *while loading it*, so a
+motion file is enough to run code on the machine that plays it.
+
+The documented cache format is tensors plus two scalars (see
+``strands_robots.policies.protomotions.motion_utils``), which is exactly what
+``torch.load(..., weights_only=True)`` accepts, so the restricted unpickler is
+sufficient for the format and the unrestricted one buys nothing. The same
+loader reads training checkpoints in ``strands_robots.training.rl.base_algo``.
+
+What is pinned here:
+
+* A well-formed payload still round-trips (the restriction is not a regression).
+* A payload carrying a ``__reduce__`` is refused, and its side effect never
+  runs. This is the one that fails against an unrestricted loader.
+* The refusal names the ``.npz`` route, so a caller holding a legitimately
+  exotic file has somewhere to go instead of a dead end.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.protomotions import MotionPlayer
+from tests.mocks.torch_mock import real_torch_installed
+
+pytestmark = pytest.mark.skipif(
+    not real_torch_installed(),
+    reason="reads a real .pt through torch.load; the torch mock has no serializer",
+)
+
+_NUM_FRAMES = 6
+_NUM_DOFS = 29
+_NUM_BODIES = 33
+
+
+def _cache_payload() -> dict[str, Any]:
+    """A well-formed MotionPlayer cache, in the documented dict-of-arrays shape."""
+    return {
+        "dof_pos": np.zeros((_NUM_FRAMES, _NUM_DOFS), dtype=np.float32),
+        "dof_vel": np.zeros((_NUM_FRAMES, _NUM_DOFS), dtype=np.float32),
+        "body_rot": np.tile(
+            np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            (_NUM_FRAMES, _NUM_BODIES, 1),
+        ),
+        "body_pos": np.zeros((_NUM_FRAMES, _NUM_BODIES, 3), dtype=np.float32),
+        "body_vel": np.zeros((_NUM_FRAMES, _NUM_BODIES, 3), dtype=np.float32),
+        "body_ang_vel": np.zeros((_NUM_FRAMES, _NUM_BODIES, 3), dtype=np.float32),
+        "control_dt": 0.02,
+        "num_frames": _NUM_FRAMES,
+    }
+
+
+class _RunsCodeOnLoad:
+    """Stand-in for a motion file that carries an executable payload.
+
+    ``__reduce__`` names a directory creation rather than anything harmful: the
+    point is only that it is observable, so the test can tell "the loader ran
+    the file's code" from "the loader refused the file".
+    """
+
+    def __init__(self, marker: Path) -> None:
+        self._marker = marker
+
+    def __reduce__(self) -> tuple[object, tuple[str]]:
+        return (os.mkdir, (str(self._marker),))
+
+
+def test_well_formed_pt_motion_round_trips(tmp_path: Path) -> None:
+    """A tensor+scalar payload still loads, so the hardened loader is sufficient."""
+    import torch
+
+    payload = {k: (torch.from_numpy(v) if isinstance(v, np.ndarray) else v) for k, v in _cache_payload().items()}
+    path = tmp_path / "motion.pt"
+    torch.save(payload, path)
+
+    player = MotionPlayer(str(path))
+
+    assert player.total_frames == _NUM_FRAMES
+    assert player.num_dofs == _NUM_DOFS
+    assert player.num_bodies == _NUM_BODIES
+
+
+def test_pt_motion_carrying_executable_payload_is_refused(tmp_path: Path) -> None:
+    """The file's ``__reduce__`` must not run while the motion is being read."""
+    import torch
+
+    marker = tmp_path / "code-ran"
+    payload = dict(_cache_payload())
+    payload["dof_pos"] = torch.zeros(_NUM_FRAMES, _NUM_DOFS)
+    payload["trailer"] = _RunsCodeOnLoad(marker)
+    path = tmp_path / "hostile.pt"
+    torch.save(payload, path)
+
+    with pytest.raises(ValueError) as excinfo:
+        MotionPlayer(str(path))
+
+    assert not marker.exists(), (
+        f"loading the motion executed code named by the file: the marker at {marker} was created while reading {path}"
+    )
+    message = str(excinfo.value)
+    assert ".npz" in message, (
+        "the refusal must point at the .npz cache route, else a caller with an "
+        f"exotic-but-legitimate file has no next step. Got: {message}"
+    )
+
+
+def test_npz_cache_needs_no_unpickler(tmp_path: Path) -> None:
+    """The ``.npz`` route is unchanged: NumPy arrays, no pickle, no torch."""
+    path = tmp_path / "motion.npz"
+    np.savez(str(path), **_cache_payload())
+
+    player = MotionPlayer(str(path))
+
+    assert player.total_frames == _NUM_FRAMES
+    assert player.control_dt == pytest.approx(0.02)

--- a/tests/policies/protomotions/test_protomotions_policy.py
+++ b/tests/policies/protomotions/test_protomotions_policy.py
@@ -1,0 +1,287 @@
+"""Unit tests for :class:`ProtoMotionsPolicy` - no ONNX weights, no CUDA.
+
+Uses the :class:`ProtoMotionsSession` injection seam so the whole test suite
+runs in CPU-only CI in single-digit seconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.factory import create_policy, import_policy_class
+from strands_robots.policies.protomotions import (
+    GTP_G1_JOINT_NAMES,
+    MotionPlayer,
+    ProtoMotionsConfig,
+    ProtoMotionsPolicy,
+    ProtoMotionsSession,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubSession:
+    """A deterministic stub tracker: outputs a known joint-target vector."""
+
+    def __init__(self, targets: np.ndarray | None = None) -> None:
+        self._targets = targets if targets is not None else np.linspace(-0.1, 0.1, 29, dtype=np.float32)
+        self.call_count = 0
+        self.last_inputs: dict[str, np.ndarray] | None = None
+
+    def run(self, output_names, inputs):
+        self.call_count += 1
+        self.last_inputs = {k: v.copy() for k, v in inputs.items()}
+        n = 29
+        actions = self._targets.reshape(1, n).astype(np.float32)
+        joint_pos = self._targets.reshape(1, n).astype(np.float32)
+        stiff = np.full((1, n), 40.0, dtype=np.float32)
+        damp = np.full((1, n), 2.5, dtype=np.float32)
+        return [actions, joint_pos, stiff, damp]
+
+
+def _make_flat_cache(num_frames: int = 20) -> dict:
+    nb, nd = 33, 29
+    return {
+        "dof_pos": np.zeros((num_frames, nd), dtype=np.float32),
+        "dof_vel": np.zeros((num_frames, nd), dtype=np.float32),
+        "body_rot": np.tile(
+            np.array([0, 0, 0, 1], dtype=np.float32),
+            (num_frames, nb, 1),
+        ),
+        "body_pos": np.zeros((num_frames, nb, 3), dtype=np.float32),
+        "body_vel": np.zeros((num_frames, nb, 3), dtype=np.float32),
+        "body_ang_vel": np.zeros((num_frames, nb, 3), dtype=np.float32),
+        "control_dt": 0.02,
+        "num_frames": num_frames,
+    }
+
+
+@pytest.fixture
+def stub_session() -> _StubSession:
+    return _StubSession()
+
+
+@pytest.fixture
+def flat_motion() -> MotionPlayer:
+    return MotionPlayer(_make_flat_cache())
+
+
+@pytest.fixture
+def policy(stub_session: _StubSession, flat_motion: MotionPlayer) -> ProtoMotionsPolicy:
+    return ProtoMotionsPolicy(session=stub_session, motion=flat_motion)
+
+
+def _minimal_obs_kwargs() -> dict:
+    return {
+        "anchor_rot_xyzw": np.array([0, 0, 0, 1], dtype=np.float32),
+        "root_ang_vel_local": np.zeros(3, dtype=np.float32),
+        "dof_pos": np.zeros(29, dtype=np.float32),
+        "dof_vel": np.zeros(29, dtype=np.float32),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_class():
+    """The factory resolves ``"protomotions"`` to the correct class."""
+    cls = import_policy_class("protomotions")
+    assert cls is ProtoMotionsPolicy
+
+
+def test_registry_shorthands_resolve_class():
+    """Every shorthand documented in ``policies.json`` resolves too."""
+    for shorthand in ("gtp", "gtp_g1", "protomotions_g1"):
+        cls = import_policy_class(shorthand)
+        assert cls is ProtoMotionsPolicy, f"shorthand {shorthand!r} failed"
+
+
+def test_factory_creates_policy(stub_session, flat_motion):
+    """``create_policy`` builds a working policy with injected knobs."""
+    p = create_policy("protomotions", session=stub_session, motion=flat_motion)
+    assert isinstance(p, ProtoMotionsPolicy)
+    assert p.provider_name == "protomotions"
+    assert p.num_dofs == 29
+
+
+# ---------------------------------------------------------------------------
+# Construction contract
+# ---------------------------------------------------------------------------
+
+
+def test_construction_requires_onnx_path_or_session():
+    """Building without ``onnx_path`` OR ``session`` is a clean refusal."""
+    with pytest.raises(ValueError, match="onnx_path|session"):
+        ProtoMotionsPolicy()
+
+
+def test_construction_history_length_positive():
+    """``history_length`` must be at least 1."""
+    with pytest.raises(ValueError, match="history_length"):
+        ProtoMotionsPolicy(session=_StubSession(), history_length=0)
+
+
+def test_construction_history_length_shapes_buffer():
+    """The history buffer's shape matches ``history_length`` x ``num_dofs``."""
+    p = ProtoMotionsPolicy(session=_StubSession(), history_length=4)
+    assert p._action_history.shape == (4, 29)
+
+
+def test_load_motion_accepts_cache_dict(stub_session):
+    """Passing a plain dict to ``motion=`` wraps it in a MotionPlayer."""
+    p = ProtoMotionsPolicy(session=stub_session, motion=_make_flat_cache())
+    assert p._motion_player is not None
+    assert p._motion_player.total_frames == 20
+
+
+def test_load_motion_rejects_bad_type(stub_session):
+    """Non-MotionPlayer/dict/str raises ``TypeError`` from ``load_motion``."""
+    p = ProtoMotionsPolicy(session=stub_session)
+    with pytest.raises(TypeError, match="MotionPlayer, cache dict, or path"):
+        p.load_motion(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Non-VLA contract
+# ---------------------------------------------------------------------------
+
+
+def test_requires_images_is_false(policy):
+    """The tracker is proprioceptive - no cameras."""
+    assert policy.requires_images is False
+
+
+def test_config_defaults_match_gtp_g1():
+    """Default config matches the pinned G1 GTP checkpoint."""
+    cfg = ProtoMotionsConfig()
+    assert cfg.num_dofs == 29
+    assert cfg.num_bodies == 33
+    assert cfg.anchor_body_index == 16  # torso_link
+    assert cfg.root_body_index == 0  # pelvis
+    assert cfg.control_dt == 0.02
+    assert cfg.future_step_indices == (1, 2, 4, 8)
+
+
+# ---------------------------------------------------------------------------
+# get_actions behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_get_actions_without_motion_raises():
+    """Calling ``get_actions`` before a motion is loaded is a loud refusal."""
+    p = ProtoMotionsPolicy(session=_StubSession())
+    with pytest.raises(RuntimeError, match="no reference motion loaded"):
+        asyncio.run(p.get_actions({}, "walk"))
+
+
+def test_get_actions_returns_29_joint_dict(policy):
+    """A successful call returns a single-frame list of 29-joint dict."""
+    actions = asyncio.run(policy.get_actions({}, "walk", **_minimal_obs_kwargs()))
+    assert isinstance(actions, list) and len(actions) == 1
+    d = actions[0]
+    assert len(d) == 29
+    assert set(d.keys()) == set(GTP_G1_JOINT_NAMES)
+    assert all(isinstance(v, float) for v in d.values())
+
+
+def test_get_actions_advances_frame_cursor(policy):
+    """Each call advances the playhead by exactly one frame."""
+    for expected in range(1, 4):
+        asyncio.run(policy.get_actions({}, "", **_minimal_obs_kwargs()))
+        assert policy._frame_cursor == expected
+
+
+def test_get_actions_fills_action_history(stub_session, flat_motion):
+    """The rolling history buffer keeps the last N actions."""
+    p = ProtoMotionsPolicy(session=stub_session, motion=flat_motion, history_length=3)
+    # Before first call - all zeros.
+    assert (p._action_history == 0).all()
+    asyncio.run(p.get_actions({}, "", **_minimal_obs_kwargs()))
+    # After one call - last row is the stub's action vector, earlier still zero.
+    assert (p._action_history[:-1] == 0).all()
+    assert not (p._action_history[-1] == 0).all()
+
+
+def test_get_actions_swaps_motion_via_kwarg(stub_session, flat_motion):
+    """Passing ``motion=`` on a per-call kwarg swaps the reference clip."""
+    p = ProtoMotionsPolicy(session=stub_session, motion=flat_motion)
+    # Advance the cursor a bit.
+    for _ in range(3):
+        asyncio.run(p.get_actions({}, "", **_minimal_obs_kwargs()))
+    assert p._frame_cursor == 3
+    # Now swap in a longer motion - cursor resets, history clears.
+    new_motion = MotionPlayer(_make_flat_cache(num_frames=50))
+    asyncio.run(p.get_actions({}, "", motion=new_motion, **_minimal_obs_kwargs()))
+    # After a fresh motion swap and one call, cursor should be exactly 1.
+    assert p._frame_cursor == 1
+
+
+def test_get_actions_uses_kwargs_over_obs(stub_session, flat_motion):
+    """Explicit ``dof_pos`` / ``dof_vel`` kwargs win over the obs dict."""
+    p = ProtoMotionsPolicy(session=stub_session, motion=flat_motion)
+    # Obs dict has malformed per-joint entries; kwargs should be used instead.
+    obs = {"garbage": 42}
+    asyncio.run(p.get_actions(obs, "", **_minimal_obs_kwargs()))
+    assert stub_session.call_count == 1
+    dof_pos_in = stub_session.last_inputs["current_dof_pos"]
+    assert dof_pos_in.shape == (1, 29)
+
+
+def test_get_actions_forwards_correct_input_shapes(policy, stub_session):
+    """The 8 ONNX inputs arrive in the right shapes."""
+    asyncio.run(policy.get_actions({}, "", **_minimal_obs_kwargs()))
+    ins = stub_session.last_inputs
+    assert ins is not None
+    assert ins["current_anchor_rot"].shape == (1, 4)
+    assert ins["current_dof_pos"].shape == (1, 29)
+    assert ins["current_dof_vel"].shape == (1, 29)
+    assert ins["current_root_local_ang_vel"].shape == (1, 3)
+    assert ins["historical_processed_actions"].shape == (1, 1, 29)
+    assert ins["mimic_future_anchor_rot"].shape == (1, 4, 4)
+    assert ins["mimic_future_dof_pos"].shape == (1, 4, 29)
+    assert ins["mimic_future_dof_vel"].shape == (1, 4, 29)
+
+
+def test_get_actions_reset_zeroes_state(policy):
+    """``reset()`` returns the policy to a clean per-episode state."""
+    for _ in range(5):
+        asyncio.run(policy.get_actions({}, "", **_minimal_obs_kwargs()))
+    assert policy._frame_cursor > 0
+    policy.reset()
+    assert policy._frame_cursor == 0
+    assert (policy._action_history == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Robot state-key wiring
+# ---------------------------------------------------------------------------
+
+
+def test_set_robot_state_keys_accepts_full_g1(policy):
+    """A full 29-joint G1 key list is accepted."""
+    keys = list(GTP_G1_JOINT_NAMES) + ["free_joint"]
+    policy.set_robot_state_keys(keys)
+    assert policy._robot_state_keys == keys
+
+
+def test_set_robot_state_keys_refuses_missing_joints(policy):
+    """A partial key list is a loud refusal, not a silent fallback."""
+    with pytest.raises(ValueError, match="missing expected G1 joints"):
+        policy.set_robot_state_keys(list(GTP_G1_JOINT_NAMES[:20]))
+
+
+# ---------------------------------------------------------------------------
+# Session Protocol adherence
+# ---------------------------------------------------------------------------
+
+
+def test_stub_satisfies_protomotions_session_protocol():
+    """The test stub is structurally a :class:`ProtoMotionsSession`."""
+    assert isinstance(_StubSession(), ProtoMotionsSession)

--- a/tests/policies/protomotions/test_protomotions_runtime_contract.py
+++ b/tests/policies/protomotions/test_protomotions_runtime_contract.py
@@ -1,0 +1,290 @@
+"""Contract pins for driving :class:`ProtoMotionsPolicy` from the runtime.
+
+The tracker needs two signals that are not joint state: the WORLD orientation
+of its anchor link and the floating base's body-frame angular velocity. Both
+reach a policy through the observation feed, so the names the policy reads have
+to be the names the runtime writes. These tests pin that agreement, and pin the
+frame itself: ``base_quat`` is the pelvis, the anchor is ``torso_link``, and on
+a G1 sweeping its waist the two differ by up to 42 degrees, so accepting the
+base as a stand-in would be a silently wrong input rather than an approximation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import inspect
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.base import Policy
+from strands_robots.policies.protomotions import (
+    GTP_G1_JOINT_NAMES,
+    ProtoMotionsConfig,
+    ProtoMotionsPolicy,
+)
+
+_NUM_BODIES = 33
+_NUM_DOFS = 29
+
+
+class _RecordingSession:
+    """Stub tracker that records the ONNX inputs it was handed."""
+
+    def __init__(self, targets: np.ndarray | None = None) -> None:
+        self.targets = np.zeros(_NUM_DOFS, dtype=np.float32) if targets is None else targets.astype(np.float32)
+        self.inputs: list[dict[str, np.ndarray]] = []
+
+    def run(self, output_names: list[str] | None, inputs: dict[str, np.ndarray]) -> list[np.ndarray]:
+        self.inputs.append({k: np.asarray(v).copy() for k, v in inputs.items()})
+        row = self.targets.reshape(1, _NUM_DOFS)
+        named = {
+            "actions": row,
+            "joint_pos_targets": row,
+            "stiffness_targets": np.full((1, _NUM_DOFS), 40.0, dtype=np.float32),
+            "damping_targets": np.full((1, _NUM_DOFS), 2.5, dtype=np.float32),
+        }
+        requested = list(output_names or named)
+        return [named[name] for name in requested]
+
+
+def _flat_cache(num_frames: int = 40) -> dict[str, Any]:
+    return {
+        "dof_pos": np.zeros((num_frames, _NUM_DOFS), dtype=np.float32),
+        "dof_vel": np.zeros((num_frames, _NUM_DOFS), dtype=np.float32),
+        "body_rot": np.tile(
+            np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+            (num_frames, _NUM_BODIES, 1),
+        ),
+        "body_pos": np.zeros((num_frames, _NUM_BODIES, 3), dtype=np.float32),
+        "body_vel": np.zeros((num_frames, _NUM_BODIES, 3), dtype=np.float32),
+        "body_ang_vel": np.zeros((num_frames, _NUM_BODIES, 3), dtype=np.float32),
+        "control_dt": 0.02,
+        "num_frames": num_frames,
+    }
+
+
+def _runtime_observation(
+    *,
+    anchor_quat_wxyz: tuple[float, float, float, float],
+    base_quat_wxyz: tuple[float, float, float, float],
+    anchor_body: str = "torso_link",
+    with_velocities: bool = True,
+) -> dict[str, Any]:
+    """Build an observation shaped exactly like a simulation rollout's."""
+    obs: dict[str, Any] = {
+        "base_pos": [0.0, 0.0, 0.79],
+        "base_quat": list(base_quat_wxyz),
+        "base_lin_vel": [0.0, 0.0, 0.0],
+        "base_ang_vel": [0.1, -0.2, 0.3],
+        f"body.{anchor_body}.quat": list(anchor_quat_wxyz),
+    }
+    for i, name in enumerate(GTP_G1_JOINT_NAMES):
+        obs[name] = 0.01 * i
+        if with_velocities:
+            obs[f"{name}.vel"] = 0.001 * i
+    return obs
+
+
+def _policy(session: _RecordingSession, **kwargs: Any) -> ProtoMotionsPolicy:
+    return ProtoMotionsPolicy(session=session, motion=_flat_cache(), **kwargs)
+
+
+def _act(policy: ProtoMotionsPolicy, obs: dict[str, Any]) -> dict[str, float]:
+    return asyncio.run(policy.get_actions(obs, ""))[0]
+
+
+# ---------------------------------------------------------------------------
+# The anchor link the policy cannot derive
+# ---------------------------------------------------------------------------
+
+
+def test_policy_declares_the_anchor_body_the_runtime_must_supply() -> None:
+    """The tracker's anchor link is declared, so the runtime merges its pose."""
+    policy = _policy(_RecordingSession())
+    assert policy.required_bodies == ("torso_link",)
+
+
+def test_anchor_rotation_is_read_from_the_anchor_body_not_the_floating_base() -> None:
+    """``body.torso_link.quat`` wins over ``base_quat`` when both are present.
+
+    A G1 with a 0.6 rad waist yaw puts 42 degrees between the two, so reading
+    the wrong one is a wrong input, not a small error.
+    """
+    session = _RecordingSession()
+    policy = _policy(session)
+    # 90 deg about z as the anchor; identity as the floating base.
+    anchor_wxyz = (0.7071068, 0.0, 0.0, 0.7071068)
+    _act(
+        policy,
+        _runtime_observation(anchor_quat_wxyz=anchor_wxyz, base_quat_wxyz=(1.0, 0.0, 0.0, 0.0)),
+    )
+    sent = session.inputs[0]["current_anchor_rot"].reshape(4)
+    # The ONNX input convention is xyzw.
+    np.testing.assert_allclose(sent, [0.0, 0.0, 0.7071068, 0.7071068], atol=1e-6)
+
+
+def test_a_rollout_observation_needs_no_hand_assembled_kwargs() -> None:
+    """Every ONNX input resolves from the runtime's own observation keys."""
+    session = _RecordingSession()
+    policy = _policy(session)
+    action = _act(
+        policy,
+        _runtime_observation(
+            anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+            base_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        ),
+    )
+    assert set(action) == set(GTP_G1_JOINT_NAMES)
+    sent = session.inputs[0]
+    # base_ang_vel is the root freejoint's qvel[3:6] - already body-frame.
+    np.testing.assert_allclose(sent["current_root_local_ang_vel"].reshape(3), [0.1, -0.2, 0.3], atol=1e-6)
+    np.testing.assert_allclose(
+        sent["current_dof_pos"].reshape(_NUM_DOFS),
+        [0.01 * i for i in range(_NUM_DOFS)],
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        sent["current_dof_vel"].reshape(_NUM_DOFS),
+        [0.001 * i for i in range(_NUM_DOFS)],
+        atol=1e-6,
+    )
+
+
+def test_the_floating_base_is_refused_as_a_stand_in_for_a_distinct_anchor() -> None:
+    """With only ``base_quat`` on the obs, the policy refuses and says why."""
+    policy = _policy(_RecordingSession())
+    obs = _runtime_observation(anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0), base_quat_wxyz=(1.0, 0.0, 0.0, 0.0))
+    del obs["body.torso_link.quat"]
+    with pytest.raises(KeyError) as excinfo:
+        _act(policy, obs)
+    message = str(excinfo.value)
+    assert "torso_link" in message
+    assert "body.torso_link.quat" in message
+    assert "base_quat" in message
+
+
+def test_the_floating_base_is_accepted_when_the_config_anchors_on_the_root() -> None:
+    """A config whose anchor IS the root can legitimately read ``base_quat``."""
+    session = _RecordingSession()
+    root_anchored = dataclasses.replace(ProtoMotionsConfig(), anchor_body_index=ProtoMotionsConfig().root_body_index)
+    policy = _policy(session)
+    policy._config = root_anchored  # noqa: SLF001 - exercising a non-default config
+    assert policy.required_bodies == (root_anchored.root_body_name,)
+    obs = _runtime_observation(
+        anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        base_quat_wxyz=(0.7071068, 0.0, 0.0, 0.7071068),
+    )
+    del obs["body.torso_link.quat"]
+    _act(policy, obs)
+    np.testing.assert_allclose(
+        session.inputs[0]["current_anchor_rot"].reshape(4),
+        [0.0, 0.0, 0.7071068, 0.7071068],
+        atol=1e-6,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-episode reset
+# ---------------------------------------------------------------------------
+
+
+def test_reset_accepts_the_seed_the_runtime_forwards() -> None:
+    """``reset(seed=...)`` is how the runtime starts an episode; it must bind.
+
+    A ``reset(self)`` override raises ``TypeError`` there. The runtime catches
+    that and continues, so the playhead would silently carry over and every
+    episode after the first would resume mid-clip.
+    """
+
+    # Compare the parameter shape, not the annotation text: this module and
+    # the policy module both use postponed annotations, so a raw Signature
+    # comparison would differ on string-vs-object annotations alone.
+    def _shape(fn: Any) -> list[tuple[str, Any]]:
+        return [(name, param.default) for name, param in inspect.signature(fn).parameters.items()]
+
+    assert _shape(ProtoMotionsPolicy.reset) == _shape(Policy.reset)
+    session = _RecordingSession()
+    policy = _policy(session)
+    obs = _runtime_observation(anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0), base_quat_wxyz=(1.0, 0.0, 0.0, 0.0))
+    for _ in range(5):
+        _act(policy, obs)
+    policy.reset(seed=1234)
+    _act(policy, obs)
+    # A reset playhead asks the clip for the same future window as frame 0 did.
+    np.testing.assert_allclose(session.inputs[-1]["mimic_future_dof_pos"], session.inputs[0]["mimic_future_dof_pos"])
+
+
+# ---------------------------------------------------------------------------
+# No silently substituted state
+# ---------------------------------------------------------------------------
+
+
+def test_absent_joint_velocities_are_refused_rather_than_zero_filled() -> None:
+    """Joint velocity is tracker feedback; zeros would degrade it silently."""
+    policy = _policy(_RecordingSession())
+    obs = _runtime_observation(
+        anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        base_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        with_velocities=False,
+    )
+    with pytest.raises(KeyError) as excinfo:
+        _act(policy, obs)
+    # Name the signal that is missing, so the refusal cannot be mistaken for
+    # some other absent input.
+    assert ".vel" in str(excinfo.value)
+
+
+def test_one_absent_joint_velocity_does_not_zero_that_joint() -> None:
+    """A partial velocity set is refused too, naming the joint that is missing."""
+    policy = _policy(_RecordingSession())
+    obs = _runtime_observation(anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0), base_quat_wxyz=(1.0, 0.0, 0.0, 0.0))
+    del obs["waist_yaw_joint.vel"]
+    with pytest.raises(KeyError) as excinfo:
+        _act(policy, obs)
+    assert "waist_yaw_joint.vel" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# ONNX outputs are named, not positional
+# ---------------------------------------------------------------------------
+
+
+def test_joint_targets_are_read_by_output_name_not_by_position() -> None:
+    """A config that declares the outputs in another order still reads targets."""
+    targets = np.linspace(-0.3, 0.3, _NUM_DOFS, dtype=np.float32)
+    session = _RecordingSession(targets=targets)
+    policy = _policy(session)
+    policy._config = dataclasses.replace(  # noqa: SLF001 - non-default output order
+        ProtoMotionsConfig(),
+        onnx_out_names=(
+            "stiffness_targets",
+            "damping_targets",
+            "joint_pos_targets",
+            "actions",
+        ),
+    )
+    action = _act(
+        policy,
+        _runtime_observation(anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0), base_quat_wxyz=(1.0, 0.0, 0.0, 0.0)),
+    )
+    np.testing.assert_allclose([action[name] for name in GTP_G1_JOINT_NAMES], targets, atol=1e-6)
+
+
+def test_a_session_without_joint_pos_targets_is_refused() -> None:
+    """An export missing the PD target output is named, not indexed past."""
+    session = _RecordingSession()
+    policy = _policy(session)
+    policy._config = dataclasses.replace(  # noqa: SLF001 - incomplete export
+        ProtoMotionsConfig(), onnx_out_names=("actions", "stiffness_targets")
+    )
+    with pytest.raises(RuntimeError, match="joint_pos_targets"):
+        _act(
+            policy,
+            _runtime_observation(
+                anchor_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+                base_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+            ),
+        )

--- a/tests/policies/test_provider_policy_docstrings.py
+++ b/tests/policies/test_provider_policy_docstrings.py
@@ -49,6 +49,7 @@ _PROVIDER_POLICIES = {
     "vera/provider.py": "VeraPolicy",
     "motionbricks/policy.py": "MotionBricksPolicy",
     "kimodo/policy.py": "KimodoPolicy",
+    "protomotions/policy.py": "ProtoMotionsPolicy",
 }
 
 # Built-in policy classes documented by test_builtin_policy_docstrings; the

--- a/tests/policies/test_state_key_name_list_contract.py
+++ b/tests/policies/test_state_key_name_list_contract.py
@@ -123,6 +123,7 @@ _MUST_VALIDATE = {
 _TOTAL_BY_MEMBERSHIP = {
     "policies/kimodo/policy.py::KimodoPolicy",
     "policies/motionbricks/policy.py::MotionBricksPolicy",
+    "policies/protomotions/policy.py::ProtoMotionsPolicy",
     "policies/wbc/policy.py::WBCPolicy",
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -5038,6 +5038,11 @@ moveit2 = [
 ollama = [
     { name = "strands-agents", extra = ["ollama"] },
 ]
+protomotions = [
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "pyyaml" },
+]
 ros2 = [
     { name = "cyclonedds" },
 ]
@@ -5120,6 +5125,7 @@ requires-dist = [
     { name = "gymnasium", marker = "extra == 'vera-sim'", specifier = "==0.29.1" },
     { name = "huggingface-hub", marker = "extra == 'all'", specifier = ">=1.5,<2.0.0" },
     { name = "huggingface-hub", marker = "extra == 'kimodo'", specifier = ">=1.5,<2.0.0" },
+    { name = "huggingface-hub", marker = "extra == 'protomotions'", specifier = ">=1.5,<2.0.0" },
     { name = "huggingface-hub", marker = "extra == 'wbc'", specifier = ">=1.5,<2.0.0" },
     { name = "hydra-core", marker = "extra == 'all'", specifier = ">=1.3.0,<2.0.0" },
     { name = "hydra-core", marker = "extra == 'motionbricks'", specifier = ">=1.3.0,<2.0.0" },
@@ -5164,6 +5170,7 @@ requires-dist = [
     { name = "omegaconf", marker = "extra == 'all'", specifier = ">=2.3.0,<3.0.0" },
     { name = "omegaconf", marker = "extra == 'motionbricks'", specifier = ">=2.3.0,<3.0.0" },
     { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.17.0,<2.0.0" },
+    { name = "onnxruntime", marker = "extra == 'protomotions'", specifier = ">=1.17.0,<2.0.0" },
     { name = "onnxruntime", marker = "extra == 'wbc'", specifier = ">=1.17.0,<2.0.0" },
     { name = "opencv-python-headless", specifier = ">=4.5.0,<5.0.0" },
     { name = "pillow", specifier = ">=8.0.0,<13.0.0" },
@@ -5174,6 +5181,7 @@ requires-dist = [
     { name = "pytorch-lightning", marker = "extra == 'all'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pytorch-lightning", marker = "extra == 'motionbricks'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=5.1,<7.0.0" },
+    { name = "pyyaml", marker = "extra == 'protomotions'", specifier = ">=5.1,<7.0.0" },
     { name = "pyyaml", marker = "extra == 'wbc'", specifier = ">=5.1,<7.0.0" },
     { name = "pyzmq", marker = "extra == 'all'", specifier = ">=27.0.0,<28.0.0" },
     { name = "pyzmq", marker = "extra == 'groot-service'", specifier = ">=27.0.0,<28.0.0" },
@@ -5214,7 +5222,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=12.0" },
     { name = "websockets", marker = "extra == 'inference'", specifier = ">=12.0" },
 ]
-provides-extras = ["all", "benchmark-libero", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "curobo", "dev", "device-connect", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "molmoact2", "motionbricks", "moveit2", "ollama", "ros2", "rosbridge", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "vera-sim", "wbc"]
+provides-extras = ["all", "benchmark-libero", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "curobo", "dev", "device-connect", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "vera-sim", "wbc"]
 
 [[package]]
 name = "sympy"


### PR DESCRIPTION
## Problem

`strands_robots` has two kinematic whole-body motion generators for the Unitree G1 - `KimodoPolicy` (text-to-motion diffusion) and `MotionBricksPolicy` - and both emit a `qpos` sequence with no notion of balance. `WBCPolicy` cannot consume one: its only command input is a target velocity / orientation / height, so it has no reference-pose channel. There is currently no provider that takes a reference motion clip and tracks it.

## Change

Adds a `protomotions` provider (shorthands `gtp`, `gtp_g1`, `protomotions_g1`) wrapping a ProtoMotions Generalist Tracking Policy ONNX export. It tracks a reference clip on the G1 and emits PD joint targets for the 29 actuators, in-process on onnxruntime, no GPU required. `qpos_to_motion_data` bridges a generated `qpos` clip into the tracker's reference cache via MuJoCo forward kinematics plus finite-diff velocities, resampled onto the tracker's control rate.

### The anchor frame is not the floating base

The tracker needs one input that is not joint state and is not derivable from joint state: the world orientation of its anchor link, `torso_link`. The observation feed publishes the floating base, and `base_quat` is the **pelvis** - the torso differs from it by the three waist joints.

Measured on the registry G1 in MuJoCo, sweeping the waist through 0.6 rad:

| waist yaw (rad) | `base_quat` vs `torso_link` |
| --- | --- |
| 0.0 | 0.00 deg |
| 0.2 | 13.79 deg |
| 0.4 | 27.92 deg |
| 0.6 | **42.33 deg** |

So the base is not an approximation of the anchor. The policy declares `required_bodies = ("torso_link",)` and the runtime merges `body.torso_link.quat` into every observation - the same "policy declares, runtime supplies" contract as `requires_images`. `base_quat` is accepted only when the config's anchor body **is** the root, where the two are the same frame by definition; otherwise the policy raises and names the key it wanted, rather than silently substituting a wrong frame.

![observation contract](https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-contract/protomotions-observation-contract.png)

### Other contract details

- `reset(seed=None)` matches `Policy.reset`, which the runtime calls once per episode. A narrower `reset(self)` raises `TypeError` there; the runtime catches it and continues, so the playhead would carry over and every episode after the first would resume mid-clip.
- An absent `<joint>.vel` is refused rather than substituted with zero. Joint velocity is tracker feedback, and zeros are a plausible-looking value that quietly degrades tracking.
- ONNX outputs are paired to the names in `config.onnx_out_names` instead of read positionally, so a config declaring them in another order still feeds `joint_pos_targets` to the PD loop, and an export missing that output is refused by name instead of indexed past.
- Optional-dependency guards go through `require_optional`, so the extra each message names is machine-checked. `mujoco` is named as `[sim-mujoco]` (the extra that actually ships it) rather than `[protomotions]`.

## Verification against the real checkpoint

The config loader reads the shipped `unified_pipeline.yaml` sidecar and recovers 29 joints, 33 bodies, anchor index 16 (`torso_link`), root index 0 (`pelvis`), `control_dt` 0.02 and lookahead `(1, 2, 4, 8)`. The graph's declared input and output names and shapes match `onnx_in_names` / `onnx_out_names` exactly.

A 400-tick rollout at 50 Hz on the registry G1, driving a real Kimodo-sampled walking clip through the bridge and the real ONNX graph, steps with `steps_used: 400` and `action_errors: 0`:

https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-contract/protomotions-real-onnx-rollout.mp4

Balanced tracking additionally needs the tracker's own per-joint PD gains to reach the actuators. `ProtoMotionsConfig` carries them (kp 14.3-99.1) and the graph emits `stiffness_targets` / `damping_targets` per tick, while the sim's position servos run a uniform kp=500. Applying them is the `action_controller` shim seam that `WBCPolicy` uses, and is left to a follow-up rather than guessed at here.

## Tests

`ProtoMotionsSession` injects a stub tracker, so the observation-to-action mapping is exercised with no onnxruntime, weights or CUDA. 31 tests: 21 unit tests over config / bridge / player / factory wiring, plus 10 in `test_protomotions_runtime_contract.py` pinning the runtime contract above - which body is declared, that the anchor wins over the base when both are present, that the base is refused for a distinct anchor and accepted for a root anchor, that `reset` binds the seed the runtime forwards, that absent velocities raise, and that outputs are read by name.

Local gate on the full tree: `ruff check`, `ruff format --check` and `mypy` over `strands_robots tests tests_integ` are clean (mypy at the pre-existing 18-error baseline), and the full `pytest tests` run shows no new failures.