### PR TITLE
fix(training): give the in-process run log a single writer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1367,6 +1367,24 @@ Corrections from code review that apply to all future contributions:
   base also carries its clock in its name (`started_mono`, `last_idle_render_mono`), so a
   later reader cannot mistake it for a stamp and subtract `time.time()` from it.
 
+### One writer per log file
+- **A file two writers share needs one file object, not one path.** Two file objects over
+  one path each track their own write offset, so a buffered writer flushes at its offset
+  and overwrites in place whatever the other appended there. The training backends' run
+  log tees stdout/stderr *and* root-logger records into a single file, so the logger
+  handler is pointed at the stream the tee already holds
+  (`logging.StreamHandler(stream)`) rather than opening the path a second time
+  (`logging.FileHandler(path)`).
+- **The failure is silent and shaped like data, not like an error.** Records vanish, and a
+  record straddling a flush boundary survives as a fragment that still reads like one - so
+  the loss surfaces as a wrong *value* somewhere downstream. The log a training backend
+  parses for its "RUNNING != learning" verdict reported a healthy 1200-step run as having
+  produced no metrics at all, with nothing raised and nothing logged.
+- Pinned by `tests/training/test_inproc.py::TestCaptureToFileIsTheOnlyWriter`, which
+  asserts the log holds exactly the lines that were written - so a dropped record and a
+  surviving fragment both fail - and hands records to the installed handler directly, so
+  the assertion does not depend on ambient logger levels or on pytest's capture plugin.
+
 ### Module-Level Side Effects
 - **If you must run code at import time, comment WHY it can't be lazy.** `MUJOCO_GL` is the canonical example: MuJoCo locks the GL backend at first `import mujoco`, so the env var must be set before any downstream import chain triggers it.
 - **Cheap-guard optional imports** - `if importlib.util.find_spec("mujoco") is not None:` before doing `from strands_robots.simulation.mujoco.backend import _configure_gl_backend`. Users without the `[sim-mujoco]` extra shouldn't pay an import-attempt cost on every `import strands_robots`.

--- a/changelog.d/2437-inproc-single-log-writer.md
+++ b/changelog.d/2437-inproc-single-log-writer.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **training**: the in-process run log now has a single writer, so a chatty stdout can no longer overwrite the root-logger records in it. The log holds stdout/stderr and logger output whole, and a trainer's "RUNNING != learning" verdict (`latest_step` / `learning` / `liveness_ok`) reads a healthy run correctly again.

--- a/strands_robots/training/_inproc.py
+++ b/strands_robots/training/_inproc.py
@@ -11,7 +11,8 @@ Two primitives:
 * :func:`call_callable` - run a Python callable in THIS interpreter with its
   stdout/stderr + root-logger output tee'd to a per-run log file (so the
   trainers can still parse a "RUNNING != learning" verdict, exactly as they did
-  from the old subprocess log).
+  from the old subprocess log). Both halves go through one file object, so
+  neither can overwrite the other's bytes.
 
 * :func:`elastic_launch_callable` - multi-GPU single-node launch via torch's
   programmatic :class:`torch.distributed.launcher.api.elastic_launch` (the same
@@ -66,6 +67,14 @@ class _Tee(io.TextIOBase):
 class capture_to_file:
     """Context manager: tee stdout/stderr + root-logger output into ``log_path``.
 
+    Exactly one file object ever writes ``log_path``: the stream the tee holds,
+    which the root-logger handler is pointed at too. Both halves therefore share
+    one write offset and land in the order they were produced. Two file objects
+    over one path would not - a buffered tee write and an appending handler each
+    track their own offset, so whichever flushes second overwrites the other's
+    bytes in place, and the log a trainer reads back for its
+    "RUNNING != learning" verdict is left holding neither stream whole.
+
     ``log_path=None`` is a no-op (used by non-rank-0 workers so only rank 0
     writes the shared log).
     """
@@ -73,7 +82,7 @@ class capture_to_file:
     def __init__(self, log_path: str | None) -> None:
         self.log_path = log_path
         self._stream: io.TextIOBase | None = None
-        self._fh: logging.FileHandler | None = None
+        self._fh: logging.StreamHandler | None = None
         self._r_out: Any = None
         self._r_err: Any = None
 
@@ -81,7 +90,12 @@ class capture_to_file:
         if not self.log_path:
             return self
         self._stream = open(self.log_path, "w", encoding="utf-8")  # noqa: SIM115
-        self._fh = logging.FileHandler(self.log_path)
+        # Records go through the *same* file object the tee writes to. Opening
+        # the path a second time (a FileHandler) gives two file objects with
+        # independent write offsets over one file: the tee's buffered writes
+        # land at its own offset and overwrite whatever the handler appended
+        # there, so the log ends up holding neither stream whole.
+        self._fh = logging.StreamHandler(self._stream)
         self._fh.setLevel(logging.INFO)
         self._fh.setFormatter(logging.Formatter("%(message)s"))
         logging.getLogger().addHandler(self._fh)

--- a/tests/training/test_inproc.py
+++ b/tests/training/test_inproc.py
@@ -11,9 +11,14 @@ Covers :mod:`strands_robots.training._inproc`:
   crash a training run on a flaky file handle or lose the RUNNING-vs-learning
   verdict log.
 * :func:`capture_to_file` - the context manager that tees stdout/stderr and
-  installs a root-logger ``FileHandler`` for the run, and is a strict no-op when
+  installs a root-logger handler for the run, and is a strict no-op when
   ``log_path is None`` (the non-rank-0 worker path, so only rank 0 writes the
-  shared log).
+  shared log). Its other load-bearing contract is that **one** file object
+  writes the log: the handler is pointed at the stream the tee already holds,
+  so the two halves share a write offset. Opening the path a second time gave
+  two offsets over one file, and the buffered tee overwrote the handler's
+  appended bytes in place - losing whole metrics lines and leaving partial ones
+  behind, in the log a trainer reads back for its RUNNING-vs-learning verdict.
 
 :func:`elastic_launch_callable` - the shell-free ``torchrun`` replacement: it
 drives torch's programmatic elastic agent to spawn ``nproc_per_node`` workers,
@@ -30,6 +35,13 @@ tee-ing and the handler lifecycle, never on which *logging records* reach the
 file: record visibility is governed by the ambient root-logger level and, under
 pytest, by the log-capture plugin's handlers - global mutable state that would
 make any record-level assertion order-dependent and flaky.
+
+:class:`TestCaptureToFileIsTheOnlyWriter` keeps that exclusion. What survives a
+write is a different question from what is *filtered into* one, and only the
+first is this module's to answer, so those tests hand records straight to the
+handler ``capture_to_file`` installed rather than logging through a logger -
+no logger level, no propagation and no capture plugin in the path. They pin
+byte survival and ordering; record visibility stays out of scope.
 """
 
 from __future__ import annotations
@@ -161,11 +173,14 @@ class TestCaptureToFile:
     def test_removes_handler_and_closes_on_exit(self, tmp_path):
         root = logging.getLogger()
         before = list(root.handlers)
-        with capture_to_file(str(tmp_path / "run.log")):
-            # Exactly one FileHandler added for the duration of the context.
+        with capture_to_file(str(tmp_path / "run.log")) as cap:
+            # Exactly one stream handler added for the duration of the context,
+            # writing the stream the tee holds rather than a second file object
+            # over the same path.
             added = [h for h in root.handlers if h not in before]
             assert len(added) == 1
-            assert isinstance(added[0], logging.FileHandler)
+            assert isinstance(added[0], logging.StreamHandler)
+            assert added[0].stream is cap._stream
         # ...and removed again on exit (no handler leak across runs).
         assert list(root.handlers) == before
 
@@ -181,7 +196,7 @@ class TestCaptureToFile:
         except RuntimeError:
             pass
         # Even on an exception inside the context, redirect_stdout/stderr unwind
-        # and the FileHandler is removed - no leaked handler, no swapped streams.
+        # and the handler is removed - no leaked handler, no swapped streams.
         assert sys.stdout is before_out
         assert sys.stderr is before_err
         assert list(root.handlers) == before_handlers
@@ -212,6 +227,155 @@ class TestCaptureToFileNoop:
         with capture_to_file(None):
             pass
         assert list(tmp_path.iterdir()) == []
+
+
+class TestCaptureToFileIsTheOnlyWriter:
+    """One file object writes the log, so neither half can overwrite the other.
+
+    ``capture_to_file`` promises the run log holds stdout/stderr *and*
+    root-logger output. Two file objects over one path cannot deliver that: the
+    tee's stream buffers and writes at its own offset while an appending handler
+    writes at end-of-file, so once the buffer spills past the handler's bytes it
+    overwrites them in place. Records vanish outright, and the ones straddling a
+    flush boundary are left as partial lines that still look like records - in
+    the file a trainer parses for ``latest_step`` / ``learning`` / ``liveness_ok``.
+
+    Records are handed to the installed handler directly (see the module
+    docstring): what survives a write is this module's contract, what is
+    filtered into one is not.
+    """
+
+    #: Print volume that guarantees the tee's stream buffer spills at least once
+    #: while records are still being appended, whatever the platform's default
+    #: text buffer size is. Below a spill both writers happen to stay ordered
+    #: and the overwrite is invisible - which is why a quieter run passes either
+    #: way, and why the chatty one is the case worth pinning.
+    _CHATTER_BYTES = io.DEFAULT_BUFFER_SIZE * 4
+
+    @staticmethod
+    def _metrics_line(step: int) -> str:
+        """A lerobot ``MetricsTracker`` line, the shape the verdict parser reads."""
+        return f"step:{step} smpl:{step * 4}K ep:{step // 100} epch:{step / 100:.2f} loss:0.1234 grdn:0.512"
+
+    def _run(self, log_path, *, steps: int, chatter_bytes: int) -> str:
+        """Interleave ``steps`` handler records with ``chatter_bytes`` of stdout."""
+        filler = "dataset: caching episode ....................................."
+        per_step = max(1, chatter_bytes // (steps * (len(filler) + 1))) if chatter_bytes else 0
+        with capture_to_file(str(log_path)) as cap:
+            assert cap._fh is not None, "premise: a handler is installed for a real log_path"
+            for i in range(1, steps + 1):
+                cap._fh.emit(
+                    logging.LogRecord(
+                        name="lerobot.scripts.lerobot_train",
+                        level=logging.INFO,
+                        pathname=__file__,
+                        lineno=0,
+                        msg=self._metrics_line(i * 100),
+                        args=(),
+                        exc_info=None,
+                    )
+                )
+                for _ in range(per_step):
+                    print(filler)
+        return log_path.read_text(encoding="utf-8", errors="replace")
+
+    def test_every_record_survives_a_chatty_stdout(self, tmp_path, capsys):
+        # The headline: a run whose stdout out-volumes its records must still
+        # hold every record. Pre-fix the tee's buffer spilled over the appended
+        # records and none of them were left in the file.
+        steps = 12
+        text = self._run(tmp_path / "run.log", steps=steps, chatter_bytes=self._CHATTER_BYTES)
+        expected = [self._metrics_line(i * 100) for i in range(1, steps + 1)]
+        missing = [line for line in expected if line not in text]
+        if missing:
+            raise AssertionError(
+                f"{len(missing)} of {steps} emitted records are absent from the log "
+                f"(first missing: {missing[0]!r}); the log kept {len(text)} bytes of "
+                f"{self._CHATTER_BYTES} bytes of stdout, so the tee's buffer overwrote "
+                "what the handler had appended"
+            )
+
+    def test_no_record_is_left_half_overwritten(self, tmp_path, capsys):
+        # Worse than a lost line is a surviving fragment of one. A short print
+        # after the records puts the tee's single close-flush over the *head* of
+        # what the handler appended, so the tail of a record is left behind as a
+        # line of its own - shorter than any record, and still numeric enough to
+        # read like one. The contract is exact: the log holds the lines that were
+        # written and nothing else.
+        log = tmp_path / "run.log"
+        records = [self._metrics_line(i * 100) for i in (1, 2, 3)]
+        tail = "training finished, saved checkpoint"
+        with capture_to_file(str(log)) as cap:
+            assert cap._fh is not None, "premise: a handler is installed for a real log_path"
+            for msg in records:
+                cap._fh.emit(
+                    logging.LogRecord(
+                        name="lerobot.scripts.lerobot_train",
+                        level=logging.INFO,
+                        pathname=__file__,
+                        lineno=0,
+                        msg=msg,
+                        args=(),
+                        exc_info=None,
+                    )
+                )
+            print(tail)
+        written = [*records, tail]
+        found = log.read_text(encoding="utf-8", errors="replace").splitlines()
+        strays = [line for line in found if line not in written]
+        assert not strays, (
+            f"the log holds {strays!r}, which was never written - a record left "
+            f"half-overwritten by the tee's flush; wrote {written!r}"
+        )
+        assert sorted(found) == sorted(written), f"log holds {found!r}, wrote {written!r}"
+
+    def test_the_verdict_reads_a_chatty_run_as_learning(self, tmp_path, capsys):
+        # The consumer. A healthy run that logged 12 metrics lines must not be
+        # reported as having produced none just because stdout was chatty.
+        from strands_robots.training.lerobot import LerobotTrainer
+
+        log = tmp_path / "run.log"
+        self._run(log, steps=12, chatter_bytes=self._CHATTER_BYTES)
+        metrics = LerobotTrainer._parse_log(LerobotTrainer.__new__(LerobotTrainer), str(log))
+        assert metrics.get("liveness_ok") is True, f"healthy run read as dead: {metrics}"
+        assert metrics.get("latest_step") == 1200, f"wrong step recovered: {metrics}"
+        assert metrics.get("learning") is True, f"finite loss read as not-learning: {metrics}"
+
+    def test_stdout_and_records_keep_their_order(self, tmp_path, capsys):
+        # One offset also means one ordering: a record emitted between two prints
+        # lands between them, not at end-of-file.
+        log = tmp_path / "run.log"
+        with capture_to_file(str(log)) as cap:
+            assert cap._fh is not None
+            print("BEFORE")
+            cap._fh.emit(
+                logging.LogRecord(
+                    name="t",
+                    level=logging.INFO,
+                    pathname=__file__,
+                    lineno=0,
+                    msg="RECORD",
+                    args=(),
+                    exc_info=None,
+                )
+            )
+            print("AFTER")
+        lines = [line for line in log.read_text(encoding="utf-8").splitlines() if line]
+        assert lines == ["BEFORE", "RECORD", "AFTER"], lines
+
+    def test_a_quiet_run_is_unchanged(self, tmp_path, capsys):
+        # Control: with no stdout to spill there was never an overwrite, so this
+        # holds either way. It fails only if pointing the handler at the tee's
+        # stream cost the records or their formatting.
+        steps = 3
+        text = self._run(tmp_path / "run.log", steps=steps, chatter_bytes=0)
+        assert text == "".join(f"{self._metrics_line(i * 100)}\n" for i in range(1, steps + 1))
+
+    def test_the_handler_writes_the_stream_the_tee_holds(self, tmp_path):
+        # The root cause, pinned directly: one file object, so one write offset.
+        with capture_to_file(str(tmp_path / "run.log")) as cap:
+            assert cap._fh is not None and cap._stream is not None
+            assert cap._fh.stream is cap._stream
 
 
 class TestCallCallable:


### PR DESCRIPTION
## Problem

`capture_to_file` (the in-process run-log capture every training backend uses) opened the log **path twice**:

```python
self._stream = open(self.log_path, "w", encoding="utf-8")   # what the stdout/stderr tee writes to
self._fh = logging.FileHandler(self.log_path)               # a second file object over the same path
```

Two file objects over one path track **independent write offsets**. The tee's stream buffers and writes at its own offset; the handler appends at end-of-file. Once the buffer spills past the handler's bytes it overwrites them **in place**. Nothing raises, and `_Tee` swallows write errors by design, so there is no signal at all.

The module's own docstring promises the log holds "stdout/stderr + root-logger output". It held neither whole.

## Why it matters

lerobot reports training progress through the **root logger** (`MetricsTracker`), while the dataset/video layers `print`. That log is what `LerobotTrainer._parse_log` reads back for the RUNNING-vs-learning verdict (`latest_step`, `latest_epoch`, `latest_loss`, `learning`, `liveness_ok`).

Measured on a healthy run that emitted 12 metrics records ending at step 1200 (835 bytes of records):

| stdout written alongside | metrics records left in `run.log` | verdict |
|---|---|---|
| 0 B | 12 / 12 | `latest_step=1200, learning=True, liveness_ok=True` |
| 780 B (one print line per step) | **0 / 12** | **`{'liveness_ok': False}`** |
| 1 560 B | 0 / 12 | `{'liveness_ok': False}` |
| 8 192 B | 0 / 12 | `{'liveness_ok': False}` |
| 32 768 B | 0 / 12 | `{'liveness_ok': False}` |

The bar is one print line per step. A healthy 1200-step run is reported as having produced no metrics at all, with no `latest_step`, no loss and no `learning` key.

Below that threshold the failure is worse than a dropped line. With a short print *after* the records, the single close-flush lands over the **head** of the appended block and leaves the tail of a record behind as a line of its own:

```
training finished, saved checkpoint
ss:0.0100 grdn:0.512 lr:1.0e-04          <- all that is left of "step:100 ... loss:0.0100 ..."
step:200 smpl:800K ep:2 epch:2.00 loss:0.0050 grdn:0.512 lr:1.0e-04
```

That fragment is shorter than any record and still numeric enough to read like one.

## Change

Point the root-logger handler at the stream the tee already holds, so one file object - and one write offset - serves both halves:

```python
self._fh = logging.StreamHandler(self._stream)
```

`StreamHandler.close()` does not close the stream, so the existing teardown order (remove handler, close handler, close stream) is unchanged. Level and formatter are unchanged. A run with no stdout produces a byte-identical log (835 bytes before and after).

## Verification

`tests/training/test_inproc.py` gains `TestCaptureToFileIsTheOnlyWriter`. Pre-fix **6 failed / 18 passed**, post-fix **24 passed**:

| test | pre-fix |
|---|---|
| `test_every_record_survives_a_chatty_stdout` | `12 of 12 emitted records are absent from the log (first missing: 'step:100 ...')` |
| `test_no_record_is_left_half_overwritten` | `the log holds ['ss:0.1234 grdn:0.512'], which was never written` |
| `test_the_verdict_reads_a_chatty_run_as_learning` | `healthy run read as dead: {'liveness_ok': False}` |
| `test_stdout_and_records_keep_their_order` | `['BEFORE', 'AFTER']` - the record vanished |
| `test_the_handler_writes_the_stream_the_tee_holds` | the root cause: `mode='a'` object is not the `mode='w'` object |
| `test_removes_handler_and_closes_on_exit` (existing) | same root cause |

`test_a_quiet_run_is_unchanged` passes on both trees - the control that fails if pointing the handler at the tee's stream cost the records or their formatting.

Two notes on the test design. The existing `test_removes_handler_and_closes_on_exit` asserted `isinstance(added[0], logging.FileHandler)`, which pinned the handler *class* - and the class was the defect; it now pins the contract (`added[0].stream is cap._stream`). And this module's docstring already excludes assertions on which logging *records* reach the file, because record visibility depends on the ambient root-logger level and pytest's capture plugin. The new tests keep that exclusion: they hand records to the installed handler directly, so no logger level, propagation or capture plugin is in the path. What survives a write and what is filtered into one are different questions, and only the first is this module's.

Gate: `ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ` (mypy 19 pre-existing errors, identical set on both trees, 0 in the changed files). A 55-file selection - every test referencing the capture primitives or the verdict parser, all of `tests/training`, and the repo-wide docstring/string/dependency/changelog guards - ran on this branch and on `upstream/main`:

- branch **3 failed / 2959 passed**, base **9 failed / 2953 passed**, both collecting 2962
- branch-only failures: **none**; base-only: exactly the 6 pre-fix failures above
- the 3 shared failures are pre-existing and environmental (`TypeError: encode() takes 1 positional argument but 2 were given` - draccus 0.8.0 locally against lerobot's `draccus>=0.11.6`)

## Artifact

Same capture script run against `upstream/main` and against this branch, driving the real `capture_to_file` and the real verdict parser; only `strands_robots` differs between the columns.

![in-process run log, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-inproc-log-32139545928/inproc-single-log-writer.png)

## Scope

One contract: the log has one writer. `_Tee`'s swallow-and-continue behaviour, the handler level and formatter, the teardown order and the `log_path=None` no-op are all untouched. The `# noqa: SIM115` on the stream open stays - the stream must outlive `__enter__`.

`AGENTS.md` gains a short convention section for the rule, in the format of the neighbouring ones, ending in the test that pins it.
