### PR TITLE
fix(simulation/newton): advertise every base-contract method the backend delivers

### DIFF
--- a/changelog.d/2329-newton-describe-delivered-contract-methods.md
+++ b/changelog.d/2329-newton-describe-delivered-contract-methods.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Newton discovery surface**: `describe()` on the Newton backend now advertises every base-contract method it delivers. Because it builds its surface from scratch instead of extending `SimEngine.describe()`, six methods it implements or inherits unchanged were absent from `describe()["methods"]` and therefore undiscoverable there - `remove_robot`, `list_robots`, `eval_policy`, `start_policy`, `replay_episode` and `register_builtin_benchmarks`. The two base-contract methods the backend does not implement, `get_contacts` and `load_scene`, remain unadvertised so the surface never points a caller at a `NotImplementedError`.

--- a/docs/simulation/newton.md
+++ b/docs/simulation/newton.md
@@ -96,8 +96,12 @@ no-op until then.
   from `list_bodies`) mounts the camera ON that body so a wrist camera tracks
   the arm. `remove_camera(name)` / `list_cameras()` round out the API and
   `describe()["cameras"]` lists every registered camera.
-- `run_policy` / `eval_policy` / `replay_episode` are inherited from the
-  `SimEngine` ABC - no backend-specific re-implementation.
+- `run_policy` / `eval_policy` / `replay_episode` / `start_policy` are
+  inherited from the `SimEngine` ABC - no backend-specific re-implementation.
+  `start_policy` is the ABC's synchronous passthrough to `run_policy` here;
+  only the MuJoCo backend runs a policy on a background thread. All four are
+  advertised in `describe()["methods"]`, as is every other base-contract
+  method this backend delivers.
 - `describe()` reports the active solver, available solvers, device, and
   the current gravity vector and timestep.
 - Gravity configured via `create_world(gravity=[x, y, z])` or `set_gravity`

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -2301,10 +2301,19 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
     def describe(self) -> dict[str, Any]:
         """Return a discovery surface describing this backend's capabilities.
 
+        This surface is built from scratch rather than by extending
+        :meth:`~strands_robots.simulation.base.SimEngine.describe`, so every
+        method the base contract advertises and this backend delivers has to be
+        listed here explicitly -- including the facades inherited unchanged from
+        the ABC. Extending the base surface instead would also advertise
+        ``get_contacts`` and ``load_scene``, which this backend does not
+        implement.
+
         Returns:
             Dict with the backend name, active solver, the solvers that can
             drive an articulated robot (the accepted domain of ``solver=``),
-            device, and current robot / object counts.
+            device, current robot / object counts, and the ``methods`` mapping a
+            caller enumerates to find a capability without guessing its name.
         """
         device = str(self._wp.get_device(self.device)) if self.device else str(self._wp.get_device())
         bodies = list(self._model.body_label) if self._model is not None else []
@@ -2332,6 +2341,10 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "color=None, mass=0.1, is_static=False, mesh_path=None) -> dict  "
                     "(add a manipulable object -- box/sphere/.../mesh -- to the scene)"
                 ),
+                "remove_robot": (
+                    "(name: str) -> dict  (remove a robot and rebuild the world; the inverse "
+                    "of add_robot, completing the add/remove pair alongside remove_object)"
+                ),
                 "remove_object": "(name: str) -> dict  (remove a previously added object)",
                 "get_robot_state": "(robot_name: str | None = None) -> dict (per-joint position + velocity)",
                 "get_state": (
@@ -2344,11 +2357,31 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "  # n_substeps must be a positive whole number; use step() to advance without commanding"
                 ),
                 "run_policy": "(robot_name: str, policy_provider='mock', n_episodes=1, ...) -> dict",
+                "eval_policy": (
+                    "(robot_name: str | None = None, policy_provider='mock', n_episodes=1, "
+                    "max_steps=300, success_fn=None, seed=None, ...) -> dict  (multi-episode "
+                    "success-rate evaluation -- the scoring sibling of run_policy)"
+                ),
+                "start_policy": (
+                    "(robot_name: str | None = None, policy_provider='mock', duration=10.0, ...) -> dict  "
+                    "(the base contract's synchronous passthrough to run_policy on this backend; "
+                    "only MuJoCo runs a policy on a background thread)"
+                ),
+                "replay_episode": (
+                    "(repo_id: str, robot_name=None, episode=0, root=None, speed=1.0, "
+                    "action_key_map=None) -> dict  (replay a recorded LeRobotDataset episode "
+                    "through the sim)"
+                ),
                 "evaluate_benchmark": (
                     "(benchmark_name: str, robot_name=None, policy_provider='mock', "
                     "n_episodes=1, seed=None, video=None, ...) -> dict  (score a registered "
                     "success/failure/dense_reward benchmark over a rollout; max_steps comes "
                     "from the benchmark, not a parameter)"
+                ),
+                "register_builtin_benchmarks": (
+                    "() -> dict  (register the shipped built-in velocity-tracking locomotion "
+                    "benchmarks so they appear in list_benchmarks and can be run via "
+                    "evaluate_benchmark)"
                 ),
                 "list_benchmarks": (
                     "() -> dict  (enumerate registered benchmarks -- names, supported robots, "
@@ -2358,6 +2391,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                     "(benchmark_name: str, spec_path: str) -> dict  (author a declarative "
                     "success/failure/dense_reward benchmark spec as YAML/JSON at runtime and register it)"
                 ),
+                "list_robots": "() -> list[str]  (ordered robot names -- what describe() reports under 'robots')",
                 "list_robots_info": "() -> dict (pretty robot listing)",
                 "list_bodies": "(robot_name: str | None = None) -> dict (body labels + gripper_body)",
                 "list_objects": "() -> dict",

--- a/tests/simulation/test_sim_engine_describe_discovery.py
+++ b/tests/simulation/test_sim_engine_describe_discovery.py
@@ -13,6 +13,7 @@ it from the discovery surface rather than the API carrying a second name.
 import ast
 import inspect
 import re
+import textwrap
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -1203,4 +1204,188 @@ class TestDescribeSignaturesAgreeWithTheMethodsOnEveryBackend:
         assert not violations, (
             f"{label}: describe() omits parameters the method requires: {sorted(violations)}. "
             "A call built from the advertised signature alone must be a complete call."
+        )
+
+
+def _describe_merges_the_base_surface(engine_cls: type) -> bool:
+    """Whether ``engine_cls.describe()`` extends the base surface or replaces it.
+
+    A backend that calls ``super().describe()`` inherits every method the base
+    contract advertises; a backend that returns a fresh dict literal advertises
+    only what it lists itself.
+
+    Args:
+        engine_cls: The engine class whose ``describe()`` to inspect.
+
+    Returns:
+        True when the override calls ``super().describe()``.
+    """
+    source_file = inspect.getsourcefile(engine_cls)
+    assert source_file is not None, f"no source file for {engine_cls.__name__}"
+    module = ast.parse(Path(source_file).read_text(encoding="utf-8"))
+    for class_def in [
+        node for node in ast.walk(module) if isinstance(node, ast.ClassDef) and node.name == engine_cls.__name__
+    ]:
+        for describe in [
+            node for node in ast.walk(class_def) if isinstance(node, ast.FunctionDef) and node.name == "describe"
+        ]:
+            for node in ast.walk(describe):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "describe"
+                    and isinstance(node.func.value, ast.Call)
+                    and isinstance(node.func.value.func, ast.Name)
+                    and node.func.value.func.id == "super"
+                ):
+                    return True
+    return False
+
+
+def _advertised_methods(engine_cls: type) -> set[str]:
+    """Method names a caller finds in ``engine_cls.describe()["methods"]``.
+
+    Args:
+        engine_cls: The engine class whose discovery surface to resolve.
+
+    Returns:
+        The effective set: the names the class lists itself, plus the base
+        contract's names when the override merges the base surface.
+    """
+    from strands_robots.simulation.base import SimEngine
+
+    names = set(_describe_signature_strings(engine_cls))
+    if engine_cls is not SimEngine and _describe_merges_the_base_surface(engine_cls):
+        names |= set(_describe_signature_strings(SimEngine))
+    return names
+
+
+def _refuses(engine_cls: type, method_name: str) -> bool | None:
+    """Whether ``method_name`` resolves to an unimplemented-on-this-backend stub.
+
+    The base class declares some contract methods as bodies that do nothing but
+    ``raise NotImplementedError`` for backends that cannot support them (there
+    is no contact list on every engine, for instance). A backend delivers such a
+    method only by overriding it with a real body.
+
+    Args:
+        engine_cls: The engine class the method is resolved on.
+        method_name: The contract method to classify.
+
+    Returns:
+        True when the resolved implementation is a bare ``NotImplementedError``
+        raise, False when it is a real implementation, and None when the name
+        does not resolve on this class at all -- the base surface advertises the
+        whole engine contract including the accessors every concrete backend
+        supplies but the ABC does not declare, so an unresolvable name says
+        nothing about whether the capability is delivered.
+    """
+    function = getattr(engine_cls, method_name, None)
+    if not callable(function):
+        return None
+    body = list(ast.parse(textwrap.dedent(inspect.getsource(function))).body[0].body)  # type: ignore[attr-defined]
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        body = body[1:]  # drop the docstring
+    return len(body) == 1 and isinstance(body[0], ast.Raise) and "NotImplementedError" in ast.dump(body[0])
+
+
+class TestEveryDeliveredContractMethodIsOnTheBackendSurface:
+    """A backend must advertise every base-contract method it actually delivers.
+
+    The class above pins that an advertised signature is *correct*; this pins
+    that a delivered capability is advertised *at all*. The base ``describe()``
+    is where the contract is stated, and three of its entries were added there
+    on the argument that a caller enumerating ``describe()["methods"]`` cannot
+    otherwise find them: ``remove_robot`` as the inverse of ``add_robot``
+    (mirroring the advertised ``add_object`` / ``remove_object`` pair), and the
+    scene-variation and world-lifecycle families.
+
+    A backend that extends the base surface with ``super().describe()`` inherits
+    those additions. A backend that returns a fresh dict literal does not, and
+    every later addition to the contract silently misses it -- so the same
+    capability is discoverable on one backend and invisible on another.
+
+    The rule is deliberately one-directional: it requires a delivered method to
+    be advertised, and says nothing about a method the backend refuses. Merging
+    the base surface wholesale is therefore not a shortcut past it -- a backend
+    that inherits an advertisement for a capability it raises
+    ``NotImplementedError`` for would satisfy this rule while dead-ending the
+    caller, which is what the Newton control below pins.
+    """
+
+    def test_the_contract_and_the_refusal_detector_are_both_non_vacuous(self):
+        """Guard the guard: a clean sweep must mean something.
+
+        If the base surface stopped being readable, or the refusal detector
+        classified everything as refused, the parametrized test below would
+        pass while checking nothing.
+        """
+        from strands_robots.simulation.base import SimEngine
+
+        contract = _describe_signature_strings(SimEngine)
+        assert len(contract) >= 20, f"base contract surface looks unreadable: {sorted(contract)}"
+        # The detector separates a real implementation from a bare raise.
+        assert _refuses(SimEngine, "get_contacts") is True
+        assert _refuses(SimEngine, "eval_policy") is False
+        # At least one backend delivers something the base only declares.
+        newton = _describe_backend("newton")
+        assert _refuses(newton, "randomize") is False, "Newton mixes in real domain randomization"
+
+    @pytest.mark.parametrize("label", sorted(_DESCRIBE_BACKENDS))
+    def test_every_delivered_contract_method_is_advertised(self, label):
+        """A capability the backend delivers must be findable on its surface.
+
+        An agent's only guess-free route to a method name is
+        ``describe()["methods"]``. A backend that implements a contract method
+        but never lists it makes that capability invisible: the caller can add a
+        robot but not discover how to remove one, or run a policy but not
+        discover how to score it over episodes.
+        """
+        from strands_robots.simulation.base import SimEngine
+
+        engine_cls = _describe_backend(label)
+        advertised = _advertised_methods(engine_cls)
+        hidden = sorted(
+            name
+            for name in _describe_signature_strings(SimEngine)
+            if _refuses(engine_cls, name) is False and name not in advertised
+        )
+        assert not hidden, (
+            f"{label}: describe() omits base-contract methods this backend delivers: {hidden}. "
+            "Advertise each one on this backend's surface (with a signature string accurate for "
+            "this backend), or the capability is undiscoverable here while being discoverable on "
+            "the backends that merge the base surface."
+        )
+
+    def test_a_backend_never_advertises_a_capability_it_refuses(self):
+        """Newton must not gain its missing entries by inheriting refusals.
+
+        Newton returns a fresh surface, so the cheap way to satisfy the test
+        above is to merge the base surface with ``super().describe()``. That
+        would also advertise ``get_contacts`` and ``load_scene``, which Newton
+        does not implement -- turning an invisible capability into an advertised
+        one that raises ``NotImplementedError`` when called. The entries have to
+        be the ones Newton delivers.
+        """
+        newton = _describe_backend("newton")
+        advertised = _advertised_methods(newton)
+        refused_but_advertised = sorted(
+            name for name in ("get_contacts", "load_scene") if _refuses(newton, name) and name in advertised
+        )
+        assert not refused_but_advertised, (
+            f"Newton's describe() advertises methods it raises NotImplementedError for: {refused_but_advertised}."
+        )
+
+    def test_the_reference_backend_needs_no_exception(self):
+        """MuJoCo is the shape the rule describes, not an exception to it.
+
+        MuJoCo merges the base surface and then re-states each method with its
+        own concrete signature, so it satisfies the rule with nothing special
+        added. Pinning that here keeps the rule readable as the house
+        convention rather than as a Newton-specific patch.
+        """
+        mujoco_engine = _describe_backend("mujoco")
+        assert _describe_merges_the_base_surface(mujoco_engine) is True
+        assert not _describe_merges_the_base_surface(_describe_backend("newton")), (
+            "Newton builds its surface from scratch -- the condition that let the contract drift"
         )


### PR DESCRIPTION
## Problem

`describe()` is the only guess-free route from an agent to a method name, and the base `SimEngine.describe()` is where the engine contract is stated. Three of its entries were added there on exactly that argument -- `remove_robot` as the inverse of `add_robot` (mirroring the advertised `add_object` / `remove_object` pair), plus the scene-variation and world-lifecycle families.

A backend that extends the base surface with `super().describe()` inherits those additions. The Newton backend returns a fresh dict literal, so it never received any of them. Six base-contract methods Newton implements or inherits unchanged were missing from `describe()["methods"]`:

| method | how Newton delivers it |
| --- | --- |
| `remove_robot` | `NewtonSimEngine.remove_robot` (own implementation) |
| `list_robots` | `NewtonSimEngine.list_robots` (own implementation) |
| `eval_policy` | `SimEngine.eval_policy` via `PolicyRunner` |
| `start_policy` | `SimEngine.start_policy` (documented synchronous passthrough) |
| `replay_episode` | `SimEngine.replay_episode` via `PolicyRunner` |
| `register_builtin_benchmarks` | `SimEngine.register_builtin_benchmarks` |

The result is a surface that is discoverable on one backend and invisible on another: on Newton a caller could learn how to add a robot and how to remove an *object*, but not how to remove a robot; and could run a policy (`run_policy` is advertised) but not discover how to score it over episodes. `docs/simulation/newton.md` already told readers `eval_policy` / `replay_episode` work here and that "`describe()` also advertises these methods ... so a single call surfaces the full contract" -- the guarantee the surface did not keep.

Measured on the real `describe()` call: **37 advertised methods before, 43 after**, no entry removed.

## Why not `super().describe()`

Merging the base surface looks like the obvious fix and is the wrong one. Newton does not implement `get_contacts` or `load_scene`; both resolve to the base's bare `raise NotImplementedError`. Inheriting the base surface would advertise them, turning an invisible capability into an advertised one that dead-ends when called. Each entry is instead listed with a signature string accurate for this backend -- including that `start_policy` is the ABC's documented synchronous passthrough to `run_policy` here, not a background thread (only MuJoCo overrides it with one).

## Change

- Newton's `describe()` advertises the six delivered base-contract methods, each grouped with its existing siblings (`remove_robot` beside `remove_object`, the rollout family beside `run_policy`, `register_builtin_benchmarks` beside `list_benchmarks`, `list_robots` beside `list_robots_info`).
- `describe()`'s docstring states why the surface is built from scratch and what that obliges, so the next contract addition is not silently missed.
- `docs/simulation/newton.md` names the fourth inherited rollout facade and how `start_policy` behaves on this backend.

## Tests

A parametrized guard in the file that already owns the discovery-surface rules. It reads each backend's advertised names from source (Newton and Isaac need simulator runtimes that cannot be installed together, which is why this drift was never compared against anything) and classifies a base-contract method as *delivered* unless it resolves to a bare `NotImplementedError` raise.

| test | before | after |
| --- | --- | --- |
| `test_every_delivered_contract_method_is_advertised[newton]` | **fail** -- names all 6 with the remedy | pass |
| `test_every_delivered_contract_method_is_advertised[base/mujoco/isaac]` | pass | pass |
| `test_a_backend_never_advertises_a_capability_it_refuses` | pass | pass |
| `test_the_reference_backend_needs_no_exception` | pass | pass |
| `test_the_contract_and_the_refusal_detector_are_both_non_vacuous` | pass | pass |

`1 failed, 49 passed` before; `50 passed` after. The four constant passes are the controls: MuJoCo and Isaac satisfy the rule with nothing added (so it is the house convention, not a Newton-specific patch), Newton must still *not* advertise `get_contacts` / `load_scene` (which is what fails if the `super()` shortcut is taken), and the premise test keeps a clean sweep from being vacuous.

Full `tests/` run on this branch and on `main`: identical failure sets, no new failures. `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Discoverability before / after

Per base-contract method, per backend: is a capability the backend delivers findable on its surface? Generated by calling each tree's own `describe()`. Only the newton column changes (mujoco 0 cells, isaac 0 cells, newton 6 cells).

![describe discoverability matrix](https://raw.githubusercontent.com/cagataycali/robots/media-newton-describe-contract/newton-describe-contract.png)
