### PR TITLE
fix(mesh): scope the drive guarantees each bridge actually keeps

### DIFF
--- a/changelog.d/2445-drive-contract-fleet-scope.md
+++ b/changelog.d/2445-drive-contract-fleet-scope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **mesh**: `RosbridgeRobot.drive` and the rosbridge integration guide presented this bridge's velocity clamp, `max_duration` ceiling and trailing zero Twist as the fleet-standard drive contract shared with `RosBridgedRobot.drive` and `RtpsRobot.drive`. Only the numeric domains and the single-shot latch are shared; the other two bridges accept no ceilings and publish no trailing zero, so a timed drive there leaves the last velocity latched rather than self-stopping. Both surfaces now scope each guarantee to where it holds, and a guard grades the prose against all three bridges.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -119,9 +119,15 @@ robot = RosbridgeRobot(
 
 All parameters are optional except `node_name`, `cmd_vel_topic`, and `odom_topic`.
 
-### Fleet drive contract
+### Drive contract
 
-The `drive()` method follows the strands fleet-standard contract:
+`drive()` takes the fleet-standard `(linear, angular, duration, count)` shape,
+and two of its guarantees are fleet-standard too: every value is checked against
+the same numeric domains the [ROS 2](ros2-integration.md) and
+[RTPS](rtps-integration.md) bridges use, and a bare single-shot command latches.
+The velocity clamps, the `max_duration` ceiling and the trailing zero Twist are
+specific to this bridge - the other two accept no ceilings and publish no
+trailing zero, so a timed drive there leaves the last velocity latched.
 
 ```python
 # Direct, programmatic control:
@@ -132,23 +138,28 @@ pose = robot.get_pose()  # read one odometry sample
 scan = robot.get_scan()  # read one laser scan (error if no scan_topic)
 ```
 
-**Safety semantics:**
+**Safety semantics** (fleet-wide unless marked):
 
 - **Finite-input guards**: non-finite (NaN, inf) linear or angular velocities
   are rejected before any publish.
-- **Velocity clamps**: linear and angular are independently clamped to
-  `max_linear` and `max_angular`.
-- **Loud duration rejection**: `duration` must be positive, finite, and at most
-  `max_duration`; anything else returns a detailed error and nothing is published.
-- **Timed-command trailing zero**: every drive with a `duration` argument and a
-  non-zero command (or multi-message publish) automatically publishes a single
-  zero Twist afterwards - even if the main publish failed - so a timed drive
-  cannot leave the robot with a live velocity.
 - **Single-shot latch**: a bare single-message `drive()` (no `duration`, no
   `count > 1`) publishes once and latches in the robot's controller until
   `stop()` is called. This is standard cmd_vel behavior.
-- **stop() never gated**: the stop method always publishes a zero Twist,
-  regardless of prior state or publish failures.
+- **Velocity clamps** (this bridge only): linear and angular are independently
+  clamped to `max_linear` and `max_angular`. The other two bridges accept no
+  velocity ceiling and put the requested value on the wire unchanged.
+- **Loud duration rejection** (this bridge only): `duration` must be positive,
+  finite, and at most `max_duration`; anything else returns a detailed error and
+  nothing is published. The other two bridges accept any positive finite hold.
+- **Timed-command trailing zero** (this bridge only): every drive with a
+  `duration` argument and a non-zero command (or multi-message publish)
+  automatically publishes a single zero Twist afterwards - even if the main
+  publish failed - so a timed drive cannot leave the robot with a live velocity.
+  The other two bridges stop publishing without a trailing zero, so do not carry
+  a timed drive on them expecting it to self-stop.
+- **stop() never gated** (this bridge only): the stop method always publishes a
+  zero Twist, regardless of prior state or publish failures. On the ROS 2 bridge
+  the halt goes through the same operator gate as `drive()`.
 
 | Method | ROS action | Notes |
 |--------|------------|-------|

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -184,13 +184,20 @@ class RosbridgeRobot:
     ) -> dict[str, Any]:
         """Publish a velocity command over rosbridge.
 
-        Fleet-standard contract, shared with :meth:`RosBridgedRobot.drive` and
-        :meth:`RtpsRobot.drive`. Inputs are validated before any side effect;
-        velocities are then clamped to the constructor limits. Every timed or
-        multi-message non-zero command is followed by a single zero Twist -
-        even if the main publish failed - so a timed drive cannot leave the
-        robot with a live velocity. A bare single-shot command latches until
-        :meth:`stop`, like any raw cmd_vel publish.
+        Fleet-standard across all three mobile-base bridges: inputs are
+        validated against the shared numeric domains before any side effect,
+        and a bare single-shot command latches until :meth:`stop`, like any
+        raw cmd_vel publish.
+
+        Specific to this bridge: velocities are clamped to ``max_linear`` and
+        ``max_angular``, a hold beyond ``max_duration`` is refused, and every
+        timed or multi-message non-zero command is followed by a single zero
+        Twist - even if the main publish failed - so a timed drive cannot
+        leave the robot with a live velocity. :meth:`RosBridgedRobot.drive`
+        and :meth:`RtpsRobot.drive` carry none of the three: they accept no
+        velocity or duration ceiling, publish the requested burst unclamped,
+        and stop publishing without a trailing zero, so a timed drive there
+        leaves the last velocity latched in the robot's controller.
 
         Args:
             linear: Forward linear velocity (m/s), mapped to ``linear.x``. Must

--- a/tests/mesh/test_drive_contract_fleet_scope.py
+++ b/tests/mesh/test_drive_contract_fleet_scope.py
@@ -1,0 +1,278 @@
+"""Which drive guarantees are fleet-wide, and which belong to one bridge only.
+
+Three mobile-base bridges expose the same ``drive(linear, angular, duration,
+count)`` call over three transports, and an operator or agent that learns the
+contract from one drives the others with it. Two of the guarantees really are
+shared - the numeric domains every value is checked against, and the single-shot
+latch - while the velocity clamp, the ``max_duration`` ceiling and the trailing
+zero Twist are carried by ``RosbridgeRobot`` alone.
+
+That split matters most for the trailing zero, because it is the guarantee that
+a *timed* drive cannot leave a live velocity behind. Presenting it as fleet-wide
+tells a reader that ``RtpsRobot("rover", "/cmd_vel").drive(linear=1.0,
+duration=5.0)`` self-stops; it publishes fifty Twists at 1.0 m/s and then stops
+publishing, leaving the last one latched in the robot's controller.
+
+Every check here therefore *measures* each guarantee on all three bridges and
+grades the prose against the measurement, rather than pinning either half to a
+hardcoded expectation. A bridge that later gains the trailing stop makes the
+scope assertion fail, which is the intended signal: the guarantee has become
+fleet-wide and the two places that scope it have to say so.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.mesh.ros_bridge as ros_bridge_mod
+import strands_robots.mesh.rosbridge_robot as rosbridge_mod
+import strands_robots.mesh.rtps_robot as rtps_mod
+
+
+class _Recorder:
+    """Records the kwargs of each forwarded transport call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+#: (label, module, forwarded transport symbol, robot factory). One publish rate
+#: for all three so a duration hold derives the same message count everywhere.
+_BRIDGES: list[tuple[str, Any, str, Callable[[], Any]]] = [
+    (
+        "RosBridgedRobot",
+        ros_bridge_mod,
+        "use_ros",
+        lambda: ros_bridge_mod.RosBridgedRobot("rover", "/cmd_vel", "/odom", publish_rate=10.0),
+    ),
+    ("RtpsRobot", rtps_mod, "use_rtps", lambda: rtps_mod.RtpsRobot("rover", "/cmd_vel", publish_rate=10.0)),
+    (
+        "RosbridgeRobot",
+        rosbridge_mod,
+        "use_rosbridge",
+        lambda: rosbridge_mod.RosbridgeRobot("rover", "/cmd_vel", "/odom", publish_rate=10.0),
+    ),
+]
+
+_ZERO_TWIST = {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+
+def _drive(
+    monkeypatch: pytest.MonkeyPatch, bridge: tuple[str, Any, str, Callable[[], Any]], **kwargs: Any
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Drive one bridge with its transport replaced by a recorder."""
+    _, module, symbol, factory = bridge
+    recorder = _Recorder()
+    monkeypatch.setattr(module, symbol, recorder)
+    return factory().drive(**kwargs), recorder.calls
+
+
+# The measurable form of each documented guarantee. Each probe returns True when
+# the bridge exhibits it, so the prose can be graded against three real bridges
+# instead of against a list someone kept by hand.
+
+
+def _validates_before_publishing(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
+    result, calls = _drive(monkeypatch, bridge, linear=float("nan"))
+    return result["status"] == "error" and calls == []
+
+
+def _latches_a_single_shot(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
+    result, calls = _drive(monkeypatch, bridge, linear=1.0, count=1)
+    return result["status"] == "success" and len(calls) == 1 and calls[0]["fields"] != _ZERO_TWIST
+
+
+def _clamps_velocity(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
+    _, calls = _drive(monkeypatch, bridge, linear=99.0, count=1)
+    return bool(calls) and calls[0]["fields"]["linear"]["x"] < 99.0
+
+
+def _refuses_a_hold_past_a_ceiling(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
+    result, calls = _drive(monkeypatch, bridge, linear=1.0, duration=3600.0)
+    return result["status"] == "error" and calls == []
+
+
+def _appends_a_trailing_zero(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
+    _, calls = _drive(monkeypatch, bridge, linear=1.0, duration=5.0)
+    return bool(calls) and calls[-1]["fields"] == _ZERO_TWIST
+
+
+#: guarantee -> (probe, docstring phrase, docs bullet label).
+_GUARANTEES: dict[str, tuple[Callable[..., bool], str, str]] = {
+    "validated inputs": (_validates_before_publishing, "validated", "Finite-input guards"),
+    "single-shot latch": (_latches_a_single_shot, "latches", "Single-shot latch"),
+    "velocity clamp": (_clamps_velocity, "clamped", "Velocity clamps"),
+    "duration ceiling": (_refuses_a_hold_past_a_ceiling, "max_duration", "Loud duration rejection"),
+    "trailing zero Twist": (_appends_a_trailing_zero, "zero Twist", "Timed-command trailing zero"),
+}
+
+_FLEET_MARKER = "Fleet-standard across all three mobile-base bridges:"
+_BRIDGE_MARKER = "Specific to this bridge:"
+
+
+def _measure(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+    """The bridges that exhibit each guarantee, measured through ``drive``."""
+    return {name: [b[0] for b in _BRIDGES if probe(monkeypatch, b)] for name, (probe, _, _) in _GUARANTEES.items()}
+
+
+def _paragraphs(text: str) -> list[str]:
+    return [" ".join(block.split()) for block in re.split(r"\n\s*\n", text) if block.strip()]
+
+
+def _scoped_paragraph(marker: str) -> str:
+    """The ``drive`` docstring paragraph introduced by ``marker``."""
+    doc = inspect.getdoc(rosbridge_mod.RosbridgeRobot.drive) or ""
+    matches = [p for p in _paragraphs(doc) if p.startswith(marker)]
+    assert len(matches) == 1, (
+        f"RosbridgeRobot.drive should carry exactly one paragraph opening {marker!r}, found {len(matches)}. "
+        "Two of its guarantees hold on all three bridges and three on this one alone, so the docstring has to "
+        "label which is which - an unlabelled list reads as fleet-wide."
+    )
+    return matches[0]
+
+
+def test_the_three_bridges_are_the_ones_under_comparison() -> None:
+    """Premise: a shrunken bridge list would make every scope check vacuous."""
+    assert [b[0] for b in _BRIDGES] == ["RosBridgedRobot", "RtpsRobot", "RosbridgeRobot"]
+
+
+def test_each_guarantee_is_exhibited_by_at_least_one_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Premise: a probe that measures nothing would let any prose pass."""
+    for name, bridges in _measure(monkeypatch).items():
+        assert bridges, f"the probe for {name!r} found no bridge that exhibits it - the probe is broken"
+
+
+def test_the_drive_guarantees_split_into_fleet_wide_and_bridge_specific(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The measured split the two prose surfaces have to describe.
+
+    Fails if a bridge gains or loses one of these, which is the point: the
+    guarantee's scope changed and the prose that scopes it is now stale.
+    """
+    measured = _measure(monkeypatch)
+    every = {b[0] for b in _BRIDGES}
+
+    fleet_wide = sorted(name for name, bridges in measured.items() if set(bridges) == every)
+    bridge_only = sorted(name for name, bridges in measured.items() if bridges == ["RosbridgeRobot"])
+
+    assert fleet_wide == ["single-shot latch", "validated inputs"], measured
+    assert bridge_only == ["duration ceiling", "trailing zero Twist", "velocity clamp"], measured
+    assert sorted(fleet_wide + bridge_only) == sorted(_GUARANTEES), (
+        f"every guarantee must be either fleet-wide or this bridge's alone, got {measured}"
+    )
+
+
+def test_a_timed_drive_self_stops_on_one_bridge_and_latches_on_the_other_two(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consequence the trailing-zero scope is about, read off the wire."""
+    final_velocity: dict[str, float] = {}
+    for bridge in _BRIDGES:
+        _, calls = _drive(monkeypatch, bridge, linear=1.0, duration=5.0)
+        assert [c["count"] for c in calls][0] == 50, "round(5.0 * 10.0) messages"
+        final_velocity[bridge[0]] = calls[-1]["fields"]["linear"]["x"]
+
+    assert final_velocity == {"RosBridgedRobot": 1.0, "RtpsRobot": 1.0, "RosbridgeRobot": 0.0}
+
+
+#: Any wording that asserts this bridge's contract is the fleet's. Matched
+#: rather than pinned so the check grades whatever phrasing is in use.
+_SHARING_CLAIM = re.compile(r"shared with|[Ff]leet-standard")
+
+
+def test_no_paragraph_claiming_a_shared_contract_states_a_bridge_specific_guarantee(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect this file exists for, graded against whatever prose is there.
+
+    A guarantee carried by one bridge, written into a sentence group that says
+    the contract is shared with the other two, is read as theirs as well. The
+    trailing zero is the costly one: it is the guarantee that a timed drive
+    cannot leave a live velocity behind, and only this bridge has it.
+    """
+    measured = _measure(monkeypatch)
+    bridge_only = {_GUARANTEES[name][1]: name for name, bridges in measured.items() if bridges == ["RosbridgeRobot"]}
+    assert bridge_only, f"premise: some guarantee must be this bridge's alone, got {measured}"
+
+    doc = inspect.getdoc(rosbridge_mod.RosbridgeRobot.drive) or ""
+    claiming = [p for p in _paragraphs(doc) if _SHARING_CLAIM.search(p)]
+    assert claiming, "premise: the docstring should say which guarantees the three bridges share"
+
+    for paragraph in claiming:
+        overreach = sorted(f"{name!r} ({phrase!r})" for phrase, name in bridge_only.items() if phrase in paragraph)
+        assert not overreach, (
+            f"this paragraph of RosbridgeRobot.drive claims a shared contract and then states "
+            f"{', '.join(overreach)}, which no other bridge carries: {paragraph}"
+        )
+
+
+@pytest.mark.parametrize("guarantee", sorted(_GUARANTEES))
+def test_the_docstring_states_each_guarantee_in_the_scope_it_holds_in(
+    monkeypatch: pytest.MonkeyPatch, guarantee: str
+) -> None:
+    """A guarantee three bridges keep and one they do not cannot share a scope."""
+    measured = _measure(monkeypatch)[guarantee]
+    is_fleet_wide = set(measured) == {b[0] for b in _BRIDGES}
+    phrase = _GUARANTEES[guarantee][1]
+    fleet, specific = _scoped_paragraph(_FLEET_MARKER), _scoped_paragraph(_BRIDGE_MARKER)
+    holder, other = (fleet, specific) if is_fleet_wide else (specific, fleet)
+    scope = "fleet-wide" if is_fleet_wide else f"carried only by {', '.join(measured)}"
+
+    assert phrase in holder, (
+        f"{guarantee!r} is {scope}, so {phrase!r} belongs in the "
+        f"{'fleet-standard' if is_fleet_wide else 'bridge-specific'} paragraph of RosbridgeRobot.drive"
+    )
+    assert phrase not in other, f"{guarantee!r} is {scope}, so {phrase!r} must not appear in the other scope"
+
+
+def test_the_docstring_names_what_the_other_two_bridges_do_instead() -> None:
+    """A reader told a guarantee is local still needs to know the alternative."""
+    specific = _scoped_paragraph(_BRIDGE_MARKER)
+    for sibling in ("RosBridgedRobot.drive", "RtpsRobot.drive"):
+        assert sibling in specific, f"the bridge-specific paragraph should name {sibling}"
+    assert "latched" in specific, "it should say a timed drive on the other two leaves the velocity latched"
+
+
+# The docs page carries the same claim, so it is graded the same way ----------
+
+
+def _drive_contract_bullets() -> dict[str, str]:
+    """``label -> bullet text`` for the safety-semantics list on the docs page."""
+    page = Path(inspect.getfile(rosbridge_mod)).parents[2] / "docs" / "rosbridge-integration.md"
+    body = page.read_text(encoding="utf-8")
+    section = re.search(r"\n### Drive contract\n(.*?)(?=\n### )", body, re.DOTALL)
+    assert section is not None, (
+        "docs/rosbridge-integration.md should carry a '### Drive contract' section. It documented this "
+        "bridge's clamp, ceiling and trailing zero under a 'Fleet drive contract' heading, which reads as "
+        "though the ROS 2 and RTPS bridges carry them too."
+    )
+    bullets = re.findall(r"\n- \*\*(.+?)\*\*(.*?)(?=\n- \*\*|\n\n|\Z)", section.group(1), re.DOTALL)
+    return {label: " ".join((label + tail).split()) for label, tail in bullets}
+
+
+@pytest.mark.parametrize("guarantee", sorted(_GUARANTEES))
+def test_the_docs_page_marks_each_bridge_specific_guarantee(monkeypatch: pytest.MonkeyPatch, guarantee: str) -> None:
+    """The page's safety list is read as the fleet's unless it says otherwise."""
+    measured = _measure(monkeypatch)[guarantee]
+    is_fleet_wide = set(measured) == {b[0] for b in _BRIDGES}
+    label = _GUARANTEES[guarantee][2]
+    bullets = _drive_contract_bullets()
+
+    assert label in bullets, f"the drive-contract list should still document {label!r}, got {sorted(bullets)}"
+    marked = "this bridge only" in bullets[label]
+    if is_fleet_wide:
+        assert not marked, f"{guarantee!r} holds on all three bridges, so {label!r} must not be scoped to one"
+    else:
+        assert marked, (
+            f"{guarantee!r} is carried only by {', '.join(measured)}, so the {label!r} bullet has to say so - "
+            "unmarked, it reads as a guarantee of every mobile-base bridge"
+        )


### PR DESCRIPTION
## Problem

`RosbridgeRobot.drive` opened its docstring with:

> **Fleet-standard contract, shared with `RosBridgedRobot.drive` and `RtpsRobot.drive`.** Inputs are validated before any side effect; velocities are then clamped to the constructor limits. Every timed or multi-message non-zero command is followed by a single zero Twist - even if the main publish failed - so a timed drive cannot leave the robot with a live velocity. A bare single-shot command latches until `stop()`, like any raw cmd_vel publish.

and `docs/rosbridge-integration.md` listed the same semantics under a **"Fleet drive contract"** heading. Four guarantees, all under one "shared with" label. Driving the three bridges through a recorder shows two of them are carried by `RosbridgeRobot` alone:

| guarantee | `RosBridgedRobot` | `RtpsRobot` | `RosbridgeRobot` |
|---|---|---|---|
| validated before any side effect | yes | yes | yes |
| bare single-shot latches | yes | yes | yes |
| velocities clamped to constructor limits | **no** | **no** | yes |
| hold beyond a ceiling refused | **no** | **no** | yes |
| timed command followed by a zero Twist | **no** | **no** | yes |

Only `RosbridgeRobot` accepts `max_linear` / `max_angular` / `max_duration`; the other two take `publish_rate` alone. Concretely, with all three built at `publish_rate=10.0`:

```
drive(linear=99.0, angular=-42.0, count=1)      # wire linear.x / angular.z
  RosBridgedRobot   99.0 / -42.0
  RtpsRobot         99.0 / -42.0
  RosbridgeRobot     2.0 /  -1.0      <- clamped

drive(linear=1.0, duration=5.0)                 # published bursts, last Twist
  RosBridgedRobot   [50]      last linear.x = 1.0
  RtpsRobot         [50]      last linear.x = 1.0
  RosbridgeRobot    [50, 1]   last linear.x = 0.0   <- trailing zero

drive(linear=1.0, duration=3600.0)              # a one-hour hold
  RosBridgedRobot   success, 36000 messages
  RtpsRobot         success, 36000 messages
  RosbridgeRobot    error, nothing published
```

The trailing zero is the costly one to mislabel, because it is the guarantee that *a timed drive cannot leave a live velocity behind*. A reader who takes it as fleet-standard expects `RtpsRobot("rover", "/cmd_vel").drive(linear=1.0, duration=5.0)` to self-stop; it publishes fifty Twists at 1.0 m/s and then simply stops publishing, leaving the last one latched in the robot's controller. `tests/mesh/test_drive_command_numeric_domains.py` names that hazard directly - "an agent that learns the contract from one bridge drives the others with it" - and `docs/rtps-integration.md` / `docs/ros2-integration.md` say nothing about latching, so nothing contradicts the label.

The split was already the intended one: that same suite is divided into a `# Cross-bridge parity` section holding the numeric domains, and a `# rosbridge-specific consequences` section holding exactly the clamp, the ceiling and the trailing zero. The prose is what collapsed the two.

## Change

Both surfaces now state each guarantee in the scope it holds in.

The docstring splits into a fleet-standard paragraph (validated inputs, single-shot latch) and a bridge-specific one, and the second names what the other two bridges do instead, so a reader who is told a guarantee is local also learns the alternative:

> `RosBridgedRobot.drive` and `RtpsRobot.drive` carry none of the three: they accept no velocity or duration ceiling, publish the requested burst unclamped, and stop publishing without a trailing zero, so a timed drive there leaves the last velocity latched in the robot's controller.

The guide's heading becomes `### Drive contract`, its intro states which two guarantees are fleet-standard, and each bridge-specific bullet is marked `(this bridge only)` with the alternative spelled out.

No behaviour changes - `drive`, `stop`, the clamps and the trailing zero are untouched.

### Out of scope

Whether the other two bridges *should* clamp, take a ceiling and append a trailing zero is a separate call: it adds three constructor parameters to two classes and changes what reaches the wire for existing callers. This PR makes the documented claim match the code rather than picking that.

## Tests

`tests/mesh/test_drive_contract_fleet_scope.py` measures all five guarantees on all three bridges and grades the prose against the measurement, so neither half is pinned to a hand-kept list. Against `upstream/main`: **12 failed, 4 passed**; after: **16 passed**.

The headline reads whatever prose is present, so it fails on the real text rather than on a missing marker:

```
AssertionError: this paragraph of RosbridgeRobot.drive claims a shared contract
and then states 'trailing zero Twist' ('zero Twist'), 'velocity clamp'
('clamped'), which no other bridge carries: Fleet-standard contract, shared
with :meth:`RosBridgedRobot.drive` and :meth:`RtpsRobot.drive`. ...
```

The 4 tests that pass on **both** trees are the controls, and they are the ones that show nothing behavioural moved: the two premises, the measured fleet-wide/bridge-specific split, and the wire-level consequence (`{RosBridgedRobot: 1.0, RtpsRobot: 1.0, RosbridgeRobot: 0.0}` as the last commanded velocity of a 5 s hold). The split assertion is deliberately two-directional - a bridge that later gains the trailing stop fails it, which is the signal that the guarantee became fleet-wide and the two places scoping it have to say so.

## Verification

Measured at `08f596d9` against `upstream/main` `f4675b15`.

- 264-file blast radius (all of `tests/mesh`, every test naming one of the three bridges or the rosbridge guide, and the repo-wide docs/docstring/changelog guards), run sequentially on both trees:
  - branch **21 failed / 6306 passed / 61 skipped / 24 errors**
  - base **33 failed / 6294 passed / 61 skipped / 24 errors**
  - `33 - 21 = 6306 - 6294 = 12`, both collected **6412**; branch-only failures **empty**; base-only exactly the 12 pre-fix ids. The 45 shared failing ids are pre-existing `awsiot`-absent `tests/mesh/test_iot_*`.
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **20 == 20**, branch-only empty, none in the changed files.
- `scripts/assemble_changelog.py --check`: OK.

## Artifact

The Twists each bridge actually publishes for `drive(linear=1.0, duration=5.0)`, above the claim graded per surface. Both panels come from one capture script run against a worktree of `upstream/main` and against this branch; each side reads its **own** tree's docstring and guide, and the measurement row is identical in both, which is the control for "no behaviour changed". Wrong claims: 5 before (2 in the docstring, 3 in the guide), 0 after.

![drive contract scope](https://raw.githubusercontent.com/cagataycali/robots/media-drive-contract-scope/drive-contract-scope.png)
