### PR TITLE
fix(simulation/mujoco): carry a latched joint force across a scene grow

### DIFF
--- a/changelog.d/2380-carry-joint-forces-across-a-scene-grow.md
+++ b/changelog.d/2380-carry-joint-forces-across-a-scene-grow.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Simulation (MuJoCo)**: a generalized force latched in `qfrc_applied` is no longer dropped when the scene grows. `spec.recompile` carries neither applied-force buffer, and while `xfrc_applied` is snapshotted by name across a rebuild, `qfrc_applied` was not - so the same latched force survived `remove_robot` (0.5 N m kept) and vanished on `add_object`, `add_camera` or `add_robot` (0.0), under a `"status": "success"`. Both buffers are now carried across both rebuild directions.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -283,6 +283,70 @@ def _snapshot_body_wrenches(model: Any, data: Any, mj: Any) -> dict[str, list[fl
     return wrenches
 
 
+def _snapshot_joint_forces(model: Any, data: Any, mj: Any) -> dict[_JointKey, list[float]]:
+    """Capture every latched generalized force, keyed by joint.
+
+    The joint-space sibling of :func:`_snapshot_body_wrenches`. ``spec.recompile``
+    drops ``qfrc_applied`` for the same reason it drops ``xfrc_applied`` -- it
+    carries neither applied-force buffer -- so a grow needs this pass just as the
+    eject does. Keyed the same way as :class:`_SceneState`'s joints, because a
+    rebuild renumbers dofs. Only non-zero slices are captured: all-zero is "no
+    force latched here", which a fresh allocation already holds.
+
+    Args:
+        model: The compiled model the slices are being read against.
+        data: The ``MjData`` holding the latched forces.
+        mj: The resolved ``mujoco`` module.
+
+    Returns:
+        ``joint key -> qfrc_applied`` slice, at the dof width the joint uses.
+    """
+    forces: dict[_JointKey, list[float]] = {}
+    for jid in range(int(model.njnt)):
+        key = _joint_key(model, jid, mj)
+        if key is None:
+            continue
+        dof_adr = int(model.jnt_dofadr[jid])
+        _, dof_w = _joint_state_widths(int(model.jnt_type[jid]), mj)
+        row = data.qfrc_applied[dof_adr : dof_adr + dof_w]
+        if not row.any():
+            continue
+        forces[key] = [float(x) for x in row]
+    return forces
+
+
+def _restore_joint_forces(model: Any, data: Any, forces: dict[_JointKey, list[float]], mj: Any) -> None:
+    """Re-apply ``forces`` to the joints that still answer to those keys.
+
+    A joint the rebuilt model no longer has is skipped: its absence is the point
+    of a rebuild that removed it. A joint whose type changed is skipped rather
+    than written with a mismatched slice, which would put one dof's force on
+    another.
+
+    Args:
+        model: The rebuilt compiled model.
+        data: The rebuilt ``MjData`` receiving the forces.
+        forces: A snapshot from :func:`_snapshot_joint_forces`.
+        mj: The resolved ``mujoco`` module.
+    """
+    for key, vals in forces.items():
+        jid = _resolve_joint_key(model, key, mj)
+        if jid < 0:
+            continue
+        _, dof_w = _joint_state_widths(int(model.jnt_type[jid]), mj)
+        if len(vals) != dof_w:
+            logger.warning(
+                "_restore_joint_forces: dof width mismatch for %r (%d!=%d), skipping",
+                key,
+                len(vals),
+                dof_w,
+            )
+            continue
+        dof_adr = int(model.jnt_dofadr[jid])
+        for i, v in enumerate(vals):
+            data.qfrc_applied[dof_adr + i] = v
+
+
 def _restore_body_wrenches(model: Any, data: Any, wrenches: dict[str, list[float]], mj: Any) -> None:
     """Re-latch ``wrenches`` onto the bodies that still carry those names.
 
@@ -325,6 +389,13 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
       model on any step where a single entry is non-finite, so one uninitialized
       entry can silently release every held pose in the scene, only on the runs
       where the leftover memory happens to be NaN.
+    * ``qfrc_applied`` and ``xfrc_applied`` -- ``spec.recompile`` transfers
+      neither applied-force buffer at all, so unlike the buffers above these are
+      not a tail problem: every entry is lost, including the slices of joints and
+      bodies that never moved. Both are therefore snapshotted by name before the
+      recompile and re-applied after it, rather than merely having a tail
+      defined. A force a caller latched otherwise stopped acting the moment
+      anything entered the scene, under a ``"status": "success"``.
     * ``qpos`` -- a new joint that no name-keyed pass reaches keeps the tail as
       its pose. The robot-scoped reset in
       :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine._reset_robot_to_reference`
@@ -367,14 +438,12 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
     old_nv = int(world._model.nv) if world._model is not None else 0
     old_nu = int(world._model.nu) if world._model is not None else 0
     old_na = int(world._model.na) if world._model is not None else 0
-    # ``spec.recompile`` carries no part of ``xfrc_applied`` -- the whole buffer
-    # comes back zero -- so the latched wrenches are read off the outgoing data
-    # here and re-latched by name below.
-    wrenches = (
-        _snapshot_body_wrenches(world._model, world._data, mj)
-        if world._model is not None and world._data is not None
-        else {}
-    )
+    # ``spec.recompile`` carries no part of EITHER applied-force buffer -- both
+    # ``xfrc_applied`` and ``qfrc_applied`` come back zero -- so the latched
+    # forces are read off the outgoing data here and re-applied by name below.
+    _have_state = world._model is not None and world._data is not None
+    wrenches = _snapshot_body_wrenches(world._model, world._data, mj) if _have_state else {}
+    joint_forces = _snapshot_joint_forces(world._model, world._data, mj) if _have_state else {}
     try:
         with filter_mujoco_attach_noise():
             new_model, new_data = spec.recompile(world._model, world._data)
@@ -398,8 +467,9 @@ def _recompile_preserving_state(world: SimWorld, spec: Any, *, raise_on_refusal:
         new_data.ctrl[old_nu:] = 0.0
     if new_model.na > old_na:
         new_data.act[old_na:] = 0.0
-    # Re-latch the external wrenches, before the forward pass reads them.
+    # Re-apply the latched external forces, before the forward pass reads them.
     _restore_body_wrenches(new_model, new_data, wrenches, mj)
+    _restore_joint_forces(new_model, new_data, joint_forces, mj)
     # Forward pass so newly-injected bodies have valid xpos/xquat and any
     # camera xforms are populated. Without this, the next render() call
     # after add_object / add_robot / add_camera returns a 100% black frame
@@ -1162,7 +1232,10 @@ class _SceneState:
             wrench :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
             latches in a body's own ``xfrc_applied`` row. ``qfrc_applied``
             above is its joint-space sibling; both are part of the state
-            ``save_state`` checkpoints, so both are carried.
+            ``save_state`` checkpoints, so both are carried -- on the eject path
+            by this snapshot, and on the grow path by
+            :func:`_snapshot_joint_forces` and :func:`_snapshot_body_wrenches`,
+            since ``spec.recompile`` carries neither.
         time: ``data.time``, the clock the physics reads.
     """
 

--- a/tests/simulation/mujoco/test_scene_grow_preserves_joint_forces.py
+++ b/tests/simulation/mujoco/test_scene_grow_preserves_joint_forces.py
@@ -1,0 +1,185 @@
+"""A generalized force latched before the scene GROWS is still applied after it.
+
+``spec.recompile`` transfers ``qpos``, ``qvel``, ``ctrl``, ``act`` and the clock
+but neither applied-force buffer, so both have to be carried across a grow by
+name. ``xfrc_applied`` already is. ``qfrc_applied`` was not, which left it
+carried when the scene SHRINKS (``eject_robot_from_scene`` snapshots it with the
+rest of the joint state) and dropped when the scene GROWS -- so the same latched
+force survived ``remove_robot`` and vanished on ``add_object``.
+
+That asymmetry also made ``_SceneState``'s own claim about the two buffers
+("both are part of the state ``save_state`` checkpoints, so both are carried")
+true on one path and not the other, and it is the reason this is a defect rather
+than a design question: ``save_state`` checkpoints ``qfrc_applied`` precisely so
+a restore reinstates "latched external forces, not just positions".
+
+The force is measured by its EFFECT, from rest. A joint that is already turning
+keeps turning once its drive is gone, so an angle that merely kept increasing
+would not distinguish a live force from momentum.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# A hinge with no actuator and no damping: only ``qfrc_applied`` can turn it.
+_HINGE_XML = """
+<mujoco model="hinge_only">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="link" pos="0 0 0.1">
+      <joint name="spin" type="hinge" axis="0 0 1"/>
+      <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_TORQUE = 0.5
+_STEPS = 50
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="devx_grow_joint_forces", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+def _spinner(sim: Simulation, tmp_path) -> None:
+    path = tmp_path / "hinge_only.xml"
+    path.write_text(_HINGE_XML)
+    assert sim.create_world(gravity=[0.0, 0.0, 0.0])["status"] == "success"
+    assert sim.add_robot(name="spinner", urdf_path=str(path))["status"] == "success"
+
+
+def _handles(sim: Simulation):
+    world = sim._world
+    assert world is not None and world._model is not None and world._data is not None
+    mj = sim._mj
+    jid = mj.mj_name2id(world._model, mj.mjtObj.mjOBJ_JOINT, "spinner/spin")
+    assert jid >= 0, "joint 'spinner/spin' missing from the compiled model"
+    return mj, world._model, world._data, jid
+
+
+def _latched_torque(sim: Simulation) -> float:
+    _, model, data, jid = _handles(sim)
+    return float(data.qfrc_applied[int(model.jnt_dofadr[jid])])
+
+
+def _latch(sim: Simulation, value: float = _TORQUE) -> None:
+    _, model, data, jid = _handles(sim)
+    data.qfrc_applied[int(model.jnt_dofadr[jid])] = value
+
+
+def _turn_from_rest(sim: Simulation) -> float:
+    """Angle swept in ``_STEPS`` starting from zero velocity.
+
+    Zeroing the velocity first is what makes this a measurement of the force
+    rather than of momentum the joint already carried.
+    """
+    mj, model, data, jid = _handles(sim)
+    data.qvel[int(model.jnt_dofadr[jid])] = 0.0
+    mj.mj_forward(model, data)
+    start = float(data.qpos[int(model.jnt_qposadr[jid])])
+    assert sim.step(_STEPS)["status"] == "success"
+    _, model, data, jid = _handles(sim)
+    return float(data.qpos[int(model.jnt_qposadr[jid])]) - start
+
+
+class TestALatchedJointForceSurvivesAGrow:
+    """The grow path must carry ``qfrc_applied`` as the eject path already does."""
+
+    @pytest.mark.parametrize(
+        "grow",
+        [
+            pytest.param(lambda s, t: s.add_object(name="crate", shape="box", position=[1, 0, 0.1]), id="add_object"),
+            pytest.param(
+                lambda s, t: s.add_camera(name="extra", position=[1, -1, 1], target=[0, 0, 0]), id="add_camera"
+            ),
+        ],
+    )
+    def test_the_joint_keeps_being_driven(self, sim, tmp_path, grow):
+        _spinner(sim, tmp_path)
+        _latch(sim)
+        baseline = _turn_from_rest(sim)
+        assert baseline > 1e-4, f"premise: the torque turns the joint before any grow (got {baseline})"
+        _latch(sim)  # the sweep above consumed no force, but re-latch to be explicit
+
+        assert grow(sim, tmp_path)["status"] == "success"
+
+        assert _latched_torque(sim) == pytest.approx(_TORQUE), (
+            "spec.recompile drops qfrc_applied, so a latched joint torque stopped "
+            "driving the joint as soon as anything entered the scene"
+        )
+        assert _turn_from_rest(sim) == pytest.approx(baseline, rel=1e-6)
+
+    def test_it_survives_a_grow_that_adds_a_robot(self, sim, tmp_path):
+        _spinner(sim, tmp_path)
+        _latch(sim)
+        baseline = _turn_from_rest(sim)
+        assert baseline > 1e-4, "premise: the torque turns the joint"
+        _latch(sim)
+
+        path = tmp_path / "hinge_only.xml"
+        assert sim.add_robot(name="newcomer", urdf_path=str(path), position=[1, 0, 0])["status"] == "success"
+
+        assert _latched_torque(sim) == pytest.approx(_TORQUE)
+        assert _turn_from_rest(sim) == pytest.approx(baseline, rel=1e-6)
+
+    def test_the_two_rebuild_directions_now_agree(self, sim, tmp_path):
+        """The point of the fix: shrink already carried it, grow did not."""
+        _spinner(sim, tmp_path)
+        path = tmp_path / "hinge_only.xml"
+        assert sim.add_robot(name="doomed", urdf_path=str(path), position=[1, 0, 0])["status"] == "success"
+        _latch(sim)
+
+        assert sim.remove_robot("doomed")["status"] == "success"
+        after_shrink = _latched_torque(sim)
+        assert sim.add_object(name="crate", shape="box", position=[1, 0, 0.1])["status"] == "success"
+        after_grow = _latched_torque(sim)
+
+        assert after_grow == pytest.approx(after_shrink), (
+            f"a rebuild that shrinks the scene kept {after_shrink} but one that grows it "
+            f"kept {after_grow}; the same latched force must survive both"
+        )
+
+
+class TestTheRestoreDoesNotReachPastTheDefect:
+    """Controls: these hold before the fix as well."""
+
+    def test_a_scene_with_no_latched_force_is_untouched(self, sim, tmp_path):
+        _spinner(sim, tmp_path)
+
+        assert sim.add_object(name="crate", shape="box", position=[1, 0, 0.1])["status"] == "success"
+
+        _, _, data, _ = _handles(sim)
+        assert not data.qfrc_applied.any(), "a scene nobody applied a force to gained one"
+
+    def test_a_new_joint_is_not_given_someone_elses_force(self, sim, tmp_path):
+        _spinner(sim, tmp_path)
+        _latch(sim)
+        path = tmp_path / "hinge_only.xml"
+
+        assert sim.add_robot(name="newcomer", urdf_path=str(path), position=[1, 0, 0])["status"] == "success"
+
+        mj, model, data, _ = _handles(sim)
+        jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "newcomer/spin")
+        assert jid >= 0
+        assert float(data.qfrc_applied[int(model.jnt_dofadr[jid])]) == 0.0, (
+            "the newcomer's joint inherited the force latched on another robot"
+        )
+
+    def test_a_reset_still_clears_it(self, sim, tmp_path):
+        _spinner(sim, tmp_path)
+        _latch(sim)
+
+        assert sim.reset()["status"] == "success"
+
+        assert _latched_torque(sim) == 0.0, "reset must still clear a latched joint force"


### PR DESCRIPTION
Follow-up to #2370, for the one applied-force cell it left uncarried.

## Problem

`spec.recompile` transfers `qpos`, `qvel`, `ctrl`, `act` and the clock but **neither** applied-force buffer. Measured on MuJoCo 3.5, growing a two-body scene by one body:

```
qpos CARRIED   qvel CARRIED   ctrl CARRIED   act CARRIED   time CARRIED
qfrc_applied DROPPED    xfrc_applied DROPPED
```

#2370 carries `xfrc_applied` across both rebuild directions. `qfrc_applied` is still dropped on the grow path, so the same latched generalized force survives a rebuild that **shrinks** the scene - `eject_robot_from_scene` snapshots it with the rest of the joint state - and vanishes on one that **grows** it:

```
latch qfrc_applied = 0.5 N m on 'spinner/spin'
remove_robot('doomed')  -> 0.5   kept
add_object('crate')     -> 0.0   dropped
```

A hinge under that torque stops turning the moment anything enters the scene, under a `"status": "success"`. Unlike the buffers `spec.recompile` does carry, this is not a tail problem, so `_recompile_preserving_state`'s tail initialization cannot help: every entry is lost, including the slices of joints that never moved.

The asymmetry also leaves #2370's new `_SceneState` docstring true on one path and false on the other:

> `qfrc_applied` above is its joint-space sibling; both are part of the state `save_state` checkpoints, so both are carried.

`save_state` does checkpoint `qfrc_applied`, precisely so a restore reinstates "latched external forces, not just positions" - which is why this is a defect rather than a design question.

## Change

Adds the joint-space siblings of #2370's helpers, `_snapshot_joint_forces` and `_restore_joint_forces`, called from the same seam in `_recompile_preserving_state`. Keyed the way `_SceneState` already keys joints, because a rebuild renumbers dofs. Only non-zero slices are carried, so a scene with no latched force is untouched and the restore is a no-op there. A joint whose type changed is skipped rather than written with a mismatched slice. The two docstrings that describe the pair are corrected to say which path carries what.

## Verification

The force is measured by its **effect, from rest**. This matters: a joint that is already turning keeps turning once its drive is gone, so an angle that merely kept increasing would not distinguish a live force from momentum. Zeroing the velocity first is what makes the assertion about the force.

`tests/simulation/mujoco/test_scene_grow_preserves_joint_forces.py` against `main` (`eff27242`, i.e. with #2370 already in) vs this branch: **4 failed / 3 passed -> 7 passed**.

```
FAILED ...::test_the_joint_keeps_being_driven[add_object]
FAILED ...::test_the_joint_keeps_being_driven[add_camera]
  spec.recompile drops qfrc_applied, so a latched joint torque stopped driving
  the joint as soon as anything entered the scene
FAILED ...::test_it_survives_a_grow_that_adds_a_robot
FAILED ...::test_the_two_rebuild_directions_now_agree
  a rebuild that shrinks the scene kept 0.5 but one that grows it kept 0.0;
  the same latched force must survive both
```

The 3 that pass on both trees are the no-overreach controls: a scene with no latched force gains none, a newly added robot's joint does **not** inherit the force latched on another robot, and `reset()` still clears it.

`tests/simulation`, same interpreter (MuJoCo 3.5, lerobot 0.6.2), run sequentially:

| | passed | failed |
|---|---|---|
| `main` (`eff27242`) | 10884 | 1 |
| this branch | 10892 | 0 |

The counts reconcile exactly: `10884 + 1 = 10885` vs `10892` is `+7`, the new tests. That single failure on `main` did not reproduce on an isolated re-run of the same selection, so I am reporting it as a flake rather than claiming this PR fixes it. `ruff check`, `ruff format --check` and `mypy strands_robots tests tests_integ` are clean over the CI scope (18 pre-existing errors, unchanged).

No visual artifact: this is the joint-space half of a buffer whose user-visible rollout #2370 already demonstrated, and `qfrc_applied` has no public setter today (it is reached through `save_state`/`load_state`), so the honest demonstration is the numeric asymmetry above rather than a rendered scene.
