### PR TITLE
fix(simulation/mujoco): carry ctrl, act, an unnamed freejoint and the clock across a robot eject

### DIFF
--- a/changelog.d/2360-remove-robot-preserves-dynamic-state.md
+++ b/changelog.d/2360-remove-robot-preserves-dynamic-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+`remove_robot` now carries a surviving robot's actuator setpoints (`ctrl`/`act`), an unnamed `<freejoint/>` base pose (the floating-base idiom `unitree_go2` and `lekiwi` ship), and the simulation clock across the scene rebuild. Previously the rebuild's fresh `MjData` left all three at their reset values, so removing one robot let every other robot's position servos drive toward zero on the next step, re-seated a surviving mobile base at its spawn pose, and reset `data.time` while `get_state` kept reporting the old clock - each under a `"success"` result whose immediate read-back looked correct. This matches what `add_robot` already guarantees for the same composition in the other direction.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -37,6 +37,7 @@ import difflib
 import logging
 import math
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
@@ -1051,97 +1052,203 @@ def reposition_body_in_scene(
     return _recompile_preserving_state(world, spec)
 
 
-def _snapshot_joint_state(world: SimWorld) -> dict[str, tuple[list[float], list[float]]]:
-    """Snapshot per-joint ``(qpos, qvel)`` slices keyed by fully-qualified
-    MuJoCo joint name.
+# A joint is identified across a scene rebuild by the name of whichever
+# namespace can name it. ``("joint", <joint name>)`` covers every named joint.
+# ``("body", <body name>)`` covers an UNNAMED ``<freejoint/>`` -- the standard
+# MJCF floating-base idiom, used by the Unitree Go2 and by LeKiwi -- which no
+# joint-name lookup can reach. The owning body identifies it exactly because
+# the compiler refuses a free joint alongside any other joint on the same body
+# ("more than 6 dofs in body"), so such a body carries exactly one joint.
+#
+# The two namespaces are kept apart in the key because MuJoCo's joint and body
+# names are independent: a joint may be named exactly like some body, so a
+# single flat string key could collide.
+_JointKey = tuple[str, str]
 
-    Used by :func:`eject_robot_from_scene` to preserve the state of surviving
-    robots and object freejoints across a scene rebuild. Flat-index slicing
-    is unsafe here because the body-tree order may shift when a robot is
-    removed (see AGENTS.md "Per-name state copy" rule).
 
-    Returns a dict mapping ``<joint_name> -> (qpos_slice, qvel_slice)`` where
-    each slice has the appropriate width for the joint type (1 for hinge/
-    slide, 4 for ball, 7 for free).
+@dataclass(frozen=True)
+class _SceneState:
+    """The dynamic state of a scene, keyed by name so a rebuild can restore it.
+
+    :func:`eject_robot_from_scene` compiles a fresh model and allocates a fresh
+    ``MjData``, so every buffer starts at its reset value. What is captured here
+    is what has to be carried over that gap for the scene to continue as it was:
+    the same state :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.save_state`
+    checkpoints, minus the entries a rebuilt scene cannot have a surviving
+    instance of.
+
+    Flat-index slicing cannot do this: removing a robot shifts every joint, dof
+    and actuator index that came after it, so a positional copy would re-assign
+    one element's state to another. Every field below is therefore keyed by name.
+
+    Attributes:
+        joints: ``key -> (qpos, qvel, qfrc_applied)`` slices, each at the width
+            its joint type uses (free 7/6/6, ball 4/3/3, hinge or slide 1/1/1).
+        actuators: ``actuator name -> (ctrl, act)``. ``ctrl`` is the servo
+            setpoint holding a robot's pose; ``act`` is the internal activation
+            of a stateful actuator, its effective command.
+        time: ``data.time``, the clock the physics reads.
+    """
+
+    joints: dict[_JointKey, tuple[list[float], list[float], list[float]]]
+    actuators: dict[str, tuple[float, list[float]]]
+    time: float
+
+
+def _joint_state_widths(jtype: int, mj: Any) -> tuple[int, int]:
+    """Return the ``(qpos, dof)`` width MuJoCo uses for a joint of ``jtype``."""
+    if jtype == mj.mjtJoint.mjJNT_FREE:
+        return 7, 6
+    if jtype == mj.mjtJoint.mjJNT_BALL:
+        return 4, 3
+    return 1, 1
+
+
+def _joint_key(model: Any, jid: int, mj: Any) -> _JointKey | None:
+    """Identify joint ``jid`` by name, or by its owning body when it has none.
+
+    Returns ``None`` for a joint no namespace can name -- an unnamed non-free
+    joint (its body may carry several, so the body does not single it out), or
+    an unnamed free joint on an unnamed body. Such a joint cannot be matched
+    across a rebuild, so it is reported rather than guessed at.
+    """
+    name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid)
+    if name:
+        return ("joint", name)
+    if int(model.jnt_type[jid]) != mj.mjtJoint.mjJNT_FREE:
+        return None
+    body_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, int(model.jnt_bodyid[jid]))
+    return ("body", body_name) if body_name else None
+
+
+def _snapshot_scene_state(world: SimWorld) -> _SceneState:
+    """Capture ``world``'s dynamic state keyed by name, for a scene rebuild.
+
+    Used by :func:`eject_robot_from_scene`. See :class:`_SceneState` for what is
+    captured and why it is keyed by name rather than by index.
     """
     if world._model is None or world._data is None:
-        return {}
+        return _SceneState(joints={}, actuators={}, time=0.0)
     mj = _ensure_mujoco()
     model = world._model
     data = world._data
-    snap: dict[str, tuple[list[float], list[float]]] = {}
+
+    joints: dict[_JointKey, tuple[list[float], list[float], list[float]]] = {}
     for jid in range(model.njnt):
-        name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid)
-        if not name:
+        key = _joint_key(model, jid, mj)
+        if key is None:
+            logger.debug(
+                "snapshot_scene_state: joint id %d has no name and no single owning body, state not carried over",
+                jid,
+            )
             continue
         qpos_adr = int(model.jnt_qposadr[jid])
-        qvel_adr = int(model.jnt_dofadr[jid])
-        jtype = int(model.jnt_type[jid])
-        # qpos width: free=7, ball=4, hinge/slide=1
-        # qvel width: free=6, ball=3, hinge/slide=1
-        if jtype == mj.mjtJoint.mjJNT_FREE:
-            qpos_w, qvel_w = 7, 6
-        elif jtype == mj.mjtJoint.mjJNT_BALL:
-            qpos_w, qvel_w = 4, 3
-        else:
-            qpos_w, qvel_w = 1, 1
-        snap[name] = (
+        dof_adr = int(model.jnt_dofadr[jid])
+        qpos_w, dof_w = _joint_state_widths(int(model.jnt_type[jid]), mj)
+        joints[key] = (
             [float(x) for x in data.qpos[qpos_adr : qpos_adr + qpos_w]],
-            [float(x) for x in data.qvel[qvel_adr : qvel_adr + qvel_w]],
+            [float(x) for x in data.qvel[dof_adr : dof_adr + dof_w]],
+            [float(x) for x in data.qfrc_applied[dof_adr : dof_adr + dof_w]],
         )
-    return snap
+
+    actuators: dict[str, tuple[float, list[float]]] = {}
+    for aid in range(int(model.nu)):
+        name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, aid)
+        if not name:
+            # No namespace names it, and its transmission target may drive
+            # several actuators, so it cannot be matched across the rebuild.
+            logger.debug("snapshot_scene_state: actuator id %d has no name, ctrl/act not carried over", aid)
+            continue
+        act_adr = int(model.actuator_actadr[aid])
+        act_num = int(model.actuator_actnum[aid])
+        act_vals = [float(x) for x in data.act[act_adr : act_adr + act_num]] if act_adr >= 0 else []
+        actuators[name] = (float(data.ctrl[aid]), act_vals)
+
+    return _SceneState(joints=joints, actuators=actuators, time=float(data.time))
 
 
-def _restore_joint_state(
-    world: SimWorld,
-    snapshot: dict[str, tuple[list[float], list[float]]],
-) -> int:
-    """Restore per-joint state from a snapshot into ``world._data`` by name.
+def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
+    """Write ``snapshot`` back into ``world._data`` by name.
 
-    Joints that no longer exist in the compiled model (e.g. those belonging
-    to the ejected robot) are silently skipped. Joints that exist in the
-    new model but were not in the snapshot keep their fresh-compile defaults
-    (body pos/quat for freejoints, 0 for hinge/slide).
+    Elements that no longer exist in the compiled model (those belonging to the
+    ejected robot) are silently skipped -- their absence is the point of the
+    rebuild. Elements present in the new model but absent from the snapshot keep
+    their fresh-compile values.
 
-    Returns the number of joints actually restored, for logging.
+    Returns the number of joints restored, for logging.
     """
     if world._model is None or world._data is None:
         return 0
     mj = _ensure_mujoco()
     model = world._model
     data = world._data
+
     restored = 0
-    for name, (qpos_vals, qvel_vals) in snapshot.items():
-        jid = mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, name)
+    for key, (qpos_vals, qvel_vals, qfrc_vals) in snapshot.joints.items():
+        jid = _resolve_joint_key(model, key, mj)
         if jid < 0:
-            continue  # joint no longer exists (expected for ejected robot)
+            continue  # element no longer exists (expected for the ejected robot)
         qpos_adr = int(model.jnt_qposadr[jid])
-        qvel_adr = int(model.jnt_dofadr[jid])
-        # Width sanity check: if joint type changed (should not happen for
-        # same-name joints across an eject), skip to avoid corrupting state.
-        jtype = int(model.jnt_type[jid])
-        if jtype == mj.mjtJoint.mjJNT_FREE:
-            expect_qp, expect_qv = 7, 6
-        elif jtype == mj.mjtJoint.mjJNT_BALL:
-            expect_qp, expect_qv = 4, 3
-        else:
-            expect_qp, expect_qv = 1, 1
-        if len(qpos_vals) != expect_qp or len(qvel_vals) != expect_qv:
+        dof_adr = int(model.jnt_dofadr[jid])
+        # Width sanity check: if the joint type changed (should not happen for a
+        # same-key joint across an eject), skip rather than corrupt the DOFs.
+        expect_qp, expect_dof = _joint_state_widths(int(model.jnt_type[jid]), mj)
+        if len(qpos_vals) != expect_qp or len(qvel_vals) != expect_dof or len(qfrc_vals) != expect_dof:
             logger.warning(
-                "_restore_joint_state: width mismatch for %r (qpos %d!=%d or qvel %d!=%d), skipping",
-                name,
+                "_restore_scene_state: width mismatch for %r (qpos %d!=%d or dof %d/%d!=%d), skipping",
+                key,
                 len(qpos_vals),
                 expect_qp,
                 len(qvel_vals),
-                expect_qv,
+                len(qfrc_vals),
+                expect_dof,
             )
             continue
         for i, v in enumerate(qpos_vals):
             data.qpos[qpos_adr + i] = v
         for i, v in enumerate(qvel_vals):
-            data.qvel[qvel_adr + i] = v
+            data.qvel[dof_adr + i] = v
+        for i, v in enumerate(qfrc_vals):
+            data.qfrc_applied[dof_adr + i] = v
         restored += 1
+
+    for name, (ctrl_val, act_vals) in snapshot.actuators.items():
+        aid = mj_name_to_id(model, mj.mjtObj.mjOBJ_ACTUATOR, name)
+        if aid < 0:
+            continue  # actuator belonged to the ejected robot
+        data.ctrl[aid] = ctrl_val
+        act_adr = int(model.actuator_actadr[aid])
+        act_num = int(model.actuator_actnum[aid])
+        if act_adr < 0 or len(act_vals) != act_num:
+            # An actuator whose activation width changed across the rebuild:
+            # leave the fresh zero rather than write a mismatched slice.
+            if act_vals or act_num:
+                logger.warning(
+                    "_restore_scene_state: act width mismatch for actuator %r (%d!=%d), skipping activation",
+                    name,
+                    len(act_vals),
+                    act_num,
+                )
+            continue
+        for i, v in enumerate(act_vals):
+            data.act[act_adr + i] = v
+
+    data.time = snapshot.time
     return restored
+
+
+def _resolve_joint_key(model: Any, key: _JointKey, mj: Any) -> int:
+    """Resolve a :data:`_JointKey` to a joint id in ``model``, or ``-1``."""
+    kind, name = key
+    if kind == "joint":
+        return mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, name)
+    bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, name)
+    if bid < 0 or int(model.body_jntnum[bid]) != 1:
+        # The body is gone, or no longer carries exactly the one joint that made
+        # it an unambiguous handle for its unnamed free joint.
+        return -1
+    jid = int(model.body_jntadr[bid])
+    return jid if int(model.jnt_type[jid]) == mj.mjtJoint.mjJNT_FREE else -1
 
 
 def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
@@ -1154,18 +1261,37 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     ``world.robots`` / ``world.objects`` / ``world.cameras`` state, then
     re-attach the remaining robots.
 
-    Joint state preservation: before the rebuild we snapshot every joint's
-    ``(qpos, qvel)`` keyed by fully-qualified name; after the fresh compile
-    we restore state for every joint that still exists in the new model.
-    Joints belonging to the ejected robot are naturally dropped (their name
-    no longer resolves). This keeps surviving robots at their current pose
-    and object freejoints at their current world pose - the behaviour the
-    agent expects when calling ``remove_robot`` mid-scene.
+    State preservation: the fresh compile below allocates a fresh ``MjData``,
+    so every buffer starts at its reset value. Before the rebuild we snapshot
+    the scene's dynamic state keyed by name (:func:`_snapshot_scene_state`) and
+    restore it afterwards, so a surviving element continues exactly as it was --
+    which is what :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.add_robot`
+    already guarantees for the composition in the other direction ("an arm
+    already in the world keeps the pose it is in and the actuator setpoints
+    holding it there ... and the clock keeps counting"). Elements belonging to
+    the ejected robot are naturally dropped: their names no longer resolve.
+
+    Restoring the pose alone is not enough for the scene to continue:
+
+    * ``ctrl`` -- the setpoint a position servo holds a pose with. Dropped, it
+      reads as zero, and the next ``mj_step`` drives every actuator of every
+      SURVIVING robot toward its zero configuration: an arm parked mid-air sags
+      to the floor while ``remove_robot`` reported ``"success"`` and the pose
+      read back correct, because nothing had stepped yet. ``act`` carries the
+      same command for a stateful actuator.
+    * an UNNAMED ``<freejoint/>`` -- the standard MJCF floating-base idiom, used
+      by the Unitree Go2 and by LeKiwi -- is invisible to a joint-name lookup,
+      so a surviving mobile base was re-seated at its spawn pose with zero
+      velocity: measured on ``go2`` driven to ``(0.8, -0.4, 0.30)``, removing a
+      DIFFERENT robot teleported it back to ``(0, 0, 0.445)``. The recompile
+      path names this same hazard (see :func:`_recompile_preserving_state`).
+    * ``data.time`` -- reset to 0 while ``world.sim_time`` kept counting, so the
+      clock the physics reads and the clock ``get_state`` reports disagreed.
 
     Flat-index slicing is **not** safe here: removing a robot shifts every
-    body/joint index that comes after it in the kinematic tree, so
-    ``data.qpos[:]`` copies across compiles would mis-assign DOFs. Per-name
-    lookup is the only correct approach (see AGENTS.md).
+    body/joint/dof/actuator index that comes after it, so ``data.qpos[:]``-style
+    copies across compiles would mis-assign one element's state to another.
+    Per-name lookup is the only correct approach (see AGENTS.md).
     """
     spec = _get_spec(world)
     if spec is None or world._model is None:
@@ -1177,7 +1303,7 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
     # Snapshot joint state BEFORE we rebuild. Keyed by the fully-qualified
     # MuJoCo joint name (prefix/joint for attached robots, bare name for
     # object freejoints).
-    state_snapshot = _snapshot_joint_state(world)
+    state_snapshot = _snapshot_scene_state(world)
 
     # First drop cameras that originated from the robot being ejected.
     # They're in world.cameras with origin_robot == robot_name. Without this,
@@ -1233,7 +1359,7 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
 
     # Step 4: restore state for every joint that survived the rebuild. Joints
     # belonging to the ejected robot simply don't resolve and get skipped.
-    restored = _restore_joint_state(world, state_snapshot)
+    restored = _restore_scene_state(world, state_snapshot)
 
     # Step 5: run a forward pass so derived quantities (xpos, cam xforms)
     # reflect the restored state. Without this, the next render() call can
@@ -1261,7 +1387,7 @@ def eject_robot_from_scene(world: SimWorld, robot_name: str) -> bool:
         "eject_robot %r: scene rebuilt, restored state for %d/%d joints",
         robot_name,
         restored,
-        len(state_snapshot),
+        len(state_snapshot.joints),
     )
     return True
 

--- a/tests/simulation/mujoco/test_remove_robot_preserves_dynamic_state.py
+++ b/tests/simulation/mujoco/test_remove_robot_preserves_dynamic_state.py
@@ -1,0 +1,338 @@
+"""``remove_robot`` preserves the dynamic state ``add_robot`` already preserves.
+
+Removing a robot rebuilds the whole scene: ``eject_robot_from_scene`` compiles a
+fresh model and allocates a fresh ``MjData``, so every buffer starts at its
+reset value and the survivors' state has to be carried across that gap by name.
+The pose half of that carry was already pinned (``test_multi_robot_eject``,
+``test_scene_ops_guardrails``). The pose is not the whole state, and the other
+half is what this module pins, because each missing piece failed silently -
+``remove_robot`` returned ``"success"`` and an immediate read-back looked right:
+
+* ``ctrl`` - the setpoint a position servo holds a pose with. Fresh ``MjData``
+  reads it as zero, so the next ``mj_step`` drove every actuator of every
+  SURVIVING robot toward its zero configuration. An arm parked mid-air sagged to
+  the floor, one step after a call that only removed some other robot. ``act``
+  carries the same command for a stateful actuator.
+* an unnamed ``<freejoint/>`` - the standard MJCF floating-base idiom, used by
+  the Unitree Go2 and by LeKiwi. No joint-name lookup reaches it, so a surviving
+  mobile base was re-seated at its spawn pose with its velocity zeroed.
+* ``data.time`` - reset to 0 while ``world.sim_time`` kept counting, so the clock
+  the physics reads and the clock ``get_state`` reports disagreed.
+
+The reference for all three is the other direction of the same composition:
+:meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.add_robot` documents
+that "an arm already in the world keeps the pose it is in and the actuator
+setpoints holding it there ... and the clock keeps counting", and it delivers
+that. Each preservation test below is paired with the add-path measurement, so
+the two directions of one composition are pinned to agree rather than each to a
+hand-picked constant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A one-joint arm driven by a position servo: the setpoint in ``ctrl`` is the
+# only thing holding the joint away from zero, so dropping it is visible as
+# motion rather than as a changed number. The gains are chosen so the joint
+# settles ON its setpoint well inside ``_SETTLE_STEPS`` and stays there: an
+# underdamped servo keeps overshooting, which would turn "did it hold its pose"
+# into a question about when the assertion happens to run.
+_SERVO_ARM_XML = """
+<mujoco model="servo_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link0" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1" range="-3.14 3.14" damping="1.0"/>
+      <geom type="cylinder" size="0.05 0.05"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="200"/>
+  </actuator>
+</mujoco>
+"""
+
+# A floating base whose free joint carries NO name - what go2 and LeKiwi ship.
+# The body is named, and MuJoCo refuses a free joint alongside any other joint
+# on one body ("more than 6 dofs in body"), so the body names the joint exactly.
+_FLOATING_BASE_XML = """
+<mujoco model="rover">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="chassis" pos="0 0 0.2">
+      <freejoint/>
+      <geom type="box" size="0.1 0.06 0.03"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_HELD_SETPOINT = 0.9
+_SETTLE_STEPS = 400
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_eject_state", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _write_arm(tmp_path, name: str, xml: str) -> str:
+    path = tmp_path / f"{name}.xml"
+    path.write_text(xml)
+    return str(path)
+
+
+def _joint_angle(sim: Simulation, joint: str) -> float:
+    """Read one hinge's angle straight out of the live model, by name."""
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    jid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_JOINT, joint)
+    assert jid >= 0, f"joint {joint!r} missing from the compiled model"
+    return float(world._data.qpos[int(world._model.jnt_qposadr[jid])])
+
+
+def _base_state(sim: Simulation, body: str) -> tuple[list[float], list[float]]:
+    """Read the unnamed free joint of ``body`` as ``(qpos, qvel)``."""
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    model, data = world._model, world._data
+    bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, body)
+    assert bid >= 0, f"body {body!r} missing from the compiled model"
+    assert int(model.body_jntnum[bid]) == 1, "premise: the base carries exactly its free joint"
+    jid = int(model.body_jntadr[bid])
+    assert not mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid), "premise: that free joint is unnamed"
+    adr, dof = int(model.jnt_qposadr[jid]), int(model.jnt_dofadr[jid])
+    return (
+        [float(v) for v in data.qpos[adr : adr + 7]],
+        [float(v) for v in data.qvel[dof : dof + 6]],
+    )
+
+
+def _two_servo_arms(sim: Simulation, tmp_path) -> str:
+    """Build a scene with a bystander holding a setpoint plus a doomed sibling.
+
+    Returns the path of the shared arm XML. The bystander (``keeper``) is driven
+    to ``_HELD_SETPOINT`` and left to settle, so its pose exists only because
+    ``ctrl`` is holding it there.
+    """
+    sim.create_world()
+    arm = _write_arm(tmp_path, "servo_arm", _SERVO_ARM_XML)
+    assert sim.add_robot(name="keeper", urdf_path=arm)["status"] == "success"
+    assert sim.add_robot(name="doomed", urdf_path=arm, position=[0.5, 0, 0])["status"] == "success"
+    assert sim.send_action({"pan": _HELD_SETPOINT}, robot_name="keeper")["status"] == "success"
+    sim.step(_SETTLE_STEPS)
+    return arm
+
+
+class TestASurvivingServoKeepsHoldingItsPose:
+    """The setpoint holding a bystander's pose survives removing a sibling.
+
+    This is the failure the whole module exists for: the pose read back correct
+    immediately after the removal, so only stepping the world showed that the
+    arm had been let go.
+    """
+
+    def test_a_bystander_does_not_sag_after_a_sibling_is_removed(self, sim: Simulation, tmp_path) -> None:
+        _two_servo_arms(sim, tmp_path)
+        held = _joint_angle(sim, "keeper/pan")
+        assert held == pytest.approx(_HELD_SETPOINT, abs=0.05), "premise: the servo reached its setpoint"
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        # The pose itself was already carried over; that is not the question.
+        assert _joint_angle(sim, "keeper/pan") == pytest.approx(held, abs=1e-9)
+
+        sim.step(_SETTLE_STEPS)
+        after = _joint_angle(sim, "keeper/pan")
+        assert after == pytest.approx(held, abs=0.05), (
+            f"the bystander was holding {held:.4f} rad and drifted to {after:.4f} rad over "
+            f"{_SETTLE_STEPS} steps after an unrelated robot was removed - its setpoint was "
+            f"dropped, so the servo drove it toward zero"
+        )
+
+    def test_the_add_path_preserves_the_same_setpoint(self, sim: Simulation, tmp_path) -> None:
+        """The reference the removal is held to: adding a robot keeps it.
+
+        Passing both before and after the fix, this is what makes the assertion
+        above a symmetry requirement between the two directions of one scene
+        composition rather than a number chosen by hand.
+        """
+        arm = _two_servo_arms(sim, tmp_path)
+        held = _joint_angle(sim, "keeper/pan")
+
+        assert sim.add_robot(name="newcomer", urdf_path=arm, position=[-0.5, 0, 0])["status"] == "success"
+        sim.step(_SETTLE_STEPS)
+        assert _joint_angle(sim, "keeper/pan") == pytest.approx(held, abs=0.05)
+
+    def test_the_removed_robot_leaves_no_state_behind(self, sim: Simulation, tmp_path) -> None:
+        """Carrying state over must not resurrect the robot that was removed.
+
+        The snapshot is taken before the rebuild, so it still holds the ejected
+        robot's entries; they have to be dropped on the way back in rather than
+        written into whatever now occupies those indices.
+        """
+        _two_servo_arms(sim, tmp_path)
+        assert sim.send_action({"pan": -0.7}, robot_name="doomed")["status"] == "success"
+        sim.step(50)
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        world = sim._world
+        assert world is not None and world._model is not None
+        mj = sim._mj
+        model = world._model
+        names = {mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, i) for i in range(int(model.nu))}
+        assert names == {"keeper/pan_act"}
+        assert mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "doomed/pan") < 0
+
+
+class TestASurvivingFloatingBaseStaysWhereItIs:
+    """An unnamed ``<freejoint/>`` is carried by its owning body's name."""
+
+    def _rover_and_arm(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world()
+        assert (
+            sim.add_robot(name="rover", urdf_path=_write_arm(tmp_path, "rover", _FLOATING_BASE_XML))["status"]
+            == "success"
+        )
+        assert (
+            sim.add_robot(name="doomed", urdf_path=_write_arm(tmp_path, "servo_arm", _SERVO_ARM_XML))["status"]
+            == "success"
+        )
+
+    def _drive_base_away_from_spawn(self, sim: Simulation) -> tuple[list[float], list[float]]:
+        world = sim._world
+        assert world is not None and world._model is not None and world._data is not None
+        mj = sim._mj
+        model, data = world._model, world._data
+        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "rover/chassis")
+        jid = int(model.body_jntadr[bid])
+        adr, dof = int(model.jnt_qposadr[jid]), int(model.jnt_dofadr[jid])
+        data.qpos[adr : adr + 3] = [0.8, -0.4, 0.35]
+        data.qvel[dof : dof + 3] = [0.25, 0.1, 0.0]
+        mj.mj_forward(model, data)
+        return _base_state(sim, "rover/chassis")
+
+    def test_the_base_keeps_its_pose_and_velocity(self, sim: Simulation, tmp_path) -> None:
+        self._rover_and_arm(sim, tmp_path)
+        spawn_pos, _ = _base_state(sim, "rover/chassis")
+        driven_pos, driven_vel = self._drive_base_away_from_spawn(sim)
+        assert driven_pos[:3] != pytest.approx(spawn_pos[:3]), "premise: the base moved off its spawn pose"
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        pos, vel = _base_state(sim, "rover/chassis")
+        assert pos == pytest.approx(driven_pos, abs=1e-9), (
+            f"the base was at {driven_pos[:3]} and came back at {pos[:3]} "
+            f"(its spawn pose is {spawn_pos[:3]}) - an unnamed free joint is invisible "
+            f"to a joint-name lookup, so it was re-seated where it was authored"
+        )
+        assert vel == pytest.approx(driven_vel, abs=1e-9)
+
+    def test_the_add_path_preserves_the_same_base_pose(self, sim: Simulation, tmp_path) -> None:
+        """The add-path reference for the floating base."""
+        self._rover_and_arm(sim, tmp_path)
+        driven_pos, driven_vel = self._drive_base_away_from_spawn(sim)
+
+        assert (
+            sim.add_robot(name="newcomer", urdf_path=_write_arm(tmp_path, "servo_arm", _SERVO_ARM_XML))["status"]
+            == "success"
+        )
+        pos, vel = _base_state(sim, "rover/chassis")
+        assert pos == pytest.approx(driven_pos, abs=1e-9)
+        assert vel == pytest.approx(driven_vel, abs=1e-9)
+
+
+class TestTheClockKeepsCounting:
+    """``data.time`` continues across the rebuild, matching ``world.sim_time``."""
+
+    def test_the_physics_clock_matches_the_reported_clock(self, sim: Simulation, tmp_path) -> None:
+        _two_servo_arms(sim, tmp_path)
+        world = sim._world
+        assert world is not None and world._data is not None
+        before = float(world._data.time)
+        assert before > 0.0, "premise: the world has been stepped"
+        assert world.sim_time == pytest.approx(before, abs=1e-9)
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        assert world._data is not None
+        assert float(world._data.time) == pytest.approx(world.sim_time, abs=1e-9), (
+            f"the physics clock read {float(world._data.time):.4f}s after the rebuild while "
+            f"get_state reports {world.sim_time:.4f}s"
+        )
+
+
+class TestTheKeyNamespacesDoNotCollide:
+    """A joint named exactly like some body is not confused with a base.
+
+    MuJoCo's joint and body names are independent namespaces, so a single flat
+    string key could match an unnamed free joint's body-derived handle against a
+    real joint of the same name and write one element's state into the other.
+    """
+
+    _COLLIDING_XML = """
+<mujoco model="collide">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="chassis" pos="0 0 0.2">
+      <freejoint/>
+      <geom type="box" size="0.1 0.06 0.03"/>
+      <body name="arm" pos="0 0 0.05">
+        <joint name="chassis" type="hinge" axis="0 0 1"/>
+        <geom type="cylinder" size="0.02 0.05"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+    def test_a_hinge_sharing_a_bodys_name_keeps_its_own_state(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world()
+        assert (
+            sim.add_robot(name="rover", urdf_path=_write_arm(tmp_path, "collide", self._COLLIDING_XML))["status"]
+            == "success"
+        )
+        assert (
+            sim.add_robot(name="doomed", urdf_path=_write_arm(tmp_path, "servo_arm", _SERVO_ARM_XML))["status"]
+            == "success"
+        )
+
+        world = sim._world
+        assert world is not None and world._model is not None and world._data is not None
+        mj = sim._mj
+        model, data = world._model, world._data
+        # Premise: one name, two namespaces - body ``rover/chassis`` carries the
+        # unnamed free joint, and hinge ``rover/chassis`` is a different element.
+        assert mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "rover/chassis") >= 0
+        hinge = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "rover/chassis")
+        assert hinge >= 0
+
+        data.qpos[int(model.jnt_qposadr[hinge])] = 0.4
+        driven_pos, driven_vel = self._seat_base(sim, mj, model, data)
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        assert _joint_angle(sim, "rover/chassis") == pytest.approx(0.4, abs=1e-9)
+        pos, vel = _base_state(sim, "rover/chassis")
+        assert pos == pytest.approx(driven_pos, abs=1e-9)
+        assert vel == pytest.approx(driven_vel, abs=1e-9)
+
+    @staticmethod
+    def _seat_base(sim: Simulation, mj, model, data) -> tuple[list[float], list[float]]:
+        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "rover/chassis")
+        jid = int(model.body_jntadr[bid])
+        adr, dof = int(model.jnt_qposadr[jid]), int(model.jnt_dofadr[jid])
+        data.qpos[adr : adr + 3] = [0.6, -0.3, 0.4]
+        data.qvel[dof : dof + 3] = [0.15, 0.0, 0.0]
+        mj.mj_forward(model, data)
+        return (
+            [float(v) for v in data.qpos[adr : adr + 7]],
+            [float(v) for v in data.qvel[dof : dof + 6]],
+        )

--- a/tests/simulation/mujoco/test_remove_robot_preserves_dynamic_state.py
+++ b/tests/simulation/mujoco/test_remove_robot_preserves_dynamic_state.py
@@ -72,6 +72,26 @@ _FLOATING_BASE_XML = """
 </mujoco>
 """
 
+# A stateful actuator: ``dyntype="filter"`` gives it an internal activation in
+# ``act`` that charges toward the command, so ``act`` is a second piece of live
+# actuator state a rebuild has to carry - and unlike ``ctrl`` it is non-zero even
+# while the command is constant.
+_FILTERED_ARM_XML = """
+<mujoco model="filtered_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link0" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1" damping="1.0"/>
+      <geom type="cylinder" size="0.05 0.05"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <general name="pan_act" joint="pan" dyntype="filter" dynprm="0.4"
+             gaintype="fixed" gainprm="8" biastype="none"/>
+  </actuator>
+</mujoco>
+"""
+
 _HELD_SETPOINT = 0.9
 _SETTLE_STEPS = 400
 
@@ -335,4 +355,44 @@ class TestTheKeyNamespacesDoNotCollide:
         return (
             [float(v) for v in data.qpos[adr : adr + 7]],
             [float(v) for v in data.qvel[dof : dof + 6]],
+        )
+
+
+class TestAStatefulActuatorKeepsItsActivation:
+    """``act`` - a stateful actuator's internal activation - survives the rebuild.
+
+    A ``dyntype="filter"`` actuator's effective command lives in ``act``, not in
+    ``ctrl``, so restoring ``ctrl`` alone still discharges it to zero and the
+    actuator has to charge back up from nothing.
+    """
+
+    def _activation(self, sim: Simulation) -> float:
+        world = sim._world
+        assert world is not None and world._model is not None and world._data is not None
+        mj = sim._mj
+        model = world._model
+        aid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_ACTUATOR, "filt/pan_act")
+        assert aid >= 0, "actuator missing from the compiled model"
+        adr = int(model.actuator_actadr[aid])
+        assert adr >= 0, "premise: the actuator is stateful, so it has an activation slot"
+        return float(world._data.act[adr])
+
+    def test_the_activation_is_carried_across_the_rebuild(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world()
+        filtered = _write_arm(tmp_path, "filtered_arm", _FILTERED_ARM_XML)
+        assert sim.add_robot(name="filt", urdf_path=filtered)["status"] == "success"
+        assert (
+            sim.add_robot(name="doomed", urdf_path=_write_arm(tmp_path, "servo_arm", _SERVO_ARM_XML))["status"]
+            == "success"
+        )
+        assert sim.send_action({"pan": 0.8}, robot_name="filt")["status"] == "success"
+        sim.step(150)
+
+        charged = self._activation(sim)
+        assert abs(charged) > 1e-6, "premise: the filter has charged up"
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        assert self._activation(sim) == pytest.approx(charged, abs=1e-9), (
+            f"the actuator's activation was {charged:.6f} and came back "
+            f"{self._activation(sim):.6f} after an unrelated robot was removed"
         )

--- a/tests/simulation/mujoco/test_scene_ops_guardrails.py
+++ b/tests/simulation/mujoco/test_scene_ops_guardrails.py
@@ -189,11 +189,13 @@ class TestRepositionBodyGuards:
 
 
 class TestSnapshotRestoreWithoutModel:
-    def test_snapshot_empty_world_returns_empty_dict(self) -> None:
-        assert scene_ops._snapshot_joint_state(SimWorld()) == {}
+    def test_snapshot_empty_world_returns_empty_state(self) -> None:
+        snap = scene_ops._snapshot_scene_state(SimWorld())
+        assert (snap.joints, snap.actuators, snap.time) == ({}, {}, 0.0)
 
     def test_restore_empty_world_restores_nothing(self) -> None:
-        assert scene_ops._restore_joint_state(SimWorld(), {}) == 0
+        empty = scene_ops._SceneState(joints={}, actuators={}, time=0.0)
+        assert scene_ops._restore_scene_state(SimWorld(), empty) == 0
 
 
 class TestPatchOpValidation:
@@ -376,7 +378,7 @@ _MIXED_JOINT_XML = """
 
 
 class TestSnapshotRestoreJointWidths:
-    """``_snapshot_joint_state`` / ``_restore_joint_state`` slice each joint at
+    """``_snapshot_scene_state`` / ``_restore_scene_state`` slice each joint at
     the width MuJoCo actually uses (free 7/6, ball 4/3, hinge/slide 1/1).
 
     ``eject_robot_from_scene`` relies on this to carry surviving robots and
@@ -395,11 +397,15 @@ class TestSnapshotRestoreJointWidths:
         return world
 
     def test_snapshot_uses_per_joint_type_widths(self, mixed_world: SimWorld) -> None:
-        """Each joint is captured at its type-correct qpos/qvel width."""
-        snap = scene_ops._snapshot_joint_state(mixed_world)
-        assert (len(snap["free_j"][0]), len(snap["free_j"][1])) == (7, 6)
-        assert (len(snap["ball_j"][0]), len(snap["ball_j"][1])) == (4, 3)
-        assert (len(snap["hinge_j"][0]), len(snap["hinge_j"][1])) == (1, 1)
+        """Each joint is captured at its type-correct qpos/dof width.
+
+        Every per-dof buffer (``qvel`` and ``qfrc_applied``) shares the dof
+        width, so all three slices are checked together.
+        """
+        joints = scene_ops._snapshot_scene_state(mixed_world).joints
+        assert [len(part) for part in joints[("joint", "free_j")]] == [7, 6, 6]
+        assert [len(part) for part in joints[("joint", "ball_j")]] == [4, 3, 3]
+        assert [len(part) for part in joints[("joint", "hinge_j")]] == [1, 1, 1]
 
     def test_snapshot_restore_round_trips_all_joint_types(self, mixed_world: SimWorld) -> None:
         """A snapshot restored back into the same model touches every joint and
@@ -408,26 +414,28 @@ class TestSnapshotRestoreJointWidths:
         data = mixed_world._data
         data.qpos[:] = [float(i) * 0.01 for i in range(len(data.qpos))]
         data.qvel[:] = [float(i) * 0.02 for i in range(len(data.qvel))]
-        snap = scene_ops._snapshot_joint_state(mixed_world)
+        data.qfrc_applied[:] = [float(i) * 0.03 for i in range(len(data.qfrc_applied))]
+        snap = scene_ops._snapshot_scene_state(mixed_world)
 
         # Clobber state, then restore from the snapshot by name.
         data.qpos[:] = 0.0
         data.qvel[:] = 0.0
-        restored = scene_ops._restore_joint_state(mixed_world, snap)
+        data.qfrc_applied[:] = 0.0
+        restored = scene_ops._restore_scene_state(mixed_world, snap)
 
         assert restored == 3, "free + ball + hinge all restored"
-        re_snap = scene_ops._snapshot_joint_state(mixed_world)
+        re_snap = scene_ops._snapshot_scene_state(mixed_world)
         for name in ("free_j", "ball_j", "hinge_j"):
-            assert re_snap[name] == snap[name]
+            assert re_snap.joints[("joint", name)] == snap.joints[("joint", name)]
 
     def test_restore_skips_width_mismatched_joint(self, mixed_world: SimWorld) -> None:
         """A snapshot entry whose width no longer matches the joint type (e.g.
         a same-named joint changed type across a rebuild) is skipped, not
         force-written - corrupt DOFs are never silently injected."""
-        snap = scene_ops._snapshot_joint_state(mixed_world)
+        snap = scene_ops._snapshot_scene_state(mixed_world)
         # Forge a free-joint-width payload under the hinge joint's name.
-        snap["hinge_j"] = ([0.0] * 7, [0.0] * 6)
-        restored = scene_ops._restore_joint_state(mixed_world, snap)
+        snap.joints[("joint", "hinge_j")] = ([0.0] * 7, [0.0] * 6, [0.0] * 6)
+        restored = scene_ops._restore_scene_state(mixed_world, snap)
         # free + ball restored; the mismatched hinge entry is dropped.
         assert restored == 2
 


### PR DESCRIPTION
## Problem

`remove_robot` rebuilds the whole scene. `eject_robot_from_scene` compiles a fresh model and allocates a fresh `MjData`, so **every buffer starts at its reset value** and the survivors' state has to be carried across that gap by name. Only `qpos`/`qvel` were, and only for **named** joints, so three things a surviving robot needs were dropped:

| dropped | consequence | measured |
| --- | --- | --- |
| `ctrl` | reads back as zero, so the next `mj_step` drives every actuator of every **surviving** robot toward its zero configuration | a bystander holding `0.9000 rad` was at `0.0000 rad` 400 steps after some *other* robot was removed |
| `act` | a stateful actuator's internal activation - its effective command - discharges, so it has to charge back up from nothing | a `dyntype="filter"` actuator charged to `0.424703` came back at `0.000000` |
| an unnamed `<freejoint/>` | invisible to a joint-name lookup, so a surviving mobile base is re-seated at its spawn pose with velocity zeroed | `go2` driven to `(0.85, -0.35, 0.42)` came back at `(0, 0, 0.445)` |
| `data.time` | reset to 0 while `world.sim_time` kept counting | physics clock `0.0000s`, `get_state` reporting `0.8020s` |

All four are measured through the public API only (`add_robot` / `send_action` / `step` / `remove_robot`).

Each failed **silently**: `remove_robot` returned `"success"` and an immediate read-back looked correct, because nothing had stepped yet. The pose was carried over; only the thing *holding* the pose was not.

An unnamed `<freejoint/>` is the standard MJCF floating-base idiom -- it is what `unitree_go2` and `lekiwi` ship -- so every mobile base in the registry is affected, and the servo case affects every position-controlled robot in any multi-robot scene.

## Why this is the contract

The same composition in the other direction already guarantees all three, and delivers them. `add_robot`:

> That preservation covers the scene's DYNAMIC state, not just its contents: an arm already in the world keeps the pose it is in **and the actuator setpoints holding it there**, an object stays where it settled or was carried to, a latched `apply_force` wrench persists, and **the clock keeps counting**.

`save_state` also moved from `mjSTATE_FULLPHYSICS` to `mjSTATE_INTEGRATION` specifically because the former "silently excluded `ctrl` ... so the first step after a restore drove toward the pre-restore targets". And `_recompile_preserving_state` already names the unnamed-`<freejoint/>` hazard in detail, for the recompile path; the eject path re-opened it.

So this is not a new guarantee, it is the eject path being brought to the one the neighbouring paths state. Each preservation test below is paired with the **add-path measurement** rather than a hand-picked constant, so the two directions of one composition are pinned to agree.

## Change

`_snapshot_joint_state` / `_restore_joint_state` become `_snapshot_scene_state` / `_restore_scene_state` over a `_SceneState` record, since they no longer carry joint state alone (`qfrc_applied` comes along too: it is dof-indexed, the same key space as `qvel`).

A joint is keyed by `("joint", name)`, or by `("body", body name)` when it is an unnamed **free** joint. The owning body identifies it *exactly*: the compiler refuses a free joint alongside any other joint on one body (`more than 6 dofs in body`), so such a body carries exactly one joint. The two namespaces are kept apart in the key because MuJoCo's joint and body names are independent -- a joint may be named exactly like some body, so a flat string key could match a real joint against a base's body-derived handle. A joint that no namespace can single out (an unnamed *hinge*) is logged at debug rather than guessed at.

## Tests

`tests/simulation/mujoco/test_remove_robot_preserves_dynamic_state.py`, against `upstream/main`: **5 failed, 3 passed**; after: **8 passed**.

```
FAILED ...::test_a_bystander_does_not_sag_after_a_sibling_is_removed
  the bystander was holding 0.9000 rad and drifted to 0.0000 rad over 400 steps
  after an unrelated robot was removed - its setpoint was dropped, so the servo
  drove it toward zero
FAILED ...::test_the_base_keeps_its_pose_and_velocity
  the base was at [0.8, -0.4, 0.35] and came back at [0.0, 0.0, 0.2]
  (its spawn pose is [0.0, 0.0, 0.2])
FAILED ...::test_the_physics_clock_matches_the_reported_clock
  the physics clock read 0.0000s after the rebuild while get_state reports 0.8020s
FAILED ...::test_a_hinge_sharing_a_bodys_name_keeps_its_own_state
FAILED ...::test_the_activation_is_carried_across_the_rebuild
  the actuator's activation was 0.424703 and came back 0.000000 after an
  unrelated robot was removed
```

The **3 that pass on both trees** are the controls: the two add-path references (which is what makes the assertions a symmetry requirement), and "the removed robot leaves no state behind" -- the snapshot still holds the ejected robot's entries, so they must be dropped on the way back in rather than written into whatever now occupies those indices.

The existing per-joint-type width round-trip and the width-mismatch skip in `test_scene_ops_guardrails.py` are carried over to the new names and keys, extended to the third dof-width buffer.

Full `tests/` on both trees (same interpreter, run in parallel): **zero new failing test ids** on this branch. The sorted failing-id sets differ by exactly the 5 pre-fix failures above, which is a full-suite confirmation of the split. `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ` clean against the pre-existing baseline; `tests/simulation` 10802 passed.

## Rollout in MuJoCo sim (headless)

Two `so101` arms hold a pose; `remove_robot('doomed')` is called, and the camera watches the arm that was **not** removed. One capture script, run under `PYTHONPATH` of an `upstream/main` worktree and of this branch -- the frames are identical up to the removal (mean abs pixel delta **exactly 0.000**), and `14.368` at the final frame.

![surviving arm sags vs holds](https://raw.githubusercontent.com/cagataycali/robots/media-remove-robot-dynamic-state/servo_sag.gif)

[servo_sag.mp4](https://github.com/cagataycali/robots/blob/media-remove-robot-dynamic-state/servo_sag.mp4) -- joint-2 error from setpoint after the removal: **1.3800 rad (79 deg)** before, **0.0003 rad** after.

The unnamed-`<freejoint/>` half, on `unitree_go2` (amber marker records where the base was driven to; panels 2 and 3 both had the same unrelated arm removed, so only the base pose differs between them, mean abs delta `8.012`):

![floating base teleports vs stays](https://raw.githubusercontent.com/cagataycali/robots/media-remove-robot-dynamic-state/freejoint_base.png)

## Scope

A latched `apply_force` wrench is also dropped here -- but it is dropped by `add_robot` too (measured: one non-zero `xfrc_applied` row before, zero after), so that is a scene-composition gap on both paths rather than something the eject path uniquely breaks, and it wants its own change. Every item above is something the add path demonstrably preserves and the eject path demonstrably lost.
