### PR TITLE
docs(agents): a null reviewDecision is at least two states, and the resolve clears one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -675,14 +675,42 @@ hatch run format            # ruff check --fix, ruff format
      direction - `REVIEW_REQUIRED` at least says a review is owed, whereas
      `null` reads as "no review requirement applies here" rather than "one
      resolve from merging". It is not a recompute lag: that approval was more
-     than twenty minutes old when the field was read as `null`. The two also
-     need opposite actions - the `REVIEW_REQUIRED` case above needs a second
-     account, this one needs no review at all. The distinguishing read is the
-     threads, not the decision:
+     than twenty minutes old when the field was read as `null`.
+
+     **`null` is at least two states, and the resolve clears only one of them.**
+     #2328 presented #1974's signature exactly - `MERGEABLE`, `BLOCKED`, `null`,
+     one unresolved `github-advanced-security` thread, the required check
+     `SUCCESS` - so the paragraph above prescribed resolving that thread, which
+     was the right action. It settled the decision the other way:
+
+     | pull request | approving review present | after `resolveReviewThread` |
+     |---|---|---|
+     | #1974 | one `APPROVED`, post-dating the head | `APPROVED` / `CLEAN` - merges |
+     | #2328 | none - every review `COMMENTED` | `REVIEW_REQUIRED` / still `BLOCKED` |
+
+     `null` is also what a pull request carrying **no approving review at all**
+     reads, because a `COMMENTED` review contributes no approval. So the resolve
+     was necessary on both and sufficient on one, and "this one needs no review
+     at all" is true of #1974 and false of #2328 while the field is identical on
+     the two.
+
+     Read the review set beside the threads, and read it **before** you resolve
+     anything. #2328's decision moved from `null` to `REVIEW_REQUIRED` on the
+     resolve, so the one value that says which case you are in is gone by the
+     time you re-read it:
 
      ```graphql
+     reviews(last: 20) { nodes { state author { login } submittedAt } }
      reviewThreads(first: 50) { nodes { id isResolved isOutdated } }
      ```
+
+     A `null` carrying no `APPROVED` node is `REVIEW_REQUIRED` wearing a
+     different value: the remedy is a first approving review, and no amount of
+     resolving supplies one. That leaves `REVIEW_REQUIRED` itself carrying two
+     remedies - a first approval, or a second account when the only approval
+     came from the pusher - which is the split
+     `scripts/check_last_push_approval.py --all-open` reports and which no
+     single field distinguishes either.
 
      `isOutdated: true` on an unresolved thread is the common form, and it is a
      prompt rather than reassurance: the diff moved on, so the request has

--- a/changelog.d/2343-review-decision-null-is-not-one-state.md
+++ b/changelog.d/2343-review-decision-null-is-not-one-state.md
@@ -1,0 +1,44 @@
+### Docs: a `null` reviewDecision is at least two states, and resolving the thread clears only one
+
+`AGENTS.md` > PR Workflow step 8 documented `reviewDecision: null` as a third
+reading meaning "one resolve from merging", recorded from #1974 where resolving
+the sole unresolved thread moved `mergeStateStatus` to `CLEAN` and the decision
+to `APPROVED`. That measurement is real, but the passage did not name the input
+that made the resolve *sufficient*, and it explicitly told the reader the case
+"needs no review at all".
+
+#2328 presented the same signature - `MERGEABLE`, `BLOCKED`, `null`, one
+unresolved `github-advanced-security` thread, `call-test-lint / Test and Lint`
+`SUCCESS` - and settled the other way. `null` is also what a pull request with
+no approving review at all reads, because a `COMMENTED` review contributes no
+approval:
+
+| pull request | approving review present | after `resolveReviewThread` |
+|---|---|---|
+| #1974 | one `APPROVED`, post-dating the head | `APPROVED` / `CLEAN` - merges |
+| #2328 | none - every review `COMMENTED` | `REVIEW_REQUIRED` / still `BLOCKED` |
+
+So the resolve was necessary on both and sufficient on one, and the two are
+byte-identical in the field before it. This misreads in the reassuring
+direction, which is the property step 8 already flags for `null`: following it
+yields a resolve, a re-read expecting `CLEAN`, and a pull request reported as
+ready while it waits on a first approving review - the presentation #1905
+records for another cause.
+
+Step 8 now carries the second row, prescribes reading the review set beside the
+threads, and orders that read *before* the resolve. The ordering is the
+load-bearing half: #2328's decision moved from `null` to `REVIEW_REQUIRED` on
+the resolve, so the one value identifying which case a reader is in is destroyed
+by the action the passage prescribes and cannot be recovered by re-reading. The
+bullet also notes that `REVIEW_REQUIRED` itself carries two remedies - a first
+approval, or a second account when the only approval came from the pusher -
+which is the split `scripts/check_last_push_approval.py --all-open` reports.
+
+`tests/test_review_decision_null_is_not_one_state.py` pins both halves: the
+arithmetic, showing a verdict keyed on the decision and the threads alone is
+wrong on one of the two recorded rows while one that also reads the review set
+is right on both; and the prose, including a guard that the unqualified "needs
+no review at all" claim cannot be restored without the qualification naming
+#2328. Five of its ten assertions fail against the uncorrected file.
+
+Documentation and test only - no behaviour changes.

--- a/tests/test_review_decision_null_is_not_one_state.py
+++ b/tests/test_review_decision_null_is_not_one_state.py
@@ -1,0 +1,237 @@
+"""Contract pin for the two states a ``null`` ``reviewDecision`` conflates.
+
+``AGENTS.md`` > PR Workflow > step 8 documents ``reviewDecision: null`` as a
+third reading meaning "one resolve from merging". That was recorded from #1974,
+where resolving the sole unresolved thread moved ``mergeStateStatus`` to
+``CLEAN`` and the decision to ``APPROVED``. The measurement is real. What the
+passage did not name is the input that made the resolve *sufficient*, and it was
+then acted on where that input was absent.
+
+#2328 presented the same signature - ``mergeable: MERGEABLE``,
+``mergeStateStatus: BLOCKED``, ``reviewDecision: null``, one unresolved
+``github-advanced-security`` thread, ``call-test-lint / Test and Lint``
+``SUCCESS`` - and resolving that thread settled the decision the other way:
+
+===============  ===================================  ================================
+pull request     approving review present             after ``resolveReviewThread``
+===============  ===================================  ================================
+#1974            one ``APPROVED``, post-dating head   ``APPROVED`` / ``CLEAN``
+#2328            none - every review ``COMMENTED``     ``REVIEW_REQUIRED`` / ``BLOCKED``
+===============  ===================================  ================================
+
+``null`` is also what a pull request with no approving review at all reads,
+because a ``COMMENTED`` review contributes no approval. So the resolve was
+necessary on both and sufficient on one, and the documented reading - "this one
+needs no review at all" - was true of #1974 and false of #2328 while the field
+was byte-identical on the two. It misreads in the reassuring direction, which is
+the property step 8 already flags for ``null``: acting on it yields a resolve, a
+re-read expecting ``CLEAN``, and a pull request reported as ready while it waits
+on a first approving review - the presentation #1905 records for another cause.
+
+Two halves are pinned, for the reason ``c56ab08`` pinned both halves of the
+merge-mutation bullet. The *arithmetic*: a verdict keyed on the decision and the
+threads alone is wrong on one of the two recorded rows, while one that also
+reads the review set is right on both. The *prose*, asserted inside the same
+bullet, so a later tidy-up cannot leave the bare instruction behind.
+
+The ordering assertion is the one with teeth. #2328's decision moved from
+``null`` to ``REVIEW_REQUIRED`` **on the resolve**, so the single value that
+identifies which case a reader is in is destroyed by the action the passage
+prescribes. A re-read afterwards cannot recover it, which is why the review set
+has to be read first rather than merely read. See #2343.
+
+These are text assertions rather than a parsed document because the claim being
+pinned is prose and that is the shape the existing ``AGENTS.md`` pins use
+(``tests/test_merge_gate_viewer_scope.py`` and
+``tests/test_codeql_query_filters.py`` read the file the same way).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AGENTS_PATH = _REPO_ROOT / "AGENTS.md"
+
+#: What was measured on each pull request, before and after the resolve the
+#: passage prescribes. ``review_states`` is the whole review set, because the
+#: correction turns on a set containing no ``APPROVED`` rather than on a count.
+_OBSERVED: dict[int, dict[str, Any]] = {
+    1974: {
+        "review_decision_before": None,
+        "merge_state_status_before": "BLOCKED",
+        "review_states": ("APPROVED",),
+        "unresolved_threads_before": 1,
+        "review_decision_after_resolve": "APPROVED",
+        "merge_state_status_after_resolve": "CLEAN",
+        "resolve_was_sufficient": True,
+    },
+    2328: {
+        "review_decision_before": None,
+        "merge_state_status_before": "BLOCKED",
+        "review_states": ("COMMENTED", "COMMENTED", "COMMENTED"),
+        "unresolved_threads_before": 1,
+        "review_decision_after_resolve": "REVIEW_REQUIRED",
+        "merge_state_status_after_resolve": "BLOCKED",
+        "resolve_was_sufficient": False,
+    },
+}
+
+
+def _agents_text() -> str:
+    return _AGENTS_PATH.read_text(encoding="utf-8")
+
+
+def _resolve_is_sufficient_by_decision_alone(observation: dict[str, Any]) -> bool:
+    """The uncorrected reading: ``null`` plus a thread means one resolve from merging."""
+    return observation["review_decision_before"] is None and observation["unresolved_threads_before"] > 0
+
+
+def _resolve_is_sufficient_by_review_set(observation: dict[str, Any]) -> bool:
+    """The corrected reading: an approving review has to be there already."""
+    return (
+        observation["review_decision_before"] is None
+        and observation["unresolved_threads_before"] > 0
+        and "APPROVED" in observation["review_states"]
+    )
+
+
+class TestTheDecisionAloneDoesNotPredictTheResolve:
+    """The arithmetic half: which reading matches the two recorded outcomes."""
+
+    def test_the_two_rows_are_indistinguishable_before_the_resolve(self) -> None:
+        # The premise of the whole bullet: if the pre-resolve fields differed, a
+        # reader could tell the cases apart without the review set and none of
+        # this would be worth documenting.
+        before = {
+            number: (
+                observation["review_decision_before"],
+                observation["merge_state_status_before"],
+                observation["unresolved_threads_before"],
+            )
+            for number, observation in _OBSERVED.items()
+        }
+        assert before[1974] == before[2328], (
+            "The recorded pre-resolve fields for #1974 and #2328 now differ, which would "
+            f"mean the null reading is distinguishable without the review set: {before}. "
+            "If a measurement was corrected, re-derive the AGENTS.md claim rather than "
+            "adjusting this fixture to keep it passing."
+        )
+
+    def test_the_uncorrected_reading_is_wrong_on_one_of_the_two_rows(self) -> None:
+        wrong = [
+            number
+            for number, observation in _OBSERVED.items()
+            if _resolve_is_sufficient_by_decision_alone(observation) is not observation["resolve_was_sufficient"]
+        ]
+        assert wrong == [2328], (
+            "A verdict keyed on reviewDecision and the threads alone should predict the "
+            f"resolve correctly on #1974 and incorrectly on #2328; mispredicted: {wrong}. "
+            "That asymmetry is the reason step 8 needs the review set."
+        )
+
+    def test_reading_the_review_set_is_right_on_both_rows(self) -> None:
+        for number, observation in _OBSERVED.items():
+            assert _resolve_is_sufficient_by_review_set(observation) is observation["resolve_was_sufficient"], (
+                f"Reading the review set alongside the threads mispredicts #{number}. "
+                "The corrected AGENTS.md instruction rests on this being right on both."
+            )
+
+    def test_a_commented_review_contributes_no_approval(self) -> None:
+        # Why null cannot be taken to imply an approval exists: #2328 read null
+        # with no APPROVED review anywhere in its set.
+        assert "APPROVED" not in _OBSERVED[2328]["review_states"]
+        assert _OBSERVED[2328]["review_decision_before"] is None, (
+            "#2328 is the counterexample only because it read null while carrying no "
+            "approving review. Without that, the bullet's correction has no evidence."
+        )
+
+    def test_the_resolve_destroys_the_value_that_identifies_the_case(self) -> None:
+        observation = _OBSERVED[2328]
+        assert observation["review_decision_before"] is None
+        assert observation["review_decision_after_resolve"] == "REVIEW_REQUIRED", (
+            "The ordering instruction in step 8 - read the review set before resolving - "
+            "rests on the null being gone afterwards. If #2328's decision is recorded as "
+            "still null after the resolve, the reason for the ordering has changed."
+        )
+
+
+#: The sentence the correction introduces. Everything else is positioned from
+#: it, so its absence fails loudly rather than making the rest vacuous.
+_CORRECTION = "at least two states"
+
+#: The read the correction prescribes, and the fact that makes its ordering
+#: load-bearing.
+_REVIEW_SET_READ = "reviews(last: 20)"
+_ORDERING_RATIONALE = "gone by the"
+
+#: The claim that was wrong when unqualified. It may still appear - the
+#: correction quotes it to say which case it holds for - but only next to the
+#: qualification.
+_UNQUALIFIED_CLAIM = "needs no review at all"
+_QUALIFICATION = "false of #2328"
+
+#: How far apart two phrases may sit while still reading as one instruction.
+_ADJACENCY_WINDOW = 1400
+
+
+def _window_after(text: str, anchor: str) -> str | None:
+    position = text.find(anchor)
+    if position < 0:
+        return None
+    return text[position : position + _ADJACENCY_WINDOW]
+
+
+class TestTheNullReadingNamesItsSecondState:
+    """The prose half: the instruction and its qualifier stay in one breath."""
+
+    def test_the_correction_is_still_present(self) -> None:
+        # Context guard: the assertions below are positioned from this phrase, so
+        # a silent rewording would move the pin rather than break it.
+        assert _CORRECTION in _agents_text(), (
+            f"AGENTS.md no longer contains {_CORRECTION!r}, which this class uses to locate "
+            "the null-reviewDecision correction. If it was deliberately reworded, update "
+            "_CORRECTION to match rather than deleting these tests - the point is that the "
+            "null reading and its second state stay together. See #2343."
+        )
+
+    def test_the_second_state_is_named_with_its_counterexample(self) -> None:
+        window = _window_after(_agents_text(), _CORRECTION)
+        assert window is not None and "#2328" in window, (
+            "AGENTS.md says a null reviewDecision is at least two states without naming the "
+            "pull request that measured the second one. The claim is only actionable with "
+            "the case attached: #2328 read null with no approving review, and resolving its "
+            "thread produced REVIEW_REQUIRED rather than APPROVED. See #2343."
+        )
+
+    def test_the_review_set_read_is_prescribed(self) -> None:
+        window = _window_after(_agents_text(), _CORRECTION)
+        assert window is not None and _REVIEW_SET_READ in window, (
+            "AGENTS.md names the second null state but does not give the query that tells the "
+            "two apart, leaving a reader knowing the field is ambiguous and not what to read "
+            "instead. The distinguishing read is the review set beside the threads. See #2343."
+        )
+
+    def test_the_read_is_ordered_before_the_resolve(self) -> None:
+        window = _window_after(_agents_text(), _CORRECTION)
+        assert window is not None and _ORDERING_RATIONALE in window, (
+            "AGENTS.md prescribes reading the review set but no longer says why the order "
+            "matters. #2328's decision moved from null to REVIEW_REQUIRED on the resolve, so "
+            "a reader who resolves first cannot recover the value that identified the case, "
+            "and the read is only useful beforehand. See #2343."
+        )
+
+    def test_the_unqualified_claim_is_never_restored(self) -> None:
+        text = _agents_text()
+        position = text.find(_UNQUALIFIED_CLAIM)
+        while position >= 0:
+            neighbourhood = text[max(0, position - _ADJACENCY_WINDOW) : position + _ADJACENCY_WINDOW]
+            assert _QUALIFICATION in neighbourhood, (
+                f"AGENTS.md asserts {_UNQUALIFIED_CLAIM!r} without the qualification that it "
+                "holds for #1974 and not for #2328. Unqualified, that sentence sends a reader "
+                "to resolve a thread and expect CLEAN on a pull request that has no approving "
+                "review, which is the misread #2343 records. Keep the phrase beside "
+                f"{_QUALIFICATION!r}, or reword it."
+            )
+            position = text.find(_UNQUALIFIED_CLAIM, position + 1)


### PR DESCRIPTION
Closes #2343

## The passage prescribed an action that is right on one case and insufficient on the other

`AGENTS.md` > PR Workflow step 8 documents `reviewDecision: null` as a third reading meaning "one resolve from merging". It was recorded from #1974, where resolving the sole unresolved thread moved `mergeStateStatus` to `CLEAN` and the decision to `APPROVED`. That measurement is real. What the passage did not name is the input that made the resolve *sufficient*, and it went further - it told the reader this case "needs no review at all".

#2328 presented the documented signature exactly: `mergeable: MERGEABLE`, `mergeStateStatus: BLOCKED`, `reviewDecision: null`, one unresolved `github-advanced-security` thread, required check `call-test-lint / Test and Lint` = `SUCCESS`. Following the passage, the thread was resolved. Reading the same fields back:

| pull request | approving review present | after `resolveReviewThread` |
|---|---|---|
| #1974 | one `APPROVED`, post-dating the head | `APPROVED` / `CLEAN` - merges |
| #2328 | none - every review `COMMENTED` | `REVIEW_REQUIRED` / still `BLOCKED` |

`null` is also what a pull request carrying **no approving review at all** reads, because a `COMMENTED` review contributes no approval. So the resolve was necessary on both and sufficient on one, and the field is identical on the two beforehand. Re-verified on #2328's current head while preparing this change: `reviewDecision: REVIEW_REQUIRED`, three reviews all `COMMENTED`, its one thread resolved, `call-test-lint` `SUCCESS`.

This misreads in the reassuring direction, which is the property step 8 already flags for `null`: acting on it yields a resolve, a re-read expecting `CLEAN`, and a pull request reported as ready while it is in fact waiting on a first approving review - the presentation #1905 records for a different cause.

## Change

- Step 8's `null` bullet keeps the #1974 row and gains the #2328 one, so the two are told apart by the review set rather than by the decision.
- The distinguishing read becomes `reviews(last: 20)` beside `reviewThreads(first: 50)`, and it is **ordered before** the resolve. That ordering is the load-bearing half rather than a nicety: #2328's decision moved from `null` to `REVIEW_REQUIRED` on the resolve, so the one value identifying which case a reader is in is destroyed by the action the passage prescribes, and no re-read afterwards recovers it.
- The bullet now also notes that `REVIEW_REQUIRED` itself carries two remedies - a first approval, or a second account when the only approval came from the pusher - which is the split `scripts/check_last_push_approval.py --all-open` reports and which no single field distinguishes either. Measured on the open set today: 11 open non-draft pull requests, all reading `REVIEW_REQUIRED`, of which one (#1035) is `pusher-only-approval` and ten are `awaiting-first-review`.

The correction deliberately keeps the #1974 case rather than replacing it. Both are real and they are told apart only by the review set, so deleting either row would leave the next reader with a rule that is right by luck.

## Tests

`tests/test_review_decision_null_is_not_one_state.py` pins both halves, the shape `c56ab08` used for the merge-mutation bullet:

- **Arithmetic.** A verdict keyed on the decision and the threads alone predicts the resolve correctly on #1974 and incorrectly on #2328; one that also reads the review set is right on both. The pre-resolve fields of the two rows are asserted *equal*, since that indistinguishability is the premise the whole bullet rests on.
- **Prose.** Adjacency assertions positioned from the sentence the correction introduces, so its absence fails loudly rather than making the rest vacuous - the anchoring problem `tests/test_merge_gate_viewer_scope.py` documents.
- The strongest guard is `test_the_unqualified_claim_is_never_restored`: the phrase "needs no review at all" may still appear (the correction quotes it to say which case it holds for), but only within `_ADJACENCY_WINDOW` of the qualification naming #2328. Restoring the bare instruction fails.

Against the uncorrected `AGENTS.md`: **5 failed, 5 passed** - the four prose assertions plus the unqualified-claim guard, which names the original sentence. **10 passed** after. The five that pass on both revisions are the arithmetic, which pins the reasoning rather than the file.

## Verification

- Every test in the tree that reads `AGENTS.md` - 15 files, including `tests/test_merge_gate_viewer_scope.py`, whose adjacency window this insertion shifts, and both `test_source_no_review_history_markers.py` / `test_source_strings_no_review_archaeology.py`: **322 passed**.
- `tests/test_changelog_fragments.py` + `tests/test_changelog_format.py`: 30 passed; `scripts/assemble_changelog.py --check` OK (443 pending). `tests/test_no_host_paths.py`: 2 passed.
- `ruff check` and `ruff format --check` clean on the new file; `mypy` reports no issues in it.
- Non-ASCII sweep (`grep -nP '[^\x00-\x7F]'`) over both new files: empty.

## Scope

Documentation and test only. No behaviour changes, and the resolve performed on #2328 was still the right action - its thread gate is genuinely cleared. The pull request it was blocking needs a first approving review, which is exactly what the corrected passage now says.

---

## Round 0

Opened. No review feedback yet.

---

<sub>This pull request was authored by an AI contributor. The measurements above were taken by the agent.</sub>