### PR TITLE
docs(agents): a batch no longer leaves its intermediate commits untested

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -984,9 +984,24 @@ hatch run format            # ruff check --fix, ruff format
    Then confirm the tree you verified is the tree that landed -
    `git diff --name-only <local-composition> origin/main -- strands_robots/ tests/`
    should be empty. Squash rewrites the commits, so nothing but that equivalence
-   ties your local run to `main`; and on a batch, where only the tip's
-   `call-test-lint` survives the concurrency group above, it is the sole evidence
-   the intermediate commits were ever compiled together.
+   ties your local run to `main`.
+
+   **On a batch that equivalence is still the check to run, but no longer because
+   the intermediate commits go untested - they do not.** Since the push
+   concurrency group keys on `github.sha` (above), every commit in a batch runs
+   its own suite to completion, and a commit on `main` carries merges 1..N of the
+   batch, so its own green *is* a verdict on the partial composition it is.
+   Measured on the six merges that took `main` from `239f24ab` to `0d811084` in
+   about 53 seconds - #2320, #2327, #2329, #2333, #2334, #2335 - all six report
+   `call-test-lint / Test and Lint` `success`, where before #2304 only the tip's
+   would have survived. What the equivalence buys instead is the whole batch in
+   one read: the tree-sha comparison below is scoped to `behind_by == 0`, and in
+   a batch only the *first* pull request can satisfy that - every later one is
+   behind by the merges ahead of it, so its squash tree differs from its head
+   tree for entirely correct reasons and the comparison does not apply at all.
+   Diffing the composition against the final tip is the one form that answers for
+   all N at once, and dropping the path scoping costs nothing and catches more
+   (that batch's unscoped diff was empty too).
 
    **Comparing the two commits' tree shas is the same claim without the clone,
    and a stronger one.** That `git diff` needs the local composition to still

--- a/changelog.d/2341-batch-intermediate-commits-are-tested.md
+++ b/changelog.d/2341-batch-intermediate-commits-are-tested.md
@@ -1,0 +1,13 @@
+### Docs: a batch no longer leaves its intermediate commits untested
+
+`AGENTS.md` > PR Workflow > step 8 told a maintainer that only the tip's
+`call-test-lint` survives a batch, making the composition equivalence the sole
+evidence the intermediate commits were ever compiled together. That predates the
+push-concurrency fix, and the section above it already documents the group
+keying on `github.sha` so each pushed commit runs its own suite to completion -
+so the file contradicted itself on whether a commit mid-batch has a verdict.
+Measured on the six merges taking `main` from `239f24ab` to `0d811084`, all six
+report `call-test-lint` `success`. The equivalence check stays, with the reason
+corrected: it is the one form covering a whole batch, because the tree-sha
+comparison below it is scoped to `behind_by == 0` and only the first pull
+request in a batch can satisfy that.


### PR DESCRIPTION
## What

One stale clause in `AGENTS.md` > PR Workflow > step 8. The batch paragraph says:

> and on a batch, where only the tip's `call-test-lint` survives the concurrency group above, it is the sole evidence the intermediate commits were ever compiled together.

That was true before the push-concurrency fix and is not true now. **The section directly above it already documents the fix** -- "The group now keys on `github.sha`, so each pushed commit gets its own group and runs its own suite to completion" -- so as written the file contradicts itself, roughly 400 lines apart, on the one question a maintainer asks in the middle of a batch: *did the commit I just pushed actually get tested?*

## Why it matters

The two readings prescribe opposite amounts of work. If only the tip is tested, an intermediate commit has no verdict, and the careful response is to distrust a batch -- merge serially, or hand-verify each step. That is a real cost, and it is paid in the diligent direction, which is the shape this file repeatedly warns is the expensive one to get wrong. The clause is also load-bearing for a decision the file actively encourages elsewhere ("A batch is still defensible on the same grounds as before").

## Evidence

Measured on a six-merge batch that took `main` from `239f24ab` to `0d811084` in about 53 seconds -- #2320, #2327, #2329, #2333, #2334, #2335. Every commit ran its own suite to completion:

| commit | PR | `call-test-lint / Test and Lint` |
|---|---|---|
| `8349f8be` | #2320 | success |
| `4f86f787` | #2327 | success |
| `51296985` | #2329 | success |
| `7b43b35f` | #2333 | success |
| `4cc19823` | #2334 | success |
| `0d811084` | #2335 | success |

Six for six, where the stale clause predicts one. Each of those commits carries merges 1..N of the batch, so its own green is a verdict on the partial composition it *is* -- which is strictly more than the clause claims exists.

## What replaces it

The equivalence check is still the right thing to run on a batch, so this does not delete the advice -- it corrects the reason, which is the part that decides what a reader does next. What the composition diff uniquely buys now is **coverage of the whole batch in one read**, because the tree-sha comparison immediately below it is scoped to `behind_by == 0` and in a batch only the *first* pull request can satisfy that: every later one is behind by the merges ahead of it, so its squash tree differs from its head tree for entirely correct reasons and the comparison does not apply at all. (In the batch above not even the first qualified -- #2320 was `behind_by=1` at merge.)

Also noted: dropping the path scoping costs nothing and catches more. That batch's unscoped `git diff --name-only <composition> origin/main` was empty across every path, not just `strands_robots/` and `tests/`, which is the stronger claim for free.

## Scope

One paragraph in one file. `+18/-3`, no behaviour change.

No new test: the claim corrected here is a property of GitHub's scheduling, not of this tree, and the mechanism it now points at is already pinned by `tests/test_push_concurrency_group.py`. The 99 existing tests that assert on `AGENTS.md` content all pass -- `test_composition_run_precondition.py` (29), `test_timeline_filter_count_is_unfiltered.py` (29), `test_merge_mutation_error_is_not_a_verdict.py` (22), `test_push_concurrency_group.py` (8), `test_pull_request_trigger_types.py` (7), `test_merge_gate_viewer_scope.py` (4).

A changelog fragment follows in a second commit, since the convention names it after this PR's number.