### PR TITLE
feat(policies/cosmos3): OpenArm embodiment - post-training path for openarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ create_policy("lerobot/act_aloha_sim_transfer_cube")   # local HF inference
 |----------|---------|-------|
 | `mock` | none | Sinusoidal trajectories; `requires_images=False` (~10x faster) |
 | `groot` | NVIDIA GR00T N1.5/N1.6/N1.7 | Service mode (ZMQ to a Docker container) or local in-process (`model_path=`) |
-| `cosmos3` | NVIDIA Cosmos 3 omnimodal VLA | Service mode (WebSocket to a Cosmos Framework RoboLab policy server); embodiments: `droid`, `umi`, `av`, `bridge` |
+| `cosmos3` | NVIDIA Cosmos 3 omnimodal VLA | Service mode (WebSocket to a Cosmos Framework RoboLab policy server); embodiments: `droid`, `umi`, `av`, `bridge`, `openarm` |
 | `lerobot_local` | HuggingFace | Direct ACT / Pi0 / SmolVLA / Diffusion inference, no server |
 | `lerobot_async` | HuggingFace via gRPC | Offload a LeRobot policy to a remote `PolicyServer` over lerobot's native async-inference gRPC transport (edge/light robot host) |
 | `remote` | any policy, over WebSocket | Drop-in client that forwards observations to a remote `PolicyServer` and returns its action chunk: `create_policy("remote", endpoint="ws://gpu-box:8765")` (or the smart string `create_policy("ws://gpu-box:8765")`). For a light robot host with a GPU box elsewhere; mirrors the server policy's RTC support |
@@ -728,7 +728,8 @@ arm, so use the `franka` (or `panda`) sim asset:
 MUJOCO_GL=egl python examples/vla/cosmos3_sim_rollout.py --record /tmp/c3.mp4
 ```
 
-Embodiments: `droid` (10D, chunk 32, 15 fps), `umi`, `av`, `bridge`. If the
+Embodiments: `droid` (10D, chunk 32, 15 fps), `umi`, `av`, `bridge`, `openarm`
+(post-training only). If the
 server is not running, the policy raises a `ConnectionError` with the exact
 command to start it.
 

--- a/changelog.d/2461-cosmos3-openarm-embodiment.md
+++ b/changelog.d/2461-cosmos3-openarm-embodiment.md
@@ -1,0 +1,18 @@
+### Added: cosmos3 OpenArm embodiment (post-training path)
+
+The cosmos3 provider's embodiment table gains an `openarm` entry
+(`Cosmos3Embodiment`: domain `openarm_lerobot`, 10D unified action = 9D EE pose
++ 1D grasp, `midtrain` action space, front + wrist camera keys), closing the
+record -> post-train -> deploy loop for the Enactic OpenArm with cosmos3 the
+way `droid`/`umi`/`av`/`bridge` already close it. The entry is data-driven
+through the same service-mode, in-proc diffusers and `sim_ik` decode paths as
+the existing four; aliases `openarm_lerobot`, `openarm_follower` and
+`enactic_openarm` resolve to it. It documents the post-training expectation
+explicitly: no released Cosmos 3 checkpoint ships this domain, so it maps a
+checkpoint post-trained on OpenArm episodes via the existing `cosmos3` trainer
+(SFT recipe TOML -> `cosmos_framework` launch) rather than promising zero-shot
+behavior, and no action stats are bundled - the decode refuses the unbundled
+domain by name and accepts the post-trained domain's own quantiles via
+`stats=` + `stats_domain="openarm_lerobot"`. Unknown embodiment names keep
+failing loudly. `bi_openarm` (bimanual) is a deliberate follow-up once the
+single-arm mapping is validated.

--- a/docs/policies/cosmos3.md
+++ b/docs/policies/cosmos3.md
@@ -1,5 +1,5 @@
 ---
-description: NVIDIA Cosmos 3 omnimodal VLA - WebSocket service, droid/umi/av/bridge embodiments, MuJoCo rollout.
+description: NVIDIA Cosmos 3 omnimodal VLA - WebSocket service, droid/umi/av/bridge/openarm embodiments, MuJoCo rollout.
 ---
 
 # Cosmos 3
@@ -27,7 +27,7 @@ python -m cosmos_framework.scripts.action_policy_server_robolab \
 
 ```python
 Cosmos3Policy(
-    embodiment="droid",          # droid | umi | av | bridge
+    embodiment="droid",          # droid | umi | av | bridge | openarm
     host="localhost",
     port=8000,
     action_space=None,
@@ -52,6 +52,7 @@ Cosmos3Policy(
 | `umi` | UMI gripper | - |
 | `av` | Autonomous vehicle cameras | - |
 | `bridge` | Bridge dataset robots | - |
+| `openarm` | Enactic OpenArm (7-DOF + gripper) | `"openarm"` |
 
 ### Action spaces
 
@@ -244,7 +245,7 @@ concern, not an IK one.)
 #### De-normalization stats are per domain
 
 The de-normalize step needs that domain's own `q01`/`q99` quantiles. Two domains
-ship them bundled; the other two registered embodiments do not:
+ship them bundled; the other three registered embodiments do not:
 
 | embodiment | domain | raw dim | bundled stats |
 |---|---|---|---|
@@ -252,9 +253,10 @@ ship them bundled; the other two registered embodiments do not:
 | `bridge` | `bridge_orig_lerobot` | 10 | yes |
 | `umi` | `umi` | 10 | no |
 | `av` | `av` | 9 | no |
+| `openarm` | `openarm_lerobot` | 10 | no |
 
 `nvidia/Cosmos3-Edge` documents its forward-dynamics example on `umi` and its
-inverse-dynamics example on `av` — exactly the two without bundled quantiles — so
+inverse-dynamics example on `av` — both without bundled quantiles — so
 driving the sim bridge from Edge means supplying that domain's stats yourself:
 
 ```python
@@ -266,8 +268,9 @@ out = decode_cosmos_chunk_to_targets(
 ```
 
 `stats_domain` is required whenever `stats` is passed, and must match the
-embodiment's domain. It is not bookkeeping: `umi`, `droid_lerobot` and
-`bridge_orig_lerobot` are all 10 columns, so the width check cannot tell one
+embodiment's domain. It is not bookkeeping: `umi`, `droid_lerobot`,
+`bridge_orig_lerobot` and `openarm_lerobot` are all 10 columns, so the width
+check cannot tell one
 domain's quantiles from another's, and the two bundled domains disagree by up to
 **2.77x** on the physical translation they decode from the same normalized
 action. Substituting another domain's stats would rescale every commanded pose

--- a/strands_robots/policies/cosmos3/__init__.py
+++ b/strands_robots/policies/cosmos3/__init__.py
@@ -36,8 +36,10 @@ In MuJoCo (the ``droid`` embodiment drives a Franka/DROID-class arm - use the
                    control_frequency=15.0)
 
 See ``examples/vla/cosmos3_sim_rollout.py`` for a complete, runnable rollout +
-recording. Available embodiments: droid, umi, av, bridge
-(see :mod:`strands_robots.policies.cosmos3.embodiments`).
+recording. Available embodiments: droid, umi, av, bridge, openarm
+(see :mod:`strands_robots.policies.cosmos3.embodiments`; ``openarm`` requires
+post-training on OpenArm episodes via the ``cosmos3`` trainer - it is not a
+released zero-shot checkpoint).
 """
 
 from .action_decode import decode_pose_trajectory, denormalize_quantile, load_action_stats

--- a/strands_robots/policies/cosmos3/embodiments.py
+++ b/strands_robots/policies/cosmos3/embodiments.py
@@ -154,6 +154,44 @@ EMBODIMENTS: dict[str, Cosmos3Embodiment] = {
         raw_action_layout=_RAW_POSE9_GRASP,
         default_action_space="midtrain",
     ),
+    # Enactic OpenArm (7-DOF + gripper; registry ``openarm``, lerobot
+    # ``openarm_follower``). **Requires post-training** - no released Cosmos 3
+    # checkpoint ships this domain, so the entry promises no zero-shot
+    # behavior: it is the deploy-side mapping for a checkpoint post-trained on
+    # OpenArm episodes via the existing ``cosmos3`` trainer
+    # (:class:`strands_robots.training.cosmos3.Cosmos3Trainer`: SFT recipe TOML
+    # -> ``cosmos_framework`` launch). The unified action is the standard
+    # single-arm 9D EE pose + 1D grasp (eef-space), so the MuJoCo sim loop
+    # closes through the de-normalize + IK bridge
+    # (:func:`strands_robots.policies.cosmos3.sim_ik.decode_cosmos_chunk_to_targets`).
+    # No action stats are bundled for ``openarm_lerobot`` - post-training
+    # produces the domain's own ``q01``/``q99``, which the caller passes as
+    # ``stats=`` + ``stats_domain="openarm_lerobot"`` (another domain's stats
+    # are refused by name, never silently substituted). Camera keys mirror the
+    # recorded OpenArm episode set (front + wrist, the ``openarm_real``
+    # lerobot embodiment); chunk size and FPS mirror the DROID single-arm
+    # manipulator recipe defaults and must match the post-training recipe.
+    # ``bi_openarm`` (16-DOF bimanual) is a deliberate follow-up once this
+    # single-arm mapping is validated on post-trained weights.
+    "openarm": Cosmos3Embodiment(
+        name="openarm",
+        domain_name="openarm_lerobot",
+        raw_action_dim=10,
+        action_chunk_size=32,
+        fps=15,
+        camera_keys=[
+            "observation/image",
+            "observation/wrist_image",
+        ],
+        action_layouts={
+            # ``midtrain`` is the unified action itself, un-converted. There is
+            # no ``joint_pos`` entry: the RoboLab server's joint conversion is
+            # DROID-only, so promising a joint layout here would fabricate one.
+            "midtrain": _RAW_POSE9_GRASP,
+        },
+        raw_action_layout=_RAW_POSE9_GRASP,
+        default_action_space="midtrain",
+    ),
 }
 
 # Aliases → canonical embodiment key.
@@ -163,6 +201,11 @@ _EMBODIMENT_ALIASES = {
     "franka": "droid",
     "bridge_orig_lerobot": "bridge",
     "autonomous_vehicle": "av",
+    # OpenArm: the conditioning domain, the lerobot driver type, and the
+    # registry alias all resolve to the one canonical entry.
+    "openarm_lerobot": "openarm",
+    "openarm_follower": "openarm",
+    "enactic_openarm": "openarm",
 }
 
 

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -105,7 +105,11 @@ class Cosmos3Policy(Policy):
 
     Args:
         embodiment: Embodiment key/alias (``"droid"``, ``"umi"``, ``"av"``,
-            ``"bridge"``). Selects domain, action layout, and defaults.
+            ``"bridge"``, ``"openarm"``). Selects domain, action layout, and
+            defaults. ``"openarm"`` is a post-training-only embodiment: it maps
+            a checkpoint post-trained on OpenArm episodes (see
+            :mod:`strands_robots.policies.cosmos3.embodiments`), not a released
+            zero-shot model.
         host: Policy-server hostname.
         port: Policy-server WebSocket port, an ``int`` in ``[1, 65535]``.
             Read only when this constructor builds the client; an injected

--- a/strands_robots/policies/cosmos3/sim_ik.py
+++ b/strands_robots/policies/cosmos3/sim_ik.py
@@ -141,8 +141,8 @@ def decode_cosmos_chunk_to_targets(
             the bundled per-domain stats are loaded for ``embodiment.domain_name``.
             When supplied, ``stats_domain`` must name the domain they were
             measured on: several Cosmos 3 domains share an action width
-            (``umi``, ``droid_lerobot`` and ``bridge_orig_lerobot`` are all 10
-            columns), so the width check in
+            (``umi``, ``droid_lerobot``, ``bridge_orig_lerobot`` and
+            ``openarm_lerobot`` are all 10 columns), so the width check in
             :func:`~strands_robots.policies.cosmos3.action_decode.denormalize_quantile`
             cannot tell one domain's quantiles from another's.
         stats_domain: Domain the explicit ``stats`` describe. Required whenever
@@ -189,8 +189,9 @@ def decode_cosmos_chunk_to_targets(
         raise ValueError(
             "decode_cosmos_chunk_to_targets: explicit stats= must declare the domain "
             "they were measured on via stats_domain=. Cosmos 3 domains share action "
-            "widths (umi, droid_lerobot and bridge_orig_lerobot are all 10 columns), "
-            "so a width check cannot tell one domain's quantiles from another's, and "
+            "widths (umi, droid_lerobot, bridge_orig_lerobot and openarm_lerobot are "
+            "all 10 columns), so a width check cannot tell one domain's quantiles "
+            "from another's, and "
             f"de-normalizing a {embodiment.domain_name!r} action with the wrong "
             "domain's quantiles silently rescales every commanded pose delta. Pass "
             f"stats_domain={embodiment.domain_name!r}."

--- a/strands_robots/registry/policies.json
+++ b/strands_robots/registry/policies.json
@@ -113,7 +113,7 @@
     "cosmos3": {
       "module": "strands_robots.policies.cosmos3",
       "class": "Cosmos3Policy",
-      "description": "NVIDIA Cosmos 3 omnimodal VLA policy (DROID/UMI/AV/bridge) via Cosmos Framework",
+      "description": "NVIDIA Cosmos 3 omnimodal VLA policy (DROID/UMI/AV/bridge/OpenArm) via Cosmos Framework",
       "requires": [],
       "config_keys": [
         "embodiment",

--- a/tests/policies/cosmos3/test_embodiments.py
+++ b/tests/policies/cosmos3/test_embodiments.py
@@ -11,7 +11,7 @@ from strands_robots.policies.cosmos3.embodiments import (
 
 def test_known_embodiments_present():
     names = list_embodiments()
-    assert {"droid", "umi", "av", "bridge"} <= set(names)
+    assert {"droid", "umi", "av", "bridge", "openarm"} <= set(names)
 
 
 def test_droid_spec_matches_released_policy():
@@ -58,3 +58,50 @@ def test_embodiment_is_frozen():
     assert isinstance(e, Cosmos3Embodiment)
     with pytest.raises(Exception):
         e.fps = 99  # frozen dataclass
+
+
+class TestOpenArmEmbodiment:
+    """The OpenArm entry (#2461): single-arm, post-training-only domain."""
+
+    def test_spec(self):
+        e = get_embodiment("openarm")
+        assert e.name == "openarm"
+        assert e.domain_name == "openarm_lerobot"
+        # Single-arm unified action: 9D EE pose (3D translation + 6D rot) + grasp.
+        assert e.raw_action_dim == 10
+        assert e.normalization == "quantile"
+        # Recorded OpenArm episodes carry front + wrist views (openarm_real).
+        assert e.camera_keys == ["observation/image", "observation/wrist_image"]
+
+    def test_action_dim_and_mapping_round_trip(self):
+        """Every named layout matches its width; midtrain IS the raw action."""
+        e = get_embodiment("openarm")
+        assert e.default_action_space == "midtrain"
+        assert e.default_action_space in e.action_layouts
+        layout = e.action_layouts["midtrain"]
+        assert len(layout) == e.raw_action_dim
+        assert layout == e.raw_action_layout
+        assert layout == ["tx", "ty", "tz", "r0", "r1", "r2", "r3", "r4", "r5", "grasp"]
+        # eef-space with a trailing grasp column - the sim_ik decode contract.
+        assert layout[-1] == "grasp"
+
+    def test_no_fabricated_joint_pos_layout(self):
+        """The RoboLab server's joint conversion is DROID-only - an openarm
+        ``joint_pos`` layout would promise a server post-process that does not
+        exist for this domain."""
+        e = get_embodiment("openarm")
+        assert "joint_pos" not in e.action_layouts
+
+    def test_aliases_resolve(self):
+        for alias in ("openarm_lerobot", "openarm_follower", "enactic_openarm", "OpenArm"):
+            assert get_embodiment(alias).name == "openarm", alias
+
+    def test_no_bundled_stats_fails_loudly_naming_the_domain(self):
+        """Post-training produces the domain's own q01/q99; until then the
+        stats lookup refuses by name (no silent substitute)."""
+        from strands_robots.policies.cosmos3.action_decode import load_action_stats
+
+        with pytest.raises(FileNotFoundError, match="openarm_lerobot") as excinfo:
+            load_action_stats(get_embodiment("openarm").domain_name)
+        # The refusal advises the safe explicit-stats route.
+        assert "stats_domain='openarm_lerobot'" in str(excinfo.value)

--- a/tests/policies/cosmos3/test_sim_ik_openarm.py
+++ b/tests/policies/cosmos3/test_sim_ik_openarm.py
@@ -1,0 +1,188 @@
+"""MuJoCo rollout smoke path for the OpenArm Cosmos 3 embodiment (#2461).
+
+End-to-end over the same seams the four original embodiments use, with a mock
+policy server instead of GPU weights: a raw ``[T, 10]`` unified-action chunk is
+served through :class:`~strands_robots.policies.cosmos3.policy.Cosmos3Policy`
+(service mode, ``midtrain`` action space) into per-step column dicts, then the
+same chunk is closed onto the OpenArm MuJoCo model through the de-normalize +
+IK bridge
+(:func:`~strands_robots.policies.cosmos3.sim_ik.decode_cosmos_chunk_to_targets`).
+
+The ``openarm_lerobot`` domain ships **no bundled stats** (it is a
+post-training-only domain - the entry maps a checkpoint post-trained on OpenArm
+episodes via the ``cosmos3`` trainer, not a released zero-shot model), so the
+decode here declares synthetic stats via ``stats=`` + ``stats_domain=``,
+exactly the route the bundled-stats refusal advises. The stats are shaped so
+the de-normalized chunk is physically reachable (millimetre translation deltas,
+near-identity rotations), keeping this a geometry smoke test rather than a
+model-quality claim.
+
+``mujoco`` + ``mink`` (the ``cosmos3-sim`` extra) and ``robot_descriptions``
+(for the OpenArm MJCF, the same ``openarm_v1_mj_description`` module the robot
+registry's ``openarm`` entry declares) are imported via ``importorskip`` so the
+module skips cleanly when the sim stack is absent, mirroring
+``test_sim_ik.py``.
+"""
+
+import asyncio
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Optional sim stack: skip cleanly when the cosmos3-sim extra is not installed.
+mujoco = pytest.importorskip("mujoco", reason="mujoco not installed - pip install 'strands-robots[cosmos3-sim]'")
+pytest.importorskip("mink", reason="mink not installed - pip install 'strands-robots[cosmos3-sim]'")
+openarm_mj_description = pytest.importorskip(
+    "robot_descriptions.openarm_v1_mj_description",
+    reason="robot_descriptions not installed",
+)
+
+# E402: importorskip must run before these imports so the module skips cleanly.
+from strands_robots.policies.cosmos3.embodiments import get_embodiment  # noqa: E402
+from strands_robots.policies.cosmos3.policy import Cosmos3Policy  # noqa: E402
+from strands_robots.policies.cosmos3.sim_ik import (  # noqa: E402
+    MinkIKBridge,
+    decode_cosmos_chunk_to_targets,
+)
+
+from .test_policy import FakeClient  # noqa: E402
+
+# Tracking-error acceptance bar - same numbers test_sim_ik.py pins for DROID.
+_MEAN_MM_BAR = 12.0
+_MAX_MM_BAR = 45.0
+
+# Elbow-bent OpenArm home (inside every joint range) so the EE starts
+# mid-workspace and the synthetic targets stay reachable.
+_Q_HOME = np.array([0.0, 0.6, 0.0, 1.2, 0.0, 0.5, 0.0], dtype=np.float64)
+
+
+def _openarm_stats(dim: int = 10) -> dict[str, np.ndarray]:
+    """Synthetic, physically-reachable quantile stats for ``openarm_lerobot``.
+
+    Translation columns de-normalize to +-10 mm per step, the rot6d block to
+    itself (so near-identity normalized rotations stay near-identity), and the
+    grasp column to the OpenArm finger range [0, 0.044] m.
+    """
+    q01 = np.array([-0.01] * 3 + [-1.0] * 6 + [0.0], dtype=np.float32)
+    q99 = np.array([0.01] * 3 + [1.0] * 6 + [0.044], dtype=np.float32)
+    assert q01.shape[-1] == dim and q99.shape[-1] == dim
+    return {"q01": q01, "q99": q99}
+
+
+def _reachable_chunk(t: int, dim: int) -> np.ndarray:
+    """A normalized [-1, 1] chunk whose de-normalized deltas stay reachable."""
+    rng = np.random.default_rng(0)
+    chunk = rng.uniform(-0.3, 0.3, (t, dim)).astype(np.float32)
+    # Near-identity rot6d so the synthetic deltas do not wander out of the
+    # workspace (a scaling concern, not an IK one - same note as test_sim_ik).
+    chunk[:, 3:9] = np.tile([1, 0, 0, 0, 1, 0], (t, 1))
+    return chunk
+
+
+@pytest.fixture(scope="module")
+def openarm_model():
+    # The registry's ``openarm`` entry resolves the single-arm ``openarm.xml``
+    # inside the ``openarm_v1_mj_description`` asset dir (the module's own
+    # MJCF_PATH names the bimanual variant - the #2461 follow-up).
+    xml = Path(openarm_mj_description.MJCF_PATH).with_name("openarm.xml")
+    if not xml.exists():
+        pytest.skip(f"single-arm openarm.xml not shipped next to {openarm_mj_description.MJCF_PATH}")
+    return mujoco.MjModel.from_xml_path(str(xml))
+
+
+@pytest.fixture
+def q_init(openarm_model):
+    q = np.zeros(openarm_model.nq, dtype=np.float64)
+    q[:7] = _Q_HOME
+    return q
+
+
+@pytest.fixture
+def bridge(openarm_model):
+    # link7 is the last arm link (the single-arm MJCF has no hand_tcp body).
+    return MinkIKBridge(openarm_model, ee_frame_name="openarm_link7", ee_frame_type="body")
+
+
+def test_openarm_chunk_decodes_to_joint_targets_within_bar(bridge, q_init):
+    """Raw normalized chunk -> declared stats -> EE poses -> OpenArm joints."""
+    emb = get_embodiment("openarm")
+    chunk = _reachable_chunk(16, emb.raw_action_dim)
+
+    out = decode_cosmos_chunk_to_targets(
+        chunk,
+        emb,
+        bridge,
+        q_init,
+        stats=_openarm_stats(emb.raw_action_dim),
+        stats_domain=emb.domain_name,
+    )
+
+    assert out["qpos"].shape == (16, bridge.model.nq)
+    assert out["poses"].shape == (16, 4, 4)
+    # The openarm raw layout ends in "grasp" -> gripper column is split off.
+    assert out["gripper"] is not None
+    assert out["gripper"].shape == (16,)
+    assert out["tracking_error"]["mean_mm"] <= _MEAN_MM_BAR, out["tracking_error"]
+    assert out["tracking_error"]["max_mm"] <= _MAX_MM_BAR, out["tracking_error"]
+    # Joint targets respect the OpenArm model's own limits (MinkIKBridge
+    # enforces them - normalized columns fed raw would not).
+    lo, hi = bridge.model.jnt_range[:, 0], bridge.model.jnt_range[:, 1]
+    for q in out["qpos"]:
+        assert np.all(q >= lo - 1e-6) and np.all(q <= hi + 1e-6)
+
+
+def test_openarm_decode_without_stats_fails_loudly(bridge, q_init):
+    """No bundled openarm_lerobot stats: the default path refuses by name
+    instead of silently substituting another domain's quantiles."""
+    emb = get_embodiment("openarm")
+    chunk = _reachable_chunk(4, emb.raw_action_dim)
+    with pytest.raises(FileNotFoundError, match="openarm_lerobot"):
+        decode_cosmos_chunk_to_targets(chunk, emb, bridge, q_init)
+
+
+def test_openarm_mock_server_to_mujoco_end_to_end(bridge, q_init):
+    """Mock policy server -> Cosmos3Policy column dicts -> IK joint targets.
+
+    The full deploy-side loop for the OpenArm mapping, with the served chunk
+    standing in for a post-trained checkpoint's output: the policy names every
+    column of the ``midtrain`` layout per step, and reassembling those columns
+    reproduces the exact chunk the IK bridge closes onto the MuJoCo arm.
+    """
+    emb = get_embodiment("openarm")
+    chunk = _reachable_chunk(8, emb.raw_action_dim)
+    policy = Cosmos3Policy(embodiment="openarm", client=FakeClient(chunk))
+
+    img = np.zeros((240, 320, 3), dtype=np.uint8)
+    obs = {"observation/image": img, "observation/wrist_image": img}
+    steps = asyncio.run(policy.get_actions(obs, "hand over the cube"))
+
+    layout = emb.action_layouts["midtrain"]
+    assert len(steps) == 8
+    assert all(sorted(s) == sorted(layout) for s in steps)
+
+    # Round-trip: the named columns reassemble into the served chunk...
+    reassembled = np.array([[s[c] for c in layout] for s in steps], dtype=np.float32)
+    np.testing.assert_allclose(reassembled, chunk, atol=1e-6)
+
+    # ...which the sim bridge closes onto the OpenArm model within the bar.
+    out = decode_cosmos_chunk_to_targets(
+        reassembled,
+        emb,
+        bridge,
+        q_init,
+        stats=_openarm_stats(emb.raw_action_dim),
+        stats_domain=emb.domain_name,
+    )
+    assert out["qpos"].shape == (8, bridge.model.nq)
+    assert out["tracking_error"]["mean_mm"] <= _MEAN_MM_BAR, out["tracking_error"]
+
+
+def test_openarm_requires_its_full_camera_set():
+    """The camera guard covers the openarm entry: a missing wrist view is
+    refused client-side, naming the missing key."""
+    emb = get_embodiment("openarm")
+    policy = Cosmos3Policy(embodiment="openarm", client=FakeClient(_reachable_chunk(4, emb.raw_action_dim)))
+    obs = {"observation/image": np.zeros((240, 320, 3), dtype=np.uint8)}
+    with pytest.raises(ValueError, match="observation/wrist_image"):
+        asyncio.run(policy.get_actions(obs, "hand over the cube"))


### PR DESCRIPTION
# feat(policies/cosmos3): OpenArm embodiment - post-training path for openarm

Closes #2461

## What changed

The cosmos3 provider's embodiment table (`strands_robots/policies/cosmos3/embodiments.py`) gains an `openarm` entry, closing the record -> post-train -> deploy loop for the Enactic OpenArm with cosmos3 the way `droid`/`umi`/`av`/`bridge` already close it:

- **`Cosmos3Embodiment("openarm")`**: conditioning domain `openarm_lerobot`, `raw_action_dim=10` (the standard single-arm unified action: 9D EE pose + 1D grasp), `midtrain` action space, front + wrist camera keys (mirroring the recorded OpenArm episode set / `openarm_real` lerobot embodiment). Aliases `openarm_lerobot`, `openarm_follower`, `enactic_openarm` resolve to it.
- **Wired through the same paths as the existing four** - the embodiment table is data-driven, so service mode, the in-proc diffusers backend, and the `sim_ik.py` decode (the domain emits eef-space actions) pick the entry up through `get_embodiment` with no per-backend special cases. Deliberately **no `joint_pos` layout**: the RoboLab server's joint conversion is DROID-only, so promising one here would fabricate a server post-process that does not exist (pinned by a test).
- **Post-training expectation documented on the entry itself**: no released Cosmos 3 checkpoint ships this domain, so the entry maps a checkpoint post-trained on OpenArm episodes via the existing `cosmos3` trainer (SFT recipe TOML -> `cosmos_framework` launch) rather than promising zero-shot behavior. Consistently, **no action stats are bundled** for `openarm_lerobot`: `load_action_stats` keeps refusing the unbundled domain by name, and the post-trained domain's own quantiles go in via the existing `stats=` + `stats_domain="openarm_lerobot"` route.
- Docstrings/messages that enumerate the embodiments or the shared 10-column width (`policy.py`, `__init__.py`, `sim_ik.py`, `registry/policies.json` description) updated to stay truthful.

## Test surface

- `tests/policies/cosmos3/test_embodiments.py` (`TestOpenArmEmbodiment`): spec, action-dim/mapping round-trip (every named layout matches its width; `midtrain` IS the raw layout, ending in `grasp`), no fabricated `joint_pos`, aliases, and the bundled-stats refusal naming the domain + the safe explicit-stats remedy.
- `tests/policies/cosmos3/test_sim_ik_openarm.py` (new): MuJoCo rollout smoke path on the single-arm OpenArm MJCF (`robot_descriptions.openarm_v1_mj_description`, the same module the robot registry's `openarm` entry declares) - mock policy server -> `Cosmos3Policy` per-step column dicts -> reassembled chunk -> de-normalize + IK bridge -> joint targets within the existing tracking-error bar (mean <= 12 mm / max <= 45 mm) and inside the model's own joint limits; plus the no-stats loud failure and the full-camera-set client-side guard. Skips cleanly (`importorskip`) without the `cosmos3-sim` extra, mirroring `test_sim_ik.py`.

`hatch run format` / `hatch run lint` clean; full `hatch run test`: **32617 passed, 270 skipped, 0 failed** (run with `MUJOCO_GL=egl` - the default GL backend has no display on the dev runner, which is environmental).

## Acceptance criteria (from #2461)

- [x] Unit tests in `tests/policies/cosmos3/test_embodiments.py` cover the new entry (action-dim/mapping round-trip), matching the existing embodiment tests
- [x] A MuJoCo rollout smoke path (mock server) exercises the OpenArm mapping end-to-end
- [x] No silent fallback: an unknown embodiment name keeps failing loudly (pinned), and the unbundled `openarm_lerobot` stats are refused by name rather than substituted

## Out of scope / follow-ups

- `bi_openarm` (16-DOF bimanual) embodiment - deliberate follow-up per the issue, once this single-arm mapping is validated on post-trained weights (the bimanual MJCF is already in `openarm_v1_mj_description`).
- GPU integration tests against a real post-trained checkpoint - sibling issue #2462 (cosmos3 `tests_integ` gap).

Board: please move #2461 to "In review" on the [Strands Labs - Robots board](https://github.com/orgs/strands-labs/projects/2) (filing account lacks org project write).
