### PR TITLE
docs(policies): send a documented per-call goal to the sink that reads it

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,10 +816,13 @@ actions = policy.get_actions_sync(
 )
 ```
 
-Agents share one goal vocabulary across VLA and planner providers:
-`Robot.start_task(..., policy_provider="curobo", target_pose=[...])` and
-`mesh.tell(peer, "...", policy_provider="curobo", target_pose=[...])` flow the
-same `target_pose` / `target_joints` / `world_update` kwargs through.
+`mesh.tell(peer, "...", policy_provider="curobo", target_pose=[...])` forwards
+the same `target_pose` / `target_joints` / `world_update` vocabulary to a sim
+peer. In-process, the goal goes to `run_policy(policy_kwargs={...})`, which the
+runner hands to every `get_actions()` call - `run_policy` itself has no
+`target_pose` parameter. `Robot.start_task` takes no goal payload: its
+parameters are `instruction`, `policy_port`, `policy_host`, `policy_provider`
+and `duration`.
 
 </details>
 

--- a/changelog.d/2314-documented-goal-kwarg-sink.md
+++ b/changelog.d/2314-documented-goal-kwarg-sink.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Documented `run_policy` examples for the `curobo`, `moveit2` and `wbc_gait`
+  providers wrote a per-call goal (`target_pose`, `target_velocity`,
+  `gait_frequency`) directly as a `run_policy` keyword. `run_policy` has no such
+  parameter and no `**kwargs`, so the example raised `TypeError` before the first
+  tick; the goal belongs in `policy_kwargs`, which the runner hands to every
+  `get_actions()` call. The `gr00t_inference` lifecycle example passed `tag=` and
+  `model_id=`, neither of which exists - the image name is operator config
+  (`STRANDS_GR00T_IMAGE`, allowlist-checked) and the checkpoint keyword is
+  `hf_repo`. Three prose passages claimed `Robot.start_task` forwards a goal
+  through a `**policy_kwargs` it does not have. A new guard grades every `python`
+  fence in `docs/` and `README.md` against the real signatures.

--- a/docs/policies/curobo.md
+++ b/docs/policies/curobo.md
@@ -114,17 +114,22 @@ sim.run_policy(
     instruction="",               # ignored by the planner
     policy_provider="curobo",
     policy_config={"robot_config": "franka.yml", "action_horizon": 16},
-    target_pose=[0.5, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+    policy_kwargs={"target_pose": [0.5, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]},
     duration=10.0,
     control_frequency=50.0,
 )
 ```
 
-The LLM-agent demo path
-(`Robot.start_task(..., policy_provider="curobo", target_pose=[...])`) flows
-the same `target_pose` / `target_joints` kwargs through `start_task`'s
-`**policy_kwargs`, so agents share one goal vocabulary across VLA and planner
-providers.
+`policy_config` and `policy_kwargs` are two different sinks. `policy_config`
+is expanded into the policy **constructor**; the per-call goal belongs in
+`policy_kwargs`, which the runner hands to every `get_actions()` call. Passing
+`target_pose=` directly to `run_policy` raises `TypeError` - it has no such
+parameter and no `**kwargs`.
+
+The mesh path forwards the same goal vocabulary:
+`mesh.tell(peer, "...", policy_provider="curobo", target_pose=[...])`.
+`Robot.start_task` does not - it accepts only `instruction`, `policy_port`,
+`policy_host`, `policy_provider` and `duration`.
 
 ## See also
 

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -93,11 +93,12 @@ agibot_*            galaxea_r1_pro
 ```python
 from strands_robots.tools import gr00t_inference
 
-gr00t_inference(action="build_image",         tag="gr00t-n1.7:latest")
-gr00t_inference(action="download_checkpoint", model_id="nvidia/GR00T-N1.7-3B")
-gr00t_inference(action="start_container",     tag="gr00t-n1.7:latest",
-                                              model_id="nvidia/GR00T-N1.7-3B",
-                                              data_config="so100_dualcam")
+# The image name is operator config, not an agent parameter: set
+# STRANDS_GR00T_IMAGE (default "gr00t:latest") and it must pass the
+# STRANDS_GR00T_IMAGE_ALLOW allowlist.
+gr00t_inference(action="build_image")
+gr00t_inference(action="download_checkpoint", hf_repo="nvidia/GR00T-N1.7-3B")
+gr00t_inference(action="start_container",     data_config="so100_dualcam")
 # ... run policy ...
 gr00t_inference(action="stop", container_name="gr00t-inference")  # stop only
 gr00t_inference(action="lifecycle", lifecycle="teardown",

--- a/docs/policies/moveit2.md
+++ b/docs/policies/moveit2.md
@@ -148,16 +148,22 @@ sim.run_policy(
     instruction="",               # ignored by the planner
     policy_provider="moveit2",
     policy_config={"host": "127.0.0.1", "port": 5556, "planning_group": "arm"},
-    target_pose=[0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+    policy_kwargs={"target_pose": [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0]},
     duration=10.0,
     control_frequency=50.0,
 )
 ```
 
-The LLM-agent demo path (`Robot.start_task(..., policy_provider="moveit2",
-target_pose=[...])`) flows the same `target_pose` / `target_joints` kwargs
-through `start_task`'s `**policy_kwargs`, so agents share one goal vocabulary
-across VLA and planner providers.
+`policy_config` and `policy_kwargs` are two different sinks. `policy_config`
+is expanded into the policy **constructor**; the per-call goal belongs in
+`policy_kwargs`, which the runner hands to every `get_actions()` call. Passing
+`target_pose=` directly to `run_policy` raises `TypeError` - it has no such
+parameter and no `**kwargs`.
+
+The mesh path forwards the same goal vocabulary:
+`mesh.tell(peer, "...", policy_provider="moveit2", target_pose=[...])`.
+`Robot.start_task` does not - it accepts only `instruction`, `policy_port`,
+`policy_host`, `policy_provider` and `duration`.
 
 ## See also
 

--- a/docs/policies/wbc_gait.md
+++ b/docs/policies/wbc_gait.md
@@ -30,7 +30,8 @@ policy = create_policy(
     gait_frequency=1.5,               # freq_cmd (steps/s)
 )
 sim.run_policy(robot_name="unitree_g1", policy_object=policy,
-               target_velocity=[0.5, 0.0, 0.0], gait_frequency=1.5,
+               policy_kwargs={"target_velocity": [0.5, 0.0, 0.0],
+                              "gait_frequency": 1.5},
                duration=5.0, control_frequency=50.0)
 ```
 

--- a/tests/test_docs_python_examples_are_callable.py
+++ b/tests/test_docs_python_examples_are_callable.py
@@ -1,0 +1,259 @@
+"""Every documented Python example must be callable as written.
+
+A prose reference can be read loosely, but a fenced ``python`` block is code a
+reader copies. When such a block passes a keyword the callable does not accept,
+the example raises :class:`TypeError` on the first line the reader runs, and
+nothing in the repository notices: the docs build renders the block verbatim and
+the test suite never executes it.
+
+This module grades every ``python`` fence in ``docs/**/*.md`` and ``README.md``
+against the real signatures of the public library surface. For each call with at
+least one keyword argument whose callee name resolves to a known public
+callable, the keyword set must be accepted by at least one same-named candidate.
+Names outside the library surface (third-party calls, illustrative helpers
+defined in the block itself) are not graded - a missing candidate degrades to
+"not graded", never to a failure.
+
+The distinction this pins in practice is a sink one: ``run_policy`` expands
+``policy_config`` into the policy constructor and forwards ``policy_kwargs`` to
+every ``get_actions()`` call, and it accepts no ``**kwargs``, so a per-call goal
+written as ``run_policy(target_pose=...)`` is not a slower path - it is a
+``TypeError``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import pkgutil
+import re
+from pathlib import Path
+from typing import Any
+
+import strands_robots
+
+_REPO_ROOT = Path(strands_robots.__file__).resolve().parent.parent
+
+_PYTHON_FENCE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+# Modules whose public callables are graded. ``strands_robots.tools`` is walked
+# so every ``@tool`` entry point is included under its own name.
+_CANDIDATE_MODULES: tuple[str, ...] = (
+    "strands_robots",
+    "strands_robots.registry",
+    "strands_robots.policies",
+)
+
+# Classes whose public methods are graded, keyed by method name. A documented
+# ``sim.run_policy(...)`` cannot be attributed to one backend from the source
+# text alone, so every backend contributes a candidate and acceptance by any one
+# of them is enough.
+_CANDIDATE_CLASSES: tuple[tuple[str, str], ...] = (
+    ("strands_robots.simulation.base", "SimEngine"),
+    ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
+    ("strands_robots.simulation.newton.simulation", "NewtonSimEngine"),
+    ("strands_robots.simulation.isaac.simulation", "IsaacSimulation"),
+    ("strands_robots.hardware_robot", "Robot"),
+    ("strands_robots.policies.base", "Policy"),
+    ("strands_robots.dataset_recorder", "DatasetRecorder"),
+    ("strands_robots.mesh.core", "Mesh"),
+)
+
+# A fence that grades nothing is indistinguishable from a clean sweep, so the
+# corpus size is asserted. The floor is well below the current count; it only
+# has to fail if the extractor stops reaching the documentation.
+_MINIMUM_GRADED_CALLS = 150
+
+
+def _unwrap(obj: object) -> object:
+    """Return the plain function behind a decorated tool, else *obj* itself.
+
+    ``@tool`` replaces a module-level function with a wrapper object whose
+    ``__wrapped__`` attribute holds the real signature.
+    """
+    return getattr(obj, "__wrapped__", obj)
+
+
+def _candidates() -> dict[str, list[Any]]:
+    """Map a callee name to every public callable in the library with that name."""
+    found: dict[str, list[Any]] = {}
+
+    def record(name: str, obj: object) -> None:
+        target = _unwrap(obj)
+        if callable(target):
+            found.setdefault(name, []).append(target)
+
+    module_names = list(_CANDIDATE_MODULES)
+    tools_pkg = importlib.import_module("strands_robots.tools")
+    module_names += [f"strands_robots.tools.{info.name}" for info in pkgutil.iter_modules(tools_pkg.__path__)]
+
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        for name in dir(module):
+            if name.startswith("_"):
+                continue
+            try:
+                record(name, getattr(module, name))
+            except AttributeError:
+                # A lazily exported symbol whose optional dependency is absent.
+                continue
+
+    for module_name, class_name in _CANDIDATE_CLASSES:
+        klass = getattr(importlib.import_module(module_name), class_name)
+        record(class_name, klass)
+        for method_name, method in inspect.getmembers(klass, predicate=inspect.isfunction):
+            if not method_name.startswith("_"):
+                record(method_name, method)
+
+    return found
+
+
+def _accepted_keywords(candidate: Any) -> set[str] | None:
+    """Return the keyword names *candidate* accepts, or ``None`` for any keyword."""
+    try:
+        parameters = inspect.signature(candidate).parameters
+    except (TypeError, ValueError):
+        return set()
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return None
+    return set(parameters)
+
+
+def _callee_name(call: ast.Call) -> str | None:
+    """Return the trailing name of a call target (``a.b.run_policy`` -> ``run_policy``)."""
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _documentation_files() -> list[Path]:
+    """Return every markdown file whose ``python`` fences are graded."""
+    files = sorted(_REPO_ROOT.glob("docs/**/*.md"))
+    readme = _REPO_ROOT / "README.md"
+    if readme.exists():
+        files.append(readme)
+    return files
+
+
+def _grade_documentation() -> tuple[list[str], int]:
+    """Return ``(offenders, graded_call_count)`` for the whole documentation set."""
+    candidates = _candidates()
+    offenders: list[str] = []
+    graded = 0
+
+    for path in _documentation_files():
+        text = path.read_text(encoding="utf-8")
+        for fence in _PYTHON_FENCE.finditer(text):
+            block = fence.group(1)
+            fence_line = text[: fence.start()].count("\n") + 1
+            try:
+                tree = ast.parse(block)
+            except SyntaxError:
+                # An intentionally elided snippet ("..." inside a signature).
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not node.keywords:
+                    continue
+                if any(keyword.arg is None for keyword in node.keywords):
+                    # ``**mapping`` - the keyword names are not in the source.
+                    continue
+                name = _callee_name(node)
+                if name is None:
+                    continue
+                same_named = candidates.get(name)
+                if not same_named:
+                    continue
+                graded += 1
+                written = {keyword.arg for keyword in node.keywords if keyword.arg}
+                accepted_by_any: set[str] = set()
+                binds = False
+                for candidate in same_named:
+                    accepted = _accepted_keywords(candidate)
+                    if accepted is None or written <= accepted:
+                        binds = True
+                        break
+                    accepted_by_any |= accepted
+                if binds:
+                    continue
+                rejected = sorted(written - accepted_by_any)
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT)}:{fence_line + node.lineno} "
+                    f"{name}(...) passes {rejected}, which no public {name} accepts"
+                )
+    return offenders, graded
+
+
+def test_every_documented_keyword_is_one_the_callable_accepts() -> None:
+    """No documented example may pass a keyword its callee would reject."""
+    offenders, graded = _grade_documentation()
+    assert graded >= _MINIMUM_GRADED_CALLS, (
+        f"only {graded} documented calls were graded (expected at least "
+        f"{_MINIMUM_GRADED_CALLS}); the extractor is no longer reaching the "
+        "documentation, so a clean result would be meaningless"
+    )
+    assert not offenders, "documented examples that raise TypeError as written:\n  " + "\n  ".join(offenders)
+
+
+def test_run_policy_has_no_goal_parameter_so_a_goal_needs_policy_kwargs() -> None:
+    """The sink the documentation must name for a per-call goal is ``policy_kwargs``.
+
+    ``run_policy`` deliberately takes no ``**kwargs``: an unknown keyword is a
+    caller mistake, not a payload to forward. So the goal vocabulary a planner
+    policy reads from ``get_actions(**kwargs)`` can only arrive via
+    ``policy_kwargs``, and the documentation has exactly one correct spelling.
+    """
+    from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+    parameters = inspect.signature(MuJoCoSimEngine.run_policy).parameters
+    assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+    assert "policy_kwargs" in parameters
+    for goal_keyword in ("target_pose", "target_joints", "target_velocity", "gait_frequency", "world_update"):
+        assert goal_keyword not in parameters, (
+            f"run_policy grew a {goal_keyword!r} parameter; the documentation says a "
+            "per-call goal travels in policy_kwargs and must be updated with it"
+        )
+
+
+def test_start_task_takes_no_goal_payload() -> None:
+    """``start_task`` has no ``**policy_kwargs`` for a goal to flow through.
+
+    The documentation previously said it did. Its parameter list is fixed, so a
+    goal-bearing ``start_task`` call raises ``TypeError``.
+    """
+    from strands_robots.hardware_robot import Robot
+
+    parameters = inspect.signature(Robot.start_task).parameters
+    assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+    assert set(parameters) == {
+        "self",
+        "instruction",
+        "policy_port",
+        "policy_host",
+        "policy_provider",
+        "duration",
+    }
+
+
+def test_the_grader_reports_a_keyword_the_callable_would_reject() -> None:
+    """A planted bad keyword is reported, so a clean sweep means something.
+
+    Without this the repository-wide assertion could pass because the grader
+    accepts everything rather than because the documentation is correct.
+    """
+    candidates = _candidates()
+    accepted = _accepted_keywords(candidates["run_policy"][0])
+    assert accepted is not None and "target_pose" not in accepted
+
+    block = "sim.run_policy(robot_name='panda', target_pose=[0.0] * 7)\n"
+    tree = ast.parse(block)
+    call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    written = {keyword.arg for keyword in call.keywords}
+    binds = any(
+        (_accepted_keywords(candidate) is None or written <= (_accepted_keywords(candidate) or set()))
+        for candidate in candidates["run_policy"]
+    )
+    assert not binds, "a goal keyword passed straight to run_policy must not be graded as acceptable"


### PR DESCRIPTION
## Problem

A fenced ```python block is code a reader copies. Six of them passed a keyword
the callable does not accept, so the documented example raises `TypeError` on
the first line the reader runs - and nothing in the repository noticed, because
the docs build renders the block verbatim and the suite never executed it.

| Location | Written | Reality |
| --- | --- | --- |
| `docs/policies/curobo.md:112` | `run_policy(..., target_pose=[...])` | `TypeError: MuJoCoSimEngine.run_policy() got an unexpected keyword argument 'target_pose'` |
| `docs/policies/moveit2.md:146` | `run_policy(..., target_pose=[...])` | same |
| `docs/policies/wbc_gait.md:32` | `run_policy(..., target_velocity=..., gait_frequency=...)` | same, both keywords |
| `docs/policies/groot.md:96-98` | `gr00t_inference(..., tag=...)`, `model_id=...` | no `tag` / `model_id` parameter, and neither is in the tool schema |

`run_policy` has two forwarding sinks and no `**kwargs`: `policy_config` is
expanded into the policy **constructor**, and `policy_kwargs` is handed to every
`get_actions()` call. `CuroboPolicy`, `MoveIt2Policy` and `WBCGaitPolicy` all
read their goal from `get_actions(**kwargs)`, so `policy_kwargs` is the only
sink that reaches them. Written directly on `run_policy` the goal is not a
slower path - it is a `TypeError`.

`gr00t_inference` has no `tag` parameter *by design*: `_resolve_image_name()`
takes the image from `STRANDS_GR00T_IMAGE` and checks it against an allowlist
precisely so an agent cannot choose it ("The agent has no say in the image").
The documented `tag=` advertised caller control over a surface that is
deliberately closed, and never told the reader about the real knob. The
checkpoint keyword is `hf_repo`.

Three prose passages additionally claimed `Robot.start_task` flows a goal
through a `**policy_kwargs`:

> flows the same `target_pose` / `target_joints` kwargs through `start_task`'s `**policy_kwargs`

`start_task`'s parameters are `instruction`, `policy_port`, `policy_host`,
`policy_provider`, `duration` - no variadic keywords, and no goal. `mesh.tell`
*does* accept the goal vocabulary, so the corrected text points there instead.

## Change

- The three `run_policy` examples now write `policy_kwargs={"target_pose": ...}`.
- `groot.md` drops the fictional `tag=`, documents `STRANDS_GR00T_IMAGE` +
  `STRANDS_GR00T_IMAGE_ALLOW` as the operator knob, and uses `hf_repo=`.
- The `start_task` claim is replaced in `curobo.md`, `moveit2.md` and `README.md`
  with what each entry point actually accepts.
- `tests/test_docs_python_examples_are_callable.py` grades every `python` fence
  in `docs/**/*.md` and `README.md` against the real signatures of the public
  surface (module functions, `@tool` entry points unwrapped via `__wrapped__`,
  and the public methods of `SimEngine` / the three backends / `Robot` /
  `Policy` / `DatasetRecorder` / `Mesh`). A call is graded only when its callee
  name resolves to a known public callable, so a name outside the library
  degrades to "not graded", never to a false failure.

## Verification

Pre-fix, with only the test file added on top of `main`: **1 failed / 3 passed**.
The failure names every offender with `file:line`:

```
docs/policies/curobo.md:112 run_policy(...) passes ['target_pose'], which no public run_policy accepts
docs/policies/groot.md:96 gr00t_inference(...) passes ['tag'], which no public gr00t_inference accepts
docs/policies/groot.md:97 gr00t_inference(...) passes ['model_id'], which no public gr00t_inference accepts
docs/policies/groot.md:98 gr00t_inference(...) passes ['model_id', 'tag'], which no public gr00t_inference accepts
docs/policies/moveit2.md:146 run_policy(...) passes ['target_pose'], which no public run_policy accepts
docs/policies/wbc_gait.md:32 run_policy(...) passes ['gait_frequency', 'target_velocity'], which no public run_policy accepts
```

Post-fix: 4 passed. 296 documented calls are graded and 0 offend. The three
tests that pass on both trees are the no-overreach controls - `run_policy` has
no goal parameter and does have `policy_kwargs`; `start_task`'s parameter set is
exactly its five; and the grader still reports a planted bad keyword, so a clean
sweep means the documentation is right rather than that the grader accepts
everything.

## Rollout

The corrected `moveit2.md` example, run headless in MuJoCo against a stub
sidecar (`panda`, 90 ticks at 50 Hz, `n_steps=90`). Left panel is the call
exactly as the documentation read it; right panel is the corrected spelling.

![documented goal-kwarg sink](https://raw.githubusercontent.com/cagataycali/robots/media-doc-goal-kwarg-sink/goal_kwarg_sink.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-doc-goal-kwarg-sink/goal_kwarg_sink.mp4)

| | Before (`target_pose=`) | After (`policy_kwargs={...}`) |
| --- | --- | --- |
| Outcome | `TypeError` before tick 0 | `status=success`, 90 ticks |
| Rendered frames | 1 (static - nothing ran) | 45, every one moving (per-frame mean abs pixel delta 0.026-1.65) |
| Mean joint error vs goal | 0.8357 rad (unchanged) | **0.0024 rad** |

Panel-to-panel mean abs pixel delta on the final frame is 4.42.

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`.
`mypy` 18 pre-existing errors, identical on this branch and `main`. Full
`tests/` run compared against a `main` worktree on the same interpreter - no new
failures.
