### PR TITLE
fix(robot): forward the spawn parameters add_robot accepts

### DIFF
--- a/changelog.d/2392-factory-forwards-spawn-parameters.md
+++ b/changelog.d/2392-factory-forwards-spawn-parameters.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **robot**: `Robot(...)` now forwards `orientation` and `keyframe` to the backend's
+  `add_robot`. Both are `SimEngine.add_robot` parameters, but the factory did not pass them
+  on, so they fell into `**kwargs` and were absorbed by the backend constructor: a requested
+  base rotation or `<keyframe>` spawn pose was silently dropped and the robot came up
+  unrotated in the zero configuration while the factory reported success. The refusals
+  `add_robot` documents for a malformed quaternion and for an unknown keyframe now reach the
+  caller too, instead of the unknown keyframe falling back to zeros. Both are keyword-only
+  and omitting them is unchanged.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -1,5 +1,5 @@
 ---
-description: Robot(name, mode, backend, urdf_path, cameras, position, data_config, mesh, peer_id, **kwargs) - the full signature with every kwarg explained.
+description: Robot(name, mode, backend, urdf_path, cameras, position, data_config, mesh, peer_id, orientation, keyframe, **kwargs) - the full signature with every kwarg explained.
 ---
 
 # Robot factory
@@ -27,6 +27,8 @@ robot = Robot("so100", mode="auto")  # probes USB, falls back to sim
 | `data_config` | str | `None` | GR00T data_config name. |
 | `mesh` | bool | `True` | Auto-join Zenoh mesh. |
 | `peer_id` | str | `None` | Stable mesh peer id. Auto-generated if omitted. |
+| `orientation` | list | `None` | Robot base orientation `[w, x, y, z]` in sim world. |
+| `keyframe` | str \| int | `None` | Spawn in a model `<keyframe>` pose (name or index) instead of the zero configuration. |
 | `**kwargs` | | | Forwarded to backend constructor. Unknown kwargs raise `ValueError`. |
 
 ## Name resolution

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -66,6 +66,13 @@ out-of-distribution:
 sim.add_robot(name="panda", data_config="panda", keyframe="home")  # or keyframe=0
 ```
 
+The `Robot(...)` factory forwards `keyframe=` (and `orientation=`) to
+`add_robot`, so a one-line spawn reaches the same pose:
+
+```python
+robot = Robot("panda", keyframe="home")
+```
+
 The pose is applied to the robot's joints by name and is restored by `reset()`,
 so a keyframe spawn is sticky across episodes. A MuJoCo `<key>` pairs that pose
 with the actuator command that *holds* it, and both are applied and restored

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -198,6 +198,9 @@ def Robot(
     cameras: dict[str, dict[str, Any]] | None = ...,
     position: list[float] | None = ...,
     data_config: str | None = ...,
+    *,
+    orientation: list[float] | None = ...,
+    keyframe: str | int | None = ...,
     **kwargs: Any,
 ) -> Simulation: ...
 
@@ -211,6 +214,9 @@ def Robot(
     cameras: dict[str, dict[str, Any]] | None = ...,
     position: list[float] | None = ...,
     data_config: str | None = ...,
+    *,
+    orientation: list[float] | None = ...,
+    keyframe: str | int | None = ...,
     **kwargs: Any,
 ) -> HardwareRobot: ...
 
@@ -224,6 +230,9 @@ def Robot(
     cameras: dict[str, dict[str, Any]] | None = ...,
     position: list[float] | None = ...,
     data_config: str | None = ...,
+    *,
+    orientation: list[float] | None = ...,
+    keyframe: str | int | None = ...,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot: ...
 
@@ -238,6 +247,11 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     data_config: str | None = None,
     mesh: bool | None = None,
     peer_id: str | None = None,
+    # Keyword-only: appended after the existing parameters, so no positional
+    # call shifts meaning and the overloads above stay positionally faithful.
+    *,
+    orientation: list[float] | None = None,
+    keyframe: str | int | None = None,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot:
     """Create a robot - returns a Simulation or HardwareRobot instance.
@@ -286,6 +300,21 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
         data_config: Data configuration name for observation/action schema.
                      Defaults to the canonical robot name. For multi-camera
                      setups, specify explicitly: ``data_config="so100_dualcam"``.
+        orientation: Robot base orientation in the sim world as a quaternion
+            ``[w, x, y, z]``. Forwarded to the backend's ``add_robot`` verbatim
+            on the same terms as ``position``: omitting it spawns unrotated, and
+            a wrong-length, non-numeric or non-finite quaternion is refused with
+            an actionable message (surfaced here as ``RuntimeError``) rather
+            than being replaced by the identity rotation.
+        keyframe: Spawn the robot in a canonical pose declared by a
+            ``<keyframe>`` in its source model (e.g. panda ``"home"``, aloha
+            ``"neutral_pose"``) instead of the default all-zero configuration.
+            Accepts the keyframe name (``str``) or index (``int``) and is
+            forwarded to the backend's ``add_robot`` verbatim, so that method's
+            contract governs: the pose is sticky across ``reset()`` and an
+            unknown keyframe is a hard error naming the available keyframes
+            (surfaced here as ``RuntimeError``) instead of a silent zero-pose
+            spawn.
         mesh: Attach a Zenoh fleet-coordination mesh. ``None`` (default) keeps
               mesh OFF for a quiet bare ``Robot(...)`` but honours the
               ``STRANDS_MESH=true`` opt-in. Pass ``True`` to force it on or
@@ -391,11 +420,23 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
             # unnecessary: ``position=None`` is what ``add_robot`` already
             # documents as "spawn at the origin", so passing it through keeps ONE
             # source of truth for that default instead of a copy that can drift.
+            # ``orientation`` and ``keyframe`` travel with ``position`` for the
+            # same reason it is passed through unmodified: all three are
+            # ``SimEngine.add_robot`` parameters whose defaults and refusals that
+            # method already documents, so forwarding the caller's value verbatim
+            # keeps ONE source of truth for each. Dropping them here made the
+            # factory silently disagree with the backend it delegates to - a
+            # requested rotation or keyframe spawn was absorbed by ``**kwargs``
+            # and the robot came up unrotated in the zero configuration, and the
+            # refusals ``add_robot`` raises for a malformed quaternion or an
+            # unknown keyframe never reached the caller.
             result = sim.add_robot(
                 name=name,
                 urdf_path=urdf_path,
                 data_config=data_config or canonical,
                 position=position,
+                orientation=orientation,
+                keyframe=keyframe,
             )
             if result.get("status") == "error":
                 content = result.get("content", [])

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -399,6 +399,192 @@ class TestFactoryForwardsPosition:
             assert factory_accepts is backend_accepts, f"verdicts differ for position={position!r}"
 
 
+class TestFactorySpawnParameterForwarding:
+    """``Robot(...)`` must express every spawn parameter ``add_robot`` accepts.
+
+    The factory is a thin front door to ``SimEngine.add_robot``, and ``position``
+    is documented as forwarded verbatim so the backend's contract governs both
+    its default and its refusals. ``orientation`` and ``keyframe`` are the same
+    kind of parameter on the same method - both declared by the ABC and by every
+    backend - but were not forwarded. The backend constructor's ``**kwargs``
+    absorbed them, so a requested rotation or keyframe spawn was silently dropped
+    and the robot came up unrotated in the zero configuration while the factory
+    reported success. The refusals ``add_robot`` documents did not reach the
+    caller either, including the one it states outright for a bad keyframe: "a
+    hard error that names the available keyframes; it never silently falls back
+    to zeros".
+    """
+
+    # A named actuator and a <keyframe> carrying BOTH halves of a keyframe: the
+    # pose and the actuator command that holds it. The actuator is named because
+    # a keyed ctrl is applied by actuator name, so an unnamed one is skipped and
+    # could not show whether the command travelled.
+    MJCF = """<mujoco model="test_arm">
+      <worldbody>
+        <light pos="0 0 3"/>
+        <geom type="plane" size="1 1 0.1"/>
+        <body name="link0" pos="0 0 0.1">
+          <joint name="joint0" type="hinge" axis="0 0 1"/>
+          <geom type="capsule" size="0.02" fromto="0 0 0  0 0 0.2"/>
+        </body>
+      </worldbody>
+      <actuator><position name="act0" joint="joint0" kp="10" ctrlrange="-2 2"/></actuator>
+      <keyframe><key name="home" qpos="0.6" ctrl="0.6"/></keyframe>
+    </mujoco>"""
+
+    ROTATION = [0.7071068, 0.0, 0.0, 0.7071068]  # 90 deg about x, wxyz
+
+    @classmethod
+    def _model(cls, tmp_path):
+        """Write the inline arm so no downloaded asset is needed."""
+        path = tmp_path / "keyframed_arm.xml"
+        path.write_text(cls.MJCF)
+        return str(path)
+
+    def _spawn(self, tmp_path, **kwargs):
+        """Return the spawn state the factory actually gave the backend."""
+        sim = Robot("so100", mode="sim", urdf_path=self._model(tmp_path), mesh=False, **kwargs)
+        try:
+            return {
+                "orientation": list(sim._world.robots["so100"].orientation),
+                "qpos": [float(v) for v in sim._world._data.qpos],
+                "ctrl": [float(v) for v in sim._world._data.ctrl],
+            }
+        finally:
+            sim.destroy()
+
+    def _add_robot(self, tmp_path, **kwargs):
+        """The same spawn state reached through ``add_robot`` directly."""
+        from strands_robots import Simulation
+
+        sim = Simulation(tool_name="direct", mesh=False)
+        try:
+            sim.create_world()
+            result = sim.add_robot(name="so100", urdf_path=self._model(tmp_path), **kwargs)
+            assert result["status"] != "error", result
+            return {
+                "orientation": list(sim._world.robots["so100"].orientation),
+                "qpos": [float(v) for v in sim._world._data.qpos],
+                "ctrl": [float(v) for v in sim._world._data.ctrl],
+            }
+        finally:
+            sim.destroy()
+
+    def test_factory_can_express_every_add_robot_spawn_parameter(self):
+        """Root cause: a parameter the factory cannot name is one a caller cannot reach.
+
+        ``Robot(**kwargs)`` forwards leftovers to the *backend constructor*, not
+        to ``add_robot``, and that constructor takes ``**kwargs`` of its own - so
+        an unforwarded spawn parameter is absorbed with no error and no warning
+        rather than surfacing as an unexpected-keyword failure.
+        """
+        import inspect
+
+        from strands_robots.simulation.base import SimEngine
+
+        backend = set(inspect.signature(SimEngine.add_robot).parameters) - {"self"}
+        factory = set(inspect.signature(Robot).parameters) - {"kwargs"}
+        unreachable = sorted(backend - factory)
+        assert not unreachable, (
+            f"Robot() cannot express add_robot parameter(s) {unreachable}; a caller passing "
+            "one gets it absorbed by the backend constructor's **kwargs and silently dropped. "
+            "Forward it in the factory's add_robot call, or give it a factory parameter that "
+            "documents why the front door omits it."
+        )
+
+    def test_keyframe_reaches_the_pose_the_backend_would_spawn(self, tmp_path):
+        """The whole point of the parameter: a non-zero canonical start pose."""
+        pytest.importorskip("mujoco")
+        assert self._spawn(tmp_path, keyframe="home")["qpos"] == pytest.approx([0.6])
+
+    def test_keyframe_also_carries_the_actuator_command_that_holds_the_pose(self, tmp_path):
+        """A MuJoCo ``<key>`` pairs a pose with the command that holds it.
+
+        Forwarding only the pose would leave a gravity-loaded arm standing at its
+        home configuration with its actuators commanded to zero, so the pose is
+        not self-holding and collapses as soon as the world steps.
+        """
+        pytest.importorskip("mujoco")
+        assert self._spawn(tmp_path, keyframe="home")["ctrl"] == pytest.approx([0.6])
+
+    def test_keyframe_by_index_is_forwarded_too(self, tmp_path):
+        """``add_robot`` documents a name *or* an index; both must reach it."""
+        pytest.importorskip("mujoco")
+        assert self._spawn(tmp_path, keyframe=0)["qpos"] == pytest.approx([0.6])
+
+    def test_orientation_reaches_the_backend(self, tmp_path):
+        pytest.importorskip("mujoco")
+        assert self._spawn(tmp_path, orientation=self.ROTATION)["orientation"] == pytest.approx(self.ROTATION)
+
+    def test_factory_and_add_robot_reach_the_same_spawn_state(self, tmp_path):
+        """Parity: the front door and the method it wraps must agree.
+
+        A difference here is a spawn state the caller can only reach by dropping
+        out of the factory and calling the backend directly.
+        """
+        pytest.importorskip("mujoco")
+        kwargs = {"keyframe": "home", "orientation": self.ROTATION}
+        through_factory = self._spawn(tmp_path, **kwargs)
+        through_backend = self._add_robot(tmp_path, **kwargs)
+        for field in ("orientation", "qpos", "ctrl"):
+            assert through_factory[field] == pytest.approx(through_backend[field]), (
+                f"{field}: factory gave {through_factory[field]} but add_robot gives {through_backend[field]}"
+            )
+
+    def test_unknown_keyframe_is_refused_not_silently_spawned_at_zero(self, tmp_path):
+        """``add_robot`` promises this is a hard error naming the available keyframes.
+
+        Absorbed instead, the caller gets a robot in the zero configuration -
+        out-of-distribution for a policy trained from the home pose - and nothing
+        says the requested pose was never applied.
+        """
+        pytest.importorskip("mujoco")
+        with pytest.raises(RuntimeError, match="home"):
+            Robot(
+                "so100",
+                mode="sim",
+                urdf_path=self._model(tmp_path),
+                mesh=False,
+                keyframe="not_a_keyframe",
+            )
+
+    def test_malformed_orientation_is_refused(self, tmp_path):
+        """A 3-vector is a caller mistake, not a request for the identity rotation."""
+        pytest.importorskip("mujoco")
+        with pytest.raises(RuntimeError, match="4-element vector"):
+            Robot(
+                "so100",
+                mode="sim",
+                urdf_path=self._model(tmp_path),
+                mesh=False,
+                orientation=[0.0, 0.0, 1.0],
+            )
+
+    def test_non_finite_orientation_is_refused(self, tmp_path):
+        """nan/inf in a base quaternion would propagate through the physics state."""
+        pytest.importorskip("mujoco")
+        with pytest.raises(RuntimeError, match="finite numbers"):
+            Robot(
+                "so100",
+                mode="sim",
+                urdf_path=self._model(tmp_path),
+                mesh=False,
+                orientation=[float("nan"), 0.0, 0.0, 0.0],
+            )
+
+    def test_omitting_them_keeps_the_historical_spawn(self, tmp_path):
+        """No-overreach: forwarding must not change what an existing caller gets.
+
+        Omitted, both parameters keep the documented defaults - the zero joint
+        configuration, its actuators commanded to zero, and no rotation.
+        """
+        pytest.importorskip("mujoco")
+        spawned = self._spawn(tmp_path)
+        assert spawned["qpos"] == pytest.approx([0.0])
+        assert spawned["ctrl"] == pytest.approx([0.0])
+        assert spawned["orientation"] == pytest.approx([1.0, 0.0, 0.0, 0.0])
+
+
 class TestRobotRealMode:
     """Tests for mode='real' path (mocked - no physical hardware)."""
 


### PR DESCRIPTION
## Problem

`Robot(...)` is documented as a thin front door to `SimEngine.add_robot`, and it forwards
four of that method's six parameters. `orientation` and `keyframe` were not forwarded, so
they fell through to `**kwargs` — which the factory sends to the *backend constructor*, and
that constructor takes `**kwargs` of its own. Both were absorbed with no error and no
warning, and the factory reported success.

Measured on the built-in `panda`, through the factory only:

| Request | `add_robot` gives | `Robot(...)` gave |
|---|---|---|
| `keyframe="home"` spawn qpos | the model's `home` pose | **all zeros** (zero configuration) |
| `keyframe="home"` spawn ctrl | the command that holds that pose | **all zeros** |
| distance from `home` after 320 steps | 0.0066 rad | **1.5708 rad**, from step 0 on |
| `orientation=[0.7071, 0, 0, 0.7071]` | `[0.7071, 0, 0, 0.7071]` | **`[1, 0, 0, 0]`** (unrotated) |
| `keyframe="not_a_keyframe"` | error naming the available keyframes | **accepted** |
| `orientation=[0, 0, 1]` | `'orientation' must be a 4-element vector, got 3` | **accepted** |

The two halves compound. A keyframe spawn is how a caller reaches a pose a policy was
trained from — the zero configuration is out-of-distribution — and a MuJoCo `<key>` pairs
that pose with the actuator command that *holds* it, so dropping the parameter loses both.
The bypassed refusals are worse than the dropped values, because `add_robot` states the
keyframe one outright: "a hard error that names the available keyframes; **it never
silently falls back to zeros**". Through the factory it silently fell back to zeros.

## Why this is a forwarding fix and not a new contract

`orientation` and `keyframe` are declared by `SimEngine.add_robot` itself and by all three
backends (MuJoCo, Newton, Isaac), so they are part of the backend-agnostic contract rather
than a backend extra. And `position` — their sibling in the same call — already documents
exactly the terms they now travel on:

> Passed through to the backend's `add_robot` verbatim, so the backend's contract governs:
> omitting it spawns at the origin, and a wrong-length, non-numeric or non-finite vector is
> refused with an actionable message [...] instead of being replaced by the origin.

with the call site adding that passing the caller's value through "keeps ONE source of truth
for that default instead of a copy that can drift". That reasoning was settled once for
`position`; this applies it to the other two parameters of the same call. No default changes
and no value is interpreted by the factory.

## Change

- Forward `orientation` and `keyframe` in the factory's `add_robot` call.
- Declare them on the three `@overload`s and the implementation, **keyword-only** and
  appended after the existing parameters, so no existing positional call shifts meaning and
  the overloads stay positionally faithful to the implementation.
- Document them beside `position`, whose contract they share, and add them to the factory
  reference table and the spawn-pose docs.

## Verification

`tests/test_robot_factory.py::TestFactorySpawnParameterForwarding`, run against `main`
with only the test file applied: **9 failed, 1 passed** → 10 passed after.

The headline tests fail pre-fix with measured values, not with a missing keyword:

```
Robot() cannot express add_robot parameter(s) ['keyframe', 'orientation']; a caller passing
one gets it absorbed by the backend constructor's **kwargs and silently dropped.

orientation: factory gave [1.0, 0.0, 0.0, 0.0] but add_robot gives [0.7071068, 0.0, 0.0, 0.7071068]
```

The first of those is the root-cause guard: it compares the factory's parameters against
`SimEngine.add_robot`'s, so a parameter added to the ABC later cannot be silently dropped
by the front door again.

The one test that passes on both trees is the no-overreach control — omitting both
parameters still gives the zero joint configuration, its actuators commanded to zero, and no
rotation, so an existing caller is unaffected.

Also run: `ruff check` / `ruff format --check` and `mypy` over `strands_robots tests
tests_integ` clean with no new findings, and `tests/test_robot_factory.py` fully green
(119 passed).

## Rollout in MuJoCo sim (headless)

One capture script, run against `main` and against this branch — same camera, same steps,
only `strands_robots` differs.

`Robot("panda", keyframe="home")` stepping 320 times. On the left the requested pose never
arrives; on the right it arrives and the keyed actuator command holds it (0.0066 rad of
settle over the whole rollout):

![keyframe rollout](https://raw.githubusercontent.com/cagataycali/robots/media-factory-spawn-params/keyframe_rollout.gif)

Both parameters, plus the two refusals now reaching the caller:

![spawn parameter forwarding](https://raw.githubusercontent.com/cagataycali/robots/media-factory-spawn-params/spawn_forwarding.png)

[MP4 of the rollout](https://raw.githubusercontent.com/cagataycali/robots/media-factory-spawn-params/keyframe_rollout.mp4)

## Notes on scope

While measuring this I found that the factory reference table's `**kwargs` row claims
"Unknown kwargs raise `ValueError`", which does not hold in general — an arbitrary
`Robot("panda", total_nonsense=1)` is absorbed by the backend constructor too. Whether the
factory should reject unknown keywords is a behaviour change for existing callers rather
than a correction, so it is left out of this PR; with `orientation` and `keyframe` forwarded,
the two absorbed names that were real `add_robot` parameters are no longer among them.
