### PR TITLE
fix(simulation/mujoco): render the camera an observation key names, never the free camera

### DIFF
--- a/changelog.d/2290-observation-camera-key-view.md
+++ b/changelog.d/2290-observation-camera-key-view.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **MuJoCo observation cameras**: an observation image key now carries the view of
+  the camera it names. A robot's own MJCF cameras are registered under their short
+  name (`wrist`) while the compiled scene holds them namespaced (`arm0/wrist`), and
+  the render loop resolved only the key, so every short key fell through to the free
+  camera and published the scene overview under it - a policy reading
+  `observation.images.wrist`, a recorded dataset column and the agent-tool
+  observation all received the wrong view under a success result, and two cameras on
+  one robot reported the same frame. A key the compiled model cannot answer for
+  (such as one stranded by `remove_robot`) is now omitted rather than filled in with
+  another view, matching `SimEngine.get_observation`'s schema. Joint state is
+  unaffected.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -105,6 +105,15 @@ warning is logged when the implicit `default` overview camera is swept in
 alongside your real sensor cameras, so the stray view is never recorded
 silently.
 
+A robot's own cameras are offered under two names: the short name from its
+MJCF (`wrist`) and the namespaced name the compiled scene uses
+(`arm0/wrist`). Both address the same physical camera and record the same
+frames, so pick one per dataset - listing both records the same view twice
+under two columns. Every camera key carries the view of the camera it names:
+a key the scene can no longer render (for example a camera that left with a
+`remove_robot`) is absent from the observation rather than filled in with the
+overview, so a column is never quietly populated from the wrong camera.
+
 `cameras=` is a list of **distinct** camera names, and every surface that accepts
 one - `start_recording`, `render_all`, and the plain-MP4
 `start_cameras_recording` / `start_cameras_recording_synchronous` - enforces that

--- a/strands_robots/simulation/base.py
+++ b/strands_robots/simulation/base.py
@@ -1090,8 +1090,14 @@ class SimEngine(ABC):
               at the physics-engine level.
             - ``"<camera_name>"`` (np.ndarray): One RGB uint8 frame per
               camera associated with the robot, keyed by camera name.
-              Shape ``(H, W, 3)``. Cameras whose render fails MAY be
-              omitted; joint state MUST still be returned.
+              Shape ``(H, W, 3)``. A key MUST carry the view of the camera it
+              names; a backend that cannot render that camera MUST omit the key
+              rather than substitute another view (the free/overview camera in
+              particular), because every consumer of this schema - a policy
+              reading ``observation.images.<name>``, a recorded dataset column -
+              reads the key as a promise about which camera it is looking
+              through and has no way to detect a substitution. Cameras whose
+              render fails MAY be omitted; joint state MUST still be returned.
             - Floating base: a robot whose root is a 6-DoF free joint (a
               humanoid's named ``floating_base_joint`` or a mobile base's
               unnamed ``<freejoint>``) does NOT report that free joint as a

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -394,7 +394,13 @@ class RenderingMixin:
         (e.g. ``arm0/shoulder_pan`` in MuJoCo to allow multiple same-config
         robots), we look up the prefixed MuJoCo name but return the short
         name in the observation dict so the policy sees a stable, config-level
-        schema regardless of how many robots are in the scene.
+        schema regardless of how many robots are in the scene. That holds for
+        the robot's CAMERAS as well as its joints: ``add_robot`` registers them
+        under their short name (``wrist``) while the compiled model holds them
+        namespaced (``arm0/wrist``), and the registered ``SimCamera`` carries
+        the namespaced name the render lookup needs. A camera key that names
+        nothing in the compiled model is omitted rather than answered with the
+        free camera, per :meth:`SimEngine.get_observation`'s schema.
         """
         mj = _ensure_mujoco()
         assert self._world is not None  # callers must check
@@ -477,8 +483,35 @@ class RenderingMixin:
         for cname in cameras_to_render:
             if not cname:
                 continue
-            cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, cname)
             cam_info = registry_entry(self._world.cameras, cname)
+            # Resolve the MODEL camera this observation key names. The key alone
+            # is not always that name: ``add_robot`` registers a robot's own
+            # MJCF cameras under their SHORT name - the stable, config-level
+            # schema this method documents for joints as well - while the
+            # compiled model holds them namespaced (``arm0/wrist``). The
+            # registered entry carries that namespaced name, so it answers for
+            # the keys the bare lookup cannot.
+            cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, cname)
+            if cam_id < 0:
+                cam_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_CAMERA, getattr(cam_info, "name", None))
+            if cam_id < 0:
+                # Nothing in the compiled model answers for this key, so there
+                # is no view to report under it. Rendering the FREE camera here
+                # instead published the scene overview under a key that names a
+                # specific camera: every consumer of this schema - a policy
+                # reading ``observation.images.<name>``, a recorded LeRobot
+                # dataset column, the agent-tool observation - was handed the
+                # wrong view under a success result, with no signal that the
+                # camera it asked for had not been rendered. An absent key is
+                # the honest answer and the one the other backends give (the
+                # Newton engine omits a camera whose render yields no frame),
+                # and it leaves the joint state intact for callers that only
+                # need proprioception.
+                logger.debug(
+                    "Camera %r names no camera in the compiled model; omitting it from the observation",
+                    cname,
+                )
+                continue
             h = cam_info.height if cam_info else self.default_height
             w = cam_info.width if cam_info else self.default_width
             try:
@@ -486,10 +519,7 @@ class RenderingMixin:
                 if renderer is None:
                     continue
                 viz_option = self._get_viz_option()
-                if cam_id >= 0:
-                    renderer.update_scene(data, camera=cam_id, scene_option=viz_option)
-                else:
-                    renderer.update_scene(data, scene_option=viz_option)
+                renderer.update_scene(data, camera=cam_id, scene_option=viz_option)
                 obs[cname] = renderer.render().copy()
             except (RuntimeError, ValueError) as e:
                 # Individual camera failure shouldn't stop joint state collection.

--- a/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
+++ b/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
@@ -1,0 +1,262 @@
+"""Regression tests: every image key in a MuJoCo observation carries that camera's view.
+
+``_get_sim_observation`` publishes one image per camera key, and those keys come
+from two places: the compiled model's own camera names, and the python-side
+``world.cameras`` registry. The two do not use the same spelling. ``add_robot``
+registers a robot's own MJCF cameras under their SHORT name - the stable,
+config-level schema the method documents for joints as well, so a policy sees
+``wrist`` whatever the robot instance is called - while the compiled model holds
+them namespaced (``arm0/wrist``). The registered ``SimCamera`` carries that
+namespaced name; the key does not.
+
+The render loop resolved the model camera from the KEY alone, so every short key
+missed, and the miss branch rendered the FREE camera and published it under that
+key. The scene overview was therefore served as ``observation["wrist"]``: a
+policy reading ``observation.images.wrist``, a recorded LeRobot dataset column,
+and the agent-tool observation all received the wrong view under a success
+result, with nothing to distinguish it from the camera they asked for. Two short
+keys on one robot were byte-identical to each other for the same reason.
+
+The same branch answered for a key that names no compiled camera at all, which
+``remove_robot`` leaves behind: it deletes the entries whose ``origin_robot`` is
+the departing robot, and a key registered against a different robot survives
+pointing at a camera that left with the model.
+
+So the contract is one sentence - an observation key that names a camera carries
+that camera's view, or is absent - and it is pinned here from both directions:
+
+==================================================  =========================
+case                                                pre-fix
+==================================================  =========================
+short key carries its own robot's view               FAILS (shows overview)
+two short keys carry two different views             FAILS (identical)
+key with no compiled camera is absent                FAILS (shows overview)
+model-named keys unaffected                          passes
+joint state survives an unrenderable key             passes
+==================================================  =========================
+
+The last two rows are the control: the fix must not disturb the keys that
+already resolved, and dropping an image must not cost a caller its
+proprioception. They pass before and after, which is what shows the change is
+scoped to the keys that were wrong.
+
+The oracle is a renderer driven directly against the compiled model, so the
+expectation comes from MuJoCo rather than from the code under test: each model
+camera by name, plus the free camera the buggy branch substituted. Comparing
+against BOTH is what makes the assertions non-vacuous - asserting only "not the
+overview" would pass for any other wrong camera.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.mujoco.simulation import Simulation
+from tests.simulation.mujoco._gl_probe import requires_gl
+
+# A robot carrying two cameras with deliberately dissimilar poses: a close
+# body-mounted view and a wide side view. They must differ from each other and
+# from the free overview for the assertions below to distinguish them.
+TWO_CAMERA_ROBOT_XML = """
+<mujoco model="two_camera_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="key_light" pos="0 0 3" dir="0 0 -1"/>
+    <body name="link" pos="0 0 0.3">
+      <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      <geom name="link_geom" type="box" size="0.05 0.05 0.25" rgba="0.9 0.1 0.1 1"/>
+      <camera name="wrist" pos="0 -0.2 0.25" xyaxes="1 0 0 0 0 1" fovy="70"/>
+    </body>
+    <body name="post" pos="0.6 0 0.2">
+      <geom name="post_geom" type="capsule" size="0.03" fromto="0 0 0 0 0 0.4" rgba="0.1 0.9 0.1 1"/>
+    </body>
+    <camera name="side" pos="0 -1.2 0.4" xyaxes="1 0 0 0 0.3 1" fovy="55"/>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_act" joint="shoulder" kp="20"/>
+  </actuator>
+</mujoco>
+"""
+
+# A second robot with no camera of its own. Adding it is what gives the world a
+# camera key owned by a robot other than the one whose model declares it, and
+# removing the camera-bearing robot is what strands that key.
+CAMERALESS_ROBOT_XML = """
+<mujoco model="cameraless_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="fill_light" pos="1 0 3" dir="0 0 -1"/>
+    <body name="rod" pos="0.5 0 0.2">
+      <joint name="elbow" type="hinge" axis="0 1 0" range="-1.0 1.0"/>
+      <geom name="rod_geom" type="capsule" size="0.03" fromto="0 0 0 0 0 0.3" rgba="0.1 0.1 0.9 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="elbow_act" joint="elbow" kp="20"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _write(xml: str) -> str:
+    path = os.path.join(tempfile.mkdtemp(), "model.xml")
+    with open(path, "w") as handle:
+        handle.write(xml)
+    return path
+
+
+@pytest.fixture
+def sim() -> Any:
+    engine = Simulation()
+    assert engine.create_world()["status"] == "success"
+    try:
+        yield engine
+    finally:
+        engine.destroy()
+
+
+def _image_keys(observation: dict[str, Any]) -> dict[str, np.ndarray]:
+    """The image entries of an observation, keyed as the observation keys them."""
+    return {
+        key: value
+        for key, value in observation.items()
+        if isinstance(value, np.ndarray) and value.ndim == 3 and value.shape[2] == 3
+    }
+
+
+def _reference_views(engine: Simulation, height: int, width: int) -> dict[str, np.ndarray]:
+    """Ground-truth renders straight from MuJoCo: each model camera, plus the free view.
+
+    The expectation for every assertion below comes from here rather than from
+    the observation under test. ``"<free>"`` is the view the miss branch used to
+    publish, so naming it lets a failure say which wrong camera was served.
+    """
+    import mujoco as mj
+
+    world = engine._world
+    assert world is not None
+    model, data = world._model, world._data
+    views: dict[str, np.ndarray] = {}
+    with mj.Renderer(model, height=height, width=width) as renderer:
+        for cam_id in range(int(model.ncam)):
+            name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, cam_id)
+            if not name:
+                continue
+            mj.mj_forward(model, data)
+            renderer.update_scene(data, camera=name)
+            views[name] = renderer.render().copy()
+        mj.mj_forward(model, data)
+        renderer.update_scene(data)
+        views["<free>"] = renderer.render().copy()
+    return views
+
+
+def _view_shown(image: np.ndarray, views: dict[str, np.ndarray]) -> str:
+    """Which reference view ``image`` is, by closest mean absolute pixel difference."""
+    return min(views, key=lambda name: float(np.abs(views[name].astype(int) - image.astype(int)).mean()))
+
+
+def _observe_with_views(engine: Simulation) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    observation = engine.get_observation()
+    images = _image_keys(observation)
+    assert images, "the observation carried no images at all, so nothing below is exercised"
+    height, width = next(iter(images.values())).shape[:2]
+    return images, _reference_views(engine, height, width)
+
+
+@requires_gl
+def test_short_key_carries_the_robots_own_camera_view(sim: Simulation) -> None:
+    """``observation["wrist"]`` is the robot's wrist camera, not the scene overview.
+
+    The key is the short name; the compiled camera is ``arm0/wrist``. Resolving
+    only the key missed and served the free camera under it.
+    """
+    assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
+    images, views = _observe_with_views(sim)
+    assert "arm0/wrist" in views, "premise: the robot's camera compiled under a namespaced name"
+
+    assert "wrist" in images, "the short camera key is part of the observation schema"
+    assert _view_shown(images["wrist"], views) == "arm0/wrist"
+
+
+@requires_gl
+def test_two_short_keys_carry_two_different_views(sim: Simulation) -> None:
+    """Two cameras on one robot contribute two distinct frames.
+
+    Both short keys resolved to the same substituted free camera, so they were
+    byte-identical - a two-camera rig recorded the same image twice.
+    """
+    assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
+    images, views = _observe_with_views(sim)
+
+    assert {"wrist", "side"} <= set(images)
+    assert not np.array_equal(images["wrist"], images["side"]), (
+        "each camera must contribute its own frame; identical frames mean both keys resolved to one substituted camera"
+    )
+    assert _view_shown(images["wrist"], views) == "arm0/wrist"
+    assert _view_shown(images["side"], views) == "arm0/side"
+
+
+@requires_gl
+def test_key_naming_no_compiled_camera_is_absent(sim: Simulation) -> None:
+    """A camera key the compiled model cannot answer for is omitted, not filled in.
+
+    ``remove_robot`` drops the entries owned by the departing robot, so the
+    duplicate key another robot owns outlives the camera it names. There is no
+    view to report under it, and the overview is not a stand-in.
+    """
+    assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
+    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
+    assert sim.remove_robot("arm0")["status"] == "success"
+
+    world = sim._world
+    assert world is not None
+    stranded = [key for key, cam in world.cameras.items() if key.startswith("arm0/")]
+    assert stranded, "premise: removing the camera-bearing robot strands a camera key"
+
+    observation = sim.get_observation()
+    images = _image_keys(observation)
+    for key in stranded:
+        assert key not in images, (
+            f"observation[{key!r}] names a camera that is no longer in the model, so it must be "
+            "absent rather than carrying some other camera's view"
+        )
+
+
+@requires_gl
+def test_model_named_keys_are_unaffected(sim: Simulation) -> None:
+    """The keys that already resolved keep resolving to the same cameras.
+
+    Control: the namespaced model names and the built-in ``default`` view were
+    never mis-resolved, so the fix must leave them exactly as they were.
+    """
+    assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
+    images, views = _observe_with_views(sim)
+
+    for key in ("arm0/wrist", "arm0/side", "default"):
+        assert key in images, f"observation[{key!r}] is part of the schema"
+        assert _view_shown(images[key], views) == key
+
+
+@requires_gl
+def test_joint_state_survives_a_key_with_no_compiled_camera(sim: Simulation) -> None:
+    """Dropping an unrenderable image does not cost the caller its joint state.
+
+    Control: the loop's whole reason for tolerating a per-camera failure is that
+    proprioception must still be reported, so omitting an image must be as
+    survivable as the render failure the loop already handled.
+    """
+    assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
+    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
+    assert sim.remove_robot("arm0")["status"] == "success"
+
+    observation = sim.get_observation("arm1")
+    assert observation["elbow"] == pytest.approx(0.0, abs=1e-6)
+    assert "elbow.vel" in observation


### PR DESCRIPTION
## Problem

`_get_sim_observation` publishes one image per camera key, and those keys come from two places that do not spell a robot's cameras the same way:

- the compiled model's own camera names, which are namespaced per robot (`arm0/wrist`);
- the python-side `world.cameras` registry, where `add_robot` registers a robot's MJCF cameras under their **short** name (`wrist`) - the stable, config-level schema `_get_sim_observation` already documents for joints, so a policy sees `wrist` whatever the robot instance is called.

The render loop resolved the model camera from the **key** alone. Every short key therefore missed, and the miss branch rendered the **free camera** and published it under that key. `observation["wrist"]` was the scene overview - under a success result, indistinguishable from the camera that was asked for. A policy reading `observation.images.wrist`, a recorded LeRobot dataset column and the agent-tool observation all received the wrong view.

Because every short key on a robot collapsed onto the same substituted camera, a multi-camera rig also reported the *same* frame twice. Measured on a two-camera arm over a 110-tick scripted rollout, `observation["front"]` and `observation["wrist"]` were byte-identical on **97 of 110** ticks.

The same branch also answered for a key that names no compiled camera at all, which `remove_robot` strands: it drops the entries whose `origin_robot` is the departing robot, so a key registered against a different robot outlives the camera it names and kept reporting the overview.

## Change

Resolve the model camera through the registered `SimCamera`'s model name when the key itself does not resolve, and omit a key the compiled model cannot answer for instead of substituting a view.

This is what the schema already asked for. `SimEngine.get_observation` documents "one RGB uint8 frame per camera ... keyed by camera name" and that cameras whose render fails "MAY be omitted; joint state MUST still be returned" - and the Newton backend already behaves this way, setting an observation key only when its render yields a frame. MuJoCo was the one backend filling the gap with another camera. Joint state is untouched, so callers that only need proprioception are unaffected.

The contract is now stated on `SimEngine.get_observation`: a key carries the view of the camera it names, or is absent.

## Measured, on the same scripted rollout

| observation key | before | after |
|---|---|---|
| `front` (short key) | scene overview | the robot's front camera |
| `wrist` (short key) | scene overview | the robot's wrist camera |
| `front` vs `wrist` identical | 97 / 110 ticks | 0 / 110 ticks |
| `arm0/wrist`, `arm0/side`, `default` | correct | correct (unchanged) |
| key stranded by `remove_robot` | scene overview | absent |

Ground truth is a `mujoco.Renderer` driven directly against the compiled model - each model camera by name, plus the free camera the miss branch substituted - so the expectation comes from MuJoCo rather than from the code under test. Comparing against both is what makes the assertions non-vacuous: "not the overview" alone would pass for any other wrong camera.

## Visual artifact

Same scripted rollout of one arm, run against `main` and against this branch, showing what `get_observation` actually returns for the two short camera keys. Top row (`main`): two copies of the scene overview. Bottom row (this branch): the front camera and the wrist camera.

![observation camera keys before and after](https://raw.githubusercontent.com/cagataycali/robots/media-obs-camera-keys/obs-camera-keys.gif)

MP4 (higher quality): https://raw.githubusercontent.com/cagataycali/robots/media-obs-camera-keys/obs-camera-keys.mp4

Rendered headless in MuJoCo (`MUJOCO_GL=egl`). Every frame moves (per-frame mean absolute pixel delta min 0.76, mean 2.25), so the panels are a live rollout rather than a still.

## Tests

`tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py`, built from inline MJCF so it needs no downloaded assets and drives only the public API (`add_robot` / `remove_robot` / `get_observation`).

| case | pre-fix |
|---|---|
| short key carries its own robot's view | FAILS (shows overview) |
| two short keys carry two different views | FAILS (identical frames) |
| key with no compiled camera is absent | FAILS (shows overview) |
| model-named keys unaffected | passes |
| joint state survives an unrenderable key | passes |

3 failed / 2 passed before, 5 passed after. The two rows that pass either way are the control: the fix must not disturb the keys that already resolved, and dropping an image must not cost a caller its proprioception.

Full suite run against this branch and against `main` on the same interpreter: identical failure sets (347 pre-existing failing ids on both, all missing optional extras or unrelated), zero new failures, +5 passing. `ruff check`, `ruff format --check` and `mypy` clean over `strands_robots tests tests_integ`.