### PR TITLE
fix(rtps): refuse a ROS 2 name this mangling cannot map

### DIFF
--- a/changelog.d/2434-rtps-mangling-refuses-unmappable-names.md
+++ b/changelog.d/2434-rtps-mangling-refuses-unmappable-names.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **rtps**: `dds_type_name` now maps message interfaces only. ROS 2 generates one DDS type per constituent message of a service or an action, so there is no single type to return for one; a `pkg/srv/Name` or `pkg/action/Name` is refused with the types ROS 2 does generate quoted (`pkg::srv::dds_::Name_Request_` / `..._Response_`) instead of returning a `pkg::srv::dds_::Name_` the participant would then advertise for a struct that exists nowhere in the ROS 2 type system. `ros_topic_name` checks the name it recovers against the same rule `dds_topic_name` applies, so the documented inverse no longer hands back a ROS 2 topic name the module itself refuses.

--- a/docs/rtps-integration.md
+++ b/docs/rtps-integration.md
@@ -60,6 +60,15 @@ becomes `rt/turtle1/cmd_vel`, and a type `geometry_msgs/msg/Twist` becomes
 `geometry_msgs::msg::dds_::Twist_` - the conventions that make a bare DDS
 participant interoperable with real ROS 2 nodes.
 
+Message interfaces only. ROS 2 has no single DDS type for a service or an
+action: `rosidl` generates one type per constituent message, so
+`example_interfaces/srv/AddTwoInts` becomes
+`example_interfaces::srv::dds_::AddTwoInts_Request_` and
+`..._Response_` on the `rq`/`rr` prefixes rather than `rt`. A `pkg/srv/Name` or
+`pkg/action/Name` type is therefore refused, with the types ROS 2 does generate
+quoted - an invented `pkg::srv::dds_::AddTwoInts_` would match no participant,
+and DDS reports a type mismatch as silence rather than as an error.
+
 ## Examples
 
 ```python

--- a/strands_robots/rtps/mangling.py
+++ b/strands_robots/rtps/mangling.py
@@ -23,6 +23,19 @@ A ROS 2 type ``geometry_msgs/msg/Twist`` becomes the DDS type
 * the final segment gains a trailing underscore (``Twist`` -> ``Twist_``),
 * a ``dds_`` segment is inserted before the final segment.
 
+Message interfaces only. ROS 2 has no single DDS type for a service or an
+action: ``rosidl`` renders the message template once per constituent message, so
+``pkg/srv/Name`` becomes ``pkg::srv::dds_::Name_Request_`` and
+``pkg::srv::dds_::Name_Response_`` (an action adds goal/result/feedback and two
+nested services), exchanged over the ``rq``/``rr`` prefixes. There is no name
+this mangling could return for one, so it refuses them and says which types
+ROS 2 does generate. Returning ``pkg::srv::dds_::Name_`` instead would make the
+participant advertise, in DDS discovery, a type name ROS 2 generates no struct
+for, and nothing reports that: matching is by topic name, so a reader created
+with the wrong name can still receive, leaving a participant that misrepresents
+itself to every discovery tool and to any stack that does enforce type
+consistency.
+
 Both directions are pure string transforms with no ROS or DDS import, so they
 are trivially unit-testable with no middleware present.
 """
@@ -34,10 +47,37 @@ import re
 # ROS 2 graph names: leading slash plus alnum/_ segments (tilde/braces are
 # substitution syntax that must already be resolved before mangling).
 _ROS_TOPIC_RE = re.compile(r"^/[A-Za-z0-9_/]*[A-Za-z0-9_]$")
-_ROS_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(msg|srv|action)/[A-Za-z0-9_]+$")
+
+# Message interfaces only - see the module docstring for why ``srv``/``action``
+# cannot appear here.
+_ROS_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/msg/[A-Za-z0-9_]+$")
+
+# A well-formed service or action interface. Matched separately so it is refused
+# with the mapping explained instead of being reported as a malformed name.
+_ROS_SERVICE_TYPE_RE = re.compile(r"^[A-Za-z0-9_]+/(srv|action)/[A-Za-z0-9_]+$")
 
 # DDS topic prefixes per the ROS 2 mapping. Only ``rt`` (topics) is used in v1.
 _TOPIC_PREFIX = "rt"
+
+
+def _require_ros_topic(ros_topic: str, *, source: str = "") -> None:
+    """Refuse a name this module's topic mangling cannot map.
+
+    Both directions apply this one rule, so a name :func:`dds_topic_name` would
+    refuse is never a name :func:`ros_topic_name` hands back either.
+
+    Args:
+        ros_topic: Candidate absolute ROS 2 topic name.
+        source: DDS topic the name was recovered from, quoted in the refusal so
+            a caller of :func:`ros_topic_name` sees which name it came from.
+
+    Raises:
+        ValueError: If *ros_topic* is not a valid absolute ROS 2 topic name.
+    """
+    if _ROS_TOPIC_RE.match(ros_topic):
+        return
+    recovered = f" recovered from {source!r}" if source else ""
+    raise ValueError(f"invalid ROS 2 topic {ros_topic!r}{recovered}: expected an absolute name like /turtle1/cmd_vel")
 
 
 def dds_topic_name(ros_topic: str, *, prefix: str = _TOPIC_PREFIX) -> str:
@@ -52,8 +92,7 @@ def dds_topic_name(ros_topic: str, *, prefix: str = _TOPIC_PREFIX) -> str:
     Raises:
         ValueError: If *ros_topic* is not a valid absolute ROS 2 topic name.
     """
-    if not _ROS_TOPIC_RE.match(ros_topic):
-        raise ValueError(f"invalid ROS 2 topic {ros_topic!r}: expected an absolute name like /turtle1/cmd_vel")
+    _require_ros_topic(ros_topic)
     return prefix + ros_topic
 
 
@@ -62,17 +101,26 @@ def ros_topic_name(dds_topic: str, *, prefix: str = _TOPIC_PREFIX) -> str:
 
     ``rt/turtle1/cmd_vel`` -> ``/turtle1/cmd_vel``
 
+    A DDS graph carries topics no ROS 2 node published, so stripping the prefix
+    is not enough to have recovered a ROS 2 name: the result is checked against
+    the same rule :func:`dds_topic_name` applies, which is what makes this its
+    inverse rather than a transform that can hand back a name the module itself
+    refuses.
+
     Args:
         dds_topic: A DDS topic name carrying a ROS 2 domain prefix.
         prefix: The DDS domain prefix to strip (default ``rt``).
 
     Raises:
-        ValueError: If *dds_topic* does not begin with ``<prefix>/``.
+        ValueError: If *dds_topic* does not begin with ``<prefix>/``, or if what
+            remains after the prefix is not a valid absolute ROS 2 topic name.
     """
     head = prefix + "/"
     if not dds_topic.startswith(head):
         raise ValueError(f"DDS topic {dds_topic!r} does not carry the {prefix!r} ROS 2 prefix")
-    return dds_topic[len(prefix) :]
+    ros_topic = dds_topic[len(prefix) :]
+    _require_ros_topic(ros_topic, source=dds_topic)
+    return ros_topic
 
 
 def dds_type_name(ros_type: str) -> str:
@@ -80,13 +128,33 @@ def dds_type_name(ros_type: str) -> str:
 
     ``geometry_msgs/msg/Twist`` -> ``geometry_msgs::msg::dds_::Twist_``
 
+    Message interfaces only. A service or action is refused with the per-message
+    types ROS 2 generates for it quoted, because there is no single DDS type this
+    could return for one (see the module docstring for what returning one anyway
+    would advertise on the graph).
+
     Args:
-        ros_type: A ``pkg/msg/Name`` (or ``srv``/``action``) interface type.
+        ros_type: A ``pkg/msg/Name`` interface type.
 
     Raises:
-        ValueError: If *ros_type* is not a valid ``pkg/<kind>/Name`` triple.
+        ValueError: If *ros_type* is not a valid ``pkg/msg/Name`` triple, or
+            names a service or action interface.
     """
+    if _ROS_SERVICE_TYPE_RE.match(ros_type):
+        pkg, kind, name = ros_type.split("/")
+        if kind == "srv":
+            generated = f"{pkg}::srv::dds_::{name}_Request_ and {pkg}::srv::dds_::{name}_Response_"
+        else:
+            generated = (
+                f"{pkg}::action::dds_::{name}_Goal_, ..._Result_ and ..._Feedback_, "
+                "plus the types of its nested send_goal/get_result services"
+            )
+        raise ValueError(
+            f"ROS 2 {kind} interface {ros_type!r} has no single DDS type: ROS 2 generates one type "
+            f"per constituent message ({generated}), exchanged over the rq/rr topic prefixes rather "
+            f"than rt. This package maps topics only, so pass a pkg/msg/Name type."
+        )
     if not _ROS_TYPE_RE.match(ros_type):
-        raise ValueError(f"invalid ROS 2 type {ros_type!r}: expected pkg/msg/Name (or pkg/srv/Name, pkg/action/Name)")
+        raise ValueError(f"invalid ROS 2 type {ros_type!r}: expected pkg/msg/Name")
     pkg, kind, name = ros_type.split("/")
     return f"{pkg}::{kind}::dds_::{name}_"

--- a/tests/rtps/test_mangling.py
+++ b/tests/rtps/test_mangling.py
@@ -1,10 +1,29 @@
-"""Unit tests for ROS 2 <-> DDS name mangling (pure string transforms)."""
+"""Unit tests for ROS 2 <-> DDS name mangling (pure string transforms).
+
+Beyond the happy-path transforms, these pin one property: every name this module
+returns is a name it would itself accept, and a ROS 2 name it cannot map is
+refused rather than mangled into something plausible.
+
+Two edges settle that. ``dds_type_name`` maps *message* interfaces only - ROS 2
+generates one DDS type per constituent message of a service or an action, so
+there is no single type to return for one, and an invented
+``pkg::srv::dds_::Name_`` is what the participant would then advertise in DDS
+discovery for a struct ROS 2 never generates. ``ros_topic_name`` checks the name
+it recovers against the same rule ``dds_topic_name`` applies, because a DDS graph
+carries topics no ROS 2 node published, so stripping the prefix alone does not
+yield a ROS 2 name.
+"""
 
 from __future__ import annotations
 
 import pytest
 
+from strands_robots.rtps.idl import REGISTRY, have_cyclonedds
 from strands_robots.rtps.mangling import dds_topic_name, dds_type_name, ros_topic_name
+
+# Names the module's topic rule refuses. Shared by both directions so the two
+# cannot come to disagree about what a valid ROS 2 topic name is.
+_MALFORMED_ROS_TOPICS = ("cmd_vel", "", "/", "/bad name", "/a/", "/x;y")
 
 
 @pytest.mark.parametrize(
@@ -20,10 +39,44 @@ def test_topic_roundtrip(ros: str, dds: str) -> None:
     assert ros_topic_name(dds) == ros
 
 
-@pytest.mark.parametrize("bad", ["cmd_vel", "", "/", "/bad name", "/a/", "/x;y"])
+@pytest.mark.parametrize("bad", _MALFORMED_ROS_TOPICS)
 def test_topic_rejects_malformed(bad: str) -> None:
     with pytest.raises(ValueError, match="invalid ROS 2 topic"):
         dds_topic_name(bad)
+
+
+@pytest.mark.parametrize("bad", [t for t in _MALFORMED_ROS_TOPICS if t.startswith("/")])
+def test_ros_topic_name_never_hands_back_a_name_dds_topic_name_refuses(bad: str) -> None:
+    """The documented inverse has to survive a DDS topic that is not a ROS 2 one.
+
+    A subscriber enumerating a DDS graph feeds whatever it discovered here. If
+    stripping the prefix is the whole transform, a caller gets a "ROS 2 topic
+    name" this module refuses, and the failure surfaces at whatever it hands the
+    name to next rather than at the name it came from.
+    """
+    dds_topic = "rt" + bad
+    try:
+        recovered = ros_topic_name(dds_topic)
+    except ValueError:
+        return
+    try:
+        dds_topic_name(recovered)
+    except ValueError as exc:
+        pytest.fail(
+            f"ros_topic_name({dds_topic!r}) handed back {recovered!r}, a name dds_topic_name itself "
+            f"refuses ({exc}), so the documented inverse does not hold"
+        )
+    pytest.fail(f"premise: dds_topic_name({recovered!r}) was expected to be refused")
+
+
+@pytest.mark.parametrize(
+    ("ros", "dds"),
+    [("/turtle1/cmd_vel", "rt/turtle1/cmd_vel"), ("/j/state", "rt/j/state")],
+)
+def test_a_valid_topic_survives_the_recovered_name_check(ros: str, dds: str) -> None:
+    """Checking the recovered name must not narrow what a valid graph can carry."""
+    assert ros_topic_name(dds) == ros
+    assert dds_topic_name(ros_topic_name(dds)) == dds
 
 
 def test_ros_topic_name_requires_prefix() -> None:
@@ -47,3 +100,75 @@ def test_type_mangling(ros: str, dds: str) -> None:
 def test_type_rejects_malformed(bad: str) -> None:
     with pytest.raises(ValueError, match="invalid ROS 2 type"):
         dds_type_name(bad)
+
+
+@pytest.mark.parametrize(
+    ("ros_type", "generated"),
+    [
+        (
+            "example_interfaces/srv/AddTwoInts",
+            ("example_interfaces::srv::dds_::AddTwoInts_Request_", "AddTwoInts_Response_"),
+        ),
+        ("std_srvs/srv/Trigger", ("std_srvs::srv::dds_::Trigger_Request_", "Trigger_Response_")),
+        (
+            "control_msgs/action/FollowJointTrajectory",
+            ("control_msgs::action::dds_::FollowJointTrajectory_Goal_", "_Result_"),
+        ),
+    ],
+)
+def test_a_service_interface_is_refused_rather_than_given_a_type_ros2_never_generates(
+    ros_type: str, generated: tuple[str, ...]
+) -> None:
+    """A service has no single DDS type, so there is nothing to return for one.
+
+    ``rosidl`` renders its message template once per constituent message, so a
+    service yields ``Name_Request_`` and ``Name_Response_`` structs (an action
+    yields goal/result/feedback plus two nested services) and never a ``Name_``.
+    Returning ``pkg::srv::dds_::Name_`` is what the participant then advertises in
+    DDS discovery, for a struct that exists nowhere in the ROS 2 type system, and
+    nothing reports it: matching is by topic name, so the wrong name does not
+    even surface as a failure to connect. The refusal has to name the types ROS 2
+    does generate, or it just moves the dead end one call further out.
+    """
+    try:
+        minted = dds_type_name(ros_type)
+    except ValueError as exc:
+        message = str(exc)
+        for expected in generated:
+            assert expected in message, f"the refusal {message!r} does not name {expected!r}"
+        return
+    pytest.fail(
+        f"dds_type_name({ros_type!r}) returned {minted!r}, but ROS 2 generates no such struct: the "
+        f"wire types are {' / '.join(generated)}. That name is what the participant would advertise "
+        "in DDS discovery, and nothing reports the disagreement."
+    )
+
+
+def test_the_malformed_type_refusal_does_not_offer_an_interface_kind_it_will_not_map() -> None:
+    """A refusal must not send the caller after a spelling that is also refused."""
+    with pytest.raises(ValueError) as excinfo:
+        dds_type_name("Twist")
+    message = str(excinfo.value)
+    assert "pkg/msg/Name" in message
+    for unmappable in ("pkg/srv/Name", "pkg/action/Name"):
+        assert unmappable not in message, f"the refusal {message!r} offers {unmappable!r}, which it also refuses"
+
+
+def test_an_unknown_interface_kind_is_still_reported_as_malformed() -> None:
+    """Only ``srv``/``action`` get the mapping explanation; anything else is a typo."""
+    with pytest.raises(ValueError, match="invalid ROS 2 type"):
+        dds_type_name("pkg/badkind/Name")
+
+
+@pytest.mark.skipif(not have_cyclonedds(), reason="cyclonedds not installed ([ros2] extra)")
+def test_every_bundled_message_type_mangles_to_the_name_cyclonedds_puts_on_the_wire() -> None:
+    """The message path is graded against the binding that carries it, not a copy.
+
+    ``cyclonedds`` derives a topic's wire type name from the IDL dataclass, so
+    the bundle's ``typename=`` annotations are what a real ROS 2 node matches
+    against. Mangling has to agree with them for every bundled type.
+    """
+    assert len(REGISTRY) >= 9, f"premise: the IDL bundle looks empty ({sorted(REGISTRY)})"
+    for ros_type, idl_cls in sorted(REGISTRY.items()):
+        on_the_wire = idl_cls.__idl_typename__
+        assert dds_type_name(ros_type) == on_the_wire, ros_type


### PR DESCRIPTION
## Problem

`strands_robots.rtps.mangling` maps ROS 2 graph names onto DDS names. Two of its
three functions returned names that cannot be what they claim to be.

### 1. `dds_type_name` returned a struct ROS 2 never generates

`_ROS_TYPE_RE` enumerated `msg|srv|action`, so a service or action was accepted:

```
dds_type_name("example_interfaces/srv/AddTwoInts")     -> 'example_interfaces::srv::dds_::AddTwoInts_'
dds_type_name("std_srvs/srv/Trigger")                  -> 'std_srvs::srv::dds_::Trigger_'
dds_type_name("control_msgs/action/FollowJointTrajectory")
                                                       -> 'control_msgs::action::dds_::FollowJointTrajectory_'
```

ROS 2 has no single DDS type for a service. `rosidl_generator_dds_idl`'s
`srv.idl.em` renders `msg.idl.em` once per constituent message, and `msg.idl.em`
emits `struct <Name>_` inside `module dds_` - so a service yields
`AddTwoInts_Request_` and `AddTwoInts_Response_` (plus the event message) and
never an `AddTwoInts_`. `rmw` agrees: `rmw_client.cpp` calls
`_create_type_name(request_members)` and `_create_type_name(response_members)`
against two separate *message* type supports, and puts them on the `rq`/`rr`
prefixes rather than `rt`. An action expands further, into
goal/result/feedback plus two nested services.

The consequence is a participant that misrepresents itself and nothing that says
so. Advertising the returned name and reading back DDS discovery
(`DCPSPublication.type_name`) on one topic:

```
topic  rq/add_two_intsRequest
advertised  example_interfaces::srv::dds_::AddTwoInts_Request_   <- what ROS 2 generates
advertised  example_interfaces::srv::dds_::AddTwoInts_           <- what this returned
```

Matching is by topic name, so the disagreement does not even surface as a
failure to connect: a reader created on the returned name still received all
three samples a writer published under the real type. So there is no error, no
log line, and no failed match - only a name that disagrees with every real ROS 2
participant's advertisement, and with any stack that does enforce type
consistency.

Three places already state the intended scope, and the pattern was the one thing
that did not:

- `strands_robots/rtps/__init__.py`: "Scope (v1): topics only ... Services and
  actions need the ROS 2 request/reply-over-DDS protocol and are deliberately
  deferred to a focused follow-up."
- `mangling.py`'s own docstring: "services use `rq`/`rr`, out of scope here".
- `docs/rtps-integration.md`: "validated against an allowlist before mangling
  (absolute `/`-rooted alnum/`_` names; **`pkg/msg/Name` types**)".

The refusal for a malformed name compounded it by advertising the two spellings
that are also refused: `expected pkg/msg/Name (or pkg/srv/Name, pkg/action/Name)`.

### 2. `ros_topic_name` handed back names `dds_topic_name` refuses

It is documented as "Inverse of `dds_topic_name`", and stripped the prefix
without checking what remained. A DDS graph carries topics no ROS 2 node
published, so a subscriber enumerating one gets back a "ROS 2 topic name" this
module itself rejects:

| `ros_topic_name(...)` | returned | `dds_topic_name` on that |
|---|---|---|
| `'rt/'` | `'/'` | refused |
| `'rt/bad name'` | `'/bad name'` | refused |
| `'rt/a/'` | `'/a/'` | refused |
| `'rt/x;y'` | `'/x;y'` | refused |

4 of 6 malformed names the module's own topic test already pins came back
through the inverse, so the failure landed at whatever the caller passed the name
to next rather than at the name it came from.

## Change

One property: every name this module returns is a name it would itself accept,
and a ROS 2 name it cannot map is refused rather than mangled.

- `_ROS_TYPE_RE` is message-only. A well-formed `srv`/`action` is matched
  separately and refused with the types ROS 2 does generate quoted, so the
  refusal is not itself a dead end - and it is not reported as "malformed",
  because it is a valid ROS 2 type this mangling simply cannot name:
  ```
  ROS 2 srv interface 'example_interfaces/srv/AddTwoInts' has no single DDS type: ROS 2
  generates one type per constituent message (example_interfaces::srv::dds_::AddTwoInts_Request_
  and example_interfaces::srv::dds_::AddTwoInts_Response_), exchanged over the rq/rr topic
  prefixes rather than rt. This package maps topics only, so pass a pkg/msg/Name type.
  ```
- The malformed-name refusal drops the `pkg/srv/Name` / `pkg/action/Name`
  suggestion it also rejects. An unrecognised kind (`pkg/badkind/Name`) still
  reports as malformed.
- `_require_ros_topic` is the one topic rule, applied by both directions, so
  `dds_topic_name` and `ros_topic_name` cannot come to disagree about what a
  valid ROS 2 topic name is. `ros_topic_name` names the DDS topic the rejected
  name was recovered from:
  ```
  invalid ROS 2 topic '/' recovered from 'rt/': expected an absolute name like /turtle1/cmd_vel
  ```

Message mangling is untouched. No production caller is affected: `use_rtps` and
the RTPS hardware bridge use `dds_topic_name` and resolve types through
`rtps.idl.get_type`, which is message-only by construction; `dds_type_name` has
no in-package caller.

## Tests

`tests/rtps/test_mangling.py` extended in place. Copying only that file onto
`e9240dc5` runs the new cases against the unfixed source: **8 failed, 21 passed**
-> 29 passed. Every failure carries the measured value, e.g.

```
dds_type_name('std_srvs/srv/Trigger') returned 'std_srvs::srv::dds_::Trigger_', but ROS 2
generates no such struct: the wire types are std_srvs::srv::dds_::Trigger_Request_ /
Trigger_Response_. ...

ros_topic_name('rt/bad name') handed back '/bad name', a name dds_topic_name itself refuses
(invalid ROS 2 topic '/bad name': ...), so the documented inverse does not hold
```

The 21 that pass on both trees bound the change:

- Every type in the bundled IDL registry still mangles to the name **cyclonedds
  itself** derives from the dataclass (`__idl_typename__`) - 9/9 locally. This
  grades the message path against the binding that carries it rather than a
  copied table. Skipped without the `[ros2]` extra.
- A valid topic still round-trips through both directions, so checking the
  recovered name does not narrow what a valid graph can carry.
- `pkg/badkind/Name` still reports as malformed, so the new branch is narrow.
- The pre-existing happy-path and rejection cases are unchanged; the malformed
  topic set is now a shared constant used by both directions.

The malformed-topic list is reused rather than restated, so the two directions
cannot drift.

## Verification

At `611ad465` against `e9240dc5`, on the 96 test files that reference these
symbols, the `rtps`/`mesh` suites, the pages that read the docs, and the
repo-wide docstring/ASCII/changelog guards:

| | passed | failed | collected |
|---|---|---|---|
| branch | 3171 | 0 | 3223 |
| base (+ the new test file) | 3163 | 8 | 3223 |

`3163 + 8 == 3171` and both collect 3223, so the only verdicts that moved are the
8 new cases; no branch-only failure, and no pre-existing failure in the
selection. `ruff check` / `ruff format --check` clean over
`strands_robots tests tests_integ`; `mypy` 19 pre-existing errors on both trees,
none in the changed files.

No visual artifact: this is a pure string transform with no policy, simulation,
rendering, recording or asset behaviour to show. The DDS discovery readback and
the receive counts above are the measured evidence, taken with real cyclonedds
participants on one domain.
