### PR TITLE
fix(deps): name a remedy that can supply rclpy when the ROS 2 bridge refuses

### DIFF
--- a/changelog.d/2340-rclpy-refusal-names-a-working-remedy.md
+++ b/changelog.d/2340-rclpy-refusal-names-a-working-remedy.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Point the missing-`rclpy` refusal at the step that supplies it. `ros2_bridge=True`
+  without a sourced ROS 2 distro offered two remedies and neither worked: `pip install
+  'strands-robots[ros2]'` exits 0 having installed only the cyclonedds RMW binding, which
+  leaves `rclpy` exactly as missing, and `pip install rclpy` fails because `rclpy` is not
+  published on PyPI. `require_optional` gains `system_install=` for a module that arrives
+  with a system package rather than from an index, and the two `rclpy` sites now name
+  sourcing a distro - plus, where the caller can take it, the pure-RTPS transport that
+  publishes the same topics over the pip-installable cyclonedds binding.

--- a/docs/ros2-integration.md
+++ b/docs/ros2-integration.md
@@ -181,10 +181,12 @@ ros2 topic list | grep so101          # /so101/joint_states, /so101/<cam>/image_
 ros2 topic echo /so101/joint_states   # live joint positions, updated every step
 ```
 
-`rclpy` is an optional, system-provided dependency (the `[ros2]` extra). When it
-is missing, `ros2_bridge=True` raises a clear `ImportError` at construction;
-`ros2_bridge=False` (the default) never touches ROS 2, so the base sim install
-stays lightweight. The bridge node is torn down cleanly on `destroy()`.
+`rclpy` is an optional, system-provided dependency: it arrives with a sourced ROS
+2 distro, not with the `[ros2]` extra (which installs only the cyclonedds RMW
+binding, as above). When it is missing, `ros2_bridge=True` raises an `ImportError`
+at construction naming the `source /opt/ros/<distro>/setup.bash` step that
+supplies it; `ros2_bridge=False` (the default) never touches ROS 2, so the base
+sim install stays lightweight. The bridge node is torn down cleanly on `destroy()`.
 
 See `examples/ros2/sim_bridge_demo.py` for a runnable end-to-end script.
 
@@ -256,7 +258,10 @@ ros2 topic echo /so101/joint_states   # live joint positions from the real arm
 The bridge is **opt-in**: `ros2_bridge=False` (the default) never touches ROS 2,
 so a robot only becomes a ROS 2 device when an operator explicitly asks for it -
 the same safety stance as `Robot(mode="sim")` being the default. When `rclpy` is
-missing, `ros2_bridge=True` raises a clear `ImportError` at construction. The
+missing, `ros2_bridge=True` raises an `ImportError` at construction naming both
+routes forward: sourcing a ROS 2 distro, or `ros2_transport="rtps"`, which
+publishes the same topics over the pip-installable cyclonedds binding and needs
+no distro at all. The
 inbound command path is on by default (`ros2_commands=True`); set
 `ros2_commands=False` for a read-only telemetry bridge that publishes but cannot
 be driven. A daemon thread spins the node so inbound commands are serviced

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -36,6 +36,7 @@ from strands.tools.tools import AgentTool
 from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
+from strands_robots.ros_telemetry import ROS2_SYSTEM_INSTALL_HINT
 from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
     dds_domain_id_error,
@@ -52,6 +53,21 @@ if TYPE_CHECKING:
     from .policies import Policy
 
 logger = logging.getLogger(__name__)
+
+
+# Remedy for a missing ``rclpy`` when the caller asked for the rclpy transport.
+# The shared hint names the step that supplies rclpy; this adds the alternative
+# only a Robot can take, because ``ros2_transport`` is the caller's choice: the
+# pure-RTPS bridge publishes the same topics (both transports share the wire
+# contract in ``RosTelemetryBase``) over cyclonedds, which is a pip wheel, so it
+# is the one route here the ``[ros2]`` extra really does complete.
+_RCLPY_TRANSPORT_INSTALL_HINT = (
+    f"{ROS2_SYSTEM_INSTALL_HINT}\n"
+    "Or select the pure-RTPS transport, which publishes the same topics and "
+    "needs no sourced distro:\n"
+    "  pip install 'strands-robots[ros2]'\n"
+    "  Robot(..., ros2_bridge=True, ros2_transport='rtps')"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -566,9 +582,9 @@ class Robot(TeleopMixin, AgentTool):
         # Validate the ROS 2 bridge precondition (transport + its optional
         # dependency) BEFORE _initialize_robot imports lerobot. Otherwise, in an
         # environment without the [lerobot] extra, _initialize_robot raises a
-        # lerobot ImportError first and masks the documented
-        # "pip install 'strands-robots[ros2]'" hint that the operator who set
-        # ros2_bridge=True actually needs to see. require_optional caches the
+        # lerobot ImportError first and masks the transport-specific install
+        # hint that the operator who set ros2_bridge=True actually needs to see.
+        # require_optional caches the
         # module, so the real bridge construction in _init_ros_bridge pays nothing.
         if ros2_bridge:
             self._check_ros2_bridge_deps(ros2_transport=ros2_transport)
@@ -621,10 +637,12 @@ class Robot(TeleopMixin, AgentTool):
 
         Called from ``__init__`` BEFORE ``_initialize_robot`` (which imports
         lerobot) so that, when ``ros2_bridge=True``, an invalid transport or a
-        missing ``rclpy`` / ``cyclonedds`` surfaces its documented
-        ``pip install 'strands-robots[ros2]'`` error immediately - rather than
-        being masked by the lerobot ImportError ``_initialize_robot`` raises
-        first in an environment without the ``[lerobot]`` extra.
+        missing backend dependency surfaces its own remedy immediately - rather
+        than being masked by the lerobot ImportError ``_initialize_robot`` raises
+        first in an environment without the ``[lerobot]`` extra. The two
+        transports need different remedies: ``cyclonedds`` is a pip wheel the
+        ``[ros2]`` extra installs, while ``rclpy`` comes from a sourced ROS 2
+        distro, so only the RTPS branch can name an extra.
         ``require_optional`` caches the resolved module, so constructing the
         real bridge later in ``_init_ros_bridge`` costs nothing extra.
 
@@ -644,7 +662,11 @@ class Robot(TeleopMixin, AgentTool):
                 purpose="the pure-RTPS hardware bridge (Robot ros2_transport='rtps')",
             )
         else:
-            require_optional("rclpy", extra="ros2", purpose="the ROS 2 telemetry bridge (ros2_bridge=True)")
+            require_optional(
+                "rclpy",
+                system_install=_RCLPY_TRANSPORT_INSTALL_HINT,
+                purpose="the ROS 2 telemetry bridge (ros2_bridge=True)",
+            )
 
     def _init_ros_bridge(
         self,

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -39,6 +39,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+#: Remedy for a missing ``rclpy``, shared by every surface that refuses for want
+#: of it. ``rclpy`` is not published on PyPI: it arrives with a system ROS 2
+#: install, which is why the ``[ros2]`` extra declares only the pip-installable
+#: cyclonedds RMW binding (see ``pyproject.toml`` and ``docs/ros2-integration.md``).
+#: An install hint naming a pip command for it is therefore a remedy the caller
+#: can follow to no effect - ``pip install 'strands-robots[ros2]'`` exits 0 with
+#: ``rclpy`` exactly as missing, and ``pip install rclpy`` fails outright - so
+#: this names the step that does supply it. Callers that also offer the pure-RTPS
+#: transport append that alternative, which needs no sourced distro.
+ROS2_SYSTEM_INSTALL_HINT = (
+    "rclpy is not published on PyPI - it ships with a system ROS 2 install "
+    "(apt / RoboStack / conda).\n"
+    "Source a distro in the shell that launches this process:\n"
+    "  source /opt/ros/jazzy/setup.bash   # or your distro / RoboStack / conda env\n"
+    "The [ros2] extra installs only the cyclonedds RMW binding; it does not "
+    "provision ROS 2 by itself."
+)
+
+
 #: Env var an operator sets to explicitly run an INBOUND ``joint_command``
 #: surface on an unsecured DDS graph (no ``dds_security_config``). Truthy values
 #: mirror the mesh insecure opt-out (``STRANDS_MESH_I_KNOW_THIS_IS_INSECURE``):
@@ -382,7 +401,9 @@ class RosTelemetryBridge(RosTelemetryBase):
         os.environ["ROS_DOMAIN_ID"] = str(domain_id)
 
         rclpy_mod: Any = require_optional(
-            "rclpy", extra="ros2", purpose="the ROS 2 telemetry bridge (ros2_bridge=True)"
+            "rclpy",
+            system_install=ROS2_SYSTEM_INSTALL_HINT,
+            purpose="the ROS 2 telemetry bridge (ros2_bridge=True)",
         )
         sensor_msgs: Any = require_optional(
             "sensor_msgs.msg", pip_install="ros-<distro>-sensor-msgs", purpose="the ROS 2 telemetry bridge"

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -21,6 +21,7 @@ def require_optional(
     pip_install: str | None = None,
     extra: str | None = None,
     purpose: str = "",
+    system_install: str | None = None,
 ) -> object:
     """Import an optional dependency, raising a clear error if missing.
 
@@ -31,6 +32,13 @@ def require_optional(
         pip_install: Explicit pip package name if it differs from *module_name*.
         extra: ``pyproject.toml`` extras group (e.g. ``"groot-service"``).
         purpose: Human-readable description shown in the error message.
+        system_install: Remedy for a module that arrives with a system package
+            rather than from an index - the ROS 2 client libraries are the case
+            in this package. Replaces the ``pip install`` block entirely, and
+            *pip_install* / *extra* are then not consulted, because a pip
+            command for such a module is a remedy the caller can follow to no
+            effect: it either installs something that leaves the module exactly
+            as missing, or fails outright.
 
     Returns:
         The imported module object.
@@ -46,14 +54,19 @@ def require_optional(
         _lazy_modules[module_name] = module
         return module
     except ImportError:
-        install_hint = pip_install or module_name
         parts = [f"'{module_name}' is required"]
         if purpose:
             parts[0] += f" for {purpose}"
-        parts.append("Install with:")
-        if extra:
-            parts.append(f"  pip install 'strands-robots[{extra}]'")
-        parts.append(f"  pip install {install_hint}")
+        if system_install is not None:
+            # No pip line at all: naming one here would hand the caller an
+            # instruction that reports success without supplying the module.
+            parts.append(system_install)
+        else:
+            install_hint = pip_install or module_name
+            parts.append("Install with:")
+            if extra:
+                parts.append(f"  pip install 'strands-robots[{extra}]'")
+            parts.append(f"  pip install {install_hint}")
         raise ImportError("\n".join(parts)) from None
 
 

--- a/tests/test_dependency_audit.py
+++ b/tests/test_dependency_audit.py
@@ -1102,3 +1102,146 @@ def test_the_lockfile_pins_a_diffusers_that_ships_the_omni_pipeline() -> None:
             f"uv.lock pins diffusers {version}, which ships no Cosmos3OmniPipeline; "
             f"run `uv lock` after raising the floor"
         )
+
+
+# ---------------------------------------------------------------------------
+# Naming an extra that exists is not the same as naming one that supplies the
+# module.
+#
+# The guard above pins that every `require_optional(extra=...)` names a declared
+# extra. `[ros2]` is declared, so `require_optional("rclpy", extra="ros2")`
+# passed it -- and still emitted a refusal whose every line was a dead end:
+#
+#     'rclpy' is required for the ROS 2 telemetry bridge (ros2_bridge=True)
+#     Install with:
+#       pip install 'strands-robots[ros2]'
+#       pip install rclpy
+#
+# `pip install 'strands-robots[ros2]'` exits 0 having installed only the
+# cyclonedds RMW binding, leaving rclpy exactly as missing -- verbatim the
+# failure mode the comment above describes, an install that reported success and
+# changed nothing. `pip install rclpy` fails outright ("No matching distribution
+# found for rclpy"). So the operator who asked for `ros2_bridge=True` was handed
+# two instructions and no way forward, while pyproject.toml, the `[ros2]` block
+# in docs/ros2-integration.md, the `ros_telemetry` module docstring and the
+# `use_ros` tool's own hint all already stated the remedy that works: source a
+# system ROS 2 distro.
+#
+# pyproject.toml names the libraries this applies to verbatim -- "rclpy /
+# rosidl_runtime_py ... are NOT distributed on PyPI ... and cannot be `pip
+# install`ed" -- so the inventory below records that statement rather than making
+# a new judgement. `sensor_msgs` is deliberately absent: its hint is the template
+# `ros-<distro>-sensor-msgs`, and `ros-jazzy-sensor-msgs` does resolve on PyPI,
+# so that hint is a hole for the reader to fill, not a dead end.
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROVIDED_MODULES = frozenset({"rclpy", "rosidl_runtime_py"})
+
+
+def _require_optional_call_sites() -> list[tuple[str, int, str, set[str]]]:
+    """Every ``require_optional``/``require_optionals`` call site in the package.
+
+    Returns:
+        One ``(relative path, line number, module name, keyword names)`` tuple
+        per requested module -- the aggregate helper takes a list, so a single
+        call can request several.
+    """
+    sites: list[tuple[str, int, str, set[str]]] = []
+    for path in sorted((_REPO_ROOT / "strands_robots").rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name not in {"require_optional", "require_optionals"} or not node.args:
+                continue
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                modules = [first.value]
+            elif isinstance(first, ast.List | ast.Tuple):
+                modules = [e.value for e in first.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+            else:
+                continue
+            keywords = {kw.arg for kw in node.keywords if kw.arg}
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            sites.extend((rel, node.lineno, module, keywords) for module in modules)
+    return sites
+
+
+def test_require_optional_offers_no_pip_remedy_for_a_system_provided_module() -> None:
+    """A module pip cannot supply must be refused with ``system_install=``.
+
+    ``pip_install``/``extra`` both render a ``pip install`` line, and for these
+    libraries every such line is an instruction the caller can follow to no
+    effect. ``system_install`` replaces the block with the step that does supply
+    the module, so passing it is what makes the refusal actionable.
+    """
+    offenders: list[str] = []
+    checked = 0
+    for rel, lineno, module, keywords in _require_optional_call_sites():
+        if module.split(".")[0] not in _SYSTEM_PROVIDED_MODULES:
+            continue
+        checked += 1
+        pip_remedies = sorted(keywords & {"pip_install", "extra"})
+        if pip_remedies:
+            offenders.append(f"{rel}:{lineno} requests {module!r} but passes {', '.join(pip_remedies)}")
+        elif "system_install" not in keywords:
+            offenders.append(f"{rel}:{lineno} requests {module!r} with no system_install= remedy")
+    assert checked, (
+        f"no require_optional site requests any of {sorted(_SYSTEM_PROVIDED_MODULES)}; "
+        f"the sweep has stopped seeing them and would pass vacuously"
+    )
+    assert not offenders, (
+        "these sites refuse for want of a library that ships with a system ROS 2 install and is "
+        "not on PyPI, yet hand the caller a pip command: an extra that installs something else "
+        "and exits 0, or a distribution name that does not resolve. Pass "
+        "system_install=ROS2_SYSTEM_INSTALL_HINT instead.\n" + "\n".join(offenders)
+    )
+
+
+def test_the_rclpy_refusals_name_the_step_that_supplies_it() -> None:
+    """Both rclpy refusals must point at sourcing a distro, not at installing it.
+
+    Asserted on the messages the two production sites really raise, with the
+    import forced to fail so the check holds whether or not the interpreter
+    running the suite happens to have a ROS 2 distro sourced.
+    """
+    from strands_robots import utils
+
+    class _BlockRclpy:
+        """Meta-path finder that makes ``import rclpy`` fail."""
+
+        def find_spec(self, name: str, path: object = None, target: object = None) -> None:
+            """Refuse ``rclpy`` and defer every other name to the real finders."""
+            if name == "rclpy" or name.startswith("rclpy."):
+                raise ImportError("rclpy blocked for this test")
+            return None
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(sys, "meta_path", [_BlockRclpy(), *sys.meta_path])
+        # A fresh cache, restored on exit: require_optional short-circuits on a
+        # module it has already resolved.
+        patch.setattr(utils, "_lazy_modules", {})
+
+        from strands_robots.hardware_robot import Robot
+        from strands_robots.ros_telemetry import RosTelemetryBridge
+
+        messages = {}
+        with pytest.raises(ImportError) as bridge_error:
+            RosTelemetryBridge(domain_id=0)
+        messages["RosTelemetryBridge()"] = str(bridge_error.value)
+        with pytest.raises(ImportError) as robot_error:
+            Robot._check_ros2_bridge_deps(ros2_transport="rclpy")
+        messages["Robot(ros2_bridge=True)"] = str(robot_error.value)
+
+    for label, message in messages.items():
+        assert "source /opt/ros/" in message, f"{label} names no way to obtain rclpy:\n{message}"
+        assert "pip install rclpy" not in message, (
+            f"{label} tells the caller to install a distribution that does not exist:\n{message}"
+        )
+        assert "Install with:\n  pip install 'strands-robots[ros2]'" not in message, (
+            f"{label} leads with an extra that installs the cyclonedds binding and leaves rclpy missing:\n{message}"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,56 @@ class TestRequireOptional:
         mod = require_optional("os.path")
         assert hasattr(mod, "join")
 
+    def test_system_install_replaces_the_pip_block(self):
+        """A system-provided module must be refused with its own remedy, no pip line.
+
+        Some modules arrive with a system package and are absent from PyPI, so any
+        ``pip install`` line is an instruction the caller can follow to no effect.
+        ``system_install`` is the way to say that, and it has to leave the message
+        with no pip command at all.
+        """
+        with pytest.raises(ImportError) as excinfo:
+            require_optional(
+                "nonexistent_xyz",
+                purpose="testing",
+                system_install="Source a distro:\n  source /opt/ros/jazzy/setup.bash",
+            )
+        message = str(excinfo.value)
+        assert "'nonexistent_xyz' is required for testing" in message
+        assert "source /opt/ros/jazzy/setup.bash" in message
+        assert "pip install" not in message
+        assert "Install with:" not in message
+
+    def test_system_install_wins_over_a_pip_remedy(self):
+        """Neither ``extra`` nor ``pip_install`` may leak back into the message.
+
+        A caller migrating a site is likely to leave the old arguments in place;
+        emitting both would put the dead-end command back in front of the reader
+        next to the one that works.
+        """
+        with pytest.raises(ImportError) as excinfo:
+            require_optional(
+                "nonexistent_xyz",
+                pip_install="not-a-real-distribution",
+                extra="my-extra",
+                system_install="Source a distro first.",
+            )
+        message = str(excinfo.value)
+        assert message.endswith("Source a distro first.")
+        assert "not-a-real-distribution" not in message
+        assert "my-extra" not in message
+
+    def test_pip_block_is_unchanged_without_system_install(self):
+        """Omitting ``system_install`` must leave the pip remedy exactly as it was."""
+        with pytest.raises(ImportError) as excinfo:
+            require_optional("nonexistent_xyz", purpose="testing", extra="my-extra", pip_install="my-package")
+        assert str(excinfo.value) == (
+            "'nonexistent_xyz' is required for testing\n"
+            "Install with:\n"
+            "  pip install 'strands-robots[my-extra]'\n"
+            "  pip install my-package"
+        )
+
 
 # safe_join / get_search_paths tests (added for PR #84 follow-up)
 


### PR DESCRIPTION
## Problem

With no ROS 2 distro sourced, `Robot("so101", mode="real", ros2_bridge=True)` (and the
sim/hardware `RosTelemetryBridge` behind it) refuses like this:

```
'rclpy' is required for the ROS 2 telemetry bridge (ros2_bridge=True)
Install with:
  pip install 'strands-robots[ros2]'
  pip install rclpy
```

Every line offered is a dead end.

| Offered remedy | What actually happens |
|---|---|
| `pip install 'strands-robots[ros2]'` | Exits 0. Installs the cyclonedds RMW binding. `rclpy` is exactly as missing as before. |
| `pip install rclpy` | `ERROR: No matching distribution found for rclpy` - it is not published on PyPI. |

So an operator who explicitly asked for `ros2_bridge=True` gets two instructions and no
way forward, and the first one is the worse kind: it reports success and changes nothing
relevant, which is verbatim the failure mode `tests/test_dependency_audit.py` already
describes for a misnamed extra.

The remedy that works was already written down in four places, none of them this message:

- `pyproject.toml`, on the `[ros2]` extra: "Those core client libraries are NOT distributed
  on PyPI - they ship with the system ROS 2 install (apt / RoboStack / conda) and cannot be
  `pip install`ed. ... Installing this extra does NOT by itself provision ROS 2 - source a
  real distro first."
- `docs/ros2-integration.md`: "The `[ros2]` extra ... only pulls the pip-installable
  `cyclonedds` DDS RMW binding. It does **not** provision ROS 2 by itself."
- The `strands_robots.ros_telemetry` module docstring: "`rclpy` and the ROS 2 message
  packages are optional, system-provided dependencies (they are not on PyPI)".
- `use_ros`, whose own hint reads "source a ROS 2 distro before launching the agent
  (e.g. `source /opt/ros/jazzy/setup.bash`) ... not on PyPI".

`test_require_optional_call_sites_name_declared_extras` pins that `extra=` names a
*declared* extra. `[ros2]` is declared, so the site passed - existing is not the same as
supplying the module, and that is the level that was never checked.

## Change

`require_optional` could not express a non-pip remedy: `pip_install` and `extra` each render
a `pip install` line. It gains `system_install=`, which replaces the pip block for a module
that arrives with a system package; `pip_install`/`extra` are then not consulted, so a
half-migrated call site cannot put the dead-end command back next to the working one.

The two `rclpy` sites (`hardware_robot._check_ros2_bridge_deps`, `RosTelemetryBridge.__init__`)
route through one shared `ROS2_SYSTEM_INSTALL_HINT`. The hardware site appends the
alternative only a `Robot` can take, because `ros2_transport` is the caller's choice there:
the pure-RTPS bridge publishes the same topics (both transports share the wire contract in
`RosTelemetryBase`) over cyclonedds, a pip wheel - the one route here that `[ros2]` really
does complete.

After:

```
'rclpy' is required for the ROS 2 telemetry bridge (ros2_bridge=True)
rclpy is not published on PyPI - it ships with a system ROS 2 install (apt / RoboStack / conda).
Source a distro in the shell that launches this process:
  source /opt/ros/jazzy/setup.bash   # or your distro / RoboStack / conda env
The [ros2] extra installs only the cyclonedds RMW binding; it does not provision ROS 2 by itself.
Or select the pure-RTPS transport, which publishes the same topics and needs no sourced distro:
  pip install 'strands-robots[ros2]'
  Robot(..., ros2_bridge=True, ros2_transport='rtps')
```

`docs/ros2-integration.md` also contradicted itself: two sections attributed `rclpy` to the
`[ros2]` extra while a third said that extra does not provision ROS 2. Both now say where
`rclpy` comes from and what the ImportError names.

## Scope, bounded by measurement

A sweep of all 40 `require_optional` module requests against PyPI found exactly one family
whose hints resolve to nothing:

- `sensor_msgs.msg` keeps its `ros-<distro>-sensor-msgs` hint: `ros-jazzy-sensor-msgs` does
  resolve on PyPI, so that is a template for the reader to fill, not a dead end.
- `curobo` and `motionbricks` keep theirs: `pip install -e git+...` and
  `pip install -e <path>` are runnable commands.
- Naming a third-party `ros-<distro>-rclpy` wheel would be a supply-chain endorsement (and
  no such name exists for humble or rolling), so this PR does not.

The regression guard's inventory is therefore just the two names pyproject already calls out
(`rclpy`, `rosidl_runtime_py`), not a new judgement.

## Tests

`tests/test_dependency_audit.py`, beside the guard that pins `extra=` names an extra that exists:

- `test_require_optional_offers_no_pip_remedy_for_a_system_provided_module` - AST sweep;
  a site requesting one of those libraries must pass `system_install=` and neither
  `pip_install` nor `extra`. Has a premise assert so it cannot pass vacuously.
- `test_the_rclpy_refusals_name_the_step_that_supplies_it` - asserts on the messages the two
  production sites really raise, with `import rclpy` forced to fail through a meta-path
  finder so the check holds whether or not the interpreter has a distro sourced.

`tests/test_utils.py`: `system_install` replaces the pip block; it wins over
`pip_install`/`extra`; and the pip block is byte-identical without it.

Pre-fix vs post-fix on the same files (`upstream/main` + these test files only):

| | pre-fix | post-fix |
|---|---|---|
| failed | 4 | 0 |
| passed | 92 | 96 |

The 4 pre-fix failures name both offending sites and both dead-end lines. The passes include
`test_pip_block_is_unchanged_without_system_install`, which holds on both trees - the
no-overreach control for the ~38 sites that legitimately do name a pip remedy.

## Refusal, before and after

Both panels are the real ImportError from one script run twice, same environment, only
`strands_robots` differing.

![rclpy install hint, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-rclpy-hint-31962445144/rclpy-install-hint.png)

## Full suite

`pytest tests` on this branch and on `upstream/main`, same interpreter, run in parallel:
37 failed / 24 errors on both, and the two sorted failing-id sets are identical (`comm`
empty in both directions). Passed count 30388 vs 30383, i.e. exactly the 5 tests added
here. `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests
tests_integ` (mypy reports the same 18 pre-existing errors on both trees).
