### PR TITLE
fix(simulation/mujoco): register a robot's own cameras on add_robot, not another robot's

### DIFF
--- a/changelog.d/2291-add-robot-camera-ownership.md
+++ b/changelog.d/2291-add-robot-camera-ownership.md
@@ -1,0 +1,11 @@
+### Fixed
+
+`add_robot` now registers only the cameras the robot being added contributed. It
+walked the merged model's camera table and stripped just that robot's namespace,
+so a camera an earlier robot declared was registered a second time as belonging
+to the new robot: `remove_robot` (which cleans up by owner) then left the
+duplicate advertising a camera the compiled model no longer had, and when two
+robots declared the same short camera name the second robot's own camera was
+dropped from the registry entirely. A second claimant of a short name is now
+registered under its qualified name (`arm2/wrist`) rather than being dropped;
+the short alias stays first-come, so a single-robot scene is unchanged.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -427,6 +427,16 @@ half-applied scene. Use
 
 Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.
 
+A discovered camera is registered under its short MJCF name (`wrist`), and the
+compiled model also carries it namespaced (`so101/wrist`); `render` takes the
+namespaced form, `get_observation` keys on the short one. The short name is
+first-come across robots: when a second robot declares a camera whose short name
+is already taken, that camera is registered under its namespaced name instead
+(logged, naming both), so two arms that both declare `wrist` give you `wrist` and
+`arm2/wrist` rather than one of them shadowing the other. Each camera belongs to
+exactly one robot, which is what makes `remove_robot` take that robot's cameras
+with it and leave every other robot's alone.
+
 To mount a camera ON a moving body (a realistic wrist/gripper view that rides with the arm), pass `parent_body`. Body names are namespaced `<robot>/<body>`; discover the exact mount point with `list_bodies` instead of guessing:
 
 ```python

--- a/strands_robots/simulation/models.py
+++ b/strands_robots/simulation/models.py
@@ -112,6 +112,12 @@ class SimCamera:
     scene builder knows NOT to re-add the camera at the top level (it'll be
     re-introduced via ``spec.attach(robot_spec)``). For user-added cameras
     (via the ``add_camera`` tool action) this stays empty.
+
+    A discovered camera belongs to exactly one robot: the one whose namespace
+    prefixes ``name``. Removing a robot removes its cameras and only its
+    cameras, so ``origin_robot`` must never name a robot outside ``name``'s
+    namespace - otherwise the wrong robot's departure strands or drops the
+    entry.
     """
 
     name: str

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1459,24 +1459,46 @@ class MuJoCoSimEngine(
             # ``{robot.name}/<cam_name>``. We probe the post-compile model
             # instead of the source, which avoids loading a second model
             # just for introspection.
-            pfx = robot.namespace or ""
+            #
+            # The probe walks the MERGED model, so it sees every camera in the
+            # scene - the overview camera, cameras a caller added, and the
+            # cameras of robots already attached. Only the ones under THIS
+            # robot's namespace are its own, hence the prefix test: without it
+            # a camera another robot contributed is registered a second time
+            # under its qualified name and recorded as belonging to the robot
+            # being added now, which makes ``origin_robot`` (the key
+            # ``remove_robot`` cleans up by) name the wrong robot.
+            pfx = robot.namespace or f"{name}/"
             model = self._world._model
             for i in range(model.ncam):
                 cam_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i)
-                if not cam_name:
+                if not cam_name or not cam_name.startswith(pfx):
                     continue
-                # Strip the robot namespace for our Python-side key - the
-                # registry is keyed on the short name and we re-attach the
-                # namespace when passing to the renderer.
-                short = cam_name[len(pfx) :] if cam_name.startswith(pfx) else cam_name
-                if not registered(self._world.cameras, short):
-                    self._world.cameras[short] = SimCamera(
-                        name=cam_name,
-                        camera_id=i,
-                        width=self.default_width,
-                        height=self.default_height,
-                        origin_robot=name,
+                # Key on the short name - the registry is keyed on it and we
+                # re-attach the namespace when passing to the renderer. When
+                # another robot already claimed that short alias (two arms both
+                # declaring ``wrist``), key on the qualified name instead: it is
+                # unique per robot by construction, so the camera stays
+                # addressable and owned rather than being dropped.
+                short = cam_name[len(pfx) :]
+                key = short if not registered(self._world.cameras, short) else cam_name
+                if key != short:
+                    logger.info(
+                        "Robot '%s' camera '%s' registered as '%s': the short name '%s' is "
+                        "already taken by camera '%s'.",
+                        name,
+                        cam_name,
+                        key,
+                        short,
+                        getattr(registry_entry(self._world.cameras, short), "name", short),
                     )
+                self._world.cameras[key] = SimCamera(
+                    name=cam_name,
+                    camera_id=i,
+                    width=self.default_width,
+                    height=self.default_height,
+                    origin_robot=name,
+                )
 
             # Leave the freshly-added robot in a clean, deterministic state:
             # the zero configuration by default, or -- when a spawn keyframe was

--- a/tests/simulation/mujoco/test_add_robot_camera_ownership.py
+++ b/tests/simulation/mujoco/test_add_robot_camera_ownership.py
@@ -1,0 +1,199 @@
+"""``add_robot`` registers the cameras of the robot it is adding, and no others.
+
+A robot's source MJCF may declare its own cameras (a wrist cam, a chest cam).
+``Simulation.add_robot`` picks those up after the attach by walking the compiled
+model's camera table and recording each one in ``world.cameras`` with
+``origin_robot`` set to the robot being added - the field
+:func:`~strands_robots.simulation.mujoco.scene_ops.eject_robot_from_scene`
+later cleans up by, so that removing a robot removes exactly its cameras.
+
+The probe walks the MERGED model, which holds every camera in the scene: the
+overview camera, cameras a caller added, and the cameras of robots already
+attached. It stripped only the namespace of the robot being added now, so a
+camera contributed by an EARLIER robot failed that strip, kept its qualified
+name, and - because that qualified name was free as a registry key - was
+registered a second time as belonging to the robot being added. One physical
+camera, two entries, the second one owned by a robot that does not have it.
+
+Three observable consequences, all pinned below:
+
+* The registry grows an entry per already-attached robot camera on every
+  subsequent ``add_robot``, so it stops agreeing with the compiled model.
+* ``remove_robot`` cleans up by ``origin_robot``, so it takes the first robot's
+  camera entry out with the SECOND robot, and leaves the duplicate behind when
+  the first robot leaves - stranding an entry that names a camera the model no
+  longer has. That is exactly the drift
+  ``tests/simulation/mujoco/test_remove_object_camera_cascade.py`` pins for the
+  object path, whose premise is that the robot path already gets this right.
+* When two robots declare a camera with the SAME short name (two arms both with
+  ``wrist``), the second robot's own camera was dropped from the registry
+  entirely: the short key was taken, and the only entry the add produced was the
+  duplicate of the FIRST robot's camera. The robot's camera had no owner, so no
+  ``remove_robot`` would ever clean it up, and nothing recorded its dimensions.
+
+The short alias stays first-come - it is what a single-robot caller addresses a
+camera by, and the control tests below pin that a lone robot is unaffected. A
+second claimant is registered under its qualified name, which is unique per
+robot by construction, rather than being dropped.
+
+GL-free: ``mesh=False`` and no rendering, so this runs without a GPU. Robots are
+inline MJCF written to ``tmp_path``, so no asset download is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco import simulation as sim_mod  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+_SIM_LOGGER = sim_mod.__name__
+
+# A one-joint robot carrying exactly one camera, so the camera table stays small
+# enough to read directly. No meshes and no <compiler> asset references, so the
+# spec compiles with nothing downloaded.
+_ROBOT_XML = """
+<mujoco model="{model}">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.2">
+      <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" damping="1"/>
+      <geom name="body_geom" type="box" size="0.05 0.05 0.05" rgba="{rgba}"/>
+      <camera name="{camera}" pos="0.3 0 0.1" xyaxes="0 -1 0 0 0 1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def _write_robot(tmp_path: Path, model: str, camera: str, rgba: str = "0.8 0.2 0.2 1") -> str:
+    path = tmp_path / f"{model}.xml"
+    path.write_text(_ROBOT_XML.format(model=model, camera=camera, rgba=rgba))
+    return str(path)
+
+
+def _model_camera_names(sim: Any) -> list[str]:
+    """Camera names the compiled model actually carries."""
+    import mujoco as mj
+
+    model = sim._world._model
+    names = [mj.mj_id2name(model, mj.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+    return [n for n in names if n]
+
+
+def _registry(sim: Any) -> dict[str, tuple[str, str]]:
+    """``world.cameras`` as ``{key: (camera name, owning robot)}``."""
+    return {key: (cam.name, cam.origin_robot) for key, cam in sim._world.cameras.items()}
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_add_robot_camera_ownership_sim", mesh=False)
+    s.create_world(gravity=[0, 0, -9.81])
+    yield s
+    s.cleanup(policy_stop_timeout=0.5)
+
+
+@pytest.fixture
+def two_robots(sim, tmp_path):
+    """``rover`` (camera ``front``) then ``arm`` (camera ``wrist``)."""
+    assert sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_model", "front"))["status"] == "success"
+    assert (
+        sim.add_robot("arm", urdf_path=_write_robot(tmp_path, "arm_model", "wrist", "0.2 0.8 0.2 1"))["status"]
+        == "success"
+    )
+    return sim
+
+
+class TestEachCameraIsRegisteredOnceToTheRobotThatHasIt:
+    def test_adding_a_second_robot_does_not_re_register_the_first_robots_camera(self, two_robots) -> None:
+        registry = _registry(two_robots)
+        entries_per_camera: dict[str, list[str]] = {}
+        for key, (cam_name, _owner) in registry.items():
+            entries_per_camera.setdefault(cam_name, []).append(key)
+        duplicated = {cam: keys for cam, keys in entries_per_camera.items() if len(keys) > 1}
+        assert duplicated == {}, f"one camera under several registry keys: {duplicated} (registry {registry})"
+
+    def test_no_robot_owns_a_camera_from_another_robots_namespace(self, two_robots) -> None:
+        registry = _registry(two_robots)
+        misowned = {
+            key: (cam_name, owner)
+            for key, (cam_name, owner) in registry.items()
+            if owner and not cam_name.startswith(f"{owner}/")
+        }
+        assert misowned == {}, f"entries owned by a robot outside their namespace: {misowned}"
+
+    def test_the_registry_holds_one_entry_per_camera_in_the_model(self, two_robots) -> None:
+        assert sorted(cam for cam, _ in _registry(two_robots).values()) == sorted(_model_camera_names(two_robots))
+
+
+class TestRemovingARobotRemovesExactlyItsOwnCameras:
+    def test_the_departed_robots_camera_leaves_the_registry(self, two_robots) -> None:
+        assert two_robots.remove_robot("rover")["status"] == "success"
+        assert [cam for cam, _ in _registry(two_robots).values() if cam.startswith("rover/")] == []
+
+    def test_no_entry_survives_naming_a_camera_the_model_no_longer_has(self, two_robots) -> None:
+        two_robots.remove_robot("rover")
+        present = set(_model_camera_names(two_robots))
+        stranded = {key: cam for key, (cam, _owner) in _registry(two_robots).items() if cam not in present}
+        assert stranded == {}, f"registry advertises cameras the compiled model does not have: {stranded}"
+
+    def test_the_remaining_robot_keeps_its_own_camera(self, two_robots) -> None:
+        two_robots.remove_robot("rover")
+        assert ("arm/wrist", "arm") in _registry(two_robots).values()
+
+
+class TestASharedShortNameKeepsBothCamerasOwned:
+    @pytest.fixture
+    def colliding(self, sim, tmp_path):
+        """Both robots declare a camera named ``front``."""
+        sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_c", "front"))
+        sim.add_robot("arm", urdf_path=_write_robot(tmp_path, "arm_c", "front", "0.2 0.8 0.2 1"))
+        return sim
+
+    def test_the_second_robots_camera_is_registered_and_owned(self, colliding) -> None:
+        assert ("arm/front", "arm") in _registry(colliding).values(), _registry(colliding)
+
+    def test_the_first_robot_keeps_the_short_alias(self, colliding) -> None:
+        assert _registry(colliding)["front"] == ("rover/front", "rover")
+
+    def test_removing_the_first_robot_keeps_the_second_robots_camera(self, colliding) -> None:
+        colliding.remove_robot("rover")
+        assert ("arm/front", "arm") in _registry(colliding).values()
+        present = set(_model_camera_names(colliding))
+        assert all(cam in present for cam, _ in _registry(colliding).values()), _registry(colliding)
+
+    def test_the_qualified_key_is_reported_with_the_name_that_took_the_alias(self, sim, tmp_path, caplog) -> None:
+        sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_l", "front"))
+        with caplog.at_level(logging.INFO, logger=_SIM_LOGGER):
+            sim.add_robot("arm", urdf_path=_write_robot(tmp_path, "arm_l", "front", "0.2 0.8 0.2 1"))
+        reported = [r.getMessage() for r in caplog.records if "already taken" in r.getMessage()]
+        assert len(reported) == 1, [r.getMessage() for r in caplog.records]
+        for token in ("'arm'", "'arm/front'", "'front'", "'rover/front'"):
+            assert token in reported[0], reported[0]
+
+
+class TestTheSingleRobotAndUserCameraPathsAreUnchanged:
+    """Controls: these hold both before and after the ownership fix."""
+
+    def test_a_lone_robots_camera_is_addressed_by_its_short_name(self, sim, tmp_path) -> None:
+        sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_solo", "front"))
+        assert _registry(sim)["front"] == ("rover/front", "rover")
+
+    def test_a_robot_add_leaves_a_user_camera_unowned(self, sim, tmp_path) -> None:
+        assert sim.add_camera(name="overview", position=[0.9, -0.9, 0.6], target=[0.0, 0.0, 0.1])["status"] == "success"
+        sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_user", "front"))
+        assert _registry(sim)["overview"][1] == ""
+
+    def test_a_robot_add_does_not_claim_the_scene_overview_camera(self, sim, tmp_path) -> None:
+        sim.add_robot("rover", urdf_path=_write_robot(tmp_path, "rover_default", "front"))
+        assert _registry(sim)["default"][1] == ""


### PR DESCRIPTION
## Problem

`add_robot` discovers the cameras a robot's MJCF declared by walking the compiled model's camera table after the attach. That table belongs to the **merged** model, so it also holds the overview camera, cameras a caller added, and the cameras of robots already attached. The loop stripped only the namespace of the robot being added:

```python
short = cam_name[len(pfx):] if cam_name.startswith(pfx) else cam_name
if not registered(self._world.cameras, short):
    self._world.cameras[short] = SimCamera(..., origin_robot=name)
```

A camera contributed by an **earlier** robot fails that `startswith`, keeps its qualified name, and - because the qualified name is free as a registry key - is registered a second time with `origin_robot` set to the robot being added now.

Measured, two robots each declaring one camera (`rover` then `arm`):

| | model cameras | `world.cameras` |
|---|---|---|
| after `add_robot("rover")` | `default`, `rover/front` | `front` -> `rover/front` (owner `rover`) |
| after `add_robot("arm")` | `default`, `rover/front`, `arm/wrist` | `front` -> `rover/front` (`rover`), **`rover/front` -> `rover/front` (`arm`)**, `wrist` -> `arm/wrist` (`arm`) |

Four entries for three cameras, and the extra one is owned by a robot that does not have it. Three consequences follow:

1. **`remove_robot` cleans up by `origin_robot`**, so the duplicate outlives its real owner. After `remove_robot("rover")` the model has 2 cameras and the registry still advertises `rover/front` - the exact drift `tests/simulation/mujoco/test_remove_object_camera_cascade.py` pins for the object path, whose premise is that the robot path already gets this right.
2. **A robot's own camera can be dropped entirely.** When both robots declare a camera named `front`, the short key is already taken, so the only entry `add_robot("arm")` produces is the duplicate of *rover's* camera. `arm/front` gets no registry entry at all: no owner (so no `remove_robot` ever cleans it up) and no recorded dimensions.
3. The registry stops agreeing with the compiled model, and it grows another stale entry per already-attached robot camera on every subsequent `add_robot`.

## Change

Register only the cameras under this robot's namespace (`robot.namespace` is always `"<name>/"`, set by `add_robot` itself). When another robot already holds the short alias, key on the qualified name - unique per robot by construction - instead of dropping the camera, and log it naming both keys.

The short alias stays first-come: it is what a single-robot caller addresses a camera by, so a lone robot is byte-identical. Two arms that both declare `wrist` now give `wrist` and `arm2/wrist` rather than one shadowing the other.

No change to `eject_robot_from_scene` - its `origin_robot` filter was already correct; it was being fed the wrong owner.

## Visual

Two robots, each with a body-mounted camera named `front` looking back at itself (red box = `rover`, green post = `arm`). Each panel is the camera `world.cameras` says that robot owns, rendered in MuJoCo headless.

![add_robot camera ownership before and after](https://raw.githubusercontent.com/cagataycali/robots/media-add-robot-camera-ownership/camera_ownership.png)

Before, the camera the library attributes to `arm` is `rover/front`, so both panels are the same image: mean absolute pixel delta between them is **0.00012** on a 0-255 scale - pixel-identical. After, they differ by **25.38**, and the `rover` panel is unchanged by the fix (**0.00011**), which is the no-op control for the single-robot path.

## Tests

`tests/simulation/mujoco/test_add_robot_camera_ownership.py`, 13 tests, GL-free (`mesh=False`, no rendering) with inline MJCF robots in `tmp_path` so nothing is downloaded. Against `main`: **8 fail, 5 pass**. With the fix: 13 pass.

Fail pre-fix - one entry per camera, no cross-namespace ownership, registry agrees with the model, the departed robot's camera leaves, nothing survives naming a camera the model lost, the second robot's camera is registered and owned, it survives the first robot's removal, and the collision is reported.

Pass pre-fix (the boundary and over-reach controls, so the fix is pinned as not reaching further than the defect): a lone robot's camera keeps its short name, the first robot keeps the short alias, the surviving robot keeps its own camera, an `add_camera` camera stays unowned, and the scene overview camera is never claimed by a robot.

Full suite on the branch vs `main`: 116 vs 117 failing ids, `comm` of the sorted id sets shows **no new failures**. The one delta (`test_hardware_task_loop_dispatch.py::TestTheRolloutIsDrivenExactlyOnce::test_on_the_sync_branch`, `assert 9 == 10`) is a wall-clock flake in a rate-guarded loop that also fails intermittently on `main` in isolation, not something this change fixes. `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Docs

`docs/simulation/world-building.md` gains the naming rule next to the sentence that already documents auto-discovery: short name first-come, qualified name for a second claimant, one owner per camera. `SimCamera.origin_robot` states the invariant it has to hold for `remove_robot` to be correct.