### PR TITLE
fix(hardware): measure a control-loop time budget on a clock that cannot step

### DIFF
--- a/changelog.d/2406-control-loop-budget-monotonic-clock.md
+++ b/changelog.d/2406-control-loop-budget-monotonic-clock.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **hardware**: measure a control-loop time budget on a clock that cannot step. The policy
+  rollout bounded by `Robot.run_policy(duration=...)` / `start_task(duration=...)` and the
+  session bounded by `teleoperate(duration=...)` both compared elapsed wall-clock time
+  against the budget, so an NTP correction, a `date -s` or a resume from suspend moved the
+  bound with it: forward the loop ended early and left the arm parked mid-task, backward it
+  kept commanding the servo bus for the budget plus the step, and the reported duration was
+  wrong in both directions while the task still reported `success`. Every duration in both
+  loops - the bound, the deadline, the elapsed/Hz reports and the `publish_step` throttle -
+  now reads `time.monotonic()`. `RobotTaskState.start_time` is renamed `start_mono` for the
+  clock it holds.

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -68,6 +68,13 @@ themselves apply, so a port the arm accepts is a port the provider can dial.
 of them can honor is reported by name, with the arm still disconnected and the
 command bus still free for a task that could run.
 
+`duration` is measured on a monotonic clock, not on the date. It is an elapsed
+time rather than a point in time, so an NTP correction or a resume from suspend
+cannot cut a rollout short or hold the servo bus past the budget - and the
+`duration` the task reports back is the time that actually elapsed. The same
+holds for `teleoperate(duration=...)`; see
+[Teleoperation](teleoperation.md#mixin-api).
+
 `cleanup()` (and `stop()`, which delegates to it) is terminal: it latches a
 shutdown, releases the task executor, tears down the mesh and ROS bridges, and
 disconnects the robot. It holds whatever state the robot is in - never

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -111,6 +111,9 @@ Every hardware `Robot` and `Simulation` host exposes:
 - **`block`** - run inline until `duration` elapses / Ctrl+C (`True`) vs
   background thread (`False`, default).
 - **`duration`** - auto-stop after N seconds (`None` = until stopped).
+  Measured on a monotonic clock, so a wall-clock correction mid-session neither
+  ends it early nor keeps the follower driven past the budget, and the reported
+  `elapsed_s` is the time that actually elapsed.
 
 Each tick: poll every selected device's `get_action()` → apply its `map_fn` →
 **merge** (last-wins on key conflict, with a one-time warning) → check the

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -414,7 +414,12 @@ class RobotTaskState:
 
     status: TaskStatus = TaskStatus.IDLE
     instruction: str = ""
-    start_time: float = 0.0
+    #: ``time.monotonic()`` reading taken when the task began. Every reader
+    #: subtracts it from a later reading of the same clock to get an elapsed
+    #: duration, and none of them reports it as a point in time - so it is
+    #: monotonic rather than wall-clock, which a step cannot move. Named for
+    #: its clock so a future reader does not reach for ``time.time()``.
+    start_mono: float = 0.0
     duration: float = 0.0
     step_count: int = 0
     error_message: str = ""
@@ -547,7 +552,11 @@ class Robot(TeleopMixin, AgentTool):
         # Task execution state
         self._task_state = RobotTaskState()
         # Stream-telemetry throttle (publish_step from the control loop).
-        self._last_stream_pub: float = 0.0
+        # A ``time.monotonic()`` reading, like every other elapsed-time base
+        # here. ``-inf`` rather than ``0.0`` because monotonic readings are
+        # only meaningful relative to each other: the first tick is due
+        # regardless of where this platform's monotonic epoch happens to sit.
+        self._last_stream_pub: float = float("-inf")
         # Imported here rather than at module top for the reason every other
         # mesh import in this file is: ``strands_robots.mesh`` pulls the
         # transport package, and a hardware Robot must construct without it.
@@ -1468,7 +1477,7 @@ class Robot(TeleopMixin, AgentTool):
             self._stop_requested.clear()
             self._task_state.status = TaskStatus.CONNECTING
             self._task_state.instruction = instruction
-            self._task_state.start_time = time.time()
+            self._task_state.start_mono = time.monotonic()
             self._task_state.duration = 0.0
             self._task_state.step_count = 0
             self._task_state.error_message = ""
@@ -1544,10 +1553,17 @@ class Robot(TeleopMixin, AgentTool):
                 return
 
             self._task_state.status = TaskStatus.RUNNING
-            start_time = time.time()
+            # The rollout budget is a duration, so it is measured on a clock
+            # that only ever moves forward at one second per second. Read on
+            # ``time.time()`` an NTP correction, a ``date -s`` or a resume from
+            # suspend moved this comparison by the size of the step: forward it
+            # ended the rollout early and left the arm parked mid-task, and
+            # backward it kept commanding the servo bus past the budget
+            # ``_duration_error`` exists to bound. Neither was reported.
+            start_mono = time.monotonic()
 
             while (
-                time.time() - start_time < duration
+                time.monotonic() - start_mono < duration
                 and (n_steps is None or self._task_state.step_count < n_steps)
                 and self._task_state.status == TaskStatus.RUNNING
                 and not self._stop_requested.is_set()
@@ -1594,8 +1610,8 @@ class Robot(TeleopMixin, AgentTool):
                     # limited; failures never touch the control loop.
                     _mesh = getattr(self, "mesh", None)
                     if _mesh is not None:
-                        _now_stream = time.time()
-                        if _now_stream - getattr(self, "_last_stream_pub", 0.0) >= self._stream_min_period:
+                        _now_stream = time.monotonic()
+                        if _now_stream - self._last_stream_pub >= self._stream_min_period:
                             self._last_stream_pub = _now_stream
                             try:
                                 _mesh.publish_step(
@@ -1612,7 +1628,7 @@ class Robot(TeleopMixin, AgentTool):
                     await asyncio.sleep(self.action_sleep_time)
 
             # Update final state
-            elapsed = time.time() - start_time
+            elapsed = time.monotonic() - start_mono
             self._task_state.duration = elapsed
 
             if self._task_state.status == TaskStatus.RUNNING:
@@ -1648,8 +1664,8 @@ class Robot(TeleopMixin, AgentTool):
     def _duration_error(duration: Any, method: str) -> dict[str, Any] | None:
         """Reject a task ``duration`` the control loop cannot honor.
 
-        ``duration`` is the wall-clock budget the loop compares against
-        (``time.time() - start_time < duration``), and on hardware it bounds
+        ``duration`` is the elapsed-time budget the loop compares against
+        (``time.monotonic() - start_mono < duration``), and on hardware it bounds
         every rollout: unlike the simulation's ``run_policy`` - where an
         ``n_steps`` recomputes ``duration`` and supersedes it - the two
         conditions are ANDed here, so ``duration`` is the effective horizon
@@ -2290,7 +2306,7 @@ class Robot(TeleopMixin, AgentTool):
 
         # Update duration for running tasks
         if self._task_state.status == TaskStatus.RUNNING:
-            self._task_state.duration = time.time() - self._task_state.start_time
+            self._task_state.duration = time.monotonic() - self._task_state.start_mono
 
         status_text = f"Robot Status: {self._task_state.status.value.upper()}\n"
 

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -222,7 +222,11 @@ class TeleopMixin:
             self._teleop_robot_name: str | None = None
             self._teleop_frames: int = 0
             self._teleop_errors: int = 0
-            self._teleop_start_time: float = 0.0
+            # ``time.monotonic()`` reading taken when the session began.
+            # Every reader subtracts it from a later reading of the same clock
+            # (the deadline, the elapsed/Hz report), and none reports it as a
+            # point in time, so a wall-clock step cannot move any of them.
+            self._teleop_start_mono: float = 0.0
             self._teleop_slew_rejected: int = 0
             # Baseline for the per-joint slew bound: for each joint, the last
             # value actually sent and when. Merged rather than replaced, so a
@@ -515,7 +519,7 @@ class TeleopMixin:
         self._teleop_errors = 0
         self._teleop_slew_rejected = 0
         self._teleop_slew_baseline = {}
-        self._teleop_start_time = time.time()
+        self._teleop_start_mono = time.monotonic()
         self._teleop_running = True
 
         loop = lambda: self._teleop_loop(selected, robot_name, hz, duration)  # noqa: E731
@@ -583,7 +587,7 @@ class TeleopMixin:
     def get_teleoperate_status(self) -> dict[str, Any]:
         """Status of the local teleop loop (distinct from mesh get_teleop_status)."""
         self._ensure_teleop_state()
-        elapsed = time.time() - self._teleop_start_time if self._teleop_start_time else 0
+        elapsed = time.monotonic() - self._teleop_start_mono if self._teleop_start_mono else 0
         hz = self._teleop_frames / elapsed if elapsed > 0 else 0
         return {
             "status": "success",
@@ -625,7 +629,7 @@ class TeleopMixin:
         # caller), so the division is safe. ``duration`` is read by membership,
         # not truthiness: a falsy-but-supplied value must not read as "absent".
         period = 1.0 / float(hz)
-        deadline = (self._teleop_start_time + duration) if duration is not None else None
+        deadline = (self._teleop_start_mono + duration) if duration is not None else None
         warned_conflicts: set[str] = set()
 
         # Per-joint slew bound, the same one the mesh receive path applies, so a
@@ -698,7 +702,13 @@ class TeleopMixin:
 
         while self._teleop_running and not self._teleop_stop_event.is_set():
             loop_start = time.perf_counter()
-            if deadline is not None and time.time() >= deadline:
+            # ``duration`` is an elapsed-time budget, so the deadline is
+            # compared on the clock it was built from. Read on ``time.time()``
+            # an NTP correction or a resume from suspend moved this comparison
+            # by the size of the step: forward the session ended early with the
+            # leader still held, and backward it kept driving the follower past
+            # the budget the caller asked for. Neither was reported.
+            if deadline is not None and time.monotonic() >= deadline:
                 logger.info("[teleop] duration elapsed (%.1fs); stopping", duration)
                 break
 
@@ -776,7 +786,7 @@ class TeleopMixin:
                 stop_pub()  # stops all publishers/receivers on the host
 
     def _teleop_stats(self, *, blocking: bool, publish_results: list | None = None) -> dict[str, Any]:
-        elapsed = time.time() - self._teleop_start_time if self._teleop_start_time else 0
+        elapsed = time.monotonic() - self._teleop_start_mono if self._teleop_start_mono else 0
         hz = self._teleop_frames / elapsed if elapsed > 0 else 0
         note = ""
         if publish_results:

--- a/tests/test_control_loop_budgets_survive_a_clock_step.py
+++ b/tests/test_control_loop_budgets_survive_a_clock_step.py
@@ -53,6 +53,7 @@ fakes and the policy is a structural stub.
 
 from __future__ import annotations
 
+import importlib
 import threading
 import time as real_time
 from concurrent.futures import ThreadPoolExecutor
@@ -60,17 +61,18 @@ from typing import Any, cast
 
 import pytest
 
-# The teleop loop lazily imports strands_robots.mesh.security on its first
-# tick. That import is heavy, and paying it inside a short session would eat
-# the very budget under test, so it is resolved here instead - which is what a
-# process that has already teleoperated once looks like.
-import strands_robots.mesh.security  # noqa: F401
 from strands_robots import hardware_robot as hardware_robot_module
 from strands_robots import teleop_mixin as teleop_mixin_module
 from strands_robots.hardware_robot import Robot as HardwareRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from tests.test_hardware_control_loop_rate_guard import _FakeArm
 from tests.test_teleop import FakeHost, FakeTeleop
+
+# The teleop loop lazily imports strands_robots.mesh.security on its first tick.
+# That import is heavy, and paying it inside a short session would eat the very
+# budget under test, so it is resolved here instead - which is what a process
+# that has already teleoperated once looks like.
+importlib.import_module("strands_robots.mesh.security")
 
 #: Rollout/session budget every test hands the loop, in seconds. Short enough
 #: to keep the suite quick, long enough that a loop honoring it applies many

--- a/tests/test_control_loop_budgets_survive_a_clock_step.py
+++ b/tests/test_control_loop_budgets_survive_a_clock_step.py
@@ -1,0 +1,424 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""A hardware control loop's time budget is honored across a wall-clock step.
+
+Two loops command physical actuators for a caller-supplied number of seconds:
+``Robot._execute_task_async`` (a policy rollout, bounded by ``duration``) and
+``TeleopMixin._teleop_loop`` (a teleoperation session, bounded by the same
+parameter). Both budgets used to be measured against ``time.time()``, which is
+not a clock but the current opinion about the date: an NTP correction, a
+``date -s`` or a resume from suspend moves it by an arbitrary amount, and both
+loops moved with it.
+
+The harm is not symmetric with the step's sign, and neither direction was
+reported. Driving the real loops with a stub driver, a 1.0s budget and a clock
+that takes one step mid-rollout::
+
+    rollout budget 1.0s          seconds commanding the arm   actions   reported
+    no step (control)                          0.980               49     1.001
+    wall clock steps +30s                      0.000                1    30.021
+    wall clock steps +1h                       0.000                1  3600.021
+    wall clock steps -2s                       2.990              147     1.010
+
+    teleop budget 1.0s        seconds driving the follower   frames   reported
+    no step (control)                          1.005              50      1.005
+    wall clock steps +30s                      0.040               2     30.040
+    wall clock steps -2s                       3.016             150      1.016
+
+Every row reported ``status="success"``.
+
+Forward, the rollout is abandoned after its first action and the arm is left
+parked at that pose mid-task, while the record claims the task ran for the size
+of the step. Backward, the loop keeps commanding the servo bus for the budget
+*plus* the step - three times the authorized window here - and the reported
+duration under-reports it by exactly the step, so the overrun leaves no trace.
+
+That budget is the only thing bounding a rollout on hardware.
+``Robot._duration_error`` exists because a value the comparison cannot honor
+means "the loop commands the servo bus indefinitely", and it validates the
+value; a clock step defeats the same guarantee from outside the value's domain.
+
+These tests pin the contract on behavior rather than on which clock is called:
+each drives a real loop through a clock double that takes a known step, and
+asserts the loop spent the budget it was given, applied a rollout's worth of
+commands, and reported the time that actually elapsed. The safety subsystem
+settled the same boundary three times (``tests/mesh/test_replay_cache_monotonic.py``,
+``tests/mesh/test_bridge_dedup.py::TestDedupClock``,
+``tests/mesh/test_corroboration_clock_domain.py``): a duration is local
+bookkeeping and belongs on a monotonic clock, while an absolute stamp a reader
+correlates with other logs stays on the wall clock.
+
+No serial/USB hardware is touched: the driver and the leader are in-memory
+fakes and the policy is a structural stub.
+"""
+
+from __future__ import annotations
+
+import threading
+import time as real_time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, cast
+
+import pytest
+
+# The teleop loop lazily imports strands_robots.mesh.security on its first
+# tick. That import is heavy, and paying it inside a short session would eat
+# the very budget under test, so it is resolved here instead - which is what a
+# process that has already teleoperated once looks like.
+import strands_robots.mesh.security  # noqa: F401
+from strands_robots import hardware_robot as hardware_robot_module
+from strands_robots import teleop_mixin as teleop_mixin_module
+from strands_robots.hardware_robot import Robot as HardwareRobot
+from strands_robots.hardware_robot import RobotTaskState, TaskStatus
+from tests.test_hardware_control_loop_rate_guard import _FakeArm
+from tests.test_teleop import FakeHost, FakeTeleop
+
+#: Rollout/session budget every test hands the loop, in seconds. Short enough
+#: to keep the suite quick, long enough that a loop honoring it applies many
+#: commands rather than a handful.
+BUDGET = 0.4
+
+#: Command period installed on the loops, so ``BUDGET`` covers ~80 commands.
+PERIOD = 0.005
+
+#: Steps a wall clock really takes: a routine NTP correction, an hour of clock
+#: skew or a timezone-shaped jump, and a backward correction.
+FORWARD_STEPS = [30.0, 3600.0]
+BACKWARD_STEPS = [-2.0]
+
+
+class SteppingWallClock:
+    """A ``time`` stand-in whose ``time()`` takes one step, mid-wait.
+
+    Every other member delegates to the real module, so a loop that measures a
+    duration on ``monotonic()`` sees an untouched clock and a loop that
+    measures it on ``time()`` sees the step. ``reads`` counts ``time()`` calls
+    and ``stepped`` records whether the step was ever handed out - a loop on
+    the monotonic clock never reads ``time()`` at all, so neither is used as a
+    precondition for the behavior under test.
+    """
+
+    def __init__(self, step_by: float, after_reads: int = 3, after_seconds: float = 0.0) -> None:
+        self.step_by = step_by
+        #: The step is withheld until this many reads have happened, so it
+        #: always lands after the loop has taken the base it will subtract.
+        #: A step that moved the base too would shift both sides of every
+        #: comparison equally and change nothing.
+        self.after_reads = after_reads
+        #: ...and until this long into the run, for a comparison whose base is
+        #: rewritten as it goes (the telemetry throttle): the step has to land
+        #: between two of its readings to be visible at all.
+        self.after_seconds = after_seconds
+        self.reads = 0
+        self.stepped = False
+        self._created = real_time.monotonic()
+
+    def time(self) -> float:
+        self.reads += 1
+        due = self.reads > self.after_reads and real_time.monotonic() - self._created >= self.after_seconds
+        if due and self.step_by:
+            self.stepped = True
+            return real_time.time() + self.step_by
+        return real_time.time()
+
+    def monotonic(self) -> float:
+        return real_time.monotonic()
+
+    def perf_counter(self) -> float:
+        return real_time.perf_counter()
+
+    def sleep(self, seconds: float) -> None:
+        real_time.sleep(seconds)
+
+
+class _RecordingArm(_FakeArm):
+    """A fake arm that records when each command reached it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.command_times: list[float] = []
+
+    def send_action(self, action: dict[str, Any]) -> None:
+        self.command_times.append(real_time.monotonic())
+        super().send_action(action)
+
+
+class _Policy:
+    """Structural stand-in for a policy: the members the loop reads."""
+
+    supports_rtc = False
+    execution_horizon = 1
+
+    def set_control_frequency(self, hz: float) -> None:
+        return None
+
+    def set_rtc_observed_delay(self, steps: int | None) -> None:
+        return None
+
+    def reset(self, seed: int | None = None) -> None:
+        return None
+
+    async def get_actions(self, observation: Any, instruction: str) -> list[dict[str, Any]]:
+        return [{"j0.pos": 0.1}]
+
+
+class _RecordingMesh:
+    """Records every ``publish_step`` the control loop's throttle lets through."""
+
+    def __init__(self) -> None:
+        self.publish_times: list[float] = []
+
+    def publish_step(self, step: int, observation: Any, action: Any, **kwargs: Any) -> None:
+        self.publish_times.append(real_time.monotonic())
+
+    def stop(self) -> None:
+        return None
+
+
+def _hardware_robot(mesh: Any = None, stream_min_period: float = 0.05) -> HardwareRobot:
+    """A ``Robot`` wired to an in-memory arm, with the connect path stubbed."""
+    robot = HardwareRobot.__new__(HardwareRobot)
+    robot.tool_name_str = "test_arm"
+    robot.action_horizon = 1
+    robot.data_config = None
+    robot.control_frequency = 1.0 / PERIOD
+    robot.action_sleep_time = PERIOD
+    robot._task_state = RobotTaskState()
+    robot._executor = ThreadPoolExecutor(max_workers=1)
+    robot._shutdown_event = threading.Event()
+    robot._stop_requested = threading.Event()
+    robot._task_admission = threading.Lock()
+    robot._task_claimed = False
+    robot.mesh = mesh
+    robot.peer_id = "probe" if mesh is not None else None
+    robot.robot = _RecordingArm()
+    robot._last_stream_pub = float("-inf")
+    robot._stream_min_period = stream_min_period
+
+    async def _connected() -> tuple[bool, str]:
+        return (True, "")
+
+    async def _ready() -> bool:
+        return True
+
+    def _init_policy(policy: Any) -> Any:
+        return _ready()
+
+    def _no_telemetry(observation: dict[str, Any], *, skip_images: bool = False) -> None:
+        return None
+
+    robot._connect_robot = _connected  # type: ignore[method-assign]
+    robot._initialize_policy = _init_policy  # type: ignore[method-assign]
+    robot._publish_ros_telemetry = _no_telemetry  # type: ignore[method-assign]
+    return robot
+
+
+def _run_rollout(
+    monkeypatch: pytest.MonkeyPatch,
+    step_by: float,
+    *,
+    mesh: Any = None,
+    stream_min_period: float = 0.05,
+    step_after_seconds: float = 0.0,
+) -> dict[str, Any]:
+    """Drive one real rollout with ``BUDGET`` seconds and a stepping clock."""
+    clock = SteppingWallClock(step_by, after_seconds=step_after_seconds)
+    monkeypatch.setattr(hardware_robot_module, "time", clock)
+    robot = _hardware_robot(mesh=mesh, stream_min_period=stream_min_period)
+    try:
+        started = real_time.monotonic()
+        result = robot.run_policy(policy_object=cast(Any, _Policy()), instruction="probe", duration=BUDGET)
+        wall_span = real_time.monotonic() - started
+        times = robot.robot.command_times
+        return {
+            "status": result["status"],
+            "commanded_span": (times[-1] - times[0]) if len(times) > 1 else 0.0,
+            "commands": len(times),
+            "reported_duration": robot._task_state.duration,
+            "call_span": wall_span,
+            "clock": clock,
+        }
+    finally:
+        robot._shutdown_event.set()
+        robot._task_state.status = TaskStatus.STOPPED
+        robot._executor.shutdown(wait=False)
+
+
+def _run_teleop_session(monkeypatch: pytest.MonkeyPatch, step_by: float) -> dict[str, Any]:
+    """Drive one real teleop session with ``BUDGET`` seconds and a stepping clock."""
+    clock = SteppingWallClock(step_by)
+    monkeypatch.setattr(teleop_mixin_module, "time", clock)
+    host = FakeHost()
+    leader = FakeTeleop({"a.pos": 1.0})
+    host.attach_teleop(leader, name="lead")
+    try:
+        started = real_time.monotonic()
+        result = host.teleoperate(hz=1.0 / PERIOD, duration=BUDGET, block=True)
+        wall_span = real_time.monotonic() - started
+        telemetry = [block["json"] for block in result["content"] if "json" in block][0]
+        return {
+            "status": result["status"],
+            "frames": len(host.sent),
+            "reported_elapsed": telemetry["elapsed_s"],
+            "call_span": wall_span,
+            "clock": clock,
+        }
+    finally:
+        host.stop_teleoperate()
+
+
+class TestTheClockDoubleIsFaithful:
+    """The double really moves the wall clock, so a clean run means something."""
+
+    @pytest.mark.parametrize("step_by", [*FORWARD_STEPS, *BACKWARD_STEPS])
+    def test_the_double_hands_out_the_step_it_advertises(self, step_by: float):
+        clock = SteppingWallClock(step_by, after_reads=1)
+
+        real_before = real_time.time()
+        reported_before = clock.time()
+        reported_after = clock.time()
+        real_after = real_time.time()
+
+        assert clock.stepped is True
+        # Relative: what the double added beyond the real clock's own advance
+        # is the step, whatever the real clock did meanwhile.
+        drift = (reported_after - reported_before) - (real_after - real_before)
+        assert drift == pytest.approx(step_by, abs=0.05)
+
+    def test_a_zero_step_never_moves_the_clock(self):
+        clock = SteppingWallClock(0.0, after_reads=1)
+        for _ in range(5):
+            clock.time()
+        assert clock.stepped is False
+
+
+class TestTheRolloutSpendsTheBudgetItWasGiven:
+    """``duration`` bounds the rollout regardless of what the date does."""
+
+    def test_no_step_is_the_control(self, monkeypatch: pytest.MonkeyPatch):
+        run = _run_rollout(monkeypatch, 0.0)
+        assert run["status"] == "success"
+        assert run["commanded_span"] >= BUDGET * 0.5
+        assert run["commands"] >= 5
+
+    @pytest.mark.parametrize("step_by", FORWARD_STEPS)
+    def test_a_forward_step_does_not_abandon_the_rollout(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        """The arm is not left parked mid-task by a clock correction."""
+        run = _run_rollout(monkeypatch, step_by)
+
+        assert run["commanded_span"] >= BUDGET * 0.5, (
+            f"a +{step_by}s wall-clock step ended the rollout after "
+            f"{run['commanded_span']:.3f}s of a {BUDGET}s budget "
+            f"({run['commands']} commands)"
+        )
+        assert run["commands"] >= 5
+
+    @pytest.mark.parametrize("step_by", BACKWARD_STEPS)
+    def test_a_backward_step_does_not_extend_the_rollout(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        """The servo bus is not commanded past the authorized window.
+
+        Bounded at half the step so the assertion distinguishes "spent the
+        budget" from "spent the budget plus the step" without asserting how
+        fast the host runs the loop.
+        """
+        limit = BUDGET + abs(step_by) / 2
+        run = _run_rollout(monkeypatch, step_by)
+
+        assert run["commanded_span"] < limit, (
+            f"a {step_by}s wall-clock step kept the arm commanded for "
+            f"{run['commanded_span']:.3f}s on a {BUDGET}s budget"
+        )
+
+    @pytest.mark.parametrize("step_by", [*FORWARD_STEPS, *BACKWARD_STEPS])
+    def test_the_reported_duration_is_the_time_that_elapsed(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        """A record of the rollout that a clock step cannot rewrite."""
+        run = _run_rollout(monkeypatch, step_by)
+
+        assert run["reported_duration"] == pytest.approx(run["call_span"], abs=0.2), (
+            f"a {step_by}s wall-clock step made a {run['call_span']:.3f}s rollout "
+            f"report itself as {run['reported_duration']:.3f}s"
+        )
+
+
+class TestTheTeleopSessionSpendsTheBudgetItWasGiven:
+    """``duration`` bounds a teleoperation session on the same terms."""
+
+    def test_no_step_is_the_control(self, monkeypatch: pytest.MonkeyPatch):
+        run = _run_teleop_session(monkeypatch, 0.0)
+        assert run["status"] == "success"
+        assert run["frames"] >= 5
+
+    @pytest.mark.parametrize("step_by", FORWARD_STEPS)
+    def test_a_forward_step_does_not_end_the_session_early(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        run = _run_teleop_session(monkeypatch, step_by)
+
+        assert run["call_span"] >= BUDGET * 0.5, (
+            f"a +{step_by}s wall-clock step ended the session after "
+            f"{run['call_span']:.3f}s of a {BUDGET}s budget ({run['frames']} frames)"
+        )
+        assert run["frames"] >= 5
+
+    @pytest.mark.parametrize("step_by", BACKWARD_STEPS)
+    def test_a_backward_step_does_not_extend_the_session(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        limit = BUDGET + abs(step_by) / 2
+        run = _run_teleop_session(monkeypatch, step_by)
+
+        assert run["call_span"] < limit, (
+            f"a {step_by}s wall-clock step kept the follower driven for {run['call_span']:.3f}s on a {BUDGET}s budget"
+        )
+
+    @pytest.mark.parametrize("step_by", [*FORWARD_STEPS, *BACKWARD_STEPS])
+    def test_the_reported_elapsed_is_the_time_that_elapsed(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        run = _run_teleop_session(monkeypatch, step_by)
+
+        assert run["reported_elapsed"] == pytest.approx(run["call_span"], abs=0.2), (
+            f"a {step_by}s wall-clock step made a {run['call_span']:.3f}s session "
+            f"report itself as {run['reported_elapsed']:.3f}s"
+        )
+
+
+class TestTheStepTelemetryThrottleHoldsItsRate:
+    """The rollout's ``publish_step`` throttle is a duration too.
+
+    It is best-effort telemetry rather than a command, so it is the least
+    dangerous of the three sites - but it is measured the same way, and it
+    carries its own base forward as it goes: each publish records when it
+    happened, and the next one is due a period later.
+
+    That makes it visible only to a step landing *between* two publishes. A
+    step landing before the first one moves the base and every later comparison
+    together, which changes nothing - so this test asks for the step part-way
+    into the rollout rather than at its start.
+    """
+
+    @pytest.mark.parametrize("step_by", BACKWARD_STEPS)
+    def test_a_backward_step_does_not_stall_the_stream(self, monkeypatch: pytest.MonkeyPatch, step_by: float):
+        """A step must not silence the stream until the date catches up."""
+        mesh = _RecordingMesh()
+        period = 0.05
+        _run_rollout(monkeypatch, step_by, mesh=mesh, stream_min_period=period, step_after_seconds=BUDGET / 3)
+
+        assert len(mesh.publish_times) >= 2, "the stream published at most once"
+        stamps = mesh.publish_times
+        gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
+        assert max(gaps) < abs(step_by) / 2, f"a {step_by}s wall-clock step stalled the stream for {max(gaps):.3f}s"
+
+
+class TestTheThrottleStartsDue:
+    """A monotonic base is only meaningful relative to another reading.
+
+    ``_last_stream_pub`` therefore starts at ``-inf`` rather than ``0.0``: the
+    first tick of a rollout is due wherever this platform's monotonic epoch
+    happens to sit, instead of depending on it being far from zero.
+    """
+
+    def test_a_fresh_robot_owes_its_first_publish(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(HardwareRobot, "_initialize_robot", lambda self, robot, cameras, **kw: _FakeArm())
+        monkeypatch.setattr(HardwareRobot, "_migrate_legacy_calibration", lambda self: None)
+        robot = HardwareRobot(tool_name="test_arm", robot="fake_arm")
+        try:
+            assert real_time.monotonic() - robot._last_stream_pub >= robot._stream_min_period
+        finally:
+            robot.cleanup()
+
+    def test_a_fresh_task_state_has_no_start_reading(self):
+        assert RobotTaskState().start_mono == 0.0

--- a/tests/test_hardware_after_shutdown.py
+++ b/tests/test_hardware_after_shutdown.py
@@ -4,7 +4,7 @@
 ``_shutdown_event`` is one of the control loop's exit conditions::
 
     while (
-        time.time() - start_time < duration
+        time.monotonic() - start_mono < duration
         and (n_steps is None or self._task_state.step_count < n_steps)
         and self._task_state.status == TaskStatus.RUNNING
         and not self._stop_requested.is_set()

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -18,16 +18,40 @@ import asyncio
 import pkgutil
 import sys
 import threading
+import time as real_time
 import types
 from typing import Any
 
 import pytest
 
+from strands_robots import hardware_robot as hardware_robot_module
 from strands_robots.hardware_robot import Robot as HwRobot
 from strands_robots.hardware_robot import RobotTaskState, TaskStatus
 from strands_robots.policies.base import Policy
 from tests._daemon_executor import DaemonThreadExecutor
 from tests.tool_result_contract import tool_json
+
+
+def _script_loop_clock(monkeypatch: pytest.MonkeyPatch, clock: dict[str, float]) -> None:
+    """Make the control loop's elapsed-time clock read ``clock["now"]``.
+
+    The loop measures its budget on ``time.monotonic()``, which is also
+    asyncio's event-loop clock. Patching the attribute on the ``time`` module
+    would therefore freeze the event loop's own scheduling and the
+    ``asyncio.sleep`` between two commands would never return, so the module
+    reference the robot holds is swapped instead: the script reaches the code
+    under test and nothing else.
+    """
+    monkeypatch.setattr(
+        hardware_robot_module,
+        "time",
+        types.SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            time=real_time.time,
+            sleep=real_time.sleep,
+            perf_counter=real_time.perf_counter,
+        ),
+    )
 
 
 class _FakeLeRobot:
@@ -126,9 +150,9 @@ class TestTaskStatusReporting:
         hw = _make_robot()
         hw._task_state.status = TaskStatus.RUNNING
         hw._task_state.instruction = "pick cube"
-        hw._task_state.start_time = 100.0
+        hw._task_state.start_mono = 100.0
         hw._task_state.step_count = 7
-        monkeypatch.setattr("strands_robots.hardware_robot.time.time", lambda: 103.5)
+        _script_loop_clock(monkeypatch, {"now": 103.5})
 
         text = hw.get_task_status()["content"][0]["text"]
         assert "RUNNING" in text
@@ -323,9 +347,10 @@ class TestExecuteTaskAsync:
     def test_full_loop_sends_actions_and_completes(self, monkeypatch):
         """One observe->act iteration runs, then the loop terminates.
 
-        The control loop is bounded by ``while time.time() - start < duration``.
-        Driving that with a hand-counted finite iterator is fragile: it assumes
-        the code reads ``time.time()`` an exact number of times before the loop
+        The control loop is bounded by
+        ``while time.monotonic() - start < duration``. Driving that with a
+        hand-counted finite iterator is fragile: it assumes the code reads the
+        clock an exact number of times before the loop
         (connect/policy-init logging, the Python/lerobot build, or any future
         refactor that adds a clock read would desync the iterator, leave the
         captured ``start`` pinned to the terminal value, and spin the loop
@@ -338,10 +363,7 @@ class TestExecuteTaskAsync:
         hw = _make_robot(fake, control_frequency=1000.0)
 
         clock = {"now": 0.0}
-        monkeypatch.setattr(
-            "strands_robots.hardware_robot.time.time",
-            lambda: clock["now"],
-        )
+        _script_loop_clock(monkeypatch, clock)
 
         class _ClockAdvancingPolicy(_StubPolicy):
             async def get_actions(self, observation, instruction):
@@ -531,10 +553,7 @@ class TestExecuteTaskAsyncRtcContract:
         hw = _make_robot(fake, control_frequency=control_frequency)
 
         clock = {"now": 0.0}
-        monkeypatch.setattr(
-            "strands_robots.hardware_robot.time.time",
-            lambda: clock["now"],
-        )
+        _script_loop_clock(monkeypatch, clock)
 
         # Advance the clock past the duration once the chunk is fetched so the
         # loop runs exactly one observe->infer->apply iteration.

--- a/tests/test_hardware_task_duration_guard.py
+++ b/tests/test_hardware_task_duration_guard.py
@@ -1,7 +1,7 @@
 """Behavior tests for the accepted ``duration`` domain of a hardware task.
 
 ``strands_robots.hardware_robot.Robot`` bounds every rollout by comparing
-elapsed wall-clock time against ``duration`` (``time.time() - start_time <
+elapsed time against ``duration`` (``time.monotonic() - start_mono <
 duration``). On hardware that comparison is ANDed with the optional ``n_steps``
 cap rather than superseded by it, so ``duration`` is the effective horizon of
 every task. These tests pin that a budget the loop cannot honor is refused at
@@ -203,7 +203,7 @@ class TestAnEndlessBudgetIsRefused:
     def test_run_policy_returns_instead_of_commanding_forever(self, hw: Any):
         """The blocking call returns; the loop is never entered.
 
-        ``inf`` never makes ``time.time() - start_time < duration`` false, so
+        ``inf`` never makes ``time.monotonic() - start_mono < duration`` false, so
         the loop kept commanding the servo bus with no bound and the caller
         never got control back. Driven from a worker thread so the assertion
         fails as a timeout rather than hanging the suite.

--- a/tests/test_tool_result_contract.py
+++ b/tests/test_tool_result_contract.py
@@ -108,7 +108,7 @@ def test_teleop_stats_contract_and_status(frames, errors, expected):
     host._ensure_teleop_state()
     host._teleop_frames = frames
     host._teleop_errors = errors
-    host._teleop_start_time = 1.0  # non-zero so elapsed/hz compute
+    host._teleop_start_mono = 1.0  # non-zero so elapsed/hz compute
 
     result = host._teleop_stats(blocking=True)
     assert_strands_tool_result(result)


### PR DESCRIPTION
## Problem

Two loops command physical actuators for a number of seconds the caller supplies:
`Robot._execute_task_async` (a policy rollout, bounded by `duration`) and
`TeleopMixin._teleop_loop` (a teleoperation session, bounded by the same parameter). Both
measured that budget against `time.time()`, which is not a clock but the current opinion
about the date: an NTP correction, a `date -s` or a resume from suspend moves it by an
arbitrary amount, and both loops moved with it.

That budget is the only thing bounding a rollout on hardware. `Robot._duration_error`
exists because a value the comparison cannot honor means "the loop commands the servo bus
indefinitely", and `tests/test_hardware_task_duration_guard.py` pins that such a value is
refused "instead of being spent on the arm". Both guard the *value*. A clock step defeats
the same guarantee from outside the value's domain, and neither direction is reported.

Driving the real loops with a stub driver, a 1.0s budget, and a clock that takes one step
mid-rollout:

| rollout, budget 1.0s | seconds commanding the arm | actions applied | reported duration | status |
|---|---|---|---|---|
| no step (control) | 0.980 | 49 | 1.001 | success |
| wall clock steps **+30s** | 0.000 | **1** | **30.021** | success |
| wall clock steps **+1h** | 0.000 | **1** | **3600.021** | success |
| wall clock steps **-2s** | **2.990** | **147** | 1.010 | success |

| teleop session, budget 1.0s | seconds driving the follower | frames applied | reported elapsed | status |
|---|---|---|---|---|
| no step (control) | 1.005 | 50 | 1.005 | success |
| wall clock steps **+30s** | 0.040 | **2** | **30.040** | success |
| wall clock steps **+1h** | 0.040 | **2** | **3600.040** | success |
| wall clock steps **-2s** | **3.016** | **150** | 1.016 | success |

Forward, the rollout is abandoned after its first action and the arm is left parked at that
pose mid-task, while the record claims the task ran for the size of the step. Backward, the
loop keeps commanding the servo bus for the budget *plus* the step - three times the
authorized window here - and the reported duration under-reports it by exactly the step, so
the overrun leaves no trace in the task record. The step's size does not have to be large to
matter, and the `+1h` row shows the truncation is not proportional to it: what is lost is the
remainder of the budget, whatever the step.

## Change

Every *duration* in both loops now reads `time.monotonic()`:

- the rollout bound (`while time.monotonic() - start_mono < duration`) and the `elapsed`
  it reports, which share the same base;
- the live duration `get_task_status()` computes for a running task;
- the teleop session deadline, and the `elapsed_s`/`hz_actual` both status surfaces derive
  from the same base;
- the control loop's `publish_step` telemetry throttle, which is a duration too.

The two bases are renamed for the clock they hold - `RobotTaskState.start_mono` and
`_teleop_start_mono` - because "start_time" is what invited `time.time()` in the first place.
Neither was ever read as a point in time: every reader subtracted it from a later reading to
get an elapsed duration, which is why this is a clock swap rather than a second field.
`_last_stream_pub` starts at `-inf` rather than `0.0`, since a monotonic reading is only
meaningful relative to another one and the first tick should be due wherever a platform's
monotonic epoch happens to sit.

Absent a clock step, nothing changes: the control rows above are unchanged, and two tests
assert exactly that.

This is the boundary the safety subsystem already settled three times -
`tests/mesh/test_replay_cache_monotonic.py`, `tests/mesh/test_bridge_dedup.py::TestDedupClock`,
`tests/mesh/test_corroboration_clock_domain.py`, whose docstring calls monotonic "the same
domain as every other local bookkeeping timestamp". Absolute stamps a reader correlates with
other logs stay on the wall clock and are untouched.

### Scope

`teleoperate(duration=...)` has a second, unrelated way to lose its budget: `_teleop_loop`
computes the deadline and *then* resolves a lazy `strands_robots.mesh.security` import, which
costs 2.17s in a cold process, so a short first session can end before polling the leader at
all. That is a different root cause with a different fix and is left out of this change; the
new tests resolve that import at module scope so it cannot confound the measurement.

## Visual

The real rollout loop, driven with a 1.0s budget while the wall clock is corrected back 2s.
The commands each run sent to the arm are replayed into MuJoCo (headless, `MUJOCO_GL=egl`) -
same script, same policy, same budget; only `strands_robots` differs between the panels.

![rollout](https://raw.githubusercontent.com/cagataycali/robots/media-hw-budget-clock-32051900530/rollout.gif)

[full-resolution MP4](https://raw.githubusercontent.com/cagataycali/robots/media-hw-budget-clock-32051900530/rollout.mp4)

Both panels are the same rollout up to the budget mark (panel-to-panel mean |pixel| 0.84, a
sub-command sampling offset between two real runs). Past it they separate: the BEFORE arm
keeps sweeping (motion after the budget, mean |pixel| vs the first post-budget frame, max
**8.147**) while the AFTER arm holds the pose the last authorized command left it in
(max **0.000**). BEFORE sent 147 commands over 2.998s and reported 1.019s; AFTER sent 49 over
0.986s and reported 1.007s.

## Tests

`tests/test_control_loop_budgets_survive_a_clock_step.py` drives each real loop through a
clock double that takes a known step, and asserts the loop spent the budget it was given,
applied a rollout's worth of commands, and reported the time that actually elapsed. The
contract is pinned on behavior, not on which clock is called.

**14 failed / 7 passed** on `main`, 21 pass after, with messages like:

```
a +30.0s wall-clock step ended the rollout after 0.000s of a 0.4s budget (1 commands)
a -2.0s wall-clock step kept the arm commanded for 2.395s on a 0.4s budget
a 3600.0s wall-clock step made a 0.007s rollout report itself as 3600.006s
a -2.0s wall-clock step made a 2.404s session report itself as 0.404s
a -2.0s wall-clock step stalled the stream for 2.053s
```

Thirteen of those fourteen are behavioral; the fourteenth just names the renamed field. The
seven that pass on both trees are the bound on the change: four assert the clock double
really hands out the step it advertises (so a clean run means something), and two assert the
no-step rollout and session are unchanged - which is what fails if the fix is ever mistaken
for a change in how long a loop runs. Correct code never reads the wall clock at all, so
"the double stepped" is deliberately not used as a precondition for any behavioral assertion.

Four existing tests were updated rather than added to:

- `tests/test_hardware_robot_lifecycle.py` drives the loop to exactly one iteration with a
  scripted clock the policy advances. It scripted `time.time()`, so after this change the
  script no longer reached the loop and the test ran the real budget (40 commands instead of
  2). It now scripts the clock the loop reads - by swapping the module reference the robot
  holds, not the attribute on `time`, because `time.monotonic()` is also asyncio's
  event-loop clock and freezing it would stop the `asyncio.sleep` between two commands from
  ever returning.
- `tests/test_hardware_task_duration_guard.py`, `tests/test_hardware_after_shutdown.py` and
  `tests/test_tool_result_contract.py` quote the comparison or the base by name.

`docs/hardware/robot-control.md` and `docs/hardware/teleoperation.md` state the clock beside
the `duration` they govern.

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 19 errors, the same 19 as `main` (none in a
  touched file).
- Blast radius - every test file referencing either module, `RobotTaskState`, either base, or
  a touched docs page, plus all of `tests/mesh` and the repo-wide guards (219 files, 5134
  tests): **21 failed / 5084 passed** here vs **35 failed / 5070 passed** on `main`.
  Comparing failing test ids, **branch-only is empty** (no regressions); the 14 base-only ids
  are exactly this file's pre-fix failures. `5084 - 5070 = 14` and `21 + 14 = 35` reconcile.
  The 45 shared failures are pre-existing (`awsiot` / zenoh not installed here).
