### PR TITLE
fix(dataset_recorder): un-count frames a discarded episode never wrote

### DIFF
--- a/changelog.d/2388-recorder-uncount-discarded-frames.md
+++ b/changelog.d/2388-recorder-uncount-discarded-frames.md
@@ -1,0 +1,12 @@
+### Fixed
+
+`DatasetRecorder.clear_episode_buffer` now un-counts the frames it discards.
+`add_frame` counts a frame when it is buffered, but frames only reach disk on
+`save_episode`, so a discarded (aborted) episode left `frame_count` reporting a
+total no parquet row backed. Because `stop_recording` asks that counter whether
+anything was ever captured before refusing an empty dataset, the inflated count
+blinded the refusal: discarding a partial rollout and then stopping reported
+success for a dataset holding only `meta/info.json`. The un-count applies only
+when the discard actually happened - if no clear surface is available the frames
+are still buffered and will be written by the recommended
+`stop_recording`/`save_episode` drain, so both counters are left in place.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1634,6 +1634,15 @@ class DatasetRecorder:
           * leave the buffer in place and warn (caller must ``stop_recording`` /
             ``save_episode`` to drain it before recording again).
 
+        Discarded frames are un-counted from both ``frame_count`` and
+        ``episode_frame_count``, because ``add_frame`` counts at buffer time
+        while frames only reach disk on ``save_episode``. Both counters
+        therefore describe frames that reached, or will reach, disk - never
+        frames that were thrown away. When no clear surface is available the
+        frames are still buffered and will be written by the
+        ``stop_recording``/``save_episode`` drain the warning recommends, so
+        neither counter changes in that case.
+
         Returns:
             True if the buffer was actively cleared; False if no clear surface
             was available (a warning is logged in that case).
@@ -1650,10 +1659,25 @@ class DatasetRecorder:
             logger.warning("clear_episode_buffer failed: %s", e)
             cleared = False
 
-        # Reset the per-episode frame counter regardless: the next episode
-        # reports frames from 0. frame_count (cumulative) is left untouched
-        # since those frames were really written to disk only on save_episode.
-        self.episode_frame_count = 0
+        if cleared:
+            # The buffered frames are gone. They were counted optimistically by
+            # add_frame (which counts at buffer time) but never reached disk,
+            # since frames are only written by save_episode - so un-count them
+            # from the cumulative total as well as the per-episode one. Both
+            # counters describe frames that reached, or will reach, disk:
+            # resume() seeds frame_count from dataset.meta.total_frames, and
+            # stop_recording refuses an empty dataset by asking frame_count
+            # whether anything was ever captured. Leaving the discarded frames
+            # counted makes the recorder report a total no parquet row backs,
+            # and blinds that refusal.
+            self.frame_count -= self.episode_frame_count
+            self.episode_frame_count = 0
+        # When the discard did NOT happen the frames are still buffered, and the
+        # warning below tells the caller to drain them with
+        # stop_recording()/save_episode() - which writes them to disk. Nothing
+        # was thrown away, so both counters are left as they are: the eventual
+        # flush then reports the frames it really wrote, and a later successful
+        # clear can still un-count them.
 
         if not cleared:
             logger.warning(

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -24,7 +24,12 @@ import pytest
 
 pytest.importorskip("mujoco")
 
+from strands_robots.dataset_recorder import DatasetRecorder  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.test_recorder_counters_track_on_disk_frames import (  # noqa: E402
+    _BufferedDataset,
+    _record,
+)
 
 
 class _FakeRecorder:
@@ -310,6 +315,42 @@ class TestStopRecordingEmptyDataset:
         assert "run_policy" in text
         # save_episode must NOT be called on the empty buffer.
         assert rec.calls == []
+
+    def test_a_discarded_episode_does_not_blind_the_refusal(self, recording_sim):
+        """An aborted episode leaves nothing on disk, so case 3 must still fire.
+
+        ``clear_episode_buffer`` discards a buffered episode. Those frames were
+        counted by ``add_frame`` at buffer time but never flushed, so a recorder
+        whose only episode was aborted holds no on-disk frames - exactly the
+        state this refusal exists for. Driven through the real
+        ``DatasetRecorder`` so the counter contract is what makes it fire.
+        """
+        rec = DatasetRecorder(dataset=_BufferedDataset(), task="probe")
+        _record(rec, 12)
+        rec.clear_episode_buffer()  # the abort path (run_multi_policy's finally)
+        assert rec.dataset.disk_frames == 0, "premise: nothing reached disk"
+
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+
+        assert result["status"] == "error", (
+            "stop_recording reported success for a dataset with no frames on "
+            f"disk (recorder.frame_count={rec.frame_count})"
+        )
+        assert "captured no frames" in result["content"][0]["text"]
+
+    def test_a_dataset_with_frames_on_disk_is_still_finalized(self, recording_sim):
+        """Control: the refusal must not fire once an episode really saved."""
+        rec = DatasetRecorder(dataset=_BufferedDataset(), task="probe")
+        _record(rec, 6)
+        rec.save_episode()  # flushed to disk; nothing pending afterwards
+        assert rec.dataset.disk_frames == 6
+
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+
+        assert result["status"] == "success"
+        assert "6 frames" in result["content"][0]["text"]
 
     def test_empty_recording_does_not_finalize_or_upload(self, recording_sim):
         rec = _FakeRecorder(

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -60,9 +60,11 @@ def test_clear_episode_buffer_prefers_native_clear():
 
     assert rec.clear_episode_buffer() is True
     assert ds.cleared == 1
-    # Next episode starts at frame 0; cumulative frame_count is untouched
-    # (those frames were only ever in the open buffer, not flushed to disk).
+    # Next episode starts at frame 0, and the cumulative total drops by the
+    # discarded frames: they were counted at buffer time but never flushed to
+    # disk, so counting them would report a total no parquet row backs.
     assert rec.episode_frame_count == 0
+    assert rec.frame_count == 0
 
 
 def test_clear_episode_buffer_falls_back_to_create_buffer():
@@ -73,6 +75,7 @@ def test_clear_episode_buffer_falls_back_to_create_buffer():
     assert ds.created == 1
     assert ds.episode_buffer == {}
     assert rec.episode_frame_count == 0
+    assert rec.frame_count == 0
 
 
 def test_clear_episode_buffer_warns_when_no_surface(caplog):
@@ -85,8 +88,12 @@ def test_clear_episode_buffer_warns_when_no_surface(caplog):
         result = rec.clear_episode_buffer()
 
     assert result is False
-    # Counter still resets so reporting does not carry over the discarded frames.
-    assert rec.episode_frame_count == 0
+    # Nothing was discarded here - the frames are still buffered, and the
+    # warning tells the caller to drain them with stop_recording()/
+    # save_episode(), which writes them to disk. So neither counter may be
+    # un-counted: that drain must report the frames it really wrote.
+    assert rec.episode_frame_count == 5
+    assert rec.frame_count == 5
     assert any("partial episode" in r.message for r in caplog.records)
 
 
@@ -107,7 +114,10 @@ def test_clear_episode_buffer_swallows_dataset_error(caplog):
         result = rec.clear_episode_buffer()
 
     assert result is False
-    assert rec.episode_frame_count == 0
+    # The discard failed, so the frames are still buffered and still pending a
+    # drain - neither counter may drop them.
+    assert rec.episode_frame_count == 5
+    assert rec.frame_count == 5
 
 
 def test_clear_episode_buffer_ascii_only_warnings(caplog):

--- a/tests/test_recorder_counters_track_on_disk_frames.py
+++ b/tests/test_recorder_counters_track_on_disk_frames.py
@@ -1,0 +1,197 @@
+"""``DatasetRecorder`` frame counters must describe what is on disk.
+
+``add_frame`` counts a frame the moment it is buffered, but frames only reach
+disk when ``save_episode`` flushes the buffer. ``clear_episode_buffer``
+discards a buffered (aborted) episode, so the frames it throws away never
+become parquet rows and must not stay counted.
+
+Two surfaces define ``frame_count`` as the on-disk total, which is what makes
+this a correctness contract rather than a cosmetic one:
+
+* ``resume()`` seeds ``frame_count`` from ``dataset.meta.total_frames``, i.e.
+  straight from disk truth;
+* ``RecordingMixin.stop_recording`` refuses to finalize an empty dataset by
+  asking ``frame_count`` whether anything was ever captured, so an inflated
+  count reports success for a dataset holding only ``meta/info.json``.
+
+The dataset here is a stub that models the buffer/disk split the contract lives
+in, so these run without the ``lerobot`` extra. Its ``save_episode`` refuses an
+empty buffer exactly as ``LeRobotDataset`` does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.dataset_recorder import DatasetRecorder
+
+JOINTS = ["j1", "j2"]
+
+
+class _BufferedDataset:
+    """Stub dataset that distinguishes buffered frames from written frames."""
+
+    def __init__(self) -> None:
+        self.repo_id = "local/counters"
+        self.root = "/tmp/counters"
+        self.features = {
+            "observation.state": {"names": list(JOINTS)},
+            "action": {"names": list(JOINTS)},
+        }
+        self.buffered = 0
+        self.disk_frames = 0
+        self.episodes = 0
+
+    def add_frame(self, frame) -> None:
+        self.buffered += 1
+
+    def save_episode(self) -> None:
+        if self.buffered == 0:
+            # LeRobotDataset raises here; a stub that silently accepted an
+            # empty flush would hide the state this contract is about.
+            raise RuntimeError("You must add one or several frames with `add_frame`")
+        self.disk_frames += self.buffered
+        self.buffered = 0
+        self.episodes += 1
+
+    def clear_episode_buffer(self) -> None:
+        self.buffered = 0
+
+
+class _WedgedDataset(_BufferedDataset):
+    """Dataset whose discard fails, leaving the frames buffered and pending."""
+
+    def clear_episode_buffer(self) -> None:
+        raise RuntimeError("buffer is wedged")
+
+
+def _record(rec: DatasetRecorder, n: int) -> None:
+    """Buffer ``n`` frames through the real ``add_frame`` path."""
+    for i in range(n):
+        rec.add_frame({j: 0.01 * i for j in JOINTS}, {j: 0.02 * i for j in JOINTS})
+
+
+@pytest.fixture
+def recorder() -> DatasetRecorder:
+    return DatasetRecorder(dataset=_BufferedDataset(), task="probe", strict=True)
+
+
+class TestDiscardedFramesAreUncounted:
+    """A discarded episode never reached disk, so it must not stay counted."""
+
+    def test_reported_total_matches_the_frames_on_disk_after_an_abort(self, recorder):
+        ds = recorder.dataset
+        _record(recorder, 10)
+        recorder.clear_episode_buffer()  # episode aborted: 10 frames discarded
+        _record(recorder, 5)
+        result = recorder.save_episode()
+
+        assert result["status"] == "success"
+        assert result["episode_frames"] == 5
+        assert result["total_frames"] == ds.disk_frames, (
+            f"reported total_frames={result['total_frames']} but only "
+            f"{ds.disk_frames} frames reached disk; the "
+            f"{10} discarded frames are still counted"
+        )
+
+    def test_every_frame_discarded_leaves_nothing_counted(self, recorder):
+        """The input ``stop_recording``'s empty-dataset refusal reads."""
+        _record(recorder, 12)
+        recorder.clear_episode_buffer()
+
+        assert recorder.dataset.disk_frames == 0
+        assert recorder.frame_count == 0, (
+            "nothing reached disk, but frame_count still reports "
+            f"{recorder.frame_count} - stop_recording asks this counter whether "
+            "anything was captured before refusing an empty dataset"
+        )
+
+    def test_a_recorder_seeded_from_disk_stays_consistent_across_an_abort(self, recorder):
+        """``resume()`` seeds ``frame_count`` from ``meta.total_frames``."""
+        ds = recorder.dataset
+        ds.disk_frames = 6  # a previous session's on-disk frames
+        recorder.frame_count = 6  # exactly what resume() does
+
+        _record(recorder, 4)
+        recorder.clear_episode_buffer()
+
+        assert recorder.frame_count == ds.disk_frames
+
+    def test_each_abort_leaves_no_residue(self, recorder):
+        """Drift must not accumulate over repeated aborts."""
+        ds = recorder.dataset
+        for _ in range(3):
+            _record(recorder, 4)
+            recorder.clear_episode_buffer()
+        _record(recorder, 2)
+        recorder.save_episode()
+
+        assert recorder.frame_count == ds.disk_frames == 2
+
+    def test_repeated_discards_do_not_uncount_twice(self, recorder):
+        _record(recorder, 5)
+        recorder.clear_episode_buffer()
+        recorder.clear_episode_buffer()  # nothing buffered the second time
+
+        assert recorder.frame_count == 0
+
+
+class TestAFailedDiscardKeepsItsFramesCounted:
+    """Nothing was thrown away, so nothing may be un-counted."""
+
+    @pytest.fixture
+    def wedged(self) -> DatasetRecorder:
+        return DatasetRecorder(dataset=_WedgedDataset(), task="probe", strict=True)
+
+    def test_the_frames_stay_counted_for_the_recommended_drain(self, wedged):
+        ds = wedged.dataset
+        _record(wedged, 7)
+        assert wedged.clear_episode_buffer() is False
+        assert ds.buffered == 7, "premise: the discard failed, so nothing was dropped"
+
+        assert wedged.frame_count == 7
+        assert wedged.episode_frame_count == 7
+
+    def test_the_recommended_drain_reports_the_frames_it_wrote(self, wedged):
+        """The warning tells the caller to drain with save_episode."""
+        ds = wedged.dataset
+        _record(wedged, 7)
+        wedged.clear_episode_buffer()
+        result = wedged.save_episode()
+
+        assert ds.disk_frames == 7
+        assert result["episode_frames"] == 7
+        assert result["total_frames"] == ds.disk_frames
+
+    def test_a_later_successful_discard_still_uncounts_them(self, wedged):
+        _record(wedged, 7)
+        wedged.clear_episode_buffer()  # fails
+        wedged.dataset.__class__ = _BufferedDataset  # discard surface recovers
+        assert wedged.clear_episode_buffer() is True
+
+        assert wedged.frame_count == 0
+
+
+class TestTheOrdinaryPathIsUnchanged:
+    """Controls: recording without an abort must behave exactly as before."""
+
+    def test_a_saved_episode_reports_the_frames_it_wrote(self, recorder):
+        _record(recorder, 5)
+        result = recorder.save_episode()
+
+        assert result["episode_frames"] == 5
+        assert result["total_frames"] == recorder.dataset.disk_frames == 5
+
+    def test_frames_accumulate_across_saved_episodes(self, recorder):
+        for n in (3, 4):
+            _record(recorder, n)
+            result = recorder.save_episode()
+
+        assert result["total_frames"] == recorder.dataset.disk_frames == 7
+
+    def test_discarding_an_empty_buffer_changes_no_counter(self, recorder):
+        _record(recorder, 5)
+        recorder.save_episode()
+        recorder.clear_episode_buffer()  # nothing buffered
+
+        assert recorder.frame_count == recorder.dataset.disk_frames == 5


### PR DESCRIPTION
## Problem

`DatasetRecorder.add_frame` counts a frame the moment it is **buffered**, but frames only reach disk when `save_episode` flushes the buffer. `clear_episode_buffer` discards a buffered (aborted) episode and deliberately left the cumulative counter untouched:

```python
# Reset the per-episode frame counter regardless: the next episode
# reports frames from 0. frame_count (cumulative) is left untouched
# since those frames were really written to disk only on save_episode.
self.episode_frame_count = 0
```

The stated reason is inverted. *Because* frames reach disk only on `save_episode`, the frames just discarded **never became parquet rows**, so leaving them counted over-reports by exactly the aborted episode's length — permanently, and cumulatively across aborts.

Two surfaces define `frame_count` as the on-disk total, which is what makes this a correctness contract rather than a cosmetic one:

- **`resume()` seeds `frame_count` from `dataset.meta.total_frames`** — straight from disk truth. So a resumed recorder starts consistent and re-drifts on its first abort.
- **`RecordingMixin.stop_recording` refuses to finalize an empty dataset by asking `frame_count` whether anything was ever captured.** An inflated count blinds that refusal.

That second one is the reason this is more than a reporting bug. `stop_recording`'s own comment describes the regression it was added to prevent:

> Previously stop_recording reported success with "0 frames, 0 episode(s)", silently producing a dataset with only meta/info.json (no parquet/video).

Driving the documented flow on `upstream/main` reproduces exactly that, with a number attached:

```
start_recording -> run_policy(n_steps=12) -> discard the partial rollout -> stop_recording

stop_recording -> status: "success"
  "Episode saved to LeRobotDataset
   local/art_aborted -- 12 frames, 0 episode(s)"

actually on disk:  data/ empty, 0 parquet rows, meta/info.json total_frames = 0
```

"Episode saved ... 12 frames" for a dataset holding only `meta/info.json`. The `#708` parquet-truth gate below it reconciles `episode_count` against `meta.total_episodes` but never `frame_count`, so the inflated count flows into both the text and the JSON payload unchecked.

This is reachable through normal use, not a corner case: `run_multi_policy` calls `clear_episode_buffer()` from its `finally` when a rollout bails mid-episode (MuJoCo and Isaac), and `reset()`'s docstring recommends it to callers as the way to discard a partial rollout.

## Change

Un-count discarded frames from both counters, **conditional on the discard actually happening**:

- **Discard succeeded** — the frames are gone and will never be written, so `frame_count` drops by the buffered amount and `episode_frame_count` resets.
- **No clear surface available** — nothing was thrown away. The frames are still buffered and the warning tells the caller to drain them with `stop_recording()`/`save_episode()`, which writes them to disk. Neither counter changes.

The conditional matters. Decrementing unconditionally (the obvious one-liner) introduces the opposite defect: measured on the failure path, it reports **0 frames for 7 frames that reached disk**. Keeping the counters there also lets the recommended drain report the frames it really wrote, and lets a later successful clear still un-count them.

`clear_episode_buffer`'s docstring now states the counter contract, since it is caller-visible.

## Verification

Blast radius: 77 test files (everything referencing the counters, the recorder, or the recording lifecycle), same selection on both trees, `MUJOCO_GL=egl`.

| | branch | `upstream/main` |
|---|---|---|
| collected | 2911 | 2911 |
| failed | 1 | 15 |
| passed | 2908 | 2891 |

**Branch-only failing IDs: none.** The single branch failure (`test_every_on_frame_call_site_excludes_a_lost_recording_frame`, `KeyError`) fails identically on both trees under this subset and passes 7/7 in isolation on both — a selection artifact, not a regression. Of `main`'s 15, 13 are this PR's pre-fix failures and one is a pre-existing lerobot/draccus e2e-train env failure. `main` also module-skipped 5 isaac recording tests via a transient `has_lerobot_dataset()` probe under load; all 5 pass on both trees when run directly.

Pre-fix split, new + changed tests: **13 failed / 147 passed** on `upstream/main`, all 160 pass after. Representative pre-fix messages:

```
reported total_frames=15 but only 5 frames reached disk; the 10 discarded frames are still counted
nothing reached disk, but frame_count still reports 12 - stop_recording asks this counter
  whether anything was captured before refusing an empty dataset
stop_recording reported success for a dataset with no frames on disk (recorder.frame_count=12)
assert 10 == 6   # resume() seeded from disk, then drifted on one abort
assert 14 == 2   # drift accumulating over three aborts
```

Four of the new tests **pass on both trees** — the no-overreach controls: a saved episode reports what it wrote, frames accumulate across saved episodes, discarding an empty buffer changes nothing, and `stop_recording` still finalizes a dataset that really has frames on disk.

`tests/test_dataset_recorder.py` needed four assertion updates. One is the comment that stated the un-counted total as intended while never actually asserting `frame_count`. The other two paths asserted `episode_frame_count == 0` after a *failed* discard, justified as "does not carry over the discarded frames" — but nothing was discarded there, so the premise was false; they now assert the counters are preserved and that the recommended drain reports the frames it wrote.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` identical to `main` (19 errors on both, zero branch-only).

## Artifact

Same script run against both trees, MuJoCo sim headless. Top row aborts the rollout; bottom row is the control that does not. Each badge is graded from the measured report-vs-disk agreement, not from the wording.

![recorder frame accounting](https://raw.githubusercontent.com/cagataycali/robots/media-recorder-uncount-discarded/recorder-uncount-discarded-frames.png)

The control row is byte-identical on both trees — 12 frames written, 12 frames when reopened through `LeRobotDataset` — so the change only affects a rollout whose frames were discarded.

## Scope

Two things I checked and deliberately left alone:

- **`push_to_hub`'s empty-dataset guard is not defeated by this drift.** It is `frame_count == 0 or episode_count == 0`, and `episode_count` only advances on a successful `save_episode`, which LeRobot refuses on an empty buffer. So the `episode_count` half already holds. Its refusal *message* did quote the inflated frame count; that is fixed as a consequence.
- **`stop_recording` does not cross-check `frame_count` against the parquet** the way the `#708` gate cross-checks `episode_count`. Adding that is defence-in-depth for a different contract and belongs in its own change; this PR removes the drift at its source so the existing refusal works again.
