### PR TITLE
fix(policies/protomotions): fill the cache's body rows in the order the tracker reads them

### DIFF
--- a/changelog.d/2417-protomotions-cache-body-row-order.md
+++ b/changelog.d/2417-protomotions-cache-body-row-order.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **policies/protomotions**: `qpos_to_motion_data` now fills the reference-motion
+  cache's body rows by name against `GTP_G1_BODY_NAMES` - the order the tracker
+  indexes them by - and refuses an MJCF that cannot supply a body it reads or whose
+  `qpos` layout is not the tracker's. Read positionally, a fingerless 30-body G1
+  shifted every row after the missing `head`, so the tracker was handed
+  `left_shoulder_pitch_link` where it asked for its `torso_link` anchor.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -112,6 +112,32 @@ cache["num_frames"], cache["control_dt"]
 `MotionPlayer` accepts that dict, an `.npz` written by
 `MotionPlayer.save_cache_npz`, or a raw ProtoMotions `.pt`.
 
+### The MJCF has to be the tracker's own embodiment
+
+`proto_mjcf_path` is not just any G1. The tracker reads a body out of the cache
+by **row index**, never by name: `anchor_body_index` and `root_body_index` are
+offsets into `GTP_G1_BODY_NAMES`, the 33-name list pinned from the checkpoint's
+sidecar. `qpos_to_motion_data` fills those rows by name from the model you hand
+it, so the model has to carry all 33 - plus a free root and the 29
+`GTP_G1_JOINT_NAMES` joints, for a `qpos` width of 36.
+
+The G1 family does not agree on that body set. The widely-shipped fingerless
+models omit `head` and both `rubber_hand` placeholders and expose 30 bodies;
+`g1_29dof_with_hand` and `g1_with_hands` expose 44 and a `qpos` width of 50.
+Passing one of those is refused, with a message that names what is missing:
+
+```text
+ValueError: ProtoMotions G1 MJCF .../g1_29dof.xml is missing 3 of the 33 bodies
+the tracker reads by row index: ['head', 'left_rubber_hand', 'right_rubber_hand'].
+```
+
+The refusal is the point. Read positionally, a 30-body model shifts every row
+after the gap by one, so the tracker asks for `torso_link` at row 16 and is
+handed `left_shoulder_pitch_link` - on a walking clip, an anchor orientation
+some 20 degrees out, with nothing in the cache to say so. A model whose `qpos`
+layout differs is refused separately and says so, so a model-side mismatch is
+not read as a bad `qpos` argument.
+
 ### Cache velocities are world-frame
 
 `body_pos` and `body_rot` are world poses, and `body_vel` and `body_ang_vel`

--- a/strands_robots/policies/protomotions/bridge.py
+++ b/strands_robots/policies/protomotions/bridge.py
@@ -29,12 +29,20 @@ import numpy as np
 
 from strands_robots.utils import require_optional
 
+from .config import GTP_G1_BODY_NAMES, GTP_G1_JOINT_NAMES, GTP_G1_ROOT_BODY_INDEX
 from .motion_utils import lerp, slerp
 from .state_utils import mujoco_wxyz_to_xyzw
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["qpos_to_motion_data"]
+
+#: qpos entries a free root joint occupies: xyz translation + wxyz quaternion.
+_ROOT_QPOS_WIDTH = 7
+
+#: Total qpos width the tracker's embodiment has: the free root plus one
+#: entry per :data:`GTP_G1_JOINT_NAMES` hinge.
+_EXPECTED_NQ = _ROOT_QPOS_WIDTH + len(GTP_G1_JOINT_NAMES)
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +99,68 @@ def _patch_and_load_mjcf(mjcf_path: Path):
 
     data = mujoco.MjData(model)  # type: ignore[attr-defined]
     return mujoco, model, data
+
+
+# ---------------------------------------------------------------------------
+# Embodiment check
+# ---------------------------------------------------------------------------
+
+
+def _proto_body_rows(mujoco, model, mjcf_path: Path) -> np.ndarray:
+    """Resolve the MuJoCo body ids the cache's body rows must hold.
+
+    The tracker reads a body out of the cache by ROW INDEX, not by name:
+    :attr:`~strands_robots.policies.protomotions.config.ProtoMotionsConfig.anchor_body_index`
+    and ``root_body_index`` are offsets into
+    :data:`~strands_robots.policies.protomotions.config.GTP_G1_BODY_NAMES`. So the
+    cache's rows have to be that list, in that order - MuJoCo's own body order is
+    only the same thing when the supplied MJCF is the tracker's own embodiment.
+    Resolving each row by name keeps the two orders from being paired positionally.
+
+    Args:
+        mujoco: The imported ``mujoco`` module.
+        model: A compiled ``MjModel``.
+        mjcf_path: Path the model was compiled from, quoted in refusals.
+
+    Returns:
+        MuJoCo body ids, one per :data:`GTP_G1_BODY_NAMES` entry, in that order.
+
+    Raises:
+        ValueError: If the model's qpos layout is not a free root followed by the
+            tracker's joints, or if it does not carry every tracker body.
+    """
+    has_free_root = model.njnt > 0 and model.jnt_type[0] == mujoco.mjtJoint.mjJNT_FREE
+    if not has_free_root or model.nq != _EXPECTED_NQ:
+        root = "a free root joint" if has_free_root else "no free root joint"
+        raise ValueError(
+            f"ProtoMotions G1 MJCF {mjcf_path} does not have the tracker's qpos "
+            f"layout: it has {root} and nq={model.nq}, but the cache is built for "
+            f"nq={_EXPECTED_NQ} (a free root's {_ROOT_QPOS_WIDTH} entries plus "
+            f"{len(GTP_G1_JOINT_NAMES)} joints). This is the MJCF's layout, not the "
+            f"qpos argument's - supply the MJCF the tracker checkpoint was exported "
+            f"against."
+        )
+
+    rows: list[int] = []
+    missing: list[str] = []
+    for name in GTP_G1_BODY_NAMES:
+        body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+        if body_id < 0:
+            missing.append(name)
+        else:
+            rows.append(body_id)
+    if missing:
+        raise ValueError(
+            f"ProtoMotions G1 MJCF {mjcf_path} is missing {len(missing)} of the "
+            f"{len(GTP_G1_BODY_NAMES)} bodies the tracker reads by row index: "
+            f"{missing!r}. The tracker indexes cache rows against "
+            f"GTP_G1_BODY_NAMES (row 0 is the root, row "
+            f"{GTP_G1_BODY_NAMES.index('torso_link')} is the anchor), so a model "
+            f"with a different body set shifts every row after the gap and the "
+            f"tracker reads a different link than it asked for. Supply the MJCF the "
+            f"tracker checkpoint was exported against."
+        )
+    return np.asarray(rows, dtype=np.intp)
 
 
 # ---------------------------------------------------------------------------
@@ -178,19 +248,31 @@ def qpos_to_motion_data(
             with a warning (some Kimodo variants emit trailing padding).
         fps: Source frame rate in Hz (Kimodo default is 30).
         proto_mjcf_path: Path to the ProtoMotions G1 MJCF (the caller supplies
-            it; this module ships no asset bundle).
+            it; this module ships no asset bundle). It must be the tracker's own
+            embodiment: a free root plus the
+            :data:`~strands_robots.policies.protomotions.config.GTP_G1_JOINT_NAMES`
+            joints, carrying every
+            :data:`~strands_robots.policies.protomotions.config.GTP_G1_BODY_NAMES`
+            body. A G1 variant with a different body set is refused rather than
+            bridged into rows the tracker would misread.
         control_dt: Target control period, seconds (default 0.02 = 50Hz).
 
     Returns:
         A dict with the keys
         :class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`
-        accepts. ``body_pos``/``body_rot`` are world poses read straight off
-        MuJoCo's ``xpos``/``xquat``, and ``body_vel``/``body_ang_vel`` are
-        WORLD-frame velocities derived from them - not body-local ones.
+        accepts. ``body_pos``/``body_rot`` are world poses read off MuJoCo's
+        ``xpos``/``xquat``, one row per
+        :data:`~strands_robots.policies.protomotions.config.GTP_G1_BODY_NAMES`
+        entry IN THAT ORDER - the order the tracker's ``anchor_body_index`` and
+        ``root_body_index`` are offsets into, resolved by name rather than by
+        MuJoCo's own body order. ``body_vel``/``body_ang_vel`` are WORLD-frame
+        velocities derived from them - not body-local ones.
 
     Raises:
         FileNotFoundError: If ``proto_mjcf_path`` does not exist.
-        ValueError: If ``qpos.shape[1]`` is not exactly 36 (after truncation).
+        ValueError: If ``qpos.shape[1]`` is not exactly 36 (after truncation), or
+            if the MJCF is not the tracker's embodiment - a distinct message that
+            names the MJCF, so a model-side mismatch is not read as a bad ``qpos``.
         RuntimeError: If MuJoCo is not installed.
     """
     proto_mjcf_path = Path(proto_mjcf_path)
@@ -215,8 +297,9 @@ def qpos_to_motion_data(
     T = qpos.shape[0]
     mujoco, model, data = _patch_and_load_mjcf(proto_mjcf_path)
 
-    num_bodies = model.nbody - 1  # skip world body at index 0
-    num_dofs = model.nq - 7
+    body_rows = _proto_body_rows(mujoco, model, proto_mjcf_path)
+    num_bodies = len(body_rows)
+    num_dofs = model.nq - _ROOT_QPOS_WIDTH
 
     logger.info(
         "qpos_to_motion_data: MJCF has %d bodies, %d dofs. Processing %d frames @ %.1f Hz.",
@@ -234,11 +317,11 @@ def qpos_to_motion_data(
         data.qpos[:] = qpos[t]
         data.qvel[:] = 0.0
         mujoco.mj_forward(model, data)  # type: ignore[attr-defined]
-        body_pos[t] = data.xpos[1:].astype(np.float32)
-        body_rot_xyzw[t] = mujoco_wxyz_to_xyzw(data.xquat[1:]).astype(np.float32)
+        body_pos[t] = data.xpos[body_rows].astype(np.float32)
+        body_rot_xyzw[t] = mujoco_wxyz_to_xyzw(data.xquat[body_rows]).astype(np.float32)
         # Root body's rot is the canonical freejoint quaternion from qpos.
-        body_rot_xyzw[t, 0] = mujoco_wxyz_to_xyzw(data.qpos[3:7].astype(np.float32))
-        dof_pos[t] = data.qpos[7:].astype(np.float32)
+        body_rot_xyzw[t, GTP_G1_ROOT_BODY_INDEX] = mujoco_wxyz_to_xyzw(data.qpos[3:_ROOT_QPOS_WIDTH].astype(np.float32))
+        dof_pos[t] = data.qpos[_ROOT_QPOS_WIDTH:].astype(np.float32)
 
     dt_src = 1.0 / max(fps, 1e-6)
     dof_vel = np.zeros_like(dof_pos)

--- a/tests/policies/protomotions/test_cache_body_rows_match_the_tracker_order.py
+++ b/tests/policies/protomotions/test_cache_body_rows_match_the_tracker_order.py
@@ -1,0 +1,321 @@
+"""The reference-motion cache's body rows are the order the tracker indexes.
+
+The tracker does not look a body up by name. ``ProtoMotionsPolicy`` reads its
+anchor orientation as ``future["body_rot"][:, config.anchor_body_index]``, and
+``anchor_body_index``/``root_body_index`` are offsets into
+:data:`~strands_robots.policies.protomotions.config.GTP_G1_BODY_NAMES` - a fixed
+33-name list pinned from the checkpoint's own sidecar, whose comment states the
+order outright ("Index 0 = pelvis (root), 16 = torso_link (anchor)").
+
+:func:`~strands_robots.policies.protomotions.bridge.qpos_to_motion_data` fills
+those rows by running forward kinematics through a caller-supplied MJCF. A G1
+variant with a different body set therefore yields rows in *its* order, and every
+row after the first gap names a different link than the tracker asked for. The
+G1 family is full of such variants - the fingerless 30-body models omit ``head``
+and both ``rubber_hand`` placeholders - so the pairing has to be made by name,
+and refused when a body the tracker reads is absent, rather than taken on trust
+positionally.
+
+These tests grade the cache's rows against an independent MuJoCo oracle that
+resolves each body by name, so a row can never be confirmed by the same
+index arithmetic that produced it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.protomotions import bridge
+from strands_robots.policies.protomotions.config import (
+    GTP_G1_ANCHOR_BODY_INDEX,
+    GTP_G1_BODY_NAMES,
+    GTP_G1_JOINT_NAMES,
+    GTP_G1_ROOT_BODY_INDEX,
+)
+
+FPS = 50.0
+FRAMES = 12
+
+# The three bodies the tracker reads that carry no joint of their own. Real G1
+# MJCFs either ship them as fixed placeholder links or omit them entirely.
+JOINTLESS = ("head", "left_rubber_hand", "right_rubber_hand")
+
+
+def g1_like_mjcf(
+    path: pathlib.Path,
+    *,
+    body_names: tuple[str, ...] = GTP_G1_BODY_NAMES,
+    joint_names: tuple[str, ...] = GTP_G1_JOINT_NAMES,
+    free_root: bool = True,
+    extra_hinges: int = 0,
+) -> pathlib.Path:
+    """Write a hermetic G1-shaped chain MJCF carrying the given names.
+
+    MuJoCo orders bodies depth-first, so a single chain makes the compiled body
+    order exactly ``body_names`` - which is what lets a test choose an order that
+    does or does not match the tracker's.
+
+    Each jointed link hinges about a different axis so no two bodies share a world
+    rotation; a fixture whose bodies rotated together could not tell a
+    correctly-aligned row from a shifted one.
+
+    Args:
+        path: File to write.
+        body_names: Body names, outermost first. ``body_names[0]`` is the root.
+        joint_names: Hinge names handed out to the links in order. Bodies named in
+            :data:`JOINTLESS` are skipped, mirroring the real model.
+        free_root: Write a ``<freejoint/>`` on the root. When ``False`` the root's
+            seven qpos entries are made up with hinges instead, so ``nq`` is
+            unchanged and only the root's joint TYPE differs.
+        extra_hinges: Additional hinges, widening ``nq`` past the tracker's.
+
+    Returns:
+        ``path``, for convenience.
+    """
+    axes = ("1 0 0", "0 1 0", "0 0 1")
+    joints: list[list[str]] = [[] for _ in body_names]
+    dofs = [0] * len(body_names)
+
+    if free_root:
+        joints[0].append("<freejoint/>")
+        dofs[0] = 6  # a free joint fills the per-body dof budget
+
+    pending = list(joint_names)
+    for index, name in enumerate(body_names):
+        if index == 0 or name in JOINTLESS or not pending:
+            continue
+        joints[index].append(f'<joint name="{pending.pop(0)}" type="hinge" axis="{axes[index % 3]}"/>')
+        dofs[index] += 1
+    assert not pending, f"chain has no room for {pending}"
+
+    # MuJoCo caps a body at six dofs, so filler hinges spread along the chain.
+    remaining = (0 if free_root else 7) + extra_hinges
+    made = 0
+    for index in range(len(body_names)):
+        while remaining and dofs[index] < 6:
+            joints[index].append(f'<joint name="filler{made}" type="hinge" axis="{axes[made % 3]}"/>')
+            dofs[index] += 1
+            remaining -= 1
+            made += 1
+    assert not remaining, "chain has no room for the requested hinges"
+
+    chunks: list[str] = []
+    for index, name in enumerate(body_names):
+        chunks.append(f'<body name="{name}" pos="0 0.01 0.04">')
+        chunks.extend(joints[index])
+        chunks.append('<geom type="box" size="0.02 0.02 0.02" mass="0.1"/>')
+    body_xml = "".join(chunks) + "</body>" * len(body_names)
+    path.write_text(f"<mujoco><worldbody>{body_xml}</worldbody></mujoco>")
+    return path
+
+
+def _qpos(frames: int = FRAMES) -> np.ndarray:
+    """A ``[T, 36]`` clip: the root turning about world Z, every hinge sweeping."""
+    qpos = np.zeros((frames, 36))
+    for t in range(frames):
+        half = 0.35 * t / max(frames - 1, 1)
+        qpos[t, 2] = 1.0
+        qpos[t, 3] = np.cos(half)
+        qpos[t, 6] = np.sin(half)
+        qpos[t, 7:] = 0.25 * np.sin(np.arange(29) * 0.7 + t * 0.2)
+    return qpos
+
+
+def _world_rotation_by_name(mjcf: pathlib.Path, qpos_frame: np.ndarray) -> dict[str, np.ndarray]:
+    """Oracle: each body's world ``xyzw`` rotation, resolved by NAME not index."""
+    mujoco = pytest.importorskip("mujoco")
+    mj_model, mj_data = bridge._patch_and_load_mjcf(mjcf)[1:]
+    mj_data.qpos[:] = qpos_frame
+    mj_data.qvel[:] = 0.0
+    mujoco.mj_forward(mj_model, mj_data)
+    out: dict[str, np.ndarray] = {}
+    for body_id in range(1, mj_model.nbody):
+        name = mujoco.mj_id2name(mj_model, mujoco.mjtObj.mjOBJ_BODY, body_id)
+        if name:
+            w, x, y, z = mj_data.xquat[body_id]
+            out[name] = np.array([x, y, z, w], dtype=np.float64)
+    return out
+
+
+#: Componentwise tolerance for one cached rotation against the float64 oracle.
+#: Well above float32 storage error and far below any two distinct G1 links.
+ROW_ATOL = 1e-5
+
+
+def _same_rotation(cached: np.ndarray, oracle: np.ndarray) -> bool:
+    """Whether a cached ``xyzw`` row is the oracle rotation, up to float32 storage.
+
+    Compared componentwise rather than as a geodesic angle: ``arccos`` is
+    ill-conditioned near identity, where float32 storage alone reads as tenths of
+    a degree, which would make the tolerance say more about the metric than about
+    the row.
+    """
+    both = np.asarray(oracle, dtype=np.float64)
+    return bool(
+        np.allclose(np.asarray(cached, dtype=np.float64), both, atol=ROW_ATOL)
+        or np.allclose(np.asarray(cached, dtype=np.float64), -both, atol=ROW_ATOL)
+    )
+
+
+def _angle_deg(a: np.ndarray, b: np.ndarray) -> float:
+    """Geodesic angle between two ``xyzw`` rotations, in degrees - for messages."""
+    a = np.asarray(a, dtype=np.float64) / np.linalg.norm(a)
+    b = np.asarray(b, dtype=np.float64) / np.linalg.norm(b)
+    return float(2.0 * np.degrees(np.arccos(np.clip(abs(float(a @ b)), 0.0, 1.0))))
+
+
+def _bridge(mjcf: pathlib.Path) -> dict[str, Any]:
+    pytest.importorskip("mujoco")
+    return bridge.qpos_to_motion_data(_qpos(), fps=FPS, proto_mjcf_path=mjcf, control_dt=1.0 / FPS)
+
+
+# A complete embodiment whose compiled body order is NOT the tracker's: `head`
+# moved to the end of the chain. Every body the tracker reads is present, so the
+# cache is fully servable - only the positional pairing is wrong.
+_SHUFFLED = (GTP_G1_BODY_NAMES[0], *GTP_G1_BODY_NAMES[2:], GTP_G1_BODY_NAMES[1])
+
+
+class TestEveryCacheRowHoldsTheBodyTheTrackerReadsThere:
+    """Rows are paired to the tracker's list by name, not by MuJoCo body index."""
+
+    def test_the_anchor_row_holds_the_anchor_body(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "shuffled.xml", body_names=_SHUFFLED)
+        cache = _bridge(mjcf)
+        oracle = _world_rotation_by_name(mjcf, _qpos()[0])
+        anchor_name = GTP_G1_BODY_NAMES[GTP_G1_ANCHOR_BODY_INDEX]
+        row = cache["body_rot"][0, GTP_G1_ANCHOR_BODY_INDEX]
+        error = _angle_deg(row, oracle[anchor_name])
+        nearest = min(oracle, key=lambda n: _angle_deg(row, oracle[n]))
+        assert _same_rotation(row, oracle[anchor_name]), (
+            f"the tracker reads row {GTP_G1_ANCHOR_BODY_INDEX} as its {anchor_name!r} anchor, but that row is "
+            f"{error:.2f} deg from {anchor_name!r} and matches {nearest!r} instead"
+        )
+
+    def test_the_root_row_holds_the_root_body(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "shuffled.xml", body_names=_SHUFFLED)
+        cache = _bridge(mjcf)
+        oracle = _world_rotation_by_name(mjcf, _qpos()[0])
+        root_name = GTP_G1_BODY_NAMES[GTP_G1_ROOT_BODY_INDEX]
+        row = cache["body_rot"][0, GTP_G1_ROOT_BODY_INDEX]
+        error = _angle_deg(row, oracle[root_name])
+        assert _same_rotation(row, oracle[root_name]), (
+            f"row {GTP_G1_ROOT_BODY_INDEX} is {error:.2f} deg from the root body {root_name!r}"
+        )
+
+    def test_no_row_names_a_different_body_than_the_tracker_expects(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "shuffled.xml", body_names=_SHUFFLED)
+        cache = _bridge(mjcf)
+        oracle = _world_rotation_by_name(mjcf, _qpos()[0])
+        wrong = [
+            (row, name, round(_angle_deg(cache["body_rot"][0, row], oracle[name]), 2))
+            for row, name in enumerate(GTP_G1_BODY_NAMES)
+            if not _same_rotation(cache["body_rot"][0, row], oracle[name])
+        ]
+        assert not wrong, f"{len(wrong)} of {len(GTP_G1_BODY_NAMES)} rows hold another body's rotation: {wrong[:4]}"
+
+    def test_body_positions_are_aligned_the_same_way_as_rotations(self, tmp_path: pathlib.Path) -> None:
+        mujoco = pytest.importorskip("mujoco")
+        mjcf = g1_like_mjcf(tmp_path / "shuffled.xml", body_names=_SHUFFLED)
+        cache = _bridge(mjcf)
+        mj_model, mj_data = bridge._patch_and_load_mjcf(mjcf)[1:]
+        mj_data.qpos[:] = _qpos()[0]
+        mujoco.mj_forward(mj_model, mj_data)
+        anchor_id = mujoco.mj_name2id(mj_model, mujoco.mjtObj.mjOBJ_BODY, GTP_G1_BODY_NAMES[GTP_G1_ANCHOR_BODY_INDEX])
+        assert cache["body_pos"][0, GTP_G1_ANCHOR_BODY_INDEX] == pytest.approx(mj_data.xpos[anchor_id], abs=1e-5)
+
+
+class TestAnMjcfThatIsNotTheTrackerEmbodimentIsRefused:
+    """A model that cannot fill the tracker's rows is refused, not shifted."""
+
+    @staticmethod
+    def _fingerless(tmp_path: pathlib.Path) -> pathlib.Path:
+        """The real 30-body shape: no ``head``, no ``rubber_hand`` placeholders."""
+        kept = tuple(n for n in GTP_G1_BODY_NAMES if n not in JOINTLESS)
+        return g1_like_mjcf(tmp_path / "fingerless.xml", body_names=kept)
+
+    def test_a_variant_missing_tracker_bodies_is_refused(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(self._fingerless(tmp_path))
+        assert "missing" in str(excinfo.value).lower()
+
+    def test_the_refusal_names_every_missing_body(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(self._fingerless(tmp_path))
+        message = str(excinfo.value)
+        assert [name for name in JOINTLESS if name not in message] == [], message
+
+    def test_the_refusal_says_the_rows_are_read_by_index(self, tmp_path: pathlib.Path) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(self._fingerless(tmp_path))
+        message = str(excinfo.value)
+        assert "row index" in message and "GTP_G1_BODY_NAMES" in message, message
+
+    def test_a_model_whose_qpos_layout_is_wider_is_refused_as_a_model_problem(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "wide.xml", extra_hinges=14)  # nq=50, as a G1 with hands
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(mjcf)
+        message = str(excinfo.value)
+        assert str(mjcf) in message, f"a model-side mismatch has to name the model: {message}"
+        assert "layout" in message and "nq=" in message, message
+
+    def test_a_model_with_no_free_root_is_refused(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "fixed_base.xml", free_root=False)
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(mjcf)
+        assert "free root" in str(excinfo.value), str(excinfo.value)
+
+    def test_the_layout_refusal_distinguishes_itself_from_a_bad_qpos_argument(self, tmp_path: pathlib.Path) -> None:
+        mjcf = g1_like_mjcf(tmp_path / "fixed_base.xml", free_root=False)
+        with pytest.raises(ValueError) as excinfo:
+            _bridge(mjcf)
+        assert "not the qpos argument" in str(excinfo.value).replace("'", ""), str(excinfo.value)
+
+
+class TestTheTrackerOwnEmbodimentIsUnchanged:
+    """Controls: the accepted path keeps every verdict it already had."""
+
+    def test_the_tracker_order_model_produces_the_declared_row_count(self, tmp_path: pathlib.Path) -> None:
+        cache = _bridge(g1_like_mjcf(tmp_path / "tracker.xml"))
+        assert cache["body_rot"].shape[1] == len(GTP_G1_BODY_NAMES)
+        assert cache["body_pos"].shape[1] == len(GTP_G1_BODY_NAMES)
+
+    def test_the_declared_anchor_and_root_indices_are_in_range(self, tmp_path: pathlib.Path) -> None:
+        cache = _bridge(g1_like_mjcf(tmp_path / "tracker.xml"))
+        rows = cache["body_rot"].shape[1]
+        assert GTP_G1_ANCHOR_BODY_INDEX < rows and GTP_G1_ROOT_BODY_INDEX < rows
+
+    def test_the_joint_block_is_still_read_straight_off_qpos(self, tmp_path: pathlib.Path) -> None:
+        cache = _bridge(g1_like_mjcf(tmp_path / "tracker.xml"))
+        assert cache["dof_pos"].shape[1] == len(GTP_G1_JOINT_NAMES)
+        assert cache["dof_pos"][0] == pytest.approx(_qpos()[0, 7:], abs=1e-5)
+
+    def test_a_too_narrow_qpos_is_still_refused_as_a_qpos_problem(self, tmp_path: pathlib.Path) -> None:
+        pytest.importorskip("mujoco")
+        mjcf = g1_like_mjcf(tmp_path / "tracker.xml")
+        with pytest.raises(ValueError) as excinfo:
+            bridge.qpos_to_motion_data(_qpos()[:, :30], fps=FPS, proto_mjcf_path=mjcf, control_dt=1.0 / FPS)
+        assert "qpos" in str(excinfo.value)
+
+    def test_a_padded_qpos_is_still_truncated_rather_than_refused(self, tmp_path: pathlib.Path) -> None:
+        pytest.importorskip("mujoco")
+        mjcf = g1_like_mjcf(tmp_path / "tracker.xml")
+        padded = np.concatenate([_qpos(), np.zeros((FRAMES, 4))], axis=1)
+        cache = bridge.qpos_to_motion_data(padded, fps=FPS, proto_mjcf_path=mjcf, control_dt=1.0 / FPS)
+        assert cache["dof_pos"].shape[1] == len(GTP_G1_JOINT_NAMES)
+
+
+class TestTheDocumentedRowOrderMatchesTheCode:
+    """The Returns section is the only place a caller can read the row order."""
+
+    def test_the_returns_section_names_the_body_row_order(self) -> None:
+        doc = bridge.qpos_to_motion_data.__doc__ or ""
+        returns = re.split(r"\n\s*Raises:", re.split(r"\n\s*Returns:", doc)[1])[0]
+        assert "GTP_G1_BODY_NAMES" in returns, (
+            "the tracker indexes the cache's body rows positionally, so the Returns "
+            f"section has to name the order they are in; it reads {returns.strip()[:160]!r}"
+        )

--- a/tests/policies/protomotions/test_cache_velocity_frames.py
+++ b/tests/policies/protomotions/test_cache_velocity_frames.py
@@ -28,6 +28,8 @@ import pytest
 from strands_robots.policies.protomotions import bridge, motion_utils, state_utils
 from strands_robots.policies.protomotions.state_utils import quat_rotate_inverse
 
+from .test_cache_body_rows_match_the_tracker_order import g1_like_mjcf
+
 # A quarter turn about world X, xyzw. Chosen so a world-Z spin has a *different*
 # local-frame representation - a frame-agnostic pose would make every assertion
 # below pass for either convention.
@@ -215,22 +217,15 @@ class TestTheBridgedCacheIsWorldFrameEndToEnd:
 
     @staticmethod
     def _mjcf(tmp_path: pathlib.Path) -> pathlib.Path:
-        """A freejoint root plus 29 hinges, so ``nq`` is exactly 36."""
-        links = "".join(
-            f'<body name="l{i}" pos="0 0 0.05">'
-            f'<joint name="j{i}" type="hinge" axis="0 1 0"/>'
-            f'<geom type="box" size="0.02 0.02 0.02" mass="0.1"/>'
-            for i in range(29)
-        )
-        xml = (
-            "<mujoco><worldbody>"
-            '<body name="root" pos="0 0 1"><freejoint/>'
-            '<geom type="box" size="0.05 0.05 0.05" mass="1"/>'
-            f"{links}{'</body>' * 29}</body></worldbody></mujoco>"
-        )
-        path = tmp_path / "chain36.xml"
-        path.write_text(xml)
-        return path
+        """The tracker's embodiment: a freejoint root plus 29 hinges, ``nq`` 36.
+
+        Carries the tracker's own body and joint names, because the bridge fills
+        the cache's rows against
+        :data:`~strands_robots.policies.protomotions.config.GTP_G1_BODY_NAMES` and
+        refuses a model that cannot supply them. Row 0 is still the root, which is
+        the row every assertion below reads.
+        """
+        return g1_like_mjcf(tmp_path / "tracker36.xml")
 
     @staticmethod
     def _qpos(frames: int, dt: float, speed: float) -> np.ndarray:


### PR DESCRIPTION
The tracker never looks a body up by name. `ProtoMotionsPolicy` reads its anchor orientation as `future["body_rot"][:, config.anchor_body_index]`, and `anchor_body_index`/`root_body_index` are offsets into `GTP_G1_BODY_NAMES` - the 33-name list pinned from the checkpoint's sidecar, whose comment in `config.py` states the order outright: *"Index 0 = pelvis (root), 16 = torso_link (anchor)"*.

`qpos_to_motion_data` filled those rows from `data.xpos[1:]` - the supplied MJCF's own body order - pairing the two lists positionally, with nothing checking they are the same list.

## The G1 family does not agree on that body set

Of the 44 loadable G1 MJCFs on a machine with mujoco-menagerie, `unitree_ros` and a GR00T checkout, **only 20 have the tracker's `qpos` width at all**, and the widely-shipped fingerless models expose **30** bodies rather than 33: they omit `head` and both `rubber_hand` placeholders. Both `mujoco_menagerie/unitree_g1/g1.xml` - what `Robot("unitree_g1")` resolves to - and the `g1_29dof.xml` shipped beside the tracker assets are in that group.

Handed one, every row after the gap shifts by one. Measured on a real 120-frame Kimodo walk clip:

| | value |
|---|---|
| row 16 resolves to | `left_shoulder_pitch_link` (tracker asked for `torso_link`) |
| anchor orientation error | **mean 20.80 deg, max 28.16 deg** |
| rows holding another body's rotation | 29 of 33 |
| reported status | success, 30 rows |

The physical models agree: `torso_link` sits at row 15 of that cache, and comparing row 15 against the tracker MJCF's torso gives **0.00 deg**. The entire error is the index.

![anchor row before and after](https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-body-rows-32077438012/anchor-row-before-after.png)

Green is `torso_link`, the body the tracker names as its anchor; red is the row it was actually handed. Rendered headless from the worst frame of the clip.

## Change

Resolve each row by name against `GTP_G1_BODY_NAMES`, and refuse a model that cannot supply a body the tracker reads:

```text
ValueError: ProtoMotions G1 MJCF .../g1_29dof.xml is missing 3 of the 33 bodies the
tracker reads by row index: ['head', 'left_rubber_hand', 'right_rubber_hand']. ...
```

Refusing rather than dropping the row is the only non-silent option: the bridge cannot synthesise a pose for a body the model does not have, and a short row array would leave `anchor_body_index` pointing at whatever ended up there.

The model's `qpos` layout is validated the same way - a free root plus the 29 tracker joints. Previously a 50-wide model surfaced as `could not broadcast input array from shape (36,) into shape (50,)`, naming neither the model nor a width, and raising the same `ValueError` the docstring documents for a bad `qpos` **argument** - so a model-side mismatch read as a caller-side one. It now says which it is.

**For the tracker's own embodiment this is a no-op:** all six cache arrays are byte-identical to `main` (`body_pos`, `body_rot`, `body_vel`, `body_ang_vel`, `dof_pos`, `dof_vel`).

## Tests

`tests/policies/protomotions/test_cache_body_rows_match_the_tracker_order.py`, 16 tests, graded against an independent MuJoCo oracle that resolves each body **by name**, so a row is never confirmed by the same index arithmetic that produced it. Pre-fix on `main`: **10 failed / 6 passed**.

Failing pre-fix:

- the anchor row holds another body - `row 16 ... is 12.60 deg from 'torso_link' and matches 'left_shoulder_pitch_link' instead`
- 29 of 33 rows hold another body's rotation; body positions shift the same way
- a variant missing tracker bodies is refused, and the refusal names all three and says the rows are read by index (all three **DID NOT RAISE** before)
- a wider `qpos` layout is refused as a model problem, naming the model
- **a model with no free root is refused** - previously accepted silently, writing the root pose into hinge joints
- the `Returns:` section names the row order

Passing on both trees, so they bound the change rather than restate it: the root row is right in either order; the row count and the declared anchor/root indices stay in range; `dof_pos` is still read straight off `qpos` (joint order is untouched - it already matched for every 36-wide G1); a too-narrow `qpos` is still a `qpos` refusal; a padded `qpos` is still truncated rather than refused.

`test_cache_velocity_frames.py`'s end-to-end fixture built a generic 36-dof chain named `root`/`l0..l28`. It was only ever accepted because nothing checked, so it now carries the tracker's names via the shared builder; row 0 is still the root that every assertion there reads, and all of its assertions are unchanged.

## Verification

- `tests/policies/protomotions` 60 passed.
- Blast radius (26 files: every test touching protomotions/`MotionPlayer`/a docs page, plus the repo-wide docstring, xref, unicode, ASCII, dependency and changelog guards): branch **1034 passed / 0 failed**, base **1024 passed / 10 failed** - 1024 + 10 = 1034, same collected total, base failures exactly the 10 pre-fix ones, zero branch-only.
- `ruff check` + `ruff format --check` + `mypy` over `strands_robots tests tests_integ` clean; mypy 19 pre-existing errors on both trees, 0 in the touched files.
