### PR TITLE
fix(simulation/mujoco): resolve a mesh reference the way MuJoCo resolves it

### DIFF
--- a/changelog.d/2402-mesh-reference-resolution.md
+++ b/changelog.d/2402-mesh-reference-resolution.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation/mujoco**: a mesh-presence check now resolves a reference the way MuJoCo does - honouring `assetdir` as well as `meshdir`, reading the model-global `<compiler>` subdirectory once, and resolving against the main model file's directory. Four registry robots (`stretch3`, `stretch`, `skydio_x2`, `ability_hand`) reported their meshes missing while MuJoCo compiled them, which spent a `force=True` asset re-download on every `add_robot` and refused the robot outright when that download could not run. The download path shared the same blind spot and now reads the rule from the same place.

--- a/docs/simulation/world-building.md
+++ b/docs/simulation/world-building.md
@@ -533,7 +533,8 @@ other.load_scene(scene_path="/tmp/handoff.xml")   # same scene, same structure
 
 Mesh, texture and height-field assets are referenced by ABSOLUTE path. MuJoCo
 resolves a relative `file=` against the model's own directory (plus `meshdir` /
-`texturedir`), and that directory is not part of the serialised XML - so a
+`texturedir`, or the `assetdir` that sets both), and that directory is not part
+of the serialised XML - so a
 relative reference would resolve against wherever the export happened to be
 written. Absolute references keep the export reloadable from any location, and a
 scene composed from several models needs them: each model contributes assets from

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -108,6 +108,63 @@ def _resolve_robot_descriptions_module(name: str, info: dict) -> str | None:
 get_user_assets_dir = get_assets_dir
 
 
+def _mjcf_mesh_subdir(*contents: str) -> str:
+    """Return the mesh search subdirectory declared by MJCF text.
+
+    MuJoCo's ``<compiler>`` element offers two attributes for this. ``meshdir``
+    names the mesh directory specifically; ``assetdir`` names the mesh AND
+    texture directories at once, and ``meshdir`` overrides it where both appear.
+    Both are model-global: they apply across ``<include>``, so the fragment
+    declaring the directory need not be the fragment declaring the mesh.
+
+    A reader that knows only ``meshdir`` resolves an ``assetdir`` model against
+    the model directory itself, so it reports a mesh that is present as absent.
+
+    Args:
+        *contents: MJCF text fragments making up one model, in any order.
+
+    Returns:
+        The declared subdirectory, or ``""`` when no fragment declares one.
+    """
+    for attr in ("meshdir", "assetdir"):
+        for content in contents:
+            if match := re.search(rf'{attr}="([^"]*)"', content):
+                return match.group(1)
+    return ""
+
+
+def _mjcf_mesh_candidates(mesh_ref: str, model_dir: str, mesh_subdir: str, include_dir: str = "") -> list[str]:
+    """Return the on-disk locations MuJoCo accepts for one mesh reference.
+
+    MuJoCo resolves a ``<mesh file=...>`` against the MAIN model file's
+    directory joined with the model's mesh subdirectory - never against the
+    directory of whichever ``<include>``d fragment happened to declare it. When
+    the declaring fragment lives in a subdirectory of the model, MuJoCo also
+    accepts the reference relative to that fragment's directory, so a reference
+    is satisfied by either location.
+
+    Both branches are load-bearing on shipped Menagerie assets: ``skydio_x2``
+    and ``stretch3`` place their meshes under the first, ``lekiwi`` under the
+    second. Resolving against the declaring fragment's directory instead - a
+    location MuJoCo rejects - reports a present mesh as absent.
+
+    Args:
+        mesh_ref: The ``file=`` value as authored, e.g. ``meshes/base.stl``.
+        model_dir: Directory of the main model file.
+        mesh_subdir: Subdirectory from :func:`_mjcf_mesh_subdir`.
+        include_dir: Directory of the declaring fragment, relative to
+            *model_dir*. Empty when the main file declares the mesh itself.
+
+    Returns:
+        Candidate absolute paths; the reference is present if any one exists.
+    """
+    base = os.path.join(model_dir, mesh_subdir)
+    candidates = [os.path.join(base, mesh_ref)]
+    if include_dir:
+        candidates.append(os.path.join(base, include_dir, mesh_ref))
+    return candidates
+
+
 def _needs_download(name: str, info: dict[str, Any] | None, force: bool = False) -> bool:
     """Return *True* if a robot's mesh files are missing."""
     if info is None:
@@ -127,10 +184,11 @@ def _needs_download(name: str, info: dict[str, Any] | None, force: bool = False)
             mesh_files = re.findall(r'file="([^"]+\.(?:stl|STL|obj|OBJ|msh))"', content)
             if not mesh_files:
                 return False
-            meshdir_match = re.search(r'meshdir="([^"]*)"', content)
-            meshdir = meshdir_match.group(1) if meshdir_match else ""
+            meshdir = _mjcf_mesh_subdir(content)
             for mesh in mesh_files:
-                if not (model_path.parent / meshdir / mesh).exists():
+                # The model file declares these itself, so there is no
+                # include-relative candidate to consider.
+                if not any(os.path.exists(p) for p in _mjcf_mesh_candidates(mesh, str(model_path.parent), meshdir)):
                     return True
             return force
         except Exception:

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1183,7 +1183,22 @@ class MuJoCoSimEngine(
         the error dict back to the agent - previously the return value was
         ignored and the error was silently swallowed, leaving the agent to
         hit a cryptic 'mesh not found' from MuJoCo instead.
+
+        A reference is resolved the way MuJoCo resolves it (see
+        :func:`strands_robots.assets.download._mjcf_mesh_candidates`): against
+        the MAIN model file's directory plus the model's mesh subdirectory, and
+        the subdirectory is read once for the whole model because
+        ``<compiler>`` applies across ``<include>``. Resolving against the
+        directory of whichever fragment declared the mesh - a location MuJoCo
+        does not accept - reports a present mesh as absent, which costs a full
+        ``force=True`` re-download on every ``add_robot`` and refuses the robot
+        outright when that download cannot run.
         """
+        # One owner for the resolution rule: the download path applies the same
+        # rule to decide whether a robot's assets need fetching, so a second
+        # copy here could disagree with it about the same model.
+        from strands_robots.assets.download import _mjcf_mesh_candidates, _mjcf_mesh_subdir
+
         model_dir = os.path.dirname(os.path.abspath(model_path))
 
         files_to_check = [model_path]
@@ -1194,27 +1209,32 @@ class MuJoCoSimEngine(
                 inc_path = os.path.join(model_dir, inc)
                 if os.path.exists(inc_path):
                     files_to_check.append(inc_path)
-        except Exception:
+        except (OSError, UnicodeDecodeError):
+            # An unreadable top-level model contributes no includes to scan.
+            # MuJoCo names the unreadable file itself on the load that follows,
+            # which is a better report than anything this check could invent.
             pass
 
-        missing = False
+        # (fragment directory relative to model_dir, fragment text)
+        fragments: list[tuple[str, str]] = []
         for xml_path in files_to_check:
             try:
                 with open(xml_path) as _f:
                     content = _f.read()
-            except Exception:
+            except (OSError, UnicodeDecodeError):
+                # Same reasoning: a fragment we cannot read declares no mesh
+                # references, and MuJoCo reports it on load.
                 continue
+            frag_dir = os.path.dirname(os.path.abspath(xml_path))
+            rel_dir = os.path.relpath(frag_dir, model_dir)
+            fragments.append(("" if rel_dir == os.curdir else rel_dir, content))
 
-            mesh_files = re.findall(r'file="([^"]+\.(?:stl|STL|obj))"', content)
-            if not mesh_files:
-                continue
+        mesh_subdir = _mjcf_mesh_subdir(*(text for _rel, text in fragments))
 
-            meshdir_match = re.search(r'meshdir="([^"]*)"', content)
-            meshdir = meshdir_match.group(1) if meshdir_match else ""
-            xml_dir = os.path.dirname(os.path.abspath(xml_path))
-
-            for mf in mesh_files:
-                if not os.path.exists(os.path.join(xml_dir, meshdir, mf)):
+        missing = False
+        for rel_dir, content in fragments:
+            for mf in re.findall(r'file="([^"]+\.(?:stl|STL|obj))"', content):
+                if not any(os.path.exists(p) for p in _mjcf_mesh_candidates(mf, model_dir, mesh_subdir, rel_dir)):
                     missing = True
                     break
             if missing:

--- a/tests/simulation/mujoco/test_ensure_meshes.py
+++ b/tests/simulation/mujoco/test_ensure_meshes.py
@@ -16,6 +16,7 @@ one callers MUST propagate, so it is pinned here explicitly.
 
 from __future__ import annotations
 
+import inspect
 import os
 
 import pytest
@@ -146,3 +147,197 @@ def test_unreadable_model_path_is_tolerated(tmp_path):
     """
     missing_path = str(tmp_path / "does_not_exist.xml")
     assert _ensure_meshes(missing_path, "robot") is None
+
+
+class TestAReferenceIsResolvedTheWayMuJoCoResolvesIt:
+    """``_ensure_meshes`` must agree with MuJoCo about where a mesh lives.
+
+    MuJoCo resolves a ``<mesh file=...>`` against the MAIN model file's
+    directory plus the model's mesh subdirectory. Two details are easy to get
+    wrong and both make a present mesh look absent:
+
+    * the subdirectory can be declared as ``assetdir`` (which sets the mesh and
+      texture directories together) rather than ``meshdir``, and
+    * ``<compiler>`` is model-global, so the fragment declaring the directory
+      need not be the fragment declaring the mesh, and neither is resolved
+      against the declaring fragment's own directory.
+
+    A false "missing" is not cosmetic: it spends a full ``force=True``
+    re-download on every ``add_robot``, and ``add_robot`` returns that
+    download's error dict when the download cannot run - refusing a robot whose
+    meshes are all on disk.
+    """
+
+    @staticmethod
+    def _no_download(monkeypatch):
+        """Fail the test if any download is attempted."""
+
+        def _boom(*a, **k):
+            raise AssertionError("meshes are on disk; no download expected")
+
+        monkeypatch.setattr("strands_robots.assets.download.download_robots", _boom)
+
+    def test_assetdir_is_honored_like_meshdir(self, tmp_path, monkeypatch):
+        """``assetdir`` names the mesh directory too, so it must be joined on."""
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "arm.stl").write_bytes(b"solid\n")
+        model = _write(
+            tmp_path / "robot.xml",
+            '<mujoco><compiler assetdir="assets"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+        )
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_meshdir_overrides_assetdir(self, tmp_path, monkeypatch):
+        """When both appear, ``meshdir`` wins - as it does in MuJoCo."""
+        (tmp_path / "meshes").mkdir()
+        (tmp_path / "meshes" / "arm.stl").write_bytes(b"solid\n")
+        model = _write(
+            tmp_path / "robot.xml",
+            '<mujoco><compiler assetdir="nowhere" meshdir="meshes"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+        )
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_a_compiler_in_the_top_file_applies_to_an_included_mesh(self, tmp_path, monkeypatch):
+        """``<compiler>`` is model-global: it reaches a mesh declared elsewhere."""
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "arm.stl").write_bytes(b"solid\n")
+        _write(tmp_path / "parts.xml", '<mujoco><asset><mesh file="arm.stl"/></asset></mujoco>')
+        model = _write(
+            tmp_path / "robot.xml",
+            '<mujoco><compiler meshdir="assets"/><include file="parts.xml"/></mujoco>',
+        )
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_a_compiler_in_an_included_file_applies_to_a_top_level_mesh(self, tmp_path, monkeypatch):
+        """The same, in the other direction."""
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "arm.stl").write_bytes(b"solid\n")
+        _write(tmp_path / "parts.xml", '<mujoco><compiler meshdir="assets"/></mujoco>')
+        model = _write(
+            tmp_path / "robot.xml",
+            '<mujoco><include file="parts.xml"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+        )
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_an_included_fragments_mesh_resolves_against_the_main_model_dir(self, tmp_path, monkeypatch):
+        """A fragment in a subdirectory still resolves against the model root.
+
+        This is the shipped ``skydio_x2`` / ``stretch3`` layout: the fragment
+        that declares the meshes lives beside the model file's directory while
+        the meshes sit under the model's own asset directory.
+        """
+        (tmp_path / "assets").mkdir()
+        (tmp_path / "assets" / "arm.stl").write_bytes(b"solid\n")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        _write(
+            sub / "parts.xml",
+            '<mujoco><compiler assetdir="assets"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+        )
+        model = _write(tmp_path / "robot.xml", '<mujoco><include file="sub/parts.xml"/></mujoco>')
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_an_included_fragments_mesh_may_also_sit_beside_that_fragment(self, tmp_path, monkeypatch):
+        """MuJoCo also accepts the reference relative to the fragment's directory.
+
+        This is the shipped ``lekiwi`` layout, and it is why both candidate
+        locations are checked rather than only the model root.
+        """
+        sub = tmp_path / "sub"
+        (sub / "meshes").mkdir(parents=True)
+        (sub / "meshes" / "arm.stl").write_bytes(b"solid\n")
+        _write(sub / "parts.xml", '<mujoco><asset><mesh file="meshes/arm.stl"/></asset></mujoco>')
+        model = _write(tmp_path / "robot.xml", '<mujoco><include file="sub/parts.xml"/></mujoco>')
+        self._no_download(monkeypatch)
+        assert _ensure_meshes(model, "robot") is None
+
+    def test_a_genuinely_absent_mesh_is_still_reported(self, tmp_path, monkeypatch):
+        """Widening where we look must not stop us noticing a real absence."""
+        (tmp_path / "assets").mkdir()
+        _write(
+            tmp_path / "robot.xml",
+            '<mujoco><compiler assetdir="assets"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+        )
+        called = {}
+        monkeypatch.setattr("strands_robots.assets.resolve_robot_name", lambda n: n)
+        monkeypatch.setattr(
+            "strands_robots.assets.download.download_robots",
+            lambda names, force: called.update(names=names, force=force),
+        )
+        assert _ensure_meshes(str(tmp_path / "robot.xml"), "robot") is None
+        assert called == {"names": ["robot"], "force": True}
+
+
+class TestTheDownloadPathUsesTheSameRule:
+    """``_needs_download`` decides the same question and must not disagree.
+
+    Both paths ask "are this model's meshes on disk?". They read the rule from
+    one place so a model cannot be judged present by one and absent by the
+    other.
+    """
+
+    def test_needs_download_honors_assetdir(self, tmp_path):
+        from strands_robots.assets.download import _needs_download
+
+        (tmp_path / "robots" / "assets").mkdir(parents=True)
+        (tmp_path / "robots" / "assets" / "arm.stl").write_bytes(b"solid\n")
+        (tmp_path / "robots" / "robot.xml").write_text(
+            '<mujoco><compiler assetdir="assets"/><asset><mesh file="arm.stl"/></asset></mujoco>',
+            encoding="utf-8",
+        )
+        info = {"asset": {"model_xml": "robot.xml", "dir": "robots"}}
+        import strands_robots.assets.download as dl_mod
+
+        original = dl_mod.get_search_paths
+        try:
+            dl_mod.get_search_paths = lambda: [tmp_path]
+            assert _needs_download("robot", info) is False
+        finally:
+            dl_mod.get_search_paths = original
+
+    def test_both_paths_read_the_subdir_rule_from_one_place(self):
+        """The rule has a single owner, so the two callers cannot drift."""
+        import strands_robots.assets.download as dl_mod
+        from strands_robots.simulation.mujoco import simulation as sim_mod
+
+        assert callable(dl_mod._mjcf_mesh_subdir)
+        assert callable(dl_mod._mjcf_mesh_candidates)
+        source = inspect.getsource(sim_mod.MuJoCoSimEngine._ensure_meshes)
+        assert "_mjcf_mesh_subdir" in source
+        assert "_mjcf_mesh_candidates" in source
+        # ...and no second copy of the regex it replaces.
+        assert 'meshdir="([^"]*)"' not in source
+
+
+class TestTheSubdirRuleItself:
+    """Unit coverage for the shared rule, including the precedence."""
+
+    def test_meshdir_wins_over_assetdir_across_fragments(self):
+        from strands_robots.assets.download import _mjcf_mesh_subdir
+
+        assert _mjcf_mesh_subdir('<compiler assetdir="a"/>', '<compiler meshdir="m"/>') == "m"
+        assert _mjcf_mesh_subdir('<compiler meshdir="m"/>', '<compiler assetdir="a"/>') == "m"
+
+    def test_assetdir_is_used_when_no_meshdir_is_declared(self):
+        from strands_robots.assets.download import _mjcf_mesh_subdir
+
+        assert _mjcf_mesh_subdir('<compiler assetdir="a"/>') == "a"
+
+    def test_nothing_declared_yields_the_model_dir_itself(self):
+        from strands_robots.assets.download import _mjcf_mesh_subdir
+
+        assert _mjcf_mesh_subdir("<mujoco/>") == ""
+        assert _mjcf_mesh_subdir() == ""
+
+    def test_the_declaring_fragments_dir_is_not_a_candidate(self):
+        """MuJoCo rejects <fragment dir>/<subdir>/<file>, so we must not accept it."""
+        from strands_robots.assets.download import _mjcf_mesh_candidates
+
+        candidates = _mjcf_mesh_candidates("arm.stl", "/model", "assets", "sub")
+        assert candidates == ["/model/assets/arm.stl", "/model/assets/sub/arm.stl"]
+        assert "/model/sub/assets/arm.stl" not in candidates


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine._ensure_meshes` answers one question before a model is compiled: are this model's mesh files on disk? A "no" triggers `download_robots(force=True)` - a full unconditional Menagerie re-fetch - and `add_robot` returns that download's error dict when the fetch cannot run.

It answered "no" for models whose meshes were all present, because it resolved a reference against the directory of whichever fragment declared it, joined with a `meshdir` attribute read from that same fragment. MuJoCo resolves neither part that way.

Measured on MuJoCo 3.5.0 and 3.10.0 by loading models whose mesh sits at exactly one candidate location:

| declared where | mesh on disk at | MuJoCo |
|---|---|---|
| `assetdir="bag"` in an included fragment | `<model dir>/bag/tet.stl` | accepted |
| `assetdir="bag"` in an included fragment | `<fragment dir>/bag/tet.stl` | **rejected** |
| no attribute, `file="meshes/tet.stl"` | `<model dir>/meshes/tet.stl` | accepted |
| no attribute, `file="meshes/tet.stl"` | `<fragment dir>/meshes/tet.stl` | accepted |
| `meshdir` + `assetdir` together | under `meshdir` | accepted (`meshdir` wins) |
| `<compiler>` in the top file, `<mesh>` in an include | - | accepted |
| `<compiler>` in an include, `<mesh>` in the top file | - | accepted |

So three things hold, and the old check got all three wrong:

- the mesh directory may be declared as **`assetdir`** (which sets the mesh and texture directories together); `meshdir` overrides it where both appear;
- `<compiler>` is **model-global** - the fragment naming the directory need not be the fragment naming the mesh;
- a reference resolves against the **main model file's** directory plus that subdirectory, and additionally relative to the declaring fragment's directory when that fragment sits under the model. `<fragment dir>` joined with the subdirectory - the only base the old code used - is a location MuJoCo rejects.

### Blast radius

Of the 62 loadable registry robots, **4 reported meshes missing while MuJoCo compiled the model without complaint**; the other 58 verdicts are unchanged.

| robot | why it was misread |
|---|---|
| `stretch3`, `stretch`, `skydio_x2` | declare `assetdir="assets"`, never `meshdir` |
| `ability_hand` | declares `meshdir="./assets"` in a fragment one directory below the model |

The user-visible effect, with the asset download unable to run:

| | `stretch3` | `skydio_x2` | `ability_hand` | `panda` |
|---|---|---|---|---|
| before | `error`, `robots=[]` | `error`, `robots=[]` | `error`, `robots=[]` | `success` |
| after | `success` | `success` | `success` | `success` |

The refusal reads `Auto-download failed for 'stretch3': network unreachable. Install robot_descriptions: pip install strands-robots[sim-mujoco]` - which names neither the real cause nor anything the caller can act on, since the meshes were already there.

## Change

- `_mjcf_mesh_subdir(*contents)` and `_mjcf_mesh_candidates(ref, model_dir, subdir, include_dir="")` in `strands_robots.assets.download` hold the rule, with the measurements above recorded in their docstrings.
- `_ensure_meshes` reads the subdirectory once for the whole model and checks both candidate locations.
- `_needs_download` asked the same question with its own copy of the same regex and the same `assetdir` blind spot; both now read the rule from one place, so they cannot disagree about a model.
- `docs/simulation/world-building.md` stated the resolution rule as "`meshdir` / `texturedir`"; it now names `assetdir` too.

Behaviour is unchanged where the old base happened to coincide with a MuJoCo-accepted one, which is every model whose meshes are declared in the model file itself or in a fragment beside it.

## Tests

`tests/simulation/mujoco/test_ensure_meshes.py`, +13. Against `upstream/main`: **10 failed / 10 passed**; after: **20 passed**. Same 20 on MuJoCo 3.5.0 and on the pinned 3.10.0.

Failing before, one per rule:

- `test_assetdir_is_honored_like_meshdir`
- `test_a_compiler_in_the_top_file_applies_to_an_included_mesh`
- `test_a_compiler_in_an_included_file_applies_to_a_top_level_mesh`
- `test_an_included_fragments_mesh_resolves_against_the_main_model_dir` (the `skydio_x2`/`stretch3` layout)
- `test_needs_download_honors_assetdir` (`assert True is False`)

Passing on **both** trees, so they bound the change rather than describe it:

- `test_an_included_fragments_mesh_may_also_sit_beside_that_fragment` - the `lekiwi` layout. An earlier revision resolved against the model directory only and broke exactly this; the test is why both candidates are checked.
- `test_a_genuinely_absent_mesh_is_still_reported` - widening where we look must not stop us noticing a real absence.
- `test_meshdir_overrides_assetdir`, plus the 7 pre-existing tests.
- `test_the_declaring_fragments_dir_is_not_a_candidate` pins that the location MuJoCo rejects stays rejected.

## Verification

- Registry sweep: spurious "missing" **4 -> 0** across 62 robots; `add_robot` download calls for the 4 go 1 -> 0.
- Blast radius, 220 test files on both trees, identical collection (5038): branch **5024 passed / 0 failed**, base 5014 / 10 - the 10 being exactly the pre-fix failures above, and **no branch-only failure**.
- `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`; `mypy` 19 errors on both trees, none in the changed files.

## Artifact

`add_robot` for each robot with the asset download unavailable, rendered headless. Top row is `upstream/main`: three robots refused with nothing to render. `panda` is byte-identical across both rows (mean |px| = 0.000487), so the change alters only where a reference is looked for.

![mesh reference resolution before and after](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-resolution-32040256256/mesh_resolution.png)
