### PR TITLE
fix(simulation/mujoco): name the hardware route when a registered robot has no sim model

### DIFF
--- a/changelog.d/2369-hardware-only-robot-refusal-names-the-route.md
+++ b/changelog.d/2369-hardware-only-robot-refusal-names-the-route.md
@@ -1,0 +1,10 @@
+### Fixed
+
+`add_robot` and `Robot(name, mode="sim")` now say when a registered robot is hardware-only.
+Nine `registry/robots.json` entries declare a LeRobot `hardware` backend and no simulation
+`asset`; those names took the unknown-name branch, so a correctly spelled request was
+answered with a spelling suggestion and the cause went unmentioned. The suggestion pool was
+the whole registry, so the correction offered could itself be hardware-only - following the
+sole remedy offered for `earthrover` led to `hope_jr` and then back again. The refusal now
+names the LeRobot type and the `Robot(name, mode="real")` route, and suggestions are drawn
+from `list_robots(mode="sim")` so every offered name is one the backend can spawn.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1196,12 +1196,28 @@ class MuJoCoSimEngine(
     def _unknown_model_msg(requested: str) -> str:
         """Build the 'model could not be resolved' error for a robot name.
 
-        Two conditions reach this message and they have different remedies, so
-        it diagnoses which one it is instead of reporting both as a bad name:
+        Three conditions reach this message and they have different remedies, so
+        it diagnoses which one it is instead of reporting them all as a bad name:
 
         * The registry does not know ``requested`` - a typo or an unknown robot.
-          Names the closest registry keys via :func:`close_match_hint` so the
-          caller can fix it in place without a discovery round-trip.
+          Names the closest sim-loadable registry keys via
+          :func:`close_match_hint` so the caller can fix it in place without a
+          discovery round-trip. The pool is deliberately the ``mode="sim"``
+          listing rather than the whole registry: a suggestion this engine
+          cannot spawn sends the caller straight back here, and the registry
+          holds hardware-only entries close enough to be suggested (the sole
+          suggestion offered for ``earthrover`` was ``hope_jr``, which is itself
+          hardware-only, so the one remedy on offer reproduced the same
+          refusal). ``close_match_hint`` already drops a suggestion identical to
+          ``requested`` for the same reason - it carries no information and
+          displaces a real one out of the three slots.
+        * The registry knows ``requested`` and the entry declares a hardware
+          backend and no simulation asset - a real robot strands drives over
+          LeRobot that has no model to load. The name is already correct, so
+          spelling suggestions are the wrong advice here too; names the hardware
+          entry point instead, the way
+          :func:`~strands_robots.robot.Robot` already answers a leader-arm name
+          with the teleoperator entry point rather than the registry listing.
         * The registry knows ``requested`` and its model XML is simply not on
           disk. Here the name is already correct, so spelling suggestions are
           the wrong advice - ``difflib`` ranks an exact match first, so this was
@@ -1223,13 +1239,18 @@ class MuJoCoSimEngine(
         try:
             from strands_robots.registry import list_robots as _list_robots
 
-            known = [r.get("name", "") for r in _list_robots() if r.get("name")]
+            # mode="sim" so a suggestion is a name this engine can actually
+            # spawn. A user model added through ``register_urdf`` is absent from
+            # every ``list_robots`` mode, so narrowing the pool drops nothing
+            # that was suggestable before.
+            known = [r.get("name", "") for r in _list_robots(mode="sim") if r.get("name")]
         except Exception:  # noqa: BLE001 - suggestions are best-effort
             known = []
 
         # Probed independently of the suggestion list so an unreadable registry
         # listing cannot mask the more specific diagnosis, and vice versa.
         asset_gap: tuple[str, str, str, bool, list[str]] | None = None
+        hardware_only: tuple[str, str] | None = None
         try:
             from strands_robots.assets.manager import get_search_paths, is_robot_asset_present
             from strands_robots.registry import get_robot as _get_robot
@@ -1240,7 +1261,8 @@ class MuJoCoSimEngine(
             # that cannot be a registry key raises and is caught, which keeps
             # the availability listing above ungated on the name's type.
             canonical = _resolve_name(requested)
-            asset = ((_get_robot(canonical) or {}) if canonical else {}).get("asset") or {}
+            entry = ((_get_robot(canonical) or {}) if canonical else {}) or {}
+            asset = entry.get("asset") or {}
             if asset and not is_robot_asset_present(canonical):
                 asset_gap = (
                     canonical,
@@ -1249,8 +1271,14 @@ class MuJoCoSimEngine(
                     asset.get("auto_download") is False,
                     [str(path) for path in get_search_paths()],
                 )
+            elif entry and not asset:
+                # Registered, correct, and simply not a simulation robot. The
+                # LeRobot type is what the hardware route is keyed on, so it is
+                # quoted when the entry declares one.
+                hardware_only = (canonical, str((entry.get("hardware") or {}).get("lerobot_type") or ""))
         except Exception:  # noqa: BLE001 - the diagnosis is best-effort
             asset_gap = None
+            hardware_only = None
 
         if asset_gap is not None:
             canonical, asset_dir, model_xml, never_downloads, search_paths = asset_gap
@@ -1273,6 +1301,17 @@ class MuJoCoSimEngine(
             else:
                 msg += f" Fetch it with the download_assets tool (robots='{canonical}')."
             return msg
+
+        if hardware_only is not None:
+            canonical, lerobot_type = hardware_only
+            typed = f" (LeRobot type '{lerobot_type}')" if lerobot_type else ""
+            return (
+                f"Robot '{requested}' is registered for real hardware only{typed}: its registry "
+                f"entry declares no simulation asset, so there is no model to load. The name is "
+                f"already correct, so there is no spelling to fix - drive it as hardware with "
+                f"Robot('{canonical}', mode='real'), or pass urdf_path= to supply a model of your "
+                f"own. Use list_robots(mode='sim') to see the robots this backend can spawn."
+            )
 
         msg = f"No model found for '{requested}'."
         msg += close_match_hint(requested, known)
@@ -4004,10 +4043,15 @@ class MuJoCoSimEngine(
     def list_urdfs(self) -> dict[str, Any]:
         """List every robot/URDF known to the registry (built-in + user-registered).
 
-        The names returned here are exactly the identifiers ``add_robot`` and
-        ``load_scene`` accept; ``register_urdf`` adds a new one. This is the
-        discovery entry point an agent uses to learn what it can spawn without
-        guessing a model name.
+        This is the discovery entry point an agent uses to learn what it can
+        spawn without guessing a model name; ``register_urdf`` adds a new one.
+
+        Read the ``Sim`` column: the registry also holds hardware-only entries -
+        robots strands drives over LeRobot that have no simulation model - and
+        those names are listed with ``Sim`` blank. ``add_robot`` and
+        ``load_scene`` accept the names marked ``Sim``; a hardware-only name is
+        refused with the hardware entry point instead. ``list_robots(mode="sim")``
+        returns just the spawnable subset.
         """
         return {"status": "success", "content": [{"text": list_available_models()}]}
 

--- a/tests/simulation/mujoco/test_unresolved_model_message_names_the_hardware_only_route.py
+++ b/tests/simulation/mujoco/test_unresolved_model_message_names_the_hardware_only_route.py
@@ -1,0 +1,169 @@
+"""A registered robot with no simulation asset must be told so, not spell-checked.
+
+``strands_robots/registry/robots.json`` holds two kinds of entry. Most declare an
+``asset`` block and can be spawned in simulation; nine declare only a
+``hardware`` block, because they are robots strands drives over LeRobot that
+mujoco_menagerie has no model for. ``list_robots(mode="sim")`` already reports
+that split, so the distinction is registry fact rather than a guess.
+
+``MuJoCoSimEngine._unknown_model_msg`` did not consult it. A hardware-only name
+took the unknown-name branch, so a request whose name was already correct was
+answered with a spelling suggestion and a pointer to the robot listing - and the
+suggestion pool was the *whole* registry, so the correction offered could itself
+be hardware-only. ``earthrover`` was the extreme: its sole offered remedy was
+``hope_jr``, which has no simulation asset either, so following the one remedy on
+offer reproduced the identical refusal.
+
+These tests pin both halves of that: the refusal for a hardware-only robot names
+the hardware entry point instead of a spelling, and every name any refusal from
+this engine offers as a remedy is one the engine can actually spawn.
+"""
+
+import pytest
+
+from strands_robots.registry import get_hardware_type, get_robot, has_hardware, has_sim, list_robots
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine
+
+# A hardware-only entry and one of its aliases. Both postures are asserted as a
+# premise below rather than assumed, so editing robots.json fails here with a
+# readable reason instead of quietly making a case vacuous.
+HARDWARE_ONLY_ROBOT = "reachy2"
+HARDWARE_ONLY_ALIAS = "earth_rover"  # -> earthrover
+HARDWARE_ONLY_ALIAS_CANONICAL = "earthrover"
+DISTINCTLY_TYPED_ROBOT = "omx"  # lerobot_type "omx_follower" != the registry name
+
+
+def _offered(message: str) -> list[str]:
+    """The names a refusal offers as corrections, in the order it offers them."""
+    if "Did you mean:" not in message:
+        return []
+    listed = message.split("Did you mean:")[1].split("?")[0]
+    return [part.strip() for part in listed.split(",") if part.strip()]
+
+
+def _hardware_only_names() -> list[str]:
+    """Every registry robot that declares hardware support and no sim asset."""
+    return sorted(r["name"] for r in list_robots() if not has_sim(r["name"]) and has_hardware(r["name"]))
+
+
+def test_the_registry_split_these_tests_depend_on_still_exists() -> None:
+    """Non-vacuity: the registry must still hold hardware-only entries."""
+    hardware_only = _hardware_only_names()
+    assert hardware_only, (
+        "no registry entry declares hardware support without a simulation asset, "
+        "so every case below would pass without exercising anything"
+    )
+    sim_listed = {r["name"] for r in list_robots(mode="sim")}
+    assert not sim_listed & set(hardware_only), (
+        f"list_robots(mode='sim') offers hardware-only robots {sorted(sim_listed & set(hardware_only))}, "
+        "so it is no longer the authority this message reads"
+    )
+    for subject in (HARDWARE_ONLY_ROBOT, HARDWARE_ONLY_ALIAS_CANONICAL):
+        assert subject in hardware_only, f"{subject!r} is no longer a hardware-only registry entry"
+
+
+class TestAHardwareOnlyRobotIsToldItIsHardwareOnly:
+    """The name is already correct, so the remedy is the route, not the spelling."""
+
+    def test_the_refusal_does_not_offer_a_spelling_fix(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ROBOT)
+        assert "Did you mean:" not in msg, (
+            f"{HARDWARE_ONLY_ROBOT!r} is spelled exactly as the registry holds it, yet the "
+            f"refusal offered a correction: {msg}"
+        )
+        assert "No model found" not in msg, f"a robot the registry knows was reported as an unknown name: {msg}"
+
+    def test_the_refusal_says_why_there_is_no_model(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ROBOT)
+        assert "hardware" in msg, msg
+        assert "no simulation asset" in msg, msg
+
+    def test_the_refusal_names_the_hardware_entry_point(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ROBOT)
+        assert f"Robot('{HARDWARE_ONLY_ROBOT}', mode='real')" in msg, (
+            f"the refusal does not name the route that can drive this robot: {msg}"
+        )
+
+    def test_the_refusal_names_the_lerobot_type_the_route_is_keyed_on(self) -> None:
+        # Graded on a subject whose LeRobot type differs from its registry name,
+        # so the echoed request name cannot satisfy the assertion on its own.
+        expected = get_hardware_type(DISTINCTLY_TYPED_ROBOT)
+        assert expected and expected != DISTINCTLY_TYPED_ROBOT, (
+            f"premise: {DISTINCTLY_TYPED_ROBOT!r} must declare a lerobot_type that is not "
+            f"its own name, or this case passes on the echoed request name alone (got {expected!r})"
+        )
+        assert expected in MuJoCoSimEngine._unknown_model_msg(DISTINCTLY_TYPED_ROBOT)
+
+    def test_the_named_route_exists_for_every_hardware_only_robot(self) -> None:
+        """The advertised remedy is checked against the registry, not just quoted."""
+        for name in _hardware_only_names():
+            msg = MuJoCoSimEngine._unknown_model_msg(name)
+            assert "mode='real'" in msg, f"{name}: {msg}"
+            assert has_hardware(name), f"{name} was pointed at the hardware route but declares no hardware backend"
+            assert get_hardware_type(name), f"{name} was pointed at the hardware route with no lerobot_type to use"
+
+    def test_an_alias_reports_the_canonical_route(self) -> None:
+        assert get_robot(HARDWARE_ONLY_ALIAS), f"premise: {HARDWARE_ONLY_ALIAS!r} no longer resolves"
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ALIAS)
+        assert HARDWARE_ONLY_ALIAS in msg, msg
+        assert f"Robot('{HARDWARE_ONLY_ALIAS_CANONICAL}', mode='real')" in msg, msg
+
+    def test_the_refusal_points_at_what_this_backend_can_spawn(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ROBOT)
+        assert "list_robots(mode='sim')" in msg, msg
+
+    def test_the_message_stays_ascii(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg(HARDWARE_ONLY_ROBOT)
+        assert msg.isascii(), [ch for ch in msg if not ch.isascii()]
+
+
+class TestEveryOfferedRemedyIsOneThisBackendCanSpawn:
+    """A correction the engine would refuse in turn is not a correction."""
+
+    def test_no_hardware_only_name_is_offered_to_a_hardware_only_request(self) -> None:
+        for name in _hardware_only_names():
+            offered = _offered(MuJoCoSimEngine._unknown_model_msg(name))
+            unloadable = [candidate for candidate in offered if not has_sim(candidate)]
+            assert not unloadable, (
+                f"the refusal for {name!r} offered {unloadable} as corrections, and those have no "
+                "simulation asset either, so the caller lands back on this same message"
+            )
+
+    @pytest.mark.parametrize("typo", ["hope", "rebot", "reachy2x", "lekiwi_clint", "omxx", "earthrove"])
+    def test_no_hardware_only_name_is_offered_to_a_typo(self, typo: str) -> None:
+        offered = _offered(MuJoCoSimEngine._unknown_model_msg(typo))
+        unloadable = [candidate for candidate in offered if not has_sim(candidate)]
+        assert not unloadable, (
+            f"the refusal for {typo!r} offered {unloadable}, which this backend cannot spawn: "
+            f"{MuJoCoSimEngine._unknown_model_msg(typo)}"
+        )
+
+    def test_a_typo_of_a_hardware_only_name_still_gets_help(self) -> None:
+        """Narrowing the pool must not empty it: a near miss still gets a name."""
+        msg = MuJoCoSimEngine._unknown_model_msg("lekiwi_clint")
+        assert "lekiwi" in _offered(msg), msg
+
+
+class TestTheOtherTwoConditionsAreUnchanged:
+    """Over-reach controls: the new branch sits between two existing ones."""
+
+    def test_a_registered_robot_with_a_missing_asset_still_names_the_asset(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STRANDS_ASSETS_DIR", str(tmp_path))
+        asset = (get_robot("panda") or {})["asset"]
+        msg = MuJoCoSimEngine._unknown_model_msg("panda")
+        assert f"{asset['dir']}/{asset['model_xml']}" in msg, msg
+        assert "download_assets" in msg, msg
+        assert "hardware" not in msg, f"a robot with an asset was reported as hardware-only: {msg}"
+
+    def test_an_unknown_name_still_gets_the_generic_form(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg("so10x")
+        assert "No model found for 'so10x'." in msg, msg
+        assert "so101" in msg or "so100" in msg, msg
+        assert "list_urdfs" in msg, msg
+
+    def test_a_name_with_no_neighbours_omits_the_suggestion(self) -> None:
+        msg = MuJoCoSimEngine._unknown_model_msg("zzqqxx0000nope")
+        assert "Did you mean:" not in msg, msg
+        assert "list_urdfs" in msg, msg

--- a/tests/simulation/mujoco/test_unresolved_model_message_names_the_missing_asset.py
+++ b/tests/simulation/mujoco/test_unresolved_model_message_names_the_missing_asset.py
@@ -1,12 +1,15 @@
 """A model that cannot be resolved must say which of two causes it hit.
 
-``MuJoCoSimEngine._unknown_model_msg`` serves two conditions with different
-remedies:
+``MuJoCoSimEngine._unknown_model_msg`` serves two of its three conditions here:
 
 * the registry does not know the name (a typo) - the remedy is a spelling fix,
   and naming close registry keys is what lets the caller make it in place;
 * the registry knows the name and its model XML is not on disk - the name is
   already correct, so the remedy is the asset, not the spelling.
+
+The third - the registry knows the name and the entry declares no simulation
+asset at all - is pinned in
+``test_unresolved_model_message_names_the_hardware_only_route.py``.
 
 Only the second condition can put the requested name inside the candidate set
 the suggestion is drawn from, and :func:`difflib.get_close_matches` scores an
@@ -124,7 +127,7 @@ class TestATypoStillGetsSpellingHelp:
     def test_an_unreadable_registry_degrades_to_the_bare_form(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import strands_robots.registry as registry
 
-        def _boom() -> list[dict[str, str]]:
+        def _boom(mode: str = "all") -> list[dict[str, str]]:
             raise RuntimeError("registry exploded")
 
         monkeypatch.setattr(registry, "list_robots", _boom)


### PR DESCRIPTION
## Problem

`registry/robots.json` holds two kinds of entry. Most declare an `asset` block and can be spawned in simulation; **nine declare only a `hardware` block** — robots strands drives over LeRobot that mujoco_menagerie has no model for. `list_robots(mode="sim")` already reports that split exactly:

```
list_robots()            -> 72
list_robots(mode="sim")  -> 63
set(all) - set(sim)      == {bi_openarm, bi_rebot_b601, earthrover, hope_jr,
                             hope_jr_hand, lekiwi_client, omx, reachy2, rebot_b601}
```

`_unknown_model_msg` did not consult it, so those nine names took the **unknown-name** branch. A request whose spelling was already exactly right was answered with a spelling correction plus a pointer to the robot listing, and the actual cause — the entry declares no simulation asset at all — went unmentioned:

```
>>> Robot("reachy2", mode="sim")
RuntimeError: Failed to create sim robot 'reachy2': No model found for 'reachy2'.
              Did you mean: reachy_mini, stretch, stretch3?
              Use action='list_urdfs' to see all available robots.
```

Worse, the suggestion pool was the **whole** registry, so the correction offered could itself be hardware-only. A script that applies whatever remedy the message hands it walks a cycle:

```
hop 1  add_robot(data_config='earthrover')   -> Did you mean: hope_jr?
hop 2  add_robot(data_config='hope_jr')      -> Did you mean: hope_jr_hand, openarm, piper?
hop 3  add_robot(data_config='hope_jr_hand') -> Did you mean: hope_jr, ...   # back to hop 2
```

Three refusals, zero robots spawned, ending where it already was. Plain typos hit the same wall: `add_robot('omxx')` offered only `omx` and `add_robot('earthrove')` only `earthrover`, both unloadable. Over generated typos of all 72 registry names, **53 of 197** refusals offered at least one name this backend cannot spawn.

The distinguishing information was available at the call site and discarded: the function already resolves the canonical name and reads the entry, then only acts when `asset` is *present but missing on disk*. When `asset` is empty it fell through to the generic form, throwing away the fact that the entry exists at all.

## Why this is the message's job

`tests/registry/test_groot_data_configs_resolve_to_a_registry_robot.py` already states the consequence verbatim, and guards the groot catalogue against *creating* it:

> Pointing one at a hardware-only entry would resolve cleanly and still refuse, which reads as the same "No model found" as claiming nothing.

`tests/registry/test_lekiwi_simulatable.py` records the same failure from the other side: LeKiwi "previously failed with `No model found for 'lekiwi'` because the registry entry carried only a `hardware` block and no `asset` block". That one was fixed by finding it a model; the nine here have none to find, so the message is what has to carry the difference.

And `close_match_hint` already argues the suggestion rule this change extends — it drops a suggestion identical to the request because it "carries no information and displaces a real one out of the three slots". A hardware-only suggestion offered to a sim caller does both.

## Change

`_unknown_model_msg` gains the third condition where the other two already live:

```
Robot 'reachy2' is registered for real hardware only (LeRobot type 'reachy2'): its
registry entry declares no simulation asset, so there is no model to load. The name is
already correct, so there is no spelling to fix - drive it as hardware with
Robot('reachy2', mode='real'), or pass urdf_path= to supply a model of your own. Use
list_robots(mode='sim') to see the robots this backend can spawn.
```

and suggestions are drawn from `list_robots(mode="sim")`, so every offered name is one the engine can actually spawn. `register_urdf` models are absent from every `list_robots` mode, so narrowing the pool drops nothing that was suggestable before.

The named route was checked, not just quoted: `Robot("earthrover", mode="real")` builds, and `Robot("reachy2", mode="real")` reaches an actionable `pip install 'lerobot[reachy2]'`.

`list_urdfs`'s docstring claimed "the names returned here are exactly the identifiers `add_robot` and `load_scene` accept", which was false for those nine. Corrected to point at the `Sim` column its own table already prints.

## Deliberate consequence

Narrowing the pool means a typo whose only close neighbour is hardware-only now gets no suggestion instead of an unusable one — `'omxx'` no longer offers `'omx'`. A near miss that does have a spawnable neighbour still gets one (`'lekiwi_clint'` -> `'lekiwi'`), which is pinned as a test.

## Tests

New `tests/simulation/mujoco/test_unresolved_model_message_names_the_hardware_only_route.py`, sibling to the `#2317` file that pinned the other two conditions.

**14 failed / 6 passed** on `upstream/main`, **20 passed** after. Sample pre-fix output:

```
FAILED ...test_no_hardware_only_name_is_offered_to_a_typo[earthrove]
  the refusal for 'earthrove' offered ['earthrover'], which this backend cannot spawn
FAILED ...test_no_hardware_only_name_is_offered_to_a_hardware_only_request
  the refusal for 'bi_openarm' offered ['hope_jr'] as corrections, and those have no
  simulation asset either, so the caller lands back on this same message
```

The 6 constant passes are the over-reach controls: a registered robot whose asset is merely missing still gets the asset diagnosis and is *not* reported as hardware-only; an unknown name still gets the generic form with a spelling hint; a name with no neighbours still omits the suggestion; and the registry split the file depends on is asserted as a premise so a `robots.json` edit fails here with a reason instead of quietly making cases vacuous.

Also fixed a latent vacuity in the sibling file: its registry stub took no arguments, so once the message passes `mode="sim"` it would have raised `TypeError` instead of the `RuntimeError` that case is about.

## Artifact

Both panels are one script that parses the remedy out of the message it just received and applies it. Only the tree on `PYTHONPATH` differs.

![add_robot remedy walk](https://raw.githubusercontent.com/cagataycali/robots/media-hardware-only-refusal/add_robot_remedy_walk.png)

## Gate

`ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` 18 pre-existing errors on both trees, zero branch-only.

Full `tests/` run on this branch and on `upstream/main` with the new file copied into both:

```
branch    29 failed, 30794 passed, 283 skipped, 24 errors
main      42 failed, 30781 passed, 283 skipped, 24 errors
```

Diffing the sorted failure IDs, the base-only set is **exactly the 14 pre-fix failures** of the new
file and nothing else. The one branch-only ID is
`test_policy_runner_async_rtc.py::test_async_rtc_masks_inference_latency`, a wall-clock threshold
test that passed 3/3 in isolation on this branch (and 1/1 on main) once the machine was quiet; this
change touches no timing path.
