### PR TITLE
docs(policies/wbc): the intro no longer calls CompositePolicy future

### DIFF
--- a/changelog.d/2491-wbc-docs-composite-is-shipped.md
+++ b/changelog.d/2491-wbc-docs-composite-is-shipped.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **docs/policies/wbc**: the intro no longer calls `CompositePolicy` future and out of scope.
+  Layering an upper-body manipulation policy on WBC locomotion has been supported since
+  `CompositePolicy` landed, and the same page documents it - the routing rules, a runnable
+  `CompositePolicy(...)` snippet, `examples/wbc/wbc_g1_composite.py`, and a rollout of a G1
+  walking under WBC while the upper body moves its arms - 260 lines below the sentence saying
+  it was not possible. A reader who stopped at the intro walked away believing the page's own
+  worked example described something unavailable. The intro now states that layering is
+  supported and links to that section. `tests/test_docs_no_stale_future_symbol_claims.py`
+  grades every "future" / "out of scope" claim in `docs/` against the symbols the package
+  defines, so a page cannot keep calling a shipped symbol a plan.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -16,9 +16,10 @@ It is a non-VLA, locomotion controller: it reads its goal from the well-known
 locomotion `**kwargs` (`target_velocity`), ignores camera frames
 (`requires_images = False`), and never parses the instruction string for
 control. The controller drives the **15 leg+waist DOFs** of the G1; the arm
-joints are held at their nominal defaults. Layering an upper-body manipulation
-policy (e.g. GR00T) on top of WBC locomotion is the job of a future
-`CompositePolicy`, out of scope for this provider.
+joints are held at their nominal defaults. To drive the arms as well, layer an
+upper-body manipulation policy (e.g. GR00T) on top of WBC locomotion with
+[`CompositePolicy`](#composing-an-upper-body-manipulation-on-top-of-wbc): WBC
+keeps the robot balanced and walking while the upper policy owns the arm joints.
 
 ## Install
 

--- a/tests/test_docs_no_stale_future_symbol_claims.py
+++ b/tests/test_docs_no_stale_future_symbol_claims.py
@@ -1,0 +1,277 @@
+"""Repo hygiene: the docs never call a symbol future when the package ships it.
+
+A page written while a symbol was still a plan keeps that sentence after the
+symbol lands. The reader who stops at the sentence walks away believing a
+capability is unavailable, and nothing in the toolchain notices: ruff, mypy and
+the xref guards all check symbols the docs *name*, never claims about whether a
+named symbol exists yet. ``docs/policies/wbc.md`` said layering an upper body on
+WBC locomotion "is the job of a future ``CompositePolicy``, out of scope for this
+provider" for two months after ``CompositePolicy`` landed - and the same page
+documented it, with a runnable example and a rollout artifact, 260 lines further
+down.
+
+This guard grades the claim against the code: a sentence that says a symbol is
+future, planned or out of scope must not name a symbol the package defines. The
+package index is built with :mod:`ast` rather than by importing, so a symbol
+behind an optional extra is still resolved.
+
+Two deliberate narrowings, each measured against the current tree:
+
+* ``is planned`` is not a marker. "The full collision-free trajectory is planned
+  and cached on the first call" (``docs/policies/curobo.md``) is the domain verb,
+  not a roadmap claim.
+* ``future`` must not open a hyphenated compound. "the lookahead offsets for the
+  future-reference window" (``docs/policies/protomotions.md``) describes a
+  window, not a plan.
+
+A claim about a name the package does not define is left alone: it is either
+forward-looking prose that is still true, or it is about a third party. "any new
+type a future lerobot or a plugin adds", naming lerobot's own
+``RewardModelConfig``, is the live example and is graded clean.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+PACKAGE_DIR = REPO_ROOT / "strands_robots"
+
+#: A sentence saying the thing it names does not exist yet.
+_NOT_YET = re.compile(
+    r"\b(?:a|an|the)\s+future(?![-\w])"
+    r"|\bnot\s+yet\s+(?:implemented|supported|available|shipped|wired|exists?)\b"
+    r"|\bout\s+of\s+scope\b"
+    r"|\bwill\s+(?:be\s+)?(?:added|land|ship)\b"
+    r"|\bdoes\s+not\s+(?:currently\s+)?(?:ship|support|exist)\b",
+    re.IGNORECASE,
+)
+
+#: A backticked class-like name. Restricting to CamelCase keeps the sweep on
+#: claims about a *symbol*: "Per-episode velocity variation in eval is out of
+#: scope for this provider" names only snake_case functions and is not a claim
+#: that any of them is missing.
+_BACKTICKED_SYMBOL = re.compile(r"`([A-Z][A-Za-z0-9]*)`")
+
+_FENCE = re.compile(r"^\s*```")
+_ABBREVIATION = re.compile(r"\b(?:e\.g|i\.e|etc|vs|cf|approx)\.$", re.IGNORECASE)
+_HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+_ON_PAGE_LINK = re.compile(r"\[[^\]]*\]\(#([a-z0-9-]+)\)")
+
+
+def _defined_symbols() -> dict[str, str]:
+    """Map every public module-level class/function name to the file defining it.
+
+    Read with :mod:`ast` so a symbol whose module needs an uninstalled extra is
+    still indexed.
+    """
+    found: dict[str, str] = {}
+    for path in sorted(PACKAGE_DIR.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a syntax error is another test's
+            continue
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+                if not node.name.startswith("_"):
+                    found.setdefault(node.name, str(path.relative_to(REPO_ROOT)))
+    return found
+
+
+def _prose_blocks(text: str) -> list[tuple[int, str]]:
+    """Whitespace-normalized prose paragraphs, as ``(first line number, text)``.
+
+    Fenced code is skipped; a blockquote marker is stripped so a claim inside a
+    ``> **Note:**`` block is graded like any other prose.
+    """
+    blocks: list[tuple[int, str]] = []
+    buffer: list[str] = []
+    start = 0
+    in_fence = False
+
+    def flush() -> None:
+        nonlocal buffer
+        if buffer:
+            blocks.append((start, " ".join(" ".join(buffer).split())))
+            buffer = []
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if _FENCE.match(raw):
+            in_fence = not in_fence
+            flush()
+            continue
+        if in_fence:
+            continue
+        line = re.sub(r"^>\s?", "", raw).strip()
+        if line:
+            if not buffer:
+                start = lineno
+            buffer.append(line)
+        else:
+            flush()
+    flush()
+    return blocks
+
+
+def _sentences(paragraph: str) -> list[str]:
+    """Split on sentence ends, keeping ``e.g.``-style abbreviations intact."""
+    sentences: list[str] = []
+    pending: list[str] = []
+    for chunk in re.split(r"(?<=[.!?])\s+", paragraph):
+        pending.append(chunk)
+        if not _ABBREVIATION.search(chunk.strip()):
+            sentences.append(" ".join(pending))
+            pending = []
+    if pending:
+        sentences.append(" ".join(pending))
+    return sentences
+
+
+def _not_yet_claims(pages: dict[Path, str]) -> list[tuple[Path, int, list[str], str]]:
+    """Every ``(page, line, backticked symbols, sentence)`` claiming "not yet"."""
+    claims: list[tuple[Path, int, list[str], str]] = []
+    for path, text in pages.items():
+        for lineno, paragraph in _prose_blocks(text):
+            for sentence in _sentences(paragraph):
+                if not _NOT_YET.search(sentence):
+                    continue
+                symbols = sorted(set(_BACKTICKED_SYMBOL.findall(sentence)))
+                if symbols:
+                    claims.append((path, lineno, symbols, sentence))
+    return claims
+
+
+def _stale_claims(pages: dict[Path, str]) -> list[str]:
+    """Report every not-yet claim that names a symbol the package defines."""
+    defined = _defined_symbols()
+    offenders: list[str] = []
+    for path, lineno, symbols, sentence in _not_yet_claims(pages):
+        try:
+            shown = path.relative_to(REPO_ROOT)
+        except ValueError:  # a synthetic page outside the repo
+            shown = path
+        for symbol in (s for s in symbols if s in defined):
+            documented_here = pages[path].count(f"`{symbol}`") > 1
+            offenders.append(
+                f"{shown}:{lineno} calls `{symbol}` future or out of scope, "
+                f"but {defined[symbol]} defines it"
+                + (" and this same page documents it further down" if documented_here else "")
+                + f" -- {sentence}"
+            )
+    return offenders
+
+
+def _docs_pages() -> dict[Path, str]:
+    return {p: p.read_text(encoding="utf-8") for p in sorted(DOCS_DIR.rglob("*.md"))}
+
+
+def _heading_anchor(heading: str) -> str:
+    """The slug python-markdown's ``toc`` extension derives for a heading.
+
+    Reimplemented here rather than imported: the docs toolchain is not a test
+    dependency, and this rule reproduces ``toc``'s slug for all of the headings
+    under ``docs/``.
+    """
+    text = re.sub(r"`|\*\*|\*", "", heading)
+    text = unicodedata.normalize("NFKD", text)
+    text = re.sub(r"[^\w\s-]", "", text).strip().lower()
+    return re.sub(r"[-\s]+", "-", text)
+
+
+def _anchors(text: str) -> set[str]:
+    return {_heading_anchor(m.group(2)) for line in text.splitlines() if (m := _HEADING.match(line))}
+
+
+class TestNoDocsPageCallsAShippedSymbolFuture:
+    """The claim "this does not exist yet" is graded against the package."""
+
+    def test_no_not_yet_claim_names_a_symbol_the_package_defines(self) -> None:
+        offenders = _stale_claims(_docs_pages())
+        assert not offenders, "docs claim a shipped symbol does not exist yet:\n" + "\n".join(offenders)
+
+    def test_a_claim_about_a_name_the_package_does_not_define_is_left_alone(self, tmp_path: Path) -> None:
+        """A sentence naming both kinds of symbol reports only the shipped one.
+
+        Forward-looking prose about a third party's type is still true: the docs
+        say "any new type a future lerobot or a plugin adds" of lerobot's own
+        ``RewardModelConfig``. Fails if the sweep is widened to report every
+        "not yet" sentence rather than the ones naming a symbol this package
+        ships.
+        """
+        defined = _defined_symbols()
+        shipped = "CompositePolicy"
+        unshipped = "NoSuchSymbolThePackageDefines"
+        assert shipped in defined, f"premise: the package no longer defines {shipped}"
+        assert unshipped not in defined, f"premise: the package now defines {unshipped}"
+
+        page = tmp_path / "mixed.md"
+        page.write_text(
+            f"# Mixed\n\nThat is the job of a future `{shipped}`, and of a future `{unshipped}`.\n",
+            encoding="utf-8",
+        )
+        offenders = _stale_claims({page: page.read_text(encoding="utf-8")})
+        assert len(offenders) == 1, f"expected only the shipped symbol reported, got {offenders}"
+        assert f"calls `{shipped}`" in offenders[0]
+        assert f"calls `{unshipped}`" not in offenders[0]
+
+    def test_the_sweep_reaches_the_docs_tree(self) -> None:
+        """A clean result must mean the docs are right, not that nothing was read."""
+        pages = _docs_pages()
+        assert len(pages) > 50, f"only {len(pages)} docs pages were read"
+        assert DOCS_DIR / "policies" / "wbc.md" in pages
+        assert len(_defined_symbols()) > 100, "the package symbol index is suspiciously small"
+        assert _not_yet_claims(pages), "premise: no docs sentence was graded at all"
+
+    def test_a_planted_claim_about_a_shipped_symbol_is_reported(self, tmp_path: Path) -> None:
+        """The grader reports the shape it exists to catch."""
+        shipped = "CompositePolicy"
+        assert shipped in _defined_symbols(), f"premise: the package no longer defines {shipped}"
+        page = tmp_path / "planted.md"
+        page.write_text(
+            f"# Planted\n\nDoing that is the job of a future `{shipped}`, out of scope here.\n",
+            encoding="utf-8",
+        )
+        offenders = _stale_claims({page: page.read_text(encoding="utf-8")})
+        assert len(offenders) == 1 and shipped in offenders[0], (
+            f"a planted claim about `{shipped}` was not reported: {offenders}"
+        )
+
+    def test_a_hyphenated_compound_and_the_planning_verb_are_not_claims(self, tmp_path: Path) -> None:
+        """The two measured narrowings, pinned so neither is widened back."""
+        page = tmp_path / "narrow.md"
+        page.write_text(
+            "# Narrow\n\n"
+            "`Alpha` reads the lookahead offsets for the future-reference window.\n\n"
+            "The trajectory is planned and cached, then `Beta` streams it.\n",
+            encoding="utf-8",
+        )
+        pages = {page: page.read_text(encoding="utf-8")}
+        assert _not_yet_claims(pages) == []
+        assert _stale_claims(pages) == []
+
+
+class TestTheWBCPagePointsAtTheCompositeSection:
+    """The intro sends a reader to the section that shows how to compose."""
+
+    @pytest.fixture
+    def page(self) -> str:
+        return (DOCS_DIR / "policies" / "wbc.md").read_text(encoding="utf-8")
+
+    def test_the_first_composite_mention_links_to_a_heading_on_the_page(self, page: str) -> None:
+        intro = next(p for _, p in _prose_blocks(page) if "CompositePolicy" in p)
+        targets = _ON_PAGE_LINK.findall(intro)
+        assert targets, f"the intro names CompositePolicy without linking the section: {intro}"
+        anchors = _anchors(page)
+        dangling = [t for t in targets if t not in anchors]
+        assert not dangling, f"intro links {dangling}, which is not a heading on the page"
+
+    def test_the_composite_section_it_points_at_shows_the_call(self, page: str) -> None:
+        """The linked section is the one carrying the runnable composite."""
+        assert "## Composing an upper body" in page
+        assert "CompositePolicy(" in page


### PR DESCRIPTION
Closes #2490.

## Problem

`docs/policies/wbc.md` contradicted itself about `CompositePolicy`. The intro said:

> Layering an upper-body manipulation policy (e.g. GR00T) on top of WBC locomotion is the job of a **future** `CompositePolicy`, out of scope for this provider.

The same page then spends 60 lines showing how to do it: the "Composing an upper body" section with the routing rules, a runnable `CompositePolicy(...)` snippet, `examples/wbc/wbc_g1_composite.py`, and an embedded rollout of a G1 walking under WBC while the upper body moves its arms.

Archaeology explains it, and it is the reason nothing caught it. `git log -S` puts the intro sentence in **#483**, the PR that added the provider - true when written. `CompositePolicy` landed in **#849**, and that same commit added this page's composite section: `docs/policies/wbc.md | 51 +++++`, **51 insertions and zero deletions**. The section that falsifies the intro and the intro itself arrived in one change, and only the section was written.

A reader who stops at the intro walks away believing the page's own worked example describes something unavailable.

## Change

The intro states that layering is supported and links to the section on the same page:

```
-policy (e.g. GR00T) on top of WBC locomotion is the job of a future
-`CompositePolicy`, out of scope for this provider.
+upper-body manipulation policy (e.g. GR00T) on top of WBC locomotion with
+[`CompositePolicy`](#composing-an-upper-body-manipulation-on-top-of-wbc): WBC
+keeps the robot balanced and walking while the upper policy owns the arm joints.
```

No code changes. `CompositePolicy` and the example were already correct.

The `eval is out of scope for this provider` note is about per-episode velocity variation in eval, not compositing, and is unchanged.

## The claim is verified, not just reworded

The new sentence asserts two things, so both were measured by running exactly what it describes: a `CompositePolicy` with `WBCPolicy` (real GR00T-WBC SONIC ONNX checkpoints) on the 15 leg+waist DOFs and a manipulation policy on the 14 arm DOFs, driven through `sim.run_policy` in MuJoCo (headless).

| Claim | Measured |
| --- | --- |
| WBC keeps the robot balanced and walking | advanced **1.561 m** in 5.0 s at a commanded `vx = 0.4`; pelvis height held **0.741-0.766 m**, never below |
| the upper policy owns the arm joints | **14** arm joints moved, **25.05 rad** of total travel, shoulder-pitch range **1.25 rad** |
| the composition runs at all | `status=success`, 250/250 steps @ 50 Hz, 126-frame clip, all 125 transitions moving |

![WBC composite: the corrected claim, verified](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-composite-docs/wbc_composite_docs.png)

The rollout ([MP4](https://github.com/cagataycali/robots/raw/media-wbc-composite-docs/composite.mp4)):

![G1 walking under WBC while the composite upper body moves its arms](https://raw.githubusercontent.com/cagataycali/robots/media-wbc-composite-docs/g1_composite_verify.gif)

## Guard

`tests/test_docs_no_stale_future_symbol_claims.py` grades the claim against the code rather than pinning wording. A sentence in `docs/` saying something is future, not yet shipped or out of scope must not name a symbol the package defines. The symbol index is built with `ast` instead of by importing, so a symbol behind an uninstalled extra still resolves.

Two narrowings, each measured against the tree rather than assumed, and each pinned so it cannot be widened back:

- **`is planned` is not a marker.** "The full collision-free trajectory is planned and cached on the first call" (`docs/policies/curobo.md`) is the domain verb in a motion-planning page.
- **`future` must not open a hyphenated compound.** "the lookahead offsets for the future-reference window" (`docs/policies/protomotions.md`) describes a window, not a plan.

A claim about a name the package does not define is left alone, because it is either still true or about a third party: the training docs say "any new type a future lerobot or a plugin adds" of lerobot's own `RewardModelConfig`, and that grades clean. Restricting to backticked CamelCase keeps the sweep on claims about a *symbol*, so "Per-episode velocity variation in eval is out of scope for this provider" - which names only snake_case functions - is not read as a claim that any of them is missing.

Over the whole `docs/` tree the sweep grades **2** sentences and reports **1**.

## Tests

Only the test file was copied onto `upstream/main`, so the split is behavioural:

| | `upstream/main` | this branch |
| --- | --- | --- |
| `tests/test_docs_no_stale_future_symbol_claims.py` | **2 failed / 5 passed** | 7 passed |

Pre-fix, the headline names the page, the symbol, the file defining it, and that the same page documents it:

```
docs/policies/wbc.md:15 calls `CompositePolicy` future or out of scope, but
strands_robots/policies/composite.py defines it and this same page documents it
further down -- Layering an upper-body manipulation policy (e.g. GR00T) on top of
WBC locomotion is the job of a future `CompositePolicy`, out of scope for this provider.
```

The 5 that pass on both trees are the controls, and each fails for a specific wrong fix: a mixed claim naming a shipped and an unshipped symbol reports only the shipped one (fails if the sweep is widened to every "not yet" sentence); a planted claim about a shipped symbol *is* reported (fails if the grader accepts anything); the hyphenated compound and the planning verb stay clean (fails if either narrowing is dropped); and the sweep must reach more than 50 pages and index more than 100 symbols, so a clean result cannot mean nothing was read.

## Verification

Measured at `40410f50` against `upstream/main` `0acbfc93`.

- Blast radius: every test that reads a docs page, every `tests/test_docs*` / `test_changelog*` guard, every test naming `wbc` / `composite`, and the repo-wide docstring, xref, unicode-dash, ASCII-log and dependency guards - 78 files. Branch **2321 passed / 0 failed / 4 skipped**; base with the new test file copied in **2 failed / 2319 passed / 4 skipped**. `2319 + 2 = 2321`, both collected 2325, the 2 base failures are exactly the pre-fix ones, no branch-only failure, and no pre-existing failure in the selection.
- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 24 errors on this branch and 24 on a pristine `upstream/main` worktree, identical sets, none in the changed files.
- `scripts/assemble_changelog.py --check`: OK.
- The `#composing-an-upper-body-manipulation-on-top-of-wbc` anchor is checked by the guard against the page's own headings. The slug rule is reimplemented in the test rather than imported, because the docs toolchain is not a test dependency; it reproduces python-markdown's `toc` slug for all 760 headings under `docs/`.
