### PR TITLE
fix(simulation): check randomize()'s axis flags instead of reading them by truthiness

### DIFF
--- a/changelog.d/2487-randomize-axis-flag-domain.md
+++ b/changelog.d/2487-randomize-axis-flag-domain.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **simulation**: `randomize()` checks each axis flag on the shared boolean-flag
+  domain instead of reading it for truthiness, on both backends that implement
+  it. `randomize_colors` / `randomize_lighting` / `randomize_physics` /
+  `randomize_positions` select a posture, so `"false"`, `"no"`, `"off"` and
+  `"0"` - every spelling an operator reaches for to turn an axis off - are
+  non-empty strings that turned that axis **on** while the call reported it
+  applied. Randomization is destructive and the physics and position axes
+  default to `False` for that reason: the misread rescaled mass, inertia and
+  friction and displaced every object by up to 44 mm, and because the position
+  axis writes `model.qpos0` the displacement survived `reset()`. On Newton the
+  flags are stored through `bool()`, so a misread persisted to every later
+  rebuild, and the MuJoCo-parity refusal - which branches on
+  `randomize_positions` - answered `randomize_positions="false"` with
+  "not supported by the Newton backend", an unsupported-axis verdict for a
+  caller who had asked *not* to randomize positions. A misspelled axis *name*
+  was already refused with the valid list; this is the same guarantee for the
+  value that name carries.

--- a/docs/simulation/domain-randomization.md
+++ b/docs/simulation/domain-randomization.md
@@ -33,6 +33,25 @@ sim.randomize(randomize_position=True)   # singular
 #                      'randomize_positions', 'seed']
 ```
 
+**An axis flag must be a boolean.** The four flags select a *posture* - run this
+axis or leave it alone - so each is checked rather than read for truthiness.
+Every non-empty string is truthy, so `"false"`, `"no"`, `"off"` and `"0"` - the
+spellings you reach for when turning an axis off - each turned that axis **on**,
+and the call reported it applied. That is the same guarantee as the misspelled
+key above, one level down: a value an axis cannot be read from can never look
+like a successful randomization either.
+
+```python
+sim.randomize(randomize_physics="false")
+# status=error: randomize: randomize_physics must be a boolean, got 'false'.
+#              It selects a posture, so it is not read for truthiness ...
+```
+
+Both backends that implement `randomize()` (MuJoCo and Newton) check the same
+domain, so an axis you can turn off on one is not left on by the other. The
+numeric knobs in the same signature keep their own domain: a `mass_range` is a
+quantity, and it is still refused as a range rather than as a flag.
+
 **Destructive** - writes into MuJoCo model arrays. To restore: `load_scene(...)` or recreate the sim.
 
 **Every axis survives `reset()`.** A reset restores the world's initial state,

--- a/strands_robots/simulation/mujoco/randomization.py
+++ b/strands_robots/simulation/mujoco/randomization.py
@@ -13,6 +13,7 @@ from strands_robots.simulation.base import (
 )
 from strands_robots.simulation.mujoco.backend import _NO_WORLD_MSG, _ensure_mujoco, mj_name_to_id
 from strands_robots.simulation.mujoco.scene_ops import _get_spec
+from strands_robots.utils import boolean_flag_error
 
 if TYPE_CHECKING:
     from strands_robots.simulation.models import SimWorld
@@ -128,6 +129,13 @@ class RandomizationMixin:
           - ``randomize_physics=False`` - friction/mass left untouched unless asked.
           - ``randomize_positions=False`` - object qpos left untouched unless asked.
 
+        Each flag selects a posture, so each is checked on the shared
+        boolean-flag domain
+        (:func:`~strands_robots.utils.boolean_flag_error`) before anything is
+        written: an axis is not turned off by ``"false"``, ``"no"``, ``"off"``
+        or ``"0"``, every one of which is a truthy non-empty string that turned
+        the axis ON instead.
+
         "No flags" means "nothing is randomized" - the call is a no-op. This
         matches the LLM ergonomics principle: explicit is better than implicit.
         Randomization IS destructive; recompile the scene to undo. Every axis
@@ -201,7 +209,8 @@ class RandomizationMixin:
 
         Returns:
             Status dict listing the axes applied, or an error dict when a
-            keyword is unknown, a range/noise/seed value cannot be applied, the
+            keyword is unknown, an axis flag is not a boolean, a range/noise/seed
+            value cannot be applied, the
             lighting axis cannot resolve the authored light positions it jitters
             around, no world exists, or a policy is running.
         """
@@ -212,6 +221,25 @@ class RandomizationMixin:
         # domain randomization mutates model arrays; a running policy racing with it is UB
         if err := self._require_no_running_policy("randomize"):
             return err
+        # The four flags select which axes run, so each is checked on the shared
+        # boolean-flag domain rather than read by truthiness. Randomization is
+        # destructive - the physics and position axes default to OFF precisely
+        # because undoing them means recompiling the scene - and every spelling
+        # an operator reaches for to turn an axis off ("false", "no", "off",
+        # "0") is a non-empty string, so it turned that axis ON and the call
+        # reported the axis applied. The ``randomize_lighting`` refusal further
+        # down branches on its own flag, so a truthy non-boolean also made it
+        # describe the axis the caller had asked to skip. A misspelled axis
+        # NAME is already refused above; this is the same guarantee for the
+        # value that name carries.
+        for flag_param, flag_value in (
+            ("randomize_colors", randomize_colors),
+            ("randomize_lighting", randomize_lighting),
+            ("randomize_physics", randomize_physics),
+            ("randomize_positions", randomize_positions),
+        ):
+            if msg := boolean_flag_error(flag_value, flag_param, "randomize"):
+                return {"status": "error", "content": [{"text": msg}]}
         # Every numeric knob below is written straight into the live model (or
         # into ``data.qpos``), so a value with no valid sampling interval either
         # raises deep inside the mutation loop - past the tool envelope - or

--- a/strands_robots/simulation/newton/randomization.py
+++ b/strands_robots/simulation/newton/randomization.py
@@ -36,6 +36,7 @@ from strands_robots.simulation.base import (
     randomization_seed_error,
     unknown_kwargs_error,
 )
+from strands_robots.utils import boolean_flag_error
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,11 @@ class DomainRandomizationMixin:
         """Apply domain randomization to the Newton scene.
 
         Keyword names and defaults mirror the MuJoCo backend so randomization
-        code transfers across backends unchanged. Each axis is opt-in:
+        code transfers across backends unchanged - including the shared
+        boolean-flag domain each axis flag is checked on
+        (:func:`~strands_robots.utils.boolean_flag_error`), so an axis is not
+        turned off by ``"false"``, ``"no"``, ``"off"`` or ``"0"``. Each axis is
+        opt-in:
 
           - ``randomize_colors=True``  - per-shape RGB resampled in ``color_range``.
           - ``randomize_lighting=True`` - directional-light orientation jittered.
@@ -135,22 +140,44 @@ class DomainRandomizationMixin:
             seed: Optional seed for reproducible randomization; a non-negative
                 integer, or None for fresh entropy.
             **kwargs: Tolerated for MuJoCo-signature parity: ``randomize_positions``
-                and ``position_noise`` are accepted keywords, and a truthy
-                ``randomize_positions`` returns an error (Newton does not yet
-                support object-position randomization). Nothing else is
+                and ``position_noise`` are accepted keywords, and
+                ``randomize_positions=True`` returns an error (Newton does not
+                yet support object-position randomization). It is checked on the
+                same boolean-flag domain as the declared axes first, so that
+                refusal cannot inherit a misread and blame an axis the caller
+                asked to skip. Nothing else is
                 forwarded, so any other keyword is rejected with an error naming
                 the valid parameters instead of being silently dropped.
 
         Returns:
             Status dict. On success the ``json`` block carries the applied
             multipliers; an error dict is returned when a keyword is unknown, no
-            world exists, a range is invalid, or an unsupported axis is
-            requested.
+            world exists, an axis flag is not a boolean, a range is invalid, or
+            an unsupported axis is requested.
         """
         if kwargs_error := unknown_kwargs_error("randomize", kwargs, _RANDOMIZE_PARAMS):
             return kwargs_error
         if self._world is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world (or load_scene) first."}]}
+        # Each flag selects a posture, so each is checked on the shared domain
+        # rather than read by truthiness - the same rule the MuJoCo backend's
+        # keyword parity promises. ``randomize_positions`` is declared only
+        # there, so here it arrives through ``**kwargs``; it is checked with the
+        # rest and BEFORE the parity refusal below, which branches on it and so
+        # would otherwise report an unsupported axis to a caller who had spelled
+        # "do not randomize positions" as ``"false"``. The stored spec applies
+        # ``bool()`` to each flag, so a misread would persist to every later
+        # rebuild rather than to this call alone.
+        axis_flags: list[tuple[str, Any]] = [
+            ("randomize_colors", randomize_colors),
+            ("randomize_lighting", randomize_lighting),
+            ("randomize_physics", randomize_physics),
+        ]
+        if "randomize_positions" in kwargs:
+            axis_flags.append(("randomize_positions", kwargs["randomize_positions"]))
+        for flag_param, flag_value in axis_flags:
+            if msg := boolean_flag_error(flag_value, flag_param, "randomize"):
+                return {"status": "error", "content": [{"text": msg}]}
         if kwargs.get("randomize_positions"):
             return {
                 "status": "error",

--- a/tests/simulation/test_randomize_axis_flag_domain.py
+++ b/tests/simulation/test_randomize_axis_flag_domain.py
@@ -1,0 +1,300 @@
+"""A domain-randomization axis flag must be a boolean, not anything truthy.
+
+``randomize`` takes one flag per axis, and each selects a *posture* - run this
+axis or leave it alone - rather than scaling a quantity. Every non-empty string
+is truthy, so ``"false"`` / ``"no"`` / ``"off"`` / ``"0"`` - the spellings an
+operator reaches for when turning an axis off - turned that axis **on**, and the
+call reported the axis applied:
+
+* On MuJoCo, ``randomize(randomize_physics="false", randomize_positions="false")``
+  ran both axes. Those two default to ``False`` precisely because they cannot be
+  undone: the physics axis rewrites ``body_mass`` / ``body_inertia`` /
+  ``geom_friction`` and the position axis rewrites ``model.qpos0`` - the pose a
+  ``reset`` restores - so the misread persists for the rest of the scene's life
+  and recompiling is the only way back.
+* On Newton the three flags are stored in the randomization spec through
+  ``bool()``, so ``randomize_colors="false"`` was stored as ``True`` and the
+  axis re-applied on **every** later rebuild, not just the call that misread it.
+* ``0`` / ``""`` / ``None`` / ``[]`` took the other branch without ever being a
+  declared spelling of it.
+
+Newton's MuJoCo-parity refusal branches on the same flag, so it inherited the
+misread: ``randomize_positions="false"`` was answered with "randomize_positions
+is not supported by the Newton backend yet ... Use the MuJoCo backend for
+object-position randomization" - an unsupported-axis verdict for a caller who
+had asked *not* to randomize positions.
+
+A misspelled axis *name* was already refused with the valid list, which the
+``**kwargs``-typed :meth:`~strands_robots.simulation.base.SimEngine.randomize`
+base signature requires "so a misspelled axis cannot report success while
+leaving that axis untouched". These tests pin the same guarantee for the *value*
+that name carries, on :func:`~strands_robots.utils.boolean_flag_error`, and pin
+that both backends that implement the method reach it - the numeric knobs in the
+same signature have been checked on a shared domain across both backends since
+the physics defect they caused.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+from strands_robots.simulation.newton.randomization import (  # noqa: E402
+    DomainRandomizationMixin as NewtonRandomization,
+)
+from strands_robots.utils import boolean_flag_error  # noqa: E402
+
+#: Values no posture can be read from. The four string spellings and the
+#: non-zero number are the ones that selected the *enabled* branch; ``0`` /
+#: ``""`` / ``None`` / ``[]`` silently took the other one without ever being a
+#: declared spelling of it.
+UNUSABLE_FLAGS: list[Any] = ["false", "no", "off", "0", "true", 1, 0, "", None, []]
+
+#: The subset that reads as "off" to a human and as "on" to ``if flag:``.
+TRUTHY_NON_BOOLEANS: list[Any] = ["false", "no", "off", "0", 1, float("nan")]
+
+#: The MuJoCo axis flags, in signature order. Derived from the live signature
+#: rather than copied, so an axis added later is graded without an edit.
+MUJOCO_AXIS_FLAGS = [
+    name
+    for name, param in inspect.signature(Simulation.randomize).parameters.items()
+    if param.annotation is bool or param.annotation == "bool"
+]
+
+#: Newton declares three of the four; ``randomize_positions`` reaches it through
+#: ``**kwargs`` for the MuJoCo-parity refusal.
+NEWTON_DECLARED_AXIS_FLAGS = [
+    name
+    for name, param in inspect.signature(NewtonRandomization.randomize).parameters.items()
+    if param.annotation is bool or param.annotation == "bool"
+]
+
+CUBE_Z = 0.30
+
+
+@pytest.fixture
+def sim():
+    """A MuJoCo world holding one dynamic 1 kg cube hovering at 0.30 m."""
+    s = Simulation(tool_name="randomize_axis_flag_domain", mesh=False)
+    created = s.create_world(gravity=[0, 0, -9.81])
+    assert created["status"] == "success", _text(created)
+    added = s.add_object(name="cube", shape="box", size=[0.06, 0.06, 0.06], position=[0.0, 0.0, CUBE_Z], mass=1.0)
+    assert added["status"] == "success", _text(added)
+    yield s
+    s.cleanup()
+
+
+def _text(result: dict) -> str:
+    return " ".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _newton_engine() -> Any:
+    """A stand-in ``self`` carrying only what ``randomize`` reads.
+
+    Newton's runtime is not importable here, and ``randomize`` reaches none of
+    it: the axis flags, the ranges and the seed are all decided before the
+    rebuild that would need it. Annotated ``Any`` because the stand-in
+    deliberately satisfies the method's reads rather than the engine's type.
+    """
+    engine = types.SimpleNamespace(_world=object(), _lock=threading.RLock(), _dr={}, _dr_applied={})
+    engine._rebuild = lambda: None
+    return engine
+
+
+def _fingerprint(sim: Simulation) -> dict[str, np.ndarray]:
+    """Every model array an axis of ``randomize`` writes."""
+    assert sim._world is not None and sim._world._model is not None
+    model = sim._world._model
+    return {
+        "qpos0": np.array(model.qpos0, copy=True),
+        "geom_rgba": np.array(model.geom_rgba, copy=True),
+        "geom_friction": np.array(model.geom_friction, copy=True),
+        "body_mass": np.array(model.body_mass, copy=True),
+        "light_pos": np.array(model.light_pos, copy=True),
+    }
+
+
+def _assert_untouched(sim: Simulation, before: dict[str, np.ndarray]) -> None:
+    after = _fingerprint(sim)
+    for field, expected in before.items():
+        assert np.array_equal(after[field], expected), f"a refused randomize wrote {field}"
+
+
+class TestTheSharedDomainOwnsTheSpellings:
+    """The refused set is the shared domain's, not a list copied into here."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_FLAGS)
+    def test_every_listed_spelling_is_refused_by_the_shared_domain(self, value):
+        assert boolean_flag_error(value, "randomize_colors", "randomize") is not None
+
+    @pytest.mark.parametrize("value", [True, False, np.bool_(True), np.bool_(False)])
+    def test_a_real_boolean_is_accepted_by_the_shared_domain(self, value):
+        assert boolean_flag_error(value, "randomize_colors", "randomize") is None
+
+    def test_the_scan_found_the_axis_flags_it_grades(self):
+        """A clean run must mean the flags were graded, not that none was found."""
+        assert MUJOCO_AXIS_FLAGS == [
+            "randomize_colors",
+            "randomize_lighting",
+            "randomize_physics",
+            "randomize_positions",
+        ]
+        assert NEWTON_DECLARED_AXIS_FLAGS == ["randomize_colors", "randomize_lighting", "randomize_physics"]
+
+
+class TestMujocoRefusesAnAxisFlagItCannotRead:
+    """Every declared axis flag is checked before the first model write."""
+
+    @pytest.mark.parametrize("param", MUJOCO_AXIS_FLAGS)
+    @pytest.mark.parametrize("value", UNUSABLE_FLAGS)
+    def test_an_unusable_axis_flag_is_refused_with_nothing_applied(self, sim, param, value):
+        before = _fingerprint(sim)
+        result = sim.randomize(**{param: value}, seed=7)
+        assert result["status"] == "error", f"{param}={value!r} was honored: {_text(result)}"
+        assert param in _text(result)
+        _assert_untouched(sim, before)
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_the_destructive_axes_are_not_run_by_a_spelling_of_off(self, sim, value):
+        """Pre-fix: both axes ran and the call reported them applied.
+
+        These two default to ``False`` because undoing them means recompiling
+        the scene: the physics axis rewrites mass/inertia/friction and the
+        position axis rewrites ``qpos0``, the pose a ``reset`` restores.
+        """
+        before = _fingerprint(sim)
+        result = sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_physics=value,
+            randomize_positions=value,
+            seed=7,
+        )
+        assert result["status"] == "error"
+        _assert_untouched(sim, before)
+        assert np.array_equal(_fingerprint(sim)["body_mass"], before["body_mass"])
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_the_lighting_axis_is_checked_before_it_resolves_its_reference(self, sim, value):
+        """The lighting refusal branches on this flag, so the flag comes first.
+
+        Pre-fix a truthy non-boolean sent the call into the authored-light
+        lookup, whose own refusal then advises ``randomize_lighting=False`` -
+        the value the caller believes they passed.
+        """
+        before = _fingerprint(sim)
+        result = sim.randomize(randomize_colors=False, randomize_lighting=value, seed=7)
+        assert result["status"] == "error"
+        assert "randomize_lighting" in _text(result)
+        assert "must be a boolean" in _text(result)
+        _assert_untouched(sim, before)
+
+
+class TestNewtonRefusesAnAxisFlagItCannotRead:
+    """Newton stores its spec through ``bool()``, so a misread would persist."""
+
+    @pytest.mark.parametrize("param", NEWTON_DECLARED_AXIS_FLAGS)
+    @pytest.mark.parametrize("value", UNUSABLE_FLAGS)
+    def test_an_unusable_axis_flag_is_refused_with_no_spec_stored(self, param, value):
+        engine = _newton_engine()
+        result = NewtonRandomization.randomize(engine, **{param: value})
+        assert result["status"] == "error", f"{param}={value!r} was honored: {_text(result)}"
+        assert param in _text(result)
+        assert engine._dr == {}, "a refused randomize stored a randomization spec"
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_the_parity_refusal_does_not_inherit_the_misread(self, value):
+        """Pre-fix: refused as an unsupported axis the caller had opted out of."""
+        engine = _newton_engine()
+        result = NewtonRandomization.randomize(
+            engine, randomize_colors=False, randomize_lighting=False, randomize_positions=value
+        )
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "must be a boolean" in text, text
+        assert "not supported by the Newton backend" not in text, text
+        assert engine._dr == {}
+
+
+class TestTheDocumentedSpellingsAreUnchanged:
+    """Controls: what already worked keeps working, on both backends."""
+
+    def test_mujoco_false_leaves_every_axis_alone(self, sim):
+        before = _fingerprint(sim)
+        result = sim.randomize(
+            randomize_colors=False,
+            randomize_lighting=False,
+            randomize_physics=False,
+            randomize_positions=False,
+            seed=7,
+        )
+        assert result["status"] == "success"
+        _assert_untouched(sim, before)
+
+    def test_mujoco_true_still_applies_the_axis(self, sim):
+        before = _fingerprint(sim)
+        result = sim.randomize(randomize_colors=True, randomize_lighting=False, seed=7)
+        assert result["status"] == "success"
+        assert not np.array_equal(_fingerprint(sim)["geom_rgba"], before["geom_rgba"])
+
+    def test_newton_false_stores_exactly_false(self):
+        engine = _newton_engine()
+        result = NewtonRandomization.randomize(
+            engine, randomize_colors=False, randomize_lighting=False, randomize_physics=False
+        )
+        assert result["status"] == "success"
+        assert engine._dr["randomize_colors"] is False
+        assert engine._dr["randomize_lighting"] is False
+        assert engine._dr["randomize_physics"] is False
+
+    def test_newton_still_refuses_the_unsupported_axis_when_it_is_asked_for(self):
+        engine = _newton_engine()
+        result = NewtonRandomization.randomize(engine, randomize_positions=True)
+        assert result["status"] == "error"
+        assert "not supported by the Newton backend" in _text(result)
+
+    def test_a_misspelled_axis_name_still_names_the_valid_parameters(self, sim):
+        """The guarantee that already existed, at the level above the value."""
+        result = sim.randomize(randomize_postions=True, seed=7)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "randomize_postions" in text
+        assert "randomize_positions" in text, "the refusal must name the parameter that was meant"
+
+    def test_the_numeric_knobs_keep_their_own_domain(self, sim):
+        """A range is a quantity, not a posture: it keeps the numeric verdict."""
+        result = sim.randomize(
+            randomize_colors=False, randomize_lighting=False, randomize_physics=True, mass_range=(0.0, 0.0)
+        )
+        assert result["status"] == "error"
+        assert "mass_range" in _text(result)
+        assert "must be a boolean" not in _text(result)
+
+
+class TestBothBackendsReachTheSameDomain:
+    """The accepted spellings must not diverge between the two backends."""
+
+    @pytest.mark.parametrize("value", TRUTHY_NON_BOOLEANS)
+    def test_a_shared_axis_flag_is_refused_identically(self, sim, value):
+        mujoco_result = sim.randomize(randomize_physics=value)
+        newton_result = NewtonRandomization.randomize(_newton_engine(), randomize_physics=value)
+        assert mujoco_result["status"] == newton_result["status"] == "error"
+        for text in (_text(mujoco_result), _text(newton_result)):
+            assert "randomize_physics" in text
+            assert "must be a boolean" in text
+
+    @pytest.mark.parametrize(
+        "randomize",
+        [Simulation.randomize, NewtonRandomization.randomize],
+        ids=["mujoco", "newton"],
+    )
+    def test_each_implementation_calls_the_shared_helper(self, randomize):
+        assert "boolean_flag_error" in inspect.getsource(randomize)


### PR DESCRIPTION
## Problem

`randomize()` takes one flag per axis, and each selects a *posture* - run this axis or leave it alone - rather than scaling a quantity. Every non-empty string is truthy, so `"false"` / `"no"` / `"off"` / `"0"` - the spellings you reach for when turning an axis off - turned that axis **on**, and the call reported the axis applied.

Measured on MuJoCo, one 1 kg cube per colour on a floor, `seed=11`:

| `randomize_colors=` `randomize_physics=` `randomize_positions=` | status | colours re-sampled | mass/friction rescaled | objects displaced |
|---|---|---|---|---|
| `False` (a real bool) | success | no | no | no |
| `"false"` / `"no"` / `"off"` / `"0"` | **success** | **yes** | **yes** | **yes** |
| `0` / `""` / `None` / `[]` | success | no | no | no |

The two axes that ran there default to `False` precisely because they cannot be undone - the docstring says so ("Randomization IS destructive; recompile the scene to undo"). The physics axis rewrites `body_mass` / `body_inertia` / `geom_friction`, and the position axis rewrites `model.qpos0`, the pose a `reset` restores. So the misread outlives the call: in the capture below every object moves 44.1 mm and is **still 44.1 mm out after `reset()`**.

Newton has the same three declared flags and stores them in its randomization spec through `bool()`, so `randomize_colors="false"` was stored as `True` and the axis re-applied on **every later rebuild**, not just the call that misread it.

Newton's MuJoCo-parity refusal branches on `randomize_positions`, so it inherited the misread:

```
randomize(randomize_positions="false")
-> error: randomize_positions is not supported by the Newton backend yet.
          Supported axes: ... Use the MuJoCo backend for object-position randomization.
```

an unsupported-axis verdict for a caller who had asked *not* to randomize positions.

A misspelled axis **name** was already refused with the valid list, which the `**kwargs`-typed `SimEngine.randomize` base signature exists to require - "so a misspelled axis cannot report success while leaving that axis untouched". The value that name carries had no such check.

## Change

Each axis flag is checked on the shared `boolean_flag_error` domain before anything is written, on both backends that implement `randomize()`.

- **MuJoCo**: all four declared flags, checked with the other caller-value checks and ahead of the first model write - and ahead of the `randomize_lighting` refusal, which branches on its own flag and so would otherwise describe the axis the caller had asked to skip.
- **Newton**: the three declared flags plus `randomize_positions`, which is declared only by MuJoCo and so arrives through `**kwargs`. It is checked **before** the parity refusal, which is what stops that refusal blaming an unsupported axis for a misread value.

The numeric knobs in the same signature keep their own domain: a `mass_range` is a quantity and is still refused as a range. That half was promoted to a shared rule across both backends when the physics defect it caused was fixed; this brings the flag half along, so the accepted spellings cannot diverge between backends either.

## Sim capture

Same call on both trees, three renders each: the scene as built, after the call, and after `reset()`.

![randomize axis flag domain](https://raw.githubusercontent.com/cagataycali/robots/media-randomize-axis-flag-domain/randomize_axis_flag_domain.png)

|  | status | colours | mass | max displacement | after `reset()` |
|---|---|---|---|---|---|
| before | `success` | red `[0.9, 0.15, 0.15]` -> `[0.216, 0.549, 0.641]` | `1.0` -> `1.2686` | **44.1 mm** | **44.1 mm** |
| after | `error` | unchanged | unchanged | 0.0 mm | 0.0 mm |

Panel 1 is **pixel-identical across the two trees** (mean abs level `0.00000`), so both start from the same scene; panel 2 differs by `20.834` and panel 3 by the same `20.834` - the displacement is not something the reset undoes.

## Tests

`tests/simulation/test_randomize_axis_flag_domain.py`, parametrized over `boolean_flag_error` itself rather than a copied spelling list, and over the axis flags read from the live signatures - so a spelling added to the shared domain, or an axis added to a backend, is graded without an edit.

Against `upstream/main` (0acbfc93): **96 failed / 21 passed**. Every one of the 21 is a control that passes on both trees:

- the six documented spellings keep working: MuJoCo `False` leaves every axis alone and `True` still applies one; Newton `False` stores exactly `False`; Newton still refuses `randomize_positions=True`; a misspelled axis *name* still names the parameter that was meant; and `mass_range=(0, 0)` is still refused as a **range**, not as a flag.
- the premise tests, which keep the refused set the shared domain's rather than a list copied into the file, plus a non-vacuity check that the signature scan found the flags it grades.

Local gate at `b3d89ebd`, 37 files covering every test that touches randomization, the flag domain or a docs page, plus the repo-wide docstring / changelog / string guards:

- branch **2535 passed, 0 failed**, 12 skipped
- base **2439 passed, 96 failed**, 12 skipped, the same 2535 collected
- branch-only failures: none. Every base failure is from the new file, and the selection has no pre-existing failures.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 errors on both trees, none in the changed files.
