### PR TITLE
fix(lerobot_local): route processor_overrides to the pipeline that declares the step

### DIFF
--- a/changelog.d/2375-processor-overrides-per-pipeline-routing.md
+++ b/changelog.d/2375-processor-overrides-per-pipeline-routing.md
@@ -1,0 +1,14 @@
+### Fixed
+
+`processor_overrides` now reaches the pipeline that declares the step. A
+checkpoint's preprocessor and postprocessor carry disjoint step keys
+(`normalizer_processor` vs `unnormalizer_processor`), and LeRobot refuses an
+override key that matches no step in the pipeline it is loading, so passing the
+caller's dict to both made every pipeline-specific step unreachable -- only
+`device_processor`, present in both, could be applied. Supplying normalizer
+`stats` is the documented remedy for a pretraining base checkpoint whose
+dataset-prefixed stats leave its declared normalization inert, and that remedy
+raised `KeyError` instead of applying. Each override is now routed to the
+pipeline that declares it, a key declared by neither is still refused with both
+pipelines' step names listed, and the inert-normalization diagnostic names both
+steps.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -310,6 +310,45 @@ producing off-policy / micro-motion trajectories. An explicit
 `processor_overrides={"device_processor": {"device": ...}}` is still honored
 as-is and takes precedence over the automatic reconciliation.
 
+### Overriding a processor step
+
+`processor_overrides` is keyed by step name -- a step's `registry_name`, or its
+class name when the step is not registry-backed. A checkpoint ships two
+pipelines whose step names are mostly disjoint, so each override is routed to
+the pipeline that declares it:
+
+| step | pipeline | what it controls |
+| --- | --- | --- |
+| `normalizer_processor` | preprocessor | `observation.state` normalization |
+| `unnormalizer_processor` | postprocessor | `action` un-normalization |
+| `device_processor` | both | tensor placement |
+
+A key no pipeline declares is refused, and the refusal lists both pipelines'
+step names.
+
+This is how you supply stats to a checkpoint whose declared normalization is
+inert -- a pretraining *base* checkpoint such as `lerobot/smolvla_base` ships
+stats keyed by its training dataset (`so100.buffer.action`) rather than the
+canonical `action` / `observation.state` keys, so LeRobot's normalizer finds no
+matching key and passes those tensors through untouched. Both halves live in
+different pipelines, so a remedy has to name both steps:
+
+```python
+policy = create_policy(
+    "lerobot_local",
+    pretrained_name_or_path="lerobot/smolvla_base",
+    policy_type="smolvla",
+    processor_overrides={
+        "normalizer_processor": {"stats": dataset_stats},    # observation.state
+        "unnormalizer_processor": {"stats": dataset_stats},  # action
+    },
+)
+```
+
+Naming only one leaves the other inert, and the diagnostic keeps reporting
+whichever half is still unnormalized. Fine-tuning the checkpoint writes stats
+under the canonical keys and needs no override at all.
+
 ## State routing
 
 `observation.state` is composed from `robot_state_keys` (set explicitly with

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -1211,8 +1211,12 @@ class LerobotLocalPolicy(Policy):
                         "dataset-prefixed stats (e.g. 'so100.buffer.action') instead "
                         "of the canonical 'action'/'observation.state' keys. "
                         "Fine-tune the checkpoint (which writes proper stats) or pass "
-                        "processor_overrides={'normalizer_processor': {'stats': "
-                        "<dataset stats>}} -- if the arm reaches an out-of-distribution "
+                        "processor_overrides={'normalizer_processor': {'stats': <dataset "
+                        "stats>}, 'unnormalizer_processor': {'stats': <dataset stats>}} -- "
+                        "state normalization lives in the preprocessor's "
+                        "'normalizer_processor' step and action unnormalization in the "
+                        "postprocessor's 'unnormalizer_processor' step, so naming only one "
+                        "leaves the other inert. If the arm reaches an out-of-distribution "
                         "pose or ignores proprioception, this is why.",
                         self.pretrained_name_or_path or "<model>",
                         inert,

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -15,6 +15,7 @@ Architecture:
 """
 
 import logging
+import pathlib
 from typing import Any
 
 from ...utils import partial_construction_repr, require_optional
@@ -73,6 +74,68 @@ def _load_checkpoint_state_dict(pretrained_name_or_path: str, revision: str | No
         # No single-file weights on the Hub (sharded), offline, corrupt, or unreadable.
         logger.debug("No single-file model.safetensors for %s: %s", pretrained_name_or_path, exc)
         return None
+
+
+def _pipeline_step_keys(
+    pretrained_name_or_path: str,
+    config_filename: str,
+    revision: str | None = None,
+) -> set[str] | None:
+    """Override keys one processor pipeline's saved config accepts.
+
+    LeRobot resolves an override key per step as its ``registry_name``, or the
+    final component of its ``class`` path when the step is not registry-backed
+    (``DataProcessorPipeline._validate_overrides_used``), and raises
+    ``KeyError`` for any key that matches no step in the pipeline being loaded.
+    A checkpoint's two pipelines therefore accept DISJOINT key sets - a
+    preprocessor carries ``normalizer_processor`` while its postprocessor
+    carries ``unnormalizer_processor`` - so the caller's overrides have to be
+    routed per pipeline rather than handed to both.
+
+    Best-effort by design: returns ``None`` when the config cannot be read
+    (offline, absent, unreadable, or a shape this rule does not describe), and
+    the caller then passes the overrides through unrouted, exactly as before.
+    Never raises into the load path.
+
+    Args:
+        pretrained_name_or_path: HF model ID or local checkpoint path.
+        config_filename: Pipeline config filename (e.g. ``policy_preprocessor.json``).
+        revision: Optional Hub revision to pin the config to.
+
+    Returns:
+        The set of accepted override keys, or ``None`` when undetermined.
+    """
+    import json
+    import os
+
+    raw: str | None = None
+    local = os.path.join(pretrained_name_or_path, config_filename)
+    if os.path.isfile(local):
+        try:
+            raw = pathlib.Path(local).read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.debug("Could not read %s: %s", local, exc)
+            return None
+    else:
+        try:
+            from huggingface_hub import hf_hub_download
+            from huggingface_hub.errors import HfHubHTTPError
+
+            downloaded = hf_hub_download(pretrained_name_or_path, config_filename, revision=revision)
+            raw = pathlib.Path(downloaded).read_text(encoding="utf-8")
+        except ImportError:
+            return None
+        except (HfHubHTTPError, OSError, ValueError) as exc:
+            logger.debug("No %s for %s: %s", config_filename, pretrained_name_or_path, exc)
+            return None
+
+    try:
+        steps = json.loads(raw)["steps"]
+        keys = {step.get("registry_name") or str(step["class"]).rsplit(".", 1)[1] for step in steps}
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.debug("Could not read step keys from %s: %s", config_filename, exc)
+        return None
+    return keys or None
 
 
 def _try_import_processor() -> Any | None:
@@ -274,11 +337,28 @@ class ProcessorBridge:
         # leaving model_inputs empty at inference time. See B10.
         _register_policy_processor_steps(policy_type)
 
+        # Route each override to the pipeline that declares its step. LeRobot
+        # raises KeyError for an override key matching no step in the pipeline
+        # being loaded, and the two pipelines carry DISJOINT step keys
+        # (``normalizer_processor`` pre, ``unnormalizer_processor`` post), so
+        # handing the same dict to both makes every pipeline-specific step
+        # unoverridable: the key is rejected by whichever pipeline lacks it.
+        # Only ``device_processor``, present in both, ever got through -- which
+        # is why supplying normalizer ``stats`` (the documented remedy for a
+        # base checkpoint whose stats are dataset-prefixed and therefore inert)
+        # could not be applied at all.
+        pre_overrides, post_overrides = cls._route_overrides(
+            overrides or {},
+            pretrained_name_or_path,
+            preprocessor_config,
+            postprocessor_config,
+            revision,
+        )
         preprocessor = cls._load_pipeline(
             DataProcessorPipeline,
             pretrained_name_or_path,
             preprocessor_config,
-            overrides or {},
+            pre_overrides,
             device,
             kind="preprocessor",
             revision=revision,
@@ -287,7 +367,7 @@ class ProcessorBridge:
             DataProcessorPipeline,
             pretrained_name_or_path,
             postprocessor_config,
-            overrides or {},
+            post_overrides,
             device,
             kind="postprocessor",
             revision=revision,
@@ -318,6 +398,64 @@ class ProcessorBridge:
             postprocessor=postprocessor,
             device=device,
         )
+
+    @classmethod
+    def _route_overrides(
+        cls,
+        overrides: dict[str, Any],
+        pretrained_name_or_path: str,
+        preprocessor_config: str,
+        postprocessor_config: str,
+        revision: str | None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Split ``processor_overrides`` into the per-pipeline dicts each accepts.
+
+        A checkpoint's preprocessor and postprocessor declare disjoint step keys,
+        and LeRobot raises ``KeyError`` for an override key that matches no step
+        in the pipeline it is loading. Passing the caller's whole dict to both
+        therefore rejects every pipeline-specific step, so each key is routed to
+        the pipeline(s) that declare it.
+
+        A key declared by NEITHER pipeline is still a typo and is still refused -
+        LeRobot's protection is preserved, and the refusal names both pipelines'
+        keys rather than only the one that happened to be loaded first.
+
+        When a pipeline's step keys cannot be determined (offline, absent, or an
+        unrecognized config shape) that pipeline receives the overrides unrouted,
+        which is the behavior before routing existed.
+
+        Args:
+            overrides: Caller-provided step overrides (never mutated).
+            pretrained_name_or_path: HF model ID or local checkpoint path.
+            preprocessor_config: Preprocessor config filename.
+            postprocessor_config: Postprocessor config filename.
+            revision: Optional Hub revision to pin the configs to.
+
+        Returns:
+            ``(preprocessor_overrides, postprocessor_overrides)``.
+
+        Raises:
+            KeyError: If an override key is declared by neither pipeline.
+        """
+        if not overrides:
+            return {}, {}
+        pre_keys = _pipeline_step_keys(pretrained_name_or_path, preprocessor_config, revision)
+        post_keys = _pipeline_step_keys(pretrained_name_or_path, postprocessor_config, revision)
+        if pre_keys is None and post_keys is None:
+            return dict(overrides), dict(overrides)
+
+        known = (pre_keys or set()) | (post_keys or set())
+        unmatched = sorted(k for k in overrides if k not in known)
+        if unmatched:
+            raise KeyError(
+                f"Override keys {unmatched} do not match any step in "
+                f"{pretrained_name_or_path}. Preprocessor steps: {sorted(pre_keys or [])}. "
+                f"Postprocessor steps: {sorted(post_keys or [])}. Make sure override keys "
+                f"match exact step class names or registry names."
+            )
+        pre = dict(overrides) if pre_keys is None else {k: v for k, v in overrides.items() if k in pre_keys}
+        post = dict(overrides) if post_keys is None else {k: v for k, v in overrides.items() if k in post_keys}
+        return pre, post
 
     @staticmethod
     def _load_pipeline(

--- a/tests/policies/lerobot_local/test_processor_override_pipeline_routing.py
+++ b/tests/policies/lerobot_local/test_processor_override_pipeline_routing.py
@@ -1,0 +1,231 @@
+"""Regression tests: route ``processor_overrides`` to the pipeline that owns the step.
+
+A checkpoint ships two processor pipelines whose step keys are DISJOINT: state
+normalization lives in the preprocessor's ``normalizer_processor`` step and
+action un-normalization in the postprocessor's ``unnormalizer_processor`` step.
+LeRobot raises ``KeyError`` for an override key that matches no step in the
+pipeline it is loading (``DataProcessorPipeline._validate_overrides_used``, a
+typo guard).
+
+Pre-fix, :meth:`ProcessorBridge.from_pretrained` handed the caller's whole
+``overrides`` dict to BOTH pipelines, so every pipeline-specific step was
+rejected by whichever pipeline lacked it -- ``normalizer_processor`` by the
+postprocessor, ``unnormalizer_processor`` by the preprocessor, and naming both
+by each in turn. Only ``device_processor``, the one step present in both
+pipelines, ever got through. Supplying normalizer ``stats`` was therefore
+impossible, even though that is the documented remedy for a pretraining base
+checkpoint whose stats are dataset-prefixed (``so100.buffer.action``) and whose
+declared normalization is consequently inert -- state reaches the model raw and
+predicted actions reach the robot un-unnormalized.
+
+These tests build real pipeline configs on disk with LeRobot's own
+``save_pretrained`` and load them through the real LeRobot pipeline, so they
+verify behavior against actual LeRobot internals rather than mocks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("lerobot.processor.pipeline")
+torch = pytest.importorskip("torch")
+
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature  # noqa: E402
+from lerobot.processor import (  # noqa: E402
+    DataProcessorPipeline,
+    DeviceProcessorStep,
+    NormalizerProcessorStep,
+    UnnormalizerProcessorStep,
+)
+
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge  # noqa: E402
+
+_FEATURES = {
+    "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+    "action": PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+}
+_NORM_MAP = {
+    FeatureType.STATE: NormalizationMode.MEAN_STD,
+    FeatureType.ACTION: NormalizationMode.MEAN_STD,
+}
+
+
+def _stats(*keys: str) -> dict[str, dict[str, Any]]:
+    """Mean/std stats under the given lookup keys."""
+    return {key: {"mean": torch.zeros(6), "std": torch.ones(6)} for key in keys}
+
+
+def _canonical_stats() -> dict[str, dict[str, Any]]:
+    """Stats a caller computes from their own dataset, under canonical keys."""
+    return _stats("observation.state", "action")
+
+
+def _write_checkpoint(directory: Path) -> None:
+    """Write both pipelines of a base checkpoint whose declared norm is inert.
+
+    Mirrors ``lerobot/smolvla_base``: a preprocessor carrying only
+    ``normalizer_processor``, a postprocessor carrying only
+    ``unnormalizer_processor``, and stats keyed by the training dataset rather
+    than the canonical ``observation.state`` / ``action`` keys -- so both
+    declared normalizations silently pass through.
+    """
+    dataset_prefixed = _stats("ds.buffer.action")
+    DataProcessorPipeline(
+        steps=[
+            NormalizerProcessorStep(features=dict(_FEATURES), norm_map=dict(_NORM_MAP), stats=dict(dataset_prefixed))
+        ],
+        name="policy_preprocessor",
+    ).save_pretrained(str(directory))
+    DataProcessorPipeline(
+        steps=[
+            UnnormalizerProcessorStep(
+                features={"action": _FEATURES["action"]},
+                norm_map=dict(_NORM_MAP),
+                stats=dict(dataset_prefixed),
+            )
+        ],
+        name="policy_postprocessor",
+    ).save_pretrained(str(directory))
+
+
+def test_the_documented_remedy_makes_the_inert_pipeline_normalize_again(tmp_path: Path) -> None:
+    """Supplying canonical stats for both steps leaves nothing inert.
+
+    This is the remedy the inert-normalization diagnostic points callers at.
+    Fails pre-fix with ``KeyError``: each key is rejected by the pipeline that
+    does not declare it, so no stats could be supplied at all.
+    """
+    _write_checkpoint(tmp_path)
+    stats = _canonical_stats()
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path),
+        device="cpu",
+        overrides={
+            "normalizer_processor": {"stats": stats},
+            "unnormalizer_processor": {"stats": stats},
+        },
+    )
+
+    assert bridge.inert_normalization_features() == []
+
+
+def test_a_preprocessor_only_step_override_is_applied(tmp_path: Path) -> None:
+    """``normalizer_processor`` stats reach the preprocessor and normalize state.
+
+    The action half stays inert, because only the preprocessor step was given
+    stats -- the diagnostic keeps reporting exactly what remains unnormalized.
+    """
+    _write_checkpoint(tmp_path)
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path), device="cpu", overrides={"normalizer_processor": {"stats": _canonical_stats()}}
+    )
+
+    assert bridge.inert_normalization_features() == ["action (ACTION/MEAN_STD)"]
+
+
+def test_a_postprocessor_only_step_override_is_applied(tmp_path: Path) -> None:
+    """``unnormalizer_processor`` stats reach the postprocessor and unnormalize actions."""
+    _write_checkpoint(tmp_path)
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path), device="cpu", overrides={"unnormalizer_processor": {"stats": _canonical_stats()}}
+    )
+
+    assert bridge.inert_normalization_features() == ["observation.state (STATE/MEAN_STD)"]
+
+
+def test_both_pipelines_load_when_a_pipeline_specific_override_is_given(tmp_path: Path) -> None:
+    """A pipeline-specific override does not cost the caller the other pipeline.
+
+    Pre-fix the rejected key raised out of the load, so neither pipeline was
+    reached; the bridge was never even constructed.
+    """
+    _write_checkpoint(tmp_path)
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path), device="cpu", overrides={"normalizer_processor": {"stats": _canonical_stats()}}
+    )
+
+    assert bridge.has_preprocessor is True
+    assert bridge.has_postprocessor is True
+
+
+def test_an_unknown_override_key_names_both_pipelines_steps(tmp_path: Path) -> None:
+    """A key matching neither pipeline is refused, and the refusal names both.
+
+    Pre-fix a typo was also refused (LeRobot's guard), but the message listed
+    only the steps of whichever pipeline happened to be loaded first, so a
+    caller reaching for a step of the OTHER pipeline was shown a key list that
+    did not contain it.
+    """
+    _write_checkpoint(tmp_path)
+
+    with pytest.raises(KeyError) as excinfo:
+        ProcessorBridge.from_pretrained(
+            str(tmp_path), device="cpu", overrides={"nomalizer_processor": {"stats": _canonical_stats()}}
+        )
+
+    message = str(excinfo.value)
+    assert "nomalizer_processor" in message
+    assert "normalizer_processor" in message
+    assert "unnormalizer_processor" in message
+
+
+def test_a_typo_is_still_refused(tmp_path: Path) -> None:
+    """LeRobot's typo protection survives routing (passes pre-fix and post-fix)."""
+    _write_checkpoint(tmp_path)
+
+    with pytest.raises(KeyError):
+        ProcessorBridge.from_pretrained(
+            str(tmp_path), device="cpu", overrides={"not_a_step": {"stats": _canonical_stats()}}
+        )
+
+
+def test_a_step_declared_by_both_pipelines_still_reaches_both(tmp_path: Path) -> None:
+    """``device_processor`` is in both pipelines and is still applied to both.
+
+    The one override that worked pre-fix keeps working: routing must not narrow
+    a key that both pipelines declare. Passes pre-fix and post-fix.
+    """
+    DataProcessorPipeline(
+        steps=[
+            NormalizerProcessorStep(features=dict(_FEATURES), norm_map=dict(_NORM_MAP), stats=_canonical_stats()),
+            DeviceProcessorStep(device="cpu"),
+        ],
+        name="policy_preprocessor",
+    ).save_pretrained(str(tmp_path))
+    DataProcessorPipeline(
+        steps=[
+            UnnormalizerProcessorStep(
+                features={"action": _FEATURES["action"]}, norm_map=dict(_NORM_MAP), stats=_canonical_stats()
+            ),
+            DeviceProcessorStep(device="cpu"),
+        ],
+        name="policy_postprocessor",
+    ).save_pretrained(str(tmp_path))
+
+    bridge = ProcessorBridge.from_pretrained(
+        str(tmp_path), device="cpu", overrides={"device_processor": {"device": "cpu"}}
+    )
+
+    assert bridge.has_preprocessor is True
+    assert bridge.has_postprocessor is True
+
+
+def test_no_overrides_loads_both_pipelines_unchanged(tmp_path: Path) -> None:
+    """The default path is untouched: no overrides, both pipelines, still inert."""
+    _write_checkpoint(tmp_path)
+
+    bridge = ProcessorBridge.from_pretrained(str(tmp_path), device="cpu")
+
+    assert bridge.has_preprocessor is True
+    assert bridge.has_postprocessor is True
+    assert bridge.inert_normalization_features() == [
+        "observation.state (STATE/MEAN_STD)",
+        "action (ACTION/MEAN_STD)",
+    ]


### PR DESCRIPTION
## Problem

A checkpoint ships two processor pipelines whose step keys are **disjoint**:

| step | pipeline | controls |
| --- | --- | --- |
| `normalizer_processor` | preprocessor | `observation.state` normalization |
| `unnormalizer_processor` | postprocessor | `action` un-normalization |
| `device_processor` | **both** | tensor placement |

LeRobot raises `KeyError` for an override key matching no step in the pipeline it
is loading (`DataProcessorPipeline._validate_overrides_used`, a typo guard).
`ProcessorBridge.from_pretrained` passed the caller's whole `overrides` dict to
**both** `_load_pipeline` calls, so every pipeline-specific step was rejected by
whichever pipeline lacked it. Measured on `lerobot/smolvla_base`:

| `processor_overrides=` | result on `main` |
| --- | --- |
| `{'normalizer_processor': {'stats': …}}` | `KeyError … Available step keys: ['unnormalizer_processor', 'device_processor']` |
| `{'unnormalizer_processor': {'stats': …}}` | `KeyError … Available step keys: [… 'normalizer_processor']` |
| both keys together | `KeyError` |
| `{'device_processor': {'device': 'cuda'}}` | loads |

`device_processor` is the only step present in both pipelines, so it was the only
override that could ever be applied -- which is also the only example the docs
gave. Every other step was unreachable.

That matters because supplying normalizer `stats` is the remedy the
inert-normalization diagnostic points callers at. A pretraining *base* checkpoint
ships stats keyed by its training dataset rather than the canonical keys --
`lerobot/smolvla_base` carries `so100.buffer.action`, `so100-red.buffer.action`,
`so100-blue.buffer.action` and no `observation.state` entry at all -- so LeRobot's
normalizer finds no matching key and returns those tensors unchanged. The
diagnostic detects it correctly and then names a remedy that cannot be applied:

```
lerobot/smolvla_base has an ACTIVE normalization pipeline but its stats do not
cover ['observation.state (STATE/MEAN_STD)', 'action (ACTION/MEAN_STD)'] …
pass processor_overrides={'normalizer_processor': {'stats': <dataset stats>}}
```

The remedy also named only the preprocessor step, while the message reports an
inert feature from each pipeline.

## Change

- Route each override to the pipeline that declares its step, reading the
  available keys from each pipeline's saved config by LeRobot's own rule
  (`registry_name`, else the final component of `class`).
- A key declared by **neither** pipeline is still refused -- LeRobot's typo
  protection is preserved -- and the refusal now lists both pipelines' step
  names instead of only the one that happened to load first.
- When a pipeline's step keys cannot be determined (offline, absent, or an
  unrecognized config shape) that pipeline receives the overrides unrouted,
  which is the existing behavior.
- The inert-normalization diagnostic now names both steps and says which half
  each one covers.

## Verification

Loading `lerobot/smolvla_base` and reading back the step's own resolved stats:

| `processor_overrides=` | `inert_normalization_features()` | unnormalizer stat keys |
| --- | --- | --- |
| *(none)* | `[observation.state (STATE/MEAN_STD), action (ACTION/MEAN_STD)]` | `so100-blue.buffer.action, so100-red.buffer.action, so100.buffer.action` |
| `normalizer_processor` only | `[action (ACTION/MEAN_STD)]` | *(unchanged)* |
| `unnormalizer_processor` only | `[observation.state (STATE/MEAN_STD)]` | `action` |
| both | `[]` | `action, observation.state` |

Each override applies exactly the half it names, and the diagnostic keeps
reporting whichever half is still unnormalized. On `main` every row except the
first raises `KeyError`.

`tests/policies/lerobot_local/test_processor_override_pipeline_routing.py`
builds both pipelines on disk with LeRobot's own `save_pretrained` (no network)
in the same shape as a base checkpoint, and loads them through the real LeRobot
pipeline. **5 failed / 3 passed on `main`, 8 pass here.** The three that pass on
both are the boundary controls: a typo is still refused, `device_processor` still
reaches both pipelines, and the no-overrides path is byte-identical.

Gate: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests
tests_integ` unchanged (14 pre-existing, all in `examples/isaac_gs/`);
`tests/policies` + `tests/simulation` = 15017 passed with the same 3
environment-bound failures (2 docker-absent VERA, 1 Newton) as `main`.

## Rollout

A 120-step SmolVLA rollout on an SO-101 in MuJoCo (headless), driving the
documented remedy. Left: what `main` does -- the override raises, so the
pipeline stays inert and un-normalized values reach the actuators. Right: the
override applies and the stats the caller supplied are used.

![processor override routing](https://raw.githubusercontent.com/cagataycali/robots/media-processor-override-routing/artifact.gif)

https://raw.githubusercontent.com/cagataycali/robots/media-processor-override-routing/artifact.mp4

Emitted `|action|` mean goes 0.596 -> 81.5 once the checkpoint's own action
stats are applied, i.e. un-normalization is genuinely live rather than a
silent passthrough.

## Out of scope

Whether a hardware-pretrained checkpoint's action units should be reconciled
with a simulated robot's joint units is a separate question and not touched
here: `smolvla_base`'s action stats are in the SO-100 degree convention
(mean ~120, std ~52), so once correctly un-normalized they land far outside a
MuJoCo revolute joint's radian range. This PR only makes the documented remedy
applicable.
