### PR TITLE
fix(simulation): resolve joint predicates against the whole scene

### DIFF
--- a/changelog.d/2344-joint-predicates-resolve-scene-joints.md
+++ b/changelog.d/2344-joint-predicates-resolve-scene-joints.md
@@ -1,0 +1,10 @@
+### Fixed
+
+`joint_above`, `joint_below` and `joint_progress` now resolve their joint
+anywhere in the scene, not only on the robot the unscoped `get_observation`
+happens to report. An articulated fixture -- a drawer slide, a door hinge -- is a
+second entity alongside the arm being controlled, so its joint was previously
+invisible under every spelling and the term degraded to a constant: the
+predicate and its negation both answered `False`, and `joint_progress` returned
+`0.0`, the maximum of a negative-distance reward. Drawer and door tasks, the case
+`joint_progress` documents itself for, could not be scored.

--- a/strands_robots/simulation/predicates.py
+++ b/strands_robots/simulation/predicates.py
@@ -212,26 +212,88 @@ def _body_position(sim: SimEngine, body: str) -> list[float] | None:
 def _joint_position(sim: SimEngine, joint: str) -> float | None:
     """Best-effort joint-position lookup via ``get_observation``.
 
-    ``get_observation`` is on the ABC and returns ``{<joint_name>: float}``.
-    When the joint is absent from the observation dict (wrong robot, wrong
-    namespace) we return ``None`` so predicates can decide between ``False``
-    and an explicit error path.
+    ``get_observation`` is on the ABC and returns ``{<joint_name>: float}``,
+    but it is *robot-scoped*: called without ``robot_name`` it reports the
+    joints of one robot only. A benchmark spec names joints at *scene* scope,
+    and the joints that make ``joint_above`` / ``joint_below`` /
+    ``joint_progress`` worth having - a drawer slide, a door hinge - belong to
+    an articulated fixture that is necessarily a *second* entity alongside the
+    arm being controlled. Reading only the unscoped observation therefore never
+    resolves them, and the term degrades to a constant: the predicate *and its
+    negation* both answer ``False``, so no success criterion over that joint
+    can ever hold.
+
+    So resolve over the scene, mirroring the bounded ladder
+    :func:`_body_position` already uses for the LIBERO body-name convention:
+    the unscoped observation first (single-robot scenes, and the controlled
+    robot's own joints, keep their existing fast path), then each robot the
+    world reports by name via the same ``robot_name`` route the ``base_*``
+    helpers use. Only once every entity has been asked is the name genuinely
+    absent - which is what lets :func:`_warn_unresolved` say so truthfully and
+    list what was tried.
+
+    Returns ``None`` when no entity in the scene exposes ``joint``, so
+    predicates can decide between ``False`` and an explicit error path.
     """
+
+    saw_observation = False
+
+    def _read(robot: str | None) -> float | None:
+        nonlocal saw_observation
+        try:
+            obs = (
+                sim.get_observation(skip_images=True)
+                if robot is None
+                else sim.get_observation(robot_name=robot, skip_images=True)
+            )
+        except Exception as e:  # noqa: BLE001 - defensive
+            logger.debug("get_observation(robot_name=%r) failed: %s", robot, e)
+            return None
+        if not isinstance(obs, dict):
+            return None
+        if obs:
+            saw_observation = True
+        val = obs.get(joint)
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return float(val)
+        return None
+
+    val = _read(None)
+    if val is not None:
+        return val
+
     try:
-        obs = sim.get_observation(skip_images=True)
+        robots = sim.list_robots()
     except Exception as e:  # noqa: BLE001 - defensive
-        logger.debug("get_observation() failed: %s", e)
-        return None
-    if not isinstance(obs, dict):
-        return None
-    val = obs.get(joint)
-    if isinstance(val, (int, float)) and not isinstance(val, bool):
-        return float(val)
-    # The backend produced an observation but this joint is not in it: almost
-    # always a spec typo (an empty obs is a backend/capability gap, not a name
-    # error, so stay silent there).
-    if obs and joint not in obs:
-        _warn_unresolved("joint", joint)
+        logger.debug("list_robots() failed: %s", e)
+        robots = []
+    names = [r for r in robots if isinstance(r, str)] if isinstance(robots, list) else []
+
+    hits = [(name, v) for name in names if (v := _read(name)) is not None]
+    if hits:
+        if len(hits) > 1:
+            # ``list_robots`` is documented as ordered and is already the
+            # library's default-robot resolution order, so first-match is
+            # deterministic - but a spec that names a joint several entities
+            # share is under-specified, so say which one answered.
+            logger.warning(
+                "predicate/reward DSL: joint %r is exposed by %d entities %s; "
+                "resolving against %r (first in list_robots() order). Qualify "
+                "the spec if a different entity was meant.",
+                joint,
+                len(hits),
+                [name for name, _ in hits],
+                hits[0][0],
+            )
+        return hits[0][1]
+
+    # Every entity in the scene has been asked and none exposes the joint:
+    # almost always a spec typo. A backend that produces no observation at all
+    # is a capability gap rather than a name error, so stay silent there - the
+    # same condition the single-robot path has always used, now evaluated over
+    # every entity consulted.
+    if saw_observation:
+        _warn_unresolved("joint", joint, ("<controlled robot>", *names))
     return None
 
 
@@ -1168,7 +1230,9 @@ def _joint_progress(joint: str, target: float, weight: float = 1.0) -> RewardTer
     """Negative absolute distance from a joint to its target, weighted.
 
     Useful for drawer/door tasks where success is "joint near target
-    position" and you want dense signal during training.
+    position" and you want dense signal during training. ``joint`` is resolved
+    at scene scope by :func:`_joint_position`, so it may name a joint on an
+    articulated fixture as well as one on the robot being controlled.
     """
     w = float(weight)
     t = float(target)

--- a/tests/simulation/mujoco/test_scene_joint_predicates.py
+++ b/tests/simulation/mujoco/test_scene_joint_predicates.py
@@ -1,0 +1,123 @@
+"""A drawer joint in a real compiled scene must be reachable by a joint predicate.
+
+``joint_progress`` documents itself as being for "drawer/door tasks where
+success is 'joint near target position'". Such a fixture is necessarily a
+second entity alongside the arm being controlled, and ``get_observation`` is
+robot-scoped, so an unscoped read never reports the fixture's joint. These
+tests drive the real MuJoCo backend rather than a stub, so they pin the
+resolution against the observation structure the engine actually produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation import create_simulation
+from strands_robots.simulation.predicates import make_predicate
+
+CABINET_MJCF = """<mujoco model="cabinet">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="carcass" pos="0 0 0">
+      <geom type="box" size="0.075 0.075 0.006" pos="0 0 0.006"/>
+      <geom type="box" size="0.075 0.006 0.057" pos="0 0.069 0.066"/>
+    </body>
+    <body name="front" pos="0 -0.069 0.066">
+      <joint name="drawer" type="slide" axis="0 -1 0" range="0 0.20" damping="1"/>
+      <geom type="box" size="0.063 0.006 0.045" mass="0.12"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+ARM_MJCF = """<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.05">
+      <joint name="shoulder" type="hinge" axis="0 0 1" range="-1 1"/>
+      <geom type="capsule" fromto="0 0 0 0.1 0 0" size="0.01" mass="0.2"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def scene(tmp_path):
+    """Arm plus an articulated cabinet, the arm registered first."""
+    arm = tmp_path / "arm.xml"
+    arm.write_text(ARM_MJCF)
+    cab = tmp_path / "cabinet.xml"
+    cab.write_text(CABINET_MJCF)
+    sim = create_simulation(backend="mujoco", tool_name="scene_joint_pred", mesh=False)
+    assert sim.create_world(ground_plane=True)["status"] == "success"
+    assert sim.add_robot(name="arm", urdf_path=str(arm))["status"] == "success"
+    assert sim.add_robot(name="cabinet", urdf_path=str(cab), position=[0.0, -0.3, 0.0])["status"] == "success"
+    try:
+        yield sim
+    finally:
+        sim.destroy()
+
+
+def _set_drawer(sim, metres: float) -> None:
+    """Place the compiled drawer joint and settle kinematics."""
+    import mujoco
+
+    model, data = sim.mj_model, sim.mj_data
+    jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "cabinet/drawer")
+    assert jid >= 0, "the compiled scene must contain the namespaced drawer joint"
+    data.qpos[model.jnt_qposadr[jid]] = metres
+    mujoco.mj_forward(model, data)
+
+
+def test_the_scene_exposes_the_drawer_joint_only_when_the_fixture_is_named(scene):
+    """Premise: an unscoped observation cannot see the fixture's joint.
+
+    This is the structure that makes the resolution necessary; if it ever
+    changes, the tests below stop measuring what they claim to.
+    """
+    assert "drawer" not in scene.get_observation(skip_images=True)
+    assert "drawer" in scene.get_observation(robot_name="cabinet", skip_images=True)
+
+
+@pytest.mark.parametrize("metres", [0.06, 0.12, 0.18])
+def test_an_open_drawer_satisfies_an_open_criterion(scene, metres):
+    _set_drawer(scene, metres)
+    assert make_predicate("joint_above", joint="drawer", value=0.05)(scene) is True
+
+
+def test_a_shut_drawer_satisfies_a_close_criterion(scene):
+    _set_drawer(scene, 0.0)
+    assert make_predicate("joint_below", joint="drawer", value=0.005)(scene) is True
+
+
+def test_an_open_drawer_never_satisfies_a_close_criterion(scene):
+    _set_drawer(scene, 0.18)
+    assert make_predicate("joint_below", joint="drawer", value=0.005)(scene) is False
+
+
+def test_the_drawer_criterion_tracks_the_compiled_joint(scene):
+    """The verdict must follow physics across the threshold, both ways."""
+    pred = make_predicate("joint_above", joint="drawer", value=0.10)
+    _set_drawer(scene, 0.02)
+    assert pred(scene) is False
+    _set_drawer(scene, 0.15)
+    assert pred(scene) is True
+    _set_drawer(scene, 0.02)
+    assert pred(scene) is False
+
+
+def test_joint_progress_gives_a_live_reward_for_the_drawer(scene):
+    term = make_predicate("joint_progress", joint="drawer", target=0.20, weight=10.0)
+    _set_drawer(scene, 0.05)
+    far = term(scene)
+    _set_drawer(scene, 0.19)
+    near = term(scene)
+    assert far == pytest.approx(-1.5)
+    assert near == pytest.approx(-0.1)
+    assert near > far, "the reward must improve as the drawer approaches its target"
+
+
+def test_the_arms_own_joint_still_resolves(scene):
+    """The controlled robot's joints keep their existing unscoped fast path."""
+    assert make_predicate("joint_below", joint="shoulder", value=0.5)(scene) is True

--- a/tests/simulation/test_benchmark_predicates.py
+++ b/tests/simulation/test_benchmark_predicates.py
@@ -54,6 +54,29 @@ class _BodyStateSim:
         return {}
 
 
+class _ScopedJointObsSim:
+    """Sim whose ``get_observation`` is robot-scoped, like the real backends.
+
+    ``get_observation()`` without ``robot_name`` reports one robot's joints;
+    each entity's joints are reachable only by naming it. This is the structure
+    a scene with an arm plus an articulated fixture actually has, so it is what
+    a scene-scoped joint name must be resolved against. ``_JointObsSim`` returns
+    the same flat dict for every call and therefore cannot express it.
+    """
+
+    def __init__(self, per_robot: dict[str, dict[str, float]]):
+        self._per_robot = per_robot
+
+    def list_robots(self) -> list[str]:
+        return list(self._per_robot)
+
+    def get_observation(self, robot_name: str | None = None, *, skip_images: bool = False) -> dict[str, float]:
+        if robot_name is None:
+            first = next(iter(self._per_robot), None)
+            return dict(self._per_robot[first]) if first is not None else {}
+        return dict(self._per_robot.get(robot_name, {}))
+
+
 class _JointObsSim:
     """Sim that exposes joint positions via ``get_observation``."""
 
@@ -283,6 +306,90 @@ class TestJointPredicates:
         sim = _JointObsSim({"drawer": 0.2})
         term = make_predicate("joint_progress", joint="drawer", target=0.2, weight=1.0)
         assert term(sim) == pytest.approx(0.0)
+
+
+class TestJointPredicatesResolveSceneJoints:
+    """A joint predicate must reach the joint it names anywhere in the scene.
+
+    ``get_observation`` is robot-scoped, so an articulated fixture's joint - a
+    drawer slide, a door hinge - is invisible to an unscoped read: such a
+    fixture is necessarily a second entity alongside the arm being controlled.
+    That is exactly the task class ``joint_progress`` documents itself for, and
+    before the fix the term degraded to a constant for all of them, so a
+    predicate *and its negation* both answered ``False`` and no success
+    criterion over the joint could ever hold.
+    """
+
+    def setup_method(self):
+        _reset_resolution_warnings()
+
+    def test_open_drawer_criterion_holds_when_the_drawer_is_open(self):
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.18}})
+        # FAILS pre-fix: the unscoped observation reports only the arm.
+        assert make_predicate("joint_above", joint="drawer", value=0.15)(sim) is True
+
+    def test_close_drawer_criterion_holds_when_the_drawer_is_shut(self):
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.001}})
+        assert make_predicate("joint_below", joint="drawer", value=0.005)(sim) is True
+
+    def test_a_predicate_and_its_negation_do_not_both_hold(self):
+        """The constant-False degradation made both answer False at once."""
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.037}})
+        above = make_predicate("joint_above", joint="drawer", value=0.005)(sim)
+        below = make_predicate("joint_below", joint="drawer", value=0.005)(sim)
+        assert above is True and below is False
+        assert above is not below, "a joint cannot be neither above nor below a threshold"
+
+    def test_joint_progress_measures_a_fixture_joint(self):
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.1}})
+        term = make_predicate("joint_progress", joint="drawer", target=0.2, weight=10.0)
+        assert term(sim) == pytest.approx(-1.0)  # FAILS pre-fix: dead 0.0 reward
+
+    def test_a_scene_joint_that_is_open_is_not_reported_shut(self):
+        """The worst shape: a fully open drawer scoring as successfully closed."""
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.20}})
+        assert make_predicate("joint_below", joint="drawer", value=0.005)(sim) is False
+
+    def test_the_controlled_robot_keeps_its_unscoped_fast_path(self):
+        """A joint on the default robot must still resolve without a scan."""
+        sim = _ScopedJointObsSim({"arm": {"gripper": 0.02}, "cabinet": {"drawer": 0.18}})
+        assert make_predicate("joint_below", joint="gripper", value=0.05)(sim) is True
+
+    def test_the_default_robot_wins_a_name_it_shares(self):
+        """Shadowed names resolve to the controlled robot, as before the fix."""
+        sim = _ScopedJointObsSim({"arm": {"j": 0.10}, "cabinet": {"j": 0.90}})
+        assert make_predicate("joint_above", joint="j", value=0.5)(sim) is False
+
+    def test_a_genuinely_absent_joint_still_degrades_and_warns_once(self, caplog):
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cabinet": {"drawer": 0.18}})
+        pred = make_predicate("joint_above", joint="ghost_slide", value=0.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert pred(sim) is False
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "ghost_slide" in msg
+        # Having asked every entity, the message may now say so truthfully.
+        assert "cabinet" in msg
+
+    def test_an_ambiguous_fixture_joint_resolves_deterministically_and_says_so(self, caplog):
+        sim = _ScopedJointObsSim({"arm": {"shoulder": 0.0}, "cab_a": {"drawer": 0.18}, "cab_b": {"drawer": 0.90}})
+        pred = make_predicate("joint_above", joint="drawer", value=0.5)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert pred(sim) is False  # cab_a (first in list_robots order) answers
+        assert any(
+            "cab_a" in r.getMessage() and "cab_b" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_a_backend_without_introspection_stays_silent(self, caplog):
+        """No observation at all is a capability gap, not a spec typo."""
+        sim = _NoHelpersSim()
+        term = make_predicate("joint_progress", joint="drawer", target=0.2, weight=1.0)
+        with caplog.at_level(logging.WARNING, logger=_PRED_LOGGER):
+            assert term(sim) == 0.0
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
 
 # Contact predicates


### PR DESCRIPTION
## Problem

`joint_above`, `joint_below` and `joint_progress` resolve their `joint` through
`_joint_position`, which read `get_observation()` with no `robot_name`. That
observation is **robot-scoped**: called unscoped it reports one robot's joints.

An articulated fixture -- a drawer slide, a door hinge -- is necessarily a
*second* entity alongside the arm being controlled, so its joint was never in
that dict, under any spelling. Measured on a scene with an SO-101 and a cabinet
whose drawer joint sits at **43.97 mm**:

| lookup | result |
|---|---|
| compiled model joints | `so101/1..6`, `cabinet/drawer` |
| `get_observation(robot_name="cabinet")` | `{"drawer": 0.043974, ...}` |
| `get_observation()` | `{"1": ..., ..., "6": ...}` -- the arm only |
| `joint_above(joint="drawer")` / `"cabinet/drawer"` / `"cabinet_drawer"` | `False`, `False`, `False` |

So the term degraded to a constant, and a constant makes a predicate **and its
negation** both answer `False`. At 43.97 mm, `joint_above(0.005)` was `False`
*and* `joint_below(0.005)` was `False`, so neither an "opened the drawer" nor a
"closed the drawer" criterion could ever hold. `joint_progress` returned
`+0.000` -- and since it is a *negative* absolute distance, `0.0` is its
maximum, so a dead term is indistinguishable from being exactly on target.

`joint_progress`'s own docstring says it is "useful for drawer/door tasks where
success is 'joint near target position'". That was the one task class it could
not serve.

The existing unresolved-name warning fired, but its advice -- "Check the name
against the loaded scene / benchmark spec" -- could not be followed, because no
name worked, and its claim that the joint "is not present in the simulation" was
untrue.

## Change

Resolve the joint over the scene, mirroring the bounded ladder
`_body_position` already uses for the LIBERO `<name>_main` root-body convention:

1. the unscoped observation first, so single-robot scenes and the controlled
   robot's own joints keep their existing fast path (unchanged call, unchanged
   precedence when a name is shared);
2. then each robot `list_robots()` reports, by name, through the same
   `robot_name` route the `base_*` helpers in this module already use --
   `_joint_position` was the only `get_observation` call in the file without it;
3. a name several entities expose resolves against the first in
   `list_robots()`'s documented order (already the library's default-robot
   resolution order) and logs which one answered, so an under-specified spec is
   deterministic rather than silent;
4. only once every entity has been asked is the name genuinely absent -- which
   is what lets the existing warning say so truthfully and list what it tried.

A backend that produces no observation at all is still a capability gap rather
than a spec typo, so it stays silent, exactly as before.

## Tests

`tests/simulation/mujoco/test_scene_joint_predicates.py` drives the real MuJoCo
backend with an arm plus an articulated cabinet, and leads with a premise test
pinning the observation structure that makes the resolution necessary, so the
file cannot quietly stop measuring what it claims to.

`TestJointPredicatesResolveSceneJoints` adds a `_ScopedJointObsSim` stub that
reproduces the robot-scoped shape. The existing `_JointObsSim` returns the same
flat dict for every call, so it cannot express a scene with two entities -- which
is why the current joint tests pass against a structure the engine never
produces for a drawer, while the sibling body tests use `_BodyStateSim` and are
faithful.

**12 fail / 7 pass on `main`; 19 pass after.** The 7 that pass on both bound the
change: the premise test, the arm's own joint still resolving, the controlled
robot keeping its unscoped fast path, the default robot still winning a name it
shares, and a backend without introspection staying silent.

## Rollout

An SO-101 grasps the handle and pulls; the drawer joint travels
`0.000 -> 43.97 mm` (`d.qpos`, trace `0 -> 10.7 -> 29.1 -> 43.4`). The same
criterion is then evaluated on that same final state by each revision.

![rollout](https://raw.githubusercontent.com/cagataycali/robots/media-scene-joint-predicates/pull.gif)

![before and after](https://raw.githubusercontent.com/cagataycali/robots/media-scene-joint-predicates/figure.png)

| criterion on the final state (drawer at 43.97 mm) | before | after |
|---|---|---|
| `joint_above(joint="open", value=0.005)` "was opened" | `False` | `True` |
| `joint_below(joint="open", value=0.005)` "is shut" | `False` | `False` |
| `joint_progress(joint="open", target=0.10)` reward | `+0.000` | `-0.560` |

## Gate

`ruff check` / `ruff format --check` clean over `strands_robots tests
tests_integ`; `mypy` 14 errors on the branch and 14 on `main`, identical set,
all in `examples/isaac_gs/`. Full `tests`: **6 failed / 30677 passed** on the
branch against 19 failed / 30664 passed on `main` carrying the new test files.
Diffed on sorted test ids there are no new failures -- the 7 shared ones are
environment-bound (docker-absent vera, the GL probe, newton, mesh node-id) and
the single id that differs is in `tests/mesh/test_zenoh_transport_security.py`,
whose failures rotate under two parallel suites and which passes 9/9 three times
running in isolation.
