### PR TITLE
fix(ci): give each commit pushed to a protected branch its own concurrency group

### DIFF
--- a/.github/workflows/pr-and-push.yml
+++ b/.github/workflows/pr-and-push.yml
@@ -17,8 +17,36 @@ on:
     branches: [ main, dev ]
   push:
     branches: [ main, dev ]
+# Cancelling is right per pull request and wrong per commit, so the key differs by
+# event, and the fallback is the half that matters. On a 'pull_request' event
+# 'github.event.pull_request.number' is set: the group is per pull request, a new push
+# supersedes the previous verdict about the same branch, and discarding the in-flight
+# run is the point. That branch of the expression is untouched.
+#
+# On a push to 'main' or 'dev' the number is empty. Keyed on 'github.ref' the fallback
+# was 'refs/heads/main' for *every* commit - one group for the whole branch - so each
+# merge cancelled the previous merge's run and left the commit it was testing with a
+# permanently unfinished 'call-test-lint'. A cancelled context is not SUCCESS and one
+# non-SUCCESS context drags 'statusCheckRollup.state' to FAILURE, so that commit read
+# red forever with no failing check anywhere in it, and unlike a branch it gets no next
+# push to clear it. Measured over the last 25 commits on 'main' (#2304): 11 red, of
+# which 9 had no failing check at all. #1800 measured the same mechanism on
+# #1788/#1794/#1796 and concluded it was tolerable to read around; what #2304 adds is
+# that the misread destroys the evidence for *which* commit in a burst broke 'main', in
+# the same burst that creates the fault - #2303 read rollups along the branch to date a
+# breakage while two of the commits it read were red only from cancellation.
+#
+# 'github.sha' is the commit, so each pushed commit gets its own group and runs to
+# completion. Not interchangeable with keeping 'github.ref' and setting
+# 'cancel-in-progress: ${{ github.event_name == 'pull_request' }}': that leaves one group
+# for the branch, and GitHub holds at most one *pending* run per group, so in a burst of
+# three merges the third cancels the second while it is still queued - reproducing the
+# CANCELLED context this removes. The cost is that a burst of N merges runs N suites
+# instead of 1, which is the point: on a branch nobody rewrites, each commit is a
+# distinct artifact and 'was this commit green' is a question only its own completed run
+# can answer. Pinned by tests/test_push_concurrency_group.py.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,26 +467,40 @@ hatch run format            # ruff check --fix, ruff format
      tests/test_merge_mutation_error_is_not_a_verdict.py.
    - *And on `main` afterwards.* A rollup of `FAILURE` on a merge commit is not
      evidence that the squash broke anything: a **cancelled** check aggregates
-     into `FAILURE`. `pr-and-push.yml` keys its concurrency group on
-     `github.event.pull_request.number || github.ref`, and on a push there is no
-     PR number, so every push to `refs/heads/main` shares one group under
-     `cancel-in-progress: true` - each merge kills the run of the merge before
-     it. Read each context's own `conclusion` before you believe the rollup.
-     Four PRs merged in the 22 minutes from 03:03:44 to 03:25:25 left three
-     consecutive commits - #1788, #1794, #1796 - each reporting rollup
-     `FAILURE` whose only non-`SUCCESS` context was
-     `call-test-lint / Test and Lint` = `CANCELLED`, killed at 1m07s, 15m00s
-     and 5m38s into their runs. Nothing had failed. See #1800.
+     into `FAILURE` and the rollup carries no reason, so read each context's own
+     `conclusion` before you believe it.
 
-     The same timings carry a cost that is not a misread: that suite had not
-     finished in 15m00s, so merging faster than it runs leaves **only the tip
-     verified** and no intermediate commit attributable. A batch is still
-     defensible - each of those four was individually green, passed
-     `Detect an untested overlap with the base branch`, and touched a file set
-     disjoint from the others - but price it knowingly: a red tip then costs a
-     manual bisect, and an intermediate commit's green is not available to lean
-     on. Do not read the intermediate `FAILURE`s as the culprit; they are the
-     batching, not a defect.
+     The producer this used to name is gone. `pr-and-push.yml` keyed its
+     concurrency group on `github.event.pull_request.number || github.ref`, and a
+     push carries no PR number, so every push to `refs/heads/main` shared one
+     group under `cancel-in-progress: true` and each merge killed the run of the
+     merge before it. Four PRs merged in the 22 minutes from 03:03:44 to 03:25:25
+     left three consecutive commits - #1788, #1794, #1796 - each reporting rollup
+     `FAILURE` whose only non-`SUCCESS` context was
+     `call-test-lint / Test and Lint` = `CANCELLED`, killed at 1m07s, 15m00s and
+     5m38s into their runs. Nothing had failed. See #1800.
+
+     Counting the whole branch is what turned that from a wrong colour into a
+     wrong answer: of the last 25 commits on `main`, 24 had a settled rollup, 11
+     of those read `FAILURE`, and **9 of the 11 had no failing check at all**
+     (#2304). A commit on `main` is immutable and already merged, so unlike a
+     branch it gets no next push to clear the answer - and a burst of merges
+     destroys the evidence for *which* commit in it broke `main` in the same act
+     as creating the fault, which is the read #2303 had to make. The group now
+     keys on `github.sha`, so each pushed commit gets its own group and runs its
+     own suite to completion. Pinned by tests/test_push_concurrency_group.py.
+
+     Two things survive that fix. A `main` commit can still carry a cancelled
+     context from `docs.yml`, which keys on the ref and holds a `build` (a
+     per-commit verdict, where cancelling has the same defect) in the same group
+     as a `deploy` (a shared resource, where superseding is wanted) - three of
+     #2304's eleven are that, and splitting the two is #2305. And a batch of N
+     merges now runs N suites rather than 1, which is what buys each commit its
+     own answer; what it no longer costs is a manual bisect after a red tip,
+     because an intermediate commit's own green is available to lean on. A batch
+     is still defensible on the same grounds as before - each PR individually
+     green, passing `Detect an untested overlap with the base branch`, and
+     touching a file set disjoint from the others.
    - *And when `main` itself is red, a re-run cannot clear the PRs it blocked.*
      `pr-and-push.yml` checks out the PR **head commit**, not
      `refs/pull/N/merge` - the job log reads `HEAD is now at <branch head>` - so

--- a/changelog.d/2304-main-commit-runs-its-own-suite.md
+++ b/changelog.d/2304-main-commit-runs-its-own-suite.md
@@ -1,0 +1,42 @@
+### Fixed: a commit pushed to `main` runs its own suite to completion
+
+`pr-and-push.yml` keyed its concurrency group on
+`github.event.pull_request.number || github.ref` under `cancel-in-progress: true`.
+Only the first operand is ever set, so the expression was two behaviours in one
+line: per pull request, where cancelling a superseded run is the point, and - on a
+push, which carries no pull request number - `refs/heads/main` for *every* commit.
+One group for the whole branch, so each merge cancelled the previous merge's run
+and the commit it was testing kept a permanently unfinished `call-test-lint`.
+
+A cancelled context is not `SUCCESS` and one non-`SUCCESS` context drags
+`statusCheckRollup.state` to `FAILURE`, so that commit read red with no failing
+check anywhere in it. #1800 measured this on #1788/#1794/#1796 and concluded it
+was tolerable to read around. Counting the branch is what changes the verdict: of
+the last 25 commits on `main`, 24 had a settled rollup, 11 of those read `FAILURE`
+and **9 of the 11 had no failing check at all**. The false reds arrive in bursts
+because that is what the mechanism requires - three landed inside 55 seconds, two
+more inside 7.
+
+What makes it a wrong answer rather than a wrong colour is that reading rollups
+along the branch is the only way to ask *when did `main` break*, and a burst
+destroys the evidence for which commit in it broke `main` in the same act as
+creating the fault: #2303 dated a breakage that way while two of the commits it
+read were red only from cancellation. A branch's stale red clears on its next
+push; a commit on `main` is immutable and already merged, so the wrong answer is
+permanent.
+
+The push side now keys on `github.sha`, leaving the pull-request operand
+byte-identical. The two spellings the issue offered are not interchangeable and
+the pin is written against the rendered group rather than the text for that
+reason: keeping `github.ref` and gating `cancel-in-progress` on the event name
+still leaves one group per branch, and GitHub holds at most one *pending* run per
+group, so a third merge cancels the second while it is queued and reproduces the
+context being removed.
+
+A burst of N merges now runs N suites instead of 1, which is what buys each commit
+its own answer, and it removes the older cost recorded in `AGENTS.md` step 8:
+merging faster than the suite runs no longer leaves only the tip verified, so a
+red tip no longer costs a manual bisect. `docs.yml` holds a per-commit `build` and
+a shared-resource `deploy` under one ref-keyed group and so keeps a narrower form
+of the defect; it is pinned as an explicit exemption with the decision tracked
+separately.

--- a/tests/test_pull_request_trigger_types.py
+++ b/tests/test_pull_request_trigger_types.py
@@ -27,11 +27,21 @@ commits and ``AGENTS.md`` > PR Workflow tells a reader to consult each context's
 own ``conclusion`` before believing the roll-up. What that entry describes is a
 *different producer* of the symptom -- pushes to ``main`` share one concurrency
 group because a push carries no pull request number, so each merge kills the
-previous merge's run. That producer is arguably wanted (a superseded ``main`` run
-is of no interest) and is not touched here.
+previous merge's run. That producer read as wanted when this module was written -- a
+superseded ``main`` run is of no interest -- and was left alone here.
 
-This one is on pull request head shas, and unlike the ``main`` case it discards
-work for no possible gain, so it is removable rather than merely readable-around.
+It is gone now, for a reason that only shows up once the commits are counted: #2304
+measured 24 settled rollups on ``main``, of which 11 read ``FAILURE`` and **9 had no
+failing check at all**, and a commit on ``main`` is immutable and already merged, so
+unlike a branch it gets no next push to clear the wrong answer. Worse, a burst of
+merges destroys the evidence for which commit in it broke ``main`` in the same act
+as creating the fault. The push side is now keyed on ``github.sha``, which leaves
+the pull-request operand this module is about untouched; it is pinned by rendering
+the group in ``tests/test_push_concurrency_group.py``.
+
+This one is on pull request head shas, and it discards work for no possible gain,
+which is why it was removable here first: cancelling on ``main`` at least superseded
+something, while an event that cannot change the head sha supersedes nothing.
 Measured twice, ten minutes apart, no new run in between::
 
     19:35Z   #1899 FAILURE   #1901 FAILURE   #1902 FAILURE
@@ -75,8 +85,9 @@ That premise is true and it was the wrong group to check. The run an exempt even
 cancels first is the exempt workflow's **own**, which shares both a workflow name
 and a pull request number with the run already in flight. Being exempt is exactly
 what makes this reachable -- an exempt workflow is the only kind that can be
-started twice on one head sha -- so unlike the ``main`` case above the cancelled
-context lands on the *live* head. #2216 measured it on #1722 and #2205: each head
+started twice on one head sha -- so unlike the ``main`` case above, whose cancelled
+context sat on an immutable commit nobody was reviewing, it lands on the *live*
+head. #2216 measured it on #1722 and #2205: each head
 carried ``Refuse a closing keyword that only appears in the title`` as ``SUCCESS``
 and ``CANCELLED`` together, with every other context ``SUCCESS``, and #2205's
 roll-up read ``SUCCESS``, then ``FAILURE``, then ``SUCCESS`` across three reads of
@@ -289,10 +300,20 @@ def test_the_required_check_discards_its_in_flight_run() -> None:
     away the required check's progress, and the pin above would be a
     cost-control rule rather than a correctness one. Either way the reasoning
     above needs to be re-read, which is what this failing would say.
+
+    Only the pull-request operand is asserted. The fallback operand is the push
+    side, which #2304 changed from ``github.ref`` to ``github.sha``, and pinning
+    the whole expression here would put a second copy of that decision in a file
+    that does not reason about it -- so the push half is asserted by rendering the
+    group in ``tests/test_push_concurrency_group.py`` instead.
     """
     text = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
     assert "cancel-in-progress: true" in text
-    assert "group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}" in text
+    assert "group: ${{ github.workflow }}-${{ github.event.pull_request.number ||" in text, (
+        "the concurrency group no longer keys on the pull request number, so two runs over one "
+        "pull request need not share a group and the cost this module is about disappears; "
+        "re-derive the pins above"
+    )
 
 
 def test_no_workflow_gates_on_draft_status() -> None:

--- a/tests/test_push_concurrency_group.py
+++ b/tests/test_push_concurrency_group.py
@@ -1,0 +1,393 @@
+"""Contract pins for the concurrency group of every workflow a push can start.
+
+``pr-and-push.yml`` cancels an in-flight run when a new one starts in the same
+concurrency group. Keyed on ``github.event.pull_request.number || github.ref``
+that was two different behaviours wearing one expression, because only the first
+operand is ever set:
+
+- On a ``pull_request`` event the number is present, so the group is per pull
+  request. Cancelling is then exactly right - a new push supersedes the previous
+  verdict about the same branch - and ``tests/test_pull_request_trigger_types.py``
+  is about making sure nothing *but* a new push can trigger it.
+- On a push to ``main`` or ``dev`` the number is empty and the fallback answered
+  ``refs/heads/main`` for **every** commit. One group for the whole branch, so
+  each merge cancelled the previous merge's run and the commit it was testing kept
+  a permanently unfinished ``call-test-lint``.
+
+A cancelled check run is not ``SUCCESS``, and a single non-``SUCCESS`` context
+drags ``statusCheckRollup.state`` to ``FAILURE``, so the second case left the
+commit reading red with no failing check anywhere in it. Measured over the last 25
+commits on ``main`` (#2304): 24 had a settled rollup, 11 of those read
+``FAILURE``, and **9 of the 11 had no failing check at all** - their only
+non-``SUCCESS`` context was ``CANCELLED``. The false reds arrive in bursts because
+that is what the mechanism requires: three of them landed inside 55 seconds and
+two more inside 7.
+
+#1800 measured the same mechanism on #1788/#1794/#1796 and concluded it was
+tolerable to read around, which is why ``AGENTS.md`` carried a reading rule for it
+rather than a fix. Two things #2304 adds turn it from a wrong colour into a wrong
+answer:
+
+- **It corrupts the only method available for dating a breakage.** #2303 diagnosed
+  a red ``main`` by reading rollups along the branch. That conclusion holds, but
+  the same burst that broke ``main`` also cancelled the runs of the two commits
+  immediately before it, which now read red identically to the commit that
+  actually broke. The burst destroyed the evidence for which commit in it was at
+  fault in the same act as creating the fault.
+- **Nothing ever re-establishes it.** A branch's stale red clears on its next
+  push. A commit on ``main`` is immutable and already merged, so it gets no next
+  push and the wrong answer is permanent.
+
+The remedy keys the push side on the commit rather than the ref. Each pushed
+commit then gets its own group and runs to completion, and the pull-request
+operand is untouched. The cost is that a burst of N merges runs N suites instead
+of 1, which is the point: on a branch nobody rewrites, each commit is a distinct
+artifact, and *was this commit green* is a question only its own completed run can
+answer.
+
+The two spellings #2304 offers are **not** interchangeable, which is why this
+module renders the group rather than asserting a string. Keeping ``github.ref``
+and setting ``cancel-in-progress: ${{ github.event_name == 'pull_request' }}``
+still leaves one group for the branch, and GitHub holds at most one *pending* run
+per group - so in a burst of three merges the third cancels the second while it is
+still queued, reproducing the CANCELLED context the change is removing.
+``test_two_commits_pushed_to_main_do_not_share_a_group`` is written against the
+rendered group for that reason: it fails on the ref-keyed spelling however
+``cancel-in-progress`` is written.
+
+These are text assertions rather than parsed YAML for the reason the sibling
+CI-config pins state (``tests/test_codeql_query_filters.py``,
+``tests/test_pull_request_trigger_types.py``): ``pyyaml`` is an optional
+dependency here, and a pin that skips when a dep is missing is not a pin.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_REQUIRED_CHECK_WORKFLOW = _WORKFLOW_DIR / "pr-and-push.yml"
+
+#: Workflows a push may start whose group is allowed to collapse two commits into
+#: one bucket, mapped to the reason. An entry is not a waiver of the rule but a
+#: statement that the job being cancelled is not a per-commit verdict, and it has
+#: to say which job and where the remaining question is being settled - so a
+#: deferral cannot hide here as a decision.
+_CANCELS_A_SUPERSEDED_DEPLOY = {
+    "docs.yml": (
+        "Its `deploy` job publishes to GitHub Pages. A superseded run there is not a "
+        "superseded verdict but a superseded deployment - the newest commit's site is "
+        "the one that should be live - so cancelling an older in-flight publish is "
+        "wanted, and a per-commit group would let two publishes of different trees race "
+        "for one resource. Its `build` job is a per-commit verdict and does share the "
+        "defect, so the fix is splitting the two rather than changing this key: "
+        "decision tracked as #2305, with the three commits it accounts for."
+    ),
+}
+
+#: Matches a top-level ``concurrency:`` key (column 0), which is the only scope
+#: that can cancel a whole workflow run. A job-level block is indented and is a
+#: different statement.
+_TOP_LEVEL_CONCURRENCY = "concurrency:"
+
+#: Matches one ``${{ ... }}`` expression. GitHub allows no nested braces inside
+#: one, so a non-greedy body is exact rather than approximate.
+_EXPRESSION_RE = re.compile(r"\$\{\{(?P<body>[^}]*)\}\}")
+
+
+def _workflow_paths() -> list[Path]:
+    return sorted(_WORKFLOW_DIR.glob("*.yml"))
+
+
+def _workflow_name(text: str) -> str:
+    """Return a workflow's ``name:``, which is the ``github.workflow`` its group keys on."""
+    match = re.search(r"^name:\s*(?P<name>.+?)\s*$", text, re.MULTILINE)
+    return match.group("name") if match else ""
+
+
+def _subscribes_to_push(text: str) -> bool:
+    """Whether the workflow has a ``push:`` trigger.
+
+    Read as a trigger key rather than as a substring: ``paths`` filters and job
+    steps mention ``push`` freely, and ``pypi-publish-on-release.yml`` mentions it
+    in prose.
+    """
+    return re.search(r"^\s+push:\s*$", text, re.MULTILINE) is not None
+
+
+def _concurrency(text: str) -> tuple[str, str] | None:
+    """Return ``(group, cancel_in_progress)`` from the top-level block, or ``None``.
+
+    ``None`` means the workflow declares no workflow-level concurrency, so it
+    cancels nothing and the question this module asks does not arise for it -
+    ``codeql.yml`` is in that position and is deliberately not exempted, because
+    there is nothing to exempt.
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.rstrip() != _TOP_LEVEL_CONCURRENCY:
+            continue
+        group = ""
+        cancel = ""
+        for follower in lines[index + 1 :]:
+            if not follower.startswith((" ", "\t")):
+                break
+            stripped = follower.strip()
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("group:"):
+                group = stripped[len("group:") :].strip()
+            elif stripped.startswith("cancel-in-progress:"):
+                cancel = stripped[len("cancel-in-progress:") :].strip()
+        return group, cancel
+    return None
+
+
+def _render(expression: str, context: Mapping[str, str]) -> str:
+    """Evaluate the ``${{ a || b }}`` idiom the group keys use, under one context.
+
+    Only the operators the groups in this repository actually use are modelled -
+    ``||`` over context lookups and single-quoted literals. An operand outside the
+    model raises rather than rendering empty: a group written with an expression
+    this cannot evaluate would otherwise collapse to a constant and satisfy every
+    assertion below for the wrong reason.
+    """
+
+    def _one(match: re.Match[str]) -> str:
+        for operand in (part.strip() for part in match.group("body").split("||")):
+            if operand.startswith("'") and operand.endswith("'"):
+                return operand[1:-1]
+            if operand not in context:
+                raise AssertionError(
+                    f"the concurrency group reads {operand!r}, which this module does not "
+                    "model. Add it to the simulated contexts below so the pin keeps "
+                    "meaning what it says, rather than passing on an unevaluated key."
+                )
+            value = context[operand]
+            if value:
+                return value
+        return ""
+
+    return _EXPRESSION_RE.sub(_one, expression)
+
+
+def _push_context(workflow_name: str, sha: str, ref: str = "refs/heads/main") -> dict[str, str]:
+    """The context a push to a protected branch supplies.
+
+    ``github.event.pull_request.*`` is empty rather than absent, which is the whole
+    mechanism: the fallback operand is the one that gets used.
+    """
+    return {
+        "github.workflow": workflow_name,
+        "github.event_name": "push",
+        "github.ref": ref,
+        "github.sha": sha,
+        "github.event.pull_request.number": "",
+        "github.event.pull_request.head.sha": "",
+    }
+
+
+def _pull_request_context(workflow_name: str, number: str, head_sha: str) -> dict[str, str]:
+    """The context a ``pull_request`` event supplies, where cancelling is wanted."""
+    return {
+        "github.workflow": workflow_name,
+        "github.event_name": "pull_request",
+        "github.ref": f"refs/pull/{number}/merge",
+        "github.sha": f"merge-of-{head_sha}",
+        "github.event.pull_request.number": number,
+        "github.event.pull_request.head.sha": head_sha,
+    }
+
+
+def test_the_scanner_finds_the_push_workflows() -> None:
+    """Guard every pin below against a scanner that quietly matches nothing.
+
+    Each assertion here is a statement about the workflows the scanner found; if
+    it found none they would all hold for the wrong reason. Asserted as a floor
+    rather than an equality, because adding a push workflow is routine and must
+    inherit the rule instead of failing this.
+    """
+    paths = _workflow_paths()
+    assert paths, f"no workflows under {_WORKFLOW_DIR}"
+    pushed = sorted(p.name for p in paths if _subscribes_to_push(p.read_text(encoding="utf-8")))
+    assert _REQUIRED_CHECK_WORKFLOW.name in pushed, pushed
+    assert len(pushed) >= 2, pushed
+    assert _concurrency(_REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")) is not None
+
+
+def test_two_commits_pushed_to_main_do_not_share_a_group() -> None:
+    """The fix: a pushed commit's run is not cancellable by the next merge.
+
+    Written against the rendered group, not the expression's text, because the two
+    spellings #2304 proposes are not equivalent - keeping ``github.ref`` and
+    gating ``cancel-in-progress`` on the event name leaves one group per branch,
+    where a third merge cancels the second's *pending* run and produces the same
+    CANCELLED context. Only a group that distinguishes the commits settles it.
+    """
+    text = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    concurrency = _concurrency(text)
+    assert concurrency is not None
+    group, _ = concurrency
+    name = _workflow_name(text)
+
+    first = _render(group, _push_context(name, "aaaaaaaaaaaa"))
+    second = _render(group, _push_context(name, "bbbbbbbbbbbb"))
+
+    assert first != second, (
+        f"two commits pushed to main both render the group {first!r}, so the second merge "
+        "cancels the first's run of the required check and the first commit keeps a "
+        "CANCELLED context forever - which reads as FAILURE and, unlike a branch, gets no "
+        "next push to clear it. Key the push side on the commit (github.sha)."
+    )
+
+
+def test_two_commits_pushed_to_dev_do_not_share_a_group() -> None:
+    """``dev`` is a push branch too, so the property cannot be main-specific.
+
+    The defect was never about ``main``'s name - it was about a group keyed on
+    something every commit on a branch shares - and a fix that special-cased the
+    default branch would leave ``dev`` behind while reading as done.
+    """
+    text = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    assert "branches: [ main, dev ]" in text, "the push branch list moved; re-derive this pin"
+    concurrency = _concurrency(text)
+    assert concurrency is not None
+    group, _ = concurrency
+    name = _workflow_name(text)
+
+    first = _render(group, _push_context(name, "cccccccccccc", ref="refs/heads/dev"))
+    second = _render(group, _push_context(name, "dddddddddddd", ref="refs/heads/dev"))
+
+    assert first != second, f"two commits pushed to dev both render the group {first!r}"
+
+
+def test_two_pushes_to_one_pull_request_still_share_a_group() -> None:
+    """Preservation control: cancelling per pull request is wanted and unchanged.
+
+    Passes before and after the change, which is what makes it a control: the
+    pull-request operand is what supersedes a stale verdict, and #1914's whole
+    finding is that the *cost* of cancelling there is a run that had nothing new
+    to say. A group that also split by commit would keep both runs alive and
+    leave the superseded one to finish, which is the behaviour that file exists to
+    prevent.
+    """
+    text = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    concurrency = _concurrency(text)
+    assert concurrency is not None
+    group, _ = concurrency
+    name = _workflow_name(text)
+
+    first = _render(group, _pull_request_context(name, "2306", "eeeeeeeeeeee"))
+    second = _render(group, _pull_request_context(name, "2306", "ffffffffffff"))
+
+    assert first == second, (
+        f"two pushes to one pull request render different groups ({first!r} vs {second!r}), so "
+        "the superseded run is no longer cancelled and a 27-minute suite runs to completion "
+        "over a commit nobody will read a verdict about"
+    )
+
+
+def test_two_pull_requests_do_not_share_a_group() -> None:
+    """Preservation control: one pull request's push cannot cancel another's run."""
+    text = _REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8")
+    concurrency = _concurrency(text)
+    assert concurrency is not None
+    group, _ = concurrency
+    name = _workflow_name(text)
+
+    assert _render(group, _pull_request_context(name, "2306", "eeeeeeeeeeee")) != _render(
+        group, _pull_request_context(name, "2307", "eeeeeeeeeeee")
+    )
+
+
+def test_the_required_check_still_cancels_in_progress() -> None:
+    """Premise: the group key is load-bearing only while cancelling happens.
+
+    Pins today's behaviour rather than a wish. Were ``cancel-in-progress`` turned
+    off, the group key would stop deciding anything and every assertion above
+    would hold vacuously - so this failing is a prompt to re-read the module, not
+    to delete it. It is also the premise
+    ``tests/test_pull_request_trigger_types.py`` states for the pull-request side.
+    """
+    concurrency = _concurrency(_REQUIRED_CHECK_WORKFLOW.read_text(encoding="utf-8"))
+    assert concurrency is not None
+    _, cancel = concurrency
+    assert cancel == "true", (
+        f"cancel-in-progress is {cancel!r}; if cancelling has been turned off, the reasoning "
+        "in this module and in tests/test_pull_request_trigger_types.py both need re-deriving"
+    )
+
+
+def test_every_push_workflow_keys_its_group_on_the_commit() -> None:
+    """The rule the next push workflow inherits instead of rediscovering.
+
+    Swept over the whole directory rather than asserted of one file, because the
+    defect is a property of the idiom (``pull_request.number || <something a whole
+    branch shares>``) and #2304 found it by noticing the idiom appears more than
+    once. A workflow with no top-level ``concurrency`` cancels nothing and is
+    skipped rather than exempted.
+    """
+    offenders: dict[str, str] = {}
+    scanned: list[str] = []
+    for path in _workflow_paths():
+        text = path.read_text(encoding="utf-8")
+        if not _subscribes_to_push(text):
+            continue
+        concurrency = _concurrency(text)
+        if concurrency is None:
+            continue
+        group, cancel = concurrency
+        if cancel != "true":
+            continue
+        scanned.append(path.name)
+        if path.name in _CANCELS_A_SUPERSEDED_DEPLOY:
+            continue
+        name = _workflow_name(text)
+        first = _render(group, _push_context(name, "111111111111"))
+        second = _render(group, _push_context(name, "222222222222"))
+        if first == second:
+            offenders[path.name] = first
+
+    assert _REQUIRED_CHECK_WORKFLOW.name in scanned, (
+        f"the sweep did not reach the required check ({scanned}); it cancels in progress on a "
+        "push, so it must be one of the workflows this rule is checked against"
+    )
+    assert not offenders, (
+        "these workflows cancel in progress and give two different pushed commits the same "
+        f"concurrency group: {offenders}. The second push then cancels the first commit's run, "
+        "and the cancelled context is permanent, reads as FAILURE, and gets no next push to "
+        "clear it. Key the push side on github.sha, or record why the cancelled job is not a "
+        "per-commit verdict in _CANCELS_A_SUPERSEDED_DEPLOY."
+    )
+
+
+def test_every_exemption_still_applies_to_a_workflow_a_push_can_start() -> None:
+    """An exemption may not outlive the situation that justified it.
+
+    Each entry claims a workflow is started by a push and cancels in progress. If
+    either stops being true the entry is documenting a defect that no longer
+    exists, and the next reader inherits a reason for a rule that is not there.
+    """
+    assert _CANCELS_A_SUPERSEDED_DEPLOY, "the exemption table is empty; this pin has nothing to check"
+    for name, reason in _CANCELS_A_SUPERSEDED_DEPLOY.items():
+        path = _WORKFLOW_DIR / name
+        assert path.exists(), f"{name} is exempt but does not exist"
+        text = path.read_text(encoding="utf-8")
+        assert _subscribes_to_push(text), f"{name} is exempt but no push can start it; drop the entry"
+        concurrency = _concurrency(text)
+        assert concurrency is not None, f"{name} is exempt but declares no concurrency; drop the entry"
+        group, cancel = concurrency
+        assert cancel == "true", f"{name} is exempt but no longer cancels in progress; drop the entry"
+        assert "#" in reason, (
+            f"the exemption for {name} cites no issue. An exemption without somewhere the "
+            "remaining question is being settled is a deferral, and reads as a decision"
+        )
+        first = _render(group, _push_context(_workflow_name(text), "333333333333"))
+        second = _render(group, _push_context(_workflow_name(text), "444444444444"))
+        assert first == second, (
+            f"{name} now gives two pushed commits distinct groups ({first!r} vs {second!r}), so it "
+            "no longer needs the exemption; drop the entry and let the sweep cover it"
+        )


### PR DESCRIPTION
Closes #2304.

## Problem

`pr-and-push.yml` cancels an in-flight run when a new one starts in the same group:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

Only the first operand is ever set, so one line carried two behaviours. On a `pull_request` event the number is present and the group is per pull request - cancelling is exactly right there, and `tests/test_pull_request_trigger_types.py` exists to keep anything *but* a new push from triggering it. On a **push** the number is empty and the fallback answered `refs/heads/main` for every commit: one group for the whole branch, so each merge cancelled the previous merge's run and the commit it was testing kept a permanently unfinished `call-test-lint`.

A cancelled context is not `SUCCESS`, and a single non-`SUCCESS` context drags `statusCheckRollup.state` to `FAILURE` with no reason attached. That commit therefore reads red forever with no failing check anywhere in it.

#1800 measured this exact mechanism on #1788/#1794/#1796 and concluded it was tolerable to read around, which is why `AGENTS.md` carried a reading rule for it rather than a fix. Counting the branch is what changes the verdict (#2304): of the last 25 commits on `main`, 24 had a settled rollup, 11 of those read `FAILURE`, and **9 of the 11 had no failing check at all**. Two further facts make it a wrong answer rather than a wrong colour:

- Reading rollups along the branch is the only way to ask *when did `main` break* - #2303 did exactly that - and a burst of merges destroys the evidence for which commit in it broke `main` in the same act as creating the fault. Two of the commits #2303 read were red only from cancellation.
- A branch's stale red clears on its next push. A commit on `main` is immutable and already merged, so it gets no next push and the wrong answer is permanent.

## Change

The push side keys on the commit instead of the ref:

```diff
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
```

The pull-request operand is byte-identical, so nothing about pull-request behaviour moves. Each pushed commit now gets its own group and runs its own suite to completion.

**The two spellings #2304 offered are not interchangeable**, and this is why the new pin renders the group rather than asserting a string. Keeping `github.ref` and setting `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` still leaves one group for the branch. GitHub holds at most one *pending* run per group and cancels the previously pending one, so in a burst of three merges the third cancels the second while it is still queued - reproducing the CANCELLED context the change is removing. `test_two_commits_pushed_to_main_do_not_share_a_group` fails on that spelling too, because it asks whether two pushed commits render distinct groups rather than what the line says.

### What this deliberately does not change

`docs.yml` is the other workflow a push can start with a cancelling group, and it does not have the same answer, so it is pinned as an **explicit exemption** carrying its reason rather than treated as an oversight. Its `deploy` job publishes to GitHub Pages, where a superseded run is a superseded *deployment* and the newest commit's site is the one that should be live - cancelling is wanted there, and a per-commit group would let two publishes of different trees race for one resource. Its `build` job *is* a per-commit verdict and does share the defect, so the fix is splitting the two rather than changing the key. That is the decision in #2305, which also records which three of #2304's eleven commits it accounts for. `test_every_exemption_still_applies_to_a_workflow_a_push_can_start` fails the exemption if it stops citing an issue, or if `docs.yml` stops being a push workflow that cancels.

`codeql.yml` also subscribes to `push` and declares no workflow-level concurrency, so it cancels nothing. It is skipped by the sweep rather than exempted - there is nothing to exempt.

## Coupled updates in the same diff

Three places asserted or described the behaviour being removed. Leaving any of them would have left the repository stating two different things:

| file | what it said | now |
|---|---|---|
| `tests/test_pull_request_trigger_types.py` | `assert "group: ...|| github.ref }}" in text` | pins only the pull-request operand it reasons about; the push half is asserted by rendering in the new module, so the decision has one home |
| same, module docstring | "That producer is arguably wanted (a superseded `main` run is of no interest) and is not touched here" | records that it *was* left alone here and why counting the branch overturned that, and points at the new pin |
| `AGENTS.md` step 8 | a reading rule for the rollup, plus the cost that merging faster than the suite runs leaves "only the tip verified" | the producer is named as removed; the reading rule survives for the remaining producer (`docs.yml`, #2305); the tip-only cost is replaced by its successor - N suites per burst of N merges, and no manual bisect after a red tip |

## Tests

`tests/test_push_concurrency_group.py`, 8 tests. It evaluates the `${{ a || b }}` idiom under simulated `push` and `pull_request` contexts, so the assertions are about the group a commit lands in rather than about the text of a line. An operand outside the model raises rather than rendering empty, so a group rewritten with an expression the module cannot evaluate fails loudly instead of collapsing to a constant and passing for the wrong reason.

| test | on the parent commit |
|---|---|
| `test_two_commits_pushed_to_main_do_not_share_a_group` | **fails** - both render `Pull Request and Push Action-refs/heads/main` |
| `test_two_commits_pushed_to_dev_do_not_share_a_group` | **fails** - both render `...-refs/heads/dev` |
| `test_every_push_workflow_keys_its_group_on_the_commit` | **fails** - names `pr-and-push.yml` |
| `test_two_pushes_to_one_pull_request_still_share_a_group` | passes (preservation control) |
| `test_two_pull_requests_do_not_share_a_group` | passes (preservation control) |
| `test_the_required_check_still_cancels_in_progress` | passes (premise pin) |
| `test_the_scanner_finds_the_push_workflows` | passes (non-vacuity guard) |
| `test_every_exemption_still_applies_to_a_workflow_a_push_can_start` | passes (exemption cannot outlive its reason) |

The three preservation controls are the point of the split: `dev` is included because the defect was never about `main`'s name - it was about a key every commit on a branch shares - and a fix that special-cased the default branch would read as done while leaving `dev` behind.

Run locally: `tests/test_push_concurrency_group.py` + `tests/test_pull_request_trigger_types.py` = 15 passed; the CI-config and AGENTS.md-reading neighbours (`test_last_push_approval`, `test_merge_mutation_error_is_not_a_verdict`, `test_ref_creation_ruleset_scope`, `test_push_time_claim_recheck`, `test_workflow_jobs_are_bounded`, `test_changelog_fragments`, `test_changelog_format`, `test_codeql_query_filters`, `test_duplicate_claim_check`, `test_graphql_node_id_targeting`, `test_merge_gate_viewer_scope`, `test_composition_*`, `test_dependabot_config_location`) = 377 passed. `ruff check` / `ruff format --check` clean on both touched test modules.

## Acceptance against #2304

1. *Two commits merged inside one run duration both settle.* Structural half done here - they no longer share a group, so neither can cancel the other. The observational half is only visible after this lands and the next two merges land close together.
2. *Pinned so the regression cannot return silently.* `test_two_commits_pushed_to_main_do_not_share_a_group` plus the directory sweep, which is what makes the next workflow subscribing to `push` inherit the rule rather than rediscover it.
