### PR TITLE
fix(doctor): report on the HuggingFace token file the Hub will read

### DIFF
--- a/changelog.d/2484-doctor-hf-token-path.md
+++ b/changelog.d/2484-doctor-hf-token-path.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **doctor**: `check_hf_auth` reports on the token file `huggingface_hub` will actually read, resolving it from `HF_TOKEN_PATH` / `HF_HOME` / `XDG_CACHE_HOME` as the Hub does instead of a hardcoded `~/.cache/huggingface/token`, and names that path in its verdict. A relocated cache previously read as "not logged in" while the Hub held a token, and a stale token at the default path read as "logged in" for an environment where the Hub resolved none. The login command offered is now `hf auth login`, matching the rest of the package: `huggingface-cli` is not published as a console script at the declared `huggingface_hub>=1.5` floor, and the later 1.x releases that install it refuse to run.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -64,7 +64,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | `start_recording` fails: lerobot missing | `[lerobot]` not installed | `uv pip install "strands-robots[lerobot]"` |
 | Need MP4 without LeRobot | - | Use `start_cameras_recording` / `stop_cameras_recording` |
 | Empty MP4 files | Stopped before any frames | Check `get_recording_status()` frame count |
-| Push fails | Not logged into HF | `huggingface-cli login` |
+| Push fails | Not logged into HF | `hf auth login` (the `huggingface-cli` entry point is not published at the declared `huggingface_hub>=1.5` floor) |
 
 ## Mesh
 

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -94,6 +94,49 @@ def _resolve_version(import_name: str, dist_name: str) -> str:
     return str(getattr(module, "__version__", "unknown"))
 
 
+def _hf_token_path() -> Path:
+    """Path a cached HuggingFace login token is read from.
+
+    ``huggingface_hub`` owns this resolution: ``HF_TOKEN_PATH`` when set, else
+    ``<HF_HOME>/token``, where ``HF_HOME`` is ``$HF_HOME`` when set, else
+    ``<XDG_CACHE_HOME>/huggingface``, else ``~/.cache/huggingface``. Answering
+    about a hardcoded ``~/.cache/huggingface/token`` instead describes a file the
+    Hub will not open on any host that relocated its cache, and it is wrong in
+    both directions: a relocated token reads as "not logged in", and a stale
+    token left at the default path reads as "logged in" for an environment where
+    every Hub call resolves no token at all.
+
+    Prefer the constant the Hub computed for itself, so the two cannot drift.
+    ``huggingface_hub`` ships only in the extras that pull a checkpoint
+    (``[wbc]``, ``[kimodo]``, ``[protomotions]``), so a base install has no Hub
+    to ask and the fallback transcribes the same rule. Each variable is read by
+    presence rather than truthiness, so an explicitly empty value resolves the
+    way the Hub resolves it rather than being treated as unset.
+
+    Returns:
+        The token path, with ``~`` and ``$VAR`` expanded.
+    """
+    try:
+        from huggingface_hub.constants import HF_TOKEN_PATH
+
+        return Path(HF_TOKEN_PATH)
+    except ImportError:
+        # No Hub installed, so nothing here can ask it where it would look;
+        # fall through to the transcription of its rule below.
+        pass
+
+    default_home = os.path.join(os.path.expanduser("~"), ".cache")
+    hf_home = os.path.expandvars(
+        os.path.expanduser(
+            os.environ.get(
+                "HF_HOME",
+                os.path.join(os.environ.get("XDG_CACHE_HOME", default_home), "huggingface"),
+            )
+        )
+    )
+    return Path(os.path.expandvars(os.path.expanduser(os.environ.get("HF_TOKEN_PATH", os.path.join(hf_home, "token")))))
+
+
 def check_python_version() -> str:
     """Python >= 3.12 required."""
     v = sys.version_info
@@ -224,13 +267,18 @@ def check_hf_auth() -> str:
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if token:
         return _pass("HF_TOKEN set")
-    # Check huggingface-cli login token
-    hf_token_path = Path.home() / ".cache" / "huggingface" / "token"
-    if hf_token_path.exists() and hf_token_path.read_text().strip():
-        return _pass("HuggingFace token found (~/.cache/huggingface/token)")
+    # Read the file the Hub reads (see _hf_token_path), and name it: on a host
+    # that relocated its cache the default path is not the one being consulted,
+    # so a verdict that does not say which file it read cannot be acted on.
+    hf_token_path = _hf_token_path()
+    # ``is_file`` rather than ``exists``: an explicitly empty ``HF_TOKEN_PATH``
+    # resolves to ``Path(".")``, a directory that exists, and reading it raises.
+    if hf_token_path.is_file() and hf_token_path.read_text().strip():
+        return _pass(f"HuggingFace token found ({hf_token_path})")
     return _warn(
         "No HuggingFace token found",
-        note="Needed for dataset push + gated models. Run: huggingface-cli login  # or export HF_TOKEN=hf_...",
+        note=f"Looked in {hf_token_path}. Needed for dataset push + gated models. "
+        "Run: hf auth login  # or export HF_TOKEN=hf_...",
     )
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -342,16 +343,18 @@ class TestDoctorDegradedPaths:
         result = check_python_version()
         assert "  FAIL  " in result
 
-    def test_hf_auth_no_token_anywhere_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from pathlib import Path
-
+    def test_hf_auth_no_token_anywhere_warns(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         from strands_robots.doctor import check_hf_auth
 
-        monkeypatch.delenv("HF_TOKEN", raising=False)
-        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
-        # Force the cached-token path to look absent so the warn branch is taken
-        # regardless of the host's ~/.cache/huggingface state.
-        monkeypatch.setattr(Path, "exists", lambda _self: False)
+        for name in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_HOME", "HF_TOKEN_PATH", "XDG_CACHE_HOME"):
+            monkeypatch.delenv(name, raising=False)
+        # Relocate the whole HuggingFace home to an empty tree so the warn branch
+        # is taken regardless of the host's own cache. Patching ``Path.exists``
+        # would only work while the check happened to consult that one method;
+        # driving the resolution the Hub actually uses states the premise
+        # directly and cannot go stale.
+        monkeypatch.setitem(sys.modules, "huggingface_hub.constants", None)
+        monkeypatch.setenv("HF_HOME", str(tmp_path / "empty_hf_home"))
         result = check_hf_auth()
         assert "  WARN  " in result
 

--- a/tests/test_doctor_hf_auth_answers_about_the_hub_token.py
+++ b/tests/test_doctor_hf_auth_answers_about_the_hub_token.py
@@ -1,0 +1,297 @@
+"""``doctor``'s HuggingFace check answers about the file the Hub will read.
+
+``check_hf_auth`` reports whether a HuggingFace token is available. The token it
+is reporting on belongs to ``huggingface_hub``, which resolves its location from
+``HF_TOKEN_PATH``, else ``<HF_HOME>/token``, where ``HF_HOME`` is ``$HF_HOME``,
+else ``<XDG_CACHE_HOME>/huggingface``, else ``~/.cache/huggingface``. Reading a
+hardcoded ``~/.cache/huggingface/token`` describes a different file on any host
+that relocated its cache, and it is wrong in both directions - a relocated token
+reads as "not logged in", and a token left at the default path reads as
+"logged in" for an environment where the Hub resolves nothing.
+
+Both resolution branches are covered: the constant the Hub computed for itself,
+and the transcription of the same rule a base install (no ``huggingface_hub``)
+falls back to. The parity test is what makes that duplication safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The spelling the shipped package already prescribes for an interactive login
+# (``dataset_recorder`` and the README both use it). ``huggingface-cli`` is not
+# published as a console script at the declared ``huggingface_hub>=1.5`` floor
+# at all, and the 1.x releases that do ship it exit with "deprecated and no
+# longer works", so prescribing it is a dead end across the whole declared range.
+_LOGIN_COMMAND = "hf auth login"
+_DEAD_LOGIN_COMMAND = "huggingface-cli"
+
+
+def _plain(result: str) -> str:
+    """Strip the ANSI colour wrappers ``doctor`` adds to a verdict."""
+    for code in ("\033[32m", "\033[33m", "\033[31m", "\033[1m", "\033[0m"):
+        result = result.replace(code, "")
+    return result
+
+
+def _verdict(result: str) -> str:
+    """``"PASS"`` / ``"WARN"`` / ``"FAIL"`` for a ``doctor`` check result."""
+    head = _plain(result).strip().splitlines()[0].strip()
+    return head.split()[0]
+
+
+def _clear_hf_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset every variable that participates in token resolution."""
+    for name in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_HOME", "HF_TOKEN_PATH", "XDG_CACHE_HOME"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, with_token: bool) -> Path:
+    """Point ``HOME`` at a scratch tree, optionally holding a default token.
+
+    ``HOME`` is what makes these assertions independent of the machine running
+    them: without it the default path is the developer's own, so the two
+    directions of the defect are not separable.
+    """
+    home = tmp_path / ("home_with_token" if with_token else "home_without_token")
+    default = home / ".cache" / "huggingface"
+    default.mkdir(parents=True, exist_ok=True)
+    if with_token:
+        (default / "token").write_text("hf_defaultPathToken\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def _block_the_hub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``huggingface_hub.constants`` unimportable (a base install)."""
+    monkeypatch.setitem(sys.modules, "huggingface_hub.constants", None)
+
+
+def _token_file(tmp_path: Path, name: str) -> Path:
+    """A file holding a token, standing in for a completed login."""
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("hf_relocatedToken\n", encoding="utf-8")
+    return path
+
+
+class TestTheVerdictFollowsTheHubsOwnTokenPath:
+    """With a Hub installed, its own resolved path is the one consulted."""
+
+    def test_a_token_the_hub_resolves_is_reported_as_found(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An authenticated host whose token is not at the default path passes.
+
+        This is the false-negative direction: the Hub would hand every call a
+        token, so reporting "No HuggingFace token found" describes a machine
+        other than the one being diagnosed.
+        """
+        pytest.importorskip("huggingface_hub")
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=False)
+        relocated = _token_file(tmp_path, "relocated/token")
+        monkeypatch.setattr("huggingface_hub.constants.HF_TOKEN_PATH", str(relocated))
+
+        result = check_hf_auth()
+        assert _verdict(result) == "PASS", (
+            f"the Hub reads {relocated} and would resolve a token there, but doctor reported {_plain(result).strip()!r}"
+        )
+
+    def test_no_token_where_the_hub_looks_is_reported_as_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A stale token at the default path must not read as authenticated.
+
+        This is the false-positive direction, and the worse one: every gated
+        download and every dataset push will fail with a 401 on this host, and
+        the check whose job is to surface that ahead of runtime says it is fine.
+        """
+        pytest.importorskip("huggingface_hub")
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        home = _isolated_home(monkeypatch, tmp_path, with_token=True)
+        assert (home / ".cache" / "huggingface" / "token").exists(), "premise: the default path holds a token"
+        empty = tmp_path / "relocated_empty" / "token"
+        empty.parent.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr("huggingface_hub.constants.HF_TOKEN_PATH", str(empty))
+
+        result = check_hf_auth()
+        assert _verdict(result) == "WARN", (
+            f"the Hub reads {empty}, which does not exist, so it resolves no token; doctor reported "
+            f"{_plain(result).strip()!r}"
+        )
+
+    def test_the_verdict_names_the_file_it_read(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Both branches name the path consulted, so the verdict is actionable."""
+        pytest.importorskip("huggingface_hub")
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=False)
+        relocated = _token_file(tmp_path, "named/token")
+        monkeypatch.setattr("huggingface_hub.constants.HF_TOKEN_PATH", str(relocated))
+        found = _plain(check_hf_auth())
+        assert str(relocated) in found, "the PASS verdict must name the file it read"
+
+        relocated.unlink()
+        missing = _plain(check_hf_auth())
+        assert str(relocated) in missing, "the WARN verdict must name the file it looked in"
+
+
+class TestTheFallbackTranscribesTheHubsRule:
+    """With no Hub installed there is nothing to ask, so the rule is restated."""
+
+    @pytest.mark.parametrize("relocation", ["HF_TOKEN_PATH", "HF_HOME", "XDG_CACHE_HOME"])
+    def test_each_relocation_variable_is_honored(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, relocation: str
+    ) -> None:
+        """Every variable the Hub reads relocates the file doctor consults."""
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=False)
+        _block_the_hub(monkeypatch)
+        if relocation == "HF_TOKEN_PATH":
+            monkeypatch.setenv("HF_TOKEN_PATH", str(_token_file(tmp_path, "explicit/hf.token")))
+        elif relocation == "HF_HOME":
+            token = _token_file(tmp_path, "hf_home/token")
+            monkeypatch.setenv("HF_HOME", str(token.parent))
+        else:
+            token = _token_file(tmp_path, "xdg/huggingface/token")
+            monkeypatch.setenv("XDG_CACHE_HOME", str(token.parent.parent))
+
+        result = check_hf_auth()
+        assert _verdict(result) == "PASS", f"{relocation} relocated the token, but doctor reported {_plain(result)!r}"
+
+    def test_a_relocated_empty_home_is_not_answered_from_the_default_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A stale default token does not answer for a relocated ``HF_HOME``."""
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=True)
+        _block_the_hub(monkeypatch)
+        empty = tmp_path / "hf_home_empty"
+        empty.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HF_HOME", str(empty))
+
+        result = check_hf_auth()
+        assert _verdict(result) == "WARN", (
+            f"a token at the default path answered for HF_HOME={empty}: {_plain(result).strip()!r}"
+        )
+
+    def test_the_fallback_resolves_what_the_hub_resolves(self, tmp_path: Path) -> None:
+        """The transcription and the Hub's own constant agree.
+
+        The fallback exists only because ``huggingface_hub`` is not a base
+        dependency, so it is a second statement of a rule the Hub owns. This is
+        what keeps the two from drifting: the variables are read in a
+        subprocess, because the Hub computes its constants at import time and no
+        in-process assignment can move them.
+        """
+        pytest.importorskip("huggingface_hub")
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            "import json, sys\n"
+            "from pathlib import Path\n"
+            "from huggingface_hub.constants import HF_TOKEN_PATH\n"
+            "sys.modules['huggingface_hub.constants'] = None\n"
+            "from strands_robots.doctor import _hf_token_path\n"
+            # Both branches wrap the resolved string in ``Path``, so the primary
+            # answer is ``Path(HF_TOKEN_PATH)`` - that is what the fallback has
+            # to reproduce, including ``Path("")`` normalising to ``Path(".")``.
+            "print(json.dumps({'hub': str(Path(HF_TOKEN_PATH)), 'fallback': str(_hf_token_path())}))\n",
+            encoding="utf-8",
+        )
+        # Each case is one environment the Hub resolves differently, including
+        # the empty-string spellings: the Hub reads every one of these by
+        # presence, so "" must not be treated as unset.
+        cases: list[dict[str, str]] = [
+            {},
+            {"HF_TOKEN_PATH": str(tmp_path / "explicit.token")},
+            {"HF_HOME": str(tmp_path / "home")},
+            {"XDG_CACHE_HOME": str(tmp_path / "xdg")},
+            {"HF_HOME": str(tmp_path / "home"), "XDG_CACHE_HOME": str(tmp_path / "xdg")},
+            {"HF_TOKEN_PATH": str(tmp_path / "wins.token"), "HF_HOME": str(tmp_path / "home")},
+            {"HF_HOME": ""},
+            {"XDG_CACHE_HOME": ""},
+            {"HF_TOKEN_PATH": ""},
+        ]
+        for case in cases:
+            env = {k: v for k, v in os.environ.items() if k not in ("HF_HOME", "HF_TOKEN_PATH", "XDG_CACHE_HOME")}
+            env.update(case)
+            env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(Path.cwd()), env.get("PYTHONPATH", "")]))
+            out = subprocess.run(  # noqa: S603 - fixed interpreter, no shell
+                [sys.executable, str(probe)], capture_output=True, text=True, env=env, check=True
+            )
+            resolved = json.loads(out.stdout)
+            assert resolved["fallback"] == resolved["hub"], (
+                f"with {case or '{}'} the Hub reads {resolved['hub']} but the fallback resolved {resolved['fallback']}"
+            )
+
+
+class TestTheDocumentedSpellingsAreUnchanged:
+    """The spellings ``doctor`` already answered for keep their verdicts."""
+
+    @pytest.mark.parametrize("variable", ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"])
+    def test_an_environment_token_still_passes(self, monkeypatch: pytest.MonkeyPatch, variable: str) -> None:
+        """An env token outranks any file, exactly as the Hub reads it."""
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        monkeypatch.setenv(variable, "hf_environmentToken")
+        result = check_hf_auth()
+        assert _verdict(result) == "PASS", _plain(result)
+
+    def test_a_token_at_the_default_path_still_passes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The unrelocated host - the common case - is unaffected."""
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=True)
+        _block_the_hub(monkeypatch)
+        result = check_hf_auth()
+        assert _verdict(result) == "PASS", _plain(result)
+
+    def test_no_token_anywhere_still_warns(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """An unauthenticated host is still reported as one."""
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=False)
+        _block_the_hub(monkeypatch)
+        result = check_hf_auth()
+        assert _verdict(result) == "WARN", _plain(result)
+
+    def test_the_remedy_names_a_command_the_declared_floor_ships(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The login command offered must be one that runs.
+
+        ``huggingface-cli`` is not a console script at the declared
+        ``huggingface_hub>=1.5`` floor, and the later 1.x releases that do
+        install it refuse to run, so a caller who follows that advice gets
+        either "command not found" or "deprecated and no longer works".
+        """
+        from strands_robots.doctor import check_hf_auth
+
+        _clear_hf_env(monkeypatch)
+        _isolated_home(monkeypatch, tmp_path, with_token=False)
+        _block_the_hub(monkeypatch)
+        note = _plain(check_hf_auth())
+        assert _LOGIN_COMMAND in note, f"the remedy must offer {_LOGIN_COMMAND!r}, got {note!r}"
+        assert _DEAD_LOGIN_COMMAND not in note, (
+            f"{_DEAD_LOGIN_COMMAND!r} is not installed at the declared floor and refuses to run on the "
+            f"releases that ship it, so it cannot be prescribed: {note!r}"
+        )


### PR DESCRIPTION
## Problem

`doctor`'s `check_hf_auth` reported whether a HuggingFace token was available by reading a hardcoded path:

```python
hf_token_path = Path.home() / ".cache" / "huggingface" / "token"
```

That is not the file `huggingface_hub` reads. The Hub resolves its token file from `HF_TOKEN_PATH`, else `<HF_HOME>/token`, where `HF_HOME` is `$HF_HOME`, else `<XDG_CACHE_HOME>/huggingface`, else `~/.cache/huggingface`. So on any host that relocated its cache - a shared model store, an XDG-configured workstation, a container with `HF_HOME` set - the check answered about a different file, and it was wrong in **both** directions.

Measured against `huggingface_hub.get_token()` on the same environment (`HOME` isolated so the result does not depend on the developer's own cache), `huggingface_hub` 1.12.2:

| environment | Hub resolves | doctor said | |
|---|---|---|---|
| `HF_HOME` points at a dir holding a token | `hf_relocatedToken` | `WARN  No HuggingFace token found` | disagrees |
| `HF_TOKEN_PATH` points at a token file | `hf_relocatedToken` | `WARN  No HuggingFace token found` | disagrees |
| `XDG_CACHE_HOME` relocated, token present | `hf_xdgToken` | `WARN  No HuggingFace token found` | disagrees |
| `HF_HOME` empty, default path holds an old login | `None` | `PASS  HuggingFace token found` | disagrees |
| `XDG_CACHE_HOME` empty, default path holds one | `None` | `PASS  HuggingFace token found` | disagrees |
| default path holds a token (control) | `hf_defaultToken` | `PASS` | agrees |
| default path holds none (control) | `None` | `WARN` | agrees |
| `HF_TOKEN` set (control) | `hf_envToken` | `PASS` | agrees |
| `HUGGING_FACE_HUB_TOKEN` set (control) | `hf_legacyToken` | `PASS` | agrees |

**5 disagreements, 4 controls agreeing.** The false-positive rows are the worse ones: every gated download and every dataset push on that host will fail with a 401, and the check whose stated job is to let users "fix problems before they hit cryptic errors at runtime" reports the setup as fine. The verdict also did not say which file it read, so neither direction was actionable.

Separately, the remedy in the same message - `Run: huggingface-cli login` - cannot be followed. `huggingface-cli` is not published as a console script at the declared `huggingface_hub>=1.5` floor (`console_scripts` there are `['hf', 'tiny-agents']`), and the 1.x releases that do install it exit with `Warning: huggingface-cli is deprecated and no longer works. Use hf instead.` The rest of the package already prescribes `hf auth login` (`dataset_recorder.py:158,214`, `README.md:375`); `doctor` and `docs/troubleshooting.md` were the two places still naming the dead one.

## Change

`strands_robots/doctor.py`

- New `_hf_token_path()` resolves the file the Hub reads. It prefers `huggingface_hub.constants.HF_TOKEN_PATH` - the constant the Hub computed for itself - so the two cannot drift.
- `huggingface_hub` ships only in the extras that pull a checkpoint (`[wbc]`, `[kimodo]`, `[protomotions]`), so a base install has no Hub to ask. The fallback transcribes the same rule and reads each variable by **presence** rather than truthiness, so an explicitly empty value resolves the way the Hub resolves it. A parity test pins the transcription against the Hub's own constant.
- `check_hf_auth` reads that path and names it in both verdicts, so a relocated host can see which file was consulted.
- The path is read with `is_file()` rather than `exists()`: an explicitly empty `HF_TOKEN_PATH` resolves to `Path(".")`, a directory that exists, and reading it would raise.
- The remedy is now `hf auth login`.

`docs/troubleshooting.md` - the one row giving the same login remedy for the same problem, which contradicted `dataset_recorder`.

Behaviour on an unrelocated host is unchanged; that is what the four control tests pin.

## Verification

Measured at `3a8e9cb6` against `upstream/main` `d059c6c3`.

New file `tests/test_doctor_hf_auth_answers_about_the_hub_token.py` (13 tests), covering **both** resolution branches - the Hub's own constant, and the no-Hub transcription.

Copied onto `upstream/main` together with the one repaired existing test: **10 failed / 4 passed** -> all pass after. Every pre-fix failure is behavioural and quotes the mismatch, e.g.

```
AssertionError: XDG_CACHE_HOME relocated the token, but doctor reported
'  WARN  No HuggingFace token found\n        Needed for dataset push + gated
models. Run: huggingface-cli login  # or export HF_TOKEN=hf_...'
```

The 4 tests that pass on both trees are the controls: `HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, a token at the default path, and no token anywhere. They fail for the obvious wrong fixes - dropping the env-var precedence, or making the file check unconditional.

`tests/test_doctor.py::test_hf_auth_no_token_anywhere_warns` is repaired rather than left: it forced the warn branch with `monkeypatch.setattr(Path, "exists", lambda _self: False)`, which only worked while the check happened to consult that one method. It now relocates `HF_HOME` to an empty tree and blocks the Hub import, which states its premise ("regardless of the host's own cache") directly. Its assertion is unchanged.

Blast radius - 76 files (every test naming `doctor` / `check_hf_auth` / `HF_TOKEN` / `huggingface` / a docs page, plus the repo-wide docs, changelog, docstring and dependency guards), same selection on both trees:

| | failed | passed | skipped | collected |
|---|---|---|---|---|
| this branch | 2 | 2801 | 31 | 2803 |
| `upstream/main` (+ the new tests) | 12 | 2791 | 31 | 2803 |

Branch-only failures: **none**. Base-only: exactly the 10 pre-fix failures, no others. The 2 shared failures are pre-existing `TestDoctorVersionResolution` cases that need installed distribution metadata.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`. `mypy` 24 errors on this branch and 24 on a pristine `upstream/main`, none in the changed files.

## What the operator sees

Both columns run the same probe against the same environment; only `strands_robots` differs. The green line above each pair is what `huggingface_hub` itself resolves.

![doctor HuggingFace verdict, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-doctor-hf-token-path/doctor-hf-token-path.png)

Scenario 1 is an operator who moved the cache to shared storage and logged in there: before, `WARN No HuggingFace token found` for a host that is authenticated, and the prescribed recovery command does not run. Scenario 2 is the same operator before logging in, with an old token still at the default path: before, `PASS HuggingFace token found (~/.cache/huggingface/token)` for a host where the Hub resolves nothing.

## Notes on scope

`examples/libero/run_isaac.py`, `run_isaac_agent.py`, `run_mujoco.py` and `run_mujoco_agent.py` carry both problems - a hardcoded `~/.cache/huggingface/token` and the `huggingface-cli login` remedy. They are left alone here: they are on the LIBERO asset-download path with their own fallback semantics, and folding them in would make this a sweep rather than one check's contract.
