### PR TITLE
fix(mesh): report an absent eclipse-zenoh at the level a consumer sees

### DIFF
--- a/changelog.d/2478-zenoh-absent-report-level.md
+++ b/changelog.d/2478-zenoh-absent-report-level.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **mesh**: report an absent `eclipse-zenoh` at `WARNING` instead of `DEBUG`, so a
+  default-configured consumer learns why the mesh never came up. Both session-open
+  paths and `Mesh.start` left the degradation below the level anything prints, so the
+  first observable symptom was whichever downstream wait expired first. The
+  dependency is named once per process with the extra that supplies it; the mesh
+  still stays off rather than raising.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,7 @@ description: Error → fix table for the most common gotchas across install, sim
 |---------|--------------|-----|
 | `mesh.peers` empty | Other peer not running | Wait ~1s; verify `mesh.alive == True` on both |
 | Port already bound | Another zenoh process | Mesh auto falls back to client mode; or set `STRANDS_MESH_PORT` |
-| `init_mesh` raises | `eclipse-zenoh` missing | `uv pip install "strands-robots[mesh]"` |
+| `mesh.alive` is `False`, `mesh.peers` stays empty | `eclipse-zenoh` missing (logged at WARNING: "eclipse-zenoh is not installed") | `uv pip install "strands-robots[mesh]"` |
 | Want mesh off | - | `STRANDS_MESH=false` or `Robot(..., mesh=False)` |
 
 ## Agent integration

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -682,7 +682,17 @@ class Mesh(SensorLoopsMixin):
                 # state.
                 _acl_config._clear_thread_snapshot()
             if session is None:
-                logger.debug("[mesh] %s: zenoh unavailable, mesh off", self.peer_id)
+                # The sibling refusal above leaves the mesh not-started and says
+                # so at ERROR.  Arriving here leaves it not-started too, so the
+                # caller learns that ``mesh.alive`` is False from the same level
+                # rather than from whichever downstream wait expires first.  The
+                # cause is reported by the session/transport layer that returned
+                # None; this names the peer it applies to.
+                logger.warning(
+                    "[mesh] %s: no mesh transport - mesh off (mesh.alive is False, so this "
+                    "peer publishes no presence and discovers no peers)",
+                    self.peer_id,
+                )
                 return
 
             self._has_session_ref = True

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -60,6 +60,15 @@ _SESSION: Any | None = None  # zenoh.Session when open, else None
 _SESSION_LOCK = threading.Lock()
 _SESSION_REFS: int = 0
 
+# One-shot guard so an absent ``eclipse-zenoh`` is reported at most once per
+# process.  Both session-open paths re-attempt the import on every call (nothing
+# is cached when it fails), so a fleet of N robots in one process would otherwise
+# emit N copies of an identical, static fact.  A set (mutated via .add, never
+# reassigned) avoids a `global` rebind so static analysis sees it as used -- the
+# same shape as ``_software_render_warned`` in the MuJoCo backend.  Mutated only
+# under ``_SESSION_LOCK``.
+_zenoh_missing_warned: set[str] = set()
+
 
 # Constants
 
@@ -615,6 +624,34 @@ def current_session() -> Any | None:
         return _SESSION
 
 
+def _report_zenoh_missing() -> None:
+    """Report an absent ``eclipse-zenoh`` at WARNING, once per process.
+
+    Every other way a session open can end with no session -- a refused
+    endpoint, a failed open -- is reported at WARNING, and even a bad
+    ``STRANDS_MESH_PORT`` that still yields a working mesh warns.  A missing
+    dependency is the most total of those outcomes: nothing publishes, nothing
+    is discovered, and ``Mesh.alive`` stays ``False`` for the whole process.
+    Reporting it below the level a default-configured consumer sees left the
+    first observable symptom to whatever downstream wait expired first.
+
+    Warning rather than raising keeps the documented contract: a robot that
+    does not need the mesh still runs, and the mesh stays off without taking
+    the host process with it.
+
+    Callers must hold ``_SESSION_LOCK``; the once-guard is read and mutated
+    without further synchronisation.
+    """
+    if _zenoh_missing_warned:
+        return
+    _zenoh_missing_warned.add("warned")
+    logger.warning(
+        "eclipse-zenoh is not installed, so the mesh stays off: this process "
+        "publishes no presence and discovers no peers, and Mesh.alive is "
+        "False. Install it with: pip install 'strands-robots[mesh]'"
+    )
+
+
 def get_session() -> Any | None:
     """Acquire the shared mesh transport (lazy, ref-counted).
 
@@ -652,7 +689,7 @@ def get_session() -> Any | None:
         try:
             import zenoh  # noqa: F811 - lazy import
         except ImportError:
-            logger.debug("eclipse-zenoh not installed - mesh disabled")
+            _report_zenoh_missing()
             return None
 
         # STRANDS_MESH_PORT is read at session-open time so a process can be
@@ -820,7 +857,7 @@ def _get_zenoh_session_directly() -> Any | None:
         try:
             import zenoh
         except ImportError:
-            logger.debug("eclipse-zenoh not installed - mesh disabled")
+            _report_zenoh_missing()
             return None
 
         port_env = os.getenv("STRANDS_MESH_PORT", "7447")

--- a/tests/mesh/test_zenoh_absent_is_reported.py
+++ b/tests/mesh/test_zenoh_absent_is_reported.py
@@ -1,0 +1,197 @@
+"""A missing ``eclipse-zenoh`` is reported at the level a consumer sees.
+
+The mesh is optional, and a robot that does not need it must keep running when
+the extra is absent -- so the session layer returns ``None`` and ``Mesh.start``
+returns early rather than raising.  What made that degradation undiagnosable was
+the *level*: both session-open paths reported the absent dependency at DEBUG, so
+under default logging nothing named it and the first observable symptom was
+whichever downstream wait expired first (in the fleet examples, a 15 s
+presence-discovery timeout whose message mentions no dependency at all).
+
+Every other way those functions end with no session already reports at WARNING,
+and even a bad ``STRANDS_MESH_PORT`` -- which still yields a working mesh --
+warns.  The most total outcome was the quietest one.  These tests pin the level,
+the actionability of the remedy, that it is said once per process, and that
+warning did not turn into raising.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import re
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import strands_robots.mesh.session as session_mod
+from strands_robots.mesh.core import Mesh
+
+_REPO_ROOT = Path(session_mod.__file__).resolve().parents[2]
+
+# Both session-open entry points reach the same lazy ``import zenoh``.  The
+# public one routes ordinary callers; the private one is what a
+# ``BridgeTransport``'s zenoh leg uses, and it carried the same DEBUG report.
+_SESSION_OPENERS = ("get_session", "_get_zenoh_session_directly")
+
+
+@pytest.fixture(autouse=True)
+def _fresh_session_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test with no cached session and nothing reported yet."""
+    monkeypatch.setattr(session_mod, "_SESSION", None)
+    monkeypatch.setattr(session_mod, "_SESSION_REFS", 0)
+    monkeypatch.setattr(session_mod, "_zenoh_missing_warned", set(), raising=False)
+    # Keep get_session on the raw zenoh path rather than the transport factory.
+    monkeypatch.delenv("STRANDS_MESH_BACKEND", raising=False)
+
+
+def _open_without_zenoh(opener: str) -> Any:
+    """Call one session opener with ``import zenoh`` failing.
+
+    A ``None`` entry in ``sys.modules`` is what the interpreter treats as a
+    halted import, so this reproduces an absent extra without touching the
+    installed one.
+    """
+    with patch.dict("sys.modules", {"zenoh": None}):
+        return getattr(session_mod, opener)()
+
+
+class TestTheAbsentDependencyIsNamedAtWarning:
+    """The cause reaches a default-configured consumer."""
+
+    @pytest.mark.parametrize("opener", _SESSION_OPENERS)
+    def test_every_session_opener_reports_it(self, opener: str, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.session"):
+            result = _open_without_zenoh(opener)
+
+        assert result is None, "premise: the opener must have taken the missing-dependency branch"
+        named = [r for r in caplog.records if "eclipse-zenoh" in r.getMessage()]
+        assert named, (
+            f"{opener}() returned None because eclipse-zenoh is absent, but no record at WARNING or "
+            f"above names it, so a default-configured consumer learns nothing. Records seen: "
+            f"{[(r.levelname, r.getMessage()[:60]) for r in caplog.records]}"
+        )
+
+    def test_mesh_start_names_the_peer_whose_mesh_stayed_off(self, caplog: pytest.LogCaptureFixture) -> None:
+        mesh = Mesh(SimpleNamespace(name="arm"), peer_id="bot-7")
+
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            with patch("strands_robots.mesh.core.get_session", return_value=None):
+                mesh.start()
+
+        assert mesh.alive is False, "premise: start() must have taken the no-transport branch"
+        named = [r for r in caplog.records if "bot-7" in r.getMessage() and "mesh off" in r.getMessage()]
+        assert named, (
+            "start() left mesh.alive False and reported nothing at WARNING, so the caller finds out "
+            f"from whichever downstream wait expires first. Records seen: "
+            f"{[(r.levelname, r.getMessage()[:60]) for r in caplog.records]}"
+        )
+
+
+class TestTheRemedyIsRunnable:
+    """The message quotes an extra that really supplies the dependency."""
+
+    def test_the_named_extra_declares_eclipse_zenoh(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.session"):
+            _open_without_zenoh("get_session")
+
+        text = "\n".join(r.getMessage() for r in caplog.records)
+        offered = re.findall(r"strands-robots\[([a-z0-9-]+)\]", text)
+        assert offered, f"the report offers no installable extra: {text!r}"
+
+        declared = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())["project"]["optional-dependencies"]
+        for extra in offered:
+            assert extra in declared, f"the report names extra {extra!r}, which pyproject does not declare"
+            assert any("eclipse-zenoh" in req for req in declared[extra]), (
+                f"extra {extra!r} is declared but does not supply eclipse-zenoh, so following the "
+                f"report leaves the mesh off: {declared[extra]}"
+            )
+
+
+class TestItIsSaidOncePerProcess:
+    """A static fact is not repeated once per robot."""
+
+    def test_repeated_opens_report_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.session"):
+            for opener in (*_SESSION_OPENERS, *_SESSION_OPENERS):
+                _open_without_zenoh(opener)
+
+        named = [r for r in caplog.records if "eclipse-zenoh" in r.getMessage()]
+        assert len(named) == 1, (
+            f"four session opens reported the same absent dependency {len(named)} times; a fleet of "
+            "robots in one process would bury the rest of the log"
+        )
+
+
+class TestTheReportIsAttachedToTheMissingDependencyOnly:
+    """The root cause: the warning belongs to the ImportError branch."""
+
+    def test_every_call_sits_in_an_importerror_handler(self) -> None:
+        tree = ast.parse(inspect.getsource(session_mod))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_report_zenoh_missing"
+        ]
+        assert len(calls) == len(_SESSION_OPENERS), (
+            f"expected one report per session opener ({len(_SESSION_OPENERS)}), found {len(calls)}"
+        )
+
+        guarded: set[int] = set()
+        for handler in (n for n in ast.walk(tree) if isinstance(n, ast.ExceptHandler)):
+            caught = handler.type
+            names = (
+                {caught.id}
+                if isinstance(caught, ast.Name)
+                else {e.id for e in getattr(caught, "elts", []) if isinstance(e, ast.Name)}
+            )
+            if "ImportError" not in names:
+                continue
+            guarded |= {id(n) for n in ast.walk(handler) if isinstance(n, ast.Call)}
+
+        for call in calls:
+            assert id(call) in guarded, (
+                f"_report_zenoh_missing() is called at line {call.lineno} outside an ImportError "
+                "handler, so it would blame a missing dependency for some other failure"
+            )
+
+
+class TestReportingDidNotBecomeRaising:
+    """Controls: the optional-dependency contract is unchanged."""
+
+    @pytest.mark.parametrize("opener", _SESSION_OPENERS)
+    def test_the_opener_still_returns_none(self, opener: str) -> None:
+        result = _open_without_zenoh(opener)
+
+        assert result is None
+        assert session_mod._SESSION is None
+
+    def test_mesh_start_is_still_a_clean_no_op(self) -> None:
+        mesh = Mesh(SimpleNamespace(name="arm"), peer_id="bot-8")
+
+        with patch("strands_robots.mesh.core.get_session", return_value=None):
+            mesh.start()
+
+        assert mesh.alive is False
+
+    def test_init_mesh_returns_a_mesh_rather_than_raising(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The suite sets STRANDS_MESH=false process-wide so tests never touch a
+        # real mesh, and that kill switch makes init_mesh return None before it
+        # reaches a session at all.  Clear it so this asserts the behaviour under
+        # an absent dependency rather than under the switch.
+        monkeypatch.delenv("STRANDS_MESH", raising=False)
+
+        from strands_robots.mesh.core import init_mesh
+
+        with patch("strands_robots.mesh.core.get_session", return_value=None):
+            mesh = init_mesh(SimpleNamespace(name="arm", tool_name_str="arm"), peer_id="bot-9")
+
+        assert mesh is not None
+        assert mesh.alive is False


### PR DESCRIPTION
## Problem

With `eclipse-zenoh` absent, a mesh-requiring workflow fails as an opaque presence-discovery timeout. Nothing in the output names the absent dependency, because the degradation is reported below the level a default-configured consumer prints.

Measured with `import zenoh` failing, root logger at its default `WARNING`:

| call | result | records naming the cause |
|---|---|---|
| `get_session()` | `None` | 0 |
| `_get_zenoh_session_directly()` | `None` | 0 |
| `Mesh.start()` | `mesh.alive` is `False` | 0 |

The only record a consumer *does* see is an unrelated e-stop advisory that describes fleet-wide e-stop semantics for a mesh that is not running at all.

## Why this is the odd one out

`get_session` reports every other way it can end with no session at `WARNING`, and even a bad `STRANDS_MESH_PORT` -- which still yields a **working** mesh -- warns:

| line | event | level | mesh comes up? |
|---|---|---|---|
| `Invalid STRANDS_MESH_PORT ... falling back to 7447` | recoverable misconfiguration | `WARNING` | yes |
| `Zenoh listener ... unavailable - trying client mode` | recoverable | `DEBUG` | yes (recovers) |
| `Zenoh session open failed (peer fallback)` | total | `WARNING` | no |
| `Zenoh session open failed` | total | `WARNING` | no |
| `eclipse-zenoh not installed` | total | **`DEBUG`** | **no** |

`_get_zenoh_session_directly` has the same shape. `Mesh.start` does too: the sibling ACL refusal a few lines above also leaves the mesh not-started and reports at `ERROR`.

So the most total outcome was the quietest one. The comment beside that port fallback is also where the quiet-off design is stated -- "falls back to the default and **warns once** - never raises (the default behaviour is to keep the mesh quietly off rather than crash the host robot)" -- i.e. quiet-off means *does not raise*, not *does not warn*.

## Change

`_report_zenoh_missing()` reports the absent dependency at `WARNING`, once per process, naming the extra that supplies it. Both openers re-attempt the import on every call (nothing is cached when it fails), so a fleet of N robots in one process would otherwise emit N copies of one static fact. The guard is a module-level set mutated via `.add` and never rebound -- the same shape as `_software_render_warned` in the MuJoCo backend, whose comment records why (`global` rebinding reads as unused to static analysis) -- and it is touched only under the existing `_SESSION_LOCK`, so it needs no new synchronisation. `Mesh.start`'s no-transport branch reports at `WARNING` and names the peer.

Return behaviour is untouched: the openers still return `None`, `Mesh.start` is still a clean no-op, and `init_mesh` still returns a `Mesh` rather than raising. A robot that does not need the mesh runs unchanged.

`docs/troubleshooting.md` claimed `init_mesh` **raises** when `eclipse-zenoh` is missing. It does not -- it returns a `Mesh` whose `alive` is `False`, which is what `docs/mesh.md` already documents ("Mesh failures are non-fatal"). The two pages contradicted each other, and the one a reader consults when the mesh is broken sent them looking for an exception that never comes. That row now names the observable a caller actually gets.

Out of scope: raising in the fleet examples that treat the mesh as mandatory. After this change the cause **is** named, but the downstream wait still expires -- turning it into an immediate refusal is a behaviour change in those examples and a separate contract. `factory.get_transport()` returning `None` is a *connect* failure (certs, broker), not an absent dependency, and is left alone.

## Console

Same script, same absent extra, only `strands_robots` differs. The capture drives the real `init_mesh` twice and then the presence wait, with `import zenoh` failing:

![operator console with eclipse-zenoh absent](https://raw.githubusercontent.com/cagataycali/robots/media-zenoh-absent-report-level/zenoh-absent-console.png)

Both runs still end in the same timeout -- the mesh is optional, so it stays off rather than raising. What changed is that the cause is attributable: 0 records naming it before, 3 after (one cause + one per affected peer), and the remedy is runnable. `mesh.alive` is `False` in both.

## Tests

`tests/mesh/test_zenoh_absent_is_reported.py`, 10 items. Against `upstream/main`: **6 failed / 4 passed**; after: 10 passed.

Fails pre-fix:
- both openers name the dependency at `WARNING` (parametrized -- the private one is what a `BridgeTransport`'s zenoh leg uses and carried the same `DEBUG` report)
- `Mesh.start` names the peer whose mesh stayed off
- the offered extra is declared in `pyproject.toml` **and** supplies `eclipse-zenoh`, so following the message works (the remedy is parsed back out of the record, not restated)
- four session opens report it exactly once
- root cause: every `_report_zenoh_missing()` call sits inside an `ImportError` handler, so it cannot come to blame a missing dependency for some other failure

Passes on both trees -- the controls, which fail for a fix that raises instead of reporting:
- both openers still return `None` and leave `_SESSION` unset
- `Mesh.start` is still a clean no-op
- `init_mesh` still returns a `Mesh`

## Verification

Measured at `fdc407c2` against `upstream/main` `d059c6c3`.

- Blast radius: all of `tests/mesh` plus every test touching the changed symbols and the repo-wide doc/changelog/docstring guards -- 220 files, run sequentially. Branch **21 failed / 4959 passed / 5 skipped / 24 errors**; base with the new test file copied in **27 / 4953 / 5 / 24**. Both collected 5009; failed delta = passed delta = 6 = the pre-fix failure count; branch-only failures **empty**; base-only exactly the 6 above. The 45 shared failures are all `tests/mesh/test_iot_*` needing `awsiotsdk`, which is declared and installed in CI.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: 24 on both trees, branch-only empty, none in the changed files.

Closes #2477
