### PR TITLE
fix(simulation/mujoco): publish set_geom_properties' payload contract in the tool schema

### DIFF
--- a/changelog.d/2311-geom-property-payload-published.md
+++ b/changelog.d/2311-geom-property-payload-published.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `simulation/mujoco`: the agent-facing tool schema now publishes `set_geom_properties`' full payload. `friction` had no property at all, so a schema-constrained decoder could not pass the coefficients the action validates and applies, and `size` was described only for `add_object` - the two actions take that one field under different conventions (full extents vs the compiled geom's own `geom_size`), so `size=[0.2, 0.2, 0.2]` builds a 20 cm box through one and resizes that same box to 40 cm through the other under `status="success"`. Both conventions and `friction`'s component order are now published.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -98,6 +98,13 @@ rejected instead of being mixed with the compiled one:
 | `friction` | 3 (sliding, torsional, rolling) |
 | `size` | whatever the geom's type defines: sphere 1, capsule/cylinder 2, box/ellipsoid/plane 3 |
 
+`size` here is the geom's own `geom_size` - half-extents for a box - and not
+`add_object`'s full extents, so the same vector means two different objects
+depending on which call it is passed to. `add_object(size=[0.2, 0.2, 0.2])`
+builds a 20 cm box; `set_geom_properties(size=[0.2, 0.2, 0.2])` resizes that box
+to 40 cm. A capsule is `[radius, half-length]` here and
+`[diameter, unused, height]` there.
+
 ```python
 sim.set_geom_properties(geom_name="crate", size=[0.4])
 # status=error: 'size' must have exactly 3 component(s) (box: three half-extents),

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -213,6 +213,14 @@ differently-sized object while `add_object` reports success:
 
 At most 3 components are accepted; omit `size` entirely for the 5 cm default.
 
+`set_geom_properties(size=...)` resizes an existing geom and takes a *different*
+convention for the same word: the compiled geom's own MuJoCo `geom_size`
+components. The two are not interchangeable - `size=[0.2, 0.2, 0.2]` builds a
+20 cm box here and resizes that same box to 40 cm there, and this table's
+`[diameter, unused, height]` capsule triple is refused there (it wants
+`[radius, half-length]`). See
+[Domain randomization](domain-randomization.md).
+
 ```python
 sim.add_object("crate", shape="box", size=[0.5])
 # status=error: box needs 3 'size' component(s) [x, y, z] full edge lengths,

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1818,7 +1818,10 @@ class PhysicsMixin:
             friction: The three MuJoCo friction coefficients (sliding,
                 torsional, rolling), each ``>= 0``.
             size: The geom's half-extents, with exactly as many components as
-                its type defines, each ``> 0``.
+                its type defines, each ``> 0``. This is the compiled
+                ``geom_size``, not ``add_object``'s full extents - the same
+                vector resizes a box to twice what ``add_object`` builds
+                from it.
 
         Returns:
             A tool-result dict; ``status="error"`` if the world is missing, a

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -162,7 +162,7 @@
       "items": {
         "type": "number"
       },
-      "description": "Object size for add_object, as FULL extents in meters per axis (not MuJoCo half-extents). Pass every component the shape consumes: box/ellipsoid [x,y,z], cylinder/capsule [diameter,unused,height], sphere [diameter], plane [x] or [x,y] half-widths; mesh ignores it. At most 3 components. A partial vector (e.g. [0.5] for a box) is rejected, not padded - omit size entirely for the 5 cm default."
+      "description": "Vector extent. The convention differs per action and the two are not interchangeable. add_object: FULL extents in meters per axis (not MuJoCo half-extents), as the shape consumes them - box/ellipsoid [x,y,z], cylinder/capsule [diameter,unused,height], sphere [diameter], plane [x] or [x,y] half-widths; mesh ignores it; at most 3 components; a partial vector (e.g. [0.5] for a box) is rejected, not padded - omit size entirely for the 5 cm default. set_geom_properties: the compiled geom's own MuJoCo geom_size components, exactly as many as its type defines and each > 0 - sphere [radius], capsule/cylinder [radius, half-length], box [three half-extents], ellipsoid [three semi-axes], plane [x half-extent, y half-extent, grid spacing]; mesh/height-field/SDF geoms define none, so size is refused for them. The same value therefore means different things: size=[0.2,0.2,0.2] builds a 20 cm box via add_object and resizes that same box to 40 cm via set_geom_properties, and add_object's [diameter,unused,height] capsule triple is refused there (pass [radius, half-length])."
     },
     "color": {
       "type": "array",
@@ -380,6 +380,15 @@
     "geom_id": {
       "type": "integer",
       "description": "Geom ID (alternative to geom_name)"
+    },
+    "friction": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "set_geom_properties only: the geom's three MuJoCo friction coefficients [sliding, torsional, rolling], each finite and >= 0. Pass all three - a partial vector is rejected, not padded, since there is no value to invent for an omitted coefficient. Takes effect on the next step."
     },
     "force": {
       "type": "array",

--- a/tests/simulation/mujoco/test_tool_spec.py
+++ b/tests/simulation/mujoco/test_tool_spec.py
@@ -739,3 +739,202 @@ class TestTheRouterDispatchesOnlyPublishedOrDeclaredActions:
 
         assert self._unaccounted(_EngineWithANewCapability) == {"teleport_everything"}
         assert not self._unaccounted(), "the real engine must stay accounted for"
+
+
+# The geom-property payload contract
+#
+# ``set_geom_properties`` is the one published action whose entire purpose is
+# writing geom payload vectors, and the flat property dict described it as if
+# ``add_object`` were the only consumer. Two consequences, both invisible to the
+# router: it validates a call against the *method signature*, so a payload the
+# schema never published still dispatches when a Python caller passes it, and a
+# schema-constrained decoder cannot emit it at all.
+#
+# ``friction`` was published nowhere, so the coefficients the method validates,
+# documents and applies were unreachable from the model-facing surface.
+#
+# ``size`` is worse than unreachable, because two actions consume that one wire
+# field under different conventions: ``add_object`` takes full extents, and
+# ``set_geom_properties`` takes the compiled geom's own ``geom_size``
+# components, which are half-extents for a box. The published description named
+# only ``add_object`` and stated the other convention was explicitly not what
+# the field meant, so a caller who follows it either doubles a box under
+# ``status="success"`` or is refused for a component the same text calls unused.
+
+
+def _geom_property_params() -> set[str]:
+    """The payload parameters ``set_geom_properties`` accepts."""
+    signature = inspect.signature(Simulation.set_geom_properties)
+    return {name for name in signature.parameters if name != "self"}
+
+
+def _compiled_geom_id(sim: Simulation, geom_name: str) -> int:
+    """The live model's id for ``geom_name``, so a write can be read back."""
+    import mujoco
+
+    geom_id = int(mujoco.mj_name2id(sim.mj_model, mujoco.mjtObj.mjOBJ_GEOM, geom_name))
+    assert geom_id >= 0, f"no geom named {geom_name!r}"
+    return geom_id
+
+
+@pytest.fixture
+def world_sim(sim: Simulation) -> Simulation:
+    """A session with a world, ready for scene mutation."""
+    assert sim.create_world()["status"] == "success"
+    return sim
+
+
+class TestTheGeomPropertyPayloadIsPublished:
+    """Every payload ``set_geom_properties`` accepts is reachable from the schema."""
+
+    def test_every_geom_property_parameter_is_reachable_in_the_schema(self) -> None:
+        """A payload absent from the schema is unreachable for a model.
+
+        The router binds against the method signature rather than the schema, so
+        an unpublished payload is not refused - it is simply never emitted, and
+        the capability reads as missing rather than as undiscoverable. This is
+        the parameter-level form of the action-level accounting above, scoped to
+        the one action whose whole purpose is writing these vectors.
+        """
+        published = set(_tool_spec_properties())
+        aliases_by_param = {target: field for field, target in Simulation._FIELD_ALIASES.items()}
+
+        unreachable = sorted(
+            param for param in _geom_property_params() if not ({param, aliases_by_param.get(param, param)} & published)
+        )
+        assert not unreachable, (
+            "set_geom_properties accepts these payloads but tool_spec publishes no property for "
+            f"them, so a schema-constrained decoder cannot pass them: {unreachable}"
+        )
+
+    def test_the_published_friction_carries_the_arity_and_order_the_geom_defines(self) -> None:
+        """Three coefficients in a fixed order, so a count alone cannot pin it.
+
+        MuJoCo's friction triple is ordered (sliding, torsional, rolling) and the
+        three are not interchangeable: swapping them passes every arity check and
+        applies a different contact model under ``status="success"``. Published in
+        the same shape ``orientation`` uses for its component order, and for the
+        same reason.
+        """
+        friction = _tool_spec_properties()["friction"]
+        assert friction["type"] == "array"
+        assert friction.get("minItems") == 3 and friction.get("maxItems") == 3, (
+            "friction takes exactly three coefficients; publish the count rather than leaving a "
+            f"decoder to guess it. Got: {friction!r}"
+        )
+        description = friction.get("description", "")
+        for coefficient in ("sliding", "torsional", "rolling"):
+            assert coefficient in description, (
+                f"friction must publish its component order; {coefficient!r} is missing from {description!r}"
+            )
+
+    def test_a_friction_the_schema_publishes_is_applied(self, world_sim: Simulation) -> None:
+        """The published payload reaches the model, end to end through the router."""
+        assert (
+            world_sim(action="add_object", name="crate", shape="box", position=[0, 0, 0.1], size=[0.1, 0.1, 0.1])[
+                "status"
+            ]
+            == "success"
+        )
+
+        result = world_sim(action="set_geom_properties", geom_name="crate", friction=[0.6, 0.01, 0.001])
+
+        assert result["status"] == "success", result
+        geom_id = _compiled_geom_id(world_sim, "crate_geom")
+        applied = [float(component) for component in world_sim.mj_model.geom_friction[geom_id][:3]]
+        assert applied == [0.6, 0.01, 0.001], f"the published payload must reach the model, got {applied}"
+
+    def test_a_partial_friction_is_refused_with_the_count_it_wanted(self, world_sim: Simulation) -> None:
+        """The published bounds match the refusal, so the schema is honest.
+
+        Bounds a caller can satisfy and still be refused would be worse than no
+        bounds, so the arity the property advertises is the arity the action
+        enforces.
+        """
+        world_sim(action="add_object", name="crate", shape="box", position=[0, 0, 0.1], size=[0.1, 0.1, 0.1])
+
+        result = world_sim(action="set_geom_properties", geom_name="crate", friction=[0.6, 0.01])
+
+        assert result["status"] == "error"
+        assert "3 component" in result["content"][0]["text"]
+
+
+class TestTheSharedSizeFieldPublishesBothConventions:
+    """One wire field, two scales - so the schema names both."""
+
+    @staticmethod
+    def _geom_size(sim: Simulation, geom_name: str) -> list[float]:
+        """The compiled ``geom_size`` of ``geom_name``, read from the live model."""
+        geom_id = _compiled_geom_id(sim, geom_name)
+        return [float(component) for component in sim.mj_model.geom_size[geom_id][:3]]
+
+    def test_one_size_vector_scales_a_box_differently_through_the_two_actions(self, world_sim: Simulation) -> None:
+        """The divergence, measured, and the disclosure it requires.
+
+        ``size=[0.2, 0.2, 0.2]`` is a 20 cm box through ``add_object`` and a 40 cm
+        box through ``set_geom_properties``, because one takes full extents and the
+        other takes the geom's own half-extents. Nothing refuses the mismatch -
+        both calls report ``status="success"`` - so the only place a caller can
+        learn it is the property that carries the field.
+        """
+        world_sim(action="add_object", name="crate", shape="box", position=[0, 0, 0.5], size=[0.2, 0.2, 0.2])
+        built = self._geom_size(world_sim, "crate_geom")
+
+        assert world_sim(action="set_geom_properties", geom_name="crate", size=[0.2, 0.2, 0.2])["status"] == "success"
+        resized = self._geom_size(world_sim, "crate_geom")
+
+        assert built == [0.1, 0.1, 0.1], f"premise: add_object takes full extents, got {built}"
+        assert resized == [0.2, 0.2, 0.2], f"premise: set_geom_properties takes half-extents, got {resized}"
+
+        description = _tool_spec_properties()["size"]["description"]
+        assert "add_object" in description and "set_geom_properties" in description, (
+            "size means different things to two actions, so the property must name both rather "
+            f"than describing one of them. Got: {description!r}"
+        )
+        assert "half-extent" in description.lower(), (
+            "the resize convention is half-extents; a description that only states the full-extent "
+            f"convention doubles every box it is followed for. Got: {description!r}"
+        )
+
+    def test_the_capsule_layout_the_field_publishes_for_add_object_is_refused_by_the_resize(
+        self, world_sim: Simulation
+    ) -> None:
+        """A refusal that blames a value the other convention calls unused.
+
+        ``add_object`` spells a capsule ``[diameter, unused, height]``, and the
+        middle component is genuinely ignored there. The resize wants
+        ``[radius, half-length]``, so following the published layout is refused
+        for the zero in the slot the layout itself calls unused - a caller cannot
+        get from that message to the two-component form.
+        """
+        world_sim(action="add_object", name="rod", shape="capsule", position=[0, 0, 0.5], size=[0.1, 0.0, 0.4])
+
+        refused = world_sim(action="set_geom_properties", geom_name="rod", size=[0.1, 0.0, 0.4])
+        accepted = world_sim(action="set_geom_properties", geom_name="rod", size=[0.1, 0.4])
+
+        assert refused["status"] == "error", "premise: the add_object capsule layout is not accepted here"
+        assert accepted["status"] == "success", accepted
+
+        description = _tool_spec_properties()["size"]["description"]
+        assert "radius" in description, (
+            "the resize takes a capsule as [radius, half-length]; publish it so the add_object "
+            f"triple is not the only layout a caller can read. Got: {description!r}"
+        )
+
+    def test_a_shared_field_both_actions_scale_alike_needs_no_disclosure(self, world_sim: Simulation) -> None:
+        """``color`` is the control: one convention, so one description.
+
+        Shared by the same two actions and meaning the same thing in both, which
+        is why its description names neither. Without this the class above would
+        read as a rule about every shared field rather than about the one whose
+        meaning changes with the action.
+        """
+        world_sim(action="add_object", name="crate", shape="box", position=[0, 0, 0.1], size=[0.1, 0.1, 0.1])
+
+        assert world_sim(action="set_geom_properties", geom_name="crate", color=[0.8, 0.2, 0.2])["status"] == "success"
+
+        description = _tool_spec_properties()["color"]["description"]
+        assert "add_object" not in description and "set_geom_properties" not in description, (
+            "color means one thing to both actions, so it needs no per-action split; a mention "
+            f"here would say the conventions diverge when they do not. Got: {description!r}"
+        )


### PR DESCRIPTION
## Problem

`set_geom_properties` is the one published action whose whole purpose is writing geom payload vectors, and the flat `tool_spec.json` property dict described that payload as if `add_object` were the only consumer. The router binds a call against the *method signature*, not the schema, so neither gap fails anything - a Python caller reaches both payloads, and a schema-constrained decoder cannot.

**`friction` was published nowhere.** The method validates it (finite, `>= 0`, exactly three components), documents it, and applies it to `geom_friction`; `docs/simulation/domain-randomization.md` shows it. The model-facing schema had no property for it, so the coefficients were unreachable from the surface that decides what a model can emit. The capability read as missing rather than as undiscoverable.

**`size` is shared by two actions under two conventions.** `add_object` takes full extents; `set_geom_properties` takes the compiled geom's own `geom_size`, which is half-extents for a box. The published description named only `add_object` and stated the other convention was explicitly *not* what the field meant ("as FULL extents in meters per axis (not MuJoCo half-extents)"), so following it goes wrong two ways:

| Call | Result |
|---|---|
| `add_object(size=[0.2, 0.2, 0.2])` | `geom_size=[0.1, 0.1, 0.1]` - a 20 cm box |
| `set_geom_properties(size=[0.2, 0.2, 0.2])` on that box | `geom_size=[0.2, 0.2, 0.2]` - a 40 cm box, `status="success"`, reported as `size -> [0.2, 0.2, 0.2]` |
| `set_geom_properties(size=[0.1, 0.0, 0.4])` on a capsule | refused: `'size' values must be > 0.0` - for the middle component the published `[diameter, unused, height]` layout itself calls unused (it wants `[radius, half-length]`) |

The docstring and the docs both state the half-extent convention correctly. Only the agent-facing schema contradicted them.

## Change

`tool_spec.json` only, plus the docs that describe each convention:

- Publish `friction` with `minItems`/`maxItems` 3 and its component order (sliding, torsional, rolling) - the same shape `orientation` uses to publish scalar-first order, and for the same reason: the triple is ordered, so a count alone cannot pin it.
- `size` now states both conventions, each per-shape layout, and the value that means two different things.
- `docs/simulation/world-building.md` and `docs/simulation/domain-randomization.md` cross-reference the two conventions where each is documented; the `size:` docstring in `set_geom_properties` says it is `geom_size`, not `add_object`'s full extents.

No behaviour change - the router already forwarded both payloads. `friction` is deliberately *not* added to `_VECTOR_PARAM_LENGTHS`: the method already refuses a wrong count with a message naming the coefficients (`'friction' must have exactly 3 component(s) (sliding, torsional, rolling), got 2`), and routing it through the generic router check would replace that with `Parameter 'friction' must be a list of 3 numbers`.

## Tests

`tests/simulation/mujoco/test_tool_spec.py`, 7 cases. Pre-fix on `main`: **4 failed, 3 passed**; after: 7 passed.

Fail pre-fix:

- `test_every_geom_property_parameter_is_reachable_in_the_schema` - `['friction']`
- `test_the_published_friction_carries_the_arity_and_order_the_geom_defines` - `KeyError: 'friction'`
- `test_one_size_vector_scales_a_box_differently_through_the_two_actions` - measures the divergence from the live model (`[0.1,0.1,0.1]` vs `[0.2,0.2,0.2]`) as a `premise:` assertion, then requires the property to name both actions
- `test_the_capsule_layout_the_field_publishes_for_add_object_is_refused_by_the_resize`

Pass on both trees, so they bound the change rather than restate it:

- `test_a_friction_the_schema_publishes_is_applied` - the payload already reached `geom_friction`; only the publication was missing, which is what makes this a schema fix and not a behaviour fix
- `test_a_partial_friction_is_refused_with_the_count_it_wanted` - the published bounds equal the arity the action enforces, so a caller who satisfies the schema is not refused anyway
- `test_a_shared_field_both_actions_scale_alike_needs_no_disclosure` - `color` is the control: shared by the same two actions, one convention, so its description names neither and must keep not naming them

Full suite: 61 failing ids on this branch and on `main`, identical sets both ways (`comm` empty); 30311 vs 30304 passed, the delta being these 7. `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Artifact

MuJoCo rollout, headless. The same `size=[0.2, 0.2, 0.2]` through both actions, with an untouched 20 cm box in blue as the reference.

![size convention](https://raw.githubusercontent.com/cagataycali/robots/media-geom-size-convention/size_convention.png)

The orange crate's footprint goes 1768 px -> 5538 px (95 px -> 203 px wide, 2.1x linear) while the blue reference stays at exactly 1773 px. Both calls report `status="success"`.
