### PR TITLE
fix(dataset_recorder): un-count the frames an aborted episode discarded

### DIFF
--- a/changelog.d/2389-recorder-uncount-discarded-frames.md
+++ b/changelog.d/2389-recorder-uncount-discarded-frames.md
@@ -1,0 +1,11 @@
+### Fixed
+
+`DatasetRecorder.clear_episode_buffer` no longer leaves the frames it discarded
+counted in the cumulative `frame_count`. `add_frame` counts a frame when it
+buffers it, so an aborted episode - the path `run_multi_policy` takes when a
+rollout bails mid-episode - used to inflate every later
+`save_episode()['total_frames']` and `push_to_hub()['frames']`, and blinded
+`stop_recording`'s "captured no frames" refusal into reporting success for a
+dataset holding only `meta/info.json`. When the buffer could not be discarded
+the frames are still queued for the next `save_episode`, so both counters are
+left describing them.

--- a/strands_robots/dataset_recorder.py
+++ b/strands_robots/dataset_recorder.py
@@ -1634,9 +1634,20 @@ class DatasetRecorder:
           * leave the buffer in place and warn (caller must ``stop_recording`` /
             ``save_episode`` to drain it before recording again).
 
+        The frame counters follow that outcome. ``add_frame`` counts a frame
+        into both ``frame_count`` and ``episode_frame_count`` when it buffers
+        the frame, not when ``save_episode`` writes it, so a successful discard
+        has to take the discarded frames back out of the cumulative
+        ``frame_count``. When the discard does NOT happen the frames are still
+        queued for the next ``save_episode``, so both counters are already right
+        and are left alone.
+
         Returns:
-            True if the buffer was actively cleared; False if no clear surface
-            was available (a warning is logged in that case).
+            True if the buffer was actively cleared - the discarded frames are
+            deducted from ``frame_count`` and ``episode_frame_count`` resets to
+            0. False if no clear surface was available or the dataset raised, in
+            which case the frames remain buffered, both counters are left
+            describing them, and a warning is logged.
         """
         cleared = False
         try:
@@ -1650,10 +1661,24 @@ class DatasetRecorder:
             logger.warning("clear_episode_buffer failed: %s", e)
             cleared = False
 
-        # Reset the per-episode frame counter regardless: the next episode
-        # reports frames from 0. frame_count (cumulative) is left untouched
-        # since those frames were really written to disk only on save_episode.
-        self.episode_frame_count = 0
+        # Both counters are bumped by add_frame at BUFFER time, so they have to
+        # follow whether this discard actually happened.
+        if cleared:
+            # The buffered frames are gone and can never reach disk, but
+            # add_frame already counted them into the cumulative total. Take
+            # them back out. Leaving them counted reports frames no parquet row
+            # accounts for - the drift resume() avoids by seeding frame_count
+            # from meta.total_frames - and blinds stop_recording's "captured no
+            # frames" refusal, which asks frame_count whether anything was ever
+            # written. The next episode then reports from 0.
+            self.frame_count -= self.episode_frame_count
+            self.episode_frame_count = 0
+        # Otherwise the buffer was NOT discarded: those frames are still queued
+        # in the open episode and the warning below tells the caller to drain
+        # them with save_episode()/stop_recording(), which writes them. Nothing
+        # was thrown away, so both counters already describe that outcome -
+        # zeroing the per-episode one here would make the eventual save
+        # under-report the very episode it is about to flush.
 
         if not cleared:
             logger.warning(

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -24,7 +24,12 @@ import pytest
 
 pytest.importorskip("mujoco")
 
+from strands_robots.dataset_recorder import DatasetRecorder  # noqa: E402
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from tests.test_recorder_counters_track_on_disk_frames import (  # noqa: E402
+    _BufferedDataset,
+    _record,
+)
 
 
 class _FakeRecorder:
@@ -310,6 +315,42 @@ class TestStopRecordingEmptyDataset:
         assert "run_policy" in text
         # save_episode must NOT be called on the empty buffer.
         assert rec.calls == []
+
+    def test_a_discarded_episode_does_not_blind_the_refusal(self, recording_sim):
+        """An aborted episode leaves nothing on disk, so case 3 must still fire.
+
+        ``clear_episode_buffer`` discards a buffered episode. Those frames were
+        counted by ``add_frame`` at buffer time but never flushed, so a recorder
+        whose only episode was aborted holds no on-disk frames - exactly the
+        state this refusal exists for. Driven through the real
+        ``DatasetRecorder`` so its counter contract is what makes it fire.
+        """
+        rec = DatasetRecorder(dataset=_BufferedDataset(), task="probe")
+        _record(rec, 12)
+        rec.clear_episode_buffer()  # the abort path run_multi_policy takes
+        assert rec.dataset.disk_frames == 0, "premise: nothing reached disk"
+
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+
+        assert result["status"] == "error", (
+            "stop_recording reported success for a dataset with no frames on "
+            f"disk (recorder.frame_count={rec.frame_count})"
+        )
+        assert "captured no frames" in result["content"][0]["text"]
+
+    def test_a_dataset_with_frames_on_disk_is_still_finalized(self, recording_sim):
+        """Control: the refusal must not fire once an episode really saved."""
+        rec = DatasetRecorder(dataset=_BufferedDataset(), task="probe")
+        _record(rec, 6)
+        rec.save_episode()
+        assert rec.dataset.disk_frames == 6
+
+        _arm(recording_sim, rec)
+        result = recording_sim.stop_recording()
+
+        assert result["status"] == "success"
+        assert "6 frames" in result["content"][0]["text"]
 
     def test_empty_recording_does_not_finalize_or_upload(self, recording_sim):
         rec = _FakeRecorder(

--- a/tests/test_dataset_recorder.py
+++ b/tests/test_dataset_recorder.py
@@ -60,9 +60,11 @@ def test_clear_episode_buffer_prefers_native_clear():
 
     assert rec.clear_episode_buffer() is True
     assert ds.cleared == 1
-    # Next episode starts at frame 0; cumulative frame_count is untouched
-    # (those frames were only ever in the open buffer, not flushed to disk).
+    # Next episode starts at frame 0, and because those frames were only ever in
+    # the open buffer - never flushed to disk - they come back out of the
+    # cumulative total too. add_frame counted them when it buffered them.
     assert rec.episode_frame_count == 0
+    assert rec.frame_count == 0
 
 
 def test_clear_episode_buffer_falls_back_to_create_buffer():
@@ -85,8 +87,12 @@ def test_clear_episode_buffer_warns_when_no_surface(caplog):
         result = rec.clear_episode_buffer()
 
     assert result is False
-    # Counter still resets so reporting does not carry over the discarded frames.
-    assert rec.episode_frame_count == 0
+    # Nothing was discarded, so those 5 frames are still queued in the open
+    # episode and the warning tells the caller to drain them with
+    # save_episode()/stop_recording(). Both counters keep describing them:
+    # zeroing either here would make that save under-report its own episode.
+    assert rec.episode_frame_count == 5
+    assert rec.frame_count == 5
     assert any("partial episode" in r.message for r in caplog.records)
 
 
@@ -107,7 +113,10 @@ def test_clear_episode_buffer_swallows_dataset_error(caplog):
         result = rec.clear_episode_buffer()
 
     assert result is False
-    assert rec.episode_frame_count == 0
+    # The clear raised, so the buffer still holds the frames; the counters must
+    # not pretend they were discarded.
+    assert rec.episode_frame_count == 5
+    assert rec.frame_count == 5
 
 
 def test_clear_episode_buffer_ascii_only_warnings(caplog):

--- a/tests/test_recorder_counters_track_on_disk_frames.py
+++ b/tests/test_recorder_counters_track_on_disk_frames.py
@@ -1,0 +1,193 @@
+"""The recorder's frame counters must describe frames that reached disk.
+
+``DatasetRecorder.add_frame`` counts a frame into ``frame_count`` (cumulative)
+and ``episode_frame_count`` (current, unsaved episode) at BUFFER time, while
+frames only reach disk when ``save_episode`` flushes the episode. Every counter
+consumer treats those numbers as on-disk truth: ``save_episode`` returns
+``frame_count`` as ``total_frames``, ``push_to_hub`` reports it as ``frames`` and
+refuses an empty dataset by asking it, ``stop_recording`` asks it whether
+anything was ever captured, and ``resume`` seeds it from ``meta.total_frames``.
+
+``clear_episode_buffer`` is the abort path - both ``run_multi_policy``
+implementations call it from their ``finally`` when a rollout bails mid-episode -
+so the two have to be reconciled there, in whichever direction the discard
+actually went:
+
+  * the discard happened  -> the buffered frames can never reach disk, so they
+    come back out of the cumulative total;
+  * the discard did NOT happen -> the frames are still queued for the next
+    ``save_episode``, so both counters already describe them and are left alone.
+
+These tests drive the real ``add_frame``/``save_episode``/``clear_episode_buffer``
+against a dataset that distinguishes buffered from written frames, so a counter
+is only ever compared against what actually landed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strands_robots.dataset_recorder import DatasetRecorder
+
+_FEATURES: dict[str, Any] = {
+    "observation.state": {"dtype": "float32", "shape": (1,), "names": ["j"]},
+    "action": {"dtype": "float32", "shape": (1,), "names": ["j"]},
+}
+
+
+class _BufferedDataset:
+    """Dataset double that separates the open buffer from written frames.
+
+    ``add_frame`` only buffers; ``save_episode`` is what moves buffered frames
+    to ``disk_frames`` and appends the episode length to ``episodes``. That
+    split is the whole point: it makes "frames the recorder claims" and "frames
+    a parquet row would account for" two independently observable numbers.
+    """
+
+    def __init__(self, *, can_clear: bool = True, clear_raises: bool = False):
+        self.repo_id = "local/counters"
+        self.root = None
+        self.features = _FEATURES
+        self.meta = type("_Meta", (), {"total_frames": 0, "total_episodes": 0, "features": _FEATURES})()
+        self.buffered = 0
+        self.disk_frames = 0
+        self.episodes: list[int] = []
+        self._clear_raises = clear_raises
+        if can_clear:
+            self.clear_episode_buffer = self._clear  # type: ignore[method-assign]
+
+    def add_frame(self, frame: dict[str, Any]) -> None:
+        self.buffered += 1
+
+    def save_episode(self) -> None:
+        self.episodes.append(self.buffered)
+        self.disk_frames += self.buffered
+        self.buffered = 0
+
+    def finalize(self) -> None:
+        pass
+
+    def _clear(self) -> None:
+        if self._clear_raises:
+            raise RuntimeError("buffer is wedged")
+        self.buffered = 0
+
+
+def _record(recorder: DatasetRecorder, n: int) -> None:
+    """Feed ``n`` frames through the real ``add_frame``."""
+    for i in range(n):
+        recorder.add_frame({"j": 0.1 * i}, {"j": 0.2 * i})
+
+
+def _recorder(**kwargs: Any) -> DatasetRecorder:
+    return DatasetRecorder(dataset=_BufferedDataset(**kwargs), task="counters", strict=True)
+
+
+class TestADiscardedEpisodeIsNotCounted:
+    """A successful discard un-counts the frames it threw away."""
+
+    def test_the_reported_total_matches_the_frames_on_disk(self):
+        rec = _recorder()
+        _record(rec, 10)
+        assert rec.clear_episode_buffer() is True  # premise: the discard happened
+        assert rec.dataset.disk_frames == 0, "premise: nothing was written before the abort"
+        _record(rec, 5)
+
+        result = rec.save_episode()
+
+        assert result["total_frames"] == rec.dataset.disk_frames, (
+            f"save_episode reported total_frames={result['total_frames']} but only "
+            f"{rec.dataset.disk_frames} frame(s) reached disk; the "
+            f"{10} frame(s) discarded by clear_episode_buffer are still counted"
+        )
+
+    def test_each_abort_does_not_add_more_drift(self):
+        """Three aborts must not accumulate three aborts' worth of frames."""
+        rec = _recorder()
+        for _ in range(3):
+            _record(rec, 7)
+            assert rec.clear_episode_buffer() is True
+        _record(rec, 4)
+
+        result = rec.save_episode()
+
+        assert result["total_frames"] == rec.dataset.disk_frames == 4
+
+    def test_the_counter_never_goes_negative(self):
+        rec = _recorder()
+        _record(rec, 6)
+        assert rec.clear_episode_buffer() is True
+        assert rec.frame_count == 0
+        assert rec.episode_frame_count == 0
+
+    def test_a_resumed_recorder_stays_on_disk_truth_across_an_abort(self):
+        """resume() seeds frame_count from disk, so an abort must not drift it."""
+        rec = _recorder()
+        _record(rec, 8)
+        rec.save_episode()
+        rec.frame_count = rec.dataset.disk_frames  # what resume() seeds
+        _record(rec, 9)
+        assert rec.clear_episode_buffer() is True
+
+        assert rec.frame_count == rec.dataset.disk_frames == 8
+
+
+class TestAFailedDiscardLeavesTheFramesCounted:
+    """When nothing was discarded the frames are still queued, so still counted.
+
+    These are the boundary of the fix. The frames survive in the open episode
+    and the warning tells the caller to drain them with
+    ``save_episode``/``stop_recording``, which writes them - so deducting them
+    here would under-report the very episode about to be flushed.
+    """
+
+    @pytest.mark.parametrize(
+        "kwargs, why",
+        [
+            ({"can_clear": False}, "no clear surface on this LeRobot version"),
+            ({"clear_raises": True}, "the dataset raised mid-clear"),
+        ],
+    )
+    def test_the_queued_frames_are_still_counted(self, kwargs, why):
+        rec = _recorder(**kwargs)
+        _record(rec, 6)
+
+        assert rec.clear_episode_buffer() is False, f"premise: {why}"
+        assert rec.dataset.buffered == 6, "premise: the frames are still buffered"
+        assert rec.frame_count == 6
+        assert rec.episode_frame_count == 6
+
+    @pytest.mark.parametrize("kwargs", [{"can_clear": False}, {"clear_raises": True}])
+    def test_draining_them_reports_the_episode_it_really_wrote(self, kwargs):
+        rec = _recorder(**kwargs)
+        _record(rec, 6)
+        rec.clear_episode_buffer()  # failed discard: the 6 frames survive
+
+        result = rec.save_episode()
+
+        assert result["episode_frames"] == rec.dataset.episodes[-1] == 6
+        assert result["total_frames"] == rec.dataset.disk_frames == 6
+
+
+class TestCountersWithoutAnAbort:
+    """Controls: the counters already agreed with disk on the normal path."""
+
+    def test_a_saved_episode_reports_its_own_length_and_the_total(self):
+        rec = _recorder()
+        _record(rec, 4)
+        first = rec.save_episode()
+        _record(rec, 3)
+        second = rec.save_episode()
+
+        assert (first["episode_frames"], first["total_frames"]) == (4, 4)
+        assert (second["episode_frames"], second["total_frames"]) == (3, 7)
+        assert rec.dataset.disk_frames == 7
+        assert rec.dataset.episodes == [4, 3]
+
+    def test_clearing_an_untouched_buffer_is_a_no_op(self):
+        rec = _recorder()
+        assert rec.clear_episode_buffer() is True
+        assert rec.frame_count == 0
+        assert rec.episode_frame_count == 0


### PR DESCRIPTION
## Problem

`DatasetRecorder.add_frame` counts a frame into `frame_count` (cumulative) and `episode_frame_count` at **buffer** time; frames only reach disk when `save_episode` flushes the episode. `clear_episode_buffer` discarded the buffered frames but left `frame_count` still counting them, so after any aborted episode the recorder permanently reported frames that no parquet row accounts for.

That is not a corner case: it is the abort path. Both `run_multi_policy` implementations call it from their `finally` when a rollout bails mid-episode (`simulation/mujoco/simulation.py:5040`, `simulation/isaac/simulation.py:3924`).

The counter is on-disk truth for every consumer: `save_episode` returns it as `total_frames`, `push_to_hub` reports it as `frames` and refuses an empty dataset by asking it, and `resume` seeds it from `meta.total_frames`.

### The consequence that matters: a fail-loudly guard goes blind

`simulation/recording.py:640` is `stop_recording`'s case 3 - it asks `frame_count` whether anything was ever captured, and its own comment says it exists because *"Previously stop_recording reported success with '0 frames, 0 episode(s)', silently producing a dataset with only meta/info.json (no parquet/video)."*

An inflated `frame_count` makes `captured == 0` false, so that refusal never fires. Measured end to end with a real `LeRobotDataset` on disk (MuJoCo `so101`, 40 recorded frames, then the abort):

| | `upstream/main` | this PR |
|---|---|---|
| `recorder.frame_count` | **40** | 0 |
| `meta/info.json` `total_frames` | 0 | 0 |
| `*.parquet` on disk | **0** | 0 |
| `stop_recording()` | **`success`** - "Episode saved to LeRobotDataset ... 40 frames" | `error` - "captured no frames - dataset would be empty" |

Both runs leave a directory holding nothing but `meta/info.json`. On `main` that is reported as a saved dataset of 40 frames.

## Change

Reconcile the counters with whichever way the discard actually went:

- **cleared** - the frames can never reach disk, so deduct them from the cumulative total and reset the per-episode counter.
- **not cleared** (no clear surface on this LeRobot version, or the dataset raised) - the frames are still queued and the warning already tells the caller to drain them with `save_episode`/`stop_recording`, which writes them. Both counters already describe that outcome, so they are left alone.

That second branch is load-bearing, not defensive. A plain unconditional `frame_count -= episode_frame_count` fixes the total but then **under**-reports the not-cleared path by exactly the frames it is about to flush. Measured against this PR's tests:

| variant | cumulative total vs disk | failed-discard boundary |
|---|---|---|
| `upstream/main` | 12 failed | - |
| unconditional deduct | fixed | **6 failed** |
| this PR (follows `cleared`) | fixed | fixed |

## Tests

`tests/test_recorder_counters_track_on_disk_frames.py` drives the real `add_frame`/`save_episode`/`clear_episode_buffer` against a dataset double that separates the open buffer from written frames, so a counter is only ever compared with what actually landed. The existing fakes in `test_dataset_recorder.py` hand-assign `frame_count` and define no `add_frame`/`save_episode` at all, which is why five passing tests never noticed.

Pre-fix split on `3aac69d7`: **12 failed / 147 passed**, post-fix **159 passed**. Headline failure text:

```
save_episode reported total_frames=15 but only 5 frame(s) reached disk;
the 10 frame(s) discarded by clear_episode_buffer are still counted

stop_recording reported success for a dataset with no frames on disk
(recorder.frame_count=12)
```

Controls that pass on **both** trees (they pin that the change does not overreach): counters on the normal no-abort path, `episode_frames`/`total_frames` across two saved episodes, clearing an untouched buffer, and `stop_recording` still finalizing a dataset that really has frames.

Two existing tests changed. `test_clear_episode_buffer_warns_when_no_surface` and `test_clear_episode_buffer_swallows_dataset_error` asserted the per-episode counter resets on the not-cleared path, and their comments described the frames as "discarded" - but that branch is precisely the one where nothing was discarded and the frames survive to be written.

## Verification

- Blast radius (66 test files touching `frame_count`/`clear_episode_buffer`/`stop_recording`/`save_episode`/`total_frames`, plus the repo-wide docstring/ASCII/changelog guards), run on this branch and on a clean `upstream/main` worktree with the same selection: **branch 2 failed / 2720 passed, base 10 failed / 2710 passed**. Branch-only failures: **none**. The 8 base-only failures are this PR's pre-fix failures; the 2 remaining are pre-existing on `main` (`test_recording_frame_loss_is_not_tolerated`, and `test_lerobot_e2e` failing on a local `draccus` version).
- `ruff check` / `ruff format --check` / `mypy` over `strands_robots tests tests_integ`: clean, no new mypy errors versus base.

## Artifact

Rollout in MuJoCo sim (headless EGL): the 40 frames `run_policy` recorded, the abort that discards them, and what each tree then reports against the dataset actually on disk.

![recorder abort counters](https://raw.githubusercontent.com/cagataycali/robots/media-recorder-abort-counters/recorder-abort-counters.png)

The recorded rollout itself ([mp4](https://raw.githubusercontent.com/cagataycali/robots/media-recorder-abort-counters/recorded-rollout.mp4)): 21 frames, all 20 transitions moving (per-frame mean abs delta 2.34 to 8.27).
