### PR TITLE
fix(simulation): solve move_to IK over the joints it commands, not the whole model

### DIFF
--- a/changelog.d/2292-move-to-commanded-dof-solve.md
+++ b/changelog.d/2292-move-to-commanded-dof-solve.md
@@ -1,0 +1,15 @@
+### Fixed
+
+`move_to` now solves inverse kinematics over the joints it commands instead of
+the whole model, so `ik_residual_m` is the error the servo descent is actually
+left with. `mink` optimizes every degree of freedom in the model it is handed,
+so on a mobile manipulator or a humanoid the solve satisfied the Cartesian task
+by sliding the floating base, left the commanded arm joints untouched, and
+reported a near-zero residual for a target well outside the arm's reach; the
+primitive then accepted it, servoed its whole `max_steps` budget, and blamed the
+servo for a point it could never reach. Where the discovered tool frame sits on
+the jaw, the same borrowing opened the gripper the primitive documents as held.
+`MinkIKBridge` gained `commanded_dofs` for this, and the unreachable refusal now
+reports `unrestricted_ik_residual_m` and `uncommanded_joints_moved` so a target
+outside the robot's workspace is distinguishable from one that needs base
+motion. Behaviour on a fully actuated fixed-base arm is unchanged.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,6 +29,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | Sim hangs on `create_world` | Asset download | Wait - first call downloads MJCF, then cached |
 | `ModuleNotFoundError: trs_so_arm100_mj_description` | Auto-install failed | `uv pip install trs-so-arm100-mj-description` |
 | `add_robot` raises after `load_scene` | Scene XML overrides world | Use `add_robot` before `load_scene` |
+| `move_to` refuses with `is unreachable ... The same target solves to ... once the N degree(s) of freedom move_to does not command are free too` | The target needs motion `move_to` does not produce. It drives the arm's position servos only, so a mobile base, a floating pelvis or any unactuated joint is not available to the solve - and 35 of the shipped sim robots have one | Move those degrees of freedom first (drive the base to the work area), then call `move_to`. The refusal's `uncommanded_joints_moved` names them and `unrestricted_ik_residual_m` is what the whole robot could reach |
 
 ## Hardware
 

--- a/strands_robots/simulation/ik.py
+++ b/strands_robots/simulation/ik.py
@@ -29,6 +29,7 @@ class attributes so the error a user sees names the extra they actually need.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -131,10 +132,25 @@ class MinkIKBridge:
         dt: Integration timestep for each IK iteration (s).
         pos_threshold: Convergence threshold on position error (m).
         ori_threshold: Convergence threshold on orientation error (rad).
+        commanded_dofs: Velocity-space (``nv``) indices of the ONLY degrees of
+            freedom the caller can command, or ``None`` (default) to leave the
+            whole model free. ``mink`` optimizes over every DOF in ``model``,
+            so an unconstrained solve is free to satisfy the Cartesian task by
+            moving a DOF the caller will never send - a floating base, a second
+            robot sharing the world model, a gripper the caller holds - and
+            :meth:`solve` then returns, and :meth:`ee_pose` then scores, a
+            configuration that is never realized. Restricting the solve keeps
+            the returned configuration (and therefore any residual measured on
+            it) inside what the caller can actually reach. ``None`` is correct
+            only when the caller drives every DOF the frame depends on.
 
     Raises:
         ImportError: If ``mink``/``mujoco`` are not importable (with an
             actionable install hint).
+        ValueError: If ``commanded_dofs`` is empty or names an index outside
+            ``range(model.nv)`` - a solve that may move nothing, or a mask
+            built against a different model, is a caller bug rather than a
+            configuration to silently widen.
     """
 
     # Provider subclasses override these so failures name the extra the user
@@ -158,6 +174,7 @@ class MinkIKBridge:
         dt: float = 1e-2,
         pos_threshold: float = 1e-3,
         ori_threshold: float = 1e-3,
+        commanded_dofs: Sequence[int] | None = None,
     ) -> None:
         try:
             import mink
@@ -174,6 +191,11 @@ class MinkIKBridge:
         self.dt = dt
         self.pos_threshold = pos_threshold
         self.ori_threshold = ori_threshold
+
+        # Read model.nv only when a mask is asked for: the unrestricted path must
+        # touch nothing new, so a caller solving on a minimal model object is
+        # unaffected by this parameter existing.
+        self._dof_mask = None if commanded_dofs is None else self._build_dof_mask(int(model.nv), commanded_dofs)
 
         self._configuration = mink.Configuration(model)
         self._frame_task = mink.FrameTask(
@@ -193,6 +215,43 @@ class MinkIKBridge:
             self.solver,
             model.nq,
         )
+
+    @staticmethod
+    def _build_dof_mask(nv: int, commanded_dofs: Sequence[int] | None) -> np.ndarray | None:
+        """Boolean ``nv`` mask of the commandable DOFs, or ``None`` for all.
+
+        Args:
+            nv: The model's velocity-space dimension.
+            commanded_dofs: Indices to allow, or ``None`` to allow everything.
+
+        Returns:
+            A length-``nv`` boolean mask, or ``None`` when the whole model is
+            free (which keeps the unrestricted path allocation-free).
+
+        Raises:
+            ValueError: ``commanded_dofs`` is empty, holds a non-integer (a
+                ``bool`` included - it is an ``int`` subclass that would act as
+                index 0 or 1), or names an index outside ``range(nv)``.
+        """
+        if commanded_dofs is None:
+            return None
+        indices = list(commanded_dofs)
+        if not indices:
+            raise ValueError(
+                "commanded_dofs is empty, so the solve could not move any degree of freedom. "
+                "Pass the indices the caller commands, or None to leave the whole model free."
+            )
+        mask = np.zeros(nv, dtype=bool)
+        for index in indices:
+            if isinstance(index, bool) or not isinstance(index, (int, np.integer)):
+                raise ValueError(f"commanded_dofs must hold integer velocity-space indices; got {index!r}.")
+            if not 0 <= int(index) < nv:
+                raise ValueError(
+                    f"commanded_dofs index {int(index)} is outside range(model.nv) = range({nv}). "
+                    "The mask must be built against the same model this bridge solves on."
+                )
+            mask[int(index)] = True
+        return mask
 
     def ee_pose(self, qpos: np.ndarray) -> np.ndarray:
         """Forward kinematics: ``(4, 4)`` EE pose at a joint configuration.
@@ -218,6 +277,8 @@ class MinkIKBridge:
 
         Returns:
             The solved joint configuration (length ``model.nq``, ``float64``).
+            When ``commanded_dofs`` was given, every DOF outside it holds its
+            ``q_init`` value exactly, so the caller can realize the answer.
         """
         mink = self._mink
         q = np.asarray(q_init, dtype=np.float64).copy()
@@ -229,6 +290,15 @@ class MinkIKBridge:
 
         for _ in range(self.max_iters):
             velocity = mink.solve_ik(self._configuration, self._tasks, self.dt, self.solver, self.damping)
+            if self._dof_mask is not None:
+                # Project the step onto the commandable subspace before
+                # integrating. Zeroing here rather than post-filtering the
+                # solution keeps every later iteration honest: the next
+                # solve_ik sees the error that actually remains, so the loop
+                # converges to the best configuration the caller can command
+                # instead of one it can only report.
+                velocity = np.asarray(velocity, dtype=np.float64).copy()
+                velocity[~self._dof_mask] = 0.0
             self._configuration.integrate_inplace(velocity, self.dt)
             err = self._frame_task.compute_error(self._configuration)
             if np.linalg.norm(err[:3]) <= self.pos_threshold and np.linalg.norm(err[3:]) <= self.ori_threshold:

--- a/strands_robots/simulation/isaac/motion_primitives.py
+++ b/strands_robots/simulation/isaac/motion_primitives.py
@@ -628,6 +628,18 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
         ``_require_no_running_policy`` guard - checked up front and per
         control tick (a policy starting mid-run aborts the primitive).
 
+        COMMANDED-DOF SOLVE (contract): the IK solve is restricted to the
+        arm joints this primitive drives, so ``ik_residual_m`` is the error the
+        servo descent is actually left with. mink optimizes over every degree
+        of freedom in the IK model, and an unrestricted solve borrows whatever
+        is cheapest - a floating/mobile base, the gripper this primitive holds
+        - neither of which ``move_to`` commands; the borrowed solve then
+        reports a near-zero residual for a pose the arm cannot hold. Same rule
+        as the MuJoCo backend, so the two judge reachability identically. When
+        the restricted solve cannot reach the target, the refusal re-solves
+        unrestricted and names the degrees of freedom that would have to move
+        first.
+
         NOT collision-aware: the straight servo descent can sweep through
         obstacles - the same contract as the MuJoCo backend, which
         deliberately hides the solver so a collision-aware upgrade cannot
@@ -654,8 +666,14 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
             ``{reached, steps, position_error_m, ik_residual_m, ee_position,
             ee_orientation_wxyz, frame, frame_type}`` on arrival;
             ``{"status": "error", ...}`` with the same json block (including
-            the residual) when the target is unreachable (IK residual > tol)
-            or servo convergence times out. Never raises.
+            the residual) when servo convergence times out. The unreachable
+            refusal (restricted IK residual > tol) carries
+            ``{reached, steps, ik_residual_m, unrestricted_ik_residual_m,
+            uncommanded_joints_moved, frame, frame_type}`` - the last two
+            reporting what a solve over the whole model could have reached and
+            which uncommanded joints it needed, so the caller can tell an
+            out-of-workspace target from one needing base motion. Never
+            raises.
         """
         # ---- parameter validation (before touching the world) ----
         # Shared with the MuJoCo adapter (motion_primitives_base): same
@@ -737,12 +755,21 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
                     # for the same reason as the MuJoCo mixin: move_to jumps
                     # from the current pose to an arbitrary workspace point in
                     # one solve and needs the extra integration budget.
+                    # commanded_dofs restricts the solve to the arm joints
+                    # the articulation targets below actually drive. mink
+                    # optimizes over every DOF of the IK model, so an
+                    # unrestricted solve can satisfy the Cartesian task with a
+                    # floating base or the held gripper and then report a
+                    # residual for a configuration that is never commanded.
+                    # Same restriction as the MuJoCo mixin, so the two backends
+                    # judge reachability by the same rule.
                     bridge = MinkIKBridge(
                         model,
                         frame_name,
                         frame_type,
                         orientation_cost=1.0 if target_quat is not None else 0.0,
                         max_iters=200,
+                        commanded_dofs=self._commanded_dof_indices(model, arm_map),
                     )
                 except (ImportError, RuntimeError, ValueError) as e:
                     return _err(f"move_to: IK bridge unavailable: {e}")
@@ -806,17 +833,35 @@ class IsaacMotionPrimitivesMixin(MotionPrimitivesCore):
                             break
 
                 if ik_residual > float(tol):
-                    return _err(
-                        f"move_to: target {target_world.tolist()} is unreachable for '{name}' "
-                        f"within tol={float(tol)} m - best IK solution leaves a residual of "
-                        f"{ik_residual:.4f} m. Choose a closer target or loosen tol.",
-                        {
-                            "reached": False,
-                            "steps": 0,
-                            "ik_residual_m": ik_residual,
-                            "frame": frame_name,
-                            "frame_type": frame_type,
-                        },
+                    # Refusal-path diagnosis only (mirrors the MuJoCo mixin):
+                    # re-solve with every model DOF free so the refusal can
+                    # tell a point outside the robot's workspace from one that
+                    # needs motion this primitive does not command.
+                    unrestricted_residual = math.inf
+                    uncommanded: list[str] = []
+                    try:
+                        reference = MinkIKBridge(
+                            model,
+                            frame_name,
+                            frame_type,
+                            orientation_cost=1.0 if target_quat is not None else 0.0,
+                            max_iters=200,
+                        )
+                    except (ImportError, RuntimeError, ValueError):  # pragma: no cover - restricted build worked
+                        pass
+                    else:
+                        q_free = reference.solve(target_pose, q0)
+                        unrestricted_residual = float(np.linalg.norm(reference.ee_pose(q_free)[:3, 3] - target_local))
+                        uncommanded = self._uncommanded_joints_moved(mj, model, arm_map, q0, q_free)
+                    return self._move_to_unreachable_error(
+                        name,
+                        target_world,
+                        float(tol),
+                        ik_residual=ik_residual,
+                        frame_name=frame_name,
+                        frame_type=frame_type,
+                        unrestricted_residual=unrestricted_residual,
+                        uncommanded_joints=uncommanded,
                     )
 
                 # Command ARM DOFs to the solve, per name; HOLD gripper DOFs

--- a/strands_robots/simulation/motion_primitives_base.py
+++ b/strands_robots/simulation/motion_primitives_base.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import math
 import numbers
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 import numpy as np
@@ -307,6 +308,136 @@ class MotionPrimitivesCore:
             f"{ik_residual:.4f} m). The servo may need more steps, or the pose fights joint "
             "limits/contacts.",
             payload,
+        )
+
+    @staticmethod
+    def _commanded_dof_indices(model: Any, commanded_joint_ids: Iterable[int]) -> list[int]:
+        """Velocity-space indices of the joints a primitive's servos command.
+
+        The position servos ``move_to`` drives command one scalar per joint, so
+        the commandable subspace is the first DOF of each of those joints. This
+        is the mask handed to
+        :class:`strands_robots.simulation.ik.MinkIKBridge` as ``commanded_dofs``
+        so the solve cannot answer with motion the servo loop never sends.
+
+        Args:
+            model: The ``mujoco.MjModel`` the IK bridge solves on.
+            commanded_joint_ids: MuJoCo joint ids the primitive commands.
+
+        Returns:
+            The corresponding ``nv``-space indices, ascending.
+        """
+        return sorted(int(model.jnt_dofadr[joint_id]) for joint_id in commanded_joint_ids)
+
+    @staticmethod
+    def _uncommanded_joints_moved(
+        mj: Any,
+        model: Any,
+        commanded_joint_ids: Iterable[int],
+        q_before: np.ndarray,
+        q_after: np.ndarray,
+        namespace: str = "",
+    ) -> list[str]:
+        """Names of the uncommanded joints a solve moved, for the refusal text.
+
+        Used only on the unreachable path, to say WHY a target the arm cannot
+        reach is nonetheless solvable: an unrestricted solve reports which
+        degrees of freedom it had to borrow (a mobile base, a held gripper),
+        which is the difference between "outside the workspace" and "needs
+        motion this primitive does not command".
+
+        Args:
+            mj: The ``mujoco`` module.
+            model: The model both configurations belong to.
+            commanded_joint_ids: Joint ids the primitive commands (excluded).
+            q_before: Seed configuration (length ``model.nq``).
+            q_after: Solved configuration (length ``model.nq``).
+            namespace: Robot namespace prefix to strip from reported names.
+
+        Returns:
+            Joint names (namespace-stripped, ascending by joint id) whose
+            configuration the solve changed and which are not commanded. An
+            unnamed joint (a bare ``<freejoint/>``) is reported by index.
+        """
+        commanded = {int(joint_id) for joint_id in commanded_joint_ids}
+        moved: list[str] = []
+        for joint_id in range(int(model.njnt)):
+            if joint_id in commanded:
+                continue
+            start = int(model.jnt_qposadr[joint_id])
+            end = int(model.jnt_qposadr[joint_id + 1]) if joint_id + 1 < int(model.njnt) else int(model.nq)
+            if np.allclose(q_before[start:end], q_after[start:end], atol=1e-9, rtol=0.0):
+                continue
+            name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, joint_id) or ""
+            if namespace and name.startswith(namespace):
+                name = name[len(namespace) :]
+            moved.append(name or f"unnamed joint {joint_id}")
+        return moved
+
+    @staticmethod
+    def _move_to_unreachable_error(
+        robot_name: str,
+        target: np.ndarray,
+        tol: float,
+        *,
+        ik_residual: float,
+        frame_name: str,
+        frame_type: str,
+        unrestricted_residual: float,
+        uncommanded_joints: Sequence[str],
+    ) -> dict[str, Any]:
+        """Unreachable-target refusal for ``move_to``, shared across backends.
+
+        ``ik_residual`` is measured on a solve restricted to the joints the
+        primitive commands, so it is the error the servo descent would actually
+        be left with. ``unrestricted_residual`` is the same target solved with
+        the whole model free: when that one fits ``tol`` the target is inside
+        the reach of the ROBOT but outside the reach of this PRIMITIVE, and the
+        remedy is to move the borrowed degrees of freedom rather than to pick a
+        closer point or loosen the tolerance.
+
+        Args:
+            robot_name: Robot the target was requested for.
+            target: The requested Cartesian target (in the frame the message
+                reports it in - world for MuJoCo, world for Isaac).
+            tol: Position tolerance the request was judged against (m).
+            ik_residual: Best residual over the commanded joints (m).
+            frame_name: End-effector frame the solve tracked.
+            frame_type: ``"site"`` / ``"body"`` / ``"geom"``.
+            unrestricted_residual: Best residual with every model DOF free (m).
+            uncommanded_joints: Uncommanded joints that unrestricted solve
+                moved, as named by :meth:`_uncommanded_joints_moved`.
+
+        Returns:
+            The structured error envelope, json block included.
+        """
+        text = (
+            f"move_to: target {target.tolist()} is unreachable for '{robot_name}' within "
+            f"tol={float(tol)} m - the best solve over the joints move_to commands leaves a "
+            f"residual of {ik_residual:.4f} m."
+        )
+        if uncommanded_joints and unrestricted_residual <= float(tol):
+            text += (
+                f" The same target solves to {unrestricted_residual:.4f} m once the "
+                f"{len(uncommanded_joints)} degree(s) of freedom move_to does not command are "
+                f"free too ({', '.join(uncommanded_joints)}), so the point is not outside the "
+                "robot's workspace: reaching it needs motion this primitive cannot produce. "
+                "move_to drives the arm's position servos only, so move those degrees of "
+                "freedom first (a mobile base has to drive there), then call move_to."
+            )
+        else:
+            text += " Choose a closer target or loosen tol."
+        return _err(
+            text,
+            {
+                "reached": False,
+                "steps": 0,
+                "ik_residual_m": ik_residual,
+                "unrestricted_ik_residual_m": unrestricted_residual,
+                "uncommanded_joints_moved": list(uncommanded_joints),
+                "frame": frame_name,
+                "frame_type": frame_type,
+            },
         )
 
     @staticmethod

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -399,6 +399,60 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
         bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, frame_name)
         return np.array(data.xpos[bid], dtype=np.float64), np.array(data.xquat[bid], dtype=np.float64)
 
+    def _diagnose_unreachable(
+        self,
+        model: Any,
+        frame_name: str,
+        frame_type: str,
+        target_quat: np.ndarray | None,
+        target_pose: np.ndarray,
+        target: np.ndarray,
+        q0: np.ndarray,
+        arm_jact: dict[int, int],
+        namespace: str,
+    ) -> tuple[float, list[str]]:
+        """Best residual with every model DOF free, and the DOFs that took it.
+
+        Runs on the ``move_to`` refusal path only (see
+        :meth:`MotionPrimitivesCore._move_to_unreachable_error`): the primitive
+        solves over its commanded joints, and this reports what an unrestricted
+        solve could have done, so the refusal distinguishes a point outside the
+        robot's workspace from one that needs uncommanded motion.
+
+        Args:
+            model: The world ``mujoco.MjModel``.
+            frame_name: End-effector frame the solve tracks.
+            frame_type: ``"site"`` / ``"body"`` / ``"geom"``.
+            target_quat: Requested orientation, or ``None`` for position-only.
+            target_pose: The ``(4, 4)`` target the restricted solve was given.
+            target: World-frame target position.
+            q0: The live configuration the solve seeded from.
+            arm_jact: Commanded joint id -> actuator id map.
+            namespace: Robot namespace, stripped from reported joint names.
+
+        Returns:
+            ``(residual_m, uncommanded_joint_names)``. On a fully actuated
+            fixed-base arm the name list is empty and the residual matches the
+            restricted one, which is what keeps the refusal text unchanged
+            there.
+        """
+        from strands_robots.simulation.ik import MinkIKBridge
+
+        try:
+            reference = MinkIKBridge(
+                model,
+                frame_name,
+                frame_type,
+                orientation_cost=1.0 if target_quat is not None else 0.0,
+                max_iters=200,
+            )
+        except (ImportError, RuntimeError, ValueError):  # pragma: no cover - the restricted build succeeded
+            return math.inf, []
+        q_free = reference.solve(target_pose, q0)
+        residual = float(np.linalg.norm(reference.ee_pose(q_free)[:3, 3] - target))
+        moved = self._uncommanded_joints_moved(self._mj, model, arm_jact, q0, q_free, namespace)
+        return residual, moved
+
     # -- primitives ----------------------------------------------------------
 
     def move_to(
@@ -431,6 +485,19 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
         and transport, so ``set_gripper("close") -> move_to(...)`` carries the
         held object rather than releasing it.
 
+        COMMANDED-DOF SOLVE (contract): the IK solve is restricted to the
+        joints this primitive drives, so ``ik_residual_m`` is the error the
+        servo descent is actually left with. mink optimizes over every degree
+        of freedom in the model, and an unrestricted solve borrows whatever is
+        cheapest - a floating/mobile base, a second robot in the same world
+        model, the gripper this primitive holds - none of which ``move_to``
+        commands. A borrowed solve reports a near-zero residual for a pose the
+        arm cannot hold, which reads as a solved target whose servo merely
+        "needs more steps". When the restricted solve cannot reach the target,
+        the refusal re-solves unrestricted and names the degrees of freedom
+        that would have to move first, so an out-of-workspace point is
+        distinguishable from one that needs base motion.
+
         NOT collision-aware: the straight servo descent can sweep through
         obstacles. Collision-aware transport is the curobo provider's job; this
         primitive deliberately hides the solver backend so that upgrade cannot
@@ -459,8 +526,14 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
             ``{reached, steps, position_error_m, ik_residual_m, ee_position,
             ee_orientation_wxyz, frame, frame_type}`` on arrival;
             ``{"status": "error", ...}`` with the same json block (including
-            the residual) when the target is unreachable (IK residual > tol)
-            or servo convergence times out. Never raises.
+            the residual) when servo convergence times out. The unreachable
+            refusal (restricted IK residual > tol) carries
+            ``{reached, steps, ik_residual_m, unrestricted_ik_residual_m,
+            uncommanded_joints_moved, frame, frame_type}`` - the last two
+            reporting what a solve over the whole model could have reached and
+            which uncommanded joints it needed, so the caller can tell an
+            out-of-workspace target from one needing base motion. Never
+            raises.
         """
         # ---- parameter validation (before touching the world) ----
         # Shared with the Isaac adapter (motion_primitives_base): same
@@ -535,12 +608,21 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
                 # whereas move_to jumps from the current pose to an arbitrary
                 # workspace point in one solve and needs the extra integration
                 # budget to converge from far seeds.
+                # commanded_dofs restricts the solve to the joints the servo
+                # loop below actually drives. mink optimizes over the whole
+                # world model, so an unrestricted solve satisfies the Cartesian
+                # task with whatever DOF is cheapest - a floating base, a
+                # second robot, the held gripper - and then reports a residual
+                # for a configuration move_to never commands. On a mobile
+                # manipulator that reads as a solved target followed by a servo
+                # that "just needs more steps"; it never arrives.
                 bridge = MinkIKBridge(
                     model,
                     frame_name,
                     frame_type,
                     orientation_cost=1.0 if target_quat is not None else 0.0,
                     max_iters=200,
+                    commanded_dofs=self._commanded_dof_indices(model, arm_jact),
                 )
             except (ImportError, RuntimeError, ValueError) as e:
                 return _err(f"move_to: IK bridge unavailable: {e}")
@@ -602,17 +684,23 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
                         break
 
             if ik_residual > float(tol):
-                return _err(
-                    f"move_to: target {target.tolist()} is unreachable for '{robot_name}' "
-                    f"within tol={float(tol)} m - best IK solution leaves a residual of "
-                    f"{ik_residual:.4f} m. Choose a closer target or loosen tol.",
-                    {
-                        "reached": False,
-                        "steps": 0,
-                        "ik_residual_m": ik_residual,
-                        "frame": frame_name,
-                        "frame_type": frame_type,
-                    },
+                # Refusal-path diagnosis only: solve the same target once more
+                # with every model DOF free. If THAT fits tol, the point is
+                # inside the robot's reach and outside this primitive's, so the
+                # refusal can name the degrees of freedom that have to move
+                # first instead of advising a closer target.
+                unrestricted_residual, uncommanded = self._diagnose_unreachable(
+                    model, frame_name, frame_type, target_quat, target_pose, target, q0, arm_jact, namespace
+                )
+                return self._move_to_unreachable_error(
+                    robot_name,
+                    target,
+                    float(tol),
+                    ik_residual=ik_residual,
+                    frame_name=frame_name,
+                    frame_type=frame_type,
+                    unrestricted_residual=unrestricted_residual,
+                    uncommanded_joints=uncommanded,
                 )
 
             # Command ARM joints to the solve; HOLD gripper joints at their

--- a/tests/simulation/mujoco/test_move_to_solves_over_commanded_joints_only.py
+++ b/tests/simulation/mujoco/test_move_to_solves_over_commanded_joints_only.py
@@ -1,0 +1,356 @@
+"""``move_to`` judges reachability by the joints it actually commands.
+
+``move_to`` solves inverse kinematics with
+:class:`strands_robots.simulation.ik.MinkIKBridge` and then drives the arm's
+position-servo actuators toward the solution. ``mink`` optimizes over every
+degree of freedom in the model it is handed, and the MuJoCo backend hands it the
+whole WORLD model, so an unrestricted solve is free to satisfy the Cartesian
+task with a degree of freedom the servo loop never sends: a floating/mobile
+base, a second robot sharing the world, or the gripper the primitive holds at
+its live position.
+
+The consequences are not cosmetic. On the mobile manipulator below, an
+unrestricted solve slides the free base 0.91 m and rotates it, leaves both
+commanded arm joints at exactly their seed values, and reports an IK residual of
+4e-12 m. ``move_to`` accepts that as reachable, servos for the full
+``max_steps`` budget, and returns a timeout whose text reads "IK residual was
+0.0000 m ... The servo may need more steps" for a point 1.23 m outside the arm's
+reach - so the one number the caller has to diagnose with says the target is
+solved and blames the servo. More steps never arrive.
+
+The same borrowing contradicts the primitive's own GRASP PRESERVATION contract,
+which states that gripper actuators "are excluded from the IK solve". Whenever
+the discovered TCP sits on the jaw body, the jaw is kinematically relevant and
+an unrestricted solve reaches the target by opening it 40 mm - a solve the
+grasp-preserving servo will not carry out.
+
+The fix restricts the solve to the commanded joints (``commanded_dofs``), so
+``ik_residual_m`` is the error the servo descent is genuinely left with and the
+unreachable refusal fires up front. Because the restriction removes the cheap
+answer, the solver works the arm instead: it lands at 0.68 m, better than the
+1.25 m the borrowed solution's commanded half is worth. The refusal then
+re-solves unrestricted purely to diagnose, so it can distinguish a point outside
+the robot's workspace ("choose a closer target") from one that needs uncommanded
+motion (name the base, and say to drive it first).
+
+The controls in the last two classes pin that nothing changes where every
+kinematically relevant joint is commanded, which is every fixed-base arm in the
+suite: the same target is reached, and an out-of-workspace point keeps its
+existing advice.
+"""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("mink")
+
+import mujoco as mj  # noqa: E402
+
+from strands_robots.simulation.ik import MinkIKBridge, discover_ee_frame  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_motion_primitives import ARM_XML, REACHABLE, UNREACHABLE  # noqa: E402
+
+_TOL = 0.01
+_REACH_TOL = 0.02
+_MAX_STEPS = 400
+
+# A two-joint arm on a free-floating base: a mobile manipulator's kinematics.
+# Only the two hinges carry position servos, so the base is exactly the kind of
+# degree of freedom move_to cannot command but mink can move. The base free
+# joint is NAMED here so the refusal's wording can be pinned; an unnamed
+# <freejoint/> (what several registry mobile bases ship) is reported by index.
+MOBILE_ARM_XML = """
+<mujoco model="mobile_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+  </default>
+  <worldbody>
+    <geom name="floor" type="plane" size="5 5 0.1"/>
+    <body name="base" pos="0 0 0.15">
+      <freejoint name="base_free"/>
+      <geom type="box" size="0.12 0.12 0.05"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-1.8 1.8"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.30" size="0.03"/>
+        <body name="hand" pos="0 0 0.30">
+          <joint name="elbow" type="hinge" axis="0 1 0" range="-2.2 2.2"/>
+          <geom type="capsule" fromto="0 0 0 0 0 0.25" size="0.025"/>
+          <site name="attachment_site" pos="0 0 0.25"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder" joint="shoulder" kp="80" ctrlrange="-1.8 1.8"/>
+    <position name="elbow" joint="elbow" kp="60" ctrlrange="-2.2 2.2"/>
+  </actuator>
+</mujoco>
+"""
+
+# A fixed-base arm whose TCP site sits on the JAW body, so the held gripper DOF
+# is kinematically relevant to the end-effector task. ARM_XML deliberately puts
+# its site upstream of the jaw, which is why the grasp-preservation claim about
+# the solve had never been exercised.
+GRIPPER_TCP_ARM_XML = """
+<mujoco model="gripper_tcp_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002" gravity="0 0 0"/>
+  <default>
+    <joint armature="0.05" damping="0.5"/>
+  </default>
+  <worldbody>
+    <body name="base" pos="0 0 0">
+      <geom type="cylinder" size="0.04 0.02"/>
+      <body name="link1" pos="0 0 0.05">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+        <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02"/>
+        <body name="hand" pos="0.2 0 0">
+          <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.018"/>
+          <body name="jaw_body" pos="0.1 0 0">
+            <joint name="jaw" type="slide" axis="1 0 0" range="0 0.25"/>
+            <geom type="box" size="0.01 0.01 0.02" contype="0" conaffinity="0"/>
+            <site name="grasp_site" pos="0.02 0 0"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder" joint="shoulder" kp="20" ctrlrange="-3.14 3.14"/>
+    <position name="elbow" joint="elbow" kp="20" ctrlrange="-3.14 3.14"/>
+    <position name="jaw" joint="jaw" kp="20" ctrlrange="0 0.25"/>
+  </actuator>
+</mujoco>
+"""
+
+# 1.20 m out in +x at the tool frame's home height: unreachable for the 0.55 m
+# arm from its home base pose, and trivially reachable if the base drives there.
+# Inside the 5 m workspace sanity box, so it reaches the solver, not the guard.
+NEEDS_BASE_MOTION = [1.20, 0.0, 0.75]
+
+
+def _sim_with(tmp_path: Any, name: str, xml: str, *, weightless: bool = False) -> Any:
+    """A world holding ``xml`` under the ``name/`` namespace.
+
+    ``weightless`` matches the shared motion-primitive fixture, which zeroes
+    world gravity so a servo descent settles on its set-point instead of
+    hanging under load - the premise the reach controls below inherit.
+    """
+    path = tmp_path / f"{name}.xml"
+    path.write_text(xml)
+    sim = Simulation(backend="mujoco", mesh=False)
+    created = sim.create_world(gravity=[0, 0, 0]) if weightless else sim.create_world()
+    assert created["status"] == "success"
+    added = sim.add_robot(name=name, urdf_path=str(path))
+    assert added["status"] == "success", added
+    return sim
+
+
+def _json_block(result: dict[str, Any]) -> dict[str, Any]:
+    """The primitive's structured payload."""
+    return next(c["json"] for c in result["content"] if "json" in c)
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The primitive's message text."""
+    return next(c["text"] for c in result["content"] if "text" in c)
+
+
+@pytest.fixture
+def mobile_sim(tmp_path):
+    """The floating-base mobile manipulator."""
+    sim = _sim_with(tmp_path, "rover", MOBILE_ARM_XML, weightless=True)
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+@pytest.fixture
+def gripper_tcp_sim(tmp_path):
+    """The fixed-base arm whose TCP rides on the jaw."""
+    sim = _sim_with(tmp_path, "grip", GRIPPER_TCP_ARM_XML, weightless=True)
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+@pytest.fixture
+def fixed_sim(tmp_path):
+    """The suite's shared fully actuated fixed-base arm."""
+    sim = _sim_with(tmp_path, "arm", ARM_XML, weightless=True)
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+class TestAnUncommandedDegreeOfFreedomCannotSolveTheTarget:
+    """The floating base is not available to the solve that judges the target."""
+
+    def test_the_target_is_refused_rather_than_accepted_and_servoed(self, mobile_sim):
+        """The point 1.23 m out of reach is refused as unreachable, up front.
+
+        Pre-fix the solve slid the base, reported a 4e-12 m residual, and this
+        call spent the whole ``max_steps`` budget before returning a servo
+        timeout - the wrong failure, with the wrong remedy, at 400x the cost.
+        """
+        result = mobile_sim.move_to(robot_name="rover", position=NEEDS_BASE_MOTION, tol=_TOL, max_steps=_MAX_STEPS)
+        assert result["status"] == "error"
+        assert "unreachable" in _text(result)
+        assert _json_block(result)["steps"] == 0
+
+    def test_the_reported_residual_is_the_one_the_arm_is_left_with(self, mobile_sim):
+        """``ik_residual_m`` measures a configuration the servo can command.
+
+        The target sits 1.23 m beyond the arm's reach, so any residual small
+        enough to look solved is measured on borrowed motion.
+        """
+        payload = _json_block(
+            mobile_sim.move_to(robot_name="rover", position=NEEDS_BASE_MOTION, tol=_TOL, max_steps=_MAX_STEPS)
+        )
+        assert payload["ik_residual_m"] > 0.5
+
+    def test_the_refusal_names_the_borrowed_joint_and_what_it_would_reach(self, mobile_sim):
+        """A solvable-but-not-by-this-primitive target says so, and names why.
+
+        This is the difference between "choose a closer target" (useless: the
+        point is well inside the robot's workspace once the base drives) and
+        "move the base first".
+        """
+        result = mobile_sim.move_to(robot_name="rover", position=NEEDS_BASE_MOTION, tol=_TOL, max_steps=_MAX_STEPS)
+        payload = _json_block(result)
+        assert payload["uncommanded_joints_moved"] == ["base_free"]
+        assert payload["unrestricted_ik_residual_m"] <= _TOL
+        assert "base_free" in _text(result)
+        assert "Choose a closer target" not in _text(result)
+
+    def test_the_diagnosis_solve_does_not_write_the_world(self, mobile_sim):
+        """The refusal is a pure query: no stepping, no solved pose written.
+
+        The diagnosis re-solve produces a configuration that slides the base
+        0.91 m, so it must stay a measurement. The world is weightless, which
+        removes gravity as an alternative explanation for base travel: whatever
+        moves here was moved by ``move_to``. Pre-fix this call accepted the
+        borrowed solve and stepped the servo 400 times instead of refusing, so
+        it disturbed the world it had nothing to do in.
+        """
+        before = np.array(mobile_sim._world._data.qpos[:7], dtype=float, copy=True)
+        mobile_sim.move_to(robot_name="rover", position=NEEDS_BASE_MOTION, tol=_TOL, max_steps=_MAX_STEPS)
+        np.testing.assert_allclose(mobile_sim._world._data.qpos[:7], before, atol=1e-12)
+
+
+class TestTheHeldGripperIsExcludedFromTheSolveAsDocumented:
+    """The GRASP PRESERVATION contract covers the solve, not only the servo."""
+
+    def test_a_tcp_on_the_jaw_is_not_reached_by_opening_the_jaw(self, gripper_tcp_sim):
+        """A target only the jaw's 0.25 m of travel can reach is refused.
+
+        The jaw is held at its live position for the whole descent, so a solve
+        that spends jaw travel is a solve the servo will not carry out.
+        """
+        model = gripper_tcp_sim._world._model
+        assert discover_ee_frame(model, "grip/") == ("grip/grasp_site", "site")
+        # 0.05 m past the arm's full extension, inside the jaw's travel.
+        result = gripper_tcp_sim.move_to(robot_name="grip", position=[0.37, 0.0, 0.05], tol=_TOL, max_steps=_MAX_STEPS)
+        assert result["status"] == "error"
+        assert "unreachable" in _text(result)
+        assert _json_block(result)["uncommanded_joints_moved"] == ["jaw"]
+
+
+class TestNothingChangesWhereEveryRelevantJointIsCommanded:
+    """Controls: the fully actuated fixed-base arm every other test uses."""
+
+    def test_a_reachable_target_is_still_reached(self, fixed_sim):
+        """The restriction is a no-op when the arm commands every relevant DOF.
+
+        ``_REACH_TOL`` is the tolerance the shared suite reaches this arm at
+        (``test_motion_primitives.py``), so the premise is the suite's, not a
+        value tuned here.
+        """
+        result = fixed_sim.move_to(robot_name="arm", position=REACHABLE, tol=_REACH_TOL, max_steps=_MAX_STEPS)
+        assert result["status"] == "success", result
+        payload = _json_block(result)
+        assert payload["reached"] is True
+        assert payload["ik_residual_m"] <= _REACH_TOL
+
+    def test_an_out_of_workspace_target_keeps_its_existing_advice(self, fixed_sim):
+        """No uncommanded DOF would help, so the refusal reads as it always did."""
+        result = fixed_sim.move_to(robot_name="arm", position=UNREACHABLE, tol=_TOL, max_steps=_MAX_STEPS)
+        assert result["status"] == "error"
+        assert "unreachable" in _text(result)
+        assert "Choose a closer target or loosen tol." in _text(result)
+
+
+class TestTheBridgeHonoursItsCommandedDofMask:
+    """The solver-level contract the primitive relies on."""
+
+    @staticmethod
+    def _bridge_pair(model: Any, commanded: list[int]) -> tuple[Any, Any]:
+        """An unrestricted bridge and one restricted to ``commanded``."""
+        free = MinkIKBridge(model, "rover/attachment_site", "site", orientation_cost=0.0, max_iters=200)
+        restricted = MinkIKBridge(
+            model,
+            "rover/attachment_site",
+            "site",
+            orientation_cost=0.0,
+            max_iters=200,
+            commanded_dofs=commanded,
+        )
+        return free, restricted
+
+    def test_uncommanded_dofs_hold_their_seed_value_exactly(self, mobile_sim):
+        """Every DOF outside the mask comes back bit-identical to the seed.
+
+        Exactness is the point: a solution the caller can only partially apply
+        is a solution whose residual means nothing.
+        """
+        model = mobile_sim._world._model
+        shoulder = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "rover/shoulder")
+        elbow = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "rover/elbow")
+        commanded_qpos = [int(model.jnt_qposadr[shoulder]), int(model.jnt_qposadr[elbow])]
+        free, restricted = self._bridge_pair(model, [int(model.jnt_dofadr[shoulder]), int(model.jnt_dofadr[elbow])])
+
+        q0 = np.array(mobile_sim._world._data.qpos, dtype=float, copy=True)
+        target_pose = np.eye(4)
+        target_pose[:3, 3] = NEEDS_BASE_MOTION
+        target_pose[:3, :3] = free.ee_pose(q0)[:3, :3]
+
+        q_free = free.solve(target_pose, q0)
+        q_restricted = restricted.solve(target_pose, q0)
+
+        base = [i for i in range(int(model.nq)) if i not in commanded_qpos]
+        assert np.linalg.norm(q_free[base] - q0[base]) > 0.1, "the unrestricted solve borrows the base"
+        assert list(q_restricted[base]) == list(q0[base])
+
+    @pytest.mark.parametrize(
+        ("commanded", "expected"),
+        [
+            ([], "empty"),
+            ([0, 99], r"outside range\(model\.nv\)"),
+            ([-1], r"outside range\(model\.nv\)"),
+            ([True], "integer velocity-space indices"),
+            ([1.5], "integer velocity-space indices"),
+        ],
+    )
+    def test_a_mask_that_cannot_describe_this_model_is_refused(self, mobile_sim, commanded, expected):
+        """A mask built against another model, or one that frees nothing, raises.
+
+        ``True`` is refused explicitly: ``bool`` is an ``int`` subclass that
+        would silently act as DOF index 1.
+        """
+        with pytest.raises(ValueError, match=expected):
+            MinkIKBridge(
+                mobile_sim._world._model,
+                "rover/attachment_site",
+                "site",
+                commanded_dofs=commanded,
+            )


### PR DESCRIPTION
## Problem

`move_to` solves inverse kinematics with the shared mink bridge and then drives the arm's position servos toward the solution. `mink` optimizes over **every** degree of freedom in the model it is handed, and both backends hand it a model with more than the arm: the MuJoCo backend passes the whole world model, the Isaac backend the registry MJCF including its base. So the solve was free to satisfy the Cartesian task with a degree of freedom the servo loop never sends.

On a mobile manipulator (two hinges with servos on a free base), a target 1.20 m out measures:

| | reported `ik_residual_m` | base travel in the solve | commanded arm travel in the solve | delivered error | ticks spent |
|---|---|---|---|---|---|
| before | **3.9e-12 m** ("reachable") | 0.934 m | **1.0e-07 rad** | 1.2000 m | 400 |
| after | 0.7793 m (refused) | 0.000 m | 1.036 rad | n/a | 0 |

The solve used **none** of the joints `move_to` commands, and the residual it reported described a configuration that is never realized. `move_to` accepted it as reachable, servoed the full `max_steps` budget, and returned

```
move_to: 'rover' did not reach [1.2, 0.0, 0.75] within tol=0.01 m after max_steps=400
(residual 1.2000 m; IK residual was 0.0000 m). The servo may need more steps, or the
pose fights joint limits/contacts.
```

The one diagnostic the caller has says the target is solved and blames the servo. More steps never arrive: the point is 1.20 m outside a 0.55 m arm's reach. Sweeping the registry, **35 of the 62 loadable sim robots** carry a floating base the solve can borrow this way (every mobile manipulator - `lekiwi`, `stretch`, `stretch3`, `tiago_dual`, `spot` - and every humanoid - `unitree_g1/h1/h1_2`, `apollo`, `talos`, `toddlerbot`, `jvrc`, `op3`, `elf2`), and **50 of 62** have at least one uncommanded degree of freedom.

The same borrowing contradicts the primitive's own documented GRASP PRESERVATION contract, which states gripper actuators "are excluded from the IK solve". Where the discovered TCP sits on the jaw body the jaw is kinematically relevant, and an unrestricted solve reaches the target by opening the held jaw 39.9 mm - motion the grasp-preserving servo will not carry out (measured: reported residual 0.0002 m, delivered 0.0500 m off).

## Change

`MinkIKBridge` takes `commanded_dofs` and projects each iteration's velocity onto that subspace before integrating, so every uncommanded DOF holds its seed value **exactly** and the returned configuration is one the caller can realize. Zeroing before integration rather than filtering the answer keeps the loop honest: the next `solve_ik` sees the error that actually remains, so it converges to the best commandable configuration (0.78 m above, better than the 1.20 m the borrowed solution's commanded half was worth) instead of one it can only report.

Both backends pass the joints their servo loop drives, so `ik_residual_m` is the error the descent is genuinely left with and the existing unreachable refusal fires up front instead of after a futile 400-tick descent.

The refusal then re-solves unrestricted purely to diagnose, and reports `unrestricted_ik_residual_m` + `uncommanded_joints_moved`, so a point outside the robot's workspace stays distinguishable from one that needs base motion:

```
move_to: target [1.2, 0.0, 0.75] is unreachable for 'rover' within tol=0.01 m - the best
solve over the joints move_to commands leaves a residual of 0.7793 m. The same target
solves to 0.0000 m once the 1 degree(s) of freedom move_to does not command are free too
(base_free), so the point is not outside the robot's workspace: reaching it needs motion
this primitive cannot produce. move_to drives the arm's position servos only, so move
those degrees of freedom first (a mobile base has to drive there), then call move_to.
```

Both backends share one refusal envelope (`_move_to_unreachable_error` in `motion_primitives_base`), so MuJoCo and Isaac judge reachability by the same rule and the existing Isaac parity assertions keep them in step.

## No change where every relevant joint is commanded

A fully actuated fixed-base arm commands every kinematically relevant joint, so the projection is a strict no-op there. The shared suite arm reaching `REACHABLE` reports `ik_residual_m = 0.001656543414291106` and `position_error_m = 0.014211443877695771` in 400 ticks on `main` and **byte-identically** on this branch, and an out-of-workspace target keeps its `Choose a closer target or loosen tol.` advice. `commanded_dofs=None` is the default and reads nothing new off the model, so every other bridge caller (the cosmos3 / vera decode paths) is untouched.

## Visual

Three real configurations, rendered headless in MuJoCo (`MUJOCO_GL=egl`) from one explicitly framed world camera. Red sphere = the requested target. Left: the configuration the solve scored - the whole robot has jumped to the target on borrowed base motion, arm untouched. Middle: what the servo then delivered - the robot standing at home, 1.20 m short, reported as a servo that needs more steps. Right: the restricted solve - the arm worked to its limit, base held, refused up front and naming `base_free`.

![move_to commanded-dof solve comparison](https://raw.githubusercontent.com/cagataycali/robots/media-move-to-commanded-dofs/move_to_commanded_dofs.png)

## Tests

`tests/simulation/mujoco/test_move_to_solves_over_commanded_joints_only.py` (13 tests, real mink on inline MJCF, no asset downloads). Against `main`: **11 fail, 2 pass**; on this branch all 13 pass. The 2 that pass on both are the controls (the fixed-base arm still reaches its target; an out-of-workspace point keeps its existing advice) - they are what pin that the restriction does not reach past the defect.

Representative pre-fix failures:

```
assert 'unreachable' in "move_to: 'rover' did not reach ... IK residual was 0.0000 m"
assert 4.332300456663996e-12 > 0.5
KeyError: 'uncommanded_joints_moved'
```

Full suite, same interpreter on both trees: **355 failing test ids on `main` and 355 on this branch, identical sets** (`comm` empty both ways), 29508 -> 29521 passed (+13 = the new file). `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` reports the same 18 pre-existing errors as `main` and no new ones.