### PR TITLE
fix(registry): resolve every GR00T data_config name to its embodiment's robot

### DIFF
--- a/changelog.d/2350-groot-data-config-registry-aliases.md
+++ b/changelog.d/2350-groot-data-config-registry-aliases.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Registry**: every GR00T `data_config` name now resolves to its embodiment's robot. Five names the
+  shipped catalog advertises were claimed by no registry entry, so `Robot("unitree_g1_sonic")` and
+  `add_robot(data_config="oxe_droid_relative_eef_relative_joint")` refused a robot that sibling configs
+  of the same embodiment loaded, and `move_to`'s registry gripper lookup silently fell back to the
+  heuristic that metadata exists to replace. `unitree_g1_real`, `unitree_g1_sonic` and
+  `real_g1_relative_eef_relative_joints` now resolve the Unitree G1; `oxe_droid_relative_eef_relative_joint`
+  and `oxe_droid_rel` resolve the Panda they declare via `_extends`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -43,7 +43,7 @@ from strands_robots.registry import (
 | `has_sim(name)` / `has_hardware(name)` | Sim / real support flags. |
 | `get_hardware_type(name)` | LeRobot type string for `mode="real"`. |
 | `list_robots_by_category()` | `{category: [names]}`. |
-| `list_aliases()` | All 106 aliases. |
+| `list_aliases()` | All 119 aliases, including every GR00T `data_config` spelling (so `data_config` names resolve as robot names). |
 | `format_robot_table()` | Pretty-printed robot table. |
 | `register_robot(name, entry)` | Add user-defined robot at runtime. |
 | `unregister_robot(name)` | Remove a runtime-registered robot. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ graph TB
 | Module | What it owns | Key types |
 |--------|--------------|-----------|
 | `strands_robots/robot.py` | Factory `Robot(name, mode, backend, **kwargs)`. Name resolution, sim/real dispatch, mesh attach. | `Robot()` function |
-| `strands_robots/registry/` | 72 robots, 114 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
+| `strands_robots/registry/` | 72 robots, 119 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
 | `strands_robots/simulation/` | MuJoCo `AgentTool` - 60+ actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -88,6 +88,19 @@ unitree_g1_real     unitree_g1_sonic
 agibot_*            galaxea_r1_pro
 ```
 
+Every name above is also a robot identifier: the registry declares each
+embodiment's `data_config` spellings as aliases of the robot they name, so
+`unitree_g1_sonic` resolves the same Unitree G1 that `unitree_g1` does.
+
+```python
+Robot("unitree_g1_sonic", mode="sim")          # same robot as Robot("unitree_g1")
+sim.add_robot(name="g1", data_config="unitree_g1_sonic")
+```
+
+That is what lets `add_robot(data_config=...)` find the model to load, lets the
+Isaac IK solve resolve an MJCF for the robot, and lets `move_to` read the
+registry `gripper` block instead of guessing the gripper heuristically.
+
 ## Container lifecycle
 
 ```python

--- a/docs/robots/arms.md
+++ b/docs/robots/arms.md
@@ -28,7 +28,7 @@ sim = Robot("so100")            # SO-ARM100 (low-cost Feetech)
 | `kuka_iiwa` | KUKA LBR iiwa 14 (7-DOF collaborative) | 11 | `kuka_iiwa_14` |
 | `omx` | OMX Robot Arm (ROBOTIS, CAN bus motors) _(hardware-only, no sim asset)_ | ? | `omx_follower`, `omx_robot`, `robotis_omx` |
 | `openarm` | Enactic OpenArm (7-DOF, DAMIAO motors, CAN bus) | 9 | `enactic_openarm`, `open_arm`, `openarm_v10` |
-| `panda` | Franka Emika Panda (7-DOF + gripper) | 7 | `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka`, `franka_emika_panda`, `franka_panda`, `libero_panda`, `oxe_droid`, `single_panda_gripper` |
+| `panda` | Franka Emika Panda (7-DOF + gripper) | 7 | `bimanual_panda_gripper`, `bimanual_panda_hand`, `franka`, `franka_emika_panda`, `franka_panda`, `libero_panda`, `oxe_droid`, `oxe_droid_rel`, `oxe_droid_relative_eef_relative_joint`, `single_panda_gripper` |
 | `piper` | AgileX Piper (6-DOF + gripper) | 11 | `agilex_piper` |
 | `rebot_b601` | Seeed Studio reBot B601-DM (6-DOF + gripper, Damiao CAN motors) _(hardware-only, no sim asset)_ | 7 | `rebot_b601_follower`, `seeed_rebot_b601`, `b601_dm` |
 | `sawyer` | Rethink Robotics Sawyer (7-DOF) | 7 | `rethink_sawyer` |

--- a/docs/robots/humanoids.md
+++ b/docs/robots/humanoids.md
@@ -34,7 +34,7 @@ sim = Robot("reachy_mini")      # Pollen Reachy Mini (expressive)
 | `talos` | PAL Robotics TALOS Humanoid (32-DOF) | 45 | `pal_talos` |
 | `toddlerbot_2xc` | Toddlerbot 2xC Humanoid (45-DOF) | 45 | - |
 | `toddlerbot_2xm` | Toddlerbot 2xM Humanoid (45-DOF) | 45 | - |
-| `unitree_g1` | Unitree G1 Humanoid (29-DOF + dexterous hands) | 46 | `g1`, `g1_wbc`, `unitree_g1_full_body`, `unitree_g1_locomanip`, `unitree_g1_wbc` |
+| `unitree_g1` | Unitree G1 Humanoid (29-DOF + dexterous hands) | 46 | `g1`, `g1_wbc`, `real_g1_relative_eef_relative_joints`, `unitree_g1_full_body`, `unitree_g1_locomanip`, `unitree_g1_real`, `unitree_g1_sonic`, `unitree_g1_wbc` |
 | `unitree_h1` | Unitree H1 Humanoid (19-DOF) | 20 | `h1` |
 | `unitree_h1_2` | Unitree H1-2 Humanoid (52-DOF, with hands) | 52 | `h1_2` |
 

--- a/strands_robots/registry/robots.json
+++ b/strands_robots/registry/robots.json
@@ -198,6 +198,8 @@
         "franka_panda",
         "libero_panda",
         "oxe_droid",
+        "oxe_droid_rel",
+        "oxe_droid_relative_eef_relative_joint",
         "single_panda_gripper"
       ]
     },
@@ -791,8 +793,11 @@
       "aliases": [
         "g1",
         "g1_wbc",
+        "real_g1_relative_eef_relative_joints",
         "unitree_g1_full_body",
         "unitree_g1_locomanip",
+        "unitree_g1_real",
+        "unitree_g1_sonic",
         "unitree_g1_wbc"
       ]
     },

--- a/tests/registry/test_groot_data_configs_resolve_to_a_registry_robot.py
+++ b/tests/registry/test_groot_data_configs_resolve_to_a_registry_robot.py
@@ -1,0 +1,148 @@
+"""Every GR00T ``data_config`` name must resolve to a registry robot.
+
+``data_config`` is not only a GR00T inference concept: it is an accepted robot
+identifier. ``add_robot(data_config=...)`` resolves it through
+``resolve_name`` -> ``get_robot`` to find the model to load, ``resolve_model``
+resolves the MJCF/URDF the Isaac IK solve runs on, and
+``MotionPrimitivesCore._registry_gripper_metadata`` reads the registry
+``gripper`` block for it so ``move_to`` can hold a grasp instead of guessing
+the gripper heuristically.
+
+The registry encodes that by declaring each embodiment's ``data_config``
+spellings in the ``aliases`` list of the robot they name - ``panda`` claims
+``libero_panda`` and ``oxe_droid``, ``so101`` claims ``so101_dualcam`` and
+``so101_tricam``. A config name that no entry claims resolves to nothing, so
+naming it refuses a robot the catalog advertises, and the two failures are not
+symmetric: ``add_robot`` reports an error, while the gripper metadata lookup
+returns "no metadata" and silently falls back to the heuristic it exists to
+replace.
+
+The GR00T catalog is the vocabulary owner and grows independently of the
+registry, so these tests are keyed on the live ``data_configs.json`` rather
+than a copied list: a config added there fails here until the registry offers
+a robot for it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.registry import get_robot, resolve_name
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DATA_CONFIGS_PATH = _REPO_ROOT / "strands_robots" / "policies" / "groot" / "data_configs.json"
+
+# A floor, not the exact count: the catalog is expected to grow. It guards
+# against an extractor that silently reaches nothing, which would make every
+# assertion below pass vacuously.
+_MINIMUM_CATALOG_SIZE = 25
+
+_REMEDY = (
+    "Add each name to the 'aliases' list of the robot entry for its embodiment in "
+    "strands_robots/registry/robots.json (the spelling the GR00T catalog uses, "
+    "e.g. 'panda' claims 'oxe_droid'), so naming that data_config resolves the same "
+    "robot as the rest of the embodiment's configs."
+)
+
+
+@pytest.fixture(scope="module")
+def catalog() -> dict[str, Any]:
+    """The shipped GR00T data_config catalog."""
+    return dict(json.loads(_DATA_CONFIGS_PATH.read_text()))
+
+
+@pytest.fixture(scope="module")
+def config_names(catalog: dict[str, Any]) -> list[str]:
+    """Every name a caller may pass as a ``data_config`` - configs and aliases."""
+    return sorted(set(catalog["configs"]) | set(catalog["aliases"]))
+
+
+def test_the_catalog_is_read_and_not_empty(config_names: list[str]) -> None:
+    """Premise: a clean sweep below must mean the registry agrees, not that nothing was read."""
+    assert len(config_names) >= _MINIMUM_CATALOG_SIZE, (
+        f"Only {len(config_names)} data_config names were read from {_DATA_CONFIGS_PATH.name}; "
+        f"expected at least {_MINIMUM_CATALOG_SIZE}. The other tests in this module would pass "
+        "vacuously, so the extractor is treated as broken rather than the catalog as clean."
+    )
+
+
+def test_every_data_config_name_resolves_to_a_registry_robot(config_names: list[str]) -> None:
+    """No advertised ``data_config`` may resolve to nothing.
+
+    An unclaimed name makes ``add_robot(data_config=...)`` refuse with "No model
+    found" for an embodiment whose other configs load, and makes the registry
+    gripper metadata silently unavailable.
+    """
+    unresolved = [name for name in config_names if get_robot(name) is None]
+    assert not unresolved, (
+        "These GR00T data_config names resolve to no registry robot: "
+        + ", ".join(f"{name!r} -> {resolve_name(name)!r}" for name in unresolved)
+        + ". "
+        + _REMEDY
+    )
+
+
+def test_a_config_that_extends_another_resolves_to_the_same_robot(catalog: dict[str, Any]) -> None:
+    """``_extends`` declares the parent embodiment, so both must name one robot.
+
+    A config that inherits another's keys describes the same hardware with a
+    different action representation. Resolving the two to different robots (or
+    the child to none) would load different models for one embodiment.
+    """
+    configs = catalog["configs"]
+    mismatches: list[str] = []
+    checked = 0
+    for name, spec in configs.items():
+        parent = spec.get("_extends")
+        if not parent:
+            continue
+        checked += 1
+        child_robot = resolve_name(name)
+        parent_robot = resolve_name(parent)
+        if get_robot(name) is None or child_robot != parent_robot:
+            mismatches.append(f"{name!r} -> {child_robot!r} but its _extends parent {parent!r} -> {parent_robot!r}")
+    assert checked, "No config declares '_extends', so this test proves nothing about inheritance."
+    assert not mismatches, "A config resolves to a different robot than the one it extends:\n  " + "\n  ".join(
+        mismatches
+    )
+
+
+def test_a_catalog_alias_resolves_to_the_same_robot_as_its_target(catalog: dict[str, Any]) -> None:
+    """A catalog alias and its target name one robot.
+
+    Mirrors the GR00T-side guarantee that an alias resolves to the same
+    ``Gr00tDataConfig`` as its target: the registry must agree, or the two
+    spellings of one config would load different robots.
+    """
+    mismatches: list[str] = []
+    for alias, target in catalog["aliases"].items():
+        alias_robot, target_robot = resolve_name(alias), resolve_name(target)
+        if get_robot(alias) is None or get_robot(target) is None or alias_robot != target_robot:
+            mismatches.append(f"{alias!r} -> {alias_robot!r} but target {target!r} -> {target_robot!r}")
+    assert catalog["aliases"], "The catalog declares no aliases, so this test proves nothing."
+    assert not mismatches, "A catalog alias and its target resolve to different robots:\n  " + "\n  ".join(mismatches)
+
+
+def test_a_resolved_data_config_lands_on_an_entry_that_declares_a_simulation_asset(
+    config_names: list[str],
+) -> None:
+    """Resolving is not enough - ``add_robot(data_config=...)`` needs a model to load.
+
+    Scoped to the names that do resolve, so this stays independent of whether
+    any name resolves at all: it pins that a config name is only ever pointed
+    at an embodiment carrying an ``asset`` block. Pointing one at a
+    hardware-only entry would resolve cleanly and still refuse, which reads as
+    the same "No model found" as claiming nothing.
+    """
+    resolved = [(name, entry) for name in config_names if (entry := get_robot(name)) is not None]
+    assert resolved, "No data_config name resolves at all, so this test proves nothing about what they resolve to."
+    assetless = [name for name, entry in resolved if not entry.get("asset")]
+    assert not assetless, (
+        "These data_config names resolve to a registry entry with no 'asset' block, so "
+        "add_robot(data_config=...) has no model to load: "
+        + ", ".join(f"{name!r} -> {resolve_name(name)!r}" for name in assetless)
+    )


### PR DESCRIPTION
## Problem

A GR00T `data_config` is not only an inference concept, it is an accepted **robot identifier**. The registry encodes that by declaring each embodiment's `data_config` spellings in the `aliases` list of the robot they name -- `panda` claims `libero_panda` and `oxe_droid`, `so101` claims `so101_dualcam` and `so101_tricam`. Three separate surfaces depend on that resolution:

- `add_robot(data_config=...)` resolves it to find the model to load,
- `resolve_model` resolves the MJCF/URDF the Isaac IK solve runs on,
- `MotionPrimitivesCore._registry_gripper_metadata` reads the registry `gripper` block for it so `move_to` can hold a grasp instead of guessing the gripper heuristically.

Five names the shipped catalog advertises were never claimed by any entry, so they resolved to nothing while sibling configs of the *same* embodiment loaded normally:

```
Robot("unitree_g1_locomanip")                    -> OK
Robot("unitree_g1_sonic")                        -> ValueError: Unknown robot 'unitree_g1_sonic'
Robot("oxe_droid")                               -> OK
Robot("oxe_droid_relative_eef_relative_joint")   -> ValueError: Unknown robot '...'
```

The embodiment each one names is read out of the data, not guessed:

| Unclaimed name | Belongs to | Evidence |
|---|---|---|
| `oxe_droid_relative_eef_relative_joint` | `panda` | its spec is literally `{"_extends": "oxe_droid"}`, and `oxe_droid` is a `panda` alias |
| `oxe_droid_rel` | `panda` | the catalog's own alias for the entry above |
| `unitree_g1_real`, `unitree_g1_sonic` | `unitree_g1` | the `gr00t_inference` docstring groups them under **"Unitree G1 humanoid"** beside `unitree_g1_full_body` / `unitree_g1_locomanip`, which the registry already claims; their state keys are the same G1 whole-body vocabulary |
| `real_g1_relative_eef_relative_joints` | `unitree_g1` | the catalog's own alias for `unitree_g1_real` |

**The two failure modes are not symmetric.** `add_robot` reports an error, but the gripper metadata lookup returns "no metadata" and silently falls back to the heuristic the registry block exists to replace:

```
oxe_droid                              -> {'actuators': ['actuator8'], 'closed': 'low', 'open': 'high'}
oxe_droid_relative_eef_relative_joint  -> (None, None)   # heuristic fallback, no error
```

`unitree_g1_sonic` is the config the SONIC whole-body controller uses, the same controller this package ships a WBC policy for.

## Change

Five alias entries in `strands_robots/registry/robots.json` -- two on `panda`, three on `unitree_g1`. No code change; the resolution mechanism already existed and already claimed the other 25 names.

After: all 30 catalog names (27 configs + 3 catalog aliases) resolve, and each of the five loads the same robot its sibling configs do.

## Visual check

Same script, same four names, run under `upstream/main` and under this branch (MuJoCo, headless EGL). The BEFORE row has nothing to render for two of them; in the AFTER row each pair is pixel-equal, which is the point -- they name one robot.

![data_config resolution before and after](https://raw.githubusercontent.com/cagataycali/robots/media-groot-data-config-aliases/data_config_registry_aliases.png)

| Pair | mean abs pixel delta | Reading |
|---|---|---|
| `unitree_g1_locomanip` vs `unitree_g1_sonic` (after) | 0.000016 | same robot |
| `oxe_droid` vs `oxe_droid_relative_eef_relative_joint` (after) | 0.000153 | same robot |
| `unitree_g1_locomanip`, branch vs main | 0.000010 | unchanged |
| `oxe_droid`, branch vs main | 0.000318 | unchanged |

## Tests

`tests/registry/test_groot_data_configs_resolve_to_a_registry_robot.py`, keyed on the live `data_configs.json` rather than a copied list, so a config added to the catalog fails here until the registry offers a robot for it. `tests/policies/groot/test_data_config.py::TestDataConfigMap::test_all_defs_are_resolved` already pins that every catalog name resolves *in the GR00T code*; this pins that it resolves to a *robot*.

Pre-fix **3 failed / 2 passed**, post-fix **5 passed**:

| Test | Pre-fix |
|---|---|
| every catalog name resolves to a registry robot | fails, naming all 5 with the remedy |
| a config resolves to the same robot it `_extends` | fails on `oxe_droid_relative_eef_relative_joint` |
| a catalog alias resolves to the same robot as its target | fails on `oxe_droid_rel`, `real_g1_relative_eef_relative_joints` |
| a resolved name lands on an entry with an `asset` block | passes (control) |
| the catalog was actually read (premise) | passes (control) |

The two passing tests are the controls. The `asset` one is scoped to names that *do* resolve so it stays independent of the headline: it pins that a config name is only ever pointed at an embodiment carrying a model, since pointing one at a hardware-only entry would resolve cleanly and still refuse.

Full suite: **61 failing ids on both this branch and `upstream/main`** -- identical sets, `comm` empty in both directions -- with 30481 -> 30486 passed, exactly the 5 new tests. `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ` (18 pre-existing errors, unchanged).

## Docs

`tests/test_docs_robot_catalog_coverage.py` already pins the docs catalog against `robots.json`, so it named most of these itself:

- `docs/robots/arms.md`, `docs/robots/humanoids.md`: the `panda` and `unitree_g1` alias columns.
- `docs/architecture.md`: the registry summary line, 114 -> 119 aliases.
- `docs/api-reference.md`: the `list_aliases()` count, which read 106 and was already stale at 114 before this change.
- `docs/policies/groot.md`: the config list now states that each name is also a robot identifier, with a two-line example, since that was the part no guard could have caught.
