### PR TITLE
fix(simulation/mujoco): refuse remove_robot when the cooperative stop lapses instead of un-tracking a live worker

### DIFF
--- a/changelog.d/2355-remove-robot-cooperative-stop-lapse.md
+++ b/changelog.d/2355-remove-robot-cooperative-stop-lapse.md
@@ -1,0 +1,10 @@
+### Fixed
+
+`remove_robot` no longer reports a robot as removed when its policy worker outlived the
+cooperative-stop budget. The join's `TimeoutError` was swallowed and the worker's tracking
+entry deleted regardless, which left a live worker unobservable: the global scene-mutation
+gate then admitted `add_object` / `set_timestep` / `add_robot` for the rest of the session,
+`list_policies_running` reported nothing, and `cleanup`'s bounded join had nothing to wait
+on. The rebuild is now refused with the budget waited and the retry that resolves it, and
+the worker stays tracked. A lapse is distinguished from a worker that raised by
+`Future.done()` rather than by exception class, since `socket.timeout` is `TimeoutError`.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1902,10 +1902,45 @@ class MuJoCoSimEngine(
         # when the target robot has an active policy (the common case).
         if registered(self._policy_threads, name):
             self._world.robots[name].policy_running = False
-            try:
-                self._policy_threads[name].result(timeout=5.0)
-            except Exception:
-                pass
+            fut = self._policy_threads[name]
+            timeout = self._DEFAULT_POLICY_STOP_TIMEOUT
+            with contextlib.suppress(Exception):
+                # ``result`` raises either the worker's own exception - it has
+                # exited, which is all we needed - or the join timeout. Which
+                # one happened is decided by ``fut.done()`` below rather than by
+                # the exception type, because the two are not distinguishable
+                # that way: ``socket.timeout`` IS ``TimeoutError``, so a policy
+                # server that stops answering raises the same class the join
+                # does. Typing on the class would refuse a removal whose worker
+                # has already exited.
+                fut.result(timeout=timeout)
+            if not fut.done():
+                # The cooperative stop lapsed: the worker is still live (it is
+                # blocked somewhere the stop flag is not read yet - inside a
+                # policy inference call, typically). Keep the tracking entry.
+                # It is the single record every bound on a live worker reads:
+                # the global gate in step 2, ``list_policies_running``, and
+                # cleanup's own bounded join. Deleting it here does not end the
+                # worker, it only makes the worker unobservable - the gate then
+                # admits every later scene mutation (``add_object``,
+                # ``set_timestep``, ``add_robot``) for the rest of the session,
+                # and cleanup's ``executor.shutdown(wait=False)`` runs on the
+                # premise that all policy workers were drained.
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"Robot '{name}' still has a live policy worker after waiting "
+                                f"{timeout:.1f}s for it to stop, so the scene rebuild was refused: "
+                                "it would reallocate the model/data that worker holds. The "
+                                "cooperative stop has been requested and the worker exits at its "
+                                "next control tick - retry action='remove_robot' (until it does, "
+                                "action='list_policies_running' still reports it)."
+                            )
+                        }
+                    ],
+                }
             del self._policy_threads[name]
 
         # Step 2: after stopping our own, there must be no OTHER policy
@@ -1935,7 +1970,9 @@ class MuJoCoSimEngine(
         robot_obj = self._world.robots[name]
 
         # The cooperative stop + no-running-policy gate above guarantee no
-        # PolicyRunner worker is mid-mj_step. The XML round-trip below still
+        # PolicyRunner worker is mid-mj_step: step 1 refuses outright when its
+        # own robot's worker outlived the stop budget, so reaching here means
+        # every worker is done. The XML round-trip below still
         # reallocates model/data, so serialize it under self._lock to exclude
         # the render/recorder daemon (rendering.py reads mjData under the same
         # lock). remove_robot is dispatched WITHOUT the blanket lock (see
@@ -5357,10 +5394,17 @@ class MuJoCoSimEngine(
 
     # Cleanup
 
-    # Default cleanup shutdown timeout (seconds). A policy worker might be
-    # mid-step when cleanup is called; give it bounded time to see the
-    # cooperative-stop flag and exit cleanly before we null the world and
-    # its in-flight ``mj_step`` segfaults on a nulled ``_model``/``_data``.
+    # Cooperative-stop budget (seconds) - how long a caller-facing action waits
+    # for a policy worker to notice ``policy_running = False`` and exit. A
+    # policy worker might be mid-step when cleanup is called; give it bounded
+    # time to see the cooperative-stop flag and exit cleanly before we null the
+    # world and its in-flight ``mj_step`` segfaults on a nulled
+    # ``_model``/``_data``. ``remove_robot`` waits the same budget on the one
+    # worker it stops itself, so the two paths cannot drift to different
+    # answers about how long the protocol gets. Bounded rather than open-ended
+    # so a wedged worker can never hang the caller; each path then decides what
+    # to do with a lapse - cleanup logs and continues teardown, remove_robot
+    # refuses the scene rebuild.
     # Override in tests via ``cleanup(policy_stop_timeout=...)`` if needed.
     _DEFAULT_POLICY_STOP_TIMEOUT = 5.0
 

--- a/tests/simulation/mujoco/test_engine_locking_discipline.py
+++ b/tests/simulation/mujoco/test_engine_locking_discipline.py
@@ -7,6 +7,11 @@ against a PolicyRunner worker or the recorder/render daemon:
   (no swallowed cooperative-stop timeout) and let the worker exit cleanly,
   instead of stalling on a join held under the dispatch lock and then
   rebuilding the scene under a still-live worker.
+* When that cooperative stop *does* lapse - the worker is blocked somewhere the
+  stop flag is not read yet - ``remove_robot`` must refuse the rebuild and keep
+  the worker tracked, rather than reporting success and un-tracking a live
+  worker (which blinds the global scene-mutation gate for the rest of the
+  session and hides the worker from cleanup's own bounded join).
 * A long-running dispatched ``step`` must not block ``stop_policy`` (or any
   other lightweight action): ``step`` releases the engine lock between
   batches and ``stop_policy`` runs without the blanket dispatch lock.
@@ -17,13 +22,16 @@ against a PolicyRunner worker or the recorder/render daemon:
   ``mj_step`` cannot tear the frame or crash on ``data.contact``.
 """
 
+import re
 import threading
 import time
+from concurrent.futures import Future
 
 import pytest
 
 mj = pytest.importorskip("mujoco")
 
+from strands_robots.policies.base import Policy  # noqa: E402
 from strands_robots.simulation.mujoco.backend import _can_render  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
 
@@ -67,25 +75,70 @@ def sim_with_arm(arm_xml_path):
     sim.cleanup(policy_stop_timeout=1.0)
 
 
-class _SlowPolicy:
+class _SlowPolicy(Policy):
     """A trivial policy whose per-step inference sleeps, keeping the worker
-    demonstrably alive while ``remove_robot`` races it."""
+    demonstrably alive while ``remove_robot`` races it.
 
-    provider_name = "slow_test"
-    requires_images = False
+    Subclasses :class:`~strands_robots.policies.base.Policy` rather than
+    duck-typing the surface: the runner also calls ``set_control_frequency``
+    and ``set_rtc_observed_delay``, and it wants an action *chunk*. A stub
+    missing any of those dies on its first query, the runner records the
+    exception on the Future, and every test that meant to race a *live* worker
+    silently races a finished one instead.
+    """
 
-    def set_robot_state_keys(self, keys):  # noqa: D401 - test stub
+    @property
+    def provider_name(self):
+        return "slow_test"
+
+    @property
+    def requires_images(self):
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys):  # noqa: D401 - test stub
         pass
 
-    def reset(self, seed=None):
-        pass
-
-    def get_actions_sync(self, observation, instruction):
+    async def get_actions(self, observation, instruction, **kwargs):
         time.sleep(0.05)
-        return {"shoulder_pan": 0.1}
+        return [{"shoulder_pan": 0.1} for _ in range(8)]
 
-    async def get_actions(self, observation, instruction):
-        return {"shoulder_pan": 0.1}
+
+class _WedgedPolicy(Policy):
+    """A policy whose inference outlasts the cooperative-stop budget.
+
+    Models the real shapes that do: a policy server that stops answering, a
+    stalled RTC query, a long VLA forward pass. The flag ``remove_robot`` sets
+    is only read between control ticks, so a worker parked inside inference
+    cannot honor it however long the join waits.
+    """
+
+    def __init__(self, block_s):
+        super().__init__()
+        self._block_s = block_s
+        self._queries = 0
+        self.inference_entered = threading.Event()
+        self.inference_left = threading.Event()
+
+    @property
+    def provider_name(self):
+        return "wedged_test"
+
+    @property
+    def requires_images(self):
+        return False
+
+    def set_robot_state_keys(self, robot_state_keys):  # noqa: D401 - test stub
+        pass
+
+    async def get_actions(self, observation, instruction, **kwargs):
+        self._queries += 1
+        # Block on the second query so the worker is demonstrably past startup
+        # and inside the control loop when it parks.
+        if self._queries == 2:
+            self.inference_entered.set()
+            time.sleep(self._block_s)
+            self.inference_left.set()
+        return [{"shoulder_pan": 0.1} for _ in range(8)]
 
 
 def test_remove_robot_during_active_policy_returns_and_worker_exits_clean(sim_with_arm, arm_xml_path):
@@ -107,6 +160,11 @@ def test_remove_robot_during_active_policy_returns_and_worker_exits_clean(sim_wi
     # Let the worker enter its control loop.
     time.sleep(0.3)
     assert "arm1" in sim._policy_threads
+    # Premise: the worker has to be genuinely live for the race to exist. A
+    # stub that dies on its first query leaves a *finished* Future tracked
+    # here, and every assertion below then passes without a worker to race.
+    worker = sim._policy_threads["arm1"]
+    assert not worker.done(), f"premise: worker already finished ({worker.exception(timeout=1)!r})"
 
     # Dispatch through __call__ -> _dispatch_action (the path that used to
     # hold the blanket lock across the join).
@@ -297,3 +355,223 @@ def test_concurrent_render_and_step_do_not_crash(sim_with_arm):
         stop.set()
         renderer.join(timeout=10.0)
     assert not errors, errors
+
+
+class TestALapsedCooperativeStopRefusesTheRebuild:
+    """``remove_robot`` waits a bounded budget for the target robot's own policy
+    worker to notice the cooperative stop. When that budget lapses the worker is
+    still live, and the scene rebuild that follows reallocates the ``MjModel`` /
+    ``MjData`` it holds.
+
+    The tracked Future is the single record every bound on a live worker reads:
+    the global scene-mutation gate, ``list_policies_running``, and cleanup's own
+    bounded join. Dropping it does not end the worker - it only makes the worker
+    unobservable, and the blindness outlives the ``remove_robot`` call.
+
+    ``Future.done()`` - not the exception class - is what separates a lapsed join
+    from a worker that raised: ``socket.timeout`` *is* ``TimeoutError``, so a
+    policy server that stops answering raises exactly the class the join does.
+    """
+
+    @staticmethod
+    def _sim_with_tracked_future(arm_xml_path, fut, stop_budget=0.2):
+        """A one-arm world whose arm is tracked by ``fut``.
+
+        Injecting the Future directly makes the two branches of the join
+        deterministic (no sleeping, no scheduler luck): an unresolved Future is
+        a lapse, a resolved one is a worker that has exited.
+        """
+        sim = Simulation(tool_name="test_lapse", mesh=False)
+        assert sim.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+        assert sim.add_robot("arm1", urdf_path=arm_xml_path)["status"] == "success"
+        sim._DEFAULT_POLICY_STOP_TIMEOUT = stop_budget
+        sim._policy_threads["arm1"] = fut
+        sim._world.robots["arm1"].policy_running = True
+        return sim
+
+    def test_a_live_worker_refuses_the_removal_instead_of_reporting_success(self, arm_xml_path):
+        """The headline: a worker that outlives the budget must not be reported
+        as removed. Pre-fix the join's ``TimeoutError`` was swallowed and the
+        call answered ``success`` with the worker still running."""
+        fut = Future()  # never resolved: the join can only lapse
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            result = sim.remove_robot("arm1")
+
+            assert result["status"] == "error", (
+                f"remove_robot reported {result['status']!r} while its policy worker was still "
+                f"live (future.done() == {fut.done()})"
+            )
+            text = result["content"][0]["text"]
+            assert "arm1" in text
+            # The refusal has to name the budget it actually waited, so the
+            # reader can tell a lapse from a different refusal.
+            assert f"{sim._DEFAULT_POLICY_STOP_TIMEOUT:.1f}s" in text, text
+            # The robot survives the refused mutation.
+            assert "arm1" in sim.list_robots()
+        finally:
+            fut.set_result(None)
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_live_worker_stays_visible_to_the_scene_mutation_gate(self, arm_xml_path):
+        """The blindness outlives the call: pre-fix the worker was un-tracked, so
+        every later global-scope mutation was admitted while it ran. Those are
+        exactly the model/data reallocations the gate exists to refuse."""
+        fut = Future()
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            assert sim.remove_robot("arm1")["status"] == "error"
+
+            assert sim._require_no_running_policy("add_object") is not None
+            admitted = {
+                "add_object": sim.add_object(name="cube", shape="box", position=[0.4, 0, 0.1], size=[0.05, 0.05, 0.05])[
+                    "status"
+                ],
+                "set_timestep": sim.set_timestep(0.004)["status"],
+                "add_robot": sim.add_robot("arm2", urdf_path=arm_xml_path)["status"],
+            }
+            assert admitted == {k: "error" for k in admitted}, (
+                f"a live policy worker was admitted past the scene-mutation gate: {admitted}"
+            )
+        finally:
+            fut.set_result(None)
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_live_worker_stays_visible_to_list_policies_running(self, arm_xml_path):
+        """The surface a caller reads to answer "is anything running?" must not
+        report a live worker as gone."""
+        fut = Future()
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            assert sim.remove_robot("arm1")["status"] == "error"
+
+            assert sim._active_policy_robots() == ["arm1"]
+            assert "arm1" in sim.list_policies_running()["content"][0]["text"]
+        finally:
+            fut.set_result(None)
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_live_worker_stays_joinable_by_cleanup(self, arm_xml_path):
+        """cleanup's bounded join iterates ``_policy_threads``, and its
+        ``executor.shutdown(wait=False)`` rests on having drained every worker
+        there. An un-tracked worker is joined by nobody."""
+        fut = Future()
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            assert sim.remove_robot("arm1")["status"] == "error"
+
+            assert "arm1" in sim._policy_threads, (
+                "the live worker is no longer tracked, so cleanup's bounded join cannot wait on it"
+            )
+        finally:
+            fut.set_result(None)
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_the_remedy_the_refusal_names_removes_the_robot(self, arm_xml_path):
+        """Apply the refusal's own instruction and it must work.
+
+        Pins the remedy rather than the wording: the action is read back out of
+        the message, so a refusal that named an action which does not resolve
+        the situation fails here.
+        """
+        fut = Future()
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            text = sim.remove_robot("arm1")["content"][0]["text"]
+            actions = re.findall(r"action='([a-z_]+)'", text)
+            assert "remove_robot" in actions, f"the refusal names no retryable action: {text}"
+
+            # ...and once the worker has exited, that retry succeeds.
+            fut.set_result(None)
+            retried = sim.remove_robot("arm1")
+            assert retried["status"] == "success", retried
+            assert "arm1" not in sim.list_robots()
+            assert sim.step(n_steps=1)["status"] == "success"
+        finally:
+            if not fut.done():
+                fut.set_result(None)
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_worker_that_raised_timeout_error_is_still_removed(self, arm_xml_path):
+        """No-overreach control, and the one that fails if the lapse is detected
+        by exception class instead of by ``done()``.
+
+        A policy server that stops answering raises ``socket.timeout``, which
+        *is* ``TimeoutError`` - the very class the join raises. That worker has
+        exited, so its robot must still be removable.
+        """
+        fut = Future()
+        fut.set_exception(TimeoutError("policy server did not answer"))
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            result = sim.remove_robot("arm1")
+
+            assert result["status"] == "success", result
+            assert "arm1" not in sim.list_robots()
+            assert "arm1" not in sim._policy_threads
+        finally:
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_worker_that_stopped_within_the_budget_is_removed_unchanged(self, arm_xml_path):
+        """No-overreach control for the common path: the worker honors the stop,
+        so the removal proceeds exactly as before."""
+        fut = Future()
+        fut.set_result(None)
+        sim = self._sim_with_tracked_future(arm_xml_path, fut)
+        try:
+            result = sim.remove_robot("arm1")
+
+            assert result["status"] == "success", result
+            assert "arm1" not in sim.list_robots()
+            assert "arm1" not in sim._policy_threads
+            assert sim.step(n_steps=1)["status"] == "success"
+        finally:
+            sim.cleanup(policy_stop_timeout=0.2)
+
+    def test_a_robot_with_no_policy_is_removed_unchanged(self, sim_with_arm):
+        """No-overreach control: the join is skipped entirely when nothing is
+        tracked, so the untracked case cannot reach the new refusal."""
+        sim = sim_with_arm
+        assert sim._policy_threads == {}
+
+        assert sim.remove_robot("arm1")["status"] == "success"
+        assert "arm1" not in sim.list_robots()
+
+    def test_a_real_wedged_policy_worker_is_refused_then_removable(self, arm_xml_path):
+        """End-to-end with a real PolicyRunner worker parked inside inference.
+
+        The deterministic tests above inject the Future; this one earns it, so
+        the refusal is pinned against the way a worker actually outlives the
+        budget rather than against a hand-made Future.
+        """
+        sim = Simulation(tool_name="test_lapse_e2e", mesh=False)
+        assert sim.create_world(gravity=[0, 0, -9.81])["status"] == "success"
+        assert sim.add_robot("arm1", urdf_path=arm_xml_path)["status"] == "success"
+        sim._DEFAULT_POLICY_STOP_TIMEOUT = 0.2
+        policy = _WedgedPolicy(block_s=3.0)
+        try:
+            started = sim.start_policy(robot_name="arm1", policy_object=policy, duration=60.0, control_frequency=50.0)
+            assert started["status"] == "success"
+            assert policy.inference_entered.wait(30.0), "premise: the worker never reached inference"
+            worker = sim._policy_threads["arm1"]
+            assert not worker.done(), f"premise: worker already finished ({worker.exception(timeout=1)!r})"
+
+            refused = sim.remove_robot("arm1")
+            assert refused["status"] == "error", refused
+            assert not worker.done()
+            assert sim._active_policy_robots() == ["arm1"]
+            assert "arm1" in sim.list_robots()
+
+            # The stop was requested, so the worker leaves at its next tick and
+            # the retry the refusal advertises then succeeds.
+            assert policy.inference_left.wait(30.0)
+            deadline = time.monotonic() + 30.0
+            while not worker.done() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert worker.done(), "the cooperative stop never took effect"
+
+            assert sim.remove_robot("arm1")["status"] == "success"
+            assert "arm1" not in sim.list_robots()
+            assert sim.step(n_steps=1)["status"] == "success"
+        finally:
+            sim.cleanup(policy_stop_timeout=1.0)


### PR DESCRIPTION
## Problem

`remove_robot` stops the target robot's own policy worker cooperatively, then waits a bounded 5s for it to exit:

```python
self._world.robots[name].policy_running = False
try:
    self._policy_threads[name].result(timeout=5.0)
except Exception:
    pass
del self._policy_threads[name]          # deleted regardless
```

`Future.result(timeout=...)` raises `TimeoutError` when the worker has *not* exited. That is swallowed and the tracking entry is deleted anyway, so a worker that outlived the budget is reported as removed while it is still running.

The tracked Future is the single record every bound on a live worker reads: the global scene-mutation gate (`_require_no_running_policy`), `list_policies_running`, and `cleanup`'s own bounded join. Deleting it does not end the worker - it makes the worker **unobservable**, and the blindness outlives the `remove_robot` call.

## Measured

A policy parked inside inference (a policy server that stops answering, a stalled RTC query, a long VLA forward pass) cannot read the stop flag, which is only checked between control ticks. Driving the shipped path on a one-arm world:

| observable | before | after |
| --- | --- | --- |
| `remove_robot` verdict | `success` - "Robot 'arm1' removed." (after 5.01s) | `error`, naming the budget + the retry |
| worker actually running | `True` | `True` |
| tracked in `_policy_threads` | **`False`** | `True` |
| `list_policies_running` | "No policies running." | "Active policies (1): - arm1" |
| global scene-mutation gate | **ALLOWS** | REFUSES |
| `add_object` while worker runs | **`success`** | `error` |
| `set_timestep` while worker runs | **`success`** | `error` |
| `add_robot` while worker runs | **`success`** | `error` |
| `cleanup` has anything to join | **`False`** (0.0s, no warning) | `True` |
| retry after the worker exits | n/a | `success`, robot gone, `step` OK |

Nothing raises and nothing is logged - `Future.exception()` is `None`, because `PolicyRunner` unwinds cleanly.

The three admitted mutations are the point. Each reallocates `MjModel`/`MjData`, which is exactly what the gate's own docstring says it exists to refuse ("any live PolicyRunner worker holding pointers to the old arrays will segfault when it next calls `mj_step`. Hard-fail."). Because the entry is gone for good, that admission is not confined to `remove_robot`'s own rebuild - it lasts the rest of the session. `cleanup` then runs `executor.shutdown(wait=False)` on the documented premise that "we've already drained policy workers above", which is not true of a worker nobody tracks.

Scope note on the mechanism: the woken worker does **not** write through stale actuator ids. `send_action` resolves keys by name each tick and the robot is gone from `world.robots`, so a second arm's `ctrl` stayed at `0.0` throughout (measured). The defect is the broken safety invariant, the surface that misreports it, and the worker no path can join - not memory corruption.

## Change

Keep the tracking entry and refuse the rebuild:

```
Robot 'arm1' still has a live policy worker after waiting 5.0s for it to stop, so the
scene rebuild was refused: it would reallocate the model/data that worker holds. The
cooperative stop has been requested and the worker exits at its next control tick -
retry action='remove_robot' (until it does, action='list_policies_running' still
reports it).
```

Keeping one entry makes all four surfaces consistent at once: the gate refuses, `list_policies_running` is truthful, `cleanup` can join it, and the retry the message names works because the stop has already been requested.

**The lapse is decided by `Future.done()`, not by exception class.** `socket.timeout` *is* `TimeoutError` (both are `OSError` subclasses), so a policy server that stops answering raises the very class the join raises. Typing on the class would refuse a removal whose worker had already exited; `done()` answers `True` vs `False` for the two cases. `done()` is also what `_require_no_running_policy` and `_prune_done_futures` already use.

Refusing rather than joining unbounded is deliberate: an open-ended join is the caller hang that `_DEFAULT_POLICY_STOP_TIMEOUT` exists to prevent. The budget is now read from that constant instead of a second hardcoded `5.0`, so the two paths that implement one cooperative-stop protocol cannot drift to different answers.

An AST sweep for the same shape across `strands_robots/` - a suppressed join/wait followed by unconditionally dropping the tracking state it was waiting on - finds exactly one site, the one fixed here. `cleanup` is the other place that joins policy futures, and it already handles a lapse correctly: it logs, naming the robot and the budget, because continuing is the deliberate choice on a teardown path. `remove_robot` is a mutation path, where continuing is what breaks the invariant.

## The test that pinned this contract was vacuous

`tests/simulation/mujoco/test_engine_locking_discipline.py` already names this exact failure - its module docstring says `remove_robot` must return "(no swallowed cooperative-stop timeout) ... instead of ... rebuilding the scene under a still-live worker", and `test_remove_robot_during_active_policy_returns_and_worker_exits_clean` describes it in full. It could not observe it: its `_SlowPolicy` stub omits `set_control_frequency` (and `set_rtc_observed_delay`, and returns a single dict where the runner wants an action chunk), so the worker died on its first query and the test raced a *finished* Future.

Adding only a premise assert to that test, on unmodified `main`:

```
AssertionError: premise: worker already finished
  (AttributeError("'_SlowPolicy' object has no attribute 'set_control_frequency'"))
```

The stub now subclasses `Policy`, and the premise assert stays so it can never silently go vacuous again. That test still passes with a genuinely live worker, which confirms the lock half of the contract is real.

## Artifact

One probe script, run against each tree, in MuJoCo sim headless (`MUJOCO_GL=egl`). A policy worker is parked inside inference so it cannot read the stop flag; the render is the resulting scene after the cascade.

![remove_robot cooperative-stop lapse](https://raw.githubusercontent.com/cagataycali/robots/media-remove-robot-stop-lapse/remove_robot_cooperative_stop_lapse.png)

Left: `remove_robot` answers `success` after 5.0s, and the cube and second arm are then injected into the scene while the worker is still live (`robots=['arm2'] bodies=3`). Right: the rebuild is refused and the scene the gate protected is unchanged (`robots=['arm1'] bodies=2`). Render panels differ by mean|delta| 11.89; the injected cube is 841 px on the left and 0 on the right.

## Tests

`6 failed / 10 passed` on `upstream/main`, `16 passed` after. Headline failure:

```
remove_robot reported 'success' while its policy worker was still live (future.done() == False)
```

The failing six cover the verdict, the gate blindness, `list_policies_running`, cleanup joinability, the remedy roundtrip (the action is parsed back out of the message and applied, so a refusal naming an action that does not resolve the situation fails), and an end-to-end case with a real `PolicyRunner` worker parked inside inference.

Three pass on both trees as no-overreach controls:

- a worker that raised `TimeoutError` is still removed - this is the one that fails if the lapse is detected by exception class;
- a worker that stopped within the budget is removed unchanged;
- a robot with no policy is removed unchanged (the join is skipped entirely).

The deterministic tests inject the Future so the two branches need no sleeping or scheduler luck; the end-to-end test earns it with a real worker.

Full `tests/` on Thor (mujoco 3.5.0, lerobot 0.6.2), branch and `upstream/main` run in parallel under identical load: **no regressions** - the set difference of failing test ids is empty (`28 failed / 30668 passed` vs `30 failed / 30657 passed`; the `+11` is the 9 new tests plus two known wall-clock-sensitive tests that happened to pass on the branch run, not fixes). `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.
