### PR TITLE
fix(rendering): check the environment-map resolution knobs before baking with them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1421,6 +1421,39 @@ Corrections from code review that apply to all future contributions:
   `boolean_flag_error` itself rather than a copied spelling list, so a spelling added to
   the shared domain is covered without an edit.
 
+### A resolution knob is validated before the work it sizes
+- **Check the knob that sizes an expensive result before producing the result.** A
+  resolution is caller input like any other, and the numeric domains
+  (`positive_whole_number_error` for a pixel or frame count) are what it is checked
+  against. Checking it late is not merely a worse message: `render_environment_map`
+  paid six full background renders - GPU-bound for a `GsplatBackground` - before
+  returning a `(H, 0, 3)` map for `equi_w=0`, and `bake_environment_map` probed and
+  wrote its cache file before anything looked at the size it was baking.
+- **A zero-sized grid is a resolution mistake, and the consumer will misdiagnose it
+  as a property of the scene.** An empty map is not distinguishable from a dark one
+  by the code that reads it, so `derive_key_light` blamed the background - "the map
+  is black above the horizon" - and advised a search flag. Following that advice
+  fails identically, because a map with no texels has no hemisphere to search, so
+  the only remedy on offer was a dead end and the knob the caller actually got
+  wrong was named nowhere. Refuse at the entry point and the accurate diagnosis is
+  the first one the caller sees.
+- **Check the domain, not the quality.** A resolution the module cannot use is a
+  refusal; a resolution that merely buys a poor result is the caller's call, and
+  the two are worth keeping apart. `face_size` is the example: the equirect
+  reprojection scales by `face_size - 1`, so 1, 2 and 3 each resolve almost
+  nothing within a cube face, and the detail a map carries grows smoothly from
+  there with no boundary to pin a floor to. `0` cannot produce a map at all, so
+  that is refused; `1` can, so it is accepted.
+- **Normalize after checking.** The numeric domains deliberately accept an integral
+  float and a NumPy integer, so the value has to be put through `int()` before it
+  indexes anything - `HybridCompositor` does this for its own `default_width` /
+  `default_height`. Where the value is formatted into a cache key that is not
+  cosmetic: `2048` and `2048.0` spelled two different environment-map filenames for
+  one set of pixels, so a bake already on disk was missed and paid for again.
+- Pinned by `tests/rendering/test_environment_map_resolution_domain.py`, which
+  parametrizes over `positive_whole_number_error` itself rather than a copied value
+  list, so a value added to the shared domain is covered without an edit.
+
 ### One writer per log file
 - **A file two writers share needs one file object, not one path.** Two file objects over
   one path each track their own write offset, so a buffered writer flushes at its offset

--- a/changelog.d/2446-environment-map-resolution-domain.md
+++ b/changelog.d/2446-environment-map-resolution-domain.md
@@ -1,0 +1,10 @@
+### Fixed
+- **rendering**: `render_environment_map`, `bake_environment_map` and
+  `environment_map_cache_path` check `face_size` / `equi_w` / `equi_h` against the
+  shared `positive_whole_number_error` domain before rendering anything, and
+  normalize them with `int()` afterwards. `equi_w=0` previously returned a
+  zero-pixel map after six background renders, leaving `derive_key_light` to
+  report the scene as black and advise a search flag that cannot fix it; an
+  integral float such as `equi_w=32.0` - which that domain accepts - raised a bare
+  `TypeError` from `numpy`, and in the cache path spelled a second filename for
+  pixels already baked.

--- a/strands_robots/rendering/ibl.py
+++ b/strands_robots/rendering/ibl.py
@@ -37,10 +37,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
-from strands_robots.utils import boolean_flag_error
+from strands_robots.utils import boolean_flag_error, positive_whole_number_error
 
 from .camera import CameraParams
 from .color import relative_luminance, srgb_to_linear
@@ -93,6 +94,42 @@ def _face_camera(
     K = np.array([[f, 0.0, face_size / 2], [0.0, f, face_size / 2], [0.0, 0.0, 1.0]])
     cam = CameraParams(K=K, T_world_cam=Twc, width=face_size, height=face_size, znear=znear, zfar=zfar)
     return cam, right, u
+
+
+def _resolution_error(
+    context: str,
+    *,
+    face_size: Any,
+    equi_w: Any,
+    equi_h: Any,
+) -> str | None:
+    """Error text when a resolution knob cannot produce a usable map, else None.
+
+    The three knobs that size the pixel grid share one domain, checked in one
+    place so the render, the bake and the cache-path cannot disagree about which
+    resolutions this module can honor.
+
+    Only the domain is checked here, not the *quality* a resolution buys. A very
+    coarse cube face is still a cube face: the reprojection scales by
+    ``face_size - 1``, so 1, 2 and 3 each resolve almost nothing within a face
+    (measured on a background with a gradient inside every face: 4, 4 and 5
+    distinct colours in the whole map, growing smoothly from 4 upward). Where
+    "too coarse" begins is a judgement about acceptable quality rather than a
+    value the module cannot use, so it is left to the caller.
+
+    Args:
+        context: Calling function name, quoted in the message.
+        face_size: Cube-face resolution in pixels.
+        equi_w: Equirect width in pixels.
+        equi_h: Equirect height in pixels.
+
+    Returns:
+        The refusal text, or ``None`` when every knob is usable.
+    """
+    for value, param in ((face_size, "face_size"), (equi_w, "equi_w"), (equi_h, "equi_h")):
+        if text := positive_whole_number_error(value, param, context):
+            return text
+    return None
 
 
 def _equirect_directions(equi_w: int, equi_h: int, half_texel: bool = False) -> np.ndarray:
@@ -149,7 +186,18 @@ def render_environment_map(
 
     Returns:
         ``(equi_h, equi_w, 3) uint8`` equirectangular environment map.
+
+    Raises:
+        ValueError: if any resolution knob is not a positive whole number.
+            Checked before the six background renders,
+            which are GPU-bound for a
+            :class:`~strands_robots.rendering.backgrounds.GsplatBackground`.
     """
+    if text := _resolution_error("render_environment_map", face_size=face_size, equi_w=equi_w, equi_h=equi_h):
+        raise ValueError(text)
+    # Normalize to plain ints: the shared domain accepts an integral float and a
+    # NumPy integer, and both index the grid below.
+    face_size, equi_w, equi_h = int(face_size), int(equi_w), int(equi_h)
     origin = np.asarray(origin_world, dtype=np.float64).reshape(3)
     face_imgs: list[np.ndarray] = []
     face_bases: list[tuple[np.ndarray, np.ndarray, np.ndarray]] = []
@@ -210,7 +258,17 @@ def environment_map_cache_path(
     Returns:
         The cache path (a ``.png`` -- environment maps feed light sampling,
         so JPEG block artifacts are not welcome).
+
+    Raises:
+        ValueError: if any resolution knob is not a positive whole number. The name
+            encodes the resolutions, so a knob this module refuses to render must
+            not be named a cache entry.
     """
+    if text := _resolution_error("environment_map_cache_path", face_size=face_size, equi_w=equi_w, equi_h=equi_h):
+        raise ValueError(text)
+    # Normalize before formatting: this name IS the cache key, so an integral
+    # float must not spell a second file for pixels already baked.
+    face_size, equi_w, equi_h = int(face_size), int(equi_w), int(equi_h)
     scene_path = Path(scene_path)
     ox, oy, oz = (float(c) for c in origin_world)
     stem = f"{scene_path.stem}_env_{equi_w}x{equi_h}_f{face_size}_o{ox:+.3f}_{oy:+.3f}_{oz:+.3f}"
@@ -243,7 +301,16 @@ def bake_environment_map(
 
     Returns:
         The path to the written (or cached) environment map.
+
+    Raises:
+        ValueError: if any resolution knob is not a positive whole number.
+            Checked before the cache probe, so an
+            unusable resolution never writes a file the short-circuit would then
+            serve on every later call.
     """
+    if text := _resolution_error("bake_environment_map", face_size=face_size, equi_w=equi_w, equi_h=equi_h):
+        raise ValueError(text)
+    face_size, equi_w, equi_h = int(face_size), int(equi_w), int(equi_h)
     out = Path(out_path)
     if out.exists() and out.stat().st_size > 0:
         return out

--- a/tests/rendering/test_environment_map_resolution_domain.py
+++ b/tests/rendering/test_environment_map_resolution_domain.py
@@ -1,0 +1,220 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The environment-map resolution knobs are validated before anything is rendered.
+
+``face_size``, ``equi_w`` and ``equi_h`` size the pixel grid of every
+environment map this module bakes. ``derive_key_light``, in the same module,
+checks both of its own knobs -- ``brightest_fraction`` four ways and
+``upper_hemisphere`` on the shared flag domain -- and validates the map's shape;
+the three functions that take the resolutions checked none of them. What follows
+is pinned here.
+
+A zero-sized grid produced a map rather than a refusal. ``equi_w=0`` returned a
+``(H, 0, 3)`` array of no pixels, reporting success, and only after paying six
+full background renders -- GPU-bound for a ``GsplatBackground``. The refusal the
+caller eventually saw came from ``derive_key_light`` and blamed the scene: "the
+map is black above the horizon -- pass ``upper_hemisphere=False`` to search the
+full sphere". Following that advice fails the same way, because the map has no
+texels at all rather than a dark upper half, so the only remedy offered was a
+dead end and the resolution the caller had asked for was named nowhere.
+
+Only the domain is pinned here, not the quality a resolution buys. A very coarse
+cube face is still a usable one, and there is no sharp boundary to hold it to:
+the reprojection scales by ``face_size - 1``, so 1, 2 and 3 each resolve almost
+nothing within a face (measured on a background carrying a gradient inside every
+face: 4, 4 and 5 distinct colours in the whole map, growing smoothly from 4
+upward). Where "too coarse" begins is a judgement about acceptable quality rather
+than a value the module cannot use, so ``face_size=1`` is still accepted and the
+tests below assert only that a positive whole number reaches the bake.
+
+That shared domain accepts an integral float and a NumPy integer ("a ``30.0``
+computed from a config float passes"), which these three then could not index a
+grid with -- ``equi_w=32.0`` raised a bare ``TypeError`` from ``np.zeros`` and
+``face_size=8.0`` an ``IndexError``. They are normalized with ``int()`` after the
+check, the way ``HybridCompositor`` normalizes its own ``default_width`` /
+``default_height``. In the cache path that normalization is load-bearing rather
+than cosmetic: the name IS the cache key, so ``2048`` and ``2048.0`` spelled two
+files for one set of pixels and a bake already on disk was paid for twice.
+
+The domain is :func:`~strands_robots.utils.positive_whole_number_error`, the
+shared one for a knob counting pixels, so what this refuses cannot diverge from
+the recorders' ``width``/``height`` or ``encode_clip``'s rate. It is also the
+authority these tests parametrize over, so a value added there is covered here
+without an edit.
+"""
+
+import re
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import (
+    bake_environment_map,
+    derive_key_light,
+    environment_map_cache_path,
+    render_environment_map,
+)
+from strands_robots.utils import positive_whole_number_error
+
+# A resolution every entry point can honor, small enough to keep the fake
+# background cheap.
+GOOD = {"face_size": 8, "equi_w": 32, "equi_h": 16}
+
+# Values the shared domain refuses. Parametrized over rather than hand-listed so
+# the two cannot drift; each is asserted to be out of domain as a premise.
+OUT_OF_DOMAIN = [0, -8, 2.5, True, False, float("nan"), float("inf"), None, "16"]
+
+RESOLUTION_PARAMS = ["face_size", "equi_w", "equi_h"]
+
+
+def _sizes(**overrides: Any) -> dict[str, Any]:
+    """The usable resolution with ``overrides`` applied, as loose kwargs.
+
+    Typed ``Any`` deliberately: half of these cases pass a value the signatures
+    reject, which is the point of the test.
+    """
+    return {**GOOD, **overrides}
+
+
+class WindowBackground:
+    """Warm window on the +X wall of a dimly bounced room.
+
+    Direction-aware, like a real background: the face direction is the camera
+    rotation's ``-Z`` (the bake builds ``T_world_cam`` columns
+    ``[right, up, -fwd]``), and only the ``+X`` face carries the window. A
+    background that painted every face alike would hide what a coarse cube face
+    costs, since there would be nothing inside a face to lose.
+
+    Records how many renders it was asked for, so a refusal that arrives before
+    the bake can be told from one that arrives after it.
+    """
+
+    name = "window"
+
+    def __init__(self) -> None:
+        self.renders = 0
+
+    def render(self, cam):
+        self.renders += 1
+        w, h = int(cam.width), int(cam.height)
+        fwd = -np.asarray(cam.T_world_cam, dtype=float)[:3, 2]
+        rgb = np.zeros((h, w, 3), np.uint8)
+        rgb[:, :] = (46, 54, 72)
+        if fwd[0] > 0.9:
+            top = int(h * 0.30)
+            rgb[top : max(top + 1, int(h * 0.55)), max(0, w // 2 - w // 6) : w // 2 + max(1, w // 6)] = (
+                252,
+                206,
+                128,
+            )
+        return rgb, np.full((h, w), 1e3, np.float32)
+
+
+class TestAZeroSizedGridIsRefusedRatherThanBaked:
+    """The headline: a grid with no pixels must not be reported as a map."""
+
+    @pytest.mark.parametrize("param", ["equi_w", "equi_h"])
+    def test_a_zero_sized_equirect_is_refused_naming_the_knob(self, param: str) -> None:
+        bg = WindowBackground()
+        try:
+            env = render_environment_map(bg, **_sizes(**{param: 0}))
+        except ValueError as exc:
+            assert param in str(exc), f"the refusal must name {param}, got {exc}"
+            assert bg.renders == 0, f"refused after {bg.renders} background renders; check before rendering"
+            return
+        # Pre-fix: a map was returned. Report what the caller is left holding,
+        # including the remedy the only refusal they ever see advertises.
+        message = ""
+        try:
+            derive_key_light(env)
+        except ValueError as exc:
+            message = str(exc)
+        remedy = re.search(r"pass (upper_hemisphere=\w+)", message)
+        followed = "no remedy was offered"
+        if remedy:
+            try:
+                derive_key_light(env, upper_hemisphere=False)
+                followed = "the remedy worked"
+            except ValueError as exc:
+                followed = f"following it fails again: {exc}"
+        raise AssertionError(
+            f"{param}=0 returned a map of shape {env.shape} ({env.size} pixels) after "
+            f"{bg.renders} background renders instead of naming {param}. The caller's only "
+            f"refusal blames the scene: {message!r} -- and {followed}."
+        )
+
+    def test_the_scene_diagnosis_is_not_reachable_from_an_empty_grid(self) -> None:
+        """A resolution mistake must not be reported as a dark scene."""
+        with pytest.raises(ValueError) as excinfo:
+            render_environment_map(WindowBackground(), **_sizes(equi_w=0))
+        text = str(excinfo.value)
+        assert "upper_hemisphere" not in text, f"a resolution refusal must not advise a search flag: {text}"
+        assert "black" not in text, f"a resolution refusal must not blame the scene: {text}"
+
+
+class TestEveryEntryPointSharesTheDomain:
+    """The render, the bake and the cache path agree on what they can honor."""
+
+    @pytest.mark.parametrize("bad", OUT_OF_DOMAIN)
+    @pytest.mark.parametrize("param", RESOLUTION_PARAMS)
+    def test_render_refuses_what_the_shared_domain_refuses(self, param: str, bad: object) -> None:
+        assert positive_whole_number_error(bad, param, "ctx") is not None, "premise: out of the shared domain"
+        bg = WindowBackground()
+        with pytest.raises(ValueError, match=re.escape(param)):
+            render_environment_map(bg, **_sizes(**{param: bad}))
+        assert bg.renders == 0
+
+    @pytest.mark.parametrize("bad", OUT_OF_DOMAIN)
+    @pytest.mark.parametrize("param", RESOLUTION_PARAMS)
+    def test_bake_refuses_it_too_and_writes_nothing(self, param: str, bad: object, tmp_path) -> None:
+        out = tmp_path / f"env_{param}.png"
+        with pytest.raises(ValueError, match=re.escape(param)):
+            bake_environment_map(WindowBackground(), out, **_sizes(**{param: bad}))
+        assert not out.exists()
+
+    @pytest.mark.parametrize("bad", OUT_OF_DOMAIN)
+    @pytest.mark.parametrize("param", RESOLUTION_PARAMS)
+    def test_the_cache_path_names_no_file_for_a_refused_resolution(self, param: str, bad: object, tmp_path) -> None:
+        with pytest.raises(ValueError, match=re.escape(param)):
+            environment_map_cache_path(tmp_path / "scene.ply", (0.0, 0.0, 0.4), **_sizes(**{param: bad}))
+
+
+class TestTheAcceptedDomainIsUnchanged:
+    """Controls: what worked before still works, and no floor was invented."""
+
+    def test_a_usable_resolution_still_bakes(self, tmp_path) -> None:
+        bg = WindowBackground()
+        env = render_environment_map(bg, **_sizes())
+        assert env.shape == (GOOD["equi_h"], GOOD["equi_w"], 3)
+        assert bg.renders == 6
+        out = tmp_path / "env.png"
+        baked = bake_environment_map(WindowBackground(), out, **_sizes())
+        assert baked == out
+        assert out.stat().st_size > 0
+
+    @pytest.mark.parametrize("param", RESOLUTION_PARAMS)
+    def test_an_integral_float_and_a_numpy_int_are_still_accepted(self, param: str) -> None:
+        """The shared domain accepts these, so the entry points must too."""
+        for value in (float(GOOD[param]), np.int64(GOOD[param])):
+            assert positive_whole_number_error(value, param, "ctx") is None, "premise: in the shared domain"
+            env = render_environment_map(WindowBackground(), **_sizes(**{param: value}))
+            assert env.size > 0
+
+    def test_an_integral_float_names_the_same_cache_entry_as_the_int(self, tmp_path) -> None:
+        """The name is a cache key, so one resolution must spell one file."""
+        scene = tmp_path / "scene.ply"
+        as_int = environment_map_cache_path(scene, (0.0, 0.0, 0.4), **_sizes())
+        as_float = environment_map_cache_path(
+            scene, (0.0, 0.0, 0.4), **_sizes(**{k: float(v) for k, v in GOOD.items()})
+        )
+        assert as_int == as_float, (
+            f"the same resolution spelled two cache entries ({as_int.name} vs {as_float.name}), so a bake "
+            "already on disk is missed and paid for again"
+        )
+
+    @pytest.mark.parametrize("param", ["equi_w", "equi_h"])
+    def test_a_single_texel_equirect_axis_is_still_accepted(self, param: str) -> None:
+        """A one-texel axis is small but usable, so it stays accepted."""
+        env = render_environment_map(WindowBackground(), **_sizes(**{param: 1}))
+        assert env.shape[0 if param == "equi_h" else 1] == 1


### PR DESCRIPTION
## Problem

`render_environment_map`, `bake_environment_map` and `environment_map_cache_path` take `face_size`, `equi_w` and `equi_h` and validated none of them. `derive_key_light`, in the same module, checks both of its own knobs (`brightest_fraction` four ways, `upper_hemisphere` on the shared flag domain) and validates the map's shape.

**A zero-sized grid produced a map rather than a refusal.** `equi_w=0` returned a `(64, 0, 3)` array of **0 pixels**, reporting success, after paying **six full background renders** - GPU-bound for a `GsplatBackground`. The only refusal the caller ever saw came from the consumer, and it blamed the scene:

```
derive_key_light: no light in the searched region (the map is black above the
horizon -- pass upper_hemisphere=False to search the full sphere, or keep the
caller's default key light).
```

Following that advice fails identically, because the map has no texels at all rather than a dark upper half:

```
derive_key_light: no light in the searched region (the map is black ; keep the
caller's default key light).
```

So the sole remedy on offer was a dead end, and `equi_w` - the knob that was actually wrong - was named nowhere. `environment_map_cache_path` would meanwhile happily name `room_env_0x64_f32_o+0.000_+0.000_+0.600.png` for an image that cannot exist.

**The values that did raise reported numpy internals**, naming neither the parameter nor the function, which for a call with five resolution knobs leaves the caller guessing: `equi_w=-8` -> `negative dimensions are not allowed`; `face_size=0` -> `index -1 is out of bounds for axis 0 with size 0`; `face_size=2.5` -> `arrays used as indices must be of integer (or boolean) type`; `equi_w=nan` -> `arange: cannot compute length`.

**An integral float, which the shared domain accepts, could not be used.** `positive_whole_number_error` deliberately accepts `30.0` "computed from a config float" and a NumPy integer, but `equi_w=32.0` raised a bare `TypeError` from `np.zeros` and `face_size=8.0` an `IndexError`. In the cache path the same value split the key: `2048` and `2048.0` spelled two different filenames for one set of pixels, so a bake already on disk was missed and paid for again.

## Change

All three functions check the three knobs against `positive_whole_number_error` - the shared domain for a pixel count, so what they refuse cannot diverge from the recorders' `width`/`height` or `encode_clip`'s rate - through one private helper, before any render or cache probe. Each then normalizes with `int()`, the way `HybridCompositor` normalizes its own `default_width`/`default_height` ("so a `np.int64` must not leak through").

| case | before | after |
|---|---|---|
| `equi_w=0` | `(64, 0, 3)` map, 6 renders, success | refused in **0** renders, names `equi_w` |
| `equi_h=0` | `(0, 64, 3)` map, 6 renders, success | refused in 0 renders, names `equi_h` |
| `face_size=0` / `-8` / `2.5` / `inf` | numpy internals | names the parameter and the function |
| `equi_w=True` | `an integer is required` | refused as a bool |
| `equi_w=32.0` | `TypeError` from `np.zeros` | accepted, normalized to `32` |
| cache key `2048` vs `2048.0` | two filenames | one filename |
| valid resolution | works | **byte-identical** |

`znear`/`zfar` are deliberately untouched: they are handed to the background, whose own contract governs them, and no consequence of a bad value is observable in this module.

Only the *domain* is checked, not the *quality* a resolution buys. A very coarse cube face is still a usable one and there is no boundary to pin a floor to: the reprojection scales by `face_size - 1`, so 1, 2 and 3 each resolve almost nothing within a face (measured on a background carrying a gradient inside every face: 4, 4 and 5 distinct colours in the whole map, growing smoothly from 4 upward). `0` cannot produce a map at all, so it is refused; `1` can, so it is accepted, and two tests pin that no floor was invented for `equi_w`/`equi_h` either.

## Tests

`tests/rendering/test_environment_map_resolution_domain.py`, parametrized over `positive_whole_number_error` itself rather than a copied value list, so a value added to the shared domain is covered without an edit.

Against `upstream/main`: **88 failed / 3 passed** -> **91 passed**. The headline failure reports the measured consequence rather than a missing raise:

```
AssertionError: equi_w=0 returned a map of shape (16, 0, 3) (0 pixels) after 6
background renders instead of naming equi_w. The caller's only refusal blames
the scene: "...the map is black above the horizon -- pass upper_hemisphere=False
..." -- and following it fails again: ...
```

The 3 that pass on both trees are the controls: a usable resolution still bakes (6 renders, correct shape, non-empty file), and a one-texel `equi_w` / `equi_h` axis is still accepted - the last two fail if anyone extends the refusal into a coarseness floor.

## Verification

Measured at `72d81fc6` against `upstream/main` `0640c9c9`, same interpreter, 104-file selection (all of `tests/rendering`, every test naming the changed symbols or `positive_whole_number_error`, plus the repo-wide docstring / string / changelog / dependency guards):

- branch **1 failed / 5212 passed / 33 skipped**, base **89 failed / 5124 passed / 33 skipped**
- `5124 + 89 == 5212 + 1 == 5213` collected on both; **branch-only failures: none**; base-only 88, all in the new file, zero foreign
- the single shared failure is pre-existing and unrelated (`tests/mesh/test_safety_timing_and_replay_defenses.py::TestResumeLockoutTimingOracleClosed::test_correct_override_code_clears_lockout`, `AttributeError: 'Mesh' object has no attribute '_safety_publishers_lock'`)
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 20 errors on both trees, none in the changed files

## Artifact

One capture script run against `upstream/main` and against this branch, same fake room background, only `strands_robots` differing. The left panel is the control: at a usable resolution both trees derive the identical key light (azimuth `+0.10 deg`, elevation `+10.72 deg`, colour `(1.0, 0.634, 0.222)`) and the MuJoCo render of a `ur5e` lit by it differs by a mean of `0.000123` levels.

![environment-map resolution domain](https://raw.githubusercontent.com/cagataycali/robots/media-envmap-resolution/resolution_domain.png)

The background is a stand-in for a `GsplatBackground` (`gsplat` ships in the `sim-gs` extra); everything else in the capture is shipped code.
