### PR TITLE
docs(annotation): say which camera the steerable labels are derived from

### DIFF
--- a/changelog.d/2419-annotation-camera-selection.md
+++ b/changelog.d/2419-annotation-camera-selection.md
@@ -1,0 +1,9 @@
+### Documentation
+
+- **docs/data/annotation.md**: document which camera `lerobot-annotate` derives
+  its steerable labels from. The `plan` and `interjections` modules read only the
+  dataset's first video key, and `start_recording` writes video features in the
+  caller's `cameras=` order, so that list decides the view. Records the
+  gripper-mounted hazard - a camera parented to the gripper renders a carried
+  object as image-static and a stationary object as sweeping out of frame - and
+  names the `--vlm.camera_key` escape hatch.

--- a/docs/data/annotation.md
+++ b/docs/data/annotation.md
@@ -83,7 +83,64 @@ Common flags:
 - `--vlm.api_base=http://host:8000/v1` with `--vlm.auto_serve=false` - reuse a
   running vLLM server instead of spawning one.
 - `--only_episodes=0,1,2` - annotate a subset while iterating.
+- `--vlm.camera_key=observation.images.<name>` - choose which camera the
+  `plan` and `interjections` modules read; see [Which camera the labels come
+  from](#which-camera-the-labels-come-from).
 - toggle modules with `--plan.enabled`, `--interjections.enabled`, `--vqa.enabled`.
+
+## Which camera the labels come from
+
+A multi-camera dataset does not get one label per camera. The `plan` module
+(subtasks, plan, memory) and the `interjections` module read **one** stream: the
+dataset's *first* video key. `VideoFrameProvider` picks it in
+`lerobot/annotations/steerable_pipeline/frames.py` (`self.camera_key = keys[0]`)
+and those two modules call `frames_at()` without naming a camera, so they
+inherit that default. Only the `vqa` module iterates every camera, which is why
+`vqa`/`trace` rows carry a `camera` field and every other style carries
+`camera=None`.
+
+The first video key is the one **you** chose when you recorded:
+
+| how you recorded | first video key |
+| --- | --- |
+| `start_recording(...)` with no `cameras=` | `observation.images.default` - the implicit overview camera `create_world` adds |
+| `start_recording(..., cameras=[...])` | the **first name in your list** |
+
+So the `cameras=` list that scopes a dataset to its real sensors - the list the
+`start_recording` warning tells you to pass - also decides which view every
+subtask label is derived from.
+
+**Do not let that first key be a gripper-mounted camera.** A camera added with
+`add_camera(..., parent_body="<arm>/gripper")` travels with whatever the gripper
+is holding, so its image evidence about object motion is *inverted* with respect
+to the scene. Measured in simulation on one recorded episode, tracking the
+manipuland's centroid in each recorded video (256x256, 90 frames):
+
+| recorded view | object carried 0.3049 m | object left on its stand |
+| --- | --- | --- |
+| world-fixed, front | 174.4 px of image motion | 13.7 px |
+| world-fixed, overhead | 174.2 px | 16.3 px |
+| gripper-mounted (wrist) | **2.0 px** (visible 90/90) | **140.0 px** (visible 46/90) |
+
+A carried object is pinned in the wrist view; a *stationary* object is what
+sweeps across it and leaves the frame. A labeller reading that stream has the
+evidence for "the object moved" exactly when the object did not move, so a
+transport gets described as static and an idle sweep gets described as a
+transport.
+
+Point the shared modules at a world-fixed view whenever the first key is a
+wrist camera:
+
+```bash
+lerobot-annotate \
+    --root="$HF_LEROBOT_HOME/user/pick_place" \
+    --vlm.camera_key=observation.images.front \
+    --vlm.model_id=Qwen/Qwen2.5-VL-7B-Instruct
+```
+
+Equivalently, list a world-fixed camera first when you record:
+`start_recording(..., cameras=["front", "wrist"])`. Wrist views stay valuable
+for the `vqa` module, which grounds per camera and records which one it used.
 
 ## What it writes: the language columns
 

--- a/tests/test_docs_annotation_camera_selection.py
+++ b/tests/test_docs_annotation_camera_selection.py
@@ -48,10 +48,11 @@ def _vlm_config_camera_field() -> str:
     Parsed rather than imported: importing the annotation package pulls the whole
     pipeline (and its optional deps) for one dataclass field name.
     """
+    __tracebackhide__ = True
     lerobot = pytest.importorskip("lerobot")
     config_py = Path(lerobot.__file__).parent / "annotations" / "steerable_pipeline" / "config.py"
     if not config_py.is_file():
-        pytest.skip(f"lerobot annotation pipeline not present at {config_py}")
+        raise pytest.skip.Exception(f"lerobot annotation pipeline not present at {config_py}")
     tree = ast.parse(config_py.read_text(encoding="utf-8"))
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == "VlmConfig":
@@ -66,7 +67,7 @@ def _vlm_config_camera_field() -> str:
                 "annotation guide's advice needs rewriting, not just renaming."
             )
             return camera_fields[0]
-    pytest.skip("lerobot's VlmConfig not found in the installed annotation pipeline")
+    raise pytest.skip.Exception("lerobot's VlmConfig not found in the installed annotation pipeline")
 
 
 class TestTheGuideNamesTheStreamSelector:
@@ -147,7 +148,8 @@ class TestTheRecordedOrderFollowsTheCaller:
                 fast_mode=True,
             )
             assert ran["status"] == "success", ran
-            assert sim.stop_recording()["status"] == "success"
+            stopped = sim.stop_recording()
+            assert stopped["status"] == "success", stopped
         finally:
             sim.cleanup()
 

--- a/tests/test_docs_annotation_camera_selection.py
+++ b/tests/test_docs_annotation_camera_selection.py
@@ -1,0 +1,164 @@
+"""Keep the annotation guide honest about which camera the labels come from.
+
+``lerobot-annotate``'s ``plan`` and ``interjections`` modules read exactly one
+video stream - the dataset's first video key. ``VideoFrameProvider`` resolves
+that default in ``lerobot/annotations/steerable_pipeline/frames.py``
+(``self.camera_key = keys[0]``) and both modules call ``frames_at()`` without
+naming a camera, so a multi-camera dataset gets every subtask/plan/memory label
+derived from one view.
+
+Which view that is comes straight out of ``start_recording``: the recorder
+writes its video features in the caller's ``cameras=`` order, so the first name
+in that list becomes the first video key. That makes the choice load-bearing,
+and it is a bad choice when the first camera is gripper-mounted: a camera added
+with ``parent_body="<arm>/gripper"`` travels with whatever the gripper holds, so
+a carried object is pinned in its frame while a stationary object sweeps out of
+it. The image evidence for "the object moved" is then present exactly when the
+object did not move.
+
+Two assertions, deliberately of different kinds:
+
+* the ordering contract the guidance rests on is measured against a real
+  recording (a caller that lists a world-fixed camera first really does get it
+  as the first video key), and
+* the guide names the escape hatch - the ``camera_key`` field ``lerobot``'s
+  ``VlmConfig`` actually exposes, read out of that dataclass rather than
+  hard-coded here - and warns about the gripper-mounted case.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOC = _REPO_ROOT / "docs" / "data" / "annotation.md"
+
+
+def _doc_text() -> str:
+    return _DOC.read_text(encoding="utf-8")
+
+
+def _vlm_config_camera_field() -> str:
+    """The ``VlmConfig`` field that selects the stream, read from lerobot's source.
+
+    Parsed rather than imported: importing the annotation package pulls the whole
+    pipeline (and its optional deps) for one dataclass field name.
+    """
+    lerobot = pytest.importorskip("lerobot")
+    config_py = Path(lerobot.__file__).parent / "annotations" / "steerable_pipeline" / "config.py"
+    if not config_py.is_file():
+        pytest.skip(f"lerobot annotation pipeline not present at {config_py}")
+    tree = ast.parse(config_py.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "VlmConfig":
+            fields = [
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+            ]
+            camera_fields = [name for name in fields if "camera" in name]
+            assert camera_fields, (
+                "lerobot's VlmConfig no longer exposes a camera-selection field; the "
+                "annotation guide's advice needs rewriting, not just renaming."
+            )
+            return camera_fields[0]
+    pytest.skip("lerobot's VlmConfig not found in the installed annotation pipeline")
+
+
+class TestTheGuideNamesTheStreamSelector:
+    """The guide must say which view the labels come from, and how to change it."""
+
+    def test_guide_names_the_vlm_camera_field(self) -> None:
+        field = _vlm_config_camera_field()
+        text = _doc_text()
+        assert f"--vlm.{field}" in text, (
+            f"docs/data/annotation.md never mentions --vlm.{field}, so a reader "
+            "cannot tell that the plan/interjections modules read only the first "
+            "video key, nor how to point them somewhere else."
+        )
+
+    def test_guide_warns_about_a_gripper_mounted_first_camera(self) -> None:
+        text = _doc_text().lower()
+        assert "parent_body" in text, (
+            "docs/data/annotation.md does not mention parent_body, so it never "
+            "warns that a gripper-mounted camera is the wrong stream to derive "
+            "scene-level motion labels from."
+        )
+
+    def test_guide_explains_the_recording_order_lever(self) -> None:
+        text = _doc_text()
+        assert "cameras=" in text, (
+            "docs/data/annotation.md does not mention the cameras= recording "
+            "argument, which is what decides the first video key."
+        )
+
+
+class TestTheRecordedOrderFollowsTheCaller:
+    """The lever the guide points at has to be real: the recorded video-feature
+    order is the caller's ``cameras=`` order, so listing a world-fixed camera
+    first really does make it the stream the shared modules read."""
+
+    def test_first_video_key_is_the_callers_first_camera(self, tmp_path: Path) -> None:
+        pytest.importorskip("mujoco")
+        pytest.importorskip("lerobot")
+        from strands_robots.simulation.mujoco.backend import _can_render
+
+        if not _can_render():
+            pytest.skip("No GL context available (headless CI without EGL/OSMesa)")
+        from strands_robots.dataset_recorder import has_lerobot_dataset
+        from strands_robots.simulation.mujoco.simulation import Simulation
+
+        if not has_lerobot_dataset():
+            pytest.skip("dataset recording needs the [lerobot] extra")
+
+        sim = Simulation(tool_name="annotation_camera_order", mesh=False)
+        try:
+            sim.create_world()
+            added = sim.add_robot(name="arm", data_config="so101")
+            assert added["status"] == "success", added
+            for name, kwargs in (
+                ("wrist", {"parent_body": "arm/gripper", "position": [0.0, 0.1, 0.0]}),
+                ("front", {"position": [-0.5, -0.1, 0.25], "target": [-0.2, -0.1, 0.07]}),
+            ):
+                cam = sim.add_camera(name=name, width=64, height=64, **kwargs)
+                assert cam["status"] == "success", (name, cam)
+
+            # A caller who wants the world-fixed view to drive the labels lists it
+            # first; the recorded schema has to honour that order.
+            root = tmp_path / "ds"
+            started = sim.start_recording(
+                repo_id="local/annotation_camera_order",
+                task="probe",
+                fps=30,
+                root=str(root),
+                overwrite=True,
+                cameras=["front", "wrist"],
+            )
+            assert started["status"] == "success", started
+            ran = sim.run_policy(
+                robot_name="arm",
+                policy_provider="mock",
+                n_steps=2,
+                control_frequency=30.0,
+                fast_mode=True,
+            )
+            assert ran["status"] == "success", ran
+            assert sim.stop_recording()["status"] == "success"
+        finally:
+            sim.cleanup()
+
+        info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
+        video_keys = [key for key, feature in info["features"].items() if feature["dtype"] == "video"]
+        assert video_keys[:2] == [
+            "observation.images.front",
+            "observation.images.wrist",
+        ], (
+            "the recorded video-feature order no longer follows the caller's "
+            f"cameras= order (got {video_keys}), so listing a world-fixed camera "
+            "first is no longer enough to keep it out of the annotation "
+            "pipeline's default stream and the guide's advice is stale."
+        )


### PR DESCRIPTION
## Problem

`docs/data/annotation.md` tells you how to run `lerobot-annotate` against a
`strands-robots` dataset, but not which camera the labels come from. On a
multi-camera dataset that turns out to be load-bearing, and the answer is
decided by a `strands-robots` argument the page never mentions.

`lerobot-annotate` does not label per camera. Its `plan` module (subtasks, plan,
memory) and its `interjections` module read **one** stream:

- `VideoFrameProvider.__post_init__` sets `self.camera_key = keys[0]`
  (`lerobot/annotations/steerable_pipeline/frames.py`), where `keys` is
  `LeRobotDatasetMetadata.video_keys` - the dataset's video features in
  insertion order.
- `modules/plan_subtasks_memory.py` and `modules/interjections_and_speech.py`
  call `frames_at(record, timestamps)` with no `camera_key`, so they inherit
  that default. Only `modules/general_vqa.py` passes one explicitly, which is
  why `vqa`/`trace` rows carry a `camera` field and every other style carries
  `camera=None`.

`start_recording` writes its video features in the caller's `cameras=` order, so
the first name in that list becomes `keys[0]`:

| how you recorded | first video key |
| --- | --- |
| no `cameras=` | `observation.images.default` - the implicit overview camera |
| `cameras=[...]` | the first name in your list |

Verified against a recorded dataset with lerobot's own class:

```
>>> VideoFrameProvider(root=<recorded dataset>).camera_key
'observation.images.cam_wrist'
```

The gap is that the recommended path leads to the bad case. The
`start_recording` warning already tells you to pass `cameras=` so the implicit
`default` overview view stays out of the dataset - and doing that replaces a
world-fixed first key with whichever sensor you happen to list first.

## Why a gripper-mounted first camera is the wrong stream

A camera added with `add_camera(..., parent_body="<arm>/gripper")` moves with
whatever the gripper is holding, so its image evidence about object motion runs
*opposite* to the scene. One recorded episode, two conditions differing only in
whether the manipuland is held, tracking the manipuland's centroid in each
recorded 256x256 video (90 frames), ground truth from `d.xpos`:

| recorded view | carried 0.3049 m | left on its stand (0.0198 m) |
| --- | --- | --- |
| world-fixed, front | 174.4 px | 13.7 px |
| world-fixed, overhead | 174.2 px | 16.3 px |
| gripper-mounted (wrist) | **2.0 px**, visible 90/90 | **140.0 px**, visible 46/90 |

A carried object is pinned in the wrist frame; a *stationary* object is what
sweeps across it and leaves. So a labeller reading that stream has the evidence
for "the object moved" exactly when the object did not move. The wrist view is
also the one where the manipuland is *largest* (8-10% of frame vs 1-2% for the
world-fixed views), so this is not a visibility or resolution problem - it is
which frame the camera is rigid to.

![camera comparison](https://raw.githubusercontent.com/cagataycali/robots/media-annotation-camera-selection/figure.png)

The same 0.3049 m transport, as the three recorded videos show it. The cube
travels across both world-fixed views and stays pinned in the wrist view:

![rollout](https://raw.githubusercontent.com/cagataycali/robots/media-annotation-camera-selection/rollout.gif)

## Change

Docs only, plus a test. A new "Which camera the labels come from" section states
the selection rule, both recording paths, the gripper-mounted hazard with the
measured numbers, and the two ways to fix it - `--vlm.camera_key` (already
supported by `VlmConfig`, previously unmentioned here) or listing a world-fixed
camera first when recording. It also adds `--vlm.camera_key` to the existing
"Common flags" list. No behaviour changes: the camera-selection default is
lerobot's, and the recording order deliberately follows the caller.

## Tests

`tests/test_docs_annotation_camera_selection.py`, two kinds of assertion:

- **Fails before this change** (3 tests): the guide must name the
  camera-selection field that lerobot's `VlmConfig` actually exposes - read out
  of that dataclass with `ast` rather than hard-coded, so a rename upstream
  fails the test instead of rotting the doc - and must mention `parent_body` and
  `cameras=`.
- **Passes before and after** (1 test): the behavioural control. A real
  recording with `cameras=["front", "wrist"]` must put `observation.images.front`
  first, because the guidance is only actionable while the recorded order
  follows the caller. Confirmed non-vacuous by inverting the caller's list,
  which fails with the expected ordering diff.

```
branch          4 passed
upstream/main   3 failed, 1 passed
```

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy tests/test_docs_annotation_camera_selection.py`: no issues.
- Doc-scanning and repo-wide guard selection (23 files, including
  `test_docs_*`, docstring, changelog and source-string guards):
  661 passed, 2 skipped.
- No added non-ASCII in the edited page; fence count even; every markdown table
  block has a consistent cell count.
