### PR TITLE
fix(training): refuse streaming alongside a validation split instead of dropping the stream

### DIFF
--- a/changelog.d/2352-streaming-validation-split-exclusive.md
+++ b/changelog.d/2352-streaming-validation-split-exclusive.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `LerobotTrainer.validate()` now refuses `streaming=True` together with `val_episodes`
+  instead of reporting a launchable spec that delivers neither. A non-zero
+  `dataset.eval_split` routes lerobot into `make_train_eval_datasets`, which rebuilds both
+  splits as map-style `LeRobotDataset` objects without consulting `dataset.streaming`, so
+  the whole dataset was materialized - the disk/RAM blowup `streaming` exists to avoid -
+  with nothing reported. The refusal names both remedies.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -91,12 +91,12 @@ supports and **ignores the rest** (the same tolerance rule as
 |-------|---------|-------|
 | `dataset_root` | LeRobotDataset v3 root | a data source; has `meta/info.json` (optional when `dataset_repo_id` is set) |
 | `dataset_repo_id` | Hub dataset id `org/name` | alternative data source; train from the Hub (lerobot) |
-| `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local) |
+| `streaming` | stream frames, no full materialize | lerobot `StreamingLeRobotDataset`; bounded disk (Hub) / RAM (local); mutually exclusive with `val_episodes` |
 | `base_model` | HF id / local ckpt to tune from | required for GR00T & Cosmos |
 | `steps` / `global_batch_size` | the run size: optimizer steps x batch | each must be a positive integer; `validate()` refuses `0`, a fractional or non-finite value, and a `bool` (`True` would read as a silent one-step run) before anything is loaded |
 | `method` | `full` \| `lora` \| `expert_only` \| `frozen_backbone` | `lora`+`expert_only` are mutually exclusive |
 | `tune` | `{llm,visual,projector,diffusion}` | GR00T only |
-| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count, and that count must be readable from a local `meta/info.json` (see the Hub-source note below). `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating) |
+| `val_episodes` | hold out the LAST N episodes | deterministic split; must be a positive integer below the dataset's episode count, and that count must be readable from a local `meta/info.json` (see the Hub-source note below). `validate()` refuses `0` or a negative (they produced no split and no eval cadence at all - the run trained on everything and logged no validation loss), a `bool`, and a fractional value (`2.7` reserved 3 episodes, `0.5` reserved none while still evaluating); mutually exclusive with `streaming` |
 | `num_gpus` / `num_nodes` | multi-GPU / multi-node | selects the launcher |
 | `seed` | reproducibility seed | must be a non-negative integer; `validate()` refuses a negative (`torch.manual_seed` would take it modulo `2**64`, so `-1` silently becomes `2**64 - 1`), a fractional or non-finite value, and a `bool`. `None` uses the backend's own default |
 | `extra["policy_type"]` | lerobot `--policy.type` | act/diffusion/smolvla/pi0/pi05/... |
@@ -314,6 +314,15 @@ than launch a run that trains on every episode and logs no validation loss. The
 refusal names the two ways to get the split: point `dataset_root` at a populated
 local copy of the dataset, or pass lerobot's own knobs directly with
 `extra={"dataset.eval_split": 0.1, "eval_steps": 1000}`.
+
+`streaming` and `val_episodes` cannot both be honored, so `validate()` refuses
+the pair. A non-zero `eval_split` routes lerobot into `make_train_eval_datasets`,
+which rebuilds BOTH splits as map-style `LeRobotDataset` objects without
+consulting `dataset.streaming` - the streaming dataset it opened first is
+discarded. The run therefore materializes the whole dataset, which is exactly
+what `streaming` exists to avoid, and nothing reports it: an annulled stream is
+indistinguishable from `streaming=False`. Set `streaming=False` to keep the
+validation split, or `val_episodes=None` to keep the stream.
 
 ### GR00T (`groot`)
 

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -70,7 +70,12 @@ class TrainSpec:
             With :attr:`dataset_repo_id` this streams shards from the Hub with no
             full download (bounded disk); with a local ``dataset_root`` it
             streams from disk (bounded RAM). LeRobot-only; other backends ignore
-            it (tolerance rule).
+            it (tolerance rule). Mutually exclusive with :attr:`val_episodes` on
+            the lerobot backend: a held-out split sends lerobot down a map-style
+            path that rebuilds both splits as ``LeRobotDataset`` and drops the
+            stream, so asking for both materializes the whole dataset. The
+            backend refuses the pair in :meth:`Trainer.validate` rather than
+            deliver one of the two silently.
         base_model: HF model id or local checkpoint path to post-tune *from*.
         output_dir: Directory for checkpoints, logs, and the final artifact.
         embodiment: Embodiment tag / robot id. Required by GR00T
@@ -140,7 +145,9 @@ class TrainSpec:
             backend MUST check it with
             :meth:`Trainer._validation_episodes_problems` rather than compare it
             itself: a non-positive value produces no split at all, and ``True``
-            / ``2.7`` / ``0.5`` reserve 1 / 3 / 0 episodes respectively.
+            / ``2.7`` / ``0.5`` reserve 1 / 3 / 0 episodes respectively. On the
+            lerobot backend this is mutually exclusive with :attr:`streaming`
+            (see that field).
         augmentation: Backend-specific data augmentation (GR00T
             ``color_jitter_params`` / ``random_rotation_angle``; Cosmos
             dataset filter dict).

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -505,6 +505,35 @@ class LerobotTrainer(Trainer):
             "directly with extra={'dataset.eval_split': <fraction>, 'eval_steps': <steps>}."
         )
 
+    def _streaming_validation_split_problem(self, spec: TrainSpec) -> str:
+        """Refusal text for ``streaming`` and ``val_episodes`` asked for together.
+
+        Each field is honored on its own, and neither survives the pair.
+        :meth:`_val_eval_split` turns ``val_episodes`` into lerobot's
+        ``dataset.eval_split``, and a non-zero ``eval_split`` sends lerobot down
+        ``make_train_eval_datasets``, which rebuilds BOTH splits as map-style
+        ``LeRobotDataset`` objects without consulting ``dataset.streaming`` - the
+        ``StreamingLeRobotDataset`` it built first is discarded. So the run
+        materializes the whole dataset, which is the outcome ``streaming``
+        exists to avoid, and it does so while reporting nothing: an annulled
+        stream is indistinguishable from ``streaming=False``.
+
+        Refusing here mirrors :meth:`_unreadable_episode_count_problem`, which
+        refuses rather than let a requested validation split be silently
+        dropped. Both remedies named here are honored by this backend: dropping
+        either field delivers the other one whole, and the raw ``extra``
+        passthrough still reaches lerobot's own knobs for a caller who wants the
+        combination anyway.
+        """
+        return (
+            f"{self.provider_name}: streaming=True cannot be combined with "
+            f"val_episodes={spec.val_episodes}. A held-out split makes lerobot rebuild both "
+            "splits as map-style datasets, so the whole dataset is materialized and the stream "
+            "is dropped - the disk/RAM blowup streaming exists to avoid. Either set "
+            "streaming=False to keep the validation split, or val_episodes=None to keep the "
+            "stream."
+        )
+
     def _dataset_total_tasks(self, dataset_root: str) -> int:
         """``total_tasks`` from ``meta/info.json``, or 0 when not recorded."""
         from pathlib import Path
@@ -579,7 +608,8 @@ class LerobotTrainer(Trainer):
         ``dataset_repo_id`` (for streaming) - an ``output_dir``, a usable run
         size (``steps`` / ``global_batch_size``), single-node only
         (``num_nodes == 1``), a ``val_episodes``
-        split below the dataset total, usable LoRA hyperparameters when
+        split below the dataset total and not asked for alongside ``streaming``
+        (lerobot's split path is map-style only), usable LoRA hyperparameters when
         ``method == "lora"``, and that ``lerobot.scripts.lerobot_train``
         is importable. ``extra['reward_model']`` switches to reward-model
         preflight; otherwise the default policy path is checked. Returns the
@@ -666,6 +696,12 @@ class LerobotTrainer(Trainer):
                 )
                 if split_err:
                     problems.append(split_err)
+                if spec.streaming and self._val_eval_split(spec) is not None:
+                    # Both fields were honored in isolation and neither survives
+                    # the pair: lerobot's split path rebuilds the dataset
+                    # map-style, so the stream is dropped. Refuse rather than
+                    # emit a config that silently delivers one of the two.
+                    problems.append(self._streaming_validation_split_problem(spec))
 
         problems.extend(self._lora_hyperparameter_problems(spec))
 

--- a/tests/training/test_lerobot.py
+++ b/tests/training/test_lerobot.py
@@ -6,6 +6,7 @@ end-to-end sim->train->load is exercised separately.
 
 import json
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -1800,3 +1801,144 @@ class TestInProcessTrainerCorrectness:
         message = str(excinfo.value)
         assert str(cfg_file) in message, "the error must name the checkpoint config path"
         assert "resume=False" in message, "the error must offer a way forward"
+
+
+class TestStreamingAndValidationSplitAreMutuallyExclusive:
+    """``streaming`` and ``val_episodes`` cannot both be honored by lerobot.
+
+    ``val_episodes`` becomes lerobot's ``dataset.eval_split``, and any non-zero
+    ``eval_split`` routes lerobot into ``make_train_eval_datasets``, which
+    rebuilds both splits as map-style ``LeRobotDataset`` objects without
+    consulting ``dataset.streaming``. The whole dataset is materialized - the
+    outcome ``streaming`` exists to avoid - and nothing reports it, because an
+    annulled stream looks exactly like ``streaming=False``. Preflight refuses
+    the pair instead, the same way an unreadable episode count is refused rather
+    than allowed to drop a requested split.
+    """
+
+    def _spec(self, dataset_root, tmp_path, **kw):
+        fields = {
+            "dataset_root": dataset_root,
+            "base_model": "",
+            "output_dir": str(tmp_path / "out"),
+            "extra": {"policy_type": "act"},
+        }
+        fields.update(kw)
+        return TrainSpec(**fields)
+
+    def test_asking_for_both_is_refused(self, dataset_root, tmp_path):
+        spec = self._spec(dataset_root, tmp_path, streaming=True, val_episodes=2)
+        problems = LerobotTrainer().validate(spec)
+        assert problems, "streaming + val_episodes delivers neither field, so it is not launchable"
+        assert any("streaming=True cannot be combined with val_episodes=2" in p for p in problems)
+
+    def test_the_refusal_names_the_cost_of_the_silent_outcome(self, dataset_root, tmp_path):
+        spec = self._spec(dataset_root, tmp_path, streaming=True, val_episodes=2)
+        (message,) = [p for p in LerobotTrainer().validate(spec) if "streaming=True" in p]
+        # A caller who reads only the message must learn WHY the pair is refused:
+        # not a policy choice, but that the stream is dropped and the dataset lands
+        # on disk/in RAM in full.
+        assert "materialized" in message
+        assert "stream is dropped" in message
+
+    @pytest.mark.parametrize(
+        ("remedy", "keeps_the_split"),
+        [
+            ({"streaming": False}, True),
+            ({"val_episodes": None}, False),
+        ],
+    )
+    def test_either_remedy_the_message_offers_clears_it(self, dataset_root, tmp_path, remedy, keeps_the_split):
+        # Both remedies are quoted in the refusal, so both must actually work -
+        # and each must deliver the field it keeps, not merely silence the message.
+        trainer = LerobotTrainer()
+        asked = {"streaming": True, "val_episodes": 2, **remedy}
+        spec = self._spec(dataset_root, tmp_path, **asked)
+        assert trainer.validate(spec) == []
+        split = trainer._val_eval_split(spec)
+        assert (split is not None and split > 0.0) is keeps_the_split
+        assert spec.streaming is not keeps_the_split
+
+    def test_streaming_alone_is_launchable(self, dataset_root, tmp_path):
+        # The control that keeps the refusal from swallowing the feature itself.
+        spec = self._spec(dataset_root, tmp_path, streaming=True)
+        assert LerobotTrainer().validate(spec) == []
+
+    def test_validation_split_alone_is_launchable(self, dataset_root, tmp_path):
+        spec = self._spec(dataset_root, tmp_path, val_episodes=2)
+        assert LerobotTrainer().validate(spec) == []
+
+    def test_a_hub_source_with_no_readable_count_keeps_its_own_refusal(self, tmp_path):
+        # With no local meta/info.json no split is emitted at all, so the pair is
+        # not what is wrong here - the episode count is. Reporting both would name
+        # a conflict that this spec does not have.
+        spec = TrainSpec(
+            dataset_root="",
+            dataset_repo_id="lerobot/aloha_sim_transfer_cube_human",
+            base_model="",
+            output_dir=str(tmp_path / "out"),
+            streaming=True,
+            val_episodes=2,
+            extra={"policy_type": "act"},
+        )
+        problems = LerobotTrainer().validate(spec)
+        assert any("episode count is unavailable" in p for p in problems)
+        assert not any("cannot be combined with" in p for p in problems)
+
+    def test_lerobot_split_path_still_drops_the_stream(self, monkeypatch):
+        """The measured constraint the refusal stands on, pinned against lerobot.
+
+        Asserts the property that makes the pair unsatisfiable: lerobot's
+        eval-split path constructs a map-style dataset even when
+        ``dataset.streaming`` is set. If lerobot starts honoring the stream
+        there, this fails and the refusal above should be lifted rather than
+        left to reject a combination that has become supportable.
+        """
+        pytest.importorskip("lerobot")
+        import lerobot.datasets.factory as factory
+
+        built: list[str] = []
+
+        class _StubDataset:
+            def __init__(self, *args, **kwargs):
+                built.append(type(self).__name__)
+                self.episodes = kwargs.get("episodes")
+                self.num_episodes = 4
+                self.meta = SimpleNamespace(
+                    episodes={"tasks": [["t"], ["t"], ["t"], ["t"]]},
+                    camera_keys=[],
+                    depth_keys=[],
+                    stats={},
+                )
+
+        class _StubMapStyle(_StubDataset):
+            pass
+
+        class _StubStreaming(_StubDataset):
+            pass
+
+        monkeypatch.setattr(factory, "LeRobotDataset", _StubMapStyle)
+        monkeypatch.setattr(factory, "StreamingLeRobotDataset", _StubStreaming)
+        monkeypatch.setattr(factory, "make_dataset", lambda cfg: _StubStreaming())
+        monkeypatch.setattr(factory, "resolve_delta_timestamps", lambda *a, **k: None)
+
+        cfg = SimpleNamespace(
+            dataset=SimpleNamespace(
+                repo_id="local",
+                root=None,
+                revision=None,
+                streaming=True,
+                eval_split=0.25,
+                video_backend=None,
+                image_transforms=SimpleNamespace(enable=False),
+                use_imagenet_stats=False,
+            ),
+            trainable_config=None,
+            rename_map=None,
+            tolerance_s=1e-4,
+            num_workers=1,
+        )
+        train_dataset, eval_dataset = factory.make_train_eval_datasets(cfg)
+        assert built.count("_StubStreaming") == 1, "the stream is built once, to read metadata"
+        assert type(train_dataset) is _StubMapStyle, "lerobot rebuilds the TRAIN split map-style, discarding the stream"
+        assert type(eval_dataset) is _StubMapStyle


### PR DESCRIPTION
## Problem

`TrainSpec` exposes `streaming` and `val_episodes` as independent fields, and `LerobotTrainer.validate()` reported no problem when both were set. Neither field is delivered.

`val_episodes` becomes lerobot's `dataset.eval_split`, and any non-zero `eval_split` routes lerobot into `make_train_eval_datasets`, which rebuilds **both** splits as map-style `LeRobotDataset` objects without ever consulting `dataset.streaming` — the `StreamingLeRobotDataset` it opened one line earlier is discarded. So the run materializes the whole dataset, which is precisely the outcome `streaming` exists to avoid ("streams shards from the Hub with no full download (bounded disk); with a local `dataset_root` it streams from disk (bounded RAM)"), and it does so reporting nothing: an annulled stream is indistinguishable from `streaming=False`.

Measured on lerobot 0.6.2 with a local v3 root and `TrainSpec(streaming=True, val_episodes=1, ...)`:

```
validate() -> []
emitted:  --dataset.streaming=true --dataset.eval_split=0.1666... --eval_steps=1000
lerobot:  train dataset type: LeRobotDataset
          eval  dataset type: LeRobotDataset
          train is streaming? False
```

![streaming + val_episodes preflight, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-streaming-val-split/streaming-val-episodes-preflight.png)

One script, one spec, one local v3 dataset root; only the `strands_robots` tree on `sys.path` differs between the two panels.

The blast radius is the whole point of the field: a caller who asks for a bounded-disk run over a 50-500 GB Hub dataset *and* a validation split gets an unbounded one, with no warning, no log line, and a clean preflight.

## Change

`validate()` refuses the pair, naming both remedies:

```
lerobot_local: streaming=True cannot be combined with val_episodes=2. A held-out split
makes lerobot rebuild both splits as map-style datasets, so the whole dataset is
materialized and the stream is dropped - the disk/RAM blowup streaming exists to avoid.
Either set streaming=False to keep the validation split, or val_episodes=None to keep
the stream.
```

Refusing rather than picking one field mirrors the existing sibling `_unreadable_episode_count_problem`, whose docstring already states the principle for the other direction: "a missing `eval_split` is indistinguishable from 'no validation asked for'. Refuse instead, naming both remedies, rather than launch a run that trains on every episode and records no validation loss." This is the same class, with the streaming request as the thing being silently dropped. It also matches how the backend already handles `num_nodes > 1` and `lora` + `expert_only`: refuse a spec it cannot honor instead of silently delivering something narrower.

The gate fires only when a split will actually be emitted (`_val_eval_split(spec) is not None`), so a Hub source with no readable episode count keeps its own, more accurate refusal instead of gaining a second one about a conflict that spec does not have. `extra` still reaches lerobot's own knobs unchanged for a caller who wants the combination anyway.

## Tests

`TestStreamingAndValidationSplitAreMutuallyExclusive`, 8 tests. Against `main`: **2 fail / 6 pass**; after the change 8 pass.

Failing pre-fix:
- `test_asking_for_both_is_refused` — `validate()` returned `[]` for a spec that delivers neither field.
- `test_the_refusal_names_the_cost_of_the_silent_outcome` — the message must say the dataset is *materialized* and the *stream is dropped*, so a caller learns this is a backend constraint and not a style preference.

Passing on both trees (the controls that keep the refusal from over-reaching):
- `test_streaming_alone_is_launchable` / `test_validation_split_alone_is_launchable` — the refusal must not swallow either feature.
- `test_either_remedy_the_message_offers_clears_it` — both quoted remedies clear the refusal *and* deliver the field they keep, not merely silence the message.
- `test_a_hub_source_with_no_readable_count_keeps_its_own_refusal` — no double-reporting.
- `test_lerobot_split_path_still_drops_the_stream` — pins the measured constraint the refusal stands on: lerobot's eval-split path builds the stream once (to read metadata) and then constructs map-style datasets for both splits. If lerobot starts honoring the stream there, this test fails and the refusal should be lifted rather than left rejecting a combination that has become supportable. That keeps the gate from outliving its reason.

Full `tests/` on lerobot 0.6.2, run on both trees: **61 failing ids on this branch vs 66 on `main`, zero branch-only** (the 5 base-only ids are the 2 pre-fix failures above plus 3 known load-sensitive timing flakes). 30637 passed vs 30632.

## Docs

`TrainSpec.streaming` and `TrainSpec.val_episodes` now state the exclusion and why; `docs/training/overview.md` gains it in the field table and a paragraph next to the existing `val_episodes` source-requirement note.

---

## Round 2 changes

No review feedback; this round is a merge-base update only. The approval was dismissed by the push, and nothing about the change under review moved.

**Merged `main` in to resolve a conflict this PR's sibling created.** #2351 landed while this was green and waiting, and it appended a clause to the *same sentence* of `LerobotTrainer.validate`'s docstring that this branch appended one to, so the branch went `CONFLICTING` the moment #2351 merged. The two changes are independent in behaviour and adjacent in text: one refuses an unreadable dataset format version, the other refuses `streaming` alongside a validation split, and both belong in the same enumeration of what the preflight checks.

The conflict is entirely inside that docstring — one hunk, three lines — and the resolution keeps **both** clauses, in the order the checks run:

```
(``num_nodes == 1``), a ``val_episodes``
split below the dataset total and not asked for alongside ``streaming``
(lerobot's split path is map-style only), a local dataset format version
the installed lerobot can read, usable LoRA hyperparameters when
``method == "lora"``, ...
```

No code hunk conflicted, and both siblings' checks are present and independently reachable in the merged `validate()`: `_streaming_validation_split_problem` inside the `val_episodes` block, `_dataset_codebase_version_problems` appended after it. A docstring-only conflict is the failure mode #1784's fragment convention removes for changelog entries, and the same shape shows up in a shared summary docstring — worth noting, but not worth a shared-file convention for one sentence.

Verified against the merged tree rather than either parent, since no check had compiled the two together: `tests/training/` — `test_lerobot.py` (this PR's suite), `test_dataset_codebase_version_preflight.py` (#2351's), and the three docstring gates that read this exact docstring (`test_docstring_module_xrefs.py`, `test_public_member_docstrings.py`, `test_trainer_provider_docstrings.py`) — 109 passed, 37 skipped, with the 23 failures all reporting `lerobot is not installed` (the optional dep is absent from this sandbox; the same ids fail identically on unmodified `main` here). `ruff check` and `ruff format --check` clean on the resolved file.