### PR TITLE
fix(training): refuse a val_episodes whose episode count cannot be read

### DIFF
--- a/changelog.d/2346-val-episodes-unreadable-episode-count.md
+++ b/changelog.d/2346-val-episodes-unreadable-episode-count.md
@@ -1,0 +1,5 @@
+### Fixed
+
+`val_episodes` is no longer silently dropped when the LeRobot backend cannot read the dataset's episode count. The count becomes lerobot's `dataset.eval_split` fraction, so without it no split was emitted — and an absent split is indistinguishable from "no validation was asked for", leaving a run that trained on every episode, logged no validation loss, and reported no problem. `validate()` now refuses, naming the two remedies the backend honors: point `dataset_root` at a populated local copy, or pass `extra={"dataset.eval_split": ..., "eval_steps": ...}`. This affected a Hub `dataset_repo_id` with no `dataset_root`, and a `dataset_root` that is a Hub cache directory nothing had been downloaded into yet.
+
+Migration: `validation_split_error` takes a required keyword-only `passthrough_param` naming the caller's own raw-flag parameter (`extra_flags` on the `lerobot_train` tool, `extra` on `TrainSpec` / `train_policy`). It was previously hardcoded to `extra_flags`, which raised `TypeError` when applied verbatim on the `TrainSpec` surface; the argument is required rather than defaulted so a new surface cannot inherit a keyword it does not accept.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -96,7 +96,7 @@ supports and **ignores the rest** (the same tolerance rule as
 | `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
-| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count. `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating) |
+| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count, and that count must be readable from a local `meta/info.json` (see the Hub-source note below). `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating) |
 | `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher |
 | `seed` | reproducibility seed | must be a non-negative integer; `validate()` refuses a negative (`torch.manual_seed` would take it modulo `2**64`, so `-1` silently becomes `2**64 - 1`), a fractional or non-finite value, and a `bool`. `None` uses the backend's own default |
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
@@ -303,9 +303,17 @@ TrainSpec(
 
 `dataset_root` is optional here - if given it is used as a local cache root.
 `streaming=True` also works with a local `dataset_root` (streams from disk with
-bounded RAM). Held-out `val_episodes` splitting needs a local `meta/info.json`
-to count episodes, so it is a no-op when streaming a Hub dataset with no local
-cache (the full Hub dataset is used).
+bounded RAM).
+
+Held-out `val_episodes` splitting needs a local `meta/info.json` to count
+episodes, because lerobot's split is a FRACTION and the count is what turns an
+episode number into one. `validate()` therefore refuses `val_episodes` whenever
+that count is unreadable - a Hub source with no `dataset_root`, or a
+`dataset_root` cache directory nothing has been downloaded into yet - rather
+than launch a run that trains on every episode and logs no validation loss. The
+refusal names the two ways to get the split: point `dataset_root` at a populated
+local copy of the dataset, or pass lerobot's own knobs directly with
+`extra={"dataset.eval_split": 0.1, "eval_steps": 1000}`.
 
 ### GR00T (`groot`)
 

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -538,7 +538,9 @@ def build_train_command(
             raise ValueError(
                 f"val_episodes={val_episodes} leaves no training data (dataset has {total} episodes); reserve fewer."
             )
-        split_err = validation_split_error(val_episodes, _read_total_tasks(dataset_root), "lerobot_train")
+        split_err = validation_split_error(
+            val_episodes, _read_total_tasks(dataset_root), "lerobot_train", passthrough_param="extra_flags"
+        )
         if split_err:
             raise ValueError(split_err)
         # Hand the split to lerobot instead of restricting --dataset.episodes

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -142,7 +142,11 @@ def train_policy(
             logs an eval loss over them at the checkpoint cadence. A positive
             integer below the dataset's episode count, or None for no held-out
             set - the split is a fraction lerobot takes the ceiling of, so a
-            fractional count would reserve a different number of episodes.
+            fractional count would reserve a different number of episodes. The
+            count is read from the dataset's local ``meta/info.json``, so a Hub
+            source (``dataset_repo_id`` with no populated ``dataset_root``) is
+            refused with the two ways to get a split instead of being launched
+            without one.
         augmentation: Backend-specific augmentation dict.
         fps: Dataset control rate (when a backend needs it).
         extra: Backend-specific passthrough. lerobot: ``policy_type``,

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -129,7 +129,13 @@ class TrainSpec:
             the lerobot backend maps it onto ``--dataset.eval_split`` plus a
             non-zero ``--eval_steps`` so an eval loss is logged periodically.
             Must be a positive integer below the dataset's episode count, or
-            ``None`` to train on every episode. Because the count is converted
+            ``None`` to train on every episode. That upper bound is also a SOURCE
+            requirement: the count comes from the dataset's local
+            ``meta/info.json``, so a backend that cannot read one (a Hub source
+            with no populated :attr:`dataset_root`) MUST refuse rather than emit
+            no split - an absent split is indistinguishable from ``None``, and
+            reporting no problem would launch exactly the validation-less run
+            this field exists to avoid. Because the count is converted
             into a real-valued split fraction whose ceiling lerobot takes, a
             backend MUST check it with
             :meth:`Trainer._validation_episodes_problems` rather than compare it

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -476,6 +476,35 @@ class LerobotTrainer(Trainer):
             return validation_split_fraction(spec.val_episodes, total)
         return None
 
+    def _unreadable_episode_count_problem(self, spec: TrainSpec) -> str:
+        """Refusal text for a ``val_episodes`` whose episode count cannot be read.
+
+        :meth:`_val_eval_split` turns ``val_episodes`` into lerobot's
+        ``dataset.eval_split`` FRACTION, which needs the dataset's
+        ``total_episodes``. That count is only available from a local
+        ``meta/info.json``, so it is unreadable for a Hub dataset with no local
+        copy (``dataset_repo_id`` set, ``dataset_root`` empty) and for a
+        ``dataset_root`` that is a Hub cache directory nothing has been
+        downloaded into yet.
+
+        Both remedies named here are honored by this backend: pointing
+        ``dataset_root`` at a populated local copy makes the count readable, and
+        the raw ``extra`` passthrough reaches lerobot's own two knobs directly.
+        """
+        where = (
+            f"no readable 'meta/info.json' under dataset_root={spec.dataset_root!r}"
+            if spec.dataset_root
+            else "no dataset_root was given to read one from"
+        )
+        return (
+            f"{self.provider_name}: val_episodes={spec.val_episodes} cannot be reserved because the "
+            f"dataset's episode count is unavailable ({where}). A held-out split is a FRACTION in "
+            "lerobot (it holds out ceil(episodes_in_task * eval_split)), so the count is what turns "
+            "an episode number into that fraction. Either point dataset_root at a local copy of the "
+            "dataset - for a Hub dataset that is its local cache directory - or pass the split "
+            "directly with extra={'dataset.eval_split': <fraction>, 'eval_steps': <steps>}."
+        )
+
     def _dataset_total_tasks(self, dataset_root: str) -> int:
         """``total_tasks`` from ``meta/info.json``, or 0 when not recorded."""
         from pathlib import Path
@@ -617,15 +646,26 @@ class LerobotTrainer(Trainer):
         val_problems = self._validation_episodes_problems(spec)
         problems.extend(val_problems)
 
-        if not val_problems and spec.val_episodes is not None and spec.dataset_root:
-            total = self._dataset_total_episodes(spec.dataset_root)
-            if total is not None and spec.val_episodes >= total:
-                problems.append(f"val_episodes={spec.val_episodes} >= total_episodes={total}")
-            split_err = validation_split_error(
-                spec.val_episodes, self._dataset_total_tasks(spec.dataset_root), "LeRobotTrainer"
-            )
-            if split_err:
-                problems.append(split_err)
+        if not val_problems and spec.val_episodes is not None:
+            total = self._dataset_total_episodes(spec.dataset_root) if spec.dataset_root else None
+            if total is None:
+                # The split is a FRACTION derived from the episode count, so with
+                # no count to divide by there is nothing to emit - and a missing
+                # eval_split is indistinguishable from "no validation asked for".
+                # Refuse instead, naming both remedies, rather than launch a run
+                # that trains on every episode and records no validation loss.
+                problems.append(self._unreadable_episode_count_problem(spec))
+            else:
+                if spec.val_episodes >= total:
+                    problems.append(f"val_episodes={spec.val_episodes} >= total_episodes={total}")
+                split_err = validation_split_error(
+                    spec.val_episodes,
+                    self._dataset_total_tasks(spec.dataset_root),
+                    self.provider_name,
+                    passthrough_param="extra",
+                )
+                if split_err:
+                    problems.append(split_err)
 
         problems.extend(self._lora_hyperparameter_problems(spec))
 

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2360,7 +2360,7 @@ def validation_split_fraction(val_episodes: int, total_episodes: int) -> float:
     return (val_episodes - 0.5) / total_episodes
 
 
-def validation_split_error(val_episodes: int, total_tasks: Any, context: str) -> str | None:
+def validation_split_error(val_episodes: int, total_tasks: Any, context: str, *, passthrough_param: str) -> str | None:
     """Error text when a global episode COUNT cannot be honored as a split.
 
     lerobot expresses a validation split as one ``eval_split`` FRACTION and
@@ -2379,6 +2379,13 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str) ->
         val_episodes: The requested held-out episode count, for the message.
         total_tasks: ``total_tasks`` from the dataset's ``meta/info.json``.
         context: Caller label the message is prefixed with.
+        passthrough_param: Name of the caller's own raw-flag passthrough
+            parameter, interpolated into the remedy. Required rather than
+            defaulted because the surfaces disagree: the ``lerobot_train`` tool
+            spells it ``extra_flags`` while :class:`TrainSpec` (and the
+            ``train_policy`` tool) spell it ``extra``, so a default would name a
+            keyword one of them does not accept - the reader would apply the
+            remedy verbatim and get a ``TypeError``.
 
     Returns:
         The error text, or None when the count can be honored exactly.
@@ -2391,8 +2398,8 @@ def validation_split_error(val_episodes: int, total_tasks: Any, context: str) ->
         "fraction in lerobot (it holds out ceil(episodes_in_task * eval_split) "
         "from every task), so a single global count is not expressible: the "
         "ceiling would be applied once per task. Pass the fraction directly, "
-        "e.g. extra_flags={'dataset.eval_split': 0.1, 'eval_steps': 1000}, and "
-        "the split will hold out a tenth of each task."
+        f"e.g. {passthrough_param}={{'dataset.eval_split': 0.1, 'eval_steps': 1000}}, "
+        "and the split will hold out a tenth of each task."
     )
 
 

--- a/tests/test_refusal_messages_never_raise.py
+++ b/tests/test_refusal_messages_never_raise.py
@@ -523,19 +523,19 @@ class TestValidationSplitRendersATaskCountItCannotRender:
     """
 
     def test_an_outsized_task_count_is_answered(self) -> None:
-        refusal = validation_split_error(1, BEYOND_INT_STR_LIMIT, "train")
+        refusal = validation_split_error(1, BEYOND_INT_STR_LIMIT, "train", passthrough_param="extra")
         assert refusal is not None
         assert f"<int of {BEYOND_INT_STR_LIMIT.bit_length()} bits>" in refusal
         refusal.encode("ascii")
 
     def test_an_ordinary_task_count_still_renders_as_a_plain_number(self) -> None:
-        refusal = validation_split_error(1, 5, "train")
+        refusal = validation_split_error(1, 5, "train", passthrough_param="extra")
         assert refusal is not None
         assert "dataset with 5 tasks" in refusal
 
     def test_a_single_task_dataset_is_still_accepted(self) -> None:
-        assert validation_split_error(1, 1, "train") is None
-        assert validation_split_error(1, None, "train") is None
+        assert validation_split_error(1, 1, "train", passthrough_param="extra") is None
+        assert validation_split_error(1, None, "train", passthrough_param="extra") is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/tools/test_val_episodes_yields_validation_loss.py
+++ b/tests/tools/test_val_episodes_yields_validation_loss.py
@@ -14,8 +14,11 @@ episode COUNT exactly, and that a count which cannot be honored is refused
 rather than silently rounded.
 """
 
+import dataclasses
+import inspect
 import json
 import math
+import re
 from pathlib import Path
 from typing import Any
 
@@ -113,10 +116,10 @@ class TestCountThatCannotBeHonoredIsRefused:
     @pytest.mark.parametrize("tasks", [0, 1, None, True, "2"])
     def test_absent_or_single_task_count_is_honored(self, tasks: object) -> None:
         """0 / None mean 'no task count recorded', which lerobot treats as one task."""
-        assert validation_split_error(2, tasks, "ctx") is None
+        assert validation_split_error(2, tasks, "ctx", passthrough_param="extra_flags") is None
 
     def test_refusal_names_the_task_count_and_the_direct_knobs(self) -> None:
-        err = validation_split_error(1, 4, "lerobot_train")
+        err = validation_split_error(1, 4, "lerobot_train", passthrough_param="extra_flags")
         assert err is not None
         assert err.startswith("lerobot_train: ")
         assert "4 tasks" in err
@@ -157,3 +160,143 @@ class TestEverySurfaceAgrees:
         root = _write_dataset(tmp_path / "ds", total_episodes=10, total_tasks=3)
         spec = TrainSpec(dataset_root=str(root), output_dir=str(tmp_path / "out"), val_episodes=2)
         assert any("cannot be reserved exactly" in p for p in LerobotTrainer().validate(spec))
+
+
+def _spec(**kwargs: Any) -> Any:
+    """A launchable :class:`TrainSpec`, overridden per case."""
+    from strands_robots.training.base import TrainSpec
+
+    return TrainSpec(output_dir="/tmp/strands-val-episodes-out", steps=10, save_freq=5, **kwargs)
+
+
+def _passthrough_keyword(message: str) -> str:
+    """The passthrough parameter a refusal tells the reader to use instead."""
+    match = re.search(r"(\w+)=\{'dataset\.eval_split'", message)
+    assert match is not None, f"refusal names no dataset.eval_split passthrough: {message}"
+    return match.group(1)
+
+
+class TestAnUnreadableEpisodeCountIsRefused:
+    """A count that cannot become a fraction must be refused, not dropped.
+
+    The split is ``ceil(episodes_in_task * eval_split)``, so turning an episode
+    COUNT into lerobot's fraction needs the dataset's ``total_episodes``. That
+    number is only in a local ``meta/info.json``, which a Hub source need not
+    have: ``dataset_repo_id`` with no ``dataset_root``, or a ``dataset_root``
+    that is a Hub cache directory nothing has been downloaded into yet. Emitting
+    no fraction there is indistinguishable from "no validation was asked for" -
+    the run trains on every episode and records no validation loss, which is the
+    outcome this module exists to prevent.
+    """
+
+    def test_a_hub_source_with_no_local_root_is_refused(self) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        spec = _spec(dataset_repo_id="lerobot/svla_so101_pickplace", val_episodes=2)
+        trainer = LerobotTrainer()
+        problems = trainer.validate(spec)
+        assert any("val_episodes=2" in p for p in problems), (
+            "a Hub source drops val_episodes silently: validate() reported "
+            f"{problems} while build_command() emits "
+            f"{[c for c in trainer.build_command(spec) if 'eval' in c]}"
+        )
+
+    def test_a_hub_cache_root_with_nothing_downloaded_is_refused(self, tmp_path: Path) -> None:
+        """The documented Hub-cache shape: repo id plus an empty local cache dir."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        cache = tmp_path / "hf-cache"
+        cache.mkdir()
+        spec = _spec(dataset_repo_id="lerobot/svla_so101_pickplace", dataset_root=str(cache), val_episodes=2)
+        assert any("val_episodes=2" in p for p in LerobotTrainer().validate(spec))
+
+    def test_the_refusal_is_load_bearing_so_no_run_launches_without_the_split(self) -> None:
+        """``train`` fails closed on validate(), so the request cannot be dropped."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        result = LerobotTrainer().train(_spec(dataset_repo_id="lerobot/svla_so101_pickplace", val_episodes=2))
+        assert result.status != "success"
+        assert "val_episodes=2" in result.message
+
+
+class TestARefusalNamesAPassthroughItsOwnSurfaceAccepts:
+    """Every remedy pointing at raw flags must name a keyword that surface has.
+
+    The passthrough is spelled ``extra_flags`` on the ``lerobot_train`` tool and
+    ``extra`` on :class:`TrainSpec` (and the ``train_policy`` tool), so one
+    hardcoded spelling makes the remedy a dead end on the other surface: applied
+    verbatim it raises ``TypeError`` for an unexpected keyword.
+    """
+
+    def test_the_trainer_names_a_real_trainspec_field(self) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.training.base import TrainSpec
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        problems = LerobotTrainer().validate(_spec(dataset_repo_id="lerobot/x", val_episodes=2))
+        keyword = _passthrough_keyword(" ".join(problems))
+        assert keyword in {f.name for f in dataclasses.fields(TrainSpec)}
+
+    def test_the_tool_names_a_real_lerobot_train_parameter(self) -> None:
+        from strands_robots.tools.lerobot_train import lerobot_train
+
+        err = validation_split_error(1, 4, "lerobot_train", passthrough_param="extra_flags")
+        assert err is not None
+        target = getattr(lerobot_train, "__wrapped__", lerobot_train)
+        assert _passthrough_keyword(err) in inspect.signature(target).parameters
+
+    def test_applying_the_trainer_remedy_verbatim_produces_the_pair(self) -> None:
+        """Parse the remedy out of the refusal, apply it, and it must work."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        trainer = LerobotTrainer()
+        keyword = _passthrough_keyword(" ".join(trainer.validate(_spec(dataset_repo_id="lerobot/x", val_episodes=2))))
+        remedied = _spec(dataset_repo_id="lerobot/x", **{keyword: {"dataset.eval_split": 0.1, "eval_steps": 5}})
+        assert trainer.validate(remedied) == []
+        cmd = trainer.build_command(remedied)
+        assert _flag(cmd, "dataset.eval_split") == "0.1"
+        assert _flag(cmd, "eval_steps") == "5"
+
+    def test_pointing_dataset_root_at_a_local_copy_is_the_other_named_remedy(self, tmp_path: Path) -> None:
+        """The refusal's first remedy: a populated cache root makes the count readable."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        root = _write_dataset(tmp_path / "cache", total_episodes=10)
+        spec = _spec(dataset_repo_id="lerobot/x", dataset_root=str(root), val_episodes=2)
+        trainer = LerobotTrainer()
+        assert trainer.validate(spec) == []
+        assert math.ceil(10 * float(_flag(trainer.build_command(spec), "dataset.eval_split") or "0")) == 2
+
+
+class TestTheRefusalDoesNotReachPastTheDefect:
+    """Controls: only an unhonorable request may be refused."""
+
+    def test_a_local_root_still_emits_the_pair(self, tmp_path: Path) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        root = _write_dataset(tmp_path / "ds", total_episodes=50)
+        spec = _spec(dataset_root=str(root), val_episodes=5)
+        trainer = LerobotTrainer()
+        assert trainer.validate(spec) == []
+        assert math.ceil(50 * float(_flag(trainer.build_command(spec), "dataset.eval_split") or "0")) == 5
+
+    def test_a_hub_source_without_val_episodes_is_not_refused(self) -> None:
+        """None is the documented "train on everything" sentinel, not a problem."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        assert LerobotTrainer().validate(_spec(dataset_repo_id="lerobot/x")) == []
+
+    def test_an_unusable_count_still_names_the_count_domain_first(self) -> None:
+        """A non-positive count is a domain problem wherever the data lives."""
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        problems = LerobotTrainer().validate(_spec(dataset_repo_id="lerobot/x", val_episodes=0))
+        assert any("must be a positive integer" in p for p in problems)


### PR DESCRIPTION
## Problem

The LeRobot backend turns `val_episodes` into lerobot's `dataset.eval_split` **fraction**, and that conversion needs the dataset's `total_episodes` from a local `meta/info.json`. When the count is unreadable, `_val_eval_split` returned `None` and nothing was emitted — and an absent `eval_split` is indistinguishable from "no validation was asked for". So the run trained on **every** episode, logged **no** validation loss, and `validate()` reported **no problem at all**.

Because `Trainer.train` fails closed on `validate()`, "no problem" means the run launches. `train_policy(action="validate", ...)` — the preflight whose whole job is to say the spec will run as specified — answered `"[lerobot_local] spec is valid and launchable."`

Two reachable sources hit this, both fully supported data sources:

- `dataset_repo_id` with no `dataset_root` (a Hub dataset)
- a `dataset_root` that is a Hub cache directory nothing has been downloaded into yet — which the docs present as the way to combine the two

The capability itself is not missing: lerobot's `make_train_eval_datasets` calls `make_dataset(cfg)`, which builds an ordinary `LeRobotDataset` from the HF cache for a Hub `repo_id`, so the split works there. Adding a populated `dataset_root` to the identical spec emits the pair correctly. Only strands' derivation gave up.

This is the same outcome `validation_episodes_problems` already refuses a non-positive count to prevent, in its own words: *"The caller asked for a validation set and got a run without one."* The decision was enforced for one cause and not the other. `tests/tools/test_val_episodes_yields_validation_loss.py` opens by pinning that "every surface taking `val_episodes` emits the pair … and that a count which cannot be honored is refused rather than silently rounded" — the Hub source was the untested branch.

Measured on one 3-episode dataset, `val_episodes=1`, two real `lerobot-train` runs:

| | before | after |
|---|---|---|
| `validate()` | `[]` | 1 problem, 2 working remedies |
| emitted `eval_split` / `eval_steps` | none | `0.33` / `6` (after remedy) |
| `Train/eval split` logged by lerobot | never | `2 train, 1 eval` |
| episodes trained on (of 3) | **3** | **2** |
| validation losses logged | **0** | `eval_loss=0.7205` |
| run launched | yes | only after a remedy |

## Change

`LerobotTrainer.validate` now refuses a `val_episodes` whose episode count it cannot read, instead of dropping it. The refusal names both remedies that this backend actually honors — point `dataset_root` at a populated local copy, or pass lerobot's own knobs via `extra={"dataset.eval_split": ..., "eval_steps": ...}` — and the guard is keyed on the same reader `_val_eval_split` uses, so the check and the emission cannot drift.

The `>= total_episodes` bound and the multi-task refusal were also gated behind `dataset_root`; they now sit on the branch where the count is readable, which is the only branch where either is meaningful.

Second half, same contract: `validation_split_error`'s remedy hardcoded `extra_flags={...}`. That is right for the `lerobot_train` tool and wrong for `TrainSpec` / `train_policy`, whose field is `extra` — applied verbatim it raises `TypeError: unexpected keyword argument 'extra_flags'`. The helper now takes the caller's own spelling. It is **required**, not defaulted, precisely so a new surface cannot inherit a keyword it does not accept.

`self.provider_name` replaces a hardcoded `"LeRobotTrainer"` context string, which is what `validation_episodes_problems` documents the argument to be ("the backend's `provider_name`, so a problem names the backend that refused the value") and what the sibling refusal on the same surface already used.

## Tests

Added to the module that already owns this contract. **12 failed / 27 passed before, 39 passed after.** The headline failure states the finding directly:

```
AssertionError: a Hub source drops val_episodes silently: validate() reported [] while build_command() emits []
```

and the load-bearing one fails with `assert 'success' != 'success'` — before, `train()` returned success for a spec whose validation request it dropped.

- `TestAnUnreadableEpisodeCountIsRefused` — both reachable sources, plus that the refusal actually stops `train()`.
- `TestARefusalNamesAPassthroughItsOwnSurfaceAccepts` — the keyword is parsed **out of the message** and asserted to be a real `TrainSpec` field / a real `lerobot_train` parameter, then applied verbatim and required to produce the pair. This pins the remedy rather than the wording.
- `TestTheRefusalDoesNotReachPastTheDefect` — the 27 that pass on both revisions are the controls: a local root still emits the pair, a Hub source with `val_episodes=None` is still not refused (`None` is the documented "train on everything" sentinel), and a non-positive count still reports the count-domain problem first.

## Docs

`docs/training/overview.md` described this as a no-op only "when streaming a Hub dataset with no local cache". It is not streaming-specific and it also fires on an unpopulated cache root, so the paragraph now states the refusal, the reason the count is required, and both remedies. The `val_episodes` row gains the source requirement, and `TrainSpec.val_episodes` / `train_policy`'s docstring say the bound is a source requirement as well as a domain.

## Note for the breaking-change check

griffe reports exactly one change — `validation_split_error(passthrough_param)` added as required. It is deliberate: a default would name a keyword one of the two calling surfaces does not accept, which is the dead-end this PR removes. All four in-tree call sites are updated.

## Verification

Rollout of the two runs above (same request, same dataset, real `lerobot-train`):

![val_episodes on a Hub source, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-val-episodes-hub-source/val_episodes_hub_source.png)

Local gate: `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` clean (mypy 14 findings, identical to `main`). Full `tests` suite run on this branch and on `main`: 7 failed / 2 errors on both, identical sets apart from four rotating ids in `tests/mesh/test_zenoh_transport_security.py`, which passes 9/9 three times in isolation on both trees. `+10 passed` on the branch is exactly the ten tests added here.
