### PR TITLE
fix(simulation/mujoco): check actuate_robot's posture flags instead of reading them by truthiness

### DIFF
--- a/changelog.d/2422-actuate-robot-posture-flags.md
+++ b/changelog.d/2422-actuate-robot-posture-flags.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **simulation/mujoco**: `actuate_robot` now checks `gravity_compensation` and
+  `disable_self_collision` on the shared boolean domain instead of reading them
+  by truthiness. Both are published as `"type": "boolean"` on the agent tool
+  surface, and both were laundered through `bool()` before reaching the spec, so
+  `disable_self_collision="false"` (also `"no"`, `"off"`, `"0"`, `nan`) zeroed
+  `contype`/`conaffinity` on every one of the robot's geoms - the branch the
+  caller was opting out of - while `None` and `0.0` took the other branch
+  without being a declared spelling of it. Their four numeric siblings in the
+  same signature have been on a shared domain all along.

--- a/strands_robots/simulation/mujoco/manipulation.py
+++ b/strands_robots/simulation/mujoco/manipulation.py
@@ -43,6 +43,7 @@ from strands_robots.simulation.mujoco.scene_ops import (
     add_weld_constraint,
     remove_equality_constraint,
 )
+from strands_robots.utils import boolean_flag_error
 
 if TYPE_CHECKING:
     from strands_robots.simulation.models import SimRobot
@@ -523,18 +524,23 @@ class ManipulationMixin:
             armature: Per-joint armature (rotor inertia) floor; existing
                 larger values are kept. Must be finite and >= 0.
             gravity_compensation: Apply ``gravcomp=1`` to the robot's bodies
-                so modest gains track tightly.
+                so modest gains track tightly. Must be a boolean - a truthy
+                string such as ``"no"`` is refused rather than read as True.
             disable_self_collision: Zero contype/conaffinity on the robot's
                 own geoms. Planners like cuRobo ignore adjacent-link contacts,
                 which otherwise block planned motion in MuJoCo. NOTE: this
                 disables ALL collision on the robot's geoms (not just
                 link-vs-link), so add contact geoms that must keep colliding
                 (e.g. fingertip pads) AFTER this call via ``patch_scene_mjcf``.
+                Must be a boolean, for the same reason and more sharply: read by
+                truthiness, ``"false"`` would disable every collision on the
+                robot for a caller spelling the opt-out.
 
         Returns:
             ``{status, content}`` tool result; ``status="error"`` when no world
             exists, a policy is running, the robot is unknown or already driven,
-            ``kp``/``damping``/``armature`` are invalid, or the recompile fails.
+            ``kp``/``damping``/``armature`` are invalid, either posture flag was
+            not supplied as a boolean, or the recompile fails.
             The already-driven refusal names the joints it found and the
             actuators driving them, because what a caller does next differs by
             whether the robot is driven throughout or only in part.
@@ -556,6 +562,19 @@ class ManipulationMixin:
                 "status": "error",
                 "content": [{"text": f"actuate_robot: 'armature' must be a finite number >= 0, got {armature!r}."}],
             }
+
+        # Read by truthiness these two would invert for exactly the spellings a
+        # caller opting out reaches for: "false", "no", "off" and "0" are all
+        # truthy, and disable_self_collision then zeroes contype/conaffinity on
+        # every one of the robot's geoms - on the spec, so it outlives the
+        # recompile - while the caller asked to keep them colliding. Their
+        # numeric siblings above have been on a shared domain all along.
+        for flag_name, flag_value in (
+            ("gravity_compensation", gravity_compensation),
+            ("disable_self_collision", disable_self_collision),
+        ):
+            if text := boolean_flag_error(flag_value, flag_name, "actuate_robot"):
+                return {"status": "error", "content": [{"text": text}]}
 
         mj = _ensure_mujoco()
         with self._lock:
@@ -634,8 +653,8 @@ class ManipulationMixin:
                 kp_by_joint,
                 damping=float(damping),
                 armature=float(armature),
-                gravity_compensation=bool(gravity_compensation),
-                disable_self_collision=bool(disable_self_collision),
+                gravity_compensation=gravity_compensation,
+                disable_self_collision=disable_self_collision,
             ):
                 return {
                     "status": "error",

--- a/tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py
+++ b/tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py
@@ -1,0 +1,249 @@
+"""``actuate_robot``'s two posture flags must be booleans, not anything truthy.
+
+``actuate_robot`` takes six parameters. Four scale a quantity - ``kp``,
+``damping``, ``armature`` (and ``torquescale`` on the sibling
+``attach_bodies``) - and each has been checked on a shared numeric domain,
+which rejects a string and rejects ``bool`` because ``bool`` is an ``int``
+subclass that would pass as a silent ``1``. The other two select a *posture*,
+and both were read by truthiness after a ``bool()`` that laundered whatever
+arrived into a well-typed ``True`` before it reached the spec:
+
+* ``disable_self_collision="false"`` (also ``"no"``, ``"off"``, ``"0"``, and
+  ``math.nan``) zeroed ``contype``/``conaffinity`` on *every* geom of the
+  robot - measured on MuJoCo through the agent-facing router, which publishes
+  the parameter as ``"type": "boolean"`` and binds it against the method
+  signature without checking the value. The caller spelling the opt-out got the
+  branch its own docstring warns "disables ALL collision on the robot's geoms",
+  the change lives on the spec so it outlives the recompile, and undoing it
+  needs a separate ``patch_scene_mjcf`` call. ``status`` was ``"success"``.
+* ``gravity_compensation="no"`` reached the spec as True and set
+  ``gravcomp=1`` on the robot's bodies.
+
+``None`` and ``0.0`` took the other branch just as silently, without ever
+being a declared spelling of it.
+
+Both are now checked on :func:`~strands_robots.utils.boolean_flag_error` - the
+domain the sibling ``set_joint_positions``' ``hold`` flag in this same backend
+already applies, and the one ``start_recording``'s ``overwrite`` /
+``push_to_hub`` were moved onto for the same reason - ahead of the recompile
+and ahead of anything written to the spec, so a rejected call leaves the robot
+exactly as it found it.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.utils import boolean_flag_error
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+from .test_actuate_robot import MINI_ARM_URDF  # noqa: E402
+
+# Spellings a caller reaches for when opting out, plus the two values that take
+# a branch without being a declared spelling of either posture. Every one is
+# accepted by ``bool()``: the strings and ``nan`` as True, ``None``/``0.0`` as
+# False.
+NOT_BOOLEANS: tuple[Any, ...] = ("false", "no", "off", "0", "1", math.nan, None, 0.0, 1, [], "true")
+
+POSTURE_FLAGS = ("gravity_compensation", "disable_self_collision")
+
+
+@pytest.fixture
+def arm_sim(tmp_path: Path):
+    """A world holding an actuator-less URDF arm, ready for ``actuate_robot``."""
+    sim = Simulation(tool_name="test_actuate_posture_flags", mesh=False)
+    sim.create_world(gravity=[0, 0, -9.81])
+    urdf = tmp_path / "mini_arm.urdf"
+    urdf.write_text(MINI_ARM_URDF)
+    added = sim.add_robot(name="arm", urdf_path=str(urdf))
+    if added["status"] != "success":
+        raise AssertionError(f"premise: the URDF arm must load, got {added}")
+    if int(_model(sim).nu) != 0:
+        raise AssertionError("premise: a URDF arm must load actuator-less")
+    yield sim
+    sim.cleanup(policy_stop_timeout=0.5)
+
+
+def _model(sim: Simulation) -> Any:
+    """The compiled ``MjModel``, past the ``SimWorld | None`` on the engine."""
+    assert sim._world is not None and sim._world._model is not None
+    return sim._world._model
+
+
+def _robot_collision(sim: Simulation) -> list[tuple[int, int]]:
+    """``(contype, conaffinity)`` for every geom belonging to robot ``arm``."""
+    model = _model(sim)
+    pairs = []
+    for geom in range(int(model.ngeom)):
+        body = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, int(model.geom_bodyid[geom])) or ""
+        if body.startswith("arm/"):
+            pairs.append((int(model.geom_contype[geom]), int(model.geom_conaffinity[geom])))
+    if not pairs:
+        raise AssertionError("premise: the arm must own at least one geom")
+    return pairs
+
+
+def _robot_gravcomp(sim: Simulation) -> list[float]:
+    """``body_gravcomp`` for every body belonging to robot ``arm``."""
+    model = _model(sim)
+    values = [
+        float(model.body_gravcomp[body])
+        for body in range(int(model.nbody))
+        if (mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, body) or "").startswith("arm/")
+    ]
+    if not values:
+        raise AssertionError("premise: the arm must own at least one body")
+    return values
+
+
+class TestATruthyValueDoesNotSelectAPosture:
+    """The failure that motivated the guard, measured on the compiled model."""
+
+    @pytest.mark.parametrize("value", NOT_BOOLEANS)
+    def test_disable_self_collision_leaves_the_robot_colliding(self, arm_sim, value: Any) -> None:
+        """A non-boolean must not disable collision on the robot's geoms.
+
+        Pre-fix every truthy spelling reached the spec as True and left the arm
+        with ``contype == conaffinity == 0`` everywhere, which is what
+        ``mode="kinematic"`` grasp assist and any planner-driven rollout then
+        run against: nothing on the robot collides with anything.
+        """
+        before = _robot_collision(arm_sim)
+        result = arm_sim.actuate_robot(robot_name="arm", disable_self_collision=value)
+
+        assert result["status"] == "error", (
+            f"disable_self_collision={value!r} was accepted; the robot's geoms are now "
+            f"{_robot_collision(arm_sim)} (was {before})"
+        )
+        assert _robot_collision(arm_sim) == before, (
+            f"disable_self_collision={value!r} was refused but the robot's collision state "
+            f"changed to {_robot_collision(arm_sim)}"
+        )
+        assert int(_model(arm_sim).nu) == 0, "a refused call must not add actuators"
+
+    @pytest.mark.parametrize("value", NOT_BOOLEANS)
+    def test_gravity_compensation_is_not_selected_by_a_string(self, arm_sim, value: Any) -> None:
+        """A non-boolean must not decide whether gravity is compensated."""
+        before = _robot_gravcomp(arm_sim)
+        result = arm_sim.actuate_robot(robot_name="arm", gravity_compensation=value)
+
+        assert result["status"] == "error", (
+            f"gravity_compensation={value!r} was accepted; body_gravcomp is now "
+            f"{_robot_gravcomp(arm_sim)} (was {before})"
+        )
+        assert _robot_gravcomp(arm_sim) == before, (
+            f"gravity_compensation={value!r} was refused but body_gravcomp changed to {_robot_gravcomp(arm_sim)}"
+        )
+        assert int(_model(arm_sim).nu) == 0, "a refused call must not add actuators"
+
+    def test_the_agent_facing_router_refuses_it_too(self, arm_sim) -> None:
+        """The tool call is the reachable route, and it publishes a boolean.
+
+        ``tool_spec.json`` declares both flags ``"type": "boolean"`` and the
+        router binds an action's parameters against the method signature without
+        checking values, so the schema's own declaration was the only thing
+        saying the value had to be one.
+        """
+        before = _robot_collision(arm_sim)
+        result = arm_sim(action="actuate_robot", robot_name="arm", disable_self_collision="false")
+
+        assert result["status"] == "error", result
+        assert _robot_collision(arm_sim) == before
+
+
+class TestTheRefusalNamesWhatToSupply:
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    def test_the_message_names_the_flag_and_the_method(self, arm_sim, flag: str) -> None:
+        result = arm_sim.actuate_robot(robot_name="arm", **{flag: "false"})
+        text = result["content"][0]["text"]
+
+        assert flag in text, text
+        assert "actuate_robot" in text, text
+
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    @pytest.mark.parametrize("value", NOT_BOOLEANS)
+    def test_both_flags_answer_exactly_the_shared_domain(self, arm_sim, flag: str, value: Any) -> None:
+        """Keyed on the shared helper, so the domain cannot drift here alone."""
+        expected = boolean_flag_error(value, flag, "actuate_robot")
+        if expected is None:
+            raise AssertionError(f"premise: {value!r} must be outside the shared boolean domain")
+
+        result = arm_sim.actuate_robot(robot_name="arm", **{flag: value})
+
+        assert result["status"] == "error"
+        assert result["content"][0]["text"] == expected
+
+
+class TestARealBooleanStillSelectsItsPosture:
+    """Controls: the capability is unchanged for every value that was usable."""
+
+    @pytest.mark.parametrize("flag", POSTURE_FLAGS)
+    @pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+    def test_a_python_or_numpy_boolean_is_accepted(self, arm_sim, flag: str, value: Any) -> None:
+        result = arm_sim.actuate_robot(robot_name="arm", **{flag: value})
+
+        assert result["status"] == "success", result
+        assert int(_model(arm_sim).nu) == 2, "both hinges must still gain a servo"
+
+    def test_true_disables_collision_and_false_keeps_it(self, arm_sim, tmp_path: Path) -> None:
+        """Both branches still reachable, and they still differ."""
+        assert arm_sim.actuate_robot(robot_name="arm", disable_self_collision=False)["status"] == "success"
+        kept = _robot_collision(arm_sim)
+
+        other = Simulation(tool_name="test_actuate_posture_flags_b", mesh=False)
+        try:
+            other.create_world(gravity=[0, 0, -9.81])
+            urdf = tmp_path / "mini_arm.urdf"
+            assert other.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+            assert other.actuate_robot(robot_name="arm", disable_self_collision=True)["status"] == "success"
+            disabled = _robot_collision(other)
+        finally:
+            other.cleanup(policy_stop_timeout=0.5)
+
+        assert all(pair == (1, 1) for pair in kept), kept
+        assert all(pair == (0, 0) for pair in disabled), disabled
+
+    def test_true_compensates_gravity_and_false_does_not(self, arm_sim, tmp_path: Path) -> None:
+        assert arm_sim.actuate_robot(robot_name="arm", gravity_compensation=False)["status"] == "success"
+        assert _robot_gravcomp(arm_sim) == pytest.approx([0.0] * len(_robot_gravcomp(arm_sim)))
+
+        other = Simulation(tool_name="test_actuate_posture_flags_c", mesh=False)
+        try:
+            other.create_world(gravity=[0, 0, -9.81])
+            urdf = tmp_path / "mini_arm.urdf"
+            assert other.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
+            assert other.actuate_robot(robot_name="arm", gravity_compensation=True)["status"] == "success"
+            assert _robot_gravcomp(other) == pytest.approx([1.0] * len(_robot_gravcomp(other)))
+        finally:
+            other.cleanup(policy_stop_timeout=0.5)
+
+    def test_the_success_text_still_names_both_postures(self, arm_sim) -> None:
+        result = arm_sim.actuate_robot(robot_name="arm", gravity_compensation=True, disable_self_collision=True)
+
+        text = result["content"][0]["text"]
+        assert "gravcomp=on" in text, text
+        assert "self_collision=off" in text, text
+
+    @pytest.mark.parametrize(
+        ("param", "value"),
+        [("damping", "2.0"), ("armature", "0.01"), ("kp", "100.0"), ("damping", True), ("kp", False)],
+    )
+    def test_the_numeric_siblings_keep_their_own_domain(self, arm_sim, param: str, value: Any) -> None:
+        """A number is still a number: these four were never the defect.
+
+        They also still reject ``bool``, which the posture domain requires -
+        the two domains are inverses and must not be conflated.
+        """
+        result = arm_sim.actuate_robot(robot_name="arm", **{param: value})
+
+        assert result["status"] == "error"
+        assert f"'{param}'" in result["content"][0]["text"]
+        assert "finite number" in result["content"][0]["text"]

--- a/tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py
+++ b/tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py
@@ -63,13 +63,22 @@ def arm_sim(tmp_path: Path):
     sim.create_world(gravity=[0, 0, -9.81])
     urdf = tmp_path / "mini_arm.urdf"
     urdf.write_text(MINI_ARM_URDF)
-    added = sim.add_robot(name="arm", urdf_path=str(urdf))
-    if added["status"] != "success":
-        raise AssertionError(f"premise: the URDF arm must load, got {added}")
+    _ok(sim.add_robot(name="arm", urdf_path=str(urdf)), "premise: the URDF arm must load")
     if int(_model(sim).nu) != 0:
         raise AssertionError("premise: a URDF arm must load actuator-less")
     yield sim
     sim.cleanup(policy_stop_timeout=0.5)
+
+
+def _ok(result: dict[str, Any], what: str) -> dict[str, Any]:
+    """Return *result*, raising when it is not a success.
+
+    A call that mutates the scene must not sit inside an ``assert``: ``python
+    -O`` strips the statement, and with it the setup the test is about.
+    """
+    if result["status"] != "success":
+        raise AssertionError(f"{what}: {result}")
+    return result
 
 
 def _model(sim: Simulation) -> Any:
@@ -195,15 +204,15 @@ class TestARealBooleanStillSelectsItsPosture:
 
     def test_true_disables_collision_and_false_keeps_it(self, arm_sim, tmp_path: Path) -> None:
         """Both branches still reachable, and they still differ."""
-        assert arm_sim.actuate_robot(robot_name="arm", disable_self_collision=False)["status"] == "success"
+        _ok(arm_sim.actuate_robot(robot_name="arm", disable_self_collision=False), "actuate with False")
         kept = _robot_collision(arm_sim)
 
         other = Simulation(tool_name="test_actuate_posture_flags_b", mesh=False)
         try:
             other.create_world(gravity=[0, 0, -9.81])
             urdf = tmp_path / "mini_arm.urdf"
-            assert other.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
-            assert other.actuate_robot(robot_name="arm", disable_self_collision=True)["status"] == "success"
+            _ok(other.add_robot(name="arm", urdf_path=str(urdf)), "add_robot")
+            _ok(other.actuate_robot(robot_name="arm", disable_self_collision=True), "actuate with True")
             disabled = _robot_collision(other)
         finally:
             other.cleanup(policy_stop_timeout=0.5)
@@ -212,15 +221,15 @@ class TestARealBooleanStillSelectsItsPosture:
         assert all(pair == (0, 0) for pair in disabled), disabled
 
     def test_true_compensates_gravity_and_false_does_not(self, arm_sim, tmp_path: Path) -> None:
-        assert arm_sim.actuate_robot(robot_name="arm", gravity_compensation=False)["status"] == "success"
+        _ok(arm_sim.actuate_robot(robot_name="arm", gravity_compensation=False), "actuate with False")
         assert _robot_gravcomp(arm_sim) == pytest.approx([0.0] * len(_robot_gravcomp(arm_sim)))
 
         other = Simulation(tool_name="test_actuate_posture_flags_c", mesh=False)
         try:
             other.create_world(gravity=[0, 0, -9.81])
             urdf = tmp_path / "mini_arm.urdf"
-            assert other.add_robot(name="arm", urdf_path=str(urdf))["status"] == "success"
-            assert other.actuate_robot(robot_name="arm", gravity_compensation=True)["status"] == "success"
+            _ok(other.add_robot(name="arm", urdf_path=str(urdf)), "add_robot")
+            _ok(other.actuate_robot(robot_name="arm", gravity_compensation=True), "actuate with True")
             assert _robot_gravcomp(other) == pytest.approx([1.0] * len(_robot_gravcomp(other)))
         finally:
             other.cleanup(policy_stop_timeout=0.5)


### PR DESCRIPTION
## Problem

`actuate_robot` takes six parameters. Four scale a quantity - `kp`, `damping`,
`armature` - and each is checked on a shared numeric domain that refuses a
string by name and refuses `bool` (an `int` subclass that would pass as a silent
`1`). The other two select a *posture*, and both were read by truthiness after a
`bool()` that laundered whatever arrived into a well-typed `True` before it
reached the spec.

Every non-empty string is truthy, so the spellings a caller reaches for when
opting out selected the branch it was opting *out* of. Measured on MuJoCo
through the agent-facing router, which publishes both parameters as
`"type": "boolean"` and binds them against the method signature without
checking the value:

| `disable_self_collision=` | verdict | `contype`/`conaffinity` on the robot's geoms |
| --- | --- | --- |
| `False` | success | `(1, 1)` - kept, as asked |
| `"no"` / `"false"` / `"off"` / `"0"` / `nan` | **success** | **`(0, 0)`** - every geom, opt-out inverted |
| `None` / `0.0` | success | `(1, 1)` - never a declared spelling of either posture |
| `True` | success | `(0, 0)` - disabled, as asked |
| `damping="2.0"` (same signature) | error | `'damping' must be a finite number >= 0, got '2.0'.` |

`gravity_compensation="no"` reached the spec the same way and set `gravcomp=1`
on the robot's bodies.

Two things make the `disable_self_collision` case the sharper one. Its own
docstring warns the branch "disables ALL collision on the robot's geoms (not
just link-vs-link)", so the robot stops colliding with the floor and with every
object in the scene, not only with itself. And the change lives on the spec, as
documented, so it outlives the recompile and undoing it needs a separate
`patch_scene_mjcf` call.

## Change

Both flags now go through `strands_robots.utils.boolean_flag_error`, ahead of
`_ensure_mujoco()` and ahead of anything written to the spec, so a rejected
call leaves the robot exactly as it found it - no actuators added, `nu` still 0.
The redundant `bool()` at the call site is gone: it was the laundering that let
the inverted value reach `actuate_robot_in_scene` well-typed, where nothing
downstream could tell it apart from a real `True`.

That is the domain the sibling `set_joint_positions`' `hold` flag in this same
backend already applies, and the one `start_recording`'s `overwrite` /
`push_to_hub` were moved onto after the same failure. Validation stays at the
one public entry point rather than being repeated in `actuate_robot_in_scene`,
whose only caller this is.

Scope: this is `actuate_robot`'s signature, where the numeric half was already
checked and the posture half was not. Other boolean parameters elsewhere in the
backend are a wider question about which of them are postures worth bounding,
and are deliberately left alone here.

## Tests

`tests/simulation/mujoco/test_actuate_robot_posture_flag_domain.py`, **47
failed / 16 passed before, 63 passed after**. The headline reads:

```
AssertionError: disable_self_collision='false' was accepted; the robot's geoms
are now [(0, 0), (0, 0), (0, 0)] (was [(1, 1), (1, 1), (1, 1)])
```

Each refusal test also asserts the compiled model is untouched (`nu == 0`,
collision and `body_gravcomp` unchanged), and one drives the agent-facing router
rather than the method, because that is the reachable route.

The 16 that pass on both trees are the controls, and they are what fails if the
guard reaches too far: a python or numpy boolean is still accepted for both
flags, `True` still disables collision while `False` still keeps it, `True`
still compensates gravity while `False` does not, the success text still names
both postures, and the four numeric siblings keep their own domain - including
their rejection of `bool`, since the two domains are inverses and must not be
conflated. One test is keyed on `boolean_flag_error` itself so the accepted
domain cannot drift here alone.

## Verification

- Blast radius: every test referencing `actuate_robot`, `boolean_flag_error`,
  `actuate_robot_in_scene`, `disable_self_collision` or
  `_apply_kinematic_attachments`, plus the repo-wide docstring / ASCII /
  changelog / tool-spec guards. Same selection on both trees at the pre-merge
  base: branch **1487 passed, 0 failed**; base **1440 passed, 47 failed**.
  `1440 + 47 == 1487`, both collected 1488, every base-only failure is in the
  new file, zero branch-only failures. After merging `main` (#2419 and #2420
  landed, and #2420 touches this same module) the selection is 33 files and the
  composed tree is **1797 passed, 0 failed**, with the pre-fix split re-measured
  against the new base and unchanged at 47 / 16.
- `ruff check` / `ruff format --check` and `mypy` over `strands_robots tests
  tests_integ` clean; mypy is 19 pre-existing errors on both trees, none in the
  touched files.

## Rollout in MuJoCo (headless)

One capture script per tree, same URDF arm, same crate, same sweep. The caller
wants the arm's geoms to keep colliding and spells the opt-out `"no"`; where the
call is refused the script reads the refusal and supplies the boolean it asks
for. Only `strands_robots` differs between the panels.

![actuate_robot posture flag](https://raw.githubusercontent.com/cagataycali/robots/media-actuate-posture-flags/collision-flag.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-actuate-posture-flags/collision-flag.mp4)

Left: `"no"` accepted, `contype` `[0, 0, 0]`, the arm sweeps straight through the
crate, which travels **0.11 mm** over the whole sweep. Right: refused, retried
with `False`, `contype` `[1, 1, 1]`, the arm pushes the crate **54.58 mm**. The
panels are pixel-identical at frame 0 (mean abs delta 0.0000) and 5.97 apart at
the end, so they differ only where the flag bites. A rollout recorded against
the left scene contains no contacts at all.

The headlight is lifted in the capture script for legibility - this scene has no
MJCF `<light>` - which changes nothing physical and nothing measured above.
