### PR TITLE
docs(policies/protomotions): name the frame the reference-motion cache's velocity channels are in

### DIFF
--- a/changelog.d/2411-protomotions-cache-velocity-frames.md
+++ b/changelog.d/2411-protomotions-cache-velocity-frames.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **policies/protomotions**: name the frame the reference-motion cache's velocity
+  channels are in. `_quat_finite_diff_ang_vel` documented its return as a
+  local-frame angular velocity while left-multiplying the quaternion delta, which
+  is the world-frame quantity that every other surface here already expects -
+  `compute_root_local_ang_vel` takes a world-frame `rigid_body_ang_vel` and the
+  policy reads a `body_ang_vel_world` observation key. Neither
+  `qpos_to_motion_data`'s `Returns:` section nor the `MotionPlayer` cache-format
+  contract named a frame at all, so a caller building a cache by hand had nothing
+  to follow; local-frame rows stored there are rotated a second time rather than
+  used as-is. On a bridged G1 walk clip the two frames differ by up to 6 rad/s.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -112,6 +112,18 @@ cache["num_frames"], cache["control_dt"]
 `MotionPlayer` accepts that dict, an `.npz` written by
 `MotionPlayer.save_cache_npz`, or a raw ProtoMotions `.pt`.
 
+### Cache velocities are world-frame
+
+`body_pos` and `body_rot` are world poses, and `body_vel` and `body_ang_vel`
+are **world-frame** velocities derived from them - the same convention a raw
+ProtoMotions motion library uses for `rigid_body_ang_vel`. That matters when
+you hand-build a cache instead of bridging one: the tracker's root input is a
+*local*-frame angular velocity, and `compute_root_local_ang_vel` produces it by
+rotating a world-frame row into the root's frame. Storing local-frame rows here
+gets them rotated a second time. The frames are not interchangeable - on a
+walking G1 clip they differ by whole rad/s, the same class of silent wrong-frame
+error as substituting the base for the anchor link above.
+
 ### Motion files are read with a restricted unpickler
 
 An `.npz` cache is read by NumPy and needs no torch. A raw `.pt` is read with

--- a/strands_robots/policies/protomotions/bridge.py
+++ b/strands_robots/policies/protomotions/bridge.py
@@ -105,12 +105,22 @@ def _quat_finite_diff_ang_vel(quats_xyzw: np.ndarray, dt: float) -> np.ndarray:
     then keeps the vector part. Output copies the last frame from the
     second-to-last so shapes match the input trajectory.
 
+    The delta is left-multiplied (``q_{t+1} * q_t^-1``), so the result is a
+    WORLD-frame angular velocity, matching the frame every other surface here
+    uses for a per-body angular-velocity array: the ``rigid_body_ang_vel``
+    argument of
+    :func:`~strands_robots.policies.protomotions.state_utils.compute_root_local_ang_vel`,
+    which exists to rotate one body's row of it into that body's local frame.
+    Right-multiplying instead (``q_t^-1 * q_{t+1}``) would give the local-frame
+    quantity; on a walking G1 the two differ by whole rad/s, so a caller that
+    treats one as the other feeds the tracker a wrong reference.
+
     Args:
         quats_xyzw: Shape ``[T, num_bodies, 4]`` xyzw quaternions.
         dt: Source period, seconds.
 
     Returns:
-        Shape ``[T, num_bodies, 3]`` local-frame angular velocities.
+        Shape ``[T, num_bodies, 3]`` world-frame angular velocities.
     """
     T = quats_xyzw.shape[0]
     if T < 2:
@@ -174,7 +184,9 @@ def qpos_to_motion_data(
     Returns:
         A dict with the keys
         :class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`
-        accepts.
+        accepts. ``body_pos``/``body_rot`` are world poses read straight off
+        MuJoCo's ``xpos``/``xquat``, and ``body_vel``/``body_ang_vel`` are
+        WORLD-frame velocities derived from them - not body-local ones.
 
     Raises:
         FileNotFoundError: If ``proto_mjcf_path`` does not exist.

--- a/strands_robots/policies/protomotions/motion_utils.py
+++ b/strands_robots/policies/protomotions/motion_utils.py
@@ -19,12 +19,19 @@ Cache format (dict-of-numpy):
 
 * ``dof_pos``       - ``[num_frames, num_dofs]``   float32
 * ``dof_vel``       - ``[num_frames, num_dofs]``   float32
-* ``body_rot``      - ``[num_frames, num_bodies, 4]``  float32 (xyzw)
-* ``body_pos``      - ``[num_frames, num_bodies, 3]``  float32
-* ``body_vel``      - ``[num_frames, num_bodies, 3]``  float32
-* ``body_ang_vel``  - ``[num_frames, num_bodies, 3]``  float32
+* ``body_rot``      - ``[num_frames, num_bodies, 4]``  float32 (xyzw, world)
+* ``body_pos``      - ``[num_frames, num_bodies, 3]``  float32 (world)
+* ``body_vel``      - ``[num_frames, num_bodies, 3]``  float32 (world frame)
+* ``body_ang_vel``  - ``[num_frames, num_bodies, 3]``  float32 (world frame)
 * ``control_dt``    - python float, seconds per control tick
 * ``num_frames``    - python int
+
+The two velocity channels are WORLD-frame, the same convention as a raw
+ProtoMotions motion library's ``rigid_body_ang_vel``. A hand-built cache must
+follow it: the tracker's own root input is a local-frame angular velocity that
+:func:`~strands_robots.policies.protomotions.state_utils.compute_root_local_ang_vel`
+derives by rotating a world-frame row, so supplying local-frame rows here is
+rotated a second time rather than used as-is.
 
 Clean-room from ProtoMotions (Apache 2.0) deployment/motion_utils.py.
 """

--- a/tests/policies/protomotions/test_cache_velocity_frames.py
+++ b/tests/policies/protomotions/test_cache_velocity_frames.py
@@ -1,0 +1,277 @@
+"""The reference-motion cache's velocity channels are world-frame, and say so.
+
+``MotionPlayer`` accepts a hand-built cache dict as a first-class input mode, so
+the frame of its ``body_vel`` / ``body_ang_vel`` rows is a contract a caller has
+to be able to read. The frame is not a detail: the tracker's own root input is a
+*local*-frame angular velocity that
+:func:`~strands_robots.policies.protomotions.state_utils.compute_root_local_ang_vel`
+derives by rotating a world-frame row, so a cache built in the local frame is
+rotated a second time instead of used as-is. On a walking G1 clip the two frames
+differ by whole rad/s.
+
+These tests grade every frame claim in the package against what the code
+measurably produces, rather than against each other, so the claim and the
+behaviour cannot drift apart in either direction.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.protomotions import bridge, motion_utils, state_utils
+from strands_robots.policies.protomotions.state_utils import quat_rotate_inverse
+
+# A quarter turn about world X, xyzw. Chosen so a world-Z spin has a *different*
+# local-frame representation - a frame-agnostic pose would make every assertion
+# below pass for either convention.
+TILT_X90_XYZW = np.array([np.sin(np.pi / 4), 0.0, 0.0, np.cos(np.pi / 4)])
+OMEGA = 0.4  # rad/s about world Z
+FPS = 200.0
+
+
+def _qmul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Hamilton product of two ``xyzw`` quaternions."""
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return np.array(
+        [
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+            aw * bw - ax * bx - ay * by - az * bz,
+        ]
+    )
+
+
+def _world_z_spin_of_a_tilted_body(frames: int, dt: float) -> np.ndarray:
+    """``[T, 1, 4]`` xyzw trajectory: a tilted body spinning about world Z."""
+    out = np.zeros((frames, 1, 4))
+    for t in range(frames):
+        half = OMEGA * t * dt * 0.5
+        spin = np.array([0.0, 0.0, np.sin(half), np.cos(half)])
+        out[t, 0] = _qmul(spin, TILT_X90_XYZW)  # left-multiply == world-frame spin
+    return out
+
+
+def _measured_frame_of_the_helper() -> str:
+    """Return ``"world"`` or ``"local"`` - whichever the helper actually emits."""
+    dt = 1.0 / FPS
+    quats = _world_z_spin_of_a_tilted_body(40, dt)
+    mid = 20
+    got = bridge._quat_finite_diff_ang_vel(quats, dt)[mid, 0]
+    world = np.array([0.0, 0.0, OMEGA], dtype=np.float32)
+    local = quat_rotate_inverse(quats[mid, 0].astype(np.float32), world)
+    assert not np.allclose(world, local, atol=1e-3), "premise: the probe pose must distinguish the two frames"
+    return "world" if np.linalg.norm(got - world) < np.linalg.norm(got - local) else "local"
+
+
+# --- docstring reading -----------------------------------------------------
+
+_FRAME_RE = re.compile(r"\b(world|local)[- ]frame\b", re.IGNORECASE)
+
+
+def _frames_named(text: str) -> set[str]:
+    """Frame words named in ``text``, lowercased."""
+    return {m.group(1).lower() for m in _FRAME_RE.finditer(text)}
+
+
+def _section(doc: str, name: str) -> str:
+    """The body of a Google-style ``name:`` section of ``doc`` (or "")."""
+    lines = (doc or "").splitlines()
+    for i, line in enumerate(lines):
+        if line.strip() == f"{name}:":
+            indent = len(line) - len(line.lstrip())
+            body = []
+            for nxt in lines[i + 1 :]:
+                if nxt.strip() and (len(nxt) - len(nxt.lstrip())) <= indent:
+                    break
+                body.append(nxt)
+            return "\n".join(body)
+    return ""
+
+
+def _docstrings_in_the_package() -> list[tuple[str, str]]:
+    """``(qualname, docstring)`` for every module/class/function in the package."""
+    pkg_dir = pathlib.Path(inspect.getfile(state_utils)).parent
+    out: list[tuple[str, str]] = []
+    for path in sorted(pkg_dir.glob("*.py")):
+        tree = ast.parse(path.read_text())
+        mod_doc = ast.get_docstring(tree)
+        if mod_doc:
+            out.append((f"{path.name}:<module>", mod_doc))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                doc = ast.get_docstring(node)
+                if doc:
+                    out.append((f"{path.name}:{node.name}", doc))
+    return out
+
+
+def _multi_body_ang_vel_entries() -> list[tuple[str, str, str]]:
+    """``(qualname, section, line)`` for each per-body angular-velocity claim.
+
+    An entry qualifies when one line of an ``Args:``/``Returns:`` section names
+    both a ``num_bodies`` axis and an angular velocity - i.e. it describes the
+    full body array, not the single root row the tracker consumes.
+    """
+    found: list[tuple[str, str, str]] = []
+    for qualname, doc in _docstrings_in_the_package():
+        for section in ("Args", "Returns"):
+            for line in _section(doc, section).splitlines():
+                if "num_bodies" in line and re.search(r"angular velocit", line, re.IGNORECASE):
+                    found.append((qualname, section, line.strip()))
+    return found
+
+
+# --- the frame the code produces -------------------------------------------
+
+
+class TestTheFiniteDiffHelperProducesAWorldFrameVelocity:
+    """Pin the frame itself, so a change to the math has to change these."""
+
+    def test_a_world_axis_spin_of_a_tilted_body_is_reported_in_the_world_frame(self) -> None:
+        dt = 1.0 / FPS
+        quats = _world_z_spin_of_a_tilted_body(40, dt)
+        got = bridge._quat_finite_diff_ang_vel(quats, dt)[20, 0]
+        assert got == pytest.approx([0.0, 0.0, OMEGA], abs=1e-4)
+
+    def test_it_is_not_the_body_local_representation_of_that_same_spin(self) -> None:
+        dt = 1.0 / FPS
+        quats = _world_z_spin_of_a_tilted_body(40, dt)
+        got = bridge._quat_finite_diff_ang_vel(quats, dt)[20, 0]
+        local = quat_rotate_inverse(quats[20, 0].astype(np.float32), np.array([0.0, 0.0, OMEGA], dtype=np.float32))
+        assert np.linalg.norm(got - local) > 0.1, (
+            f"the two frames must stay distinguishable here: got {got}, local would be {local}"
+        )
+
+    def test_a_row_of_it_composes_with_compute_root_local_ang_vel(self) -> None:
+        """The pair contract: rotating one row yields the local-frame quantity."""
+        dt = 1.0 / FPS
+        quats = _world_z_spin_of_a_tilted_body(40, dt)
+        body_ang_vel = bridge._quat_finite_diff_ang_vel(quats, dt)
+        got_local = state_utils.compute_root_local_ang_vel(quats[20].astype(np.float32), body_ang_vel[20], 0)
+        want_local = quat_rotate_inverse(quats[20, 0].astype(np.float32), np.array([0.0, 0.0, OMEGA], dtype=np.float32))
+        assert got_local == pytest.approx(want_local, abs=1e-3)
+
+
+# --- every claim matches that frame ----------------------------------------
+
+
+class TestEveryFrameClaimNamesTheFrameTheCodeProduces:
+    """A frame word is a claim about behaviour; grade it against the behaviour."""
+
+    def test_no_per_body_angular_velocity_claim_calls_the_array_local_frame(self) -> None:
+        measured = _measured_frame_of_the_helper()
+        entries = _multi_body_ang_vel_entries()
+        assert entries, "premise: the package must document at least one per-body angular-velocity array"
+        wrong = [(q, s, line) for q, s, line in entries if _frames_named(line) - {measured}]
+        assert not wrong, (
+            f"the per-body angular-velocity array is measurably {measured}-frame, but "
+            f"{len(wrong)} documented entr(y/ies) name another frame: "
+            + "; ".join(f"{q} {s}: {line!r}" for q, s, line in wrong)
+        )
+
+    def test_the_helper_returns_section_names_a_frame_and_it_is_the_measured_one(self) -> None:
+        measured = _measured_frame_of_the_helper()
+        returns = _section(bridge._quat_finite_diff_ang_vel.__doc__ or "", "Returns")
+        assert _frames_named(returns) == {measured}, (
+            f"_quat_finite_diff_ang_vel returns a {measured}-frame velocity but its "
+            f"Returns section names {sorted(_frames_named(returns)) or 'no frame'}: {returns.strip()!r}"
+        )
+
+    def test_the_public_bridge_returns_section_names_the_velocity_frame(self) -> None:
+        returns = _section(bridge.qpos_to_motion_data.__doc__ or "", "Returns")
+        assert _frames_named(returns) == {"world"}, (
+            "qpos_to_motion_data builds the cache's velocity channels, so its Returns "
+            f"section has to say which frame they are in; it names {sorted(_frames_named(returns)) or 'none'}"
+        )
+
+    def test_the_cache_format_contract_names_the_frame_of_both_velocity_channels(self) -> None:
+        doc = motion_utils.__doc__ or ""
+        bullets = {
+            channel: [ln for ln in doc.splitlines() if f"``{channel}``" in ln]
+            for channel in ("body_vel", "body_ang_vel")
+        }
+        for channel, lines in bullets.items():
+            assert lines, f"premise: the cache-format list must describe {channel}"
+            assert any("world" in ln.lower() for ln in lines), (
+                f"a hand-built cache is a documented input mode, so the cache-format entry for "
+                f"{channel} has to name its frame; it reads {lines[0].strip()!r}"
+            )
+
+
+# --- end to end through MuJoCo forward kinematics --------------------------
+
+
+class TestTheBridgedCacheIsWorldFrameEndToEnd:
+    """Drive the real public entry point on a hermetic 36-dof MJCF."""
+
+    @staticmethod
+    def _mjcf(tmp_path: pathlib.Path) -> pathlib.Path:
+        """A freejoint root plus 29 hinges, so ``nq`` is exactly 36."""
+        links = "".join(
+            f'<body name="l{i}" pos="0 0 0.05">'
+            f'<joint name="j{i}" type="hinge" axis="0 1 0"/>'
+            f'<geom type="box" size="0.02 0.02 0.02" mass="0.1"/>'
+            for i in range(29)
+        )
+        xml = (
+            "<mujoco><worldbody>"
+            '<body name="root" pos="0 0 1"><freejoint/>'
+            '<geom type="box" size="0.05 0.05 0.05" mass="1"/>'
+            f"{links}{'</body>' * 29}</body></worldbody></mujoco>"
+        )
+        path = tmp_path / "chain36.xml"
+        path.write_text(xml)
+        return path
+
+    @staticmethod
+    def _qpos(frames: int, dt: float, speed: float) -> np.ndarray:
+        """Root tilted a quarter turn about Y, spinning about world Z, sliding along world X."""
+        tilt_y90 = np.array([0.0, np.sin(np.pi / 4), 0.0, np.cos(np.pi / 4)])
+        qpos = np.zeros((frames, 36))
+        for t in range(frames):
+            half = OMEGA * t * dt * 0.5
+            spin = np.array([0.0, 0.0, np.sin(half), np.cos(half)])
+            q_xyzw = _qmul(spin, tilt_y90)
+            qpos[t, 0] = speed * t * dt
+            qpos[t, 2] = 1.0
+            qpos[t, 3:7] = [q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]]  # wxyz for MuJoCo
+        return qpos
+
+    def _cache(self, tmp_path: pathlib.Path, speed: float = 0.0, control_dt: float | None = None) -> dict[str, Any]:
+        pytest.importorskip("mujoco")
+        dt = 1.0 / FPS
+        return bridge.qpos_to_motion_data(
+            self._qpos(40, dt, speed),
+            fps=FPS,
+            proto_mjcf_path=self._mjcf(tmp_path),
+            control_dt=dt if control_dt is None else control_dt,
+        )
+
+    def test_the_root_row_of_body_ang_vel_is_the_world_frame_spin(self, tmp_path: pathlib.Path) -> None:
+        cache = self._cache(tmp_path)
+        got = cache["body_ang_vel"][20, 0]
+        assert got == pytest.approx([0.0, 0.0, OMEGA], abs=1e-3)
+
+    def test_resampling_does_not_change_the_frame(self, tmp_path: pathlib.Path) -> None:
+        cache = self._cache(tmp_path, control_dt=2.0 / FPS)
+        got = cache["body_ang_vel"][10, 0]
+        assert got == pytest.approx([0.0, 0.0, OMEGA], abs=1e-3)
+
+    def test_body_vel_is_a_world_frame_linear_velocity(self, tmp_path: pathlib.Path) -> None:
+        speed = 0.7
+        cache = self._cache(tmp_path, speed=speed)
+        got = cache["body_vel"][20, 0]
+        assert got == pytest.approx([speed, 0.0, 0.0], abs=1e-3)
+        local = quat_rotate_inverse(cache["body_rot"][20, 0], np.array([speed, 0.0, 0.0], dtype=np.float32))
+        assert np.linalg.norm(got - local) > 0.1, (
+            f"premise: the probe pose must distinguish the frames (local would be {local})"
+        )


### PR DESCRIPTION
## Problem

`MotionPlayer` accepts a hand-built cache dict as a first-class input mode, so the frame of its `body_vel` / `body_ang_vel` rows is a contract a caller has to be able to read. Two things were wrong.

**A private helper named the wrong frame.** `_quat_finite_diff_ang_vel` documented its return as `local-frame angular velocities`. It left-multiplies the quaternion delta (`q1 * q0^-1`), which is the *world*-frame quantity. Driven on an analytic world-Z spin of a body tilted a quarter turn about X - a pose chosen so the two frames differ - it matches the world value exactly and misses the body-local one by `0.57 rad/s`:

```
analytic omega_world : [0. 0. 0.4]     err vs WORLD: 0.000000
analytic omega_local : [0. 0.4 0. ]    err vs LOCAL: 0.565685
bridge output        : [-0. 0. 0.4]
```

Every other surface in the package already names that channel world-frame, so the helper was the odd one out:

| surface | how it names the per-body angular-velocity array |
| --- | --- |
| `state_utils.compute_root_local_ang_vel` arg | `rigid_body_ang_vel: Shape [num_bodies, 3] (world frame)` |
| `policy.py` observation key | `body_ang_vel_world` |
| `bridge._quat_finite_diff_ang_vel` Returns | `local-frame angular velocities` |

`compute_root_local_ang_vel` exists precisely to rotate one row of that array into a body's local frame, so a producer that emits local-frame rows is rotated a second time rather than used as-is.

**The public contract named no frame at all.** Neither `qpos_to_motion_data`'s `Returns:` section nor the cache-format list in `motion_utils` said which frame `body_vel` / `body_ang_vel` are in, so a caller assembling a cache by hand had nothing to follow.

This is not a cosmetic distinction. Bridging a Kimodo G1 walk clip (120 frames @ 30 Hz) through `qpos_to_motion_data` and reading each row in both frames:

| quantity | peak world-vs-local gap |
| --- | --- |
| body `left_ankle_pitch_link` | **6.015 rad/s** |
| worst over all 30 bodies | 6.015 rad/s |
| pelvis alone | 0.329 rad/s |

## Change

Documentation and tests only - no behaviour changes.

- `bridge._quat_finite_diff_ang_vel`: `Returns:` now says world-frame, and the body explains *why* (left- vs right-multiplication) and points at `compute_root_local_ang_vel` for the local conversion.
- `bridge.qpos_to_motion_data`: `Returns:` names the frame of the pose and velocity channels it builds.
- `motion_utils` cache-format contract: annotates all four body channels and states what a hand-built cache must follow.
- `docs/policies/protomotions.md`: a "Cache velocities are world-frame" subsection, next to the existing anchor-vs-base discussion of the same class of wrong-frame error.

## Tests

`tests/policies/protomotions/test_cache_velocity_frames.py`, 10 tests in two complementary classes: one pins **which** frame the code produces, the other pins that **every claim names that frame**. Neither alone is sufficient, and together they close both drift directions.

Pre-fix split on `upstream/main`: **4 failed, 6 passed**. The failures name the offender and the measured frame:

```
the per-body angular-velocity array is measurably world-frame, but 1 documented
entr(y/ies) name another frame: bridge.py:_quat_finite_diff_ang_vel Returns:
'Shape ``[T, num_bodies, 3]`` local-frame angular velocities.'

qpos_to_motion_data builds the cache's velocity channels, so its Returns section
has to say which frame they are in; it names none
```

The 6 that pass on both trees are the behaviour controls, and they are load-bearing rather than decoration: flipping the implementation to genuinely right-multiply (`q0^-1 * q1`, i.e. actually local-frame) fails **7** of the 10, including all three analytic controls and both end-to-end angular-velocity checks. The root-cause guard is deliberately consistency-based, so it correctly stays green in that scenario while the behaviour class catches it - which is why both classes exist.

The end-to-end class drives the real `qpos_to_motion_data` on a hermetic MJCF generated in the test (a freejoint root plus 29 hinges, so `nq` is exactly 36), so it downloads nothing and skips cleanly without `mujoco`. It also covers the resample branch, since that path re-interpolates the velocity rows.

## Verification

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 19 pre-existing errors, identical set on this branch and on `upstream/main`; zero in the touched files.
- Blast radius - all `tests/policies/protomotions`, every test referencing the changed symbols, and the repo-wide docstring / xref / ASCII / docs-coverage / changelog guards (19 files): **branch 690 passed, 0 failed**; base with the new file copied in **4 failed, 686 passed**. Same 691 collected on both, no branch-only failures, and the base-only failures are exactly the 4 pre-fix ones.

## Artifact

The clip whose bridged cache the measurement above comes from, rendered headless in MuJoCo, beside the two frames of the same physical rotation for the worst-diverging body and the full claim-vs-measurement table.

![reference-motion cache velocity frames](https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-cache-frames/protomotions-cache-velocity-frames.png)
