### PR TITLE
fix(tools): signal every gr00t service pid and report whether the port was freed

### DIFF
--- a/changelog.d/2357-gr00t-stop-service-port-teardown.md
+++ b/changelog.d/2357-gr00t-stop-service-port-teardown.md
@@ -1,0 +1,14 @@
+### Fixed: `gr00t_inference(action="stop")` signals every service pid and reports whether the port was actually freed
+
+Port teardown escalated SIGTERM then SIGKILL with `subprocess.run(..., check=True)`
+per pid. The pid list comes from a scan, so a pid can exit before it is signalled;
+`kill` then exits non-zero ("No such process") and the raised `CalledProcessError`
+aborted the sweep, leaving the remaining pids unsignalled and skipping the SIGKILL
+escalation. In the `docker exec` branch - tried first - the exception was swallowed
+by a `continue`, the host fallback found nothing for a containerised process, and the
+call returned `{"status": "success", "message": "No service running on port N"}` while
+the sidecar still held the port; `restart` discards that result, so the next bind
+failed while naming the bind rather than the surviving process. Signalling is now
+best effort per pid, and the port is rescanned after the escalation: `"success"` means
+nothing is left holding it, and an owner that survives both signals is reported as an
+error naming the port and the surviving pids.

--- a/docs/policies/groot.md
+++ b/docs/policies/groot.md
@@ -119,6 +119,13 @@ gr00t_inference(action="lifecycle", lifecycle="teardown",
                 remove_volumes=True)  # stop + remove container (and volumes)
 ```
 
+`action="stop"` escalates SIGTERM then SIGKILL over every process serving the
+port, inside the GR00T container first and on the host as a fallback. A process
+that had already exited is not a failure, but a port still held after both
+signals is: the result is then `{"status": "error", ...}` naming the port and the
+surviving pid, because reporting success there would send the next `start` into a
+bind that cannot succeed. Check the status before rebinding the same port.
+
 ## See also
 
 - [Policy providers](../policies/overview.md)

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -1039,8 +1039,86 @@ def _check_service_status(port: int) -> dict[str, Any]:
         }
 
 
+def _signal_service_pids(exec_prefix: list[str], pids: list[str], signal: str) -> None:
+    """Send ``signal`` to every pid in ``pids``, best effort.
+
+    Teardown is best effort *per pid*. A pid that exits between the scan that
+    listed it and the signal that targets it makes ``kill`` exit non-zero
+    ("No such process") -- and that is the outcome teardown wanted, not a
+    failure. Signalling therefore must never abort the sweep: the pids after it
+    in the list, and the SIGKILL escalation that follows, still have to run.
+
+    Args:
+        exec_prefix: Argv prefix that selects where the signal lands, e.g.
+            ``["docker", "exec", "gr00t"]`` for a container or ``[]`` for the
+            host.
+        pids: Process ids to signal. Empty strings are skipped.
+        signal: ``kill`` signal flag, e.g. ``"-TERM"`` or ``"-KILL"``.
+    """
+    for pid in pids:
+        if pid:
+            subprocess.run([*exec_prefix, "kill", signal, pid], capture_output=True, text=True, check=False)
+
+
+def _service_pids_in_container(container_name: str, port: int) -> list[str]:
+    """Return the inference-service pids serving ``port`` inside a container.
+
+    Args:
+        container_name: Container to scan.
+        port: Port the inference service was started on.
+
+    Returns:
+        The matching pids, or an empty list when the container has none or
+        cannot be scanned at all. A container that cannot be scanned is
+        skipped by the caller rather than aborting the whole teardown.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "exec", container_name, "pgrep", "-f", f"inference_service.py.*--port {port}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [pid for pid in result.stdout.strip().split("\n") if pid]
+
+
+def _service_pids_on_host(port: int) -> list[str]:
+    """Return the host pids holding ``port``.
+
+    Args:
+        port: Port to inspect.
+
+    Returns:
+        The pids holding the port, or an empty list when it is free (or when
+        ``lsof`` is unavailable).
+    """
+    try:
+        result = subprocess.run(["lsof", "-t", f"-i:{port}"], capture_output=True, text=True, check=False)
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [pid for pid in result.stdout.strip().split("\n") if pid]
+
+
 def _stop_service(port: int) -> dict[str, Any]:
-    """Stop GR00T inference service running on specific port."""
+    """Stop the GR00T inference service running on ``port``.
+
+    Escalates SIGTERM -> SIGKILL over every pid found, then rescans and reports
+    what is actually true. A pid that had already exited is not an error, but a
+    port still held after the escalation is: reporting success there would tell
+    the caller the port is free when the next bind is about to fail.
+
+    Args:
+        port: Port whose inference service should be stopped.
+
+    Returns:
+        A tool result. ``"success"`` only when nothing is left holding ``port``.
+    """
     try:
         containers_result = _find_gr00t_containers()
         if containers_result["status"] == "success":
@@ -1048,67 +1126,63 @@ def _stop_service(port: int) -> dict[str, Any]:
 
             for container in running_containers:
                 container_name = container["name"]
-                try:
-                    result = subprocess.run(
-                        ["docker", "exec", container_name, "pgrep", "-f", f"inference_service.py.*--port {port}"],
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                    )
-
-                    if result.returncode == 0 and result.stdout.strip():
-                        pids = result.stdout.strip().split("\n")
-                        for pid in pids:
-                            if pid:
-                                subprocess.run(["docker", "exec", container_name, "kill", "-TERM", pid], check=True)
-
-                        time.sleep(2)
-
-                        result = subprocess.run(
-                            ["docker", "exec", container_name, "pgrep", "-f", f"inference_service.py.*--port {port}"],
-                            capture_output=True,
-                            text=True,
-                            check=False,
-                        )
-
-                        if result.returncode == 0 and result.stdout.strip():
-                            pids = result.stdout.strip().split("\n")
-                            for pid in pids:
-                                if pid:
-                                    subprocess.run(["docker", "exec", container_name, "kill", "-KILL", pid], check=True)
-
-                        return {
-                            "status": "success",
-                            "port": port,
-                            "container": container_name,
-                            "message": f"GR00T service on port {port} stopped in container {container_name}",
-                        }
-
-                except subprocess.CalledProcessError:
+                alive = _service_pids_in_container(container_name, port)
+                if not alive:
                     continue
 
+                exec_prefix = ["docker", "exec", container_name]
+                _signal_service_pids(exec_prefix, alive, "-TERM")
+                time.sleep(2)
+
+                alive = _service_pids_in_container(container_name, port)
+                if alive:
+                    _signal_service_pids(exec_prefix, alive, "-KILL")
+                    alive = _service_pids_in_container(container_name, port)
+
+                if alive:
+                    return {
+                        "status": "error",
+                        "port": port,
+                        "container": container_name,
+                        "message": (
+                            f"GR00T service on port {port} in container {container_name} survived SIGTERM and "
+                            f"SIGKILL: pid(s) {', '.join(alive)} still match. The port is still held, so a "
+                            f"restart will fail to bind it. Check the container with "
+                            f"'docker exec {container_name} ps -ef'."
+                        ),
+                    }
+
+                return {
+                    "status": "success",
+                    "port": port,
+                    "container": container_name,
+                    "message": f"GR00T service on port {port} stopped in container {container_name}",
+                }
+
         # Fallback: try host system
-        result = subprocess.run(["lsof", "-t", f"-i:{port}"], capture_output=True, text=True)
-
-        if result.returncode == 0:
-            pids = result.stdout.strip().split("\n")
-            for pid in pids:
-                if pid:
-                    subprocess.run(["kill", "-TERM", pid], check=True)
-
-            time.sleep(2)
-
-            result = subprocess.run(["lsof", "-t", f"-i:{port}"], capture_output=True, text=True)
-
-            if result.returncode == 0:
-                pids = result.stdout.strip().split("\n")
-                for pid in pids:
-                    if pid:
-                        subprocess.run(["kill", "-KILL", pid], check=True)
-
-            return {"status": "success", "port": port, "message": f"Service on port {port} stopped"}
-        else:
+        alive = _service_pids_on_host(port)
+        if not alive:
             return {"status": "success", "port": port, "message": f"No service running on port {port}"}
+
+        _signal_service_pids([], alive, "-TERM")
+        time.sleep(2)
+
+        alive = _service_pids_on_host(port)
+        if alive:
+            _signal_service_pids([], alive, "-KILL")
+            alive = _service_pids_on_host(port)
+
+        if alive:
+            return {
+                "status": "error",
+                "port": port,
+                "message": (
+                    f"Port {port} is still held by pid(s) {', '.join(alive)} after SIGTERM and SIGKILL. "
+                    f"The owning process may belong to another user; inspect it with 'lsof -i:{port}'."
+                ),
+            }
+
+        return {"status": "success", "port": port, "message": f"Service on port {port} stopped"}
 
     except Exception as e:
         return {"status": "error", "message": f"Failed to stop service: {e}"}

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -21,6 +21,7 @@ Coverage:
 
 from __future__ import annotations
 
+import itertools
 import os
 import subprocess
 from pathlib import Path
@@ -1252,20 +1253,26 @@ class TestServiceDiscovery:
         inference process is still alive (the second ``pgrep`` still reports it),
         escalate to KILL so a wedged service cannot leak the port. This pins that
         escalation - dropping it would silently leave a hung server holding the
-        port after ``stop`` reports success.
+        port after ``stop`` reports success. Success is only reported once a
+        rescan shows the port is actually free.
         """
         containers = {
             "status": "success",
             "containers": [{"name": "groot", "image": "isaac-gr00t", "status": "Up 3 hours", "ports": ""}],
         }
         calls: list[list[str]] = []
+        probes = itertools.count()
 
         def fake_run(cmd, *args, **kwargs):
             calls.append(cmd)
             if "pgrep" in cmd:
-                # The process stays alive across both probes -> TERM did not
-                # reap it, so the KILL escalation branch must run.
-                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="4242\n", stderr="")
+                # Alive across the first two probes -> TERM did not reap it, so
+                # the KILL escalation must run; gone on the third, which is what
+                # lets the teardown be reported as a success.
+                alive = next(probes) < 2
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0 if alive else 1, stdout="4242\n" if alive else "", stderr=""
+                )
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with (
@@ -1321,12 +1328,18 @@ class TestServiceDiscovery:
         """
         containers = {"status": "success", "containers": []}
         calls: list[list[str]] = []
+        probes = itertools.count()
 
         def fake_run(cmd, *args, **kwargs):
             calls.append(cmd)
             if "lsof" in cmd:
-                # Process is listed on both lsof probes -> survives TERM.
-                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="9999\n", stderr="")
+                # Listed on the first two lsof probes -> survives TERM, so the
+                # KILL escalation must run; gone on the third, so the port is
+                # genuinely free and the teardown can report success.
+                alive = next(probes) < 2
+                return subprocess.CompletedProcess(
+                    args=cmd, returncode=0 if alive else 1, stdout="9999\n" if alive else "", stderr=""
+                )
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         with (

--- a/tests/tools/test_gr00t_stop_service_port_teardown.py
+++ b/tests/tools/test_gr00t_stop_service_port_teardown.py
@@ -1,0 +1,211 @@
+"""Pin: gr00t_inference port teardown signals every pid and reports the truth.
+
+``_stop_service`` is the teardown half of the service lifecycle: the ``stop``
+action calls it directly and ``restart`` calls it to free the port before
+rebinding. Two properties have to hold, and they pull in opposite directions:
+
+  1. **Per-pid teardown is best effort.** The pid list comes from a scan, so a
+     pid can exit in the window between being listed and being signalled. That
+     makes ``kill`` exit non-zero ("No such process") -- which is the outcome
+     teardown wanted. It must not stop the remaining pids from being signalled,
+     and it must not skip the SIGKILL escalation.
+
+  2. **The report must be true.** ``"status": "success"`` tells the caller the
+     port is free. When something still holds the port after SIGTERM *and*
+     SIGKILL -- a pid owned by another user, a failing ``docker exec`` -- saying
+     success sends ``restart`` on to a bind that cannot succeed, and the
+     resulting error names the wrong thing.
+
+Both branches (``docker exec`` into a GR00T container, and the host ``lsof``
+fallback) implement the same escalation, so every property is pinned on both.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ``from strands_robots.tools import gr00t_inference`` resolves via the package's
+# lazy __getattr__ to the *tool function*, not the module -- import_module
+# returns the module object so ``gi.subprocess`` is patchable. This mirrors the
+# idiom in test_gr00t_docker_lifecycle_failsoft.py.
+gi = importlib.import_module("strands_robots.tools.gr00t_inference")
+
+PORT = 5555
+CONTAINER = "gr00t-jetson"
+
+
+class _Result:
+    """Stand-in for ``subprocess.CompletedProcess``."""
+
+    def __init__(self, returncode: int, stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = ""
+
+
+class FakeHost:
+    """A process table that answers ``pgrep``/``lsof``/``kill`` consistently.
+
+    Args:
+        in_container: When True the service pids live inside a GR00T container
+            (so ``docker ps`` lists one and ``pgrep`` answers); when False they
+            live on the host and only ``lsof`` answers.
+        live: Pids that are running and respond to SIGKILL.
+        stale: Pids the *first* scan lists and that exit immediately after --
+            the race this module exists to survive.
+        unkillable: Pids that stay alive no matter what signal arrives, i.e.
+            ``kill`` keeps failing (another user's process, a broken
+            ``docker exec``).
+    """
+
+    def __init__(
+        self,
+        *,
+        in_container: bool,
+        live: tuple[str, ...] = (),
+        stale: tuple[str, ...] = (),
+        unkillable: tuple[str, ...] = (),
+    ) -> None:
+        self.in_container = in_container
+        self.alive = set(live) | set(stale) | set(unkillable)
+        self._stale = set(stale)
+        self._unkillable = set(unkillable)
+        self._scans = 0
+        self.signals: list[str] = []
+
+    def run(self, cmd: Any, *_args: Any, **kwargs: Any) -> _Result:
+        argv = [str(part) for part in cmd]
+        if argv[:2] == ["docker", "ps"]:
+            if not self.in_container:
+                return _Result(0, "")
+            return _Result(0, f"{CONTAINER}\tnvcr.io/nvidia/isaac-gr00t:latest\tUp 3 hours\t{PORT}->{PORT}")
+        if "pgrep" in argv or argv[0] == "lsof":
+            asks_container = "pgrep" in argv
+            if asks_container is not self.in_container:
+                return _Result(1, "")
+            self._scans += 1
+            listed = sorted(self.alive, key=int)
+            if self._scans == 1:
+                # The scan sees the stale pids; they exit before anyone signals.
+                self.alive -= self._stale
+            return _Result(0, "\n".join(listed)) if listed else _Result(1, "")
+        if "kill" in argv:
+            signal, pid = argv[-2], argv[-1]
+            self.signals.append(f"{signal} {pid}")
+            if pid not in self.alive or pid in self._unkillable:
+                if kwargs.get("check"):
+                    raise subprocess.CalledProcessError(1, argv, stderr=f"kill: ({pid}): No such process")
+                return _Result(1)
+            if signal == "-KILL":
+                self.alive.discard(pid)
+            return _Result(0)
+        return _Result(0, "")
+
+
+def _stop(host: FakeHost) -> dict[str, Any]:
+    """Drive ``_stop_service`` against ``host`` with the teardown pause elided."""
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+    ):
+        return gi._stop_service(PORT)
+
+
+def _signalled(host: FakeHost, pid: str) -> bool:
+    return any(entry.endswith(f" {pid}") for entry in host.signals)
+
+
+# --- a pid that exited between the scan and the signal is not a failure ------
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_a_stale_pid_does_not_stop_the_remaining_pids_from_being_signalled(in_container: bool) -> None:
+    """Pid 111 exits before it is signalled; pid 222 must still get SIGTERM."""
+    host = FakeHost(in_container=in_container, live=("222",), stale=("111",))
+    _stop(host)
+    assert _signalled(host, "222"), (
+        f"pid 222 was never signalled: {host.signals}. Pid 111 had already exited, so 'kill' exited "
+        "non-zero and aborted the sweep before reaching the pid that is actually holding the port."
+    )
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_the_sigkill_escalation_still_runs_after_a_stale_pid(in_container: bool) -> None:
+    """A pid that ignores SIGTERM is still escalated to SIGKILL."""
+    host = FakeHost(in_container=in_container, live=("222",), stale=("111",))
+    _stop(host)
+    assert "-KILL 222" in host.signals, (
+        f"the SIGKILL escalation never ran: {host.signals}. A pid that survives SIGTERM is exactly "
+        "what the escalation exists for."
+    )
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_a_stale_pid_alone_still_reports_the_port_stopped(in_container: bool) -> None:
+    """Every pid gone (one exited on its own) is a successful teardown."""
+    host = FakeHost(in_container=in_container, live=("222",), stale=("111",))
+    result = _stop(host)
+    assert result["status"] == "success", result
+    assert host.alive == set(), f"pid(s) {sorted(host.alive)} survived a teardown reported as success"
+
+
+# --- a port still held after the escalation is not a success -----------------
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_a_port_still_held_after_sigkill_is_not_reported_as_stopped(in_container: bool) -> None:
+    """An unkillable owner must not be reported as a stopped service.
+
+    ``success`` here tells ``restart`` the port is free, and the bind that
+    follows then fails while naming the bind rather than the surviving process.
+    """
+    host = FakeHost(in_container=in_container, unkillable=("222",))
+    result = _stop(host)
+    assert result["status"] == "error", (
+        f"reported {result} while pid 222 still holds port {PORT}. A caller cannot distinguish this "
+        "from a port that was actually freed."
+    )
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_a_port_still_held_names_the_port_and_the_surviving_pid(in_container: bool) -> None:
+    """The refusal has to identify what to go look at."""
+    host = FakeHost(in_container=in_container, unkillable=("222",))
+    message = _stop(host).get("message", "")
+    assert str(PORT) in message, f"message does not name the port: {message!r}"
+    assert "222" in message, f"message does not name the surviving pid: {message!r}"
+
+
+# --- controls: the paths that already worked must keep working ---------------
+
+
+@pytest.mark.parametrize("in_container", [True, False], ids=["container", "host"])
+def test_a_single_live_pid_is_stopped_and_reported_success(in_container: bool) -> None:
+    """The ordinary teardown path is unchanged."""
+    host = FakeHost(in_container=in_container, live=("222",))
+    result = _stop(host)
+    assert result["status"] == "success", result
+    assert result["port"] == PORT
+    assert host.alive == set()
+
+
+def test_a_free_port_reports_success_without_signalling_anything() -> None:
+    """Nothing to stop is a success, and must not signal a pid."""
+    host = FakeHost(in_container=False)
+    result = _stop(host)
+    assert result["status"] == "success", result
+    assert f"No service running on port {PORT}" in result["message"]
+    assert host.signals == []
+
+
+def test_an_unexpected_error_is_still_converted_to_an_error_tool_result() -> None:
+    """The fail-soft dispatch contract still holds (see the failsoft module)."""
+    with patch.object(gi, "_find_gr00t_containers", side_effect=RuntimeError("daemon gone")):
+        result = gi._stop_service(PORT)
+    assert result["status"] == "error"
+    assert "Failed to stop service" in result["message"]


### PR DESCRIPTION
## Problem

`_stop_service` escalates SIGTERM then SIGKILL over the pids serving a port, in the
`docker exec` branch first and the host `lsof` branch as a fallback. Every one of
those four `kill` invocations used `subprocess.run(..., check=True)`.

The pid list comes from a scan, so a pid can exit in the window between being
listed and being signalled. `kill` then exits non-zero (`kill: (111): No such
process`), `CalledProcessError` is raised, and the sweep aborts: the pids after it
are never signalled and the SIGKILL escalation never runs. That pid exiting on its
own is the outcome teardown wanted, so the one process that needs no help is the
one that stops the rest from being helped.

The two branches then diverge on how they report it, and the container branch --
which is tried first -- reports the opposite of the truth. There the exception is
caught by `except subprocess.CalledProcessError: continue`, so the container is
abandoned mid-teardown, the host fallback finds nothing for a process that lives
inside a container, and the call returns:

```python
{"status": "success", "port": 5555, "message": "No service running on port 5555"}
```

while the sidecar is still running and still holding the port. `restart` calls
`_stop_service` to free the port and discards the result, so the bind that follows
fails while naming the bind rather than the surviving process.

## Measured

Driven through `_stop_service` with a process table that answers `pgrep`/`lsof`/`kill`
consistently. Pid `111` is listed by the first scan and exits before it is signalled;
pid `222` is the one actually holding the port.

| case | signals delivered | port freed | reported |
|---|---|---|---|
| container, `111` stale + `222` live | `-TERM 111` only | no, `222` alive | `success` -- "No service running on port 5555" |
| host, `111` stale + `222` live | `-TERM 111` only | no, `222` alive | `error` -- `Command '['kill', '-TERM', '111']' returned non-zero exit status 1.` |
| container, `222` cannot be killed | `-TERM 222` only | no | `success` -- "No service running on port 5555" |

After this change all three deliver `-TERM` then `-KILL` to every listed pid; the
first two report `success` because the port really is free, and the third reports
an error naming the port and the surviving pid.

The third row is why `check=False` on its own is not the fix: it stops the sweep
aborting, but an owner that survives both signals is still reported as a stopped
service.

![stop-service teardown before and after](https://raw.githubusercontent.com/cagataycali/robots/media-gr00t-stop-teardown/gr00t-stop-teardown.png)

The same three cases rendered from each tree's own `_stop_service` output. In `BEFORE`
two of the three report `success` while the port is still held; the SIGKILL escalation
runs in none of them. In `AFTER` every case delivers both signals to every listed pid
and the reported status matches reality in all three.

## Change

`strands_robots/tools/gr00t_inference.py`

- `_signal_service_pids(exec_prefix, pids, signal)` -- one best-effort signal loop
  replacing four `check=True` call sites. A pid that has already exited no longer
  stops the remaining pids or the escalation.
- `_service_pids_in_container()` / `_service_pids_on_host()` -- the scan, previously
  inlined four times as `returncode == 0 and stdout.strip()` plus a split. Each is
  total over subprocess failure at its own boundary (matching `_container_state`), so
  a container that cannot be scanned yields no pids and the caller skips it rather
  than aborting the teardown -- the multi-container resilience `except ...: continue`
  provided, now without the fall-through that lied.
- After the escalation the port is rescanned. `"status": "success"` now means nothing
  is left holding the port; otherwise the result is an error naming the port, the
  surviving pids and where to look.

The existing `stop` behaviour is otherwise unchanged: an ordinary teardown, a free
port, and the fail-soft conversion of an unexpected error into an error tool-result
all return exactly what they did before.

## Tests

`tests/tools/test_gr00t_stop_service_port_teardown.py` (new, 14 cases, every property
pinned on both branches). Against the pre-fix tree: **9 failed, 5 passed**; after:
14 passed.

Representative pre-fix failures:

```
test_a_port_still_held_after_sigkill_is_not_reported_as_stopped[container]
  reported {'status': 'success', 'port': 5555, 'message': 'No service running on port 5555'}
  while pid 222 still holds port 5555. A caller cannot distinguish this from a port
  that was actually freed.

test_a_stale_pid_does_not_stop_the_remaining_pids_from_being_signalled[host]
  pid 222 was never signalled: ['-TERM 111'].

test_a_port_still_held_names_the_port_and_the_surviving_pid[host]
  assert '5555' in "Failed to stop service: Command '['kill', '-TERM', '222']'
  returned non-zero exit status 1."
```

The 5 that pass on both trees are the controls: an ordinary single-pid teardown still
reports success on both branches, a free port still reports success without signalling
anything, and an unexpected error is still converted to an error tool-result.
`[host]` also already reported *an* error for an unkillable owner, so only the
sharper assertion (that the message names the port) fails there pre-fix.

Non-vacuity checked by reverting the escalation in a scratch tree: 8 tests fail,
including the pre-existing `test_stop_escalates_to_sigkill_on_host_when_process_survives_term`.

### Two existing tests adjusted

`test_stop_escalates_to_sigkill_{when_container_process,on_host_when}_..._survives_term`
made `pgrep`/`lsof` answer "still alive" on *every* probe, i.e. they modelled a process
that survives SIGKILL and then asserted `status == "success"` -- the report this change
makes impossible. Their docstring already described the harm ("dropping it would
silently leave a hung server holding the port after `stop` reports success"), so their
intent is the escalation, not the unconditional success. Their stubs now show the
process gone on the rescan, which is what "survives SIGTERM, dies to SIGKILL" actually
looks like. Both still pass unchanged against pre-fix code, so their stated intent is
preserved rather than relaxed; the sabotage check above confirms they still detect a
dropped escalation.

## Docs

`docs/policies/groot.md` -- the container-lifecycle section now states that `stop`
escalates SIGTERM then SIGKILL, that an already-exited process is not a failure, and
that a port still held is reported as an error so a caller can check before rebinding.

## Follow-up (not in this change)

`restart` discards `_stop_service`'s result (`gr00t_inference.py`, the `restart` arm)
and proceeds to `_start_service` regardless. With teardown now reporting truthfully
that is a one-line check, but whether `restart` should refuse to rebind or continue
and let the bind fail is a behaviour choice, so it is left out of this change.

## Local verification

Full `tests/` run on both trees in parallel under identical load (mujoco 3.5.0,
lerobot 0.6.2):

| | failing ids | passed | wall |
|---|---|---|---|
| `upstream/main` | 52 | 30659 | 26m26s |
| this branch | 53 | 30672 | 26m26s |

`comm` of the sorted `FAILED`/`ERROR` ids is empty in the base-only direction. The
one branch-only id is
`tests/test_hardware_task_loop_dispatch.py::TestTheRolloutIsDrivenExactlyOnce::test_on_the_sync_branch`,
a load-sensitive assertion in a rate-guarded loop: it passes 3/3 in isolation on
**both** trees and that module contains no reference to `gr00t_inference`. Counts
reconcile exactly -- `+13` passed and `+1` failed is `+14` collected, the 14 new
tests, with the flake moving one pre-existing test across the line.

`ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ`
match the pre-existing baseline (18 mypy errors, unchanged, none in the touched
files). No non-ASCII characters added (counts identical to `upstream/main` in every
touched file).
