### PR TITLE
fix(policies): make an explicit CompositePolicy joint group exclusive on every tick

### DIFF
--- a/changelog.d/2385-composite-explicit-group-ownership.md
+++ b/changelog.d/2385-composite-explicit-group-ownership.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- `CompositePolicy` now treats an explicit `upper_joints` group as exclusive on every tick.
+  A defaulted `lower_joints` kept every name the lower policy emits, so a lower policy whose
+  action space reached the upper group also commanded it: when the upper policy emitted that
+  name too the merge raised, and when it was silent on it the lower policy's value was
+  written to a joint the caller had assigned away, reported as success. The lower policy
+  commanding into an explicit upper group is now refused whether or not the upper policy
+  emits that name, naming the contested joints, both policies and the remedy. Precedence
+  between two defaulted groups is unchanged, and `WBCPolicy` emits no arm joints so the
+  shipped locomotion pairing is unaffected.

--- a/strands_robots/policies/composite.py
+++ b/strands_robots/policies/composite.py
@@ -67,6 +67,12 @@ class CompositePolicy(Policy):
       every name it emits that the lower policy did not already claim - lower
       precedence).
 
+    An explicit group is EXCLUSIVE: the policy it names is the only one allowed to
+    command those joints. A defaulted ``lower_joints`` therefore still may not
+    command into an explicit ``upper_joints`` - that tick is refused, on every tick
+    alike, rather than resolved by whichever child emitted the name. Precedence
+    only decides between two DEFAULTED groups, where the caller declared no owner.
+
     Routing that discards a child's ENTIRE action dict raises: the composite
     would otherwise silently be the surviving child alone. Two children that
     drive the same joint set cannot be composed, only cascaded (module docstring).
@@ -81,10 +87,13 @@ class CompositePolicy(Policy):
         lower: Policy driving the lower joint group (e.g. legs+waist locomotion).
         upper: Policy driving the upper joint group (e.g. arms manipulation).
         lower_joints: Joint/actuator names the lower policy is authoritative for.
-            ``None`` (default) accepts every name the lower policy emits.
+            ``None`` (default) accepts every name the lower policy emits, minus
+            any that ``upper_joints`` assigns to the upper policy - commanding
+            into an explicit upper group is refused, not silently resolved.
         upper_joints: Joint/actuator names the upper policy is authoritative for.
-            ``None`` (default) accepts every upper name not already owned by the
-            lower policy.
+            Exclusive: no other child may command these, whichever names the upper
+            policy emits on a given tick. ``None`` (default) accepts every upper
+            name not already owned by the lower policy.
         lower_obs_keys: Observation keys to forward to the lower policy. ``None``
             (default) forwards the full observation (children read by name).
         upper_obs_keys: Observation keys to forward to the upper policy. ``None``
@@ -208,8 +217,8 @@ class CompositePolicy(Policy):
         Raises:
             ValueError: If either child returns an empty chunk, if routing
                 discards a child's entire action dict (the composite would be
-                the other child alone), or if the routed lower and upper action
-                dicts both assign the same joint name.
+                the other child alone), or if the lower policy commands a joint
+                ``upper_joints`` assigns to the upper policy.
         """
         lower_obs = self._filter_obs(observation_dict, self._lower_obs_keys)
         upper_obs = self._filter_obs(observation_dict, self._upper_obs_keys)
@@ -239,13 +248,7 @@ class CompositePolicy(Policy):
         up = self._route(upper_action, self._upper_joints, exclude=None if self._upper_joints else set(lo))
         self._reject_discarded_child("lower", self._lower, lower_action, lo, self._lower_joints, set())
         self._reject_discarded_child("upper", self._upper, upper_action, up, self._upper_joints, set(lo))
-        collision = set(lo) & set(up)
-        if collision:
-            raise ValueError(
-                "CompositePolicy: lower and upper policies both produced joint(s) "
-                f"{sorted(collision)}. Set lower_joints / upper_joints so each joint "
-                "is driven by exactly one policy."
-            )
+        self._reject_contested_upper_ownership(lo)
         lo.update(up)
         return lo
 
@@ -300,6 +303,53 @@ class CompositePolicy(Policy):
             "locomotion legs+waist plus manipulation arms); it does not feed one policy's targets "
             "into another policy. Give each joint exactly one owner via lower_joints / "
             "upper_joints, or drive the whole body with a single policy."
+        )
+
+    def _reject_contested_upper_ownership(self, lo: dict[str, Any]) -> None:
+        """Refuse a tick in which the lower policy commands an upper-owned joint.
+
+        ``upper_joints`` names the joints the upper policy is authoritative for. A
+        defaulted ``lower_joints`` keeps every name the lower policy emits, so a
+        lower policy whose action space covers the whole robot (a whole-body
+        kinematic generator emits all 29 G1 joints) also commands the names the
+        caller assigned to the upper policy. Which value reached the actuator then
+        depended on whether the upper policy happened to emit that name on this
+        tick: when it did, the merge raised; when it did not, the lower policy's
+        value was written to a joint the caller had given away, with no error. One
+        configuration, two outcomes, chosen per tick by the upper policy's chunk
+        contents.
+
+        Refusing on the condition that is actually ambiguous - the lower policy
+        commanding into an explicit upper group - is the same answer on every tick.
+        Dropping the lower policy's value instead would leave that joint on its
+        previous command with nothing to say so, which is the silent dropped
+        command this class raises on everywhere else.
+
+        Only an explicit ``upper_joints`` can be contested: with it defaulted the
+        upper dict is routed with the lower's names excluded, so the two dicts are
+        disjoint by construction and there is nothing to arbitrate.
+
+        Args:
+            lo: The routed lower action dict for this tick.
+
+        Raises:
+            ValueError: If the lower policy commanded any name ``upper_joints``
+                assigns to the upper policy.
+        """
+        if self._upper_joints is None:
+            return
+        contested = set(lo) & self._upper_joints
+        if not contested:
+            return
+        raise ValueError(
+            f"CompositePolicy: upper_joints assigns joint(s) {sorted(contested)} to the upper "
+            f"policy '{self._upper.provider_name}', but the lower policy "
+            f"'{self._lower.provider_name}' also commanded them this tick. An explicit joint "
+            "group is exclusive - the policy that owns a name is the only one allowed to "
+            "command it, whether or not the other child emits that name on a given tick. Set "
+            "lower_joints so the lower policy does not command into the upper group (e.g. "
+            "lower_joints=WBC_G1_LEG_WAIST_JOINTS for a G1 locomotion policy), or remove those "
+            "names from upper_joints."
         )
 
     @staticmethod

--- a/tests/policies/test_composite.py
+++ b/tests/policies/test_composite.py
@@ -137,13 +137,14 @@ class TestErrorPaths:
         with pytest.raises(ValueError, match="both a 'lower' and an 'upper'"):
             CompositePolicy(None, MockPolicy())  # type: ignore[arg-type]
 
-    def test_runtime_collision_raises(self):
-        # Default routing with lower precedence cannot collide; force a collision
-        # by making the upper group explicitly claim a name the lower also emits.
+    def test_lower_commanding_an_upper_owned_joint_raises(self):
+        # Two defaulted groups cannot contest a name (the upper dict is routed with
+        # the lower's names excluded), so reach the ownership branch the way it is
+        # reachable: an explicit upper group claiming a name the lower also emits.
         lower = StubPolicy([{"hip": 1.0, "shoulder": 5.0}])
         upper = StubPolicy([{"shoulder": 2.0}])
         c = CompositePolicy(lower, upper, upper_joints=["shoulder"])
-        with pytest.raises(ValueError, match="both produced joint"):
+        with pytest.raises(ValueError, match="also commanded them this tick"):
             _run(c)
 
     def test_empty_lower_chunk_raises(self):

--- a/tests/policies/test_composite_explicit_group_ownership.py
+++ b/tests/policies/test_composite_explicit_group_ownership.py
@@ -1,0 +1,144 @@
+"""An explicit CompositePolicy joint group is exclusive, on every tick alike.
+
+``upper_joints`` names the joints the upper policy is authoritative for. A
+defaulted ``lower_joints`` keeps every name the lower policy emits, so a lower
+policy whose action space covers the whole robot also commands the names the
+caller assigned to the upper policy. Which value reached the actuator was then
+decided per tick by the upper policy's chunk contents::
+
+    c = CompositePolicy(whole_body, arms, upper_joints=["armA", "armB"])
+
+    c._merge_tick({"leg": 1.0, "armB": 9.9}, {"armA": 0.5, "armB": 0.5})
+    # -> ValueError: both produced joint(s) ['armB']
+
+    c._merge_tick({"leg": 1.0, "armB": 9.9}, {"armA": 0.5})
+    # -> {'leg': 1.0, 'armB': 9.9, 'armA': 0.5}
+    #                  ^^^^^^^^^^ armB is the upper policy's, driven by the lower
+    #                             policy, status success, no warning
+
+One configuration, two outcomes in different KINDS - crash or wrong actuator
+command - chosen by whether the upper policy's chunk happened to cover that joint
+on that tick. A chunk-emitting manipulation policy is silent on some of its own
+joints on most ticks, so both outcomes occur within one rollout.
+
+These pin that the lower policy may not command into an explicit upper group at
+all, so the answer is the same on every tick, plus the boundaries: precedence
+still arbitrates two DEFAULTED groups (where the caller declared no owner), and
+the disjoint splits every doc and example uses are untouched.
+"""
+
+import pytest
+
+from strands_robots.policies import CompositePolicy
+from strands_robots.policies.wbc.policy import WBC_G1_ALL_JOINTS, WBC_G1_LEG_WAIST_JOINTS
+from tests.policies.test_composite import StubPolicy, _run
+
+G1_ARM_JOINTS = [j for j in WBC_G1_ALL_JOINTS if j not in set(WBC_G1_LEG_WAIST_JOINTS)]
+
+
+def _outcome(lower_tick: dict, upper_tick: dict, **groups) -> tuple[str, object]:
+    """Run one tick through the public path; report the kind of answer it gave."""
+    c = CompositePolicy(StubPolicy([dict(lower_tick)]), StubPolicy([dict(upper_tick)]), **groups)
+    try:
+        return ("merged", _run(c)[0])
+    except ValueError as exc:
+        return ("refused", str(exc))
+
+
+class TestAnExplicitUpperGroupIsExclusive:
+    """The lower policy may not command a joint ``upper_joints`` gave to the upper."""
+
+    def test_the_answer_does_not_depend_on_what_upper_emitted_this_tick(self):
+        """One config, two ticks: the same ownership question gets the same answer.
+
+        The only difference between the ticks is whether the upper policy emitted
+        ``armB`` - a property of its chunk, not of the ownership the caller
+        declared. It must not decide who drives ``armB``.
+        """
+        lower_tick = {"leg": 1.0, "armB": 9.9}
+        groups = {"upper_joints": ["armA", "armB"]}
+        silent_on_armb = _outcome(lower_tick, {"armA": 0.5}, **groups)
+        emits_armb = _outcome(lower_tick, {"armA": 0.5, "armB": 0.5}, **groups)
+        assert silent_on_armb[0] == emits_armb[0], (
+            f"the same composite answered {silent_on_armb[0]!r} when the upper policy was silent "
+            f"on its own joint 'armB' and {emits_armb[0]!r} when it emitted it; the silent tick "
+            f"returned {silent_on_armb[1]!r}"
+        )
+
+    def test_the_lower_policy_never_drives_a_joint_upper_explicitly_owns(self):
+        """An upper-owned joint carries the upper policy's value or the tick is refused."""
+        kind, payload = _outcome({"leg": 1.0, "armB": 9.9}, {"armA": 0.5}, upper_joints=["armA", "armB"])
+        assert kind == "refused", (
+            f"'armB' is assigned to the upper policy, which did not command it this tick, "
+            f"yet the merged action drives it with the lower policy's value: {payload!r}"
+        )
+
+    def test_a_whole_body_lower_overlapping_the_arm_group_is_still_refused(self):
+        """A lower policy that commands every arm joint every tick stays refused.
+
+        The whole-body kinematic generators emit all 29 G1 joints, so they command
+        the upper policy's whole group on every tick and therefore always overlap
+        whatever the upper policy emits. That case was already refused - it is the
+        tick where the two emitted sets happen NOT to overlap that went silently
+        wrong - so this pins that the refusal survives.
+        """
+        lower = StubPolicy([{j: -0.9 for j in WBC_G1_ALL_JOINTS}], name="whole_body")
+        upper = StubPolicy([{G1_ARM_JOINTS[0]: 0.3}], name="manipulation")
+        c = CompositePolicy(lower, upper, upper_joints=G1_ARM_JOINTS)
+        with pytest.raises(ValueError) as excinfo:
+            _run(c)
+        assert "upper_joints" in str(excinfo.value)
+
+    def test_the_refusal_names_the_contested_joint_the_owner_and_a_remedy(self):
+        """A refusal a caller can act on without reading the merge implementation."""
+        kind, message = _outcome(
+            {"leg": 1.0, "armB": 9.9},
+            {"armA": 0.5},
+            upper_joints=["armA", "armB"],
+        )
+        assert kind == "refused", message
+        assert "armB" in message, message  # the contested joint
+        assert "armA" not in message, message  # ... and not the uncontested one
+        assert "stub" in message  # both children, by provider name
+        assert "lower_joints" in message  # the remedy
+
+
+class TestTheBoundariesAreUnchanged:
+    """Only a lower policy commanding into an EXPLICIT upper group is refused."""
+
+    def test_two_defaulted_groups_are_still_arbitrated_by_lower_precedence(self):
+        """With no group declared there is no owner to honour, so precedence stands.
+
+        The upper policy's ``knee`` is still dropped in the lower policy's favour:
+        that is the documented default, not a contested explicit assignment.
+        """
+        kind, merged = _outcome({"hip": 1.0, "knee": 1.0}, {"knee": 2.0, "wrist": 2.0})
+        assert kind == "merged", merged
+        assert merged == {"hip": 1.0, "knee": 1.0, "wrist": 2.0}
+
+    def test_an_explicit_lower_group_with_a_defaulted_upper_is_unchanged(self):
+        """The mirror config never had the hole and gains no refusal."""
+        kind, merged = _outcome({"hip": 1.0, "wrist": 9.9}, {"wrist": 2.0}, lower_joints=["hip"])
+        assert kind == "merged", merged
+        assert merged == {"hip": 1.0, "wrist": 2.0}
+
+    def test_an_upper_group_the_lower_does_not_command_still_composes(self):
+        """Correct use of the very config that had the hole keeps working."""
+        kind, merged = _outcome({"leg": 1.0}, {"armA": 0.5, "armB": 0.5}, upper_joints=["armA", "armB"])
+        assert kind == "merged", merged
+        assert merged == {"leg": 1.0, "armA": 0.5, "armB": 0.5}
+
+    def test_the_shipped_locomotion_split_is_unaffected(self):
+        """A locomotion policy emits its own group only, so nothing is contested.
+
+        ``WBCPolicy`` emits its 15 leg+waist joints and none of the 14 arm joints,
+        so the pairing the class exists for does not reach the new refusal even
+        with ``lower_joints`` left default.
+        """
+        lower = StubPolicy([{j: -0.9 for j in WBC_G1_LEG_WAIST_JOINTS}], name="wbc")
+        upper = StubPolicy([{j: 0.3 for j in G1_ARM_JOINTS}], name="manipulation")
+        c = CompositePolicy(lower, upper, upper_joints=G1_ARM_JOINTS)
+        merged = _run(c)[0]
+        assert set(merged) == set(WBC_G1_ALL_JOINTS)
+        assert all(merged[j] == -0.9 for j in WBC_G1_LEG_WAIST_JOINTS)
+        assert all(merged[j] == 0.3 for j in G1_ARM_JOINTS)


### PR DESCRIPTION
## Problem

`CompositePolicy` documents `upper_joints` as "joint/actuator names the upper policy is
authoritative for". Nothing subtracted that group from the lower policy's route, so a
defaulted `lower_joints` kept **every** name the lower policy emits, including names the
caller had explicitly assigned to the upper policy.

Which value reached the actuator was then decided per tick by the upper policy's chunk
contents:

```python
c = CompositePolicy(whole_body, arms, upper_joints=["armA", "armB"])

# tick where the upper policy also emits armB
c._merge_tick({"leg": 1.0, "armB": 9.9}, {"armA": 0.5, "armB": 0.5})
# -> ValueError: both produced joint(s) ['armB']

# tick where the upper policy is silent on its own joint
c._merge_tick({"leg": 1.0, "armB": 9.9}, {"armA": 0.5})
# -> {'leg': 1.0, 'armB': 9.9, 'armA': 0.5}
#                  ^^^^^^^^^^ armB is the upper policy's by declaration, driven by the
#                             lower policy. status success, no warning, no log line.
```

One configuration, two outcomes in different **kinds** - refuse, or write a wrong actuator
target - selected by whether the upper policy's chunk happened to cover that joint. A
chunk-emitting manipulation policy is silent on some of its own joints on most ticks, so a
single rollout can produce both.

## The measurement

An exhaustive sweep of the four group configurations, over every non-empty lower/upper
emission pair on a 3-name joint set (49 pairs each, 196 total):

| configuration | conflict refused | silently drove an upper-owned joint | outcomes changed by this PR |
| --- | --- | --- | --- |
| both groups explicit | 0 | 0 | 0 of 49 |
| `lower_joints` only | 0 | 0 | 0 of 49 |
| **`upper_joints` only** | **35** | **8** | **8 of 49** |
| both defaulted | 0 | 0 | 0 of 49 |

`upper_joints`-only is the only configuration that can silently override an explicit
assignment, and it is also the only configuration from which the documented
ownership-conflict refusal was reachable at all. With either group defaulted the upper dict
is routed with the lower's names excluded; with both explicit the groups are disjoint at
construction. So the class's headline guarantee ("a genuine ownership conflict is raised,
never silently resolved") lived entirely inside the one configuration whose ownership was
ill-defined, where it fired on some ticks and not others.

All 8 changed outcomes are exactly the 8 that were silently wrong. No previously-correct
merge changes.

## Change

Refuse on the condition that is actually ambiguous - the lower policy commanding into an
explicit upper group - whether or not the upper policy emits that name this tick. The new
check subsumes the collision check it replaces (a contested name was only ever reachable
that way), so this is one refusal rather than two, and the answer is the same on every tick.

```
ValueError: CompositePolicy: upper_joints assigns joint(s) ['armB'] to the upper policy
'manipulation_upper', but the lower policy 'whole_body_lower' also commanded them this
tick. An explicit joint group is exclusive - the policy that owns a name is the only one
allowed to command it, whether or not the other child emits that name on a given tick. Set
lower_joints so the lower policy does not command into the upper group (e.g.
lower_joints=WBC_G1_LEG_WAIST_JOINTS for a G1 locomotion policy), or remove those names
from upper_joints.
```

### Why refuse rather than drop the lower policy's value

Silently filtering the lower policy's value out would leave that joint on its previous
command with nothing to say so - a dropped command, which is what this class raises on
everywhere else ("a dropped command on a humanoid is a fall, not a warning";
`_reject_discarded_child` exists for the same reason). Trading a wrong value for a missing
one keeps the failure silent. Refusing does not.

## Scope: what does not change

- **Precedence between two defaulted groups is untouched.** With no group declared there is
  no owner to honour, so the documented lower-precedence rule still arbitrates. Only an
  explicit assignment is enforced.
- **`lower_joints`-only is untouched.** The mirror configuration never had the hole.
- **The shipped locomotion pairing is unaffected.** `WBCPolicy` emits its 15 leg+waist
  joints and none of the 14 arm joints, so nothing is contested even with `lower_joints`
  left default - pinned as a test.
- **No shipped usage changes.** `examples/wbc/wbc_g1_composite.py`, `docs/policies/wbc.md`
  and the class docstring example all set both groups.

The class docstring, the `Args` entries and `get_actions`'s `Raises` are updated to state
that an explicit group is exclusive, since "authoritative for" and "accepts every name the
lower policy emits" disagreed in exactly this configuration.

## Tests

`tests/policies/test_composite_explicit_group_ownership.py`, **3 failed / 5 passed on
`main`, 8 passed after**. The headline test compares two ticks of one config and fails
pre-fix with the defect stated outright:

```
AssertionError: the same composite answered 'merged' when the upper policy was silent on
its own joint 'armB' and 'refused' when it emitted it; the silent tick returned
{'leg': 1.0, 'armB': 9.9, 'armA': 0.5}
```

The 5 that pass on both trees are the boundaries: defaulted-group precedence still applies,
`lower_joints`-only is unchanged, correct use of this very config still composes, a
whole-body lower that overlaps on every tick is still refused, and the WBC leg/arm split is
untouched.

`test_runtime_collision_raises` in `tests/policies/test_composite.py` is renamed to
`test_lower_commanding_an_upper_owned_joint_raises` and matches the new wording. Its intent
is unchanged - it reaches the ownership branch through the only configuration that reaches
it - and its comment now says so.

## Verification

- `tests/policies tests/registry` + the repo-wide docstring/ASCII/dependency guards: 5253
  passed, 3 skipped.
- `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ`.

## Rollout in MuJoCo sim (headless)

One capture script, one scene, one camera; only the tree on `PYTHONPATH` differs. The
manipulation policy owns both arms and its chunk covers only the left arm this tick, while
the locomotion policy's action space also reaches the right arm.

![CompositePolicy explicit group ownership](https://raw.githubusercontent.com/cagataycali/robots/media-composite-ownership/composite_ownership.png)

Left: `main` reports success for 29 joints and drives `right_shoulder_roll_joint` to
`-1.52`, the locomotion policy's value, on a joint the manipulation policy owns. Middle:
refused, nothing written. Right: with the remedy applied the right arm holds because its
declared owner chose not to command it - and that render is pixel-identical to `main`'s for
the same config (2.7e-06 mean absolute pixel difference), so the fix is a no-op once
ownership is unambiguous.
