### PR TITLE
fix(policies/kimodo): let the caller decide whether a checkpoint runs its own code

### DIFF
--- a/changelog.d/2365-kimodo-remote-code-callers-decision.md
+++ b/changelog.d/2365-kimodo-remote-code-callers-decision.md
@@ -1,0 +1,17 @@
+### Fixed: `KimodoPolicy` lets the caller decide whether a checkpoint runs its own code
+
+`KimodoConfig.trust_remote_code` defaulted to `True` and was reachable by no
+keyword at all: it was neither a `KimodoPolicy.__init__` parameter nor a
+`config_keys` entry, so `KimodoPolicy(trust_remote_code=False)` and
+`create_policy("kimodo", trust_remote_code=False)` raised `TypeError` while
+`build_policy_kwargs` - the route a JSON `policy_config` travels - dropped the
+key without a word and loaded with `True` anyway. Only hand-building the frozen
+dataclass could reach the flag. `STRANDS_TRUST_REMOTE_CODE` did not cover the
+gap: it decides whether the provider may be constructed and never sets this
+field, so opting in to the provider also opted in to executing repository code
+for every `model_id` the process loaded.
+
+The flag now defaults to `False` and is an explicit constructor parameter and
+`config_keys` entry, alongside `cache_dir`, which was unreachable for the same
+reason. The shipped default `model_id` is refused at load time either way, so a
+default rollout is unchanged.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -28,13 +28,33 @@ pip install "strands-robots[kimodo]"
 ```
 
 The extra installs the `diffusers` loader, which drives any checkpoint published
-in *diffusers pipeline layout*. `trust_remote_code=True` is forwarded for a
-pipeline that ships custom code, and the factory gates it behind an explicit
-opt-in:
+in *diffusers pipeline layout*.
+
+Two independent opt-ins guard that loader, and both are off by default. The
+first decides whether the provider may be built at all:
 
 ```bash
 export STRANDS_TRUST_REMOTE_CODE=1
 ```
+
+The second decides whether a checkpoint's own Python code may run when it is
+loaded. It is per call, defaults to `False`, and is never set by the environment
+variable above, so opting in to the provider does not also opt in to executing a
+repository's code:
+
+```python
+sim.run_policy(
+    policy_provider="kimodo",
+    policy_config={
+        "model_id": "your-org/kimodo-pipeline",
+        "trust_remote_code": True,      # only for a repo you have vetted
+    },
+    instruction="walk forward",
+)
+```
+
+Leave it unset for any checkpoint that does not genuinely need it; `diffusers`
+reports plainly when a pipeline requires the flag.
 
 Weights are fetched from HuggingFace on first use under the NVIDIA Open Model
 License; nothing is bundled with `strands_robots`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -101,13 +101,14 @@ Some policy providers load models from the HuggingFace Hub with `trust_remote_co
 
 Because this is code execution, not just data loading, Strands Robots forces an explicit, deliberate opt-in before any such provider will load:
 
-- The provider `lerobot_local` (`LerobotLocalPolicy`) is on the remote-code list. Any provider that loads models with `trust_remote_code=True` must be listed in `_HF_REMOTE_CODE_PROVIDERS` so the opt-in is enforced.
+- The providers `lerobot_local` (`LerobotLocalPolicy`) and `kimodo` (`KimodoPolicy`) are on the remote-code list. Any provider that loads models with `trust_remote_code=True` must be listed in `_HF_REMOTE_CODE_PROVIDERS` so the opt-in is enforced.
 - Loading is blocked by default. Attempting to create a gated provider without opting in raises `UntrustedRemoteCodeError` with an explanation, rather than silently executing remote code.
 - To opt in, set `STRANDS_TRUST_REMOTE_CODE=1` (`1` / `true` / `yes` are accepted). The example CLI enforces the same gate before it will run `--policy lerobot_local`.
 
 Operator guidance:
 
 - Only set `STRANDS_TRUST_REMOTE_CODE=1` when you are loading checkpoints from organizations you trust - ideally your own org, or a small allowlist of vendors you have vetted (e.g. `lerobot/`, `nvidia/`). The opt-in is a per-process, whole-environment switch: once set, it trusts every model the process loads for the life of that process, not just the one you had in mind. Scope it tightly (set it on the specific command, not globally in a shell profile) and pin checkpoints to a known revision where the loader supports it.
+- Where a provider exposes a per-call `trust_remote_code` setting, use it rather than relying on the environment variable alone. `KimodoPolicy` takes `trust_remote_code` (default `False`), so a process that has opted in to the provider can still refuse to execute a given repository's code. The two are independent: the environment variable decides whether the provider may be built, the setting decides whether a checkpoint's code runs.
 - Prefer providers that do not require remote code where you can. The default Mock policy, the GR00T container path, and many LeRobot policy families do not need this flag. Reach for `lerobot_local` with `trust_remote_code` only when a specific model genuinely requires it.
 - A mesh peer can request a model load too. When the mesh forwards a `pretrained_name_or_path` in an `execute`/`start` command, it is additionally constrained to an org allowlist (`STRANDS_MESH_HF_REPO_ALLOW`, default `nvidia,huggingface,lerobot`) so an authenticated peer cannot steer a robot into loading an arbitrary repo. Keep that allowlist as narrow as your fleet allows, and remember it is independent of the per-process `STRANDS_TRUST_REMOTE_CODE` opt-in - both gates apply.
 

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -120,10 +120,14 @@ class KimodoConfig:
             ``"fp32"`` for reproducibility.
         cache_dir: Optional local HF cache override; ``None`` uses
             ``$HF_HOME``.
-        trust_remote_code: Forwarded to ``from_pretrained`` so a checkpoint that
-            ships custom pipeline code can load; gated by
-            ``STRANDS_TRUST_REMOTE_CODE`` at the factory layer. This only
-            applies to a ``model_id`` published in diffusers pipeline layout -
+        trust_remote_code: Whether ``from_pretrained`` may execute code that
+            ships inside the checkpoint repository. Defaults to ``False``, so
+            loading a checkpoint does not run its code unless the caller asks
+            for it. ``STRANDS_TRUST_REMOTE_CODE`` is a separate and coarser
+            gate: it decides whether this provider may be constructed at all
+            and never sets this field, so opting in to the provider does not
+            also opt in to executing a repository's code. Only a ``model_id``
+            published in diffusers pipeline layout reaches the flag at all -
             NVIDIA's own Kimodo checkpoints are not, and are refused at load
             time in favour of a ``motion_agent=`` sampler.
         seed: RNG seed for reproducible sampling. ``None`` = fresh each call.
@@ -139,7 +143,7 @@ class KimodoConfig:
     device: str | None = None
     dtype: str = "fp16"
     cache_dir: str | None = None
-    trust_remote_code: bool = True
+    trust_remote_code: bool = False
     seed: int | None = None
 
     def __post_init__(self) -> None:

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -277,6 +277,8 @@ class KimodoPolicy(Policy):
         tracker_fps: int | None = None,
         device: str | None = None,
         dtype: str | None = None,
+        cache_dir: str | None = None,
+        trust_remote_code: bool | None = None,
         seed: int | None = None,
     ) -> None:
         """Build the policy from a config object and/or per-field overrides.
@@ -303,6 +305,10 @@ class KimodoPolicy(Policy):
             tracker_fps: Tracker consumption rate override.
             device: torch device string override.
             dtype: Sampler dtype override (``"fp16"``/``"bf16"``/``"fp32"``).
+            cache_dir: Local HuggingFace cache directory override.
+            trust_remote_code: Whether the loader may execute code shipped in
+                the checkpoint repository. ``None`` leaves the resolved
+                config's value, which defaults to ``False``.
             seed: Sampling seed override.
 
         Raises:
@@ -320,6 +326,8 @@ class KimodoPolicy(Policy):
             tracker_fps=tracker_fps,
             device=device,
             dtype=dtype,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
             seed=seed,
         )
         self._motion_agent: KimodoMotionAgent | None = motion_agent

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -317,6 +317,8 @@
         "tracker_fps",
         "device",
         "dtype",
+        "cache_dir",
+        "trust_remote_code",
         "seed",
         "motion_agent"
       ],

--- a/tests/policies/kimodo/test_remote_code_execution_is_the_callers_decision.py
+++ b/tests/policies/kimodo/test_remote_code_execution_is_the_callers_decision.py
@@ -1,0 +1,190 @@
+"""Whether a Kimodo checkpoint runs its own code is the caller's decision.
+
+``DiffusersKimodoAgent`` forwards ``KimodoConfig.trust_remote_code`` to
+``DiffusionPipeline.from_pretrained``, and
+``test_the_configured_model_id_cache_dir_and_trust_flag_reach_from_pretrained``
+already pins that forwarding with the reason spelled out: the flag is
+"security-relevant ... so the caller's decision has to be the one that reaches
+diffusers rather than a value this agent picks".  That test builds a
+``KimodoConfig`` directly, so it never exercised a route a caller actually has,
+and two properties the sentence depends on went unchecked:
+
+* the value the agent picks when the caller says nothing, and
+* whether any supported keyword route can carry the caller's decision at all.
+
+Both failed.  The field defaulted to ``True``, and it was neither a
+``KimodoPolicy.__init__`` parameter nor a ``config_keys`` entry, so
+``KimodoPolicy(trust_remote_code=False)`` and
+``create_policy("kimodo", trust_remote_code=False)`` raised ``TypeError`` while
+``build_policy_kwargs`` - the route a JSON ``policy_config`` travels - dropped
+the key and loaded with ``True`` anyway.  A caller could only reach the flag by
+hand-building the frozen dataclass, which an agent driving the tool surface
+cannot do.
+
+``STRANDS_TRUST_REMOTE_CODE`` does not cover the gap: it decides whether the
+provider may be constructed at all and never sets this field, so opting in to
+the provider silently opted in to executing repository code for every
+``model_id`` the process went on to load.
+
+Reachability arrives as an explicit parameter, not as a ``**kwargs`` absorber,
+and it keeps the documented precedence: an explicit keyword beats a ``config=``
+base.  The three controls at the bottom pass before and after the fix, pinning
+that the coarse provider gate is untouched, that the dataclass route is
+undisturbed, and that a typo is still refused rather than swallowed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.policies import UntrustedRemoteCodeError, create_policy
+from strands_robots.policies.kimodo import KimodoPolicy
+from strands_robots.policies.kimodo.config import KimodoConfig
+from strands_robots.registry import build_policy_kwargs
+
+_TRUST_ENV = "STRANDS_TRUST_REMOTE_CODE"
+
+
+@pytest.fixture
+def loader_kwargs(monkeypatch):
+    """Return ``(policy) -> load_kwargs`` recorded from a stubbed diffusers.
+
+    Registers a stub ``diffusers`` module carrying only ``DiffusionPipeline``,
+    the single name :mod:`strands_robots.policies.kimodo._diffusers_agent`
+    imports from it, then drives the policy's own lazy agent construction so the
+    recorded kwargs are the ones production would send.
+    """
+    recorded: dict[str, Any] = {}
+
+    class _StubPipe:
+        def to(self, _device: str) -> _StubPipe:
+            return self
+
+    class _StubDiffusionPipeline:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _StubPipe:
+            recorded.clear()
+            recorded.update({"model_id": model_id, **kwargs})
+            return _StubPipe()
+
+    stub = types.ModuleType("diffusers")
+    stub.DiffusionPipeline = _StubDiffusionPipeline  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "diffusers", stub)
+
+    def _load(policy: KimodoPolicy) -> dict[str, Any]:
+        policy._build_real_agent()
+        assert recorded, "the stub pipeline was never asked to load"
+        return recorded
+
+    return _load
+
+
+def test_a_default_policy_does_not_let_the_checkpoint_run_its_own_code(loader_kwargs):
+    """With no instruction from the caller, the loader is told not to execute code."""
+    kwargs = loader_kwargs(KimodoPolicy(device="cpu"))
+
+    assert kwargs["trust_remote_code"] is False, (
+        "a caller who said nothing about remote code had the checkpoint's own code "
+        f"executed: from_pretrained received trust_remote_code={kwargs['trust_remote_code']!r}"
+    )
+
+
+def test_the_factory_path_carries_the_callers_refusal_to_the_loader(monkeypatch, loader_kwargs):
+    """``create_policy`` accepts the flag instead of raising on it."""
+    monkeypatch.setenv(_TRUST_ENV, "1")
+    policy = create_policy("kimodo", trust_remote_code=False, device="cpu")
+
+    assert loader_kwargs(policy)["trust_remote_code"] is False
+
+
+def test_a_policy_config_dict_carries_the_callers_refusal(monkeypatch, loader_kwargs):
+    """The route a JSON ``policy_config`` travels must not drop the decision.
+
+    ``build_policy_kwargs`` forwards only keys the provider declares in
+    ``config_keys`` and drops the rest, so an undeclared security flag is
+    discarded in silence and the load proceeds on the default.
+    """
+    monkeypatch.setenv(_TRUST_ENV, "1")
+    forwarded = build_policy_kwargs("kimodo", trust_remote_code=False, device="cpu")
+
+    assert "trust_remote_code" in forwarded, (
+        "build_policy_kwargs dropped the caller's trust_remote_code; a policy_config "
+        f"asking not to execute repository code forwarded only {sorted(forwarded)}"
+    )
+    assert loader_kwargs(create_policy("kimodo", **forwarded))["trust_remote_code"] is False
+
+
+def test_the_caller_can_still_opt_in_to_running_repository_code(monkeypatch, loader_kwargs):
+    """Opting in stays possible, which is what makes the default safe to flip."""
+    monkeypatch.setenv(_TRUST_ENV, "1")
+    policy = create_policy("kimodo", trust_remote_code=True, device="cpu")
+
+    assert loader_kwargs(policy)["trust_remote_code"] is True
+
+
+def test_every_config_field_is_reachable_through_a_keyword():
+    """No ``KimodoConfig`` field may be settable only by building the dataclass.
+
+    ``KimodoPolicy.__init__`` documents that it takes no ``**kwargs`` so an
+    unknown knob raises rather than being swallowed.  That makes an unlisted
+    field strictly unreachable: the keyword is a ``TypeError`` and, being absent
+    from ``config_keys``, it is dropped before ``create_policy`` ever sees it.
+    """
+    params = set(inspect.signature(KimodoPolicy.__init__).parameters) - {"self", "config"}
+    unreachable = sorted(set(KimodoConfig.__dataclass_fields__) - params)
+
+    assert unreachable == [], (
+        f"KimodoConfig fields {unreachable} can only be set by hand-building the "
+        "frozen dataclass: they are neither KimodoPolicy parameters nor config_keys"
+    )
+
+
+def test_the_registry_advertises_every_field_the_constructor_accepts():
+    """``config_keys`` is the filter, so an unlisted parameter is unreachable."""
+    from strands_robots.registry import get_policy_provider
+
+    advertised = set((get_policy_provider("kimodo") or {}).get("config_keys", []))
+    for field in ("trust_remote_code", "cache_dir"):
+        assert field in advertised, (
+            f"'{field}' is a KimodoPolicy parameter the registry does not advertise, "
+            "so build_policy_kwargs drops a caller who passes it"
+        )
+
+
+def test_an_explicit_override_still_beats_a_config_base(loader_kwargs):
+    """Precedence is unchanged: an explicit keyword wins over the base config."""
+    policy = KimodoPolicy(config={"trust_remote_code": False, "device": "cpu"}, trust_remote_code=True)
+
+    assert loader_kwargs(policy)["trust_remote_code"] is True
+
+
+# --- controls: these pass before and after the fix -------------------------
+
+
+def test_a_config_object_that_opts_in_is_left_alone(loader_kwargs):
+    """The dataclass route keeps working exactly as it did."""
+    policy = KimodoPolicy(config={"trust_remote_code": True, "device": "cpu"})
+
+    assert loader_kwargs(policy)["trust_remote_code"] is True
+
+
+def test_an_unknown_knob_is_still_refused_rather_than_swallowed():
+    """Reachability must not arrive as a ``**kwargs`` that absorbs typos."""
+    signature = inspect.signature(KimodoPolicy.__init__)
+    assert not any(p.kind is p.VAR_KEYWORD for p in signature.parameters.values())
+
+    with pytest.raises(TypeError):
+        KimodoPolicy(trust_remote_cod=False)  # deliberate typo
+
+
+def test_the_provider_gate_still_requires_the_env_opt_in(monkeypatch):
+    """The coarse provider gate is untouched by making the field reachable."""
+    monkeypatch.delenv(_TRUST_ENV, raising=False)
+
+    with pytest.raises(UntrustedRemoteCodeError):
+        create_policy("kimodo", trust_remote_code=False)

--- a/tests/policies/kimodo/test_remote_code_execution_is_the_callers_decision.py
+++ b/tests/policies/kimodo/test_remote_code_execution_is_the_callers_decision.py
@@ -174,12 +174,21 @@ def test_a_config_object_that_opts_in_is_left_alone(loader_kwargs):
 
 
 def test_an_unknown_knob_is_still_refused_rather_than_swallowed():
-    """Reachability must not arrive as a ``**kwargs`` that absorbs typos."""
+    """Reachability must not arrive as a ``**kwargs`` that absorbs typos.
+
+    The rejected name is derived from the live signature rather than hard-coded,
+    so this stays a statement about unknown keywords: it cannot rot into passing
+    a real parameter if one is later named after the string a literal happened
+    to hold.
+    """
     signature = inspect.signature(KimodoPolicy.__init__)
     assert not any(p.kind is p.VAR_KEYWORD for p in signature.parameters.values())
 
+    unknown = max(signature.parameters, key=len) + "_x"
+    assert unknown not in signature.parameters
+
     with pytest.raises(TypeError):
-        KimodoPolicy(trust_remote_cod=False)  # deliberate typo
+        KimodoPolicy(**dict.fromkeys([unknown], False))
 
 
 def test_the_provider_gate_still_requires_the_env_opt_in(monkeypatch):


### PR DESCRIPTION
## Problem

`DiffusersKimodoAgent` forwards `KimodoConfig.trust_remote_code` to `DiffusionPipeline.from_pretrained`, and the test that pins that forwarding states the contract:

> `trust_remote_code` is security-relevant: Kimodo ships a custom pipeline class, so **the caller's decision has to be the one that reaches diffusers rather than a value this agent picks.**

That test builds a `KimodoConfig` directly, so two properties the sentence rests on were never exercised: the value picked when the caller says nothing, and whether any supported keyword route can carry a decision at all. Both were wrong.

The field defaulted to `True`, and it was neither a `KimodoPolicy.__init__` parameter nor a `config_keys` entry. Measured on `upstream/main`, with `STRANDS_TRUST_REMOTE_CODE=1` set so the provider gate is open:

| caller route | what reached `from_pretrained` |
| --- | --- |
| nothing passed | `trust_remote_code=True` - repository code allowed to run |
| `KimodoPolicy(trust_remote_code=False)` | `TypeError: unexpected keyword argument` |
| `create_policy("kimodo", trust_remote_code=False)` | `TypeError: unexpected keyword argument` |
| `policy_config={"trust_remote_code": False}` | `trust_remote_code=True` - **the refusal was dropped in silence** |

The last row is the one that matters most: `build_policy_kwargs` forwards only keys the provider declares in `config_keys` and drops the rest, so it forwarded `['device']` and the load proceeded on `True`. That is the route a JSON `policy_config` travels, i.e. the one an agent driving the tool surface uses. The only way to reach the flag was hand-building the frozen dataclass.

`STRANDS_TRUST_REMOTE_CODE` does not cover the gap. It decides whether the provider may be *constructed* and never sets this field, so opting in to the provider silently opted in to executing repository code for every `model_id` the process went on to load. `docs/security.md` already warns that this switch is "a per-process, whole-environment switch ... it trusts every model the process loads for the life of that process" - there was simply no finer control behind it.

## Change

- `KimodoConfig.trust_remote_code` defaults to `False`, so loading a checkpoint does not run its code unless asked. This matches the `diffusers`/`transformers` library default and LeRobot's own `eval.py` (`trust_remote_code: bool = False`).
- `trust_remote_code` and `cache_dir` become explicit `KimodoPolicy.__init__` parameters and `config_keys` entries. They were the only two `KimodoConfig` fields reachable by no keyword at all; the class deliberately takes no `**kwargs`, which is what made an unlisted field strictly unreachable rather than merely absorbed.
- The docstring and `docs/policies/kimodo.md` no longer say the environment variable gates this flag. They now describe the two opt-ins as independent, which is what they are.
- `docs/security.md` records `kimodo` on the remote-code list (it is in `_HF_REMOTE_CODE_PROVIDERS`, but only `lerobot_local` was named) and points operators at the per-call setting.

Flipping the default is observably safe for existing callers: the shipped default `model_id` is not a diffusers pipeline and is refused at load time either way. Verified against the real Hub, both values give the byte-identical refusal:

```
trust_remote_code=True  -> RuntimeError: Kimodo model_id 'nvidia/Kimodo-G1-RP-v1' is not a diffusers pipeline: ...
trust_remote_code=False -> RuntimeError: Kimodo model_id 'nvidia/Kimodo-G1-RP-v1' is not a diffusers pipeline: ...
```

The flag only reaches a caller-supplied checkpoint in diffusers pipeline layout - exactly the case where the caller should be the one deciding, and which they can now opt in to.

## Tests

`tests/policies/kimodo/test_remote_code_execution_is_the_callers_decision.py`, driving the policy's own lazy agent construction against a stubbed `diffusers` so the recorded kwargs are the ones production sends.

Pre-fix on `upstream/main`: **7 failed, 3 passed**. The headline failure reads

```
AssertionError: a caller who said nothing about remote code had the checkpoint's own code
executed: from_pretrained received trust_remote_code=True
assert True is False
```

and the silent route reads

```
AssertionError: build_policy_kwargs dropped the caller's trust_remote_code; a policy_config
asking not to execute repository code forwarded only ['device']
```

The three that pass on both trees are the boundary controls: the coarse provider gate still raises `UntrustedRemoteCodeError` without the environment opt-in, the `config=` dataclass route is undisturbed, and a typo is still a `TypeError` rather than being swallowed by a newly added `**kwargs` - the obvious wrong way to make the field reachable. A drift guard asserts that no `KimodoConfig` field is settable only by building the dataclass, so this cannot recur for a future field.

Full `tests/` on the same interpreter (lerobot 0.6.2, mujoco 3.5.0), both trees run in parallel and finishing within 1 s of each other:

| | failing ids | passed |
| --- | --- | --- |
| this branch | 54 | 30727 |
| `upstream/main` + this test file | 59 | 30720 |

`comm` on the sorted ids gives base-only = exactly the 7 pre-fix failures above, which is the full-suite confirmation of the split. Branch-only = 2 ids, both pre-existing timing flakes rather than regressions, measured in isolation 5x per tree: `test_async_rtc_masks_inference_latency` 5/5 on both trees (it only trips under full-suite load), and `test_on_the_nested_branch` 4/5 on **both** trees, i.e. the identical failure rate on `upstream/main`. Neither touches this diff, which is confined to `policies/kimodo/`, the kimodo `config_keys` block, and docs.

## Rollout in MuJoCo (headless)

![kimodo trust_remote_code caller decision](https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-remote-code-callers-decision/kimodo-trust-remote-code.png)

`STRANDS_TRUST_REMOTE_CODE=1` is set in both panels, so the only difference is the per-call decision. The bottom strip is `KimodoPolicy` driving the Unitree G1 through the documented `motion_agent=` seam; commanded joint targets are bit-identical across the two trees (`max|delta| = 0.0` over 60 ticks x 29 joints), so only the loader decision changed.

![G1 rollout](https://raw.githubusercontent.com/cagataycali/robots/media-kimodo-remote-code-callers-decision/kimodo-g1-rollout.gif)

## Out of scope

`lerobot_local` is also in `_HF_REMOTE_CODE_PROVIDERS` and passes no such flag itself, but the LeRobot policy classes it loads do: `gaussian_actor`, `groot`, `pi0_fast` and `wall_x` hardcode `trust_remote_code=True` in their own modeling code (11 call sites in 0.6.2). The gate is therefore protecting a real path, and narrowing it per policy type would need the checkpoint's type before construction - a separate contract decision, not a bound correction. `tool_spec.json` advertises `trust_remote_code` as a `lerobot_local` `policy_config` key that its `**kwargs` absorbs; also left alone here to keep this change to one contract.
