### PR TITLE
fix(device_connect): read an empty e-stop allowlist as unset whatever its spelling

### DIFF
--- a/changelog.d/2436-device-connect-empty-estop-allowlist.md
+++ b/changelog.d/2436-device-connect-empty-estop-allowlist.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **device_connect**: an empty `DEVICE_CONNECT_ESTOP_ALLOW` now inherits `DEVICE_CONNECT_RPC_ALLOW` whatever its spelling. The fallback tested the raw string's truthiness while `_parse_allowlist` strips and drops blank entries, so a whitespace- or comma-only value - what a templated list produces when its ids never got populated - counted as a configured allowlist that then parsed to nothing, reading as "no allowlist" and authorizing every caller for `emergencyStop`, anonymous ones included. `_parse_allowlist` is now the single owner of whether an allowlist is set. Corrects the documented default for that variable, which is the RPC allowlist rather than "allow all".

--- a/docs/device-connect.md
+++ b/docs/device-connect.md
@@ -141,7 +141,7 @@ You rarely touch more than one or two of these. Grouped by what they control:
 |----------|---------|--------------|
 | `STRANDS_MESH_HITL_ACTIONS` | built-in set | Which actions need operator (human-in-the-loop) approval. |
 | `DEVICE_CONNECT_RPC_ALLOW` | allow all | Caller allowlist for state-mutating RPCs (`execute`/`stop`/`step`/`reset`); `*` globs. |
-| `DEVICE_CONNECT_ESTOP_ALLOW` | allow all | Caller allowlist for `emergencyStop`. |
+| `DEVICE_CONNECT_ESTOP_ALLOW` | inherits `DEVICE_CONNECT_RPC_ALLOW` | Caller allowlist for `emergencyStop`. Unset - or holding no entry after stripping, so `""`, `" "` and `","` all count - falls back to the RPC allowlist. |
 | `STRANDS_ROBOT_MESH_AGENT_ID` | anonymous | Caller id the agent presents — **required** when a device sets an allowlist (else it's denied). |
 
 #### Other

--- a/strands_robots/device_connect/_authz.py
+++ b/strands_robots/device_connect/_authz.py
@@ -11,8 +11,9 @@ code changes:
 
 * ``DEVICE_CONNECT_RPC_ALLOW`` - comma-separated device ids permitted to call
   state-mutating RPCs. ``*`` (or unset) means "allow all" but logs a warning so
-  the permissive posture is visible. An explicit empty value (``""`` after
-  stripping) is treated as unset.
+  the permissive posture is visible. An empty value is treated as unset, and a
+  value is empty when it holds no non-blank entry after stripping - so ``""``,
+  ``" "`` and ``","`` are all unset.
 * ``DEVICE_CONNECT_ESTOP_ALLOW`` - comma-separated device ids permitted to
   trigger emergency-stop handling. Falls back to ``DEVICE_CONNECT_RPC_ALLOW``
   when unset.
@@ -73,7 +74,14 @@ def _warn_insecure_acl_once(scope: str) -> None:
 
 
 def _parse_allowlist(raw: str | None) -> list[str] | None:
-    """Parse a comma-separated allowlist. Returns None when unset/empty."""
+    """Parse a comma-separated allowlist. Returns None when unset/empty.
+
+    This is the one place that decides whether an allowlist is set. A value is
+    empty when it holds no non-blank entry after stripping, so ``""``, ``" "``
+    and ``","`` all parse to None. Every emptiness question routes here rather
+    than testing the raw string's truthiness, which would call a whitespace- or
+    comma-only value "set" and leave it parsing to nothing.
+    """
     if raw is None:
         return None
     entries = [e.strip() for e in raw.split(",") if e.strip()]
@@ -106,13 +114,20 @@ def is_authorized_caller(caller: str | None, *, scope: str = "rpc") -> bool:
     scope="estop" -> emergency-stop event handling
     """
     if scope == "estop":
-        raw = os.environ.get(_ESTOP_ALLOW_ENV) or os.environ.get(_RPC_ALLOW_ENV)
+        # Fall back through the parser, not through the raw string's truthiness:
+        # a whitespace- or comma-only value (a templated list whose ids never got
+        # populated) is an empty allowlist, so it must inherit the RPC allowlist.
+        # Testing truthiness here would call it "set", skip the fallback, and
+        # then parse it to nothing - opening emergencyStop to every caller,
+        # anonymous ones included.
+        patterns = _parse_allowlist(os.environ.get(_ESTOP_ALLOW_ENV))
+        if patterns is None:
+            patterns = _parse_allowlist(os.environ.get(_RPC_ALLOW_ENV))
         env_scope = "estop"
     else:
-        raw = os.environ.get(_RPC_ALLOW_ENV)
+        patterns = _parse_allowlist(os.environ.get(_RPC_ALLOW_ENV))
         env_scope = "rpc"
 
-    patterns = _parse_allowlist(raw)
     if patterns is None:
         # No allowlist configured - preserve out-of-the-box dev usability but
         # make the permissive posture loud so operators notice.

--- a/tests/test_device_connect_hardening.py
+++ b/tests/test_device_connect_hardening.py
@@ -298,6 +298,128 @@ def test_emergencystop_ignores_unauthorized_source(monkeypatch):
     assert robot.stopped is True
 
 
+# ── what counts as an unset allowlist ─────────────────────────
+
+# Every spelling of "an allowlist holding no entry". ``_parse_allowlist`` is the
+# module's single owner of that question, so the premise below asserts each of
+# these really does parse to None rather than hard-coding the vocabulary here.
+_EMPTY_ALLOWLIST_SPELLINGS = ["", " ", "\t", ",", ", ,", " , "]
+
+
+@pytest.mark.parametrize("spelling", _EMPTY_ALLOWLIST_SPELLINGS)
+def test_an_empty_estop_allowlist_inherits_the_rpc_allowlist_whatever_its_spelling(monkeypatch, spelling):
+    """An empty DEVICE_CONNECT_ESTOP_ALLOW must fall back to the RPC allowlist.
+
+    ``_parse_allowlist`` calls a value empty when it holds no non-blank entry
+    after stripping, so a whitespace- or comma-only value is an empty allowlist
+    just as ``""`` is. Deciding the fallback on the raw string's truthiness
+    instead splits that one concept in two: the spellings truthiness calls "set"
+    skip the fallback and then parse to nothing, which reads as "no allowlist
+    configured" and opens emergencyStop to every caller. A comma-only value is
+    what a templated list produces when its ids never got populated
+    (``ESTOP_ALLOW="$PRIMARY,$BACKUP"`` with both unset), so the permissive
+    reading is reachable from an ordinary deployment mistake.
+    """
+    import strands_robots.device_connect._authz as az
+
+    assert az._parse_allowlist(spelling) is None, f"premise: {spelling!r} is an empty allowlist"
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "safety-1")
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", spelling)
+
+    assert az.is_authorized_caller("safety-1", scope="estop") is True
+    assert az.is_authorized_caller("rogue-device", scope="estop") is False, (
+        f"ESTOP_ALLOW={spelling!r} holds no entry, so the estop scope must inherit "
+        "the RPC allowlist rather than authorize every caller"
+    )
+
+
+def test_an_empty_estop_allowlist_still_denies_an_anonymous_caller(monkeypatch):
+    """The fail-closed promise must survive an empty estop allowlist.
+
+    With an allowlist in force a caller carrying no identity cannot be matched
+    and is denied. An empty estop value that reads as "no allowlist configured"
+    silently lifts that, authorizing the anonymous caller the inherited RPC
+    allowlist would have refused.
+    """
+    import strands_robots.device_connect._authz as az
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "safety-1")
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", ",")
+
+    assert az.is_authorized_caller(None, scope="estop") is False
+
+
+def test_emergencystop_from_a_rogue_device_is_ignored_when_estop_allowlist_is_blank(monkeypatch):
+    """End-to-end: a spoofed emergencyStop must not stop the robot.
+
+    ``onEmergencyStop`` guards on the estop scope precisely so a spoofed event
+    from an arbitrary device cannot interrupt operations. An estop allowlist
+    that holds no entry must inherit the RPC allowlist, not admit the rogue
+    device and halt the running task.
+    """
+    from strands_robots.device_connect.robot_driver import RobotDeviceDriver
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "safety-1")
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", ",")
+    robot = _FakeRobot()
+    d = RobotDeviceDriver(robot)
+
+    _run(d.onEmergencyStop("rogue-device", "emergencyStop", {}))
+    assert robot.stopped is False, "a rogue device must not be able to halt the task"
+
+    # The inherited allowlist still lets the real safety controller through.
+    _run(d.onEmergencyStop("safety-1", "emergencyStop", {}))
+    assert robot.stopped is True
+
+
+def test_a_populated_estop_allowlist_still_overrides_the_rpc_allowlist(monkeypatch):
+    """Inheriting on empty must not become inheriting always.
+
+    A configured estop allowlist is the authority for that scope: it admits its
+    own entries and refuses an RPC-only caller. Falling back unconditionally
+    would widen emergencyStop to every state-mutating caller.
+    """
+    import strands_robots.device_connect._authz as az
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", "rpc-only")
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", "estop-only")
+
+    assert az.is_authorized_caller("estop-only", scope="estop") is True
+    assert az.is_authorized_caller("rpc-only", scope="estop") is False
+
+
+def test_both_allowlists_empty_stays_permissive(monkeypatch):
+    """Out-of-the-box usability is unchanged: no allowlist anywhere allows all.
+
+    Nothing to inherit means nothing is configured, which stays permissive (and
+    logs the warning that makes the posture visible) rather than becoming
+    fail-closed for every deployment that never set an allowlist.
+    """
+    import strands_robots.device_connect._authz as az
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", ",")
+    monkeypatch.setenv("DEVICE_CONNECT_ESTOP_ALLOW", " ")
+
+    assert az.is_authorized_caller("anyone", scope="estop") is True
+    assert az.is_authorized_caller(None, scope="estop") is True
+
+
+@pytest.mark.parametrize("spelling", _EMPTY_ALLOWLIST_SPELLINGS)
+def test_the_rpc_scope_reads_an_empty_allowlist_as_unset(monkeypatch, spelling):
+    """The RPC scope's own handling of an empty allowlist is unchanged.
+
+    It has one variable and no fallback, so every empty spelling already meant
+    "unset" there. This pins that the estop fix did not disturb it.
+    """
+    import strands_robots.device_connect._authz as az
+
+    monkeypatch.setenv("DEVICE_CONNECT_RPC_ALLOW", spelling)
+
+    assert az.is_authorized_caller("anyone", scope="rpc") is True
+    assert az.is_authorized_caller(None, scope="rpc") is True
+
+
 # ── playMove path traversal ───────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`DEVICE_CONNECT_ESTOP_ALLOW` falls back to `DEVICE_CONNECT_RPC_ALLOW` when unset, and `_authz.py` documents an empty value as unset — empty meaning "holds no non-blank entry **after stripping**", which is exactly what `_parse_allowlist` implements. The fallback decided on the raw string's truthiness instead:

```python
raw = os.environ.get(_ESTOP_ALLOW_ENV) or os.environ.get(_RPC_ALLOW_ENV)
patterns = _parse_allowlist(raw)
```

So one concept had two rules at two rungs of the same ladder, and the values in the gap between them skipped the fallback as a "configured" allowlist and then parsed to nothing — which reads as *no allowlist configured* and authorizes every caller.

Measured with `DEVICE_CONNECT_RPC_ALLOW="safety-1"`:

| `ESTOP_ALLOW` | `safety-1` | `rogue-device` | anonymous | effective posture |
|---|---|---|---|---|
| *absent* | allowed | denied | denied | inherits RPC allowlist |
| `""` | allowed | denied | denied | inherits RPC allowlist |
| `" "` | allowed | **allowed** | **allowed** | **allow all** |
| `","` | allowed | **allowed** | **allowed** | **allow all** |
| `", ,"` | allowed | **allowed** | **allowed** | **allow all** |
| `"\t"` | allowed | **allowed** | **allowed** | **allow all** |

Two documented rules invert at once: the fallback is skipped, and the module's fail-closed rule for a caller with no identity ("a missing/None caller cannot be authorized and is denied") stops applying because no allowlist appears to be in force.

A comma-only value is not exotic — it is what a templated list produces when its ids never got populated. `ESTOP_ALLOW="$PRIMARY,$BACKUP"` with both unset expands to exactly `,`, as does `",".join(ids)` over a list holding blanks.

## Why it matters

All three `onEmergencyStop` handlers guard on this scope, and their docstrings say why: *"only act on emergency-stop events whose source is in the emergency-stop allowlist, so a spoofed event from an arbitrary device cannot interrupt operations."* On the simulation driver the handler clears `policy_running` for every robot in the world, which `MuJoCoSimEngine`'s rollout hook reads as a cooperative stop and raises `CooperativeStop`. So an arbitrary device can interrupt operations, which is the stated harm.

Driving the real `SimulationDeviceDriver.onEmergencyStop` from `rogue-device` at tick 90 of a 240-step so101 rollout, with the configuration above:

| | `rogue-device` for estop scope | ticks executed | rollout report |
|---|---|---|---|
| before | AUTHORIZED | **91 / 240** | `Policy stopped on 'so101'` |
| after | REFUSED | 240 / 240 | `Policy complete on 'so101'` |

![e-stop allowlist emptiness](https://raw.githubusercontent.com/cagataycali/robots/media-estop-allowlist-emptiness/estop-allowlist-emptiness.gif)

One script, one scene, one configuration; only `strands_robots` differs between the panels. The recorded `qpos` is **bit-identical** across the 91 shared ticks (`max|Δ| = 0.000e+00`) and the rendered panels are `0.0001` mean-abs apart up to the moment the e-stop lands, then `33.78` apart at the end — the two runs are the same rollout until the change bites. After the halt the left panel is frozen (per-frame `|Δ| max 0.0001`) while the right keeps moving (`27.96`).

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-estop-allowlist-emptiness/estop-allowlist-emptiness.mp4) · [still](https://raw.githubusercontent.com/cagataycali/robots/media-estop-allowlist-emptiness/estop-allowlist-emptiness.png)

## Change

`_parse_allowlist` becomes the single owner of whether an allowlist is set, and both rungs consult it:

```python
patterns = _parse_allowlist(os.environ.get(_ESTOP_ALLOW_ENV))
if patterns is None:
    patterns = _parse_allowlist(os.environ.get(_RPC_ALLOW_ENV))
```

The RPC scope has one variable and no fallback, so every empty spelling already meant "unset" there; its behaviour is unchanged.

`docs/device-connect.md` documented this variable's default as "allow all". It is the RPC allowlist — corrected in the same change, since it is the docs statement of the rule being fixed.

## Tests

Added to `tests/test_device_connect_hardening.py`, whose subject is already caller authorization. **7 failed / 9 passed pre-fix, 16 pass after.**

The root-cause test is a property parametrized over the emptiness spellings: the effective estop allowlist must not depend on which spelling of empty is used. It premise-asserts `_parse_allowlist(spelling) is None` for each, so the parser stays the authority and a spelling added there is covered automatically rather than needing this list updated.

The nine that pass on both trees are the bounds:

- a **populated** estop allowlist still overrides the RPC allowlist — fails if inheriting-on-empty ever becomes inheriting-always, which would widen `emergencyStop` to every state-mutating caller
- **both** allowlists empty stays permissive — fails for the obvious wrong fix of making the estop scope fail-closed by default, which would change the posture of every deployment that never set an allowlist
- the RPC scope reads every empty spelling as unset (parametrized) — pins that this did not disturb the neighbouring scope
- `ESTOP_ALLOW=""` already inherited correctly, so that parameter is a built-in control

## Verification

Measured at `3a1a785` (merged with `main` at `f803770`; #2435 shares no file with this change, and the merged tree was re-linted and re-run).

- 48-file selection covering every test that touches `_authz`, the allowlist variables, the Device Connect drivers or a docs page, plus the repo-wide guards: branch **2 failed / 3164 passed**, `main` with the same test file **9 failed / 3157 passed**; both collect 3174. Failed delta 7 == passed delta 7 == the pre-fix failure count, and the branch-only failure set is empty.
- The 2 shared failures are `device-connect-agent-tools` missing from this environment; it is a declared dependency, so they pass where it is installed.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 19 pre-existing errors, identical set on both trees, none in the touched files.

## Scope

Two adjacent observations measured while reading this module are deliberately left out, as each needs a decision rather than a correction:

- `_matches` uses `fnmatch.fnmatchcase`, so the full glob vocabulary applies while the docstring promises trailing-`*` prefixes only. An entry like `robot[1]` therefore denies the literal id `robot[1]` and admits `robot1`. Narrowing the matcher would change behaviour for anyone relying on `?` or a character class today.
- `is_authorized_caller` treats any `scope` that is not `"estop"` as `"rpc"`, so a misspelled scope would silently read the RPC allowlist. Every call site passes a literal `"rpc"` or `"estop"`, so this is not reachable today.
