### PR TITLE
docs(policies/cosmos3): name the receiver that accepts the safety-checker flag

### DIFF
--- a/changelog.d/2458-cosmos3-documented-backend-knob-route.md
+++ b/changelog.d/2458-cosmos3-documented-backend-knob-route.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **policies/cosmos3**: the safety-checker note in `docs/policies/cosmos3.md` told readers to
+  `pass enable_safety_checker=True`, which no surface the page names accepts - `Cosmos3Policy`
+  declares no such parameter and takes no `**kwargs`, so both documented routes raise `TypeError`,
+  and the registry route filters the key out and runs with the checker off. The note now names the
+  `Cosmos3DiffusersBackend` parameter it is, with a snippet handing that backend to
+  `Cosmos3Policy(diffusers_backend=...)`, and lists the other load and sampling knobs the same
+  route carries. `Cosmos3Policy`'s own `diffusers_backend` docstring no longer calls itself
+  test-only injection.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -111,10 +111,29 @@ The `cosmos3-diffusers` extra is native `diffusers` + `torch` + `transformers`
 > `cosmos_guardrail` package and otherwise raises `ImportError: cosmos_guardrail
 > is not installed`. The diffusers backend disables it by default
 > (`enable_safety_checker=False`, passed through to `from_pretrained`) so the
-> pipeline loads without that extra. Install `cosmos_guardrail` and pass
-> `enable_safety_checker=True` to re-enable it. Note Cosmos runs in `bfloat16`,
-> so the backend up-casts the half-precision action tensor to `float32` before
-> returning the chunk.
+> pipeline loads without that extra. To re-enable it, install `cosmos_guardrail`
+> and build the backend with `enable_safety_checker=True`, then hand that backend
+> to the policy - the flag is a `Cosmos3DiffusersBackend` parameter, not a
+> `Cosmos3Policy` one:
+>
+> ```python
+> from strands_robots.policies.cosmos3.embodiments import get_embodiment
+> from strands_robots.policies.cosmos3.policy import Cosmos3Policy
+> from strands_robots.policies.cosmos3.policy_diffusers import Cosmos3DiffusersBackend
+>
+> backend = Cosmos3DiffusersBackend(
+>     embodiment=get_embodiment("droid"),
+>     model="nvidia/Cosmos3-Nano",
+>     enable_safety_checker=True,   # needs cosmos_guardrail installed
+> )
+> policy = Cosmos3Policy(embodiment="droid", backend="diffusers", diffusers_backend=backend)
+> ```
+>
+> `Cosmos3Policy` forwards only `embodiment`, `model` and `mode` to the backend, so
+> the same route is how you reach its other load and sampling knobs
+> (`resolution_tier`, `view_point`, `device`, `dtype`, `num_inference_steps`,
+> `guidance_scale`, `enable_sound`). Note Cosmos runs in `bfloat16`, so the backend
+> up-casts the half-precision action tensor to `float32` before returning the chunk.
 
 ### `backend="diffusers"` — world video alongside the action chunk
 

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -155,8 +155,14 @@ class Cosmos3Policy(Policy):
             (default ``"nvidia/Cosmos3-Nano"``). Ignored by the service backend
             (the server selects the checkpoint via ``--checkpoint-path``).
         diffusers_backend: Pre-built
-            :class:`~strands_robots.policies.cosmos3.policy_diffusers.Cosmos3DiffusersBackend`
-            (dependency injection for tests; skips the heavy import).
+            :class:`~strands_robots.policies.cosmos3.policy_diffusers.Cosmos3DiffusersBackend`.
+            Injecting one skips the heavy import (how the tests drive this
+            backend), and it is also the supported route to the backend's own
+            load and sampling knobs: this constructor forwards only
+            ``embodiment``, ``model`` and ``mode``, so ``resolution_tier``,
+            ``view_point``, ``device``, ``dtype``, ``num_inference_steps``,
+            ``guidance_scale``, ``enable_sound`` and ``enable_safety_checker``
+            are set on the backend and reach the policy through this parameter.
 
     Notes:
         * This policy needs camera frames **and** robot state in the

--- a/tests/policies/cosmos3/test_documented_backend_knob_routes.py
+++ b/tests/policies/cosmos3/test_documented_backend_knob_routes.py
@@ -1,0 +1,234 @@
+"""Every knob ``docs/policies/cosmos3.md`` tells a reader to pass must be passable.
+
+The in-process ``diffusers`` backend is configured on
+:class:`~strands_robots.policies.cosmos3.policy_diffusers.Cosmos3DiffusersBackend`,
+but the page's worked examples build the policy - :class:`Cosmos3Policy` /
+``create_policy("cosmos3", ...)`` - and that constructor forwards only
+``embodiment``, ``model`` and ``mode``. It takes no ``**kwargs``, so a keyword
+the page tells the reader to pass and that constructor does not declare is a
+``TypeError`` rather than a slower path, and the registry route drops it: the
+provider's ``config_keys`` filter keeps only the keys the constructor names, so
+``build_policy_kwargs`` returns without it and the run proceeds with the
+opposite setting reported as success.
+
+So the rule graded here is that an instruction to pass a keyword has to name a
+receiver the page also names. That is checked against ``inspect.signature`` of
+the classes the page actually mentions rather than against a copied list, so a
+knob promoted onto the policy later, or a newly documented one, is graded
+without touching this file.
+
+The page's Python fences are graded the same way in the other direction: every
+keyword they pass must be accepted by the call's own receiver.
+"""
+
+import ast
+import inspect
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.cosmos3 import Cosmos3DiffusersBackend, Cosmos3Policy
+from strands_robots.policies.cosmos3.client import Cosmos3WebsocketClient
+from strands_robots.policies.cosmos3.embodiments import get_embodiment
+from strands_robots.registry import build_policy_kwargs
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DOC = _REPO_ROOT / "docs" / "policies" / "cosmos3.md"
+
+# Classes the page can name as the receiver of a documented keyword.
+_RECEIVERS: dict[str, type] = {
+    "Cosmos3Policy": Cosmos3Policy,
+    "Cosmos3DiffusersBackend": Cosmos3DiffusersBackend,
+    "Cosmos3WebsocketClient": Cosmos3WebsocketClient,
+}
+
+# A clean sweep must mean the page is right, not that nothing was graded.
+_MINIMUM_INSTRUCTIONS = 1
+_MINIMUM_FENCE_KEYWORDS = 15
+
+
+def _page() -> str:
+    return _DOC.read_text(encoding="utf-8")
+
+
+def _named_receivers(page: str) -> dict[str, type]:
+    """Receivers the page mentions by name, plus the factory that forwards to one."""
+    named = {name: cls for name, cls in _RECEIVERS.items() if name in page}
+    if "create_policy(" in page and '"cosmos3"' in page:
+        named['create_policy("cosmos3")'] = Cosmos3Policy
+    return named
+
+
+def _params(cls: type) -> set[str]:
+    """Keyword names ``cls(...)`` accepts."""
+    return set(inspect.signature(cls).parameters)
+
+
+def _instructed_keywords(page: str) -> set[str]:
+    """Keywords the prose tells the reader to pass or set."""
+    found: set[str] = set()
+    for pattern in (r"(?:pass|set)\s+`([a-z_][a-z0-9_]*)\s*=", r"\(`([a-z_][a-z0-9_]*)\s*=[^`]*`"):
+        found |= set(re.findall(pattern, page))
+    return found
+
+
+def _listed_backend_knobs(page: str) -> set[str]:
+    """Knob names the page presents as carried by the backend object route."""
+    block = re.search(r"load and sampling knobs\s*\n?>?\s*\(([^)]*)\)", page, re.S)
+    if block is None:
+        return set()
+    return set(re.findall(r"`([a-z_][a-z0-9_]*)`", block.group(1)))
+
+
+def _fence_keywords(page: str) -> dict[str, set[str]]:
+    """Keyword arguments each Python fence passes, grouped by the call's receiver."""
+    per_call: dict[str, set[str]] = {}
+    for block in re.findall(r"```python\n(.*?)```", page, re.S):
+        try:
+            tree = ast.parse(block)
+        except SyntaxError:  # a fence may be an excerpt
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                target = ast.unparse(node.func)
+                for keyword in node.keywords:
+                    if keyword.arg:
+                        per_call.setdefault(target, set()).add(keyword.arg)
+    return per_call
+
+
+class TestTheDocumentedKnobsNameAReachableReceiver:
+    """An instruction to pass a keyword must name a receiver that accepts it."""
+
+    def test_every_instructed_keyword_is_a_parameter_of_a_named_receiver(self) -> None:
+        page = _page()
+        instructed = _instructed_keywords(page)
+        assert len(instructed) >= _MINIMUM_INSTRUCTIONS, (
+            f"premise: found {len(instructed)} 'pass `kw=`' instructions in {_DOC.name}; "
+            "a clean sweep would prove nothing"
+        )
+        named = _named_receivers(page)
+        reachable: set[str] = set()
+        for cls in named.values():
+            reachable |= _params(cls)
+        unreachable = sorted(k for k in instructed if k not in reachable)
+        assert not unreachable, (
+            f"{_DOC.name} tells the reader to pass {unreachable}, which no receiver it "
+            f"names accepts. Named receivers: {sorted(named)}. "
+            "Name the class the keyword belongs to, or promote the keyword."
+        )
+
+    def test_the_grader_reports_a_planted_instruction(self) -> None:
+        """A clean sweep means the page is right, not that the grader accepts anything."""
+        planted = _page() + "\nInstall it and pass `not_a_parameter_of_anything=True` to enable it.\n"
+        assert "not_a_parameter_of_anything" in _instructed_keywords(planted)
+
+    @pytest.mark.parametrize("keyword", sorted(_instructed_keywords(_DOC.read_text(encoding="utf-8"))))
+    def test_each_instructed_keyword_resolves_to_exactly_the_class_that_declares_it(self, keyword: str) -> None:
+        page = _page()
+        owners = sorted(name for name, cls in _named_receivers(page).items() if keyword in _params(cls))
+        assert owners, f"{keyword!r} is instructed by {_DOC.name} but declared by no receiver it names"
+
+
+class TestTheInstructionRoundTrips:
+    """Applying the page's instruction to the receiver it names reaches the backend."""
+
+    def test_the_safety_checker_flag_reaches_the_policy_through_the_documented_route(self) -> None:
+        page = _page()
+        assert "enable_safety_checker=True" in page, "premise: the page still instructs this flag"
+        named = _named_receivers(page)
+        owners = [cls for cls in named.values() if "enable_safety_checker" in _params(cls)]
+        assert owners, "the page names no receiver that declares enable_safety_checker"
+
+        backend = Cosmos3DiffusersBackend(
+            embodiment=get_embodiment("droid"),
+            enable_safety_checker=True,
+            pipeline=_stub_pipeline(),
+            condition_cls=_StubCondition,
+        )
+        policy = Cosmos3Policy(embodiment="droid", backend="diffusers", diffusers_backend=backend)
+        assert policy.last_rollout is None or isinstance(policy.last_rollout, dict)
+        reached = getattr(getattr(policy, "_diffusers", None), "enable_safety_checker", None)
+        assert reached is True, f"the flag did not reach the backend the policy runs (got {reached!r})"
+
+    def test_any_documented_knob_list_names_only_real_backend_parameters(self) -> None:
+        """A list of knobs the object route carries must not name a missing one.
+
+        Silent when the page lists none, so this grades the claim rather than
+        requiring one; the planted case below keeps that from being vacuous.
+        """
+        backend_params = _params(Cosmos3DiffusersBackend)
+        listed = _listed_backend_knobs(_page())
+        unknown = sorted(listed - backend_params)
+        assert not unknown, f"{_DOC.name} lists {unknown} as backend knobs, which Cosmos3DiffusersBackend has not"
+
+        planted = "load and sampling knobs\n> (`resolution_tier`, `not_a_backend_parameter`)"
+        assert _listed_backend_knobs(planted) - backend_params == {"not_a_backend_parameter"}
+
+
+class TestThePolicySurfaceIsUnchanged:
+    """Controls: the routes that already worked still answer the same way."""
+
+    def test_every_fenced_keyword_is_accepted_by_its_own_receiver(self) -> None:
+        page = _page()
+        per_call = _fence_keywords(page)
+        graded = 0
+        offenders: list[str] = []
+        for target, keywords in per_call.items():
+            cls: type | None = None
+            if target.startswith("create_policy") or target == "Cosmos3Policy":
+                cls = Cosmos3Policy
+            elif target in _RECEIVERS:
+                cls = _RECEIVERS[target]
+            if cls is None:
+                continue
+            accepted = _params(cls)
+            graded += len(keywords)
+            offenders += [f"{target}({k}=)" for k in sorted(keywords) if k not in accepted]
+        assert graded >= _MINIMUM_FENCE_KEYWORDS, f"premise: graded only {graded} fenced keywords in {_DOC.name}"
+        assert not offenders, f"{_DOC.name} passes keywords its own receiver refuses: {offenders}"
+
+    def test_the_forwarded_subset_still_reaches_the_backend(self) -> None:
+        """``model`` and ``mode`` are the knobs the policy itself carries."""
+        backend = Cosmos3DiffusersBackend(
+            embodiment=get_embodiment("droid"),
+            model="nvidia/Cosmos3-Nano",
+            mode="inverse_dynamics",
+            pipeline=_stub_pipeline(),
+            condition_cls=_StubCondition,
+        )
+        policy = Cosmos3Policy(embodiment="droid", backend="diffusers", diffusers_backend=backend)
+        assert policy._diffusers is not None
+        assert policy._diffusers.model == "nvidia/Cosmos3-Nano"
+        assert policy._diffusers.mode == "inverse_dynamics"
+
+    def test_the_registry_route_carries_only_the_declared_config_keys(self) -> None:
+        """Why the page names an object route: the JSON route filters the flag out."""
+        built = build_policy_kwargs("cosmos3", backend="diffusers", mode="policy", enable_safety_checker=True)
+        assert built["backend"] == "diffusers"
+        assert built["mode"] == "policy"
+        assert "enable_safety_checker" not in built
+
+
+class _StubCondition:
+    """Stand-in for ``diffusers.CosmosActionCondition`` (records its kwargs)."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+def _stub_pipeline() -> Any:
+    """A ``Cosmos3OmniPipeline``-shaped callable returning one action chunk."""
+    embodiment = get_embodiment("droid")
+    chunk = np.zeros((embodiment.action_chunk_size, embodiment.raw_action_dim), dtype=np.float32)
+
+    class _Pipeline:
+        def __call__(self, **kwargs: Any) -> Any:
+            import types
+
+            return types.SimpleNamespace(action=[chunk], video=None, sound=None)
+
+    return _Pipeline()


### PR DESCRIPTION
## Problem

The safety-checker callout in `docs/policies/cosmos3.md` tells the reader:

> Install `cosmos_guardrail` and pass `enable_safety_checker=True` to re-enable it.

No surface that page names accepts it. Every worked example on the page builds the
policy - `Cosmos3Policy(...)` or `create_policy("cosmos3", ...)` - and that
constructor declares no `enable_safety_checker` parameter and takes no `**kwargs`.
The flag belongs to `Cosmos3DiffusersBackend`, which the page never mentions.

Applying the instruction on every route a reader of that page has:

| route | before |
| --- | --- |
| `Cosmos3Policy(..., enable_safety_checker=True)` | `TypeError: Cosmos3Policy.__init__() got an unexpected keyword argument 'enable_safety_checker'` |
| `create_policy("cosmos3", ..., enable_safety_checker=True)` | same `TypeError` |
| the registry route (`build_policy_kwargs`) | accepted, then dropped - returns `['backend', 'embodiment', 'host', 'mode', 'port']`, so the run proceeds with the checker off |
| `Cosmos3Policy(diffusers_backend=...)` | carries the flag, but the page never names it |

So 0 of 4 routes deliver the setting. The third row is the quiet one: the
provider's `config_keys` filter keeps only the keys the constructor declares, so a
caller who "enabled" the checker through a config dict gets a successful run with
it disabled and nothing said.

The cause is that `Cosmos3Policy` forwards only `embodiment`, `model` and `mode`
of the backend's 13 parameters, so `resolution_tier`, `view_point`, `device`,
`dtype`, `num_inference_steps`, `guidance_scale`, `enable_sound` and
`enable_safety_checker` are all reachable on the backend object only.

## Change

Docs and a docstring; no behaviour change.

* The callout now names the class the flag belongs to and shows the route that
  carries it - build a `Cosmos3DiffusersBackend` with the flag and hand it to
  `Cosmos3Policy(diffusers_backend=...)` - and lists the other load and sampling
  knobs the same route carries, noting that the policy forwards only
  `embodiment`, `model` and `mode`.
* `Cosmos3Policy`'s `diffusers_backend` docstring said "(dependency injection for
  tests; skips the heavy import)". Injection is still how the tests drive this
  backend, but it is also the supported route to those knobs, so the docstring now
  says both.

The alternative - promoting the eight knobs onto `Cosmos3Policy` - changes a public
constructor and the provider's `config_keys`, and picking which subset belongs
there is a design call rather than a correction, so it is out of scope here.

## Tests

`tests/policies/cosmos3/test_documented_backend_knob_routes.py` grades every
keyword the page instructs against `inspect.signature` of the receivers the page
actually names, so a knob promoted onto the policy later, or a newly documented
one, is graded without editing the test. The page's Python fences are graded in
the other direction: every keyword they pass must be accepted by that call's own
receiver.

Against `upstream/main`: **3 failed, 5 passed**. Afterwards: **8 passed**.

The headline failure reports the offender rather than a wording mismatch:

```
cosmos3.md tells the reader to pass ['enable_safety_checker'], which no receiver
it names accepts. Named receivers: ['Cosmos3Policy', 'create_policy("cosmos3")'].
Name the class the keyword belongs to, or promote the keyword.
```

The five that pass on both trees are the controls:

* every keyword the page's Python fences pass is accepted by its own receiver
  (19 graded, so the examples themselves are pinned as correct);
* `model` and `mode` still reach the backend, which is the subset the policy carries;
* the registry route still returns exactly its declared `config_keys` - this is why
  the page names an object route rather than a config key;
* a knob list that named a parameter `Cosmos3DiffusersBackend` does not have would
  be reported, with a planted case so a clean result is not vacuous;
* a planted instruction is picked up by the extractor, so a clean sweep means the
  page is right rather than that the grader accepts anything.

## Verification

Measured at `c51da2ef` against `upstream/main` `ae57b3fa`.

* `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
* `mypy strands_robots tests tests_integ`: 24 pre-existing errors on both trees,
  none in the changed files.
* Blast radius (all of `tests/policies/cosmos3`, every test touching
  `Cosmos3Policy` / `config_keys` / `build_policy_kwargs` / a docs page, plus the
  repo-wide docs, docstring, source-string and changelog guards - 80 files):
  branch **1 failed / 2743 passed**, base **4 failed / 2740 passed**, 2744
  collected on both. Branch-only failures: none. Base-only: exactly the 3 pre-fix
  failures above. The single shared failure is
  `tests/training/test_lerobot_e2e.py::test_record_train_load_loop`, which fails
  the same way on both trees from a local `draccus` older than the `lerobot` pin
  (`TypeError: encode() takes 1 positional argument but 2 were given`).
* `scripts/assemble_changelog.py --check`: OK.

## Artifact

One capture script per tree, reading the instruction out of whichever page it runs
against and applying it on all four routes. The package code is identical in both
columns; only the page differs.

![documented knob route](https://raw.githubusercontent.com/cagataycali/robots/media-cosmos3-documented-knob-route/documented_knob_route.png)

Routes delivering the flag: 0/4 before, 1/4 after.
