### PR TITLE
fix(tools/lerobot_teleoperate): keep the session record of a process that exists but cannot be inspected

### DIFF
--- a/changelog.d/2400-teleop-session-store-keeps-a-live-pid.md
+++ b/changelog.d/2400-teleop-session-store-keeps-a-live-pid.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tools/lerobot_teleoperate**: a teleop session whose process exists but cannot be inspected (`psutil.AccessDenied`, e.g. a session started under `sudo` for serial-port access and later listed as the invoking user) is no longer erased from the session store. The prune is written back to disk and that store holds the only copy of the detached process's pid, so dropping the record left the session unlisted, unstoppable, and still driving the arm. A process reaped mid-probe (`psutil.NoSuchProcess`) is still pruned, and a retained record is now reported at `WARNING`.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -56,6 +56,25 @@ that means "stop at once", so treating it as unset would invert the request.
 Passing a value an action ignores is never an error: `action="start"` without a
 `dataset_repo_id` teleoperates and reads no `dataset_*` option.
 
+### A session is only forgotten once its process is gone
+
+Because the session runs detached, the on-disk session store is the only place
+its pid is recorded - `stop` and `status` both look the session up there. Every
+load prunes finished sessions and writes the pruned store back, so what counts
+as "finished" decides whether a session stays stoppable:
+
+| What the probe reports | Verdict |
+|------------------------|---------|
+| the pid no longer exists | finished - pruned |
+| `psutil.NoSuchProcess` (reaped between the existence check and the probe) | finished - pruned |
+| `is_running()` returns `False` (a zombie, or the pid was reused) | not this session - pruned |
+| `psutil.AccessDenied` (the pid exists, this user may not inspect it) | kept, and reported at `WARNING` |
+
+The last row is why a session started under `sudo` - a common way to reach a
+serial port - is still listed and still stoppable when the tool is later invoked
+as the unprivileged user. Being kept is not a claim that it is running: `list`
+and `status` each derive that from the pid's existence at the moment you ask.
+
 ### A raw servo write is bounded by the register it encodes into
 
 `serial_tool` writes Feetech registers by masking the value into fixed-width

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -267,7 +267,30 @@ class SessionManager:
         self.sessions_file = SESSION_DIR / "active_sessions.json"
 
     def _load_sessions(self) -> dict[str, Any]:
-        """Load active sessions from disk."""
+        """Load the session store, pruning records whose process is gone.
+
+        ``psutil.pid_exists`` answers whether the PID exists;
+        ``Process(pid).is_running()`` refines that (it also rules out PID reuse).
+        The two probes can disagree, and the two ways they disagree mean opposite
+        things, so they are handled separately:
+
+        * :class:`psutil.NoSuchProcess` - the process was reaped between the two
+          calls. The record names nothing, so it is pruned.
+        * :class:`psutil.AccessDenied` - the process exists (``pid_exists`` just
+          said so) but this user may not inspect it; a session started under
+          ``sudo`` for serial-port access and then listed as the invoking user
+          reads this way. That is not death, so the record is kept.
+
+        Keeping it matters because the prune below is *written back to disk* and
+        this store is the only place a detached session's PID is recorded: a
+        pruned record leaves the teleoperation process running with no supported
+        way to stop it. Presence here is not the running claim - ``list`` and
+        ``status`` each derive that from ``pid_exists`` - so a retained record is
+        reported running only while its PID really exists.
+
+        Returns:
+            The surviving session records, keyed by session name.
+        """
         if not self.sessions_file.exists():
             return {}
 
@@ -284,8 +307,18 @@ class SessionManager:
                         proc = psutil.Process(pid)
                         if proc.is_running():
                             active_sessions[name] = info
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    except psutil.NoSuchProcess:
                         pass
+                    except psutil.AccessDenied:
+                        # Exists but not inspectable: keep the record (see above)
+                        # and say so, because the store is written back below and
+                        # silence here loses the PID for good.
+                        active_sessions[name] = info
+                        logger.warning(
+                            "Teleop session PID %s exists but cannot be inspected; "
+                            "keeping its record so the session stays stoppable",
+                            pid,
+                        )
 
             # Update sessions file with only active sessions
             if len(active_sessions) != len(sessions):

--- a/strands_robots/tools/lerobot_teleoperate.py
+++ b/strands_robots/tools/lerobot_teleoperate.py
@@ -308,6 +308,8 @@ class SessionManager:
                         if proc.is_running():
                             active_sessions[name] = info
                     except psutil.NoSuchProcess:
+                        # Reaped between pid_exists and this probe: the record
+                        # names nothing, so pruning it loses no live session.
                         pass
                     except psutil.AccessDenied:
                         # Exists but not inspectable: keep the record (see above)

--- a/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
+++ b/tests/tools/test_teleop_session_store_keeps_a_live_pid.py
@@ -1,0 +1,205 @@
+"""The teleop session store must not delete the record of a live process.
+
+``SessionManager._load_sessions`` prunes finished sessions and *writes the
+pruned map back to disk*, and that store is the only place a detached
+teleoperation subprocess's PID is recorded. So the prune's classification is
+load-bearing: a record dropped by mistake is gone for good, and the process it
+named keeps driving the arm with no supported way to stop it.
+
+Two probes decide the classification. ``psutil.pid_exists`` answers existence;
+``Process(pid).is_running()`` refines it. When the second one raises they
+disagree, and the two ways it can raise mean opposite things:
+
+* ``NoSuchProcess`` - reaped between the two calls, so the record names nothing.
+* ``AccessDenied`` - the process exists and this user may not inspect it (a
+  session started under ``sudo`` for serial-port access, listed as the invoking
+  user). Existence was already established, so this is not death.
+
+These tests pin that only the first prunes, that no read path erases a record it
+could not inspect, and that ``stop`` can still reach such a session. The prune
+of a genuinely finished session is pinned unchanged alongside, so the retention
+cannot grow into "never prune anything".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_teleoperate as tele_mod
+import strands_robots.tools.lerobot_train as train_mod
+
+SessionManager = tele_mod.SessionManager
+lerobot_teleoperate = tele_mod.lerobot_teleoperate
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect both session stores to a temp dir so no test touches the tree."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(tele_mod, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+def _live_pid() -> int:
+    """A PID that certainly exists and that we own: this test process."""
+    pid = os.getpid()
+    assert tele_mod.psutil.pid_exists(pid), "premise: the test process must exist"
+    return pid
+
+
+def _raise_on_probe(monkeypatch: pytest.MonkeyPatch, module: Any, exc: type[Exception]) -> None:
+    """Make ``is_running()`` raise ``exc`` while ``pid_exists`` stays truthful."""
+
+    class _Probe:
+        def __init__(self, pid: int) -> None:
+            self._pid = pid
+
+        def is_running(self) -> bool:
+            raise exc(self._pid)
+
+    monkeypatch.setattr(module.psutil, "Process", _Probe)
+
+
+def _stored(mgr: Any) -> dict[str, Any]:
+    """The records the store holds on disk, independent of what a load returns."""
+    if not mgr.sessions_file.exists():
+        return {}
+    return json.loads(mgr.sessions_file.read_text())
+
+
+# ---------------------------------------------------------------------------
+# A process that exists but cannot be inspected keeps its record.
+# ---------------------------------------------------------------------------
+def test_an_uninspectable_live_session_survives_on_disk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AccessDenied`` on a PID that exists must not erase the stored record."""
+    mgr = SessionManager()
+    pid = _live_pid()
+    mgr.add_session("arm_teleop", {"pid": pid, "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
+
+    assert mgr.get_session("arm_teleop") is not None, (
+        "a session whose PID exists must remain reachable when the deeper probe is denied"
+    )
+    assert "arm_teleop" in _stored(mgr), (
+        "the prune is written back to disk, so dropping the record destroys the only copy of the PID"
+    )
+
+
+def test_a_read_only_query_does_not_delete_such_a_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``list`` is a query; it must not mutate the store it reads."""
+    mgr = SessionManager()
+    mgr.add_session("arm_teleop", {"pid": _live_pid(), "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
+
+    mgr.list_sessions()
+
+    assert "arm_teleop" in _stored(mgr), "listing sessions erased the record it could not inspect"
+
+
+def test_adding_a_session_does_not_erase_an_uninspectable_sibling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every write path loads first, so a denied probe must not take bystanders."""
+    mgr = SessionManager()
+    mgr.add_session("arm_teleop", {"pid": _live_pid(), "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
+
+    mgr.add_session("second", {"pid": _live_pid(), "action": "record", "start_time": 0.0})
+
+    stored = _stored(mgr)
+    assert "second" in stored, "premise: the new session must be persisted"
+    assert "arm_teleop" in stored, "starting a session erased a sibling whose probe was denied"
+
+
+def test_stop_can_still_reach_a_session_it_could_not_inspect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The operator-visible point: such a session stays stoppable."""
+    pid = _live_pid()
+    SessionManager().add_session("arm_teleop", {"pid": pid, "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
+    signalled: list[tuple[int, int]] = []
+    monkeypatch.setattr(tele_mod.os, "kill", lambda p, sig: signalled.append((p, sig)))
+    monkeypatch.setattr(tele_mod.time, "sleep", lambda s: None)
+
+    result = lerobot_teleoperate(action="stop", session_name="arm_teleop")
+
+    assert result["status"] == "success", "a live session the tool started must remain stoppable"
+    assert signalled and signalled[0][0] == pid, "stop must signal the recorded PID"
+
+
+def test_retaining_the_record_is_reported(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """A denied probe is the operator's only clue, so it must not be silent."""
+    mgr = SessionManager()
+    pid = _live_pid()
+    mgr.add_session("arm_teleop", {"pid": pid, "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.AccessDenied)
+
+    with caplog.at_level("WARNING"):
+        mgr.list_sessions()
+
+    assert any(str(pid) in r.getMessage() for r in caplog.records), (
+        "a session that could not be inspected must be reported, naming the PID"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Controls: a session that really is finished is still pruned.
+# ---------------------------------------------------------------------------
+def test_a_process_reaped_mid_probe_is_still_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``NoSuchProcess`` names nothing, so the record goes - including on disk."""
+    mgr = SessionManager()
+    mgr.add_session("racy", {"pid": _live_pid(), "action": "teleoperate", "start_time": 0.0})
+    _raise_on_probe(monkeypatch, tele_mod, tele_mod.psutil.NoSuchProcess)
+
+    assert mgr.list_sessions() == {}
+    assert _stored(mgr) == {}, "a reaped session must still be pruned from the store"
+
+
+def test_a_pid_that_no_longer_exists_is_still_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordinary finished-session path is unchanged."""
+    mgr = SessionManager()
+    mgr.add_session("done", {"pid": _live_pid(), "action": "teleoperate", "start_time": 0.0})
+    monkeypatch.setattr(tele_mod.psutil, "pid_exists", lambda pid: False)
+
+    assert mgr.list_sessions() == {}
+    assert _stored(mgr) == {}, "a session whose PID is gone must still be pruned"
+
+
+def test_a_pid_that_is_not_running_is_still_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``is_running() -> False`` (a zombie, or a reused PID) is not our session."""
+    mgr = SessionManager()
+    mgr.add_session("zombie", {"pid": _live_pid(), "action": "teleoperate", "start_time": 0.0})
+
+    class _NotRunning:
+        def __init__(self, pid: int) -> None:
+            self._pid = pid
+
+        def is_running(self) -> bool:
+            return False
+
+    monkeypatch.setattr(tele_mod.psutil, "Process", _NotRunning)
+
+    assert mgr.list_sessions() == {}
+    assert _stored(mgr) == {}, "a PID that is not running must still be pruned"
+
+
+# ---------------------------------------------------------------------------
+# The sibling store this fix is measured against.
+# ---------------------------------------------------------------------------
+def test_the_training_session_store_prune_stays_non_destructive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``lerobot_train``'s prune never writes back, so its records survive.
+
+    Pinned here because it is the reference this store is aligned with: both
+    now keep a record whose process could not be inspected. If the training
+    store ever starts persisting its prune, it acquires the same defect.
+    """
+    mgr = train_mod.SessionManager()
+    mgr.add_session("training", {"pid": _live_pid(), "action": "train"})
+    _raise_on_probe(monkeypatch, train_mod, train_mod.psutil.AccessDenied)
+
+    mgr.list_sessions()
+
+    assert "training" in _stored(mgr), "the training store must not erase a record it could not inspect"


### PR DESCRIPTION
## Problem

`SessionManager._load_sessions` prunes finished teleop sessions **and writes the pruned store back to disk**. That store is the only place a detached teleoperation subprocess's pid is recorded - `stop` and `status` both look the session up there - so the prune's classification decides whether a session stays stoppable.

Two probes decide it. `psutil.pid_exists(pid)` answers existence; `psutil.Process(pid).is_running()` refines that (it also rules out pid reuse). Both ways the second one can raise were caught in one clause:

```python
except (psutil.NoSuchProcess, psutil.AccessDenied):
    pass
```

They mean opposite things. `NoSuchProcess` means the process was reaped between the two calls, so the record names nothing. `AccessDenied` means the process **exists** - `pid_exists` just said so - and this user may not inspect it; a session started under `sudo` to reach a serial port and later listed as the invoking user reads exactly this way. Treating that as death erased the record.

Measured against a real live subprocess and the real tool (pid exists throughout):

| | before | after |
|---|---|---|
| `list` | `**Active Teleoperation Sessions** (0)` | `(1)` |
| session store on disk after that `list` | `{}` - erased by a read-only query | `{"arm_teleop": ...}` |
| `stop` | `error` / `Session 'arm_teleop' not found` | `success` / `**Session Stopped**` |
| the process afterwards | **still running** | terminated (signal 15) |

The erasure is irreversible and happens on any load, including `list` and `status`; because `add_session`/`remove_session` load first, merely starting another session persists it. The teleoperation process keeps driving the arm with no supported way to stop it.

## Why this is a classification bug rather than a policy choice

* The loop's own comment says it cleans up **dead** sessions. `pid_exists` had already returned `True`.
* The sibling store, `lerobot_train.SessionManager._load_sessions`, reaches the same "cannot confirm running" verdict and **never writes it back**, so its record survives and its comment spells out the reason: *"only the running flag is derived from the PID."* This store conflated the record with the running flag and then persisted the conflation.
* Presence here is not the running claim in this module either - `list` and `status` each compute `is_running` from `pid_exists` at the moment of the call. So a retained record is reported running only while its pid really exists.

## Change

Split the handlers. `NoSuchProcess` still prunes, unchanged. `AccessDenied` keeps the record and reports it at `WARNING`, naming the pid - silence was the operator's only signal that a session had vanished. The docstring records which probe result means what, and `docs/hardware/tools.md` gains the verdict table.

## Tests

`tests/tools/test_teleop_session_store_keeps_a_live_pid.py`, **5 failed / 4 passed on `main`, 9 passed after**:

| test | on `main` |
|---|---|
| an uninspectable live session survives on disk | `assert None is not None` |
| a read-only query does not delete such a record | `assert 'arm_teleop' in {}` |
| adding a session does not erase an uninspectable sibling | `assert 'arm_teleop' in {'second': ...}` |
| `stop` can still reach a session it could not inspect | `assert 'error' == 'success'` |
| retaining the record is reported | no log record |
| a process reaped mid-probe is still pruned | passes |
| a pid that no longer exists is still pruned | passes |
| a pid that is not running is still pruned | passes |
| the training store's prune stays non-destructive | passes |

The four that pass on both trees are the bound: they fail if the retention grows into "never prune anything", and the last pins the sibling store this one is aligned with.

## Verification

* 35-file blast radius (everything referencing the session stores, these tools or `psutil`, plus the repo-wide guards): branch **2 failed / 2370 passed**, `main` with the new file copied in **7 failed / 2365 passed**; branch-only failures **none**, and `7 - 5 = 2` shared pre-existing failures unrelated to this change.
* `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` identical on both trees, none in the touched files.
* Docs/changelog/docstring/ASCII guards: 542 passed.

## Scope

Whether such a session should be *reported* by `lerobot_train`'s store is pinned the other way by its own test, with reasoning, and its prune is already non-destructive - so it is left alone and pinned here instead.

## Artifact

One capture script run against each tree: same live subprocess, same session record, same tool calls, only `strands_robots` differs.

![before and after](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-session-store/session_store.png)
