### PR TITLE
fix(simulation): name the variable that lifts a sandbox refusal, not a glob

### DIFF
--- a/changelog.d/2296-sandbox-refusal-names-opt-in-variable.md
+++ b/changelog.d/2296-sandbox-refusal-names-opt-in-variable.md
@@ -1,0 +1,17 @@
+### Fixed
+
+A sandbox confinement refusal now names the environment variable that lifts it
+instead of the pattern `*_ALLOW_ABS`. Artifact sinks confine an LLM-supplied
+output path to a sandbox root, and each sink has its own opt-in spelling
+(`STRANDS_ROBOTS_RENDER_ALLOW_ABS` for `render(output_path=...)`,
+`STRANDS_ROBOTS_VIDEO_ALLOW_ABS` for `run_policy(video=...)` and
+`start_cameras_recording(output_dir=...)`), but the refusal reported the glob, so
+acting on the one message whose job is to state the next step meant grepping the
+package for the name. The name was available at every call site and discarded:
+only the resolved boolean reached `validate_output_path`. It is now threaded
+through as `allow_abs_env` and quoted, along with the alternative that needs no
+variable at all (a path under the sandbox); `video_sandbox_args` returns the
+spelling beside the flag it derives from it, so the value read and the name
+reported cannot drift apart. The confinement decision is unchanged, and refusals
+the opt-in cannot lift (`..` traversal, shell metacharacters, backslash
+separators, a symlinked target) still do not advertise it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,6 +29,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | Sim hangs on `create_world` | Asset download | Wait - first call downloads MJCF, then cached |
 | `ModuleNotFoundError: trs_so_arm100_mj_description` | Auto-install failed | `uv pip install trs-so-arm100-mj-description` |
 | `add_robot` raises after `load_scene` | Scene XML overrides world | Use `add_robot` before `load_scene` |
+| `render(output_path=...)` refuses with `is outside the sandbox` | `output_path` resolved outside the render sandbox (`~/.strands_robots/renders`, or `STRANDS_ROBOTS_RENDER_ROOT`). Artifact sinks confine LLM-supplied paths | Write under the sandbox (a bare filename like `frame.png` is placed INTO it), or set the variable the refusal names - `STRANDS_ROBOTS_RENDER_ALLOW_ABS=1` for `render`, `STRANDS_ROBOTS_VIDEO_ALLOW_ABS=1` for the video/recording sinks under `STRANDS_ROBOTS_VIDEO_ROOT` |
 | `move_to` refuses with `is unreachable ... The same target solves to ... once the N degree(s) of freedom move_to does not command are free too` | The target needs motion `move_to` does not produce. It drives the arm's position servos only, so a mobile base, a floating pelvis or any unactuated joint is not available to the solve - and 35 of the shipped sim robots have one | Move those degrees of freedom first (drive the base to the work area), then call `move_to`. The refusal's `uncommanded_joints_moved` names them and `unrestricted_ik_residual_m` is what the whole robot could reach |
 
 ## Hardware

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -68,13 +68,20 @@ def _max_render_bytes() -> int:
     return val
 
 
+# Environment variable that re-permits absolute ``render(output_path=...)``
+# destinations outside the render sandbox. One owner for the spelling, so the
+# value read and the name quoted in a refusal cannot drift apart.
+_RENDER_ALLOW_ABS_ENV = "STRANDS_ROBOTS_RENDER_ALLOW_ABS"
+
+
 def _validate_render_output_path(output_path: str) -> Path:
     """Validate an LLM-supplied render path, confined to the render sandbox.
 
     Thin render-specific binding over
     :func:`strands_robots.simulation.safe_output.validate_output_path`: absolute
     paths outside the sandbox are rejected unless ``STRANDS_ROBOTS_RENDER_ALLOW_ABS``
-    opts in.
+    opts in. That variable's name is passed down as well as read, so a
+    confinement refusal quotes the spelling the caller must set.
 
     Raises:
         ValueError: If the path is unsafe (the caller maps this to a tool error).
@@ -82,7 +89,8 @@ def _validate_render_output_path(output_path: str) -> Path:
     return validate_output_path(
         output_path,
         sandbox_root=_render_sandbox_root(),
-        allow_abs=env_flag("STRANDS_ROBOTS_RENDER_ALLOW_ABS"),
+        allow_abs=env_flag(_RENDER_ALLOW_ABS_ENV),
+        allow_abs_env=_RENDER_ALLOW_ABS_ENV,
     )
 
 
@@ -1976,9 +1984,15 @@ class RenderingMixin:
             if name is not None:
                 sanitize_name_component(name, label="name")
             if output_dir is not None:
-                _sb_root, _allow_abs = video_sandbox_args()
+                _sb_root, _allow_abs, _allow_abs_env = video_sandbox_args()
                 out_dir = str(
-                    validate_output_path(output_dir, sandbox_root=_sb_root, allow_abs=_allow_abs, label="output_dir")
+                    validate_output_path(
+                        output_dir,
+                        sandbox_root=_sb_root,
+                        allow_abs=_allow_abs,
+                        label="output_dir",
+                        allow_abs_env=_allow_abs_env,
+                    )
                 )
             else:
                 out_dir = _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings")
@@ -2425,9 +2439,15 @@ class RenderingMixin:
             if name is not None:
                 sanitize_name_component(name, label="name")
             if output_dir is not None:
-                _sb_root, _allow_abs = video_sandbox_args()
+                _sb_root, _allow_abs, _allow_abs_env = video_sandbox_args()
                 out_dir = str(
-                    validate_output_path(output_dir, sandbox_root=_sb_root, allow_abs=_allow_abs, label="output_dir")
+                    validate_output_path(
+                        output_dir,
+                        sandbox_root=_sb_root,
+                        allow_abs=_allow_abs,
+                        label="output_dir",
+                        allow_abs_env=_allow_abs_env,
+                    )
                 )
             else:
                 out_dir = _os.path.join(_tempfile.gettempdir(), "strands_robots", "recordings")

--- a/strands_robots/simulation/policy_runner.py
+++ b/strands_robots/simulation/policy_runner.py
@@ -440,10 +440,16 @@ class _RolloutVideoWriter:
         # separators, ".." traversal, and a symlinked target before we makedirs +
         # open a writer on it. Absolute paths stay allowed (the historic
         # contract); set STRANDS_ROBOTS_VIDEO_ROOT to sandbox them.
-        _sb_root, _allow_abs = video_sandbox_args()
+        _sb_root, _allow_abs, _allow_abs_env = video_sandbox_args()
         try:
             resolved = str(
-                validate_output_path(video.path, sandbox_root=_sb_root, allow_abs=_allow_abs, label="video path")
+                validate_output_path(
+                    video.path,
+                    sandbox_root=_sb_root,
+                    allow_abs=_allow_abs,
+                    label="video path",
+                    allow_abs_env=_allow_abs_env,
+                )
             )
         except ValueError as _e:
             return None, {"status": "error", "content": [{"text": f"video recording: {_e}"}]}

--- a/strands_robots/simulation/safe_output.py
+++ b/strands_robots/simulation/safe_output.py
@@ -36,6 +36,13 @@ from pathlib import Path
 # shell and serve no purpose in a legitimate filesystem path.
 PATH_BAD_CHARS = frozenset({";", "|", "$", "`", ">", "<", "\n", "\r", "\x00"})
 
+# Environment variable that re-permits absolute paths for the video / camera-
+# recording sinks. Named here so :func:`video_sandbox_args` can hand the exact
+# spelling to :func:`validate_output_path`, which quotes it in the refusal: a
+# caller told only that "a *_ALLOW_ABS variable" exists has to grep the package
+# to act on the message.
+_VIDEO_ALLOW_ABS_ENV = "STRANDS_ROBOTS_VIDEO_ALLOW_ABS"
+
 
 def env_flag(name: str) -> bool:
     """Return True when env var ``name`` is a truthy opt-in (``1``/``true``/``yes``)."""
@@ -71,6 +78,7 @@ def validate_output_path(
     sandbox_root: Path | None,
     allow_abs: bool,
     label: str = "output_path",
+    allow_abs_env: str | None = None,
 ) -> Path:
     """Validate and resolve an LLM-supplied output path (file or directory).
 
@@ -94,6 +102,11 @@ def validate_output_path(
         allow_abs: When True, skip the sandbox confinement check even if
             ``sandbox_root`` is provided (explicit absolute-path opt-in).
         label: Noun used in error messages (e.g. ``"output_path"``/``"output_dir"``).
+        allow_abs_env: Name of the environment variable that sets ``allow_abs``
+            for this sink, quoted verbatim in the confinement refusal so the
+            caller can act on the message without searching for the spelling.
+            Every sink that establishes confinement supplies it; ``None`` (a
+            sink with no opt-in variable) falls back to naming the convention.
 
     Returns:
         The fully-resolved destination ``Path``.
@@ -132,15 +145,25 @@ def validate_output_path(
         try:
             resolved.relative_to(sandbox_root)
         except ValueError as e:
+            # Name the variable that lifts this refusal. The glob this replaced
+            # ("set the corresponding *_ALLOW_ABS env var") told the caller a
+            # pattern rather than a name, so acting on the message meant
+            # grepping the package for the sink's actual spelling -- a dead end
+            # in the one place the caller most needs a next step. Every
+            # confining sink knows its own variable, so the message can state
+            # it, matching the sibling env-var refusal in
+            # ``strands_robots.simulation.isaac.config`` (which interpolates the
+            # variable name it read).
+            opt_in = f"set {allow_abs_env}=1" if allow_abs_env else "set this sink's *_ALLOW_ABS env var"
             raise ValueError(
                 f"{label} {resolved} is outside the sandbox {sandbox_root} "
-                "(set the corresponding *_ALLOW_ABS env var to permit absolute paths)"
+                f"({opt_in} to permit absolute paths, or pass a path under the sandbox)"
             ) from e
     return resolved
 
 
-def video_sandbox_args() -> tuple[Path | None, bool]:
-    """Return ``(sandbox_root, allow_abs)`` for video / recording output paths.
+def video_sandbox_args() -> tuple[Path | None, bool, str]:
+    """Return ``(sandbox_root, allow_abs, allow_abs_env)`` for video / recording paths.
 
     Unlike ``render``, the video and camera-recording sinks have historically
     accepted arbitrary absolute paths, so confinement is OPT-IN: when
@@ -148,14 +171,17 @@ def video_sandbox_args() -> tuple[Path | None, bool]:
     ``STRANDS_ROBOTS_VIDEO_ALLOW_ABS`` re-permits absolute paths inside that
     mode); otherwise absolute paths are allowed. The metacharacter, backslash,
     symlink, and traversal guards in :func:`validate_output_path` apply in
-    either mode.
+    either mode. The third element is the opt-in variable's name, passed
+    through to :func:`validate_output_path` so a confinement refusal quotes the
+    exact spelling instead of a ``*_ALLOW_ABS`` pattern.
     """
     if os.getenv("STRANDS_ROBOTS_VIDEO_ROOT"):
         return (
             resolve_sandbox_root("STRANDS_ROBOTS_VIDEO_ROOT", "videos"),
-            env_flag("STRANDS_ROBOTS_VIDEO_ALLOW_ABS"),
+            env_flag(_VIDEO_ALLOW_ABS_ENV),
+            _VIDEO_ALLOW_ABS_ENV,
         )
-    return None, True
+    return None, True, _VIDEO_ALLOW_ABS_ENV
 
 
 def sanitize_name_component(name: str, *, label: str = "name") -> str:

--- a/tests/simulation/test_output_path_sandbox.py
+++ b/tests/simulation/test_output_path_sandbox.py
@@ -150,25 +150,29 @@ def test_sandbox_accepts_intermediate_symlink_staying_inside(tmp_path):
 def test_video_sandbox_args_default_allows_abs(monkeypatch):
     """Without STRANDS_ROBOTS_VIDEO_ROOT, video paths are unconfined (historic contract)."""
     monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ROOT", raising=False)
-    root, allow_abs = video_sandbox_args()
+    root, allow_abs, allow_abs_env = video_sandbox_args()
     assert root is None
     assert allow_abs is True
+    # The opt-in name is reported even when nothing is confined, so a sink can
+    # quote it without re-deriving the spelling.
+    assert allow_abs_env == "STRANDS_ROBOTS_VIDEO_ALLOW_ABS"
 
 
 def test_video_sandbox_args_confines_when_root_set(monkeypatch, tmp_path):
     """Setting STRANDS_ROBOTS_VIDEO_ROOT switches to sandbox-confined mode."""
     monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
     monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", raising=False)
-    root, allow_abs = video_sandbox_args()
+    root, allow_abs, allow_abs_env = video_sandbox_args()
     assert root == (tmp_path / "vids").resolve()
     assert allow_abs is False
+    assert allow_abs_env == "STRANDS_ROBOTS_VIDEO_ALLOW_ABS"
 
 
 def test_video_sandbox_args_allow_abs_override(monkeypatch, tmp_path):
     """STRANDS_ROBOTS_VIDEO_ALLOW_ABS re-permits absolute paths inside sandbox mode."""
     monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
     monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", "1")
-    _, allow_abs = video_sandbox_args()
+    _, allow_abs, _env = video_sandbox_args()
     assert allow_abs is True
 
 

--- a/tests/simulation/test_sandbox_refusal_names_the_opt_in_variable.py
+++ b/tests/simulation/test_sandbox_refusal_names_the_opt_in_variable.py
@@ -1,0 +1,175 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A sandbox refusal must name the variable that lifts it, not a glob.
+
+``validate_output_path`` confines LLM-supplied artifact destinations to a
+sandbox root. When it refuses, the caller's only next step is the environment
+variable that re-permits absolute paths -- and each sink has its own spelling
+(``STRANDS_ROBOTS_RENDER_ALLOW_ABS`` for ``render(output_path=...)``,
+``STRANDS_ROBOTS_VIDEO_ALLOW_ABS`` for the video / camera-recording sinks).
+Reporting the pattern ``*_ALLOW_ABS`` instead of the name left the caller to
+grep the package for it, in the one message that exists to say what to do next.
+
+The load-bearing assertion here is a round trip: the name is parsed back OUT of
+the refusal, set, and the same call retried. That fails for a missing name and
+for a wrong one, so it pins the remedy rather than the wording.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from strands_robots.simulation.mujoco.rendering import _validate_render_output_path
+from strands_robots.simulation.safe_output import validate_output_path, video_sandbox_args
+
+# The refusal states its opt-in as "set <NAME>=1". Parsing it is how a caller
+# (human or agent) acts on the message, so the test consumes it the same way.
+_OPT_IN_RE = re.compile(r"set ([A-Z][A-Z0-9_]+)=1")
+
+
+def _named_opt_in(message: str) -> str | None:
+    """Return the env var the refusal tells the caller to set, if it names one."""
+    match = _OPT_IN_RE.search(message)
+    return match.group(1) if match else None
+
+
+def test_render_refusal_names_its_own_opt_in_variable(monkeypatch, tmp_path):
+    """The render sink's refusal quotes STRANDS_ROBOTS_RENDER_ALLOW_ABS by name."""
+    monkeypatch.setenv("STRANDS_ROBOTS_RENDER_ROOT", str(tmp_path / "renders"))
+    monkeypatch.delenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS", raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_render_output_path(str(tmp_path / "elsewhere" / "frame.png"))
+
+    message = str(excinfo.value)
+    assert _named_opt_in(message) == "STRANDS_ROBOTS_RENDER_ALLOW_ABS"
+    # The glob is what sent the caller grepping; it must not survive as the
+    # only actionable token in the message.
+    assert "*_ALLOW_ABS" not in message
+
+
+def test_the_variable_the_render_refusal_names_is_the_one_that_lifts_it(monkeypatch, tmp_path):
+    """Following the refusal's own instruction permits the write it refused.
+
+    Round-trip: parse the name out of the message, set it, retry. A refusal that
+    named nothing (or named a variable the sink does not read) fails here.
+    """
+    monkeypatch.setenv("STRANDS_ROBOTS_RENDER_ROOT", str(tmp_path / "renders"))
+    monkeypatch.delenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS", raising=False)
+    outside = tmp_path / "elsewhere" / "frame.png"
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_render_output_path(str(outside))
+
+    named = _named_opt_in(str(excinfo.value))
+    assert named is not None, f"refusal named no variable to set: {excinfo.value}"
+
+    monkeypatch.setenv(named, "1")
+    assert _validate_render_output_path(str(outside)) == outside.resolve()
+
+
+def test_the_variable_the_video_refusal_names_is_the_one_that_lifts_it(monkeypatch, tmp_path):
+    """Same round trip for the video / recording sink, which has its own spelling."""
+    monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
+    monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", raising=False)
+    outside = tmp_path / "elsewhere" / "rollout.mp4"
+
+    root, allow_abs, allow_abs_env = video_sandbox_args()
+    with pytest.raises(ValueError) as excinfo:
+        validate_output_path(
+            str(outside),
+            sandbox_root=root,
+            allow_abs=allow_abs,
+            label="video path",
+            allow_abs_env=allow_abs_env,
+        )
+
+    named = _named_opt_in(str(excinfo.value))
+    assert named == "STRANDS_ROBOTS_VIDEO_ALLOW_ABS"
+
+    monkeypatch.setenv(named, "1")
+    root, allow_abs, allow_abs_env = video_sandbox_args()
+    resolved = validate_output_path(
+        str(outside),
+        sandbox_root=root,
+        allow_abs=allow_abs,
+        label="video path",
+        allow_abs_env=allow_abs_env,
+    )
+    assert resolved == outside.resolve()
+
+
+def test_the_two_sinks_name_different_variables(monkeypatch, tmp_path):
+    """Each sink names ITS OWN opt-in, so one message cannot misdirect the other.
+
+    A single shared string would be wrong for whichever sink it did not
+    describe; that is the failure mode the glob papered over.
+    """
+    monkeypatch.setenv("STRANDS_ROBOTS_RENDER_ROOT", str(tmp_path / "renders"))
+    monkeypatch.delenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS", raising=False)
+    monkeypatch.setenv("STRANDS_ROBOTS_VIDEO_ROOT", str(tmp_path / "vids"))
+    monkeypatch.delenv("STRANDS_ROBOTS_VIDEO_ALLOW_ABS", raising=False)
+    outside = tmp_path / "elsewhere" / "artifact.bin"
+
+    with pytest.raises(ValueError) as render_exc:
+        _validate_render_output_path(str(outside))
+
+    root, allow_abs, allow_abs_env = video_sandbox_args()
+    with pytest.raises(ValueError) as video_exc:
+        validate_output_path(str(outside), sandbox_root=root, allow_abs=allow_abs, allow_abs_env=allow_abs_env)
+
+    assert _named_opt_in(str(render_exc.value)) == "STRANDS_ROBOTS_RENDER_ALLOW_ABS"
+    assert _named_opt_in(str(video_exc.value)) == "STRANDS_ROBOTS_VIDEO_ALLOW_ABS"
+
+
+def test_a_sink_that_names_no_variable_still_refuses(tmp_path):
+    """``allow_abs_env=None`` keeps the confinement check and stays a clean refusal.
+
+    The name is message-only: omitting it must not widen the sandbox or raise
+    something other than the documented ``ValueError``.
+    """
+    with pytest.raises(ValueError, match="outside the sandbox"):
+        validate_output_path(
+            str(tmp_path / "elsewhere" / "x.png"),
+            sandbox_root=(tmp_path / "box").resolve(),
+            allow_abs=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_path,reason",
+    [
+        ("../escape.png", "path traversal"),
+        ("frame;rm -rf /.png", "shell metacharacters"),
+        ("dir\\frame.png", "backslash separators"),
+    ],
+)
+def test_refusals_the_opt_in_cannot_fix_do_not_advertise_it(monkeypatch, tmp_path, bad_path, reason):
+    """Traversal / metacharacter / backslash refusals must not suggest the opt-in.
+
+    Those guards run in every mode, so ``*_ALLOW_ABS=1`` would not lift them;
+    offering it there would send the caller after a remedy that cannot work.
+    """
+    monkeypatch.setenv("STRANDS_ROBOTS_RENDER_ROOT", str(tmp_path / "renders"))
+    monkeypatch.delenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS", raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_render_output_path(bad_path)
+
+    message = str(excinfo.value)
+    assert reason in message
+    assert _named_opt_in(message) is None
+
+
+def test_a_path_inside_the_sandbox_is_still_accepted(monkeypatch, tmp_path):
+    """Control: the confinement decision itself is unchanged by naming the variable."""
+    root = tmp_path / "renders"
+    monkeypatch.setenv("STRANDS_ROBOTS_RENDER_ROOT", str(root))
+    monkeypatch.delenv("STRANDS_ROBOTS_RENDER_ALLOW_ABS", raising=False)
+
+    inside = root / "frame.png"
+    assert _validate_render_output_path(str(inside)) == inside.resolve()
+    # A bare filename is anchored into the sandbox, not the CWD.
+    assert _validate_render_output_path("bare.png") == (root / "bare.png").resolve()


### PR DESCRIPTION
## Problem

`validate_output_path` confines an LLM-supplied artifact destination to a sandbox root. When it refused, the message told the caller to set **`the corresponding *_ALLOW_ABS env var`** -- a pattern, not a name:

```
output_path /home/me/artifacts/overview.png is outside the sandbox
/home/me/.strands_robots/renders (set the corresponding *_ALLOW_ABS env var to
permit absolute paths)
```

The one message whose entire job is to state the next step made the caller grep the package for the sink's actual spelling. There are two, and they differ per sink:

| Sink | Variable |
|---|---|
| `render(output_path=...)` | `STRANDS_ROBOTS_RENDER_ALLOW_ABS` |
| `run_policy(video=...)`, `start_cameras_recording(output_dir=...)` | `STRANDS_ROBOTS_VIDEO_ALLOW_ABS` |

The name was **available at every call site and discarded** -- `_validate_render_output_path` did `allow_abs=env_flag("STRANDS_ROBOTS_RENDER_ALLOW_ABS")` and `video_sandbox_args()` did the same for its own variable, passing only the resolved boolean down. So the refusal had no way to say what it knew one frame up.

This is the same standard the sibling env-var refusal in `simulation.isaac.config` already meets -- it interpolates the variable name it read (`f"{name}={raw!r} is not a recognized switch value..."`) and its docstring states the rule outright: "the message names both vocabularies and the variable".

## Change

Thread the spelling through as `allow_abs_env` and quote it, plus the alternative that needs no variable at all:

```
output_path /home/me/artifacts/overview.png is outside the sandbox
/home/me/.strands_robots/renders (set STRANDS_ROBOTS_RENDER_ALLOW_ABS=1 to permit
absolute paths, or pass a path under the sandbox)
```

- `video_sandbox_args()` returns the name alongside the flag it derives *from that name*, so the value read and the name reported cannot drift apart.
- The render binding reads both from one module constant (`_RENDER_ALLOW_ABS_ENV`).
- All four sinks updated (`render`, `run_policy` video, the two `start_cameras_recording` paths).

**The confinement decision itself is unchanged** -- this is the message only. Refusals the opt-in *cannot* lift (traversal, shell metacharacters, backslash separators, a symlinked target) run before the confinement check, so they still do not advertise it; offering `*_ALLOW_ABS=1` there would point at a remedy that cannot work.

The issue also suggested inverting the default (sandbox only under an opt-in strict flag). That is a security-policy change, so it is deliberately not part of this PR; only the dead-end message is fixed.

## Tests

`tests/simulation/test_sandbox_refusal_names_the_opt_in_variable.py`. The load-bearing assertion is a **round trip**: parse the variable name back out of the refusal, set it, retry the same call. That fails for a missing name *and* for a wrong one, so it pins the remedy rather than the wording.

| | pre-fix | post-fix |
|---|---|---|
| render refusal names `STRANDS_ROBOTS_RENDER_ALLOW_ABS` | FAIL `assert None == 'STRANDS_ROBOTS_RENDER_ALLOW_ABS'` | pass |
| the named variable is the one that lifts it (render) | FAIL `refusal named no variable to set` | pass |
| same round trip for the video sink | FAIL | pass |
| the two sinks name different variables | FAIL | pass |
| traversal / metacharacter / backslash refusals do **not** advertise the opt-in (3 cases) | pass | pass |
| a path inside the sandbox is still accepted; bare name anchored into it | pass | pass |
| `allow_abs_env=None` still refuses, still `ValueError` | pass | pass |

**4 fail / 5 pass pre-fix.** The 5 that pass on both trees are the no-overreach controls -- they are what show the change does not widen the sandbox or reach past the message.

Full `tests/` on both trees: **358 pre-existing failing ids on each, identical sets** (`comm` empty both ways), `+9 passed` on the branch = exactly the 9 new tests. `ruff check` / `ruff format --check` clean; `mypy` unchanged from baseline.

## Artifact

Before/after refusal text, and the write the named variable unlocks: an Apple RoomPlan USDZ room scan (170,022 verts) imported as a static geom with `so101`, rendered headless to an absolute path (MuJoCo 3.5.0, `MUJOCO_GL=egl`).

![sandbox refusal, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-sandbox-refusal-opt-in/sandbox_refusal.png)

## Docs

`docs/troubleshooting.md` gains a Simulation row for `is outside the sandbox`, naming both variables and the write-under-the-sandbox alternative. The variables were already in the README env table; the gap was the runtime message, which is where a caller actually meets the refusal.