### PR TITLE
test(simulation/mujoco): repair the camera-key premise invalidated by #2291 (main is red)

### DIFF
--- a/changelog.d/2301-camera-key-premise-repair.md
+++ b/changelog.d/2301-camera-key-premise-repair.md
@@ -1,0 +1,14 @@
+### Fixed
+
+Repaired the regression test whose premise the camera-ownership fix invalidated,
+which had left `main` failing CI. `test_key_naming_no_compiled_camera_is_absent`
+manufactured a camera key with no compiled camera by adding a camera-bearing
+robot, adding a second robot, and removing the first -- a sequence that stranded
+the entry only because `add_robot` registered one robot's cameras against
+another. `SimCamera` now pins that `origin_robot` never names a robot outside the
+camera's namespace, so removing a robot removes its cameras and only its cameras
+and nothing is stranded. The contract under test is unchanged: a registry key the
+compiled model cannot answer for yields no image rather than the free camera's
+overview, so the entry is now registered directly instead of routed through a
+path the registry contract forbids, and the answerable keys are asserted to still
+report so an omitted key cannot be mistaken for a broken render.

--- a/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
+++ b/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
@@ -17,10 +17,9 @@ and the agent-tool observation all received the wrong view under a success
 result, with nothing to distinguish it from the camera they asked for. Two short
 keys on one robot were byte-identical to each other for the same reason.
 
-The same branch answered for a key that names no compiled camera at all, which
-``remove_robot`` leaves behind: it deletes the entries whose ``origin_robot`` is
-the departing robot, and a key registered against a different robot survives
-pointing at a camera that left with the model.
+The same branch answered for a key that names no compiled camera at all. The
+registry is an input to the render loop, so an entry naming a camera the compiled
+model does not have must yield no image rather than the overview.
 
 So the contract is one sentence - an observation key that names a camera carries
 that camera's view, or is absent - and it is pinned here from both directions:
@@ -56,6 +55,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from strands_robots.simulation.models import SimCamera
 from strands_robots.simulation.mujoco.simulation import Simulation
 from tests.simulation.mujoco._gl_probe import requires_gl
 
@@ -208,26 +208,35 @@ def test_two_short_keys_carry_two_different_views(sim: Simulation) -> None:
 def test_key_naming_no_compiled_camera_is_absent(sim: Simulation) -> None:
     """A camera key the compiled model cannot answer for is omitted, not filled in.
 
-    ``remove_robot`` drops the entries owned by the departing robot, so the
-    duplicate key another robot owns outlives the camera it names. There is no
-    view to report under it, and the overview is not a stand-in.
+    The registry is an input to the render loop, so a key in it that the compiled
+    model cannot answer for must produce no image rather than some other camera's
+    view - the overview is not a stand-in.
+
+    The condition is constructed directly on the registry instead of through an
+    ``add_robot`` / ``remove_robot`` sequence. That route used to strand a key
+    (a robot claimed a camera outside its own namespace, so the owner's departure
+    left the entry behind), and :class:`~strands_robots.simulation.models.SimCamera`
+    now pins that ``origin_robot`` never names a robot outside the camera's
+    namespace - removing a robot removes its cameras and only its cameras. Driving
+    this case through a path that is now guaranteed not to strand keys would assert
+    on a premise the registry contract forbids, so the entry is registered here.
     """
     assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
-    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
-    assert sim.remove_robot("arm0")["status"] == "success"
 
     world = sim._world
     assert world is not None
-    stranded = [key for key, cam in world.cameras.items() if key.startswith("arm0/")]
-    assert stranded, "premise: removing the camera-bearing robot strands a camera key"
+    orphan = "arm0/departed"
+    assert orphan not in sim.list_cameras(), "premise: the compiled model has no such camera"
+    world.cameras[orphan] = SimCamera(name=orphan, origin_robot="arm0")
 
     observation = sim.get_observation()
     images = _image_keys(observation)
-    for key in stranded:
-        assert key not in images, (
-            f"observation[{key!r}] names a camera that is no longer in the model, so it must be "
-            "absent rather than carrying some other camera's view"
-        )
+    assert orphan not in images, (
+        f"observation[{orphan!r}] names a camera the model does not have, so it must be "
+        "absent rather than carrying some other camera's view"
+    )
+    # The unanswerable key must not cost the answerable ones their frames.
+    assert {"wrist", "side"} <= set(images), "the cameras the model does have still report"
 
 
 @requires_gl


### PR DESCRIPTION
## main is red

`main` has failed CI since #2290 merged, and every open PR inherits the failure:

```
FAILED tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py::
  test_key_naming_no_compiled_camera_is_absent
  - AssertionError: premise: removing the camera-bearing robot strands a camera key
    assert []
=========== 1 failed, 11222 passed, 42 skipped ===========
```

It is the only failure on `main`. Because the suite runs with `-x`, it aborts there and masks the rest of the run for every PR.

## Cause: a semantic merge conflict between #2290 and #2291

Neither PR is wrong; they are incompatible in a way git cannot see, and #2290's branch predated #2291 landing.

#2290 pinned the contract *an observation key that names a camera carries that camera's view, or is absent*. To build a key with no compiled camera, its test used the only route that produced one at the time:

```python
add_robot("arm0", ...)   # declares cameras
add_robot("arm1", ...)   # cameraless
remove_robot("arm0")
stranded = [k for k in world.cameras if k.startswith("arm0/")]
assert stranded, "premise: removing the camera-bearing robot strands a camera key"
```

That premise *was itself the #2291 defect*: `add_robot` re-registered arm0's cameras under their qualified names with `origin_robot="arm1"`, so removing arm0 left them behind. #2291 fixed it and `SimCamera` now states the invariant outright:

> A discovered camera belongs to exactly one robot [...] Removing a robot removes its cameras and only its cameras, so `origin_robot` must never name a robot outside `name`'s namespace.

So the premise is now **structurally impossible**, which is exactly what #2291 guarantees. `stranded == []`.

## Change

The contract #2290 guards is unaffected and still worth pinning -- only the *setup* depended on the fixed bug. The registry is an input to the render loop, so the unanswerable entry is now registered directly instead of being manufactured through a sequence the registry contract forbids:

```python
orphan = "arm0/departed"
assert orphan not in sim.list_cameras()      # premise: the model has no such camera
world.cameras[orphan] = SimCamera(name=orphan, origin_robot="arm0")

images = _image_keys(sim.get_observation())
assert orphan not in images                  # not answered with the overview
assert {"wrist", "side"} <= set(images)      # and the answerable keys still report
```

The added second assertion closes a gap in the original: an omitted key is now distinguishable from a broken render.

Test-only; no source change.

## Verified non-vacuous

The risk in rewriting a premise is turning a real guard into a test that cannot fail. Checked directly -- with #2290's `rendering.py` fix reverted (`git checkout 696f5a12^ -- strands_robots/simulation/mujoco/rendering.py`) and this test in place:

```
FAILED ...::test_short_key_carries_the_robots_own_camera_view - assert '<free>' == 'arm0/wrist'
FAILED ...::test_two_short_keys_carry_two_different_views - identical frames
FAILED ...::test_key_naming_no_compiled_camera_is_absent -
  observation['arm0/departed'] names a camera the model does not have, so it must be
  absent rather than carrying some other camera's view
===== 3 failed, 2 passed =====
```

That reproduces the exact 3-fail / 2-pass split recorded in the module docstring's table, so the guard is preserved rather than relaxed.

## Gate

| check | result |
|---|---|
| the file, mujoco **3.10.0** (the lockfile pin CI installs) | 5 passed |
| the file, mujoco **3.5.0** | 5 passed |
| `tests/simulation` on mujoco 3.10.0 | 10495 passed, 1 pre-existing failure also present on `main` (`test_pose_vector_rule_parity`, a local numpy artifact -- `main`'s own CI reports `11222 passed` with it green) |
| `tests/simulation/mujoco/test_remove_object_camera_cascade.py` (the #2291 sibling) | 10 passed |
| `ruff check` / `ruff format --check` | clean |
| `mypy` | 18, unchanged from baseline |