### PR TITLE
test(simulation/mujoco): build the unanswerable camera key instead of relying on a stranding bug

### DIFF
--- a/changelog.d/2302-stranded-camera-key-premise.md
+++ b/changelog.d/2302-stranded-camera-key-premise.md
@@ -1,0 +1,8 @@
+### Fixed
+
+Repaired `test_key_naming_no_compiled_camera_is_absent`, which reached its case
+through a camera double-registration that has since been fixed and so failed its
+own premise assert on `main`. The unanswerable camera key is now registered
+directly against the camera registry the render loop resolves against, keeping
+the contract pinned (an observation key that names a camera carries that
+camera's view, or is absent) without depending on another module's defect.

--- a/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
+++ b/tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py
@@ -17,10 +17,12 @@ and the agent-tool observation all received the wrong view under a success
 result, with nothing to distinguish it from the camera they asked for. Two short
 keys on one robot were byte-identical to each other for the same reason.
 
-The same branch answered for a key that names no compiled camera at all, which
-``remove_robot`` leaves behind: it deletes the entries whose ``origin_robot`` is
-the departing robot, and a key registered against a different robot survives
-pointing at a camera that left with the model.
+The same branch answered for a key that names no compiled camera at all. The
+registry and the compiled model are separate stores, so an entry can name a
+camera the model does not hold; no public call sequence produces that state
+today (``remove_robot`` drops the departing robot's own cameras and any user
+camera parented to its bodies), so the case is constructed directly against the
+registry the branch reads.
 
 So the contract is one sentence - an observation key that names a camera carries
 that camera's view, or is absent - and it is pinned here from both directions:
@@ -56,6 +58,7 @@ from typing import Any
 import numpy as np
 import pytest
 
+from strands_robots.simulation.models import SimCamera
 from strands_robots.simulation.mujoco.simulation import Simulation
 from tests.simulation.mujoco._gl_probe import requires_gl
 
@@ -208,26 +211,30 @@ def test_two_short_keys_carry_two_different_views(sim: Simulation) -> None:
 def test_key_naming_no_compiled_camera_is_absent(sim: Simulation) -> None:
     """A camera key the compiled model cannot answer for is omitted, not filled in.
 
-    ``remove_robot`` drops the entries owned by the departing robot, so the
-    duplicate key another robot owns outlives the camera it names. There is no
-    view to report under it, and the overview is not a stand-in.
+    The registry and the compiled model are separate stores, so a registry entry
+    can name a camera the model does not hold. There is no view to report under
+    that key, and the scene overview is not a stand-in.
+
+    The divergence is built directly here because no public call sequence
+    produces it: ``remove_robot`` drops both the departing robot's own cameras
+    and any user camera parented to its bodies. The registry is what the branch
+    under test resolves against, so it is the input this pins.
     """
     assert sim.add_robot("arm0", urdf_path=_write(TWO_CAMERA_ROBOT_XML))["status"] == "success"
-    assert sim.add_robot("arm1", urdf_path=_write(CAMERALESS_ROBOT_XML))["status"] == "success"
-    assert sim.remove_robot("arm0")["status"] == "success"
 
     world = sim._world
     assert world is not None
-    stranded = [key for key, cam in world.cameras.items() if key.startswith("arm0/")]
-    assert stranded, "premise: removing the camera-bearing robot strands a camera key"
+    world.cameras["ghost"] = SimCamera(name="arm0/no_such_camera")
 
     observation = sim.get_observation()
     images = _image_keys(observation)
-    for key in stranded:
-        assert key not in images, (
-            f"observation[{key!r}] names a camera that is no longer in the model, so it must be "
-            "absent rather than carrying some other camera's view"
-        )
+
+    assert "ghost" not in images, (
+        "observation['ghost'] names a camera the compiled model does not have, so it must be "
+        "absent rather than carrying some other camera's view"
+    )
+    # Control: dropping the unanswerable key costs the answerable ones nothing.
+    assert {"wrist", "side"} <= set(images)
 
 
 @requires_gl


### PR DESCRIPTION
## Problem

`tests/simulation/mujoco/test_observation_camera_keys_carry_their_own_view.py::test_key_naming_no_compiled_camera_is_absent` fails on `main`:

```
assert stranded, "premise: removing the camera-bearing robot strands a camera key"
AssertionError: assert []
```

The test reached its case by composing public calls -- add a camera-bearing robot, add a second robot, remove the first, then read back a camera key the registry still held. That only ever produced a stranded key because `add_robot` re-registered the *first* robot's cameras against the second, so `remove_robot` (which deletes by `origin_robot`) could not find them. That double-registration has since been fixed: `add_robot` now skips cameras it does not own, so nothing is stranded and the premise assert fails.

Because the suite runs with `-x`, this is the first failure CI reports, so it currently blocks unrelated pull requests.

## Change

The contract being pinned is still real: the registry and the compiled model are separate stores, so an entry can name a camera the model does not hold, and the render loop must omit that key rather than substitute the free camera. What changed is that no public call sequence produces that state any more -- `remove_robot` drops both the departing robot's own cameras and any user camera parented to its bodies (`eject_robot: dropping camera 'extra' - its parent body 'arm0/link' belonged to the removed robot 'arm0'`), which I verified directly.

So the diverging entry is now registered directly against the registry the branch under test resolves against, rather than being manufactured by another module's bug. A control assertion in the same test keeps the answerable keys pinned, so dropping the unanswerable key is shown not to cost the others.

The module docstring's description of how that row is reached is updated to match; `CAMERALESS_ROBOT_XML` is still used by the neighbouring test and stays.

## Verification

**Non-vacuous**: temporarily restoring the free-camera fallback (`cam_id = -1` in place of the `continue`) makes the rewritten test fail with the right message, so it still guards the behaviour it was written for:

```
AssertionError: observation['ghost'] names a camera the compiled model does not have,
so it must be absent rather than carrying some other camera's view
```

`test_observation_camera_keys_carry_their_own_view.py`: 5 passed (was 4 passed / 1 failed).

`tests/simulation/mujoco` + `tests/rendering`: 3387 passed, 5 failed -- all five pre-existing on `main` on this host and unrelated to cameras (`mju_sym2dense` absence and other MuJoCo-version drift on a 3.5.0 build; `test_add_object_mass_contract`, `test_get_world_point`, two `TestFullMassMatrixSignatureDrift` cases, `test_pose_vector_rule_parity`). Zero new failures. `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` clean, 18 pre-existing mypy errors unchanged.

Test-only change, so there is no rendered artifact to attach -- the evidence is the pass/fail split above.