### PR TITLE
fix(mesh): forward a tell() goal to the call that reads it

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,10 +992,12 @@ a.mesh.tell(b.peer_id, "pick up the cube")
 a.mesh.emergency_stop()         # broadcast E-STOP, audited to disk
 ```
 
-`tell()` routes to hardware **and** sim peers. Per-call policy kwargs
-(`target_pose`, `target_joints`, `world_update`) and constructor extras are
-forwarded end-to-end via `policy_config`, so a planner-style policy on a sim
-peer sees the goal payload it needs:
+`tell()` routes to hardware **and** sim peers. Each payload is forwarded to
+the sink that reads it: constructor extras (`model_path`, `server_address`,
+...) via `policy_config`, and the per-call goal (`target_pose`,
+`target_joints`, `world_update`) via `policy_kwargs`, which the runner hands
+to every `get_actions()` call. So a planner-style policy on a sim peer sees
+the goal payload it needs:
 
 ```python
 a.mesh.tell(

--- a/changelog.d/2312-mesh-goal-payload-sink.md
+++ b/changelog.d/2312-mesh-goal-payload-sink.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **mesh**: a `tell()` goal payload now reaches the call that reads it. The
+  sim-peer dispatcher forwarded the well-known goal (`target_pose` /
+  `target_joints` / `world_update`) in `policy_config`, which is expanded into
+  the Policy constructor; no provider names a goal key there, so the goal was
+  discarded and the planner then refused the request that had carried it. It now
+  travels in `policy_kwargs`, which the runner forwards verbatim to every
+  `get_actions` call, while constructor extras (`model_path`, `server_address`,
+  `policy_type`, `pretrained_name_or_path`) keep travelling in `policy_config`.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1795,10 +1795,11 @@ class Mesh(SensorLoopsMixin):
 
     # Well-known per-call policy kwargs from issue #300 - keys that planner-
     # style providers (cuRobo, MoveIt2, MPC) consume to encode goals beyond
-    # natural-language ``instruction``. Forwarded from ``tell()`` payload
-    # into ``policy_config`` so a ``policy_provider="curobo"`` peer sees the
-    # ``target_pose`` it needs without the dispatch layer dropping it
-    # silently.
+    # natural-language ``instruction``. Forwarded from the ``tell()``
+    # payload into ``policy_kwargs`` -- the run_policy/start_policy parameter
+    # that reaches ``get_actions(obs, instruction, **policy_kwargs)`` -- so a
+    # ``policy_provider="curobo"`` peer sees the ``target_pose`` it needs
+    # without the dispatch layer dropping it silently.
     #
     # See AGENTS.md > Public API Hygiene: "Forward all advertised kwargs
     # end-to-end. Silent drops are bugs masquerading as features."
@@ -1832,12 +1833,19 @@ class Mesh(SensorLoopsMixin):
             * Otherwise return an error - ambiguous targets must be
               explicit so the agent can't accidentally drive the wrong arm.
 
-        Forwards both the existing ``extra`` constructor kwargs
-        (``model_path``, ``server_address``, ``policy_type``,
-        ``pretrained_name_or_path``) and the issue #300 well-known per-call
-        kwargs (``target_pose``, ``target_joints``, ``world_update``) via
-        ``policy_config``. Per #300 the receiving Policy ignores unknown
-        kwargs rather than raising, so VLA providers stay compatible.
+        Each forwarded payload goes to the sink that reads it. The
+        ``extra`` constructor kwargs (``model_path``, ``server_address``,
+        ``policy_type``, ``pretrained_name_or_path``) travel in
+        ``policy_config``, which ``create_policy`` hands to the Policy
+        constructor. The issue #300 well-known per-call goal
+        (``target_pose``, ``target_joints``, ``world_update``) travels in
+        ``policy_kwargs``, which the runner forwards verbatim to every
+        ``get_actions(obs, instruction, **policy_kwargs)`` call: no provider
+        names a goal key on its constructor, so ``policy_config`` would hand
+        the goal to a forward-compatibility absorber that ignores it and the
+        planner would then refuse the payload the caller supplied. Per #300
+        the receiving Policy ignores unknown per-call kwargs rather than
+        raising, so VLA providers stay compatible.
         """
         sim = self.robot
 
@@ -1865,13 +1873,13 @@ class Mesh(SensorLoopsMixin):
         if robot_name not in available:
             return {"error": f"robot_name={robot_name!r} not in sim (available: {available})"}
 
-        # Build policy_config: existing constructor kwargs + well-known
-        # per-call kwargs from #300. ``policy_config`` is the documented
-        # passthrough on SimEngine.run_policy/start_policy.
+        # Constructor kwargs and the per-call goal have different sinks:
+        # ``policy_config`` is expanded into the Policy constructor, while
+        # ``policy_kwargs`` is forwarded verbatim to every ``get_actions``
+        # call. Every provider reads the #300 goal in ``get_actions``, so
+        # routing it through the constructor drops it.
         policy_config: dict[str, Any] = dict(extra)
-        for key in self._SIM_WELL_KNOWN_POLICY_KWARGS:
-            if key in cmd:
-                policy_config[key] = cmd[key]
+        policy_kwargs: dict[str, Any] = {key: cmd[key] for key in self._SIM_WELL_KNOWN_POLICY_KWARGS if key in cmd}
 
         # Optional sim-side controls. We expose only the fields that already
         # have validator coverage in the wire schema - control_frequency,
@@ -1881,6 +1889,7 @@ class Mesh(SensorLoopsMixin):
         run_kwargs: dict[str, Any] = {
             "policy_provider": policy_provider,
             "policy_config": policy_config,
+            "policy_kwargs": policy_kwargs,
             "instruction": instruction,
             "duration": duration,
         }

--- a/tests/mesh/test_mesh_rpc_sim_dispatch.py
+++ b/tests/mesh/test_mesh_rpc_sim_dispatch.py
@@ -4,8 +4,12 @@ The HardwareRobot dispatch path is covered by ``test_mesh_rpc.py``. This
 module pins the sim-peer branch added by issue #303: ``tell()`` against a
 peer whose ``robot`` is a ``Simulation`` (or any ``SimEngine``-shaped
 object) routes ``execute`` -> ``run_policy`` and ``start`` -> ``start_policy``
-with the issue #300 well-known kwargs (``target_pose`` / ``target_joints`` /
-``world_update``) forwarded into ``policy_config``.
+with the issue #300 well-known goal payload (``target_pose`` /
+``target_joints`` / ``world_update``) forwarded into ``policy_kwargs`` - the
+runner parameter that reaches ``get_actions(obs, instruction, **kwargs)``,
+which is where every provider reads that goal. Constructor extras
+(``model_path`` / ``server_address`` / ...) keep travelling in
+``policy_config``, which is expanded into the Policy constructor.
 
 Tests are 100% mocked - no MuJoCo / Isaac install required. A
 ``_FakeSim`` exposes the SimEngine surface duck-typed minimally to what
@@ -14,6 +18,7 @@ Tests are 100% mocked - no MuJoCo / Isaac install required. A
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
 from strands_robots.mesh import Mesh
@@ -69,8 +74,9 @@ def test_execute_routes_to_run_policy_with_default_robot() -> None:
     assert kwargs["instruction"] == "wave"
     assert kwargs["policy_provider"] == "mock"
     # Even when the caller passes no extras, we always forward an empty
-    # policy_config dict so the receiving sim sees a stable type.
+    # dict for both sinks so the receiving sim sees a stable type.
     assert kwargs["policy_config"] == {}
+    assert kwargs["policy_kwargs"] == {}
     assert sim.start_policy_calls == []
 
 
@@ -90,8 +96,15 @@ def test_start_routes_to_start_policy_async() -> None:
     assert sim.run_policy_calls == []
 
 
-def test_execute_forwards_well_known_kwargs_via_policy_config() -> None:
-    """Issue #300 well-known kwargs land in ``policy_config``, not silently dropped.
+def test_execute_forwards_the_goal_payload_via_policy_kwargs() -> None:
+    """The issue #300 goal lands in the sink the providers read it from.
+
+    Every provider reads the goal inside ``get_actions(**kwargs)``, which the
+    runner fills from ``policy_kwargs``; no provider names a goal key on its
+    constructor, so routing the goal through ``policy_config`` hands it to a
+    forward-compatibility absorber that discards it. The caller then gets the
+    planner's "requires at least one of target_pose=... / target_joints=..."
+    refusal for a request that carried exactly that.
 
     See AGENTS.md > Public API Hygiene: "Forward all advertised kwargs
     end-to-end. Silent drops are bugs masquerading as features."
@@ -114,10 +127,69 @@ def test_execute_forwards_well_known_kwargs_via_policy_config() -> None:
         }
     )
     args, kwargs = sim.run_policy_calls[0]
-    pc = kwargs["policy_config"]
-    assert pc["target_pose"] == target_pose
-    assert pc["target_joints"] == target_joints
-    assert pc["world_update"] == world_update
+    goal = kwargs["policy_kwargs"]
+    assert goal["target_pose"] == target_pose
+    assert goal["target_joints"] == target_joints
+    assert goal["world_update"] == world_update
+    # The constructor sink must not also receive it: create_policy() expands
+    # policy_config into the Policy constructor, where a goal key is an
+    # unknown kwarg the provider is required to ignore.
+    assert kwargs["policy_config"] == {}
+
+
+def test_start_forwards_the_goal_payload_via_policy_kwargs() -> None:
+    """The async ``start`` branch carries the goal, not only ``execute``.
+
+    ``start_policy`` takes the same ``policy_kwargs`` parameter as
+    ``run_policy``, so a fire-and-forget ``tell()`` must not be the one route
+    that loses the goal.
+    """
+    sim = _FakeSim(robots=["so100"])
+    m = Mesh(sim, peer_id="sim-a")
+
+    target_pose = [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
+    m._dispatch(
+        {
+            "action": "start",
+            "instruction": "reach",
+            "policy_provider": "curobo",
+            "target_pose": target_pose,
+        }
+    )
+    kwargs = sim.start_policy_calls[0][1]
+    assert kwargs["policy_kwargs"]["target_pose"] == target_pose
+    assert kwargs["policy_config"] == {}
+
+
+def test_planner_providers_read_the_goal_per_call_not_at_construction() -> None:
+    """Pin the invariant that makes ``policy_kwargs`` the goal's only sink.
+
+    The dispatcher has two sinks and no way to ask a provider which one it
+    reads, so the choice is only correct while every provider that consumes
+    the issue #300 goal consumes it per call. A provider that grew a
+    ``target_pose`` constructor parameter would make that choice ambiguous
+    and this test says so before the dispatcher silently picks wrong.
+
+    ``tests/simulation/test_policy_kwargs_forwarding.py`` pins the other half
+    of the chain: the runner forwards ``policy_kwargs`` verbatim to every
+    ``get_actions`` call.
+    """
+    from strands_robots.policies.curobo.policy import CuroboPolicy
+    from strands_robots.policies.moveit2.policy import MoveIt2Policy
+
+    for policy_class in (CuroboPolicy, MoveIt2Policy):
+        constructor = inspect.signature(policy_class.__init__).parameters
+        named_at_construction = [key for key in Mesh._SIM_WELL_KNOWN_POLICY_KWARGS if key in constructor]
+        assert not named_at_construction, (
+            f"{policy_class.__name__}.__init__ names {named_at_construction}; the mesh dispatcher "
+            "sends the goal to get_actions, so a constructor parameter of the same name would be "
+            "filled from a different payload"
+        )
+
+        per_call = inspect.signature(policy_class.get_actions).parameters
+        assert any(p.kind is p.VAR_KEYWORD for p in per_call.values()), (
+            f"{policy_class.__name__}.get_actions takes no **kwargs, so it cannot receive the goal"
+        )
 
 
 def test_execute_forwards_constructor_extras_via_policy_config() -> None:
@@ -139,11 +211,15 @@ def test_execute_forwards_constructor_extras_via_policy_config() -> None:
             "pretrained_name_or_path": "nvidia/GR00T-N1.5",
         }
     )
-    pc = sim.run_policy_calls[0][1]["policy_config"]
+    kwargs = sim.run_policy_calls[0][1]
+    pc = kwargs["policy_config"]
     assert pc["model_path"] == "nvidia/GR00T-N1.5"
     assert pc["server_address"] == "127.0.0.1:5555"
     assert pc["policy_type"] == "groot"
     assert pc["pretrained_name_or_path"] == "nvidia/GR00T-N1.5"
+    # A constructor extra is not a per-call goal: it must not be re-sent to
+    # get_actions on every tick.
+    assert kwargs["policy_kwargs"] == {}
 
 
 def test_execute_requires_robot_name_when_multiple_robots() -> None:

--- a/tests/mesh/test_mesh_tell_sim_e2e.py
+++ b/tests/mesh/test_mesh_tell_sim_e2e.py
@@ -16,6 +16,8 @@ contract; this module pins that the contract holds against the real
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from strands_robots.mesh import Mesh
@@ -89,27 +91,34 @@ def test_dispatch_start_then_status_on_real_simulation(real_sim) -> None:
     assert out["status"] == "success", out
 
 
-def test_well_known_kwargs_reach_policy_config_on_real_simulation(real_sim) -> None:
-    """Issue #300 well-known kwargs land in the ``policy_config`` of ``create_policy``.
+def test_the_goal_payload_reaches_get_actions_on_a_real_simulation(real_sim) -> None:
+    """The issue #300 goal arrives at the call that reads it, not at the constructor.
 
-    We intercept ``create_policy`` to capture the kwargs the dispatcher
-    forwards, then let the rest of ``run_policy`` proceed against the
-    real sim with a ``MockPolicy``.
+    Every provider reads the goal inside ``get_actions(**kwargs)``, so this
+    wraps the built policy's ``get_actions`` and asserts the payload is present
+    on every call the real ``MuJoCoSimEngine.run_policy`` makes. The constructor
+    kwargs are captured too, as the control: a goal key there would have been
+    handed to a forward-compatibility absorber that ignores it, leaving the
+    provider to refuse the request that carried it.
     """
     from unittest.mock import patch
 
     from strands_robots.policies import create_policy as real_create_policy
 
-    captured: dict[str, object] = {}
+    constructor_kwargs: dict[str, object] = {}
+    per_call_kwargs: list[dict[str, object]] = []
 
     def _spy(provider: str, **kwargs):
-        captured["provider"] = provider
-        captured.update(kwargs)
-        # Strip planner-only kwargs MockPolicy does not accept; the
-        # dispatch layer's contract is to forward them, the policy's
-        # contract (per #300) is to ignore unknown kwargs at construction.
-        # MockPolicy ignores **kwargs in __init__ so we can pass them all.
-        return real_create_policy(provider, **kwargs)
+        constructor_kwargs.update(kwargs)
+        policy: Any = real_create_policy(provider, **kwargs)
+        inner = policy.get_actions
+
+        async def recording(observation, instruction, **goal):
+            per_call_kwargs.append(dict(goal))
+            return await inner(observation, instruction, **goal)
+
+        policy.get_actions = recording
+        return policy
 
     target_pose = [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]
     target_joints = {"joint_0": 0.5}
@@ -129,6 +138,13 @@ def test_well_known_kwargs_reach_policy_config_on_real_simulation(real_sim) -> N
             }
         )
     assert out["status"] == "success", out
-    assert captured["provider"] == "mock"
-    assert captured["target_pose"] == target_pose
-    assert captured["target_joints"] == target_joints
+
+    assert per_call_kwargs, "run_policy never queried the policy, so nothing was delivered"
+    for goal in per_call_kwargs:
+        assert goal["target_pose"] == target_pose
+        assert goal["target_joints"] == target_joints
+
+    for key in ("target_pose", "target_joints", "world_update"):
+        assert key not in constructor_kwargs, (
+            f"{key} was expanded into the Policy constructor, where providers ignore it"
+        )


### PR DESCRIPTION
## Problem

`Mesh._dispatch` routes a `tell()` against a simulation peer to
`Simulation.run_policy` / `start_policy`, forwarding the issue #300 well-known
goal payload (`target_pose` / `target_joints` / `world_update`) so a
planner-style provider gets the goal it needs. It forwarded that payload in
`policy_config`, which `create_policy(provider, **policy_config)` expands into
the **Policy constructor**.

No provider names a goal key on its constructor. Every one reads the goal
inside `get_actions(observation, instruction, **kwargs)`, and every constructor
treats an unknown key as a forward-compatibility absorber to ignore
(`MoveIt2Policy` logs `ignoring unknown constructor kwargs`). So the payload was
handed to the one sink guaranteed to discard it, and the planner then refused
the request that had carried it:

```python
mesh.tell(peer, "reach the pose", policy_provider="moveit2",
          target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0])
```

```
status: error
Policy failed: MoveIt2Policy.get_actions requires at least one of
  target_pose=[x,y,z,qw,qx,qy,qz] or target_joints={joint:value}.
  These are the well-known kwargs from issue #300; the natural-language
  `instruction` is ignored by motion planners.
```

That is the whole goal vocabulary on the mesh: `curobo` and `moveit2` are the
providers it exists for, and neither could be driven through `tell()`.

## Change

`run_policy` and `start_policy` both take `policy_kwargs`, which the runner
forwards verbatim to every `get_actions` call. Route the goal there; leave the
constructor extras (`model_path`, `server_address`, `policy_type`,
`pretrained_name_or_path`) in `policy_config`, where the constructor reads them.
One dict comprehension plus a second key in `run_kwargs` - the two payloads now
each go to the sink that reads them.

The existing dispatcher comment already cited the rule this broke (AGENTS.md >
Public API Hygiene: "Forward all advertised kwargs end-to-end. Silent drops are
bugs masquerading as features"); the drop was one layer below where it looked.

## Blast radius

Measured over every shipped `Policy` subclass (15 classes, all import without
their optional dependencies):

| Property | Result |
|---|---|
| `get_actions` accepts `**kwargs` | 15 / 15 |
| `__init__` names `target_pose` / `target_joints` / `world_update` | 0 / 15 |

So no provider stops receiving a payload it previously received, and none can
be handed a per-call goal it cannot absorb. A call that carries no goal forwards
`policy_kwargs={}`, which is the runner's documented no-kwargs path.

## Tests

`tests/mesh/test_mesh_rpc_sim_dispatch.py`, on `main` vs this branch: **4 failed
/ 9 passed** before, **13 passed** after.

- `test_execute_forwards_the_goal_payload_via_policy_kwargs` - the goal lands in
  `policy_kwargs` and **not** in `policy_config` (was `test_..._via_policy_config`,
  which pinned the drop).
- `test_start_forwards_the_goal_payload_via_policy_kwargs` - the async branch
  carries it too, not only `execute`.
- `test_execute_forwards_constructor_extras_via_policy_config` - a constructor
  extra keeps its own sink and is not re-sent on every tick.
- `test_execute_routes_to_run_policy_with_default_robot` - both sinks forward a
  stable empty dict when the caller passes nothing.
- `test_planner_providers_read_the_goal_per_call_not_at_construction` - passes on
  both trees. The dispatcher cannot ask a provider which sink it reads, so this
  pins the invariant that makes the choice correct: a provider that grew a
  `target_pose` constructor parameter would make it ambiguous again.

`tests/mesh/test_mesh_tell_sim_e2e.py` closes the loop against a real
`MuJoCoSimEngine`: **1 failed / 2 passed** before, **3 passed** after.
`test_the_goal_payload_reaches_get_actions_on_a_real_simulation` wraps the built
policy's `get_actions` and asserts the payload is present on every call the real
`run_policy` makes, keeping the constructor kwargs as the control that no goal
key is expanded there. It replaces
`test_well_known_kwargs_reach_policy_config_on_real_simulation`, which spied on
`create_policy` and so pinned the drop.

`tests/simulation/test_policy_kwargs_forwarding.py` already pins the other half
of the chain (runner -> `get_actions`). Full `tests/` on this branch shows no new
failures against `main` (61 failing ids on both, identical set).

## Rollout

`mesh.tell(execute, policy_provider="moveit2", target_joints={...})` against a
MuJoCo panda, headless. Identical request and identical planner sidecar in both
panels; only the dispatcher's forwarding sink differs. Everything between the
`tell()` and MuJoCo is shipped code (`Mesh._dispatch` -> `run_policy` ->
`PolicyRunner` -> `MoveIt2Policy` -> `MoveIt2Client`); the ZMQ sidecar is a stub
planner that interpolates to the requested configuration and answers in the
documented row format, the same boundary `tests/policies/moveit2/` doubles.

![mesh goal payload before and after](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-goal-payload/mesh_goal_payload.gif)

[mesh_goal_payload.mp4](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-goal-payload/mesh_goal_payload.mp4)

| | before | after |
|---|---|---|
| dispatch status | `error` | `success` |
| control ticks | 0 | 90 |
| mean `abs(q - goal)` | 0.7475 rad (unchanged) | 0.7475 -> 0.0139 rad |
| per-frame pixel delta | max 0.0003 (static) | 0.053 - 3.28 |

The left panel never moves: the goal was dropped, so no action was ever
commanded.
