### PR TITLE
test(docs): check a cross-reference target that wraps over a line break

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1267,6 +1267,7 @@ Corrections from code review that apply to all future contributions:
 ### Naming & Module Organization
 - **`robot.py` is for the `Robot()` factory**, the user-facing entry point. Hardware-specific code lives in `hardware_robot.py`. Don't have two files both named "robot something" with different responsibilities.
 - **Reference module names, not filenames, in docstrings** - `strands_robots.hardware_robot` not `robot.py`. Filenames change; module paths are the public contract.
+- **Keep a cross-reference target on one line** - a `:class:`/`:func:`/`:meth:` path is only a dotted path while it is contiguous. Wrapping `:class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`` over a line break leaves a token carrying a newline and the next line's indentation, which imports nowhere. Break the prose before the role and give the path its own line.
 
 ### Unicode & String Hygiene
 - **No emojis in user-facing strings** - this is a project rule. Tool result dicts (`{"content": [{"text": ...}]}`), log messages, error messages: plain ASCII only. Agents read these strings programmatically; emojis just add tokenizer noise.

--- a/changelog.d/2307-docstring-xref-wrapped-target.md
+++ b/changelog.d/2307-docstring-xref-wrapped-target.md
@@ -1,0 +1,8 @@
+### Fixed
+
+The docstring cross-reference guard now checks a `:class:`/`:func:`/`:meth:` target
+whose dotted path wraps over a line break. Its pattern stopped at the newline, so
+such a role was never extracted and was exempt from the guard entirely; five live
+roles in `strands_robots.policies` were dead pointers while the guard passed. A
+target is now graded on being a contiguous dotted path as well as resolving, and
+the refusal names the contiguous path to rewrap to. The five offenders are rewrapped.

--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -6,10 +6,11 @@ Some LeRobot-compatible checkpoints (notably the MolmoAct2 SO-100/101 family,
 Instead they carry a single ``norm_stats.json`` describing per-feature
 quantile/min-max/mean-std statistics keyed by an embodiment *tag*.
 
-Without those standard configs, :class:`~strands_robots.policies.lerobot_local
-.processor.ProcessorBridge` would build empty pipelines and pass observations
-and actions through untouched: state reaches the policy un-normalized and the
-predicted actions reach the motors un-unnormalized. That silent passthrough is
+Without those standard configs,
+:class:`~strands_robots.policies.lerobot_local.processor.ProcessorBridge`
+would build empty pipelines and pass observations and actions through
+untouched: state reaches the policy un-normalized and the predicted actions
+reach the motors un-unnormalized. That silent passthrough is
 the single biggest functional cause of off-policy arm motion on these
 checkpoints.
 

--- a/strands_robots/policies/protomotions/__init__.py
+++ b/strands_robots/policies/protomotions/__init__.py
@@ -11,11 +11,11 @@ Two entry points:
 * Direct construction with a ``.pt`` / ``.npz`` motion cache:
   ``ProtoMotionsPolicy(onnx_path=..., yaml_path=..., motion_path=...)``.
 * Chained after :class:`~strands_robots.policies.kimodo.KimodoPolicy` - Kimodo
-  samples a qpos trajectory, :func:`~strands_robots.policies.protomotions.
-  bridge.qpos_to_motion_data` converts it to a MotionPlayer cache, this policy
-  tracks it under physics. See :issue:`279` for why this is the correct
-  pairing for a whole-body kinematic generator (WBC would overwrite Kimodo's
-  leg+waist reference).
+  samples a qpos trajectory,
+  :func:`~strands_robots.policies.protomotions.bridge.qpos_to_motion_data`
+  converts it to a MotionPlayer cache, this policy tracks it under physics.
+  See :issue:`279` for why this is the correct pairing for a whole-body
+  kinematic generator (WBC would overwrite Kimodo's leg+waist reference).
 
 The pretrained artifact lives on HuggingFace at
 ``cagataydev/protomotions-gtp-unitree-g1`` (``unified_pipeline.onnx`` +

--- a/strands_robots/policies/protomotions/bridge.py
+++ b/strands_robots/policies/protomotions/bridge.py
@@ -172,8 +172,9 @@ def qpos_to_motion_data(
         control_dt: Target control period, seconds (default 0.02 = 50Hz).
 
     Returns:
-        A dict with the keys :class:`~strands_robots.policies.protomotions.
-        motion_utils.MotionPlayer` accepts.
+        A dict with the keys
+        :class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`
+        accepts.
 
     Raises:
         FileNotFoundError: If ``proto_mjcf_path`` does not exist.

--- a/strands_robots/policies/protomotions/motion_utils.py
+++ b/strands_robots/policies/protomotions/motion_utils.py
@@ -1,10 +1,10 @@
 """MotionPlayer - a fixed-rate reference-motion window for the ProtoMotions tracker.
 
-The ONNX Generalist Tracking Policy (GTP) that :class:`~strands_robots.policies.
-protomotions.policy.ProtoMotionsPolicy` wraps expects, each control tick, a
-window of FUTURE reference frames: joint pos + joint vel + anchor rotation at a
-handful of step-offsets ahead (default ``[1, 2, 4, 8]`` control steps). This
-module is the source of that window.
+The ONNX Generalist Tracking Policy (GTP) that
+:class:`~strands_robots.policies.protomotions.policy.ProtoMotionsPolicy` wraps
+expects, each control tick, a window of FUTURE reference frames: joint pos +
+joint vel + anchor rotation at a handful of step-offsets ahead (default
+``[1, 2, 4, 8]`` control steps). This module is the source of that window.
 
 Two input modes:
 

--- a/strands_robots/policies/protomotions/policy.py
+++ b/strands_robots/policies/protomotions/policy.py
@@ -2,9 +2,10 @@
 
 Wraps ``cagataydev/protomotions-gtp-unitree-g1``'s ``unified_pipeline.onnx``
 into the :class:`~strands_robots.policies.base.Policy` interface. Given a
-reference :class:`~strands_robots.policies.protomotions.motion_utils.
-MotionPlayer` and a per-tick observation dict, emits PD joint targets for the
-G1's 29 actuators.
+reference
+:class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`
+and a per-tick observation dict, emits PD joint targets for the G1's 29
+actuators.
 
 Contract:
 

--- a/tests/test_docstring_xref_roles_resolve.py
+++ b/tests/test_docstring_xref_roles_resolve.py
@@ -15,6 +15,13 @@ form - the ``:mod:`` / ``:class:`` / ``:func:`` / ``:meth:`` roles that name a
 dotted API path - by verifying that every fully-qualified ``strands_robots.*``
 target actually resolves to a real module or attribute.
 
+A target only counts as named if it is a CONTIGUOUS dotted path. A role whose
+path is long enough to wrap over a line break carries a newline plus the next
+line's indentation, so the token a reader copies out of the source does not
+import - and neither does the whitespace-collapsed form a renderer would see.
+The pattern here therefore admits whitespace inside the target and reports such
+a role, rather than failing to match it and exempting it from the guard.
+
 Scope is deliberately conservative: only targets that start with
 ``strands_robots.`` are checked. Unqualified roles (``:func:`reset```) and roles
 into third-party packages resolve against Sphinx's current-module context or an
@@ -34,8 +41,11 @@ import strands_robots
 _PKG_ROOT = Path(strands_robots.__file__).resolve().parent
 
 # Sphinx cross-reference roles naming a dotted Python target, optionally with a
-# leading ``~`` (display-shortening) tilde.
-_ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][\w.]*)`")
+# leading ``~`` (display-shortening) tilde. Whitespace is admitted INSIDE the
+# target so a role whose long dotted path was wrapped over a line break is
+# still extracted and checked: a pattern that stopped at the newline skipped
+# such a role outright, which exempted it from this guard entirely.
+_ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][\w.\s]*)`")
 
 
 def _resolves(target: str) -> bool:
@@ -64,8 +74,43 @@ def _resolves(target: str) -> bool:
     return True
 
 
+def _offending_roles_in(doc: str) -> list[str]:
+    """Report every ``strands_robots.*`` role target in ``doc`` a reader cannot follow.
+
+    Two distinct ways a target fails to name an object, both reported here:
+
+    * It is not a contiguous dotted path, because the role was wrapped over a
+      line break. The token as written carries a newline and the following
+      indentation, so it does not import, and no renderer reassembles it - the
+      whitespace collapses to a space, which does not import either. Rewrap the
+      line so the dotted path stays intact.
+    * It is a contiguous path that does not resolve - the dead pointer this
+      guard was written for.
+
+    A wrapped target is reported even when joining its segments WOULD resolve:
+    the path a reader copies out of the source is the one that has to work.
+
+    Args:
+        doc: One raw docstring.
+
+    Returns:
+        One entry per offending target, each naming the target and, for a
+        wrapped one, the contiguous path it was meant to be.
+    """
+    offenders: list[str] = []
+    for target in _ROLE_RE.findall(doc):
+        contiguous = "".join(target.split())
+        if not contiguous.startswith("strands_robots."):
+            continue
+        if target != contiguous:
+            offenders.append(f"{target!r} is wrapped over a line break; write it as {contiguous!r}")
+        elif not _resolves(target):
+            offenders.append(target)
+    return offenders
+
+
 def _unresolved_xref_roles() -> dict[str, list[str]]:
-    """Map ``relpath::qualname`` -> list of unresolved ``strands_robots.*`` roles."""
+    """Map ``relpath::qualname`` -> list of unfollowable ``strands_robots.*`` roles."""
     offenders: dict[str, list[str]] = {}
     for source_file in sorted(_PKG_ROOT.rglob("*.py")):
         if "__pycache__" in source_file.parts:
@@ -77,7 +122,7 @@ def _unresolved_xref_roles() -> dict[str, list[str]]:
             doc = ast.get_docstring(node, clean=False)
             if not doc:
                 continue
-            bad = [t for t in _ROLE_RE.findall(doc) if t.startswith("strands_robots.") and not _resolves(t)]
+            bad = _offending_roles_in(doc)
             if bad:
                 qualname = getattr(node, "name", "<module>")
                 rel = source_file.relative_to(_PKG_ROOT)
@@ -91,7 +136,8 @@ def test_qualified_strands_robots_xref_roles_resolve() -> None:
         "docstring cross-reference roles must name a real importable object. "
         "Cite a registered predicate/backend by its literal name (``base_below_z``) "
         "rather than a :func:`...` role, and reference actual API objects with "
-        ":mod:/:class:/:func:/:meth:. Offending docstrings: " + repr(offenders)
+        ":mod:/:class:/:func:/:meth:. A path long enough to wrap must be moved "
+        "onto its own line so it stays contiguous. Offending docstrings: " + repr(offenders)
     )
 
 
@@ -99,3 +145,59 @@ def test_guard_resolver_accepts_real_symbol_and_rejects_bogus() -> None:
     """The resolver walks module.attr chains and rejects nonexistent paths."""
     assert _resolves("strands_robots.simulation.base.SimEngine.get_observation")
     assert not _resolves("strands_robots.simulation.predicates.base_below_z")
+
+
+# A real object, and a path that has never existed, used below to separate
+# "the guard cannot see this role" from "the target does not resolve".
+_REAL = "strands_robots.simulation.base.SimEngine.get_observation"
+_BOGUS = "strands_robots.simulation.predicates.base_below_z"
+
+
+def test_the_role_pattern_extracts_a_target_wrapped_over_a_line_break() -> None:
+    """A wrapped dotted path is still a role target, so the pattern must match it.
+
+    A pattern that stops at the newline finds nothing here, which is how a
+    wrapped role escapes every check below it.
+    """
+    doc = "See :class:`~strands_robots.policies.protomotions.motion_utils.\n    MotionPlayer` for the window."
+    assert _ROLE_RE.findall(doc) == ["strands_robots.policies.protomotions.motion_utils.\n    MotionPlayer"]
+
+
+def test_a_wrapped_target_is_reported_even_when_its_segments_would_resolve() -> None:
+    """The path as written is what a reader copies, so a wrap is refused on its own.
+
+    Joining the segments of this target reaches a real class; the token in the
+    source does not, and that is the pointer being graded.
+    """
+    head, tail = _REAL.rsplit(".", 1)
+    doc = f"Delegates to :meth:`~{head}.\n    {tail}` on every backend."
+
+    offenders = _offending_roles_in(doc)
+
+    assert len(offenders) == 1, offenders
+    assert "wrapped over a line break" in offenders[0]
+    assert _REAL in offenders[0], "the remedy must spell out the contiguous path"
+    assert _resolves(_REAL), "premise: joining the wrapped segments reaches a real object"
+
+
+def test_a_wrapped_target_that_does_not_resolve_is_reported() -> None:
+    """A wrap must not hide a dead pointer - the case the widened pattern recovers."""
+    head, tail = _BOGUS.rsplit(".", 1)
+    doc = f"Registered as :func:`~{head}.\n    {tail}`."
+
+    assert _offending_roles_in(doc), "a wrapped role naming nothing must not pass unseen"
+
+
+def test_a_contiguous_resolving_target_is_accepted() -> None:
+    """Control: the ordinary, correct form stays silent."""
+    assert _offending_roles_in(f"Delegates to :meth:`~{_REAL}`.") == []
+
+
+def test_a_contiguous_target_that_does_not_resolve_is_reported() -> None:
+    """Control: the original dead-pointer check is unchanged by the widening."""
+    assert _offending_roles_in(f"See :func:`~{_BOGUS}`.") == [_BOGUS]
+
+
+def test_a_wrapped_target_outside_the_package_is_left_alone() -> None:
+    """Control: third-party targets stay out of scope, wrapped or not."""
+    assert _offending_roles_in("See :class:`~mujoco.\n    MjSpec` for the spec API.") == []


### PR DESCRIPTION
## Problem

`tests/test_docstring_xref_roles_resolve.py` asserts that every fully-qualified `strands_robots.*` Sphinx cross-reference names a real importable object, so a reader following the pointer is never sent to a path that does not import. Its own docstring states the stakes: "Sphinx renders a plain-text token, IDEs cannot jump to it, and the reader chases a path that does not import."

The role pattern is:

```python
_ROLE_RE = re.compile(r":(?:mod|class|func|meth|attr|data|obj|exc):`~?([A-Za-z_][\w.]*)`")
```

`[\w.]` does not match whitespace. A role whose dotted path is long enough to wrap over a line break is therefore **not matched at all** - the target is never extracted, so the invariant is never applied to it. That is the one form of the defect the guard cannot see.

Five such roles are live in the package today, and the guard passes:

| file | target as written | joined |
| --- | --- | --- |
| `policies/lerobot_local/norm_stats.py` | `strands_robots.policies.lerobot_local` + newline + `.processor.ProcessorBridge` | resolves |
| `policies/protomotions/__init__.py` | `...protomotions.` + newline + `bridge.qpos_to_motion_data` | resolves |
| `policies/protomotions/bridge.py` | `...protomotions.` + newline + `motion_utils.MotionPlayer` | resolves |
| `policies/protomotions/motion_utils.py` | `strands_robots.policies.` + newline + `protomotions.policy.ProtoMotionsPolicy` | resolves |
| `policies/protomotions/policy.py` | `...motion_utils.` + newline + `MotionPlayer` | resolves |

Each is a dead pointer in exactly the way the guard exists to prevent. The token as written carries a newline plus the next line's indentation, so it does not import. Collapsing that whitespace to a single space, as a renderer does, does not import either - measured for all five. The segments joined *do* reach a real object in every case, which is why the rot is invisible on review: the author's intent is right, only the written path is broken.

Measured on the shipped pattern versus a whitespace-tolerant one, for a single wrapped role:

```
shipped pattern extracts : []
widened pattern extracts : ['strands_robots.policies.protomotions.motion_utils.\n    MotionPlayer']
```

## Change

Admit whitespace inside the target so such a role is extracted, then grade a target on two counts instead of one:

1. it must be a **contiguous** dotted path, and
2. it must resolve.

A wrapped target is reported even when joining its segments would resolve, because the path a reader copies out of the source is the one that has to work. The refusal names the contiguous path to rewrap to:

```
'strands_robots.policies.protomotions.motion_utils.\nMotionPlayer' is wrapped over a line break;
write it as 'strands_robots.policies.protomotions.motion_utils.MotionPlayer'
```

The two failure modes are reported distinctly by one helper, so the original dead-pointer check is unchanged for a contiguous target. The five offenders are rewrapped in the same change, and the contiguous-path requirement joins the sibling docstring rule in `AGENTS.md` ("Reference module names, not filenames").

## Evidence

**The guard cannot currently see the defect.** On unmodified `main`, with `[all]` installed, the shipped guard passes while all five roles are broken:

```
tests/test_docstring_xref_roles_resolve.py ..                            [100%]
2 passed
```

**Each half of the change is necessary.** Applying only the test-file change to `main` fails and names all five, each with its remedy:

```
1 failed, 7 passed
Offending docstrings: {
  'policies/lerobot_local/norm_stats.py::<module>': [... is wrapped over a line break; write it as ...],
  'policies/protomotions/__init__.py::<module>':   [...],
  'policies/protomotions/bridge.py::qpos_to_motion_data': [...],
  'policies/protomotions/motion_utils.py::<module>': [...],
  'policies/protomotions/policy.py::<module>':     [...]}
```

With both halves: `8 passed`.

**Test split.** Six new tests; the three controls pass both before and after, which is what bounds the change:

| test | pre-fix | role |
| --- | --- | --- |
| the pattern extracts a target wrapped over a line break | fails (`findall` returns `[]`) | headline |
| a wrapped target is reported even when its segments would resolve | fails | pins the contract choice |
| a wrapped target that does not resolve is reported | fails | the case recovered |
| a contiguous resolving target is accepted | passes | control - no false positive |
| a contiguous target that does not resolve is reported | passes | control - original check intact |
| a wrapped target outside the package is left alone | passes | control - scope unchanged |

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 18 errors, byte-identical to `main` (all pre-existing, 14 in `examples/isaac_gs/`, outside lint scope).
- Full `tests/` on both this branch and `main`, same interpreter: **63 failing test IDs on each, identical set** (`comm` empty in both directions). Passed count 29968 vs 29962 = the six new tests.

No visual artifact: this changes a test guard and docstring text only - no policy, simulation, rendering, recording or asset behavior.