### PR TITLE
fix(deps): raise the websockets floor to the release that ships the name the server imports

### DIFF
--- a/changelog.d/2342-websockets-floor-ships-the-server-name.md
+++ b/changelog.d/2342-websockets-floor-ships-the-server-name.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **deps**: `[inference]` and `[cosmos3-service]` now require `websockets>=13.0`. Both declared `>=12.0`, but `strands_robots/inference/server.py` annotates `PolicyServer._server` with `websockets.sync.server.Server`, a name that first ships in 13.0 (12.0 spells the class `WebSocketServer`). The import is under `TYPE_CHECKING`, so a 12.0 install serves correctly at runtime and only fails type checking, reporting the missing attribute rather than the too-old dependency. `tests/test_websockets_floor_ships_the_imported_api.py` now derives the required floor from a measured table of every websockets name the sources reach for, so a future use of a newer API cannot leave the floor behind.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,7 +15,7 @@ Requires **Python >= 3.12**. Examples use [`uv`](https://docs.astral.sh/uv/) (`c
 | `[sim-mujoco]` | `sim` + `mujoco`, `imageio`, `imageio-ffmpeg` | Any `Robot()` with default `mode="sim"` |
 | `[lerobot]` | `lerobot>=0.6.1,<0.7.0` | `LerobotLocalPolicy` + dataset recording |
 | `[groot-service]` | `pyzmq`, `msgpack` | `Gr00tPolicy` (ZMQ to a GR00T container) |
-| `[cosmos3-service]` | `msgpack`, `websockets` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
+| `[cosmos3-service]` | `msgpack`, `websockets>=13.0` | `Cosmos3Policy` (WebSocket to Cosmos 3 server) |
 | `[mesh]` | `eclipse-zenoh`, `json5` | Multi-robot mesh discovery + RPC |
 | `[mesh-iot]` | `mesh` + `awsiotsdk`, `awscrt`, `boto3` | AWS IoT Core transport for mesh |
 | `[benchmark-libero]` | `libero` eval deps | LIBERO benchmark suite |
@@ -36,6 +36,13 @@ MJCF and meshes, and that package gains one module per newly packaged robot.
 registered robot - on an older one, robots such as `so100` and `so101` have no
 module to import and no fallback, so `Robot("so101", mode="sim")` cannot resolve
 a model file.
+
+The `websockets` floor in `[inference]` and `[cosmos3-service]` is set the same
+way. `strands_robots/inference/server.py` annotates `PolicyServer._server` with
+`websockets.sync.server.Server`, which first ships in websockets 13.0 - 12.0
+spells that class `WebSocketServer`. Both extras declare `>=13.0`, and they
+declare the *same* floor on purpose: an environment resolves one `websockets`, so
+two different floors would leave the lower one describing an install nobody gets.
 
 ## Platform notes
 

--- a/docs/inference/remote.md
+++ b/docs/inference/remote.md
@@ -23,11 +23,13 @@ hardware control loop - a remote one works too.
 ## Install
 
 ```bash
-pip install 'strands-robots[inference]'   # pulls websockets (numpy-agnostic)
+pip install 'strands-robots[inference]'   # pulls websockets>=13.0 (numpy-agnostic)
 ```
 
 The extra depends only on `websockets`, so it composes cleanly with `lerobot`
-(`numpy>=2`) in the same environment.
+(`numpy>=2`) in the same environment. The `>=13.0` floor is the release that
+first ships `websockets.sync.server.Server`, the class this module annotates
+`PolicyServer._server` with; 12.0 spells it `WebSocketServer`.
 
 ## 1. Start the server (GPU box)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,13 @@ cosmos3-service = [
     # extra numpy-version agnostic so it composes cleanly with `lerobot`
     # (numpy>=2) for dataset recording in the same env.
     "msgpack>=1.0.0,<2.0.0",
-    "websockets>=12.0",
+    # >=13.0 is the floor of the websockets API the package reaches for, not a
+    # preference: `websockets.sync.server.Server` (annotating
+    # PolicyServer._server) first ships in 13.0 - 12.0 spells that class
+    # `WebSocketServer`. One environment resolves one websockets, so this floor
+    # and [inference]'s are deliberately the same number. Owned and measured by
+    # tests/test_websockets_floor_ships_the_imported_api.py.
+    "websockets>=13.0",
 ]
 # In-process Cosmos 3 backend (Cosmos3Policy(backend="diffusers")). Loads the
 # Cosmos3OmniPipeline directly via native Hugging Face `diffusers` (no RoboLab
@@ -469,7 +475,9 @@ ollama = [
 # (numpy-version agnostic, so it composes with lerobot's numpy>=2). See
 # strands_robots/inference/ and docs/inference/remote.md.
 inference = [
-    "websockets>=12.0",
+    # See [cosmos3-service]: >=13.0 is where `websockets.sync.server.Server`
+    # first ships, and both extras must declare the same floor.
+    "websockets>=13.0",
 ]
 # rosbridge WebSocket transport: drive ROS1 (or remote ROS 2) robots from a host
 # with no ROS install at all. Pure-pip `roslibpy` speaks the rosbridge JSON

--- a/tests/test_websockets_floor_ships_the_imported_api.py
+++ b/tests/test_websockets_floor_ships_the_imported_api.py
@@ -1,0 +1,268 @@
+"""The declared websockets floor must ship the websockets API the package imports.
+
+``strands_robots/inference/server.py`` annotates ``PolicyServer._server`` with
+``websockets.sync.server.Server``::
+
+    if TYPE_CHECKING:
+        from websockets.sync.server import Server, ServerConnection
+    ...
+        self._server: Server | None = None
+
+websockets 12.0 has no such name - it spells that class ``WebSocketServer``, and
+``Server`` first appears in 13.0. Both ``[inference]`` and ``[cosmos3-service]``
+declared ``websockets>=12.0``, so the manifest described an install in which the
+package's own annotation does not resolve. Measured against the released wheels
+(``Server`` is the only name above the 12.0 line):
+
+===========  ==================================================
+release      names missing of the nine the sources reach for
+===========  ==================================================
+11.0.3       ``websockets.sync.server.Server``
+12.0         ``websockets.sync.server.Server``
+13.0         none
+13.1 - 17.x  none
+===========  ==================================================
+
+Nothing caught it because the import lives under ``TYPE_CHECKING`` and is never
+executed: on 12.0 the package imports, binds a port, serves and stops cleanly.
+Only a type checker notices, and it reports the dependency by name -
+``error: Module "websockets.sync.server" has no attribute "Server"
+[attr-defined]`` - so a 12.0 environment fails the type gate for a reason no
+source change can fix. CI type-checks the locked resolve (16.0 today), never the
+declared floor, and nothing compared what the manifest admits against what the
+sources import.
+
+:data:`_WEBSOCKETS_SYMBOL_FLOORS` is the single owner of the measurement. The
+tests below derive the required floor from it rather than restating a number, and
+:meth:`TestTheFloorIsSelfMaintaining.test_every_websockets_import_has_a_recorded_floor`
+fails the moment the package reaches for a websockets name that is not in the
+table - so a future use of a newer websockets API cannot silently leave the floor
+behind.
+
+No upper bound is asserted. Capping ``websockets`` narrows every consumer's
+resolve and is a separate call from correcting a floor that is measurably wrong;
+the table above records the releases that were probed, not a supported range.
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+import strands_robots
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PACKAGE_ROOT = Path(strands_robots.__file__).resolve().parent
+
+_DEP = "websockets"
+_DISTRIBUTION = "websockets"
+
+#: Sentinel symbol for "the module itself", used by a bare ``import websockets``
+#: or by ``from websockets.sync.server import ...`` (which needs the module too).
+_MODULE = "<module>"
+
+# (module, symbol) -> first websockets release that ships it, measured against
+# the released wheels. The whole ``websockets.sync`` package arrives in 12.0;
+# everything recorded at 12.0 was present the moment that package existed.
+_WEBSOCKETS_SYMBOL_FLOORS: dict[tuple[str, str], str] = {
+    ("websockets", _MODULE): "12.0",
+    ("websockets", "connect"): "12.0",
+    ("websockets.sync.client", _MODULE): "12.0",
+    ("websockets.sync.client", "ClientConnection"): "12.0",
+    ("websockets.sync.client", "connect"): "12.0",
+    ("websockets.sync.server", _MODULE): "12.0",
+    ("websockets.sync.server", "Server"): "13.0",
+    ("websockets.sync.server", "ServerConnection"): "12.0",
+    ("websockets.sync.server", "serve"): "12.0",
+}
+
+# A refactor that stops the walk from reaching the sources would make the
+# self-maintaining checks vacuous, so pin the size of what it must find.
+_MINIMUM_IMPORTED_NAMES = 5
+
+
+def _required_floor() -> Version:
+    """The highest first-shipped release among the websockets names the package uses."""
+    return max(Version(v) for v in _WEBSOCKETS_SYMBOL_FLOORS.values())
+
+
+def _is_dep(module: str) -> bool:
+    """True when ``module`` is websockets or a submodule of it."""
+    return module == _DEP or module.startswith(_DEP + ".")
+
+
+def _imported_websockets_names(source: str) -> set[tuple[str, str]]:
+    """Every ``(module, symbol)`` one source file reaches for in websockets.
+
+    Covers the three shapes the package uses:
+
+    * ``from websockets.sync.server import Server`` - including under
+      ``TYPE_CHECKING``, which is where the name that set this floor lives;
+    * ``import websockets`` followed by a dotted use (``websockets.connect``);
+    * ``import websockets.sync.client as _wsc`` followed by ``_wsc.connect``.
+
+    Only maximal attribute chains are reported, so ``a.b.c`` yields
+    ``("<pkg>.b", "c")`` rather than also ``("<pkg>", "b")``.
+    """
+    tree = ast.parse(source)
+    found: set[tuple[str, str]] = set()
+    # Local name -> real module path, for both `import websockets` and
+    # `import websockets.sync.client as _wsc`.
+    bound: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if not _is_dep(alias.name):
+                    continue
+                found.add((alias.name, _MODULE))
+                bound[alias.asname or alias.name.split(".")[0]] = (
+                    alias.name if alias.asname else alias.name.split(".")[0]
+                )
+        elif isinstance(node, ast.ImportFrom):
+            if node.level or not _is_dep(node.module or ""):
+                continue
+            module = node.module or ""
+            found.add((module, _MODULE))
+            for alias in node.names:
+                found.add((module, alias.name))
+
+    # `a.b.c` is not maximal if it is the receiver of another attribute access.
+    receivers = {id(n.value) for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or id(node) in receivers:
+            continue
+        parts: list[str] = []
+        cursor: ast.expr = node
+        while isinstance(cursor, ast.Attribute):
+            parts.append(cursor.attr)
+            cursor = cursor.value
+        if not isinstance(cursor, ast.Name) or cursor.id not in bound:
+            continue
+        parts.reverse()
+        module = ".".join((bound[cursor.id], *parts[:-1]))
+        found.add((module, parts[-1]))
+    return found
+
+
+def _websockets_names_by_file() -> dict[tuple[str, str], list[str]]:
+    """Map every websockets name the shipped sources reach for to its files.
+
+    Parses the sources rather than reading ``sys.modules``, so a name used only
+    under ``TYPE_CHECKING`` - or in a module whose optional deps are absent - is
+    still audited.
+    """
+    found: dict[tuple[str, str], list[str]] = {}
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        rel = str(path.relative_to(_PACKAGE_ROOT.parent))
+        for name in _imported_websockets_names(path.read_text(encoding="utf-8")):
+            found.setdefault(name, []).append(rel)
+    return found
+
+
+def _declared_websockets_specifiers() -> dict[str, Requirement]:
+    """Every declared ``websockets`` requirement, keyed by where it lives."""
+    data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = data["project"]
+    out: dict[str, Requirement] = {}
+    for raw in project.get("dependencies", []):
+        req = Requirement(raw)
+        if req.name == _DISTRIBUTION:
+            out["project.dependencies"] = req
+    for extra, entries in project.get("optional-dependencies", {}).items():
+        for raw in entries:
+            req = Requirement(raw)
+            if req.name == _DISTRIBUTION:
+                out[f"optional-dependencies.{extra}"] = req
+    return out
+
+
+class TestTheDeclaredFloorCoversEveryImportedName:
+    """Packaging must not admit a websockets too old for the code it installs."""
+
+    def test_every_declared_specifier_floors_at_the_capability(self) -> None:
+        required = _required_floor()
+        specifiers = _declared_websockets_specifiers()
+        assert specifiers, "expected at least one declared websockets requirement"
+
+        too_low = {}
+        for where, req in specifiers.items():
+            lower = [s for s in req.specifier if s.operator in (">=", "==", "~=")]
+            assert lower, f"{where}: {req} declares no lower bound"
+            floor = min(Version(s.version) for s in lower)
+            if floor < required:
+                too_low[where] = str(req)
+        assert not too_low, (
+            f"websockets floor must be >= {required} because the package reaches for "
+            f"{sorted(f'{m}.{s}' for (m, s), v in _WEBSOCKETS_SYMBOL_FLOORS.items() if Version(v) == required)}; "
+            f"these specifiers admit older releases: {too_low}"
+        )
+
+    def test_the_floors_agree_across_every_extra(self) -> None:
+        # An environment resolves one websockets, so two different floors would
+        # leave the lower one describing an install nobody gets.
+        floors = {
+            where: min(Version(s.version) for s in req.specifier if s.operator in (">=", "==", "~="))
+            for where, req in _declared_websockets_specifiers().items()
+        }
+        assert len(set(floors.values())) == 1, f"every websockets specifier should declare the same floor; got {
+            {w: str(v) for w, v in floors.items()}
+        }"
+
+
+class TestTheFloorIsSelfMaintaining:
+    """The table must stay in step with what the sources actually reach for."""
+
+    def test_the_walk_reaches_the_sources(self) -> None:
+        # Without this, a walk that silently found nothing would make the two
+        # checks below pass while auditing an empty set.
+        found = _websockets_names_by_file()
+        assert len(found) >= _MINIMUM_IMPORTED_NAMES, (
+            f"expected at least {_MINIMUM_IMPORTED_NAMES} websockets names in the shipped "
+            f"sources, found {len(found)}: {sorted(f'{m}.{s}' for m, s in found)}"
+        )
+
+    def test_every_websockets_import_has_a_recorded_floor(self) -> None:
+        imported = _websockets_names_by_file()
+        unrecorded = {name: files for name, files in imported.items() if name not in _WEBSOCKETS_SYMBOL_FLOORS}
+        assert not unrecorded, (
+            "these websockets names are reached for with no recorded first-shipped release, "
+            "so nothing checks the packaging floor against them: "
+            f"{ {f'{m}.{s}': files for (m, s), files in unrecorded.items()} }. "
+            "Add each to _WEBSOCKETS_SYMBOL_FLOORS with the release that first ships it, "
+            "and raise the pyproject floor if it is higher."
+        )
+
+    def test_the_table_records_nothing_the_package_stopped_importing(self) -> None:
+        # A stale entry could hold the floor above what the code needs.
+        imported = set(_websockets_names_by_file())
+        stale = sorted(f"{m}.{s}" for (m, s) in _WEBSOCKETS_SYMBOL_FLOORS if (m, s) not in imported)
+        assert not stale, f"_WEBSOCKETS_SYMBOL_FLOORS records names the package no longer reaches for: {stale}"
+
+
+class TestTheRecordedNamesExistInTheInstalledWebsockets:
+    """Guard the table against websockets removing or moving a name."""
+
+    def test_the_installed_websockets_satisfies_the_declared_floor(self) -> None:
+        # Otherwise the per-name checks below report on a build no correctly
+        # pinned install can get, and a genuine floor violation reads as green.
+        installed = Version(pytest.importorskip(_DEP).__version__)
+        for where, req in _declared_websockets_specifiers().items():
+            assert req.specifier.contains(installed, prereleases=True), (
+                f"installed websockets {installed} does not satisfy {where}: {req}"
+            )
+
+    @pytest.mark.parametrize(("module", "symbol"), sorted(_WEBSOCKETS_SYMBOL_FLOORS))
+    def test_name_resolves(self, module: str, symbol: str) -> None:
+        imported = pytest.importorskip(module)
+        if symbol == _MODULE:
+            return
+        assert hasattr(imported, symbol), (
+            f"{module}.{symbol} is recorded in _WEBSOCKETS_SYMBOL_FLOORS and reached for by "
+            "the package, but the installed websockets does not provide it"
+        )

--- a/tests/test_websockets_floor_ships_the_imported_api.py
+++ b/tests/test_websockets_floor_ships_the_imported_api.py
@@ -12,16 +12,15 @@ websockets 12.0 has no such name - it spells that class ``WebSocketServer``, and
 ``Server`` first appears in 13.0. Both ``[inference]`` and ``[cosmos3-service]``
 declared ``websockets>=12.0``, so the manifest described an install in which the
 package's own annotation does not resolve. Measured against the released wheels
-(``Server`` is the only name above the 12.0 line):
+(``Server`` is the only name the declared floor was missing):
 
-===========  ==================================================
-release      names missing of the nine the sources reach for
-===========  ==================================================
-11.0.3       ``websockets.sync.server.Server``
-12.0         ``websockets.sync.server.Server``
-13.0         none
-13.1 - 17.x  none
-===========  ==================================================
+=============  ================================================
+release        names missing of the nine the sources reach for
+=============  ================================================
+9.1, 10.x      all seven ``websockets.sync.*`` names
+11.0 - 12.0    ``websockets.sync.server.Server``
+13.0 - 17.0.1  none
+=============  ================================================
 
 Nothing caught it because the import lives under ``TYPE_CHECKING`` and is never
 executed: on 12.0 the package imports, binds a port, serves and stops cleanly.
@@ -66,19 +65,26 @@ _DISTRIBUTION = "websockets"
 #: or by ``from websockets.sync.server import ...`` (which needs the module too).
 _MODULE = "<module>"
 
-# (module, symbol) -> first websockets release that ships it, measured against
-# the released wheels. The whole ``websockets.sync`` package arrives in 12.0;
-# everything recorded at 12.0 was present the moment that package existed.
+#: The releases probed to produce the table below, oldest first.
+_PROBED_RELEASES = ("9.1", "10.0", "10.4", "11.0", "11.0.3", "12.0", "13.0", "13.1", "14.0", "15.0", "16.0", "17.0.1")
+
+# (module, symbol) -> first release that ships it, measured against the released
+# wheels across _PROBED_RELEASES. The synchronous implementation
+# (``websockets.sync``) lands in 11.0 and ``Server`` joins it in 13.0. The two
+# ``websockets``-level names predate the oldest release probed, so they are
+# recorded at that release rather than at their true origin - only the maximum of
+# this table feeds the floor, so an older origin cannot change the answer, and an
+# entry can never understate the release the code needs.
 _WEBSOCKETS_SYMBOL_FLOORS: dict[tuple[str, str], str] = {
-    ("websockets", _MODULE): "12.0",
-    ("websockets", "connect"): "12.0",
-    ("websockets.sync.client", _MODULE): "12.0",
-    ("websockets.sync.client", "ClientConnection"): "12.0",
-    ("websockets.sync.client", "connect"): "12.0",
-    ("websockets.sync.server", _MODULE): "12.0",
+    ("websockets", _MODULE): "9.1",
+    ("websockets", "connect"): "9.1",
+    ("websockets.sync.client", _MODULE): "11.0",
+    ("websockets.sync.client", "ClientConnection"): "11.0",
+    ("websockets.sync.client", "connect"): "11.0",
+    ("websockets.sync.server", _MODULE): "11.0",
     ("websockets.sync.server", "Server"): "13.0",
-    ("websockets.sync.server", "ServerConnection"): "12.0",
-    ("websockets.sync.server", "serve"): "12.0",
+    ("websockets.sync.server", "ServerConnection"): "11.0",
+    ("websockets.sync.server", "serve"): "11.0",
 }
 
 # A refactor that stops the walk from reaching the sources would make the
@@ -236,6 +242,15 @@ class TestTheFloorIsSelfMaintaining:
             f"{ {f'{m}.{s}': files for (m, s), files in unrecorded.items()} }. "
             "Add each to _WEBSOCKETS_SYMBOL_FLOORS with the release that first ships it, "
             "and raise the pyproject floor if it is higher."
+        )
+
+    def test_every_recorded_release_was_probed(self) -> None:
+        # A row invented from a changelog rather than measured against a wheel
+        # could name a release that never shipped the name.
+        unprobed = sorted({v for v in _WEBSOCKETS_SYMBOL_FLOORS.values() if v not in _PROBED_RELEASES})
+        assert not unprobed, (
+            f"_WEBSOCKETS_SYMBOL_FLOORS records releases that are not in _PROBED_RELEASES: {unprobed}. "
+            "Probe the wheel and add it to _PROBED_RELEASES, so every number in the table is measured."
         )
 
     def test_the_table_records_nothing_the_package_stopped_importing(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5218,9 +5218,9 @@ requires-dist = [
     { name = "vector-quantize-pytorch", marker = "extra == 'all'", specifier = ">=1.14.0" },
     { name = "vector-quantize-pytorch", marker = "extra == 'motionbricks'", specifier = ">=1.14.0" },
     { name = "warp-lang", marker = "extra == 'sim-newton'", specifier = ">=1.14.0,<2.0.0" },
-    { name = "websockets", marker = "extra == 'all'", specifier = ">=12.0" },
-    { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=12.0" },
-    { name = "websockets", marker = "extra == 'inference'", specifier = ">=12.0" },
+    { name = "websockets", marker = "extra == 'all'", specifier = ">=13.0" },
+    { name = "websockets", marker = "extra == 'cosmos3-service'", specifier = ">=13.0" },
+    { name = "websockets", marker = "extra == 'inference'", specifier = ">=13.0" },
 ]
 provides-extras = ["all", "benchmark-libero", "cosmos3-diffusers", "cosmos3-service", "cosmos3-sim", "curobo", "dev", "device-connect", "groot-service", "inference", "kimodo", "lerobot", "lerobot-async", "mesh", "mesh-iot", "molmoact2", "motionbricks", "moveit2", "ollama", "protomotions", "ros2", "rosbridge", "sim", "sim-gs", "sim-isaac", "sim-mujoco", "sim-newton", "vera-sim", "wbc"]
 


### PR DESCRIPTION
Closes #2339

## Problem

`strands_robots/inference/server.py` annotates `PolicyServer._server` with `websockets.sync.server.Server`:

```python
if TYPE_CHECKING:
    from websockets.sync.server import Server, ServerConnection
...
    self._server: Server | None = None
```

websockets 12.0 has no such name - it spells that class `WebSocketServer`, and `Server` first appears in 13.0. Both `[inference]` and `[cosmos3-service]` declared `websockets>=12.0`, so the manifest described an install in which the package's own annotation does not resolve.

Measured against the released wheels in a pristine environment, across 9.1, 10.0, 10.4, 11.0, 11.0.3, 12.0, 13.0, 13.1, 14.0, 15.0, 16.0 and 17.0.1. Of the nine websockets names the shipped sources reach for:

| release | names missing |
| --- | --- |
| 9.1, 10.x | all seven `websockets.sync.*` names |
| 11.0 - 12.0 | `websockets.sync.server.Server` |
| 13.0 - 17.0.1 | none |

So `Server` is the one name the declared floor was missing, and 13.0 is where it lands.

## Why nothing caught it, and what the consequence is

The import lives under `TYPE_CHECKING`, so it is never executed. On a 12.0 install the package imports, binds a port, serves and stops cleanly:

```
websockets 12.0
bound port: 34237 running: True
stopped cleanly; runtime is unaffected on 12.0
```

Only a type checker notices - and it names the dependency:

```
$ mypy strands_robots/inference/server.py     # websockets 12.0
strands_robots/inference/server.py:40: error: Module "websockets.sync.server" has no attribute "Server"  [attr-defined]
Found 4 errors in 4 files

$ mypy strands_robots/inference/server.py     # websockets 16.0
Found 3 errors in 3 files      # the three pre-existing baseline errors
```

A resolve anywhere inside the declared range therefore produces an install that fails the type gate for a reason no source change can fix. CI type-checks the locked resolve (16.0 today), never the declared floor, and nothing compared what the manifest admits against what the sources import.

## Change

Both specifiers move to `websockets>=13.0`. They declare the *same* floor on purpose: an environment resolves one `websockets`, so two different floors would leave the lower one describing an install nobody gets. `[all]` pulls `strands-robots[inference]` and follows. The locked resolve does not move (16.0 already satisfies both), so `uv.lock` changes only the three `requires-dist` specifiers.

`tests/test_websockets_floor_ships_the_imported_api.py` owns the measurement in one table and *derives* the required floor from it rather than restating a number, following `tests/test_strands_agents_floor_ships_the_imported_api.py`:

```python
_PROBED_RELEASES = ("9.1", "10.0", "10.4", "11.0", "11.0.3", "12.0",
                    "13.0", "13.1", "14.0", "15.0", "16.0", "17.0.1")

_WEBSOCKETS_SYMBOL_FLOORS: dict[tuple[str, str], str] = {
    ("websockets", "<module>"): "9.1",
    ("websockets", "connect"): "9.1",
    ("websockets.sync.client", "<module>"): "11.0",
    ("websockets.sync.client", "ClientConnection"): "11.0",
    ("websockets.sync.client", "connect"): "11.0",
    ("websockets.sync.server", "<module>"): "11.0",
    ("websockets.sync.server", "Server"): "13.0",
    ("websockets.sync.server", "ServerConnection"): "11.0",
    ("websockets.sync.server", "serve"): "11.0",
}
```

The two `websockets`-level names are present at 9.1, the oldest release probed, and are recorded there rather than at their true origin: only the *maximum* of the table feeds the floor, so an older origin cannot change the answer, and a row can never understate the release the code needs.

An AST walk over the shipped sources feeds the table. It covers the three shapes the package actually uses, and the first is what makes this defect class visible at all:

* `from websockets.sync.server import Server` - including under `TYPE_CHECKING`;
* `import websockets` followed by `websockets.connect`;
* `import websockets.sync.client as _wsc` followed by `_wsc.connect`.

Five properties, all deterministic:

1. every declared specifier floors at `max(table)`;
2. all declared specifiers agree on that floor;
3. every name the sources reach for has a row, so a future use of a newer API cannot leave the floor behind;
4. no row is stale, and every recorded number comes from `_PROBED_RELEASES`, so a value read off a changelog rather than measured against a wheel fails rather than being taken on trust;
5. the installed websockets satisfies the declared floor, so the per-name resolution checks are not reporting on a build no correctly-pinned install can get.

A premise check pins that the walk reaches the sources at all, so a refactor cannot turn a silently-empty audit into a green one.

## Tests

Against `upstream/main` (specifiers at `>=12.0`), **1 failed / 15 passed**, naming both offenders and the reason:

```
AssertionError: websockets floor must be >= 13.0 because the package reaches for
['websockets.sync.server.Server']; these specifiers admit older releases:
{'optional-dependencies.cosmos3-service': 'websockets>=12.0',
 'optional-dependencies.inference': 'websockets>=12.0'}
```

After the change, 16 passed. The 15 constant passes are the controls - they hold on both trees, so the table, the walk and the per-name resolution are unaffected by the specifier edit.

The guard is not a tautology either. Run the same file against a real websockets 12.0 wheel with the corrected specifiers and 2 of 16 fail - one for the mis-pinned environment, one for the name itself:

```
FAILED ...::test_the_installed_websockets_satisfies_the_declared_floor
  - installed websockets 12.0 does not satisfy optional-dependencies.cosmos3-service: websockets>=13.0
FAILED ...::test_name_resolves[websockets.sync.server-Server]
  - websockets.sync.server.Server is recorded in _WEBSOCKETS_SYMBOL_FLOORS and reached for by
    the package, but the installed websockets does not provide it
```

Full suite, this branch vs `upstream/main` on the same interpreter: **61 failing ids on each, identical sets** (`comm` empty in both directions), so no regressions. Passed count 30435 vs 30419 - exactly the 16 tests this adds. `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`, `mypy` at the pre-existing baseline, `uv lock --check` parity holds, `tests/inference` 124 passed.

## Measurement

![websockets floor audit](https://raw.githubusercontent.com/cagataycali/robots/media-websockets-floor-server-name/websockets_floor.png)

Left: every websockets name the sources reach for, probed against the released wheels. Seven names arrive together with the synchronous implementation in 11.0; `websockets.sync.server.Server` is the single cell that moves after that, and 13.0 is where it lands - which is what sets the floor. Right: the two verdicts a 12.0 install produces - a clean runtime, because the import is never executed, and a type gate that fails naming the dependency.

## Out of scope

An upper cap on `websockets`. Adding one narrows every consumer's resolve and is a separate call from correcting a floor that is measurably wrong; the table records the releases that were probed, not a supported range.

## Docs

* `docs/getting-started/installation.md` - the `[cosmos3-service]` row names the pin, and a paragraph beside the existing `[sim]` floor note explains where this floor comes from and why both extras share it.
* `docs/inference/remote.md` - the install line and the surrounding note state the `>=13.0` floor and the name that sets it.

<sub>This pull request was authored by an AI contributor. The implementation, measurements and tests were produced by the AI agent.</sub>
