### PR TITLE
fix(teleop): read a device selector by membership instead of by truthiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1421,6 +1421,35 @@ Corrections from code review that apply to all future contributions:
   `boolean_flag_error` itself rather than a copied spelling list, so a spelling added to
   the shared domain is covered without an edit.
 
+### A subset selector is read by membership, never by truthiness
+- **A parameter that names a SUBSET of a collection the call already owns is not a value
+  with a default; it is a selection.** `None` means "all of it" on these surfaces, so
+  reading the parameter by truthiness makes every other falsy value take that same branch
+  - and for a selector, that is not a wider default but the *opposite* answer. An empty
+  selection asks for nothing and was served everything: `teleoperate(names=[])`, which is
+  what a filter that matched nothing produces, connected and drove every attached leader,
+  and `detach_teleop("")` removed the whole attached set. Both reported success.
+- **Read it `is None`, and refuse the empty selection rather than widening it.** A scalar
+  default (a path, a device string, an empty `fields` dict) can be read by truthiness
+  because empty and absent genuinely coincide there - the value is derived either way. A
+  subset selector is the case where they diverge, so it needs the membership read plus its
+  own verdict on emptiness, which the shared name-list domain deliberately leaves to the
+  caller ("a surface where an absent value IS an error keeps that verdict its own").
+- **The other unhonorable spellings belong to `name_list_error`.** A single name as a bare
+  string is iterable per character, a repeated name makes the call do its unit of work
+  twice, and a one-shot iterator is consumed by whichever check reads it first, leaving the
+  real consumer nothing. Route the shape through the shared domain and keep only the
+  emptiness verdict local; refuse before the call touches hardware, a filesystem or a
+  thread, so a refused selection has no partial effect to undo.
+- **A selection widened to everything can also reach past the call.** `detach_teleop` stops
+  the local loop once nothing is left to drive, so a detach widened from one stream to all
+  of them ended a running session as a side effect of the misread.
+- Pinned by `tests/test_teleop_device_selection_domain.py`, whose controls assert that the
+  documented spellings (`names=None`, a real subset, `detach_teleop(None)`) are unchanged,
+  and by the render path's `cameras` resolution, which has read the same kind of selector
+  `is None` all along - an empty camera selection there resolves to no camera rather than
+  to every one.
+
 ### One writer per log file
 - **A file two writers share needs one file object, not one path.** Two file objects over
   one path each track their own write offset, so a buffered writer flushes at its offset

--- a/changelog.d/2448-teleop-device-selection-membership.md
+++ b/changelog.d/2448-teleop-device-selection-membership.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **teleop**: read a teleop device selector by membership instead of by truthiness, so an
+  empty selection is refused rather than widened to every attached device.
+  `teleoperate(names=[])` - what a filter that matched nothing produces - connected and
+  drove every attached leader and reported success, and `detach_teleop("")` detached the
+  whole attached set, which also ended a running session because `detach_teleop` stops the
+  loop once nothing is left to drive. `names` now goes through the shared name-list domain
+  as well, so a single name passed as a bare string, a repeated name (polled twice per
+  tick) and a one-shot iterator (consumed before the loop could poll it) are refused before
+  any device is connected. `names=None`, a named subset and `detach_teleop(None)` are
+  unchanged.

--- a/docs/hardware/teleoperation.md
+++ b/docs/hardware/teleoperation.md
@@ -102,7 +102,16 @@ Every hardware `Robot` and `Simulation` host exposes:
 
 ### `teleoperate`
 
-- **`names`** - subset of attached streams to run (default: all).
+- **`names`** - subset of attached streams to run (`None`, the default, runs
+  every attached stream). The selection is read by membership, so only `None`
+  means "all": `names=[]` names no stream and is **refused** rather than widened
+  to every device, because a filter that matched nothing must not energise and
+  drive every leader attached to the host. The list is held to the shared
+  name-list domain - several distinct names, as a list - so `names="leader"` is
+  refused as a single string rather than read as one stream per character, a
+  repeated name is refused rather than polling that device twice per tick, and a
+  one-shot iterator is refused rather than being consumed before the loop can
+  poll it. Every one of these is refused before any device is connected.
 - **`robot_name`** - target robot in a multi-robot simulation world.
 - **`hz`** - control-loop rate (default `50.0`).
 - **`publish`** - also publish each device to the mesh via the host's
@@ -150,6 +159,16 @@ Refusals are not errors, but a session with any of them does not report
 `success`, so a device whose units the bound does not expect (degree-valued or
 normalized-percent) cannot look like a clean run while moving nothing - widen
 the bound for those.
+
+### `detach_teleop`
+
+- **`name`** - which attached stream to remove. `None` (the default) detaches
+  every one; any other value names a single stream. Read by membership, like
+  `teleoperate(names=)`, so a value naming no attached stream is refused rather
+  than widened to the whole set - `detach_teleop("")` reports
+  `No teleop named ''.` and leaves every stream attached. That matters mid-
+  session: `detach_teleop` stops the loop once nothing is left to drive, so a
+  detach widened to all streams would also end a running session.
 
 ## Action-key compatibility
 

--- a/strands_robots/teleop_mixin.py
+++ b/strands_robots/teleop_mixin.py
@@ -47,7 +47,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from strands_robots.utils import positive_finite_number_error
+from strands_robots.utils import name_list_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -333,10 +333,27 @@ class TeleopMixin:
 
         Stops the local loop first if it's running and would be left with no
         devices. Disconnects each detached device if it was connected.
+
+        Args:
+            name: Which attached stream to detach. ``None`` = every attached
+                device. Read by membership, so only ``None`` selects all: any
+                other value names one stream, and a value naming no attached
+                stream is refused rather than widened to the whole set.
+
+        Returns:
+            Status dict; error when ``name`` names no attached teleoperator.
         """
         self._ensure_teleop_state()
 
-        names = [name] if name else list(self._teleops)
+        # ``name`` selects which attached devices this call operates on, so it is
+        # read by membership: ``None`` is the documented "detach every attached
+        # device", and any other value names one. Read by truthiness, ``""`` took
+        # the all-devices branch, so a detach aimed at a single stream removed the
+        # whole set - and, with a session running, ended it, because the branch
+        # below stops the loop once nothing is left to drive. An empty name is not
+        # a spelling of "all"; it names no attached device, so it now reaches the
+        # not-found refusal below.
+        names = list(self._teleops) if name is None else [name]
         detached = []
         for n in names:
             att = self._teleops.pop(n, None)
@@ -401,7 +418,14 @@ class TeleopMixin:
         ``self.send_action(merged, robot_name=...)``.
 
         Args:
-            names: Subset of attached device names to drive. ``None`` = all.
+            names: Subset of attached device names to drive. ``None`` = every
+                attached device. Read by membership, so an explicitly empty
+                selection is not a spelling of "all": ``names=[]`` is refused
+                rather than widened to every device. The list itself is held to
+                the shared name-list domain - several distinct non-blank names,
+                as a sequence - so a single name passed as a bare string, a
+                repeated name, and a one-shot iterator are refused rather than
+                reinterpreted.
             robot_name: Target robot for ``send_action``. ``None`` -> the
                 host's default (single hardware robot, or first sim robot).
                 In a multi-robot sim, name the specific robot.
@@ -431,7 +455,9 @@ class TeleopMixin:
             with any of them does not report ``success``, so a device whose
             units the bound does not expect cannot look like a clean run while
             moving nothing. An ``hz`` or ``duration`` the loop cannot honor is
-            refused here rather than reported as a started session.
+            refused here rather than reported as a started session, as is a
+            ``names`` that does not name a usable subset - both are refused
+            before any device is connected.
         """
         self._ensure_teleop_state()
 
@@ -459,7 +485,43 @@ class TeleopMixin:
                 "content": [{"text": "Teleoperation already running. Call stop_teleoperate() first."}],
             }
 
-        selected = names or list(self._teleops)
+        # ``names`` selects a SUBSET of the attached devices, so it is read by
+        # membership - the same rule ``duration`` is read by in this call and
+        # ``cameras`` is resolved by on the render path, where an empty selection
+        # resolves to no camera rather than to every one. ``None`` is the
+        # documented "every attached device"; an explicitly empty selection is the
+        # opposite of that, not a spelling of it. Read by truthiness, ``names=[]``
+        # - what a filter that matched nothing produces - connected and drove
+        # every attached device, so a call that selected no leader energised all
+        # of them and reported success.
+        #
+        # The shape goes through the shared name-list domain, because the other
+        # ways this selector cannot be honored as written were reinterpreted too:
+        # a single name as a bare string is iterable per character, so it was read
+        # as one device per letter; a repeated name polled that device twice per
+        # tick and then warned that it conflicted with itself; and a one-shot
+        # iterator was consumed by the membership check below, leaving the loop
+        # nothing to poll while the session still reported success.
+        if names is None:
+            selected = list(self._teleops)
+        else:
+            if error := name_list_error(names, "names", "teleoperate"):
+                return {"status": "error", "content": [{"text": error}]}
+            selected = list(names)
+            if not selected:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                "teleoperate(names=[]) selects no teleoperator, so there is nothing to "
+                                "drive. Pass names=None to drive every attached device "
+                                f"(attached: {sorted(self._teleops)}), or name the subset to drive."
+                            )
+                        }
+                    ],
+                }
+
         unknown = [n for n in selected if n not in self._teleops]
         if unknown:
             return {

--- a/tests/test_teleop_device_selection_domain.py
+++ b/tests/test_teleop_device_selection_domain.py
@@ -1,0 +1,250 @@
+"""A teleop device selector is read by membership, never by truthiness.
+
+``teleoperate(names=)`` and ``detach_teleop(name=)`` both pick which of the
+already-attached streams a call operates on, and both document ``None`` as
+"every attached device". Read by truthiness, every other falsy value took that
+same branch, so a selection that named *nothing* was widened to *everything* -
+the opposite of what the caller asked for, reported as success:
+
+* ``teleoperate(names=[])`` - what a filter that matched nothing produces -
+  connected and drove every attached device.
+* ``detach_teleop("")`` removed the whole attached set and, with a session
+  running, ended it, because ``detach_teleop`` stops the loop once nothing is
+  left to drive.
+
+Two surfaces in the same module already read a selector the way these did not:
+``teleoperate`` itself validates ``duration`` by membership so "a falsy-but-
+supplied value must not read as absent", and the render path resolves its
+``cameras`` subset by membership, where an empty selection resolves to no
+camera rather than to every one.
+
+The list shape goes through the shared name-list domain, which is where the
+other unhonorable spellings of this selector live: a single name as a bare
+string is iterable per character, a repeated name polls one device twice per
+tick, and a one-shot iterator is consumed by the membership check that resolves
+unknown names, leaving the loop nothing to poll.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.test_teleop import FakeHost, FakeTeleop
+
+
+def _host_with_two_devices() -> FakeHost:
+    """A host with a leader and a gamepad, neither connected yet."""
+    host = FakeHost()
+    host.attach_teleop(FakeTeleop({"shoulder.pos": 1.0}, name="so101_leader"), name="leader")
+    host.attach_teleop(FakeTeleop({"btn.x": 2.0}, name="gamepad"), name="pad")
+    return host
+
+
+def _driven(host: FakeHost) -> dict[str, int]:
+    """How many times each attached device was polled for an action."""
+    return {name: att.device.get_action_calls for name, att in host._teleops.items()}
+
+
+def _connected(host: FakeHost) -> dict[str, int]:
+    """How many times each attached device was connected."""
+    return {name: att.device.connect_calls for name, att in host._teleops.items()}
+
+
+class TestAnEmptySelectionSelectsNothing:
+    """``names=[]`` names no device, so it cannot resolve to every device."""
+
+    def test_an_empty_selection_does_not_drive_an_unselected_device(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=[], block=True, duration=0.15, hz=50.0)
+
+        polled = _driven(host)
+        if polled["pad"]:
+            pytest.fail(
+                f"teleoperate(names=[]) selected no device and then polled "
+                f"{sum(1 for v in polled.values() if v)} of them {polled}, including 'pad', "
+                f"which the call did not name; it connected {_connected(host)} and reported "
+                f"{result['status']!r}."
+            )
+        assert result["status"] == "error"
+
+    def test_an_empty_selection_is_not_the_same_call_as_no_selection(self) -> None:
+        """The two must not be interchangeable: they ask for opposite things."""
+        empty = _host_with_two_devices()
+        empty_result = empty.teleoperate(names=[], block=True, duration=0.15, hz=50.0)
+
+        absent = _host_with_two_devices()
+        absent_result = absent.teleoperate(names=None, block=True, duration=0.15, hz=50.0)
+
+        assert absent_result["status"] == "success", "premise: names=None drives every device"
+        assert all(v > 0 for v in _driven(absent).values()), "premise: names=None polled both"
+
+        assert empty_result["status"] != absent_result["status"], (
+            f"names=[] and names=None both reported {empty_result['status']!r}; an empty "
+            f"selection resolved to the same set as no selection ({_driven(empty)})"
+        )
+
+    def test_the_empty_refusal_names_the_spelling_that_drives_everything(self) -> None:
+        """Follow the remedy the refusal gives and it must do what it promises."""
+        host = _host_with_two_devices()
+
+        refusal = host.teleoperate(names=[], block=True, duration=0.15, hz=50.0)
+        assert refusal["status"] == "error"
+        text = refusal["content"][0]["text"]
+        assert "names=None" in text, f"refusal does not name the all-devices spelling: {text!r}"
+        for attached in ("leader", "pad"):
+            assert attached in text, f"refusal does not list the attached devices: {text!r}"
+
+        # Apply the remedy verbatim on a fresh host.
+        remedied = _host_with_two_devices()
+        result = remedied.teleoperate(names=None, block=True, duration=0.15, hz=50.0)
+        assert result["status"] == "success"
+        assert all(v > 0 for v in _driven(remedied).values()), (
+            f"the remedy the refusal advertised did not drive every device: {_driven(remedied)}"
+        )
+
+    def test_an_empty_selection_is_refused_before_any_device_is_connected(self) -> None:
+        """A refused selection must not have touched hardware on its way out."""
+        host = _host_with_two_devices()
+
+        host.teleoperate(names=[], block=True, duration=0.15, hz=50.0)
+
+        assert _connected(host) == {"leader": 0, "pad": 0}
+        assert all(not att.device.is_connected for att in host._teleops.values())
+
+
+class TestTheListShapeGoesThroughTheSharedDomain:
+    """Spellings of ``names`` that cannot be honored as written are refused."""
+
+    @pytest.mark.parametrize(
+        ("names", "expected_fragment"),
+        [
+            pytest.param("leader", "not a single string", id="bare-string"),
+            pytest.param(["leader", "leader"], "must not repeat a name", id="repeated-name"),
+            pytest.param({"leader": 1}, "not a mapping", id="mapping"),
+        ],
+    )
+    def test_an_unhonorable_shape_is_refused_naming_the_value(self, names: object, expected_fragment: str) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=names, block=True, duration=0.15, hz=50.0)  # type: ignore[arg-type]
+
+        assert result["status"] == "error"
+        text = result["content"][0]["text"]
+        assert expected_fragment in text, f"refusal does not diagnose the shape: {text!r}"
+        assert _driven(host) == {"leader": 0, "pad": 0}, f"a refused shape still drove devices: {_driven(host)}"
+
+    def test_a_repeated_name_does_not_poll_one_device_twice_per_tick(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=["leader", "leader"], block=True, duration=0.2, hz=50.0)
+
+        frames = result["content"][-1].get("json", {}).get("frames", 0)
+        polled = _driven(host)["leader"]
+        assert result["status"] == "error", (
+            f"a repeated name ran a session that polled 'leader' {polled} times across {frames} frames"
+        )
+
+    def test_a_one_shot_iterator_is_refused_rather_than_consumed(self) -> None:
+        """Consumed by the unknown-name check, an iterator left the loop nothing."""
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=iter(["leader"]), block=True, duration=0.15, hz=50.0)  # type: ignore[arg-type]
+
+        telemetry = result["content"][-1].get("json", {})
+        assert result["status"] == "error", (
+            f"an iterator ran a session reporting {result['status']!r} with "
+            f"{telemetry.get('frames')} frames after polling {_driven(host)}"
+        )
+
+
+class TestOnlyNoneDetachesEveryDevice:
+    """``detach_teleop`` selects by membership too."""
+
+    def test_an_empty_name_does_not_detach_a_device_it_does_not_name(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.detach_teleop("")
+
+        assert sorted(host._teleops) == ["leader", "pad"], (
+            f"detach_teleop('') detached {result['content'][0]['text']!r}; remaining: {sorted(host._teleops)}"
+        )
+        assert result["status"] == "error"
+        assert "''" in result["content"][0]["text"]
+
+    def test_an_empty_name_does_not_end_a_running_session(self) -> None:
+        host = _host_with_two_devices()
+        started = host.teleoperate(hz=50.0)
+        assert started["status"] == "success", "premise: session started"
+        time.sleep(0.1)
+        assert host._teleop_running, "premise: the loop is running"
+        try:
+            frames_before = host._teleop_frames
+
+            host.detach_teleop("")
+            time.sleep(0.1)
+
+            assert host._teleop_running, (
+                "detach_teleop('') stopped a running session by detaching every device "
+                f"(frames froze at {frames_before})"
+            )
+            assert host._teleop_frames > frames_before, "the loop stopped producing frames"
+        finally:
+            host.stop_teleoperate()
+
+
+class TestTheDocumentedSelectionsAreUnchanged:
+    """Controls: the spellings that already worked keep working."""
+
+    def test_no_selection_still_drives_every_attached_device(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=None, block=True, duration=0.15, hz=50.0)
+
+        assert result["status"] == "success"
+        assert all(v > 0 for v in _driven(host).values()), _driven(host)
+
+    def test_a_named_subset_still_drives_only_its_own_devices(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=["leader"], block=True, duration=0.15, hz=50.0)
+
+        assert result["status"] == "success"
+        polled = _driven(host)
+        assert polled["leader"] > 0 and polled["pad"] == 0, polled
+        assert {k for action, _ in host.sent for k in action} == {"shoulder.pos"}
+
+    def test_an_unknown_name_in_a_usable_list_still_reports_it(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.teleoperate(names=["ghost"], block=True, duration=0.15, hz=50.0)
+
+        assert result["status"] == "error"
+        assert "Unknown teleop name(s): ['ghost']" in result["content"][0]["text"]
+
+    def test_detach_with_no_name_still_detaches_every_device(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.detach_teleop()
+
+        assert result["status"] == "success"
+        assert host._teleops == {}
+
+    def test_detach_of_an_unattached_name_still_changes_nothing(self) -> None:
+        host = _host_with_two_devices()
+
+        result = host.detach_teleop("nosuch")
+
+        assert result["status"] == "error"
+        assert sorted(host._teleops) == ["leader", "pad"]
+
+    def test_an_empty_selection_on_a_host_with_no_devices_reports_the_real_problem(self) -> None:
+        """Nothing attached outranks an empty selection: it is the fixable one."""
+        host = FakeHost()
+
+        result = host.teleoperate(names=[], block=True, duration=0.15, hz=50.0)
+
+        assert result["status"] == "error"
+        assert "No teleoperators attached" in result["content"][0]["text"]


### PR DESCRIPTION
## Problem

`teleoperate(names=)` and `detach_teleop(name=)` both name which of the already-attached
streams a call operates on, and both document `None` as "every attached device". Both read
that selector by **truthiness**, so every other falsy value took the all-devices branch - and
for a selector, that is not a wider default, it is the opposite answer. A selection naming
*nothing* was served *everything*, and reported success.

`teleoperate(names=[])` is what a filter that matched nothing produces:

```python
robot.attach_teleop("so101_leader", port="/dev/ttyACM1", name="wrist")
robot.attach_teleop("so101_leader", port="/dev/ttyACM2", name="shoulder")

pads = [n for n in robot.list_teleops_json() if method_of(n) == "gamepad"]   # -> []
robot.teleoperate(names=pads)     # asked for no leader; got, and drove, both
```

Measured through the real mixin on a MuJoCo SO-101 with a wrist stream and a shoulder stream:

| `names=` | status | devices connected | polled | joints driven |
|---|---|---|---|---|
| `None` (documented "all") | `success` | both | 50 / 50 | `['1', '5']` |
| `[]` (**empty selection**) | `success` | **both** | **50 / 50** | **`['1', '5']`** |
| `['wrist']` (real subset) | `success` | wrist only | 50 / 0 | `['5']` |

`names=[]` was byte-identical to `names=None`: it energised and drove every attached leader
and returned `Teleoperation completed: 50 frames, 0 errors, 24.9Hz over 2.0s.`

`detach_teleop("")` is the same misread on the other selector, and it reaches past the call:

```
detach_teleop("")        -> success  "Detached: ['leader', 'pad']"   remaining: []
detach_teleop("nosuch")  -> error    "No teleop named 'nosuch'."     remaining: ['leader', 'pad']
```

With a session running, that also **ended the session** - `detach_teleop` stops the loop once
nothing is left to drive, so `running` went `True -> False` and the frame count froze, from a
call that named a single stream.

Two selectors already read this the intended way, and one of them is in the same call.
`teleoperate` validates `duration` by membership, with the rule stated in the loop it feeds:

> `duration` is read by membership, not truthiness: a falsy-but-supplied value must not read
> as "absent".

And the render path resolves its `cameras` subset `is None`, so an empty camera selection
resolves to no camera rather than to every one - measured, `render_all(cameras=[])` returns
`error` with 0 images while `render_all()` returns 1.

## Change

Both selectors read `is None`. `detach_teleop("")` therefore reaches the existing not-found
refusal (`No teleop named ''.`) instead of the all-devices branch, and needs no new message.

`names` additionally goes through the shared name-list domain, which is where this selector's
other unhonorable spellings belong - each was reinterpreted rather than refused:

| `names=` | before | after |
|---|---|---|
| `"leader"` (bare string) | refused as 6 unknown names, `['l','e','a','d','e','r']` | refused as a single string, naming the value |
| `["leader", "leader"]` | `success`, that device polled **20 times across 10 frames**, warned it conflicted with itself | refused as a repeated name |
| `iter(["leader"])` | `success` with **0 frames** - consumed by the unknown-name check, so the loop had nothing to poll | refused as not a sequence |
| `{"leader": 1}` | `success`, iterated its keys, values discarded | refused as a mapping |

The domain deliberately leaves the empty verdict to the caller ("a surface where an absent
value IS an error keeps that verdict its own"), so the emptiness refusal lives at the call
site and names the spelling that does drive everything:

```
teleoperate(names=[]) selects no teleoperator, so there is nothing to drive. Pass
names=None to drive every attached device (attached: ['leader', 'pad']), or name
the subset to drive.
```

Every refusal happens **before any device is connected**, so a refused selection has no
half-open hardware to roll back.

`names=None`, a named subset and `detach_teleop(None)` are unchanged.

## Rollout

Left and right are the same MuJoCo SO-101, the same two attached leaders and the same call;
only `strands_robots` differs. Each panel replays the commanded stream that tree's own session
recorded, so what is drawn is exactly what the selection let reach the robot.

![teleop device selection](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-device-selection/teleop_selection.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-device-selection/teleop_selection.mp4) - [full-resolution still](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-device-selection/teleop_selection.png)

- **before**: 50 frames, joints `1` (shoulder pan) and `5` (wrist roll) swept their full
  commanded spans (`-1.500..+1.499` and `-2.400..+2.399` rad), 49/49 frame transitions moving,
  total rendered motion 512.8.
- **after**: refused, 0 frames, 0 polls, **total rendered motion exactly 0.000**. The still
  arm is the finding, not a broken capture.
- **control**, byte-identical in both trees: `names=None` -> 15 frames driving `['1','5']`,
  and `names=['wrist']` -> 15 frames driving `['5']`.

## Tests

`tests/test_teleop_device_selection_domain.py`, asserting only through the public surface, so
it collects unchanged on `main`: **11 failed / 6 passed** before, 17 pass after. Every pre-fix
failure is behavioural -

```
teleoperate(names=[]) selected no device and then polled 2 of them {'leader': 8, 'pad': 8},
including 'pad', which the call did not name; it connected {'leader': 1, 'pad': 1} and
reported 'success'.

a repeated name ran a session that polled 'leader' 20 times across 10 frames

detach_teleop('') stopped a running session by detaching every device (frames froze at 5)
```

The 6 that pass on both trees are the controls: `names=None` still drives every device, a
named subset still drives only its own, an unknown name in a usable list still reports itself,
`detach_teleop(None)` still detaches all, `detach_teleop("nosuch")` still changes nothing, and
an empty selection on a host with nothing attached still reports the more fixable problem
("No teleoperators attached") rather than the empty selection.

## Verification

Blast radius - the 104 test files touching the changed symbols, the docs page, `AGENTS.md`, or
the repo-wide guards - run on this branch and on a pristine `upstream/main` worktree:

| | failed | passed | skipped |
|---|---|---|---|
| this branch | 1 | 4898 | 29 |
| `upstream/main` | 1 | 4879 | 29 |

Branch-only failures: **none**. The one shared failure is pre-existing
(`tests/mesh/test_safety_timing_and_replay_defenses.py`, a missing `_safety_publishers_lock`).
The `+19` passed reconciles exactly: 17 new tests, plus 2 cases
`tests/test_args_docstring_completeness.py` gains because `detach_teleop` now carries an
`Args:` block (416 vs 414 in that file).

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy`
reports the same 20 pre-existing errors on both trees, none in the changed files;
`scripts/assemble_changelog.py --check` OK.

Those figures were measured at `51ecb0cd`, before `main` advanced past this branch's merge
base. `upstream/main` has since merged #2446 and #2447, which this branch now has merged in;
the only textual overlap was two additive `AGENTS.md` sections, both kept. Re-verified on the
merged tree: the pre-fix split against the new `main` is unchanged at 11 failed / 6 passed,
the affected teleop, budget, docstring and changelog suites are 732 passed, and `ruff check` /
`ruff format --check` / `assemble_changelog.py --check` are clean.

## Scope

Package-wide there are exactly **two** subset selectors read by truthiness - a parameter whose
fallback enumerates the collection the object already owns - and both are in this diff, so the
class is closed rather than sampled. Deliberately untouched:

- Scalar defaults read by truthiness (`output_dir or ...`, `device or _auto_device()`,
  `fields or {}`). Empty and absent genuinely coincide there: the value is derived either way.
- `attach_teleop(name=)`, which asks what to *call* a new stream rather than which existing
  ones to operate on, so its fallback chain is a naming rule, not a selection.

