### PR TITLE
fix(simulation/newton): advertise set_timestep under the parameter name it accepts

### DIFF
--- a/changelog.d/2308-newton-describe-set-timestep-param.md
+++ b/changelog.d/2308-newton-describe-set-timestep-param.md
@@ -1,0 +1,10 @@
+### Fixed
+
+`NewtonSimEngine.describe()` advertised `set_timestep` as `"(dt: float) -> dict"`
+while the method has always been `set_timestep(timestep: float)`, so a caller
+following the discovery surface hit `TypeError: got an unexpected keyword
+argument 'dt'`. The advertised string now names `timestep` and its unit, and the
+existing rule that every advertised parameter must be a real parameter now
+covers every backend that overrides `describe()` - previously only the ABC and
+MuJoCo were checked, because the check needed a constructible engine and the
+Newton and Isaac runtimes cannot be installed in the same environment.

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -2366,7 +2366,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 "list_urdfs": "() -> dict (registry + robot_descriptions URDF long tail; json.robot_descriptions_urdf)",
                 "register_urdf": "(data_config: str, urdf_path: str) -> dict",
                 "set_gravity": "(gravity: list[float] | float) -> dict",
-                "set_timestep": "(dt: float) -> dict",
+                "set_timestep": "(timestep: float) -> dict (seconds; takes effect on the next step)",
                 "render": "(camera_name='default', width=None, height=None) -> dict (named camera or 'default')",
                 "add_camera": (
                     "(name: str, position=None, target=None, fov=60.0, width=640, height=480, "

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -10,8 +10,11 @@ Also pins the no-alias rule: the registry must NOT export a duplicate
 it from the discovery surface rather than the API carrying a second name.
 """
 
+import ast
+import inspect
 import re
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -982,3 +985,222 @@ class TestNoAlias:
             "not by aliasing a wrong guess."
         )
         assert "get_robot_info" not in getattr(registry, "__all__", [])
+
+
+def _folded_string(node: ast.AST) -> str | None:
+    """Fold a string literal or an ``+``-concatenated chain into one value.
+
+    describe() writes its longer signature strings as parenthesised implicit
+    concatenations, which the parser hands back as a single ``ast.Constant``,
+    and a few as explicit ``+`` chains. Anything that is not a compile-time
+    string (an f-string interpolating live state) folds to ``None`` and is
+    skipped: a signature string is a constant by construction.
+
+    Args:
+        node: The expression node to fold.
+
+    Returns:
+        The string value, or ``None`` when the node is not a constant string.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _folded_string(node.left)
+        right = _folded_string(node.right)
+        return None if left is None or right is None else left + right
+    return None
+
+
+def _describe_signature_strings(engine_cls: type) -> dict[str, str]:
+    """Read the signature strings ``engine_cls.describe()`` hands out.
+
+    Read from the source rather than from a live ``describe()`` call, because
+    an engine has to exist before it can describe itself and two of the three
+    backends need a runtime (``newton`` + ``warp``, ``isaacsim``) that cannot
+    be installed alongside the others. Their classes import fine, so the
+    signature strings can be compared against the real signatures without
+    constructing anything. Reading the source also covers strings on branches a
+    live call happens not to take.
+
+    Recognizes both spellings describe() uses: a ``{"name": "(...) -> ..."}``
+    entry in a dict literal, and a ``base["methods"]["name"] = "(...) -> ..."``
+    assignment. Only values that begin with ``(`` are collected, so the
+    non-signature entries in the same dict (backend name, solver, note) are
+    skipped.
+
+    Args:
+        engine_cls: The engine class whose ``describe()`` to read.
+
+    Returns:
+        Mapping of advertised method name to its advertised signature string.
+    """
+    source_file = inspect.getsourcefile(engine_cls)
+    assert source_file is not None, f"no source file for {engine_cls.__name__}"
+    module = ast.parse(Path(source_file).read_text(encoding="utf-8"))
+
+    class_defs = [
+        node for node in ast.walk(module) if isinstance(node, ast.ClassDef) and node.name == engine_cls.__name__
+    ]
+    assert class_defs, f"{engine_cls.__name__} not found in {source_file}"
+
+    signatures: dict[str, str] = {}
+    for class_def in class_defs:
+        for describe in [
+            node for node in ast.walk(class_def) if isinstance(node, ast.FunctionDef) and node.name == "describe"
+        ]:
+            for node in ast.walk(describe):
+                if isinstance(node, ast.Dict):
+                    for key, value in zip(node.keys, node.values, strict=True):
+                        name = _folded_string(key) if key is not None else None
+                        text = _folded_string(value)
+                        if name and text and text.lstrip().startswith("("):
+                            signatures[name] = text
+                elif (
+                    isinstance(node, ast.Assign)
+                    and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Subscript)
+                ):
+                    name = _folded_string(node.targets[0].slice)
+                    text = _folded_string(node.value)
+                    if name and text and text.lstrip().startswith("("):
+                        signatures[name] = text
+    return signatures
+
+
+def _real_parameters(engine_cls: type, method_name: str) -> tuple[set[str], set[str]] | None:
+    """Real and required parameter names of an advertised method.
+
+    Args:
+        engine_cls: The engine class the method is resolved on.
+        method_name: The advertised method name.
+
+    Returns:
+        ``(all_names, required_names)``, or ``None`` when the method is not
+        introspectable on this class or accepts ``**kwargs`` (a pass-through
+        signature may legitimately advertise keywords it forwards).
+    """
+    function = getattr(engine_cls, method_name, None)
+    if not callable(function):
+        # The backend-agnostic facade advertises the full engine contract,
+        # including the two accessors every concrete backend supplies but the
+        # ABC does not declare. A caller always holds a concrete engine, and
+        # the live-engine tests above pin that an advertised name resolves.
+        return None
+    try:
+        parameters = inspect.signature(function).parameters
+    except (TypeError, ValueError):
+        return None
+    if any(p.kind == p.VAR_KEYWORD for p in parameters.values()):
+        return None
+    required = {
+        name
+        for name, p in parameters.items()
+        if name != "self" and p.default is p.empty and p.kind in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY)
+    }
+    return set(parameters) | {"self"}, required
+
+
+# Every backend that overrides describe(), keyed by the label a failure names.
+# Resolved lazily: importing a backend module needs no simulator runtime, but it
+# does need the package's own optional deps, so the import happens inside the
+# test rather than at collection time.
+_DESCRIBE_BACKENDS = {
+    "base": ("strands_robots.simulation.base", "SimEngine"),
+    "mujoco": ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
+    "newton": ("strands_robots.simulation.newton.simulation", "NewtonSimEngine"),
+    "isaac": ("strands_robots.simulation.isaac.simulation", "IsaacSimulation"),
+}
+
+
+def _describe_backend(label: str) -> type:
+    """Import the engine class registered under ``label``.
+
+    Args:
+        label: Key into :data:`_DESCRIBE_BACKENDS`.
+
+    Returns:
+        The engine class. None of these modules needs its simulator runtime
+        (``newton`` + ``warp``, ``isaacsim``) at import time, which is what
+        makes every backend reachable from one environment.
+    """
+    import importlib
+
+    module_name, class_name = _DESCRIBE_BACKENDS[label]
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+class TestDescribeSignaturesAgreeWithTheMethodsOnEveryBackend:
+    """Every backend's advertised signatures name the real parameters.
+
+    The live-engine tests above pin this invariant where an engine can be
+    constructed: the ABC (through a minimal concrete subclass) and MuJoCo. The
+    Newton and Isaac backends need a simulator runtime that cannot be installed
+    in the same environment, so their hardcoded signature strings were never
+    compared against anything, and Newton's ``set_timestep`` drifted to
+    advertise a ``dt`` keyword its method has never accepted. These tests close
+    that gap by reading the strings from source and resolving the signatures on
+    the imported class, so the discovery surface of every backend is held to
+    one rule.
+    """
+
+    def test_every_backend_advertises_signatures(self):
+        """The extraction really finds signature strings on all four surfaces.
+
+        Without this the two tests below would pass vacuously if the source
+        layout of describe() changed and the reader stopped matching.
+        """
+        counts = {
+            label: len(_describe_signature_strings(_describe_backend(label))) for label in sorted(_DESCRIBE_BACKENDS)
+        }
+        assert all(count >= 10 for count in counts.values()), counts
+        assert sum(counts.values()) >= 140, counts
+
+    @pytest.mark.parametrize("label", sorted(_DESCRIBE_BACKENDS))
+    def test_every_advertised_parameter_is_a_real_parameter(self, label):
+        """An advertised keyword must exist, or the caller dead-ends.
+
+        An agent reads a signature string out of describe() and calls the
+        method with those keywords. A keyword no longer on the method raises
+        ``TypeError``, and the discovery surface is the only place the agent
+        looked.
+        """
+        engine_cls = _describe_backend(label)
+        violations = []
+        for method_name, signature in sorted(_describe_signature_strings(engine_cls).items()):
+            resolved = _real_parameters(engine_cls, method_name)
+            if resolved is None:
+                continue
+            real, _ = resolved
+            violations += [
+                f"{method_name}(...{advertised}=...)"
+                for advertised in _advertised_param_names(signature)
+                if advertised not in real
+            ]
+        assert not violations, (
+            f"{label}: describe() advertises parameters the method does not accept: "
+            f"{sorted(violations)}. Update the signature string when the signature changes."
+        )
+
+    @pytest.mark.parametrize("label", sorted(_DESCRIBE_BACKENDS))
+    def test_every_required_parameter_is_advertised(self, label):
+        """A required parameter left out of the string dead-ends the caller too.
+
+        The mirror of the test above: a call built from the advertised
+        parameters alone must be a complete call. A required parameter the
+        string never names raises ``TypeError`` for the missing argument, which
+        is how Newton's renamed ``timestep`` presented from the far side.
+        """
+        engine_cls = _describe_backend(label)
+        violations = []
+        for method_name, signature in sorted(_describe_signature_strings(engine_cls).items()):
+            resolved = _real_parameters(engine_cls, method_name)
+            if resolved is None:
+                continue
+            _, required = resolved
+            missing = sorted(required - set(_advertised_param_names(signature)))
+            if missing:
+                violations.append(f"{method_name}: {missing}")
+        assert not violations, (
+            f"{label}: describe() omits parameters the method requires: {sorted(violations)}. "
+            "A call built from the advertised signature alone must be a complete call."
+        )


### PR DESCRIPTION
## Problem

`NewtonSimEngine.describe()` advertised `set_timestep` as `"(dt: float) -> dict"`. The method has always been `set_timestep(timestep: float)`. So a caller that reads the discovery surface and calls what it was told to call:

```python
sim.set_timestep(dt=0.002)
# TypeError: NewtonSimEngine.set_timestep() got an unexpected keyword argument 'dt'
```

That is a dead end from the one surface whose documented purpose is letting a caller learn the contract without guessing, and the error names the keyword rather than the surface that supplied it. Everything else already spells it `timestep`: the MuJoCo backend's `describe()`, `strands_robots/simulation/mujoco/tool_spec.json`, and the parameter table in `docs/simulation/overview.md`. Only the Newton discovery string drifted, and `dt` appears in the Newton module solely as a local (`dt = self._world.timestep / self.substeps`).

![describe set_timestep before and after](https://raw.githubusercontent.com/cagataycali/robots/media-newton-describe-set-timestep/describe_set_timestep.png)

## Why it was not caught

The invariant is already stated and already enforced. `_assert_advertised_params_are_real` in `tests/simulation/test_sim_engine_describe_discovery.py` exists precisely so that "a rename that dropped or renamed a parameter without updating the hardcoded describe() string" cannot ship. It runs on a live engine, so it runs only where an engine can be constructed: the ABC (through a minimal concrete subclass) and MuJoCo. Newton and Isaac need a simulator runtime that cannot be installed in the same environment, so their hardcoded signature strings were never compared against anything.

Their classes do import without that runtime. That is what makes the gap closable: the strings can be read from the source and the signatures resolved on the imported class, with nothing constructed.

## Change

1. `describe()["methods"]["set_timestep"]` now reads `"(timestep: float) -> dict (seconds; takes effect on the next step)"`, matching the method and naming the unit the way the MuJoCo entry does.
2. The parameter-agreement rule now covers every backend that overrides `describe()`, by reading the advertised strings from source and resolving each signature on the imported class. This also covers strings sitting on branches a live `describe()` call happens not to take.

Both directions are pinned, because a rename presents as each of them: an advertised keyword the method does not accept, and a required parameter the string never names. Newton's drift produced both.

## Scope

The sweep covers **145 advertised signatures** across the four surfaces (base 27, MuJoCo 68, Newton 37, Isaac 13). Exactly one disagreed with its method. The other 144 are the control: they pass unchanged, so the new rule adds no constraint beyond the one already stated for the ABC and MuJoCo.

## Tests

Against unmodified `main`, with only the test file applied: **2 failed, 41 passed**.

```
FAILED ...::test_every_advertised_parameter_is_a_real_parameter[newton]
  newton: describe() advertises parameters the method does not accept:
  ['set_timestep(...dt=...)']
FAILED ...::test_every_required_parameter_is_advertised[newton]
  newton: describe() omits parameters the method requires:
  ["set_timestep: ['timestep']"]
```

After the change, 43 passed. The 7 other new cases (`base`, `mujoco`, `isaac` in both directions, plus the non-vacuity check that the reader really found signatures on all four surfaces) pass on both trees, which is what shows the rule does not reach past the defect.

Full `tests/` on both trees: **61 failing ids, identical set**, zero regressions; 30265 passed against 30256, the difference being exactly the 9 new cases. `ruff check` / `ruff format --check` clean, `mypy` identical on both trees.

## Docs

No documentation change: `docs/simulation/overview.md` already lists `set_timestep` with key param `timestep`, and `docs/simulation/newton.md` describes the method without naming a keyword. The prose was correct; the machine-readable surface was the one that had drifted.
