### PR TITLE
fix(simulation/mujoco): report the geom a mesh add compiled, not the ignored size

### DIFF
--- a/changelog.d/2298-mesh-add-reports-compiled-geometry.md
+++ b/changelog.d/2298-mesh-add-reports-compiled-geometry.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `add_object(shape="mesh")` on the MuJoCo backend no longer echoes the `size` it
+  discards. A mesh consumes no `size` component, so the result asserted an extent
+  the call never applied - an omitted vector reported a 5 cm object for an asset of
+  any size, and an explicit one read as honoured. The success text now reports the
+  extent read back off the compiled geom and names the collision geometry, which
+  for every mesh geom is its convex hull rather than the triangles that render.
+  Primitive shapes are unchanged.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -295,7 +295,36 @@ file; the extent is defined by the mesh's own units, so `size` is ignored.
 ```python
 sim.add_object(name="bracket", shape="mesh", mesh_path="/abs/path/bracket.stl",
                position=[0.3, 0.0, 0.1])
+# 'bracket' added: mesh at [0.3, 0.0, 0.1], extent=[0.12, 0.08, 0.03]m from the
+# asset (collision uses its convex hull), 0.1kg
 ```
+
+Because no `size` component is consumed, the success text reports the extent
+read back off the compiled geom rather than echoing the request - the request
+carries no extent for a mesh, and the asset can be any size.
+
+### A mesh geom collides as its convex hull
+
+MuJoCo collides a mesh geom as its **convex hull**, not as the triangles that
+render. For a convex asset (a bracket, a mug body, a crate) the two coincide and
+there is nothing to think about. For a concave one - a scanned or generated room
+shell, a tray, a shelf, a bowl - the hull fills every cavity, so:
+
+* an object placed "inside" the cavity starts inside solid geometry and is pushed
+  out, and one dropped in rests on the filled hull instead of on the interior
+  floor;
+* a camera still shows the open interior, because rendering uses the triangles.
+  Nothing looks wrong.
+
+To get load-bearing concave geometry, decompose the asset into convex parts and
+add one mesh object per part:
+
+```python
+for i, part in enumerate(convex_parts):          # e.g. a V-HACD decomposition
+    sim.add_object(name=f"room_{i}", shape="mesh", mesh_path=part, is_static=True)
+```
+
+A single-mesh room is still useful as a visual backdrop; it just is not a floor.
 
 `mesh_path` is required for `shape="mesh"` - a mesh without a path is rejected
 with an actionable error rather than an opaque recompile failure. If the mesh

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -180,6 +180,31 @@ def _jnt_dof_width(mj: Any, jnt_type: int) -> int:
     return 1
 
 
+def _compiled_geom_extent(mj: Any, model: Any, geom_name: str) -> list[float] | None:
+    """Full extent in meters of a compiled geom's local bounding box.
+
+    Reads MuJoCo's own ``geom_aabb`` row (centre plus half-extent per local
+    axis) rather than re-deriving the extent from the request, so the number
+    describes the geometry that actually compiled. For a primitive that
+    reproduces the caller's ``size``; for a mesh it is the asset's own extent,
+    which no request component defines.
+
+    Args:
+        mj: the cached ``mujoco`` module.
+        model: a compiled ``MjModel``.
+        geom_name: name of the geom to measure.
+
+    Returns:
+        ``[x, y, z]`` full extents, or ``None`` when ``geom_name`` resolves to
+        no geom -- a caller then reports no extent rather than a wrong one.
+    """
+    geom_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, geom_name)
+    if geom_id < 0:
+        return None
+    aabb = model.geom_aabb[geom_id]
+    return [round(float(2.0 * aabb[3 + axis]), 4) for axis in range(3)]
+
+
 def _validated_mesh_handle(mesh: Any) -> Any:
     """Normalize the constructor ``mesh`` argument to a stoppable client or None.
 
@@ -2699,7 +2724,9 @@ class MuJoCoSimEngine(
         * ``plane``: ``size[0]`` / ``size[1]`` are visual half-widths; planes are
           infinite for collision and are forced static.
         * ``mesh``: ``size`` is ignored -- the asset's own units define the
-          extent (requires ``mesh_path``).
+          extent (requires ``mesh_path``). Because no component is consumed, the
+          success text reports the compiled extent read back off the geom
+          instead of echoing the request.
 
         A free (non-static) body rests on a horizontal support at
         ``rest_z = support_top + size_z / 2`` -- e.g. a 5 cm cube on a table
@@ -2752,7 +2779,15 @@ class MuJoCoSimEngine(
             is_static: Fix the body in the world. ``shape="plane"`` forces this
                 True; other shapes default to dynamic.
             mesh_path: Mesh asset path; required and only used when
-                ``shape="mesh"``.
+                ``shape="mesh"``. The asset defines the geom's extent, and
+                MuJoCo collides a mesh geom as its **convex hull** -- not as the
+                triangles that render. For a convex asset the two coincide; for
+                a concave one (a room shell, a tray, a shelf, a bowl) the hull
+                fills every cavity, so an object dropped "inside" rests on the
+                filled hull and a camera still shows the open interior. To get
+                load-bearing concave geometry, decompose the asset into convex
+                parts and add one mesh object per part. The success text names
+                the hull for this reason.
             material: Optional MuJoCo material for the object's geom, given as
                 a mapping of material attribute to value. The accepted keys are
                 ``builtin``, ``reflectance``, ``rgb1``, ``rgb2``, ``shininess``,
@@ -2973,11 +3008,27 @@ class MuJoCoSimEngine(
                 "content": [{"text": f"Failed to inject '{name}' into live scene: {e}"}],
             }
 
+        # A mesh consumes no 'size' component (``_SIZE_LAYOUT["mesh"]`` is 0),
+        # so echoing the request back reports an extent this add never applied:
+        # the default read as a 5 cm object for an asset of any size, and an
+        # explicit vector read as honoured. Report what compiled instead -- the
+        # asset's own extent, and the collision geometry, which for every mesh
+        # geom is its convex hull rather than the surface that renders. Both are
+        # what a caller placing a robot or an object against the asset needs, and
+        # neither is derivable from the request. Primitive shapes keep echoing
+        # ``size``: there it is the extent, and the geom compiles to it.
+        if shape == "mesh":
+            extent = _compiled_geom_extent(self._mj, self._world._model, f"{name}_geom")
+            geometry = "extent unavailable" if extent is None else f"extent={extent}m from the asset"
+            detail = f"{geometry} (collision uses its convex hull)"
+        else:
+            detail = f"size={obj.size}"
+
         return {
             "status": "success",
             "content": [
                 {
-                    "text": f"'{name}' added: {shape} at {obj.position}, size={obj.size}, {'static' if is_static else f'{mass}kg'}"
+                    "text": f"'{name}' added: {shape} at {obj.position}, {detail}, {'static' if is_static else f'{mass}kg'}"
                 }
             ],
         }

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -190,15 +190,18 @@ def _compiled_geom_extent(mj: Any, model: Any, geom_name: str) -> list[float] | 
     which no request component defines.
 
     Args:
-        mj: the cached ``mujoco`` module.
+        mj: the cached ``mujoco`` module, for the ``mjtObj`` enum.
         model: a compiled ``MjModel``.
-        geom_name: name of the geom to measure.
+        geom_name: name of the geom to measure. Resolved through
+            :func:`~strands_robots.simulation.mujoco.backend.mj_name_to_id`, so a
+            name that is not a string reports no extent rather than reaching the
+            binding.
 
     Returns:
         ``[x, y, z]`` full extents, or ``None`` when ``geom_name`` resolves to
         no geom -- a caller then reports no extent rather than a wrong one.
     """
-    geom_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, geom_name)
+    geom_id = mj_name_to_id(model, mj.mjtObj.mjOBJ_GEOM, geom_name)
     if geom_id < 0:
         return None
     aabb = model.geom_aabb[geom_id]

--- a/tests/simulation/mujoco/test_mesh_add_reports_compiled_geometry.py
+++ b/tests/simulation/mujoco/test_mesh_add_reports_compiled_geometry.py
@@ -170,6 +170,16 @@ class TestTheReportedGeometryIsTheGeometryThatActsOnObjects:
     def test_an_unresolvable_geom_reports_no_extent_rather_than_a_wrong_one(self, sim) -> None:
         assert _compiled_geom_extent(sim._mj, sim.mj_model, "never_added_geom") is None
 
+    def test_a_non_string_geom_name_reports_no_extent_rather_than_crashing(self, sim) -> None:
+        """The lookup routes through ``mj_name_to_id``, so it inherits its guard.
+
+        Reaching ``mujoco.mj_name2id`` with a non-string name terminates the
+        interpreter with SIGSEGV rather than raising, which no envelope can
+        recover from.
+        """
+        not_a_name: Any = None
+        assert _compiled_geom_extent(sim._mj, sim.mj_model, not_a_name) is None
+
     def test_a_concave_asset_collides_as_its_filled_hull(self, sim, channel_mesh: str) -> None:
         """The documented consequence, pinned so the warning cannot go stale.
 

--- a/tests/simulation/mujoco/test_mesh_add_reports_compiled_geometry.py
+++ b/tests/simulation/mujoco/test_mesh_add_reports_compiled_geometry.py
@@ -1,0 +1,194 @@
+"""``add_object(shape="mesh")`` reports the geom it compiled, not the request.
+
+A mesh consumes no ``size`` component -- ``_SIZE_LAYOUT["mesh"]`` is ``0``, and
+``_normalize_size`` maps it to ``[]`` -- yet the success text echoed ``size=``
+back. So the one shape whose extent the request never carries was the one shape
+whose extent the result asserted: an omitted ``size`` reported ``[0.05, 0.05,
+0.05]`` for an asset of any size (a 3.5 x 10.5 x 12.5 m generated room shell
+reported as a 5 cm object), and an explicit vector was echoed as though it had
+been honoured. ``_validate_size`` already records why that shape of report is a
+defect for primitives -- a short vector "compiled a differently-sized object
+while reporting success and echoed the requested ``[0.5]``" -- and the mesh row
+is where the echo is wrong unconditionally, because zero components are consumed.
+
+The result now reports the extent read back off the compiled geom
+(:func:`~strands_robots.simulation.mujoco.simulation._compiled_geom_extent`,
+over MuJoCo's own ``geom_aabb``) and names the collision geometry, which for
+every mesh geom is its convex hull rather than the triangles that render. Both
+are properties of the asset that no request component defines, and both are what
+a caller placing a robot or an object against the asset needs.
+
+Primitive shapes are unchanged: there ``size`` *is* the extent and the geom
+compiles to it, so it stays echoed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import (  # noqa: E402
+    Simulation,
+    _compiled_geom_extent,
+)
+
+# An open-topped channel: a thin floor plate spanned by two tall side walls.
+# Concave by construction -- its convex hull is the full 0.3 x 0.4 x 0.4 m box,
+# which fills the cavity between the walls. Written as an explicit triangle soup
+# so the fixture needs no mesh library.
+_CHANNEL_BOXES: tuple[tuple[tuple[float, float, float], tuple[float, float, float]], ...] = (
+    ((-0.20, -0.20, 0.00), (0.20, 0.20, 0.02)),  # floor plate, 2 cm thick
+    ((-0.20, -0.20, 0.00), (-0.18, 0.20, 0.30)),  # left wall, 30 cm tall
+    ((0.18, -0.20, 0.00), (0.20, 0.20, 0.30)),  # right wall
+)
+_CHANNEL_EXTENT = (0.3, 0.4, 0.4)
+_CHANNEL_CAVITY_FLOOR_Z = 0.02
+_CHANNEL_WALL_TOP_Z = 0.30
+
+
+def _write_box_soup(
+    path: Path,
+    boxes: tuple[tuple[tuple[float, float, float], tuple[float, float, float]], ...],
+) -> str:
+    """Write ``boxes`` (``(lo, hi)`` corner pairs) as one OBJ triangle soup."""
+    verts: list[tuple[float, float, float]] = []
+    faces: list[tuple[int, int, int]] = []
+    for lo, hi in boxes:
+        base = len(verts) + 1  # OBJ indices are 1-based
+        for sx in (0, 1):
+            for sy in (0, 1):
+                for sz in (0, 1):
+                    verts.append(
+                        (
+                            hi[0] if sx else lo[0],
+                            hi[1] if sy else lo[1],
+                            hi[2] if sz else lo[2],
+                        )
+                    )
+        corner = {(sx, sy, sz): base + sx * 4 + sy * 2 + sz for sx in (0, 1) for sy in (0, 1) for sz in (0, 1)}
+        for quad in (
+            ((0, 0, 0), (0, 1, 0), (0, 1, 1), (0, 0, 1)),
+            ((1, 0, 0), (1, 0, 1), (1, 1, 1), (1, 1, 0)),
+            ((0, 0, 0), (0, 0, 1), (1, 0, 1), (1, 0, 0)),
+            ((0, 1, 0), (1, 1, 0), (1, 1, 1), (0, 1, 1)),
+            ((0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)),
+            ((0, 0, 1), (0, 1, 1), (1, 1, 1), (1, 0, 1)),
+        ):
+            a, b, c, d = (corner[k] for k in quad)
+            faces.append((a, b, c))
+            faces.append((a, c, d))
+    path.write_text(
+        "".join(f"v {x:.6f} {y:.6f} {z:.6f}\n" for x, y, z in verts) + "".join(f"f {a} {b} {c}\n" for a, b, c in faces),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _reported_extent(result: dict[str, Any]) -> list[float]:
+    """Parse the ``extent=[...]`` vector out of an add_object success text."""
+    match = re.search(r"extent=\[([^\]]+)\]", _text(result))
+    assert match is not None, f"no extent reported: {_text(result)!r}"
+    return [float(part) for part in match.group(1).split(",")]
+
+
+@pytest.fixture
+def channel_mesh(tmp_path: Path) -> str:
+    return _write_box_soup(tmp_path / "channel.obj", _CHANNEL_BOXES)
+
+
+@pytest.fixture
+def sim():
+    engine = Simulation(tool_name="test_mesh_add_reports_compiled_geometry", mesh=False)
+    assert engine.create_world()["status"] == "success"
+    try:
+        yield engine
+    finally:
+        engine.cleanup(policy_stop_timeout=0.5)
+
+
+class TestAMeshReportsTheAssetsExtent:
+    """The extent comes off the compiled geom, because the request has none."""
+
+    def test_an_omitted_size_reports_the_assets_extent_not_the_5cm_default(self, sim, channel_mesh: str) -> None:
+        """Pre-fix: ``size=[0.05, 0.05, 0.05]`` for a 0.3 x 0.4 x 0.4 m asset."""
+        result = sim.add_object("channel", shape="mesh", mesh_path=channel_mesh, is_static=True)
+        assert result["status"] == "success", _text(result)
+        assert _reported_extent(result) == pytest.approx(_CHANNEL_EXTENT, abs=1e-3)
+        assert "size=" not in _text(result)
+
+    def test_an_explicit_size_is_not_echoed_as_though_it_were_honoured(self, sim, channel_mesh: str) -> None:
+        """A mesh consumes no component, so an echoed vector reports a fiction."""
+        result = sim.add_object("channel", shape="mesh", mesh_path=channel_mesh, size=[2.0, 2.0, 2.0])
+        assert result["status"] == "success", _text(result)
+        assert "2.0" not in _text(result)
+        assert _reported_extent(result) == pytest.approx(_CHANNEL_EXTENT, abs=1e-3)
+
+    def test_the_message_names_the_convex_hull_as_the_collision_geometry(self, sim, channel_mesh: str) -> None:
+        """The property that makes a concave asset behave unlike it renders."""
+        result = sim.add_object("channel", shape="mesh", mesh_path=channel_mesh, is_static=True)
+        assert "convex hull" in _text(result)
+
+
+class TestPrimitiveShapesAreUnchanged:
+    """The no-overreach control: ``size`` is the extent for every other shape."""
+
+    def test_a_box_still_reports_the_size_it_compiled_to(self, sim) -> None:
+        result = sim.add_object("crate", shape="box", size=[0.2, 0.3, 0.4])
+        assert result["status"] == "success", _text(result)
+        assert "size=[0.2, 0.3, 0.4]" in _text(result)
+        assert "convex hull" not in _text(result)
+
+    def test_a_sphere_still_reports_its_one_component_size(self, sim) -> None:
+        result = sim.add_object("ball", shape="sphere", size=[0.06])
+        assert result["status"] == "success", _text(result)
+        assert "size=[0.06]" in _text(result)
+
+
+class TestTheReportedGeometryIsTheGeometryThatActsOnObjects:
+    """Both halves of the report are checked against the compiled model."""
+
+    def test_the_reported_extent_matches_the_geoms_own_bounding_box(self, sim, channel_mesh: str) -> None:
+        assert sim.add_object("channel", shape="mesh", mesh_path=channel_mesh, is_static=True)["status"] == "success"
+        extent = _compiled_geom_extent(sim._mj, sim.mj_model, "channel_geom")
+        assert extent == pytest.approx(_CHANNEL_EXTENT, abs=1e-3)
+
+    def test_a_primitives_extent_reads_back_as_the_size_that_was_asked_for(self, sim) -> None:
+        """The same read is correct for every shape, which is why it is trusted."""
+        assert sim.add_object("crate", shape="box", size=[0.2, 0.3, 0.4])["status"] == "success"
+        extent = _compiled_geom_extent(sim._mj, sim.mj_model, "crate_geom")
+        assert extent == pytest.approx([0.2, 0.3, 0.4], abs=1e-3)
+
+    def test_an_unresolvable_geom_reports_no_extent_rather_than_a_wrong_one(self, sim) -> None:
+        assert _compiled_geom_extent(sim._mj, sim.mj_model, "never_added_geom") is None
+
+    def test_a_concave_asset_collides_as_its_filled_hull(self, sim, channel_mesh: str) -> None:
+        """The documented consequence, pinned so the warning cannot go stale.
+
+        Dropped into the channel's open cavity, a ball comes to rest on the
+        convex hull that spans the wall tops rather than on the interior floor
+        2 cm up. This is MuJoCo's mesh-collision contract, not a defect -- the
+        test exists so the sentence that documents it stays true.
+        """
+        import mujoco
+
+        assert sim.add_object("channel", shape="mesh", mesh_path=channel_mesh, is_static=True)["status"] == "success"
+        assert (
+            sim.add_object("ball", shape="sphere", size=[0.06], position=[0.0, 0.0, 0.45], mass=0.05)["status"]
+            == "success"
+        )
+        model, data = sim.mj_model, sim.mj_data
+        for _ in range(3000):
+            mujoco.mj_step(model, data)
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "ball")
+        rest_z = float(data.xpos[body_id][2])
+        assert rest_z > _CHANNEL_WALL_TOP_Z - 0.05, f"expected a rest on the hull near the wall tops, got z={rest_z}"
+        assert rest_z > _CHANNEL_CAVITY_FLOOR_Z + 0.1, f"the cavity is not load-bearing, yet z={rest_z}"


### PR DESCRIPTION
## Problem

`add_object` documents that `shape="mesh"` consumes no `size` component -- `_SIZE_LAYOUT["mesh"]` is `(0, "unused - the asset's own units define the extent")`, `_validate_size` returns early for it, and `_normalize_size` maps it to `[]`. The success text echoed `size=` back anyway. So the one shape whose extent the request never carries was the one shape whose extent the result asserted:

```python
sim.add_object("room", shape="mesh", mesh_path="room.obj", is_static=True)
# 'room' added: mesh at [0.0, 0.0, 0.0], size=[0.05, 0.05, 0.05], static
```

That asset is 3.5 x 10.5 x 12.5 m. The report understates it by about 250x, and an explicit `size=[2, 2, 2]` was echoed as though it had been honoured -- for a value the call discarded.

`_validate_size` already records why this shape of report is a defect for primitives: a short vector "compiled a differently-sized object while reporting success" and "echoed the requested `[0.5]`". The mesh row is where the echo is wrong unconditionally, because zero components are consumed.

A second property is invisible in the same result. MuJoCo collides a mesh geom as its **convex hull**, not as the triangles that render. Measured on a 98,099-vertex concave room shell, the compiled hull is 531 vertices; a ball dropped inside slid 4.0 m and never came to rest, floating 0.99 m above the surface directly beneath it. Rendering shows the open interior, so nothing looks wrong. Both facts are properties of the asset that no request component defines, and both are what a caller placing a robot or an object against it needs.

## Change

For `shape="mesh"`, report the extent read back off the compiled geom (MuJoCo's own `geom_aabb`, via a new private `_compiled_geom_extent`) and name the collision geometry:

```
'channel' added: mesh at [0.0, 0.0, 0.0], extent=[0.3, 0.4, 0.4]m from the asset (collision uses its convex hull), static
```

Primitive shapes are untouched: there `size` *is* the extent and the geom compiles to it, so it stays echoed. `geom_aabb` is the same read for every shape -- on a `size=[0.2, 0.3, 0.4]` box it returns exactly `[0.2, 0.3, 0.4]` -- which is why it is trusted for the mesh. The lookup goes through `mj_name_to_id` from `.backend`, so it inherits the guard that keeps a non-string name from reaching the binding and terminating the interpreter.

The `mesh_path` and `size` docstrings and `docs/simulation/world-building.md` now state the hull contract and the remedy (decompose into convex parts, one mesh object per part).

This does not touch the three per-shape axes #1858 tracks (component count, short-vector completion, positivity). It is about what the result reports, not what is accepted.

## Tests

`tests/simulation/mujoco/test_mesh_add_reports_compiled_geometry.py`, hermetic -- the concave fixture is an OBJ triangle soup written by the test, so it needs no mesh library, no asset and no network.

On `main`, **3 fail / 7 pass**; with the change, **10 pass**.

| pre-fix | test |
|---|---|
| FAIL | an omitted size reports the asset's extent, not the 5 cm default |
| FAIL | an explicit size is not echoed as though it were honoured |
| FAIL | the message names the convex hull as the collision geometry |
| pass | a box still reports the size it compiled to |
| pass | a sphere still reports its one-component size |
| pass | a primitive's extent reads back as the size that was asked for |
| pass | an unresolvable geom reports no extent rather than a wrong one |
| pass | a non-string geom name reports no extent rather than crashing |
| pass | the reported extent matches the geom's own bounding box |
| pass | a concave asset collides as its filled hull |

The seven that pass on both trees are the no-overreach controls: primitives keep their message, and the hull characterisation pins the sentence the docs now make so it cannot go stale.

Gate: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` at 18 errors on this branch and on `main` (no new); full `tests/` gives 346 failing ids on both trees, `comm` empty in both directions, 29614 vs 29604 passed (+10, exactly the new tests).

## Rollout in MuJoCo sim (headless)

An open-topped channel mesh -- a floor plate at z=0.02 m spanned by two 0.30 m walls, concave by construction -- with a ball dropped into the cavity. It comes to rest at **z=0.330 m**, on the convex hull that spans the wall tops, 0.28 m above the interior floor it appears to fall toward. The right panel draws the hull in.

![mesh geom: rendered surface vs collision hull](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-convex-hull/hull_vs_render.png)

![ball resting on the hull above the open cavity](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-convex-hull/drop.gif)

[drop.mp4](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-convex-hull/drop.mp4) -- same rollout, 66 frames at 30 fps.

The rest height is asserted by `test_a_concave_asset_collides_as_its_filled_hull`, so the artifact and the suite measure the same thing.