### PR TITLE
docs(groot): document STRANDS_GROOT_WIRE_LOG as the directory it is read as

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,7 +1163,7 @@ other spelling is refused. See
 |----------|-------------|---------|
 | `STRANDS_LIBERO_ACTION_LOG` / `_MAX` | Per-step OSC controller diagnostics | unset / `50` |
 | `STRANDS_LIBERO_STATE_LOG` / `_MAX` | Per-step state values fed to GR00T | unset / `50` |
-| `STRANDS_GROOT_WIRE_LOG` / `_MAX_CALLS` | Dump pre/post inference payloads to verify LOCAL vs SERVICE parity | unset / `10` |
+| `STRANDS_GROOT_WIRE_LOG` / `_MAX_CALLS` | Directory to dump pre/post inference payloads to, e.g. `/tmp/groot-wire`, to verify LOCAL vs SERVICE parity | unset / `10` |
 
 </details>
 

--- a/changelog.d/2319-groot-wire-log-doc-value.md
+++ b/changelog.d/2319-groot-wire-log-doc-value.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Document `STRANDS_GROOT_WIRE_LOG` as the directory the GR00T wire-payload dumps land
+  in. The api-reference table offered `1` as the value that enables the diagnostic, but
+  the value is passed straight to `os.makedirs`, so following the table wrote pickle
+  archives into a directory named `1` under the process working directory. The same row
+  described the dumps as raw ZMQ frames although the diagnostic also covers the
+  in-process inference path, which opens no socket.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -196,7 +196,7 @@ LIBERO task suites, BDDL parser. Install: `uv pip install "strands-robots[benchm
 | `STRANDS_MESH_AUDIT_DIR` | Safety event audit log | `~/.strands_robots/` |
 | `MUJOCO_GL` | GL backend for MuJoCo | auto |
 | `GROOT_API_TOKEN` | GR00T cloud inference token | (unset) |
-| `STRANDS_GROOT_WIRE_LOG` | Log raw ZMQ frames when `1` | (unset) |
+| `STRANDS_GROOT_WIRE_LOG` | Directory to dump pre/post-inference payloads to, e.g. `/tmp/groot-wire`; covers the in-process path as well as the service path, capped by `STRANDS_GROOT_WIRE_LOG_MAX_CALLS` | (unset) |
 
 ## See also
 

--- a/tests/policies/groot/test_wire_log_documentation_matches_the_diagnostic.py
+++ b/tests/policies/groot/test_wire_log_documentation_matches_the_diagnostic.py
@@ -1,0 +1,228 @@
+"""The wire-payload diagnostic tables must describe the diagnostic that ships.
+
+``STRANDS_GROOT_WIRE_LOG`` is read as the directory the wire-payload dumps land
+in: :func:`strands_robots.policies.groot.policy._wire_log_dir` returns the raw
+value and :meth:`Gr00tPolicy._maybe_dump_wire_payload` passes it straight to
+``os.makedirs``. Its two nearest neighbours in the same diagnostic family,
+``STRANDS_LIBERO_ACTION_LOG`` and ``STRANDS_LIBERO_STATE_LOG``, are plain
+on/off flags, so the family reads as if one convention covered all three.
+
+A table that offers a bare flag token as the value therefore does not merely
+mis-describe the knob: following it dumps pickle archives into a directory of
+that name under whatever the process CWD happens to be, and the reader is never
+told the value is theirs to choose.
+
+These tests grade the shipped tables through the resolvers themselves, so
+widening what a resolver accepts later cannot silently invalidate the guard.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from strands_robots.mesh.audit import audit_log_path
+from strands_robots.policies.groot.policy import Gr00tPolicy, _wire_log_dir
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Environment variables whose value IS a filesystem destination, mapped to the
+# shipped resolver that turns the raw value into that destination. Only
+# side-effect-free resolvers belong here: grading must never create a directory
+# on the machine running the suite (which is why ``STRANDS_ASSETS_DIR`` is
+# absent - ``get_assets_dir`` mkdirs what it resolves).
+_PATH_VALUED: dict[str, Callable[[], object]] = {
+    "STRANDS_GROOT_WIRE_LOG": _wire_log_dir,
+    "STRANDS_MESH_AUDIT_DIR": audit_log_path,
+}
+
+# The guard is only meaningful while it still reaches the shipped tables. If a
+# rename or a reformat drops them all, fail loudly instead of reporting clean.
+_MINIMUM_DOCUMENTED_ROWS = 2
+
+_BACKTICKED = re.compile(r"`([^`]+)`")
+
+
+def _documented_rows() -> list[tuple[str, str, int, str]]:
+    """Return every markdown table row that documents a path-valued variable.
+
+    A variable is matched when its backticked name appears in the row's first
+    cell, so a row that bundles a companion variable into the same cell (the
+    README documents this variable alongside its ``_MAX_CALLS`` companion) is
+    graded rather than skipped.
+
+    Returns:
+        A list of ``(env_var, relative_path, line_number, description_cell)``
+        tuples.
+    """
+    docs = [_REPO_ROOT / "README.md", *sorted((_REPO_ROOT / "docs").rglob("*.md"))]
+    rows: list[tuple[str, str, int, str]] = []
+    for doc in docs:
+        if not doc.exists():
+            continue
+        for lineno, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if not stripped.startswith("|") or not stripped.endswith("|"):
+                continue
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if len(cells) < 3:
+                continue
+            for env in _PATH_VALUED:
+                if f"`{env}`" in cells[0]:
+                    rows.append((env, str(doc.relative_to(_REPO_ROOT)), lineno, cells[1]))
+    return rows
+
+
+def _advertised_values(description: str) -> list[str]:
+    """Return the backticked tokens a description cell offers as a value to export.
+
+    Two kinds of backticked token in a description are not values for the
+    variable and are skipped:
+
+    * an ALL-CAPS token names a companion environment variable
+      (``STRANDS_GROOT_WIRE_LOG_MAX_CALLS``);
+    * a token with an extension and no separator names an artifact written
+      inside the directory (``mesh_audit.jsonl``), not the directory itself.
+
+    Everything else is something a reader would plausibly export.
+    """
+    values = []
+    for tok in _BACKTICKED.findall(description):
+        # An all-uppercase token must contain a letter to be a variable name:
+        # ``"1".upper() == "1"`` would otherwise skip the numeric literals
+        # this guard exists to catch.
+        if any(char.isalpha() for char in tok) and tok == tok.upper():
+            continue
+        if "/" not in tok and "." in tok:
+            continue
+        values.append(tok)
+    return values
+
+
+def _is_a_destination(value: str) -> bool:
+    """Return whether a documented value names a place the reader chose.
+
+    An absolute path or a home-relative path does; a bare token does not, since
+    it lands under whatever the process CWD happens to be.
+    """
+    return Path(value).is_absolute() or value.startswith("~")
+
+
+class TestTheResolverTakesTheValueAsTheDestination:
+    """The oracle the documented values are graded against."""
+
+    @pytest.mark.parametrize("env", sorted(_PATH_VALUED))
+    def test_the_raw_value_is_used_as_the_path(self, env: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whatever is exported reaches the filesystem verbatim.
+
+        This is what makes a bare flag token harmful rather than merely wrong:
+        there is no flag branch to fall into, so ``1`` names a directory.
+        """
+        monkeypatch.setenv(env, "/tmp/strands-robots-doc-guard")
+        assert "/tmp/strands-robots-doc-guard" in str(_PATH_VALUED[env]())
+
+    def test_a_flag_token_resolves_to_a_relative_directory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``STRANDS_GROOT_WIRE_LOG=1`` is a directory named ``1``, not an on-switch."""
+        monkeypatch.setenv("STRANDS_GROOT_WIRE_LOG", "1")
+        resolved = _wire_log_dir()
+        assert resolved == "1"
+        assert not Path(str(resolved)).is_absolute()
+
+
+class TestEveryDocumentedValueIsADestination:
+    """The tables must not offer a value that is not a place."""
+
+    def test_the_guard_reaches_the_shipped_tables(self) -> None:
+        """A clean sweep over zero rows would prove nothing."""
+        rows = _documented_rows()
+        assert len(rows) >= _MINIMUM_DOCUMENTED_ROWS, (
+            f"expected at least {_MINIMUM_DOCUMENTED_ROWS} documented rows for "
+            f"{sorted(_PATH_VALUED)}, found {len(rows)}"
+        )
+
+    def test_no_row_offers_a_value_that_is_not_a_path(self) -> None:
+        """Every value a row advertises must name a directory.
+
+        A relative token would send the dumps to a directory of that name under
+        whatever the process CWD happens to be, which is never what a reader
+        copying a configuration table is asking for.
+        """
+        offenders = [
+            f"{path}:{lineno}: {env} is documented with value {value!r}, which "
+            f"{_PATH_VALUED[env].__name__}() resolves to a CWD-relative path; "
+            f"document the directory the dumps should land in instead"
+            for env, path, lineno, description in _documented_rows()
+            for value in _advertised_values(description)
+            if not _is_a_destination(value)
+        ]
+        assert not offenders, "\n".join(offenders)
+
+    def test_the_wire_log_row_still_shows_a_value_a_reader_can_export(self) -> None:
+        """Correcting the convention must not remove the worked example.
+
+        Deleting the value rather than fixing it would clear the check above
+        while leaving the reader with nothing to copy.
+        """
+        rows = [row for row in _documented_rows() if row[0] == "STRANDS_GROOT_WIRE_LOG"]
+        assert rows, "STRANDS_GROOT_WIRE_LOG is no longer documented anywhere"
+        for env, path, lineno, description in rows:
+            assert _advertised_values(description), (
+                f"{path}:{lineno}: the {env} row no longer shows a directory a reader can export"
+            )
+
+
+class TestTheDiagnosticCoversTheInProcessPath:
+    """The dumper is not a wire tap on the service transport.
+
+    :meth:`Gr00tPolicy._maybe_dump_wire_payload` is called from the in-process
+    inference path as well as the service path, and the resulting archive is a
+    pickle of the observation and the action chunk rather than the frames a
+    socket carried. Describing the diagnostic in terms of the transport would
+    hide the half a LOCAL-versus-SERVICE comparison needs, since in-process
+    inference opens no socket at all.
+    """
+
+    def _policy(self) -> Gr00tPolicy:
+        """Build a policy without contacting a server or loading a checkpoint."""
+        policy = Gr00tPolicy.__new__(Gr00tPolicy)
+        policy._groot_version = "n1.7"
+        policy.data_config_name = "libero_panda"
+        return policy
+
+    def test_the_in_process_path_writes_its_own_archive(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A ``local`` dump lands beside the ``service`` dumps it is compared to."""
+        import pickle
+
+        monkeypatch.setenv("STRANDS_GROOT_WIRE_LOG", str(tmp_path))
+        policy = self._policy()
+
+        policy._maybe_dump_wire_payload(
+            "local",
+            {"video": {"image": "frame"}, "state": {"joints": [0.0]}},
+            {"action.x": [0.1]},
+        )
+
+        written = sorted(p.name for p in tmp_path.iterdir())
+        assert written == ["local_call0000.pkl"]
+        payload = pickle.loads((tmp_path / written[0]).read_bytes())
+        assert payload["mode"] == "local"
+        assert payload["observation"] == {"video": {"image": "frame"}, "state": {"joints": [0.0]}}
+        assert payload["action_chunk"] == {"action.x": [0.1]}
+
+    def test_both_paths_dump_into_one_directory_under_distinct_names(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The two archives coexist, which is what makes them diffable."""
+        monkeypatch.setenv("STRANDS_GROOT_WIRE_LOG", str(tmp_path))
+        policy = self._policy()
+
+        policy._maybe_dump_wire_payload("local", {"state": {"joints": [0.0]}}, {"action.x": [0.1]})
+        policy._maybe_dump_wire_payload("service", {"state.joints": [0.0]}, {"action.x": [0.1]})
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == [
+            "local_call0000.pkl",
+            "service_call0001.pkl",
+        ]


### PR DESCRIPTION
## Problem

`docs/api-reference.md` offers `1` as the value that turns the GR00T wire-payload diagnostic on:

```
| `STRANDS_GROOT_WIRE_LOG` | Log raw ZMQ frames when `1` | (unset) |
```

The variable's value is not a flag, it is the directory the dumps land in.
`_wire_log_dir()` returns whatever is exported verbatim and
`Gr00tPolicy._maybe_dump_wire_payload` hands it straight to `os.makedirs`, so there
is no flag branch to fall into. Following the table writes pickle archives into a
directory literally named `1` under whatever the process CWD happens to be:

![documented value vs where the dumps land](https://raw.githubusercontent.com/cagataycali/robots/media-groot-wire-log-doc/wire-log-doc.png)

Both panels are the shipped `_maybe_dump_wire_payload` running unmodified; the only
difference is the value each table tells the reader to export.

Neither table says the destination is the reader's to choose, so the real contract is
not discoverable from either one. The README row describes the payloads correctly but
also never mentions that the value is a path.

## Why the value convention drifted

The variable sits in a three-member diagnostic family that reads as one convention,
and one member is the odd one out:

| Variable | How the code reads the value |
|---|---|
| `STRANDS_LIBERO_ACTION_LOG` | flag - `os.environ.get(...).strip().lower() in ("1", "true", "yes", "on")` (`benchmarks/libero/adapter.py:4742`) |
| `STRANDS_LIBERO_STATE_LOG` | flag - same expression (`benchmarks/libero/adapter.py:710`) |
| `STRANDS_GROOT_WIRE_LOG` | **directory** - `_wire_log_dir()` returns the raw value (`policies/groot/policy.py:1363`) |

They share a naming pattern (`X` plus an `X_MAX`/`X_MAX_CALLS` companion), a default
cell shape, and a row in the same README table, so the flag convention got generalised
to the one member that takes a path.

## The second claim in the same row

"Log raw ZMQ frames" also mis-states what is captured and where from.
`_maybe_dump_wire_payload` is called from the in-process inference path
(`policy.py:1000`) as well as the service path (`policy.py:1124`), and it pickles the
observation and the action chunk rather than transport frames. In-process inference
opens no socket at all, so a transport-flavoured description hides exactly the half a
LOCAL-versus-SERVICE parity comparison needs - which is the diagnostic's stated purpose
in the README.

## Change

Correct both rows to state the contract the code implements: the value is the directory,
with a worked example, and the diagnostic covers the in-process path as well as the
service path. Behaviour is untouched; no `strands_robots` source is modified.

Add a guard that grades the documented values through the shipped resolvers rather than
a hand-copied list of spellings, so widening what a resolver accepts later cannot
silently invalidate it. A `_MINIMUM_DOCUMENTED_ROWS` premise assertion fails loudly if a
reformat ever drops the tables, so a clean sweep cannot come from reaching nothing.

Also pin the in-process half of the dumper, which had no coverage: all five existing
tests in `TestWirePayloadDiagnostic` exercise `service` only.

## Tests

`tests/policies/groot/test_wire_log_documentation_matches_the_diagnostic.py`, run
against the pre-fix docs: **2 failed, 6 passed**. After: **8 passed**.

The headline failure names the offender and the remedy:

```
docs/api-reference.md:199: STRANDS_GROOT_WIRE_LOG is documented with value '1',
which _wire_log_dir() resolves to a CWD-relative path; document the directory the
dumps should land in instead
```

| Test | Pre-fix | Role |
|---|---|---|
| `test_no_row_offers_a_value_that_is_not_a_path` | fail | the defect |
| `test_the_wire_log_row_still_shows_a_value_a_reader_can_export` | fail | pre-fix the README row shows no value at all; post-fix it guards against "fixing" the row by deleting the example |
| `test_the_raw_value_is_used_as_the_path` (x2) | pass | oracle: the resolvers take the value verbatim |
| `test_a_flag_token_resolves_to_a_relative_directory` | pass | oracle: `1` is a directory name, not an on-switch |
| `test_the_guard_reaches_the_shipped_tables` | pass | premise |
| `test_the_in_process_path_writes_its_own_archive` | pass | new coverage for the untested `local` mode |
| `test_both_paths_dump_into_one_directory_under_distinct_names` | pass | the two archives coexist, which is what makes them diffable |

Full `tests/` shows no new failures against `upstream/main`; `ruff check`, `ruff format
--check` and `mypy` are clean over `strands_robots tests tests_integ`.
