### PR TITLE
fix(mesh/input): report a failed teleop-event read instead of publishing it as no signal

### DIFF
--- a/changelog.d/2399-teleop-event-read-is-reported.md
+++ b/changelog.d/2399-teleop-event-read-is-reported.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **mesh/input**: a failed `get_teleop_events()` read is no longer published as `events: None`
+  with no other trace. `null` is also what a leader arm with no event surface publishes, so a
+  teleoperator whose event surface stopped answering dropped the operator's `terminate_episode`
+  signal while joint commands kept flowing and `stats` reported a clean session. The read stays
+  best-effort and never drops the frame the follower is tracking, but a failure now increments
+  `InputPublisher.stats["event_read_errors"]` and logs a warning naming the device and the cause.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -139,6 +139,17 @@ follower.stop_teleop("leader")
 
 `get_teleop_status()` on either side inspects current teleop state.
 
+Each published frame carries the operator's control signals from the
+teleoperator's `get_teleop_events()` - `terminate_episode`, `success`,
+`rerecord_episode`, `is_intervention` - alongside the joint action. Reading them
+is best-effort: a teleoperator whose event surface stops answering (a keyboard
+listener thread that died, a gamepad unplugged mid-session) never stops the joint
+stream the follower is tracking. Because that field is also `null` for a leader
+arm with no event surface at all, a failed read is reported on the publisher
+rather than only on the wire - it increments `event_read_errors` in
+`get_teleop_status()` and logs a warning naming the device and the cause, so an
+operator whose signals are being dropped can see it.
+
 `source_peer_id` and `device_name` are single segments of the mesh key
 expression `strands/{peer_id}/input/{device_name}`, so both must be plain
 identifiers (`[A-Za-z0-9_.-]+`, at most 128 chars). A Zenoh wildcard (`*`,

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -15,6 +15,11 @@ Topic schema for ``strands/{peer_id}/input/{device_name}``::
         "action": {"motor.pos": float, ...},
         "events": {"terminate_episode": bool, ...} | null
     }
+
+``events`` is ``null`` both when the teleoperator exposes no
+``get_teleop_events()`` surface and when reading it failed, so the publisher
+side reports a failed read through ``InputPublisher.stats``
+(``event_read_errors``) and a log line rather than only on the wire.
 """
 
 from __future__ import annotations
@@ -47,6 +52,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 INPUT_HZ_DEFAULT = 50.0
+
+#: How many times each :class:`InputPublisher` loop failure is logged before
+#: going quiet. The loop runs at ``hz`` (50 Hz by default), so an unbounded
+#: log of a persistent fault - a dead publish transport, a teleoperator whose
+#: event surface stopped answering - floods the operator's console at the
+#: control rate. The counters in :attr:`InputPublisher.stats` stay exact.
+_MAX_LOGGED_LOOP_ERRORS = 5
 
 #: Default ceiling on the rate at which an InputReceiver will
 #: APPLY inbound teleop frames to the robot. The publisher streams at
@@ -162,6 +174,7 @@ class InputPublisher:
         self._stop_event = threading.Event()
         self._seq = 0
         self._error_count = 0
+        self._event_read_error_count = 0
         self._frame_count = 0
         self._start_time = 0.0
 
@@ -185,7 +198,10 @@ class InputPublisher:
     def stats(self) -> dict[str, Any]:
         """Live publishing counters: the target device/method, whether the
         loop is ``running``, cumulative ``frames`` published and ``errors``
-        hit, and the achieved vs. requested rate (``hz_actual`` / ``hz_target``).
+        hit, ``event_read_errors`` (frames published with ``events: null``
+        because ``get_teleop_events()`` raised, rather than because the
+        teleoperator has no event surface), and the achieved vs. requested rate
+        (``hz_actual`` / ``hz_target``).
         """
         elapsed = time.time() - self._start_time if self._start_time else 0
         return {
@@ -194,6 +210,7 @@ class InputPublisher:
             "running": self._running,
             "frames": self._frame_count,
             "errors": self._error_count,
+            "event_read_errors": self._event_read_error_count,
             "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
             "hz_target": self.hz,
         }
@@ -246,8 +263,25 @@ class InputPublisher:
                 if hasattr(self.teleoperator, "get_teleop_events"):
                     try:
                         events = self.teleoperator.get_teleop_events()
-                    except Exception:
-                        pass
+                    except Exception as event_err:  # noqa: BLE001
+                        # The operator's control signals (terminate_episode /
+                        # success / rerecord_episode) are secondary to the joint
+                        # stream, so a failure reading them must not stop the
+                        # arm: letting it reach the handler below would drop the
+                        # whole frame, action included. It must not be silent
+                        # either - ``events: null`` is also what a teleoperator
+                        # with no event surface publishes, so an unreported
+                        # failure is indistinguishable from "the operator
+                        # signalled nothing" while joint commands keep flowing.
+                        self._event_read_error_count += 1
+                        if self._event_read_error_count <= _MAX_LOGGED_LOOP_ERRORS:
+                            logger.warning(
+                                "[mesh] input teleop-event read failed (%s): %s - "
+                                "publishing events=None, so operator signals are "
+                                "not reaching subscribers",
+                                self.device_name,
+                                event_err,
+                            )
 
                 payload = {
                     "peer_id": self.mesh.peer_id,
@@ -268,7 +302,7 @@ class InputPublisher:
                 self._frame_count += 1
             except Exception as exc:
                 self._error_count += 1
-                if self._error_count <= 5:
+                if self._error_count <= _MAX_LOGGED_LOOP_ERRORS:
                     logger.warning("[mesh] input publish error (%s): %s", self.device_name, exc)
 
             elapsed = time.perf_counter() - loop_start

--- a/tests/mesh/test_input_teleop_event_read_is_reported.py
+++ b/tests/mesh/test_input_teleop_event_read_is_reported.py
@@ -1,0 +1,188 @@
+"""A failed teleop-event read must be reported, not published as ``events: None``.
+
+:class:`~strands_robots.mesh.input.InputPublisher` streams a leader's joint
+action and, alongside it, the operator's control signals from the
+teleoperator's ``get_teleop_events()`` - ``terminate_episode`` (the operator
+asking to end the episode), ``success``, ``rerecord_episode``,
+``is_intervention``. The published topic schema declares that field nullable,
+and ``null`` is the correct value for a plain leader arm that exposes no event
+surface at all.
+
+That made a failed read indistinguishable from "the operator signalled
+nothing": a teleoperator whose event surface stops answering (a keyboard
+listener thread that died, a gamepad unplugged mid-session) published
+``events: None`` on every frame while joint commands kept flowing, and left no
+trace anywhere - ``stats`` reported a clean session and no log line was emitted.
+An operator pressing quit could not tell their signal was being dropped.
+
+The read stays best-effort: the event surface is secondary to the joint stream,
+so a failure must not drop the frame the arm is following. What the failure must
+not do is disappear. These tests pin both halves - the frame survives, and the
+failure is counted in ``stats["event_read_errors"]`` and logged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import pytest
+
+from strands_robots.mesh.input import InputPublisher
+
+_ACTION = {"shoulder.pos": 0.25, "elbow.pos": -0.10}
+_LOGGER = "strands_robots.mesh.input"
+
+
+class _StopAfterMesh:
+    """Mesh double that ends the publish loop after ``limit`` frames.
+
+    Driving the loop synchronously (rather than through the real background
+    thread) keeps the assertions on exact frame counts deterministic.
+    """
+
+    peer_id = "leader-01"
+
+    def __init__(self, limit: int = 3) -> None:
+        self.limit = limit
+        self.published: list[dict[str, Any]] = []
+        self.publisher: InputPublisher | None = None
+
+    def publish(self, topic: str, payload: dict[str, Any]) -> None:
+        self.published.append(payload)
+        if len(self.published) >= self.limit and self.publisher is not None:
+            self.publisher._running = False
+
+
+class _Leader:
+    """Leader arm whose ``get_teleop_events`` either answers or raises."""
+
+    def __init__(self, *, raises: BaseException | None = None, events: Any = None) -> None:
+        self._raises = raises
+        self._events = events
+        self.event_calls = 0
+
+    def get_action(self) -> dict[str, float]:
+        return dict(_ACTION)
+
+    def get_teleop_events(self) -> Any:
+        self.event_calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return self._events
+
+
+class _EventlessLeader:
+    """Plain leader arm: no ``get_teleop_events`` surface at all."""
+
+    def get_action(self) -> dict[str, float]:
+        return dict(_ACTION)
+
+
+def _drive(teleoperator: Any, frames: int = 3) -> tuple[_StopAfterMesh, InputPublisher]:
+    """Run the real publish loop for exactly ``frames`` frames, synchronously."""
+    mesh = _StopAfterMesh(limit=frames)
+    # A high rate leaves no sleep budget, so the loop never blocks in tests.
+    publisher = InputPublisher(cast(Any, mesh), teleoperator, device_name="leader", hz=10_000.0)
+    mesh.publisher = publisher
+    publisher._running = True
+    publisher._publish_loop()
+    assert len(mesh.published) == frames, f"premise: expected {frames} frames, got {len(mesh.published)}"
+    return mesh, publisher
+
+
+def _event_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING and "teleop-event" in r.getMessage()]
+
+
+class TestAFailedEventReadIsDistinguishableFromNoEventSurface:
+    """The two states that both publish ``events: None`` must not look alike."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("keyboard listener thread is dead"),
+            OSError("gamepad /dev/input/js0 disconnected"),
+        ],
+        ids=["listener-died", "device-unplugged"],
+    )
+    def test_a_raising_event_read_is_counted(self, error: BaseException, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            mesh, publisher = _drive(_Leader(raises=error))
+
+        # ``.get(..., 0)`` so a build that does not report the failure at all
+        # fails on the count rather than on a missing key.
+        assert publisher.stats.get("event_read_errors", 0) == 3, (
+            "every frame published events=None because the read raised "
+            f"{error!r}, but stats reported "
+            f"event_read_errors={publisher.stats.get('event_read_errors', 0)} - "
+            "indistinguishable from a leader with no event surface"
+        )
+        assert all(frame["events"] is None for frame in mesh.published)
+
+    @pytest.mark.parametrize(
+        "error",
+        [RuntimeError("keyboard listener thread is dead"), OSError("js0 disconnected")],
+        ids=["listener-died", "device-unplugged"],
+    )
+    def test_a_raising_event_read_is_logged_with_the_device_and_the_cause(
+        self, error: BaseException, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            _drive(_Leader(raises=error))
+
+        warnings = _event_warnings(caplog)
+        assert warnings, "a failed teleop-event read emitted no warning at all"
+        assert "leader" in warnings[0], warnings[0]
+        assert str(error) in warnings[0], warnings[0]
+
+    def test_no_event_surface_is_not_reported_as_a_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The legitimate ``events: None`` must stay silent - no over-reporting."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            mesh, publisher = _drive(_EventlessLeader())
+
+        assert publisher.stats.get("event_read_errors", 0) == 0
+        assert _event_warnings(caplog) == []
+        assert all(frame["events"] is None for frame in mesh.published)
+
+    def test_a_successful_read_is_silent_and_carries_the_events(self, caplog: pytest.LogCaptureFixture) -> None:
+        signals = {"terminate_episode": True, "success": False}
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            mesh, publisher = _drive(_Leader(events=dict(signals)))
+
+        assert publisher.stats.get("event_read_errors", 0) == 0
+        assert _event_warnings(caplog) == []
+        assert all(frame["events"] == signals for frame in mesh.published)
+
+
+class TestTheJointStreamSurvivesAFailedEventRead:
+    """The event surface is secondary: its failure must not stop the arm."""
+
+    def test_every_frame_is_still_published_with_its_action(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            mesh, publisher = _drive(_Leader(raises=RuntimeError("listener dead")), frames=4)
+
+        assert publisher.stats["frames"] == 4
+        assert [frame["action"] for frame in mesh.published] == [_ACTION] * 4
+        assert [frame["seq"] for frame in mesh.published] == [0, 1, 2, 3]
+
+    def test_the_publish_error_counter_is_not_conflated(self, caplog: pytest.LogCaptureFixture) -> None:
+        """``errors`` counts lost frames; a lost event read loses no frame."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            _mesh, publisher = _drive(_Leader(raises=RuntimeError("listener dead")))
+
+        assert publisher.stats["errors"] == 0
+
+
+class TestTheLogIsBoundedButTheCounterIsNot:
+    """A persistent fault at control rate must not flood the console."""
+
+    def test_warnings_are_capped_while_the_count_stays_exact(self, caplog: pytest.LogCaptureFixture) -> None:
+        frames = 30
+        with caplog.at_level(logging.WARNING, logger=_LOGGER):
+            _mesh, publisher = _drive(_Leader(raises=RuntimeError("listener dead")), frames=frames)
+
+        assert publisher.stats.get("event_read_errors", 0) == frames, (
+            "the counter must record every failed read, not just the logged ones"
+        )
+        assert len(_event_warnings(caplog)) <= 5


### PR DESCRIPTION
## Problem

`InputPublisher` streams a leader's joint action and, alongside it, the operator's control
signals read from the teleoperator's `get_teleop_events()` - `terminate_episode` (the operator
asking to end the episode), `success`, `rerecord_episode`, `is_intervention`. The published
topic schema in the module docstring declares that field nullable, and `null` is the correct
value for a plain leader arm that exposes no event surface at all.

The read was wrapped in a bare `except Exception: pass`, so a failed read published exactly the
same thing. A teleoperator whose event surface stops answering - a keyboard listener thread that
died, a gamepad unplugged mid-session - published `events: None` on every frame while joint
commands kept flowing, and left no trace anywhere: `stats` reported a clean session and nothing
was logged. An operator pressing quit could not tell their signal was being dropped, and neither
could a subscriber watching the stream.

Measured through the real publish loop, 8 frames per case:

**Before** - the three rows that mean different things are byte-identical in every observable:

| case | wire `events` | action delivered | `stats["errors"]` | `stats["event_read_errors"]` | warnings |
|---|---|---|---|---|---|
| read raises (`RuntimeError`, listener died) | `None` | yes | 0 | *(absent)* | 0 |
| read raises (`OSError`, device unplugged) | `None` | yes | 0 | *(absent)* | 0 |
| no event surface (legitimate null) | `None` | yes | 0 | *(absent)* | 0 |
| read OK (operator pressed quit) | `{'terminate_episode': True, ...}` | yes | 0 | *(absent)* | 0 |

**After**:

| case | wire `events` | action delivered | `stats["errors"]` | `stats["event_read_errors"]` | warnings |
|---|---|---|---|---|---|
| read raises (`RuntimeError`, listener died) | `None` | yes | 0 | **8** | 5 |
| read raises (`OSError`, device unplugged) | `None` | yes | 0 | **8** | 5 |
| no event surface (legitimate null) | `None` | yes | 0 | 0 | 0 |
| read OK (operator pressed quit) | `{'terminate_episode': True, ...}` | yes | 0 | 0 | 0 |

```
[mesh] input teleop-event read failed (leader): keyboard listener thread is dead -
publishing events=None, so operator signals are not reaching subscribers
```

![teleop-event read observability, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-event-read/teleop_event_read.png)

Both panels are the same capture script run against `main` and against this branch, 8 frames
per case through the real `_publish_loop`. On `main` the three highlighted rows - two different
read failures and the legitimate "this leader has no event surface" - are byte-identical in every
observable a caller has. After the change a failed read is the only row that reports anything, and
the legitimate-null row is untouched.

## Change

The read stays best-effort, deliberately. The event surface is secondary to the joint stream, so
its failure must not drop the frame the follower is tracking - letting the exception reach the
loop handler 15 lines below would discard the whole frame, action included, and hold arm motion
hostage to a flaky event surface. What the failure must no longer do is disappear.

- `strands_robots/mesh/input.py`: a failed `get_teleop_events()` now increments a distinct
  `_event_read_error_count`, surfaced as `stats["event_read_errors"]` (and so through
  `get_teleop_status()`), and logs a warning naming the device and the cause. The handler keeps
  its breadth - it is a recovery path - and now carries the comment explaining why.
- The count is kept separate from `errors`, which counts *lost frames*; a failed event read loses
  no frame, so conflating them would misreport the loss. This mirrors how `InputReceiver` already
  breaks its losses down into `drops` / `rejected` / `rate_dropped` / `slew_rejected`.
- The log is rate-limited by `_MAX_LOGGED_LOOP_ERRORS`, a new module constant replacing the
  literal `5` the sibling handler in the same loop already used, so the two agree by construction
  rather than by coincidence. The loop runs at `hz`, so an uncapped log of a persistent fault
  would flood the console at the control rate; the counter stays exact (8 failures, 5 warnings).

## Scope

The wire value is unchanged. `events: null` remains within the documented schema, and widening
that schema to distinguish "not read" from "no event surface" is a protocol change that needs
subscriber coordination, so it is deliberately not part of this. What this fixes is that the
failure is now visible on the publisher, where the operator is.

## Tests

`tests/mesh/test_input_teleop_event_read_is_reported.py` drives the real `_publish_loop`
synchronously (a mesh double ends the loop after N frames, so the frame counts are exact rather
than thread-timing dependent).

Against `main`: **5 failed, 4 passed**. After: **9 passed**.

The 4 that pass on both trees are the controls, and each fails for a different wrong fix:

- a teleoperator with no event surface is still *not* reported as a failure, and a successful
  read is still silent - so the fix cannot over-report;
- every frame is still published with its action and a gapless `seq` - so the fix cannot be
  "let it propagate", which would drop the frame;
- `stats["errors"]` stays 0 - so the fix cannot bump the frame-loss counter instead.

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 19 errors on this branch, 19 on `main` - unchanged,
  none in the touched files.
- Blast radius (all of `tests/mesh` plus every test file referencing `InputPublisher`,
  `teleop_mixin` or a docs page, 194 files) run on this branch and on `main`:
  branch 21 failed / 4358 passed / 24 errors, `main` 26 failed / 4353 passed / 24 errors.
  Branch-only failures: none. The 5 extra failures on `main` are exactly this PR's new tests
  before the fix, and `4358 - 4353 = +5` reconciles against them. The 45 shared failures are
  pre-existing (`awsiot` / zenoh backends not installed in this environment).

## Docs

`docs/mesh.md` mesh-teleop section now states that the events read is best-effort, that it never
stops the joint stream, and that a failed read is reported through `event_read_errors` rather
than only as `null` on the wire. The module docstring's topic schema records the same ambiguity.
