### PR TITLE
fix(docs): state the factory contract Robot() implements

### DIFF
--- a/changelog.d/2393-factory-reference-states-the-real-contract.md
+++ b/changelog.d/2393-factory-reference-states-the-real-contract.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **docs**: the robot factory reference stated three contracts `Robot()` does not implement: the `mesh` Default cell read `True` where the parameter defaults to `None` (mesh is off unless `STRANDS_MESH` opts in), so the page named a state a bare `Robot(...)` is never in and never named the spelling that enables it; its Mesh snippet read `.mesh.peer_id` on that robot and raised `AttributeError` when copied; and the `**kwargs` row promised unknown keywords raise `ValueError` where they are forwarded and ignored. A new guard grades the page against `Robot()` itself - Default cells against the signature, a documented refusal by raising it, and the Mesh section against the opt-in resolver.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -25,9 +25,9 @@ robot = Robot("so100", mode="auto")  # probes USB, falls back to sim
 | `cameras` | dict | `None` | Real-hardware camera config. **Rejected in `mode="sim"`** - raises `ValueError`. |
 | `position` | list | `None` | Robot position `[x, y, z]` in sim world. |
 | `data_config` | str | `None` | GR00T data_config name. |
-| `mesh` | bool | `True` | Auto-join Zenoh mesh. |
+| `mesh` | bool \| None | `None` | Join the Zenoh fleet mesh. `None` consults `STRANDS_MESH`, which leaves it **off** unless set to `true`/`1`/`yes` - pass `mesh=True` to opt in per robot. |
 | `peer_id` | str | `None` | Stable mesh peer id. Auto-generated if omitted. |
-| `**kwargs` | | | Forwarded to backend constructor. Unknown kwargs raise `ValueError`. |
+| `**kwargs` | | | Forwarded to the backend or driver constructor as given. A name it does not recognize is ignored, not refused, so check the spelling against the forwardable list below. |
 
 ## Name resolution
 
@@ -76,14 +76,22 @@ the clamp disabled.
 
 ## Mesh
 
+Mesh is opt-in, so a bare `Robot(...)` never starts Zenoh, ACL or e-stop machinery:
+
 ```python
 sim = Robot("so100")
-sim.mesh.peer_id   # 'so100_sim-a1b2c3d4'
-sim.mesh.alive     # True
+sim.mesh                     # None - never joined
 
-Robot("so100", mesh=False)   # per-robot off
-# STRANDS_MESH=false         # process-wide off
+sim = Robot("so100", mesh=True)   # per-robot on
+sim.mesh.peer_id             # 'so100_sim-a1b2c3d4'
+sim.mesh.alive               # True
+
+# STRANDS_MESH=true          # process-wide on, for a bare Robot(...)
 ```
+
+`STRANDS_MESH=false` is a kill switch: it keeps mesh off even where a caller passed
+`mesh=True`. The environment never forces mesh on for a robot constructed with
+`mesh=False`.
 
 Mesh failure is non-fatal; `.mesh = None` if Zenoh unavailable.
 

--- a/tests/test_docs_robot_factory_reference.py
+++ b/tests/test_docs_robot_factory_reference.py
@@ -1,0 +1,209 @@
+"""The factory reference page must not state a contract the factory does not implement.
+
+``docs/getting-started/robot-factory.md`` is the reference a caller reads before
+writing ``Robot(...)``: a parameter table with a Default column, and a Mesh
+section with a copy-paste snippet. Both are hand-written, so either can outlive
+the code.
+
+A wrong Default is worse than a missing one. It names a state the caller is
+never in, and it hides the knob that would reach the state the page describes -
+the reader's only documented lever turns off something that was never on. A
+documented refusal that does not happen fails the same way in reverse: the
+caller believes a typo is caught at construction and ships the typo.
+
+These tests grade the page against :func:`strands_robots.robot.Robot` itself -
+its signature, its docstring and its observed behaviour - rather than against a
+hand-copied expectation, so changing a default cannot silently invalidate them.
+``tests/mesh/test_mesh_env_opt_in_documented_default.py`` grades the same
+opt-in contract where a table's first cell is the environment variable; this
+page states it as a constructor default instead, which that guard does not read.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from strands_robots.robot import Robot, _mesh_env_opt_in
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOC = _REPO_ROOT / "docs" / "getting-started" / "robot-factory.md"
+
+_VARIADIC = (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+
+# The guard is only meaningful while it still reaches the table. If a reformat
+# or a rename drops the rows, fail loudly instead of reporting clean.
+_MINIMUM_GRADED_ROWS = 8
+
+_PROBE_MJCF = """<mujoco model="probe">
+  <worldbody>
+    <light pos="0 0 3"/>
+    <geom type="plane" size="1 1 0.1"/>
+    <body name="link0" pos="0 0 0.1">
+      <joint name="joint0" type="hinge" axis="0 0 1"/>
+      <geom type="capsule" size="0.02" fromto="0 0 0  0 0 0.2"/>
+    </body>
+  </worldbody>
+  <actuator><motor joint="joint0" ctrlrange="-1 1"/></actuator>
+</mujoco>"""
+
+
+def _rows() -> list[tuple[int, str, str, str]]:
+    """Return the parameter table's rows.
+
+    Returns:
+        A list of ``(line_number, parameter_name, default_cell, description_cell)``
+        tuples for every row whose first cell is a single backticked identifier
+        (``**kwargs`` included, its leading asterisks stripped).
+    """
+    found: list[tuple[int, str, str, str]] = []
+    for lineno, line in enumerate(_DOC.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped.startswith("|") or not stripped.endswith("|"):
+            continue
+        # A Type cell may legitimately spell a union as ``bool \\| None``, so split
+        # on unescaped pipes only - a naive split would drop the row and report
+        # the parameter as undocumented.
+        cells = [cell.strip() for cell in re.split(r"(?<!\\)\|", stripped.strip("|"))]
+        if len(cells) != 4:
+            continue
+        match = re.fullmatch(r"`\*{0,2}([A-Za-z_][A-Za-z0-9_]*)`", cells[0])
+        if match:
+            found.append((lineno, match.group(1), cells[2], cells[3]))
+    return found
+
+
+def _mesh_section() -> str:
+    """Return the page's ``## Mesh`` section, up to the next heading."""
+    text = _DOC.read_text(encoding="utf-8")
+    start = text.index("\n## Mesh")
+    rest = text[start + 1 :]
+    end = rest.find("\n## ", 1)
+    return rest if end == -1 else rest[:end]
+
+
+def _graded() -> list[tuple[int, str, str, inspect.Parameter]]:
+    """Return the rows that name a real, non-variadic parameter."""
+    out = []
+    for lineno, name, default_cell, _ in _rows():
+        param = inspect.signature(Robot).parameters.get(name)
+        if param is not None and param.kind not in _VARIADIC:
+            out.append((lineno, name, default_cell, param))
+    return out
+
+
+class TestTheTableReachesTheSignature:
+    """Premises. A clean result must mean the page was read, not skipped."""
+
+    def test_the_page_ships(self) -> None:
+        assert _DOC.is_file(), f"premise: {_DOC.relative_to(_REPO_ROOT)} is the page under test"
+
+    def test_enough_rows_are_graded(self) -> None:
+        graded = _graded()
+        assert len(graded) >= _MINIMUM_GRADED_ROWS, (
+            f"premise: only {len(graded)} row(s) of the parameter table resolved to a "
+            f"Robot() parameter, below the {_MINIMUM_GRADED_ROWS} this guard expects. "
+            "A clean run would prove nothing."
+        )
+
+
+class TestEveryDocumentedDefaultIsTheRealDefault:
+    """A Default cell states the value the caller gets by omitting the parameter."""
+
+    def test_no_row_states_a_default_the_signature_contradicts(self) -> None:
+        wrong: list[str] = []
+        for lineno, name, cell, param in _graded():
+            shown = cell.strip("`")
+            if param.default is inspect.Parameter.empty:
+                if shown.lower() != "required":
+                    wrong.append(f"line {lineno}: `{name}` documents {cell} but has no default")
+                continue
+            try:
+                parsed = ast.literal_eval(shown)
+            except (SyntaxError, ValueError):
+                wrong.append(f"line {lineno}: `{name}` documents {cell}, which is not a literal value")
+                continue
+            if parsed != param.default or type(parsed) is not type(param.default):
+                wrong.append(f"line {lineno}: `{name}` documents {cell} but omitting it yields {param.default!r}")
+        assert not wrong, (
+            "The Default column names a value the caller never gets, so the row describes "
+            "a state a bare Robot() is not in:\n  " + "\n  ".join(wrong)
+        )
+
+    def test_every_parameter_has_a_row(self) -> None:
+        documented = {name for _, name, _, _ in _rows()}
+        missing = [
+            name
+            for name, param in inspect.signature(Robot).parameters.items()
+            if param.kind not in _VARIADIC and name not in documented
+        ]
+        assert not missing, f"Robot() accepts {missing}, which the parameter table never lists"
+
+
+class TestADocumentedRefusalReallyRefuses:
+    """A row that promises an exception is graded by raising it, not by wording."""
+
+    def test_a_promised_unknown_kwarg_refusal_happens(self, tmp_path: pytest.TempPathFactory) -> None:
+        rows = {name: description for _, name, _, description in _rows()}
+        description = rows.get("kwargs", "")
+        promised = re.search(r"raises?\s+`([A-Za-z_][A-Za-z0-9_]*)`", description)
+        if promised is None:
+            return  # The row promises no refusal, so there is nothing to verify.
+        pytest.importorskip("mujoco")
+        exc = getattr(builtins, promised.group(1), None)
+        assert isinstance(exc, type) and issubclass(exc, BaseException), (
+            f"the `**kwargs` row promises `{promised.group(1)}`, which is not a builtin exception"
+        )
+        mjcf = Path(str(tmp_path)) / "probe.xml"
+        mjcf.write_text(_PROBE_MJCF, encoding="utf-8")
+        sim = None
+        try:
+            with pytest.raises(exc):
+                sim = Robot(
+                    "so100",
+                    mode="sim",
+                    urdf_path=str(mjcf),
+                    definitely_not_a_forwardable_kwarg=1,
+                )
+        finally:
+            if sim is not None:
+                sim.destroy()
+
+
+class TestTheMeshSectionNamesTheSpellingThatEnablesMesh:
+    """The Mesh section must reach the state its snippet prints."""
+
+    def test_the_section_names_an_enabling_spelling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        section = _mesh_section()
+        candidates = {
+            *(m.group(1) for m in re.finditer(r"STRANDS_MESH\s*=\s*([A-Za-z01]+)", section)),
+        }
+        enabling = []
+        for raw in candidates:
+            monkeypatch.setenv("STRANDS_MESH", raw)
+            if _mesh_env_opt_in():
+                enabling.append(raw)
+        opts_in_by_argument = re.search(r"mesh\s*=\s*True", section) is not None
+        assert enabling or opts_in_by_argument, (
+            "The Mesh section reads .mesh attributes but names no way to turn mesh on: "
+            f"the STRANDS_MESH spellings it shows are {sorted(candidates)}, none of which "
+            "opts in, and it never passes mesh=True. Copied as written it raises "
+            "AttributeError on None."
+        )
+
+    def test_a_bare_robot_leaves_mesh_off(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """The reality the page has to describe."""
+        pytest.importorskip("mujoco")
+        monkeypatch.delenv("STRANDS_MESH", raising=False)
+        mjcf = Path(str(tmp_path)) / "probe.xml"
+        mjcf.write_text(_PROBE_MJCF, encoding="utf-8")
+        sim = Robot("so100", mode="sim", urdf_path=str(mjcf))
+        try:
+            assert sim.mesh is None
+        finally:
+            sim.destroy()


### PR DESCRIPTION
## Problem

`docs/getting-started/robot-factory.md` is the reference a caller reads before writing `Robot(...)`. Three of its statements describe a factory that does not exist.

**1. The `mesh` Default cell named the opposite state.** The row read `` `mesh` | bool | `True` ``. The parameter defaults to `None`, which consults `STRANDS_MESH` and leaves mesh **off**:

```python
>>> inspect.signature(Robot).parameters["mesh"].default
None
>>> Robot("so100", mode="sim").mesh
None
```

The harm compounds. Because the page said mesh was already on, the only knobs it offered were `Robot("so100", mesh=False)` and `STRANDS_MESH=false` -- both no-ops for the state the reader is actually in -- and the spelling that *does* enable it (`mesh=True`, `STRANDS_MESH=true`) appeared nowhere on the page.

**2. The Mesh snippet could not run.** It read `.mesh` attributes on that robot, so copied as written it raises:

```
sim = Robot("so100")
sim.mesh.peer_id   # 'so100_sim-a1b2c3d4'
    AttributeError: 'NoneType' object has no attribute 'peer_id'
```

**3. The `**kwargs` row promised a refusal that does not happen.** It read "Unknown kwargs raise `ValueError`". They are forwarded and ignored:

```python
>>> Robot("so100", mode="sim", urdf_path=..., definitely_not_a_forwardable_kwarg=1)
<MuJoCoSimEngine>          # no ValueError
```

`strands_robots/robot.py`'s own `Args:` entry is already correct here -- "Forwarded to the underlying backend constructor" -- so the table appended a guarantee the code never made. A reader who believes it ships the typo.

## Change

Correct the three statements, and grade the page against `Robot()` itself rather than against a hand-copied expectation:

- every Default cell must equal the signature default;
- every parameter must have a row;
- a row that promises an exception is verified **by raising it**, not by wording -- if the `**kwargs` row claims `ValueError`, the test constructs a robot with an unrecognized kwarg and requires it. A page that promises no refusal is graded as clean, so implementing one later and documenting it still passes;
- the Mesh section must name a spelling `_mesh_env_opt_in` accepts.

The row parser splits on *unescaped* pipes, so a union Type cell is graded rather than silently dropped. This is load-bearing today: #2392's `keyframe` row spells its type `str \| int`, and a naive split would drop that row and report the parameter as undocumented. 11 of the table's 12 rows are graded (`**kwargs` is variadic and has no default).

The precedence the Mesh section now documents was measured, not assumed:

| construction | `.mesh` |
|---|---|
| bare `Robot("so100")`, `STRANDS_MESH` unset | `None` |
| `Robot("so100", mesh=True)` | joined |
| `STRANDS_MESH=true`, bare `Robot(...)` | joined |
| `STRANDS_MESH=false` + `mesh=True` | `None` (kill switch) |

## Scope

Documentation and a guard only; no behaviour change. Whether the factory *should* refuse an unknown kwarg is a separate question -- it would change construction for existing callers -- so this states what it does today rather than changing it.

`tests/mesh/test_mesh_env_opt_in_documented_default.py` already grades this same opt-in contract wherever a table's first cell is the environment variable. This page states it as a constructor default instead, which that guard does not read, so the level it enforces at never reached here.

## Verification

Pre-fix, with the final test file copied onto an unmodified `main` tree: **3 failed, 4 passed**.

```
FAILED ...::test_no_row_states_a_default_the_signature_contradicts
  line 28: `mesh` documents `True` but omitting it yields None
FAILED ...::test_a_promised_unknown_kwarg_refusal_happens
  Failed: DID NOT RAISE <class 'ValueError'>
FAILED ...::test_the_section_names_an_enabling_spelling
  the STRANDS_MESH spellings it shows are ['false'], none of which opts in,
  and it never passes mesh=True. Copied as written it raises AttributeError on None.
```

Post-fix: **7 passed**. The 4 that pass on both trees are the controls -- the page ships, enough rows are graded for a clean result to mean something, every parameter has a row, and a bare `Robot(...)` really does leave mesh off.

Affected suite (`tests/test_docs_*`, `tests/test_robot_factory.py`, `tests/mesh/test_mesh_env_opt_in_documented_default.py`, `tests/mesh/test_mesh_wiring.py`, plus the repo-wide docstring / unicode / ASCII / dependency / changelog guards): **724 passed, 1 skipped**, against 711 passed + the 3 pre-fix failures on base -- the arithmetic reconciles with no regressions. `ruff check`, `ruff format --check` and `mypy` clean over `strands_robots tests tests_integ`.

## Artifact

The page is the input and the interpreter is the oracle: each panel extracts the `## Mesh` snippet from *that tree's own* `robot-factory.md` and runs it line by line. Package code is identical in both panels.

![factory reference](https://raw.githubusercontent.com/cagataycali/robots/media-factory-reference/factory-reference.png)

Left, the snippet dies on its second line. Right, it runs to completion and the values match the comments beside them (`sim.mesh` -> `None`, `peer_id` -> `'so100_sim-af5c92ae'`, `alive` -> `True`).
