### PR TITLE
fix(rendering): key the baked-panorama cache on the geometry it was baked for

### DIFF
--- a/changelog.d/2297-bake-pano-cache-geometry.md
+++ b/changelog.d/2297-bake-pano-cache-geometry.md
@@ -1,0 +1,8 @@
+### Fixed
+
+`bake_gsplat_panorama` now keys its cached output on the geometry it was baked
+for. The default output path is `<stem>_pano_<equi_w>x<equi_h>_f<face_size>.jpg`
+instead of a single `<stem>_pano.jpg` shared by every bake of one scene, so a
+call asking for a different resolution or `face_size` re-renders instead of
+silently returning an earlier bake's image. An explicit `out_path` is still
+honored verbatim, and repeating one request still hits the cache.

--- a/strands_robots/rendering/backgrounds.py
+++ b/strands_robots/rendering/backgrounds.py
@@ -701,10 +701,25 @@ def bake_gsplat_panorama(
     "just works" without per-camera viewpoint alignment (the trade-off is no
     parallax -- the backdrop sits at infinity).
 
-    Returns the path to the written panorama ``.jpg`` (cached next to the ply).
+    Baking is expensive (six gaussian-splat renders), so a non-empty output
+    file short-circuits the whole pass. The default output path therefore
+    encodes the geometry that determines the pixels -- ``equi_w``, ``equi_h``
+    and ``face_size`` -- as ``<stem>_pano_<equi_w>x<equi_h>_f<face_size>.jpg``.
+    Without that, every bake of one scene shared a single ``<stem>_pano.jpg``
+    and a later call asking for a different resolution silently returned the
+    first call's image: the caller's ``equi_w`` / ``equi_h`` / ``face_size``
+    were accepted and then dropped. An explicit ``out_path`` is caller-owned
+    and is honored verbatim -- the caller named the file, so the caller owns
+    what it holds.
+
+    Returns the path to the written panorama ``.jpg`` (cached next to the ply
+    unless ``out_path`` says otherwise).
     """
     ply_path = Path(ply_path)
-    out = Path(out_path) if out_path else ply_path.with_name(ply_path.stem + "_pano.jpg")
+    if out_path is not None:
+        out = Path(out_path)
+    else:
+        out = ply_path.with_name(f"{ply_path.stem}_pano_{equi_w}x{equi_h}_f{face_size}.jpg")
     if out.exists() and out.stat().st_size > 0:
         return out
 

--- a/tests/rendering/test_backgrounds.py
+++ b/tests/rendering/test_backgrounds.py
@@ -751,6 +751,91 @@ class TestBakeGsplatPanorama:
         assert result == out
         assert out.read_bytes() == b"cached-panorama"
 
+    # ----- the cache must answer only the request it was baked for ----- #
+    #
+    # Baking is six splat renders, so a warm output short-circuits the pass.
+    # The short-circuit is keyed on the output *path*, so the default path has
+    # to identify the panorama it holds: ``equi_w`` / ``equi_h`` / ``face_size``
+    # all change the pixels, and a path that ignores them makes the second
+    # caller's geometry a no-op.
+
+    def _stub_render_boundary(self, monkeypatch, tmp_path):
+        """Double the CUDA-bound splat boundary; return the per-face render log."""
+        torch = pytest.importorskip("torch")
+
+        from strands_robots.rendering import backgrounds as bg
+
+        rng = np.random.default_rng(0)
+        means = np.column_stack([rng.uniform(-4, 4, 512), rng.uniform(-2, 2, 512), rng.uniform(-0.1, 0.1, 512)]).astype(
+            np.float32
+        )
+        rendered: list[tuple[int, int]] = []
+
+        def fake_load(inner_self) -> None:
+            inner_self._splats = {"means": torch.from_numpy(means)}
+
+        def fake_render(inner_self, cam):
+            rendered.append((cam.width, cam.height))
+            return (
+                np.full((cam.height, cam.width, 3), 128, np.uint8),
+                np.zeros((cam.height, cam.width), np.float32),
+            )
+
+        monkeypatch.setattr(bg.GsplatBackground, "_load", fake_load)
+        monkeypatch.setattr(bg.GsplatBackground, "render", fake_render)
+        ply = tmp_path / "scene.ply"
+        ply.write_bytes(b"placeholder")
+        return bg, ply, rendered
+
+    def test_a_new_equirect_resolution_is_rendered_not_served_from_the_cache(self, tmp_path, monkeypatch) -> None:
+        # The headline defect: bake small, then ask for a bigger panorama. The
+        # second request used to return the first call's small image with zero
+        # renders, so the caller silently got a backdrop at a resolution it had
+        # not asked for (and then sampled that as if it were the big one).
+        from PIL import Image
+
+        bg, ply, rendered = self._stub_render_boundary(monkeypatch, tmp_path)
+
+        first = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32, device="cpu")
+        assert Image.open(first).size == (64, 32)
+
+        rendered.clear()
+        second = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=128, equi_h=64, device="cpu")
+
+        assert Image.open(second).size == (128, 64), "the requested equirect size must be honored"
+        assert rendered, "a new resolution must re-render rather than reuse the cached panorama"
+        assert second != first, "distinct requests must not collide on one cache path"
+        # The first panorama is still intact for whoever asked for that size.
+        assert Image.open(first).size == (64, 32)
+
+    def test_a_new_face_size_is_rendered_not_served_from_the_cache(self, tmp_path, monkeypatch) -> None:
+        # face_size changes the sharpness of the cube faces the panorama is
+        # reprojected from, not the output dimensions -- so a cache keyed on the
+        # output size alone would still wrongly serve the coarser bake.
+        bg, ply, rendered = self._stub_render_boundary(monkeypatch, tmp_path)
+
+        bg.bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32, device="cpu")
+
+        rendered.clear()
+        bg.bake_gsplat_panorama(ply, face_size=64, equi_w=64, equi_h=32, device="cpu")
+
+        assert rendered, "a new face_size must re-render rather than reuse the cached panorama"
+        assert {size for size in rendered} == {(64, 64)}, "the requested face_size must be honored"
+
+    def test_repeating_one_request_reuses_the_cached_panorama(self, tmp_path, monkeypatch) -> None:
+        # Control: the cache still exists. Asking twice for the same geometry
+        # renders once, so the expensive path is not re-run per call.
+        bg, ply, rendered = self._stub_render_boundary(monkeypatch, tmp_path)
+
+        first = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32, device="cpu")
+        assert rendered, "the first bake must render"
+
+        rendered.clear()
+        second = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32, device="cpu")
+
+        assert second == first
+        assert not rendered, "an identical request must be served from the cache"
+
 
 # --------------------------------------------------------------------------- #
 # GsplatBackground._load -- splat load + alignment wiring (no gsplat/CUDA)

--- a/tests/rendering/test_backgrounds.py
+++ b/tests/rendering/test_backgrounds.py
@@ -787,26 +787,35 @@ class TestBakeGsplatPanorama:
         ply.write_bytes(b"placeholder")
         return bg, ply, rendered
 
+    @staticmethod
+    def _panorama_size(path) -> tuple[int, int]:
+        """Return the (width, height) of a baked panorama, closing the file."""
+        from PIL import Image
+
+        with Image.open(path) as img:
+            return img.size
+
     def test_a_new_equirect_resolution_is_rendered_not_served_from_the_cache(self, tmp_path, monkeypatch) -> None:
         # The headline defect: bake small, then ask for a bigger panorama. The
         # second request used to return the first call's small image with zero
         # renders, so the caller silently got a backdrop at a resolution it had
         # not asked for (and then sampled that as if it were the big one).
-        from PIL import Image
-
         bg, ply, rendered = self._stub_render_boundary(monkeypatch, tmp_path)
 
         first = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32, device="cpu")
-        assert Image.open(first).size == (64, 32)
+        first_size = self._panorama_size(first)
+        assert first_size == (64, 32)
 
         rendered.clear()
         second = bg.bake_gsplat_panorama(ply, face_size=16, equi_w=128, equi_h=64, device="cpu")
+        second_size = self._panorama_size(second)
+        first_size_after = self._panorama_size(first)
 
-        assert Image.open(second).size == (128, 64), "the requested equirect size must be honored"
+        assert second_size == (128, 64), "the requested equirect size must be honored"
         assert rendered, "a new resolution must re-render rather than reuse the cached panorama"
         assert second != first, "distinct requests must not collide on one cache path"
         # The first panorama is still intact for whoever asked for that size.
-        assert Image.open(first).size == (64, 32)
+        assert first_size_after == (64, 32)
 
     def test_a_new_face_size_is_rendered_not_served_from_the_cache(self, tmp_path, monkeypatch) -> None:
         # face_size changes the sharpness of the cube faces the panorama is

--- a/tests/rendering/test_gsplat_background_construction.py
+++ b/tests/rendering/test_gsplat_background_construction.py
@@ -115,11 +115,13 @@ def test_render_without_the_sim_gs_extra_fails_loud_with_an_install_hint() -> No
 
 def test_bake_panorama_returns_cached_image_without_loading_splats(tmp_path) -> None:
     # The bake helper is CUDA-heavy, but a warm cache hit (an existing non-empty
-    # panorama next to the .ply) must short-circuit before any gsplat load.
+    # panorama next to the .ply for the *same* requested geometry) must
+    # short-circuit before any gsplat load. The default path encodes the
+    # geometry, so the cache file is named for the request it answers.
     ply = tmp_path / "scene.ply"
     ply.write_bytes(b"placeholder")
-    cached = ply.with_name(ply.stem + "_pano.jpg")
+    cached = ply.with_name("scene_pano_64x32_f16.jpg")
     cached.write_bytes(b"\xff\xd8\xff\xe0cached-jpeg")
 
-    out = bake_gsplat_panorama(ply)
+    out = bake_gsplat_panorama(ply, face_size=16, equi_w=64, equi_h=32)
     assert out == cached


### PR DESCRIPTION
## Problem

`bake_gsplat_panorama` short-circuits on a non-empty output file, and the default output path was `ply_path.stem + "_pano.jpg"` -- independent of `equi_w`, `equi_h` and `face_size`. Every bake of one scene therefore shared a single cache entry, so the second caller's geometry was accepted and then dropped:

```python
bake_gsplat_panorama(scene, equi_w=128,  equi_h=64)    # cheap preview
bake_gsplat_panorama(scene, equi_w=2048, equi_h=1024)  # -> returns the 128x64 preview
```

The second call returns the preview with **zero renders and no warning**, and `PanoramaBackground` then samples that 128x64 image as the backdrop for a full-resolution view. `examples/mujoco_gs/app.py` bakes with the defaults, so a later quality bump is silently a no-op.

`face_size` is dropped the same way, and it is the reason a size-aware cache check is not sufficient: `face_size` changes the sharpness of the cube faces the panorama is reprojected from, not the output dimensions, so a check that only compared the cached image's width/height would still serve the coarser bake.

## Change

Derive the default output path from the geometry that determines the pixels:

```
<stem>_pano_<equi_w>x<equi_h>_f<face_size>.jpg
```

An explicit `out_path` stays honored verbatim -- the caller named the file, so the caller owns what it holds -- and repeating one request still hits the cache, so the expensive six-render pass is not re-run per call.

## Evidence

Same call sequence on both trees, with the requested final bake at 2048x1024:

| | panorama actually used | cube faces rendered on the 2nd call | backdrop detail (mean abs gradient) |
|---|---|---|---|
| before | **128x64** | **0** | 0.997 |
| after | 2048x1024 | 6 | 1.363 |

![baked panorama cache: requested resolution honored](https://raw.githubusercontent.com/cagataycali/robots/media-bake-pano-cache/bake_cache_compare.png)

Both panels are a real MuJoCo composite (headless EGL) of an so101 over a photoreal 3D-scene backdrop, produced by one script run against each tree so they differ only by this change (panel mean abs delta 6.33, max 215). The CUDA gaussian rasterizer is unavailable on the render host, so the splat render boundary is doubled exactly as `tests/rendering/test_backgrounds.py::TestBakeGsplatPanorama` does it -- each cube face is filled by sampling a real captured equirectangular panorama at that face's camera. Everything else is shipped code: the real upright transform (from real `.spz` splat means), the real cube-to-equirect reprojection, the real `PanoramaBackground` sampling and the real composite.

## Tests

Added to `TestBakeGsplatPanorama` (no gsplat/CUDA needed -- the existing doubled render boundary):

- `test_a_new_equirect_resolution_is_rendered_not_served_from_the_cache` -- **fails pre-fix** (`assert (64, 32) == (128, 64)`).
- `test_a_new_face_size_is_rendered_not_served_from_the_cache` -- **fails pre-fix** (zero renders on the second call).
- `test_repeating_one_request_reuses_the_cached_panorama` -- control, **passes pre- and post-fix**: the cache still works, so the fix does not make the expensive path unconditional.

`test_returns_cached_panorama_without_rerendering` (explicit `out_path`) is untouched and still passes -- that is the no-overreach control for caller-owned paths. `test_bake_panorama_returns_cached_image_without_loading_splats` had the derived filename inlined, so it now names the geometry it caches for; its intent (a warm cache hit short-circuits before any gsplat load) is unchanged, and it fails pre-fix because the old code does not find that cache entry.

`tests/rendering`: 3 failed / 273 passed before, 276 passed / 2 skipped after. Full `tests/`: 347 failing test ids on this branch vs 346 on `main`; the single delta is `test_eval_policy_async_rtc.py::test_eval_async_rtc_masks_inference_latency`, a wall-clock threshold test that trips under parallel-suite load and passes 3/3 in isolation on this branch. Zero new failures otherwise, +3 passed = the 3 new tests. `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` clean (18 pre-existing errors unchanged, none in the touched files).

### Note on the CI state

The `Test and Lint` failure on this branch is the red `main` it absorbs (`test_observation_camera_keys_carry_their_own_view.py::test_key_naming_no_compiled_camera_is_absent`, tracked in #2295): that id is in the failing set on `main` and on this branch identically. It is not produced by this diff.

### CodeQL follow-up (`6c54728f`)

The first revision wrote its size checks as `assert Image.open(first).size == (64, 32)`, which CodeQL flags at error severity as `py/side-effect-in-assert`, correctly:

- the opened file is never closed -- reading only `.size` leaves PIL's lazy handle open, and the form emits `ResourceWarning: unclosed file` under `-W error::ResourceWarning`;
- because the assert expression does work rather than only comparing, stripping assertions (`python -O`) changes what the program does, not just which checks run.

The size is now read first through a `_panorama_size` helper that closes the file via a context manager, and the assertions compare locals. No assert in the class contains a call, and the failure diff now names the wrong size instead of only reporting a failed comparison -- the same shape as the existing `decoded_size = ...` pattern in `tests/simulation/mujoco/test_render_output_path_roundtrip.py`. The three tests still fail pre-fix (2 failed / 3 passed against `main`, the 3 being the controls) and pass post-fix, so nothing was weakened to clear the alert.