### PR TITLE
test(docs): grade docstring cross-references in every tree, with one member rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1356,6 +1356,7 @@ Corrections from code review that apply to all future contributions:
 - **`robot.py` is for the `Robot()` factory**, the user-facing entry point. Hardware-specific code lives in `hardware_robot.py`. Don't have two files both named "robot something" with different responsibilities.
 - **Reference module names, not filenames, in docstrings** - `strands_robots.hardware_robot` not `robot.py`. Filenames change; module paths are the public contract.
 - **Keep a cross-reference target on one line** - a `:class:`/`:func:`/`:meth:` path is only a dotted path while it is contiguous. Wrapping `:class:`~strands_robots.policies.protomotions.motion_utils.MotionPlayer`` over a line break leaves a token carrying a newline and the next line's indentation, which imports nowhere. Break the prose before the role and give the path its own line.
+- **A cross-reference in a test docstring is graded too** - the roles in `tests/` and `tests_integ/` are checked against the real API alongside the package's, because a test module's docstring is where a maintainer working on that subsystem starts reading. Name the seam a fixture actually patches (`strands_robots.mesh.core.get_session`), not a local import alias dressed up as a module path.
 
 ### Unicode & String Hygiene
 - **No emojis in user-facing strings** - this is a project rule. Tool result dicts (`{"content": [{"text": ...}]}`), log messages, error messages: plain ASCII only. Agents read these strings programmatically; emojis just add tokenizer noise.

--- a/changelog.d/2427-xref-guard-scope-and-member-rule.md
+++ b/changelog.d/2427-xref-guard-scope-and-member-rule.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tests**: the docstring cross-reference guard now grades `tests/` and `tests_integ/` alongside the shipped package, and resolves a qualified target's members with the same permissive rule the short-form half already used. Two test-module docstrings cited `strands_robots.mesh_session.get_session`, a module that was folded into the `mesh` package; they now name the seam their fixtures patch.

--- a/tests/mesh/test_mesh.py
+++ b/tests/mesh/test_mesh.py
@@ -2,7 +2,7 @@
 
 All tests are 100% mocked.  No ``eclipse-zenoh`` install required: a
 ``MagicMock`` session is injected in place of the real Zenoh session by
-patching :func:`strands_robots.mesh_session.get_session`.
+patching :func:`strands_robots.mesh.core.get_session`.
 """
 
 from __future__ import annotations

--- a/tests/mesh/test_mesh_rpc.py
+++ b/tests/mesh/test_mesh_rpc.py
@@ -2,7 +2,8 @@
 
 All tests are 100% mocked.  No ``eclipse-zenoh`` install required: a
 ``MagicMock`` session is injected in place of the real Zenoh session by
-patching :func:`strands_robots.mesh_session.get_session`.
+patching :func:`strands_robots.mesh.session.get_session` and the reference
+:mod:`strands_robots.mesh.core` imported it under.
 """
 
 from __future__ import annotations

--- a/tests/test_docstring_xref_roles_resolve.py
+++ b/tests/test_docstring_xref_roles_resolve.py
@@ -1,6 +1,6 @@
 """Guard: fully-qualified ``strands_robots`` Sphinx cross-references must resolve.
 
-A docstring role such as :func:`~strands_robots.simulation.predicates.base_below_z`
+A docstring role naming ``strands_robots.simulation.predicates.base_below_z``
 promises the reader an importable API object at that exact dotted path. When the
 path is wrong - a private implementation renamed public, a symbol moved or split,
 or, as happened here, a *registered predicate name* dressed up as an importable
@@ -14,6 +14,13 @@ The sibling filename guards (for example
 form - the ``:mod:`` / ``:class:`` / ``:func:`` / ``:meth:`` roles that name a
 dotted API path - by verifying that every fully-qualified ``strands_robots.*``
 target actually resolves to a real module or attribute.
+
+Every tree a reader reads is graded: the shipped package, ``tests/`` and
+``tests_integ/``. A role is a pointer a human follows, and the roles in a test
+module's docstring are the first thing a maintainer working on that subsystem
+reads. Scoping the scan to the package left the test trees' several hundred
+qualified targets ungraded, and a module that had been folded into a package
+went on being cited at its old top-level path long after it stopped existing.
 
 A target only counts as named if it is a CONTIGUOUS dotted path. A role whose
 path is long enough to wrap over a line break carries a newline plus the next
@@ -41,6 +48,11 @@ about what counts as *evidence* means this guard can only ever under-report; a
 class-level ``hasattr`` alone reads a dataclass field with no default, and an
 attribute only ever assigned in ``__init__``, as missing.
 
+Both spellings resolve a member through that one rule. A qualified target and a
+short-form target that name the SAME member have to get the same verdict, or the
+guard reports a dead pointer for an attribute that exists and the remedy is to
+delete a correct cross-reference.
+
 Still out of scope, because these have no decidable target here: a bare
 unqualified role (``:func:`reset```), a short-form role whose head names nothing
 the package defines, and roles into third-party packages - all of which resolve
@@ -58,9 +70,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 import strands_robots
 
 _PKG_ROOT = Path(strands_robots.__file__).resolve().parent
+_REPO_ROOT = _PKG_ROOT.parent
 
 # Sphinx cross-reference roles naming a dotted Python target, optionally with a
 # leading ``~`` (display-shortening) tilde. Whitespace is admitted INSIDE the
@@ -74,7 +89,11 @@ def _resolves(target: str) -> bool:
     """True if ``target`` names a real ``strands_robots`` module or attribute.
 
     Imports the longest importable module prefix, then walks the remaining
-    dotted components as attributes (so ``pkg.mod.Class.method`` resolves).
+    dotted components as members (so ``pkg.mod.Class.method`` resolves), using
+    the same :func:`_has_member` rule the short-form half applies. A bare
+    ``hasattr`` walk here would report a dataclass field with no class-level
+    default, and an attribute only ever assigned in ``__init__``, as a dead
+    pointer - while the identical member cited in the short form resolved.
     """
     parts = target.split(".")
     module = None
@@ -90,9 +109,9 @@ def _resolves(target: str) -> bool:
         return False
     obj = module
     for attr in parts[consumed:]:
-        if not hasattr(obj, attr):
+        if not _has_member(obj, attr):
             return False
-        obj = getattr(obj, attr)
+        obj = getattr(obj, attr, obj)
     return True
 
 
@@ -131,12 +150,29 @@ def _offending_roles_in(doc: str) -> list[str]:
     return offenders
 
 
-def _unresolved_xref_roles() -> dict[str, list[str]]:
-    """Map ``relpath::qualname`` -> list of unfollowable ``strands_robots.*`` roles."""
-    offenders: dict[str, list[str]] = {}
-    for source_file in sorted(_PKG_ROOT.rglob("*.py")):
-        if "__pycache__" in source_file.parts:
+def _graded_source_files() -> list[Path]:
+    """Every Python file whose docstrings carry pointers a reader follows.
+
+    The shipped package plus both test trees. A missing tree is skipped rather
+    than assumed, so the sweep still runs in a checkout that ships only one.
+    """
+    files: list[Path] = []
+    for root in (_PKG_ROOT, _REPO_ROOT / "tests", _REPO_ROOT / "tests_integ"):
+        if not root.is_dir():
             continue
+        files.extend(f for f in sorted(root.rglob("*.py")) if "__pycache__" not in f.parts)
+    return files
+
+
+def _unresolved_xref_roles() -> tuple[dict[str, list[str]], int]:
+    """Report unfollowable qualified roles, plus how many were graded at all.
+
+    Returns:
+        ``({relpath::qualname: [offending target, ...]}, graded_count)``.
+    """
+    offenders: dict[str, list[str]] = {}
+    graded = 0
+    for source_file in _graded_source_files():
         tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
@@ -144,16 +180,27 @@ def _unresolved_xref_roles() -> dict[str, list[str]]:
             doc = ast.get_docstring(node, clean=False)
             if not doc:
                 continue
+            graded += sum(1 for t in _ROLE_RE.findall(doc) if "".join(t.split()).startswith("strands_robots."))
             bad = _offending_roles_in(doc)
             if bad:
                 qualname = getattr(node, "name", "<module>")
-                rel = source_file.relative_to(_PKG_ROOT)
+                rel = source_file.relative_to(_REPO_ROOT)
                 offenders[f"{rel}::{qualname}"] = bad
-    return offenders
+    return offenders, graded
+
+
+# The qualified spelling carries several hundred targets across the package and
+# both test trees, so a sweep that grades only a handful has stopped reaching
+# them - a reformat or a scope change must fail loudly here rather than report a
+# clean tree it never inspected.
+_MINIMUM_GRADED_QUALIFIED_ROLES = 600
 
 
 def test_qualified_strands_robots_xref_roles_resolve() -> None:
-    offenders = _unresolved_xref_roles()
+    offenders, graded = _unresolved_xref_roles()
+    assert graded >= _MINIMUM_GRADED_QUALIFIED_ROLES, (
+        f"only {graded} qualified roles were graded; a clean result would prove nothing"
+    )
     assert not offenders, (
         "docstring cross-reference roles must name a real importable object. "
         "Cite a registered predicate/backend by its literal name (``base_below_z``) "
@@ -443,3 +490,52 @@ def test_an_ambiguous_or_unknown_head_is_out_of_scope() -> None:
     assert _short_form_resolves(module, {}, "SomeThirdPartyThing.method") is None
     assert _short_form_resolves(module, {"Shared": {First, Second}}, "Shared.method") is None
     assert _short_form_resolves(module, {}, "reset") is None, "a bare name has no decidable target"
+
+
+def test_the_sweep_reaches_the_test_trees() -> None:
+    """Non-vacuity: the scan must actually open files outside the package.
+
+    A role is a pointer a reader follows, and a test module's docstring is where
+    a maintainer starts. A sweep that silently covered only the package would
+    report a clean tree while the majority of docstrings went unread.
+    """
+    scanned = {str(f.relative_to(_REPO_ROOT)).split("/", 1)[0] for f in _graded_source_files()}
+
+    assert {"strands_robots", "tests"} <= scanned, f"graded trees: {sorted(scanned)}"
+
+
+@pytest.mark.parametrize(
+    ("qualified", "short_form"),
+    [
+        # An attribute that exists only because __init__ assigns it.
+        ("strands_robots.inference.server.PolicyServer.port", "PolicyServer.port"),
+        ("strands_robots.rendering.HybridCompositor.default_width", "HybridCompositor.default_width"),
+    ],
+)
+def test_both_spellings_agree_that_a_member_is_a_member(qualified: str, short_form: str) -> None:
+    """The same member must resolve whichever way a role names it.
+
+    Two resolvers grading one concept is how a guard starts contradicting
+    itself: the short form accepted ``self``-assigned attributes while the
+    qualified form, walking with a bare ``hasattr``, called the identical
+    member a dead pointer. The only remedy such a report offers is deleting a
+    cross-reference that was correct.
+    """
+    head, member = qualified.rsplit(".", 1)
+    module = importlib.import_module(head.rsplit(".", 1)[0])
+    owner = getattr(module, head.rsplit(".", 1)[1])
+
+    assert not hasattr(owner, member), "premise: no class-level attribute exists"
+    assert _short_form_resolves(module, {}, short_form) is True, "premise: the short form resolves it"
+    assert _resolves(qualified), f"the qualified spelling of {short_form} must resolve too"
+
+
+def test_a_qualified_target_that_names_nothing_is_still_reported() -> None:
+    """Control: sharing the permissive member rule must not blunt the guard.
+
+    ``_has_member`` widens what counts as evidence, not what counts as a claim,
+    so a path naming no object at all stays an offender.
+    """
+    assert not _resolves(_BOGUS)
+    assert _offending_roles_in(f"See :func:`~{_BOGUS}`.") == [_BOGUS]
+    assert not _resolves("strands_robots.simulation.base.SimEngine.no_such_method")


### PR DESCRIPTION
## Problem

`tests/test_docstring_xref_roles_resolve.py` grades every fully-qualified
`strands_robots.*` Sphinx role against the real API, because such a role
"promises the reader an importable API object at that exact dotted path". It
scanned `strands_robots/` only.

The test trees carry a comparable population of the same promise, and two
pointers there had already rotted:

```
tests/mesh/test_mesh.py::<module>     -> strands_robots.mesh_session.get_session
tests/mesh/test_mesh_rpc.py::<module> -> strands_robots.mesh_session.get_session
```

`strands_robots/mesh_session.py` existed once and was folded into the `mesh`
package; there is no such module today. Both docstrings describe how the suite
injects a `MagicMock` Zenoh session, so this is the first pointer a maintainer
working on mesh sessions follows - and it is also the wrong seam. The fixtures
patch the name the *importing* module holds:

```python
# tests/mesh/test_mesh.py
with patch("strands_robots.mesh.core.get_session", return_value=fake_session):
# tests/mesh/test_mesh_rpc.py
patch.object(mesh_session, "get_session", ...)   # mesh_session = strands_robots.mesh.session
patch.object(mesh_core,    "get_session", ...)   # mesh_core    = strands_robots.mesh.core
```

`mesh_session` is a local import alias, which is where the bogus module path
came from.

## Widening the scan alone would have reported false positives

The guard already resolves a member permissively for short-form roles
(`_has_member`: an attribute, a dataclass field, an annotated class attribute
anywhere in the MRO, a `__slots__` entry, or a name the class assigns to
`self`). The qualified resolver walked members with a bare `hasattr`, so the
same member got opposite verdicts depending on which spelling a role used:

| target | qualified `_resolves` | short-form `_short_form_resolves` |
|---|---|---|
| `strands_robots.inference.server.PolicyServer.port` | `False` | `True` |
| `strands_robots.rendering.HybridCompositor.default_width` | `False` | `True` |
| `strands_robots.simulation.base.SimEngine.get_observation` | `True` | `True` |
| `strands_robots.simulation.predicates.base_below_z` | `False` | `False` |

Both disagreeing members exist; each is assigned in `__init__`. Widening the
scope with the old resolver reports them as dead pointers, and the only remedy
such a report offers is deleting a cross-reference that was correct:

```
graded=1173  offenders=2
   tests/_daemon_executor.py::<module> -> ['strands_robots.hardware_robot.Robot._executor']
   tests/policies/vera/test_vera_render_width_domain.py::<module>
       -> ['strands_robots.rendering.HybridCompositor.default_width']
```

So the shared member rule is a prerequisite for the widening, not a separate
cleanup. The package happens to contain no such citation today, which is why
nothing surfaced it.

## Change

- `_resolves` walks members through `_has_member`, the rule the short-form half
  already applied. One concept, one rule.
- The scan covers `strands_robots/`, `tests/` and `tests_integ/` (a missing tree
  is skipped, not assumed). Offender keys are repo-relative.
- The sweep reports how many targets it graded, with a floor, matching the
  sibling `_MINIMUM_GRADED_SHORT_FORM_ROLES` so a scan that stops reaching
  docstrings fails loudly instead of reporting a clean tree.
- The two docstrings now name the seams their fixtures patch.
- The module's own illustrative dead path is written as a literal rather than a
  role, so this guard is graded by itself instead of needing an exemption from
  it.

After: **1173 qualified targets graded across 1340 files** (220 package, 1072
`tests/`, 48 `tests_integ/`), 0 offenders.

## Tests

Pre-fix, with only the guard file taken from this branch so the two source
docstrings are still the ones on `main`:

```
tests/test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve FAILED
  Offending docstrings: {'tests/mesh/test_mesh.py::<module>': ['strands_robots.mesh_session.get_session'],
                         'tests/mesh/test_mesh_rpc.py::<module>': ['strands_robots.mesh_session.get_session']}
1 failed, 16 passed
```

Post-fix: 17 passed.

New cases:

- `test_both_spellings_agree_that_a_member_is_a_member` - parametrized over two
  `__init__`-assigned attributes, with premises asserting no class-level
  attribute exists and that the short form does resolve it. This is the
  root-cause pin; it fails on `main`'s resolver for both cases.
- `test_the_sweep_reaches_the_test_trees` - non-vacuity for the scope, so a
  revert to package-only cannot pass silently.
- `test_a_qualified_target_that_names_nothing_is_still_reported` - control:
  `_has_member` widens what counts as *evidence*, not what counts as a *claim*,
  so a path naming no object stays an offender. Passes on both trees.

## Verification

Measured at `f524d58e`. Blast radius is the 155 test files that read `AGENTS.md`,
walk a source tree, or inspect docstrings/changelog fragments, plus the two
edited mesh modules:

| | failed | passed | skipped |
|---|---|---|---|
| this branch | 9 | 6471 | 53 |
| `upstream/main` | 9 | 6467 | 53 |

Identical failing-ID sets (branch-only and base-only both empty); `6471 - 6467`
is exactly the 4 new test items. The 9 shared failures are pre-existing: 8 are
`ModuleNotFoundError: No module named 'awsiot'`, 1 is an unrelated
`_safety_publishers_lock` `AttributeError`.

`ruff check` / `ruff format --check` clean over `strands_robots tests
tests_integ`; `mypy` 19 pre-existing errors on both trees with an empty
branch-only diff.

No visual artifact: this changes a test guard, three docstrings and one
convention line, with no policy, simulation, rendering, recording or asset
behavior touched.
