### PR TITLE
fix(mesh): refuse an ACL file the JSON5 parser cannot descend

### DIFF
--- a/changelog.d/2468-acl-file-nesting-refusal.md
+++ b/changelog.d/2468-acl-file-nesting-refusal.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **mesh**: an ACL file too deeply nested for the JSON5 parser to read is now refused as an unloadable ACL instead of escaping the loader's fail-closed boundary as a `RecursionError`, so the start-time gate still refuses to bring the wire up and the operator gets the path and a remedy.

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,6 +56,7 @@ mTLS alone is not sufficient - pair it with an access-control list:
 - The built-in default ACL is permissive: any CA-signed peer may publish and subscribe on any key. If you forget to supply an ACL, the SDK warns on every session open.
 - Supply an operator ACL via `STRANDS_MESH_ACL_FILE` that enumerates each peer's certificate CN and the key expressions it may use. See [`examples/mesh/mesh_acl_example.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh/mesh_acl_example.json5) and [`examples/mesh/mesh_acl_strict_per_peer.json5`](https://github.com/strands-labs/robots/blob/main/examples/mesh/mesh_acl_strict_per_peer.json5).
 - `STRANDS_MESH_ACCEPT_PERMISSIVE_ACL=1` exists only to silence the permissive-ACL warning when you have deliberately accepted it (e.g. a closed lab). Do not set it in production - it does not make the mesh safer, it only quiets the reminder that it is not.
+- An ACL file the loader cannot read is refused, not ignored. A missing, oversize, non-UTF-8, malformed, or too-deeply-nested file is reported as an unloadable ACL, which the start-time gate treats as the permissive default and therefore refuses to bring the wire up. The error names the path and the reason, so a typo in the ACL stops the mesh rather than quietly widening it.
 
 > ⚠️ **WAN/cloud Zenoh routers MUST deploy a topic-level ACL.**
 > mTLS authenticates *who* a device is; it does **not** restrict *what* topics

--- a/strands_robots/mesh/_acl_config.py
+++ b/strands_robots/mesh/_acl_config.py
@@ -98,6 +98,13 @@ def _parse_json5(raw: str, path: Path) -> Any:
     malformed input. The ACL loader treats this as a fail-closed
     boundary: a malformed file does NOT silently degrade to the
     permissive default.
+
+    That includes a document the parser cannot descend. ``json5`` is a
+    recursive-descent parser, so a deeply nested file raises
+    :class:`RecursionError` rather than :class:`ValueError` -- a
+    :class:`RuntimeError`, outside both the class this boundary documents and
+    the ``(OSError, ValueError)`` tuple its two fail-closed callers narrow to.
+    It is converted here so the refusal reaches them.
     """
     # Use the project-standard
     # ``require_optional`` helper so the operator-facing import error
@@ -120,6 +127,31 @@ def _parse_json5(raw: str, path: Path) -> Any:
         ) from exc
     try:
         return _json5_mod.loads(raw)
+    except RecursionError as exc:
+        # ``json5`` is a recursive-descent parser, so nesting depth -- not file
+        # size -- is what it runs out of room for, and ``RecursionError`` is a
+        # ``RuntimeError``. It therefore missed both this boundary's documented
+        # ``ValueError`` and the ``(OSError, ValueError)`` tuple the two
+        # fail-closed callers narrow to (``snapshot_acl``, which reports an
+        # unloadable file as permissive so the start-time gate refuses the
+        # wire, and ``Mesh.start``'s ACL gate). The refusal escaped both, and
+        # with it the path, the reason and the remedy.
+        #
+        # ``ACL_FILE_MAX_BYTES`` does not bound this: 60 levels of nesting is
+        # 120 bytes, three orders of magnitude under that budget, while the
+        # shipped operator templates nest four levels. Every ``json5`` release
+        # the floor admits (0.9.0 through 0.15.0) raises it the same way, so
+        # this is the handler's to convert rather than a version to pin away.
+        #
+        # The message does not reuse the "not valid JSON5" wording below: a
+        # deeply nested document is valid JSON5 that this parser cannot read,
+        # and reporting it as malformed syntax would send the operator looking
+        # for a typo.
+        raise ValueError(
+            f"ACL file {path} is nested too deeply to parse: the JSON5 parser "
+            f"exhausted the interpreter stack. A role-separated ACL nests about "
+            f"four levels -- see examples/mesh/mesh_acl_example.json5."
+        ) from exc
     except ValueError as exc:
         # json5 raises ValueError (subclass) with a useful message that
         # includes line/column. Re-raise with the path attached so an

--- a/tests/mesh/test_acl_config.py
+++ b/tests/mesh/test_acl_config.py
@@ -333,6 +333,131 @@ class TestJSON5MalformedFailsLoudly:
         assert parsed["subjects"][0]["cert_common_names"] == ["op-1"]
 
 
+#: Nesting depth used by the deeply-nested cases below. The parser runs out of
+#: stack at ~60 levels measured at module scope; under pytest the interpreter is
+#: already several frames deeper, so the tests use a depth well clear of the
+#: boundary rather than pinning a number that moves with the caller's stack.
+_DEEP = 200
+
+
+def _nested_acl_text(shape: str) -> str:
+    """Return a deeply nested JSON5 document in one of the measured shapes."""
+    if shape == "arrays":
+        return "[" * _DEEP + "]" * _DEEP
+    if shape == "objects":
+        return '{"a":' * _DEEP + "1" + "}" * _DEEP
+    if shape == "unclosed-arrays":
+        return "[" * _DEEP
+    raise AssertionError(f"unknown shape {shape!r}")
+
+
+class TestADeeplyNestedACLReachesTheFailClosedBoundary:
+    """A file the parser cannot descend is refused as an unloadable ACL.
+
+    ``json5`` is a recursive-descent parser, so it exhausts the interpreter
+    stack on a deeply nested document and raises ``RecursionError``. That is a
+    ``RuntimeError``, so it is outside the ``ValueError`` :func:`_parse_json5`
+    documents for *any* malformed input, and outside the
+    ``(OSError, ValueError)`` tuple both fail-closed callers narrow to -
+    :func:`snapshot_acl`, which reports an unloadable file as permissive so the
+    start-time gate refuses the wire, and ``Mesh.start``'s ACL gate, whose own
+    comment reserves wider classes for "genuine bugs" that should propagate. An
+    unreadable ACL file is not a bug in this library, so it was misclassified:
+    the refusal escaped the boundary and took the path, the reason and the
+    remedy with it.
+
+    ``ACL_FILE_MAX_BYTES`` is not the bound that covers this. It exists for a
+    hostile file ("certainly an attacker probing for an OOM") and caps the read
+    at 256 KiB, but nesting depth rather than size is what the parser runs out
+    of room for: 60 levels is 120 bytes, and the shipped operator templates
+    nest four. :meth:`test_the_payload_is_far_inside_the_size_budget` is that
+    gap as an assertion.
+
+    The sibling class above pins the same contract for input this parser *can*
+    descend; these are the inputs it cannot.
+    """
+
+    @pytest.mark.parametrize("shape", ["arrays", "objects", "unclosed-arrays"])
+    def test_a_deeply_nested_file_is_refused_as_an_unloadable_acl(self, tmp_path, shape):
+        # Pre-fix this raises RecursionError straight through ``_load_acl_file``,
+        # so the ValueError every caller of this boundary handles never arrives.
+        path = tmp_path / "deep.json5"
+        path.write_text(_nested_acl_text(shape))
+        with pytest.raises(ValueError, match=r"nested too deeply to parse"):
+            ac._load_acl_file(path)
+
+    def test_the_refusal_names_the_file_and_a_remedy(self, tmp_path):
+        # Every other unloadable-ACL refusal names the path and points at the
+        # operator template; this one must too, or the operator is left with a
+        # bare stack-depth complaint about an unnamed file.
+        path = tmp_path / "deep.json5"
+        path.write_text(_nested_acl_text("arrays"))
+        with pytest.raises(ValueError) as excinfo:
+            ac._load_acl_file(path)
+        message = str(excinfo.value)
+        assert str(path) in message
+        assert "mesh_acl_example.json5" in message
+
+    def test_the_refusal_does_not_report_valid_json5_as_malformed(self, tmp_path):
+        # A deeply nested document is valid JSON5 this parser cannot read, so
+        # reusing the "not valid JSON5" wording would send the operator looking
+        # for a syntax error that is not there.
+        path = tmp_path / "deep.json5"
+        path.write_text(_nested_acl_text("arrays"))
+        with pytest.raises(ValueError) as excinfo:
+            ac._load_acl_file(path)
+        assert "not valid JSON5" not in str(excinfo.value)
+
+    def test_the_snapshot_gate_sees_it_as_permissive_instead_of_crashing(self, monkeypatch, tmp_path):
+        # The consequence the conversion exists for: ``snapshot_acl`` reports an
+        # unloadable file as permissive precisely so ``Mesh.start`` refuses to
+        # bring up the wire. Pre-fix the RecursionError escaped this function,
+        # so that gate never ran.
+        path = tmp_path / "deep.json5"
+        path.write_text(_nested_acl_text("arrays"))
+        monkeypatch.setenv("STRANDS_MESH_ACL_FILE", str(path))
+        ac._clear_acl_cache_for_test()
+        ac._clear_thread_snapshot()
+        is_permissive, resolved = ac.snapshot_acl("strands")
+        assert is_permissive is True
+        assert resolved == ac.default_acl("strands")
+
+    def test_the_payload_is_far_inside_the_size_budget(self, tmp_path):
+        # Severity, as an assertion: the file that defeats the parser is orders
+        # of magnitude under the bound written to keep hostile files out, so the
+        # size cap cannot stand in for this conversion.
+        path = tmp_path / "deep.json5"
+        path.write_text(_nested_acl_text("arrays"))
+        assert path.stat().st_size < ac.ACL_FILE_MAX_BYTES // 100
+
+    def test_a_shallow_malformed_file_keeps_its_own_reason(self, tmp_path):
+        # Control: the branch that already worked is untouched, byte for byte.
+        # Fails if the two are collapsed into one message.
+        path = tmp_path / "bad.json5"
+        path.write_text("{a:")
+        with pytest.raises(ValueError) as excinfo:
+            ac._load_acl_file(path)
+        assert f"ACL file {path} is not valid JSON5: " in str(excinfo.value)
+        assert "nested too deeply" not in str(excinfo.value)
+
+    def test_a_valid_acl_still_loads(self, tmp_path):
+        # Control: the new handler does not reach past the parse call. A
+        # legitimate ACL nests four levels and is unaffected.
+        path = tmp_path / "ok.json5"
+        path.write_text(json.dumps(_ENABLED_ACL))
+        loaded = ac._load_acl_file(path)
+        assert loaded["enabled"] is True
+
+    def test_an_oversize_file_is_still_refused_on_size(self, tmp_path):
+        # Control: ordering. The size cap is checked before the parser is
+        # reached, so a file that is both oversize and deeply nested is still
+        # reported as oversize rather than as unparseable.
+        path = tmp_path / "huge.json5"
+        path.write_text("[" * (ac.ACL_FILE_MAX_BYTES + 10))
+        with pytest.raises(ValueError, match=r"refusing to load"):
+            ac._load_acl_file(path)
+
+
 class TestDefaultACLPermissiveShape:
     """Pin the post-the prior permissive-allow shape of the default ACL.
 


### PR DESCRIPTION
## Problem

`_parse_json5` is the ACL loader's parse boundary and its docstring states the contract:

> Raises `ValueError` with operator-friendly diagnostics on **any** malformed input. The ACL loader treats this as a fail-closed boundary: a malformed file does NOT silently degrade to the permissive default.

`json5` is a recursive-descent parser, so a deeply nested document exhausts the interpreter stack and raises `RecursionError`. That is a `RuntimeError`, so it is outside the `ValueError` this boundary documents *and* outside the `(OSError, ValueError)` tuple both fail-closed callers narrow to:

- `snapshot_acl` reports an unloadable file as permissive precisely so the start-time gate refuses the wire.
- `Mesh.start`'s ACL gate does the same, and its comment reserves wider classes for "genuine bugs so they aren't masked at WARNING level".

An unreadable ACL file is not a bug in this library, so it was misclassified. The refusal escaped both handlers, and took the path, the reason and the remedy with it.

Measured against `48d58c02`, driving `_load_acl_file`, `snapshot_acl` and the gate:

| ACL file | size | `_parse_json5` | `snapshot_acl` | `Mesh.start` gate |
| --- | --- | --- | --- | --- |
| a valid role-separated ACL | 480 B | loaded | `permissive=False` | wire may start |
| a malformed ACL (`{a:`) | 3 B | `ValueError` | `permissive=True` | refuses the wire |
| an ACL nested 200 deep | **400 B** | **`RecursionError`** | **escapes** | **escapes** |

### `ACL_FILE_MAX_BYTES` is not the bound that covers this

The module already bounds a hostile file, with the reason written next to it ("certainly an attacker probing for an OOM"), capping the read at 256 KiB. But **nesting depth, not size, is what the parser runs out of room for**: the shallowest document that trips it is 60 levels, i.e. **120 bytes - 2185x under that budget** - while both shipped operator templates (`mesh_acl_example.json5`, `mesh_acl_strict_per_peer.json5`) nest **4** levels.

### It is not a version to pin away

Every `json5` release the declared floor (`>=0.9.0`) admits raises it identically, so there is no floor that fixes it:

| json5 | deep arrays | deep objects | malformed |
| --- | --- | --- | --- |
| 0.9.0 / 0.9.14 / 0.9.28 / 0.10.0 / 0.12.0 / 0.14.0 / 0.15.0 | `RecursionError` | `RecursionError` | `ValueError` |

`RecursionError` is also the *only* non-`ValueError` class the parser raises: a battery over deep arrays/objects/unclosed-arrays, oversized escapes, a 60k-digit integer, `bytes`, `None`, NUL bytes, a BOM and a lone surrogate produced no other escape.

## Change

`_parse_json5` converts `RecursionError` into the `ValueError` it already documents, so the established fail-closed path handles it and every downstream narrow handler starts working. One handler, at the boundary that owns the contract.

The message does not reuse the neighbouring "not valid JSON5" wording: a deeply nested document *is* valid JSON5 that this parser cannot read, and reporting it as malformed syntax would send the operator looking for a typo that is not there. It names the file, the cause, the shape a real ACL has, and the template:

```
ACL file <path> is nested too deeply to parse: the JSON5 parser exhausted the
interpreter stack. A role-separated ACL nests about four levels -- see
examples/mesh/mesh_acl_example.json5.
```

Raising the recursion limit or pre-checking a maximum depth would each invent a new bound, so both are out of scope; this only restores the class the boundary already promises.

`docs/security.md`'s ACL bullet list documented the permissive default and the opt-out but never what happens to a file the loader cannot read, so it gains that bullet.

## Tests

Added to `tests/mesh/test_acl_config.py`, extending the sibling `TestJSON5MalformedFailsLoudly` - which already pins this contract for input the parser *can* descend, and whose four existing cases are untouched.

**6 failed / 67 passed before, 73 passed after.** Every pre-fix failure is behavioural, reporting the raw `RecursionError: maximum recursion depth exceeded`.

Fails pre-fix:
- the refusal arrives as a `ValueError`, parametrized over the three measured shapes (deep arrays, deep objects, deep unclosed arrays)
- the refusal names the file and points at the operator template
- the refusal does not report valid JSON5 as malformed
- `snapshot_acl` reports it permissive so the gate runs, instead of the exception escaping

Passes on both trees, i.e. the controls:
- a shallow malformed file keeps its own message byte for byte - fails if the two branches are collapsed
- a valid ACL still loads - fails if the new handler reaches past the parse call
- an oversize file is still refused on size - pins the ordering
- the payload is orders of magnitude inside `ACL_FILE_MAX_BYTES` - the severity gap as an assertion

## Verification

Measured at `4fb6562f` against `upstream/main` `48d58c02`, same interpreter, 190 test files (all of `tests/mesh`, every test touching the ACL loader or a docs page, and the repo-wide changelog/docstring/ASCII/dependency guards):

- branch **21 failed / 4260 passed / 5 skipped / 24 errors**; base **27 / 4254 / 5 / 24**; both collected **4310**
- `27 - 21 == 4260 - 4254 == 6` == exactly the pre-fix failure count
- **branch-only failures: none.** Base-only: exactly the 6 above. The 45 shared failures are all `awsiot`-absent `tests/mesh/test_iot_*`, which CI installs.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 == 24 against a pristine `upstream/main` worktree, branch-only empty
- `scripts/assemble_changelog.py --check` OK

## Artifact

Both columns are the same probe script run against the two trees, driving the real `_load_acl_file`, `snapshot_acl` and `Mesh.start` gate. The first two rows are byte-identical in both trees - only the file the parser cannot descend changes behaviour.

![ACL nesting refusal, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-acl-nesting-refusal/acl-nesting-refusal.png)
