### PR TITLE
fix(simulation/mujoco): export a scene whose asset references still resolve

### DIFF
--- a/changelog.d/2387-export-xml-portable-asset-refs.md
+++ b/changelog.d/2387-export-xml-portable-asset-refs.md
@@ -1,0 +1,10 @@
+### Fixed
+
+`export_xml` now writes a scene that can actually be reloaded. MuJoCo resolves a `<mesh>` /
+`<texture>` / `<hfield>` `file=` against a base directory it keeps on the spec and does not emit in
+`spec.to_xml()`, and `spec.attach()` does not carry that base onto the parent - so an exported scene
+named its assets relative to wherever the XML happened to be written, and neither
+`mujoco.MjModel.from_xml_path` nor `load_scene` could recompile it. A multi-robot scene had no single
+`meshdir` that could cover it, because each model contributes assets from its own root. Asset
+references are now absolutized while the loaded spec still knows its own base directory, so the
+exported MJCF is self-describing; a reference that resolves to nothing is left as authored.

--- a/docs/simulation/overview.md
+++ b/docs/simulation/overview.md
@@ -20,7 +20,7 @@ For walkthroughs see [Simulation overview](../simulation/overview.md).
 | `reset` | - | State to t=0, keep model |
 | `get_state` | - | Sim time, joint positions, object poses |
 | `destroy` | - | Tear down model, data, executor |
-| `export_xml` | - | Serialise model to MJCF string |
+| `export_xml` | `output_path` | Serialise live scene to MJCF; reloadable via `load_scene` (assets referenced by absolute path) |
 
 ## Scene-MJCF
 

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -507,6 +507,30 @@ pre-patch state, so a bad key or a non-finite component never leaves a
 half-applied scene. Use
 `replace_scene_mjcf(xml)` for MJCF elements this vocabulary does not cover.
 
+## Exporting a scene
+
+`export_xml(output_path=...)` serialises the live scene - including every runtime
+mutation - as MJCF. It is the read sibling of `replace_scene_mjcf`, so the file it
+writes is meant to be reloadable:
+
+```python
+sim.export_xml(output_path="/tmp/handoff.xml")
+other.load_scene(scene_path="/tmp/handoff.xml")   # same scene, same structure
+```
+
+Mesh, texture and height-field assets are referenced by ABSOLUTE path. MuJoCo
+resolves a relative `file=` against the model's own directory (plus `meshdir` /
+`texturedir`), and that directory is not part of the serialised XML - so a
+relative reference would resolve against wherever the export happened to be
+written. Absolute references keep the export reloadable from any location, and a
+scene composed from several models needs them: each model contributes assets from
+its own root, so no single `meshdir` could cover them all.
+
+The consequence is that an export names paths on the machine that produced it.
+Copying the XML alone to another machine will not carry the assets with it;
+copy the referenced asset trees too, or re-compose the scene there from the same
+`add_robot` calls.
+
 ## Cameras
 
 Free cameras look from `position` toward `target` (`fov=60.0`, `width=640`, `height=480`). Robot-URDF cameras (wrist, etc.) are auto-discovered on `add_robot` - no `add_camera` needed.

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -40,6 +40,61 @@ from strands_robots.simulation.terrain import (
 
 logger = logging.getLogger(__name__)
 
+
+def _absolutize_asset_paths(spec: Any) -> int:
+    """Rewrite a spec's file-backed asset references to absolute paths.
+
+    MuJoCo resolves a ``<mesh>`` / ``<hfield>`` / ``<texture>`` ``file=`` against
+    a base directory (the model file's own directory, plus ``meshdir`` /
+    ``texturedir``). That base is tracked on the spec as ``modelfiledir`` and is
+    NOT emitted by ``spec.to_xml()``, and ``spec.attach()`` does not carry it
+    onto the parent. So a spec whose assets are named relatively compiles fine
+    in the session that loaded it while serialising to an XML that resolves
+    those names against wherever the XML happens to be written - i.e. nowhere.
+    Rewriting each reference to an absolute path makes the spec self-describing,
+    so every consumer of ``to_xml()`` gets asset locations instead of an
+    implicit dependency on a directory the text never mentions.
+
+    MuJoCo honours an absolute ``file=`` regardless of any ``meshdir`` /
+    ``texturedir`` still declared, so those attributes are left untouched.
+
+    A reference is rewritten only when it is relative AND the resolved path
+    exists. An unresolvable reference is left exactly as authored: MuJoCo's own
+    "Error opening file" names the reference the model actually declares, which
+    is more useful than an invented absolute path that was never on disk.
+
+    Args:
+        spec: the ``MjSpec`` to repair in place.
+
+    Returns:
+        Number of asset references rewritten.
+    """
+    base = getattr(spec, "modelfiledir", "") or ""
+    rewritten = 0
+    # meshdir covers meshes AND height fields; textures have their own dir.
+    for assets, subdir in (
+        (spec.meshes, getattr(spec, "meshdir", "") or ""),
+        (spec.hfields, getattr(spec, "meshdir", "") or ""),
+        (spec.textures, getattr(spec, "texturedir", "") or ""),
+    ):
+        for asset in assets:
+            ref = asset.file or ""
+            if not ref or os.path.isabs(ref):
+                continue
+            resolved = os.path.abspath(os.path.join(base, subdir, ref))
+            if not os.path.isfile(resolved):
+                continue
+            asset.file = resolved
+            rewritten += 1
+    if rewritten:
+        logger.debug(
+            "absolutized %d asset reference(s) against %r so spec.to_xml() stays reloadable",
+            rewritten,
+            base,
+        )
+    return rewritten
+
+
 # Accepted keys of the ``add_object(material=...)`` spec. Single source of truth
 # shared by :func:`material_spec_error` and :meth:`SpecBuilder._build_material`.
 MATERIAL_KEYS: Final[frozenset[str]] = frozenset(
@@ -532,14 +587,23 @@ class SpecBuilder:
 
     @staticmethod
     def from_file(path: str) -> Any:
-        """Load an MJCF/URDF file as a fresh spec.
+        """Load an MJCF/URDF file as a fresh spec, with asset refs absolutized.
 
         MuJoCo 3.2+ reads URDF as well as MJCF via the same entry point - the
         file extension + XML root determines the path. Raises ``ValueError``
         on invalid files.
+
+        Every file-backed asset reference is rewritten to an absolute path via
+        :func:`_absolutize_asset_paths` before the spec is handed back, so the
+        spec carries its own asset locations instead of depending on a base
+        directory MuJoCo tracks separately and does not serialise. This is what
+        makes ``spec.to_xml()`` (and therefore ``export_xml``) reloadable from
+        anywhere; see that helper for why the repair belongs at load time.
         """
         mujoco = _ensure_mujoco()
-        return mujoco.MjSpec.from_file(str(path))
+        spec = mujoco.MjSpec.from_file(str(path))
+        _absolutize_asset_paths(spec)
+        return spec
 
     # object add
     @staticmethod
@@ -1026,7 +1090,13 @@ class SpecBuilder:
         """
         mujoco = _ensure_mujoco()
 
-        robot_spec = mujoco.MjSpec.from_file(str(robot_file_path))
+        # Loaded through SpecBuilder.from_file (not mujoco.MjSpec.from_file) so
+        # the child's file-backed asset references are absolutized while the
+        # child still knows its own base directory. ``spec.attach`` does not
+        # carry that directory onto the parent, so a child left with bare
+        # filenames would compile here and then serialise to an XML no one can
+        # reload - see _absolutize_asset_paths.
+        robot_spec = SpecBuilder.from_file(str(robot_file_path))
 
         # Strip the robot scene's own ground/floor plane(s) before attaching.
         # Many menagerie scenes (e.g. franka_emika_panda/scene.xml) ship a

--- a/tests/simulation/mujoco/test_export_xml_asset_refs_reload.py
+++ b/tests/simulation/mujoco/test_export_xml_asset_refs_reload.py
@@ -1,0 +1,233 @@
+"""``export_xml`` output must be reloadable, by MuJoCo and by strands itself.
+
+MuJoCo resolves a ``<mesh>`` / ``<texture>`` ``file=`` against a base directory
+it tracks on the spec (``modelfiledir`` plus ``meshdir`` / ``texturedir``) and
+does NOT emit in ``spec.to_xml()``; ``spec.attach()`` does not carry that base
+onto the parent either. A scene composed from model files therefore compiled and
+stepped normally while ``export_xml`` wrote asset references that resolve
+against wherever the XML landed - so the exported "canonical MJCF" could not be
+recompiled, by ``MjModel.from_xml_path`` or by ``load_scene``, even though
+``describe()`` advertises ``export_xml`` as "the read sibling of
+``replace_scene_mjcf``".
+
+A multi-robot scene has no single ``meshdir`` that could paper over it: each
+model contributes assets from its own root. The fix makes each reference carry
+its own absolute location, so the exported text is self-describing.
+
+The tests build their models on disk (a real one-triangle STL and a real PNG
+under a ``meshdir`` / ``texturedir``) so the reference genuinely needs resolving
+and nothing is downloaded.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.mujoco.spec_builder import SpecBuilder  # noqa: E402
+
+
+def _tetrahedron_stl() -> bytes:
+    """A minimal solid binary STL: MuJoCo requires at least 4 vertices.
+
+    Binary STL layout: 80-byte header, uint32 facet count, then 50 bytes per
+    facet (a normal and three vertices as float32, plus a uint16 attribute
+    word). The facet normals are left zero - MuJoCo derives its own.
+    """
+    corners = ((0.0, 0.0, 0.0), (0.1, 0.0, 0.0), (0.0, 0.1, 0.0), (0.0, 0.0, 0.1))
+    faces = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+    body = b"".join(struct.pack("<12fH", 0.0, 0.0, 0.0, *corners[a], *corners[b], *corners[c], 0) for a, b, c in faces)
+    return b"\x00" * 80 + struct.pack("<I", len(faces)) + body
+
+
+_STL = _tetrahedron_stl()
+
+
+def _dims(model: Any) -> tuple[int, ...]:
+    """Structural fingerprint of a compiled model, order-independent of naming."""
+    return (model.nbody, model.njnt, model.nu, model.nq, model.nv, model.ngeom)
+
+
+def _write_mesh_model(root: Path, *, meshdir: str = "assets") -> Path:
+    """Write a model whose mesh lives under *meshdir*, relative to the model."""
+    (root / meshdir).mkdir(parents=True, exist_ok=True)
+    (root / meshdir / "block.stl").write_bytes(_STL)
+    model = root / "arm.xml"
+    model.write_text(
+        f"""
+        <mujoco model="meshy">
+          <compiler meshdir="{meshdir}"/>
+          <asset><mesh name="block" file="block.stl"/></asset>
+          <worldbody>
+            <body name="link" pos="0 0 0.2">
+              <joint name="hinge" type="hinge" axis="0 1 0"/>
+              <geom name="visual" type="mesh" mesh="block"/>
+            </body>
+          </worldbody>
+          <actuator><position name="drive" joint="hinge" kp="20"/></actuator>
+        </mujoco>
+        """
+    )
+    return model
+
+
+def _write_texture_model(root: Path) -> Path:
+    """Write a model carrying a file-backed texture under its own texturedir."""
+    Image = pytest.importorskip("PIL.Image", reason="Pillow renders the test texture")
+    (root / "tex").mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), (200, 40, 40)).save(root / "tex" / "skin.png")
+    model = root / "painted.xml"
+    model.write_text(
+        """
+        <mujoco model="painted">
+          <compiler texturedir="tex"/>
+          <asset>
+            <texture name="skin" type="2d" file="skin.png"/>
+            <material name="painted" texture="skin"/>
+          </asset>
+          <worldbody>
+            <body name="slab" pos="0 0 0.3">
+              <joint name="slide" type="slide" axis="0 0 1"/>
+              <geom name="face" type="box" size="0.1 0.1 0.1" material="painted"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+    )
+    return model
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="export_assets", mesh=False)
+    try:
+        yield s
+    finally:
+        s.cleanup(policy_stop_timeout=0.5)
+
+
+class TestTheExportedSceneReloads:
+    def test_a_multi_root_scene_reloads_with_the_same_structure(self, sim: Simulation, tmp_path: Path) -> None:
+        """Two models from DIFFERENT roots: no single meshdir could fix this.
+
+        The exported XML is written to a third directory that holds no assets at
+        all, which is the whole point - a portable export must not depend on
+        where it is written.
+        """
+        first = _write_mesh_model(tmp_path / "robot_one")
+        second = _write_mesh_model(tmp_path / "robot_two", meshdir="geometry")
+        sim.create_world()
+        assert sim.add_robot(name="a", urdf_path=str(first))["status"] == "success"
+        assert sim.add_robot(name="b", urdf_path=str(second))["status"] == "success"
+        assert (
+            sim.add_object(name="box", shape="box", position=[0.3, 0, 0.05], size=[0.05, 0.05, 0.05])["status"]
+            == "success"
+        )
+        live = _dims(sim.mj_model)
+
+        destination = tmp_path / "elsewhere" / "scene.xml"
+        assert sim.export_xml(output_path=str(destination))["status"] == "success"
+
+        reloaded = mujoco.MjModel.from_xml_path(str(destination))
+        assert _dims(reloaded) == live, f"exported scene recompiled to {_dims(reloaded)} but the live model is {live}"
+
+    def test_the_export_is_loadable_by_load_scene(self, sim: Simulation, tmp_path: Path) -> None:
+        """describe() calls export_xml the read sibling of replace_scene_mjcf.
+
+        strands' own loader is the consumer that pairing implies, so it must be
+        able to read what strands wrote.
+        """
+        model = _write_mesh_model(tmp_path / "src")
+        sim.create_world()
+        assert sim.add_robot(name="arm", urdf_path=str(model))["status"] == "success"
+        live = _dims(sim.mj_model)
+        assert sim.mj_model.nmesh == 1, "premise: the scene must actually carry a file-backed mesh"
+        destination = tmp_path / "handoff" / "scene.xml"
+        sim.export_xml(output_path=str(destination))
+
+        reader = Simulation(tool_name="reader", mesh=False)
+        try:
+            result = reader.load_scene(scene_path=str(destination))
+            assert result["status"] == "success", result["content"][0]["text"]
+            assert _dims(reader.mj_model) == live
+        finally:
+            reader.cleanup(policy_stop_timeout=0.5)
+
+    def test_a_file_backed_texture_reloads_too(self, sim: Simulation, tmp_path: Path) -> None:
+        """Textures resolve against texturedir, not meshdir - both are lost."""
+        model = _write_texture_model(tmp_path / "painted_src")
+        sim.create_world()
+        assert sim.add_robot(name="slab", urdf_path=str(model))["status"] == "success"
+        live = _dims(sim.mj_model)
+
+        destination = tmp_path / "out" / "scene.xml"
+        sim.export_xml(output_path=str(destination))
+        assert _dims(mujoco.MjModel.from_xml_path(str(destination))) == live
+
+    def test_a_scene_loaded_from_a_file_exports_reloadably(self, sim: Simulation, tmp_path: Path) -> None:
+        """load_scene keeps the model's meshdir but not the directory it is
+        relative TO, so the single-spec path loses the assets the same way."""
+        model = _write_mesh_model(tmp_path / "scene_src")
+        assert sim.load_scene(scene_path=str(model))["status"] == "success"
+        live = _dims(sim.mj_model)
+
+        destination = tmp_path / "exported" / "scene.xml"
+        assert sim.export_xml(output_path=str(destination))["status"] == "success"
+        assert _dims(mujoco.MjModel.from_xml_path(str(destination))) == live
+
+
+class TestTheRepairStaysWithinItsRemit:
+    """Controls: these hold both before and after the fix."""
+
+    def test_a_scene_with_no_file_backed_assets_is_unaffected(self, sim: Simulation, tmp_path: Path) -> None:
+        """The common case (primitives only) never had this defect and must
+        keep exporting exactly as before."""
+        sim.create_world()
+        sim.add_object(name="box", shape="box", position=[0, 0, 0.1], size=[0.1, 0.1, 0.1])
+        live = _dims(sim.mj_model)
+        destination = tmp_path / "plain.xml"
+        assert sim.export_xml(output_path=str(destination))["status"] == "success"
+        assert _dims(mujoco.MjModel.from_xml_path(str(destination))) == live
+
+    def test_an_unresolvable_reference_is_left_as_authored(self, tmp_path: Path) -> None:
+        """A reference that resolves to nothing must not be rewritten.
+
+        MuJoCo's own "Error opening file" names what the model declares; an
+        invented absolute path would report a location that was never on disk.
+        """
+        model = tmp_path / "ghost.xml"
+        model.write_text(
+            """
+            <mujoco model="ghost">
+              <compiler meshdir="assets"/>
+              <asset><mesh name="absent" file="not_here.stl"/></asset>
+              <worldbody><geom name="g" type="plane" size="1 1 0.1"/></worldbody>
+            </mujoco>
+            """
+        )
+        spec = SpecBuilder.from_file(str(model))
+        assert [m.file for m in spec.meshes] == ["not_here.stl"]
+
+    def test_a_reference_already_absolute_is_preserved(self, tmp_path: Path) -> None:
+        """An absolute reference is already self-describing; leave it alone."""
+        stl = tmp_path / "solo.stl"
+        stl.write_bytes(_STL)
+        model = tmp_path / "abs.xml"
+        model.write_text(
+            f"""
+            <mujoco model="abs">
+              <asset><mesh name="solo" file="{stl}"/></asset>
+              <worldbody><geom name="g" type="mesh" mesh="solo"/></worldbody>
+            </mujoco>
+            """
+        )
+        spec = SpecBuilder.from_file(str(model))
+        assert [m.file for m in spec.meshes] == [str(stl)]


### PR DESCRIPTION
## Problem

`export_xml` is the sink for "save / hand off / reload this scene", and `describe()` calls it
"the read sibling of `replace_scene_mjcf`". The file it wrote could not be recompiled -- not by
`mujoco.MjModel.from_xml_path`, and not by strands' own `load_scene`:

```python
sim.create_world()
sim.add_robot(name="a", data_config="so101")
sim.add_robot(name="b", data_config="so100")
sim.add_object(name="crate", shape="box", position=[0.22, 0.26, 0.04], size=[0.05, 0.05, 0.04])

sim.export_xml(output_path="/tmp/handoff/scene.xml")
# status=success  "Model exported to /tmp/handoff/scene.xml"

other.load_scene(scene_path="/tmp/handoff/scene.xml")
# status=error  Failed to load scene: Error: Error opening file 'sts3215_03a_v1.stl'
```

The export named all 31 mesh assets by bare filename with no `meshdir`, so MuJoCo resolved them
against the directory the XML landed in. Nothing warned: the export reported success and the
scene it described was already unloadable.

## Root cause

MuJoCo resolves a `<mesh>` / `<texture>` / `<hfield>` `file=` against a base directory it keeps on
the spec (`modelfiledir`, plus `meshdir` / `texturedir`) and does **not** emit in `spec.to_xml()`.
`spec.attach()` does not carry that base onto the parent either. So the live spec kept enough
internal state to compile while serialising to text that had lost it:

| | result |
|---|---|
| `spec.compile()` on the live spec | OK, nbody=16 nmesh=31 |
| `spec.to_xml()` then `MjSpec.from_string(...).compile()` | `Error opening file 'motor_holder_so101_wrist_v1.stl'` |

The export was strictly less capable than the spec it came from. Two things follow:

- A multi-robot scene has no single `meshdir` that could paper over it. so101 resolves under
  `.../assets/robotstudio_so101/` and so100 under `.../assets/trs_so_arm100/`; each model
  contributes assets from its own root.
- `spec.to_zip()`, MuJoCo's own portable-bundle writer, is broken by the same state: it reads
  `spec.assets`, which is empty here, so it wrote a 1-entry zip containing only the XML and
  `from_zip` failed identically. Delegating to it would not have helped.

Three separate entry points produced the same dead artifact: multi-robot `add_robot`, a
texture-bearing model, and `load_scene` (which keeps the model's `meshdir` but not the directory
it is relative to).

## Change

Absolutize each file-backed asset reference at the one point where a spec is loaded from a file,
while it still knows its own base directory -- `SpecBuilder.from_file`. `attach_robot` now goes
through that helper instead of calling `mujoco.MjSpec.from_file` directly, so the repair cannot be
bypassed and every `to_xml()` consumer inherits it. No new bookkeeping is needed: the information
is already on the child spec and is only lost afterwards.

Meshes and height fields resolve against `meshdir`, textures against `texturedir`. MuJoCo honours
an absolute `file=` regardless of any `meshdir` still declared, so those attributes are left
untouched.

A reference that resolves to nothing is left exactly as authored. MuJoCo's own "Error opening
file" names what the model declares, which is more useful than an invented absolute path that was
never on disk.

Scope: this makes the export reload from any directory on the machine that produced it, which is
what the "read sibling" contract needs. It is deliberately not an asset-bundling feature -- the
new docs section states plainly that the XML alone does not carry assets to another machine.

## Verification

Structural parity on the reported scene, `nbody/njnt/nu/nq/nv/ngeom` identical live vs reloaded:

| Scene | live | reloaded before | reloaded after |
|---|---|---|---|
| so101 + so100 + crate | `(16,13,12,19,18,63)` | compile failed | `(16,13,12,19,18,63)` |
| anymal_c (file-backed texture) | `(14,13,12,19,18,95)` | compile failed | `(14,13,12,19,18,95)` |
| `load_scene(so101)` then export | `(8,6,6,6,6,30)` | compile failed | `(8,6,6,6,6,30)` |

Absolute asset refs in the export went 0/31 to 31/31.

New tests, `tests/simulation/mujoco/test_export_xml_asset_refs_reload.py`, build their models on
disk (a real tetrahedron STL and a real PNG under a `meshdir` / `texturedir`) so a reference
genuinely needs resolving and nothing is downloaded. Against `main`: **4 failed, 3 passed**, each
failure naming the asset MuJoCo could not open. After: 7 passed.

The 3 that pass on both branches are the controls -- a primitives-only scene still exports and
reloads unchanged, an unresolvable reference is left as authored, and an already-absolute
reference is preserved. The second is what fails if the helper ever starts inventing paths.

Gate: `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 19
pre-existing errors on this branch and on `main` (zero new); full `tests/` compared against a
`main` worktree with no new failures.

## Artifact

Scene exported into a directory holding no assets, then reloaded through `load_scene` and
rendered in MuJoCo (headless EGL).

![export_xml reload](https://raw.githubusercontent.com/cagataycali/robots/media-export-xml-asset-refs/export_xml_artifact.png)

Before, there is nothing to render: `load_scene` refused the file `export_xml` had just reported
as a success. After, the reloaded scene renders, and its structure matches the live model while
the two renders differ by mean |d| = 0.003. The live scene is identical on both branches
(mean |d| = 0.0001) -- the change affects only how the export names its assets.

Fixes the `export_xml` round-trip reported for the MjSpec backend.
