### PR TITLE
fix(policies/wbc): complete an incomplete obs_scales map from the upstream defaults

### DIFF
--- a/changelog.d/2424-wbc-obs-scales-completed.md
+++ b/changelog.d/2424-wbc-obs-scales-completed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **policies/wbc**: a `WBCConfig` that states some observation scales now keeps the documented upstream default for the rest. Stating `ang_vel_scale` and `dof_pos_scale` used to replace the whole `obs_scales` map, leaving `dof_vel` to a second fallback number inside the frame builders (a bare `1.0`) instead of its documented `0.05` - scaling the 29 joint-velocity entries of every observation frame by 20x. Driving the GR00T SONIC checkpoint with such a config walked the G1 0.37 m and dropped its pelvis from 0.74 m to 0.19 m while reporting success; it now walks 3.11 m as the same scales stated explicitly do. `obs_scales` is completed once on the config, so the observation builder, the gait builder and any other consumer read the same values.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -162,6 +162,14 @@ WBC reproduces the upstream `GearWbcController` loop (NVlabs/GR00T-WholeBodyCont
   - joint positions `[13:28]` (minus `default_angles`, scaled by `dof_pos_scale`)
   - joint velocities `[28:43]` (scaled by `dof_vel_scale=0.05`)
   - previous action `[43:58]`; indices `[58:86]` are a reserved (zero) tail.
+
+  The upstream YAML spells these three scales as flat `ang_vel_scale` /
+  `dof_pos_scale` / `dof_vel_scale` keys, and `WBCConfig` normalises them into
+  the nested `obs_scales` map. A config only has to state the scales it wants to
+  change: the rest keep the upstream defaults above, so naming one scale never
+  changes what an unnamed sibling is scaled by. `config.obs_scales` is therefore
+  always the complete map the frame is built with, whichever spelling the config
+  used.
 - **Action** - the network emits a 15-dim joint-position *offset*; the policy
   forms absolute targets `target_q = default_angles + action_scale * raw` and
   returns them keyed by actuator name. For torque-actuated MuJoCo, convert with

--- a/strands_robots/policies/wbc/config.py
+++ b/strands_robots/policies/wbc/config.py
@@ -84,6 +84,14 @@ _DEFAULT_NUM_ACTIONS = 15
 # Upstream g1_gear_wbc.yaml: obs_history_len=6 (num_obs = 86*6 = 516).
 _DEFAULT_OBS_HISTORY_LEN = 6
 _DEFAULT_COMMAND_DIM = 7
+# The observation scales from upstream g1_gear_wbc.yaml, and the single owner of
+# them. Every consumer resolves an omitted key from THIS table, so a config that
+# states some scales and leaves the rest to their documented default cannot end
+# up scaled differently from one that states none: ``dof_vel`` is 0.05 either
+# way. A second fallback number (a bare ``1.0``) would silently multiply the 29
+# joint-velocity entries of the frame by 20 for exactly the configs that name a
+# sibling key, which the network reads as a malformed observation.
+_DEFAULT_OBS_SCALES: dict[str, float] = {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05}
 # Upstream cmd_scale applied to [vx, vy, omega] and the default base-height
 # command, from g1_gear_wbc.yaml.
 _DEFAULT_CMD_SCALE = (2.0, 2.0, 0.5)
@@ -124,7 +132,10 @@ class WBCConfig:
         obs_scales: Named scale factors applied to observation sub-vectors
             (``ang_vel`` / ``dof_pos`` / ``dof_vel``). Defaults match upstream
             g1_gear_wbc.yaml (ang_vel_scale=0.5, dof_pos_scale=1.0,
-            dof_vel_scale=0.05).
+            dof_vel_scale=0.05). A map that states only some of them is
+            completed with those defaults at construction, so this attribute is
+            always the full map the observation is built with - naming one scale
+            never changes what an unnamed sibling is scaled by.
         cmd_scale: Scale applied to the ``[vx, vy, omega]`` velocity command
             before it enters the observation's command block (upstream
             ``cmd_scale = [2.0, 2.0, 0.5]``).
@@ -160,7 +171,7 @@ class WBCConfig:
     kps: list[float] = field(default_factory=list)
     kds: list[float] = field(default_factory=list)
     action_scale: float = 0.25
-    obs_scales: dict[str, float] = field(default_factory=lambda: {"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05})
+    obs_scales: dict[str, float] = field(default_factory=lambda: dict(_DEFAULT_OBS_SCALES))
     cmd_scale: list[float] = field(default_factory=lambda: list(_DEFAULT_CMD_SCALE))
     height_cmd: float = _DEFAULT_HEIGHT_CMD
     freq_cmd: float = _DEFAULT_FREQ_CMD
@@ -263,6 +274,15 @@ class WBCConfig:
         for scale_name, scale in self.obs_scales.items():
             if error := finite_number_error(scale, f"obs_scales[{scale_name!r}]", "WBCConfig"):
                 raise ValueError(error)
+        # Fill the scales this config does not state from the upstream table, so
+        # ``obs_scales`` is the complete map the observation is actually built
+        # with. Done here - on the config, once - rather than per consumer, for
+        # the reason WBCPolicy fills the per-joint SONIC vectors on the config:
+        # the observation builder and the controller must see the same values.
+        # A stated scale always wins; only an omitted one is filled. Frozen
+        # dataclass, so the normalised map is installed with object.__setattr__.
+        if any(name not in self.obs_scales for name in _DEFAULT_OBS_SCALES):
+            object.__setattr__(self, "obs_scales", {**_DEFAULT_OBS_SCALES, **self.obs_scales})
 
     @property
     def num_obs(self) -> int:
@@ -282,7 +302,10 @@ class WBCConfig:
         FLAT keys (``ang_vel_scale`` / ``dof_pos_scale`` / ``dof_vel_scale``)
         rather than a nested ``obs_scales`` map. Those flat keys are normalised
         into ``obs_scales`` here so the upstream config loads unchanged. An
-        explicit ``obs_scales`` map, if present, takes precedence.
+        explicit ``obs_scales`` map, if present, takes precedence. A config that
+        states only some of the scales keeps the documented default for the rest
+        (:meth:`__post_init__` completes the map), so naming one scale does not
+        change what an unnamed sibling is scaled by.
         """
         if "policy_path" not in data:
             raise ValueError("WBCConfig requires a 'policy_path' entry")

--- a/strands_robots/policies/wbc/gait.py
+++ b/strands_robots/policies/wbc/gait.py
@@ -54,7 +54,7 @@ from numpy.typing import NDArray
 
 from strands_robots.utils import positive_finite_number_error
 
-from .config import WBCConfig
+from .config import _DEFAULT_OBS_SCALES, WBCConfig
 from .control import compute_targets, projected_gravity
 from .policy import WBCPolicy
 
@@ -256,9 +256,13 @@ def build_gait_frame(
         da = np.asarray(config.default_angles, dtype=np.float64)
         limit = min(da.shape[0], no)
         defaults[:limit] = da[:limit]
-    ang_vel_scale = config.obs_scales.get("ang_vel", 1.0)
-    dof_pos_scale = config.obs_scales.get("dof_pos", 1.0)
-    dof_vel_scale = config.obs_scales.get("dof_vel", 1.0)
+    # WBCConfig completes an incomplete obs_scales map at construction, so these
+    # keys are present. The fallback resolves from the same upstream table rather
+    # than from a bare 1.0, so a config assembled outside WBCConfig is scaled the
+    # way the layout documents instead of 20x on the dqj block.
+    ang_vel_scale = config.obs_scales.get("ang_vel", _DEFAULT_OBS_SCALES["ang_vel"])
+    dof_pos_scale = config.obs_scales.get("dof_pos", _DEFAULT_OBS_SCALES["dof_pos"])
+    dof_vel_scale = config.obs_scales.get("dof_vel", _DEFAULT_OBS_SCALES["dof_vel"])
 
     frame = np.zeros(config.single_obs_dim, dtype=np.float64)
     end = c + 12 + 2 * no + na + 2

--- a/strands_robots/policies/wbc/observation.py
+++ b/strands_robots/policies/wbc/observation.py
@@ -36,7 +36,7 @@ from collections import deque
 import numpy as np
 from numpy.typing import NDArray
 
-from .config import WBCConfig
+from .config import _DEFAULT_OBS_SCALES, WBCConfig
 
 
 def build_single_frame(
@@ -113,9 +113,13 @@ def build_single_frame(
         da = np.asarray(config.default_angles, dtype=np.float64)
         limit = min(da.shape[0], no)
         defaults[:limit] = da[:limit]
-    ang_vel_scale = config.obs_scales.get("ang_vel", 1.0)
-    dof_pos_scale = config.obs_scales.get("dof_pos", 1.0)
-    dof_vel_scale = config.obs_scales.get("dof_vel", 1.0)
+    # WBCConfig completes an incomplete obs_scales map at construction, so these
+    # keys are present. The fallback resolves from the same upstream table rather
+    # than from a bare 1.0, so a config assembled outside WBCConfig is scaled the
+    # way the layout documents instead of 20x on the dqj block.
+    ang_vel_scale = config.obs_scales.get("ang_vel", _DEFAULT_OBS_SCALES["ang_vel"])
+    dof_pos_scale = config.obs_scales.get("dof_pos", _DEFAULT_OBS_SCALES["dof_pos"])
+    dof_vel_scale = config.obs_scales.get("dof_vel", _DEFAULT_OBS_SCALES["dof_vel"])
 
     frame = np.zeros(config.single_obs_dim, dtype=np.float64)
     end = c + 6 + 2 * no + na

--- a/tests/policies/wbc/test_obs_scales_completed_from_upstream_defaults.py
+++ b/tests/policies/wbc/test_obs_scales_completed_from_upstream_defaults.py
@@ -1,0 +1,177 @@
+"""A WBC config that states some observation scales keeps the defaults for the rest.
+
+:class:`~strands_robots.policies.wbc.config.WBCConfig` documents three
+observation scales with upstream defaults (``ang_vel`` 0.5, ``dof_pos`` 1.0,
+``dof_vel`` 0.05) and the frame builders read them per tick. A config that states
+NO scale gets those defaults from the dataclass field; a config that states
+*some* of them used to replace the whole map, leaving the rest to a second
+fallback number inside the builders - a bare ``1.0`` - so the effective scale of
+an unnamed key depended on which of its siblings the config happened to name.
+``dof_vel`` resolved to 1.0 instead of 0.05, multiplying the 29 joint-velocity
+entries of the frame by 20 while the config, the docs and the layout comment all
+said 0.05.
+
+That is the whole point of these tests: naming one scale must not change what an
+unnamed sibling is scaled by. The upstream flat-key form
+(``ang_vel_scale`` / ``dof_pos_scale`` / ``dof_vel_scale``) makes a partial
+config the ordinary case, since a config that only wants to retune one scale
+states only that one.
+
+The expected values are read from a config that states no scales at all - the
+route whose defaults were never in question - rather than from a literal table,
+so these tests grade the agreement between the two routes rather than restating
+the numbers.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.wbc import WBCConfig, build_gait_frame
+from strands_robots.policies.wbc.observation import build_single_frame
+
+# The upstream flat spelling of each nested scale key, as WBCConfig.from_dict
+# accepts it. Used to build every subset of "which scales did this config state".
+_FLAT_KEY = {"ang_vel": "ang_vel_scale", "dof_pos": "dof_pos_scale", "dof_vel": "dof_vel_scale"}
+
+# A config stating nothing about the scales: the documented-default route, and
+# the reference every partial config below is graded against.
+_NO_SCALES_STATED = {"policy_path": "p.onnx"}
+
+
+def _documented_scales() -> dict[str, float]:
+    """The effective scales of a config that states none of them."""
+    return dict(WBCConfig.from_dict(_NO_SCALES_STATED).obs_scales)
+
+
+def _frame_kwargs(no: int = 29, na: int = 15, c: int = 7) -> dict[str, np.ndarray]:
+    """Sub-vectors for one observation frame, with a non-zero dqj block.
+
+    ``dqj`` has to be non-zero for a wrong ``dof_vel`` scale to be observable at
+    all - the block the defect mis-scaled is zero for a robot standing still.
+    """
+    return {
+        "command": np.zeros(c),
+        "base_ang_vel": np.full(3, 0.4),
+        "proj_gravity": np.array([0.0, 0.0, -1.0]),
+        "qj": np.linspace(-0.3, 0.3, no),
+        "dqj": np.full(no, 2.0),
+        "prev_action": np.zeros(na),
+    }
+
+
+class TestAnOmittedScaleKeepsItsDocumentedDefault:
+    """Stating one scale must not silently change an unnamed sibling."""
+
+    def test_a_config_that_omits_dof_vel_scale_still_scales_joint_velocity_by_it(self) -> None:
+        """The realistic partial config: retune two scales, inherit the third.
+
+        A config that states ``ang_vel_scale`` and ``dof_pos_scale`` and leaves
+        ``dof_vel_scale`` to its documented 0.05 must build the same joint
+        velocity block as a config that states all three.
+        """
+        documented = _documented_scales()
+        full = WBCConfig.from_dict(
+            {**_NO_SCALES_STATED, **{flat: documented[name] for name, flat in _FLAT_KEY.items()}}
+        )
+        partial = WBCConfig.from_dict(
+            {**_NO_SCALES_STATED, "ang_vel_scale": documented["ang_vel"], "dof_pos_scale": documented["dof_pos"]}
+        )
+        kwargs = _frame_kwargs()
+        no = full.n_obs_joints
+        block = slice(full.command_dim + 6 + no, full.command_dim + 6 + 2 * no)
+        expected = build_single_frame(full, **kwargs)[block]
+        got = build_single_frame(partial, **kwargs)[block]
+        assert expected.any(), "premise: the dqj block must be non-zero for a wrong scale to show"
+        ratio = float(got[0] / expected[0])
+        assert got == pytest.approx(expected), (
+            f"a config that states ang_vel_scale and dof_pos_scale but leaves dof_vel_scale to its "
+            f"documented default {documented['dof_vel']} scaled the joint velocity block by "
+            f"{ratio:g}x what the same scales state explicitly: {got[:3]} vs {expected[:3]}"
+        )
+
+    @pytest.mark.parametrize(
+        "stated",
+        [
+            pytest.param(subset, id="+".join(subset) or "none")
+            for r in range(4)
+            for subset in itertools.combinations(sorted(_FLAT_KEY), r)
+        ],
+    )
+    def test_an_omitted_scale_resolves_the_same_way_whatever_siblings_are_stated(self, stated: tuple[str, ...]) -> None:
+        """Root cause: the effective scale of an unnamed key is independent of the named ones."""
+        documented = _documented_scales()
+        config = WBCConfig.from_dict({**_NO_SCALES_STATED, **{_FLAT_KEY[name]: documented[name] for name in stated}})
+        omitted = [name for name in documented if name not in stated]
+        effective = {name: config.obs_scales.get(name, 1.0) for name in omitted}
+        assert effective == pytest.approx({name: documented[name] for name in omitted}), (
+            f"stating {list(stated)} changed the effective scale of the unnamed {omitted}: "
+            f"{effective} instead of the documented {[documented[name] for name in omitted]}"
+        )
+
+    def test_a_partial_explicit_obs_scales_map_keeps_the_defaults_for_the_rest(self) -> None:
+        """The nested-map route, reached by the constructor rather than from_dict."""
+        documented = _documented_scales()
+        config = WBCConfig(policy_path="p.onnx", obs_scales={"ang_vel": 0.25})
+        assert config.obs_scales["ang_vel"] == 0.25, "the stated scale must survive"
+        assert config.obs_scales["dof_vel"] == pytest.approx(documented["dof_vel"])
+        assert config.obs_scales["dof_pos"] == pytest.approx(documented["dof_pos"])
+
+    def test_obs_scales_reports_every_scale_the_frame_is_built_with(self) -> None:
+        """``obs_scales`` is the complete effective map, so a subscript is safe."""
+        config = WBCConfig.from_dict({**_NO_SCALES_STATED, "ang_vel_scale": 0.5})
+        assert set(config.obs_scales) >= set(_FLAT_KEY), (
+            f"obs_scales reports {sorted(config.obs_scales)}; a reader taking "
+            f"config.obs_scales['dof_vel'] to learn what the frame is scaled by raises KeyError"
+        )
+
+    def test_the_gait_frame_is_built_with_the_same_completed_scales(self) -> None:
+        """The gait variant reads the same three scales and must resolve them identically."""
+        documented = _documented_scales()
+        base = {"policy_path": "p.onnx", "command_dim": 8, "single_obs_dim": 95}
+        full = WBCConfig.from_dict({**base, **{flat: documented[name] for name, flat in _FLAT_KEY.items()}})
+        partial = WBCConfig.from_dict({**base, "ang_vel_scale": documented["ang_vel"]})
+        kwargs = {**_frame_kwargs(c=8), "clock": np.array([0.3, -0.3])}
+        expected = build_gait_frame(full, **kwargs)
+        got = build_gait_frame(partial, **kwargs)
+        assert got == pytest.approx(expected), (
+            "the gait frame differs between a config that states every scale and one that "
+            f"leaves two to their documented defaults: max delta {np.abs(got - expected).max():g}"
+        )
+
+
+class TestCompletingTheMapChangesNothingElse:
+    """Boundaries the fill must not cross."""
+
+    @pytest.mark.parametrize("route", ["flat", "nested"])
+    def test_a_stated_scale_is_never_replaced_by_the_default(self, route: str) -> None:
+        data = (
+            {**_NO_SCALES_STATED, "dof_vel_scale": 0.5}
+            if route == "flat"
+            else {**_NO_SCALES_STATED, "obs_scales": {"dof_vel": 0.5}}
+        )
+        scales = WBCConfig.from_dict(data).obs_scales
+        assert scales["dof_vel"] == 0.5
+
+    def test_an_explicit_map_still_wins_over_the_flat_key_it_overlaps(self) -> None:
+        config = WBCConfig.from_dict({**_NO_SCALES_STATED, "ang_vel_scale": 0.5, "obs_scales": {"ang_vel": 0.9}})
+        assert config.obs_scales["ang_vel"] == 0.9
+
+    def test_a_config_stating_no_scales_still_gets_the_upstream_defaults(self) -> None:
+        scales = WBCConfig.from_dict(_NO_SCALES_STATED).obs_scales
+        assert scales == pytest.approx({"ang_vel": 0.5, "dof_pos": 1.0, "dof_vel": 0.05})
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), "0.5"])
+    def test_a_scale_the_domain_refuses_is_still_refused(self, bad: object) -> None:
+        """Completing the map must not smuggle an unusable stated value past validation."""
+        with pytest.raises(ValueError, match=r"obs_scales\['dof_vel'\]"):
+            WBCConfig(policy_path="p.onnx", obs_scales={"dof_vel": bad})  # type: ignore[dict-item]
+
+    def test_a_scale_key_the_layout_does_not_read_is_kept(self) -> None:
+        """The map is open: a caller-supplied extra key survives completion."""
+        config = WBCConfig(policy_path="p.onnx", obs_scales={"height": 2.0})
+        assert config.obs_scales["height"] == 2.0
+        assert config.obs_scales["dof_vel"] == pytest.approx(0.05)


### PR DESCRIPTION
## Problem

`WBCConfig` documents three observation scales with upstream `g1_gear_wbc.yaml` defaults - `ang_vel` 0.5, `dof_pos` 1.0, `dof_vel` 0.05 - and `build_single_frame` / `build_gait_frame` read them on every tick.

A config that stated **no** scale got those defaults from the dataclass field. A config that stated **some** of them replaced the whole `obs_scales` map, leaving the rest to a second fallback number inside the builders: a bare `1.0`. So the effective scale of an unnamed key depended on which of its siblings the config happened to name.

The upstream YAML spells the scales as flat `ang_vel_scale` / `dof_pos_scale` / `dof_vel_scale` keys, which makes a partial config the ordinary case - a config that only wants to retune one scale states only that one.

| config states | `obs_scales` before | effective `dof_vel` |
|---|---|---|
| nothing about the scales | `{ang_vel: 0.5, dof_pos: 1.0, dof_vel: 0.05}` | 0.05 |
| `ang_vel_scale`, `dof_pos_scale` | `{ang_vel: 0.5, dof_pos: 1.0}` | **1.0 (20x)** |
| `dof_pos_scale` only | `{dof_pos: 1.0}` | **1.0 (20x)**, and `ang_vel` 1.0 (2x) |
| `obs_scales={"ang_vel": 0.5}` | `{ang_vel: 0.5}` | **1.0 (20x)** |
| all three flat keys | full map | 0.05 |

`dof_vel` scales the `dqj` block - 29 of the 86 entries of every frame - so a config that omitted it handed the network a frame 20x off on a third of its width, while the dataclass default, `docs/policies/wbc.md` ("joint velocities `[28:43]` (scaled by `dof_vel_scale=0.05`)") and the layout comment all said 0.05. Nothing raised and nothing warned: `config.obs_scales["dof_vel"]` raised `KeyError` rather than reporting the value the frame was built with.

Driving the GR00T SONIC checkpoint (`policy.onnx` + `walk_policy.onnx`) on the G1 with `target_velocity=[0.5, 0, 0]` for 400 ticks at 50 Hz:

| | effective `dof_vel` | pelvis min | travelled | status |
|---|---|---|---|---|
| config states two scales, omits `dof_vel_scale` | 1.0 | **0.193 m** (from 0.740) | 0.47 m | `success` |
| the same two scales, `dof_vel_scale: 0.05` stated | 0.05 | 0.740 m | 3.11 m | `success` |

## Change

`obs_scales` is completed once, on the config, from a single owner (`_DEFAULT_OBS_SCALES`) - for the reason `WBCPolicy` already fills the per-joint SONIC vectors on the config rather than in the policy: *"so the observation builder - which reads config.default_angles for the qj offset - and the controller see the same values"*. A stated scale always wins; only an omitted one is filled, so an explicit map still overrides the flat key it overlaps.

`config.obs_scales` is therefore always the complete map the frame is built with, whichever spelling the config used, and a reader taking `config.obs_scales["dof_vel"]` gets the value rather than a `KeyError`.

The builders keep a fallback but resolve it from the same table instead of a bare `1.0`, so no second number exists anywhere to drift from the first.

Out of scope: the map stays **open** - a key the layout does not read is kept, not refused, since `obs_scales` is documented as named scale factors and the gait variant may add to them. Pinned by a test.

## Rollout

Same checkpoint, same command, same config; only `strands_robots` differs. Left is `upstream/main`, right is this branch. The two panels are pixel-identical at t=0 (mean abs delta 0.0000) and diverge to 16.51 as the frame the network reads starts to matter.

![obs_scales rollout](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-obs-scales/wbc-obs-scales.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-obs-scales/wbc-obs-scales.mp4) - [final frame](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-obs-scales/wbc-obs-scales-final.png)

The free camera tracks forward progress at a fixed height, so a fall reads as the robot dropping in frame. In the final frame nothing on the left rises above the horizon (topmost structural row `-1`, the robot is entirely on the floor); on the right the head sits at row 105.

## Tests

`tests/policies/wbc/test_obs_scales_completed_from_upstream_defaults.py`, **10 failed / 10 passed** on `upstream/main`, 20 passed here. The expected values are read from a config that states no scales at all - the route whose defaults were never in question - rather than from a literal table, so the tests grade the agreement between the two routes.

Pre-fix, the headline reports:

```
a config that states ang_vel_scale and dof_pos_scale but leaves dof_vel_scale to
its documented default 0.05 scaled the joint velocity block by 20x what the same
scales state explicitly: [2. 2. 2.] vs [0.1 0.1 0.1]
```

and the root-cause test - parametrized over all 8 subsets of "which scales did this config state" - fails on the 6 partial ones, e.g.

```
stating ['ang_vel', 'dof_pos'] changed the effective scale of the unnamed
['dof_vel']: {'dof_vel': 1.0} instead of the documented [0.05]
```

The 10 that pass on both trees are the boundaries the fill must not cross: a stated scale is never replaced (flat and nested routes), an explicit map still wins over the flat key it overlaps, a config stating no scales still gets the upstream defaults, a scale the domain refuses is **still refused** (so completion cannot smuggle an unusable stated value past validation), and an unknown key survives.

## Verification

Measured at `404d924c`. Blast radius - the 48 test files referencing `obs_scales` / `WBCConfig` / the frame builders / `wbc`, plus `tests/policies/wbc/` and the repo-wide docstring, unicode, ASCII-log, args-docstring, dependency-audit and changelog guards:

- this branch: **1799 passed, 0 failed**, 1 skipped
- `upstream/main` with the new test file copied in: **1789 passed, 10 failed**, 1 skipped

`1789 + 10 == 1799` and both collected 1800, the 10 base failures are exactly the new file's pre-fix failures, and there are no branch-only failures.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` reports the same 19 pre-existing errors on both trees and none in the touched files.
