### PR TITLE
fix(rendering): state the scale of an sRGB decode input instead of guessing it

### DIFF
--- a/changelog.d/2441-srgb-decode-states-its-scale.md
+++ b/changelog.d/2441-srgb-decode-states-its-scale.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **rendering**: `srgb_to_linear` no longer guesses the scale of an integer array. It accepts two scales - byte codes in `[0, 255]` (`uint8`) and unit floats in `[0, 1]` - and decided between them from `dtype == uint8` alone, so every other integer spelling of the same byte data (a `uint16` capture, an `int32` array, or the plain Python list its `ArrayLike` annotation invites) took the float branch and was clipped, turning every code above 1 into pure white with nothing reported. Such an array is now refused with a message naming both accepted spellings and the conversion for each. `derive_key_light`, which passes its caller's environment map straight into the decode, inherits the refusal instead of reporting a key light derived from a saturated map.

--- a/strands_robots/rendering/color.py
+++ b/strands_robots/rendering/color.py
@@ -31,6 +31,18 @@ go through the helpers here:
   shadow is a multiplicative ratio of received light, which is only a
   multiplication in linear space.
 
+**Which scale a value is on**
+
+:func:`srgb_to_linear` is the one helper here that accepts two scales -- bytes
+in ``[0, 255]`` or floats in ``[0, 1]`` -- so it is the only one that can be
+handed a value whose scale it cannot know. It reads ``uint8`` as bytes and
+floats as unit values, and *refuses* any other integer dtype rather than
+guessing: a ``uint16`` array (or a plain Python list of ints) could already be
+the unit domain or could be byte-encoded, and reading byte codes as unit floats
+clips every code above 1 to pure white. :func:`linear_to_srgb` and
+:func:`relative_luminance` take unit linear light only, so an integer ``0``/``1``
+there is unambiguous and is accepted.
+
 Transfer function: IEC 61966-2-1 (sRGB), the piecewise curve -- not a bare 2.2
 power -- so round trips are exact to float precision. Luminance weights are
 Rec. 709 / sRGB primaries.
@@ -53,10 +65,26 @@ def srgb_to_linear(rgb: npt.ArrayLike) -> np.ndarray:
 
     Returns:
         ``float32`` array of the same shape, linear light in ``[0, 1]``.
+
+    Raises:
+        ValueError: if ``rgb`` is an integer array of any dtype other than
+            ``uint8``, whose scale is unknowable -- ``uint16``, ``int32`` or a
+            Python list of ints could already be the ``[0, 1]`` unit domain or
+            could be byte-encoded. The message names both accepted spellings;
+            the caller states the scale rather than this function guessing it.
     """
     x = np.asarray(rgb)
     if x.dtype == np.uint8:
         x = x.astype(np.float32) / 255.0
+    elif np.issubdtype(x.dtype, np.integer):
+        # Reading byte codes as unit floats would clip every code above 1 to
+        # white, silently, so the ambiguity is refused instead of resolved.
+        raise ValueError(
+            f"srgb_to_linear: cannot tell what scale a {x.dtype} array is on - sRGB input is "
+            "either uint8 in [0, 255] or float in [0, 1], and an integer array could be either. "
+            "Pass .astype(np.uint8) for byte-encoded values, or divide by the encoding maximum "
+            "(255 for 8-bit, 65535 for 16-bit) and pass float."
+        )
     else:
         x = x.astype(np.float32)
     x = np.clip(x, 0.0, 1.0)

--- a/tests/rendering/test_color.py
+++ b/tests/rendering/test_color.py
@@ -6,6 +6,12 @@ The sRGB transfer functions are light arithmetic's entry and exit points --
 the shadow-catcher multiply and the optional linear seam blend both go
 through them -- so their round trip and reference values are pinned here as
 pure numpy.
+
+``srgb_to_linear`` also owns the pipeline's only *scale* ambiguity: it is the
+one helper that accepts both byte codes and unit floats, so it is the one that
+can be handed a value whose scale it cannot know. That contract is pinned here
+too, including the boundary -- the two unit-only helpers must keep accepting an
+integer ``0``/``1``, which is unambiguous for them.
 """
 
 import numpy as np
@@ -49,3 +55,66 @@ def test_relative_luminance_uses_rec709_weights() -> None:
     prim = np.eye(3, dtype=np.float32)
     np.testing.assert_allclose(relative_luminance(prim), [0.2126, 0.7152, 0.0722], atol=1e-6)
     assert relative_luminance(np.ones(3, np.float32)) == pytest.approx(1.0, abs=1e-6)
+
+
+# Byte codes spanning the curve: 0 and 255 are the endpoints, 128 is the
+# reference midpoint, and every code above 1 is one the unit domain cannot hold.
+_SRGB_CODES = [0, 64, 128, 192, 255]
+
+
+@pytest.mark.parametrize("dtype", [np.uint16, np.int16, np.int32, np.int64])
+def test_a_non_uint8_integer_array_states_its_scale_instead_of_saturating(dtype) -> None:
+    """An integer array that is not ``uint8`` carries no scale of its own.
+
+    Resolving that ambiguity by assuming the unit domain reads every byte code
+    above 1 as "already fully lit" and clips it, so a 16-bit capture -- or any
+    array a caller widened -- decodes to pure white with nothing said.
+    """
+    reference = srgb_to_linear(np.array(_SRGB_CODES, np.uint8))
+    assert not np.allclose(reference, 1.0), "premise: these codes decode to a range, not to white"
+
+    try:
+        decoded = srgb_to_linear(np.array(_SRGB_CODES, dtype))
+    except ValueError as exc:
+        # A caller can only act on this if it names both accepted spellings.
+        assert "uint8" in str(exc)
+        assert "[0, 255]" in str(exc) and "[0, 1]" in str(exc)
+        return
+
+    raise AssertionError(
+        f"the same codes as {np.dtype(dtype).name} decoded to {np.round(decoded, 4).tolist()} "
+        f"instead of {np.round(reference, 4).tolist()}: every code above 1 was read as unit "
+        "linear light and clipped to white."
+    )
+
+
+def test_a_python_list_of_byte_codes_states_its_scale_too() -> None:
+    """``rgb`` is annotated ``ArrayLike`` and documented as accepting ``[0, 255]``.
+
+    ``np.asarray`` of a list of ints is ``int64``, so the plainest spelling the
+    annotation invites is the same ambiguity -- and must reach the same refusal
+    rather than the all-white decode.
+    """
+    with pytest.raises(ValueError, match="cannot tell what scale"):
+        srgb_to_linear(_SRGB_CODES)
+
+
+def test_both_documented_spellings_are_still_accepted() -> None:
+    """The guard must not narrow the contract to one of the two scales."""
+    codes = np.array(_SRGB_CODES, np.uint8)
+    np.testing.assert_allclose(srgb_to_linear(codes), srgb_to_linear(codes.astype(np.float32) / 255.0), atol=1e-7)
+    assert srgb_to_linear(np.uint8(255)) == pytest.approx(1.0)
+    assert srgb_to_linear(np.float32(1.0)) == pytest.approx(1.0)
+    # A bool mask is unit light by construction, not a byte code.
+    np.testing.assert_allclose(srgb_to_linear(np.array([True, False])), [1.0, 0.0], atol=1e-6)
+
+
+def test_the_unit_only_helpers_accept_an_integer_zero_one_array() -> None:
+    """The scale guard belongs only on the helper with two scales.
+
+    ``linear_to_srgb`` and ``relative_luminance`` take unit linear light and
+    nothing else, so an integer ``0``/``1`` is unambiguous for them; refusing it
+    there would reject a legitimate value.
+    """
+    np.testing.assert_allclose(linear_to_srgb(np.array([0, 1])), [0.0, 1.0], atol=1e-6)
+    np.testing.assert_allclose(relative_luminance(np.array([[0, 1, 0]])), [0.7152], atol=1e-6)

--- a/tests/rendering/test_ibl.py
+++ b/tests/rendering/test_ibl.py
@@ -209,3 +209,31 @@ class TestDeriveKeyLight:
     def test_non_image_env_map_is_refused(self, shape) -> None:
         with pytest.raises(ValueError, match=r"\(H, W, 3\)"):
             derive_key_light(np.zeros(shape, np.uint8))
+
+    def test_an_env_map_whose_scale_is_ambiguous_is_refused_not_read_as_another_light(self) -> None:
+        """The map's *shape* is checked; its *scale* reaches the decode untouched.
+
+        A map whose dtype carries no scale (a 16-bit capture, or an array a
+        caller widened) decoded as unit light saturates every non-black texel,
+        so the estimate stops being the brightest region's direction and
+        becomes the solid-angle centroid of everything that is not pure black --
+        a different light, reported as success.
+        """
+        env = self._env_with_blob(row=16, col=64, color=(220, 200, 40))
+        env[8:12, 100:112] = 60  # a dimmer source elsewhere, which must not win
+        reference = derive_key_light(env)
+        assert reference.color[2] < 0.5, "premise: the blob is not white, so its chromaticity is visible"
+
+        try:
+            got = derive_key_light(env.astype(np.uint16))
+        except ValueError as exc:
+            assert "uint8" in str(exc)
+            return
+
+        raise AssertionError(
+            f"the same map as uint16 derived azimuth={got.azimuth_deg:.1f} deg "
+            f"elevation={got.elevation_deg:.1f} deg color={tuple(round(c, 3) for c in got.color)}, "
+            f"not azimuth={reference.azimuth_deg:.1f} deg "
+            f"elevation={reference.elevation_deg:.1f} deg "
+            f"color={tuple(round(c, 3) for c in reference.color)}."
+        )


### PR DESCRIPTION
## Problem

`srgb_to_linear` is the entry point for every piece of light arithmetic in the hybrid-render pipeline (the shadow-catcher multiply, the optional linear seam blend, and the key-light estimate). It accepts **two scales** - byte codes in `[0, 255]` and unit floats in `[0, 1]` - and it decided between them from `dtype == np.uint8` alone:

```python
x = np.asarray(rgb)
if x.dtype == np.uint8:
    x = x.astype(np.float32) / 255.0
else:
    x = x.astype(np.float32)     # <- assumed to be [0, 1] already
x = np.clip(x, 0.0, 1.0)
```

So every *other* integer spelling of the same byte data fell into the `else` branch, was read as unit linear light, and was clipped. The parameter is annotated `npt.ArrayLike` and the docstring admits values "in `[0, 255]`", so the plainest spelling the annotation invites is already affected:

| input | decoded |
|---|---|
| `np.array([0, 64, 128, 192, 255], np.uint8)` | `[0.0, 0.0513, 0.2159, 0.5271, 1.0]` |
| the same codes as `uint16` / `int32` / `int16` / `int64` | `[0.0, 1.0, 1.0, 1.0, 1.0]` |
| `srgb_to_linear([0, 64, 128, 192, 255])` (a list is `int64`) | `[0.0, 1.0, 1.0, 1.0, 1.0]` |

Every code above 1 became pure white, with nothing raised, logged or returned to say so.

`derive_key_light` checks its environment map's *shape* and passes its *scale* straight into that decode, so the saturation reaches a user-visible result. On one map - a small bright warm window plus a broad dim cool wall glow - it stops reading the brightest region and instead reports the solid-angle centroid of everything that is not pure black:

| environment map spelled as | azimuth | elevation | colour |
|---|---|---|---|
| `uint8` | 14.8 deg | 56.0 deg | `(1.000, 0.746, 0.409)` |
| `uint16`, same codes | **70.2 deg** | **73.8 deg** | **`(1.000, 1.000, 1.000)`** |

A 55.4 deg azimuth error and the warm chromaticity gone, both reported as success. A 16-bit capture, an array a caller widened, or a hand-built map are all ordinary ways to arrive there.

## Change

Refuse an integer dtype other than `uint8` rather than resolving the ambiguity by assumption. A `uint16` array genuinely could be `[0, 255]` data or `[0, 65535]` data or already-unit values, and guessing is the present defect - so the message names both accepted spellings and the conversion for each:

```
srgb_to_linear: cannot tell what scale a uint16 array is on - sRGB input is either uint8 in
[0, 255] or float in [0, 1], and an integer array could be either. Pass .astype(np.uint8) for
byte-encoded values, or divide by the encoding maximum (255 for 8-bit, 65535 for 16-bit) and
pass float.
```

The guard belongs on this helper only, and that boundary is deliberate: `linear_to_srgb` and `relative_luminance` take unit linear light and nothing else, so an integer `0`/`1` is unambiguous for them and is still accepted. `srgb_to_linear` is the one helper with two scales, so it is the only one that can be handed a value whose scale it cannot know.

Both existing call paths already pass `uint8` (the compositor coerces `fg_rgb`/`bg_rgb` explicitly; `render_environment_map` returns `uint8`), so no shipped caller changes behaviour - the refusal is the only new outcome. `color.py`'s module docstring, which the package treats as the written-down statement of the colour-pipeline contract, now records the scale decision beside the space decision.

## Verification

Both trees on MuJoCo 3.5.0, `MUJOCO_GL=egl`.

Pre-fix split, new tests copied onto `upstream/main` (`74d078ab`): **6 failed / 29 passed**, every behavioural failure quoting the measured values (the tests use their own fixture map, so the numbers differ from the artifact's) -

```
the same codes as uint16 decoded to [0.0, 1.0, 1.0, 1.0, 1.0] instead of
[0.0, 0.0513, 0.2159, 0.5271, 1.0]: every code above 1 was read as unit linear
light and clipped to white.

the same map as uint16 derived azimuth=50.1 deg elevation=68.6 deg color=(1.0, 1.0, 1.0),
not azimuth=4.8 deg elevation=47.6 deg color=(1.0, 0.808, 0.036).
```

After: **35 passed**. Two of the 29 pre-fix passes are the controls that matter - both documented spellings (plus a `bool` mask) stay accepted, and the two unit-only helpers still take an integer `0`/`1`, which fails if the guard is ever widened to all three.

Blast radius - all of `tests/rendering`, every test naming the changed symbols, and the repo-wide docstring / ASCII / changelog / refusal guards (25 files):

| | failed | passed | skipped | collected |
|---|---|---|---|---|
| this branch | 0 | 1148 | 4 | 1152 |
| `upstream/main` + the new tests | 6 | 1142 | 4 | 1152 |

`1142 + 6 = 1148`, the base-only failures are exactly the 6 pre-fix ids, branch-only is empty, and the selection carries no pre-existing failures. `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 20 errors on both trees, none in the changed files.

## Artifact

One capture script per tree, same environment map, same camera. It derives the key light from each spelling and lights the arm with it - and where the library refuses, it parses the remedy out of the refusal and applies it, so nothing is hard-coded per side.

![sRGB input scale](https://raw.githubusercontent.com/cagataycali/robots/media-srgb-scale/srgb_scale.png)

Top row is `upstream/main`: two different lights from one map, both accepted. Bottom row is this change: the ambiguous spelling is refused and the refusal's own remedy recovers the correct light. The two renders differ by **16.38** mean absolute level before (64% of pixels by more than 8) and **0.0001** after, while the `uint8` render is unchanged by this commit (**0.00015** mean absolute level) - so the refusal is the only new behaviour.
