### PR TITLE
fix(training/lerobot): report an absent lerobot call-time dependency at preflight

### DIFF
--- a/changelog.d/2405-lerobot-call-time-dependency-preflight.md
+++ b/changelog.d/2405-lerobot-call-time-dependency-preflight.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **training/lerobot**: `LerobotTrainer.validate` now reports the packages lerobot's own `train()` requires at call time - `accelerate` always, and `peft` when `method == "lora"` - instead of returning no problems for a spec that cannot train. `lerobot.scripts.lerobot_train.train` reaches those through `require_package(...)` rather than a module-scope import, so locating lerobot said nothing about them, and no `strands-robots[lerobot]` install supplies `accelerate`. `train()` fails closed on a validate() problem, so an `output_dir` is no longer cleared on the way to a run that could never start. Each problem names the `lerobot[...]` extra that supplies the package.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -428,18 +428,22 @@ TrainSpec(..., num_gpus=8,
 as GPU.** LeRobot's `train()` calls
 `require_package("accelerate", extra="training")` *before* it branches on
 device, so "no GPU" does not mean "no extra" - and nothing on this path pulls
-`accelerate` in: the `[lerobot]` extra is exactly `lerobot[feetech,dataset]`, and
-the only `strands-robots` extra that declares `accelerate` is
-`cosmos3-diffusers`, a different provider.
+`accelerate` in: the `[lerobot]` extra is exactly `lerobot[feetech,dataset]`. The
+`strands-robots` extras that declare `accelerate` belong to other providers
+(`kimodo`, `cosmos3-diffusers`), so an install only has it by accident - `[all]`
+does, because it pulls `[kimodo]`; `[lerobot]` alone does not.
 
 ```bash
 pip install "lerobot[training]"
 ```
 
-`train()` reports the missing package in its `TrainResult` rather than raising,
-so check `result.status` and surface `result.message` - it carries LeRobot's own
-install remedy. An unchecked call hands whatever consumes `checkpoint_dir` a
-`None` instead.
+`validate()` reports an absent `accelerate` - and an absent `peft` when
+`method="lora"` - as a preflight problem, so `train()` fails closed on it and
+leaves `output_dir` untouched rather than clearing it on the way to a run that
+cannot start. Either way the cause arrives in the `TrainResult` rather than as a
+raise, so check `result.status` and surface `result.message` - it names the
+package and the `lerobot[...]` extra that supplies it. An unchecked call hands
+whatever consumes `checkpoint_dir` a `None` instead.
 
 The base `strands-robots[lerobot]` extra covers **recording, streaming, and
 loading a trained checkpoint**, and with `lerobot[training]` it covers **ACT /

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import importlib.util
 import json
 import logging
 import os
@@ -81,6 +82,48 @@ _LEROBOT_POLICY_TYPES_FALLBACK = frozenset(
 )
 
 _SUPPORTED_METHODS = {"full", "lora", "expert_only"}
+
+# Packages lerobot's own ``train()`` requires at CALL time, each with the lerobot
+# extra whose remedy names it. Transcribed from the ``require_package(...)`` call
+# sites in ``lerobot.scripts.lerobot_train``, which is the authority for what that
+# entry point will demand:
+#
+#   * ``accelerate`` (extra ``training``) is required UNCONDITIONALLY, as the first
+#     statement of ``train()`` - before it branches on device and before it loads a
+#     dataset - so every LeRobot run needs it, CPU included.
+#   * ``peft`` (extra ``peft``) is required when ``cfg.peft`` is set, which
+#     :meth:`LerobotTrainer.build_config` does exactly when ``method == "lora"``.
+#
+# ``diffusers`` (extra ``diffusion``) is the third such call site, guarded by
+# ``cfg.ema.enable``. It is deliberately absent: nothing here sets ``cfg.ema``, so
+# it is reachable only by naming ``ema.enable`` through the generic dotted
+# ``extra`` passthrough, and enumerating what an arbitrary passthrough key implies
+# is a different question from what this spec's own fields ask for.
+_LEROBOT_CALL_TIME_PACKAGES: tuple[tuple[str, str], ...] = (("accelerate", "training"),)
+_LEROBOT_LORA_PACKAGES: tuple[tuple[str, str], ...] = (("peft", "peft"),)
+
+
+def _module_available(name: str) -> bool:
+    """Whether ``name`` can be located, asked WITHOUT importing it.
+
+    Mirrors lerobot's own ``is_package_available`` - an
+    :func:`importlib.util.find_spec` lookup - so a preflight answers the very
+    question the runtime gate will ask, and keeps :meth:`Trainer.validate`
+    read-only: locating a module neither executes it nor pays its import cost.
+
+    Args:
+        name: Top-level import name of the package to locate.
+
+    Returns:
+        True when a spec was found. A lookup that raises answers False rather
+        than propagating: this runs on a preflight path whose contract is to
+        report problems, so a broken probe is "cannot confirm it is there".
+    """
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
 
 # LeRobot policy types whose config exposes ``use_relative_actions`` (the
 # relative-action processor pair: a RelativeActionsProcessorStep on the input
@@ -688,8 +731,10 @@ class LerobotTrainer(Trainer):
         split below the dataset total and not asked for alongside ``streaming``
         (lerobot's split path is map-style only), a local dataset format version
         the installed lerobot can read, usable LoRA hyperparameters when
-        ``method == "lora"``, and that ``lerobot.scripts.lerobot_train``
-        is importable. ``extra['reward_model']`` switches to reward-model
+        ``method == "lora"``, that ``lerobot.scripts.lerobot_train``
+        is importable, and that the packages its ``train()`` requires at call
+        time (``accelerate`` always, ``peft`` for ``method == "lora"``) are
+        installed. ``extra['reward_model']`` switches to reward-model
         preflight; otherwise the default policy path is checked. Returns the
         problem list; empty means launchable. Read-only.
         """
@@ -788,14 +833,59 @@ class LerobotTrainer(Trainer):
 
         # lerobot must be importable to actually train.
         try:
-            import importlib.util
-
-            if importlib.util.find_spec("lerobot.scripts.lerobot_train") is None:
+            lerobot_present = importlib.util.find_spec("lerobot.scripts.lerobot_train") is not None
+            if not lerobot_present:
                 problems.append("lerobot is not installed (no lerobot.scripts.lerobot_train)")
         except Exception:  # noqa: BLE001
+            lerobot_present = False
             problems.append("lerobot is not installed")
 
+        # An installed lerobot is not yet a launchable one: its train() requires
+        # more packages at CALL time. Reported only once lerobot itself is
+        # present, so an install with neither gets one root cause, not two.
+        if lerobot_present:
+            problems.extend(self._call_time_dependency_problems(spec))
+
         return problems
+
+    def _call_time_dependency_problems(self, spec: TrainSpec) -> list[str]:
+        """Packages lerobot's ``train()`` will require that are not installed.
+
+        ``validate()`` already reports an absent lerobot rather than "deferring
+        the failure to the training launch", but an importable lerobot is not a
+        launchable one: ``lerobot.scripts.lerobot_train.train`` calls
+        ``require_package(...)`` for packages that are NOT module-scope imports
+        of that module, so locating it says nothing about them. The first such
+        call is ``require_package("accelerate", extra="training")``, the opening
+        statement of ``train()`` - and no ``strands-robots[lerobot]`` install
+        supplies ``accelerate``.
+
+        Left unreported, that spec validates clean and :meth:`train` proceeds
+        through :meth:`prepare` and the fresh-start hygiene that removes a
+        checkpoint-less ``output_dir`` before raising - so a run knowably
+        unlaunchable at preflight time deletes a directory first. This gate is
+        what makes "empty means launchable" true of the dependency axis.
+
+        Args:
+            spec: The spec being validated; ``method`` selects the conditional
+                requirements (``lora`` sets ``cfg.peft``, which lerobot gates
+                ``peft`` on).
+
+        Returns:
+            One problem per absent package, naming the lerobot extra that
+            supplies it. Empty when every package the run will need is present.
+        """
+        required = list(_LEROBOT_CALL_TIME_PACKAGES)
+        if spec.method == "lora":
+            required.extend(_LEROBOT_LORA_PACKAGES)
+
+        return [
+            f"'{package}' is required by lerobot's train() but is not installed; "
+            f"install it with: pip install 'lerobot[{extra}]' "
+            f"(the strands-robots[lerobot] extra does not supply it)"
+            for package, extra in required
+            if not _module_available(package)
+        ]
 
     def _validate_policy(self, spec: TrainSpec) -> list[str]:
         """Policy-training preflight (the default, ``cfg.policy`` path)."""

--- a/tests/training/test_call_time_dependency_preflight.py
+++ b/tests/training/test_call_time_dependency_preflight.py
@@ -1,0 +1,197 @@
+"""Preflight for the packages lerobot's ``train()`` requires at call time.
+
+:meth:`strands_robots.training.lerobot.LerobotTrainer.validate` is documented as
+a pure preflight whose empty list "means the spec is launchable", and
+:class:`~strands_robots.training.base.Trainer` says an implementation SHOULD
+check that "any backend-required input is present". It already reports an absent
+lerobot -- ``tests/training/test_lerobot.py`` pins that as surfacing the problem
+"rather than deferring the failure to the training launch".
+
+Locating lerobot does not establish that lerobot can train. Its
+``scripts.lerobot_train.train`` calls ``require_package(...)`` for packages that
+are NOT module-scope imports of that module, so a spec lookup answers nothing
+about them, and the first such call -- ``require_package("accelerate",
+extra="training")`` -- is the opening statement of ``train()``. No
+``strands-robots[lerobot]`` install supplies ``accelerate``: that extra is
+exactly ``lerobot[feetech,dataset]``.
+
+So the deferral the lerobot check exists to prevent still happened one dependency
+out, and not merely as a late message: ``train()`` fails closed on a validate()
+problem specifically so nothing is touched before a knowably-bad run, and with
+the problem unreported it instead ran ``prepare()`` and the fresh-start hygiene
+that removes a checkpoint-less ``output_dir`` -- deleting a directory for a run
+that could never have started.
+
+Absence is simulated by making the package unlocatable to
+:func:`importlib.util.find_spec`, which is how an uninstalled one presents to
+both this preflight and lerobot's own ``is_package_available``. The alternative
+-- asserting only where the package genuinely happens to be missing -- would
+leave the contract unverified in CI, where ``[all]`` supplies ``accelerate``
+transitively (via ``[kimodo]``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from strands_robots.training import TrainSpec
+from strands_robots.training.lerobot import LerobotTrainer
+
+# The lerobot extra each package's remedy must name, per the require_package()
+# call sites in lerobot.scripts.lerobot_train. Held as a literal so this file is
+# a second opinion on the mapping rather than a mirror of the module's table.
+_PACKAGE_EXTRA = {"accelerate": "training", "peft": "peft"}
+
+
+@pytest.fixture(autouse=True)
+def _restore_lerobot_availability_cache() -> Iterator[None]:
+    """Leave lerobot's process-global availability cache as it was found.
+
+    ``lerobot.utils.import_utils.require_package`` memoizes each answer in a
+    module-level dict. A test here that hides a package can reach that memo (on a
+    tree whose preflight does not stop first), which would strand a ``False`` for
+    the rest of the session and make a later test see an installed package as
+    absent. Snapshot and restore it so hiding a package cannot outlive the test.
+    """
+    try:
+        from lerobot.utils import import_utils
+    except ImportError:
+        yield
+        return
+    saved = dict(import_utils._require_package_cache)
+    yield
+    import_utils._require_package_cache.clear()
+    import_utils._require_package_cache.update(saved)
+
+
+@pytest.fixture
+def spec(tmp_path) -> TrainSpec:
+    """A spec that validates clean on this machine: only a dependency can spoil it."""
+    root = tmp_path / "ds"
+    (root / "meta").mkdir(parents=True)
+    (root / "meta" / "info.json").write_text(json.dumps({"total_episodes": 10}))
+    return TrainSpec(
+        dataset_root=str(root),
+        base_model="",
+        output_dir=str(tmp_path / "out"),
+        steps=200,
+        global_batch_size=8,
+        save_freq=100,
+        extra={"policy_type": "act"},
+    )
+
+
+def _hide(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    """Make ``names`` unlocatable, exactly as an uninstalled package presents."""
+    hidden = set(names)
+    real = importlib.util.find_spec
+
+    def lookup(name: str, package: str | None = None) -> Any:
+        if name.split(".")[0] in hidden:
+            return None
+        return real(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", lookup)
+
+
+def _problems_naming(problems: list[str], package: str) -> list[str]:
+    return [p for p in problems if f"'{package}'" in p]
+
+
+class TestAnAbsentCallTimeDependencyIsReported:
+    """The gate: a package lerobot's train() will demand is a preflight problem."""
+
+    def test_absent_accelerate_is_reported(self, spec, monkeypatch) -> None:
+        """accelerate is required by every lerobot run, so its absence is never launchable."""
+        _hide(monkeypatch, "accelerate")
+        problems = LerobotTrainer().validate(spec)
+        assert _problems_naming(problems, "accelerate"), (
+            "validate() reported no problem for an absent 'accelerate', so it called this "
+            f"spec launchable; lerobot's train() requires it as its first statement. Got: {problems}"
+        )
+
+    def test_the_reported_remedy_names_the_lerobot_extra_that_supplies_it(self, spec, monkeypatch) -> None:
+        """A remedy has to be runnable: it must name the extra that ships the package."""
+        _hide(monkeypatch, "accelerate")
+        (problem,) = _problems_naming(LerobotTrainer().validate(spec), "accelerate")
+        assert f"pip install 'lerobot[{_PACKAGE_EXTRA['accelerate']}]'" in problem, (
+            f"the remedy must name lerobot's own 'training' extra, which declares accelerate: {problem}"
+        )
+
+    def test_lora_reports_absent_peft(self, spec, monkeypatch) -> None:
+        """method='lora' sets cfg.peft, which is exactly what lerobot gates peft on."""
+        spec.method = "lora"
+        spec.lora_r, spec.lora_alpha = 16, 32
+        _hide(monkeypatch, "peft")
+        (problem,) = _problems_naming(LerobotTrainer().validate(spec), "peft")
+        assert f"pip install 'lerobot[{_PACKAGE_EXTRA['peft']}]'" in problem, problem
+
+
+class TestNothingIsMutatedForAnUnlaunchableRun:
+    """train() fails closed on a validate() problem, so the output_dir survives."""
+
+    def test_an_existing_output_dir_survives(self, spec, monkeypatch, tmp_path) -> None:
+        """The fresh-start hygiene must not delete a directory for a run that cannot start."""
+        out = tmp_path / "out"
+        out.mkdir()
+        keepsake = out / "operator_notes.txt"
+        keepsake.write_text("notes that predate the run\n")
+        _hide(monkeypatch, "accelerate")
+
+        result = LerobotTrainer().train(spec)
+
+        assert result.status == "error"
+        assert keepsake.is_file(), (
+            "train() removed the output_dir for a spec whose dependency was absent at "
+            "preflight time; validate() must report it so train() fails closed instead."
+        )
+        assert "accelerate" in (result.message or ""), result.message
+
+
+class TestTheGateDoesNotOverreach:
+    """Controls: these hold both before and after the preflight was added."""
+
+    def test_a_clean_spec_is_still_clean(self, spec) -> None:
+        """Every call-time package is installed here, so nothing is reported."""
+        assert LerobotTrainer().validate(spec) == []
+
+    def test_full_method_does_not_require_peft(self, spec, monkeypatch) -> None:
+        """peft is conditional: a non-LoRA run never sets cfg.peft, so it must not be demanded."""
+        _hide(monkeypatch, "peft")
+        assert _problems_naming(LerobotTrainer().validate(spec), "peft") == []
+
+    def test_an_absent_lerobot_reports_one_root_cause(self, spec, monkeypatch) -> None:
+        """With neither installed the caller gets lerobot, not a second problem behind it."""
+        _hide(monkeypatch, "lerobot", "accelerate")
+        problems = LerobotTrainer().validate(spec)
+        assert any("lerobot is not installed" in p for p in problems), problems
+        assert _problems_naming(problems, "accelerate") == [], (
+            "an install with no lerobot at all should name lerobot, not also the packages "
+            f"its train() would have gone on to require: {problems}"
+        )
+
+    def test_the_probe_does_not_import_what_it_locates(self, monkeypatch) -> None:
+        """validate() is read-only, so locating a package must not pay its import cost."""
+        from strands_robots.training.lerobot import _module_available
+
+        # A stdlib module the suite has no reason to have imported; dropped from
+        # sys.modules first so the observation cannot be satisfied by a cache hit.
+        monkeypatch.delitem(sys.modules, "colorsys", raising=False)
+        assert _module_available("colorsys") is True
+        assert "colorsys" not in sys.modules, "the availability probe imported the module it located"
+
+    def test_a_probe_that_raises_answers_absent(self, monkeypatch) -> None:
+        """A broken lookup on a report-problems path is 'cannot confirm', not a raise."""
+        from strands_robots.training.lerobot import _module_available
+
+        def boom(name: str, package: str | None = None) -> Any:
+            raise ValueError("no __spec__")
+
+        monkeypatch.setattr(importlib.util, "find_spec", boom)
+        assert _module_available("accelerate") is False


### PR DESCRIPTION
## Problem

`LerobotTrainer.validate` is documented as a pure preflight whose empty list "means the spec is launchable", and `Trainer.validate` says an implementation SHOULD check that "any backend-required input is present". It already reports an absent lerobot, which `tests/training/test_lerobot.py` pins as surfacing the problem "rather than deferring the failure to the training launch".

Locating lerobot does not establish that lerobot can train. `lerobot.scripts.lerobot_train.train` calls `require_package(...)` for packages that are **not module-scope imports** of that module, so a spec lookup answers nothing about them — and the first such call is the opening statement of `train()`:

```python
require_package("accelerate", extra="training")
```

No `strands-robots[lerobot]` install supplies `accelerate`: that extra is exactly `lerobot[feetech,dataset]`. So `validate()` returned `[]` for a spec that could not train.

That is not only a late message. `train()` fails closed on a `validate()` problem precisely so nothing is touched before a knowably-bad run; with the problem unreported it instead ran on to the fresh-start hygiene that removes a checkpoint-less `output_dir` — deleting a directory for a run that never started.

Measured with `accelerate` hidden from `importlib`, `policy_type="smolvla"`:

| | `upstream/main` | this PR |
|---|---|---|
| `validate()` | `[]` (launchable) | 1 problem naming `accelerate` + `pip install 'lerobot[training]'` |
| `output_dir` after `train()` | **removed** (`operator_notes.txt`, `launch.sh` gone) | intact |
| `result.message` | lerobot's `ImportError`, raised after the delete | `validation failed: 'accelerate' is required ...` |

## Change

`validate()` now reports the packages lerobot's `train()` will require, under the conditions this trainer itself determines:

- `accelerate` — always. It is required unconditionally, before `train()` branches on device and before it loads a dataset, so "no GPU" does not mean "no extra".
- `peft` — when `method == "lora"`, which is exactly when `build_config` sets `cfg.peft`, the flag lerobot gates `peft` on.

The probe is `importlib.util.find_spec`, the same lookup lerobot's own `is_package_available` uses, so `validate()` stays read-only and answers the very question the runtime gate will ask. Each problem names the lerobot extra that supplies the package, so the remedy is runnable.

Reported only once lerobot itself is present, so an install with neither gets one root cause rather than two.

### Out of scope

`diffusers` is the third `require_package` call site, guarded by `cfg.ema.enable`. Nothing here sets `cfg.ema`, so it is reachable only by naming `ema.enable` through the generic dotted `extra` passthrough; enumerating what an arbitrary passthrough key implies is a different question from what a spec's own fields ask for.

The extras themselves are unchanged. `docs/training/overview.md` documents the `lerobot[training]` requirement deliberately, so this makes the code agree with that document rather than moving the packaging boundary.

## Docs

The same paragraph claimed "the only `strands-robots` extra that declares `accelerate` is `cosmos3-diffusers`". `[kimodo]` declares `accelerate>=0.30.0` too, and unlike `cosmos3-diffusers` it **is** in `[all]` — so `[all]` has `accelerate` transitively while `[lerobot]` does not. Corrected, and the paragraph now states that `validate()` reports the absence.

## Tests

`tests/training/test_call_time_dependency_preflight.py`, 9 tests. Absence is simulated by making the package unlocatable to `find_spec`, which is how an uninstalled one presents to both this preflight and lerobot's own probe; asserting only where the package genuinely happens to be missing would leave the contract unverified in CI, where `[all]` supplies `accelerate` via `[kimodo]`.

Against `upstream/main`: **6 failed / 3 passed**. Headline:

```
AssertionError: validate() reported no problem for an absent 'accelerate', so it
called this spec launchable; lerobot's train() requires it as its first statement. Got: []

AssertionError: train() removed the output_dir for a spec whose dependency was
absent at preflight time; validate() must report it so train() fails closed instead.
```

4 of the 6 are behavioural; 2 exercise the new availability helper directly. The 3 that pass on both trees are the controls: a clean spec stays clean, `method="full"` does **not** demand `peft` (the conditional must not become unconditional), and an install with no lerobot at all still names lerobot rather than also the packages its `train()` would have gone on to require.

An autouse fixture restores `lerobot.utils.import_utils._require_package_cache`: `require_package` memoizes each answer process-globally, so hiding a package must not strand a `False` for the rest of the session.

## Verification

Blast radius = 133 test files referencing `LerobotTrainer` / `lerobot_local` / `TrainSpec` / `create_trainer`, plus the repo-wide docstring, ASCII, dependency-audit and changelog guards, run on both trees:

- branch **3 failed / 4802 passed / 56 skipped**, base **9 failed / 4796 passed / 56 skipped** — both collected 4861.
- Branch-only failures: **none**. Base-only: exactly the 6 pre-fix failures above (`9 - 3 = 6`, `4802 - 4796 = 6`).
- The 3 shared failures are a pre-existing local environment artifact (`draccus 0.10.0` against lerobot's `draccus>=0.11.6`, `TypeError: encode() takes 1 positional argument but 2 were given`); each reproduces on a pristine `upstream/main`.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 19 pre-existing errors on both trees, branch-only set empty, zero in the two files touched.

## Artifact

One capture script run under each tree with `accelerate` hidden — same script, same environment, only `strands_robots` differs.

![call-time dependency preflight](https://raw.githubusercontent.com/cagataycali/robots/media-lerobot-calltime-dep-preflight/calltime-dependency-preflight.png)
