### PR TITLE
fix(device_connect): publish each joint's own position, not the slot its id names

### DIFF
--- a/changelog.d/2451-sim-driver-joint-observation-addressing.md
+++ b/changelog.d/2451-sim-driver-joint-observation-addressing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **device_connect**: `SimulationDeviceDriver`'s 10Hz `observationUpdate` published each joint's position by indexing `qpos` with the joint's id rather than its qpos address, so on a robot with a floating base every later joint was shifted by six - a `unitree_g1` payload carried the pelvis height and the base quaternion under leg-joint names - and the free joint itself was emitted as a degenerate scalar. The publisher now reads through the simulation's own `get_observation`, which owns qpos addressing, the free-joint exclusion and the lock that keeps a read from being torn by a concurrent physics step.

--- a/docs/device-connect.md
+++ b/docs/device-connect.md
@@ -53,6 +53,28 @@ Each robot is wrapped as a Device Connect device by a `DeviceDriver` adapter:
 | `RobotDeviceDriver` | a hardware `Robot` | the same RPC surface, driving real servos |
 | `ReachyMiniDriver` | a Pollen Reachy Mini | device-native RPCs (`look`, `nod`, …) over Zenoh / WebSocket |
 
+### Published state events
+
+Besides answering RPCs, a driver publishes its own state on a 10 Hz loop while a
+policy is running. `SimulationDeviceDriver` emits two events:
+
+| Event | Payload |
+|-------|---------|
+| `stateUpdate` | `sim_time`, `step_count`, and `running_policies` (`{robot: {steps, instruction}}`) |
+| `observationUpdate` | `robot_name`, `sim_time`, `step_count`, and `joints` |
+
+`joints` is `{joint name: position}` in **radians**, and carries exactly the
+per-joint scalars the simulation's own
+[`get_observation`](simulation/overview.md) reports for that robot:
+
+- a value is read at the joint's own qpos address, so a robot with a floating
+  base reports its leg and arm angles rather than components of its base pose;
+- a floating base has no scalar joint position (its state is a position plus a
+  quaternion), so it is **not** a key in `joints` - subscribe to the simulation's
+  observation for `base_pos` / `base_quat` if you need the base pose;
+- only that robot's own joints appear, under their short names, whatever the
+  compiled model namespaces them to in a multi-robot scene.
+
 `init_device_connect()` / `init_device_connect_sync()` attach the right driver and start the runtime — `Robot().run()` calls these for you.
 
 ## Driving it from an agent

--- a/strands_robots/device_connect/sim_driver.py
+++ b/strands_robots/device_connect/sim_driver.py
@@ -219,6 +219,47 @@ class SimulationDeviceDriver(DeviceDriver):
 
     # ── Periodic state publishing ─────────────────────────────
 
+    def _joint_positions(self, robot_name: str, robot: Any) -> dict[str, float]:
+        """Per-joint positions for ``robot_name``, in radians.
+
+        Read through the simulation's own ``get_observation`` surface rather
+        than by indexing its state arrays here. That surface already answers
+        this exact question, and it owns three facts a second reader has to
+        reproduce and can silently get wrong:
+
+        * a joint's position lives at its qpos ADDRESS, not at its joint id.
+          The two coincide only while every joint is single-DoF: one floating
+          base ahead of a chain shifts every later joint by six, so a humanoid
+          reports its pelvis height and base quaternion under leg-joint names.
+        * a free joint has no scalar position at all (its qpos is
+          ``[xyz, quat]``), so it is excluded from the per-joint state rather
+          than reported as a degenerate number.
+        * the read is serialised against a concurrent physics step, so a
+          published value is a whole number rather than a torn one.
+
+        Images are skipped: this runs on the 10Hz publish loop, which wants
+        joint state only.
+
+        Args:
+            robot_name: Registered name of the robot to read.
+            robot: The world's record for that robot, read for its
+                ``joint_names`` so only its own joints are published.
+
+        Returns:
+            ``{joint name: position}`` for every joint the observation reports
+            a scalar for. Empty when the simulation exposes no observation
+            surface.
+        """
+        get_observation = getattr(self._sim, "get_observation", None)
+        if not callable(get_observation):
+            return {}
+        obs = get_observation(robot_name, skip_images=True)
+        return {
+            name: float(obs[name])
+            for name in getattr(robot, "joint_names", [])
+            if isinstance(obs.get(name), (int, float)) and not isinstance(obs.get(name), bool)
+        }
+
     @periodic(interval=0.1, wait_for_completion=True)
     async def _publishState(self):
         """Publish simulation state at 10Hz."""
@@ -236,17 +277,11 @@ class SimulationDeviceDriver(DeviceDriver):
                 step_count=world.step_count,
                 running_policies=running,
             )
-            # Publish per-robot joint observations from MuJoCo state
-            data = getattr(world, "_data", None)
+            # Publish per-robot joint observations.
             robots = world.robots if isinstance(world.robots, dict) else {}
             for name, robot in robots.items():
                 try:
-                    joint_names = getattr(robot, "joint_names", [])
-                    joint_ids = getattr(robot, "joint_ids", [])
-                    joints = {}
-                    if data is not None and joint_names and joint_ids:
-                        for jname, jid in zip(joint_names, joint_ids):
-                            joints[jname] = float(data.qpos[jid])
+                    joints = self._joint_positions(name, robot)
                     await self.observationUpdate(
                         robot_name=name,
                         sim_time=world.sim_time,

--- a/tests/test_device_connect_drivers.py
+++ b/tests/test_device_connect_drivers.py
@@ -14,7 +14,6 @@ import sys
 import unittest
 from dataclasses import dataclass
 from enum import Enum
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # ── Mock heavy dependencies before importing ──────────────────────
@@ -502,19 +501,28 @@ class TestSimulationDriverLifecycleAndPublish(unittest.TestCase):
 
     def test_publish_state_emits_running_policy_and_joint_observations(self):
         """The 10Hz publisher emits a state update plus a per-robot joint
-        observation read from MuJoCo qpos for each running policy."""
-        import numpy as np
+        observation for each running policy.
 
+        The joint positions are the ones the simulation's own
+        ``get_observation`` surface reports, which is what owns qpos
+        addressing, the free-joint exclusion and the lock. Reading the state
+        arrays here instead would put a second answer to the same question in
+        the driver; the observation carries a non-scalar key so this also pins
+        that only per-joint scalars reach ``joints``.
+        """
         sim = _make_mock_sim()
         robot = sim._world.robots["so100"]
         robot.policy_running = True
         robot.policy_steps = 7
         robot.policy_instruction = "stack the cubes"
         robot.joint_names = ["shoulder", "elbow"]
-        robot.joint_ids = [0, 2]
         sim._world.sim_time = 1.5
         sim._world.step_count = 30
-        sim._world._data = SimpleNamespace(qpos=np.array([0.25, 0.0, -0.5, 0.0]))
+        sim.get_observation.return_value = {
+            "shoulder": 0.25,
+            "elbow": -0.5,
+            "base_pos": [0.0, 0.0, 0.4],
+        }
 
         driver = SimulationDeviceDriver(sim)
         driver.stateUpdate = AsyncMock()
@@ -534,15 +542,14 @@ class TestSimulationDriverLifecycleAndPublish(unittest.TestCase):
         )
 
     def test_publish_state_handles_missing_qpos_gracefully(self):
-        """A running policy whose joint read fails (no _data) still emits the
-        state update and a joint-less observation - the per-robot read is
-        guarded so one bad robot does not break the publish loop."""
+        """A running policy the observation surface reports no joints for still
+        emits the state update and a joint-less observation - the per-robot read
+        is guarded so one bad robot does not break the publish loop."""
         sim = _make_mock_sim()
         robot = sim._world.robots["so100"]
         robot.policy_running = True
         robot.joint_names = ["shoulder"]
-        robot.joint_ids = [0]
-        sim._world._data = None  # no MuJoCo data -> joints stay empty
+        sim.get_observation.return_value = {}  # nothing readable -> joints stay empty
 
         driver = SimulationDeviceDriver(sim)
         driver.stateUpdate = AsyncMock()
@@ -554,20 +561,14 @@ class TestSimulationDriverLifecycleAndPublish(unittest.TestCase):
         self.assertEqual(driver.observationUpdate.await_args.kwargs["joints"], {})
 
     def test_publish_state_swallows_per_robot_read_errors(self):
-        """A per-robot joint read that raises (e.g. a bad qpos index) is caught
-        and logged, not propagated - one faulty robot must not break the 10Hz
-        publish loop for the rest of the fleet."""
-
-        class _BoomQpos:
-            def __getitem__(self, idx):
-                raise IndexError("qpos out of range")
-
+        """A per-robot joint read that raises is caught and logged, not
+        propagated - one faulty robot must not break the 10Hz publish loop for
+        the rest of the fleet."""
         sim = _make_mock_sim()
         robot = sim._world.robots["so100"]
         robot.policy_running = True
         robot.joint_names = ["shoulder"]
-        robot.joint_ids = [99]
-        sim._world._data = SimpleNamespace(qpos=_BoomQpos())
+        sim.get_observation.side_effect = RuntimeError("world torn down mid-read")
 
         driver = SimulationDeviceDriver(sim)
         driver.stateUpdate = AsyncMock()

--- a/tests/test_device_connect_sim_joint_addressing.py
+++ b/tests/test_device_connect_sim_joint_addressing.py
@@ -1,0 +1,313 @@
+"""The sim driver's 10Hz joint publisher reports each joint's own position.
+
+``SimulationDeviceDriver._publishState`` emits an ``observationUpdate`` whose
+``joints`` field is documented as ``{joint name: position (radians)}``. Getting
+that mapping right needs three facts about MuJoCo state that the simulation's
+own ``get_observation`` surface already owns:
+
+* a joint's position lives at its qpos ADDRESS (``model.jnt_qposadr[jid]``),
+  which equals the joint id only while every joint is single-DoF. One floating
+  base ahead of a chain occupies seven qpos slots for one joint id, shifting
+  every later joint by six.
+* a free joint has no scalar position - its qpos is ``[xyz, quat]`` - so it is
+  excluded from the per-joint state rather than reported as one number.
+* the read has to be serialised against a concurrent physics step.
+
+The publisher used to index ``data.qpos`` by joint id directly, so on a
+floating-base robot it published the base pose under leg-joint names. These
+tests pin the published mapping against the observation surface, on a model
+where the two addressings differ, so a second in-driver reader cannot drift
+from the one that answers this question.
+"""
+
+import asyncio
+import pathlib
+import unittest
+from typing import Any
+
+import pytest
+
+pytest.importorskip("device_connect_edge")
+pytest.importorskip("mujoco")
+
+from strands_robots import create_simulation  # noqa: E402
+from strands_robots.device_connect.sim_driver import SimulationDeviceDriver  # noqa: E402
+
+# A floating base ahead of two hinges: joint ids are (0, 1, 2) while the qpos
+# addresses are (0, 7, 8). The base is authored away from the origin and both
+# hinges are driven to distinct angles, so every candidate reading is a
+# different number and a mis-addressed publish names which slot it came from.
+_FREE_BASE_ARM = """<mujoco model="free_base_arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <body name="base" pos="0 0.25 0.5">
+      <freejoint name="floating_base"/>
+      <geom type="box" size="0.08 0.08 0.04" mass="1"/>
+      <body name="link1" pos="0 0 0.04">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02" mass="0.2"/>
+        <body name="link2" pos="0 0 0.2">
+          <joint name="j2" type="hinge" axis="1 0 0"/>
+          <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02" mass="0.2"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# The same two hinges with no floating base: joint ids and qpos addresses
+# coincide, which is the shape the publisher was already correct for.
+_FIXED_BASE_ARM = """<mujoco model="fixed_base_arm">
+  <compiler angle="radian"/>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <light pos="0 0 2"/>
+    <body name="base" pos="0 0.25 0.5">
+      <geom type="box" size="0.08 0.08 0.04" mass="1"/>
+      <body name="link1" pos="0 0 0.04">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02" mass="0.2"/>
+        <body name="link2" pos="0 0 0.2">
+          <joint name="j2" type="hinge" axis="1 0 0"/>
+          <geom type="capsule" fromto="0 0 0 0 0 0.2" size="0.02" mass="0.2"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+_ANGLES = {"j1": 0.3, "j2": -0.6}
+
+
+def _ok(result: dict[str, Any], what: str) -> dict[str, Any]:
+    """Return ``result`` after refusing a non-success tool envelope.
+
+    Raises rather than asserting so the scene is still built under ``python -O``.
+    """
+    if result.get("status") != "success":
+        raise AssertionError(f"{what} failed: {result}")
+    return result
+
+
+def _sim_with(tmp_path: pathlib.Path, xml: str, name: str = "arm") -> Any:
+    """Build a one-robot MuJoCo world from ``xml`` with both hinges driven."""
+    model_path = tmp_path / f"{name}.xml"
+    model_path.write_text(xml, encoding="utf-8")
+    # Typed loose: ``create_simulation`` is declared to return the backend-
+    # agnostic engine, while this fixture drives MuJoCo-only surfaces.
+    sim: Any = create_simulation(backend="mujoco", tool_name="joint_addressing")
+    _ok(sim.create_world(), "create_world")
+    _ok(sim.add_robot(name=name, urdf_path=str(model_path)), "add_robot")
+    _ok(sim.set_joint_positions(dict(_ANGLES), robot_name=name), "set_joint_positions")
+    return sim
+
+
+def _publish(sim: Any) -> dict[str, dict[str, float]]:
+    """Run one publish cycle and return the emitted joints per robot."""
+    for robot in sim._world.robots.values():
+        robot.policy_running = True
+        robot.policy_steps = 1
+        robot.policy_instruction = "hold"
+
+    captured: dict[str, dict[str, float]] = {}
+
+    async def record_observation(**kwargs: Any) -> None:
+        captured[kwargs["robot_name"]] = dict(kwargs["joints"])
+
+    async def record_state(**kwargs: Any) -> None:
+        return None
+
+    driver: Any = SimulationDeviceDriver(sim)
+    driver.stateUpdate = record_state
+    driver.observationUpdate = record_observation
+    asyncio.run(driver._publishState())
+    return captured
+
+
+class TestTheJointPublisherAddressesEachJointsOwnState:
+    """The published position of a joint is that joint's position."""
+
+    def test_a_floating_base_shifts_no_published_joint_off_its_own_slot(self, tmp_path):
+        """Indexing qpos by joint id reads the base pose for a shifted joint.
+
+        With a free joint at id 0, ``j1`` sits at qpos address 7 and ``j2`` at
+        8, while their joint ids are 1 and 2 - the base's y and z slots. A
+        publisher that indexes by id therefore reports the base's lateral
+        offset and HEIGHT as two joint angles, in metres, under names whose
+        documented unit is radians.
+        """
+        sim = _sim_with(tmp_path, _FREE_BASE_ARM)
+        model = sim._world._model
+        robot = sim._world.robots["arm"]
+        addresses = [int(model.jnt_qposadr[jid]) for jid in robot.joint_ids]
+        assert addresses != list(robot.joint_ids), "premise: this model must shift the joints"
+
+        joints = _publish(sim)["arm"]
+        assert joints == pytest.approx(_ANGLES), (
+            f"published {joints} for a robot whose joints are {_ANGLES}; "
+            f"joint ids {list(robot.joint_ids)} address qpos slots {addresses}"
+        )
+
+    def test_the_published_joints_are_the_ones_the_observation_surface_reports(self, tmp_path):
+        """The publisher and ``get_observation`` answer the same question.
+
+        Two readers of one robot's joint state must not disagree, whichever
+        addressing each happens to use.
+        """
+        sim = _sim_with(tmp_path, _FREE_BASE_ARM)
+        observation = sim.get_observation("arm", skip_images=True)
+        expected = {
+            name: float(observation[name])
+            for name in sim._world.robots["arm"].joint_names
+            if isinstance(observation.get(name), (int, float))
+        }
+        assert expected, "premise: the observation surface must report some joints"
+
+        joints = _publish(sim)["arm"]
+        assert joints == pytest.approx(expected)
+
+    def test_a_free_joint_is_not_published_as_a_scalar_position(self, tmp_path):
+        """A free joint's qpos is ``[xyz, quat]``, so it has no scalar position.
+
+        Publishing one anyway reports a single component of the base pose as a
+        joint angle, and duplicates a value ``base_pos`` already carries in
+        full.
+        """
+        sim = _sim_with(tmp_path, _FREE_BASE_ARM)
+        assert "floating_base" in sim._world.robots["arm"].joint_names, "premise: named free joint"
+
+        joints = _publish(sim)["arm"]
+        assert "floating_base" not in joints
+
+    def test_each_robot_is_published_with_its_own_joints_and_values(self, tmp_path):
+        """In a two-robot scene neither publish carries the other's state.
+
+        Both robots here name their joints ``j1`` / ``j2``, so the compiled
+        model holds four joints whose ids and qpos addresses interleave. Each
+        observation must carry that robot's joints, at that robot's values.
+        """
+        sim = _sim_with(tmp_path, _FREE_BASE_ARM, name="alice")
+        second = tmp_path / "bob.xml"
+        second.write_text(_FIXED_BASE_ARM, encoding="utf-8")
+        _ok(sim.add_robot(name="bob", urdf_path=str(second)), "add_robot(bob)")
+        assert sim._world.robots["bob"].joint_ids != sim._world.robots["alice"].joint_ids, (
+            "premise: the two robots must occupy different joint ids"
+        )
+
+        published = _publish(sim)
+        assert set(published) == {"alice", "bob"}
+        for name, joints in published.items():
+            observation = sim.get_observation(name, skip_images=True)
+            expected = {
+                joint: float(observation[joint])
+                for joint in sim._world.robots[name].joint_names
+                if isinstance(observation.get(joint), (int, float))
+            }
+            assert joints == pytest.approx(expected), f"{name} published {joints}, expected {expected}"
+        assert published["alice"] == pytest.approx(_ANGLES), "alice keeps the angles it was driven to"
+
+
+class TestTheAlreadyCorrectAndDegradedPathsAreUnchanged:
+    """Controls: a fixed-base arm and a simulation with no observation surface."""
+
+    def test_a_fixed_base_arm_publishes_its_joint_angles(self, tmp_path):
+        """With no free joint, ids and qpos addresses coincide.
+
+        This is the shape the publisher was already correct for, so it must
+        keep reporting exactly the same values.
+        """
+        sim = _sim_with(tmp_path, _FIXED_BASE_ARM)
+        model = sim._world._model
+        robot = sim._world.robots["arm"]
+        assert [int(model.jnt_qposadr[jid]) for jid in robot.joint_ids] == list(robot.joint_ids), (
+            "premise: this model must not shift the joints"
+        )
+
+        joints = _publish(sim)["arm"]
+        assert joints == pytest.approx(_ANGLES)
+
+    def test_a_simulation_with_no_observation_surface_publishes_no_joints(self):
+        """A wrapped object that cannot answer reports nothing, not an error.
+
+        The publish loop serves the whole fleet, so one robot that cannot be
+        read must not raise into it.
+        """
+
+        class _Robot:
+            policy_running = True
+            policy_steps = 0
+            policy_instruction = ""
+            joint_names = ["j1"]
+
+        class _World:
+            robots = {"arm": _Robot()}
+            sim_time = 0.0
+            step_count = 0
+
+        class _Sim:
+            _world = _World()
+
+        captured: dict[str, Any] = {}
+
+        async def record_observation(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def record_state(**kwargs: Any) -> None:
+            return None
+
+        driver: Any = SimulationDeviceDriver(_Sim())
+        driver.stateUpdate = record_state
+        driver.observationUpdate = record_observation
+        asyncio.run(driver._publishState())
+
+        assert captured["joints"] == {}
+
+
+class TestTheReadIsDelegatedRatherThanReimplemented(unittest.TestCase):
+    """The driver consumes the observation contract instead of restating it."""
+
+    def test_the_publisher_reads_through_get_observation_without_images(self):
+        """One reader owns qpos addressing, the free-joint rule and the lock.
+
+        The 10Hz loop wants joint state only, so the read must not also render
+        every camera on the model.
+        """
+        calls: list[tuple[str, bool]] = []
+
+        class _Robot:
+            policy_running = True
+            policy_steps = 2
+            policy_instruction = "hold"
+            joint_names = ["j1", "j2"]
+
+        class _World:
+            robots = {"arm": _Robot()}
+            sim_time = 0.5
+            step_count = 5
+
+        class _Sim:
+            _world = _World()
+
+            def get_observation(self, robot_name, *, skip_images=False):
+                calls.append((robot_name, skip_images))
+                return {"j1": 0.3, "j2": -0.6, "base_pos": [0.0, 0.25, 0.5]}
+
+        captured: dict[str, Any] = {}
+
+        async def record_observation(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def record_state(**kwargs: Any) -> None:
+            return None
+
+        driver: Any = SimulationDeviceDriver(_Sim())
+        driver.stateUpdate = record_state
+        driver.observationUpdate = record_observation
+        asyncio.run(driver._publishState())
+
+        self.assertEqual(calls, [("arm", True)])
+        self.assertEqual(captured["joints"], {"j1": 0.3, "j2": -0.6})


### PR DESCRIPTION
## Problem

`SimulationDeviceDriver._publishState` emits an `observationUpdate` every 100 ms whose `joints` field is documented as `{joint name: position (radians)}`. It built that mapping by indexing `data.qpos` with each joint's MuJoCo **joint id**:

```python
for jname, jid in zip(joint_names, joint_ids):
    joints[jname] = float(data.qpos[jid])
```

A joint's position lives at its qpos **address** (`model.jnt_qposadr[jid]`). The two coincide only while every joint is single-DoF: a floating base occupies seven qpos slots for one joint id, so it shifts every later joint by six. The same loop also emitted a scalar for the free joint itself, which has no scalar position - its qpos is a position plus a quaternion.

Measured over the 62 loadable sim robots:

| | count |
|---|---|
| robots with at least one joint whose id and qpos address differ | **30** |
| mis-addressed joint readings across those robots | **724** |
| robots additionally publishing a free joint as a scalar | **15** |
| fixed-base arms unaffected | 32 |

On `unitree_g1` all 29 hinges were shifted, so the payload carried the pelvis **height** (`0.79160`) under `left_hip_roll_joint` and the base quaternion's **w** component (`0.99998`) under `left_hip_yaw_joint` - in a field whose documented unit is radians. Nothing raised and nothing logged; the values are plausible joint angles.

## Change

The simulation already answers this exact question, and `get_observation` owns three facts a second reader has to reproduce:

- it resolves each joint through `jnt_qposadr`;
- it excludes a free joint from the per-joint scalars, with a comment explaining that emitting one reports "the base x-coordinate as a joint angle ... a degenerate, misleading scalar";
- it takes the model lock "to prevent torn reads while a concurrent `mj_step` is mutating data arrays" - which the driver's own unlocked read did not, while a policy steps at 50 Hz.

The publisher now reads through that surface (`skip_images=True`: the 10 Hz loop wants joint state only, not a render of every camera). So there is one answer to "what are this robot's joint positions" instead of two, and the driver keeps its dependency surface - it still holds no MuJoCo import, where fixing the indexing in place would have put a third copy of the free-joint rule into a Device Connect adapter.

The hardware sibling already delegates this way: `RobotDeviceDriver.getState` reads the wrapped robot's own `get_observation`.

Out of scope: the payload shape is unchanged. `joints` stays per-joint scalars keyed by short name; `base_pos` / `base_quat` remain available on the simulation's observation for a subscriber that wants the base pose.

## Verification

A subscriber that renders the telemetry reconstructs the pose from `joints`. `unitree_g1` driven to a squat with both arms raised, then rendered from one publish cycle, MuJoCo headless:

![observationUpdate joint addressing](https://raw.githubusercontent.com/cagataycali/robots/media-sim-driver-joint-addressing/sim-driver-joint-addressing.png)

| | before | after |
|---|---|---|
| keys published | 30 (incl. `floating_base_joint`) | 29 |
| joints disagreeing with the simulation | **15 of 29** | **0 of 29** |
| worst joint error | **2.2000 rad** (126 deg, `left_shoulder_pitch_joint`) | **0.0000 rad** |
| reconstructed render vs the true pose | mean abs 8.201, 9.91% of pixels off by >20 levels | mean abs 0.0001 (identical) |

The ground-truth panel is byte-identical between the two trees (mean abs 0.000067), so the two reconstructions differ only in the payload they were built from.

Per-robot agreement with `get_observation`, driven through the real publish path:

| robot | before | after |
|---|---|---|
| `so101` (fixed base) | 6 / 6 | 6 / 6 |
| `unitree_g1` | 0 / 29 | 29 / 29 |
| `unitree_go2` | 0 / 12 | 12 / 12 |

### Tests

`tests/test_device_connect_sim_joint_addressing.py` builds a hermetic MJCF - a floating base ahead of two hinges, so ids are `(0, 1, 2)` and addresses are `(0, 7, 8)` - with the base authored away from the origin and both hinges driven to distinct angles, so every candidate reading is a different number. Against `main`: **5 failed / 2 passed**, headline reporting

```
published {'floating_base': 0.0, 'j1': 0.25, 'j2': 0.5} for a robot whose joints
are {'j1': 0.3, 'j2': -0.6}; joint ids [0, 1, 2] address qpos slots [0, 7, 8]
```

i.e. `j2` published as `0.5`, the base height. All 7 pass after.

The 2 that pass on both trees are the controls: a fixed-base arm (ids and addresses coincide - the shape the publisher was already correct for) and a simulation exposing no observation surface (reports nothing rather than raising into the fleet-wide publish loop).

Two existing publisher tests drove the old reader and are repaired to drive the new one. One of them pinned the defect: its fixture was a `SimpleNamespace` carrying only `qpos`, which cannot express the difference between a joint id and a qpos address, so it asserted `qpos[jid]` as the contract. The repaired pair **fails against `main`** (2 failed / 5 passed on the `publish_state` selection), so the intent is preserved rather than relaxed.

### Gate

`ruff check` / `ruff format --check` / `mypy` clean over `strands_robots tests tests_integ` (mypy 24 errors, identical set to `upstream/main`, none in the changed files).

Blast radius - every test touching the driver, the publish loop, `get_observation` or `jnt_qposadr`, plus the repo-wide docs / docstring / changelog guards (197 files), run on this branch and on `upstream/main` with both test files copied into the base tree:

| | branch | `upstream/main` |
|---|---|---|
| failed | 4 | 11 |
| passed | 6695 | 6688 |
| skipped | 129 | 129 |
| collected | 6828 | 6828 |

Branch-only failures: **none**. The 7 base-only failures are exactly the 5 new tests plus the 2 repaired ones. The 4 shared failures are pre-existing and environmental here (2 need `device_connect_agent_tools`, which is a declared dependency; 2 are `test_doctor` distribution-metadata checks under an editable install).
