### PR TITLE
fix(inference): a PolicyServer stop must not kill the thread serving it

### DIFF
--- a/changelog.d/2333-policy-server-shutdown-serving-thread.md
+++ b/changelog.d/2333-policy-server-shutdown-serving-thread.md
@@ -3,9 +3,14 @@
 `PolicyServer.stop()` no longer kills the thread serving the server. `stop()`
 closes the listening socket from the caller's thread while the accept loop is
 still waiting on it, and the websockets sync server raises out of
-`serve_forever()` when that happens - `ValueError: Invalid file descriptor: -1`
-on websockets 12.0, `OSError: [Errno 9] Bad file descriptor` on 13.0 through
-17.x. The serving thread is a daemon, so its death was reported nowhere: `stop()`
+`serve_forever()` when that happens. Both shapes come out of one call -
+registering the listening socket with the selector - and which one surfaces
+depends on where in it the close lands: before `fileno()` is read the descriptor
+is `-1` and it raises `ValueError: Invalid file descriptor: -1`, and between that
+read and `epoll_ctl` the descriptor still looks live and it raises
+`OSError: [Errno 9] Bad file descriptor`. 12.0 lets both escape; 13.0 through
+17.x guard the call against `ValueError` only, so every supported release can
+still die on the `OSError` and raising the dependency floor cannot fix this. The serving thread is a daemon, so its death was reported nowhere: `stop()`
 returned normally and the server looked cleanly shut down (measured 12 of 20
 `start()`/`stop()` cycles on websockets 12.0, 3 of 12 on 17.0.1). The accept loop
 now runs through a helper that absorbs the failure only while a stop is in

--- a/changelog.d/2333-policy-server-shutdown-serving-thread.md
+++ b/changelog.d/2333-policy-server-shutdown-serving-thread.md
@@ -1,0 +1,12 @@
+### Fixed
+
+`PolicyServer.stop()` no longer kills the thread serving the server. `stop()`
+closes the listening socket from the caller's thread while the accept loop is
+still waiting on it, and the websockets sync server raises out of
+`serve_forever()` when that happens - `ValueError: Invalid file descriptor: -1`
+on websockets 12.0, `OSError: [Errno 9] Bad file descriptor` on 13.0 through
+17.x. The serving thread is a daemon, so its death was reported nowhere: `stop()`
+returned normally and the server looked cleanly shut down (measured 12 of 20
+`start()`/`stop()` cycles on websockets 12.0, 3 of 12 on 17.0.1). The accept loop
+now runs through a helper that absorbs the failure only while a stop is in
+progress, so a socket failure with no stop pending still propagates.

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -128,9 +128,48 @@ class PolicyServer:
         self.port = port
         self._server: Server | None = None
         self._thread: threading.Thread | None = None
+        # Set by stop() before it closes the listening socket, so the serving
+        # loop can tell a teardown apart from a genuine socket failure. See
+        # _run_accept_loop.
+        self._stopping = threading.Event()
         # Serialize inference so per-episode policy state is never interleaved
         # across connections (v1 single-client contract).
         self._lock = threading.Lock()
+
+    def _run_accept_loop(self, server: Server) -> None:
+        """Run the sync server's accept loop, absorbing the teardown race only.
+
+        :meth:`stop` ends the loop by closing the listening socket from another
+        thread, and the socket is exactly what the loop is waiting on. The
+        websockets sync server does not synchronize those two, so a stop that
+        lands while the loop is entering or polling raises out of
+        ``serve_forever()`` - and the exception it raises is not stable across
+        websockets releases: 12.0 raises ``ValueError: Invalid file descriptor:
+        -1`` while registering the socket, and 13.0 through 17.x raise ``OSError:
+        [Errno 9] Bad file descriptor`` while polling it.
+
+        Left unhandled that kills the serving thread, and a daemon thread reports
+        its death nowhere: ``stop()`` returns, :attr:`_server` is cleared, and the
+        server looks cleanly shut down. So the loop is only ever run through
+        here, and the exception is absorbed *only* while a stop is in progress -
+        the same failure without a stop pending is a real one and still
+        propagates, which is why this keys on :attr:`_stopping` rather than on
+        the exception type. Keying on the type would both swallow a genuine
+        socket error and go stale the next time websockets changes which one it
+        raises.
+
+        Args:
+            server: The running sync server whose accept loop to drive.
+        """
+        try:
+            server.serve_forever()
+        except (OSError, ValueError):
+            if not self._stopping.is_set():
+                raise
+            logger.debug(
+                "PolicyServer: accept loop ended while stopping (the listening socket was closed under it)",
+                exc_info=True,
+            )
 
     def _metadata(self) -> dict[str, Any]:
         """Introspection payload advertised in the ``ready`` handshake."""
@@ -238,6 +277,9 @@ class PolicyServer:
         if self._server is not None:
             raise RuntimeError("PolicyServer is already running")
 
+        # A previous stop() left the flag set; this run's teardown has not begun.
+        self._stopping.clear()
+
         from websockets.sync.server import serve
 
         # Match the client's connect() options: an observation carrying camera
@@ -254,7 +296,8 @@ class PolicyServer:
         self.port = server.socket.getsockname()[1]
         self._server = server
         self._thread = threading.Thread(
-            target=server.serve_forever,
+            target=self._run_accept_loop,
+            args=(server,),
             name=f"policy-server-{self.port}",
             daemon=True,
         )
@@ -264,6 +307,9 @@ class PolicyServer:
 
     def stop(self) -> None:
         """Stop the background server and join its thread. Safe to call twice."""
+        # Before the close, not after: the serving thread races this and reads
+        # the flag to tell a teardown apart from a real socket failure.
+        self._stopping.set()
         if self._server is not None:
             self._server.shutdown()
             self._server = None
@@ -289,7 +335,7 @@ class PolicyServer:
             self._server = server
             logger.info("PolicyServer serving on ws://%s:%d", self.host, self.port)
             try:
-                server.serve_forever()
+                self._run_accept_loop(server)
             finally:
                 self._server = None
 

--- a/strands_robots/inference/server.py
+++ b/strands_robots/inference/server.py
@@ -142,11 +142,20 @@ class PolicyServer:
         :meth:`stop` ends the loop by closing the listening socket from another
         thread, and the socket is exactly what the loop is waiting on. The
         websockets sync server does not synchronize those two, so a stop that
-        lands while the loop is entering or polling raises out of
-        ``serve_forever()`` - and the exception it raises is not stable across
-        websockets releases: 12.0 raises ``ValueError: Invalid file descriptor:
-        -1`` while registering the socket, and 13.0 through 17.x raise ``OSError:
-        [Errno 9] Bad file descriptor`` while polling it.
+        lands while the loop is coming up raises out of ``serve_forever()``.
+
+        Both shapes come from the *same* call - ``serve_forever()`` registering
+        the listening socket with its selector - and which one surfaces depends
+        on where in that call the close lands, not on the release. ``selectors``
+        reads ``fileno()`` to build its key and then hands the descriptor to
+        ``epoll_ctl``: a close landing before the read leaves ``fileno()`` at
+        ``-1`` and raises ``ValueError: Invalid file descriptor: -1``, while a
+        close landing between the read and ``epoll_ctl`` leaves a live-looking
+        descriptor and raises ``OSError: [Errno 9] Bad file descriptor``. 12.0
+        wraps that call in nothing, so both escape it; 13.0 through 17.x wrap it
+        in ``except ValueError: return``, which absorbs the first shape and
+        leaves the second - so raising the dependency floor narrows this race
+        but does not close it.
 
         Left unhandled that kills the serving thread, and a daemon thread reports
         its death nowhere: ``stop()`` returns, :attr:`_server` is cleared, and the
@@ -155,8 +164,9 @@ class PolicyServer:
         the same failure without a stop pending is a real one and still
         propagates, which is why this keys on :attr:`_stopping` rather than on
         the exception type. Keying on the type would both swallow a genuine
-        socket error and go stale the next time websockets changes which one it
-        raises.
+        socket error and encode a release-to-exception mapping that is already
+        untrue: one call raises either shape depending on scheduling, and every
+        supported release can produce the ``OSError``.
 
         Args:
             server: The running sync server whose accept loop to drive.

--- a/tests/inference/test_policy_server_shutdown_does_not_kill_the_serving_thread.py
+++ b/tests/inference/test_policy_server_shutdown_does_not_kill_the_serving_thread.py
@@ -4,14 +4,23 @@
 background thread; :meth:`PolicyServer.stop` ends it by closing the listening
 socket from the caller's thread. That socket is exactly what the loop is waiting
 on, and the sync server does not synchronize the two, so a stop that lands while
-the loop is entering or polling raises straight out of ``serve_forever()``.
+the loop is coming up raises straight out of ``serve_forever()``.
 
-Which exception it raises is not stable across websockets releases:
+Both shapes come out of the *same* call - ``serve_forever()`` registering the
+listening socket with its selector - and which one surfaces is decided by where
+in that call the close lands rather than by the release:
 
-* 12.0 registers the socket with its selector *inside* ``serve_forever()``, so a
-  stop that lands first raises ``ValueError: Invalid file descriptor: -1``.
-* 13.0 through 17.x guard that registration, and instead raise
-  ``OSError: [Errno 9] Bad file descriptor`` from the poll that follows.
+* the close lands before ``selectors`` reads ``fileno()``, so the descriptor is
+  ``-1`` -> ``ValueError: Invalid file descriptor: -1``;
+* the close lands between that read and ``epoll_ctl``, so the descriptor still
+  looks live -> ``OSError: [Errno 9] Bad file descriptor``.
+
+The release decides only which of the two is already handled upstream. 12.0
+wraps the call in nothing and lets both escape (30 ``ValueError`` and 3
+``OSError`` over 200 contended cycles); 13.0 through 17.x wrap it in
+``except ValueError: return``, so only the ``OSError`` escapes (0 and 2 over the
+same 200). Raising the dependency floor therefore narrows this race and cannot
+close it, which is why the fix lives here.
 
 Either way the serving thread dies, and nothing reports it: the thread is a
 daemon, ``stop()`` returns normally, ``_server`` is cleared, and the server looks
@@ -34,11 +43,12 @@ import pytest
 
 from strands_robots.inference import PolicyServer
 
-#: The two failure shapes observed across websockets 12.0 through 17.x. Keyed by
-#: the release that raises each so a future change is easy to record.
+#: The two failure shapes one registration call can raise, keyed by the window
+#: that produces each. Every supported release can raise the ``OSError``; only
+#: 12.0 lets the ``ValueError`` escape, so these are windows and not versions.
 _TEARDOWN_FAILURES = [
-    pytest.param(ValueError("Invalid file descriptor: -1"), id="websockets-12.0-ValueError"),
-    pytest.param(OSError(9, "Bad file descriptor"), id="websockets-13.0-through-17.x-OSError"),
+    pytest.param(ValueError("Invalid file descriptor: -1"), id="closed-before-fileno-ValueError"),
+    pytest.param(OSError(9, "Bad file descriptor"), id="closed-before-epoll_ctl-OSError"),
 ]
 
 #: A real start/stop pair loses the race often but not always, so the end-to-end
@@ -58,8 +68,8 @@ class _RacingServer:
 
     Reproduces the window deterministically instead of hoping the scheduler
     lands in it: ``serve_forever`` blocks until ``shutdown`` closes the socket
-    and then raises, which is what the real server does when a stop arrives
-    while it is polling a socket the stop just closed.
+    and then raises, which is what the real server does when a stop closes the
+    socket underneath the registration that is about to hand it to the selector.
     """
 
     def __init__(self, failure: BaseException) -> None:

--- a/tests/inference/test_policy_server_shutdown_does_not_kill_the_serving_thread.py
+++ b/tests/inference/test_policy_server_shutdown_does_not_kill_the_serving_thread.py
@@ -1,0 +1,197 @@
+"""Stopping a :class:`PolicyServer` must not kill the thread that serves it.
+
+:meth:`PolicyServer.start` runs the websockets sync server's accept loop on a
+background thread; :meth:`PolicyServer.stop` ends it by closing the listening
+socket from the caller's thread. That socket is exactly what the loop is waiting
+on, and the sync server does not synchronize the two, so a stop that lands while
+the loop is entering or polling raises straight out of ``serve_forever()``.
+
+Which exception it raises is not stable across websockets releases:
+
+* 12.0 registers the socket with its selector *inside* ``serve_forever()``, so a
+  stop that lands first raises ``ValueError: Invalid file descriptor: -1``.
+* 13.0 through 17.x guard that registration, and instead raise
+  ``OSError: [Errno 9] Bad file descriptor`` from the poll that follows.
+
+Either way the serving thread dies, and nothing reports it: the thread is a
+daemon, ``stop()`` returns normally, ``_server`` is cleared, and the server looks
+cleanly shut down. That is why a lifecycle test asserting on the server's own
+state - ``test_stop_is_idempotent`` in ``test_policy_server_lifecycle.py`` - was
+green while the thread it started was crashing, and why the tests here assert on
+``threading.excepthook`` instead.
+
+The fix keys on a stop being in progress rather than on the exception type, so
+these tests pin both halves of that: a teardown failure is absorbed, and the same
+failure with no stop pending still propagates.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.inference import PolicyServer
+
+#: The two failure shapes observed across websockets 12.0 through 17.x. Keyed by
+#: the release that raises each so a future change is easy to record.
+_TEARDOWN_FAILURES = [
+    pytest.param(ValueError("Invalid file descriptor: -1"), id="websockets-12.0-ValueError"),
+    pytest.param(OSError(9, "Bad file descriptor"), id="websockets-13.0-through-17.x-OSError"),
+]
+
+#: A real start/stop pair loses the race often but not always, so the end-to-end
+#: guard repeats it. Measured 9 of 20 on websockets 12.0 and 3 of 12 on 17.0.1.
+_CYCLES = 12
+
+
+class _FakeSocket:
+    """Minimal stand-in for the listening socket ``start()`` reads the port from."""
+
+    def getsockname(self) -> tuple[str, int]:
+        return ("127.0.0.1", 54321)
+
+
+class _RacingServer:
+    """A sync server whose accept loop always loses the shutdown race.
+
+    Reproduces the window deterministically instead of hoping the scheduler
+    lands in it: ``serve_forever`` blocks until ``shutdown`` closes the socket
+    and then raises, which is what the real server does when a stop arrives
+    while it is polling a socket the stop just closed.
+    """
+
+    def __init__(self, failure: BaseException) -> None:
+        self.socket = _FakeSocket()
+        self._failure = failure
+        self._closed = threading.Event()
+        self.serve_forever_calls = 0
+
+    def serve_forever(self) -> None:
+        self.serve_forever_calls += 1
+        self._closed.wait(timeout=5.0)
+        raise self._failure
+
+    def shutdown(self) -> None:
+        self._closed.set()
+
+
+def _collect_thread_exceptions(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Capture every exception that escapes a thread for the test's duration.
+
+    Replacing the hook also takes it off pytest's own thread-exception plugin,
+    which only *warns*; that warning is precisely how this failure stayed
+    invisible.
+    """
+    escaped: list[tuple[str, str]] = []
+
+    def record(args: Any) -> None:
+        escaped.append((args.exc_type.__name__, str(args.exc_value)))
+
+    monkeypatch.setattr(threading, "excepthook", record)
+    return escaped
+
+
+def _install_racing_server(monkeypatch: pytest.MonkeyPatch, failure: BaseException) -> _RacingServer:
+    """Make ``start()`` build a server whose accept loop loses the race.
+
+    ``start()`` imports ``serve`` from ``websockets.sync.server`` at call time,
+    so patching the attribute on that module is what the production import sees.
+    """
+    websockets_sync_server = pytest.importorskip("websockets.sync.server")
+    racing = _RacingServer(failure)
+    monkeypatch.setattr(websockets_sync_server, "serve", lambda *args, **kwargs: racing, raising=True)
+    return racing
+
+
+@pytest.mark.parametrize("failure", _TEARDOWN_FAILURES)
+def test_a_teardown_failure_does_not_escape_the_serving_thread(
+    failure: BaseException, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stop that closes the socket under the accept loop must be absorbed."""
+    escaped = _collect_thread_exceptions(monkeypatch)
+    racing = _install_racing_server(monkeypatch, failure)
+
+    server = PolicyServer(policy_provider="mock", port=0)
+    server.start()
+    server.stop()
+
+    assert racing.serve_forever_calls == 1, "the accept loop never ran, so nothing was tested"
+    assert not escaped, f"stopping the server killed its serving thread: {escaped}"
+
+
+@pytest.mark.parametrize("failure", _TEARDOWN_FAILURES)
+def test_the_same_failure_without_a_stop_pending_still_propagates(
+    failure: BaseException, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A socket failure that is not a teardown is a real one and must surface.
+
+    This is the boundary: absorbing the exception whenever it matched a type
+    would hide a listening socket that failed on its own. Here the loop raises
+    with no stop in progress, so it has to reach the thread hook.
+    """
+    escaped = _collect_thread_exceptions(monkeypatch)
+    racing = _install_racing_server(monkeypatch, failure)
+
+    server = PolicyServer(policy_provider="mock", port=0)
+    server.start()
+    racing.shutdown()  # release the loop WITHOUT going through stop()
+    assert server._thread is not None
+    server._thread.join(timeout=5.0)
+
+    assert [name for name, _ in escaped] == [type(failure).__name__], (
+        f"a failure with no stop pending must reach the thread hook, got {escaped}"
+    )
+    server.stop()
+
+
+def test_a_stopped_server_can_be_started_again_and_still_absorbs_a_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stop marker must not latch, or the second run swallows real failures.
+
+    ``stop()`` sets the marker and nothing else clears it, so a restarted server
+    would treat any socket failure as a teardown. Restarting is a supported
+    sequence - ``stop()`` documents itself as safe to call twice and ``start()``
+    only refuses while a server is running.
+    """
+    escaped = _collect_thread_exceptions(monkeypatch)
+
+    first = _install_racing_server(monkeypatch, OSError(9, "Bad file descriptor"))
+    server = PolicyServer(policy_provider="mock", port=0)
+    server.start()
+    server.stop()
+    assert first.serve_forever_calls == 1
+    assert not escaped
+
+    second = _install_racing_server(monkeypatch, OSError(9, "Bad file descriptor"))
+    server.start()
+    second.shutdown()  # a real failure this time, no stop pending
+    assert server._thread is not None
+    server._thread.join(timeout=5.0)
+
+    assert [name for name, _ in escaped] == ["OSError"], (
+        f"after a restart a genuine socket failure must still surface, got {escaped}"
+    )
+    server.stop()
+
+
+def test_repeated_real_start_stop_cycles_leave_no_thread_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same guarantee end to end, against the real websockets server.
+
+    Nothing is stubbed here: this binds and tears down a real listening socket
+    the number of times needed to lose the race in practice.
+    """
+    pytest.importorskip("websockets.sync.server")
+    escaped = _collect_thread_exceptions(monkeypatch)
+
+    for _ in range(_CYCLES):
+        server = PolicyServer(policy_provider="mock", port=0)
+        server.start()
+        assert server.port > 0
+        server.stop()
+
+    assert not escaped, f"{len(escaped)} of {_CYCLES} start/stop cycles killed the serving thread: {escaped}"


### PR DESCRIPTION
## Problem

`PolicyServer.stop()` can kill the thread serving the server, and report nothing.

`start()` runs the websockets sync server's accept loop on a background thread.
`stop()` ends it by calling `shutdown()`, which closes the listening socket - from
the caller's thread, while the accept loop is still waiting on that same socket.
The sync server does not synchronize the two, so a stop that lands while the loop
is entering or polling raises straight out of `serve_forever()`.

It surfaces as **two different exceptions from the same call** -
`serve_forever()` registering the listening socket with its selector. `selectors`
reads `fileno()` to build its key and then hands the descriptor to `epoll_ctl`:

- a close landing **before** the read leaves `fileno()` at `-1` and raises
  `ValueError: Invalid file descriptor: -1`;
- a close landing **between** the read and `epoll_ctl` leaves a live-looking
  descriptor and raises `OSError: [Errno 9] Bad file descriptor`.

Which one appears depends on where in that call the close lands, not on the
websockets release. websockets 12.0 wraps the call in nothing, so both escape it;
13.0 through 17.x wrap it in `except ValueError: return`, which absorbs the first
shape and leaves the second. So a newer websockets narrows this race but does not
close it, and every supported release can produce the `OSError`.

Either way the serving thread dies, and nothing surfaces it: the thread is a
daemon, `stop()` returns normally, `_server` is cleared, and the server looks
cleanly shut down. Under pytest an unhandled thread exception is a *warning*, not
a failure - which is exactly how
`tests/inference/test_policy_server_lifecycle.py::test_stop_is_idempotent` stayed
green while the thread it started was crashing.

Measured on real sockets, `start()` then a prompt `stop()`:

| websockets | serving threads killed | shape observed |
| --- | --- | --- |
| 12.0 | 12 / 20 cycles | `ValueError: Invalid file descriptor: -1` |
| 17.0.1 (CI) | 3 / 12 cycles | `OSError: [Errno 9] Bad file descriptor` |

It is a race, so the counts vary run to run and with the machine - on one host the
newer releases did not lose it at all in 20 cycles while 12.0 lost it 12 times.
That variability is itself part of the problem: the failure is intermittent, silent,
and load-dependent.

![PolicyServer stop must not kill its serving thread](https://raw.githubusercontent.com/cagataycali/robots/media-websockets-floor-shutdown/policy-server-shutdown.png)

## Change

The accept loop now runs through one helper, `PolicyServer._run_accept_loop`,
which absorbs the failure **only while a stop is in progress** - a
`threading.Event` set by `stop()` before it closes the socket.

Keyed on the stop, not on the exception type, deliberately. Matching on the type
would do two wrong things: hide a listening socket that failed on its own, and
encode a release-to-exception mapping that is not true in the first place - one
call raises either shape depending on scheduling. Keyed on the stop, a socket
failure with no teardown pending still propagates unchanged, whatever its type.

Two details the fix has to get right:

- `start()` clears the flag, so a server that is stopped and started again does
  not inherit the previous teardown and start swallowing real failures. `stop()`
  documents itself as safe to call twice and `start()` only refuses while a server
  is running, so restarting is a supported sequence.
- The foreground `serve()` path goes through the same helper - it races `stop()`
  from another thread in exactly the same way.

The absorbed case logs at DEBUG with `exc_info`, so the teardown is still
inspectable without making a normal shutdown noisy.

## Tests

`tests/inference/test_policy_server_shutdown_does_not_kill_the_serving_thread.py`.
The race is reproduced **deterministically** rather than by hoping the scheduler
lands in the window: `start()` imports `serve` from `websockets.sync.server` at
call time, so the tests patch that attribute with a server whose `serve_forever`
blocks until `shutdown` releases it and then raises. Both observed exception
shapes are parametrized, and one real-socket test covers the whole path with
nothing stubbed.

They assert on `threading.excepthook`, not on the server's own state - the state
was always clean, which is why this went unnoticed.

| test | on `main` | with this change |
| --- | --- | --- |
| a teardown failure does not escape the serving thread `[ValueError]` | **fail** - `killed its serving thread: [('ValueError', 'Invalid file descriptor: -1')]` | pass |
| a teardown failure does not escape the serving thread `[OSError]` | **fail** - `[('OSError', '[Errno 9] Bad file descriptor')]` | pass |
| a stopped server can be started again and still absorbs a teardown | **fail** | pass |
| the same failure without a stop pending still propagates `[ValueError]` | pass | pass |
| the same failure without a stop pending still propagates `[OSError]` | pass | pass |
| repeated real start/stop cycles leave no thread exception | fail on websockets 12.0 (9/12), passes where the race is not lost | pass |

3 failed / 3 passed on `main`; 6 passed with the change. The two that pass on both
are the controls that pin the boundary: they are what fails if the guard is ever
widened to swallow by exception type, which would hide a genuine socket error.

## Verification

- `ruff check` / `ruff format --check` and `mypy` over
  `strands_robots tests tests_integ`: clean, no new findings.
- `tests/inference`: 124 passed (118 before, plus the 6 added here).
- Full `tests/`, this branch and `main` side by side on the same interpreter:
  identical failing-test sets, so no regressions.

## Note on scope

An earlier revision of this branch treated the 12.0 `ValueError` as a dependency
floor problem and raised `websockets>=12.0` to `>=13.0`. CI, which resolves 17.0.1,
showed that was the wrong diagnosis: the same stop kills the same thread there too.
`except ValueError: return` in 13.0 removes one of the two shapes the same call can
raise, so raising the floor narrows the window without closing it. The packaging
change is gone; this is the whole fix.
