### PR TITLE
fix(simulation/terrain): check the resolution that sizes the heightfield before generating it

### DIFF
--- a/changelog.d/2489-terrain-resolution-shared-domain.md
+++ b/changelog.d/2489-terrain-resolution-shared-domain.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **simulation/terrain**: `generate_heightfield` measures `resolution` against the shared
+  `positive_whole_number_error` domain before generating anything, so the grid-cell count that
+  sizes the returned field is checked the way `difficulty` already is. A bare `int(resolution)`
+  truncated a fractional count silently - `39.7` returned 1521 floats for a number whose square is
+  1576.09 - accepted a string outright, and let `None`/`[]`/`inf` raise `TypeError`/`OverflowError`
+  from inside `int()`, outside the `ValueError` every other terrain refusal uses. The `>= 2` floor
+  is unchanged.

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import random
 
-from strands_robots.utils import positive_finite_number_error
+from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
 
 # Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; ``"stairs"``
 # is a flight of discrete parallel step plateaus rising along +x; ``"pyramid"`` is
@@ -235,11 +235,43 @@ def generate_heightfield(
 
     Row-major (``userdata`` order for a MuJoCo ``<hfield>``). Deterministic given
     ``(kind, resolution, seed)``. Raises ``ValueError`` for an unknown/None kind
-    or a resolution below 2.
+    or an unusable resolution.
+
+    ``resolution`` is the grid-cell count the returned length is squared from, so
+    it is measured against
+    :func:`~strands_robots.utils.positive_whole_number_error` - the shared
+    positive-discrete domain every other pixel/cell count in the package is
+    checked against - before anything is generated, exactly as ``difficulty`` is
+    measured against the continuous domain by :func:`validate_difficulty`. A bare
+    ``int(resolution)`` left three axes open, and each one produced a grid the
+    caller did not ask for or an error a caller could not act on:
+
+    * A **fractional** count was truncated silently, so the documented
+      ``resolution * resolution`` length no longer held: ``39.7`` returned 1521
+      floats for a number whose square is 1576.09, and ``2.5`` returned a 2x2
+      field. Nothing raised, and the mismatch only surfaced once the caller fed
+      the field to an ``<hfield>`` sized from the number they passed, where
+      MuJoCo reports ``elevation data length must match nrow*ncol`` - a message
+      naming neither ``resolution`` nor the truncation.
+    * A **string** was accepted outright: ``"40"`` built a 40x40 field, so a
+      resolution read from a config file or an argv string passed here and was
+      refused nowhere.
+    * ``None``, ``[]`` and ``inf`` raised ``TypeError`` / ``OverflowError`` from
+      inside ``int()``. ``ValueError`` is this module's error contract - it is
+      what :func:`validate_terrain` and :func:`validate_difficulty` raise and
+      what the ``create_world`` implementations narrow to when turning a terrain
+      refusal into a ``{"status": "error"}`` tool result - so those two classes
+      escaped it entirely rather than being reported through it.
+
+    The ``>= 2`` floor below is unchanged and stays a separate check: the shared
+    domain answers whether the value is a usable count at all, and a 1x1 field
+    (which MuJoCo does compile) is this module's own refusal.
     """
     validate_terrain(kind)
     if kind is None:
         raise ValueError("generate_heightfield requires a terrain kind, got None.")
+    if positive_whole_number_error(resolution, "resolution", "terrain") is not None:
+        raise ValueError(f"terrain resolution must be a positive whole number of grid cells, got {resolution!r}.")
     n = int(resolution)
     if n < 2:
         raise ValueError(f"terrain resolution must be >= 2, got {resolution}.")

--- a/tests/simulation/test_terrain.py
+++ b/tests/simulation/test_terrain.py
@@ -12,10 +12,12 @@ are pure stdlib (no mujoco / numpy) and exercise the module in isolation.
 from __future__ import annotations
 
 import types
+from typing import Any
 
 import pytest
 
 from strands_robots.simulation import terrain
+from strands_robots.utils import positive_whole_number_error
 
 
 def test_rough_field_has_correct_length_and_range() -> None:
@@ -269,3 +271,119 @@ def test_validate_difficulty_rejects_non_positive_or_nonfinite(bad: float) -> No
 def test_validate_difficulty_accepts_positive_finite(good: float) -> None:
     terrain.validate_difficulty(good)  # no raise
     assert terrain.terrain_elevation(good) > 0.0
+
+
+class TestResolutionIsMeasuredAgainstTheSharedDiscreteDomain:
+    """``resolution`` sizes the grid, so it is checked before the grid is built.
+
+    ``generate_heightfield`` is the exported, backend-independent generator and
+    ``resolution`` is the count its documented ``resolution * resolution`` output
+    length is squared from. A bare ``int(resolution)`` truncated a fractional
+    count, accepted a string, and let ``TypeError`` / ``OverflowError`` out of a
+    module whose error contract is ``ValueError`` - the same three axes
+    :func:`~strands_robots.simulation.terrain.validate_difficulty` documents for
+    the continuous knob in this file, which is why both now report through the
+    shared numeric domains.
+
+    The expected verdicts are read from
+    :func:`~strands_robots.utils.positive_whole_number_error` itself rather than
+    from a copied value list, so a value the shared domain starts accepting or
+    refusing is covered here without an edit.
+    """
+
+    # Values whose verdict the shared domain owns. Each is a spelling a caller
+    # can plausibly arrive at: a config/argv string, a cell count computed by
+    # division, a NumPy size, a boolean flag passed to the wrong parameter.
+    DOMAIN_CASES: tuple[Any, ...] = ("40", 2.5, 39.7, True, False, None, "abc", [], float("nan"), float("inf"), -5, 0)
+
+    @pytest.mark.parametrize("value", DOMAIN_CASES)
+    def test_a_value_the_shared_domain_refuses_is_refused_here(self, value: object) -> None:
+        assert positive_whole_number_error(value, "resolution", "terrain") is not None, (
+            f"premise: the shared domain must own the verdict for {value!r}"
+        )
+        with pytest.raises(ValueError) as exc:
+            terrain.generate_heightfield("rough", resolution=value)  # type: ignore[arg-type]
+        assert "resolution" in str(exc.value), f"the refusal must name the parameter: {exc.value}"
+
+    @pytest.mark.parametrize("value", DOMAIN_CASES)
+    def test_the_refusal_is_a_value_error_and_not_a_type_or_overflow_error(self, value: object) -> None:
+        """``ValueError`` is the contract; ``int()`` raised outside it for three spellings.
+
+        ``None`` and ``[]`` raised ``TypeError`` and ``inf`` raised
+        ``OverflowError`` from inside ``int()``, so a caller narrowing to
+        ``ValueError`` - which is what every terrain refusal in this module is -
+        never saw them as a refusal at all.
+        """
+        try:
+            terrain.generate_heightfield("rough", resolution=value)  # type: ignore[arg-type]
+        except ValueError:
+            return
+        except Exception as exc:  # noqa: BLE001 - the point is which class escapes
+            raise AssertionError(
+                f"resolution={value!r} raised {type(exc).__name__}, which a ValueError-only "
+                f"caller does not see as a refusal: {exc}"
+            ) from exc
+        raise AssertionError(f"resolution={value!r} was accepted rather than refused")
+
+    def test_a_fractional_resolution_is_refused_rather_than_truncated(self) -> None:
+        """The documented length is ``resolution * resolution``, so a truncation breaks it.
+
+        ``39.7`` used to return a 39x39 field - 1521 floats for a number whose
+        square is 1576.09 - and the only place that surfaced was the consumer,
+        where MuJoCo reports ``elevation data length must match nrow*ncol``
+        without naming ``resolution`` or the truncation.
+        """
+        try:
+            heights = terrain.generate_heightfield("rough", resolution=39.7)  # type: ignore[arg-type]
+        except ValueError:
+            return
+        raise AssertionError(
+            f"resolution=39.7 was accepted and returned {len(heights)} floats, so the documented "
+            f"resolution * resolution length (1576.09) does not hold"
+        )
+
+    def test_a_string_resolution_is_refused_rather_than_parsed(self) -> None:
+        """``"40"`` built a 40x40 field, so a config/argv string was refused nowhere."""
+        try:
+            heights = terrain.generate_heightfield("rough", resolution="40")  # type: ignore[arg-type]
+        except ValueError:
+            return
+        raise AssertionError(f"resolution='40' was accepted and returned {len(heights)} floats")
+
+    # --- controls: what the domain must not change -------------------------
+
+    @pytest.mark.parametrize("value", [4, 4.0, terrain.TERRAIN_RESOLUTION])
+    def test_a_usable_whole_count_still_builds_that_grid(self, value: object) -> None:
+        """An int, an integral float and the module default are unaffected.
+
+        The shared domain deliberately accepts an integral float (a count
+        computed from a config float), so ``4.0`` must still build the same 4x4
+        field ``4`` does.
+        """
+        heights = terrain.generate_heightfield("rough", resolution=value, seed=0)  # type: ignore[arg-type]
+        n = int(value)  # type: ignore[call-overload]
+        from_int = terrain.generate_heightfield("rough", resolution=n, seed=0)
+        assert len(heights) == n * n
+        assert heights == from_int
+
+    def test_the_floor_at_two_keeps_its_own_refusal(self) -> None:
+        """``1`` is a positive whole number, so the ``>= 2`` floor is still this module's.
+
+        This fails if the shared domain is treated as the whole check and the
+        floor is dropped, or if the floor's message is folded into the domain's.
+        """
+        assert positive_whole_number_error(1, "resolution", "terrain") is None, (
+            "premise: the shared domain accepts 1, so only this module refuses it"
+        )
+        with pytest.raises(ValueError, match=r">= 2"):
+            terrain.generate_heightfield("rough", resolution=1)
+
+    def test_the_kind_is_still_checked_before_the_resolution(self) -> None:
+        """An unknown kind keeps its own actionable message even with a bad resolution.
+
+        Ordering matters: a caller who got both wrong should be told about the
+        kind, which is the one this module can enumerate a remedy for.
+        """
+        with pytest.raises(ValueError) as exc:
+            terrain.generate_heightfield("bogus", resolution=2.5)  # type: ignore[arg-type]
+        assert "Supported" in str(exc.value)


### PR DESCRIPTION
## Problem

`generate_heightfield` is the exported, backend-independent heightfield generator behind
`create_world(terrain=...)`. Its `resolution` is the grid-cell count its documented
`resolution * resolution` output length is squared from - and it was read with a bare
`int(resolution)`, while `difficulty`, the other caller-supplied knob in the same module, is
measured against the shared continuous domain by `validate_difficulty`.

That docstring already names, axis by axis, why the hand-rolled form was wrong. All three axes
were still open for `resolution`, measured on `upstream/main`:

| `resolution=` | outcome on main | why it matters |
|---|---|---|
| `39.7` | **accepted**, 1521 floats | the documented length is `resolution * resolution`; 39.7 squared is 1576.09 |
| `2.5` | **accepted**, a 2x2 field | a count computed by division silently collapses to the minimum |
| `"40"` | **accepted**, 40x40 | a resolution read from a config file or argv is refused nowhere |
| `None`, `[]` | `TypeError` from `int()` | outside the `ValueError` every terrain refusal here uses |
| `inf` | `OverflowError` from `int()` | same |
| `nan`, `'abc'` | `ValueError`, but `int()`'s own text | names neither the parameter nor the surface |

The truncation is not caught downstream either - it is only *renamed*. A caller who sizes an
`<hfield>` from the number they passed gets MuJoCo's `elevation data length must match nrow*ncol`,
which names neither `resolution` nor the truncation, so the one value they got wrong is reported
nowhere. That is the same misdiagnosis `validate_difficulty` was moved onto the shared domain to
avoid.

## Change

`resolution` goes through `positive_whole_number_error` before anything is generated, bound the
same way `validate_difficulty` binds the continuous domain (helper as the predicate, this module's
own message on the raise). Every value in the table above is now one actionable `ValueError` naming
the parameter.

The `>= 2` floor stays a **separate** check with its message unchanged. The shared domain answers
whether the value is a usable count at all; refusing a 1x1 field - which MuJoCo does compile - is
this module's own decision, and `1` still reaches it. Ordering is domain-then-floor, and the kind
is still checked first, so a caller who got both wrong is told about the kind.

`AGENTS.md` already states this rule under *A resolution knob is validated before the work it
sizes*; this is the terrain generator complying with it, so no convention text changed.

## Verification

**Regression tests** extend `tests/simulation/test_terrain.py`, so its 27 existing tests are
controls. Split against `upstream/main` (the file copied in): **16 failed / 54 passed -> 70 passed**.
Every pre-fix failure is behavioural and quotes the value and the consequence, e.g.

```
resolution=39.7 was accepted and returned 1521 floats, so the documented
resolution * resolution length (1576.09) does not hold

resolution=inf raised OverflowError, which a ValueError-only caller does not
see as a refusal: cannot convert float infinity to integer
```

The expected verdicts are read from `positive_whole_number_error` itself rather than a copied value
list, with a premise assert per case, so a value the shared domain starts accepting or refusing is
covered without an edit.

**Controls that pass on both trees** - each fails for a specific shortcut fix:

- `4`, `4.0` and the module default still build that grid, and `4.0` gives the identical field `4`
  does (the domain deliberately accepts an integral float).
- `1` still hits the `>= 2` floor with its own message - fails if the domain is treated as the whole
  check and the floor is dropped or folded in.
- An unknown kind keeps its actionable message even with a bad resolution.

**Local gate** at `c1554b7d`, against `upstream/main` `0acbfc93`: 50 test files touching terrain,
the shared domain or the repo-wide docstring/changelog/string guards - branch **3727 passed, 0
failed**; base with the new test file copied in **16 failed, 3711 passed**. `3711 + 16 == 3727`, the
same collected total, no branch-only failures, and no pre-existing failures in the selection.
`ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 errors on both
trees with none in the changed files.

## The grid a caller did not ask for

![terrain resolution](https://raw.githubusercontent.com/cagataycali/robots/media-terrain-resolution-32260712951/terrain_resolution.png)

One capture script, run once per tree with `sys.path` pointed at that tree; only `strands_robots`
differs. It calls `generate_heightfield` directly, feeds the result to an `<hfield>` exactly as the
MuJoCo spec builder does, and drops 25 balls so the facet size reads. Relief is scaled to
`difficulty=6.0` (0.48 m peak) for print legibility.

- **Left, `resolution=40` (control)**: the same world in both trees - identical settled ball spread
  to 17 significant figures (0.22609517258814468 m), mean abs pixel delta 6.25e-06.
- **Middle, `resolution=8.9` on `upstream/main`**: an 8x8 = 64-cell field, accepted, nothing raised.
  Its large blocky facets differ from the requested-scale 40x40 field over **41.2%** of the frame.
- **Right, `resolution=8.9` on this branch**: refused up front, naming the parameter, so no
  heightfield and no world are built from a number the module cannot honour.
