### PR TITLE
fix(registry): let a provider's declared host default survive build_policy_kwargs

### DIFF
--- a/changelog.d/2356-registry-declared-host-default.md
+++ b/changelog.d/2356-registry-declared-host-default.md
@@ -1,0 +1,12 @@
+### Fixed
+
+`build_policy_kwargs` no longer overrides a policy provider's declared `host`
+default. The generic `policy_host` parameter defaulted to the literal
+`"localhost"`, which the merge could not distinguish from a caller-supplied
+value, so `host` was injected on every call and no declared default was
+reachable -- contradicting the function's documented rule that "a default only
+ever fills a key the caller left unset". `moveit2` and `vera` (which declare
+`127.0.0.1` in `policies.json`) and `lerobot_async` and `remote` (which declare
+it as their constructor default) were all handed `localhost`. `policy_host` now
+defaults to `None` like the other generic parameters; an explicit `host=` or
+`policy_host=` still wins as before.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,7 +51,7 @@ from strands_robots.registry import (
 | `list_policy_providers()` | Providers from `policies.json`. |
 | `resolve_policy(uri)` | URI → provider name. |
 | `import_policy_class(provider)` | Lazy import of provider class. |
-| `build_policy_kwargs(provider, **kw)` | Normalise + validate kwargs. An explicit value beats the provider's registry default; the provider's own key (`host=`) beats the generic parameter (`policy_host=`). |
+| `build_policy_kwargs(provider, **kw)` | Normalise + validate kwargs. An explicit value beats the provider's registry default; the provider's own key (`host=`) beats the generic parameter (`policy_host=`). Every generic parameter defaults to `None`, meaning "unset", so an omitted one leaves the provider's own default -- registry, else constructor -- in place. |
 
 ## `strands_robots.simulation`
 

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -286,7 +286,7 @@ def import_policy_class(provider: str) -> type:
 def build_policy_kwargs(
     provider: str,
     policy_port: int | None = None,
-    policy_host: str = "localhost",
+    policy_host: str | None = None,
     model_path: str | None = None,
     server_address: str | None = None,
     policy_type: str | None = None,
@@ -301,7 +301,9 @@ def build_policy_kwargs(
     Args:
         provider: Policy provider name.
         policy_port: Port number (groot, cosmos3, moveit2, remote).
-        policy_host: Hostname (default: "localhost").
+        policy_host: Hostname.  ``None`` leaves the key unset so the
+            provider's registry default -- or, failing that, its own
+            constructor default -- applies.
         model_path: Local model path or HF ID.
         server_address: Full server address host:port (grpc:// URLs, remote providers).
         policy_type: Sub-type (pi0, act, smolvla, ...).
@@ -329,7 +331,9 @@ def build_policy_kwargs(
         "host": policy_host,
         "data_config": data_config,
         "server_address": server_address
-        or (f"{policy_host}:{policy_port}" if policy_port and "server_address" in allowed_keys else None),
+        or (
+            f"{policy_host}:{policy_port}" if policy_host and policy_port and "server_address" in allowed_keys else None
+        ),
         "model_path": model_path,
         "pretrained_name_or_path": (
             model_path

--- a/tests/registry/test_declared_host_default_reaches_the_policy.py
+++ b/tests/registry/test_declared_host_default_reaches_the_policy.py
@@ -21,7 +21,6 @@ covered the moment it is declared.
 """
 
 import ast
-import importlib
 import inspect
 import json
 from pathlib import Path
@@ -94,10 +93,8 @@ class TestTheConstructorHostDefaultIsReachable:
     def test_the_constructor_it_falls_back_to_does_define_a_host(self, provider):
         """Omitting the key is only safe because the constructor answers."""
         cfg = _registry()[provider]
-        try:
-            cls = getattr(importlib.import_module(cfg["module"]), cfg["class"])
-        except ImportError as exc:  # optional dependency absent
-            pytest.skip(f"{provider} needs an optional dependency: {exc}")
+        module = pytest.importorskip(cfg["module"], reason=f"{provider} needs an optional dependency")
+        cls = getattr(module, cfg["class"])
         param = inspect.signature(cls.__init__).parameters.get("host")
         assert param is not None and param.default is not inspect.Parameter.empty, (
             f"{cfg['class']} must default host= for an omitted key to be safe"

--- a/tests/registry/test_declared_host_default_reaches_the_policy.py
+++ b/tests/registry/test_declared_host_default_reaches_the_policy.py
@@ -1,0 +1,189 @@
+"""A provider's declared ``host`` default must reach the policy it configures.
+
+``build_policy_kwargs`` merges three sources and decides "the caller left this
+key unset" by testing the generic parameter against ``None``.  Five of its six
+generic parameters default to ``None``, so that test means something for them.
+``policy_host`` defaulted to the literal ``"localhost"``, which is
+indistinguishable from a caller who asked for ``localhost`` -- so ``host`` was
+injected on every call and no declared default for it was ever reachable.
+
+Four of the six providers that accept a ``host`` were affected.  ``moveit2``
+and ``vera`` declare ``127.0.0.1`` in ``policies.json``; ``lerobot_async`` and
+``remote`` declare it as their constructor default.  All four were handed
+``localhost`` -- a value none of them declares anywhere -- while this
+function's own docstring promised "A default only ever fills a key the caller
+left unset", and the sibling ``resolve_policy`` already left ``host`` unset
+unless a URL supplied one.
+
+The cases are derived from ``policies.json`` and the provider constructors
+rather than listed, so a provider that gains or changes a host default is
+covered the moment it is declared.
+"""
+
+import ast
+import importlib
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.registry.policies import build_policy_kwargs
+
+# ─── registry-derived cases ───────────────────────────────────────────
+
+
+def _registry() -> dict[str, Any]:
+    """Locate policies.json from the module under test, never a path literal."""
+    path = Path(inspect.getfile(build_policy_kwargs)).parent / "policies.json"
+    return json.loads(path.read_text())["providers"]
+
+
+def _accepts_host() -> dict[str, Any]:
+    return {n: c for n, c in sorted(_registry().items()) if "host" in (c.get("config_keys") or [])}
+
+
+DECLARED = [
+    (n, (c.get("defaults") or {})["host"]) for n, c in _accepts_host().items() if "host" in (c.get("defaults") or {})
+]
+DECLARED_IDS = [n for n, _ in DECLARED]
+
+UNDECLARED = [n for n, c in _accepts_host().items() if "host" not in (c.get("defaults") or {})]
+
+
+class TestTheCasesAreStillReal:
+    """Non-vacuity: an empty case list would make the tests below silent."""
+
+    def test_some_providers_declare_a_registry_host_default(self):
+        assert len(DECLARED) >= 2, f"only {DECLARED_IDS} declare a host default"
+
+    def test_some_providers_leave_the_host_default_to_their_constructor(self):
+        assert len(UNDECLARED) >= 2, f"only {UNDECLARED} omit a registry host default"
+
+    def test_the_two_groups_do_not_overlap(self):
+        assert not set(DECLARED_IDS) & set(UNDECLARED)
+
+
+class TestTheRegistryHostDefaultIsReachable:
+    """The headline: a declared default must not be pre-empted."""
+
+    @pytest.mark.parametrize(("provider", "declared"), DECLARED, ids=DECLARED_IDS)
+    def test_an_omitted_host_takes_the_declared_default(self, provider, declared):
+        """``moveit2``/``vera`` declare ``127.0.0.1`` and used to get ``localhost``."""
+        got = build_policy_kwargs(provider).get("host")
+        assert got == declared, (
+            f"{provider} declares host={declared!r} in policies.json but "
+            f"build_policy_kwargs returned {got!r}, which no provider declares"
+        )
+
+
+class TestTheConstructorHostDefaultIsReachable:
+    """A provider with no registry default must be left to its own."""
+
+    @pytest.mark.parametrize("provider", UNDECLARED)
+    def test_no_host_is_invented_for_a_provider_that_declares_none(self, provider):
+        """Injecting a key is what stopped the constructor default applying."""
+        kwargs = build_policy_kwargs(provider)
+        assert "host" not in kwargs, (
+            f"{provider} declares no registry host default, yet build_policy_kwargs "
+            f"supplied host={kwargs['host']!r}, overriding its constructor default"
+        )
+
+    @pytest.mark.parametrize("provider", UNDECLARED)
+    def test_the_constructor_it_falls_back_to_does_define_a_host(self, provider):
+        """Omitting the key is only safe because the constructor answers."""
+        cfg = _registry()[provider]
+        try:
+            cls = getattr(importlib.import_module(cfg["module"]), cfg["class"])
+        except ImportError as exc:  # optional dependency absent
+            pytest.skip(f"{provider} needs an optional dependency: {exc}")
+        param = inspect.signature(cls.__init__).parameters.get("host")
+        assert param is not None and param.default is not inspect.Parameter.empty, (
+            f"{cfg['class']} must default host= for an omitted key to be safe"
+        )
+
+
+class TestEveryGenericParameterCanMeanUnset:
+    """The root cause, pinned structurally so it cannot return on a sibling.
+
+    The merge tests "did the caller supply this?" as ``value is not None``.
+    A generic parameter carrying any other default silently exempts its key
+    from the precedence chain, which is exactly what ``policy_host`` did.
+    """
+
+    @staticmethod
+    def _signature() -> inspect.Signature:
+        return inspect.signature(build_policy_kwargs)
+
+    def test_no_generic_parameter_carries_a_value_as_its_default(self):
+        offenders = {
+            name: p.default
+            for name, p in self._signature().parameters.items()
+            if name != "provider"
+            and p.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+            and p.default is not None
+        }
+        assert not offenders, (
+            f"these generic parameters cannot express 'unset', so the registry "
+            f"default for their key is unreachable: {offenders}"
+        )
+
+    def test_the_scan_reaches_the_real_parameters(self):
+        """Non-vacuity: a signature that resolved elsewhere would report clean."""
+        names = set(self._signature().parameters)
+        assert {"provider", "policy_port", "policy_host", "extra"} <= names
+
+
+class TestTheDerivedServerAddressNeverCarriesTheSentinel:
+    """Scope control on the fix itself: ``None`` must not be interpolated."""
+
+    def test_a_port_alone_does_not_produce_a_none_host_address(self):
+        """``f"{policy_host}:{port}"`` would read ``"None:9000"``."""
+        for provider in _accepts_host():
+            address = build_policy_kwargs(provider, policy_port=9000).get("server_address")
+            assert address is None or "None" not in address, f"{provider}: server_address={address!r}"
+
+    def test_an_explicit_host_still_derives_the_address(self):
+        kwargs = build_policy_kwargs("lerobot_async", policy_host="gpu-box", policy_port=9000)
+        assert kwargs["server_address"] == "gpu-box:9000"
+
+
+class TestAnExplicitHostStillWins:
+    """Over-reach control: the upper tiers of the chain are unchanged."""
+
+    @pytest.mark.parametrize(("provider", "declared"), DECLARED, ids=DECLARED_IDS)
+    def test_the_generic_parameter_beats_the_declared_default(self, provider, declared):
+        assert build_policy_kwargs(provider, policy_host="gpu-box")["host"] == "gpu-box"
+
+    @pytest.mark.parametrize(("provider", "declared"), DECLARED, ids=DECLARED_IDS)
+    def test_the_provider_spelling_beats_the_generic_parameter(self, provider, declared):
+        kwargs = build_policy_kwargs(provider, policy_host="generic", host="specific")
+        assert kwargs["host"] == "specific"
+
+    def test_an_unknown_provider_still_returns_no_kwargs(self):
+        assert build_policy_kwargs("nonexistent_xyz", policy_host="gpu-box") == {}
+
+
+# ─── structural guard ─────────────────────────────────────────────────
+
+
+class TestTheMergeStillTreatsNoneAsUnset:
+    """The behavioural tests above are only sound while the merge reads ``None``.
+
+    If the ``param_map`` loop stopped testing ``is not None``, a ``None``
+    default would start writing ``host=None`` into the kwargs instead of
+    leaving the key for the registry, and every test here would still pass.
+    """
+
+    def test_the_param_map_loop_skips_none_values(self):
+        source = Path(inspect.getfile(build_policy_kwargs)).read_text()
+        fn = next(
+            n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.FunctionDef) and n.name == "build_policy_kwargs"
+        )
+        loops = {
+            str(ast.get_source_segment(source, lp.iter)): str(ast.get_source_segment(source, lp))
+            for lp in fn.body
+            if isinstance(lp, ast.For)
+        }
+        assert "value is not None" in loops["param_map.items()"]

--- a/tests/registry/test_explicit_kwarg_beats_registry_default.py
+++ b/tests/registry/test_explicit_kwarg_beats_registry_default.py
@@ -115,8 +115,8 @@ class TestAnExplicitExtraValueBeatsTheRegistryDefault:
 class TestTheProviderSpecificSpellingBeatsTheGenericParameter:
     """``host`` and ``policy_host`` name one key; the explicit one wins."""
 
-    def test_extra_host_beats_the_generic_policy_host_default(self):
-        """``policy_host`` carries its own default, so it cannot mean "unset"."""
+    def test_extra_host_beats_the_generic_policy_host(self):
+        """The provider's own spelling wins over the generic one."""
         kwargs = build_policy_kwargs("groot", host="gpu-box")
         assert kwargs["host"] == "gpu-box"
 
@@ -149,14 +149,15 @@ class TestADefaultStillFillsAnUnsetKey:
     def test_an_omitted_key_takes_the_registry_default(self, provider, key, default):
         """Honouring an explicit value must not stop a default from filling in.
 
-        ``host`` is the one exception: the generic ``policy_host`` parameter
-        carries its own default, so it fills the key before the registry can.
+        ``host`` used to be carved out of this contract: ``policy_host``
+        carried the literal default ``"localhost"``, so it filled the key
+        before the registry could.  Every generic parameter now defaults to
+        ``None``, so the rule is uniform.
         """
         kwargs = build_policy_kwargs(provider)
-        if key == "host":
-            assert kwargs[key] == "localhost"
-        else:
-            assert kwargs[key] == default
+        assert kwargs[key] == default, (
+            f"{provider}: {key} declares {default!r} but build_policy_kwargs returned {kwargs.get(key)!r}"
+        )
 
 
 class TestUnknownExtraKeysAreStillDropped:


### PR DESCRIPTION
## Problem

`build_policy_kwargs` merges three sources into one kwargs dict and decides "the caller left this key unset" by testing each generic parameter against `None`. Five of its six generic parameters default to `None`, so that test means something for them. `policy_host` defaulted to the literal `"localhost"`:

```python
policy_host: str = "localhost",
...
for key, value in param_map.items():
    if value is not None and key in allowed_keys and key not in kwargs:
        kwargs[key] = value
```

`"localhost"` is not `None`, so `host` was written on **every** call, and the `key not in kwargs` guard on the defaults loop below then skipped the provider's declared default. No declared `host` default was reachable through this function.

That contradicts the function's own docstring:

> Where two sources name the same key, the more explicit one wins ... **A default only ever fills a key the caller left unset.**

and it makes `build_policy_kwargs` the odd one out against its sibling `resolve_policy`, which leaves `host` unset unless a URL supplies one.

## Blast radius

Four of the six providers that accept a `host` were handed a value **none of them declares anywhere**:

| provider | `policies.json` default | constructor default | before | after |
|---|---|---|---|---|
| `moveit2` | `127.0.0.1` | `127.0.0.1` | `localhost` | `127.0.0.1` (registry) |
| `vera` | `127.0.0.1` | `127.0.0.1` | `localhost` | `127.0.0.1` (registry) |
| `lerobot_async` | *(none)* | `127.0.0.1` | `localhost` | key absent -> `127.0.0.1` (constructor) |
| `remote` | *(none)* | `127.0.0.1` | `localhost` | key absent -> `127.0.0.1` (constructor) |
| `cosmos3` | `localhost` | `localhost` | `localhost` | `localhost` (unchanged) |
| `groot` | `localhost` | `localhost` | `localhost` | `localhost` (unchanged) |

`moveit2` states the intent three times, including the rationale — `policy.py:66`: *"host: Sidecar hostname. Default `"127.0.0.1"` (loopback only - users opt into network exposure)"*. `vera` states it four times, and `resolve_policy`'s own comment for the `vera://` branch reads *"nothing populates host/server_port, so `create_policy("vera://gpu-box:9000")` silently connects to the default 127.0.0.1"* — describing a default the registry path could not deliver.

`lerobot_async` and `remote` are the half a registry-only reading misses: they declare no registry default, so the injected `host` overrode their **constructor** default instead.

## Change

`policy_host` now defaults to `None`, like its five siblings, so an omitted value means "unset" and the declared default applies. The derived `server_address` only interpolates a host the caller actually supplied, so the sentinel cannot reach the address string (`f"{policy_host}:{port}"` would otherwise read `"None:9000"`). `lerobot_async` composes `host:port` itself at `policy.py:218` (`address = server_address or f"{host}:{port}"`), so omitting the key leaves it to the default it documents.

The explicit tiers of the precedence chain are untouched: `host=` still beats `policy_host=`, which still beats the registry default. The merge loop order — the contract pinned by `TestTheMergeOrderIsTheContract` — is unchanged.

## Tests

`tests/registry/test_explicit_kwarg_beats_registry_default.py` had carved `host` out of its own contract:

```python
"""``host`` is the one exception: the generic ``policy_host`` parameter
carries its own default, so it fills the key before the registry can."""
kwargs = build_policy_kwargs(provider)
if key == "host":
    assert kwargs[key] == "localhost"
else:
    assert kwargs[key] == default
```

That branch is removed and the parametrised rule is now uniform. Restoring the collapsed assertion against pre-fix code fails for exactly the two registry-declared cases (`2 failed, 38 passed`), which is what shows the carve-out was load-bearing rather than cosmetic.

New `tests/registry/test_declared_host_default_reaches_the_policy.py` derives its cases from `policies.json` and the provider constructors, so a provider that gains or changes a host default is covered the moment it is declared. Against pre-fix code: **5 failed, 20 passed**.

Failing pre-fix:
- the registry default is reachable (`moveit2`, `vera` — each naming the declared value and the value returned)
- no `host` is invented for a provider that declares none (`lerobot_async`, `remote`)
- **no generic parameter carries a value as its default** — the root cause, pinned structurally so the class cannot return on a future sibling parameter

Passing pre- and post-fix (the over-reach controls):
- `policy_host=` still beats the declared default; `host=` still beats `policy_host=`
- an explicit host still derives `server_address`, and no derived address ever contains `None`
- the constructor each omitted key falls back to really does define `host`
- the `param_map` loop still tests `value is not None` — without which a `None` default would write `host=None` and every behavioural test here would still pass
- an unknown provider still returns no kwargs

## Notes on scope

The reported symptom framed the risk as `localhost` vs `127.0.0.1` resolving differently. On a dual-stack host where `localhost` prefers `::1` that is a real hazard, but it is not what makes this a defect and I could not reproduce a divergence: measured with pyzmq 27.1 / libzmq 4.3.5 against a REP socket bound on `127.0.0.1`, both spellings connect, and neither reaches an `[::1]`-only bind. The defect stands on its own without that claim — a declared default that cannot be delivered, and a documented precedence rule with a silent exception.

`hardware_robot.py`'s `start_task(..., policy_host="localhost", ...)` family keeps its own documented `localhost` default; those build `policy_config` directly and are a separate user-facing surface, so they are out of scope here.

## Artifact

One probe script, run under `PYTHONPATH` of an `upstream/main` worktree and of this branch, against the **same live ZMQ sidecar** bound on `tcp://127.0.0.1:5731` (the loopback literal `moveit2`'s docs specify). Nothing is mocked and no source differs between panels — only the library tree.

![declared host default vs delivered host](https://raw.githubusercontent.com/cagataycali/robots/media-registry-host-default/host_default.png)

The bottom of each panel is a real end-to-end run of the documented registry path, `create_policy("moveit2", **build_policy_kwargs("moveit2", policy_port=5731))`:

| | before | after |
|---|---|---|
| `build_policy_kwargs` | `{"port": 5731, "host": "localhost", "planning_group": "arm"}` | `{"port": 5731, "host": "127.0.0.1", "planning_group": "arm"}` |
| `MoveIt2Policy.host` | `'localhost'` | `'127.0.0.1'` |
| dials | `tcp://localhost:5731` | `tcp://127.0.0.1:5731` |
| sidecar handshake | reached, 2 steps returned | reached, 2 steps returned |

Both panels complete the handshake, which is the honest result on a single-stack host: what changes is *which declared value the policy is built with*, not whether the connection works here.

---

## Review rounds

### Round 1

**Code scanning `py/uninitialized-local-variable` (alert 928) — fixed.** `Analyze (Python)` was failing, so this was a merge gate, not an advisory.

The optional-dependency guard in the new test file assigned inside a `try` whose handler only called `pytest.skip`:

```python
try:
    cls = getattr(importlib.import_module(cfg["module"]), cfg["class"])
except ImportError as exc:
    pytest.skip(f"{provider} needs an optional dependency: {exc}")
param = inspect.signature(cls.__init__).parameters.get("host")
```

`pytest.skip` raises, so `cls` is in fact bound on every path that reaches the last line — but that is a property of pytest's control flow rather than of the function, and an analysis scoped to one body cannot see it.

Rather than argue the query, the `try/except` is gone: `pytest.importorskip` is the idiomatic form for exactly this case and is already how the rest of the suite gates on optional dependencies (890 call sites, 46 of them passing `reason=`). `cls` is now assigned unconditionally from a value that either is a module or has already aborted the test.

```python
cfg = _registry()[provider]
module = pytest.importorskip(cfg["module"], reason=f"{provider} needs an optional dependency")
cls = getattr(module, cfg["class"])
```

Behaviour is unchanged, verified rather than asserted: the file still reports `25 passed`, the two `test_the_constructor_it_falls_back_to_does_define_a_host` cases still resolve real classes, and an absent module still *skips* with a reason naming the provider (`SKIPPED [1] ... probe needs an optional dependency`) instead of raising `NameError`.

`getattr` is deliberately left **outside** the guard. A registry entry naming a class its module does not define is a real defect, not a missing dependency, and should fail rather than skip — the old form would have swallowed that case only if the failure surfaced as `ImportError`, which it does not.

`import importlib` is dropped; that call was its only consumer, so keeping it would fail `ruff` F401 — the same way the unused `os` import did on the sibling PR.

**Checked that it is branch-introduced rather than a pre-existing alert whose line this PR shifted.** Alert 928's only instance is on `refs/pull/2356/merge`, and nothing is owed on `main` for it. The rule does have open alerts on `main` — 3 (`tests/simulation/mujoco/test_concurrency.py:359`), 4, and 5–8 under `tests_integ/benchmarks/libero/` — all pre-existing and all the same `try`/`pytest.skip` shape. An AST sweep of `tests/` finds exactly three such sites, none introduced here, so they are left alone; they are worth a sweep of their own, not a widening of this diff.
