### PR TITLE
fix(simulation/mujoco): name policy_config keys the provider really accepts

### DIFF
--- a/changelog.d/2391-policy-config-keys-name-real-params.md
+++ b/changelog.d/2391-policy-config-keys-name-real-params.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **simulation/mujoco**: `tool_spec.json`'s `policy_config` description
+  attributed three keys to the `lerobot_local` provider that
+  `LerobotLocalPolicy.__init__` does not declare - `trust_remote_code`,
+  `observation_mapping` and `action_mapping`. `policy_config` is splatted into
+  `create_policy`, so each was swallowed by the policy's `**kwargs` absorber:
+  the build reported success and the value was dropped without a warning, which
+  reads as the capability being broken rather than as the key being wrong. The
+  list now names declared parameters, including the `camera_key_map` and
+  `obs_rename_override` keys the runtime's own camera-routing refusals already
+  tell callers to pass. A new test grades the per-provider key list against the
+  live constructor signatures so the schema cannot drift from them again.

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -472,7 +472,7 @@
     },
     "policy_config": {
       "type": "object",
-      "description": "Provider-specific config dict forwarded to strands_robots.policies.create_policy. Contents depend on policy_provider. For 'groot': host, port, api_token, observation_mapping, action_mapping. For 'lerobot_local': pretrained_name_or_path, device, trust_remote_code, actions_per_step, use_processor, processor_overrides, observation_mapping, action_mapping. For 'mock': {} is fine.",
+      "description": "Provider-specific config dict forwarded to strands_robots.policies.create_policy. Contents depend on policy_provider. For 'groot': host, port, api_token, observation_mapping, action_mapping. For 'lerobot_local': pretrained_name_or_path, policy_type, device, actions_per_step, use_processor, processor_overrides, camera_key_map, obs_rename_override. For 'mock': {} is fine.",
       "additionalProperties": true
     },
     "stop_when": {

--- a/tests/simulation/mujoco/test_policy_config_keys_are_constructor_params.py
+++ b/tests/simulation/mujoco/test_policy_config_keys_are_constructor_params.py
@@ -1,0 +1,163 @@
+"""Every ``policy_config`` key the schema attributes to a provider must exist.
+
+``policy_config`` is a free-form dict splatted into
+:func:`strands_robots.policies.create_policy`, so a key no constructor declares
+is swallowed by that policy's ``**kwargs`` forward-compatibility absorber: the
+build reports success and the value is dropped without a warning. The router
+binds against the method signature and never inspects these names, so an
+advertised-but-absent key is never *refused* - it is simply never honoured,
+which reads as the capability being broken rather than as the key being wrong.
+
+``tool_spec.json``'s ``policy_config`` description is the only per-provider key
+list an agent driving the schema ever sees, so these tests grade it against the
+live constructors rather than against a copied list, and a provider that grows
+a knob cannot leave the schema behind.
+
+``TestToolSpecIsClean`` in ``test_tool_spec.py`` already pins the *level* these
+keys live at - nested under ``policy_config``, never top-level. It says nothing
+about which provider accepts which key, which is what these tests add.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.factory import _resolve_policy_class
+from strands_robots.registry.policies import list_policy_providers
+
+_SPEC_PATH = Path(__file__).resolve().parents[3] / "strands_robots/simulation/mujoco/tool_spec.json"
+
+# A description that stopped naming per-provider key lists would make every
+# grading test below vacuous, so the shape the parser depends on is pinned.
+_MINIMUM_PROVIDER_GROUPS = 3
+_MINIMUM_ADVERTISED_KEYS = 10
+
+# "For 'lerobot_local': a, b, c." - one group per provider the description
+# bothers to enumerate keys for.
+_GROUP_RE = re.compile(r"For '([a-z0-9_]+)': ([^.]*)\.")
+
+
+def _description() -> str:
+    spec = json.loads(_SPEC_PATH.read_text())
+    return str(spec["properties"]["policy_config"]["description"])
+
+
+def _advertised(description: str) -> dict[str, list[str]]:
+    """Map each provider the description enumerates to the keys it claims.
+
+    ``For 'mock': {} is fine.`` advertises no keys, which is a legitimate entry
+    and yields an empty list rather than being dropped.
+    """
+    groups: dict[str, list[str]] = {}
+    for provider, blob in _GROUP_RE.findall(description):
+        keys = [k.strip() for k in blob.split(",")]
+        # Accumulate rather than assign: a provider named twice would otherwise
+        # have its first group silently dropped, ungraded.
+        groups.setdefault(provider, []).extend(k for k in keys if k and "is fine" not in k)
+    return groups
+
+
+def _constructor_parameters(provider: str) -> tuple[set[str], bool]:
+    """Return ``(explicit parameter names, accepts **kwargs)`` for a provider."""
+    _, cls, _ = _resolve_policy_class(provider)
+    signature = inspect.signature(cls.__init__)
+    explicit = {
+        name
+        for name, parameter in signature.parameters.items()
+        if name != "self" and parameter.kind not in (parameter.VAR_KEYWORD, parameter.VAR_POSITIONAL)
+    }
+    accepts_kwargs = any(p.kind is p.VAR_KEYWORD for p in signature.parameters.values())
+    return explicit, accepts_kwargs
+
+
+def _unbacked_keys(description: str) -> dict[str, list[str]]:
+    """Advertised keys, per provider, that the provider's constructor lacks."""
+    unbacked: dict[str, list[str]] = {}
+    for provider, keys in _advertised(description).items():
+        explicit, _ = _constructor_parameters(provider)
+        absent = [k for k in keys if k not in explicit]
+        if absent:
+            unbacked[provider] = absent
+    return unbacked
+
+
+class TestTheSchemaOnlyAdvertisesKeysAProviderAccepts:
+    """The per-provider key list is graded against the live constructors."""
+
+    def test_every_advertised_key_is_a_constructor_parameter(self) -> None:
+        unbacked = _unbacked_keys(_description())
+        assert not unbacked, (
+            "tool_spec.json's policy_config description attributes keys to providers whose "
+            f"constructors do not declare them: {unbacked}. create_policy splats policy_config, "
+            "so each of these is absorbed by that policy's **kwargs and silently dropped - the "
+            "build reports success and the value never reaches the policy. Name the parameter the "
+            "provider really accepts, or drop the key."
+        )
+
+    def test_every_named_provider_is_registered(self) -> None:
+        registered = set(list_policy_providers())
+        named = set(_advertised(_description()))
+        assert named <= registered, (
+            f"policy_config's description names providers that are not registered: {sorted(named - registered)}"
+        )
+
+
+class TestTheGradingIsNotVacuous:
+    """A clean result has to mean the description is right."""
+
+    def test_the_description_still_names_several_provider_key_lists(self) -> None:
+        groups = _advertised(_description())
+        assert len(groups) >= _MINIMUM_PROVIDER_GROUPS, (
+            f"only {len(groups)} provider group(s) parsed out of policy_config's description "
+            f"(expected at least {_MINIMUM_PROVIDER_GROUPS}); a reformat that hides the "
+            "'For <provider>: <keys>.' shape would make the grading above pass by reaching nothing"
+        )
+        total = sum(len(keys) for keys in groups.values())
+        assert total >= _MINIMUM_ADVERTISED_KEYS, (
+            f"only {total} key(s) parsed out of policy_config's description "
+            f"(expected at least {_MINIMUM_ADVERTISED_KEYS})"
+        )
+
+    def test_a_key_no_constructor_declares_is_reported(self) -> None:
+        planted = _description().replace(
+            "For 'mock': {} is fine.",
+            "For 'mock': definitely_not_a_parameter.",
+            1,
+        )
+        # Scoped to the planted group so this stays a control: it reports whether the
+        # grader can see a bogus key at all, independently of any real offender.
+        assert _unbacked_keys(planted).get("mock") == ["definitely_not_a_parameter"]
+
+    def test_a_provider_may_advertise_no_keys(self) -> None:
+        """``For 'mock': {} is fine.`` is an entry, not a parse failure."""
+        assert _advertised(_description())["mock"] == []
+
+
+class TestWhyAnUnbackedKeyIsSilent:
+    """The absorber is what makes a wrong key a dropped value, not an error."""
+
+    @pytest.mark.parametrize("provider", sorted(_advertised(_description())))
+    def test_the_constructor_absorbs_unknown_keywords(self, provider: str) -> None:
+        _, accepts_kwargs = _constructor_parameters(provider)
+        assert accepts_kwargs, (
+            f"'{provider}' no longer absorbs unknown constructor keywords, so an unbacked "
+            "policy_config key would now raise TypeError instead of being dropped. That is a "
+            "stricter contract than the one these tests assume - re-check whether the schema "
+            "still needs grading against the signature, or whether the constructor now does it."
+        )
+
+    def test_an_unknown_key_reaches_the_absorber_unvalidated(self) -> None:
+        """Nothing between the schema and the constructor filters these names."""
+        explicit, _ = _constructor_parameters("lerobot_local")
+        assert "definitely_not_a_parameter" not in explicit
+        policy: Any = _resolve_policy_class("lerobot_local")[1]
+        bound = inspect.signature(policy.__init__).bind_partial(
+            None, **dict.fromkeys(["definitely_not_a_parameter"], True)
+        )
+        assert "definitely_not_a_parameter" in bound.kwargs or "definitely_not_a_parameter" in bound.arguments


### PR DESCRIPTION
## Problem

`tool_spec.json`'s `policy_config` description carries the only per-provider key
list an agent driving the schema ever sees. Three of the eight keys it
attributes to `lerobot_local` are not parameters of
`LerobotLocalPolicy.__init__`, and the string `trust_remote_code` /
`observation_mapping` / `action_mapping` appears nowhere under
`strands_robots/policies/lerobot_local/`:

```
For 'lerobot_local': pretrained_name_or_path, device, trust_remote_code,
actions_per_step, use_processor, processor_overrides, observation_mapping,
action_mapping.
```

`policy_config` is splatted into `create_policy`, so each unbacked key is
swallowed by that policy's `**kwargs` forward-compatibility absorber. The
router binds against the method signature and never inspects these names, so an
unbacked key is never *refused* - it is simply never honoured, which reads as
the capability being broken rather than as the key being wrong.

Driven through the real `create_policy` with an out-of-domain value (`-12345`)
for each advertised key:

| advertised key | constructor parameter | `-12345` |
|---|---|---|
| `pretrained_name_or_path` | yes | not probed (identifies the checkpoint) |
| `device` | yes | refused, message names it |
| **`trust_remote_code`** | **no** | **accepted, dropped** |
| `actions_per_step` | yes | refused, message names it |
| `use_processor` | yes | accepted (a declared bool; `-12345` is truthy) |
| `processor_overrides` | yes | refused |
| **`observation_mapping`** | **no** | **accepted, dropped** |
| **`action_mapping`** | **no** | **accepted, dropped** |

Every key the constructor declares reaches a validator. The three it does not
declare take any value at all, and the build reports `success`.

`observation_mapping` / `action_mapping` are real keys - for `groot`, which
declares both. `trust_remote_code` is a real knob on `kimodo`, which declares it
as an explicit constructor parameter. Neither applies to this provider:
`lerobot_local`'s remote-code decision is the `STRANDS_TRUST_REMOTE_CODE` gate
`create_policy` enforces (via `_HF_REMOTE_CODE_PROVIDERS`) before any provider
is built, and lerobot's own modeling code sets `trust_remote_code=True`
internally, so a per-call flag on this provider could not deliver what its name
promises.

## Change

The list now names the parameters the provider declares:

```
For 'lerobot_local': pretrained_name_or_path, policy_type, device,
actions_per_step, use_processor, processor_overrides, camera_key_map,
obs_rename_override.
```

`camera_key_map` and `obs_rename_override` replace the two mapping names
because they are the keys that actually route observations here, and they are
already what the runtime's own camera-routing refusals tell callers to pass:

```
policies/lerobot_local/policy.py:216     (c) pass policy_config={'obs_rename_override': {...}} ...
policies/lerobot_local/policy.py:1560    (b) pass policy_config={'obs_rename_override': ...
policies/lerobot_local/processor.py:997  or pass policy_config={'obs_rename_override': {...}} ...
policies/lerobot_local/policy.py:2606    input - pass camera_key_map to bind cameras explicitly
```

`docs/policies/lerobot-local.md` already documents both as the `policy_config`
remap keys and never mentions the three that were advertised, so the
human-facing documentation was already correct and needs no change here.
`policy_type` replaces `trust_remote_code`: it is a declared parameter and the
remedy the provider names when a checkpoint's `config.json` carries no usable
type.

No code path changes - this is the description an agent reads, plus the tests
that keep it honest.

## Verification

`tests/simulation/mujoco/test_policy_config_keys_are_constructor_params.py`
parses the `For '<provider>': <keys>.` groups out of the live description and
grades them against `inspect.signature(cls.__init__)` for each provider, rather
than against a copied list - so a provider that grows a knob cannot leave the
schema behind.

Against `upstream/main`: **1 failed, 8 passed**. The headline names every
offender and the mechanism:

```
AssertionError: tool_spec.json's policy_config description attributes keys to
providers whose constructors do not declare them:
{'lerobot_local': ['trust_remote_code', 'observation_mapping', 'action_mapping']}.
create_policy splats policy_config, so each of these is absorbed by that
policy's **kwargs and silently dropped - the build reports success and the value
never reaches the policy. Name the parameter the provider really accepts, or
drop the key.
```

After: **9 passed**. The 8 that pass on both trees are the controls -

- every named provider is registered;
- the `For <provider>: <keys>.` shape still parses at least 3 groups and 10
  keys, so a reformat that hid the list would fail loudly instead of grading
  nothing;
- a planted bogus key is still reported (scoped to the planted group, so it
  measures the grader and not the offender);
- `For 'mock': {} is fine.` is an entry advertising no keys, not a parse
  failure;
- each graded provider still absorbs unknown constructor keywords - if one ever
  stops, the assertion says so, because that would make a wrong key raise
  instead of being dropped and change what needs grading.

Blast radius - `tests/simulation tests/policies tests/registry` plus the
repo-wide docstring/xref/unicode/ASCII/args-docstring/dependency-audit/changelog
guards - run under `MUJOCO_GL=egl` on this branch and on an `upstream/main`
worktree:

| | passed | skipped | failed/error |
|---|---|---|---|
| `upstream/main` | 16354 | 182 | 0 |
| this branch | 16363 | 182 | 0 |

`16363 - 16354 = 9`, exactly the nine tests this PR adds, and neither run
reports a single failure or error. `ruff check` and `ruff format --check` clean
over `strands_robots tests tests_integ`; `mypy` reports 19 pre-existing errors
on both trees, none of them in the touched files.

## Artifact

Both panels are one probe script run under `PYTHONPATH` of an `upstream/main`
worktree and of this branch, reading each tree's own schema and passing whatever
keys that tree advertises into the real `create_policy`.

![policy_config advertised-key grading](https://raw.githubusercontent.com/cagataycali/robots/media-policy-config-keys/policy_config_keys.png)
