### PR TITLE
docs(mesh): state the STRANDS_MESH opt-in contract the factory implements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,7 +1089,7 @@ touches ROS 2.
 | `STRANDS_ISAAC_RTX_PATHTRACING` | Isaac Sim backend: on (`1`/`true`/`yes`/`on`) enables RTX path-tracing (photorealistic, slow) instead of the default render mode; off leaves the render mode alone, any other spelling is refused | unset |
 | `STRANDS_ISAAC_NUCLEUS_URL` | Isaac Sim backend: override the Omniverse Nucleus asset-server URL | unset (Isaac default) |
 | `GROOT_API_TOKEN` | API token for the GR00T inference service | unset |
-| `STRANDS_MESH` | Set `false` to disable Zenoh mesh globally | `true` |
+| `STRANDS_MESH` | Opt a bare `Robot()` into the Zenoh mesh: `true`/`1`/`yes` turns it on. `false`/`0`/`no` is a hard kill switch that also overrides an explicit `mesh=True` | unset (mesh off) |
 | `STRANDS_MESH_LOCAL_DEV` | Set `1` for a one-var localhost preset (auth `none`, no second factor needed) | unset |
 | `STRANDS_ROS2_BRIDGE_I_KNOW_THIS_IS_INSECURE` | Second factor to expose a `Robot(ros2_transport="rtps")` inbound `joint_command` surface with no `dds_security_config` (DDS Security). Truthy: `1`/`true`/`yes` | unset |
 <details>

--- a/changelog.d/2316-mesh-env-opt-in-contract.md
+++ b/changelog.d/2316-mesh-env-opt-in-contract.md
@@ -1,0 +1,10 @@
+### Docs: `STRANDS_MESH` is documented as the opt-in it actually is
+
+Three configuration tables printed `true` as the default for `STRANDS_MESH` and
+offered `false` as the only knob. The factory resolves `mesh=None` from the
+environment, so unset means mesh off and only `true`/`1`/`yes` turns it on: the
+printed default named a state a bare `Robot()` is never in, the offered remedy
+was a no-op for the state readers were actually in, and the one spelling that
+enables the mesh appeared nowhere. The rows now state the real contract, the
+module that resolves the variable documents it, and a guard grades the tables
+against the resolver so the two cannot drift apart again.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -192,7 +192,7 @@ LIBERO task suites, BDDL parser. Install: `uv pip install "strands-robots[benchm
 | `STRANDS_ASSETS_DIR` | Robot model asset cache | `~/.strands_robots/assets/` |
 | `STRANDS_ROBOT_MODE` | Force `Robot()` mode | (kwarg honoured) |
 | `STRANDS_TRUST_REMOTE_CODE` | Allow HF `trust_remote_code=True` | unset → blocked |
-| `STRANDS_MESH` | Disable mesh globally when `false` | `true` |
+| `STRANDS_MESH` | `true` opts a bare `Robot()` into the mesh; `false` is a hard kill switch | unset (mesh off) |
 | `STRANDS_MESH_AUDIT_DIR` | Safety event audit log | `~/.strands_robots/` |
 | `MUJOCO_GL` | GL backend for MuJoCo | auto |
 | `GROOT_API_TOKEN` | GR00T cloud inference token | (unset) |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -108,7 +108,7 @@ Assets cache under `~/.strands_robots/assets/`.
 | `MUJOCO_GL` | GL backend | auto |
 | `STRANDS_TRUST_REMOTE_CODE` | Allow HF `trust_remote_code=True` | `false` |
 | `STRANDS_ROBOT_MODE` | Default `Robot()` mode | `sim` |
-| `STRANDS_MESH` | Mesh enabled by default; set to `false` to disable globally | `true` (enabled) |
+| `STRANDS_MESH` | Set to `true` to opt a bare `Robot()` into the mesh; `false` disables it globally | unset (mesh off) |
 | `GROOT_API_TOKEN` | GR00T service API token (falls back from `api_token=` kwarg) | unset |
 
 ## See also

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -10,6 +10,11 @@ Provides:
 Environment Variables:
     STRANDS_ROBOT_MODE: Override mode detection ("sim", "real", "auto").
         Case-insensitive; surrounding whitespace ignored.
+    STRANDS_MESH: Opt a bare ``Robot()`` into the Zenoh mesh. Mesh is OFF
+        unless asked for: only "true"/"1"/"yes" turns it ON, and unset or
+        "false" leaves it OFF. An explicit ``mesh=True``/``mesh=False``
+        kwarg wins over this default, except that "false" is a hard kill
+        switch honoured by ``init_mesh`` even against ``mesh=True``.
 
 Examples::
 
@@ -113,6 +118,27 @@ def _auto_detect_mode(canonical: str) -> str:
             logger.debug("USB probe failed (%s: %s); falling back to sim", type(e).__name__, e)
 
     return "sim"
+
+
+def _mesh_env_opt_in() -> bool:
+    """Return True when ``STRANDS_MESH`` opts a bare ``Robot()`` into the mesh.
+
+    Mesh is OFF unless it is asked for. ``mesh=None`` (the factory default)
+    consults this function, and only ``true``, ``1`` or ``yes``
+    (case-insensitive, surrounding whitespace ignored) turns it ON. Every
+    other value -- including unset, empty and ``false`` -- leaves mesh OFF,
+    so a bare ``Robot("so100")`` never spins up Zenoh, ACL or e-stop
+    machinery.
+
+    ``STRANDS_MESH=false`` is additionally a hard kill switch honoured by
+    :func:`strands_robots.mesh.init_mesh` even when the caller passed an
+    explicit ``mesh=True``; the env var never forces mesh ON there, so an
+    explicit ``mesh=False`` is always respected.
+
+    Returns:
+        True when the environment opts in, False otherwise.
+    """
+    return os.getenv("STRANDS_MESH", "").strip().lower() in ("true", "1", "yes")
 
 
 def _validate_known_robot(canonical: str, original: str, urdf_path: str | None) -> None:
@@ -310,7 +336,7 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     # the env default. ``STRANDS_MESH=false`` remains a hard kill switch
     # enforced in ``init_mesh`` regardless of this resolution.
     if mesh is None:
-        mesh = os.getenv("STRANDS_MESH", "").strip().lower() in ("true", "1", "yes")
+        mesh = _mesh_env_opt_in()
 
     # --- Simulation ---
     if mode == "sim":

--- a/tests/mesh/test_mesh_env_opt_in_documented_default.py
+++ b/tests/mesh/test_mesh_env_opt_in_documented_default.py
@@ -1,0 +1,114 @@
+"""A configuration table must not print a ``STRANDS_MESH`` default that opts in.
+
+Mesh is opt-in: ``strands_robots.robot._mesh_env_opt_in`` turns it on only for
+``true``/``1``/``yes``, so a bare ``Robot()`` is quiet and never spins up
+Zenoh, ACL or e-stop machinery. ``tests/mesh/test_mesh_wiring.py`` pins that
+behaviour.
+
+A table that prints an opt-in spelling in its Default column therefore tells a
+reader mesh is already running, and hides the one spelling that actually
+enables it - the reader's only documented knob ("set it to ``false``") is a
+no-op for the state they are actually in.
+
+These tests grade the shipped tables against the resolver itself rather than
+against a hand-copied list of spellings, so widening the accepted spellings
+later cannot silently invalidate the guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from strands_robots.robot import _mesh_env_opt_in
+
+_ENV = "STRANDS_MESH"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The guard is only meaningful while it still reaches the shipped tables. If a
+# rename or a reformat drops them all, fail loudly instead of reporting clean.
+_MINIMUM_DOCUMENTED_ROWS = 3
+
+
+def _documented_rows() -> list[tuple[str, int, str, str]]:
+    """Return every markdown table row whose first cell is exactly ``STRANDS_MESH``.
+
+    Returns:
+        A list of ``(relative_path, line_number, description_cell, default_cell)``
+        tuples. Rows that bundle several variables into one cell are skipped:
+        this guard grades the single-variable rows a reader copies a value from.
+    """
+    docs = [_REPO_ROOT / "README.md", *sorted((_REPO_ROOT / "docs").rglob("*.md"))]
+    rows: list[tuple[str, int, str, str]] = []
+    for doc in docs:
+        if not doc.exists():
+            continue
+        for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if not stripped.startswith("|") or not stripped.endswith("|"):
+                continue
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) < 3 or cells[0] != f"`{_ENV}`":
+                continue
+            rows.append((str(doc.relative_to(_REPO_ROOT)), lineno, cells[1], cells[-1]))
+    return rows
+
+
+class TestTheResolverOnlyEverOptsIn:
+    """The oracle the documented defaults are graded against."""
+
+    @pytest.mark.parametrize("raw", ["true", "TRUE", "True", "1", "yes", " yes "])
+    def test_an_opt_in_spelling_turns_mesh_on(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv(_ENV, raw)
+        assert _mesh_env_opt_in() is True
+
+    @pytest.mark.parametrize("raw", ["", " ", "false", "0", "no", "off", "on", "enabled", "maybe"])
+    def test_every_other_value_leaves_mesh_off(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv(_ENV, raw)
+        assert _mesh_env_opt_in() is False
+
+    def test_an_unset_env_leaves_mesh_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_ENV, raising=False)
+        assert _mesh_env_opt_in() is False
+
+
+class TestTheDocumentedDefaultLeavesMeshOff:
+    """Grade every shipped configuration table against the resolver."""
+
+    def test_the_guard_still_reaches_the_shipped_tables(self) -> None:
+        rows = _documented_rows()
+        assert len(rows) >= _MINIMUM_DOCUMENTED_ROWS, (
+            f"expected at least {_MINIMUM_DOCUMENTED_ROWS} configuration rows keyed to "
+            f"{_ENV}, found {len(rows)}: {rows}. The extractor no longer reaches the "
+            "shipped tables, so a clean result below would prove nothing."
+        )
+
+    def test_no_table_prints_an_opt_in_spelling_as_the_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        offenders: list[str] = []
+        for path, lineno, _description, default in _documented_rows():
+            for token in re.findall(r"[A-Za-z0-9]+", default):
+                monkeypatch.setenv(_ENV, token)
+                if _mesh_env_opt_in():
+                    offenders.append(
+                        f"{path}:{lineno} prints {token!r} as the default for {_ENV}, but "
+                        f"{_ENV}={token} opts IN. A bare Robot() has mesh OFF, so this row "
+                        "tells a reader mesh is already running and hides the opt-in."
+                    )
+        assert not offenders, "documented default contradicts the resolver:\n" + "\n".join(offenders)
+
+    def test_every_table_still_names_a_spelling_that_opts_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Correcting the default must not remove the only way to turn mesh on."""
+        silent: list[str] = []
+        for path, lineno, description, default in _documented_rows():
+            opts_in = False
+            for token in re.findall(r"`([^`]+)`", f"{description} {default}"):
+                monkeypatch.setenv(_ENV, token)
+                opts_in = opts_in or _mesh_env_opt_in()
+            if not opts_in:
+                silent.append(
+                    f"{path}:{lineno} documents {_ENV} without naming any value that "
+                    "turns mesh on, so the opt-in is undiscoverable from this row."
+                )
+        assert not silent, "\n".join(silent)


### PR DESCRIPTION
## Problem

`STRANDS_MESH` is documented in three configuration tables, all printing `true` as its default:

| Location | Description | Default |
|---|---|---|
| `README.md:1092` | Set `false` to disable Zenoh mesh globally | `true` |
| `docs/api-reference.md:195` | Disable mesh globally when `false` | `true` |
| `docs/getting-started/installation.md:111` | Mesh **enabled by default**; set to `false` to disable globally | `true` (enabled) |

The factory resolves it the other way round - mesh is off unless it is asked for:

```python
if mesh is None:
    mesh = os.getenv("STRANDS_MESH", "").strip().lower() in ("true", "1", "yes")
```

Measured with the variable unset, `Robot("so101", mode="sim").mesh is None`.

So each row is wrong in three ways at once:

- the printed default names a state a bare `Robot()` is never in;
- the offered knob ("set `false` to disable") is a no-op for the state the reader is actually in;
- `true`, the one spelling that enables the mesh, is presented as something you already have, so the opt-in is undiscoverable from the tables.

The drift is dated. `mesh: bool = True` became `mesh: bool | None = None` in #630 (quiet-by-default); the tables date from #371 and were not brought along. The suite already pins the current behaviour - `tests/mesh/test_mesh_wiring.py::test_robot_factory_env_opt_in_enables_mesh`, whose docstring says "mesh defaults to None (quiet), so the factory consults STRANDS_MESH". Only the tables disagree.

## Change

- The three rows now state the actual contract: unset means mesh off, `true`/`1`/`yes` opts in, `false`/`0`/`no` is a hard kill switch that also overrides an explicit `mesh=True`.
- `STRANDS_MESH` is documented in `strands_robots.robot`'s `Environment Variables:` docstring section, which previously listed only `STRANDS_ROBOT_MODE` even though this module is where the variable is resolved.
- The resolution moves into `_mesh_env_opt_in()`. Behaviour is unchanged - the expression is moved, not modified - so the guard below grades the tables against the resolver itself instead of a hand-copied spelling list. Widening the accepted spellings later therefore cannot silently invalidate the guard.

## Tests

`tests/mesh/test_mesh_env_opt_in_documented_default.py`. For every single-variable `STRANDS_MESH` row it takes each token in the Default cell, sets `STRANDS_MESH` to that token, and asserts the resolver still reports off.

| | pre-fix | post-fix |
|---|---|---|
| `test_no_table_prints_an_opt_in_spelling_as_the_default` | fail, naming all 3 rows | pass |
| 18 remaining cases | pass | pass |
| total | 1 failed, 18 passed | 19 passed |

Pre-fix message (graded against `main`'s own inlined expression, transplanted verbatim so the verdict is `main`'s):

```
README.md:1092 prints 'true' as the default for STRANDS_MESH, but STRANDS_MESH=true
opts IN. A bare Robot() has mesh OFF, so this row tells a reader mesh is already
running and hides the opt-in.
docs/api-reference.md:195 prints 'true' ...
docs/getting-started/installation.md:111 prints 'true' ...
```

The 18 cases that pass on both trees are the controls:

- the resolver's own domain, including `on` and `enabled`, which are *not* opt-in spellings and so must not be documented as if they were;
- a premise assert that the extractor still reaches at least three rows, so a reformat that hides the tables fails loudly rather than reporting clean;
- every row must still name a value that turns mesh on, so correcting the default cannot remove the only documented way to enable the mesh.

Behaviour is unchanged, so there is no rollout or render to attach. `ruff check`, `ruff format --check` and `mypy` are clean over `strands_robots tests tests_integ` (18 pre-existing errors, none in the touched files); `tests/mesh` plus `tests/test_robot_factory.py` report an identical 45-item failure set on this branch and on `main`.
