### PR TITLE
test(simulation/mujoco): re-establish the stranded-camera-key premise via replace_scene_mjcf

### DIFF
--- a/changelog.d/2295-stranded-camera-key-premise.md
+++ b/changelog.d/2295-stranded-camera-key-premise.md
@@ -1,0 +1,11 @@
+### Fixed
+
+`main` was red after #2290 and #2291 merged half a minute apart: #2290's premise
+test manufactured a stranded camera key through the `remove_robot` route that
+#2291 had just closed (`add_robot` now registers only the robot's own cameras,
+each carrying `origin_robot`, so removal takes every one of its keys with it).
+The contract the test pins - an observation key that names no compiled camera is
+absent, not filled in with another view - still matters, so the premise is
+re-established through a route that survives #2291: `replace_scene_mjcf`, whose
+documented contract leaves the python-side camera registry untouched while the
+compiled cameras its keys name go away.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -110,8 +110,9 @@ MJCF (`wrist`) and the namespaced name the compiled scene uses
 (`arm0/wrist`). Both address the same physical camera and record the same
 frames, so pick one per dataset - listing both records the same view twice
 under two columns. Every camera key carries the view of the camera it names:
-a key the scene can no longer render (for example a camera that left with a
-`remove_robot`) is absent from the observation rather than filled in with the
+a key the scene can no longer render (for example after `replace_scene_mjcf`,
+which swaps the compiled scene but leaves the camera registry untouched) is
+absent from the observation rather than filled in with the
 overview, so a column is never quietly populated from the wrong camera.
 
 `cameras=` is a list of **distinct** camera names, and every surface that accepts

--- a/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
+++ b/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
@@ -17,10 +17,17 @@ and the agent-tool observation all received the wrong view under a success
 result, with nothing to distinguish it from the camera they asked for. Two short
 keys on one robot were byte-identical to each other for the same reason.
 
-The same branch answered for a key that names no compiled camera at all, which
-``remove_robot`` leaves behind: it deletes the entries whose ``origin_robot`` is
-the departing robot, and a key registered against a different robot survives
-pointing at a camera that left with the model.
+The same branch answered for a key that names no compiled camera at all.
+``replace_scene_mjcf`` produces that state by documented contract: it swaps the
+compiled scene while leaving the python-side registries untouched, so a robot's
+camera keys outlive the compiled cameras they name. (These tests originally
+manufactured the stranded key through ``remove_robot``, which back then left
+behind a duplicate entry that ``add_robot`` had mis-registered against a later
+robot. That route closed when ``add_robot`` started registering only the
+robot's OWN cameras, each carrying ``origin_robot``, so removal now takes every
+one of its keys with it - pinned in ``test_add_robot_camera_ownership.py`` -
+and the registry-outlives-the-scene contract of ``replace_scene_mjcf`` is the
+route that remains.)
 
 So the contract is one sentence - an observation key that names a camera carries
 that camera's view, or is absent - and it is pinned here from both directions:
@@ -84,22 +91,26 @@ TWO_CAMERA_ROBOT_XML = """
 </mujoco>
 """
 
-# A second robot with no camera of its own. Adding it is what gives the world a
-# camera key owned by a robot other than the one whose model declares it, and
-# removing the camera-bearing robot is what strands that key.
-CAMERALESS_ROBOT_XML = """
-<mujoco model="cameraless_arm">
+# The scene ``replace_scene_mjcf`` swaps in for the stranded-key tests below.
+# It keeps the robot's namespaced joint (so proprioception still has something
+# to report) and a compiled camera named ``default`` (so the observation still
+# carries an image, making "the stranded key is absent" non-vacuous), but none
+# of the robot's cameras - while the registry entries for those cameras survive
+# the swap by ``replace_scene_mjcf``'s documented contract.
+REPLACED_SCENE_XML = """
+<mujoco model="replaced_scene">
   <compiler angle="radian" autolimits="true"/>
   <option timestep="0.002"/>
   <worldbody>
-    <light name="fill_light" pos="1 0 3" dir="0 0 -1"/>
-    <body name="rod" pos="0.5 0 0.2">
-      <joint name="elbow" type="hinge" axis="0 1 0" range="-1.0 1.0"/>
-      <geom name="rod_geom" type="capsule" size="0.03" fromto="0 0 0 0 0 0.3" rgba="0.1 0.1 0.9 1"/>
+    <light name="key_light" pos="0 0 3" dir="0 0 -1"/>
+    <camera name="default" pos="1.5 1.5 1.2" xyaxes="-0.707 0.707 0 -0.4 -0.4 0.82"/>
+    <body name="arm0/link" pos="0 0 0.3">
+      <joint name="arm0/shoulder" type="hinge" axis="0 1 0" range="-1.57 1.57"/>
+      <geom name="arm0/link_geom" type="box" size="0.05 0.05 0.25" rgba="0.9 0.1 0.1 1"/>
     </body>
   </worldbody>
   <actuator>
-    <position name="elbow_act" joint="elbow" kp="20"/>
+    <position name="arm0/shoulder_act" joint="arm0/shoulder" kp="20"/>
   </actuator>
 </mujoco>
 """
@@ -204,25 +215,49 @@ def test_two_short_keys_carry_two_different_views(sim: Simulation) -> None:
     assert _view_shown(images["side"], views) == "arm0/side"
 
 
+def _stranded_camera_keys(engine: Simulation) -> list[str]:
+    """The registry keys the compiled model cannot answer for.
+
+    Mirrors the render loop's two-step resolution: a key is stranded only when
+    neither the key itself nor the ``name`` its ``SimCamera`` carries resolves
+    to a compiled camera.
+    """
+    import mujoco as mj
+
+    world = engine._world
+    assert world is not None
+    model = world._model
+    return [
+        key
+        for key, cam in world.cameras.items()
+        if mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, key) < 0
+        and mj.mj_name2id(model, mj.mjtObj.mjOBJ_CAMERA, cam.name) < 0
+    ]
+
+
 @requires_gl
 def test_key_naming_no_compiled_camera_is_absent(sim: Simulation) -> None:
     """A camera key the compiled model cannot answer for is omitted, not filled in.
 
-    ``remove_robot`` drops the entries owned by the departing robot, so the
-    duplicate key another robot owns outlives the camera it names. There is no
-    view to report under it, and the overview is not a stand-in.
+    The stranded key comes from ``replace_scene_mjcf``, whose documented
+    contract is to leave the python-side registries untouched: the robot's
+    camera keys survive the swap while the compiled cameras they name do not.
+    There is no view to report under such a key, and the overview is not a
+    stand-in. The ``default`` key is the control: the replacement scene
+    compiles a camera it CAN answer for, so its presence shows the loop
+    rendered and only the stranded keys were dropped.
     """
     assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
-    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
-    assert sim.remove_robot("arm0")["status"] == "success"
+    assert sim.replace_scene_mjcf(REPLACED_SCENE_XML)["status"] == "success"
 
-    world = sim._world
-    assert world is not None
-    stranded = [key for key, cam in world.cameras.items() if key.startswith("arm0/")]
-    assert stranded, "premise: removing the camera-bearing robot strands a camera key"
+    stranded = _stranded_camera_keys(sim)
+    assert set(stranded) == {"wrist", "side"}, (
+        "premise: the robot's camera keys outlive the compiled cameras they name across replace_scene_mjcf"
+    )
 
-    observation = sim.get_observation()
+    observation = sim.get_observation("arm0")
     images = _image_keys(observation)
+    assert "default" in images, "control: a key the compiled model answers for still renders"
     for key in stranded:
         assert key not in images, (
             f"observation[{key!r}] names a camera that is no longer in the model, so it must be "
@@ -251,12 +286,14 @@ def test_joint_state_survives_a_key_with_no_compiled_camera(sim: Simulation) -> 
 
     Control: the loop's whole reason for tolerating a per-camera failure is that
     proprioception must still be reported, so omitting an image must be as
-    survivable as the render failure the loop already handled.
+    survivable as the render failure the loop already handled. The replacement
+    scene keeps the robot's namespaced joint, so the joint state has a real
+    value to report while the robot's camera keys go unanswered.
     """
     assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
-    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
-    assert sim.remove_robot("arm0")["status"] == "success"
+    assert sim.replace_scene_mjcf(REPLACED_SCENE_XML)["status"] == "success"
+    assert _stranded_camera_keys(sim), "premise: at least one camera key goes unanswered by the compiled model"
 
-    observation = sim.get_observation("arm1")
-    assert observation["elbow"] == pytest.approx(0.0, abs=1e-6)
-    assert "elbow.vel" in observation
+    observation = sim.get_observation("arm0")
+    assert observation["shoulder"] == pytest.approx(0.0, abs=1e-6)
+    assert "shoulder.vel" in observation


### PR DESCRIPTION
Closes #2295

## What changed

`main` went red at `696f5a12` with a single failure:

```
FAILED tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py::test_key_naming_no_compiled_camera_is_absent
AssertionError: premise: removing the camera-bearing robot strands a camera key
```

This is the #1763/#1766 shape from AGENTS.md step 8: #2290's premise test manufactured a stranded camera key through the `remove_robot` route that #2291 (merged ~30 seconds earlier, never compiled together with #2290 until `main`) had just closed. After #2291, `add_robot` registers only the robot's **own** cameras (each carrying `origin_robot`) and `remove_robot` drops entries by that owner, so `add arm0 / add arm1 / remove arm0` leaves no stranded key and the premise assertion fails before the behavior under test is ever exercised.

Per AGENTS.md ("If a premise test is invalidated by a fix landing, replace it rather than deleting it"), the contract the test pins — **an observation key that names no compiled camera is absent, not filled in with another view** — is kept, and its premise is re-established through a route that survives #2291:

- **`replace_scene_mjcf`** swaps the compiled scene while leaving the python-side registries untouched, by documented contract (its own docstring and success message both say so). The robot's camera keys therefore outlive the compiled cameras they name — a genuinely public path to the key/model mismatch, not a registry poke.
- The replacement scene keeps the robot's namespaced joint (`arm0/shoulder`), so the joint-state control test (`test_joint_state_survives_a_key_with_no_compiled_camera`, which used the same closed route) still reports a real value, and compiles a `default` camera the registry CAN answer for, so the observation still carries an image — making "the stranded key is absent" non-vacuous rather than "everything was omitted".
- A shared `_stranded_camera_keys` helper mirrors the render loop's two-step resolution (key, then the `SimCamera.name` it carries), so the premise assertion states exactly the condition the miss branch fires on.
- The module docstring records why the `remove_robot` route closed (with a pointer to `test_add_robot_camera_ownership.py`, which pins the new ownership behavior), and the now-unused `CAMERALESS_ROBOT_XML` fixture is deleted.
- One sentence in `docs/recording.md` cited "a camera that left with a `remove_robot`" as the example of an unanswerable key — that example is exactly what #2291 invalidated, so it now cites `replace_scene_mjcf` instead.

## Test surface

- `hatch run test`: **29969 passed, 273 skipped, 0 failed** (95.71% coverage), run with `MUJOCO_GL=egl` on a GPU box so the GL-gated tests in this file executed rather than skipped.
- The rewritten file passes all 5 tests; `test_add_robot_camera_ownership.py` (the #2291 pins) is untouched and still passes.
- `hatch run lint` clean.

## Acceptance criteria from #2295

- [x] Premise re-established by a route that survives #2291 (`replace_scene_mjcf`'s registry-outlives-the-scene contract), so the miss branch — which still exists in `_get_sim_observation` — stays pinned.
- [x] Recorded why the `remove_robot` route closed (module docstring + changelog fragment).
- [x] Changelog fragment: `changelog.d/2295-stranded-camera-key-premise.md`.
- [x] Fix goes ahead of the merge queue: while `main` is red, every PR absorbing `>= 696f5a12` inherits this failure (#2233's run already did).

## Out of scope

- No production code changes: both #2290's and #2291's behavior fixes are correct; only the premise test and one doc example were stale.

Project board: please move #2295 to "In review" (or it will auto-move to Done on merge).
