### PR TITLE
fix(training/rl): honor the documented eval-mode freeze in EmpiricalNormalization.update

### DIFF
--- a/changelog.d/2426-rl-normalizer-eval-mode-freeze.md
+++ b/changelog.d/2426-rl-normalizer-eval-mode-freeze.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **training/rl**: `EmpiricalNormalization.update()` is now a no-op in eval mode, so the documented eval-mode freeze holds for a direct `update()` call and not only for `forward(update=True)`. The running statistics are persistent buffers, so a batch folded in after `eval()` was written into the next checkpoint and changed how an exported policy whitened every observation, with nothing raised and nothing logged. Training-mode behavior, the `until` warmup freeze and the empty-batch no-op are unchanged.

--- a/docs/training/rl.md
+++ b/docs/training/rl.md
@@ -30,7 +30,7 @@ trainer = create_trainer("ppo")   # on-policy PPO, from-scratch RL
 | [`FastSacTrainer`](#fastsac) | Soft Actor-Critic (off-policy, replay buffer, twin Q critics, auto-tuned entropy). |
 | `SimpleReplayBuffer` | Off-policy transition store (fixed-capacity ring buffer). |
 | [`SimEnv`](#simenv) | Gym-style `reset -> step` adapter over a `SimEngine`. |
-| `EmpiricalNormalization` | Running observation normalizer (whitens inputs for stable training). |
+| `EmpiricalNormalization` | Running observation normalizer (whitens inputs for stable training). Statistics update only in training mode - `eval()` freezes them at both entry points (`forward` and `update`), so an exported policy whitens deterministically. |
 
 ## SimEnv
 

--- a/strands_robots/training/rl/normalization.py
+++ b/strands_robots/training/rl/normalization.py
@@ -22,9 +22,11 @@ from torch import nn
 class EmpiricalNormalization(nn.Module):
     """Normalize a tensor stream by its running (Welford) mean and std.
 
-    The running statistics update only while the module is in training mode and
-    ``update=True`` is passed to :meth:`forward`; in eval mode the learned
-    statistics are frozen, so an exported policy normalizes deterministically.
+    The running statistics update only while the module is in training mode:
+    :meth:`forward` additionally requires ``update=True``, and :meth:`update`
+    folds a batch whenever the module is training. In eval mode the learned
+    statistics are frozen at BOTH entry points, so an exported policy
+    normalizes deterministically.
 
     Args:
         shape: Per-feature shape of the observation (e.g. ``(num_obs,)``).
@@ -88,7 +90,17 @@ class EmpiricalNormalization(nn.Module):
 
     @torch.no_grad()
     def update(self, x: torch.Tensor) -> None:
-        """Fold a batch into the running mean/var (no-op once ``until`` reached)."""
+        """Fold a batch into the running mean/var.
+
+        A no-op in eval mode, and once ``until`` samples have been seen. The
+        mode check lives here rather than only in :meth:`forward` so the
+        documented eval-mode freeze holds for a direct ``update`` call too:
+        the statistics are persistent buffers, so folding a batch after
+        ``eval()`` would be written into the next checkpoint and change how an
+        exported policy whitens every observation.
+        """
+        if not self.training:
+            return
         if self.until is not None and int(self.count) >= self.until:
             return
         count_x = x.shape[0]

--- a/tests/training/test_rl_normalization.py
+++ b/tests/training/test_rl_normalization.py
@@ -1,10 +1,18 @@
 """Behavior contracts for the RL observation normalizer.
 
 ``EmpiricalNormalization`` (strands_robots.training.rl.normalization) documents
-three behaviors beyond the running-statistics happy path that RL trainers rely
+four behaviors beyond the running-statistics happy path that RL trainers rely
 on: scale-only whitening (``center=False``), a warmup freeze after ``until``
-samples, and an empty-batch no-op. Each is a small branch that is easy to break
-silently, so pin them directly.
+samples, an empty-batch no-op, and the eval-mode freeze. Each is a small branch
+that is easy to break silently, so pin them directly.
+
+The eval-mode freeze has TWO entry points - ``forward`` and the public
+``update`` - and the class documents the freeze for both. That matters because
+the statistics are persistent buffers: a batch folded in after ``eval()`` is
+written into the next checkpoint and changes how an exported policy whitens
+every observation, with nothing raised and nothing logged. ``BaseRLAlgo.evaluate``
+relies on the freeze (it flips the normalizer to ``eval()`` around a scoring
+rollout and restores the prior mode afterwards), so the round trip is pinned too.
 
 The convergence / eval-freeze happy path is covered separately in
 ``test_rl_ppo.py``; this module targets the contract edges. Imports are deferred
@@ -78,3 +86,105 @@ def test_empty_batch_update_is_noop() -> None:
 
     assert int(norm.count) == count_before
     assert torch.allclose(norm.mean, mean_before)
+
+
+@pytest.mark.parametrize("route", ["forward", "update"])
+def test_eval_mode_freezes_the_statistics_through_either_entry_point(route: str) -> None:
+    """Neither entry point may move the running statistics in eval mode.
+
+    The class documents the freeze without qualifying which call reaches it, so
+    ``forward`` and the public ``update`` have to agree. A batch folded in after
+    ``eval()`` lands in the persistent buffers and therefore in the next
+    checkpoint, so a route that ignores the mode silently changes what a
+    deployed policy computes.
+    """
+    from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+    norm = EmpiricalNormalization(3, device="cpu")
+    norm.train()
+    norm(torch.tensor([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]]))
+
+    norm.eval()
+    frozen_count = int(norm.count)
+    frozen_mean = norm.mean.clone()
+    frozen_std = norm.std.clone()
+
+    swing = torch.full((8, 3), 100.0)  # would move the mean hard if folded in
+    if route == "forward":
+        norm(swing)
+    else:
+        norm.update(swing)
+
+    assert int(norm.count) == frozen_count, (
+        f"{route}() in eval mode advanced the sample count {frozen_count} -> {int(norm.count)}"
+    )
+    assert torch.allclose(norm.mean, frozen_mean), (
+        f"{route}() in eval mode moved the running mean {frozen_mean.tolist()} -> {norm.mean.tolist()}"
+    )
+    assert torch.allclose(norm.std, frozen_std), (
+        f"{route}() in eval mode moved the running std {frozen_std.tolist()} -> {norm.std.tolist()}"
+    )
+
+
+def test_a_batch_folded_in_after_eval_does_not_reach_the_checkpoint() -> None:
+    """The statistics a checkpoint would carry must be untouched by an eval-mode fold.
+
+    ``PpoTrainer`` / ``FastSacTrainer`` persist the normalizer with
+    ``state_dict()`` and reload it in ``BaseRLAlgo.load_checkpoint``, so any
+    buffer that shifts after ``eval()`` is what the next exported policy
+    whitens with.
+    """
+    from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+    norm = EmpiricalNormalization(3, device="cpu")
+    norm.train()
+    norm(torch.tensor([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]]))
+    saved = {k: v.clone() for k, v in norm.state_dict().items()}
+
+    norm.eval()
+    norm.update(torch.full((8, 3), 100.0))
+
+    drifted = sorted(k for k, v in norm.state_dict().items() if not torch.allclose(v.float(), saved[k].float()))
+    assert drifted == [], f"buffers a checkpoint would carry drifted after eval(): {drifted}"
+
+
+def test_update_still_folds_the_batch_in_training_mode() -> None:
+    """The freeze must be mode-scoped, not a blanket disabling of ``update``.
+
+    Direct ``update`` calls are how a caller folds a batch without whitening it
+    (``test_empty_batch_update_is_noop`` uses that route), so training-mode
+    behavior has to be unchanged.
+    """
+    from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+    norm = EmpiricalNormalization(2, device="cpu")
+    norm.train()
+
+    norm.update(torch.tensor([[2.0, 6.0], [4.0, 10.0]]))
+
+    assert int(norm.count) == 2
+    assert torch.allclose(norm.mean, torch.tensor([3.0, 8.0]))
+
+
+def test_restoring_training_mode_resumes_updating() -> None:
+    """A train -> eval -> train round trip must leave ``update`` working.
+
+    ``BaseRLAlgo.evaluate`` flips the normalizer to ``eval()`` for a scoring
+    rollout and restores the previous mode afterwards, so the freeze must be
+    read from the live mode rather than latched on first use.
+    """
+    from strands_robots.training.rl.normalization import EmpiricalNormalization
+
+    norm = EmpiricalNormalization(1, device="cpu")
+    norm.train()
+    norm.update(torch.zeros(2, 1))
+
+    norm.eval()
+    norm.update(torch.full((4, 1), 50.0))  # frozen: ignored
+    count_after_eval = int(norm.count)
+
+    norm.train()
+    norm.update(torch.full((3, 1), 50.0))  # training again: folded in
+
+    assert count_after_eval == 2
+    assert int(norm.count) == 5


### PR DESCRIPTION
## Problem

`EmpiricalNormalization` documents that its running statistics are frozen in eval
mode, "so an exported policy normalizes deterministically". That freeze has two
entry points and only one of them honored it:

| route | eval-mode fold | result |
|---|---|---|
| `forward(x, update=True)` | gated on `self.training` | frozen |
| `update(x)` (public) | ungated | **folds the batch** |

Measured on a normalizer trained to `count=2`, `mean=[2, 3, 4]`, then flipped to
`eval()` and handed an 8-row batch of `100.0`:

```
forward()  count 2 -> 2    mean [2.0, 3.0, 4.0] -> [2.0, 3.0, 4.0]     frozen
update()   count 2 -> 10   mean [2.0, 3.0, 4.0] -> [80.4, 80.6, 80.8]  NOT frozen
```

Nothing is raised and nothing is logged.

## Why it is not confined to the current step

`_mean`, `_var`, `_std` and `count` are registered buffers, so they are part of
`state_dict()`. `PpoTrainer` / `FastSacTrainer` persist the normalizer with
`state_dict()` and `BaseRLAlgo.load_checkpoint` reads it back, so a batch folded
in after `eval()` becomes the statistics the next checkpoint carries and the
whitening an exported policy applies to every observation. The same observation
whitened to `-0.990` before the fold and `-2.025` after it.

`BaseRLAlgo.evaluate` is the in-repo code that flips the normalizer to `eval()`
around a scoring rollout and restores the prior mode afterwards. Its docstring
promises it "never updates the policy, the normalizers, or the replay buffer ...
with ... observation normalization frozen, so the numbers it returns are exactly
what a deployed `policy.pt` would produce", and it currently gets that from a
second, independent mechanism (`update=False`) rather than from the mode.

## Fix

`update` returns early when the module is not training - the first thing the
rsl_rl implementation this was ported from does in its own `update`:

```python
if not self.training:
    return
if self.until is not None and int(self.count) >= self.until:
    return
```

`forward` already gates on the mode, so it never reaches the new branch and
every existing call site is byte-for-byte unaffected. Training-mode folds, the
`until` warmup freeze and the empty-batch no-op are unchanged. The class and
`update` docstrings now state which calls the freeze covers, and the
`docs/training/rl.md` component row says so too.

## Measurement on a real observation stream

One script, run once per tree, driving the `evaluate`-shaped sequence over a
so101 MuJoCo rollout (D=12: 6 joint positions + 6 velocities): train on 60
observations, snapshot `state_dict()`, `eval()`, fold 40 scoring-rollout
observations, restore the mode, read `state_dict()` again.

| | sample count | buffers that drifted | action delta of a fixed deterministic actor |
|---|---|---|---|
| before | 60 -> 100 | `_mean`, `_std`, `_var`, `count` | **0.1968** max-abs |
| after | 60 -> 60 | none | **0.0000** |

The action column feeds the same fixed actor the same observation, whitened by
each tree's next-checkpoint statistics; 0.1968 is ~10% of full scale on a
tanh-bounded action space.

![EmpiricalNormalization eval-mode freeze](https://raw.githubusercontent.com/cagataycali/robots/media-rl-normalizer-eval-freeze/normalizer_eval_freeze.png)

## Tests

Extended `tests/training/test_rl_normalization.py`, which already targets this
class's contract edges. Against `upstream/main`: **3 failed / 5 passed**; after
the fix **8 passed**.

Failing pre-fix:

- `test_eval_mode_freezes_the_statistics_through_either_entry_point[update]` - *"update() in eval mode advanced the sample count 2 -> 10"*
- `test_a_batch_folded_in_after_eval_does_not_reach_the_checkpoint` - *"buffers a checkpoint would carry drifted after eval(): ['_mean', '_std', '_var', 'count']"*
- `test_restoring_training_mode_resumes_updating` - `assert 6 == 2`

Passing on both trees, as the bounds on the change:

- the same test parametrized over `[forward]` - the route that was already correct, so a fix that reached further would fail here
- `test_update_still_folds_the_batch_in_training_mode` - fails if `update` is disabled outright rather than mode-scoped
- the three pre-existing edges (`center=False`, `until`, empty batch)

## Verification

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 19 pre-existing errors, identical set on this branch and on `upstream/main`, none in the changed files.
- 63 test files covering `training/rl`, every test referencing the normalizer, and the repo-wide docstring / string / changelog guards - run on this branch and on `upstream/main` (3146 collected, 5:01 each): **branch 3132 passed / 8 failed, base 3129 passed / 11 failed**. Branch-only failures: none. Base-only: exactly the 3 pre-fix failures above. The 8 shared failures are pre-existing on both trees (5 long-running `tests_integ` RL convergence tests, plus 3 that need `draccus>=0.11.6`).
