### PR TITLE
fix(examples): record at the rate the rollout captures, not a rate the recorder refuses

### DIFF
--- a/changelog.d/2482-examples-recording-rate.md
+++ b/changelog.d/2482-examples-recording-rate.md
@@ -1,0 +1,13 @@
+### Fixed: three examples record at the rate their own rollout captures
+
+`examples/03_record_dataset.py`, `examples/07_post_tune_any_policy.py` and
+`examples/locomotion/vla_g1_workflow.py` each declared `start_recording(fps=30)`
+while their rollout captured at 50 Hz, so the recorder refused every frame and
+the episode landed empty: `03` exited reporting `0 frames` against a docstring
+promising `100 frames`, `07` printed `Recorded LeRobotDataset ->` and then died
+two steps later inside lerobot with an unrelated-looking Hub 404 for the empty
+local dataset, and the G1 workflow printed `Episode N/N recorded.` per episode
+for a dataset with nothing in it. Each rollout now captures at the rate its
+recording declares, and each checks the `run_policy` / `stop_recording` result so
+a future mismatch is reported where it happens. `07`'s DEPLOY step also runs the
+checkpoint it loads, which its own section comment already promised.

--- a/examples/03_record_dataset.py
+++ b/examples/03_record_dataset.py
@@ -34,12 +34,22 @@ if start["status"] != "success":
     raise SystemExit(1)
 
 # Run the policy - each step is automatically captured.
-sim.run_policy(
+# control_frequency must equal the recording's fps: the recorder writes one
+# frame per control step with no decimation, so the 50 Hz default rollout
+# against this 30 fps recording is refused rather than written at a distorted
+# timestamp rate, and the episode would land with zero frames.
+rollout = sim.run_policy(
     robot_name="so100",
     policy_object=MockPolicy(),
     instruction="pick up the red cube",
     n_steps=100,
+    control_frequency=30.0,
 )
+if rollout["status"] != "success":
+    # A refused rollout captures nothing, so stop_recording below would report
+    # an empty dataset instead of the reason. Surface it at its source.
+    print(f"run_policy failed: {rollout['content'][0]['text']}", file=sys.stderr)
+    raise SystemExit(1)
 
 # Finalize - writes parquet + video, ready for lerobot training scripts.
 # The response text reports the actual frame/episode count and on-disk path,

--- a/examples/07_post_tune_any_policy.py
+++ b/examples/07_post_tune_any_policy.py
@@ -38,13 +38,23 @@ sim.start_recording(
     task="pick up the red cube",
     overwrite=True,
 )
-sim.run_policy(
+# control_frequency must equal the recording's fps above: the recorder writes
+# one frame per control step with no decimation, so the 50 Hz default rollout
+# against a 30 fps recording is refused and the episode lands with zero frames.
+rollout = sim.run_policy(
     robot_name="so100",
     policy_object=MockPolicy(),
     instruction="pick up the red cube",
     n_steps=60,
+    control_frequency=30.0,
 )
-sim.stop_recording()
+if rollout["status"] != "success":
+    raise SystemExit(f"rollout failed: {rollout['content'][0]['text']}")
+stopped = sim.stop_recording()
+if stopped["status"] != "success":
+    # An empty dataset here surfaces two steps later as an unrelated-looking
+    # Hub 404 from lerobot, so report the recorder's own reason instead.
+    raise SystemExit(f"recording failed: {stopped['content'][0]['text']}")
 print(f"Recorded LeRobotDataset -> {DATASET_ROOT}")
 
 # 2. TRAIN - the trainer is selected by the SAME name as the inference policy.
@@ -78,4 +88,16 @@ print(f"exported artifact: {exported}")
 os.environ.setdefault("STRANDS_TRUST_REMOTE_CODE", "1")
 policy = create_policy(exported, device="cpu")
 print(f"loaded trained policy: {type(policy).__name__} (provider={policy.provider_name})")
-print("\nLoop closed: record -> train -> export -> load. Swap PROVIDER to 'groot'/'cosmos3' to retarget the same flow.")
+deployed = sim.run_policy(
+    robot_name="so100",
+    policy_object=policy,
+    instruction="pick up the red cube",
+    n_steps=30,
+    control_frequency=30.0,
+)
+sim.destroy()
+if deployed["status"] != "success":
+    raise SystemExit(f"deploy rollout failed: {deployed['content'][0]['text']}")
+info = next(item["json"] for item in deployed["content"] if "json" in item)
+print(f"deployed: {info['steps_used']} steps in {info['elapsed_s']}s")
+print("\nLoop closed: record -> train -> export -> load -> run. Swap PROVIDER to 'groot'/'cosmos3' to retarget the same flow.")

--- a/examples/locomotion/vla_g1_workflow.py
+++ b/examples/locomotion/vla_g1_workflow.py
@@ -104,7 +104,12 @@ def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int, che
         start = sim.start_recording(
             repo_id="local/g1_vla_demo",
             root=dataset_root,
-            fps=30,
+            # 50 fps, not 30: the rollout below captures at control_frequency
+            # =50 Hz (the WBC controller's dt=0.005 x decimation 4, and the
+            # default for the MockPolicy branch). The recorder writes one frame
+            # per control step with no decimation, so declaring a different rate
+            # here is refused and every episode lands with zero frames.
+            fps=50,
             task="walk forward",
             overwrite=(ep == 0),
         )
@@ -114,14 +119,22 @@ def stage_record(dataset_root: str, n_episodes: int, steps_per_episode: int, che
             print("  Hint: recording requires pip install 'strands-robots[lerobot]'", file=sys.stderr)
             raise SystemExit(1)
 
-        sim.run_policy(
+        rollout = sim.run_policy(
             robot_name="unitree_g1",
             policy_object=policy,
             instruction="walk forward",
             n_steps=steps_per_episode,
             **record_kwargs,
         )
-        sim.stop_recording()
+        if rollout.get("status") != "success":
+            text = (rollout.get("content") or [{}])[0].get("text", "unknown error")
+            print(f"  ERROR: run_policy failed: {text}", file=sys.stderr)
+            raise SystemExit(1)
+        stopped = sim.stop_recording()
+        if stopped.get("status") != "success":
+            text = (stopped.get("content") or [{}])[0].get("text", "unknown error")
+            print(f"  ERROR: stop_recording failed: {text}", file=sys.stderr)
+            raise SystemExit(1)
         print(f"  Episode {ep + 1}/{n_episodes} recorded.")
 
     sim.destroy()

--- a/tests/test_examples_recording_rate_matches_rollout.py
+++ b/tests/test_examples_recording_rate_matches_rollout.py
@@ -1,0 +1,186 @@
+"""Every shipped example records at the rate its own rollout captures.
+
+The dataset recorder writes one frame per control step with **no decimation**,
+so ``start_recording(fps=N)`` is only honoured by a ``run_policy`` that captures
+at ``control_frequency=N``. A mismatch is refused outright rather than written
+at a distorted timestamp rate, which means the episode lands with zero frames
+and the example demonstrates nothing it claims to.
+
+That refusal arrived with the recorder-rate guard and three shipped examples
+were left declaring 30 fps while their rollouts ran at the 50 Hz default, so
+each recorded an empty dataset: ``03_record_dataset.py`` exited on
+``stop_recording`` reporting ``0 frames`` against a docstring promising
+``100 frames``, ``07_post_tune_any_policy.py`` printed
+``Recorded LeRobotDataset ->`` and then failed two steps later inside lerobot
+with an unrelated-looking Hub 404 for the empty local set, and
+``locomotion/vla_g1_workflow.py`` printed ``Episode N/N recorded.`` per episode
+for a dataset with no frames in it.
+
+The rates are compared as the example states them, and the default is read from
+``run_policy``'s own signature rather than restated here, so a change to that
+default cannot leave this test asserting a stale number.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation.base import SimEngine
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+#: The rate a rollout captures at when the caller does not say. Read from the
+#: signature so this file cannot disagree with the code it grades.
+_DEFAULT_CONTROL_FREQUENCY = inspect.signature(SimEngine.run_policy).parameters["control_frequency"].default
+
+#: A refactor that stops reaching the examples must fail loudly rather than
+#: report a clean sweep over nothing.
+_MINIMUM_GRADED_EXAMPLES = 3
+
+_DYNAMIC = object()
+
+
+def _literal(node: ast.AST) -> Any:
+    """The literal value of ``node``, or ``_DYNAMIC`` when it is computed."""
+    try:
+        return ast.literal_eval(node)
+    except Exception:
+        return _DYNAMIC
+
+
+def _keyword(call: ast.Call, name: str) -> Any:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return _literal(kw.value)
+    return None
+
+
+def _splatted_names(call: ast.Call) -> list[str]:
+    """Names of ``**kwargs`` splats in ``call`` (``kw.arg is None``)."""
+    return [kw.value.id for kw in call.keywords if kw.arg is None and isinstance(kw.value, ast.Name)]
+
+
+def _dict_assignments(tree: ast.Module, name: str) -> list[dict[str, Any]]:
+    """Every literal dict assigned to ``name`` anywhere in ``tree``."""
+    out: list[dict[str, Any]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        if isinstance(node.value, ast.Dict):
+            keys = [_literal(k) if k is not None else _DYNAMIC for k in node.value.keys]
+            vals = [_literal(v) for v in node.value.values]
+            out.append({k: v for k, v in zip(keys, vals, strict=True) if isinstance(k, str)})
+    return out
+
+
+def _capture_rates(tree: ast.Module, call: ast.Call) -> set[Any]:
+    """Every rate ``call`` can capture at, given the module's assignments.
+
+    A caller may pass the rate directly, omit it (taking the signature
+    default), or splat a dict that carries it - a locomotion example builds one
+    dict per data source, so every branch it can take is graded.
+    """
+    direct = _keyword(call, "control_frequency")
+    if direct is not None:
+        return {direct}
+    splats = _splatted_names(call)
+    if not splats:
+        return {_DEFAULT_CONTROL_FREQUENCY}
+    rates: set[Any] = set()
+    for name in splats:
+        assignments = _dict_assignments(tree, name)
+        if not assignments:
+            rates.add(_DYNAMIC)
+            continue
+        for mapping in assignments:
+            rates.add(mapping.get("control_frequency", _DEFAULT_CONTROL_FREQUENCY))
+    return rates
+
+
+def _graded_examples() -> list[tuple[Path, float, set[Any]]]:
+    """``(path, declared fps, capture rates)`` per example that records."""
+    graded: list[tuple[Path, float, set[Any]]] = []
+    for path in sorted(_EXAMPLES.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        recordings, rollouts = [], []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr == "start_recording":
+                    recordings.append(_keyword(node, "fps"))
+                elif node.func.attr == "run_policy":
+                    rollouts.append(node)
+        declared = {f for f in recordings if isinstance(f, (int, float))}
+        # One rate per example is what a static reading can attribute; an
+        # example declaring several is left ungraded rather than guessed at.
+        if len(declared) != 1 or not rollouts:
+            continue
+        fps = float(declared.pop())
+        rates: set[Any] = set()
+        for call in rollouts:
+            rates |= _capture_rates(tree, call)
+        graded.append((path, fps, rates))
+    return graded
+
+
+def test_every_recording_example_captures_at_the_rate_it_declares() -> None:
+    """No example declares one rate and captures at another."""
+    graded = _graded_examples()
+    assert len(graded) >= _MINIMUM_GRADED_EXAMPLES, (
+        f"only {len(graded)} example(s) were graded, expected at least "
+        f"{_MINIMUM_GRADED_EXAMPLES}: the scan is no longer reaching "
+        f"{_EXAMPLES}, so a clean result would prove nothing"
+    )
+    mismatched = []
+    for path, fps, rates in graded:
+        wrong = sorted(r for r in rates if r is not _DYNAMIC and isinstance(r, (int, float)) and float(r) != fps)
+        if wrong:
+            mismatched.append(
+                f"{path.relative_to(_EXAMPLES.parent)}: records at {fps:g} fps but its "
+                f"rollout captures at {', '.join(f'{w:g}' for w in wrong)} Hz - the "
+                f"recorder refuses the mismatch and the episode lands with zero frames"
+            )
+    assert not mismatched, "example(s) record at a rate their rollout does not capture at:\n  " + "\n  ".join(
+        mismatched
+    )
+
+
+def test_the_default_capture_rate_is_read_from_the_signature() -> None:
+    """The default is the one ``run_policy`` declares, not a copy of it."""
+    assert isinstance(_DEFAULT_CONTROL_FREQUENCY, (int, float))
+    assert _DEFAULT_CONTROL_FREQUENCY > 0
+
+
+@pytest.mark.parametrize(
+    ("source", "should_flag"),
+    [
+        # Omitting the rate takes the default, which only matches a recording
+        # that declares that same rate.
+        ("sim.start_recording(fps=30)\nsim.run_policy(robot_name='r')", True),
+        (f"sim.start_recording(fps={_DEFAULT_CONTROL_FREQUENCY:g})\nsim.run_policy(robot_name='r')", False),
+        # Stating it wrongly is flagged; stating it correctly is not.
+        ("sim.start_recording(fps=30)\nsim.run_policy(control_frequency=50.0)", True),
+        ("sim.start_recording(fps=30)\nsim.run_policy(control_frequency=30.0)", False),
+        # A splatted dict is resolved through its assignment.
+        ("kw = {'control_frequency': 50.0}\nsim.start_recording(fps=30)\nsim.run_policy(**kw)", True),
+        ("kw = {'control_frequency': 30.0}\nsim.start_recording(fps=30)\nsim.run_policy(**kw)", False),
+    ],
+)
+def test_the_grader_flags_a_mismatch_and_leaves_a_match_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source: str, should_flag: bool
+) -> None:
+    """A clean sweep means the examples agree, not that the grader is blind."""
+    examples = tmp_path / "examples"
+    examples.mkdir()
+    (examples / "planted.py").write_text(source, encoding="utf-8")
+    monkeypatch.setattr(f"{__name__}._EXAMPLES", examples)
+    (path, fps, rates) = _graded_examples()[0]
+    flagged = any(r is not _DYNAMIC and isinstance(r, (int, float)) and float(r) != fps for r in rates)
+    assert flagged is should_flag, f"grader returned rates={rates!r} against fps={fps} for:\n{source}"


### PR DESCRIPTION
## Problem

Three shipped examples cannot record a dataset. Each declares
`start_recording(fps=30)` and then runs a rollout that captures at 50 Hz, and the
recorder writes one frame per control step with **no decimation**, so it refuses
the mismatch (#1746) rather than writing frames at a distorted timestamp rate.
The episode lands with zero frames, and every one of the three then reports
success or fails somewhere unrelated:

| example | what it printed | what was on disk |
|---|---|---|
| `examples/03_record_dataset.py` | `stop_recording captured no frames - dataset would be empty (0 frames)`, exit 1 - against a docstring promising `Expected output: "Episode saved ... 100 frames, 1 episode(s)"` | `total_frames: 0` |
| `examples/07_post_tune_any_policy.py` | `Recorded LeRobotDataset -> /tmp/...`, then two steps later `RepositoryNotFoundError: 404 ... huggingface.co/api/datasets/local/refs` | `total_episodes: 0, total_frames: 0`, 0 parquet files |
| `examples/locomotion/vla_g1_workflow.py` | `Episode 1/1 recorded.` then `Dataset saved -> ...` | 0 frames, per episode |

`07` is the worst diagnostic: recording is refused, nothing checks the result, and
the failure surfaces three steps later as a Hub 404 for a local dataset, naming
neither the rate nor the recording. `03` at least fails loudly, because it already
checks `stop_recording`; it just never checks `run_policy`, which is where the
refusal actually happens.

The library is right at every step here. Both refusals are precise and name the
remedy - `run_policy` says "the active recording declares 30 fps but this rollout
captures at control_frequency=50 Hz ... Align the two rates", and
`stop_recording` says "captured no frames - dataset would be empty". The examples
discard both.

## Why they drift

`#1746` ("refuse a dataset recording at a rate its frames are not captured at")
landed 2026-07-29. `examples/03_record_dataset.py` was last touched 2026-06-13
and `examples/07_post_tune_any_policy.py` on 2026-07-02, so neither was ever
brought along. The rule is already known in-tree: notebook 05 pairs
`fps=30` with `control_frequency=30.0` and carries a comment explaining exactly
why, and `docs/training/overview.md` pairs `fps=50` with the 50 Hz default. Three
examples were simply left on the wrong side of it.

## Change

Each rollout now captures at the rate its recording declares, and each site
checks the result so the next mismatch is reported where it happens:

- `03_record_dataset.py`, `07_post_tune_any_policy.py`: `control_frequency=30.0`
  to match `fps=30`, plus a `run_policy` result check. `07` also checks
  `stop_recording`, since an empty dataset there is what became the Hub 404.
- `locomotion/vla_g1_workflow.py`: the recording moves to `fps=50` rather than the
  rollout slowing to 30 Hz, because that file's own comment fixes 50 Hz as the
  WBC controller's rate ("dt=0.005 x decimation 4"), and `docs/policies/wbc.md`
  uses 50.0 throughout - dropping the control rate would be a gait change, not a
  recording fix. This is the second remedy `run_policy`'s own message offers
  ("or record at the rollout's rate"). Both branches of that file were affected:
  the WBC branch states `control_frequency: 50.0` explicitly, the `MockPolicy`
  branch takes the same 50 Hz default.
- `07`'s `# 4. DEPLOY - load the freshly-trained checkpoint back as a Policy and
  run it.` now runs it. The loaded `policy` was read only inside a `print`, so the
  step announced a rollout it never performed.

## Verification

Each example was executed before and after, with `MUJOCO_GL=egl`:

| example | before | after |
|---|---|---|
| `03_record_dataset.py` | 0 frames, exit 1 | `Episode saved ... 100 frames, 1 episode(s)`; on disk `total_episodes: 1, total_frames: 100, fps: 30` - exactly the docstring's promise |
| `07_post_tune_any_policy.py` | Hub 404 at the train step | `Recorded ... -> ` (60 frames, fps 30) then `train status: success`, `exported artifact`, `loaded trained policy: LerobotLocalPolicy`, **`deployed: 30 steps in 1.277s`**, `Loop closed: record -> train -> export -> load -> run` |
| `locomotion/vla_g1_workflow.py` | `Episode 1/1 recorded.` over 0 frames | `Episode 1/1 recorded.` over `total_episodes: 1, total_frames: 12, fps: 50` |

## Test

`tests/test_examples_recording_rate_matches_rollout.py` compares every example's
declared `fps` against every rate its rollout can capture at - a stated
`control_frequency`, the signature default when omitted, or a `**kwargs` dict
resolved through its assignments, which is what the G1 workflow needs.

The default is read from `run_policy`'s own signature rather than restated, so a
change to that default cannot leave the test asserting a stale number. Values it
cannot resolve statically degrade to "not graded" rather than to a failure, and an
example declaring several different rates is left ungraded rather than guessed at.

Against pristine `main`: **1 failed, 7 passed**, the failure naming all three
files and the reason (`records at 30 fps but its rollout captures at 50 Hz - the
recorder refuses the mismatch and the episode lands with zero frames`). On this
branch: **8 passed**.

The 7 that pass either way are what bound it: a `_MINIMUM_GRADED_EXAMPLES`
premise so a refactor that stops reaching `examples/` fails loudly instead of
reporting a clean sweep over nothing, and six planted cases (omitted rate,
matching default, wrong explicit rate, right explicit rate, wrong splatted dict,
right splatted dict) so a clean result means the examples agree rather than that
the grader is blind.

## Gate

`ruff check` and `ruff format --check` clean over 1367 files;
`assemble_changelog.py --check` OK; `mypy strands_robots tests tests_integ` 19
errors, all pre-existing in `examples/isaac_gs/` and byte-identical to a pristine
`main` worktree, so branch-only is empty. Tests: the 430 files that read the
examples tree, pin the recording-rate contract, or act as repo-wide source/doc
guards, run on this branch and on pristine `main` and compared by failing ID.
