### PR TITLE
fix(simulation/mujoco): make a randomized object position reach the rollout it randomizes

### DIFF
--- a/changelog.d/2293-randomize-positions-survive-reset.md
+++ b/changelog.d/2293-randomize-positions-survive-reset.md
@@ -1,0 +1,9 @@
+### Fixed
+
+`randomize(randomize_positions=True)` (MuJoCo backend) now writes the perturbed
+pose to `model.qpos0` as well as `data.qpos`, so an object-position
+randomization survives the `reset()` every rollout performs before its first
+step instead of being reverted before the policy observes it. The offset is
+measured from each object's commanded pose, so repeated per-episode calls draw
+independent offsets inside `position_noise` rather than compounding into a
+random walk, and the result text reports how many objects were perturbed.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -35,6 +35,20 @@ sim.randomize(randomize_position=True)   # singular
 
 **Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
 
+**Every axis survives `reset()`.** A reset restores the world's initial state,
+and each axis writes that initial state rather than only the live state - the
+colour, friction and mass axes write `model` arrays, and `randomize_positions`
+writes `model.qpos0` (the pose a reset restores) alongside the live `data.qpos`.
+This is what makes randomization reach a rollout at all: `run_policy` and
+`eval_policy` reset before an episode's first step, so an axis a reset undid
+would be gone before the policy ever saw it.
+
+`randomize_positions` measures its offset from each object's **commanded** pose -
+where `add_object` / `move_object` placed it - not from wherever physics has left
+it. The commanded pose is a fixed reference, so calling `randomize()` once per
+episode draws independent offsets that always stay inside `position_noise`
+instead of compounding into a random walk that eventually leaves the workspace.
+
 `randomize()` leaves the sim in a forwarded, render-ready state: the next `render()` / `get_observation()` reflects the perturbation immediately, with no manual `step()` in between. This matters for lighting in particular - the renderer reads light positions from the derived `data.light_xpos`, not `model.light_pos`, so a light-position jitter only reaches a render after a forward.
 
 ## Categories
@@ -44,7 +58,7 @@ sim.randomize(randomize_position=True)   # singular
 | `randomize_colors` | Object + floor RGB (alpha fixed at 1.0) | `color_range` |
 | `randomize_lighting` | Directional direction, intensity, ambient | - |
 | `randomize_physics` | Per-object mass (mult), per-geom friction (scale), joint damping | `mass_range`, `friction_range` |
-| `randomize_positions` | Object position offsets (metres) | `position_noise` |
+| `randomize_positions` | Dynamic-object position offsets (metres); static objects have no pose DOF and are skipped | `position_noise` |
 
 Defaults: `colors=True`, `lighting=True`; `physics` and `positions` default `False`.
 
@@ -52,9 +66,11 @@ Defaults: `colors=True`, `lighting=True`; `physics` and `positions` default `Fal
 
 ```python
 for episode in range(N):
-    sim.reset()
-    sim.randomize(randomize_colors=True, randomize_physics=True, seed=episode)
-    # eval_policy has no randomize= kwarg - call sim.randomize() before each episode
+    sim.randomize(randomize_colors=True, randomize_physics=True,
+                  randomize_positions=True, position_noise=0.03, seed=episode)
+    # eval_policy has no randomize= kwarg - call sim.randomize() before each episode.
+    # It resets at the start of every episode, which is why the perturbation has to
+    # survive a reset; no explicit sim.reset() is needed here.
     result = sim.eval_policy(robot_name="so100", n_episodes=1, max_steps=300,
                              success_fn=my_fn)
 ```

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -91,8 +91,14 @@ class RandomizationMixin:
 
         "No flags" means "nothing is randomized" - the call is a no-op. This
         matches the LLM ergonomics principle: explicit is better than implicit.
-        Randomization IS destructive (writes to ``model.geom_*`` / ``body_*``
-        arrays and to ``data.qpos``); recompile the scene to undo.
+        Randomization IS destructive; recompile the scene to undo. Every axis
+        persists for the rest of the scene's life, including across
+        :meth:`reset`: the colour, friction and mass axes write ``model``
+        arrays, and the position axis writes ``model.qpos0`` (the pose a reset
+        restores) alongside the live ``data.qpos``. That uniformity is what
+        makes the axis usable from a rollout entry point at all -- ``run_policy``
+        and ``eval_policy`` reset before an episode's first step, so an axis a
+        reset undoes would never reach a rollout.
 
         Args:
             randomize_colors:     Re-sample every non-ground geom's RGB (and
@@ -108,7 +114,16 @@ class RandomizationMixin:
                                   positions. A finite non-negative number: a
                                   NaN half-width writes NaN into ``qpos`` and
                                   poisons every later step, a negative one
-                                  inverts the sampling bounds.
+                                  inverts the sampling bounds. The offset is
+                                  measured from each dynamic object's commanded
+                                  pose (what ``add_object`` / ``move_object``
+                                  placed it at), so repeated calls draw
+                                  independent offsets inside this bound instead
+                                  of compounding into a random walk, and it
+                                  becomes both the live pose and the pose a
+                                  reset restores. Static objects have no pose
+                                  DOF and are skipped; the result text reports
+                                  how many objects were actually perturbed.
             color_range:          (lo, hi) for uniform RGB sampling.
             friction_range:       (lo, hi) multiplicative scale on friction[0].
             mass_range:           (lo, hi) multiplicative scale on body_mass.
@@ -231,15 +246,43 @@ class RandomizationMixin:
                 changes.append(f"   mass_scales={mass_scales}")
 
             if randomize_positions:
+                # Two writes per object, because a start pose lives in two
+                # places and the axis is only useful if it reaches both:
+                #   * ``data.qpos`` -- the live pose, and
+                #   * ``model.qpos0`` -- the pose ``mj_resetData`` restores.
+                # Every rollout entry point resets before an episode's first
+                # step (``PolicyRunner.evaluate`` resets at the top of each
+                # episode), so a qpos-only write is undone before the policy
+                # ever observes it, while the three model-array axes above
+                # persist. Writing both makes this axis behave like colour,
+                # friction and mass: it survives a reset and is undone by a
+                # recompile.
+                #
+                # The offset is measured from the object's COMMANDED pose --
+                # what ``add_object`` / ``move_object`` last placed it at, which
+                # is what the registry holds -- not from the live pose. The
+                # registry pose is a fixed reference, so each call draws an
+                # independent offset bounded by ``position_noise``; measuring
+                # from the live pose instead compounds every call into a random
+                # walk (50 episodes at a 0.03 m half-width reach 0.12 m and put
+                # a table-top object under the floor).
+                n_moved = 0
                 for obj_name, obj in self._world.objects.items():
-                    if not obj.is_static:
-                        jnt_name = f"{obj_name}_joint"
-                        jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, jnt_name)
-                        if jnt_id >= 0:
-                            qpos_addr = model.jnt_qposadr[jnt_id]
-                            noise = rng.uniform(-position_noise, position_noise, size=3)
-                            data.qpos[qpos_addr : qpos_addr + 3] += noise
-                changes.append(f"Positions: ±{position_noise}m noise on dynamic objects")
+                    if obj.is_static:
+                        continue
+                    jnt_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, f"{obj_name}_joint")
+                    if jnt_id < 0:
+                        continue
+                    qpos_addr = model.jnt_qposadr[jnt_id]
+                    noise = rng.uniform(-position_noise, position_noise, size=3)
+                    start = np.asarray(obj.position, dtype=np.float64) + noise
+                    data.qpos[qpos_addr : qpos_addr + 3] = start
+                    model.qpos0[qpos_addr : qpos_addr + 3] = start
+                    n_moved += 1
+                # Report the count actually perturbed, as the colour axis does:
+                # a scene whose objects are all static perturbs nothing, and
+                # naming the axis without a count reads as work done.
+                changes.append(f"Positions: {n_moved} dynamic objects perturbed by ±{position_noise}m")
 
             # Recompute derived state so the sim is left render-ready. Several
             # randomization axes mutate model arrays whose rendered/simulated

--- a/tests/simulation/mujoco/test_randomize_positions_persistence.py
+++ b/tests/simulation/mujoco/test_randomize_positions_persistence.py
@@ -1,0 +1,295 @@
+"""``randomize_positions`` must perturb the pose a rollout actually starts from.
+
+``randomize()`` has four axes. Colour, friction and mass write ``model`` arrays,
+so they persist for the rest of the scene's life and are undone only by a
+recompile. The position axis wrote only ``data.qpos``, which is the one place a
+:meth:`reset` overwrites -- ``mj_resetData`` restores ``data.qpos`` from
+``model.qpos0``. Every rollout entry point resets before an episode's first step
+(``PolicyRunner.evaluate`` calls ``sim.reset()`` at the top of each episode), so
+the axis was reverted before the policy ever observed it: a
+``randomize(randomize_positions=True)`` call reported success and every episode
+still began at the canonical authored pose.
+
+Making the offset persist also requires a fixed reference to measure it from.
+The registry pose (what ``add_object`` / ``move_object`` commanded) is fixed;
+the live pose is not, so measuring from the live pose turns a per-episode loop
+into a random walk that leaves the requested bound behind -- 50 episodes at a
+0.03 m half-width reach 0.12 m and put a table-top object under the floor.
+
+These tests pin the fix -- the perturbed pose is the pose the next episode
+starts from, and every offset stays inside ``position_noise`` of the commanded
+pose no matter how many episodes run -- plus the boundaries it must not cross:
+a static object is never moved, a recompile still undoes the axis (as it does
+the other three), and a call with the axis off leaves both pose stores
+untouched.
+"""
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_randomize_positions_persistence", mesh=False)
+    assert s.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _freejoint_qpos_address(sim: Simulation, name: str) -> int:
+    """qpos offset of ``name``'s freejoint, asserting the joint resolves."""
+    assert sim._world is not None
+    model = sim._world._model
+    jnt_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, f"{name}_joint")
+    assert jnt_id >= 0, f"no freejoint for dynamic object {name!r}"
+    return int(model.jnt_qposadr[jnt_id])
+
+
+def _live_position(sim: Simulation, name: str) -> np.ndarray:
+    adr = _freejoint_qpos_address(sim, name)
+    assert sim._world is not None
+    return np.asarray(sim._world._data.qpos[adr : adr + 3], dtype=np.float64).copy()
+
+
+def _reset_reference_position(sim: Simulation, name: str) -> np.ndarray:
+    """The pose ``mj_resetData`` restores for ``name`` -- ``model.qpos0``."""
+    adr = _freejoint_qpos_address(sim, name)
+    assert sim._world is not None
+    return np.asarray(sim._world._model.qpos0[adr : adr + 3], dtype=np.float64).copy()
+
+
+def _add_cube(sim: Simulation, name: str = "cube", position=(0.30, 0.00, 0.05)) -> None:
+    assert (
+        sim.add_object(name=name, shape="box", position=list(position), size=[0.03, 0.03, 0.03], mass=0.2)["status"]
+        == "success"
+    )
+
+
+def test_randomized_position_survives_the_reset_that_begins_a_rollout(sim):
+    """The perturbed pose is the pose the next episode starts from.
+
+    Pre-fix the noise reached ``data.qpos`` only, so ``reset()`` -- which every
+    rollout entry point calls before its first step -- restored the canonical
+    authored pose and the randomization never reached the policy.
+    """
+    _add_cube(sim)
+    authored = _live_position(sim, "cube")
+
+    assert (
+        sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_positions=True,
+            position_noise=0.05,
+            seed=7,
+        )["status"]
+        == "success"
+    )
+    perturbed = _live_position(sim, "cube")
+    assert not np.allclose(perturbed, authored), "randomize did not move the object at all"
+
+    assert sim.reset()["status"] == "success"
+    after_reset = _live_position(sim, "cube")
+    assert np.allclose(after_reset, perturbed), (
+        f"reset() reverted the randomized pose: perturbed {perturbed} -> {after_reset} "
+        f"(authored {authored}); every episode would start at the canonical pose"
+    )
+
+
+def test_three_randomize_then_reset_cycles_yield_three_distinct_start_poses(sim):
+    """The documented per-episode randomization loop actually varies the scene.
+
+    ``randomize(seed=episode)`` followed by the reset each rollout performs is
+    the loop the docs prescribe; pre-fix all N episodes began at the identical
+    authored pose.
+    """
+    _add_cube(sim)
+    starts = []
+    for episode in range(3):
+        assert (
+            sim.randomize(
+                randomize_colors=False,
+                randomize_lighting=False,
+                randomize_positions=True,
+                position_noise=0.04,
+                seed=episode,
+            )["status"]
+            == "success"
+        )
+        assert sim.reset()["status"] == "success"
+        starts.append(tuple(np.round(_live_position(sim, "cube"), 6)))
+
+    assert len(set(starts)) == 3, f"expected a distinct start pose per episode, got {starts}"
+
+
+def test_offsets_stay_inside_the_bound_over_many_episodes(sim):
+    """Every episode's start pose is within ``position_noise`` of the commanded pose.
+
+    The offset is measured from the registry pose, which does not move, so the
+    bound holds for episode 50 as it does for episode 0. Measuring from the live
+    pose compounds instead: the same loop reaches 0.12 m and drops the object
+    through the floor.
+    """
+    commanded = [0.30, 0.00, 0.05]
+    _add_cube(sim, position=tuple(commanded))
+    noise = 0.03
+    worst = 0.0
+    for episode in range(50):
+        assert (
+            sim.randomize(
+                randomize_colors=False,
+                randomize_lighting=False,
+                randomize_positions=True,
+                position_noise=noise,
+                seed=episode,
+            )["status"]
+            == "success"
+        )
+        assert sim.reset()["status"] == "success"
+        offset = _live_position(sim, "cube") - np.asarray(commanded, dtype=np.float64)
+        worst = max(worst, float(np.max(np.abs(offset))))
+
+    assert worst <= noise + 1e-12, (
+        f"start pose drifted {worst:.4f} m from the commanded pose over 50 episodes, "
+        f"outside the requested {noise} m half-width"
+    )
+
+
+def test_positions_result_reports_how_many_objects_were_perturbed(sim):
+    """A count, as the colour axis reports -- a static-only scene perturbs nothing."""
+    assert (
+        sim.add_object(name="table", shape="box", position=[0.0, 0.4, 0.02], size=[0.2, 0.2, 0.02], is_static=True)[
+            "status"
+        ]
+        == "success"
+    )
+    result = sim.randomize(
+        randomize_colors=False,
+        randomize_lighting=False,
+        randomize_positions=True,
+        position_noise=0.05,
+        seed=3,
+    )
+    assert result["status"] == "success"
+    assert "Positions: 0 dynamic objects perturbed" in result["content"][0]["text"], result["content"][0]["text"]
+
+    _add_cube(sim)
+    result = sim.randomize(
+        randomize_colors=False,
+        randomize_lighting=False,
+        randomize_positions=True,
+        position_noise=0.05,
+        seed=3,
+    )
+    assert result["status"] == "success"
+    assert "Positions: 1 dynamic objects perturbed" in result["content"][0]["text"], result["content"][0]["text"]
+
+
+def test_static_object_is_never_moved(sim):
+    """A welded body has no pose DOF; its registry pose must stay authored."""
+    authored = [0.0, 0.4, 0.02]
+    assert (
+        sim.add_object(name="table", shape="box", position=list(authored), size=[0.2, 0.2, 0.02], is_static=True)[
+            "status"
+        ]
+        == "success"
+    )
+    _add_cube(sim)
+    assert sim._world is not None
+    bid = mj.mj_name2id(sim._world._model, mj.mjtObj.mjOBJ_BODY, "table")
+    assert bid >= 0
+    xpos_before = np.asarray(sim._world._data.xpos[bid], dtype=np.float64).copy()
+
+    assert (
+        sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_positions=True,
+            position_noise=0.05,
+            seed=5,
+        )["status"]
+        == "success"
+    )
+
+    assert np.allclose(sim._world.objects["table"].position, authored)
+    assert np.allclose(sim._world._data.xpos[bid], xpos_before)
+
+
+def test_axis_off_leaves_live_pose_reset_reference_and_registry_untouched(sim):
+    """``randomize_positions=False`` is an exact no-op on both pose stores."""
+    _add_cube(sim)
+    assert sim._world is not None
+    live_before = _live_position(sim, "cube")
+    reference_before = _reset_reference_position(sim, "cube")
+    registered_before = list(sim._world.objects["cube"].position)
+
+    assert (
+        sim.randomize(
+            randomize_colors=True,
+            randomize_lighting=True,
+            randomize_physics=True,
+            randomize_positions=False,
+            seed=2,
+        )["status"]
+        == "success"
+    )
+
+    assert np.array_equal(_live_position(sim, "cube"), live_before)
+    assert np.array_equal(_reset_reference_position(sim, "cube"), reference_before)
+    assert sim._world.objects["cube"].position == registered_before
+
+
+def test_perturbation_stays_within_the_requested_half_width(sim):
+    """Each axis moves by at most ``position_noise`` -- the documented bound."""
+    commanded = [0.30, 0.00, 0.05]
+    _add_cube(sim, position=tuple(commanded))
+    authored = np.asarray(commanded, dtype=np.float64)
+    noise = 0.02
+    assert (
+        sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_positions=True,
+            position_noise=noise,
+            seed=13,
+        )["status"]
+        == "success"
+    )
+    delta = _live_position(sim, "cube") - authored
+    assert np.all(np.abs(delta) <= noise + 1e-12), delta
+    assert np.allclose(_reset_reference_position(sim, "cube"), _live_position(sim, "cube"))
+
+
+def test_a_recompile_still_undoes_the_position_axis(sim):
+    """Recompiling is the documented undo, and it must undo this axis too.
+
+    A recompile rebuilds ``model.qpos0`` from the spec, exactly as it rebuilds
+    the colour / friction / mass arrays, so the axis is no more sticky than its
+    three siblings.
+    """
+    _add_cube(sim)
+    authored = _reset_reference_position(sim, "cube")
+    assert (
+        sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_positions=True,
+            position_noise=0.05,
+            seed=17,
+        )["status"]
+        == "success"
+    )
+    assert not np.allclose(_reset_reference_position(sim, "cube"), authored)
+
+    # Any scene mutation recompiles the model.
+    assert (
+        sim.add_object(name="marker", shape="sphere", position=[0.8, 0.8, 0.05], size=[0.02], mass=0.05)["status"]
+        == "success"
+    )
+    assert np.allclose(_reset_reference_position(sim, "cube"), authored), (
+        "a recompile must rebuild the reset reference from the spec, as it does for colour/friction/mass"
+    )


### PR DESCRIPTION
## Problem

`randomize(randomize_positions=True)` wrote the perturbed pose to `data.qpos` only. `mj_resetData` restores `data.qpos` from `model.qpos0`, and every rollout entry point resets before an episode's first step (`PolicyRunner.evaluate` calls `sim.reset()` at the top of each episode), so the perturbation was undone before the policy ever observed it. The call reported `success` and every episode still began at the authored pose.

The other three axes write `model` arrays, so they persist. Measured on one scene, perturbing all four axes at once:

| axis | written to | after `randomize` | after `reset()` | survives |
|---|---|---|---|---|
| object position | `data.qpos` | `[0.2805, 0.026, 0.0267]` | `[0.25, 0.0, 0.05]` | **no** |
| colour | `model.geom_rgba` | `[0.321, 0.861, 0.768]` | `[0.321, 0.861, 0.768]` | yes |
| friction | `model.geom_friction` | `1.2002` | `1.2002` | yes |
| mass | `model.body_mass` | `0.1578` | `0.1578` | yes |

So the position axis was the one axis a reset silently reverted, and the two operations were inverted for it: it survived a recompile (which is the documented undo, and which does revert the other three) and was undone by a reset (which preserves the other three). Three `randomize(seed=episode)` + reset cycles produced one distinct start pose instead of three. This is also the only backend that implements the axis at all -- Newton refuses `randomize_positions` and points callers here.

## Change

- Write the perturbed pose to `model.qpos0` as well as `data.qpos`, so the axis behaves like colour, friction and mass: it survives a reset and is undone by a recompile.
- Measure the offset from each object's **commanded** pose (what `add_object` / `move_object` placed it at, which is what the registry holds) rather than from the live pose. The commanded pose is a fixed reference, so repeated calls draw independent offsets inside `position_noise`. Measuring from the live pose compounds every call into a random walk: 50 episodes at a `0.03` m half-width reach **0.1231 m** of drift and leave a table-top object at `z = -0.06`, under the floor. A per-episode `randomize()` loop is the documented usage, so the bound has to hold at episode 50 as it does at episode 0.
- Report the number of objects actually perturbed, as the colour axis already does, so a scene whose objects are all static cannot read as work done.

## Visual

`randomize(randomize_positions=True, seed=episode)` followed by the reset each rollout performs, rendered at the moment the episode starts. Top row is unchanged code: the three panels are pixel-identical (mean absolute difference `0.0000`, red-cube centroid `(207.0, 209.5)` in all three). Bottom row is this branch: three distinct start poses.

![randomize_positions start pose per episode](https://raw.githubusercontent.com/cagataycali/robots/media-randomize-positions-reset/randomize-positions-reset.png)

Rendered headless in MuJoCo (`MUJOCO_GL=egl`) by running one script twice, once with `PYTHONPATH` pointed at a worktree of `main` and once at this branch, so the panels differ only by the change.

## Tests

`tests/simulation/mujoco/test_randomize_positions_persistence.py`, 8 tests. On `main`: **5 fail, 3 pass**. On this branch: 8 pass.

Failing pre-fix (the defect):
- `test_randomized_position_survives_the_reset_that_begins_a_rollout` -- `reset() reverted the randomized pose: perturbed [0.3125 0.0397 0.0776] -> [0.3 0. 0.05]`
- `test_three_randomize_then_reset_cycles_yield_three_distinct_start_poses` -- `expected a distinct start pose per episode`, got one
- `test_perturbation_stays_within_the_requested_half_width`
- `test_a_recompile_still_undoes_the_position_axis`
- `test_positions_result_reports_how_many_objects_were_perturbed`

Passing on both trees (the boundaries the change must not cross):
- `test_static_object_is_never_moved` -- a welded body has no pose DOF
- `test_axis_off_leaves_live_pose_reset_reference_and_registry_untouched` -- `randomize_positions=False` is an exact no-op
- `test_offsets_stay_inside_the_bound_over_many_episodes` -- guards the naive fix rather than the original bug: with live-pose sampling it fails at `0.1231 m` against a `0.03 m` bound

Full `tests/` shows no new failures against `main` (identical sorted failure sets); `ruff check`, `ruff format --check` and `mypy` over `strands_robots tests tests_integ` are clean.

## Docs

`docs/simulation/domain-randomization.md` states the persistence contract for all four axes and the commanded-pose sampling reference, and the per-episode eval example now includes `randomize_positions` (it previously used only the axes that happened to survive a reset, and called `sim.reset()` itself even though `eval_policy` resets per episode).