### PR TITLE
fix(training): decode a text extra value the way lerobot's own CLI decodes it

### DIFF
--- a/changelog.d/2390-training-extra-text-decoding.md
+++ b/changelog.d/2390-training-extra-text-decoding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **training**: a text value in `TrainSpec.extra` is now decoded with the same decoder lerobot's `--key=value` CLI uses, so one spec means one run whichever path the lerobot backend takes. `extra={"policy.freeze_vision_encoder": "false"}` previously stored the truthy string `"false"` and left the encoder frozen while the identical CLI flag unfroze it, with nothing raised or warned. `false`/`no`/`off` and `true`/`yes`/`on` (any case) are booleans; text that does not decode to the field's declared type is refused naming the field, its type and a spelling that works. A value already of the field's own Python type is passed through unchanged.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -131,6 +131,53 @@ TrainSpec(..., method="lora", lora_r=16, extra={"policy_type": "pi05"})
 # -> lerobot_train --peft.method_type=LORA --peft.r=16 --policy.type=pi05
 ```
 
+#### Passing lerobot's own flags through `extra`
+
+Any key in `extra` that names a real field of lerobot's config tree is applied to
+it, dotted for a sub-config (`policy.*`, `dataset.*`, `wandb.*`). A key that
+matches no field is ignored with a warning, so a typo can never become an
+arbitrary flag.
+
+A value may be written either as the field's own Python type or as text. Text is
+read with lerobot's own draccus decoder - the same one behind `--key=value` - so
+one spec means one run whether the backend builds the config in-process or shells
+out:
+
+```python
+# these two are the same request
+extra={"policy.freeze_vision_encoder": False}
+extra={"policy.freeze_vision_encoder": "false"}
+```
+
+For a boolean field that decoder accepts `false`/`no`/`off` and
+`true`/`yes`/`on` in any case. `0` and `1` are integers to it, not booleans, and
+are refused - as they are on the command line. Text that does not decode to the
+field's declared type is refused naming the field and its type, rather than
+stored as-is: a stored string is truthy, so `"false"` would otherwise read as
+"true" and silently invert the flag.
+
+Some policies freeze most of themselves by default, which `method="full"` does
+not override - it selects strands' tuning strategy, not lerobot's per-policy
+defaults. SmolVLA, for instance, ships `freeze_vision_encoder=True` and
+`train_expert_only=True`, so full-model finetuning means asking for both:
+
+```python
+TrainSpec(
+    dataset_repo_id="org/tictactoe",
+    base_model="lerobot/smolvla_base",
+    output_dir="/tmp/ft_out",
+    steps=20000,
+    method="full",
+    extra={"policy_type": "smolvla",
+           "policy.freeze_vision_encoder": False,
+           "policy.train_expert_only": False},
+)
+```
+
+Check what a policy freezes by default before assuming `method="full"` trains
+all of it: `dataclasses.fields()` on its lerobot config class lists every knob
+and its default.
+
 #### RA-BC sample weighting (reward-aligned behavior cloning)
 
 Reward-Aligned Behavior Cloning reweights the per-sample loss so high-progress

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -154,7 +154,19 @@ class TrainSpec:
         fps: Dataset control rate, when a backend needs it explicitly.
         extra: Raw passthrough. Keys become backend-native flags / overrides
             (lerobot ``--key=value``; Cosmos Hydra ``key.path=value``). The
-            escape hatch that keeps the ABC stable as backends evolve.
+            escape hatch that keeps the ABC stable as backends evolve. A value
+            may be given either as text or as the destination field's own Python
+            type; a backend that assigns into a typed config MUST decode text
+            with the same decoder its ``--key=value`` form uses, so one spec
+            means one run whichever path the backend takes. The lerobot backend
+            reads text through lerobot's own draccus decoder: ``false``/``no``/
+            ``off`` and ``true``/``yes``/``on`` (any case) are booleans, ``0``
+            and ``1`` are not, and text that does not decode to the field's type
+            is refused rather than stored. For example, unfreezing a SmolVLA
+            vision tower takes ``extra={"policy.freeze_vision_encoder": False,
+            "policy.train_expert_only": False}`` - or the same values as
+            ``"false"`` - because both default to ``True`` in that policy's own
+            config.
     """
 
     # --- universal ---

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -53,6 +53,8 @@ import os
 import re
 import shutil
 import time
+import types
+import typing
 from typing import TYPE_CHECKING, Any
 
 from strands_robots.training._inproc import call_callable, elastic_launch_callable, resume_argv
@@ -1238,7 +1240,10 @@ class LerobotTrainer(Trainer):
         """Typed passthrough for remaining ``extra.*`` keys (validate()-gated).
 
         Only sets attributes that exist on the typed config tree; unknown keys
-        are ignored (never become an arbitrary flag).
+        are ignored (never become an arbitrary flag). A *text* value is decoded
+        to the field's declared type by :func:`_decode_extra_value`, so the same
+        spelling means the same thing here as on the ``--flag=value`` CLI that
+        :meth:`build_command` documents this config as corresponding to.
         """
         _consumed = {"policy_type", "job_name", "relative_actions", "sample_weighting", "reward_model"}
         for key, value in spec.extra.items():
@@ -1246,7 +1251,7 @@ class LerobotTrainer(Trainer):
                 continue
             target, attr = _resolve_dotted(cfg, key)
             if target is not None and hasattr(target, attr):
-                setattr(target, attr, value)
+                setattr(target, attr, _decode_extra_value(target, attr, key, value))
             else:
                 logger.warning("LerobotTrainer: ignoring extra '%s' (no matching config field).", key)
 
@@ -1603,6 +1608,114 @@ def _resolve_dotted(cfg: Any, key: str) -> tuple[Any, str]:
     if sub is None or "." in tail:
         return None, tail
     return sub, tail
+
+
+def _extra_field_type(target: Any, attr: str) -> Any:
+    """Resolved annotation of ``target.attr``, or ``None`` when unavailable.
+
+    ``dataclasses.fields()`` reports ``f.type`` as the *source text* of the
+    annotation for a module compiled with ``from __future__ import
+    annotations`` - 45 ``bool`` fields across 6 lerobot policy configs
+    (``eo1``, ``evo1``, ``fastwam``, ``molmoact2``, ``vla_jepa``, ``xvla``)
+    read back as the string ``"bool"`` there - so a caller that compared
+    ``f.type is bool`` would silently skip exactly those. The annotation is
+    resolved through :func:`typing.get_type_hints` instead, which evaluates
+    the string form.
+
+    Returns ``None`` when the annotation cannot be resolved (an unresolvable
+    forward reference, or a target that is not annotated at all), which the
+    caller reads as "leave the value alone".
+    """
+    try:
+        hints = typing.get_type_hints(type(target))
+    except (NameError, TypeError):
+        return None
+    return hints.get(attr)
+
+
+def _annotation_admits_text(hint: Any) -> bool:
+    """Whether ``hint`` already accepts a ``str`` as-is.
+
+    ``str``, ``str | None`` and ``Any`` need no decoding: the value the caller
+    passed is already the field's own type. A generic whose *parameters*
+    happen to include ``str`` (``dict[str, int]``) does not qualify - only a
+    union is searched - because the field itself is not a string there.
+    """
+    if hint is str or hint is Any:
+        return True
+    origin = typing.get_origin(hint)
+    if origin is typing.Union or origin is types.UnionType:
+        return any(_annotation_admits_text(arg) for arg in typing.get_args(hint))
+    return False
+
+
+def _decode_extra_value(target: Any, attr: str, key: str, value: Any) -> Any:
+    """Decode a text ``extra`` value the way lerobot's own CLI decodes it.
+
+    ``build_command`` renders an ``extra`` entry as ``--key=value``, where
+    lerobot's draccus parser reads the text with ``cfgparsing.parse_string``
+    (YAML scalar rules) and then decodes it to the field's declared type. The
+    in-process path assigns to the same dataclass field directly, so a text
+    value has to travel the same two stages or the two paths stop agreeing:
+    ``extra={"policy.freeze_vision_encoder": "false"}`` otherwise stores the
+    *string* ``"false"``, which is truthy, so the encoder stays frozen while
+    ``--policy.freeze_vision_encoder=false`` unfreezes it.
+
+    The decoder is borrowed from draccus rather than reimplemented so the
+    accepted spellings cannot drift from the CLI's: ``false``/``no``/``off``
+    and ``true``/``yes``/``on`` (any case) decode to bools, while ``0``/``1``
+    are *not* bools to draccus and are refused on both paths.
+
+    Args:
+        target: Config object owning the field (``cfg`` or a sub-config).
+        attr: Attribute name on ``target``.
+        key: Original ``extra`` key, quoted in the refusal so the caller can
+            find it in their spec.
+        value: Value from ``spec.extra``. A non-``str`` is returned unchanged -
+            a caller who already passed the field's own type never went through
+            text, so there is nothing to decode.
+
+    Returns:
+        The value to assign to ``target.attr``.
+
+    Raises:
+        ValueError: The text does not decode to the field's declared type.
+            The CLI refuses the same spelling, and assigning it raw is how a
+            wrong type reaches training silently, so it is refused here too.
+    """
+    if not isinstance(value, str):
+        return value
+    hint = _extra_field_type(target, attr)
+    if hint is None or _annotation_admits_text(hint):
+        return value
+
+    import draccus
+    from draccus import cfgparsing
+
+    try:
+        return draccus.decode(hint, cfgparsing.parse_string(value))
+    except Exception as e:
+        # Both stages are third-party and raise from disjoint hierarchies
+        # (draccus.ParsingError for the decode, yaml.YAMLError for the scalar
+        # parse), so the breadth here translates every decoder failure into one
+        # actionable refusal. Nothing is swallowed - the cause is chained.
+        raise ValueError(
+            f"extra['{key}']={value!r} does not decode to {_format_annotation(hint)}, "
+            f"the declared type of '{attr}' on {type(target).__name__}. "
+            f"Values are read with lerobot's own CLI decoder, so the accepted spellings are "
+            f"the ones '--{key}={value}' accepts"
+            + (
+                " - for a boolean: false/no/off or true/yes/on (any case); note 0 and 1 are not booleans."
+                if hint is bool
+                else "."
+            )
+            + f" Pass a {_format_annotation(hint)} value directly to skip decoding."
+        ) from e
+
+
+def _format_annotation(hint: Any) -> str:
+    """Human-readable name for an annotation, for use in a refusal."""
+    return getattr(hint, "__name__", None) or str(hint)
 
 
 def _lerobot_worker(policy_type: str, device: str, spec: TrainSpec, log_path: str) -> None:

--- a/tests/training/test_extra_value_decoding.py
+++ b/tests/training/test_extra_value_decoding.py
@@ -1,0 +1,220 @@
+"""``TrainSpec.extra`` text values must mean the same thing on both lerobot paths.
+
+:meth:`LerobotTrainer.build_config` assigns an ``extra`` entry straight to a
+field of lerobot's typed config tree, while :meth:`build_command` renders the
+same entry as ``--key=value`` for lerobot's draccus CLI - which the module
+docstring describes as the argv the typed config *corresponds to*. Assigning a
+text value raw broke that correspondence for every non-string field:
+``extra={"policy.freeze_vision_encoder": "false"}`` stored the string
+``"false"``, which is truthy, so the vision encoder stayed frozen and the run
+trained a fraction of the parameters the caller asked for - while the identical
+``--policy.freeze_vision_encoder=false`` unfroze it. Nothing raised and nothing
+warned.
+
+These tests use lerobot's own CLI parser as the oracle, so they pin agreement
+between the two paths rather than a hand-copied list of accepted spellings.
+"""
+
+import dataclasses
+import json
+import re
+import typing
+
+import pytest
+
+from strands_robots.training import TrainSpec
+from strands_robots.training.lerobot import LerobotTrainer
+
+# Every spelling draccus resolves to a bool, plus the ones it refuses. ``0`` and
+# ``1`` are ints to YAML, not bools, so lerobot's CLI rejects them - a fix that
+# accepted them would diverge from the CLI just as raw assignment did.
+BOOL_SPELLINGS = ["false", "False", "FALSE", "true", "no", "yes", "on", "off"]
+NON_BOOL_SPELLINGS = ["0", "1", "maybe"]
+
+
+@pytest.fixture
+def dataset_root(tmp_path):
+    meta = tmp_path / "meta"
+    meta.mkdir()
+    (meta / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def spec(dataset_root, tmp_path):
+    return TrainSpec(
+        dataset_root=dataset_root,
+        base_model="",
+        output_dir=str(tmp_path / "out"),
+        steps=200,
+        global_batch_size=8,
+        save_freq=100,
+        extra={"policy_type": "smolvla"},
+    )
+
+
+def _cli_value(trainer, spec, dotted):
+    """Value ``dotted`` takes when ``build_command``'s argv goes through the CLI.
+
+    The oracle: lerobot's own draccus parser reading the argv this same spec
+    produces, so the expectation comes from the CLI rather than from the code
+    under test.
+    """
+    import draccus
+
+    # The policy choice registry is populated by importing the config module.
+    __import__("lerobot.policies.smolvla.configuration_smolvla")
+    from lerobot.configs.train import TrainPipelineConfig
+
+    argv = trainer.build_command(spec)[1:]  # drop the "lerobot-train" head
+    cfg = draccus.parse(config_class=TrainPipelineConfig, args=argv)
+    target = cfg
+    *heads, attr = dotted.split(".")
+    for head in heads:
+        target = getattr(target, head)
+    return getattr(target, attr)
+
+
+def _config_value(trainer, spec, dotted):
+    cfg = trainer.build_config(spec)
+    target = cfg
+    *heads, attr = dotted.split(".")
+    for head in heads:
+        target = getattr(target, head)
+    return getattr(target, attr)
+
+
+class TestATextValueMeansTheSameOnBothPaths:
+    @pytest.mark.parametrize("spelling", BOOL_SPELLINGS)
+    def test_a_text_boolean_reaches_the_field_as_a_boolean(self, spec, spelling):
+        """A text boolean must arrive as a ``bool``, never as its own text.
+
+        The reported failure: the string ``"false"`` is truthy, so a spec asking
+        for an unfrozen vision encoder trained the frozen path and said nothing.
+        """
+        pytest.importorskip("lerobot")
+        spec.extra["policy.freeze_vision_encoder"] = spelling
+        got = _config_value(LerobotTrainer(device="cpu"), spec, "policy.freeze_vision_encoder")
+        assert isinstance(got, bool), (
+            f"extra['policy.freeze_vision_encoder']={spelling!r} reached the config as "
+            f"{got!r} ({type(got).__name__}); a non-empty string is truthy, so the encoder "
+            f"stays frozen while --policy.freeze_vision_encoder={spelling} unfreezes it"
+        )
+
+    @pytest.mark.parametrize("spelling", BOOL_SPELLINGS)
+    def test_the_value_agrees_with_lerobots_own_cli_parser(self, spec, spelling):
+        """Both paths built from one spec must land on the same value."""
+        pytest.importorskip("lerobot")
+        pytest.importorskip("draccus")
+        trainer = LerobotTrainer(device="cpu")
+        spec.extra["policy.freeze_vision_encoder"] = spelling
+        expected = _cli_value(trainer, spec, "policy.freeze_vision_encoder")
+        got = _config_value(trainer, spec, "policy.freeze_vision_encoder")
+        assert got == expected and isinstance(got, type(expected)), (
+            f"spelling {spelling!r}: the CLI resolves --policy.freeze_vision_encoder to "
+            f"{expected!r} but build_config produced {got!r}"
+        )
+
+    def test_a_text_integer_reaches_an_int_field_as_an_int(self, spec):
+        """Non-bools decode too - the contract is the field's declared type."""
+        pytest.importorskip("lerobot")
+        spec.extra["num_workers"] = "6"
+        got = _config_value(LerobotTrainer(device="cpu"), spec, "num_workers")
+        assert got == 6 and isinstance(got, int), f"num_workers='6' reached the config as {got!r}"
+
+
+class TestAValueTheCliRefusesIsRefusedHereToo:
+    @pytest.mark.parametrize("spelling", NON_BOOL_SPELLINGS)
+    def test_a_spelling_that_is_not_a_boolean_is_refused(self, spec, spelling):
+        """Silently storing it is how a wrong type reaches training unnoticed."""
+        pytest.importorskip("lerobot")
+        spec.extra["policy.freeze_vision_encoder"] = spelling
+        with pytest.raises(ValueError) as excinfo:
+            LerobotTrainer(device="cpu").build_config(spec)
+        message = str(excinfo.value)
+        assert "policy.freeze_vision_encoder" in message, message
+        assert "bool" in message, message
+
+    def test_the_refusal_names_a_spelling_that_works(self, spec):
+        """Following the refusal's own advice has to produce a usable value."""
+        pytest.importorskip("lerobot")
+        trainer = LerobotTrainer(device="cpu")
+        spec.extra["policy.freeze_vision_encoder"] = "maybe"
+        with pytest.raises(ValueError) as excinfo:
+            trainer.build_config(spec)
+        offered = re.findall(r"\b(false|true|no|yes|on|off)\b", str(excinfo.value))
+        assert offered, f"the refusal names no spelling to use instead: {excinfo.value}"
+        for spelling in dict.fromkeys(offered):
+            spec.extra["policy.freeze_vision_encoder"] = spelling
+            got = _config_value(trainer, spec, "policy.freeze_vision_encoder")
+            assert isinstance(got, bool), f"the refusal offered {spelling!r}, which yields {got!r}"
+
+
+class TestTheFieldTypeIsResolvedNotReadRaw:
+    def test_a_string_annotated_bool_field_still_decodes(self, spec):
+        """``dataclasses`` reports a *string* type for a postponed annotation.
+
+        Six lerobot policy configs (``eo1``, ``evo1``, ``fastwam``,
+        ``molmoact2``, ``vla_jepa``, ``xvla``) are compiled with ``from
+        __future__ import annotations``, so ``dataclasses.fields(cls)[i].type``
+        is the source text ``"bool"`` for 45 of their boolean fields. Comparing
+        that against ``bool`` is False, which would skip exactly those configs,
+        so the annotation has to be resolved before it is compared.
+        """
+        pytest.importorskip("lerobot")
+        from strands_robots.training.lerobot import _decode_extra_value, _extra_field_type
+
+        @dataclasses.dataclass
+        class Postponed:
+            flag: "bool" = True  # noqa: UP037 - the string form is the subject
+
+            def __post_init__(self) -> None:  # pragma: no cover - shape only
+                return None
+
+        declared = {f.name: f.type for f in dataclasses.fields(Postponed)}["flag"]
+        assert declared == "bool", f"premise: expected the source text, got {declared!r}"
+        assert typing.get_type_hints(Postponed)["flag"] is bool
+        assert _extra_field_type(Postponed(), "flag") is bool
+        assert _decode_extra_value(Postponed(), "flag", "flag", "false") is False
+
+
+class TestNothingElseChanges:
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("policy.freeze_vision_encoder", False),
+            ("policy.freeze_vision_encoder", True),
+            ("num_workers", 0),
+            ("num_workers", 6),
+        ],
+    )
+    def test_a_value_already_of_the_fields_type_is_passed_through(self, spec, key, value):
+        """A caller who passed a real Python value never went through text."""
+        pytest.importorskip("lerobot")
+        spec.extra[key] = value
+        got = _config_value(LerobotTrainer(device="cpu"), spec, key)
+        assert got is value if isinstance(value, bool) else got == value
+
+    @pytest.mark.parametrize("text", ["smolvla_tictactoe", "false", "off"])
+    def test_a_string_field_keeps_its_text_verbatim(self, spec, text):
+        """A string field is already the caller's type, so it is not decoded.
+
+        This is the one place the two paths differ on purpose: draccus reads a
+        CLI token as a YAML scalar first, so ``--wandb.project=false`` reaches a
+        ``str`` field as ``"False"``. Round-tripping a value through a boolean
+        to retype it as text would corrupt a legitimate name, so a field that
+        already admits text keeps exactly what the caller wrote.
+        """
+        pytest.importorskip("lerobot")
+        spec.extra["wandb.project"] = text
+        got = _config_value(LerobotTrainer(device="cpu"), spec, "wandb.project")
+        assert got == text
+
+    def test_an_unknown_extra_key_is_still_ignored(self, spec, caplog):
+        """Decoding must not turn an ignored key into a refusal."""
+        pytest.importorskip("lerobot")
+        spec.extra["definitely_not_a_field"] = "false"
+        with caplog.at_level("WARNING"):
+            cfg = LerobotTrainer(device="cpu").build_config(spec)
+        assert not hasattr(cfg, "definitely_not_a_field")
+        assert any("ignoring extra" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

`LerobotTrainer.build_config` assigns each `TrainSpec.extra` entry straight onto a field of lerobot's typed config tree. `build_command` renders the same entry as `--key=value` for lerobot's draccus CLI — the argv this module's own docstring describes the typed config as *corresponding to*. For every non-string field that correspondence did not hold, because the value was applied with a raw `setattr`:

```python
extra={"policy.freeze_vision_encoder": "false"}   # stores the string "false"
```

A non-empty string is truthy, so a SmolVLA run kept its vision encoder frozen while the identical `--policy.freeze_vision_encoder=false` unfroze it. Nothing raised, nothing warned. Measured on the same spec through both trees:

| | `cfg.policy.freeze_vision_encoder` | `bool(value)` |
|---|---|---|
| before | `'false'` (`str`) | `True` — still frozen |
| after | `False` (`bool`) | `False` — unfrozen |

SmolVLA ships `freeze_vision_encoder=True` and `train_expert_only=True` in its own config, so this is the one knob a caller must reach to train more than the action expert. `method` selects the tuning strategy, not lerobot's per-policy defaults.

![text extra value decoding, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-train-extra-decoding/extra-value-decoding.png)

## Change

A **text** value now travels the two stages lerobot's own parser uses — `cfgparsing.parse_string` (YAML scalar rules) then `draccus.decode` against the field's annotation — so the two paths honour the same spellings by construction rather than by a hand-copied list. Measured agreement, in-process vs feeding `build_command`'s argv to `draccus.parse`:

| spelling | CLI | in-process before | in-process after |
|---|---|---|---|
| `false` `False` `FALSE` `no` `off` | `False` | the string itself | `False` |
| `true` `yes` `on` | `True` | the string itself | `True` |
| `0` `1` `maybe` | refused | the string itself | refused |

**11/11 agree after; 8/11 differed before.** Note `0` and `1` are integers to draccus, not booleans, so a coercion that accepted them would have diverged from the CLI in the other direction.

Text that does not decode is refused naming the field, its declared type and a spelling that works, rather than stored with the wrong type:

```
extra['policy.freeze_vision_encoder']='0' does not decode to bool, the declared type of
'freeze_vision_encoder' on SmolVLAConfig. Values are read with lerobot's own CLI decoder,
so the accepted spellings are the ones '--policy.freeze_vision_encoder=0' accepts - for a
boolean: false/no/off or true/yes/on (any case); note 0 and 1 are not booleans. Pass a bool
value directly to skip decoding.
```

The annotation is resolved with `typing.get_type_hints`, **not** read off `dataclasses.fields()`. Six lerobot policy configs (`eo1`, `evo1`, `fastwam`, `molmoact2`, `vla_jepa`, `xvla`) are compiled with postponed annotations, so **45 of their boolean fields report the string `"bool"`** there — comparing that against `bool` is `False`, which would silently skip exactly those configs.

Deliberately unchanged: a value already of the field's own Python type is passed through untouched (so every existing caller is byte-identical), and a field that already admits text keeps the caller's text verbatim. Round-tripping a name through a boolean to retype it would corrupt e.g. `wandb.project="off"`; that is the one place the paths differ on purpose, and it is pinned by a test.

`draccus` is imported inside the function rather than declared: lerobot pins `draccus>=0.11.6,<0.12.0` and cannot function without it, and re-declaring that bound here would create a second owner for one pin. The API and the full spelling table were verified identical on both draccus 0.10.0 and 0.11.6.

## Tests

`tests/training/test_extra_value_decoding.py`, 30 cases. On `upstream/main`: **22 failed / 8 passed**; after: **30 passed**. The headline failure quotes the measurement rather than a wording diff:

```
extra['policy.freeze_vision_encoder']='false' reached the config as 'false' (str);
a non-empty string is truthy, so the encoder stays frozen while
--policy.freeze_vision_encoder=false unfreezes it
```

The parity cases use lerobot's own CLI parser as the oracle, so they pin agreement between the two paths rather than a copied list of spellings. The 8 that pass on both trees are the no-overreach controls: a typed value is passed through unchanged (bools and ints, both values), a string field keeps its text verbatim (3 cases), and an unknown key is still ignored with a warning.

## Verification

- `tests/training` plus the repo-wide guards (dependency audit, docstring xrefs, unicode dashes, ASCII logs, `Args:` completeness, changelog fragments, dangling doc refs): **2847 passed**, 3 failed. All 3 fail identically on `upstream/main` and are a local environment artifact — `TypeError: encode() takes 1 positional argument but 2 were given` from draccus 0.10.0 being below lerobot's own `draccus>=0.11.6` floor on this box.
- `ruff check` / `ruff format --check` clean; `mypy` reports no error in either changed module (the 4 it does report are pre-existing in `utils.py`, `simulation/ik.py`, `mesh/core.py`).

## Notes on scope

The reported case also raises whether `method="full"` should itself unfreeze a policy that freezes most of itself by default. That would either change what a shipped `method` value means for existing callers (a large increase in trainable parameters, and so in memory) or add a new value to the public `method` vocabulary — a contract choice, so it is not made here. What this change does is make the documented escape hatch reliable: the text form of the override now works, and the behaviour is written down in `TrainSpec.extra` and in `docs/training/overview.md` with the SmolVLA case spelled out.
