### PR TITLE
fix(kimodo): ease a chained segment off the pose last commanded

### DIFF
--- a/changelog.d/2353-kimodo-chained-prompt-transition.md
+++ b/changelog.d/2353-kimodo-chained-prompt-transition.md
@@ -1,0 +1,12 @@
+### Fixed
+
+`KimodoPolicy` now eases a newly sampled motion off the pose it last commanded
+when the prompt changes mid-rollout, instead of emitting the fresh sample from
+its own canonical start pose. Chaining prompts is the documented way to drive a
+long-horizon sequence, but every segment boundary stepped all 29 joints at once:
+across the 600 ordered pairs of a 25-motion corpus the median seam moved a joint
+1.6 rad in a single tick, and 84% of transitions exceeded the largest per-tick
+step the motions themselves ever take, all reported as a successful rollout. The
+transition length is `KimodoConfig.transition_frames` (default 5, matching the
+`num_transition_frames` Kimodo's own sampler applies to a multi-prompt
+sequence). A single-prompt rollout is byte-for-byte unchanged.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -115,6 +115,7 @@ it, or a tuned PD law) is required, and is out of scope for this provider.
 | `diffusion_steps` | int | 100 | 25–200 useful range |
 | `guidance_scale` | float | 7.5 | CFG weight |
 | `num_frames` | int | 120 | ≤196 (RP-v1 max) |
+| `transition_frames` | int | 5 | Native frames a chained segment is eased over |
 | `native_fps` | int | 30 | Sampler native rate |
 | `tracker_fps` | int | 50 | SLERP upsample target |
 | `device` | str \| None | auto | `"cuda"` / `"cpu"` |
@@ -163,6 +164,64 @@ whole run stays reproducible: re-running at the same master `seed=` replays the
 same per-episode motions. Repeating a seed replays the buffered motion rather
 than re-running the sampler for identical frames, and `reset()` without a seed
 only rewinds - neither pays for a diffusion run.
+
+## Chaining prompts into a long-horizon sequence
+
+Because a changed prompt samples the next segment and the stream simply
+continues, a long-horizon episode is a rollout that changes the instruction as
+it goes — no stitching layer required. Anything that can vary the instruction
+per tick will do; a `policy_object` driven directly is the smallest version:
+
+```python
+import asyncio
+
+from strands_robots import Robot
+from strands_robots.policies.kimodo import KIMODO_G1_JOINTS, KimodoPolicy
+
+CHAIN = [
+    ("a person walking forward with confident strides", 90),
+    ("a person turning to the left", 60),
+    ("a person waving with the right hand", 60),
+    ("a person crouching down to pick an object off the floor", 90),
+    ("a person walking forward with confident strides", 90),
+]
+
+sim = Robot("g1", mesh=False)
+policy = KimodoPolicy()
+policy.set_robot_state_keys(list(KIMODO_G1_JOINTS))
+
+for instruction, ticks in CHAIN:
+    for _ in range(ticks):
+        action = asyncio.run(policy.get_actions({}, instruction))[0]
+        sim.set_joint_positions(action, robot_name="g1")
+```
+
+Each segment is sampled once, on the tick its instruction first appears. Kimodo
+samples every motion from its own canonical start pose, which has no relation to
+wherever the previous segment left the robot, so a new segment is eased off the
+pose last commanded across `transition_frames` native frames. Without that the
+seam commands every joint to step at once — measured across the 600 ordered
+pairs of a 25-motion corpus, the median seam moved a joint 1.6 rad in a single
+tick and 84% of transitions exceeded the largest step the motions themselves
+ever take. A reference like that is not one a tracker can follow, and it is
+reported as a successful rollout.
+
+`transition_frames` defaults to 5, the same length Kimodo's own sampler uses for
+`num_transition_frames` when it generates a multi-prompt sequence. Raise it for
+wider pose gaps (opposing poses eased over more frames), lower it toward 1 to
+keep segment boundaries crisp. It is bounded below at 1, matching the domain the
+sampler enforces on its own transition length.
+
+Note the difference in kind from the sampler's native multi-prompt path: Kimodo
+conditions the *diffusion* of the next segment on the previous segment's last
+frames, so the generated motion itself leads into the transition. The agent
+protocol here takes only a prompt and sampling knobs, with no continuation
+state, so easing shapes the emitted stream rather than the sample. It removes
+the discontinuity; it does not re-plan the motion around it.
+
+An episode boundary is not a seam. `reset()` forgets the last commanded pose, so
+the next episode opens on its motion's own start pose rather than being eased
+onto wherever the previous episode finished.
 
 ## When the checkpoint is not a Kimodo checkpoint
 

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -14,6 +14,8 @@ Numeric domains follow the shared helpers in :mod:`strands_robots.utils`:
   for the G1 tracker via SLERP downstream)
 * ``num_frames`` - positive integer bounded by the model's max sequence length
   (196 for RP-v1)
+* ``transition_frames`` - positive integer, at least 1, matching the domain the
+  Kimodo sampler applies to its own ``num_transition_frames``
 
 The default ``model_id`` targets the RP-v1 checkpoint. Alternate model ids are
 accepted verbatim; the loader defers validation to ``from_pretrained``. Note
@@ -33,6 +35,11 @@ _KIMODO_DEFAULT_MODEL_ID = "nvidia/Kimodo-G1-RP-v1"
 _KIMODO_MAX_FRAMES = 196
 _KIMODO_NATIVE_FPS = 30
 _KIMODO_TRACKER_FPS = 50
+# Kimodo's own sampler blends a multi-prompt sequence over its last
+# ``num_transition_frames`` frames and defaults that to 5 (and refuses < 1), so
+# a chained rollout here adopts the same length and domain rather than inventing
+# a second convention for the same transition.
+_KIMODO_TRANSITION_FRAMES = 5
 
 
 def _positive_int(name: str, value: int, upper: int | None = None) -> int:
@@ -93,6 +100,15 @@ class KimodoConfig:
         diffusion_steps: Number of denoising steps (25-200, default 100).
         guidance_scale: Classifier-free-guidance weight (default 7.5).
         num_frames: Motion length in Kimodo native frames (30 FPS, max 196).
+        transition_frames: Number of native frames over which a newly sampled
+            motion is eased off the pose last commanded, when a prompt (or any
+            other sampler input) changes mid-rollout. A fresh sample begins at
+            its own canonical start pose, which is unrelated to wherever the
+            previous motion left the robot, so emitting it directly steps every
+            joint at once. Defaults to 5, the same length Kimodo's sampler uses
+            for its own ``num_transition_frames``. Only the first sample of a
+            rollout is unaffected: with no previously commanded pose there is no
+            seam to ease.
         native_fps: Kimodo sampler output rate (30 Hz native, do not change
             unless targeting a retrained checkpoint).
         tracker_fps: Rate the G1 tracker consumes at (50 Hz standard). Frames
@@ -117,6 +133,7 @@ class KimodoConfig:
     diffusion_steps: int = 100
     guidance_scale: float = 7.5
     num_frames: int = 120
+    transition_frames: int = _KIMODO_TRANSITION_FRAMES
     native_fps: int = _KIMODO_NATIVE_FPS
     tracker_fps: int = _KIMODO_TRACKER_FPS
     device: str | None = None
@@ -130,6 +147,7 @@ class KimodoConfig:
         _positive_int("diffusion_steps", self.diffusion_steps, upper=500)
         _positive_float("guidance_scale", self.guidance_scale)
         _positive_int("num_frames", self.num_frames, upper=_KIMODO_MAX_FRAMES)
+        _positive_int("transition_frames", self.transition_frames, upper=_KIMODO_MAX_FRAMES)
         _positive_int("native_fps", self.native_fps)
         _positive_int("tracker_fps", self.tracker_fps)
         if self.dtype not in ("fp16", "bf16", "fp32"):

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -35,6 +35,14 @@ Contract:
   ``kwargs`` (``diffusion_steps``, ``guidance_scale``, ``seed``). The instance
   synthesises ONCE on first call (or when the prompt changes) then streams
   per-frame targets on subsequent calls, one frame per call, synchronously.
+* Changing the prompt mid-rollout is how a long-horizon sequence is driven:
+  each new prompt samples the next segment and the stream continues. A fresh
+  sample starts at its own canonical start pose, unrelated to wherever the
+  previous segment left the robot, so the segment is eased off the pose last
+  commanded over ``config.transition_frames`` native frames - the same
+  transition length Kimodo's own sampler applies to a multi-prompt sequence.
+  Without it the seam commands every joint to step at once, which is not a
+  reference any tracker can follow.
 * Output is a dict of joint-name -> target angle for the G1's 29 leg + waist
   + arm joints, keyed by :data:`KIMODO_G1_JOINTS` (the canonical WBC ordering)
   so the tracker sees identical names.
@@ -98,6 +106,95 @@ class KimodoMotionAgent(Protocol):
         ...
 
 
+def _slerp_quat(
+    q0: NDArray[np.float32],
+    q1: NDArray[np.float32],
+    t: float | np.floating[Any],
+) -> NDArray[np.float32]:
+    """Spherically interpolate between two wxyz quaternions.
+
+    Shared by the native -> tracker upsample and the segment-transition ease so
+    both walk the same arc: a quaternion has two representations for one
+    rotation, and picking the shorter arc (the sign flip below) is what stops an
+    interpolation from taking the long way round.
+
+    Args:
+        q0: Start quaternion, wxyz. Assumed unit-norm.
+        q1: End quaternion, wxyz. Assumed unit-norm.
+        t: Interpolation weight, 0.0 returns ``q0`` and 1.0 returns ``q1``. A
+            numpy scalar is accepted as-is rather than widened to a Python
+            float, so the caller's precision decides the arithmetic precision.
+
+    Returns:
+        The interpolated unit quaternion, wxyz.
+    """
+    dot = float(np.dot(q0, q1))
+    if dot < 0.0:
+        q1 = -q1
+        dot = -dot
+    if dot > 0.9995:
+        # Nearly parallel - the arc is shorter than float precision resolves,
+        # so lerp+normalise avoids dividing by a vanishing sin(theta).
+        q = q0 + t * (q1 - q0)
+    else:
+        theta_0 = float(np.arccos(dot))
+        sin_theta_0 = float(np.sin(theta_0))
+        theta = theta_0 * t
+        s0 = float(np.sin(theta_0 - theta)) / sin_theta_0
+        s1 = float(np.sin(theta)) / sin_theta_0
+        q = s0 * q0 + s1 * q1
+    return q / max(float(np.linalg.norm(q)), 1e-8)  # type: ignore[no-any-return]
+
+
+def _ease_onto_previous_pose(
+    qpos: NDArray[np.float32],
+    previous_pose: NDArray[np.float32],
+    frames: int,
+) -> NDArray[np.float32]:
+    """Ease a freshly sampled motion off the pose that was last commanded.
+
+    Kimodo samples every motion from its own canonical start pose, so the first
+    frame of a new segment bears no relation to the last frame of the previous
+    one. Emitting it unmodified steps every joint in a single tick. This decays
+    that pose offset to zero across the first ``frames`` frames, leaving the
+    rest of the segment untouched: the motion keeps its own shape and velocity
+    and only its starting offset is absorbed.
+
+    The offset decays by ``1 / (frames + 1)`` per frame, so the residual step at
+    the seam is the full offset divided by ``frames + 1`` rather than the offset
+    itself. The first frame is deliberately not pinned exactly onto
+    ``previous_pose``: that would command zero motion for one frame, trading a
+    position step for a velocity stall.
+
+    Args:
+        qpos: The freshly sampled ``(n, 7 + njoints)`` motion, native rate.
+        previous_pose: The last commanded ``(7 + njoints,)`` qpos frame.
+        frames: Number of frames to spread the offset over. Clamped to the
+            length of ``qpos``.
+
+    Returns:
+        A new array of the same shape, with the leading frames eased. ``qpos``
+        is not modified.
+    """
+    count = int(min(frames, qpos.shape[0]))
+    if count <= 0:
+        return qpos
+    out = qpos.copy()
+    # Root orientation interpolates on the quaternion arc; root position and
+    # joint angles are ordinary linear channels.
+    linear = list(range(3)) + list(range(_NUM_ROOT_QPOS, qpos.shape[1]))
+    offset = previous_pose[linear] - qpos[0, linear]
+    q_prev = previous_pose[3:7]
+    q_prev = q_prev / max(float(np.linalg.norm(q_prev)), 1e-8)
+    for i in range(count):
+        weight = 1.0 - (i + 1) / (count + 1)
+        out[i, linear] = qpos[i, linear] + weight * offset
+        q_i = qpos[i, 3:7]
+        q_i = q_i / max(float(np.linalg.norm(q_i)), 1e-8)
+        out[i, 3:7] = _slerp_quat(q_i, q_prev, weight)
+    return out
+
+
 def _slerp_upsample(
     qpos: NDArray[np.float32],
     native_fps: int,
@@ -128,21 +225,7 @@ def _slerp_upsample(
     for i, t in enumerate(t_out):
         idx = np.clip(np.searchsorted(t_in, t) - 1, 0, n_in - 2)
         alpha = (t - t_in[idx]) / max(t_in[idx + 1] - t_in[idx], 1e-8)
-        q0, q1 = q_in[idx], q_in[idx + 1]
-        dot = float(np.dot(q0, q1))
-        if dot < 0.0:
-            q1 = -q1
-            dot = -dot
-        if dot > 0.9995:
-            q = q0 + alpha * (q1 - q0)
-        else:
-            theta_0 = float(np.arccos(dot))
-            sin_theta_0 = float(np.sin(theta_0))
-            theta = theta_0 * alpha
-            s0 = float(np.sin(theta_0 - theta)) / sin_theta_0
-            s1 = float(np.sin(theta)) / sin_theta_0
-            q = s0 * q0 + s1 * q1
-        out[i, 3:7] = q / max(float(np.linalg.norm(q)), 1e-8)
+        out[i, 3:7] = _slerp_quat(q_in[idx], q_in[idx + 1], alpha)
     return out
 
 
@@ -189,6 +272,7 @@ class KimodoPolicy(Policy):
         diffusion_steps: int | None = None,
         guidance_scale: float | None = None,
         num_frames: int | None = None,
+        transition_frames: int | None = None,
         native_fps: int | None = None,
         tracker_fps: int | None = None,
         device: str | None = None,
@@ -213,6 +297,8 @@ class KimodoPolicy(Policy):
             diffusion_steps: Denoising steps override.
             guidance_scale: Classifier-free-guidance weight override.
             num_frames: Motion length override, in native frames.
+            transition_frames: Override for the number of native frames a newly
+                sampled segment is eased off the last commanded pose over.
             native_fps: Sampler output rate override.
             tracker_fps: Tracker consumption rate override.
             device: torch device string override.
@@ -229,6 +315,7 @@ class KimodoPolicy(Policy):
             diffusion_steps=diffusion_steps,
             guidance_scale=guidance_scale,
             num_frames=num_frames,
+            transition_frames=transition_frames,
             native_fps=native_fps,
             tracker_fps=tracker_fps,
             device=device,
@@ -244,6 +331,15 @@ class KimodoPolicy(Policy):
         self._buffer_key: tuple[str, int, float, int | None] | None = None
         self._motion_buffer: NDArray[np.float32] | None = None
         self._frame_cursor: int = 0
+        # The last qpos frame handed out. A re-sample eases onto it so a new
+        # segment continues from where the robot actually is; ``None`` means
+        # nothing has been commanded yet, so there is no seam to ease.
+        self._last_frame: NDArray[np.float32] | None = None
+        # The sampler's own output, kept so the buffer can be rebuilt without
+        # easing (and without re-sampling) when an episode boundary means the
+        # transition it was built for no longer applies.
+        self._raw_sample: NDArray[np.float32] | None = None
+        self._buffer_eased: bool = False
         self._joint_names: tuple[str, ...] = KIMODO_G1_JOINTS
         self._robot_state_keys: list[str] = list(KIMODO_G1_JOINTS)
 
@@ -335,6 +431,10 @@ class KimodoPolicy(Policy):
         frame = self._motion_buffer[idx]
         self._frame_cursor += 1
 
+        # Record the emitted pose before returning: it is the seam a later
+        # re-sample eases onto.
+        self._last_frame = frame.copy()
+
         joint_angles = frame[_NUM_ROOT_QPOS:]
         action = {name: float(v) for name, v in zip(self._joint_names, joint_angles)}
         return [action]
@@ -350,6 +450,10 @@ class KimodoPolicy(Policy):
         :meth:`get_actions` re-samples, because the seed is part of the key
         identifying the buffered motion.
 
+        Rewinding also forgets the last commanded pose: episodes are
+        independent, so the next segment opens at the motion's own start pose
+        rather than being eased onto where the previous episode finished.
+
         Args:
             seed: Sampling seed for the next episode. ``None`` rewinds only,
                 replaying the motion already held. A seed equal to the one that
@@ -357,6 +461,15 @@ class KimodoPolicy(Policy):
                 re-running the sampler for identical frames.
         """
         self._frame_cursor = 0
+        # A new episode starts the robot afresh, so there is no previously
+        # commanded pose to stay continuous with. Forgetting the pose is not
+        # enough on its own: a buffer already eased onto it would still be
+        # replayed from frame 0, opening the new episode on a transition built
+        # for the previous one. Rebuilding from the held sample undoes that
+        # without paying for another diffusion run.
+        self._last_frame = None
+        if self._buffer_eased and self._raw_sample is not None:
+            self._rebuild_buffer(None)
         if seed is not None:
             # Store on config-shadow so next _synthesise picks it up.
             object.__setattr__(self.config, "seed", seed)
@@ -415,14 +528,10 @@ class KimodoPolicy(Policy):
                 f"Kimodo agent returned qpos with shape {raw.shape}, expected "
                 f"(*, {_NUM_ROOT_QPOS + len(KIMODO_G1_JOINTS)})"
             )
-        # Upsample native 30Hz -> tracker 50Hz for smooth control.
-        self._motion_buffer = _slerp_upsample(
-            raw.astype(np.float32),
-            native_fps=self.config.native_fps,
-            target_fps=self.config.tracker_fps,
-        )
+        self._raw_sample = raw.astype(np.float32)
+        self._rebuild_buffer(self._last_frame)
         self._buffer_key = self._sample_key(prompt, diffusion_steps, guidance_scale, seed)
-        self._frame_cursor = 0
+        assert self._motion_buffer is not None  # narrowed by _rebuild_buffer
         # The prompt is caller-supplied, so it is identified by digest rather
         # than echoed: interpolating the text would let a prompt containing a
         # newline forge an additional log record. The digest still correlates
@@ -434,6 +543,38 @@ class KimodoPolicy(Policy):
             hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12],
             len(prompt),
         )
+
+    def _rebuild_buffer(self, previous_pose: NDArray[np.float32] | None) -> None:
+        """Build the streaming buffer from the held sample and rewind the cursor.
+
+        Separated from :meth:`_synthesise` because the buffer depends on two
+        things - the sample and the pose it must continue from - and only the
+        first costs a diffusion run. An episode boundary changes the second, so
+        it rebuilds here rather than re-sampling.
+
+        Args:
+            previous_pose: The pose the segment must continue from, or ``None``
+                to emit the sample as the sampler produced it.
+        """
+        assert self._raw_sample is not None  # only called with a held sample
+        sampled = self._raw_sample
+        # Ease at the native rate so ``transition_frames`` counts the same
+        # frames Kimodo's own ``num_transition_frames`` does, and before the
+        # upsample so the interpolation smooths the eased frames with the rest.
+        if previous_pose is not None:
+            sampled = _ease_onto_previous_pose(
+                sampled,
+                previous_pose,
+                self.config.transition_frames,
+            )
+        self._buffer_eased = previous_pose is not None
+        # Upsample native 30Hz -> tracker 50Hz for smooth control.
+        self._motion_buffer = _slerp_upsample(
+            sampled,
+            native_fps=self.config.native_fps,
+            target_fps=self.config.tracker_fps,
+        )
+        self._frame_cursor = 0
 
     @staticmethod
     def _resolve_config(

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -312,6 +312,7 @@
         "diffusion_steps",
         "guidance_scale",
         "num_frames",
+        "transition_frames",
         "native_fps",
         "tracker_fps",
         "device",

--- a/tests/policies/kimodo/test_chained_prompt_transition_is_continuous.py
+++ b/tests/policies/kimodo/test_chained_prompt_transition_is_continuous.py
@@ -1,0 +1,280 @@
+"""Chaining prompts through KimodoPolicy stays continuous at the segment seam.
+
+Changing the prompt mid-rollout is the documented way to drive a long-horizon
+sequence: each new prompt samples the next segment and the stream continues.
+Kimodo samples every motion from its own canonical start pose, though, so a
+fresh segment's first frame bears no relation to the pose the previous segment
+left the robot in. Emitted unmodified it steps every joint at once - a reference
+no tracker can follow, reported as a successful rollout.
+
+The policy therefore eases a new segment off the pose last commanded across
+``config.transition_frames`` native frames, the same transition length Kimodo's
+own sampler applies to a multi-prompt sequence.
+
+The stub agent below returns a DIFFERENT motion per prompt, with a deliberate
+pose offset between them: a stub that returned the same frames for every prompt
+could not observe a seam at all.
+
+``native_fps == tracker_fps`` throughout so one native frame is one emitted
+frame and the transition window is countable directly; the upsample path is
+covered separately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.kimodo import KIMODO_G1_JOINTS, KimodoConfig, KimodoPolicy
+
+_NUM_JOINTS = len(KIMODO_G1_JOINTS)
+_ROOT = 7
+
+# Two prompts whose motions sit far apart in joint space, so the seam between
+# them is large enough to measure and not an artefact of rounding.
+_WALK = "a person walking forward with confident strides"
+_REACH = "a person crouching down to pick an object off the floor"
+
+
+class _TwoMotionAgent:
+    """Return a distinct, slowly-varying motion per prompt.
+
+    Each motion oscillates gently about its own centre, so within a segment the
+    per-frame change is small while the offset BETWEEN the two centres is large.
+    That separation is what makes a seam step distinguishable from ordinary
+    motion.
+    """
+
+    #: Joint-space centre of each motion, in radians.
+    CENTRES = {_WALK: 0.10, _REACH: -1.40}
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+        self.prompts.append(prompt)
+        centre = self.CENTRES[prompt]
+        out = np.zeros((num_frames, _ROOT + _NUM_JOINTS), dtype=np.float32)
+        out[:, 3] = 1.0  # identity quaternion, wxyz
+        # Amplitude and rate chosen so one frame's motion is roughly a tenth of
+        # the gap between the two centres, the ratio real Kimodo motions show.
+        phase = np.linspace(0.0, 4.0 * np.pi, num_frames, dtype=np.float32)
+        for j in range(_NUM_JOINTS):
+            out[:, _ROOT + j] = centre + 0.30 * np.sin(phase + 0.1 * j)
+        return out
+
+
+def _start_pose(prompt: str) -> np.ndarray:
+    """The joint pose a motion begins in, per the sampler.
+
+    Uses a throwaway agent: sampling from the agent under observation would
+    register as a sampler run and corrupt the call-count assertions.
+    """
+    return _TwoMotionAgent().sample(prompt, 40, 100, 7.5, None)[0, _ROOT:].astype(np.float64)
+
+
+def _seam_gap(last_commanded: np.ndarray, next_prompt: str) -> float:
+    """The pose gap a seam has to absorb.
+
+    Measured against the pose actually last commanded rather than the previous
+    motion's start pose: a segment ends wherever its own motion took it, so the
+    gap at a seam is generally wider than the distance between two start poses.
+    """
+    return float(np.abs(_start_pose(next_prompt) - last_commanded).max())
+
+
+def _policy(**overrides):
+    agent = _TwoMotionAgent()
+    policy = KimodoPolicy(
+        config=KimodoConfig(num_frames=40, native_fps=30, tracker_fps=30, **overrides),
+        motion_agent=agent,
+    )
+    policy.set_robot_state_keys(list(KIMODO_G1_JOINTS))
+    return policy, agent
+
+
+def _joint_vector(action: dict[str, float]) -> np.ndarray:
+    return np.asarray([action[name] for name in KIMODO_G1_JOINTS], dtype=np.float64)
+
+
+def _drive(policy, prompts_per_tick) -> np.ndarray:
+    """Run one tick per entry and return the commanded joint vectors."""
+    return np.asarray([_joint_vector(asyncio.run(policy.get_actions({}, p))[0]) for p in prompts_per_tick])
+
+
+def _per_tick_steps(commands: np.ndarray) -> np.ndarray:
+    """Largest single-joint change between consecutive ticks."""
+    return np.abs(np.diff(commands, axis=0)).max(axis=1)
+
+
+def test_a_prompt_change_spreads_the_pose_offset_instead_of_stepping_it() -> None:
+    """The seam must carry a fraction of the pose gap, not the whole of it.
+
+    Two motions start in unrelated poses, so switching between them has a pose
+    gap to absorb. The guarantee is that the gap is spread across
+    ``transition_frames`` rather than commanded in a single tick, which bounds
+    the seam step at roughly ``gap / (transition_frames + 1)``.
+
+    Asserting instead that the seam falls inside the sampled motion's own
+    per-tick envelope would be a weaker claim than it looks: whether that holds
+    depends on how fast the particular motions move relative to the gap between
+    them, so it can pass on one corpus and fail on another for no change in
+    behaviour. The bound below is a property of the transition itself.
+
+    Deliberately runs on the default configuration and compares two measured
+    quantities, so it reports the size of the step rather than the absence of a
+    setting.
+    """
+    policy, _ = _policy()
+    segment = 15
+    commands = _drive(policy, [_WALK] * segment + [_REACH] * segment)
+
+    gap = _seam_gap(commands[segment - 1], _REACH)
+    seam = _per_tick_steps(commands)[segment - 1]
+
+    assert seam <= gap / 2.0, (
+        f"changing the prompt stepped a joint {seam:.4f} rad in a single tick out of "
+        f"a {gap:.4f} rad pose gap ({100 * seam / gap:.0f}% of it): a fresh sample is "
+        "being emitted from its own start pose instead of being eased off the pose "
+        "last commanded"
+    )
+
+
+def test_the_seam_shrinks_as_the_transition_lengthens() -> None:
+    """``transition_frames`` is the knob that spreads the offset, so it must bite."""
+    seams = {}
+    for frames in (2, 5, 20):
+        policy, _ = _policy(transition_frames=frames)
+        segment = 25
+        commands = _drive(policy, [_WALK] * segment + [_REACH] * segment)
+        seams[frames] = _per_tick_steps(commands)[segment - 1]
+
+    assert seams[2] > seams[5] > seams[20], (
+        f"a longer transition must spread the same pose offset over more ticks, so each step is smaller; got {seams}"
+    )
+
+
+def test_the_segment_returns_to_the_sampler_s_own_frames_after_the_transition() -> None:
+    """Only the transition window is touched - the motion is not rescaled.
+
+    Easing must absorb the starting offset and then get out of the way, so the
+    frames after the window are exactly what the sampler produced. Anything else
+    would distort the motion the caller asked for.
+    """
+    transition = 5
+    segment = 30
+    chained, _ = _policy(transition_frames=transition)
+    chained_cmds = _drive(chained, [_WALK] * segment + [_REACH] * segment)
+
+    # The same segment sampled with nothing before it: the sampler's own frames.
+    virgin, _ = _policy(transition_frames=transition)
+    virgin_cmds = _drive(virgin, [_REACH] * segment)
+
+    eased = chained_cmds[segment:]
+    np.testing.assert_allclose(
+        eased[transition:],
+        virgin_cmds[transition:],
+        atol=1e-6,
+        err_msg="frames past the transition window must be the sampler's own",
+    )
+    assert not np.allclose(eased[0], virgin_cmds[0], atol=1e-3), (
+        "the first frame of the second segment should have been pulled toward the "
+        "pose last commanded, not emitted at the motion's own start pose"
+    )
+
+
+def test_the_transition_preserves_the_motion_s_own_velocity() -> None:
+    """The ease decays a pose offset; it must not stall the motion.
+
+    Blending toward a static pose would flatten the first frames to near-zero
+    velocity. Decaying the offset instead keeps each frame's own advance, which
+    is what makes the transition look like motion rather than a pause.
+    """
+    transition = 8
+    segment = 30
+    chained, _ = _policy(transition_frames=transition)
+    chained_cmds = _drive(chained, [_WALK] * segment + [_REACH] * segment)
+    virgin, _ = _policy(transition_frames=transition)
+    virgin_cmds = _drive(virgin, [_REACH] * segment)
+
+    eased_speed = _per_tick_steps(chained_cmds[segment : segment + transition])
+    own_speed = _per_tick_steps(virgin_cmds[:transition])
+    assert eased_speed.min() > 0.2 * own_speed.min(), (
+        "the eased frames advance far more slowly than the motion itself, so the "
+        f"transition is stalling rather than decaying an offset: {eased_speed.min():.5f} "
+        f"vs {own_speed.min():.5f} rad/tick"
+    )
+
+
+def test_chaining_many_segments_eases_every_seam_not_just_the_first() -> None:
+    """A long-horizon chain must be continuous at every seam, not just the first."""
+    policy, agent = _policy()
+    segment = 12
+    chain = [_WALK, _REACH, _WALK, _REACH, _WALK]
+    commands = _drive(policy, [p for p in chain for _ in range(segment)])
+
+    steps = _per_tick_steps(commands)
+
+    assert len(agent.prompts) == len(chain), "each prompt change should sample once"
+    for index, next_prompt in enumerate(chain[1:], start=1):
+        seam = index * segment - 1
+        gap = _seam_gap(commands[seam], next_prompt)
+        assert steps[seam] <= gap / 2.0, (
+            f"seam {index} stepped {steps[seam]:.4f} rad of a {gap:.4f} rad pose gap "
+            f"({100 * steps[seam] / gap:.0f}% of it), so it is not being eased"
+        )
+
+
+# --------------------------------------------------------------------------
+# Controls: behaviour that must NOT change.
+# --------------------------------------------------------------------------
+def test_the_first_segment_of_a_rollout_is_the_sampler_s_own_motion() -> None:
+    """With nothing commanded yet there is no seam, so nothing is eased."""
+    policy, _ = _policy()
+    segment = 20
+    commands = _drive(policy, [_WALK] * segment)
+
+    expected = _TwoMotionAgent().sample(_WALK, 40, 100, 7.5, None)[:segment, _ROOT:]
+    np.testing.assert_allclose(
+        commands,
+        expected.astype(np.float64),
+        atol=1e-6,
+        err_msg="a single-prompt rollout must be untouched by the transition logic",
+    )
+
+
+def test_an_episode_boundary_opens_on_the_motion_s_own_start_pose() -> None:
+    """``reset`` ends the episode, so the next one is not eased onto its last pose.
+
+    Episodes are independent. Forgetting the commanded pose is not enough on its
+    own: a buffer already eased onto it would still be replayed from frame 0,
+    opening the new episode on a transition built for the previous one.
+    """
+    policy, _ = _policy()
+    _drive(policy, [_WALK] * 15 + [_REACH] * 5)  # chain, so the buffer is eased
+    policy.reset()
+    reopened = _drive(policy, [_REACH] * 5)
+
+    virgin, _ = _policy()
+    expected = _drive(virgin, [_REACH] * 5)
+    np.testing.assert_array_equal(
+        reopened,
+        expected,
+        err_msg="a new episode must open on the motion's own start pose",
+    )
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5, True, float("nan")])
+def test_transition_frames_outside_the_domain_is_refused(bad: object) -> None:
+    """Kimodo's sampler refuses ``num_transition_frames < 1``; so does this knob."""
+    with pytest.raises(ValueError, match="transition_frames"):
+        KimodoConfig(transition_frames=bad)  # type: ignore[arg-type]
+
+
+def test_transition_frames_reaches_the_config_as_a_constructor_override() -> None:
+    """The knob is a real constructor parameter, like every advertised field."""
+    policy, _ = _policy()
+    assert policy.config.transition_frames == 5, "default matches Kimodo's own length"
+    assert KimodoPolicy(motion_agent=_TwoMotionAgent(), transition_frames=11).config.transition_frames == 11


### PR DESCRIPTION
## Problem

Changing the prompt mid-rollout is the documented way to drive a long-horizon sequence through `KimodoPolicy`. Its own docstring says the instance "synthesises ONCE on first call (or when the prompt changes) then streams per-frame targets", and `_sample_key` includes the prompt precisely so a new prompt samples the next segment and the stream continues.

Kimodo samples every motion from its own canonical start pose, though, so a fresh segment's first frame bears no relation to where the previous segment left the robot. It was emitted unmodified, stepping all 29 joints in a single tick.

Driving the shipped policy over the 600 ordered pairs of a 25-motion corpus (each pair = one prompt change mid-rollout):

| | before | after |
|---|---|---|
| worst seam step | 2.866 rad (164 deg) in one tick | **0.478 rad** |
| median seam step | 1.599 rad | **0.266 rad** |
| seams exceeding the largest per-tick step the motions themselves take (0.476 rad) | **507/600 (84.5%)** | 1/600 (0.2%) |

Every one reported `status=success`. The median seam moved a joint further in one tick than the motion ever moves, so the emitted reference is not one a tracker can follow, and nothing said so.

The module already carries a smoothness guarantee, on a far smaller effect: `_slerp_upsample` documents that it widens 30 Hz to 50 Hz "without introducing joint discontinuities". The 30-to-50 Hz resample was interpolated; the segment boundary was not.

## Change

A newly sampled segment is eased off the pose last commanded, decaying the pose offset to zero over `KimodoConfig.transition_frames` native frames. The motion keeps its own shape and velocity; only its starting offset is absorbed.

The default of **5** and the `>= 1` domain are not invented: they are what Kimodo's own sampler applies to `num_transition_frames` when it generates a multi-prompt sequence (it raises `ValueError` below 1). Easing is applied at the native rate, before the upsample, so `transition_frames` counts the same frames the sampler's knob counts.

This differs in kind from the sampler's native path, and the docs say so: Kimodo conditions the *diffusion* of the next segment on the previous segment's last frames. The `KimodoMotionAgent` protocol carries only a prompt and sampling knobs, with no continuation state, so easing shapes the emitted stream rather than the sample. It removes the discontinuity; it does not re-plan the motion around it.

## Scope

Only the seam is touched:

- **A single-prompt rollout is byte-for-byte unchanged** - with no previously commanded pose there is nothing to ease onto. Verified identical over a 150-tick rollout.
- Frames past the transition window are exactly the sampler's own.
- `reset()` forgets the commanded pose, so an episode boundary opens on the motion's own start pose. Forgetting the pose alone was not enough: a buffer already eased onto it would still be replayed from frame 0, so `reset()` rebuilds it from the held sample, without paying for another diffusion run.

The quaternion arm of the upsample and the new transition now share one `_slerp_quat` helper. The extraction is **bit-identical** over all 4975 upsampled frames of the corpus (`np.array_equal` true), including preserving the float32 scalar weight - widening it to a Python float shifted results by 1 ULP.

## Tests

`tests/policies/kimodo/test_chained_prompt_transition_is_continuous.py`, **5 failed / 2 passed before, 13 pass after**. The headline runs on the default config and compares two measured quantities, so on unfixed code it reports the size of the step rather than the absence of a setting:

```
AssertionError: changing the prompt stepped a joint 1.6564 rad in a single tick
out of a 1.6564 rad pose gap (100% of it): a fresh sample is being emitted from
its own start pose instead of being eased off the pose last commanded
```

The two that pass on both trees are the no-overreach controls: a single-prompt rollout is the sampler's own motion, and an episode boundary opens on the motion's own start pose.

The seam is asserted as a *bound* (the gap is spread, not stepped) rather than as "inside the motion's own per-tick envelope". The latter reads stronger but depends on how fast the particular motions move relative to the gap between them, so it can pass on one corpus and fail on another for no change in behaviour.

## Visual

Chained rollout in MuJoCo, headless EGL, worst measured transition ("walking forward" to "crouching to pick an object"), same script under `upstream/main` and this branch, driven by real Kimodo samples. The seam tick is 2.430 rad before and 0.405 rad after; nothing else in the clip exceeds 0.245 rad.

![chained prompt transition](https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-chain-31976878374/kimodo-chain.gif)

Full-resolution MP4: https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-chain-31976878374/kimodo-chain.mp4

Seam tick alone: https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-chain-31976878374/kimodo-seam.png

## Gate

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 18 errors, identical to `upstream/main` (0 new). Full `tests/` run on both trees with no new failures. Docs updated with a chaining recipe and the new config row; changelog fragment included.
