### PR TITLE
fix(simulation/mujoco): keep a latched apply_force wrench latched across a scene rebuild

### DIFF
--- a/changelog.d/2370-scene-rebuild-carries-latched-wrench.md
+++ b/changelog.d/2370-scene-rebuild-carries-latched-wrench.md
@@ -1,0 +1,3 @@
+### Fixed
+
+`add_robot`, `add_object`, `add_camera`, `remove_object` and `remove_robot` no longer silently release a latched `apply_force` wrench. Each rebuilds the MuJoCo model, and `xfrc_applied` was not carried across that rebuild, so an object a thruster or a wind field was holding up resumed free fall under a `"success"` result with nothing logged - contradicting `apply_force`, which documents the latch as holding until the next `apply_force` on that body or a `reset()`, and `add_robot`, which documents that "a latched `apply_force` wrench persists". Both rebuild paths now carry the latched wrenches by body name.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -250,6 +250,60 @@ def install_compiled_model(world: SimWorld, model: Any, data: Any) -> None:
     world._recompile_generation += 1
 
 
+def _snapshot_body_wrenches(model: Any, data: Any, mj: Any) -> dict[str, list[float]]:
+    """Capture every latched ``apply_force`` wrench, keyed by body name.
+
+    ``xfrc_applied`` is indexed by body, and a scene rebuild renumbers bodies,
+    so the wrench is carried by NAME for the same reason every other field of
+    :class:`_SceneState` is. Only non-zero rows are captured: an all-zero row is
+    "no wrench latched here", which is exactly what a fresh allocation already
+    holds, so a scene with no wrench in it costs an empty dict.
+
+    Args:
+        model: The compiled model the rows are being read against.
+        data: The ``MjData`` holding the latched wrenches.
+        mj: The resolved ``mujoco`` module.
+
+    Returns:
+        ``body name -> [fx, fy, fz, tx, ty, tz]`` for each body with a wrench.
+    """
+    wrenches: dict[str, list[float]] = {}
+    for bid in range(int(model.nbody)):
+        row = data.xfrc_applied[bid]
+        if not row.any():
+            continue
+        name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, bid)
+        if not name:
+            # No namespace names it, so it cannot be matched across the rebuild.
+            # ``apply_force`` resolves its target by name and so cannot latch
+            # one here; a wrench on an unnamed body came from elsewhere.
+            logger.debug("snapshot_body_wrenches: body id %d has no name, wrench not carried over", bid)
+            continue
+        wrenches[name] = [float(x) for x in row]
+    return wrenches
+
+
+def _restore_body_wrenches(model: Any, data: Any, wrenches: dict[str, list[float]], mj: Any) -> None:
+    """Re-latch ``wrenches`` onto the bodies that still carry those names.
+
+    A body that no longer exists is skipped: its absence is the point of a
+    rebuild that removed it. Bodies absent from ``wrenches`` keep their
+    fresh-compile zero row, which is the same "no wrench" the snapshot read.
+
+    Args:
+        model: The freshly compiled model to resolve names against.
+        data: The ``MjData`` to write the wrenches into.
+        wrenches: A snapshot from :func:`_snapshot_body_wrenches`.
+        mj: The resolved ``mujoco`` module.
+    """
+    for name, row in wrenches.items():
+        bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, name)
+        if bid < 0:
+            continue  # body no longer exists (expected for a removed robot)
+        for i, v in enumerate(row):
+            data.xfrc_applied[bid, i] = v
+
+
 def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal: bool = False) -> bool:
     """Recompile ``spec`` in place, replacing ``world._model`` and ``_data``.
 
@@ -285,6 +339,13 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
       were applied either way, so the only symptom was a quadruped lying down
       under a ``"status": "success"``.
 
+    One buffer is not transferred at all rather than only in its tail:
+    ``xfrc_applied``, the per-body row
+    :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
+    latches a wrench in, comes back entirely zero. That wrench is documented to
+    hold until the next ``apply_force`` on the same body or a ``reset()``, so it
+    is snapshotted by body name before the recompile and re-latched after.
+
     Also re-discovers per-robot joint and actuator IDs (they may have shifted
     as new bodies were inserted earlier in the body tree). Returns True on
     success, False on compile failure (logged).
@@ -306,6 +367,14 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
     old_nv = int(world._model.nv) if world._model is not None else 0
     old_nu = int(world._model.nu) if world._model is not None else 0
     old_na = int(world._model.na) if world._model is not None else 0
+    # ``spec.recompile`` carries no part of ``xfrc_applied`` -- the whole buffer
+    # comes back zero -- so the latched wrenches are read off the outgoing data
+    # here and re-latched by name below.
+    wrenches = (
+        _snapshot_body_wrenches(world._model, world._data, mj)
+        if world._model is not None and world._data is not None
+        else {}
+    )
     try:
         with filter_mujoco_attach_noise():
             new_model, new_data = spec.recompile(world._model, world._data)
@@ -329,6 +398,8 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
         new_data.ctrl[old_nu:] = 0.0
     if new_model.na > old_na:
         new_data.act[old_na:] = 0.0
+    # Re-latch the external wrenches, before the forward pass reads them.
+    _restore_body_wrenches(new_model, new_data, wrenches, mj)
     # Forward pass so newly-injected bodies have valid xpos/xquat and any
     # camera xforms are populated. Without this, the next render() call
     # after add_object / add_robot / add_camera returns a 100% black frame
@@ -1087,11 +1158,17 @@ class _SceneState:
         actuators: ``actuator name -> (ctrl, act)``. ``ctrl`` is the servo
             setpoint holding a robot's pose; ``act`` is the internal activation
             of a stateful actuator, its effective command.
+        body_wrenches: ``body name -> [fx, fy, fz, tx, ty, tz]``, the external
+            wrench :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
+            latches in a body's own ``xfrc_applied`` row. ``qfrc_applied``
+            above is its joint-space sibling; both are part of the state
+            ``save_state`` checkpoints, so both are carried.
         time: ``data.time``, the clock the physics reads.
     """
 
     joints: dict[_JointKey, tuple[list[float], list[float], list[float]]]
     actuators: dict[str, tuple[float, list[float]]]
+    body_wrenches: dict[str, list[float]]
     time: float
 
 
@@ -1128,7 +1205,7 @@ def _snapshot_scene_state(world: SimWorld) -> _SceneState:
     captured and why it is keyed by name rather than by index.
     """
     if world._model is None or world._data is None:
-        return _SceneState(joints={}, actuators={}, time=0.0)
+        return _SceneState(joints={}, actuators={}, body_wrenches={}, time=0.0)
     mj = _ensure_mujoco()
     model = world._model
     data = world._data
@@ -1164,7 +1241,12 @@ def _snapshot_scene_state(world: SimWorld) -> _SceneState:
         act_vals = [float(x) for x in data.act[act_adr : act_adr + act_num]] if act_adr >= 0 else []
         actuators[name] = (float(data.ctrl[aid]), act_vals)
 
-    return _SceneState(joints=joints, actuators=actuators, time=float(data.time))
+    return _SceneState(
+        joints=joints,
+        actuators=actuators,
+        body_wrenches=_snapshot_body_wrenches(model, data, mj),
+        time=float(data.time),
+    )
 
 
 def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
@@ -1233,6 +1315,7 @@ def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
         for i, v in enumerate(act_vals):
             data.act[act_adr + i] = v
 
+    _restore_body_wrenches(model, data, snapshot.body_wrenches, mj)
     data.time = snapshot.time
     return restored
 

--- a/tests/simulation/mujoco/test_scene_ops_guardrails.py
+++ b/tests/simulation/mujoco/test_scene_ops_guardrails.py
@@ -191,10 +191,10 @@ class TestRepositionBodyGuards:
 class TestSnapshotRestoreWithoutModel:
     def test_snapshot_empty_world_returns_empty_state(self) -> None:
         snap = scene_ops._snapshot_scene_state(SimWorld())
-        assert (snap.joints, snap.actuators, snap.time) == ({}, {}, 0.0)
+        assert (snap.joints, snap.actuators, snap.body_wrenches, snap.time) == ({}, {}, {}, 0.0)
 
     def test_restore_empty_world_restores_nothing(self) -> None:
-        empty = scene_ops._SceneState(joints={}, actuators={}, time=0.0)
+        empty = scene_ops._SceneState(joints={}, actuators={}, body_wrenches={}, time=0.0)
         assert scene_ops._restore_scene_state(SimWorld(), empty) == 0
 
 

--- a/tests/simulation/mujoco/test_scene_rebuild_carries_latched_wrench.py
+++ b/tests/simulation/mujoco/test_scene_rebuild_carries_latched_wrench.py
@@ -1,0 +1,268 @@
+"""A scene rebuild keeps every latched ``apply_force`` wrench latched.
+
+:meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force` latches a
+wrench in the target body's own ``xfrc_applied`` row and documents exactly two
+ways that latch ends: the next ``apply_force`` on the same body, or a
+``reset()``. Five other operations ended it too, because every one of them
+rebuilds the model and ``xfrc_applied`` is not carried across that rebuild --
+``spec.recompile`` returns the whole buffer zeroed, and the eject path allocates
+a fresh ``MjData``. Each op reported ``"success"``, nothing was logged, and the
+wrench was simply not applied on any later step: an object a thruster or a wind
+field was holding up began to fall one ``add_camera`` later.
+
+The contract is stated three times over, from three directions:
+
+* ``apply_force`` names the two things that end a latch, and a scene rebuild is
+  neither of them.
+* ``add_robot`` documents that its composition preserves the scene's dynamic
+  state and says so in these words: "a latched ``apply_force`` wrench persists".
+* ``_SceneState`` -- the eject path's carry -- documents itself as "the same
+  state ``save_state`` checkpoints, minus the entries a rebuilt scene cannot
+  have a surviving instance of", and it already carried ``qfrc_applied``, the
+  joint-space sibling of this very buffer. A body survives a rebuild, so its
+  wrench had no reason to be the omitted one.
+
+Each preservation test below is paired with a control that the latch still ends
+where it is documented to, so the fix is pinned to carry the wrench across a
+rebuild rather than to make it unclearable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A one-hinge arm, only present so ``remove_robot`` has something to eject.
+_ARM_XML = """
+<mujoco model="stub_arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link0" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1" damping="1.0"/>
+      <geom type="cylinder" size="0.05 0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_PUCK_MASS = 0.5
+_PUCK_Z = 0.5
+# The wrench that exactly cancels gravity on the puck. With it latched the puck
+# hovers; without it the puck is in free fall, so "is the wrench still latched"
+# is answered by where the puck is rather than by reading a buffer.
+_HOVER_FORCE = [0.0, 0.0, _PUCK_MASS * 9.81]
+# 0.2 s of free fall is ~0.196 m - two orders of magnitude above the hover
+# tolerance, and short enough that the puck cannot reach the ground from _PUCK_Z.
+_FALL_STEPS = 100
+_HOVER_TOL = 1e-3
+
+# Every operation that rebuilds the model. ``set_geom_properties`` deliberately
+# does not appear: it mutates the compiled model in place, so it never lost the
+# wrench and is a control below.
+_REBUILD_OPS = ("add_robot", "add_object", "add_camera", "remove_object", "remove_robot")
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_rebuild_wrench", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _arm_path(tmp_path) -> str:
+    path = tmp_path / "stub_arm.xml"
+    path.write_text(_ARM_XML)
+    return str(path)
+
+
+def _wrench(sim: Simulation, body: str) -> list[float]:
+    """Read the wrench latched on ``body``, straight out of the live data."""
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    bid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_BODY, body)
+    assert bid >= 0, f"body {body!r} missing from the compiled model"
+    return [float(v) for v in world._data.xfrc_applied[bid]]
+
+
+def _latched_bodies(sim: Simulation) -> dict[str, list[float]]:
+    """Every body carrying a non-zero wrench, keyed by name."""
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    model, data = world._model, world._data
+    return {
+        (mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, bid) or f"<unnamed {bid}>"): [
+            float(v) for v in data.xfrc_applied[bid]
+        ]
+        for bid in range(int(model.nbody))
+        if data.xfrc_applied[bid].any()
+    }
+
+
+def _height(sim: Simulation, body: str) -> float:
+    result = sim.get_body_state(body)
+    assert result["status"] == "success", result
+    return float([block["json"] for block in result["content"] if "json" in block][0]["position"][2])
+
+
+def _scene_with_a_hovering_puck(sim: Simulation, tmp_path) -> None:
+    """Build a scene whose puck hovers only because a wrench is holding it.
+
+    Everything a later rebuild needs to act on is added FIRST, so the wrench is
+    latched after the last setup-driven rebuild and nothing but the operation
+    under test can clear it.
+    """
+    sim.create_world()
+    assert sim.add_robot(name="doomed", urdf_path=_arm_path(tmp_path))["status"] == "success"
+    assert sim.add_object(name="spare", shape="sphere", size=[0.04], position=[-0.6, 0.0, 0.3])["status"] == "success"
+    assert (
+        sim.add_object(name="puck", shape="box", size=[0.05] * 3, position=[0.0, 0.0, _PUCK_Z], mass=_PUCK_MASS)[
+            "status"
+        ]
+        == "success"
+    )
+    assert sim.apply_force("puck", force=_HOVER_FORCE)["status"] == "success"
+    # Premise: the wrench really is holding the puck up, so a fall below means
+    # the wrench went missing rather than that it never held anything.
+    start = _height(sim, "puck")
+    sim.step(_FALL_STEPS)
+    assert _height(sim, "puck") == pytest.approx(start, abs=_HOVER_TOL), "premise: the puck is hovering"
+
+
+def _rebuild(sim: Simulation, op: str, tmp_path) -> None:
+    """Run one model-rebuilding operation and assert it reported success."""
+    if op == "add_robot":
+        result = sim.add_robot(name="newcomer", urdf_path=_arm_path(tmp_path), position=[0.8, 0.0, 0.0])
+    elif op == "add_object":
+        result = sim.add_object(name="newcomer", shape="sphere", size=[0.03], position=[0.6, 0.0, 0.3])
+    elif op == "add_camera":
+        result = sim.add_camera(name="newcomer", position=[1.0, -1.0, 0.7], target=[0.0, 0.0, 0.1])
+    elif op == "remove_object":
+        result = sim.remove_object("spare")
+    elif op == "remove_robot":
+        result = sim.remove_robot("doomed")
+    else:  # pragma: no cover - guards the parametrization against a typo
+        raise AssertionError(f"unknown rebuild op {op!r}")
+    assert result["status"] == "success", result
+
+
+class TestARebuildKeepsTheWrenchHoldingTheBodyUp:
+    """The observable half: a body a wrench was holding does not start to fall.
+
+    Pre-fix every one of these ops dropped the wrench while reporting success,
+    so the puck resumed free fall and was ~0.196 m lower 0.2 s later.
+    """
+
+    @pytest.mark.parametrize("op", _REBUILD_OPS)
+    def test_the_puck_keeps_hovering_across(self, sim: Simulation, tmp_path, op: str) -> None:
+        _scene_with_a_hovering_puck(sim, tmp_path)
+        held = _height(sim, "puck")
+
+        _rebuild(sim, op, tmp_path)
+        sim.step(_FALL_STEPS)
+
+        assert _height(sim, "puck") == pytest.approx(held, abs=_HOVER_TOL), (
+            f"{op} dropped the latched wrench: the puck fell {held - _height(sim, 'puck'):.4f} m"
+        )
+
+    @pytest.mark.parametrize("op", _REBUILD_OPS)
+    def test_the_wrench_row_survives(self, sim: Simulation, tmp_path, op: str) -> None:
+        _scene_with_a_hovering_puck(sim, tmp_path)
+
+        _rebuild(sim, op, tmp_path)
+
+        assert _wrench(sim, "puck") == pytest.approx([*_HOVER_FORCE, 0.0, 0.0, 0.0])
+
+
+class TestPerBodyIsolationSurvivesTheRebuild:
+    """Each body keeps its OWN wrench across a rebuild, not a shared one.
+
+    ``xfrc_applied`` is indexed by body and a rebuild renumbers bodies, so a
+    carry that used the old index would re-latch one body's wrench onto another.
+    """
+
+    def test_two_bodies_keep_their_own_wrenches(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world(gravity=[0.0, 0.0, 0.0])
+        for name, x in (("puck_a", 0.0), ("puck_b", 1.0)):
+            assert (
+                sim.add_object(name=name, shape="box", size=[0.05] * 3, position=[x, 0.0, 0.3], mass=0.1)["status"]
+                == "success"
+            )
+        assert sim.apply_force("puck_a", force=[1.0, 0.0, 0.0])["status"] == "success"
+        assert sim.apply_force("puck_b", torque=[0.0, 0.0, 2.0])["status"] == "success"
+
+        assert sim.add_robot(name="newcomer", urdf_path=_arm_path(tmp_path))["status"] == "success"
+
+        assert _wrench(sim, "puck_a") == pytest.approx([1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        assert _wrench(sim, "puck_b") == pytest.approx([0.0, 0.0, 0.0, 0.0, 0.0, 2.0])
+
+
+class TestTheLatchStillEndsWhereItIsDocumentedTo:
+    """Controls: carrying the wrench across a rebuild must not make it unclearable.
+
+    These three are the documented ways a latch begins, persists and ends. They
+    hold both before and after the fix - they are here so that widening the
+    carry into "the wrench can never be cleared" fails.
+    """
+
+    def test_reset_clears_every_latched_wrench(self, sim: Simulation, tmp_path) -> None:
+        _scene_with_a_hovering_puck(sim, tmp_path)
+
+        assert sim.reset()["status"] == "success"
+
+        assert _latched_bodies(sim) == {}
+
+    def test_stepping_keeps_the_wrench_latched(self, sim: Simulation, tmp_path) -> None:
+        _scene_with_a_hovering_puck(sim, tmp_path)
+
+        sim.step(_FALL_STEPS)
+
+        assert _wrench(sim, "puck") == pytest.approx([*_HOVER_FORCE, 0.0, 0.0, 0.0])
+
+    def test_a_zero_wrench_on_the_same_body_releases_it(self, sim: Simulation, tmp_path) -> None:
+        _scene_with_a_hovering_puck(sim, tmp_path)
+        held = _height(sim, "puck")
+
+        assert sim.apply_force("puck", force=[0.0, 0.0, 0.0])["status"] == "success"
+        assert (
+            sim.add_object(name="newcomer", shape="sphere", size=[0.03], position=[0.6, 0.0, 0.3])["status"]
+            == "success"
+        )
+        sim.step(_FALL_STEPS)
+
+        assert _height(sim, "puck") < held - 0.1, "a released puck must fall, rebuild or not"
+
+
+class TestAWrenchIsNeverInventedOrMisattributed:
+    """Controls on the two ways a name-keyed carry could go wrong.
+
+    Both hold before the fix - before it, no wrench was carried at all - so they
+    pin that the carry adds only the wrenches that were really latched.
+    """
+
+    def test_a_removed_robots_wrench_does_not_land_on_a_survivor(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world(gravity=[0.0, 0.0, 0.0])
+        arm = _arm_path(tmp_path)
+        assert sim.add_robot(name="keeper", urdf_path=arm)["status"] == "success"
+        assert sim.add_robot(name="doomed", urdf_path=arm, position=[0.5, 0.0, 0.0])["status"] == "success"
+        assert sim.apply_force("doomed/link0", force=[3.0, 0.0, 0.0])["status"] == "success"
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+
+        assert _latched_bodies(sim) == {}, "the ejected body's wrench must not be re-latched anywhere"
+
+    def test_a_wrenchless_scene_gains_no_wrench(self, sim: Simulation, tmp_path) -> None:
+        sim.create_world()
+        assert (
+            sim.add_object(name="puck", shape="box", size=[0.05] * 3, position=[0.0, 0.0, 0.3])["status"] == "success"
+        )
+
+        assert sim.add_robot(name="newcomer", urdf_path=_arm_path(tmp_path))["status"] == "success"
+
+        assert _latched_bodies(sim) == {}


### PR DESCRIPTION
## Problem

`apply_force` latches a wrench in the target body's own `xfrc_applied` row and documents exactly two things that end that latch:

> The wrench is latched in the target body's own `xfrc_applied` row and applied on every subsequent `mj_step` **until the next `apply_force` call for that body**. [...] `reset()` clears every latched wrench in the world.

Five other operations ended it too. Each of them rebuilds the model, and `xfrc_applied` is not carried across that rebuild: `spec.recompile` returns the whole buffer zeroed, and the eject path allocates a fresh `MjData`. Every one reported `"success"`, nothing was logged, and the wrench simply stopped being applied on any later step.

Measured with one scene (a 0.5 kg crate held at a commanded height by a wrench that cancels gravity), reading `xfrc_applied` back by name after each operation:

| operation | wrench after | verdict |
|---|---|---|
| `add_robot` | `0.0` | dropped |
| `add_object` | `0.0` | dropped |
| `add_camera` | `0.0` | dropped |
| `remove_object` | `0.0` | dropped |
| `remove_robot` | `0.0` | dropped |
| `set_geom_properties` | `25.0` | kept (mutates in place, no rebuild) |
| `step(100)` | `25.0` | kept, as documented |
| `apply_force` on another body | `25.0` | kept, as documented |
| `reset()` | `0.0` | cleared, as documented |

The three documented behaviours all hold. The five that do not are exactly the five model rebuilds. Registering one extra camera was enough: the crate resumed free fall and was **0.4601 m** lower 1.4 s later.

## The contract was already stated, three times over

- `apply_force` names the two things that end a latch, and a scene rebuild is neither.
- `add_robot` documents its composition in these words: *"an object stays where it settled or was carried to, **a latched `apply_force` wrench persists**, and the clock keeps counting"*. It did not.
- `_SceneState`, the eject path's carry, documents itself as *"the same state `save_state` checkpoints, minus the entries a rebuilt scene cannot have a surviving instance of"* -- and it already carried `qfrc_applied`, the joint-space sibling of this very buffer. A body survives a rebuild, so its wrench had no reason to be the omitted one.

## Change

Both rebuild paths now snapshot the latched wrenches and re-latch them after the compile, through one pair of helpers so there is a single rule for what identifies a latched wrench:

- `_recompile_preserving_state` (`add_robot`, `add_object`, `add_camera`, `remove_object`) reads them off the outgoing data before `spec.recompile` and re-latches before the forward pass that consumes them.
- `_SceneState` gains `body_wrenches`, so `eject_robot_from_scene` carries them the same way it already carries `qpos`, `qvel`, `qfrc_applied`, `ctrl`, `act` and the clock.

Keyed by **body name**, because a rebuild renumbers bodies -- an index-keyed carry would re-latch one body's wrench onto another. Only non-zero rows are captured: an all-zero row is "no wrench here", which is what a fresh allocation already holds, so a scene with no wrench in it carries an empty dict and the change costs nothing.

## Scope

`xfrc_applied` is the only `mjSTATE_INTEGRATION` buffer a rebuild dropped **and a caller can put a value into**. The rest are accounted for: `qpos`/`qvel` are carried by the recompile and by `_SceneState`; `qfrc_applied` is dropped by the recompile too (measured, see round 2 below) but nothing in the package ever writes a non-zero value into it, so there is nothing there to lose; `ctrl`, `act` and `time` are carried; `eq_active` is re-derived from the spec the weld equality lives on (`weld_bodies_in_scene` stores it there precisely "so it survives later recompiles"), and nothing writes `eq_active` at runtime; and no scene this package can build has mocap bodies or plugins (`nmocap == nplugin == 0`).

Not changed: `reset()` still clears every latched wrench, which is the documented way to clear them all.

## Tests

`tests/simulation/mujoco/test_scene_rebuild_carries_latched_wrench.py`, 16 cases. Against `upstream/main`: **11 failed, 5 passed**. After: 16 passed.

The 11 failures are the five rebuild operations measured two ways -- once observably (the crate keeps hovering) and once on the buffer -- plus per-body isolation across a rebuild. The observable half fails with the physical quantity rather than a buffer diff:

```
AssertionError: add_camera dropped the latched wrench: the puck fell 0.1982 m
```

The 5 that pass on both trees are the controls, and they are what fails if the carry is widened into "a wrench can never be cleared":

- `reset()` still clears every latched wrench
- stepping still keeps it latched
- a zero wrench on the same body still releases it, rebuild or not
- a removed robot's wrench is not re-latched onto a survivor
- a wrenchless scene gains no wrench

Each preservation test asserts against the commanded height rather than a hand-picked constant, and the fixture premise-asserts that the wrench really is holding the crate up, so a fall means the wrench went missing rather than that it never held anything.

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 18 errors on this branch and 18 on `upstream/main` -- the same pre-existing set.
- Full `tests/` on both trees, same interpreter, in parallel: **68 failing ids on each, identical set** (`comm` empty both ways). `44 failed, 30723 passed, 24 errors` on this branch against `44 failed, 30707 passed, 24 errors` on `upstream/main` -- the `+16` passed is exactly the 16 new tests, and none of them is in the failing set.

## Rollout in MuJoCo (headless EGL)

A thruster wrench holds the crate at its commanded height. At the marked frame an **unrelated `add_camera()`** is called -- nothing else changes, and it returns `"success"` in both panels. One script, run against each tree; only the tree differs.

![latched wrench across a scene rebuild](https://raw.githubusercontent.com/cagataycali/robots/media-rebuild-wrench-31983452314/wrench_survives_rebuild.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-rebuild-wrench-31983452314/wrench_survives_rebuild.mp4)

| | crate z at the event | crate z 1.4 s later | fell |
|---|---|---|---|
| before | 0.780 m | 0.320 m | **0.4601 m** |
| after | 0.780 m | 0.780 m | 0.0 m |

Both panels are pixel-identical up to the event (max mean abs delta 0.000053), which is the control: they diverge only because of the operation under test. The hovering phase is deliberately still -- a held crate does not move.

## 13. Post-merge correction (this PR's docstring undercounted by one)

This merged before the following could be pushed to the branch, so it lands
separately as #2376. Recording it here because this description is where
the claim originated.

**The docstring this PR adds to `_recompile_preserving_state` says "One buffer is
not transferred at all rather than only in its tail: `xfrc_applied`". Two are.**
`spec.recompile` returns `qfrc_applied` entirely zeroed as well. The Scope
section above said the opposite ("`qfrc_applied` [is] carried by the recompile"),
and it is corrected in place. Measured by growing a scene by one body, across the
whole supported range:

| mujoco | `qpos` | `qvel` | `ctrl` | `time` | `qfrc_applied` | `xfrc_applied` |
|---|---|---|---|---|---|---|
| 3.5.0 (declared floor) | carried | carried | carried | carried | **zeroed** | **zeroed** |
| 3.10.0 (locked) | carried | carried | carried | carried | **zeroed** | **zeroed** |
| 3.11.0 | carried | carried | carried | carried | **zeroed** | **zeroed** |

Confirmed end to end on the merge commit through the public API: after an
unrelated `add_camera()`, the latched `xfrc_applied` row survives -- this PR's
fix, working as approved -- while a `qfrc_applied` vector does not.

**What shipped here is right; only the count was wrong.** `qfrc_applied` stays
uncarried on this path deliberately, and #2376 makes that a documented
decision instead of an unstated assumption: nothing in the package ever writes a
non-zero value into it, so there is no value for the recompile to lose, and a
carry could only be exercised by writing the buffer from outside the public API.
The note it adds records the condition under which that changes -- a joint-force
API added later must add the carry with it.

The sentence had already cost something: I opened #2373 to carry a buffer with no
writer, having believed it. That PR is closed.
