### PR TITLE
fix(policies/wbc): point the missing-session refusal at the seam that installs one

### DIFF
--- a/changelog.d/2327-wbc-missing-session-refusal-seam.md
+++ b/changelog.d/2327-wbc-missing-session-refusal-seam.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **WBC**: the "no ONNX session loaded" refusal named `policy_session=` / `walk_session=` as its remedy, but `WBCPolicy.__init__` absorbs unknown keywords per the provider contract, so a session passed that way was dropped and the identical refusal was raised again. The message now names the `policy_session` / `walk_session` attribute assignment that installs one, and states why the constructor cannot take it.

--- a/strands_robots/policies/wbc/policy.py
+++ b/strands_robots/policies/wbc/policy.py
@@ -197,10 +197,12 @@ class WBCPolicy(Policy):
             through the mesh ``tell()`` / ``policy_config`` path that forwards
             only constructor kwargs. Per-call ``target_velocity`` overrides it.
         allow_missing_models: Test/CI seam. When ``True`` the ONNX sessions are
-            not loaded eagerly (so unit tests can inject a stub session via
-            :attr:`policy_session` / :attr:`walk_session`). Production callers
-            leave this ``False`` so a missing checkpoint fails loudly at
-            construction.
+            not loaded eagerly, so a caller can install one by assigning to the
+            :attr:`policy_session` / :attr:`walk_session` attributes after
+            construction. Assignment is the only route: ``**kwargs`` below
+            absorbs unknown keywords, so a session passed to this constructor is
+            dropped. Production callers leave this ``False`` so a missing
+            checkpoint fails loudly at construction.
         **kwargs: Forward-compatibility absorber for the smart-string / registry
             resolution path. Per the #300 contract, providers MUST ignore
             unknown kwargs rather than raising.
@@ -709,8 +711,11 @@ class WBCPolicy(Policy):
             # if a caller forgot to inject a session. Never silently emit zeros.
             raise RuntimeError(
                 "WBCPolicy has no ONNX session loaded. Construct with a valid "
-                "checkpoint (allow_missing_models=False), or inject a stub via "
-                "policy_session=/walk_session= in tests."
+                "checkpoint (allow_missing_models=False), or construct with "
+                "allow_missing_models=True and then assign a session to the "
+                "`policy_session` / `walk_session` attributes. The constructor "
+                "absorbs unknown keywords per the provider contract, so a "
+                "session handed to it is dropped rather than installed."
             )
 
         net_in = np.asarray(obs, dtype=np.float32).reshape(1, -1)

--- a/tests/policies/wbc/test_missing_session_refusal_names_a_working_seam.py
+++ b/tests/policies/wbc/test_missing_session_refusal_names_a_working_seam.py
@@ -1,0 +1,126 @@
+"""The "no ONNX session loaded" refusal must name a seam that actually installs one.
+
+:class:`~strands_robots.policies.wbc.WBCPolicy` accepts ``**kwargs`` as a
+forward-compatibility absorber (providers must ignore unknown keywords rather
+than raise), so a session handed to the constructor under a keyword the
+signature does not declare is silently dropped. A refusal that points the caller
+at such a keyword survives its own remedy: applying it verbatim reproduces the
+identical error.
+
+These tests grade the refusal mechanically - every keyword it advertises must be
+a declared constructor parameter, and the attribute spelling it names must lift
+it - so the wording cannot drift back onto a keyword the absorber eats.
+
+The sibling :class:`~strands_robots.policies.protomotions.ProtoMotionsPolicy`
+states the same principle from the other side: it declares every injectable as
+an explicit parameter and takes no ``**kwargs``, "so a typo raises ``TypeError``
+at build time rather than being swallowed".
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import WBC_G1_ALL_JOINTS, WBCPolicy
+
+_NUM_ACTIONS = 15
+
+
+class _StubInput:
+    name = "obs"
+
+
+class _StubSession:
+    """Minimal stand-in for ``onnxruntime.InferenceSession``."""
+
+    def get_inputs(self) -> list[_StubInput]:
+        return [_StubInput()]
+
+    def run(self, output_names: Any, feed: dict[str, Any]) -> list[np.ndarray]:
+        return [np.zeros((1, _NUM_ACTIONS), dtype=np.float32)]
+
+
+def _g1_keys() -> list[str]:
+    """Joint key order as ``robot_joint_names`` reports it for the MuJoCo G1."""
+    return ["floating_base_joint", *WBC_G1_ALL_JOINTS]
+
+
+def _observation() -> dict[str, float]:
+    return {k: 0.0 for k in _g1_keys()}
+
+
+def _policy_with_no_session(**init_kwargs: Any) -> WBCPolicy:
+    """A policy whose sessions were never loaded, ready to run one step."""
+    policy = WBCPolicy(allow_missing_models=True, **init_kwargs)
+    policy.set_robot_state_keys(_g1_keys())
+    return policy
+
+
+def _declared_parameters() -> set[str]:
+    """Parameter names ``WBCPolicy.__init__`` binds, excluding the absorber."""
+    return {
+        name
+        for name, param in inspect.signature(WBCPolicy.__init__).parameters.items()
+        if name != "self" and param.kind is not inspect.Parameter.VAR_KEYWORD
+    }
+
+
+def _refusal_text() -> str:
+    policy = _policy_with_no_session()
+    with pytest.raises(RuntimeError, match="no ONNX session loaded") as excinfo:
+        policy.get_actions_sync(_observation(), "")
+    return str(excinfo.value)
+
+
+class TestTheMissingSessionRefusalNamesAWorkingSeam:
+    def test_every_keyword_it_advertises_is_a_declared_constructor_parameter(self) -> None:
+        """A keyword the absorber eats is a dead-end remedy: it changes nothing."""
+        message = _refusal_text()
+        declared = _declared_parameters()
+        absorbed = sorted({name for name in re.findall(r"\b([a-z_][a-z0-9_]*)=", message)} - declared)
+        assert not absorbed, (
+            f"the refusal advertises {absorbed} as constructor keyword(s), but "
+            f"WBCPolicy.__init__ declares only {sorted(declared)} and absorbs the "
+            "rest into **kwargs, so passing them installs nothing and the same "
+            f"refusal is raised again. Message: {message!r}"
+        )
+
+    def test_assigning_the_attributes_it_names_lifts_the_refusal(self) -> None:
+        """Apply the remedy the message states, then assert the step succeeds."""
+        message = _refusal_text()
+        named = [token for token in re.findall(r"`([a-z_][a-z0-9_]*)`", message) if token.endswith("_session")]
+        assert named, (
+            "the refusal names no session attribute to assign, so a caller who "
+            f"reads it has no stated way out. Message: {message!r}"
+        )
+
+        policy = _policy_with_no_session()
+        for attribute in named:
+            assert hasattr(policy, attribute), f"WBCPolicy has no {attribute!r} attribute"
+            setattr(policy, attribute, _StubSession())
+
+        actions = policy.get_actions_sync(_observation(), "", target_velocity=[0.5, 0.0, 0.0])
+        assert len(actions) == 1
+        assert len(actions[0]) == _NUM_ACTIONS
+
+    def test_the_refusal_fires_when_no_session_was_installed(self) -> None:
+        """Premise: without a session the policy refuses instead of emitting zeros."""
+        policy = _policy_with_no_session()
+        with pytest.raises(RuntimeError, match="no ONNX session loaded"):
+            policy.get_actions_sync(_observation(), "")
+
+    def test_a_session_handed_to_the_constructor_is_still_dropped(self) -> None:
+        """Pins the fact the message states, so the two cannot drift apart."""
+        policy = _policy_with_no_session(policy_session=_StubSession(), walk_session=_StubSession())
+        assert policy.policy_session is None
+        assert policy.walk_session is None
+
+    def test_an_unknown_keyword_is_still_absorbed_without_raising(self) -> None:
+        """The provider contract stands: unknown keywords are ignored, not refused."""
+        policy = _policy_with_no_session(some_future_provider_knob=object())
+        assert isinstance(policy, WBCPolicy)


### PR DESCRIPTION
## Problem

`WBCPolicy.__init__` accepts `**kwargs` as a forward-compatibility absorber (the provider contract requires providers to ignore unknown keywords rather than raise). Any keyword the signature does not declare is therefore logged at DEBUG and discarded:

```
DEBUG WBCPolicy ignoring unknown constructor kwargs: ['policy_session', 'walk_session']
```

The `_run_session` refusal named exactly such a keyword as its remedy:

> WBCPolicy has no ONNX session loaded. Construct with a valid checkpoint (allow_missing_models=False), or inject a stub via `policy_session=`/`walk_session=` in tests.

So the refusal **survived its own remedy**. Applying it verbatim installs nothing and raises the identical error:

```python
p = WBCPolicy(allow_missing_models=True, policy_session=session, walk_session=session)
p.policy_session                      # None
p.get_actions_sync(obs, "")           # the same refusal, word for word
```

The route that works is attribute assignment, which the class docstring already documented (`:attr:`policy_session` / :attr:`walk_session``) and which **all 56 injections across the eight `tests/policies/wbc/` files use**. The advertised spelling had never worked for the audience the message named.

## Change

Restate the refusal in terms of the assignment that installs a session, and say why the constructor cannot take one:

> WBCPolicy has no ONNX session loaded. Construct with a valid checkpoint (allow_missing_models=False), or construct with allow_missing_models=True and then assign a session to the `policy_session` / `walk_session` attributes. The constructor absorbs unknown keywords per the provider contract, so a session handed to it is dropped rather than installed.

The `allow_missing_models` docstring now states that assignment is the only route, for the same reason.

No signature, attribute or control path changes - the diff is one message and one docstring paragraph. `ProtoMotionsPolicy` states the same principle from the other side: it declares every injectable as an explicit parameter and takes no `**kwargs`, "so a typo raises `TypeError` at build time rather than being swallowed". `WBCPolicy` needs the absorber, so its refusal has to name a spelling the absorber cannot eat.

## Tests

`tests/policies/wbc/test_missing_session_refusal_names_a_working_seam.py` grades the refusal mechanically rather than asserting on wording: it triggers the real error, parses the remedy back out of the message, and applies it.

| test | pre-fix | post-fix |
|---|---|---|
| every keyword it advertises is a declared constructor parameter | FAIL - `['policy_session', 'walk_session']` are absorbed | pass |
| assigning the attributes it names lifts the refusal | FAIL - names no attribute, so a reader has no stated way out | pass |
| the refusal fires when no session was installed (premise) | pass | pass |
| a session handed to the constructor is still dropped | pass | pass |
| an unknown keyword is still absorbed without raising | pass | pass |

2 failed / 3 passed before, 5 passed after. The three constant passes are the no-overreach controls: the provider contract still absorbs unknown keywords (turning the absorber into a raiser would be the wrong fix), and the dropped-keyword fact the message now states is pinned so the two cannot drift apart again.

Full `tests/` suite run against this branch and against `upstream/main` on the same interpreter: identical failure sets, no new failures.

## Rollout in MuJoCo (headless)

One script per tree: it reads the refusal from the tree it runs in, parses the remedy out of that text, applies whatever the remedy says, then hands the policy to `run_policy` with a real GR00T SONIC ONNX session. Nothing is stubbed - only the message, and therefore the route it sends you down, differs.

![remedy roundtrip](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-session-seam/compare.gif)

[full-resolution MP4](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-session-seam/compare.mp4)

Left: the remedy as previously worded (constructor keyword) - `session installed: False`, `run_policy` returns `status=error` after 0 of 260 steps with `Policy failed: <the same refusal>`. Per-frame mean absolute pixel delta **0.0000**: the panel is static because the rollout never ran.

Right: the remedy as now worded (attribute assignment) - `session installed: True`, `status=success`, 260 of 260 control steps at 50 Hz, 157 frames. Per-frame delta 1.29 to 6.12, 156/156 frames in motion.
