### PR TITLE
fix(training): refuse a dataset format version lerobot cannot read at validate() time

### DIFF
--- a/changelog.d/2351-dataset-codebase-version-preflight.md
+++ b/changelog.d/2351-dataset-codebase-version-preflight.md
@@ -1,0 +1,15 @@
+### Fixed
+
+`LerobotTrainer.validate()` now refuses a local dataset root whose declared
+`codebase_version` has an older major than the installed lerobot's
+`CODEBASE_VERSION`, instead of reporting the spec as launchable and letting the
+dataset load fail. The refusal names the root, both versions, and a remedy that
+exists: lerobot's `convert_dataset_v21_to_v30` for a v2.1 root, and an explicit
+"no converter" for an older one. Previously a v2.1 root reached
+`BackwardCompatibilityError` whose command named lerobot's `local` sentinel
+rather than a convertible repo, and every other older major reached a bare
+`NotImplementedError: Contact the maintainer on [Discord](...)` that named
+neither the dataset nor the version. The version is read from the same
+`meta/info.json` the trainer already reads, so the check stays offline: a Hub
+dataset with no local cache is left unflagged, and an unparseable version fails
+open.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -283,6 +283,38 @@ computes them by default), so they train `molmoact2` / `pi05` with no manual
 stats surgery. The check is conservative: a Hub dataset with no local cache is
 left unflagged (its quantiles are verified by lerobot when the shards load).
 
+#### Dataset format version (`codebase_version`)
+
+Every LeRobotDataset declares the format version it was written in as
+`codebase_version` in `meta/info.json`. lerobot compares it against its own
+`CODEBASE_VERSION` and refuses a dataset whose MAJOR is older - an older *minor*
+loads with a warning. Only a `v2.1` root gets a message naming the dataset and
+the converter; for any other older major lerobot raises
+`NotImplementedError: Contact the maintainer on [Discord](...)` from inside the
+exception constructor, naming neither the dataset nor the version.
+
+The version sits in the same `meta/info.json` the trainer already reads for the
+episode count, so `validate()` decides this offline and returns an actionable
+problem instead:
+
+```
+dataset_root '/data/old_dataset' declares codebase_version 'v2.1' in
+meta/info.json, which lerobot 0.6.2 cannot read (it loads 'v3.0' and refuses an
+older major). Convert it with lerobot's own converter: python -m
+lerobot.scripts.convert_dataset_v21_to_v30 --repo-id=<your-dataset-repo-id>
+```
+
+lerobot ships exactly one conversion (`v2.1` -> `v3.0`), so a root older than
+`v2.1` is told so plainly rather than handed a command that would fail. Datasets
+recorded by `Robot.start_recording()` / `DatasetRecorder` are written in the
+installed lerobot's own format, so they pass cleanly.
+
+Like the quantile-stats check, this one is conservative: it flags only a
+definite mismatch. A Hub dataset with no local cache is left unflagged -
+`validate()` does not reach the network, so Hub-side metadata (the format
+version, and the git tag lerobot resolves the revision from) is verified by
+lerobot when the dataset loads.
+
 #### Streaming a large Hub dataset (no full download)
 
 Real datasets (BitRobot / HIW-500, ~50-500 GB) do not fit on a single edge node.

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -57,7 +57,7 @@ from typing import TYPE_CHECKING, Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
 from strands_robots.training.base import Trainer, TrainResult, TrainSpec
-from strands_robots.utils import validation_split_error, validation_split_fraction
+from strands_robots.utils import lerobot_version, validation_split_error, validation_split_fraction
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from lerobot.configs.train import TrainPipelineConfig
@@ -111,6 +111,34 @@ _QUANTILE_NORM_POLICY_TYPES_FALLBACK = frozenset({"molmoact2", "pi05"})
 # stats when ANY feature's stats dict holds one of these keys (mirrors lerobot's
 # own ``augment_dataset_quantile_stats.has_quantile_stats``).
 _QUANTILE_STAT_KEYS = ("q01", "q10", "q50", "q90", "q99")
+
+#: The LeRobotDataset format version the installed lerobot reads, mirrored for
+#: the offline case.
+#:
+#: lerobot REFUSES to load a dataset whose declared ``codebase_version`` has an
+#: older MAJOR than this one: ``check_version_compatibility`` raises
+#: ``BackwardCompatibilityError``, and that class only builds a message for
+#: exactly v2.1 - for any other older major its constructor itself raises
+#: ``NotImplementedError("Contact the maintainer on [Discord](...)")``, naming
+#: neither the dataset nor the version. An older MINOR only logs a warning and
+#: still loads, so only the major is a refusal.
+#:
+#: Read live off the installed lerobot (:func:`_lerobot_codebase_version`), which
+#: reads it from the same module the loader enforces it in; this is the offline
+#: FALLBACK for the ``validate()``-without-lerobot case.
+_LEROBOT_CODEBASE_VERSION_FALLBACK = "v3.0"
+
+#: The one dataset format version lerobot's converter accepts as its source.
+#: ``BackwardCompatibilityError`` builds a message for exactly this version and
+#: raises ``NotImplementedError`` for every other older one, so it is also the
+#: boundary between the two remedies the preflight below can honestly offer.
+_V21_TO_V30_SOURCE_VERSION = "2.1"
+
+#: lerobot's own converter that upgrades a v2.1 dataset in place to the v3
+#: format, quoted by the preflight below so the advice names lerobot's remedy
+#: rather than describing one. It is the only conversion lerobot ships; a root
+#: older than v2.1 has no automated path forward.
+_V21_TO_V30_CONVERTER = "lerobot.scripts.convert_dataset_v21_to_v30"
 
 # RA-BC (Reward-Aligned Behavior Cloning) is surfaced to the agent through the
 # ``extra['sample_weighting']`` dict. lerobot >= 0.6.0 configures sample
@@ -267,6 +295,53 @@ def _dataset_quantile_stats_present(dataset_root: str) -> bool | None:
     except (OSError, json.JSONDecodeError):
         return None
     return _stats_have_quantiles(stats)
+
+
+def _format_version_major(version: str) -> int | None:
+    """MAJOR component of a ``vN.M`` / ``N.M`` dataset format version, or None.
+
+    Returns ``None`` for anything this cannot read a leading major out of, so an
+    unrecognized version string fails OPEN (no problem reported) rather than
+    blocking a possibly-loadable dataset on a cosmetic format - the same posture
+    as :func:`~strands_robots.dataset_recorder._huggingface_hub_version_error`.
+    """
+    match = re.match(r"v?(\d+)", version.strip())
+    return int(match.group(1)) if match else None
+
+
+def _lerobot_codebase_version() -> str:
+    """Dataset format version the installed lerobot reads.
+
+    Read off ``lerobot.datasets.dataset_metadata``, the module whose
+    ``_load_metadata`` enforces it, so the preflight compares against the very
+    constant the loader will compare against. Falls back to the documented
+    :data:`_LEROBOT_CODEBASE_VERSION_FALLBACK` when lerobot is unavailable, so
+    ``validate()`` still produces a useful offline verdict.
+    """
+    try:
+        from lerobot.datasets.dataset_metadata import CODEBASE_VERSION
+    except ImportError:
+        return _LEROBOT_CODEBASE_VERSION_FALLBACK
+    return CODEBASE_VERSION if isinstance(CODEBASE_VERSION, str) else _LEROBOT_CODEBASE_VERSION_FALLBACK
+
+
+def _dataset_codebase_version(dataset_root: str) -> str | None:
+    """Declared ``codebase_version`` of a local LeRobotDataset root, or None.
+
+    Reads ``meta/info.json`` (the file lerobot's ``load_info`` reads, and the one
+    :meth:`LerobotTrainer._dataset_total_episodes` already reads for the episode
+    count). Returns ``None`` when the file is absent, unreadable, or carries no
+    string ``codebase_version`` - the unknown case, e.g. a Hub dataset with no
+    materialized local cache - so a DEFINITE mismatch can be reported without
+    false positives on the unknown one.
+    """
+    info_path = os.path.join(dataset_root, "meta", "info.json")
+    try:
+        with open(info_path, encoding="utf-8") as fh:
+            declared = json.load(fh).get("codebase_version")
+    except (OSError, json.JSONDecodeError):
+        return None
+    return declared if isinstance(declared, str) else None
 
 
 def _reward_registry() -> dict[str, type] | None:
@@ -579,7 +654,8 @@ class LerobotTrainer(Trainer):
         ``dataset_repo_id`` (for streaming) - an ``output_dir``, a usable run
         size (``steps`` / ``global_batch_size``), single-node only
         (``num_nodes == 1``), a ``val_episodes``
-        split below the dataset total, usable LoRA hyperparameters when
+        split below the dataset total, a local dataset format version the
+        installed lerobot can read, usable LoRA hyperparameters when
         ``method == "lora"``, and that ``lerobot.scripts.lerobot_train``
         is importable. ``extra['reward_model']`` switches to reward-model
         preflight; otherwise the default policy path is checked. Returns the
@@ -667,6 +743,9 @@ class LerobotTrainer(Trainer):
                 if split_err:
                     problems.append(split_err)
 
+        # Shared by BOTH run types: policy and reward-model training load the
+        # same dataset, so an unreadable format version refuses either one.
+        problems.extend(self._dataset_codebase_version_problems(spec))
         problems.extend(self._lora_hyperparameter_problems(spec))
 
         # lerobot must be importable to actually train.
@@ -753,6 +832,59 @@ class LerobotTrainer(Trainer):
             "lerobot would mis-normalize or fail at train time. Add quantile stats first: "
             f"python -m lerobot.scripts.augment_dataset_quantile_stats --repo-id={repo_id} "
             f"--root={spec.dataset_root} (datasets recorded with current lerobot already include them)."
+        ]
+
+    def _dataset_codebase_version_problems(self, spec: TrainSpec) -> list[str]:
+        """Preflight a local dataset root's format version against lerobot's.
+
+        lerobot reads ``meta/info.json``'s ``codebase_version`` and refuses a root
+        whose MAJOR is older than its own ``CODEBASE_VERSION``. That refusal is a
+        poor place to learn this: only a v2.1 root gets a message naming the
+        dataset and the converter, and every OTHER older major dies inside
+        ``BackwardCompatibilityError.__init__`` with a bare
+        ``NotImplementedError: Contact the maintainer on [Discord](...)`` that
+        names neither the dataset nor the version nor the problem. This lifts the
+        refusal to spec-validation time with a message that names the root, both
+        versions, and the remedy - the same job :meth:`_quantile_stats_problems`
+        does for the dataset's quantile stats.
+
+        Read-only and conservative, mirroring that sibling: it flags only a
+        DEFINITE mismatch (a local ``meta/info.json`` declaring an older major).
+        A Hub dataset with no materialized local cache is left unflagged (its
+        metadata is not knowable without a download - ``validate()`` does not
+        reach the network), and an unparseable version on either side fails open.
+        Only the major is checked, because an older minor loads with a warning.
+        """
+        if not spec.dataset_root:
+            return []
+        declared = _dataset_codebase_version(spec.dataset_root)
+        if declared is None:
+            return []
+        current = _lerobot_codebase_version()
+        declared_major = _format_version_major(declared)
+        current_major = _format_version_major(current)
+        if declared_major is None or current_major is None or declared_major >= current_major:
+            return []
+
+        # lerobot ships exactly one converter (v2.1 -> v3.0), so an older root
+        # gets an honest "no automated path" rather than a command that would
+        # fail. The repo id is the CONVERTER's argument, and it is a Hub id: a
+        # local-only root has none (``_dataset_source`` calls it "local", which
+        # is not a repo anyone can convert), so name the placeholder instead -
+        # the same substitution ``_quantile_stats_problems`` makes.
+        repo_id = spec.dataset_repo_id or "<your-dataset-repo-id>"
+        if declared.strip().lstrip("v") == _V21_TO_V30_SOURCE_VERSION:
+            remedy = f"Convert it with lerobot's own converter: python -m {_V21_TO_V30_CONVERTER} --repo-id={repo_id}"
+        else:
+            remedy = (
+                f"lerobot ships no converter for {declared}; its only dataset conversion is "
+                f"v2.1 -> v3.0 ({_V21_TO_V30_CONVERTER}). Re-record the dataset, or bring it to "
+                "v2.1 first."
+            )
+        return [
+            f"dataset_root '{spec.dataset_root}' declares codebase_version '{declared}' in "
+            f"meta/info.json, which lerobot {lerobot_version()} cannot read (it loads "
+            f"'{current}' and refuses an older major). {remedy}"
         ]
 
     def _validate_reward_model(self, spec: TrainSpec, rm: dict[str, Any]) -> list[str]:

--- a/tests/training/test_dataset_codebase_version_preflight.py
+++ b/tests/training/test_dataset_codebase_version_preflight.py
@@ -1,0 +1,197 @@
+"""A local dataset root whose format version lerobot cannot read is refused by
+``validate()``, not by the loader.
+
+lerobot compares a dataset's declared ``codebase_version`` against its own
+``CODEBASE_VERSION`` and refuses an older MAJOR. Learning that from the loader is
+poor: only a v2.1 root gets a message naming the dataset and the converter, and
+every other older major dies inside ``BackwardCompatibilityError.__init__`` with a
+bare ``NotImplementedError: Contact the maintainer on [Discord](...)`` that names
+neither the dataset, the version, nor the problem.
+
+The version is declared in the same ``meta/info.json`` this trainer already reads
+for the episode count, so the mismatch is decidable offline - no network, no
+download - which is what lets it move ahead of the run.
+"""
+
+import json
+
+import pytest
+
+from strands_robots.training import TrainSpec
+from strands_robots.training.lerobot import LerobotTrainer
+
+#: Substring that identifies this preflight's problem among the others.
+_VERSION_HINT = "codebase_version"
+
+#: The converter lerobot ships, named by the v2.1 remedy.
+_CONVERTER_HINT = "convert_dataset_v21_to_v30"
+
+
+def _write_root(tmp_path, version, *, name="ds"):
+    """A minimal local dataset root declaring ``version`` (or none when None)."""
+    root = tmp_path / name
+    (root / "meta").mkdir(parents=True)
+    info = {"total_episodes": 10, "robot_type": "so101", "fps": 30}
+    if version is not None:
+        info["codebase_version"] = version
+    (root / "meta" / "info.json").write_text(json.dumps(info), encoding="utf-8")
+    return str(root)
+
+
+def _spec(root, tmp_path, **kw):
+    return TrainSpec(
+        dataset_root=root,
+        base_model="",
+        output_dir=str(tmp_path / "out"),
+        steps=200,
+        global_batch_size=4,
+        extra={"policy_type": "act", "job_name": "t", **kw.pop("extra", {})},
+        **kw,
+    )
+
+
+def _offending(problems):
+    return [p for p in problems if _VERSION_HINT in p]
+
+
+class TestAnUnreadableFormatVersionIsRefusedAtValidateTime:
+    """The refusal names the root, both versions, and a remedy that exists."""
+
+    def test_a_v21_root_is_refused_and_pointed_at_lerobots_converter(self, tmp_path):
+        root = _write_root(tmp_path, "v2.1")
+        problems = LerobotTrainer().validate(_spec(root, tmp_path))
+        offending = _offending(problems)
+        assert offending, f"a v2.1 root is not loadable by lerobot v3; got {problems}"
+        message = offending[0]
+        assert root in message, message
+        assert "v2.1" in message, message
+        assert _CONVERTER_HINT in message, message
+
+    @pytest.mark.parametrize("version", ["v2.0", "v1.6"])
+    def test_an_older_root_is_refused_without_claiming_a_converter_for_it(self, tmp_path, version):
+        """These are the versions whose loader failure names nothing at all.
+
+        lerobot's only conversion is v2.1 -> v3.0, so the remedy must not offer
+        to convert a version the converter does not accept.
+        """
+        root = _write_root(tmp_path, version)
+        problems = LerobotTrainer().validate(_spec(root, tmp_path))
+        offending = _offending(problems)
+        assert offending, f"{version} is not loadable by lerobot v3; got {problems}"
+        message = offending[0]
+        assert version in message, message
+        assert f"--repo-id={version}" not in message, message
+        assert "no converter" in message, message
+
+    def test_the_remedy_never_passes_the_local_sentinel_as_a_repo_id(self, tmp_path):
+        """``_dataset_source`` calls a local-only root "local".
+
+        That is lerobot's placeholder for "not a Hub dataset", not a repo id, so
+        a command built from it would name a repo nobody can convert. The
+        quantile-stats preflight makes the same substitution.
+        """
+        root = _write_root(tmp_path, "v2.1")
+        problems = LerobotTrainer().validate(_spec(root, tmp_path))
+        offending = _offending(problems)
+        assert offending, problems
+        assert "--repo-id=local" not in offending[0], offending[0]
+
+    def test_a_reward_model_run_is_gated_too(self, tmp_path):
+        """Both run types load the same dataset, so both are refused.
+
+        The gate belongs to ``validate()`` rather than to the policy path: a
+        reward-model run reads the same ``meta/info.json``.
+        """
+        root = _write_root(tmp_path, "v2.1")
+        spec = _spec(root, tmp_path, extra={"reward_model": {"type": "sarm"}})
+        assert _offending(LerobotTrainer().validate(spec)), "reward-model runs load the same dataset"
+
+
+class TestItFlagsOnlyADefiniteMismatch:
+    """Controls: every one of these is launchable, or not knowable offline."""
+
+    @pytest.mark.parametrize("version", ["v3.0", "v3.1", "v4.0"])
+    def test_a_current_or_newer_format_root_is_clean(self, tmp_path, version):
+        """Only an older MAJOR is a refusal; an older minor merely warns."""
+        root = _write_root(tmp_path, version)
+        problems = LerobotTrainer().validate(_spec(root, tmp_path))
+        assert not _offending(problems), problems
+
+    @pytest.mark.parametrize("version", [None, "banana", ""])
+    def test_an_unreadable_version_fails_open(self, tmp_path, version):
+        """A version this cannot parse must not block a possibly-loadable root."""
+        root = _write_root(tmp_path, version)
+        problems = LerobotTrainer().validate(_spec(root, tmp_path))
+        assert not _offending(problems), problems
+
+    def test_a_hub_dataset_with_no_local_cache_is_not_flagged(self, tmp_path):
+        """``validate()`` does not reach the network, so Hub metadata is unknown.
+
+        Its format version is checked by lerobot when the shards load.
+        """
+        spec = TrainSpec(
+            dataset_repo_id="acme/some-dataset",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            steps=200,
+            global_batch_size=4,
+            extra={"policy_type": "act", "job_name": "t"},
+        )
+        assert not _offending(LerobotTrainer().validate(spec))
+
+
+class TestTheVersionHelpers:
+    def test_the_declared_version_probe_is_tri_state(self, tmp_path):
+        from strands_robots.training.lerobot import _dataset_codebase_version
+
+        assert _dataset_codebase_version(str(tmp_path)) is None  # no meta/info.json
+        root = _write_root(tmp_path, "v2.1")
+        assert _dataset_codebase_version(root) == "v2.1"
+        bare = _write_root(tmp_path, None, name="bare")
+        assert _dataset_codebase_version(bare) is None
+        broken = tmp_path / "broken" / "meta"
+        broken.mkdir(parents=True)
+        (broken / "info.json").write_text("{not json", encoding="utf-8")
+        assert _dataset_codebase_version(str(broken.parent)) is None
+
+    def test_the_major_is_read_off_either_spelling(self):
+        from strands_robots.training.lerobot import _format_version_major
+
+        assert _format_version_major("v3.0") == 3
+        assert _format_version_major("3.0") == 3
+        assert _format_version_major("v12.4") == 12
+        assert _format_version_major("banana") is None
+        assert _format_version_major("") is None
+
+    def test_the_offline_fallback_matches_the_version_lerobot_enforces(self):
+        """The fallback stands in for lerobot's own constant when it is absent.
+
+        Pinned against the installed lerobot so the offline verdict cannot drift
+        from the version the loader actually compares against.
+        """
+        from strands_robots.training.lerobot import (
+            _LEROBOT_CODEBASE_VERSION_FALLBACK,
+            _lerobot_codebase_version,
+        )
+
+        pytest.importorskip("lerobot.datasets.dataset_metadata")
+        from lerobot.datasets.dataset_metadata import CODEBASE_VERSION
+
+        assert _lerobot_codebase_version() == CODEBASE_VERSION
+        assert _LEROBOT_CODEBASE_VERSION_FALLBACK == CODEBASE_VERSION
+
+    def test_the_converter_source_version_is_the_one_lerobot_messages(self):
+        """lerobot builds a real message for exactly this version.
+
+        Every other older major raises ``NotImplementedError`` from the exception
+        constructor instead, which is why the remedy branches on it.
+        """
+        from strands_robots.training.lerobot import _V21_TO_V30_SOURCE_VERSION
+
+        packaging_version = pytest.importorskip("packaging.version")
+        utils = pytest.importorskip("lerobot.datasets.utils")
+
+        supported = packaging_version.parse(_V21_TO_V30_SOURCE_VERSION)
+        assert utils.BackwardCompatibilityError("acme/ds", supported).args
+        with pytest.raises(NotImplementedError):
+            utils.BackwardCompatibilityError("acme/ds", packaging_version.parse("2.0"))


### PR DESCRIPTION
## Problem

Every LeRobotDataset declares the format version it was written in as `codebase_version` in `meta/info.json`. lerobot compares it against its own `CODEBASE_VERSION` and refuses a dataset whose **major** is older (an older *minor* loads with a warning). `LerobotTrainer.validate()` never looked at it, so an outdated local root reported as launchable and failed at load time instead — and the failure it produced is a poor place to learn this:

| local root declares | what the caller is told |
| --- | --- |
| `v2.1` | `BackwardCompatibilityError` whose remedy is `python -m lerobot.scripts.convert_dataset_v21_to_v30 --repo-id=local` — and `local` is `_dataset_source`'s placeholder for *not a Hub dataset*, not a repo anyone can convert |
| anything else older (`v2.0`, `v1.6`, ...) | `NotImplementedError: Contact the maintainer on [Discord](...)` — raised from inside `BackwardCompatibilityError.__init__`, naming neither the dataset, nor the version, nor the problem |

Measured on lerobot 0.6.2, driving the shipped API (`validate()` returned `[]` in every case):

```
codebase_version='v2.1' -> train() error: lerobot train raised BackwardCompatibilityError: ... --repo-id=local
codebase_version='v2.0' -> train() error: lerobot train raised NotImplementedError: Contact the maintainer on [Discord](...)
codebase_version='v1.6' -> train() error: lerobot train raised NotImplementedError: Contact the maintainer on [Discord](...)
```

## Change

The version sits in the same `meta/info.json` this trainer already reads for the episode count (`_dataset_total_episodes`) and the quantile stats (`_quantile_stats_problems`), so the mismatch is decidable **offline** — no network, no download. `_dataset_codebase_version_problems()` reports it at spec-validation time, naming the root, both versions, and a remedy that exists:

```
dataset_root '/data/old_dataset' declares codebase_version 'v2.1' in meta/info.json, which
lerobot 0.6.2 cannot read (it loads 'v3.0' and refuses an older major). Convert it with
lerobot's own converter: python -m lerobot.scripts.convert_dataset_v21_to_v30 --repo-id=<your-dataset-repo-id>
```

lerobot ships exactly one conversion (`v2.1` -> `v3.0`), so an older root is told that plainly rather than handed a command that would fail. The repo id is substituted with the same `<your-dataset-repo-id>` placeholder `_quantile_stats_problems` already uses, so the advice never passes the `local` sentinel to a converter.

This mirrors `_quantile_stats_problems`, whose docstring states the same job for the dataset's stats: lift a train-time dataset-metadata failure "to spec-validation time with an actionable message naming lerobot's remedy". It is deliberately as conservative as that sibling:

- only a **definite** mismatch is flagged — a local `meta/info.json` declaring an older major;
- a Hub dataset with no materialized local cache is left unflagged. `validate()` does not reach the network (the reward-model path says so to users: *"the spec itself is fine - validate() cannot reach the network to see this"*), so Hub-side metadata stays lerobot's to verify at load time;
- an unparseable version on either side fails **open**, the same posture as `_huggingface_hub_version_error`;
- only the major is compared, because an older minor loads.

It is wired into `validate()` rather than `_validate_policy` because policy and reward-model runs load the same dataset, so an unreadable format version refuses either one. The lerobot-side constant is read from `lerobot.datasets.dataset_metadata` — the module whose `_load_metadata` enforces it — with a documented static fallback so the offline verdict still works when lerobot is absent.

## Tests

`tests/training/test_dataset_codebase_version_preflight.py`, 16 tests. On `upstream/main`: **9 failed / 7 passed**; with the change: **16 passed**.

The 5 behaviour failures pre-fix are the headline (each reports `got []`):

```
test_a_v21_root_is_refused_and_pointed_at_lerobots_converter          AssertionError: ... got []
test_an_older_root_is_refused_without_claiming_a_converter_for_it[v2.0] AssertionError: ... got []
test_an_older_root_is_refused_without_claiming_a_converter_for_it[v1.6] AssertionError: ... got []
test_the_remedy_never_passes_the_local_sentinel_as_a_repo_id          AssertionError: []
test_a_reward_model_run_is_gated_too                                  AssertionError: reward-model runs load the same dataset
```

The **7 tests that pass on both trees** are the no-overreach controls, and they are the point: a current or newer root (`v3.0`, `v3.1`, `v4.0`) is clean, an absent/unparseable/empty version fails open, and a Hub spec with no local cache is not flagged. One test also pins the characterization of lerobot this change depends on — that `BackwardCompatibilityError` builds a message for exactly `2.1` and raises `NotImplementedError` for every other older major — so the branch cannot drift from the library it describes.

## Artifact

The same script and the same spec run against `upstream/main` and against this change; only the tree on `PYTHONPATH` differs. The `v2.0` "before" panel is the sparsest because it is the one where the caller is told nothing at all.

![validate-time refusal of an unreadable dataset format version](https://raw.githubusercontent.com/cagataycali/robots/media-codebase-version-preflight/codebase-version-preflight.png)

## Verification

- `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ`: clean (18 pre-existing errors, unchanged).
- Full `tests/` on this branch vs `upstream/main`: identical failing-id sets, `comm` empty both ways.
- Docs: `docs/training/overview.md` gains a "Dataset format version" section beside the quantile-stats preflight it mirrors, and `validate()`'s own docstring inventory now lists the check.
