### PR TITLE
fix(policies/groot): report the determinism mode the server got, not the one it asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1147,7 +1147,7 @@ touches ROS 2.
 | `STRANDS_GR00T_IMAGE` | Container image the `gr00t_inference` tool runs (must pass the image allowlist; agent cannot choose it) | `gr00t:latest` |
 | `STRANDS_GR00T_IMAGE_ALLOW` | Extra image-name patterns (trailing `*` = tag wildcard) added to the built-in allowlist (`gr00t:*`, `nvcr.io/nvidia/isaac-gr00t:*`) | built-in only |
 | `STRANDS_GR00T_SERVER_SEED` | Default seed the GR00T determinism wrapper applies at server start and on seedless `reset` calls (used with `gr00t_inference(..., deterministic=True)`; forwarded into the container) | `42` |
-| `STRANDS_GR00T_STRICT_DETERMINISTIC` | `1` makes the determinism wrapper additionally enable `torch.use_deterministic_algorithms(True, warn_only=True)` (slower kernels, strictest reproducibility; forwarded into the container) | `0` |
+| `STRANDS_GR00T_STRICT_DETERMINISTIC` | `1` makes the determinism wrapper additionally enable `torch.use_deterministic_algorithms(True, warn_only=True)` (slower kernels, strictest reproducibility; forwarded into the container). Best-effort: an op with no deterministic kernel makes torch refuse, degrading the server to non-strict rather than killing it, and the startup banner reports `strict=` as the mode the server ended up in | `0` |
 
 </details>
 

--- a/changelog.d/2454-groot-strict-determinism-banner.md
+++ b/changelog.d/2454-groot-strict-determinism-banner.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **policies/groot**: the determinism wrapper's startup banner now reports the mode the server
+  ended up in rather than the one it was asked for. Enabling strict mode is best-effort - an op
+  with no deterministic kernel makes `torch.use_deterministic_algorithms` refuse, which degrades
+  the server to non-strict instead of killing it - but the banner read the request, so such a run
+  logged `strict=True` one line after its own failure warning. That banner is the only record of
+  a container run's determinism configuration, so an investigation into a rollout that failed to
+  reproduce would read it and rule out the one setting that was in fact missing. A refused
+  request now reads as off and names itself.

--- a/strands_robots/policies/groot/server_wrapper.py
+++ b/strands_robots/policies/groot/server_wrapper.py
@@ -6,7 +6,8 @@ enforces:
 - ``cudnn.deterministic = True``
 - ``cudnn.benchmark = False``
 - ``torch.use_deterministic_algorithms(True, warn_only=True)`` (opt-in via
-  ``STRANDS_GR00T_STRICT_DETERMINISTIC=1``)
+  ``STRANDS_GR00T_STRICT_DETERMINISTIC=1``; a request torch refuses degrades to
+  non-strict, and the startup banner reports it as off)
 - ``CUBLAS_WORKSPACE_CONFIG=":4096:8"`` (required for cuBLAS determinism)
 - A monkey-patch on the upstream ``Gr00tPolicy.reset`` (a no-op by default)
   that reseeds torch / numpy / random at the start of each episode. The
@@ -43,7 +44,11 @@ Environment variables (read inside the container):
   can force slower kernels whose numerics differ slightly from the default,
   sometimes hurting trained-model quality; ``cudnn.deterministic=True``
   alone is the safer "deterministic enough" middle ground for diffusion
-  sampling.
+  sampling. Enabling it is best-effort: an op with no deterministic kernel
+  makes torch refuse, which degrades the server to non-strict rather than
+  killing it. The startup banner reports ``strict=`` as the mode the server
+  actually ended up in, so a refused request reads as off and names itself
+  instead of being recorded as the strict run it is not.
 """
 
 from __future__ import annotations
@@ -116,16 +121,29 @@ def main() -> None:
     # safer "deterministic enough" middle ground for diffusion sampling.
     torch.backends.cudnn.deterministic = True
     torch.backends.cudnn.benchmark = False
-    strict_det = os.environ.get("STRANDS_GR00T_STRICT_DETERMINISTIC", "0") == "1"
-    if strict_det:
+    strict_requested = os.environ.get("STRANDS_GR00T_STRICT_DETERMINISTIC", "0") == "1"
+    strict_applied = False
+    if strict_requested:
         try:
             torch.use_deterministic_algorithms(True, warn_only=True)
-            print("[srv_wrap] STRICT mode: torch.use_deterministic_algorithms(True)", flush=True)
         except Exception as e:  # noqa: BLE001 - degrade to non-strict, never kill the server
             print(f"[srv_wrap] warning: use_deterministic_algorithms failed: {e}", flush=True)
+        else:
+            strict_applied = True
+            print("[srv_wrap] STRICT mode: torch.use_deterministic_algorithms(True)", flush=True)
 
+    # Report the determinism the server got, not the determinism it was asked
+    # for. The banner below is the only record of that configuration for a
+    # container run - an operator reads it out of `docker logs` to confirm what
+    # the server enforces - so a strict mode that was requested and then refused
+    # by torch has to read as off. Naming the dropped request keeps the reason
+    # in the same line as the verdict, the way the seed path below reports a
+    # value it could not use.
+    strict_report = str(strict_applied)
+    if strict_requested and not strict_applied:
+        strict_report = "False (requested, but use_deterministic_algorithms failed)"
     print(
-        f"[srv_wrap] determinism: cudnn.deterministic=True, benchmark=False, strict={strict_det}",
+        f"[srv_wrap] determinism: cudnn.deterministic=True, benchmark=False, strict={strict_report}",
         flush=True,
     )
     print(f"[srv_wrap] CUBLAS_WORKSPACE_CONFIG={os.environ.get('CUBLAS_WORKSPACE_CONFIG')}", flush=True)

--- a/tests/policies/groot/test_server_wrapper_seed_domain.py
+++ b/tests/policies/groot/test_server_wrapper_seed_domain.py
@@ -36,7 +36,15 @@ What is pinned here:
   not installed, so the agreement is asserted rather than assumed;
 * the determinism configuration the wrapper exists to apply - cuDNN flags,
   ``CUBLAS_WORKSPACE_CONFIG``, the optional strict mode, the ``reset`` patch,
-  and the hand-off to the unmodified server entrypoint.
+  and the hand-off to the unmodified server entrypoint;
+* and that the startup banner records the mode the server *ended up in*.
+  Enabling strict mode is best-effort - an op with no deterministic kernel makes
+  torch refuse, which degrades the server rather than killing it - but the
+  banner reported the *request*, so a run whose tightening was dropped was
+  logged as ``strict=True`` one line after its own failure warning. That banner
+  is the only record of a container run's determinism, so an investigation into
+  a rollout that failed to reproduce would read it and rule out the one setting
+  that was in fact missing.
 """
 
 from __future__ import annotations
@@ -197,6 +205,37 @@ def _states_equal(left: tuple[Any, Any], right: tuple[Any, Any]) -> bool:
     return py_ok and np_ok
 
 
+_BANNER_PREFIX = "[srv_wrap] determinism: "
+
+#: ``(strict requested, what torch raises, whether strict ends up in effect)``.
+#: The two agreeing rows are the controls: they pin that reporting the outcome
+#: did not change what a server without the opt-in, or one whose opt-in torch
+#: accepted, records.
+_STRICT_STATES = [
+    pytest.param(False, None, False, id="not-requested"),
+    pytest.param(True, None, True, id="requested-and-applied"),
+    pytest.param(True, RuntimeError("no deterministic kernel for aten::foo"), False, id="requested-and-refused"),
+]
+
+
+def _strict_verdict(out: str) -> str:
+    """Return the ``strict=`` claim from the wrapper's single startup banner."""
+    banner = [line for line in out.splitlines() if line.startswith(_BANNER_PREFIX)]
+    assert len(banner) == 1, f"expected exactly one determinism banner, got {banner!r}"
+    _, _, verdict = banner[0].partition("strict=")
+    assert verdict, f"the banner must state a strict verdict: {banner[0]!r}"
+    return verdict
+
+
+def _banner_says_strict_on(out: str) -> bool:
+    """Whether the banner's verdict reads as strict mode being in effect.
+
+    Reads the leading token so the check is about the verdict rather than about
+    any reason the banner appends after it.
+    """
+    return _strict_verdict(out).split()[0] == "True"
+
+
 class TestTheStartupSeedIsAppliedOrRefusedWhole:
     """``STRANDS_GR00T_SERVER_SEED`` is applied to every RNG, or to none."""
 
@@ -273,6 +312,71 @@ class TestStrictDeterminismIsOptIn:
         server_wrapper.main()
         assert container.server_configs == ["parsed-config"], (
             "strict mode is a tightening, so losing it must degrade rather than kill the server"
+        )
+
+    def test_a_refused_strict_request_is_not_recorded_as_a_strict_run(
+        self, container: _Container, monkeypatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A run cannot log the applier failing and still record itself as strict."""
+        monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        container.strict_raises = RuntimeError("no deterministic kernel for aten::foo")
+        server_wrapper.main()
+        out = capsys.readouterr().out
+
+        warning = [line for line in out.splitlines() if "use_deterministic_algorithms failed" in line]
+        assert warning, "premise: torch must have refused the request this case is about"
+        assert not _banner_says_strict_on(out), (
+            "one log cannot both report the applier failing and record the run as strict - the banner is "
+            f"what an operator reads back to see what the server enforces. warning: {warning[0]!r}, "
+            f"banner verdict: {_strict_verdict(out)!r}"
+        )
+
+    @pytest.mark.parametrize(("requested", "raises", "in_effect"), _STRICT_STATES)
+    def test_the_banner_states_the_mode_the_server_ended_up_in(
+        self,
+        container: _Container,
+        monkeypatch,
+        capsys: pytest.CaptureFixture[str],
+        requested: bool,
+        raises: Exception | None,
+        in_effect: bool,
+    ) -> None:
+        """The banner's verdict tracks what was applied, not what was asked for."""
+        if requested:
+            monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        container.strict_raises = raises
+        server_wrapper.main()
+        out = capsys.readouterr().out
+
+        applied = container.strict_calls == [(True,)] and raises is None
+        assert applied is in_effect, "premise: the stub must reach the state this case is about"
+        assert _banner_says_strict_on(out) is in_effect, (
+            f"strict mode was {'applied' if in_effect else 'not applied'}, but the banner reads "
+            f"{_strict_verdict(out)!r}"
+        )
+
+    def test_the_banner_names_a_strict_request_it_could_not_honor(
+        self, container: _Container, monkeypatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Off-because-refused and never-asked-for are different configurations."""
+        monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        container.strict_raises = RuntimeError("no deterministic kernel for aten::foo")
+        server_wrapper.main()
+        verdict = _strict_verdict(capsys.readouterr().out)
+        assert "requested" in verdict, (
+            "an operator who set the variable needs to see that the request was read and dropped, not "
+            f"only that strict is off: {verdict!r}"
+        )
+
+    def test_the_strict_line_only_appears_when_torch_accepted_the_request(
+        self, container: _Container, monkeypatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The ``STRICT mode`` line is the applied record, so a refusal must not print it."""
+        monkeypatch.setenv("STRANDS_GR00T_STRICT_DETERMINISTIC", "1")
+        container.strict_raises = RuntimeError("no deterministic kernel for aten::foo")
+        server_wrapper.main()
+        assert "STRICT mode:" not in capsys.readouterr().out, (
+            "that line reports the tightening taking effect, so it must not announce a refused request"
         )
 
 


### PR DESCRIPTION
## Problem

`server_wrapper.main()` prints a startup banner that records the determinism configuration the GR00T server is running under:

```
[srv_wrap] determinism: cudnn.deterministic=True, benchmark=False, strict=True
```

The `strict=` value came from `strict_det` - the flag read out of `STRANDS_GR00T_STRICT_DETERMINISTIC`, i.e. the **request**, never the outcome.

Enabling strict mode is best-effort by design. An op with no deterministic kernel makes `torch.use_deterministic_algorithms` refuse, and the wrapper deliberately degrades to non-strict rather than killing the server ("strict mode is a tightening, so losing it must degrade rather than kill"). On that path the banner still reported `strict=True`, one line after its own failure warning, so a single log both reported the applier failing and recorded the run as strict:

```
[srv_wrap] warning: use_deterministic_algorithms failed: linalg_cholesky has no deterministic implementation
[srv_wrap] determinism: cudnn.deterministic=True, benchmark=False, strict=True     <- strict is off
```

That banner is the only record of a container run's determinism configuration - it is what an operator reads back out of `docker logs` to see what the server enforces. A rollout that later failed to reproduce would therefore be investigated against a log that had already ruled out the one setting that was in fact missing.

Driving the real `main()` with `torch` doubled so its refusal is exact:

| scenario | torch applied strict | banner read | |
|---|---|---|---|
| no opt-in | False | `strict=False` | agrees |
| opt-in, torch accepts | True | `strict=True` | agrees |
| opt-in, torch refuses | **False** | **`strict=True`** | **contradicts** |

The same file already gets this right for the other thing it applies: a `reset` carrying a seed it cannot use prints `warning: <reason>; using <default>`, naming the dropped request and the value the episode actually ran with. Strict mode had no equivalent.

## Change

Track whether the applier succeeded rather than whether it was asked for, and report that. A request that was read and then refused says so, so off-because-refused stays distinguishable from never-asked-for:

```
[srv_wrap] determinism: cudnn.deterministic=True, benchmark=False, strict=False (requested, but use_deterministic_algorithms failed)
```

The success announcement moves into an `else:` clause, so "strict was applied" and "the `STRICT mode` line was printed" are the same condition by construction.

No behaviour change. A server without the opt-in and a server whose opt-in torch accepted print a byte-identical banner, and losing strict mode still degrades rather than kills - all six runs above reach the unmodified server entrypoint.

## Tests

Extends `TestStrictDeterminismIsOptIn`, whose three existing tests become controls. Against `upstream/main`: **3 failed / 55 passed**; after: **58 passed**.

Failing pre-fix:

- `test_a_refused_strict_request_is_not_recorded_as_a_strict_run` - the self-contradiction, quoting both lines: `warning: '[srv_wrap] warning: use_deterministic_algorithms failed: ...', banner verdict: 'True'`.
- `test_the_banner_states_the_mode_the_server_ended_up_in[requested-and-refused]` - the root-cause property, parametrized over all three states. The other two rows **pass on both trees**, so the parametrization carries its own controls.
- `test_the_banner_names_a_strict_request_it_could_not_honor` - off-because-refused vs never-asked-for.

Passing on both trees (they fail for the plausible wrong fixes):

- `test_the_strict_line_only_appears_when_torch_accepted_the_request` - fails if the announcement is printed unconditionally.
- `test_strict_mode_is_off_by_default` / `test_the_opt_in_enables_deterministic_algorithms` - fail if the opt-in stops reaching torch.
- `test_a_strict_mode_failure_does_not_stop_the_server` - fails if a refusal is made fatal instead of reported.

The verdict is read as the banner's leading token, so the check is about the verdict rather than about any reason appended after it.

## Verification

Measured at `913b7aa0` against `upstream/main` `ab2beb7b`, on a 128-file selection (all of `tests/policies/groot`, every test naming the wrapper / its env vars / the deterministic lifecycle, plus the repo-wide docstring, changelog, ASCII-string and dependency guards):

- branch **4 failed / 4501 passed / 54 skipped**, base **7 failed / 4498 passed / 54 skipped**, **4505 collected on both**. Failed delta == passed delta == 3 == the pre-fix failure count.
- branch-only failing IDs: **none**. Base-only: exactly the 3 pre-fix failures above.
- The 4 shared failures are environmental and unrelated: 2x `test_doctor.py::TestDoctorVersionResolution` (editable-install metadata) and 2x `test_lerobot.py::TestInProcessTrainerCorrectness` (`draccus` older than lerobot's declared floor locally).
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean. `mypy`: 24 pre-existing on both trees, none in the changed files.

## Artifact

The same three scenarios driven through the real `server_wrapper.main()` in each tree - `torch` is doubled so its refusal is exact, and nothing else differs between the two rows. Banner disagrees with what torch applied: **1 of 3 scenarios before, 0 of 3 after**.

![determinism banner before and after](https://raw.githubusercontent.com/cagataycali/robots/media-groot-strict-banner/banner.png)

## Scope

Only the strict-mode verdict. `CUBLAS_WORKSPACE_CONFIG` is reported by reading the environment back, and the cuDNN flags are plain assignments that cannot partially apply, so neither can disagree with the banner. Whether `setdefault` should overwrite an operator's preset `CUBLAS_WORKSPACE_CONFIG` is a separate question with a test already pinning the current answer.
