### PR TITLE
fix(simulation): carry a kinematically attached body through run_multi_policy

### DIFF
--- a/changelog.d/2420-kinematic-attachment-multi-policy.md
+++ b/changelog.d/2420-kinematic-attachment-multi-policy.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation/mujoco**: `run_multi_policy` now re-applies the kinematic-attachment follow after its physics step, so a body attached with `attach_bodies(mode="kinematic")` is carried through a synchronized multi-robot rollout instead of being left behind while every surface reports success.

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -373,8 +373,12 @@ class ManipulationMixin:
     def _apply_kinematic_attachments(self) -> None:
         """Teleport every kinematically attached child to follow its parent.
 
-        Called after each ``mj_step`` (both the ``step()`` batch loop and the
-        policy-driven ``_apply_sim_action`` substep loop). Callers MUST hold
+        Called after EVERY ``mj_step`` the backend issues - the ``step()``
+        batch loop, the single-robot ``_apply_sim_action`` substep loop, the
+        motion-primitive tick, and the synchronized ``run_multi_policy`` loop -
+        because ``attach_bodies(mode="kinematic")`` promises the child follows
+        every physics step, and a stepping path that skips this leaves the
+        carried body behind while reporting success. Callers MUST hold
         ``self._lock``. Uses the parent's ``xpos``/``xquat`` from the step's
         forward pass (one integration step of latency at the physics timestep,
         matching the example's carry). Entries whose bodies or freejoint no

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -5507,6 +5507,11 @@ class MuJoCoSimEngine(
                         pfx = robot.namespace or ""
                         self._apply_action_by_name(self._world._model, self._world._data, act, pfx, mj)
                     mj.mj_step(self._world._model, self._world._data)
+                    # Kinematic attachments (attach_bodies mode="kinematic")
+                    # follow their parent every physics step, on this
+                    # synchronized loop as much as on the single-robot policy
+                    # path. Fast no-op when none are registered.
+                    self._apply_kinematic_attachments()
                     self._world.sim_time = self._world._data.time
                     self._world.step_count += 1
                     if hasattr(self, "_viewer_handle") and self._viewer_handle is not None:

--- a/tests/simulation/mujoco/test_kinematic_attachment_follows_on_every_stepping_path.py
+++ b/tests/simulation/mujoco/test_kinematic_attachment_follows_on_every_stepping_path.py
@@ -1,0 +1,287 @@
+"""``attach_bodies(mode="kinematic")`` carries its child on EVERY stepping path.
+
+``attach_bodies`` documents the kinematic mode as "every physics step, the
+child's freejoint pose is overwritten to follow the parent", and the follow is
+applied by one hook the backend calls after ``mj_step``. Four places in the
+MuJoCo backend advance physics: the ``step()`` batch loop, the single-robot
+``_apply_sim_action`` substep loop, the motion-primitive tick, and the
+synchronized ``run_multi_policy`` loop. Three re-applied the follow; the
+multi-robot loop did not, so a body attached for a two-arm handover was left
+behind - it fell to the floor while ``attach_bodies`` reported success,
+``run_multi_policy`` reported success, and the attachment registry still named
+it as carried. ``run_multi_policy`` is the recommended path for recording
+concurrent multi-robot episodes, so those frames went into the dataset showing
+the arms moving and the "grasped" object on the ground.
+
+Pinned here:
+
+* the contract, on the multi-robot loop: a carried child stays at the relative
+  pose the attachment recorded, and does not end the episode on the floor;
+* the root cause, as a source-level guard: every function in the MuJoCo backend
+  that calls ``mj_step`` also re-applies the follow, so a fifth stepping path
+  cannot silently drop it;
+* the boundary: ``step()`` and single-robot ``run_policy`` still carry, a weld
+  attachment (solver-enforced, not hook-driven) is untouched, and a loop with
+  no attachments leaves unattached bodies falling normally.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import tempfile
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import mujoco as mj  # noqa: E402
+
+from strands_robots.policies.mock import MockPolicy  # noqa: E402
+from strands_robots.simulation import Simulation  # noqa: E402
+from strands_robots.simulation import mujoco as mujoco_backend  # noqa: E402
+from tests.tool_result_contract import tool_json  # noqa: E402
+
+from .test_run_multi_policy_no_recording import _ROBOT_XML  # noqa: E402
+
+# The arm body the cube is carried by. It swings under the mock policy's
+# sinusoid, so a child that stops following diverges from it.
+_PARENT = "alpha/link2"
+_CHILD = "cube"
+
+# One integration step of latency is inherent to the follow: it places the child
+# from the parent pose the step that just finished produced, so the residual
+# scales with the parent's speed times the timestep. Measured on this fixture
+# the carrying paths land within 0.026 m while an unheld child reaches 0.65 m,
+# so this bound sits about 2x above the former and 13x below the latter.
+_CARRY_TOL_M = 0.05
+
+# The cube spawns airborne; anything at or below this has landed on the ground
+# plane rather than being carried.
+_FLOOR_Z = 0.08
+
+
+@pytest.fixture
+def sim_arm_and_cube():
+    """One namespaced arm plus an airborne dynamic cube, no recorder."""
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "test_arm.xml")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(_ROBOT_XML)
+
+    s = Simulation(tool_name="test_kinematic_follow", mesh=False)
+    s.create_world()
+    _ok(s.add_robot("alpha", urdf_path=path, position=[0, 0, 0]), "add_robot")
+    _ok(s.add_object(_CHILD, shape="box", size=[0.03] * 3, position=[0.12, 0, 0.45]), "add_object")
+    s.step(5)
+    yield s
+    s.destroy()
+
+
+def _relpos_in_parent_frame(sim, parent: str, child: str) -> np.ndarray:
+    """``child``'s position expressed in ``parent``'s frame - what the record stores."""
+    model, data = sim._world._model, sim._world._data
+    parent_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, parent)
+    child_id = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, child)
+    assert parent_id >= 0 and child_id >= 0, f"{parent!r}/{child!r} not in the compiled model"
+    neg = np.zeros(4)
+    mj.mju_negQuat(neg, data.xquat[parent_id])
+    rel = np.zeros(3)
+    mj.mju_rotVecQuat(rel, data.xpos[child_id] - data.xpos[parent_id], neg)
+    return rel.copy()
+
+
+def _recorded_relpos(sim, child: str) -> np.ndarray:
+    record = sim._world._backend_state["kinematic_attachments"][child]
+    return np.asarray(record["relpos"], dtype=float)
+
+
+def _carry_error(sim, parent: str, child: str) -> float:
+    """How far the child sits from the offset the attachment captured."""
+    return float(np.linalg.norm(_relpos_in_parent_frame(sim, parent, child) - _recorded_relpos(sim, child)))
+
+
+def _body_z(sim, name: str) -> float:
+    model, data = sim._world._model, sim._world._data
+    return float(data.xpos[mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, name)][2])
+
+
+def _ok(result: dict, what: str) -> dict:
+    """Return a successful tool result, or fail naming what refused and why.
+
+    A ``raise`` rather than an ``assert`` on the call, so the scene is still
+    built - and still checked - when the suite runs under ``python -O``.
+    """
+    if result["status"] != "success":
+        raise AssertionError(f"{what} refused: {result['content'][0]['text']}")
+    return result
+
+
+def _attach(sim, parent: str = _PARENT, child: str = _CHILD, mode: str = "kinematic"):
+    return _ok(sim.attach_bodies(parent, child, mode=mode), f"attach_bodies(mode={mode!r})")
+
+
+def _drive_multi_policy(sim, n_steps: int = 200):
+    return _ok(
+        sim.run_multi_policy(
+            policies={"alpha": MockPolicy()},
+            instructions="carry the cube",
+            n_steps=n_steps,
+            control_frequency=50.0,
+        ),
+        "run_multi_policy",
+    )
+
+
+class TestTheMultiRobotLoopCarriesAnAttachedBody:
+    def test_a_kinematically_carried_body_follows_through_run_multi_policy(self, sim_arm_and_cube):
+        """The child holds the recorded offset across the synchronized loop.
+
+        Before the fix the loop stepped physics without re-applying the follow,
+        so the cube fell away from the arm while every surface reported success.
+        """
+        sim = sim_arm_and_cube
+        _attach(sim)
+        assert _carry_error(sim, _PARENT, _CHILD) < _CARRY_TOL_M, "premise: attach captures the current offset"
+        z_at_attach = _body_z(sim, _CHILD)
+
+        _drive_multi_policy(sim)
+
+        error = _carry_error(sim, _PARENT, _CHILD)
+        assert error < _CARRY_TOL_M, (
+            f"run_multi_policy left the carried body {error:.4f} m from the offset the attachment "
+            f"recorded (z {z_at_attach:.4f} -> {_body_z(sim, _CHILD):.4f}); "
+            'attach_bodies(mode="kinematic") promises it follows every physics step'
+        )
+
+    def test_the_carried_body_is_not_left_on_the_floor(self, sim_arm_and_cube):
+        """The user-visible harm, read through the public body-state surface.
+
+        A dataset recorded through this loop is meant to show the object riding
+        with the arm. Without the follow the object simply falls, so the
+        episode's frames show the arms working over a cube lying on the ground.
+        """
+        sim = sim_arm_and_cube
+        _attach(sim)
+        assert _body_z(sim, _CHILD) > _FLOOR_Z, "premise: the cube starts airborne, held by the arm"
+
+        _drive_multi_policy(sim)
+
+        state = tool_json(sim.get_body_state(_CHILD))
+        carried_z = float(state["position"][2])
+        assert carried_z > _FLOOR_Z, (
+            f"the carried body ended at z={carried_z:.4f} m, on the ground rather than with its "
+            f"parent {_PARENT!r}, while run_multi_policy and attach_bodies both reported success"
+        )
+
+
+class TestEveryBackendSteppingPathReappliesTheFollow:
+    """The root cause: one hook, and every stepping path has to call it.
+
+    A source-level sweep rather than a per-path rollout, so a fifth stepping
+    path added later fails here instead of silently dropping carried bodies.
+    Scoped to the MuJoCo backend, which owns the attachment registry; an
+    ``action_controller`` that takes over stepping (LIBERO, WBC torque control)
+    replaces this loop wholesale and is a separate contract.
+    """
+
+    _BACKEND_DIR = pathlib.Path(str(next(iter(mujoco_backend.__path__))))
+    _HOOK = "_apply_kinematic_attachments"
+    # step(), _apply_sim_action, _primitive_tick, run_multi_policy.
+    _MIN_STEPPING_FUNCTIONS = 4
+
+    @staticmethod
+    def _own_calls(node: ast.AST) -> list[str]:
+        """Names of calls made by ``node`` itself, not by functions nested in it."""
+        names: list[str] = []
+        stack: list[ast.AST] = list(ast.iter_child_nodes(node))
+        while stack:
+            current = stack.pop()
+            if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+                continue
+            if isinstance(current, ast.Call):
+                func = current.func
+                if isinstance(func, ast.Attribute):
+                    names.append(func.attr)
+                elif isinstance(func, ast.Name):
+                    names.append(func.id)
+            stack.extend(ast.iter_child_nodes(current))
+        return names
+
+    def _stepping_functions(self) -> dict[str, list[str]]:
+        """``"module.function" -> its own call names`` for every mj_step caller."""
+        found: dict[str, list[str]] = {}
+        for module in sorted(self._BACKEND_DIR.glob("*.py")):
+            tree = ast.parse(module.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    continue
+                calls = self._own_calls(node)
+                if "mj_step" in calls:
+                    found[f"{module.name}::{node.name}"] = calls
+        return found
+
+    def test_the_sweep_found_every_stepping_path(self):
+        """Non-vacuity: a refactor that hides the stepping paths fails here."""
+        stepping = self._stepping_functions()
+        assert len(stepping) >= self._MIN_STEPPING_FUNCTIONS, (
+            f"expected at least {self._MIN_STEPPING_FUNCTIONS} mj_step call sites in the MuJoCo "
+            f"backend, found {sorted(stepping)} - a clean result below that proves nothing"
+        )
+
+    def test_every_stepping_path_reapplies_the_kinematic_follow(self):
+        """Each function that advances physics also re-applies the follow."""
+        missing = sorted(where for where, calls in self._stepping_functions().items() if self._HOOK not in calls)
+        assert not missing, (
+            f"these MuJoCo backend functions call mj_step without re-applying the kinematic "
+            f"follow, so a body attached with mode='kinematic' is left behind on their path: {missing}"
+        )
+
+
+class TestTheOtherStepPathsAndModesAreUnchanged:
+    """Boundary controls: these hold on both sides of the fix."""
+
+    def test_the_step_batch_loop_still_carries(self, sim_arm_and_cube):
+        sim = sim_arm_and_cube
+        _attach(sim)
+        for _ in range(5):
+            _ok(sim.send_action({"shoulder_pan": 0.7, "elbow": -0.6}, robot_name="alpha"), "send_action")
+            _ok(sim.step(40), "step")
+        assert _carry_error(sim, _PARENT, _CHILD) < _CARRY_TOL_M
+
+    def test_the_single_robot_policy_loop_still_carries(self, sim_arm_and_cube):
+        sim = sim_arm_and_cube
+        _attach(sim)
+        _ok(
+            sim.run_policy(robot_name="alpha", policy_provider="mock", n_steps=200, control_frequency=50.0),
+            "run_policy",
+        )
+        assert _carry_error(sim, _PARENT, _CHILD) < _CARRY_TOL_M
+
+    def test_a_welded_child_is_held_by_the_solver_not_the_hook(self, sim_arm_and_cube):
+        """Weld mode is an equality constraint, so it never used the step hook.
+
+        Asserted structurally (the child is absent from the follow registry)
+        plus the outcome that matters - it is still held aloft, not on the
+        floor - because a weld is solver-enforced and yields elastically under
+        a fast swing rather than tracking to millimetres.
+        """
+        sim = sim_arm_and_cube
+        _attach(sim, mode="weld")
+        assert _CHILD not in sim._world._backend_state.get("kinematic_attachments", {}), (
+            "a weld must not register a per-step follow"
+        )
+        _drive_multi_policy(sim)
+        assert _body_z(sim, _CHILD) > _FLOOR_Z, "the weld constraint must keep holding the child"
+
+    def test_an_unattached_body_still_falls_during_the_loop(self, sim_arm_and_cube):
+        """No-overreach: the loop does not freeze bodies nothing is carrying."""
+        sim = sim_arm_and_cube
+        assert not sim._world._backend_state.get("kinematic_attachments")
+        z_before = _body_z(sim, _CHILD)
+        _drive_multi_policy(sim, n_steps=100)
+        assert _body_z(sim, _CHILD) < z_before - 0.1, "an unattached airborne cube must fall"


### PR DESCRIPTION
## Problem

`attach_bodies(mode="kinematic")` documents its child as following its parent **"every physics step"**, applied by one hook the backend calls after `mj_step`. Four functions in the MuJoCo backend advance physics:

| stepping path | re-applies the follow |
|---|---|
| `simulation.py::step` (batch loop) | yes |
| `rendering.py::_apply_sim_action` (single-robot policy) | yes |
| `motion_primitives.py::_primitive_tick` | yes |
| `simulation.py::run_multi_policy` (synchronized multi-robot) | **no** |

So a body attached for a two-arm handover was simply not carried on the multi-robot loop. It fell to the floor while `attach_bodies` reported success, `run_multi_policy` reported success, and the attachment registry still named it as carried. `run_multi_policy` is the recommended path for recording concurrent multi-robot episodes, so those frames went into the dataset showing the arms working over an object lying on the ground.

Measured on two `so101` arms with a cube attached to the first arm's gripper, 300 synchronized steps at 50 Hz — the same rollout in both trees, differing only in `strands_robots`:

| path | `\|relpos - recorded\|` | cube z start -> end | dist. to gripper end | carried |
|---|---|---|---|---|
| `step()` | 0.000087 m | 0.3500 -> 0.2999 | — | yes |
| `run_policy` (1 robot) | 0.000822 m | 0.3500 -> 0.1846 | — | yes |
| `run_multi_policy` **before** | **0.301564 m** | 0.3000 -> **0.0220** (on the floor) | **0.2522 m** | **no** |
| `run_multi_policy` after | 0.002439 m | 0.3000 -> 0.2176 | 0.0865 m | yes |

After the change the cube stays within 1.6 mm of the 0.0870 m grasp offset for all 300 steps.

## Change

One line: re-apply the follow after the loop's single `mj_step`, mirroring the other policy-driven stepping path (`_apply_sim_action`), which calls the same hook and relies on its fast no-op when the registry is empty. Behaviour with no kinematic attachment registered is unchanged.

`_apply_kinematic_attachments`' docstring enumerated two of its callers; it now states the contract that every stepping path has to satisfy, which is what the new guard enforces. `attach_bodies` has no page under `docs/`, so its docstring is its documentation and already stated the promise correctly.

## Tests

`tests/simulation/mujoco/test_kinematic_attachment_follows_on_every_stepping_path.py` — hermetic (inline MJCF arm reusing the sibling suite's `_ROBOT_XML`, no assets, no GL).

**3 failed / 5 passed on `upstream/main` -> 8 passed.** The three that fail pre-fix:

- the contract: `run_multi_policy left the carried body 0.6459 m from the offset the attachment recorded (z 0.4494 -> 0.0145)`
- the user-visible harm, read through public `get_body_state`: `the carried body ended at z=0.0145 m, on the ground rather than with its parent 'alpha/link2', while run_multi_policy and attach_bodies both reported success`
- the root cause, as a source-level guard: `these MuJoCo backend functions call mj_step without re-applying the kinematic follow: ['simulation.py::run_multi_policy']`

The guard is a sweep rather than a per-path rollout, so a fifth stepping path added later fails there instead of silently dropping carried bodies. It carries a non-vacuity test (at least four `mj_step` callers must be found) so a refactor that hides them fails loudly. It is scoped to the MuJoCo backend, which owns the attachment registry; an `action_controller` that takes over stepping (LIBERO, WBC torque control) replaces the loop wholesale and is a separate contract.

The five that pass on both sides are the boundary: `step()` and single-robot `run_policy` still carry, a weld attachment is held by the solver and never used the hook, and a loop with no attachments leaves an unattached airborne body falling normally.

The carry tolerance is derived rather than invented — one integration step of latency is inherent to the follow, so the residual scales with parent speed times timestep; on this fixture the carrying paths land within 0.026 m while an unheld child reaches 0.65 m, and the bound sits about 2x above the former and 13x below the latter.

## Rollout

Two `so101` arms under `run_multi_policy`, cube attached to the first arm's gripper. Same script in both panels, only `strands_robots` differs. The panels are pixel-identical at step 0 (mean |delta| 0.0001) and diverge to 3.92 as the change takes effect; 74/74 frame transitions move.

![kinematic carry through run_multi_policy](https://raw.githubusercontent.com/cagataycali/robots/media-kinematic-carry-32086527241/kinematic-carry.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-kinematic-carry-32086527241/kinematic-carry.mp4)

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 19 errors, identical to pristine `upstream/main`, none in the changed files.
- 44-file selection (every test referencing `attach_bodies` / `kinematic_attachments` / `run_multi_policy` / `manipulation`, plus the repo-wide docstring, ASCII, dependency and changelog guards): branch **2 failed / 2420 passed**, base **5 failed / 2417 passed**; same 2422 collected on both, zero branch-only failures, the three base-only ids are exactly the pre-fix failures above. The two shared failures are a pre-existing `draccus` version mismatch in `tests/training/test_lerobot.py`, unrelated to this change.
