### PR TITLE
fix(mesh/transport): publish and release the Zenoh leg on the raw path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,26 @@ hatch run format            # ruff check --fix, ruff format
     audit dir to `tmp_path`, so there the whole log *is* the record set it
     means. Pinned by tests/test_examples_attest_only_what_they_report.py.
 
+17. **A transport delegates to the raw backend path, never to the router that
+    resolves it** - `strands_robots.mesh.session` exposes every Zenoh operation
+    twice: a public, backend-aware entry point (`get_session`, `put`,
+    `release_session`, `session_alive`) that resolves whatever
+    `STRANDS_MESH_BACKEND` selects, and a private `_*_directly` helper that
+    always takes the raw Zenoh path. A `MeshTransport` implementation must use
+    the second kind for *every* delegation, because under
+    `STRANDS_MESH_BACKEND=bridge` the router resolves the `BridgeTransport` that
+    owns that very transport - so a backend-aware call routes straight back into
+    the caller. Both re-entries are silent, which is what makes the rule worth
+    stating rather than leaving to review: a re-entrant `put` raises
+    `RecursionError`, which is a `RuntimeError` subclass and so is absorbed by
+    the narrow `except (RuntimeError, ConnectionError, OSError)` that idempotent
+    transport paths are required to use, and a re-entrant `close` blocks on the
+    factory's non-reentrant lock from the thread already holding it. Neither
+    reports anything a caller can act on. Every fixture that injects a *fake*
+    leg into a composite transport hides this by construction, so the raw path
+    has to be pinned structurally. Pinned by
+    tests/mesh/test_zenoh_transport_bypasses_backend_routing.py.
+
 ## PR Workflow
 
 1. Create the feature branch **on your fork**. Branch creation in the base

--- a/changelog.d/2438-zenoh-transport-bypasses-backend-routing.md
+++ b/changelog.d/2438-zenoh-transport-bypasses-backend-routing.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **mesh/transport**: `ZenohTransport` now publishes and releases through the raw
+  Zenoh path instead of the backend-aware `session.put` / `session.release_session`.
+  Under `STRANDS_MESH_BACKEND=bridge` those resolve the `BridgeTransport` that owns
+  the transport, so a publish re-entered the bridge until the stack was exhausted -
+  delivering nothing to the LAN, republishing a bridged topic to MQTT once per
+  re-entry, and returning normally - and a release blocked on the transport
+  factory's non-reentrant lock, so teardown never completed and the session was
+  never closed.

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -923,13 +923,33 @@ def release_session() -> None:
     ``undeclare`` calls. The "session closed" INFO line is emitted only when
     the close actually completed.
     """
-    global _SESSION, _SESSION_REFS  # noqa: PLW0603
-
     if _is_transport_backend():
         from strands_robots.mesh.transport.factory import release_transport
 
         release_transport()
         return
+
+    _release_zenoh_session_directly()
+
+
+def _release_zenoh_session_directly() -> None:
+    """Release one reference to the raw Zenoh session, bypassing backend routing.
+
+    The teardown companion to :func:`_get_zenoh_session_directly`, and the
+    function :func:`release_session` itself calls once the backend branch is
+    not taken - so the legacy refcount and its close contract (documented on
+    :func:`release_session`) live in exactly one place.
+
+    :class:`~strands_robots.mesh.transport.zenoh_transport.ZenohTransport` must
+    release through here rather than :func:`release_session` for the same
+    reason it acquires through :func:`_get_zenoh_session_directly`: under
+    ``STRANDS_MESH_BACKEND=bridge`` the backend-aware :func:`release_session`
+    delegates to the transport factory, whose last release closes the
+    :class:`~strands_robots.mesh.transport.bridge_transport.BridgeTransport`
+    that owns that very ``ZenohTransport``, re-entering the factory's
+    non-reentrant lock from the thread already holding it.
+    """
+    global _SESSION, _SESSION_REFS  # noqa: PLW0603
 
     with _SESSION_LOCK:
         if _SESSION_REFS <= 0:
@@ -993,6 +1013,28 @@ def put(key: str, data: dict[str, Any]) -> None:
             logger.debug("Mesh transport put error on %s: %s", key, exc)
         return
 
+    _put_zenoh_directly(key, data)
+
+
+def _put_zenoh_directly(key: str, data: dict[str, Any]) -> None:
+    """Publish to the raw Zenoh session, bypassing transport-backend routing.
+
+    The publish companion to :func:`_get_zenoh_session_directly`, and the
+    function :func:`put` itself calls once the backend branch is not taken - so
+    the raw JSON encode-and-publish lives in exactly one place.
+
+    :class:`~strands_robots.mesh.transport.zenoh_transport.ZenohTransport` must
+    publish through here rather than :func:`put`: under
+    ``STRANDS_MESH_BACKEND=bridge`` the backend-aware :func:`put` resolves the
+    active transport, which is the
+    :class:`~strands_robots.mesh.transport.bridge_transport.BridgeTransport`
+    that owns that very ``ZenohTransport`` - so the payload would route back
+    into the bridge instead of onto the wire.
+
+    Fire-and-forget, and it reads ``_SESSION`` without taking
+    ``_SESSION_LOCK`` exactly as :func:`put` always has: a 50 Hz teleop loop
+    must not serialise on the session lock.
+    """
     if _SESSION is None:
         return
     try:

--- a/strands_robots/mesh/transport/zenoh_transport.py
+++ b/strands_robots/mesh/transport/zenoh_transport.py
@@ -1,9 +1,14 @@
 """Eclipse Zenoh transport - thin :class:`MeshTransport` adapter over the
 existing :mod:`strands_robots.mesh.session` singleton.
 
-This wrapper deliberately delegates to the legacy ``session.get_session()`` /
-``session.put()`` / ``session.release_session()`` functions instead of
-reimplementing them. That keeps:
+This wrapper deliberately delegates to the :mod:`strands_robots.mesh.session`
+module instead of reimplementing Zenoh state. Every delegation goes to that
+module's ``_*_directly`` helpers rather than to its public, backend-aware
+``get_session`` / ``put`` / ``release_session`` / ``session_alive``: those
+resolve whatever ``STRANDS_MESH_BACKEND`` selects, and under ``bridge`` that is
+the :class:`~strands_robots.mesh.transport.bridge_transport.BridgeTransport`
+which owns this very transport - so a backend-aware call routes straight back
+into the caller. Delegating to the raw path keeps:
 
 1. **Zero behaviour change for existing callers.** Every existing
    caller that pokes ``session._SESSION`` / ``_SESSION_REFS`` keeps
@@ -18,8 +23,8 @@ reimplementing them. That keeps:
    benefits automatically.
 
 The Zenoh dependency stays **lazy**: importing this module does not import
-``zenoh``. The first :meth:`connect` call delegates to ``session.get_session``
-which performs the actual lazy import.
+``zenoh``. The first :meth:`connect` call delegates to
+``session._get_zenoh_session_directly`` which performs the actual lazy import.
 """
 
 from __future__ import annotations
@@ -36,9 +41,9 @@ class ZenohTransport:
     """Concrete :class:`MeshTransport` backed by Eclipse Zenoh.
 
     Each instance holds **one** reference to the process-wide Zenoh session
-    via ``mesh.session.get_session`` / ``release_session``. The underlying
-    session is shared by all transport instances and only closes when the
-    last reference releases.
+    via ``mesh.session._get_zenoh_session_directly`` /
+    ``_release_zenoh_session_directly``. The underlying session is shared by
+    all transport instances and only closes when the last reference releases.
 
     Thread safety: :meth:`connect` and :meth:`close` are guarded by an
     internal lock so concurrent ``Mesh.start()`` calls don't double-acquire.
@@ -77,13 +82,18 @@ class ZenohTransport:
 
         Idempotent. The underlying ``zenoh.Session`` only closes when the
         last reference (across all transports and direct callers) releases.
+
+        Releases the raw Zenoh refcount rather than calling the backend-aware
+        ``session.release_session``: in bridge mode that delegates back to the
+        transport factory, whose last release closes the bridge holding this
+        instance.
         """
         with self._lock:
             if not self._has_ref:
                 return
-            from strands_robots.mesh.session import release_session
+            from strands_robots.mesh.session import _release_zenoh_session_directly
 
-            release_session()
+            _release_zenoh_session_directly()
             self._has_ref = False
 
     # Inspection
@@ -115,11 +125,13 @@ class ZenohTransport:
     def put(self, key: str, data: dict[str, Any]) -> None:
         """Publish *data* (JSON-encoded) to *key*. Fire-and-forget.
 
-        Delegates to :func:`strands_robots.mesh.session.put`.
+        Goes to the raw Zenoh session, not to the backend-aware
+        ``session.put``: in bridge mode that would resolve the active
+        transport, which is the bridge holding this instance.
         """
-        from strands_robots.mesh.session import put
+        from strands_robots.mesh.session import _put_zenoh_directly
 
-        put(key, data)
+        _put_zenoh_directly(key, data)
 
     def declare_subscriber(self, key_expr: str, handler: Callable[[Any], None]) -> Any:
         """Subscribe to *key_expr* and route inbound samples to *handler*.

--- a/tests/mesh/test_zenoh_transport_bypasses_backend_routing.py
+++ b/tests/mesh/test_zenoh_transport_bypasses_backend_routing.py
@@ -1,0 +1,300 @@
+"""``ZenohTransport`` reaches the raw Zenoh session, never the backend router.
+
+:mod:`strands_robots.mesh.session` exposes each Zenoh operation twice: a public,
+**backend-aware** entry point that resolves whatever ``STRANDS_MESH_BACKEND``
+selects, and a private ``_*_directly`` helper that always takes the raw Zenoh
+path. :class:`~strands_robots.mesh.transport.zenoh_transport.ZenohTransport`
+must use the second kind for *every* delegation, because under
+``STRANDS_MESH_BACKEND=bridge`` the backend-aware entry points resolve the
+:class:`~strands_robots.mesh.transport.bridge_transport.BridgeTransport` that
+owns that very ``ZenohTransport`` - so a backend-aware call routes straight back
+into the caller.
+
+Both re-entries are silent in production, which is why they need pinning here:
+
+* ``put`` re-enters ``BridgeTransport.put`` until the stack is exhausted. The
+  resulting ``RecursionError`` is a ``RuntimeError`` subclass, so the bridge's
+  own narrow ``except (RuntimeError, ConnectionError, OSError)`` absorbs it and
+  logs one DEBUG line - the publish reaches neither leg and ``put`` returns
+  normally, exactly as a successful fire-and-forget publish does.
+* ``close`` re-enters the transport factory's non-reentrant lock from the thread
+  already holding it, so teardown never returns and the session is never closed.
+
+Every existing bridge test injects a *fake* Zenoh leg whose ``put``/``close``
+record instead of delegating, so no fixture in the suite could reach either
+path. These tests drive a real ``ZenohTransport`` over a fake ``zenoh.Session``
+object, which needs no broker and no ``zenoh`` wheel.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import threading
+from typing import Any, cast
+
+import pytest
+
+from strands_robots.mesh import session as session_mod
+from strands_robots.mesh.transport import factory
+from strands_robots.mesh.transport.bridge_transport import BridgeTransport
+from strands_robots.mesh.transport.zenoh_transport import ZenohTransport
+
+# A bridged topic under the bridge's exact-suffix match policy, so the IoT leg
+# is genuinely reachable and "the WAN leg is untouched" is a real assertion.
+BRIDGED_KEY = "strands/probe-peer/state"
+
+
+class _FakeZenohSession:
+    """Stands in for ``zenoh.Session``: records publishes, tracks close."""
+
+    def __init__(self) -> None:
+        self.payloads: list[tuple[str, bytes]] = []
+        self.closed = False
+
+    def put(self, key: str, payload: bytes) -> None:
+        self.payloads.append((key, payload))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _StubIot:
+    """A WAN leg that records, so the bridge's IoT half stays observable."""
+
+    def __init__(self) -> None:
+        self.payloads: list[str] = []
+
+    def connect(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        pass
+
+    def is_alive(self) -> bool:
+        return True
+
+    def put(self, key: str, data: dict[str, Any]) -> None:
+        self.payloads.append(key)
+
+    def declare_subscriber(self, key_expr: str, handler: Any) -> Any:
+        raise NotImplementedError
+
+    @property
+    def raw_session(self) -> Any | None:
+        return None
+
+
+class _CountingBridge(BridgeTransport):
+    """Counts how many times one publish enters the bridge."""
+
+    put_entries = 0
+
+    def put(self, key: str, data: dict[str, Any]) -> None:
+        self.put_entries += 1
+        super().put(key, data)
+
+
+@pytest.fixture
+def fake_session(monkeypatch) -> _FakeZenohSession:
+    """Install a fake open Zenoh session with one outstanding reference."""
+    fake = _FakeZenohSession()
+    monkeypatch.setattr(session_mod, "_SESSION", fake)
+    monkeypatch.setattr(session_mod, "_SESSION_REFS", 1)
+    return fake
+
+
+@pytest.fixture
+def bridge_backend(monkeypatch) -> None:
+    """Select the bridge backend and give the factory throwaway state.
+
+    ``_LOCK`` is replaced so that a pre-fix deadlock wedges a lock nothing
+    outside this test will ever wait on.
+    """
+    monkeypatch.setenv("STRANDS_MESH_BACKEND", "bridge")
+    monkeypatch.setattr(factory, "_LOCK", threading.Lock())
+    monkeypatch.setattr(factory, "_TRANSPORT", None)
+    monkeypatch.setattr(factory, "_TRANSPORT_REFS", 0)
+    monkeypatch.setattr(factory, "_TRANSPORT_BACKEND", "")
+
+
+def _mounted_bridge(iot: _StubIot) -> _CountingBridge:
+    """A connected bridge over a real ``ZenohTransport``, installed as the
+    factory singleton exactly as bridge mode does."""
+    zenoh_leg = ZenohTransport()
+    zenoh_leg._has_ref = True  # the fake session's outstanding reference
+    # cast: the stub satisfies the MeshTransport protocol the bridge uses, not
+    # the concrete IotMqttTransport its signature names (as in test_bridge_dedup).
+    bridge = _CountingBridge(zenoh=zenoh_leg, iot=cast(Any, iot), bridge_suffixes=frozenset({"state"}))
+    bridge._zenoh_alive = True
+    bridge._iot_alive = True
+    factory._TRANSPORT = bridge
+    factory._TRANSPORT_REFS = 1
+    factory._TRANSPORT_BACKEND = "bridge"
+    return bridge
+
+
+class TestPublishReachesTheWire:
+    """A bridge publish must land on the Zenoh session, not on the bridge."""
+
+    def test_a_bridged_publish_enters_the_bridge_once_and_reaches_the_session(self, fake_session, bridge_backend):
+        """The headline: one publish, one bridge entry, one payload on the wire.
+
+        Pre-fix the Zenoh leg published through the backend-aware
+        ``session.put``, which resolved this same bridge, so the call re-entered
+        the bridge until the stack ran out and delivered nothing to either leg
+        while still returning normally.
+        """
+        iot = _StubIot()
+        bridge = _mounted_bridge(iot)
+
+        bridge.put(BRIDGED_KEY, {"v": 1})
+
+        assert bridge.put_entries == 1, (
+            f"one publish entered BridgeTransport.put {bridge.put_entries} times "
+            f"and delivered {len(fake_session.payloads)} payload(s) to the Zenoh "
+            "session: the Zenoh leg published through the backend-aware router, "
+            "which resolves back to this bridge"
+        )
+        assert len(fake_session.payloads) == 1, (
+            f"the publish reached the Zenoh session {len(fake_session.payloads)} "
+            "time(s); a fire-and-forget put that returns normally must have "
+            "published"
+        )
+        assert fake_session.payloads[0][0] == BRIDGED_KEY
+
+    def test_the_iot_leg_receives_a_bridged_publish_exactly_once(self, fake_session, bridge_backend):
+        """One logical publish must reach the WAN leg exactly once.
+
+        ``IotMqttTransport.put`` talks to its own MQTT client, so the WAN leg
+        was never the one routing back into the bridge - but it sits below the
+        re-entry, so pre-fix each re-entry republished the same payload to MQTT.
+        """
+        iot = _StubIot()
+        bridge = _mounted_bridge(iot)
+
+        bridge.put(BRIDGED_KEY, {"v": 1})
+
+        assert iot.payloads == [BRIDGED_KEY]
+
+    def test_the_published_payload_is_the_json_the_legacy_path_encodes(self, fake_session, bridge_backend):
+        """Bypassing the router must not change the bytes on the wire."""
+        iot = _StubIot()
+        bridge = _mounted_bridge(iot)
+
+        bridge.put(BRIDGED_KEY, {"v": 1})
+
+        assert len(fake_session.payloads) == 1
+        _, payload = fake_session.payloads[0]
+        assert isinstance(payload, bytes)
+        assert json.loads(payload.decode()) == {"v": 1}
+
+
+class TestTeardownCompletes:
+    """Releasing the bridge must not re-enter the factory lock."""
+
+    def test_releasing_the_last_reference_closes_the_session_and_returns(self, fake_session, bridge_backend):
+        """The factory's last release must complete and clear the singleton.
+
+        Pre-fix the Zenoh leg released through the backend-aware
+        ``session.release_session``, which delegates back to
+        ``factory.release_transport`` - re-entering the factory's non-reentrant
+        lock from the thread already inside it, so teardown never returned.
+        Run on a worker thread with a bounded join so a pre-fix hang is a
+        failed assertion rather than a suite that stops making progress.
+        """
+        iot = _StubIot()
+        bridge = _mounted_bridge(iot)
+        assert bridge._zenoh._has_ref, "premise: the Zenoh leg holds a reference"
+
+        finished = threading.Event()
+
+        def teardown() -> None:
+            factory.release_transport()
+            finished.set()
+
+        worker = threading.Thread(target=teardown, daemon=True)
+        worker.start()
+        completed = finished.wait(timeout=10.0)
+
+        assert completed, (
+            "factory.release_transport() did not return within 10s: closing the "
+            "bridge released its Zenoh leg through the backend-aware "
+            "session.release_session, which re-enters the factory lock this "
+            "thread already holds"
+        )
+        assert factory._TRANSPORT is None
+        assert fake_session.closed, "the last release must close the Zenoh session"
+        assert not bridge._zenoh._has_ref
+
+
+class TestTheLegacyZenohBackendIsUnchanged:
+    """Controls: the default backend and the router itself must still work."""
+
+    def test_the_transport_publishes_to_the_session_on_the_zenoh_backend(self, fake_session, monkeypatch):
+        """With no bridge in play the transport still reaches the session."""
+        monkeypatch.setenv("STRANDS_MESH_BACKEND", "zenoh")
+        transport = ZenohTransport()
+        transport._has_ref = True
+
+        transport.put("strands/probe-peer/state", {"v": 2})
+
+        assert len(fake_session.payloads) == 1
+
+    def test_session_put_still_routes_to_the_active_transport_under_bridge(self, fake_session, bridge_backend):
+        """``session.put`` stays backend-aware.
+
+        Fails if the recursion is "fixed" by making the public router publish
+        raw Zenoh instead - callers that want backend routing must keep it.
+        Asserts only that the router *reached* the transport, so it states the
+        same thing on either side of the fix.
+        """
+        bridge = _mounted_bridge(_StubIot())
+
+        session_mod.put(BRIDGED_KEY, {"v": 3})
+
+        assert bridge.put_entries >= 1, "session.put must resolve the active transport"
+
+    def test_release_session_still_delegates_to_the_factory_under_bridge(self, fake_session, bridge_backend):
+        """``session.release_session`` stays backend-aware.
+
+        Fails if the deadlock is "fixed" by dropping the backend branch, which
+        would strand the transport singleton. Holds a second reference so the
+        release decrements without closing, keeping this a statement about
+        routing alone - and so it states the same thing on either side of the
+        fix.
+        """
+        bridge = _mounted_bridge(_StubIot())
+        factory._TRANSPORT_REFS = 2
+
+        session_mod.release_session()
+
+        assert factory._TRANSPORT_REFS == 1, "release_session must reach release_transport"
+        assert factory._TRANSPORT is bridge
+
+
+class TestEveryDelegationTakesTheRawPath:
+    """The root cause: a delegation that names a backend-aware entry point.
+
+    Structural, so a seventh delegation added later cannot reintroduce either
+    re-entry without failing here.
+    """
+
+    def test_the_transport_imports_only_bypass_helpers_from_session(self):
+        from strands_robots.mesh.transport import zenoh_transport
+
+        tree = ast.parse(inspect.getsource(zenoh_transport))
+        imported: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "strands_robots.mesh.session":
+                imported.extend(alias.name for alias in node.names)
+
+        assert imported, "premise: the transport delegates to the session module"
+        backend_aware = sorted(name for name in imported if not name.endswith("_directly"))
+        assert not backend_aware, (
+            f"ZenohTransport delegates to backend-aware session entry point(s) "
+            f"{backend_aware}: under STRANDS_MESH_BACKEND=bridge those resolve the "
+            "BridgeTransport that owns this transport, so the call routes back "
+            "into the caller. Use the matching _*_directly helper."
+        )


### PR DESCRIPTION
## Problem

`strands_robots.mesh.session` exposes every Zenoh operation twice: a public,
**backend-aware** entry point that resolves whatever `STRANDS_MESH_BACKEND`
selects, and a private `_*_directly` helper that always takes the raw Zenoh path.
The module ships that bypass family for one stated reason -
`_get_zenoh_session_directly`'s docstring says a backend-aware call from inside a
`BridgeTransport` "would re-enter the factory's `_LOCK` ... causing a deadlock".

`ZenohTransport` used it for four of its six delegations and reached for the
backend-aware `session.put` and `session.release_session` for the other two.
Under `STRANDS_MESH_BACKEND=bridge` both resolve the `BridgeTransport` that owns
that very `ZenohTransport`, so each routed straight back into the caller.

Both re-entries are silent, which is what let them survive:

| | measured on `upstream/main` |
|---|---|
| `bridge.put('strands/arm-01/state')` | entered `BridgeTransport.put` **249** times, returned normally |
| payloads on the Zenoh session | **0** |
| publishes to MQTT | **249** copies of the same payload |
| the only trace | one DEBUG line, `[bridge] zenoh.put error ...: maximum recursion depth exceeded` |
| a LAN-only topic (`.../camera/wrist`) | **0** on the LAN, **0** on the WAN - lost entirely |
| `factory.release_transport()` | never returned (10 s bound); singleton not cleared, session not closed |

`RecursionError` is a `RuntimeError` subclass, so the bridge's own narrow
`except (RuntimeError, ConnectionError, OSError)` absorbed it - a `put` that
publishes nothing is indistinguishable from a successful fire-and-forget publish.
The release blocked on the transport factory's non-reentrant lock from the thread
already holding it.

`docs/security.md` describes this backend as one where "a `BridgeTransport` keeps
high-rate topics local while bridging presence, health, and safety to the cloud".
Both halves were untrue: high-rate LAN-only topics reached the LAN zero times, and
a bridged topic reached the cloud 249 times rather than once.

`IotMqttTransport.put` publishes through its own MQTT client, which is why only
the Zenoh leg could route back into its owner.

## Change

Completes the bypass family with `_put_zenoh_directly` and
`_release_zenoh_session_directly`, and points the two delegations at them. Both
are **extracted from the existing legacy branches** of `put` / `release_session`
rather than copied, so the raw publish and the legacy refcount each live in one
place and the zenoh-backend path is unchanged by construction.

`put` and `release_session` stay backend-aware for the callers that want routing
(`mesh.core` releases through the public one deliberately).

| `ZenohTransport` method | session entry point | raw path before |
|---|---|---|
| `connect` | `_get_zenoh_session_directly` | yes |
| `is_alive` | `_session_alive_directly` | yes |
| `raw_session` | `_current_zenoh_session_directly` | yes |
| `declare_subscriber` | via `raw_session` | yes |
| **`put`** | `put` -> `_put_zenoh_directly` | **no** |
| **`close`** | `release_session` -> `_release_zenoh_session_directly` | **no** |

The module and class docstrings named `session.get_session` / `session.put` /
`session.release_session` as the delegation targets; they now name the bypass
family and say why.

## Tests

`tests/mesh/test_zenoh_transport_bypasses_backend_routing.py`, driving a real
`ZenohTransport` over a fake `zenoh.Session` object - no broker, no `zenoh` wheel.
Every existing bridge test injects a *fake* Zenoh leg whose `put`/`close` record
instead of delegating, so no fixture in the suite could reach either path; the one
existing `ZenohTransport.put` test is a disconnected no-op whose comment names the
delegation and which only ever ran on the backend where it was correct.

**5 failed / 3 passed before, 8 pass after.** Pre-fix messages:

- `one publish entered BridgeTransport.put 241 times and delivered 0 payload(s) to the Zenoh session`
- `factory.release_transport() did not return within 10s: closing the bridge released its Zenoh leg through the backend-aware session.release_session, which re-enters the factory lock this thread already holds`
- `ZenohTransport delegates to backend-aware session entry point(s) ['put', 'release_session']`

The deadlock test runs the teardown on a worker thread with a bounded join, so a
pre-fix hang is a failed assertion rather than a suite that stops progressing, and
it swaps in a throwaway factory lock so the wedged thread blocks nothing else.

The 3 that pass on **both** sides are the controls, each failing for an obvious
wrong fix: the legacy zenoh backend still publishes to the session; `session.put`
still resolves the active transport (fails if the router is made to publish raw);
and `session.release_session` still delegates to the factory (fails if the backend
branch is dropped). A structural test asserts every `mesh.session` import in the
transport names a `_*_directly` helper, so a seventh delegation cannot
reintroduce either re-entry.

## Verification

Measured at `388a52f2` on a 227-file selection (everything referencing the changed
symbols, all of `tests/mesh`, and the repo-wide docstring / changelog / string
guards), same selection on both trees:

- branch **21 failed / 5624 passed / 24 errors**, base **26 failed / 5619 passed / 24 errors**
- `21+5624 == 26+5619 == 5645` collected on both; branch-only failing ids **empty**;
  base-only is exactly the 5 pre-fix ids with nothing foreign
- the 21 shared failures and 24 errors are pre-existing (absent `awsiot`)
- `mypy strands_robots tests tests_integ`: 19 on both trees, identical sets, none in the changed files
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`
- re-verified after merging the base forward: 826 passed over the new tests, the
  overlapping `tests/training/test_inproc.py`, the mesh transport suites and the guards

## Measurement

![zenoh transport bypass measurement](https://raw.githubusercontent.com/cagataycali/robots/media-zenoh-bypass-32144972629/zenoh-transport-bypass.png)

One probe script, run under `PYTHONPATH` of an `upstream/main` worktree and of
this branch, publishing one bridged topic and one LAN-only topic and then
releasing the last reference. Every number in the figure is asserted against the
captured JSON before it is drawn.

## Docs

`AGENTS.md > Key Conventions` gains the rule as item 17 - a transport delegates to
the raw backend path, never to the router that resolves it - including why both
re-entries are silent and why a fixture that injects a fake leg into a composite
transport hides them.
