### PR TITLE
fix(simulation/mujoco): write a joint pose only where ctrl is a joint pose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1301,6 +1301,35 @@ Corrections from code review that apply to all future contributions:
 - **`except (ImportError, Exception)` is a bug** - `Exception` is a superclass of `ImportError`, so the tuple collapses to `except Exception`. Lint/review will catch this; don't write it.
 - **USB / hardware probing** - use `except (ImportError, OSError)`. `PermissionError` is an `OSError`, `FileNotFoundError` is an `OSError`, etc.
 
+### Actuators: a joint pose goes only where `ctrl` IS a joint pose
+- **`data.ctrl` is not a pose channel, it is whatever the actuator's force law reads.**
+  A `<position kp>` reads it as the joint target, a `<velocity kv>` as a rate, a `<motor>`
+  as a torque, an `<intvelocity>` integrates it as a rate. Writing a joint coordinate into
+  any of the latter commands a different physical quantity that happens to be numerically
+  equal to an angle, and nothing raises: the joint simply moves somewhere the caller did
+  not ask for.
+- **Anything that writes a pose asks
+  `strands_robots.simulation.mujoco.scene_ops.joint_drive_map` first.** Resolving the
+  transmission is not enough - a `<velocity>` actuator's transmission IS the joint, and
+  every stock tendon gripper measured clears the bias-type and position-gain terms a naive
+  servo check would look at. The classification is per actuator, not per robot: `openarm`
+  ships 2 position servos beside 16 motors, and 19 of the loadable registry robots have at
+  least one joint-transmission actuator that is not a servo.
+- **A drive that cannot take the pose is left uncommanded and named, not written to.** The
+  motion primitives hold the joints they can hold and report the rest, because writing a
+  live joint angle into a rate drive is what *moves* the joint the call meant to hold - and
+  a wheel angle accumulates, so that "hold" grows with every turn the wheel has already
+  made. Where the drive being targeted is the one that cannot take a pose, the primitive
+  refuses instead: a servo loop on a rate drive meets its convergence test when the joint
+  sweeps *past* the number while still accelerating, so it reports the set-point as reached
+  and the joint keeps going after the call returns.
+- Pinned by `tests/simulation/mujoco/test_pose_write_reports_whether_the_servos_hold_it.py`
+  for `set_joint_positions(hold=True)` and by
+  `tests/simulation/mujoco/test_primitives_write_a_pose_only_into_a_pose_drive.py` for
+  `move_to` / `rotate_wrist` / `set_gripper`, which also pins the boundary: a usable
+  `ctrlrange` is authoritative and already in the drive's own units, so only the
+  *substitution* of a driven joint's limits needs the drive to be a servo.
+
 ### Clocks: a duration is measured, a stamp is recorded
 - **A duration belongs on `time.monotonic()`.** Anything that decides *how long to keep
   waiting* - a timeout, a deadline, a TTL, a retry window, a rate window, a frame pacer -

--- a/changelog.d/2435-primitives-pose-drive.md
+++ b/changelog.d/2435-primitives-pose-drive.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **simulation/mujoco**: `move_to`, `rotate_wrist` and `set_gripper` now write a joint pose
+  only into an actuator whose `ctrl` IS a joint pose, the split
+  `scene_ops.joint_drive_map` already owns. A `<velocity>` drive reads the same number as a
+  rate and a `<motor>` as a torque, so the primitives previously commanded the wrong
+  physical quantity on any non-servo joint drive and reported success: `rotate_wrist` said
+  a set-point was reached while the joint kept accelerating past it, and the joints it
+  promised to hold were driven away from the pose being held. Where only other joints are
+  affected - the wheels of `lekiwi`, `stretch3` and `tiago_dual`, whose arms are fully
+  servo-driven - those drives are now left uncommanded and named in the payload; where the
+  targeted drive itself cannot take a pose, the primitive refuses and names the actuator.

--- a/strands_robots/simulation/motion_primitives_base.py
+++ b/strands_robots/simulation/motion_primitives_base.py
@@ -684,9 +684,18 @@ class MotionPrimitivesCore:
         target_yaw: float,
         final_yaw: float,
         yaw_error: float,
+        uncommanded_drives: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Success / not-reached envelope for ``rotate_wrist``, shared across backends."""
-        payload = {
+        """Success / not-reached envelope for ``rotate_wrist``, shared across backends.
+
+        *uncommanded_drives* names actuators on this robot that the primitive
+        deliberately left alone because their ``ctrl`` is not a joint pose (a
+        wheel ``<velocity>`` drive on a mobile manipulator, say), so "holds every
+        other joint" is reported for the joints it can hold rather than claimed
+        for all of them. Omitted from the payload when there are none, which
+        keeps the envelope byte-identical for a fully position-servo robot.
+        """
+        payload: dict[str, Any] = {
             "reached": reached,
             "steps": steps_used,
             "wrist_joint": wrist_name,
@@ -694,18 +703,22 @@ class MotionPrimitivesCore:
             "final_yaw": final_yaw,
             "yaw_error_rad": yaw_error,
         }
+        if uncommanded_drives:
+            payload["uncommanded_drives"] = list(uncommanded_drives)
         if reached:
+            text = (
+                f"rotate_wrist: '{robot_name}' joint '{wrist_name}' reached "
+                f"{target_yaw:.3f} rad within {float(tol)} rad in {steps_used} steps."
+            )
+            if uncommanded_drives:
+                text += (
+                    f" {len(uncommanded_drives)} actuator(s) were left uncommanded because their "
+                    f"ctrl is not a joint pose ({list(uncommanded_drives)}); command those in "
+                    "their own units with action='send_action'."
+                )
             return {
                 "status": "success",
-                "content": [
-                    {
-                        "text": (
-                            f"rotate_wrist: '{robot_name}' joint '{wrist_name}' reached "
-                            f"{target_yaw:.3f} rad within {float(tol)} rad in {steps_used} steps."
-                        )
-                    },
-                    {"json": payload},
-                ],
+                "content": [{"text": text}, {"json": payload}],
             }
         return _err(
             f"rotate_wrist: '{robot_name}' joint '{wrist_name}' did not reach {target_yaw:.3f} rad "

--- a/strands_robots/simulation/mujoco/motion_primitives.py
+++ b/strands_robots/simulation/mujoco/motion_primitives.py
@@ -76,6 +76,7 @@ from strands_robots.simulation.motion_primitives_base import (
     _quat_angle_error,
 )
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, mj_name_to_id
+from strands_robots.simulation.mujoco.scene_ops import joint_drive_map
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +180,37 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
         self._world.step_count += _SUBSTEPS_PER_TICK
         mj.mj_kinematics(model, data)
 
+    def _pose_actuator_map(self, model: Any, robot: Any) -> tuple[dict[int, int], dict[int, int]]:
+        """Split :meth:`_joint_actuator_map` into the pose-writable half and the rest.
+
+        Every primitive here drives a joint by writing a joint POSE into
+        ``data.ctrl`` - the IK solve for ``move_to``, the set-point for
+        ``rotate_wrist``, a set-point range end for ``set_gripper``. That is only
+        the joint's target on an actuator whose ``ctrl`` IS a pose, which is what
+        :func:`~strands_robots.simulation.mujoco.scene_ops.joint_drive_map`
+        decides and already decides for the one other surface that writes a pose
+        into ``ctrl`` (``set_joint_positions(hold=True)``). Writing one into any
+        other drive commands a different physical quantity numerically equal to
+        an angle: a rate on a ``<velocity>``, a torque on a ``<motor>``.
+
+        Returns:
+            ``(pose_jact, other_jact)`` - both ``jnt_id -> act_id``, together
+            exactly :meth:`_joint_actuator_map`. *other_jact* is what a primitive
+            must leave uncommanded rather than write a pose into.
+        """
+        jact = self._joint_actuator_map(model, robot)
+        servos, _ = joint_drive_map(model, self._mj)
+        pose_jact = {j: a for j, a in jact.items() if servos.get(j) == a}
+        other_jact = {j: a for j, a in jact.items() if j not in pose_jact}
+        return pose_jact, other_jact
+
+    def _drive_names(self, model: Any, act_ids: Any, namespace: str) -> list[str]:
+        """Short actuator names for a set of actuator ids, sorted for stable text."""
+        mj = self._mj
+        return sorted(
+            self._short_name(mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, int(a)), namespace) for a in set(act_ids)
+        )
+
     def _joint_actuator_map(self, model: Any, robot: Any) -> dict[int, int]:
         """Map ``jnt_id -> act_id`` for the robot's joint-transmission actuators.
 
@@ -244,6 +276,15 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
           rewrites ``ctrlrange`` to hand control to a whole-body controller and
           restores it afterwards.
         * A driven joint that is itself unlimited has no limits to lend.
+        * A drive whose ``ctrl`` is not a joint pose cannot be commanded with a
+          joint limit even though its transmission IS the joint: substituting
+          the range would command a rate (``<velocity>``) or a torque
+          (``<motor>``) numerically equal to a joint coordinate. The
+          substitution's premise is that ``ctrl`` is the joint target - exactly
+          what ``inheritrange="1"`` would have compiled - so it is the drive
+          rather than the transmission that has to supply it, which is what
+          :func:`~strands_robots.simulation.mujoco.scene_ops.joint_drive_map`
+          decides.
         * A tendon actuator's ctrlrange is a normalised command space, not joint
           units - the shipped Franka gripper is ``(0, 255)`` - so a joint range
           would command the wrong quantity. *jnt_id* is ``None`` for one by
@@ -274,6 +315,13 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
         if not bool(model.jnt_limited[jnt_id]):
             return None, (
                 f"its ctrlrange ({lo}, {hi}) is unset (ctrllimited=0) and the joint it drives is itself unlimited"
+            )
+        servos, _ = joint_drive_map(model, self._mj)
+        if servos.get(jnt_id) != act_id:
+            return None, (
+                f"its ctrlrange ({lo}, {hi}) is unset (ctrllimited=0) and its ctrl is not a joint "
+                "pose, so the driven joint's limits are not set-points it can be commanded with - "
+                "a <velocity> drive reads ctrl as a rate, a <motor> as a torque"
             )
         jnt_lo = float(model.jnt_range[jnt_id][0])
         jnt_hi = float(model.jnt_range[jnt_id][1])
@@ -622,13 +670,29 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
             grip_acts, _, grip_err = self._resolve_gripper_actuators(model, robot)
             if grip_err is not None:
                 return grip_err
-            arm_jact = {j: a for j, a in jact.items() if a not in grip_acts}
+            # Only the pose-writable half: the solve below is applied by
+            # writing each joint angle into data.ctrl, so a joint whose drive
+            # reads ctrl as a rate or a torque cannot carry it. Narrowing here
+            # narrows the IK's decision space with it (arm_jact IS the
+            # commanded_dofs set), which keeps the residual a statement about
+            # the configuration move_to actually commands.
+            pose_jact, other_jact = self._pose_actuator_map(model, robot)
+            arm_jact = {j: a for j, a in pose_jact.items() if a not in grip_acts}
             if not arm_jact:
+                non_pose = self._drive_names(model, other_jact.values(), namespace)
+                detail = (
+                    f" {len(other_jact)} actuated joint(s) are driven by an actuator whose ctrl is "
+                    f"not a joint pose ({non_pose}), so an IK solution cannot be written to them; "
+                    "drive those directly with action='send_action'."
+                    if other_jact
+                    else ""
+                )
                 return _err(
                     f"move_to: robot '{robot_name}' has no non-gripper joint-transmission "
                     "actuators to drive - every actuated joint is classified as a gripper "
-                    f"drive (registry metadata or the name heuristic {list(_GRIPPER_HINTS)}). "
-                    "Nothing can move the end-effector."
+                    f"drive (registry metadata or the name heuristic {list(_GRIPPER_HINTS)}) "
+                    "or is not driven by a position servo. "
+                    f"Nothing can move the end-effector.{detail}"
                 )
 
             try:
@@ -799,7 +863,7 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
             ctrl_targets.update(
                 {
                     act_id: float(data.qpos[int(model.jnt_qposadr[jnt_id])])
-                    for jnt_id, act_id in jact.items()
+                    for jnt_id, act_id in pose_jact.items()
                     if act_id in grip_acts
                 }
             )
@@ -1071,6 +1135,23 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
                 )
             wrist_name = jnt_short(wrist_jnt)
 
+            # The set-point below is written into the wrist actuator's ctrl as a
+            # joint angle, so that actuator has to read ctrl as a pose. On any
+            # other drive the servo loop's convergence test is met by the joint
+            # sweeping PAST the number while still accelerating - it reports
+            # reached and the joint keeps going once the primitive returns.
+            pose_jact, other_jact = self._pose_actuator_map(model, robot)
+            if wrist_jnt not in pose_jact:
+                wrist_act = self._drive_names(model, [jact[wrist_jnt]], namespace)[0]
+                servo_names = sorted(jnt_short(j) for j in pose_jact)
+                return _err(
+                    f"rotate_wrist: joint '{wrist_name}' on '{robot_name}' is driven by "
+                    f"'{wrist_act}', whose ctrl is not a joint pose (a <velocity> drive reads it "
+                    "as a rate, a <motor> as a torque), so target_yaw cannot be commanded as a "
+                    f"set-point. Position-servo joints on this robot: {servo_names}. Drive "
+                    f"'{wrist_act}' in its own units with action='send_action' instead."
+                )
+
             if bool(model.jnt_limited[wrist_jnt]):
                 lo = float(model.jnt_range[wrist_jnt][0])
                 hi = float(model.jnt_range[wrist_jnt][1])
@@ -1081,11 +1162,19 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
                     )
 
             # Hold every other actuated joint at its CURRENT position; command
-            # only the wrist to the set-point.
+            # only the wrist to the set-point - but hold only the joints whose
+            # ctrl IS a pose. Writing a live joint
+            # angle into a rate or torque drive does not hold that joint, it
+            # drives it away from the position being held (measured on
+            # tiago_velocity: joints the call promised to hold travelled up to
+            # 0.28 rad while the one position servo in the same call held to
+            # 0.004 rad). Such a drive is left uncommanded instead, and named in
+            # the payload so the caller can command it in its own units.
             ctrl_targets: dict[int, float] = {}
-            for jnt_id, act_id in jact.items():
+            for jnt_id, act_id in pose_jact.items():
                 qadr = int(model.jnt_qposadr[jnt_id])
                 ctrl_targets[act_id] = target_yaw if jnt_id == wrist_jnt else float(data.qpos[qadr])
+            uncommanded_drives = self._drive_names(model, other_jact.values(), namespace)
             wrist_qadr = int(model.jnt_qposadr[wrist_jnt])
 
         steps_used = 0
@@ -1115,4 +1204,5 @@ class MotionPrimitivesMixin(MotionPrimitivesCore):
             target_yaw=target_yaw,
             final_yaw=final_yaw,
             yaw_error=yaw_error,
+            uncommanded_drives=uncommanded_drives,
         )

--- a/tests/simulation/mujoco/test_primitives_write_a_pose_only_into_a_pose_drive.py
+++ b/tests/simulation/mujoco/test_primitives_write_a_pose_only_into_a_pose_drive.py
@@ -1,0 +1,324 @@
+"""A motion primitive writes a joint pose only where ``ctrl`` IS a joint pose.
+
+``move_to``, ``rotate_wrist`` and ``set_gripper`` all drive a joint the same way:
+they write a joint coordinate into ``data.ctrl`` and step. That is the joint's
+target only on a position servo. On a ``<velocity>`` drive the same number is a
+rate, on a ``<motor>`` a torque - so writing a joint angle there commands a
+different physical quantity that happens to be numerically equal to an angle.
+
+``joint_drive_map`` already owns that split, and already guards the one other
+surface that writes a pose into ``ctrl``
+(``set_joint_positions(hold=True)``): "writing a joint angle into its ``ctrl``
+would command a torque numerically equal to an angle in radians". The primitives
+resolved their actuators through ``_joint_actuator_map`` alone, which asks only
+whether the *transmission* is the joint, so every non-servo joint drive was
+written to as if it were a pose. Two things followed, both reported as success:
+
+* the set-point was never held. Measured on Menagerie's ``pal_tiago``
+  ``tiago_velocity.xml`` - the stock asset ``joint_drive_map`` names as reaching
+  this path - ``rotate_wrist`` reported ``reached: True`` for ``arm_7_joint`` and
+  the joint then travelled a further 0.16 rad over the next 200 steps with
+  nothing else commanded, because ``ctrl`` still held 0.4 as a rate. The
+  convergence test was met by the joint sweeping *past* the number while
+  accelerating.
+* "holds every other joint at its current position" moved them instead. In the
+  same call the joints it promised to hold travelled 0.04 - 0.28 rad, while
+  ``torso_lift_joint`` - the one position servo among them - held to 0.004 rad.
+  A wheel drive is the worst of these because a wheel angle accumulates, so the
+  "hold" grows with every turn the wheel has already made; on the scene below it
+  diverges the integrator outright (``mj_step`` reports "Nan, Inf or huge value
+  in QACC" and the state resets mid-rollout, so the wrist never reaches either).
+
+19 of the loadable registry robots have at least one joint-transmission actuator
+that is not a position servo, and they split two ways, which is why the fix is
+not a blanket refusal:
+
+* the drive the primitive *targets* is not a servo (``tiago_velocity``'s arm,
+  ``openarm``'s 16 motors) - the set-point cannot be commanded at all, so the
+  primitive refuses and names the actuator;
+* only *other* joints are non-servo - the wheels of ``lekiwi``, ``stretch3`` and
+  ``tiago_dual``, whose arms are fully servo-driven. Those calls keep working
+  with their residuals unchanged; the wheel drives are left uncommanded and named
+  in the payload rather than written to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots import create_simulation
+
+mujoco = pytest.importorskip("mujoco")
+
+
+# A velocity drive is the sharpest case: its ctrl clears the bias-type term that
+# a naive servo check would look at (biasprm = [0, 0, -kv]), so only the position
+# feedback slot distinguishes it from a servo.
+_VELOCITY_ARM = """<mujoco model="varm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <body name="base" pos="0 0 0.2">
+      <geom type="box" size="0.05 0.05 0.05" mass="2"/>
+      <body name="link1" pos="0 0 0.06">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-2 2" damping="0.5"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.12" size="0.02" mass="0.5"/>
+        <body name="link2" pos="0 0 0.12">
+          <joint name="wrist_roll" type="hinge" axis="0 0 1" range="-2 2" damping="0.5"/>
+          <geom type="capsule" fromto="0 0 0 0.08 0 0" size="0.015" mass="0.2"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <velocity joint="shoulder" kv="5" name="shoulder_vel"/>
+    <velocity joint="wrist_roll" kv="5" name="wrist_vel"/>
+  </actuator>
+</mujoco>"""
+
+# Servo arm + one velocity drive: the shape every stock mobile manipulator has.
+_MIXED_ARM = """<mujoco model="marm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <body name="base" pos="0 0 0.2">
+      <geom type="box" size="0.05 0.05 0.05" mass="2"/>
+      <body name="wheel" pos="0.07 0 0">
+        <joint name="drive_wheel" type="hinge" axis="1 0 0" damping="0.1"/>
+        <geom type="cylinder" size="0.03 0.01" quat="0.7071 0 0.7071 0" mass="0.3"/>
+      </body>
+      <body name="link1" pos="0 0 0.06">
+        <joint name="shoulder" type="hinge" axis="0 1 0" range="-2 2" damping="0.5"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.12" size="0.02" mass="0.5"/>
+        <body name="link2" pos="0 0 0.12">
+          <joint name="wrist_roll" type="hinge" axis="0 0 1" range="-2 2" damping="0.5"/>
+          <geom type="capsule" fromto="0 0 0 0.08 0 0" size="0.015" mass="0.2"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position joint="shoulder" kp="60" name="shoulder_pos" ctrlrange="-2 2"/>
+    <position joint="wrist_roll" kp="60" name="wrist_pos" ctrlrange="-2 2"/>
+    <velocity joint="drive_wheel" kv="4" name="wheel_vel" ctrlrange="-5 5"/>
+  </actuator>
+</mujoco>"""
+
+_JAW_TEMPLATE = """<mujoco model="jaw">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <body name="base" pos="0 0 0.2">
+      <geom type="box" size="0.05 0.05 0.05" mass="1"/>
+      <body name="gripper" pos="0 0 0.06">
+        <joint name="jaw" type="slide" axis="1 0 0" range="0 0.04" damping="0.5"/>
+        <geom type="box" size="0.01 0.01 0.03" mass="0.05"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>{actuator}</actuator>
+</mujoco>"""
+
+
+def _world(tmp_path: Path, xml: str, name: str) -> Any:
+    """A world holding one robot loaded from *xml*, or a hard failure saying why."""
+    path = tmp_path / f"{name}.xml"
+    path.write_text(xml, encoding="utf-8")
+    sim = create_simulation(backend="mujoco", tool_name="t", mesh=False)
+    created = sim.create_world()
+    if created["status"] != "success":
+        raise AssertionError(f"create_world: {created['content'][0]['text']}")
+    added = sim.add_robot(name=name, urdf_path=str(path))
+    if added["status"] != "success":
+        raise AssertionError(f"add_robot: {added['content'][0]['text']}")
+    return sim
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _payload(result: dict[str, Any]) -> dict[str, Any]:
+    blocks = [b for b in result["content"] if "json" in b]
+    return dict(blocks[-1]["json"]) if blocks else {}
+
+
+def _qpos(sim: Any, joint: str) -> float:
+    model, data = sim.mj_model, sim._world._data
+    jnt = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, joint)
+    if jnt < 0:
+        raise AssertionError(f"no joint {joint!r}")
+    return float(data.qpos[int(model.jnt_qposadr[jnt])])
+
+
+def _bad_qacc(sim: Any) -> int:
+    """How many times ``mj_step`` reported a diverging acceleration."""
+    return int(sim._world._data.warning[mujoco.mjtWarning.mjWARN_BADQACC].number)
+
+
+def _ctrl(sim: Any, actuator: str) -> float:
+    model, data = sim.mj_model, sim._world._data
+    act = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator)
+    if act < 0:
+        raise AssertionError(f"no actuator {actuator!r}")
+    return float(data.ctrl[act])
+
+
+class TestATargetedDriveThatIsNotAPoseIsRefused:
+    """A set-point can only be commanded where ``ctrl`` is the joint target."""
+
+    def test_rotate_wrist_refuses_a_velocity_driven_wrist(self, tmp_path: Path) -> None:
+        sim = _world(tmp_path, _VELOCITY_ARM, "varm")
+
+        result = sim.rotate_wrist(robot_name="varm", target_yaw=0.4, max_steps=200)
+
+        assert result["status"] == "error", (
+            "a velocity drive reads target_yaw as a rate, so the servo loop stops when the joint "
+            f"sweeps past the number while still accelerating, not when it settles: {_text(result)}"
+        )
+        message = _text(result)
+        assert "wrist_vel" in message, f"the refusal must name the drive that cannot take a pose: {message}"
+        assert "send_action" in message, f"the refusal must quote a way to drive it anyway: {message}"
+
+    def test_the_refusal_commands_nothing_at_all(self, tmp_path: Path) -> None:
+        """Refusing before the servo loop is what keeps the primitive atomic."""
+        sim = _world(tmp_path, _VELOCITY_ARM, "varm")
+        pose = {"shoulder": 0.30, "wrist_roll": 0.25}
+        seeded = sim.set_joint_positions(pose, robot_name="varm")
+        assert seeded["status"] == "success", _text(seeded)
+        before = {j: _qpos(sim, f"varm/{j}") for j in pose}
+
+        result = sim.rotate_wrist(robot_name="varm", target_yaw=0.4, max_steps=200)
+
+        assert result["status"] == "error"
+        for joint, was in before.items():
+            assert _qpos(sim, f"varm/{joint}") == pytest.approx(was, abs=1e-12), f"{joint} moved during a refused call"
+        for actuator in ("shoulder_vel", "wrist_vel"):
+            assert _ctrl(sim, f"varm/{actuator}") == pytest.approx(0.0, abs=1e-12), (
+                f"{actuator} was commanded by a call that refused"
+            )
+
+
+class TestANonPoseDriveIsLeftUncommandedRatherThanWritten:
+    """Holding "every other joint" is reported for the joints it can hold."""
+
+    def test_rotate_wrist_does_not_command_a_velocity_drive_while_holding(self, tmp_path: Path) -> None:
+        sim = _world(tmp_path, _MIXED_ARM, "marm")
+        # A wheel angle accumulates, so a live reading of it is a large number in
+        # rate units: writing it as a "hold" spins the wheel faster the further
+        # it has already turned.
+        spun = sim.set_joint_positions({"drive_wheel": 0.8}, robot_name="marm")
+        assert spun["status"] == "success", _text(spun)
+        wheel_before = _qpos(sim, "marm/drive_wheel")
+
+        result = sim.rotate_wrist(robot_name="marm", target_yaw=0.5, max_steps=250)
+
+        assert _ctrl(sim, "marm/wheel_vel") == pytest.approx(0.0, abs=1e-12), (
+            f"the wheel's live joint angle ({wheel_before}) was written into its ctrl, which this drive reads as a rate"
+        )
+        assert _bad_qacc(sim) == 0, (
+            "commanding a rate drive with a joint coordinate diverged the integrator: mj_step "
+            "reported 'Nan, Inf or huge value in QACC', which resets the state mid-rollout"
+        )
+        assert result["status"] == "success", _text(result)
+        assert _payload(result)["reached"] is True, "the servo wrist still converges"
+        assert _qpos(sim, "marm/drive_wheel") == pytest.approx(wheel_before, abs=5e-3), (
+            "the wheel was driven by a call that only meant to hold it"
+        )
+
+    def test_the_payload_names_the_drives_it_left_alone(self, tmp_path: Path) -> None:
+        sim = _world(tmp_path, _MIXED_ARM, "marm")
+
+        result = sim.rotate_wrist(robot_name="marm", target_yaw=0.5, max_steps=250)
+
+        assert result["status"] == "success", _text(result)
+        assert _payload(result).get("uncommanded_drives") == ["wheel_vel"], (
+            "a joint the primitive could not hold has to be named, not silently skipped"
+        )
+        assert "send_action" in _text(result)
+
+
+class TestTheGripperSetpointSubstitutionNeedsAPoseDrive:
+    """The driven-joint-range substitution asserts that ``ctrl`` is the joint target."""
+
+    def test_a_velocity_jaw_with_an_unset_ctrlrange_is_refused(self, tmp_path: Path) -> None:
+        xml = _JAW_TEMPLATE.format(actuator='<velocity joint="jaw" kv="5" name="jaw_vel"/>')
+        sim = _world(tmp_path, xml, "vj")
+
+        result = sim.set_gripper(robot_name="vj", state="open", steps=40)
+
+        assert result["status"] == "error", (
+            "the joint's 0..0.04 m limits were commanded as 0.04 m/s, so 'commanded open' left the "
+            f"jaw 1% open and still creeping: {_text(result)}"
+        )
+        assert "jaw_vel" in _text(result)
+        assert _qpos(sim, "vj/jaw") == pytest.approx(0.0, abs=1e-9)
+
+    def test_a_servo_jaw_with_an_unset_ctrlrange_still_substitutes(self, tmp_path: Path) -> None:
+        """The substitution itself is untouched - only its premise is now checked."""
+        xml = _JAW_TEMPLATE.format(actuator='<position joint="jaw" kp="80" name="jaw_pos"/>')
+        sim = _world(tmp_path, xml, "sj")
+
+        result = sim.set_gripper(robot_name="sj", state="open", steps=60)
+
+        assert result["status"] == "success", _text(result)
+        payload = _payload(result)
+        assert payload["setpoint_sources"] == {"jaw_pos": "driven joint range"}
+        assert payload["targets"] == {"jaw_pos": pytest.approx(0.04)}
+
+    def test_a_velocity_jaw_with_its_own_ctrlrange_is_still_commanded(self, tmp_path: Path) -> None:
+        """A usable ctrlrange is authoritative and is already in the drive's own units.
+
+        Only the *substitution* claims ``ctrl`` is a joint coordinate, so only the
+        substitution needs the drive to be a servo. Whether an open/close
+        set-point is the right thing to ask of a rate command is a separate
+        question about ``set_gripper``'s vocabulary, deliberately unchanged here.
+        """
+        xml = _JAW_TEMPLATE.format(actuator='<velocity joint="jaw" kv="5" name="jaw_vel" ctrlrange="-1 1"/>')
+        sim = _world(tmp_path, xml, "cj")
+
+        result = sim.set_gripper(robot_name="cj", state="open", steps=20)
+
+        assert result["status"] == "success", _text(result)
+        assert _payload(result)["setpoint_sources"] == {"jaw_vel": "actuator ctrlrange"}
+
+
+class TestAFullyServoRobotIsUnaffected:
+    """The envelope a position-servo robot gets back does not change."""
+
+    def test_rotate_wrist_reports_no_uncommanded_drives(self, tmp_path: Path) -> None:
+        xml = _MIXED_ARM.replace(
+            '<velocity joint="drive_wheel" kv="4" name="wheel_vel" ctrlrange="-5 5"/>',
+            '<position joint="drive_wheel" kp="30" name="wheel_pos" ctrlrange="-5 5"/>',
+        )
+        sim = _world(tmp_path, xml, "sarm")
+
+        result = sim.rotate_wrist(robot_name="sarm", target_yaw=0.5, max_steps=250)
+
+        assert result["status"] == "success", _text(result)
+        assert "uncommanded_drives" not in _payload(result), (
+            "a robot with nothing to skip must get the historical payload"
+        )
+        assert "uncommanded" not in _text(result)
+
+    def test_every_servo_joint_is_still_held(self, tmp_path: Path) -> None:
+        xml = _MIXED_ARM.replace(
+            '<velocity joint="drive_wheel" kv="4" name="wheel_vel" ctrlrange="-5 5"/>',
+            '<position joint="drive_wheel" kp="30" name="wheel_pos" ctrlrange="-5 5"/>',
+        )
+        sim = _world(tmp_path, xml, "sarm")
+        seeded = sim.set_joint_positions({"shoulder": 0.4}, robot_name="sarm", hold=True)
+        assert seeded["status"] == "success", _text(seeded)
+
+        result = sim.rotate_wrist(robot_name="sarm", target_yaw=0.5, max_steps=250)
+
+        assert result["status"] == "success", _text(result)
+        assert _ctrl(sim, "sarm/shoulder_pos") == pytest.approx(0.4, abs=2e-2), (
+            "a servo joint the primitive holds must still be commanded to its live position"
+        )


### PR DESCRIPTION
## Problem

`move_to`, `rotate_wrist` and `set_gripper` all drive a joint the same way: they write a joint coordinate into `data.ctrl` and step. That is the joint's target only on a position servo. A `<velocity kv>` drive reads the same number as a **rate**, a `<motor>` as a **torque** - so writing a joint angle there commands a different physical quantity that happens to be numerically equal to an angle. Nothing raises.

`scene_ops.joint_drive_map` already owns that split, and already guards the one other surface that writes a pose into `ctrl` (`set_joint_positions(hold=True)`) - its docstring states the rule outright: *"a joint angle written into a velocity drive's `ctrl` is commanded as a rate, which drives the joint away from the pose that was just written"*, and it names Menagerie's `pal_tiago` `tiago_velocity.xml` as a stock asset that reaches this path. The primitives resolved their actuators through `_joint_actuator_map` alone, which asks only whether the *transmission* is the joint - a test a `<velocity>` actuator passes.

Measured on that stock MJCF, `rotate_wrist(target_yaw=0.4)`:

| | before | after |
|---|---|---|
| status | `success`, `reached: True`, `final_yaw: 0.3815` | `error`, names `arm_velocity_7_servo` |
| `arm_7_joint` 200 steps later, nothing else commanded | **0.5413 rad** - still accelerating | 0.0000 rad (never commanded) |
| max drift of the 4 joints it promised to **hold** | **0.5033 rad** | 0.0001 rad |
| `torso_lift_joint` in the same call (the one position servo among them) | 0.0041 rad | 0.0041 rad |

The last two rows are one call: the servo channel held to 0.004 rad while the rate channels were driven up to 0.50 rad away from the pose being held. The convergence test was met by the joint sweeping *past* the set-point while accelerating, which is why it reported reached.

A wheel drive is the worst case, because a wheel angle accumulates - the "hold" grows with every turn the wheel has already made. On the scene in the new tests it diverges the integrator outright (`mj_step` reports `Nan, Inf or huge value in QACC` and the state resets mid-rollout, so the wrist never reaches either).

## Why not a blanket refusal

19 of the loadable registry robots have at least one joint-transmission actuator that is not a position servo, and they split two ways:

| | robots | outcome |
|---|---|---|
| the **targeted** drive is not a servo | `tiago_velocity`'s arm, `openarm` (2 servos beside 16 motors), `unitree_h1_2`, `jvrc`, the quadrupeds | the set-point cannot be commanded at all -> refuse, naming the actuator |
| only **other** joints are not servos | `lekiwi`, `stretch3`, `tiago_dual` - mobile manipulators whose arms are fully servo-driven, with `<velocity>` wheels | keep working; the wheel drives are left uncommanded and named |

Refusing on the second group would have regressed three stock mobile manipulators. Their `rotate_wrist` residuals are byte-identical before and after (`tiago_dual` 0.019787005230906984, `stretch3` 0.019465727775855313, `lekiwi` 0.018158874127248648); what changes is that the wheels are no longer commanded with a joint coordinate, and the payload now says so:

```
rotate_wrist: 'lekiwi' joint 'Wrist_Roll' reached 0.300 rad within 0.02 rad in 24 steps.
3 actuator(s) were left uncommanded because their ctrl is not a joint pose
(['base_back_wheel', 'base_left_wheel', 'base_right_wheel']); command those in
their own units with action='send_action'.
```

## Change

One shared `_pose_actuator_map` splits `_joint_actuator_map` through `joint_drive_map`, consulted at the three pose-write sites:

- **`rotate_wrist`** refuses when the resolved wrist joint's drive cannot take a pose; otherwise holds only the pose-writable joints and reports the rest in `uncommanded_drives`.
- **`move_to`** narrows `arm_jact` to the pose-writable half. No separate guard is needed for the solve: `arm_jact` *is* its `commanded_dofs` set, so narrowing it narrows the IK's decision space with it and keeps the residual a statement about the configuration `move_to` actually commands. On `tiago_velocity` it now reports the velocity arm joints among "the degrees of freedom move_to does not command" instead of writing rates into them.
- **`set_gripper`**'s driven-joint-range substitution gains a fourth "keeps refusing" shape. That substitution's premise is that `ctrl` is the joint target - exactly what `inheritrange="1"` would have compiled - so the drive, not just the transmission, has to supply it. Previously a velocity jaw reported `commanded open` while writing 0.04 m as 0.04 m/s, leaving the jaw 1% open and creeping.

**Deliberately out of scope**: a usable `ctrlrange` is authoritative and already in the drive's own units, so it is unchanged - only the *substitution* claims `ctrl` is a joint coordinate. Whether an open/close set-point is the right thing to ask of a rate command is a separate question about `set_gripper`'s vocabulary. A control test pins that boundary.

## Visual

`rotate_wrist(target_yaw=0.4)` on `tiago_velocity.xml`, same script under each tree, MuJoCo headless. The panels are **pixel-identical at frame 0** (mean |delta| 0.0000) and 30.70 apart at the end, so they differ only because of this change. The right panel is honestly static: the call refused, so nothing was commanded.

![rotate_wrist on a velocity-driven arm](https://raw.githubusercontent.com/cagataycali/robots/media-pose-drive-32128579456/pose-drive.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-pose-drive-32128579456/pose-drive.mp4) - [still at maximum divergence](https://raw.githubusercontent.com/cagataycali/robots/media-pose-drive-32128579456/pose-drive.png)

## Tests

`tests/simulation/mujoco/test_primitives_write_a_pose_only_into_a_pose_drive.py`, hermetic MJCF fixtures, no downloads. **5 failed / 4 passed on `upstream/main`, 9 pass here.** Pre-fix messages name the cause, including `commanding a rate drive with a joint coordinate diverged the integrator`.

The 4 that pass on both trees are the boundary: a fully position-servo robot's envelope is unchanged (no `uncommanded_drives` key, historical text), every servo joint is still held, the driven-joint-range substitution still applies for a servo jaw, and a velocity drive with its own `ctrlrange` is still commanded.

## Verification

Measured at `93480fbe`, then merged `upstream/main` (`9ba5dc22`) and re-verified.

- Blast radius: 38 files touching these primitives, `joint_drive_map`, the shared result builders and the repo-wide guards - branch **1819 passed / 0 failed**, base **1814 passed / 5 failed**; `1814 + 5 = 1819`, same collected total, branch-only failures **empty**, base-only exactly the 5 pre-fix ids.
- The 2141 tests in every AGENTS.md-scanning guard pass.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` unchanged at its baseline with zero errors in the touched files.
- `scripts/assemble_changelog.py --check` OK.

## Docs

A new AGENTS.md convention section, *"Actuators: a joint pose goes only where `ctrl` IS a joint pose"*, recording the rule and both pinning tests. No `docs/` page currently documents these primitives.
