### PR TITLE
fix(mesh/audit): poison a record the JSON encoder cannot represent instead of dropping it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1737,9 +1737,21 @@ apply to all future work on `strands_robots/mesh/{core,audit,security}.py`.
 ### Audit poison-record symmetry
 - **Every degraded audit path writes a poison record, never a silent drop.** The
   poison `sig` discriminators (`PSK_DEGRADED`, `SIGN_FAILED`, `SEQ_LOCK_DEGRADED`,
-  `NEXT_SEQ_DEGRADED`) let a `verify_audit_integrity` walker attribute a stream
-  gap to a specific failure class. When you add a new `_next_seq`/sign/persist
-  failure branch, add the matching poison `sig` instead of returning early.
+  `NEXT_SEQ_DEGRADED`, `SERIALISE_FAILED`) let a `verify_audit_integrity` walker
+  attribute a stream gap to a specific failure class. When you add a new
+  `_next_seq`/sign/serialise/persist failure branch, add the matching poison
+  `sig` instead of returning early.
+- **`_next_seq` runs before serialisation, so an early `return` is a deletion.**
+  The sequence number is consumed and persisted before the record is encoded, so
+  a branch that gives up after that point leaves the signature this module's
+  header documents as "records were deleted". A payload the JSON encoder cannot
+  represent keeps the envelope (`ts` / `event` / `peer_id` / `seq`) and swaps the
+  payload for a bounded diagnostic; the only remaining drop is an envelope that
+  is itself unrepresentable, where there is nothing left to poison with.
+- Pinned by `tests/mesh/test_audit_serialise_safety.py`, whose
+  `TestEveryDegradedPathWritesARecord` drives every degraded branch from one
+  table so a path added later is graded rather than quietly becoming the next
+  silent drop.
 
 ### Replay-cache eviction
 - **TTL purge runs unconditionally, not only when the cache is full.** On a

--- a/changelog.d/2501-audit-serialise-poison-record.md
+++ b/changelog.d/2501-audit-serialise-poison-record.md
@@ -1,0 +1,2 @@
+### Fixed
+- **mesh/audit**: a safety event whose payload the JSON encoder cannot represent now leaves an attributable poison record (`sig="SERIALISE_FAILED"`) instead of being dropped. `_next_seq` consumes and persists the peer's sequence number before the record is encoded, so the drop left the signature the module header documents as "records were deleted" - the one degraded path a `verify_audit_integrity` walker could not attribute to a failure class. The envelope (`ts` / `event` / `peer_id` / `seq`) is kept and the payload is replaced by a bounded diagnostic.

--- a/strands_robots/mesh/audit.py
+++ b/strands_robots/mesh/audit.py
@@ -23,9 +23,13 @@ Each line is one JSON object with these keys:
 * ``payload`` -- free-form dict with event-specific fields
 * ``seq`` -- process-monotonic sequence number. Useful for detecting
   truncation: gaps within a single peer's stream indicate missing events.
-* ``sig`` -- HMAC-SHA256 hex over the rest of the record. Present only when
+* ``sig`` -- HMAC-SHA256 hex over the rest of the record, present when
   ``STRANDS_MESH_AUDIT_PSK`` is configured. Verifies that the record
-  content has not been edited after write.
+  content has not been edited after write. The field also carries one of the
+  poison discriminators (``PSK_DEGRADED``, ``SIGN_FAILED``,
+  ``SEQ_LOCK_DEGRADED``, ``NEXT_SEQ_DEGRADED``, ``SERIALISE_FAILED``) in place
+  of an HMAC, signed log or not, which is how a degraded write says so instead
+  of leaving a hole; none of them is a valid HMAC, so a verifier fails closed.
 
 Integrity verification
 ----------------------
@@ -162,6 +166,11 @@ _SEQ_COUNTERS: dict[str, int] = {}
 #: input from silently denying the legitimate writer the next ~billion
 #: seq values.
 _MAX_SEED_SEQ: int = 100_000_000
+
+#: Upper bound on the diagnostic text a poison record carries. A poison
+#: record exists so a verifier can attribute a stream gap; it is not a place
+#: for an unbounded exception message to grow the audit log.
+_MAX_POISON_REASON_CHARS: int = 500
 
 # the PSK fingerprint snapshot at
 # ``_AUDIT_STATE.psk_fingerprint`` is read+modified+compared on every
@@ -1012,7 +1021,11 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
     Raises:
         Nothing - write errors are logged at WARNING and swallowed because
         an audit-log failure must never propagate up into the safety code
-        path that called this function.
+        path that called this function. A payload the JSON encoder cannot
+        represent is not dropped either: the record is written with the
+        payload replaced by a diagnostic under ``sig="SERIALISE_FAILED"``,
+        so the sequence number this call already consumed still has a
+        record naming the failure rather than reading as a deletion.
     """
     seq_lock_degraded_reason: str | None = None
     next_seq_degraded_reason: str | None = None
@@ -1114,12 +1127,36 @@ def log_safety_event(event_type: str, peer_id: str, payload: dict[str, Any]) -> 
     try:
         line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
     except (TypeError, ValueError) as exc:
-        logger.warning(
-            "[audit] could not serialise record for peer_id=%r: %s -- record dropped",
+        # A payload the JSON encoder cannot represent used to return here.
+        # ``_next_seq`` has already consumed and persisted this peer's
+        # sequence number by that point, so the drop left a gap the module
+        # header documents as "records were deleted" -- a payload mistake
+        # wearing the forensic signature of tampering, and the one degraded
+        # path a verifier could not attribute. Write a poison record
+        # (``sig="SERIALISE_FAILED"``) carrying the consumed ``seq`` and a
+        # diagnostic in place of the unrepresentable payload, the same
+        # discipline as SEQ_LOCK_DEGRADED / NEXT_SEQ_DEGRADED /
+        # PSK_DEGRADED / SIGN_FAILED.
+        logger.error(
+            "[audit] SERIALISE_FAILED for peer_id=%r: %s -- writing poison record",
             peer_id,
             exc,
         )
-        return
+        record["payload"] = {"unrepresentable": True}
+        record["payload_error"] = f"{type(exc).__name__}: {exc}"[:_MAX_POISON_REASON_CHARS]
+        record["sig"] = "SERIALISE_FAILED"
+        try:
+            line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        except (TypeError, ValueError) as poison_exc:
+            # The envelope itself is unrepresentable (a caller passed a
+            # non-string ``event_type`` / ``peer_id``), so there is nothing
+            # left to poison with. This is the only remaining drop.
+            logger.warning(
+                "[audit] could not serialise record for peer_id=%r: %s -- record dropped",
+                peer_id,
+                poison_exc,
+            )
+            return
     path = audit_log_path()
 
     with _WRITE_LOCK:

--- a/tests/mesh/test_audit_serialise_safety.py
+++ b/tests/mesh/test_audit_serialise_safety.py
@@ -1,19 +1,30 @@
-"""Pin test: log_safety_event must not raise on non-JSON-serialisable payload.
+"""A payload the JSON encoder cannot represent is poisoned, never dropped.
 
-Regression test for the P0 hold on PR #221 R5: json.dumps at the
-serialisation site (formerly line 1103) is outside the signing and
-write try blocks, so a TypeError from a non-serialisable payload
-escaped log_safety_event and crashed the safety code path.
+Two contracts meet at the serialisation site in
+:func:`strands_robots.mesh.audit.log_safety_event`.
 
-The contract at the function header says:
-    Raises: Nothing -- audit-log failure must never propagate up into
-    the safety code path that called this function.
+The first is fail-soft: the function header promises it raises nothing,
+because an audit-log failure must never propagate up into the safety code
+path that called it. A ``TypeError`` from a non-serialisable payload used to
+escape and crash that path.
 
-The fix wraps json.dumps in try/except (TypeError, ValueError) and
-drops the record with a WARNING, matching the existing fail-soft
-discipline for signing failures.
+The second is poison-record symmetry: every degraded audit path writes a
+record carrying a discriminating ``sig`` rather than returning early, so a
+:func:`strands_robots.mesh.audit.verify_audit_integrity` walker can attribute
+a stream anomaly to a failure class. ``_next_seq`` has already consumed and
+persisted this peer's sequence number before serialisation is attempted, so a
+silent drop leaves behind exactly what the module header documents as
+"records were deleted" -- a payload mistake wearing the forensic signature of
+tampering. ``SEQ_LOCK_DEGRADED``, ``NEXT_SEQ_DEGRADED``, ``PSK_DEGRADED`` and
+``SIGN_FAILED`` each keep the second contract; the serialisation branch kept
+only the first.
+
+The tests below hold both: nothing escapes, and the unrepresentable payload is
+replaced by a bounded diagnostic under ``sig="SERIALISE_FAILED"`` so the
+consumed sequence number still has a record to name it.
 """
 
+import datetime
 import logging
 
 import pytest
@@ -55,16 +66,21 @@ class TestLogSafetyEventNonSerialisablePayload:
 
         log_safety_event("test_event", "peer1", {"raw": b"\x00\x01\x02"})
 
-    def test_warning_logged_on_non_serialisable(self, caplog):
-        """A WARNING must be logged when serialisation fails."""
+    def test_the_failure_is_reported_under_its_discriminator(self, caplog):
+        """The failure must be reported, not silent.
+
+        It is reported at ERROR naming ``SERIALISE_FAILED``, the level and shape
+        the other four poison paths use, because a record that reaches the log
+        with a poison ``sig`` is an integrity event rather than a lost write.
+        """
         from strands_robots.mesh.audit import log_safety_event
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             log_safety_event("test_event", "peer1", {"obj": object()})
 
-        assert any("could not serialise record" in rec.message for rec in caplog.records), (
-            f"Expected 'could not serialise record' warning, got: {[r.message for r in caplog.records]}"
-        )
+        reported = [r for r in caplog.records if "SERIALISE_FAILED" in r.message]
+        assert reported, f"the failure was not reported: {[r.message for r in caplog.records]}"
+        assert reported[0].levelno == logging.ERROR, reported[0].levelname
 
     def test_valid_payload_still_writes(self, tmp_path):
         """A valid payload must still write successfully."""
@@ -87,3 +103,188 @@ class TestLogSafetyEventNonSerialisablePayload:
         # Still, ensure the contract holds for edge cases.
         log_safety_event("test_event", "peer1", {"val": float("nan")})
         log_safety_event("test_event", "peer1", {"val": float("inf")})
+
+
+#: The degraded paths of ``log_safety_event``, each with the ``sig`` it must
+#: leave behind. Driven from one table so a path added later is graded here
+#: instead of quietly becoming the next silent drop.
+_DEGRADED_PATHS = (
+    ("seq lockfile is a symlink", "_next_seq", "SeqLockSymlinkError", "SEQ_LOCK_DEGRADED"),
+    ("seq sidecar unreadable", "_next_seq", "OSError", "NEXT_SEQ_DEGRADED"),
+    ("PSK flipped mid-run", "_sign_record", "AuditPSKDegradedError", "PSK_DEGRADED"),
+    ("signing raised", "_sign_record", "RuntimeError", "SIGN_FAILED"),
+    ("payload not representable", None, None, "SERIALISE_FAILED"),
+)
+
+#: Payload values a robot safety event plausibly carries that the JSON encoder
+#: cannot represent. A numpy pose or a raw fingerprint is the ordinary mistake
+#: here, not an exotic one.
+_UNREPRESENTABLE = (
+    ("bytes fingerprint", {"fingerprint": b"\x01\x02\x03"}),
+    ("set of zone ids", {"zones": {"dock-a", "dock-b"}}),
+    ("datetime", {"at": datetime.datetime(2026, 1, 1)}),
+    ("bare object", {"handle": object()}),
+)
+
+
+def _degraded_record(monkeypatch, *, attr, exc_name, payload):
+    """Drive one degraded path between two clean records, return the audit log.
+
+    Returns the record list so a caller can assert on the middle record and on
+    the two that bracket it.
+    """
+    from strands_robots.mesh import audit
+
+    audit.log_safety_event("clean_before", "peer-d", {"ok": 1})
+    if attr is not None:
+        exc: BaseException
+        if exc_name == "SeqLockSymlinkError":
+            exc = audit.SeqLockSymlinkError("the seq lockfile is a symlink")
+        elif exc_name == "AuditPSKDegradedError":
+            exc = audit.AuditPSKDegradedError("signed -> unsigned mid-run")
+        elif exc_name == "OSError":
+            exc = OSError("seq sidecar unreadable")
+        else:
+            exc = RuntimeError("hmac backend unavailable")
+        if exc_name == "RuntimeError":
+            # SIGN_FAILED is only poisoned when a PSK is configured; without
+            # one the unsigned write is the documented dev-mode posture.
+            monkeypatch.setenv("STRANDS_MESH_AUDIT_PSK", "a-test-key")
+
+        def _raise(*_args, **_kwargs):
+            raise exc
+
+        monkeypatch.setattr(audit, attr, _raise)
+    audit.log_safety_event("degraded", "peer-d", payload)
+    # Deliberately no monkeypatch.undo() here: it would also revert the autouse
+    # fixture's STRANDS_MESH_AUDIT_DIR and point read_audit_log at the real
+    # default directory. pytest tears both down at test exit.
+    return audit
+
+
+class TestAnUnrepresentablePayloadLeavesAnAttributableRecord:
+    """The consumed sequence number still has a record naming the failure."""
+
+    def test_the_record_is_written_under_the_serialise_failed_discriminator(self, monkeypatch):
+        """Pre-fix: no record at all, so the seq gap named no failure class."""
+        import numpy as np
+
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("clean_before", "peer-s", {"ok": 1})
+        audit.log_safety_event("collision_imminent", "peer-s", {"pose": np.zeros(3)})
+
+        records = audit.read_audit_log(since=0)
+        poisoned = [r for r in records if r.get("event") == "collision_imminent"]
+        assert poisoned, (
+            "the unrepresentable payload left no record, so the sequence number "
+            f"_next_seq already consumed names no failure class: {records}"
+        )
+        assert poisoned[0].get("sig") == "SERIALISE_FAILED", poisoned[0]
+
+    def test_the_record_keeps_the_sequence_number_the_writer_consumed(self, monkeypatch):
+        """The poison record occupies the seq, so the anomaly has an owner."""
+        import numpy as np
+
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("first", "peer-q", {"ok": 1})
+        audit.log_safety_event("second", "peer-q", {"pose": np.zeros(2)})
+        audit.log_safety_event("third", "peer-q", {"ok": 1})
+
+        by_event = {r["event"]: r for r in audit.read_audit_log(since=0)}
+        assert set(by_event) == {"first", "second", "third"}, by_event
+        assert by_event["first"]["seq"] == 1
+        assert by_event["second"]["seq"] == 2, "the consumed seq must be the poison record's"
+        assert by_event["third"]["seq"] == 3
+
+    def test_the_record_keeps_the_envelope_forensics_reads(self, monkeypatch):
+        """event / peer_id / ts survive; only the payload could not be written."""
+        import numpy as np
+
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("estop_engaged", "arm-7", {"joints": np.zeros(6)})
+
+        record = audit.read_audit_log(since=0)[-1]
+        assert record["event"] == "estop_engaged"
+        assert record["peer_id"] == "arm-7"
+        assert isinstance(record["ts"], float)
+
+    def test_the_unrepresentable_value_is_replaced_by_a_bounded_diagnostic(self, monkeypatch):
+        """The payload is not written verbatim; the reason names the encoder error."""
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("estop_engaged", "arm-8", {"handle": object()})
+
+        record = audit.read_audit_log(since=0)[-1]
+        assert record["payload"] == {"unrepresentable": True}, record["payload"]
+        assert "TypeError" in record["payload_error"], record["payload_error"]
+        assert len(record["payload_error"]) <= audit._MAX_POISON_REASON_CHARS
+
+    @pytest.mark.parametrize(("label", "payload"), _UNREPRESENTABLE, ids=[c[0] for c in _UNREPRESENTABLE])
+    def test_every_unrepresentable_shape_is_poisoned(self, label, payload, monkeypatch):
+        """A robot payload carries poses and fingerprints, not just JSON scalars."""
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("probe", "peer-p", payload)
+
+        records = audit.read_audit_log(since=0)
+        assert records, f"{label} left no record"
+        assert records[-1].get("sig") == "SERIALISE_FAILED", f"{label}: {records[-1]}"
+
+
+class TestEveryDegradedPathWritesARecord:
+    """One rule across the whole function, not four paths and an exception."""
+
+    @pytest.mark.parametrize(
+        ("label", "attr", "exc_name", "expected_sig"),
+        _DEGRADED_PATHS,
+        ids=[c[0] for c in _DEGRADED_PATHS],
+    )
+    def test_the_path_leaves_its_discriminator(self, label, attr, exc_name, expected_sig, monkeypatch):
+        """Pre-fix the payload row wrote nothing while the other four did."""
+        import numpy as np
+
+        payload = {"pose": np.zeros(3)} if attr is None else {"ok": 1}
+        audit = _degraded_record(monkeypatch, attr=attr, exc_name=exc_name, payload=payload)
+
+        degraded = [r for r in audit.read_audit_log(since=0) if r.get("event") == "degraded"]
+        assert degraded, f"{label} wrote no record, so the anomaly names no failure class"
+        assert degraded[0].get("sig") == expected_sig, f"{label}: {degraded[0]}"
+
+    def test_the_verifier_still_fails_closed_on_a_poisoned_stream(self, monkeypatch):
+        """A degraded audit must never read as ok; the poison record is not a pass."""
+        import numpy as np
+
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("clean_before", "peer-v", {"ok": 1})
+        audit.log_safety_event("degraded", "peer-v", {"pose": np.zeros(3)})
+        audit.log_safety_event("clean_after", "peer-v", {"ok": 1})
+
+        assert audit.verify_audit_integrity()["ok"] is False
+
+
+class TestTheGoodPathAndTheLastResortAreUnchanged:
+    """Controls: a representable payload is untouched, and nothing escapes."""
+
+    def test_a_representable_payload_carries_no_poison_fields(self):
+        """The write path a caller normally takes is byte-identical."""
+        from strands_robots.mesh import audit
+
+        audit.log_safety_event("estop_engaged", "peer-g", {"reason": "operator"})
+
+        record = audit.read_audit_log(since=0)[-1]
+        assert "sig" not in record, "an unsigned good record must stay unsigned"
+        assert "payload_error" not in record
+        assert record["payload"] == {"reason": "operator"}
+
+    def test_an_unrepresentable_envelope_still_raises_nothing(self, caplog):
+        """When even the envelope cannot be written there is nothing to poison."""
+        from strands_robots.mesh import audit
+
+        with caplog.at_level(logging.WARNING):
+            audit.log_safety_event(object(), "peer-e", {"ok": 1})  # type: ignore[arg-type]
+
+        assert any("record dropped" in rec.message for rec in caplog.records), [r.message for r in caplog.records]


### PR DESCRIPTION
## Problem

`log_safety_event` has four degraded paths, and each one writes a record carrying a discriminating `sig` rather than returning early, so a `verify_audit_integrity` walker can attribute a stream anomaly to a failure class:

| trigger | `sig` written |
| --- | --- |
| the seq lockfile is a symlink | `SEQ_LOCK_DEGRADED` |
| the seq sidecar is unreadable | `NEXT_SEQ_DEGRADED` |
| the PSK flipped mid-run | `PSK_DEGRADED` |
| signing raised | `SIGN_FAILED` |
| **the payload is not representable** | **nothing - the record was dropped** |

The serialisation branch kept only the fail-soft half of the contract. That matters because of the ordering: `_next_seq` consumes **and persists** the peer's sequence number before the record is encoded, so the `return` left the sequence number spent with nothing to name it. The module header documents that state as *"sequence gaps (records were deleted)"* - an ordinary payload mistake wearing the forensic signature of tampering, on the one degraded path a walker could not classify.

Measured on the shipped path (`Mesh.publish_safety_event`, one arm, one shift: estop -> zone -> collision -> clear, where the collision payload carries the pose it is about):

```
wire:  4 safety events published to the fleet
audit: 3 records          seq 1, 2, ... 4
verify_audit_integrity(): ok=False  sequence_gaps=[(2, 4)]
log:   WARNING [audit] could not serialise record ... -- record dropped
```

The fleet was told four times; the forensic record keeps three, and the missing one is the collision.

The trigger is ordinary, not exotic. Of nine payload values a robot safety event plausibly carries, eight reach this branch - a numpy pose or joint vector, `np.float32`, raw bytes, a set of zone ids, a `datetime`, a `Path`, a `Decimal`, a bare object. With a PSK configured the code even *classifies* it (`_sign_record` raises the same `TypeError`, so `sig="SIGN_FAILED"` is set) and then discards the classification one line later.

## Change

On a serialisation failure the record is now poisoned rather than dropped: the envelope (`ts` / `event` / `peer_id` / `seq`) is kept, the unrepresentable payload is replaced by `{"unrepresentable": True}` plus a bounded `payload_error` diagnostic, and `sig` is set to `SERIALISE_FAILED`. The only remaining drop is an envelope that is itself unrepresentable - a non-string `event_type` - where there is nothing left to poison with, and that path keeps the original WARNING.

```
wire:  4 safety events published to the fleet
audit: 4 records          seq 1, 2, 3, 4
       seq 3  collision_imminent  SERIALISE_FAILED  {'unrepresentable': True}
verify_audit_integrity(): ok=False  sequence_gaps=[(2, 4)]
log:   ERROR [audit] SERIALISE_FAILED for peer_id='arm-7': ... -- writing poison record
```

Both sides report `ok=False`, and that is correct: a degraded audit is never ok. What changes is whether the anomaly can be attributed. Driven between a clean record and a clean record, the new class behaves identically to the two existing poison classes that also occupy a real sequence number:

| case | records | `sig` | `seq` | `sequence_gaps` | `ok` |
| --- | --- | --- | --- | --- | --- |
| seq lockfile is a symlink | 3 | `SEQ_LOCK_DEGRADED` | 0 | `[]` | False |
| seq sidecar unreadable | 3 | `NEXT_SEQ_DEGRADED` | 0 | `[]` | False |
| PSK flipped mid-run | 3 | `PSK_DEGRADED` | 2 | `[(1, 3)]` | False |
| signing raised | 3 | `SIGN_FAILED` | 2 | `[(1, 3)]` | False |
| payload not representable (before) | 2 | *no record* | - | `[(1, 3)]` | False |
| payload not representable (after) | 3 | `SERIALISE_FAILED` | 2 | `[(1, 3)]` | False |

## Scope

`tests/mesh/test_audit_serialise_safety.py` already owned this contract - it exists to prove the function does not raise - and its docstring justified the drop as "matching the existing fail-soft discipline for signing failures". The signing discipline it cites does not drop; it poisons. Its module docstring now states both halves, and `test_warning_logged_on_non_serialisable` becomes `test_the_failure_is_reported_under_its_discriminator`: the stated intent was that the failure is reported rather than silent, and it is now reported at ERROR under its discriminator, the level and shape the other four poison paths use.

The `sig` key description in the module header said a signature is "present only when `STRANDS_MESH_AUDIT_PSK` is configured", which the four existing poison classes already contradicted and this branch makes reachable from an ordinary payload mistake; it now names the discriminators.

## Tests

`tests/mesh/test_audit_serialise_safety.py`: **10 failed / 12 passed** against `upstream/main`, 22 passed after.

The 10 failures are behavioural - the headline reports that the unrepresentable payload left no record, so the sequence number `_next_seq` already consumed names no failure class. The 12 that pass on both trees are the controls, and each fails for a specific wrong fix:

- `TestEveryDegradedPathWritesARecord` drives all five degraded branches from one table, so the four already-compliant rows pass unchanged and a path added later is graded rather than quietly becoming the next silent drop.
- the verifier still fails closed on a poisoned stream - the poison record must not read as a pass.
- a representable payload carries no `sig` and no `payload_error`: the write path a caller normally takes is byte-identical.
- an unrepresentable *envelope* still raises nothing and still logs `record dropped`.
- the three pre-existing "does not raise" cases and the nan/inf case are untouched.

## Verification

At `d0fa014`, against `upstream/main` `0acbfc93`.

- 254-file blast radius (all of `tests/mesh`, every test touching the audit surface, and the repo-wide docstring / string / changelog / dependency guards), run sequentially on both trees.
- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24 with zero branch-only errors and none in the changed files.
- No added non-ASCII in any changed file.

![audit stream after a collision event whose payload carries a pose](https://raw.githubusercontent.com/cagataycali/robots/media-audit-serialise-poison/audit-serialise-poison.png)

The figure is one capture script run against each tree with the same package code either side; only `strands_robots` differs. The `wire: 4` line is identical in both panels, which is the control - the change touches only what the audit keeps.
