### PR TITLE
fix(robot): release the robot on Ctrl+C instead of exiting straight out of run()

### DIFF
--- a/changelog.d/2362-run-releases-devices-on-ctrl-c.md
+++ b/changelog.d/2362-run-releases-devices-on-ctrl-c.md
@@ -1,0 +1,3 @@
+### Fixed
+
+`Robot(...).run()` now releases the robot when the operator presses Ctrl+C. The interrupt handler ended with `os._exit(0)`, which runs no `atexit` hook, no `__del__` and no `finally` block, so the instance's `cleanup()` never ran -- and on hardware that is the only path to the driver's own `disconnect()`, where torque disable and gripper release live. An operator's Ctrl+C left the arm energised at its last commanded position while the process printed `"<peer> stopped."` on the way out. The release now runs first, on a background thread under a 5 s budget so a wedged task executor cannot turn one Ctrl+C into a process that never exits, and the shutdown line claims `stopped.` only when the release actually finished.

--- a/docs/device-connect.md
+++ b/docs/device-connect.md
@@ -32,6 +32,8 @@ r.run()              # serve on Device Connect (blocks until Ctrl+C)
 
 `.run()` stops the auto-started built-in mesh and serves the robot over Device Connect (D2D Zenoh multicast, no broker). Without `.run()` the robot is **agent-controlled** — discovered and invoked remotely via `robot_mesh` / `discover()`.
 
+Ctrl+C releases the robot before the process exits. `.run()` is the only entry point that holds a robot for the life of a process, so the interrupt handler is the only teardown it gets: it calls the instance's `cleanup()`, which on hardware reaches the driver's own `disconnect()` — where torque disable and gripper release live — and closes the motors bus and every camera. The exit itself stays abrupt (`cleanup()` drains the task executor, and a wedged rollout must not turn one Ctrl+C into a process that never exits), so the release runs under a 5 s budget on a background thread. It prints `<peer-id> stopped.` only when the release finished; a teardown that times out or raises is reported as `<peer-id> is exiting WITHOUT a completed shutdown: …` so an operator is never told the arm is safe when it may still be holding torque.
+
 Because the mesh is stopped *for* Device Connect, a bring-up that fails leaves the process on no transport at all — so `.run()` logs the cause (naming the extra when that is what is missing) and prints `<peer-id> is NOT online` instead of announcing a device that is not there. It keeps running, so a broker that comes back is not a lost process.
 
 !!! warning "Secure by default"

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import threading
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from strands_robots.registry import (
@@ -478,6 +479,80 @@ def _attach_device_connect(instance: Any, canonical: str, mode: str, peer_id: st
     instance.run = lambda: _run_device_connect_foreground(instance)
 
 
+#: Seconds to wait for the Ctrl+C teardown before exiting anyway. Matches
+#: ``MuJoCoSimEngine._DEFAULT_POLICY_STOP_TIMEOUT``, which bounds the same
+#: decision on the same event: a teardown step that will not finish must not
+#: keep the process alive on the way out.
+_SHUTDOWN_TIMEOUT_S: float = 5.0
+
+
+def _release_resources_on_interrupt(instance: Any, peer_id: str) -> str | None:
+    """Run the instance's terminal teardown for Ctrl+C, bounded by a budget.
+
+    ``cleanup()`` is where a robot releases what it holds, and on hardware that
+    includes the physical devices: it reaches the driver's own ``disconnect()``,
+    which is where torque disable and gripper release live. Nothing else in the
+    library reaches them - ``cleanup()`` is terminal, so no entry point runs
+    after it, and lerobot's ``Robot.disconnect()`` refuses to be called by hand
+    once the robot is half-open. So the teardown either happens here or it does
+    not happen at all: the caller ends with ``os._exit``, which runs no
+    ``atexit`` hook, no ``__del__`` and no ``finally`` block.
+
+    The budget, and why the exit stays abrupt: ``Robot.cleanup()`` drains its
+    task executor with ``shutdown(wait=True)``, which a wedged rollout does not
+    finish - measured, a submitted item that never returns keeps that call
+    running indefinitely, and a ``ThreadPoolExecutor`` worker is not a daemon
+    thread, so the interpreter's own exit hook would then join it too. Awaiting
+    the teardown on the calling thread, or returning normally and letting the
+    interpreter tear down, therefore turns one operator Ctrl+C into a process
+    that never exits - and an operator who reaches for ``SIGKILL`` gets no
+    teardown at all, which is the outcome this exists to prevent. Running it on
+    a daemon thread with a budget keeps the guarantee that Ctrl+C ends the
+    process, on the same reasoning
+    :meth:`~strands_robots.simulation.mujoco.simulation.MuJoCoSimEngine.cleanup`
+    already applies to a wedged policy worker: bound the wait, report, proceed.
+
+    Args:
+        instance: The robot or simulation the runner was bound to. An instance
+            exposing no callable ``cleanup`` holds nothing this can release, so
+            it is reported as released rather than as a failure.
+        peer_id: Peer identifier, used to name the teardown thread.
+
+    Returns:
+        ``None`` when the teardown ran to completion, so the caller may report
+        the robot stopped. Otherwise a sentence naming what stopped it, for a
+        caller that must not claim more than happened.
+    """
+    cleanup = getattr(instance, "cleanup", None)
+    if not callable(cleanup):
+        return None
+
+    failure: list[BaseException] = []
+    finished = threading.Event()
+
+    def _teardown() -> None:
+        try:
+            cleanup()
+        except Exception as exc:  # noqa: BLE001 - reported to the operator below
+            failure.append(exc)
+        finally:
+            finished.set()
+
+    threading.Thread(target=_teardown, name=f"{peer_id}-shutdown", daemon=True).start()
+
+    if not finished.wait(timeout=_SHUTDOWN_TIMEOUT_S):
+        logger.warning(
+            "%s: cleanup() did not finish within %gs; exiting anyway.",
+            peer_id,
+            _SHUTDOWN_TIMEOUT_S,
+        )
+        return f"cleanup() did not finish within {_SHUTDOWN_TIMEOUT_S:g}s."
+    if failure:
+        logger.warning("%s: cleanup() raised during shutdown: %s", peer_id, failure[0])
+        return f"cleanup() raised {type(failure[0]).__name__}: {failure[0]}."
+    return None
+
+
 def _run_device_connect_foreground(instance: Any) -> None:
     """Start Device Connect and block - the robot listens for commands.
 
@@ -492,6 +567,13 @@ def _run_device_connect_foreground(instance: Any) -> None:
     the mesh has already been stopped for a replacement that never arrived, so
     the process serves no transport at all and the operator has to be told
     that rather than the opposite.
+
+    The operator's Ctrl+C is the only teardown this loop ever gets, on either
+    branch, so it releases the instance before exiting -- on hardware that is
+    what reaches the driver's ``disconnect()``, where torque disable and gripper
+    release live. The exit stays abrupt afterwards, and the shutdown line
+    reports whether the release actually finished; see
+    :func:`_release_resources_on_interrupt`.
     """
     import time
 
@@ -538,7 +620,15 @@ def _run_device_connect_foreground(instance: Any) -> None:
             time.sleep(1)
     except KeyboardInterrupt:
         print(f"\nShutting down {peer_id}...", flush=True)
-        print(f"{peer_id} stopped.", flush=True)
+        unreleased = _release_resources_on_interrupt(instance, peer_id)
+        if unreleased is None:
+            print(f"{peer_id} stopped.", flush=True)
+        else:
+            print(
+                f"{peer_id} is exiting WITHOUT a completed shutdown: {unreleased} "
+                f"Devices this process held may not have been released.",
+                flush=True,
+            )
         os._exit(0)
 
 

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -520,8 +520,9 @@ def _release_resources_on_interrupt(instance: Any, peer_id: str) -> str | None:
 
     Returns:
         ``None`` when the teardown ran to completion, so the caller may report
-        the robot stopped. Otherwise a sentence naming what stopped it, for a
-        caller that must not claim more than happened.
+        the robot stopped. Otherwise a sentence naming what stopped it -- the
+        budget expiring, the teardown raising, or a second Ctrl+C arriving
+        during the wait -- for a caller that must not claim more than happened.
     """
     cleanup = getattr(instance, "cleanup", None)
     if not callable(cleanup):
@@ -540,7 +541,20 @@ def _release_resources_on_interrupt(instance: Any, peer_id: str) -> str | None:
 
     threading.Thread(target=_teardown, name=f"{peer_id}-shutdown", daemon=True).start()
 
-    if not finished.wait(timeout=_SHUTDOWN_TIMEOUT_S):
+    try:
+        released = finished.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+    except KeyboardInterrupt:
+        # An impatient operator interrupting again lands here rather than in the
+        # loop above, and it must not escape: the caller's ``os._exit`` is what
+        # guarantees the process ends, and letting this propagate would instead
+        # unwind into interpreter shutdown, where the executor drain this wait
+        # is covering gets joined a second time by ``concurrent.futures``' own
+        # exit hook. Before this budget existed there was no window to interrupt,
+        # so the second Ctrl+C has to keep behaving the way the first one did.
+        logger.warning("%s: shutdown interrupted again; exiting immediately.", peer_id)
+        return "the shutdown was interrupted again before it finished."
+
+    if not released:
         logger.warning(
             "%s: cleanup() did not finish within %gs; exiting anyway.",
             peer_id,

--- a/tests/test_run_releases_devices_on_interrupt.py
+++ b/tests/test_run_releases_devices_on_interrupt.py
@@ -1,0 +1,276 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Ctrl+C on ``Robot(...).run()`` has to release what the robot holds.
+
+``.run()`` is the documented way to bring a robot online as a server -- it
+blocks in ``strands_robots.robot._run_device_connect_foreground`` until the
+operator interrupts it. That handler ended with ``os._exit(0)``, which runs no
+``atexit`` hook, no ``__del__`` and no ``finally`` block, so the instance's
+``cleanup()`` never ran. Measured end to end on a real ``Robot("so101",
+mode="sim")`` with a Device Connect runtime that genuinely came online, sending
+the process a real ``SIGINT``:
+
+    marker                     before   after
+    cleanup() ran                no      yes
+    an atexit hook ran           no       no
+    printed "<peer> stopped."   yes      yes
+
+``cleanup()`` is where a robot releases what it holds, and on hardware that is
+the only path to the physical devices: it prefers the driver's own
+``disconnect()``, which is where torque disable and gripper release live (the
+contract :mod:`tests.test_hardware_cleanup_disconnects` pins). Nothing else
+reaches them -- ``cleanup()`` is terminal, so no library entry point runs after
+it, and lerobot's ``Robot.disconnect()`` is ``@check_if_not_connected`` and so
+refuses a half-open robot by hand. So an operator's Ctrl+C left the arm
+energised at its last commanded position, while the process printed
+``"<peer> stopped."`` on the way out. The serial port itself is released --
+the process dies, and the kernel closes every descriptor it held -- but the
+torque state is not a descriptor: disabling it is a write that has to happen
+*before* the port closes, and that write was skipped.
+
+The exit stays abrupt, and that is not incidental. ``Robot.cleanup()`` drains
+its task executor with ``shutdown(wait=True)``; measured, a wedged work item
+keeps that call running indefinitely, and a ``ThreadPoolExecutor`` worker is not
+a daemon thread, so the interpreter's own exit hook would join it as well.
+Awaiting the teardown inline -- or returning normally and letting the
+interpreter tear down -- therefore converts one Ctrl+C into a process that never
+exits, and an operator who then reaches for ``SIGKILL`` gets no teardown at all,
+which is the outcome this contract exists to produce. The teardown runs on a
+daemon thread under a budget instead, on the reasoning
+``MuJoCoSimEngine.cleanup`` already applies to a wedged policy worker: bound the
+wait, report, proceed.
+
+What these tests pin:
+
+    - a connected arm's devices are released, through the driver's own
+      ``disconnect()``, with torque disable requested;
+    - a simulation's ``cleanup()`` runs too, and on the failed-bring-up branch
+      as well -- the built-in mesh has already been stopped by then, so the
+      instance's own resources are all that is left to release;
+    - the shutdown line claims "stopped" only when the teardown completed, and
+      names the reason when it did not;
+    - Ctrl+C still ends the process: a teardown that never returns, and one
+      that raises, both still reach the exit;
+    - an instance exposing no ``cleanup`` is not an error.
+
+No serial port and no camera device is opened: the driver, bus, camera and port
+doubles are :mod:`tests.test_hardware_cleanup_disconnects`'s, which mirror
+lerobot's connect ordering, its ``is_connected`` composition and its decorator
+contracts, and model port exclusivity so the consequence is asserted rather than
+the call.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import types
+from typing import Any
+
+from strands_robots import robot as robot_mod
+from tests.test_hardware_cleanup_disconnects import _arm, _make_robot, _Port
+from tests.test_robot_factory import _drive_foreground
+
+#: Upper bound on any wait, so a broken contract fails instead of hanging.
+DEADLINE = 10.0
+
+
+class _Simulation:
+    """Simulation-shaped instance: the ``cleanup()`` the foreground loop owns.
+
+    ``MuJoCoSimEngine.cleanup`` takes an optional ``policy_stop_timeout``, so
+    the double accepts one too -- the runner must not pass one, but a signature
+    narrower than the real thing would pass for the wrong reason.
+    """
+
+    def __init__(self, *, blocks: threading.Event | None = None, raises: BaseException | None = None) -> None:
+        self._peer_id = "sim-1"
+        self._peer_type = "sim"
+        self.mesh = None
+        self.cleanup_calls = 0
+        self.cleanup_threads: list[str] = []
+        self._blocks = blocks
+        self._raises = raises
+
+    def cleanup(self, policy_stop_timeout: float | None = None) -> None:  # noqa: ARG002 - real signature
+        self.cleanup_calls += 1
+        self.cleanup_threads.append(threading.current_thread().name)
+        if self._raises is not None:
+            raise self._raises
+        if self._blocks is not None:
+            assert self._blocks.wait(timeout=DEADLINE), "test never released the blocked teardown"
+
+
+def _connected_arm(port: _Port) -> tuple[Any, Any]:
+    """A one-camera arm, connected, wired onto a ``Robot`` bound to ``.run()``.
+
+    ``Any`` because ``_attach_device_connect`` sets ``_peer_id``/``_peer_type``
+    on the instance at bind time rather than in ``Robot.__init__``, so they are
+    not declared attributes -- the same reason the shipped runner reads them
+    with ``getattr``.
+    """
+    driver = _arm(port)
+    hw: Any = _make_robot(driver)
+    hw._peer_id = "arm-1"
+    hw._peer_type = "robot"
+    driver.connect()
+    assert driver.is_connected, "the arm has to be connected for teardown to have anything to release"
+    return hw, driver
+
+
+class TestCtrlCReleasesTheDevicesTheArmHolds:
+    """The interrupt reaches the one path that disables torque."""
+
+    def test_a_connected_arms_devices_are_released(self, monkeypatch, capsys) -> None:
+        port = _Port()
+        hw, driver = _connected_arm(port)
+
+        _drive_foreground(monkeypatch, capsys, instance=hw)
+
+        assert driver.disconnect_calls == 1, "the driver's own disconnect() never ran on Ctrl+C"
+        assert not driver.is_connected
+        assert port.held_by is None, "the arm's port was never closed through the driver"
+        assert driver.cameras["wrist"].disconnect_calls == 1
+
+    def test_the_torque_disable_is_what_reaches_the_bus(self, monkeypatch, capsys) -> None:
+        """Torque disable is a write, and it has to precede the port close.
+
+        ``bus.disconnect(disable_torque=True)`` is the driver-preferred path;
+        the fallback in ``_close_open_devices`` deliberately passes ``False``,
+        so recording only "a disconnect happened" would accept a teardown that
+        left the motors energised.
+        """
+        port = _Port()
+        hw, driver = _connected_arm(port)
+
+        _drive_foreground(monkeypatch, capsys, instance=hw)
+
+        assert driver.bus.disconnect_calls == [True], (
+            f"expected one torque-disabling bus disconnect, got {driver.bus.disconnect_calls}"
+        )
+
+    def test_the_port_is_free_for_the_next_holder(self, monkeypatch, capsys) -> None:
+        """A serial port is exclusive, so the next holder is the consequence."""
+        port = _Port()
+        hw, _driver = _connected_arm(port)
+
+        _drive_foreground(monkeypatch, capsys, instance=hw)
+
+        port.open("the next process")
+        assert port.held_by == "the next process"
+
+
+class TestCtrlCReleasesASimulationToo:
+    """The runner is bound to sim instances as well, on both bring-up branches."""
+
+    def test_a_simulations_cleanup_runs(self, monkeypatch, capsys) -> None:
+        sim = _Simulation()
+
+        _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        assert sim.cleanup_calls == 1, "cleanup() never ran on Ctrl+C"
+
+    def test_a_failed_bring_up_still_releases_the_instance(self, monkeypatch, capsys) -> None:
+        """The mesh is already stopped by then; the instance is what is left.
+
+        A bring-up that failed keeps the process alive deliberately, so the
+        operator's Ctrl+C is still the only teardown this path ever gets.
+        """
+        sim = _Simulation()
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim, runtime=None)
+
+        assert "NOT online" in out, "this test has to exercise the failed-bring-up branch"
+        assert sim.cleanup_calls == 1, "a failed bring-up skipped the teardown entirely"
+
+
+class TestTheShutdownLineClaimsOnlyWhatHappened:
+    """ "stopped" is a claim about the teardown, so it has to follow one."""
+
+    def test_a_completed_teardown_is_reported_stopped(self, monkeypatch, capsys) -> None:
+        """The unchanged half: the ordinary path still reads the same."""
+        sim = _Simulation()
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        assert "sim-1 stopped." in out
+        assert "WITHOUT a completed shutdown" not in out
+
+    def test_a_teardown_that_never_finishes_is_not_reported_stopped(self, monkeypatch, capsys) -> None:
+        release = threading.Event()
+        sim = _Simulation(blocks=release)
+        monkeypatch.setattr(robot_mod, "_SHUTDOWN_TIMEOUT_S", 0.2, raising=False)
+        try:
+            out = _drive_foreground(monkeypatch, capsys, instance=sim)
+        finally:
+            release.set()
+
+        assert "sim-1 stopped." not in out, "claimed the robot stopped while the teardown was still running"
+        assert "WITHOUT a completed shutdown" in out
+        assert "may not have been released" in out
+
+    def test_a_teardown_that_raises_is_not_reported_stopped(self, monkeypatch, capsys) -> None:
+        sim = _Simulation(raises=OSError("bus write failed"))
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        assert "sim-1 stopped." not in out
+        assert "WITHOUT a completed shutdown" in out
+        assert "bus write failed" in out
+
+    def test_the_shutdown_report_is_ascii(self, monkeypatch, capsys) -> None:
+        """Same rule the rest of ``run()``'s output follows."""
+        sim = _Simulation(raises=OSError("bus write failed"))
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        out.encode("ascii")
+
+
+class TestCtrlCStillEndsTheProcess:
+    """A teardown that will not finish must not hold the operator hostage."""
+
+    def test_a_teardown_that_never_returns_still_reaches_the_exit(self, monkeypatch, capsys) -> None:
+        """``_drive_foreground`` returns only because ``os._exit`` was reached.
+
+        This is what fails if the teardown is ever awaited on the calling
+        thread or moved into a ``finally``: the executor drain a wedged rollout
+        leaves running never returns, so Ctrl+C would stop ending the process.
+        The blocked teardown gives up on its own after ``DEADLINE`` so a broken
+        contract fails the test instead of hanging the suite.
+        """
+        release = threading.Event()
+        sim = _Simulation(blocks=release)
+        monkeypatch.setattr(robot_mod, "_SHUTDOWN_TIMEOUT_S", 0.2, raising=False)
+
+        started = time.monotonic()
+        try:
+            out = _drive_foreground(monkeypatch, capsys, instance=sim)
+        finally:
+            release.set()
+        elapsed = time.monotonic() - started
+
+        assert "Shutting down sim-1" in out
+        assert elapsed < DEADLINE / 2, f"the exit waited {elapsed:.1f}s on a teardown that never returns"
+
+    def test_a_teardown_that_raises_still_reaches_the_exit(self, monkeypatch, capsys) -> None:
+        sim = _Simulation(raises=RuntimeError("teardown exploded"))
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        assert "Shutting down sim-1" in out
+
+    def test_an_instance_without_a_cleanup_is_not_an_error(self, monkeypatch, capsys) -> None:
+        """``_attach_device_connect`` binds ``.run()`` onto any instance."""
+        instance = types.SimpleNamespace(_peer_id="bare-1", _peer_type="sim", mesh=None)
+
+        out = _drive_foreground(monkeypatch, capsys, instance=instance)
+
+        assert "bare-1 stopped." in out
+        assert "WITHOUT a completed shutdown" not in out
+
+    def test_a_non_callable_cleanup_attribute_is_not_an_error(self, monkeypatch, capsys) -> None:
+        instance = types.SimpleNamespace(_peer_id="bare-2", _peer_type="sim", mesh=None, cleanup=None)
+
+        out = _drive_foreground(monkeypatch, capsys, instance=instance)
+
+        assert "bare-2 stopped." in out

--- a/tests/test_run_releases_devices_on_interrupt.py
+++ b/tests/test_run_releases_devices_on_interrupt.py
@@ -259,6 +259,41 @@ class TestCtrlCStillEndsTheProcess:
 
         assert "Shutting down sim-1" in out
 
+    def test_a_second_ctrl_c_during_the_release_still_reaches_the_exit(self, monkeypatch, capsys) -> None:
+        """The budget opened a window to interrupt; it must behave like the first.
+
+        Unlike the rest of this module this pins the fix rather than the defect:
+        before the budget existed there was no wait to interrupt, so there is no
+        pre-fix behaviour for it to contradict.
+
+        A ``KeyboardInterrupt`` that escaped the wait would skip ``os._exit``
+        and unwind into interpreter shutdown, where ``concurrent.futures``' own
+        exit hook joins the very executor drain the wait was covering -- so an
+        impatient operator would get the hang the budget exists to prevent.
+        """
+        interrupted = threading.Event()
+
+        class _InterruptedWait(threading.Event):
+            def wait(self, timeout: float | None = None) -> bool:  # noqa: ARG002 - stands in for the budget
+                interrupted.set()
+                raise KeyboardInterrupt
+
+        # Only the runner's view of ``threading`` is substituted; mutating the
+        # real ``threading.Event`` would reach every other user of it.
+        monkeypatch.setattr(
+            robot_mod,
+            "threading",
+            types.SimpleNamespace(Event=_InterruptedWait, Thread=threading.Thread),
+            raising=False,
+        )
+        sim = _Simulation()
+
+        out = _drive_foreground(monkeypatch, capsys, instance=sim)
+
+        assert interrupted.is_set(), "the release never reached the wait this test interrupts"
+        assert "sim-1 stopped." not in out
+        assert "interrupted again" in out
+
     def test_an_instance_without_a_cleanup_is_not_an_error(self, monkeypatch, capsys) -> None:
         """``_attach_device_connect`` binds ``.run()`` onto any instance."""
         instance = types.SimpleNamespace(_peer_id="bare-1", _peer_type="sim", mesh=None)


### PR DESCRIPTION
## Problem

`Robot(...).run()` is the documented way to bring a robot online as a server. It blocks in `_run_device_connect_foreground` until the operator interrupts it, and that handler ended with:

```python
except KeyboardInterrupt:
    print(f"\nShutting down {peer_id}...", flush=True)
    print(f"{peer_id} stopped.", flush=True)
    os._exit(0)
```

`os._exit` runs no `atexit` hook, no `__del__` and no `finally` block, so the instance's `cleanup()` never ran. Measured end to end on a real `Robot("so101", mode="sim")` whose Device Connect runtime genuinely came online (connected to a Zenoh broker, subscribed to its command topic), sending the process a real `SIGINT`:

| marker | before | after |
|---|---|---|
| `cleanup()` ran | **no** | yes |
| an `atexit` hook ran | no | no |
| printed `"<peer> stopped."` | yes | yes |

`cleanup()` is the only path to the physical devices. It prefers the driver's own `disconnect()`, which is where torque disable and gripper release live -- the contract `tests/test_hardware_cleanup_disconnects.py` already pins, and whose module docstring already names this consequence: *"a script that simply ends left the arm energised at its last commanded position instead of going through the driver's disconnect, where torque disable and gripper release live."* Nothing else reaches them: `cleanup()` is terminal, so no library entry point runs after it, and lerobot's `Robot.disconnect()` is `@check_if_not_connected` and refuses a half-open robot by hand. That guarantee was enforced at the `cleanup()` level and at the `__del__` level, and the one entry point that holds a robot for the life of a process bypassed both.

With a connected one-camera arm, the entire event sequence between the interrupt and process death was two entries:

```
BEFORE   KeyboardInterrupt (operator Ctrl+C)  ->  os._exit(0)

AFTER    KeyboardInterrupt (operator Ctrl+C)  ->  robot.disconnect
         ->  bus.disconnect  ->  camera.wrist_cam.disconnect  ->  os._exit(0)
```

|  | before | after |
|---|---|---|
| `driver.disconnect()` calls | 0 | 1 |
| bus torque-disable writes | none | `[True]` |
| camera `disconnect()` calls | 0 | 1 |
| port holder at `os._exit` | still `arm` | free |

The runner is bound to sim instances as well (`robot.py:423` alongside `:461`), so a simulation's `cleanup()` was skipped too -- including on the failed-bring-up branch, where the built-in mesh has already been stopped and the instance's own resources are all that is left to release.

To be precise about one thing: the serial **port** is released, because the process dies and the kernel closes every descriptor it held. The torque state is not a descriptor. Disabling it is a write on the bus that has to happen *before* the port closes (`MotorsBus.disconnect(disable_torque=True)`: *"can prevent damaging motors if they are left applying resisting torque after disconnect"*), and that write was skipped -- so the arm stayed energised at its last commanded position, outliving the process, while the operator was told it had stopped.

## Why the exit stays abrupt

The obvious fixes -- call `cleanup()` inline before `os._exit`, or return normally and let a `finally` handle it -- both hang. `Robot.cleanup()` drains its task executor with `shutdown(wait=True)`; measured with a wedged work item, that call does not return, `ThreadPoolExecutor` workers are not daemon threads, and `concurrent.futures` registers an interpreter-exit hook that joins them. `tests/test_abandoned_work_item_cannot_hang_exit.py` already measured this shape ("a 45s wall clock had to kill the process"). Either variant turns one operator Ctrl+C into a process that never exits, and an operator who then reaches for `SIGKILL` gets no teardown at all -- strictly worse than the bug.

So the release runs on a daemon thread under a budget, and `os._exit(0)` stays as the guaranteed exit. That is the posture `MuJoCoSimEngine.cleanup` already applies to a wedged policy worker: *"a stale-pointer segfault is the lesser evil than hanging the host process on exit"* -- bound the wait, report, proceed. `_SHUTDOWN_TIMEOUT_S = 5.0` is the same value as its `_DEFAULT_POLICY_STOP_TIMEOUT`, bounding the same decision on the same event.

## The line now claims only what happened

`"<peer> stopped."` is a claim about the teardown, so it follows one. When the release does not finish, the reason is named instead -- real program output:

```
Shutting down so101-arm...
so101-arm is exiting WITHOUT a completed shutdown: cleanup() did not finish within 5s. Devices this process held may not have been released.

Shutting down so101-arm...
so101-arm is exiting WITHOUT a completed shutdown: cleanup() raised OSError: [Errno 5] Input/output error: /dev/ttyACM0. Devices this process held may not have been released.
```

An operator is never told the arm is safe when it may still be holding torque.

## Tests

`tests/test_run_releases_devices_on_interrupt.py`, driving the shipped runner through `test_robot_factory.py`'s existing `_drive_foreground` helper with `test_hardware_cleanup_disconnects.py`'s existing lerobot-shaped driver / bus / camera / port doubles -- no new doubles, no serial port or camera opened, port exclusivity modelled so the consequence is asserted rather than the call.

**8 failed / 6 passed on `upstream/main`, 14 passed after.** The failures each name a real observable:

```
the driver's own disconnect() never ran on Ctrl+C: assert 0 == 1
expected one torque-disabling bus disconnect, got []
OSError: [Errno 16] Device or resource busy: /dev/ttyACM0 held by arm
cleanup() never ran on Ctrl+C: assert 0 == 1
a failed bring-up skipped the teardown entirely: assert 0 == 1
claimed the robot stopped while the teardown was still running
```

One of the 8 is a forward guard rather than a demonstration: a second Ctrl+C arriving inside the release window has no pre-fix behaviour to contradict, because before the budget existed there was no wait to interrupt. Left unhandled it would have been a regression -- the interrupt escapes `os._exit` and unwinds into interpreter shutdown, where `concurrent.futures`' exit hook joins the very executor drain the wait was covering, producing exactly the hang the budget prevents.

The 6 that pass on both trees are the no-overreach controls: the ordinary path still prints `stopped.`, the output is still ASCII, an instance with no `cleanup` (or a non-callable one) is not an error, and -- the one that matters most -- **a teardown that never returns, and one that raises, both still reach the exit**. That last pair is what fails if the release is ever moved inline or into a `finally`.

## Artifact

Ctrl+C shutdown sequence, measured on each tree by driving the shipped `_run_device_connect_foreground` with a connected SO-101 arm. The torque band spans the exit on `main`; after the change it flips to released before the exit. The pose render is real MuJoCo, headless EGL.

![Ctrl+C shutdown sequence, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-run-ctrlc-teardown/shutdown_sequence.png)

## Scope

Left out deliberately: the `DeviceRuntime` is also never `stop()`ed, so the device never announces going offline. Whether an abrupt disappearance is the intended presence semantics (Zenoh liveliness already covers a vanished peer) is a design question rather than a defect, and belongs in its own change.

## Gate

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` unchanged at its pre-existing count; full `tests/` run on both trees with an identical failing-id set.
