### PR TITLE
fix(simulation/isaac): measure the preview cadence and reported recording duration on a clock that cannot step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1330,7 +1330,13 @@ Corrections from code review that apply to all future contributions:
   rendering pacers - the MJPEG stream generator and the multi-camera recorder thread - are
   pinned on the same achieved-interval basis by
   `tests/simulation/test_rendering_pacers_survive_a_clock_step.py`, along with the duration
-  each recording reports.
+  each recording reports. The Isaac backend's own two - the idle gate that decides when
+  `run_pump_forever` refreshes the live preview, and the duration its camera recording
+  reports - are pinned by
+  `tests/simulation/isaac/test_isaac_durations_survive_a_clock_step.py`, which asserts the
+  achieved refresh timeline against the unstepped one rather than a tolerance. A duration
+  base also carries its clock in its name (`started_mono`, `last_idle_render_mono`), so a
+  later reader cannot mistake it for a stamp and subtract `time.time()` from it.
 
 ### Module-Level Side Effects
 - **If you must run code at import time, comment WHY it can't be lazy.** `MUJOCO_GL` is the canonical example: MuJoCo locks the GL backend at first `import mujoco`, so the env var must be set before any downstream import chain triggers it.

--- a/changelog.d/2432-isaac-durations-monotonic-clock.md
+++ b/changelog.d/2432-isaac-durations-monotonic-clock.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **simulation/isaac**: measure the live preview's refresh cadence and the duration a camera
+  recording reports on `time.monotonic()` instead of `time.time()`. Both subtracted two
+  readings of a wall clock, so a step landing between them changed the answer: a backward
+  step of 2 s stopped `run_pump_forever` refreshing the preview for 1.55 s of a 1.95 s run
+  while it kept draining the app, and a 3.0 s capture reported `after 33.0s`, `after 1.0s`
+  or `after 3603.0s`. The recording state's duration base is now spelled `started_mono`, the
+  name the MuJoCo backend's two recorders already carry.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -4966,7 +4966,10 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 "paths": paths,
                 "errors": dict.fromkeys(names, 0),
                 "output_dir": out_dir,
-                "started_at": _time.time(),
+                # A ``time.monotonic()`` reading: the only thing derived from
+                # this base is how long the recording has been running, so it
+                # is a duration base and carries its clock in its name.
+                "started_mono": _time.monotonic(),
                 "max_frames": max_frames_per_camera,
             }
             self._cams_rec_state = state
@@ -5050,7 +5053,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
 
         from strands_robots.rendering.video import encode_clip
 
-        elapsed = _time.time() - state["started_at"]
+        elapsed = _time.monotonic() - state["started_mono"]
         lines = [
             f"Stopped '{state['name']}' after {elapsed:.1f}s",
             f"   output_dir: {state['output_dir']}",
@@ -5745,7 +5748,12 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         ``is_set()`` returning truthy ends the loop. ``None`` (default)
         loops until ``KeyboardInterrupt``.
         """
-        last_idle_render = 0.0
+        # ``None`` until the first idle refresh, rather than a sentinel that
+        # only reads as "long ago" because a wall clock's epoch is large: on
+        # ``time.monotonic()`` the epoch is unspecified (seconds since boot on
+        # Linux), so a numeric sentinel would suppress the first preview refresh
+        # for the first ``_idle_render_period`` seconds of uptime.
+        last_idle_render_mono: float | None = None
         self._pump_running = True
         try:
             while stop_event is None or not stop_event.is_set():
@@ -5760,17 +5768,25 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                     job = None
                 if job is not None:
                     job()
-                    last_idle_render = 0.0
+                    last_idle_render_mono = None
                     continue
                 busy = not self._action_q.empty()
                 if busy:
                     self.pump(render=False)
                     continue
-                now = time.time()
-                do_render = (now - last_idle_render) >= self._idle_render_period
+                # ``time.monotonic()``: the comparison below decides whether
+                # the live preview is refreshed on this iteration, so this is a
+                # duration base. On ``time.time()`` a wall-clock step landing
+                # between two iterations changed that decision - backward by S
+                # the preview stopped refreshing for S while ``pump()`` kept
+                # draining the app, forward the gate fired once early.
+                now_mono = time.monotonic()
+                do_render = (
+                    last_idle_render_mono is None or (now_mono - last_idle_render_mono) >= self._idle_render_period
+                )
                 self.pump(render=do_render)
                 if do_render:
-                    last_idle_render = now
+                    last_idle_render_mono = now_mono
                 time.sleep(0.05)
         finally:
             self._pump_running = False

--- a/tests/simulation/isaac/test_cameras_recording_preflight_guards.py
+++ b/tests/simulation/isaac/test_cameras_recording_preflight_guards.py
@@ -144,7 +144,7 @@ def test_stop_cameras_recording_reports_a_refused_rate_instead_of_raising(tmp_pa
         "paths": {"front": path},
         "errors": {"front": 0},
         "output_dir": str(tmp_path),
-        "started_at": 0.0,
+        "started_mono": 0.0,
         "max_frames": 3000,
     }
 

--- a/tests/simulation/isaac/test_isaac_durations_survive_a_clock_step.py
+++ b/tests/simulation/isaac/test_isaac_durations_survive_a_clock_step.py
@@ -1,0 +1,408 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Isaac's preview cadence and reported recording duration survive a clock step.
+
+Two durations in the Isaac backend were measured by subtracting two readings of
+``time.time()``, which is not a clock but the current opinion about the date - an
+NTP correction, a ``date -s``, a resume from suspend moves it by an arbitrary
+amount - so a step landing between the readings changed the answer:
+
+**The idle-render gate** in :meth:`IsaacSimulation.run_pump_forever` decides,
+once per iteration, whether to refresh the live preview. Driving the real loop at
+a 0.2 s period through a clock double that steps once, with the loop's own
+``sleep(0.05)`` setting the granularity:
+
+    clock event              refreshes   gaps (s)   last refresh
+    no step (control)               10   0.20       t = 1.80
+    wall clock steps +30s           11   0.15, 0.20 t = 1.95
+    wall clock steps -2s             3   0.20       t = 0.40
+    wall clock steps +1h            11   0.15, 0.20 t = 1.95
+
+Backward is the damaging direction: the preview stopped refreshing for the size
+of the step - 1.55 s of that 1.95 s run - while ``pump()`` kept draining the app,
+so the viewport sat frozen on a stale frame and nothing said so. Forward fired
+the gate once early and then re-based onto the stepped clock, so it cost one
+spurious refresh rather than a run of them. Fixed, all four cases produce the
+control's timeline exactly: 10 refreshes, 0.20 s apart, the last at t = 1.80.
+
+**The recording duration** ``stop_cameras_recording`` reports came from the same
+clock as the base ``start_cameras_recording`` stamped, so a step anywhere in the
+recording corrupted it. A 3.0 s capture reported ``after 33.0s``, ``after 1.0s``
+and ``after 3603.0s`` for the same three steps.
+
+The MuJoCo backend's two recorders already hold this base on
+``time.monotonic()`` under the name ``started_mono``, and
+``test_rendering_pacers_survive_a_clock_step.py`` pins that they carry no
+``started_at`` key because "a duration base named as a wall-clock stamp invites
+the next reader to subtract ``time.time()`` from it" - which is what Isaac's
+third recorder did. These tests extend that contract to it.
+
+This is the boundary the library settled for its agent-callable tools (#2404),
+its hardware control loops (#2406), its mesh (#2408), its sim rollouts (#2413)
+and its rendering pacers (#2425), and the rule AGENTS.md states as "a duration is
+measured, a stamp is recorded", which names a frame pacer explicitly.
+
+Every assertion is on the *achieved* refresh timeline or the *reported* duration
+rather than on which clock is called, so none of them can be satisfied by
+renaming a call. The clock double counts reads of either clock, so the step lands
+at the same loop position whichever clock the loop consults. No Isaac Sim Kit
+runtime, GL context or MP4 encoder is touched: the engine is the skeleton
+``__new__`` fixture shape ``test_cameras_recording_preflight_guards.py`` uses and
+``pump`` is faked on the instance.
+"""
+
+from __future__ import annotations
+
+import queue
+import sys
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.isaac import simulation as isaac_module
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _CameraState
+
+#: Idle-render period under test, and therefore the gap the gate must hold.
+IDLE_PERIOD = 0.2
+#: Idle iterations to run. Long enough that a backward step's suppression window
+#: closes inside the run, so the timeline shows the recovery too.
+PUMP_ITERATIONS = 40
+#: Loop position the wall-clock step lands at: one read per iteration either
+#: way, so this is the iteration index. Between the refresh due at 10 and at 15.
+PUMP_STEP_AT_READ = 12
+#: The loop's own idle sleep, and therefore the resolution the gate can hold the
+#: period to: it refreshes on the first iteration at or past the period.
+PUMP_GRANULARITY = 0.05
+#: Simulated recording length, in seconds, for the reported-duration tests.
+RECORDING_SECONDS = 3.0
+#: Wall-clock steps exercised. Forward and backward, and one large enough that
+#: the forward case has visibly saturated.
+STEPS = (30.0, -2.0, 3600.0)
+STEP_IDS = ["forward_30s", "backward_2s", "forward_1h"]
+
+
+class _SteppingClock:
+    """A ``time`` double whose wall clock steps once and whose monotonic does not.
+
+    ``time()`` and ``monotonic()`` share a read counter, so ``step_after_reads``
+    names a position in the loop rather than a particular clock: a loop reading
+    ``time()`` once per iteration and a loop reading ``monotonic()`` once per
+    iteration both take the step at the same iteration. That is what lets one
+    stimulus reach the pre-fix and post-fix loops identically.
+
+    Sleeps advance the virtual clock instead of blocking, so the achieved gap is
+    exact and the suite stays fast. ``apply``ing the step moves only the wall
+    clock, which is what an NTP correction does. Every other attribute delegates
+    to the real :mod:`time`, so a module that imports this double for
+    ``perf_counter`` or ``strftime`` is unaffected.
+    """
+
+    def __init__(self, wall_step: float, step_after_reads: int | None, *, start: float = 1_000_000.0) -> None:
+        self._virtual = start
+        self._wall_offset = 0.0
+        self._wall_step = wall_step
+        self._step_after_reads = step_after_reads
+        self.reads = 0
+        self.sleeps: list[float] = []
+        self.step_applied_at_read: int | None = None
+
+    def _read(self) -> None:
+        self.reads += 1
+        if self._step_after_reads is not None and self.reads == self._step_after_reads:
+            self._wall_offset += self._wall_step
+            self.step_applied_at_read = self.reads
+
+    def time(self) -> float:
+        self._read()
+        return self._virtual + self._wall_offset
+
+    def monotonic(self) -> float:
+        self._read()
+        return self._virtual
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        if seconds > 0:
+            self._virtual += seconds
+
+    def now(self) -> float:
+        """Read the virtual clock *without* counting it as a read.
+
+        The tests stamp each refresh to recover the achieved timeline, and that
+        stamp is the test's own instrumentation rather than something the loop
+        does. Counting it would shift ``step_after_reads`` off the loop position
+        it names.
+        """
+        return self._virtual
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(time, name)
+
+
+class _StopAfter:
+    """A ``threading.Event``-shaped stop flag that ends the loop after ``n`` checks."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self.checks = 0
+
+    def is_set(self) -> bool:
+        self.checks += 1
+        return self.checks > self.n
+
+
+def _pump_engine(period: float = IDLE_PERIOD) -> Any:
+    """Skeleton engine carrying only what ``run_pump_forever`` reads."""
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._idle_render_period = period
+    engine._main_jobs = queue.Queue()
+    engine._action_q = queue.Queue()
+    engine._pump_running = False
+    return engine
+
+
+def _refresh_timeline(
+    clock: _SteppingClock,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    period: float = IDLE_PERIOD,
+    iterations: int = PUMP_ITERATIONS,
+    queue_action: bool = False,
+    main_job: Any = None,
+) -> tuple[list[float], list[bool]]:
+    """Drive the real ``run_pump_forever`` and return when the preview refreshed.
+
+    Returns ``(refresh_times, render_flags)``: the virtual times at which
+    ``pump(render=True)`` was called, and every ``render`` flag the loop passed,
+    so a caller can assert on the refreshes *and* on the pumps that did not
+    refresh.
+    """
+    monkeypatch.setattr(isaac_module, "time", clock)
+    engine = _pump_engine(period)
+    if queue_action:
+        engine._action_q.put(object())
+    if main_job is not None:
+        engine._main_jobs.put(main_job)
+
+    refreshes: list[float] = []
+    flags: list[bool] = []
+
+    def pump(render: bool = False) -> None:
+        flags.append(bool(render))
+        if render:
+            refreshes.append(clock.now())
+
+    engine.pump = pump
+    IsaacSimulation.run_pump_forever(engine, stop_event=_StopAfter(iterations))
+    assert engine._pump_running is False, "the loop must clear its running flag on the way out"
+    return refreshes, flags
+
+
+def _gaps(times: list[float]) -> list[float]:
+    """Gaps between consecutive refreshes, rounded past float noise."""
+    return [round(b - a, 6) for a, b in zip(times, times[1:], strict=False)]
+
+
+# --------------------------------------------------------------------------- #
+# 1. The idle-render gate
+# --------------------------------------------------------------------------- #
+
+
+def test_idle_refresh_cadence_without_a_step_is_the_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control: with no step the gate holds one refresh per period.
+
+    Passes before and after the clock swap. It is what makes the stepped cases
+    below a statement about the step rather than about the loop's granularity,
+    and it fails if the gate is ever made unconditional.
+    """
+    refreshes, flags = _refresh_timeline(_SteppingClock(0.0, step_after_reads=None), monkeypatch)
+
+    gaps = _gaps(refreshes)
+    assert refreshes, "premise: the loop never refreshed the preview at all"
+    assert len(set(gaps)) == 1, f"the unstepped cadence must be uniform; achieved gaps {gaps}"
+    # The gate fires on the first iteration at or past the period, and the loop
+    # advances in 0.05s sleeps, so the achieved gap is the period rounded up to
+    # that granularity.
+    assert IDLE_PERIOD <= gaps[0] < IDLE_PERIOD + PUMP_GRANULARITY, (
+        f"the gate must refresh once per {IDLE_PERIOD}s period at the loop's "
+        f"{PUMP_GRANULARITY}s granularity; achieved gaps {gaps}"
+    )
+    assert len(flags) == PUMP_ITERATIONS, "every iteration pumps, refreshing or not"
+
+
+@pytest.mark.parametrize("wall_step", STEPS, ids=STEP_IDS)
+def test_idle_refresh_cadence_survives_a_wall_clock_step(wall_step: float, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wall-clock step must not change when the live preview is refreshed.
+
+    The step lands between the refresh due at iteration 10 and the one due at 15.
+    On ``time.time()`` a backward step of S suppressed every refresh for S -
+    ``pump()`` kept draining the app, so the viewport sat frozen on a stale frame
+    with nothing reporting it - while a forward step fired the gate once early.
+
+    Asserted against the unstepped timeline rather than against a tolerance, so
+    the contract is "a step changes nothing", which no rename can satisfy.
+    """
+    control, _ = _refresh_timeline(_SteppingClock(0.0, step_after_reads=None), monkeypatch)
+
+    clock = _SteppingClock(wall_step, step_after_reads=PUMP_STEP_AT_READ)
+    stepped, _ = _refresh_timeline(clock, monkeypatch)
+
+    assert clock.step_applied_at_read is not None, "premise: the step never reached the loop"
+    assert stepped == control, (
+        f"a {wall_step:+.0f}s wall-clock step moved the preview refreshes: "
+        f"{len(stepped)} refreshes at gaps {_gaps(stepped)} where the unstepped loop "
+        f"made {len(control)} at gaps {_gaps(control)}"
+    )
+
+
+def test_the_first_idle_iteration_refreshes_whatever_the_clock_epoch_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The preview comes up on the first idle iteration, not one period later.
+
+    ``time.monotonic()``'s reference point is unspecified - seconds since boot on
+    Linux - so a numeric "never refreshed" sentinel would suppress the first
+    refresh for the first ``_idle_render_period`` seconds of uptime. The sentinel
+    is therefore ``None``, which says what it means whatever the clock reads.
+    """
+    clock = _SteppingClock(0.0, step_after_reads=None, start=IDLE_PERIOD / 4)
+
+    refreshes, flags = _refresh_timeline(clock, monkeypatch, iterations=1)
+
+    assert flags == [True], (
+        f"the first idle iteration must refresh the preview even when the clock's "
+        f"epoch reads {IDLE_PERIOD / 4}s, below the {IDLE_PERIOD}s period; pumped {flags}"
+    )
+    assert refreshes == [IDLE_PERIOD / 4]
+
+
+def test_a_busy_pump_never_refreshes_the_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A queued worker action runs the episode at full speed: pump, never render.
+
+    Passes before and after the clock swap. It pins that the gate was not made
+    unconditional, and it is the branch that never consults a clock at all.
+    """
+    clock = _SteppingClock(0.0, step_after_reads=None)
+
+    _, flags = _refresh_timeline(clock, monkeypatch, iterations=6, queue_action=True)
+
+    assert flags == [False] * 6, f"a busy pump must not spend time rendering; pumped {flags}"
+    assert clock.reads == 0, "the busy branch reads no clock"
+
+
+def test_a_main_job_forces_the_next_idle_iteration_to_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A whole-job submission freezes the preview, so the next idle pass refreshes.
+
+    Passes before and after the clock swap. It fails if the reset the job path
+    performs is dropped, which would leave the preview showing the pre-job frame
+    for up to one period after a record or plan finished.
+    """
+    ran: list[str] = []
+
+    _, flags = _refresh_timeline(
+        _SteppingClock(0.0, step_after_reads=None),
+        monkeypatch,
+        iterations=3,
+        main_job=lambda: ran.append("job"),
+    )
+
+    assert ran == ["job"], "premise: the submitted job never ran"
+    assert flags[0] is True, f"the idle iteration after a job must refresh the preview; pumped {flags}"
+
+
+# --------------------------------------------------------------------------- #
+# 2. The duration ``stop_cameras_recording`` reports
+# --------------------------------------------------------------------------- #
+
+
+def _recording_engine() -> Any:
+    """Skeleton engine with a running camera recording and empty buffers.
+
+    Empty buffers keep the flush away from ``encode_clip``, so no MP4 encoder or
+    ffmpeg import runs under the clock double.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._lock = threading.RLock()
+    engine._world_created = True
+    engine._cameras = {"front": _CameraState(name="front", prim_path="/World/Cameras/front", width=32, height=24)}
+    engine._cams_rec_state = None
+    return engine
+
+
+def _record_and_report(
+    clock: _SteppingClock, monkeypatch: pytest.MonkeyPatch, tmp_path: Any, seconds: float = RECORDING_SECONDS
+) -> str:
+    """Start a recording, let ``seconds`` pass, and return the stop line.
+
+    Both calls run with the double installed as the module a fresh
+    ``import time`` resolves to, because each resolves ``time`` inside its own
+    body.
+    """
+    # Bind the encoder module on the real clock: ``stop_cameras_recording``
+    # imports it, and a module first imported under the double would keep
+    # reading the double for the rest of the session.
+    from strands_robots.rendering.video import encode_clip  # noqa: F401
+
+    monkeypatch.setitem(sys.modules, "time", clock)
+    engine = _recording_engine()
+    started = engine.start_cameras_recording(cameras=["front"], output_dir=str(tmp_path), fps=10, name="cap")
+    assert started["status"] == "success", started["content"][0]["text"]
+    clock.sleep(seconds)
+    stopped = engine.stop_cameras_recording()
+    assert stopped["status"] == "success", stopped["content"][0]["text"]
+    return str(stopped["content"][0]["text"]).splitlines()[0]
+
+
+def test_reported_recording_duration_without_a_step_is_the_elapsed_time(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control: with no step the reported duration is the time that passed."""
+    line = _record_and_report(_SteppingClock(0.0, step_after_reads=None), monkeypatch, tmp_path)
+
+    assert f"after {RECORDING_SECONDS:.1f}s" in line, line
+
+
+@pytest.mark.parametrize("wall_step", STEPS, ids=STEP_IDS)
+def test_reported_recording_duration_survives_a_wall_clock_step(
+    wall_step: float, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A step during the recording must not move the duration it reports.
+
+    The base and the reading shared ``time.time()``, so a step anywhere in the
+    recording - not only in some window - moved the answer. The buffers carry no
+    per-frame timestamp, so the reported duration is the only thing that says how
+    much wall time the frames span.
+    """
+    clock = _SteppingClock(wall_step, step_after_reads=2)
+
+    line = _record_and_report(clock, monkeypatch, tmp_path)
+
+    assert clock.step_applied_at_read is not None, "premise: the step never reached the recording"
+    assert f"after {RECORDING_SECONDS:.1f}s" in line, (
+        f"a {wall_step:+.0f}s wall-clock step moved the duration reported for a "
+        f"{RECORDING_SECONDS:.1f}s recording: {line!r}"
+    )
+
+
+def test_the_recorder_names_the_clock_its_duration_base_holds(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isaac's recorder carries the same duration-base spelling as MuJoCo's two.
+
+    ``test_rendering_pacers_survive_a_clock_step.py`` pins that the MuJoCo
+    recorders' state carries ``started_mono`` and no ``started_at``, because a
+    duration base named as a wall-clock stamp invites the next reader to subtract
+    ``time.time()`` from it. This backend's recorder is a third one behind the
+    same tool pair, so it holds the same contract.
+    """
+    monkeypatch.setitem(sys.modules, "time", _SteppingClock(0.0, step_after_reads=None))
+    engine = _recording_engine()
+    started = engine.start_cameras_recording(cameras=["front"], output_dir=str(tmp_path), fps=10, name="cap")
+    assert started["status"] == "success", started["content"][0]["text"]
+
+    keys = set(engine._cams_rec_state)
+
+    assert "started_mono" in keys
+    assert "started_at" not in keys, (
+        "a duration base named as a wall-clock stamp invites the next reader to subtract time.time() from it"
+    )


### PR DESCRIPTION
## Problem

Two durations in the Isaac backend were measured by subtracting two readings of `time.time()`, which is not a clock but the current opinion about the date. An NTP correction, a `date -s` or a resume from suspend moves it by an arbitrary amount, so a step landing between the readings changed the answer, and nothing raised.

**1. The idle-render gate.** `run_pump_forever` decides once per iteration whether to refresh the live preview:

```python
now = time.time()
do_render = (now - last_idle_render) >= self._idle_render_period
self.pump(render=do_render)
if do_render:
    last_idle_render = now
```

Driving the real loop at a 0.2 s idle period through a clock double that steps once at iteration 12, with the loop's own `sleep(0.05)` setting the granularity:

| clock event | preview refreshes | gaps (s) | last refresh | max staleness |
|---|---|---|---|---|
| no step (control) | 10 | 0.20 | t = 1.80 | 0.15 s |
| wall clock steps +30s | 11 | 0.15, 0.20 | t = 1.95 | 0.15 s |
| wall clock steps -2s | **3** | 0.20 | **t = 0.40** | **1.55 s** |
| wall clock steps +1h | 11 | 0.15, 0.20 | t = 1.95 | 0.15 s |

Backward is the damaging direction: the preview stopped refreshing for the size of the step, 1.55 s of that 1.95 s run, while `pump()` kept draining the app. The viewport sat frozen on a stale frame with nothing reporting it. Forward fired the gate once early and then re-based onto the stepped clock, so it cost one spurious refresh rather than a run of them.

**2. The duration a camera recording reports.** `start_cameras_recording` stamped `"started_at": _time.time()` and `stop_cameras_recording` did `elapsed = _time.time() - state["started_at"]`, so a step anywhere in the recording, not only in some window, moved the answer. The same 3.0 s capture:

| clock event | reported |
|---|---|
| no step (control) | `Stopped 'cap' after 3.0s` |
| wall clock steps +30s | `Stopped 'cap' after 33.0s` |
| wall clock steps -2s | `Stopped 'cap' after 1.0s` |
| wall clock steps +1h | `Stopped 'cap' after 3603.0s` |

The buffers carry no per-frame timestamp, so that line is the only thing that says how much wall time the frames span.

## Why this scope

The MuJoCo backend's two recorders already hold this base on `time.monotonic()` under the name `started_mono`, and `tests/simulation/test_rendering_pacers_survive_a_clock_step.py` pins that they carry no `started_at` key, with the reason spelled out:

> a duration base named as a wall-clock stamp invites the next reader to subtract `time.time()` from it

Which is exactly what this backend's recorder did. It is a third recorder behind the same `start_cameras_recording` / `stop_cameras_recording` pair, so it holds the same contract. Both sites are durations in one module, which is the scope the equivalent MuJoCo change took: one pacer plus two `started_at` bases and their elapsed reports.

The rule is AGENTS.md, "Clocks: a duration is measured, a stamp is recorded", which names a frame pacer explicitly. This is the same boundary already settled for the agent-callable tools, the hardware control loops, the mesh, the sim rollouts and the rendering pacers.

## Change

`strands_robots/simulation/isaac/simulation.py`, 5 lines of logic:

- The gate reads `time.monotonic()` and its base is `last_idle_render_mono`.
- The recording state's base is `started_mono`, read back with `time.monotonic()`.
- The gate's "never refreshed" sentinel becomes `None` rather than `0.0`. `time.monotonic()`'s reference point is unspecified (seconds since boot on Linux), so a numeric sentinel would have suppressed the first preview refresh for the first `_idle_render_period` seconds of uptime; `0.0` only read as "long ago" because a wall clock's epoch is large. The `job()` path sets it to `None` for the same reason it set `0.0`: refresh on the next idle pass.

No signature, return shape or public name changes. Nothing outside this module read `started_at`.

## Tests

`tests/simulation/isaac/test_isaac_durations_survive_a_clock_step.py`, **8 failed / 4 passed on `main`, 12 pass after**. Every assertion is on the achieved refresh timeline or the reported duration rather than on which clock is called, so none can be satisfied by renaming a call. The clock double counts reads of either clock, so the step lands at the same loop position whichever clock the loop consults.

Fails before, passes after:

- `test_idle_refresh_cadence_survives_a_wall_clock_step[forward_30s|backward_2s|forward_1h]` - asserted against the unstepped timeline, so the contract is "a step changes nothing".
- `test_reported_recording_duration_survives_a_wall_clock_step[forward_30s|backward_2s|forward_1h]`
- `test_the_first_idle_iteration_refreshes_whatever_the_clock_epoch_reads` - the sentinel.
- `test_the_recorder_names_the_clock_its_duration_base_holds` - extends the MuJoCo naming contract to this recorder.

Passes on both trees, and each one fails for a different wrong fix:

- `test_idle_refresh_cadence_without_a_step_is_the_period` - fails if the gate is made unconditional. It is what makes the stepped cases a statement about the step rather than about the loop's granularity.
- `test_a_busy_pump_never_refreshes_the_preview` - the branch that consults no clock at all; asserts `clock.reads == 0`.
- `test_a_main_job_forces_the_next_idle_iteration_to_refresh` - fails if the job path's reset is dropped, which would leave the preview on the pre-job frame for up to one period after a record or plan finished.
- `test_reported_recording_duration_without_a_step_is_the_elapsed_time`

No Isaac Sim Kit runtime, GL context or MP4 encoder is touched: the engine is the skeleton `__new__` fixture shape `test_cameras_recording_preflight_guards.py` already uses, and `pump` is faked on the instance.

## Verification

At `df7a33ae` against `upstream/main` `b107aecf`, identical 112-file selection on both trees (all of `tests/simulation/isaac`, every test naming a recording-state key, `run_pump_forever` or AGENTS.md, the rendering-pacer contract, and the repo-wide docstring / changelog / string guards), 158.9 s each:

| | failed | passed | skipped |
|---|---|---|---|
| this branch | 1 | 4216 | 29 |
| `upstream/main` + this test file | 9 | 4208 | 29 |

`4216 + 1 == 4208 + 9 == 4217` collected on both. Branch-only failures: **none**. Base-only: exactly the 8 pre-fix failures listed above. The one shared failure is pre-existing and unrelated (`tests/mesh/test_safety_timing_and_replay_defenses.py::TestResumeLockoutTimingOracleClosed::test_correct_override_code_clears_lockout`, `AttributeError: 'Mesh' object has no attribute '_safety_publishers_lock'`).

`ruff check` and `ruff format --check` over `strands_robots tests tests_integ` clean. `mypy` over the same: 19 errors, the same set on both trees, none in the changed files.

## What it looks like

![Isaac preview cadence and reported recording duration across a wall-clock step](https://raw.githubusercontent.com/cagataycali/robots/media-isaac-clock-durations/isaac-clock-durations.png)

One capture script per tree, driving the real `run_pump_forever` and the real `start_cameras_recording` / `stop_cameras_recording` pair. The clock double, the faked `pump` and the stimulus are identical between the two runs; only `strands_robots` differs. Isaac Sim's renderer is not exercised, so the panels measure when the backend *decides* to refresh the preview and what it reports, which is what the change moves.

**A**: how stale the frame on the live preview is, through a run where the wall clock steps back 2 s. Before, it climbs to 1.55 s and stays there while the app keeps being pumped; after, it holds the 0.2 s sawtooth the gate promises.

**B**: the refresh ticks per clock event. Fixed, all four reproduce the control's timeline exactly, 10 refreshes 0.20 s apart.

**C**: the duration reported for the same 3.0 s capture, log scale.

## Scope

`run_pump_forever`'s idle gate and this recorder's duration report are the last two `time.time()` readings in the module; there are now none. Left alone deliberately: absolute stamps elsewhere in the tree that name a point in time another reader correlates, which is the other half of the AGENTS.md rule.
