### PR TITLE
fix(policies/lerobot_local): report a declarative state_keys mismatch with the remedy the generic path already gives

### DIFF
--- a/changelog.d/2354-declarative-state-key-mismatch-report.md
+++ b/changelog.d/2354-declarative-state-key-mismatch-report.md
@@ -1,0 +1,3 @@
+### Fixed
+
+A declarative `embodiment=` now reports a `state_keys` mismatch with the same registry-checked remedy the generic `robot_state_keys` path gives. An all-missing binding previously returned the observation untouched and reported nothing at all, so the only signal was a downstream error that knows nothing about embodiments; a partly-missing binding warned but asserted a single cause and offered no remedy. Both now name the declared keys, the keys the observation carries, and an embodiment the registry confirms binds that observation. Nothing about the packed state vector changes.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -351,6 +351,36 @@ velocity state (LeKiwi's body-frame base velocities `x.vel` / `y.vel` /
 `theta.vel`). Explicit `robot_state_keys` are never filtered - naming `elbow.vel`
 there states the model's input.
 
+### A declarative `embodiment=` reports the same two degradations
+
+A declarative `embodiment=` installs its own state step, and it reports both
+degradations with that same registry-checked remedy. A partly-bound vector names
+the absent keys, the keys the observation does carry, and the remedy; an
+all-bound-nothing configuration says so instead of handing the observation on in
+silence, since the downstream error it would otherwise produce knows nothing
+about embodiments and cannot name the one that binds this observation.
+
+The two conventions in the embodiment registry are what make an all-missing
+binding easy to reach in either direction:
+
+- **A sim embodiment driven from real hardware.** `embodiment="so101"` declares
+  the MuJoCo asset's `'1'..'6'`, and a real arm reports `'<motor>.pos'`. This
+  direction binds anyway: the step falls back to the observation's `'.pos'` keys
+  in motor order, packed raw because hardware already reports the model's
+  training units.
+- **A `*_real` embodiment driven from sim.** Several names are both a lerobot
+  driver spelling and a sim-loadable registry robot - `so100_follower`,
+  `so101_follower`, `koch_follower`, `bi_so_follower`, `lekiwi`, `openarm` - and
+  each resolves to a `*_real` configuration whose `'.pos'` keys no sim
+  observation emits. There is no fallback in this direction, so no
+  `observation.state` is packed; the report names the sim-side configuration to
+  use instead (`embodiment='so101'` for a MuJoCo so101).
+
+An unbound state is a configuration mistake rather than a degraded reading, so
+nothing is invented to stand in for it - no all-zero vector is emitted, and the
+observation is passed on unchanged for a state-less policy or the caller's own
+handling.
+
 ## Camera routing
 
 Robot/sim observations use bare camera names (`top`, `wrist`, `side`); the policy

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import math
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -514,25 +514,76 @@ class ZeroActionMonitor:
 
 # Imported lazily so this module is importable without lerobot (e.g. for unit
 # testing EmbodimentMap loading/validation in a minimal env).
-# Warn-once dedup for state_keys absent from the observation (keyed by the
-# missing-key tuple, which is stable across the 50Hz control loop).
-_WARNED_MISSING_STATE_KEYS: set[tuple[str, ...]] = set()
+# Warn-once dedup for a declared-vs-observed state_keys mismatch, keyed by the
+# (missing keys, observed keys) pair so the message repeats at most once per
+# distinct mismatch rather than at every tick of the 50Hz control loop.
+_WARNED_STATE_KEY_MISMATCH: set[tuple[tuple[str, ...], tuple[str, ...]]] = set()
 
 
-def _warn_missing_state_keys(missing: list[str]) -> None:
-    """Warn once that some declared ``state_keys`` were absent (zero-filled in place)."""
-    sig = tuple(missing)
-    if sig in _WARNED_MISSING_STATE_KEYS:
+def observed_state_keys(observation: Mapping[str, Any]) -> list[str]:
+    """Observation keys that can carry a joint/state scalar, in observation order.
+
+    Excludes ``task`` (the instruction string) and any array with 2+ dimensions
+    (a camera frame). Both observation-to-batch paths derive their state-ordering
+    fallback from this, and every state-key diagnostic quotes it back to the
+    caller, so all of them must agree on what counts as a state key - which is
+    why this is one function rather than a rule restated per call site.
+
+    Args:
+        observation: Raw strands/sim observation for this step.
+
+    Returns:
+        The candidate state keys, in the observation's own insertion order.
+    """
+    return [k for k, v in observation.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)]
+
+
+def _warn_state_key_mismatch(missing: list[str], observation: Mapping[str, Any], *, total: bool) -> None:
+    """Warn once that declared ``state_keys`` are absent from the observation.
+
+    Reports the two degradations the declarative state path can hit with the
+    same registry-checked remedy the generic ``robot_state_keys`` path uses
+    (:func:`state_key_remedy`), because both answer the same caller question and
+    a remedy invented per call site drifts from the one the registry can prove.
+
+    The remedy is chosen from what the observation carries rather than from the
+    declared keys, so it can never name an embodiment that would land back on
+    this same mismatch - the reasoning :func:`state_key_remedy` documents.
+
+    Args:
+        missing: Declared ``state_keys`` absent from ``observation``, in
+            declared order.
+        observation: The observation being packed, read for the keys it does
+            carry.
+        total: Whether NO declared key was present. A total miss leaves the
+            observation unpacked for the caller's own handling, so it is
+            reported as an unbindable configuration rather than as a
+            zero-filled dimension.
+    """
+    observed = observed_state_keys(observation)
+    sig = (tuple(missing), tuple(observed))
+    if sig in _WARNED_STATE_KEY_MISMATCH:
         return
-    _WARNED_MISSING_STATE_KEYS.add(sig)
-    logger.warning(
-        "lerobot_local: state_key(s) %s absent from the observation; zero-filled IN "
-        "PLACE so the present joints keep their model index (the missing dims read 0). "
-        "The canonical trigger is a mimic/tendon gripper actuator (e.g. left/gripper) "
-        "whose sim observation exposes finger joints instead -- the arm proprioception "
-        "stays aligned while the gripper state reads 0.",
-        missing,
-    )
+    _WARNED_STATE_KEY_MISMATCH.add(sig)
+    shown = missing[:_REMEDY_KEYS_INLINE_MAX]
+    ellipsis = "..." if len(missing) > _REMEDY_KEYS_INLINE_MAX else ""
+    if total:
+        detail = (
+            f"None of the {len(missing)} declared state_keys {shown}{ellipsis} are present in the "
+            f"observation. Observed joint/state keys: {observed}. No observation.state was packed, "
+            "so the model receives no proprioceptive input and the failure surfaces downstream. "
+            "The embodiment's declared keys describe a different robot/sim - or a different naming "
+            "convention for the same one - than the observation reporting them."
+        )
+    else:
+        detail = (
+            f"{len(missing)} declared state_keys are not present in the observation: "
+            f"{shown}{ellipsis}. Observed joint/state keys: {observed}. Present joints keep their "
+            "model index and the missing dims are zero-filled in place, but the sim/robot does not "
+            "report those joints - commonly a mimic/tendon gripper actuator whose name differs from "
+            "the observation's finger-joint names."
+        )
+    logger.warning("lerobot_local: %s %s", detail, state_key_remedy(observed))
 
 
 def register_pack_state_step() -> type | None:
@@ -649,10 +700,19 @@ def register_pack_state_step() -> type | None:
                 # No declared state key AND no usable '.pos' fallback; leave obs
                 # alone so a clearer downstream error (or a state-less policy)
                 # can handle it, rather than emitting an all-zero state vector.
+                #
+                # Say so first. Returning silently made this the one degradation
+                # on either state path that reported nothing: the generic path
+                # names the observed keys and the remedy for both an all-missing
+                # and a partly-missing binding, while here the caller learned
+                # only that something downstream wanted observation.state - after
+                # the weight download, and without the one fact that resolves it
+                # (which embodiment DOES bind this observation).
+                _warn_state_key_mismatch(list(self.state_keys), observation, total=True)
                 return observation
 
             if missing:
-                _warn_missing_state_keys(missing)
+                _warn_state_key_mismatch(missing, observation, total=False)
 
             # Convert sim units (radians + gripper joint range) to the model's
             # training units (arm degrees, gripper 0..100) BEFORE packing, so the
@@ -947,6 +1007,7 @@ __all__ = [
     "diagnose_action_dim",
     "load_embodiment",
     "matching_embodiments",
+    "observed_state_keys",
     "reconcile_dim",
     "register_pack_state_step",
     "state_key_remedy",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -22,28 +22,17 @@ import torch
 
 from ...utils import name_list_error, positive_count_error
 from .. import Policy, align_action_values, chunk_count_error
-from .embodiment import ZeroActionMonitor, diagnose_action_dim, hardware_pos_keys, state_key_remedy
+from .embodiment import (
+    ZeroActionMonitor,
+    diagnose_action_dim,
+    hardware_pos_keys,
+    observed_state_keys,
+    state_key_remedy,
+)
 from .processor import ProcessorBridge
 from .resolution import resolve_policy_class_by_name, resolve_policy_class_from_hub
 
 logger = logging.getLogger(__name__)
-
-
-def _scalar_observation_keys(observation_dict: dict[str, Any]) -> list[str]:
-    """Observation keys that can carry a joint/state scalar, in observation order.
-
-    Excludes ``task`` (the instruction string) and any array with 2+ dimensions
-    (a camera frame). Both observation-to-batch paths derive their state-ordering
-    fallback from this, and the state-key diagnostics quote it back to the
-    caller, so all three must agree on what counts as a state key.
-
-    Args:
-        observation_dict: Raw strands/sim observation for this step.
-
-    Returns:
-        The candidate state keys, in the observation's own insertion order.
-    """
-    return [k for k, v in observation_dict.items() if k != "task" and not (isinstance(v, np.ndarray) and v.ndim >= 2)]
 
 
 def _state_key_cause(configured: list[str]) -> str:
@@ -2512,10 +2501,9 @@ class LerobotLocalPolicy(Policy):
                 f"observation: {shown}{ellipsis}. Present joints keep their index and the "
                 "missing dims are zero-filled in place, but the sim/robot does not report "
                 "those joints - commonly a mimic/tendon gripper whose actuator name differs "
-                "from the observation's finger-joint names. "
+                "from the observation's finger-joint names. " + state_key_remedy(observed_state_keys(observation_dict))
                 # Same registry-checked remedy as the all-missing guard, so one
                 # rule serves both degradations.
-                + state_key_remedy(_scalar_observation_keys(observation_dict))
             )
             if self.strict_keys:
                 raise ValueError("strict_keys=True: " + msg)
@@ -2620,7 +2608,7 @@ class LerobotLocalPolicy(Policy):
             used_feats.add(feat)
 
         # 2) Collect scalar joint values into observation.state.
-        scalar_keys = _scalar_observation_keys(observation_dict)
+        scalar_keys = observed_state_keys(observation_dict)
         # Resolve the joint-state ordering, raising/warning loudly when the
         # configured robot_state_keys cannot describe this observation (the
         # generic joint_0..N vs named-joint mismatch) instead of silently
@@ -2945,7 +2933,7 @@ class LerobotLocalPolicy(Policy):
         # raises (strict_keys) or warns + falls back to the observation's own
         # scalar keys, instead of silently dropping observation.state and
         # running the policy open-loop (see _resolve_state_order).
-        scalar_keys = _scalar_observation_keys(observation_dict)
+        scalar_keys = observed_state_keys(observation_dict)
         order = self._resolve_state_order(observation_dict, scalar_keys)
 
         # Collect state values index-aligned with the resolved order. A key in

--- a/tests/policies/lerobot_local/test_declarative_state_key_mismatch_diagnostics.py
+++ b/tests/policies/lerobot_local/test_declarative_state_key_mismatch_diagnostics.py
@@ -1,0 +1,231 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A declarative embodiment must report a state_keys mismatch, with a remedy.
+
+``PackStateProcessorStep`` (the step a declarative ``embodiment=`` installs on
+the preprocessor) can bind fewer state_keys than it declares in two ways, and
+the generic ``robot_state_keys`` path already reports both the same way: it
+quotes the keys the observation actually carries and appends the
+registry-checked remedy from :func:`state_key_remedy`, which names an embodiment
+only when the registry confirms that embodiment binds THIS observation.
+
+The declarative path did neither:
+
+* An **all-missing** binding returned the observation untouched and said
+  nothing at all - no warning, no error, no remedy. The caller learned only
+  that something downstream wanted ``observation.state``, after the multi-minute
+  weight download, without the one fact that resolves it.
+* A **partly-missing** binding warned, but asserted a single cause (a
+  mimic/tendon gripper) as fact and offered no remedy and no view of what the
+  observation does carry.
+
+The all-missing case is reachable straight from the shipped catalog. Six alias
+spellings resolve a name that is ALSO a sim-loadable registry robot to a
+``*_real`` embodiment whose ``'<motor>.pos'`` state_keys no sim observation
+emits - ``so100_follower`` / ``so101_follower`` / ``koch_follower`` /
+``bi_so_follower`` / ``lekiwi`` / ``openarm``. ``embodiment="so101"`` driven from
+real hardware is the mirror of that mismatch and has always had a ``.pos``
+fallback; the sim direction had no report.
+"""
+
+import logging
+import re
+
+import numpy as np
+import pytest
+
+pytest.importorskip("lerobot")
+
+import strands_robots.policies.lerobot_local.embodiment as E
+from strands_robots.policies.lerobot_local.embodiment import (
+    load_embodiment,
+    matching_embodiments,
+    observed_state_keys,
+)
+
+_LOGGER = "strands_robots.policies.lerobot_local.embodiment"
+
+# What a MuJoCo so101 reports: the asset's numeric joints plus their velocity
+# siblings. None of the '<motor>.pos' names a *_real embodiment declares.
+SIM_SO101 = {
+    k: 0.1 * i
+    for i, k in enumerate(["1", "1.vel", "2", "2.vel", "3", "3.vel", "4", "4.vel", "5", "5.vel", "6", "6.vel"])
+}
+# What a lerobot SOFollower reports, in motor order.
+HARDWARE_SO = {
+    "shoulder_pan.pos": 1.0,
+    "shoulder_lift.pos": 2.0,
+    "elbow_flex.pos": 3.0,
+    "wrist_flex.pos": 4.0,
+    "wrist_roll.pos": 5.0,
+    "gripper.pos": 6.0,
+}
+
+# The aloha bimanual actuator convention: the gripper ACTUATORS sit at indices 6
+# and 13, and the sim exposes finger JOINTS instead - a partial mismatch.
+ALOHA_ARMS = [
+    f"{side}/{j}"
+    for side in ("left", "right")
+    for j in ("waist", "shoulder", "elbow", "forearm_roll", "wrist_angle", "wrist_rotate")
+]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warn_dedup():
+    """Each test starts with an empty warn-once ledger."""
+    E._WARNED_STATE_KEY_MISMATCH.clear()
+    yield
+    E._WARNED_STATE_KEY_MISMATCH.clear()
+
+
+def _step(state_keys, **kw):
+    Step = E.register_pack_state_step()
+    assert Step is not None, "lerobot processor framework unavailable"
+    return Step(state_keys=list(state_keys), dim_policy=kw.pop("dim_policy", "pad"), **kw)
+
+
+def _reports(caplog, step, observation):
+    """Run one observation and return the state-mismatch reports it produced."""
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        out = step.observation(dict(observation))
+    return out, [r.getMessage() for r in caplog.records if "declared state_keys" in r.getMessage()]
+
+
+def _aloha_sim_observation():
+    obs = {k: 100.0 + i for i, k in enumerate(ALOHA_ARMS)}
+    for side in ("left", "right"):
+        obs[f"{side}/left_finger"] = 0.02
+        obs[f"{side}/right_finger"] = 0.02
+    return obs
+
+
+class TestATotalMismatchIsReported:
+    def test_it_does_not_return_silently(self, caplog):
+        """FAILS pre-fix: the all-missing branch returned the observation with no
+        report of any kind, so the only signal was a downstream error that knows
+        nothing about embodiments."""
+        embodiment = load_embodiment("so101_follower")
+        out, reports = _reports(caplog, _step(embodiment.state_keys), SIM_SO101)
+        assert "observation.state" not in out, "premise: this configuration packs no state"
+        assert len(reports) == 1, f"expected exactly one report, got {reports}"
+
+    def test_it_names_the_declared_keys_and_the_observed_keys(self, caplog):
+        """Both halves of the mismatch, so the caller can see which convention
+        each side is using. FAILS pre-fix (no message at all)."""
+        embodiment = load_embodiment("so101_follower")
+        _, reports = _reports(caplog, _step(embodiment.state_keys), SIM_SO101)
+        message = reports[0]
+        assert "shoulder_pan.pos" in message
+        for observed in observed_state_keys(SIM_SO101):
+            assert repr(observed) in message, f"observed key {observed!r} not quoted"
+
+    def test_its_remedy_names_an_embodiment_that_binds_this_observation(self, caplog):
+        """The remedy must be followable: applying it has to escape the mismatch
+        rather than land back on it. FAILS pre-fix (no remedy is offered)."""
+        embodiment = load_embodiment("so101_follower")
+        _, reports = _reports(caplog, _step(embodiment.state_keys), SIM_SO101)
+        offered = re.findall(r"embodiment='([^']+)'", reports[0])
+        assert offered, f"no embodiment= remedy in {reports[0]!r}"
+        bindable = matching_embodiments(observed_state_keys(SIM_SO101))
+        for name in offered:
+            assert name in bindable, f"remedy embodiment={name!r} does not bind this observation"
+            assert set(load_embodiment(name).state_keys) <= set(SIM_SO101)
+
+    def test_reporting_replaces_the_silence_and_not_the_passthrough(self, caplog):
+        """The observation is still handed on untouched for the caller's own
+        handling; emitting an all-zero state vector instead would hide the
+        mismatch behind plausible numbers."""
+        observation = {"unrelated": 5.0}
+        out, reports = _reports(caplog, _step(["a", "b"]), observation)
+        assert out == observation
+        assert len(reports) == 1
+
+    def test_it_is_reported_once_per_distinct_mismatch(self, caplog):
+        """The report is deduplicated across the 50Hz control loop, but a second
+        mismatch with a different shape still gets its own report."""
+        step = _step(load_embodiment("so101_follower").state_keys)
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            step.observation(dict(SIM_SO101))
+            step.observation(dict(SIM_SO101))
+            step.observation({"only_this": 1.0})
+        assert len([r for r in caplog.records if "declared state_keys" in r.getMessage()]) == 2
+
+
+class TestAPartialMismatchGetsTheSameRemedy:
+    def test_it_offers_a_registry_checked_remedy(self, caplog):
+        """FAILS pre-fix: the partial warning asserted a mimic-gripper cause and
+        stopped there, while the generic path appended the same remedy it uses
+        for an all-missing binding."""
+        aloha = load_embodiment("aloha")
+        observation = _aloha_sim_observation()
+        _, reports = _reports(caplog, _step(aloha.state_keys), observation)
+        assert len(reports) == 1
+        assert "set_robot_state_keys" in reports[0], "no followable remedy offered"
+
+    def test_it_quotes_the_keys_the_observation_carries(self, caplog):
+        """The absent keys alone do not tell the caller what IS bindable.
+        FAILS pre-fix: only the missing keys were named."""
+        aloha = load_embodiment("aloha")
+        observation = _aloha_sim_observation()
+        _, reports = _reports(caplog, _step(aloha.state_keys), observation)
+        assert "left/left_finger" in reports[0]
+
+    def test_its_remedy_does_not_invent_an_embodiment(self, caplog):
+        """No shipped embodiment declares the aloha finger-joint naming, so
+        naming one would send the caller back to this same mismatch."""
+        aloha = load_embodiment("aloha")
+        observation = _aloha_sim_observation()
+        _, reports = _reports(caplog, _step(aloha.state_keys), observation)
+        for name in re.findall(r"embodiment='([^']+)'", reports[0]):
+            assert set(load_embodiment(name).state_keys) <= set(observation)
+
+
+class TestTheReportDoesNotChangeWhatIsBound:
+    """Controls: every test here passes both pre- and post-fix.
+
+    They pin the behaviour the added reporting must NOT disturb - a bound
+    embodiment stays quiet, the mirror mismatch keeps its hardware fallback, and
+    a partly-bound vector keeps its in-place zero-fill.
+    """
+
+    def test_a_fully_bound_embodiment_reports_nothing(self, caplog):
+        out, reports = _reports(caplog, _step(["a", "b", "c"]), {"a": 1.0, "b": 2.0, "c": 3.0})
+        np.testing.assert_allclose(out["observation.state"].numpy(), [1.0, 2.0, 3.0], atol=1e-5)
+        assert reports == []
+
+    def test_the_hardware_pos_fallback_still_binds_and_stays_quiet(self, caplog):
+        """A SIM embodiment driven from real hardware is the mirror mismatch and
+        has always had a fallback; it binds, so there is nothing to report."""
+        so101 = load_embodiment("so101")
+        out, reports = _reports(caplog, _step(so101.state_keys, state_units=so101.state_units), HARDWARE_SO)
+        assert "observation.state" in out
+        assert len(out["observation.state"]) == len(so101.state_keys)
+        assert reports == []
+
+    def test_a_partial_mismatch_still_zero_fills_in_place(self, caplog):
+        """The present joints keep their model index and the absent gripper slots
+        read 0.0 - unchanged by the added report."""
+        aloha = load_embodiment("aloha")
+        out, _ = _reports(caplog, _step(aloha.state_keys), _aloha_sim_observation())
+        state = out["observation.state"].numpy()
+        assert len(state) == 14
+        np.testing.assert_allclose(state[0:6], [100.0, 101.0, 102.0, 103.0, 104.0, 105.0], atol=1e-5)
+        assert state[6] == 0.0
+        np.testing.assert_allclose(state[7:13], [106.0, 107.0, 108.0, 109.0, 110.0, 111.0], atol=1e-5)
+        assert state[13] == 0.0
+
+
+class TestOneRuleAnswersWhatTheObservationCarries:
+    """``observed_state_keys`` is the single rule every state diagnostic quotes."""
+
+    def test_it_excludes_the_instruction_and_camera_frames(self):
+        keys = observed_state_keys(
+            {"1": 0.5, "task": "pick the cube", "front": np.zeros((4, 4, 3), dtype=np.uint8), "pose": np.zeros(7)}
+        )
+        assert keys == ["1", "pose"], "a 1-D state vector is a candidate; task and a frame are not"
+
+    def test_the_report_quotes_exactly_that_rule(self, caplog):
+        """The declarative report and the rule cannot drift apart, because the
+        report is built from it rather than from a filter of its own."""
+        observation = {**SIM_SO101, "task": "pick", "front": np.zeros((2, 2, 3), dtype=np.uint8)}
+        _, reports = _reports(caplog, _step(load_embodiment("so101_follower").state_keys), observation)
+        assert f"{observed_state_keys(observation)}" in reports[0]

--- a/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
+++ b/tests/policies/lerobot_local/test_embodiment_state_zerofill_alignment.py
@@ -83,7 +83,7 @@ class TestPackStateZeroFillInPlace:
         """Arm joints keep their canonical model index; the two absent gripper
         actuator slots read 0.0. FAILS pre-fix: the right arm slid into the
         left-gripper slot and both zeros landed at the tail."""
-        E._WARNED_MISSING_STATE_KEYS.clear()
+        E._WARNED_STATE_KEY_MISMATCH.clear()
         out = _step(ALOHA_14, 14).observation(_sim_obs_no_gripper())
         state = out["observation.state"].numpy()
         assert len(state) == 14
@@ -95,31 +95,34 @@ class TestPackStateZeroFillInPlace:
     def test_missing_keys_warn_once(self, caplog):
         """The degradation is surfaced once (naming the absent keys), then
         deduplicated across the hot control loop."""
-        E._WARNED_MISSING_STATE_KEYS.clear()
+        E._WARNED_STATE_KEY_MISMATCH.clear()
         step = _step(ALOHA_14, 14)
         import logging
 
         with caplog.at_level(logging.WARNING, logger="strands_robots.policies.lerobot_local.embodiment"):
             step.observation(_sim_obs_no_gripper())
             step.observation(_sim_obs_no_gripper())
-        warns = [r for r in caplog.records if "absent from the observation" in r.getMessage()]
+        # Selected by the missing-key report's stable subject rather than by a
+        # phrase: the wording is shared with the generic robot_state_keys path,
+        # so it belongs to that message's contract and not to this test's.
+        warns = [r for r in caplog.records if "declared state_keys" in r.getMessage()]
         assert len(warns) == 1
         assert "left/gripper" in warns[0].getMessage() and "right/gripper" in warns[0].getMessage()
 
     def test_all_present_unchanged(self):
         """A fully-present key set is packed verbatim with no zero-fill (the
         so101-style path); this must not regress."""
-        E._WARNED_MISSING_STATE_KEYS.clear()
+        E._WARNED_STATE_KEY_MISMATCH.clear()
         keys = ["a", "b", "c"]
         out = _step(keys, 3).observation({"a": 1.0, "b": 2.0, "c": 3.0})
         state = out["observation.state"].numpy()
         np.testing.assert_allclose(state, [1.0, 2.0, 3.0], atol=1e-5)
-        assert not E._WARNED_MISSING_STATE_KEYS  # no missing -> no warn recorded
+        assert not E._WARNED_STATE_KEY_MISMATCH  # no missing -> no warn recorded
 
     def test_all_missing_passthrough(self):
         """When NONE of the declared keys are present, leave the observation
         untouched so a clearer downstream error can fire (do not emit all-zero)."""
-        E._WARNED_MISSING_STATE_KEYS.clear()
+        E._WARNED_STATE_KEY_MISMATCH.clear()
         obs = {"unrelated": 5.0}
         out = _step(["a", "b"], 2).observation(dict(obs))
         assert "observation.state" not in out
@@ -141,7 +144,7 @@ class TestAlohaEmbodimentActuatorConvention:
     def test_aloha_state_build_is_canonically_aligned(self):
         """End-to-end: build observation.state from a gripper-less sim obs through
         the real aloha embodiment config; arm stays aligned, grippers zero-filled."""
-        E._WARNED_MISSING_STATE_KEYS.clear()
+        E._WARNED_STATE_KEY_MISMATCH.clear()
         emb = E.load_embodiment("aloha")
         step = _step(emb.state_keys, 14, dim_policy=emb.dim_policy)
         state = step.observation(_sim_obs_no_gripper())["observation.state"].numpy()

--- a/tests/policies/lerobot_local/test_sim_embodiment_on_hardware_state_fallback.py
+++ b/tests/policies/lerobot_local/test_sim_embodiment_on_hardware_state_fallback.py
@@ -81,7 +81,7 @@ def _step(state_keys: list[str], expected_dim: int, **kw: Any) -> Any:
 @pytest.fixture(autouse=True)
 def _reset_warn_dedup() -> None:
     """The missing-key warning is deduplicated process-wide; start each test clean."""
-    E._WARNED_MISSING_STATE_KEYS.clear()
+    E._WARNED_STATE_KEY_MISMATCH.clear()
 
 
 class TestSimEmbodimentDrivenFromHardware:
@@ -113,7 +113,7 @@ class TestSimEmbodimentDrivenFromHardware:
         with caplog.at_level(logging.WARNING, logger="strands_robots.policies.lerobot_local.embodiment"):
             _step(SIM_KEYS_SO101, 6).observation(_hardware_observation())
         assert [r for r in caplog.records if "absent from the observation" in r.getMessage()] == []
-        assert not E._WARNED_MISSING_STATE_KEYS
+        assert not E._WARNED_STATE_KEY_MISMATCH
 
     def test_consumed_pos_keys_leave_and_every_other_key_passes_through(self) -> None:
         """The bound ``.pos`` keys are replaced by ``observation.state``; a camera


### PR DESCRIPTION
## Problem

The generic `robot_state_keys` path reports both of its binding degradations the same way: it quotes the keys the observation actually carries, and appends the registry-checked remedy from `state_key_remedy`, which names an embodiment only when the registry confirms that embodiment binds THIS observation. Its own comment says so - *"Same registry-checked remedy as the all-missing guard, so one rule serves both degradations."*

A declarative `embodiment=` installs `PackStateProcessorStep` instead, and it got neither half:

* **All-missing** - the branch returned the observation untouched and said **nothing at all**. No warning, no error, no remedy, no telemetry. `stop()`-style silence: the run continues, downloads the checkpoint, and fails somewhere downstream for want of `observation.state` - a message that knows nothing about embodiments and so cannot name the one that binds this observation.
* **Partly-missing** - warned, but asserted a single cause (a mimic/tendon gripper) as fact, showed nothing of what the observation does carry, and offered no remedy. Asserting a cause is the exact anti-pattern the generic path documents avoiding: it reads the cause instead, *"so a caller who configured a NAMED set describing a different robot is not told their keys were auto-generated placeholders they never configured."*

`docs/policies/lerobot-local.md` already claimed the fixed behaviour - *"Both degradations quote a remedy chosen from the observation itself rather than a fixed example"* - which held only on the generic path.

## How it is reached

The embodiment registry has two key conventions: sim entries use bare MuJoCo joint names, `*_real` entries use lerobot driver `'<motor>.pos'` names. One direction already had a fallback; the other had no report.

Six alias spellings are **both** a lerobot driver name and a sim-loadable registry robot, and each resolves to a `*_real` configuration:

| `embodiment=` | resolves to | declared state_keys | present in a sim observation |
|---|---|---|---|
| `so100_follower`, `so101_follower` | `so_real` | 6 x `'<motor>.pos'` | 0 of 6 |
| `koch_follower` | `koch_real` | 6 x `'<motor>.pos'` | 0 of 6 |
| `bi_so_follower` | `bi_so_real` | 12 x `'<motor>.pos'` | 0 of 12 |
| `openarm` | `openarm_real` | 8 x `'<motor>.pos'` | 0 of 8 |
| `lekiwi` | `lekiwi_real` | 6 x `.pos` + 3 x `.vel` | 0 of 9 |

Measured on `Robot("so101_follower", mode="sim")`: declared `['shoulder_pan.pos' ... 'gripper.pos']`, observed `['1','1.vel' ... '6','6.vel']`, `observation.state` not packed, **0 log records**. The mirror case (`embodiment="so101"` on a real arm) binds via the `'.pos'` fallback and is untouched here.

## Change

Both degradations now go through one report that quotes the declared keys, the observed keys, and `state_key_remedy(...)`. For the sim case above that resolves to `Pass embodiment='so101', whose state_keys this observation carries, or call set_robot_state_keys([...])` - checked against the registry, so the embodiment it names is one the observation provably binds.

**Nothing about the packed vector changes.** The all-missing branch still passes the observation on untouched (an unbound state is a configuration mistake, not a degraded reading, so no all-zero vector is invented), and a partly-bound vector keeps its in-place zero-fill.

The state-key candidate rule is now one function, `observed_state_keys`, instead of the same rule restated in two modules - which is what lets both paths quote the same answer. Its former copy in `policy.py` is deleted and its three call sites updated; no alias is kept.

One existing test selected the partial-mismatch warning by a phrase now shared with the generic path's message; it selects on the report's subject instead, which is what it was actually asserting.

## Tests

`tests/policies/lerobot_local/test_declarative_state_key_mismatch_diagnostics.py`, run against `main`: **9 failed, 4 passed**; after: **13 passed**.

| pre-fix | test |
|---|---|
| FAIL | a total mismatch does not return silently (`expected exactly one report, got []`) |
| FAIL | it names the declared keys and the observed keys |
| FAIL | its remedy names an embodiment that binds this observation |
| FAIL | reporting replaces the silence and not the passthrough |
| FAIL | it is reported once per distinct mismatch (`assert 0 == 2`) |
| FAIL | a partial mismatch offers a registry-checked remedy (`assert 0 == 1`) |
| FAIL | a partial mismatch quotes the keys the observation carries |
| FAIL | a partial mismatch remedy does not invent an embodiment |
| FAIL | the report quotes exactly the shared candidate rule |
| pass | a fully bound embodiment reports nothing |
| pass | the hardware `.pos` fallback still binds and stays quiet |
| pass | a partial mismatch still zero-fills in place |
| pass | the rule excludes the instruction and camera frames |

The four constant passes are the controls: they pin what the added reporting must not disturb - the mirror direction keeps its fallback, a bound embodiment stays quiet, and the zero-filled vector keeps its indices.

The remedy assertion parses `embodiment='X'` back out of the message and checks `X` against `matching_embodiments(observed)`, so it fails for a missing remedy and for a wrong one - it pins that the advice is followable rather than pinning its wording.

## Verification

`ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ` (mypy reports only the errors already present on `main`, none in `policies/lerobot_local`).

The change's blast radius - `tests/policies`, `tests/simulation`, `tests/registry`, and the repo-wide docstring / doc-coverage / ASCII / dependency-audit / changelog guards - was run on this branch and on `main` with the same interpreter:

| | passed | skipped | failed |
|---|---|---|---|
| `main` | 16079 | 232 | 0 |
| this branch | 16092 | 232 | 0 |

`+13` is exactly the new test count, and no test fails on either side.

## Rollout

Real MuJoCo so101 (headless EGL), shipped catalog, the step a declarative `embodiment=` installs - nothing stubbed. One capture script run under each tree; the rendered robot is identical between them (mean abs pixel delta 0.0001), so the only difference is the report.

![declarative embodiment state_keys mismatch, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-declarative-state-key-report/declarative-state-key-report.png)
