### PR TITLE
docs(simulation/mujoco): name both applied-force buffers the recompile drops

### DIFF
--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -339,12 +339,30 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
       were applied either way, so the only symptom was a quadruped lying down
       under a ``"status": "success"``.
 
-    One buffer is not transferred at all rather than only in its tail:
-    ``xfrc_applied``, the per-body row
-    :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
-    latches a wrench in, comes back entirely zero. That wrench is documented to
-    hold until the next ``apply_force`` on the same body or a ``reset()``, so it
-    is snapshotted by body name before the recompile and re-latched after.
+    TWO buffers are not transferred at all rather than only in their tail --
+    both applied-force buffers come back entirely zero, so for these the tail
+    initialization above is beside the point: every entry is lost, including the
+    rows of elements that were there all along. Measured by growing a scene by
+    one body on mujoco 3.5.0 (the floor this package declares), 3.10.0 (the
+    locked version) and 3.11.0, identically on all three -- ``qpos``, ``qvel``,
+    ``ctrl`` and the clock carried, ``qfrc_applied`` and ``xfrc_applied``
+    zeroed.
+
+    * ``xfrc_applied``, the per-body row
+      :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
+      latches a wrench in, IS carried here. That wrench is documented to hold
+      until the next ``apply_force`` on the same body or a ``reset()``, and a
+      scene rebuild is neither, so it is snapshotted by body name before the
+      recompile and re-latched after.
+    * ``qfrc_applied``, its joint-space sibling, is deliberately NOT carried
+      here: nothing in this package ever writes a non-zero value into it.
+      ``apply_force`` documents why it latches the per-body buffer instead (one
+      world-wide generalized-force vector has no slice that belongs to one
+      body), and no other caller touches it, so there is no value for the
+      recompile to lose and a carry here could only be exercised by writing the
+      buffer from outside the public API. A joint-force API added later must add
+      the carry with it -- ``_SceneState`` already carries this buffer on the
+      eject path, where it is free because that path snapshots joints anyway.
 
     Also re-discovers per-robot joint and actuator IDs (they may have shifted
     as new bodies were inserted earlier in the body tree). Returns True on


### PR DESCRIPTION
## Problem

#2370 landed a docstring on `_recompile_preserving_state` that enumerates what `spec.recompile` carries and what it does not. One sentence in it is false:

> One buffer is not transferred at all rather than only in its tail: `xfrc_applied` [...]

Two are. `spec.recompile` returns `qfrc_applied` entirely zeroed as well. Measured by growing a scene by one body, across the whole range this package supports (`mujoco>=3.5.0,<4.0.0`, lock at 3.10.0):

| mujoco | `qpos` | `qvel` | `ctrl` | `time` | `qfrc_applied` | `xfrc_applied` |
|---|---|---|---|---|---|---|
| 3.5.0 (declared floor) | carried | carried | carried | carried | **zeroed** | **zeroed** |
| 3.10.0 (locked) | carried | carried | carried | carried | **zeroed** | **zeroed** |
| 3.11.0 | carried | carried | carried | carried | **zeroed** | **zeroed** |

Confirmed end to end on `main` through the public API -- `create_world` / `add_object` / `apply_force`, then an unrelated `add_camera()`:

```
before rebuild   xfrc_applied[puck] = [12.  -3.   5.   0.4  0.2 -0.1]
before rebuild   qfrc_applied       = [1. 2. 3. 4. 5. 6.]
after add_camera xfrc_applied[puck] = [12.  -3.   5.   0.4  0.2 -0.1]   <- carried, #2370's fix working
after add_camera qfrc_applied       = [0. 0. 0. 0. 0. 0.]               <- zeroed
```

#2370's description carried the same error in its Scope section ("`qpos`/`qvel`/`qfrc_applied` are carried by the recompile"), and that description is where the claim came from.

## Why a docstring sentence is worth a PR

This docstring is where the recompile's carry contract is enumerated, so a reader who needs to know whether a buffer survives a rebuild comes to that list and stops. As written it says `qfrc_applied` is either carried or unproblematic, which is neither true nor the reason it is safe.

It had already cost something. I opened a second PR (#2373, now closed) to carry a buffer that has no writer, having believed this sentence and then measured against it. The next person to ask the same question either re-derives the measurement or trusts the list.

## Change

One docstring, no code. The list now names both buffers and separates them by what is actually different about them -- whether a caller can put a value in:

* **`xfrc_applied` is carried**, because `apply_force` latches a wrench there and documents it as holding until the next `apply_force` on that body or a `reset()`. That is #2370's fix, unchanged.
* **`qfrc_applied` is deliberately not carried**, because nothing in this package ever writes a non-zero value into it. `apply_force` documents why it latches the per-body buffer instead (a world-wide generalized-force vector has no slice that belongs to one body), and no other caller touches it. The only writes anywhere in the tree are tests poking `data.qfrc_applied` directly. So there is no value for the recompile to lose, and a carry on this path could only be exercised by writing the buffer from outside the public API.

The note records the condition under which that stops being true, which is the part worth keeping: **a joint-force API added later must add the carry with it.** `_SceneState` already carries the buffer on the eject path, where it is free because that path snapshots joints anyway -- so the asymmetry between the two rebuild paths is now explained rather than latent.

## Scope

No behaviour change; `git diff --stat` is one file, docstring lines only. The classification stays exactly as #2370 shipped and was approved.

No changelog fragment: `changelog.d/README.md` scopes fragments to behavioural changes ("It is fragments, not the log, that behavioural PRs write to"), and this changes no behaviour and no public surface -- `_recompile_preserving_state` is module-private.

Deliberately **not** pinned by a test. The only assertion available would be "the upstream library still drops this buffer", which fails the day MuJoCo starts carrying it and guards no in-package behaviour that could regress. The version table above is the artifact, and the docstring is where it is kept.

## Verification

- `ruff check` / `ruff format --check` on the changed file: clean.
- `tests/simulation/mujoco/{test_scene_rebuild_carries_latched_wrench,test_scene_ops_guardrails,test_apply_force_per_body_latch,test_public_member_docstrings}.py`: **70 passed** (mujoco 3.11.0). The docstring guard suite is included because this PR only changes a docstring.
