### PR TITLE
fix(examples/fleet): refuse a mesh that did not start instead of awaiting presence

### DIFF
--- a/changelog.d/2510-fleet-examples-refuse-a-dead-mesh.md
+++ b/changelog.d/2510-fleet-examples-refuse-a-dead-mesh.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **examples/fleet**: refuse a mesh that did not start instead of proceeding to the
+  presence wait. `init_mesh` returns `None` only when the mesh is switched off on
+  purpose; when it is enabled but no session opens it returns a `Mesh` whose `alive`
+  is `False`, which passed the four live-fleet builders' `is None` guard. Examples 02,
+  03 and 04 then spent their 15 s presence-discovery timeout on a message naming no
+  dependency, and 05 - which has no presence wait - ran its whole queue, attributed
+  every order to a per-robot `dispatch_failed`, and exited 0. Each builder now checks
+  `mesh.alive` (the observable `dashboard.py` already refuses on) and names the peer,
+  the remedy and the `--dry-run` alternative. The deliberate `STRANDS_MESH=0` opt-out
+  keeps its own distinct advice.

--- a/examples/fleet/02_cross_zone_transport.py
+++ b/examples/fleet/02_cross_zone_transport.py
@@ -374,11 +374,24 @@ def _build_live_zones() -> tuple[Any, Callable[[], None]]:
             mesh = init_mesh(sim, peer_id=zone_id, peer_type="sim")
             if mesh is None:
                 raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+            # A peer whose mesh did not start is not a slow peer: it publishes no
+            # presence and discovers none, so the presence wait below can only
+            # expire.  Refuse here, where the cause is still known.
+            if not mesh.alive:
+                raise RuntimeError(
+                    f"mesh did not start for peer {zone_id!r} (mesh.alive is False): install the mesh "
+                    'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+                )
             sim.mesh, sim.peer_id = mesh, mesh.peer_id
             meshes.append(mesh)
         coordinator = init_mesh(_Coordinator(), peer_id=COORDINATOR_ID)
         if coordinator is None:
             raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+        if not coordinator.alive:
+            raise RuntimeError(
+                f"mesh did not start for peer {COORDINATOR_ID!r} (mesh.alive is False): install the mesh "
+                'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+            )
     except BaseException:
         cleanup()
         raise

--- a/examples/fleet/03_failover_and_degraded_ops.py
+++ b/examples/fleet/03_failover_and_degraded_ops.py
@@ -487,11 +487,24 @@ def _build_live_fleet() -> tuple[dict[str, Any], Any, Callable[[], None]]:
             mesh = init_mesh(sim, peer_id=robot_id, peer_type="sim")
             if mesh is None:
                 raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+            # A peer whose mesh did not start publishes no presence and discovers
+            # none, so the presence wait below can only expire.  Refuse here,
+            # where the cause is still known.
+            if not mesh.alive:
+                raise RuntimeError(
+                    f"mesh did not start for peer {robot_id!r} (mesh.alive is False): install the mesh "
+                    'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+                )
             sim.mesh, sim.peer_id = mesh, mesh.peer_id
             meshes[robot_id] = mesh
         orch_mesh = init_mesh(_Orchestrator(), peer_id=ORCHESTRATOR_ID)
         if orch_mesh is None:
             raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+        if not orch_mesh.alive:
+            raise RuntimeError(
+                f"mesh did not start for peer {ORCHESTRATOR_ID!r} (mesh.alive is False): install the mesh "
+                'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+            )
     except BaseException:
         cleanup()
         raise
@@ -576,6 +589,11 @@ def _run_live(n_steps: int) -> tuple[dict[str, Any], dict[str, Any], list[dict[s
         orch_mesh2 = init_mesh(_Orchestrator(), peer_id=ORCHESTRATOR_ID)
         if orch_mesh2 is None:
             raise RuntimeError("mesh is disabled (STRANDS_MESH=0)")
+        if not orch_mesh2.alive:
+            raise RuntimeError(
+                f"the restarted {ORCHESTRATOR_ID!r} peer did not join the mesh (mesh.alive is False), "
+                "so the presence wait below cannot succeed"
+            )
         try:
             _wait_for(
                 lambda: all(robot in orch_mesh2.peers_by_id for robot in survivors),

--- a/examples/fleet/04_emergency_evacuation.py
+++ b/examples/fleet/04_emergency_evacuation.py
@@ -846,6 +846,15 @@ def _build_live_world() -> tuple[MujocoEvacuationWorld, Any, Callable[[], None]]
         coordinator = init_mesh(_Coordinator(), peer_id=COORDINATOR_ID)
         if sim_mesh is None or coordinator is None:
             raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+        # A peer whose mesh did not start publishes no presence and discovers
+        # none, so the presence wait below can only expire.  Refuse here, where
+        # the cause is still known.
+        for peer_id, peer in ((FLEET_PEER_ID, sim_mesh), (COORDINATOR_ID, coordinator)):
+            if not peer.alive:
+                raise RuntimeError(
+                    f"mesh did not start for peer {peer_id!r} (mesh.alive is False): install the mesh "
+                    'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+                )
     except BaseException:
         cleanup()
         raise

--- a/examples/fleet/05_work_order_dispatch.py
+++ b/examples/fleet/05_work_order_dispatch.py
@@ -502,12 +502,28 @@ def _build_live_transport() -> tuple[Callable[[str, str, int], dict[str, Any]], 
     if sim_mesh is None:
         sim.destroy()
         raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+    # A peer whose mesh did not start answers every RPC with "mesh not running",
+    # so without this the queue below runs to completion and reports each order
+    # as a per-robot dispatch failure.  Refuse here, where the cause is known.
+    if not sim_mesh.alive:
+        sim.destroy()
+        raise RuntimeError(
+            "mesh did not start for peer 'fleet-sites' (mesh.alive is False): install the mesh "
+            'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+        )
     sim.mesh, sim.peer_id = sim_mesh, sim_mesh.peer_id
     orch_mesh = init_mesh(_Dispatcher(), peer_id=DISPATCHER_ID)
     if orch_mesh is None:
         sim_mesh.stop()
         sim.destroy()
         raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+    if not orch_mesh.alive:
+        sim_mesh.stop()
+        sim.destroy()
+        raise RuntimeError(
+            f"mesh did not start for peer {DISPATCHER_ID!r} (mesh.alive is False): install the mesh "
+            'extra with pip install "strands-robots[mesh]", or rerun with --dry-run'
+        )
 
     def send(robot_name: str, instruction: str, n_steps: int) -> dict[str, Any]:
         # "execute" runs the policy synchronously, so multi-step orders are

--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -300,3 +300,4 @@ with the network off, given cached robot assets).
 | `STRANDS_MESH_LOCAL_DEV=1` | Skip TLS for local development (defaulted by the examples). |
 | `STRANDS_MESH_MULTICAST=true` | Enable multicast scouting so separate processes (e.g. the dashboard and an example) discover each other. Off by default; trusted networks only. |
 | `STRANDS_MESH=0` | Disable the mesh entirely; use `--dry-run` in that posture. |
+| _(mesh extra absent)_ | With `eclipse-zenoh` not installed the mesh stays off (`mesh.alive` is `False`): the live paths refuse at start-up naming the peer and the remedy. Install `strands-robots[mesh]` or use `--dry-run`. |

--- a/tests/test_examples_refuse_a_mesh_that_did_not_start.py
+++ b/tests/test_examples_refuse_a_mesh_that_did_not_start.py
@@ -109,13 +109,26 @@ def fleet_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr("strands_robots.simulation.Simulation", _StubSim)
 
 
-def _build_with_no_session(module: Any, builder: str) -> BaseException:
-    """Run one builder with no session available; return what it raised."""
+def _refusal_from(module: Any, builder: str) -> RuntimeError:
+    """Run one builder with no session available; return the refusal it raised.
+
+    Every refusal these builders raise is a ``RuntimeError`` -- the
+    ``mesh.alive`` path and the deliberate ``STRANDS_MESH=0`` opt-out alike -- so
+    anything else is a leak to report here rather than an exception to hand back
+    for the caller to classify. Reporting it here is also what keeps the clause
+    that catches a leak of any kind ending in a lexical ``raise``, matching the
+    tree's other two leak-catching test helpers.
+    """
     with patch("strands_robots.mesh.core.get_session", return_value=None):
         try:
             getattr(module, builder)()
-        except BaseException as exc:  # noqa: BLE001 - the refusal is the subject
+        except RuntimeError as exc:
             return exc
+        except BaseException as exc:  # noqa: BLE001 - the point is to catch a leak
+            raise AssertionError(
+                f"{builder} raised {type(exc).__name__} ({exc}) instead of refusing to build a "
+                f"fleet whose peers are not on the mesh"
+            ) from exc
     raise AssertionError(f"{builder} returned a fleet whose peers are not on the mesh")
 
 
@@ -129,10 +142,8 @@ class TestEachLiveBuilderRefusesAMeshThatDidNotStart:
         module = _load(script)
         peer = expected_peer(module)
 
-        exc = _build_with_no_session(module, builder)
+        message = str(_refusal_from(module, builder))
 
-        message = str(exc)
-        assert isinstance(exc, RuntimeError), f"{builder} raised {type(exc).__name__}: {message}"
         assert "mesh.alive is False" in message, f"the refusal does not name the observable it read: {message}"
         assert peer in message, f"the refusal does not name the peer that failed ({peer!r}): {message}"
         assert "strands-robots[mesh]" in message, f"the refusal does not name the remedy: {message}"
@@ -156,7 +167,7 @@ class TestEachLiveBuilderRefusesAMeshThatDidNotStart:
             built.append(self)
 
         with patch.object(_StubSim, "__init__", record):
-            exc = _build_with_no_session(module, builder)
+            exc = _refusal_from(module, builder)
 
         assert "mesh.alive is False" in str(exc), (
             f"{builder} did not refuse on the alive observable, so this proves nothing about its "
@@ -178,7 +189,7 @@ class TestTheDeliberateOptOutKeepsItsOwnAdvice:
         monkeypatch.setenv("STRANDS_MESH", "false")
         module = _load(script)
 
-        exc = _build_with_no_session(module, builder)
+        exc = _refusal_from(module, builder)
 
         message = str(exc)
         assert "STRANDS_MESH=0" in message, f"the opt-out refusal no longer names the switch: {message}"

--- a/tests/test_examples_refuse_a_mesh_that_did_not_start.py
+++ b/tests/test_examples_refuse_a_mesh_that_did_not_start.py
@@ -1,0 +1,277 @@
+"""A fleet example refuses a mesh that did not start instead of awaiting presence.
+
+``init_mesh`` returns ``None`` only when the mesh is switched off on purpose.
+When the mesh is *enabled* but no session opens -- ``eclipse-zenoh`` absent, or
+any of the other paths on which ``get_session`` yields nothing -- it returns a
+``Mesh`` whose ``alive`` is ``False``.  That peer publishes no presence and
+discovers none, so it is not a slow peer: every wait below it can only expire.
+
+``mesh.alive`` is the documented observable for that state (docs/troubleshooting.md),
+and ``examples/fleet/dashboard.py`` already refuses on it with the remedy named.
+The four live-fleet builders checked only ``is None``, so a dead peer passed the
+guard.  Measured with ``import zenoh`` failing, before this branch:
+
+* 02 built both zones, then died 15 s later in "timed out after 15s waiting for
+  presence discovery of both zone peers" -- a message naming no dependency.
+* 03 and 04 did the same against their own presence waits.
+* 05 has no presence wait at all: every RPC came back ``{'status': 'error',
+  'error': 'mesh not running'}``, so it ran the whole queue, wrote four
+  ``work_order_failed`` / ``work_order_nacked`` events attributing the failure to
+  a per-robot ``dispatch_failed``, printed a plausible audit reconstruction, and
+  **exited 0**.
+
+Two rules here.  The behavioural tests drive each real builder with a session
+that will not open and require an actionable refusal.  The structural rule is
+derived from the builders themselves rather than hand-listed, so a sixth peer
+start is graded on arrival: every function that starts a peer and guards it for
+``None`` must also refuse on ``alive``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_FLEET_DIR = _REPO_ROOT / "examples" / "fleet"
+
+# The peer-starting example scripts.  ``capabilities.py`` starts no peer.
+_PEER_SCRIPTS = (
+    "02_cross_zone_transport.py",
+    "03_failover_and_degraded_ops.py",
+    "04_emergency_evacuation.py",
+    "05_work_order_dispatch.py",
+    "dashboard.py",
+)
+
+# The live-fleet builders, with the peer each one starts first.  ``peer`` is read
+# off the loaded module so a renamed constant updates the expectation with it.
+_BUILDERS = (
+    ("02_cross_zone_transport.py", "_build_live_zones", lambda m: next(iter(m.ZONES))),
+    ("03_failover_and_degraded_ops.py", "_build_live_fleet", lambda m: next(iter(m.ROBOT_EMBODIMENT))),
+    ("04_emergency_evacuation.py", "_build_live_world", lambda m: m.FLEET_PEER_ID),
+    ("05_work_order_dispatch.py", "_build_live_transport", lambda m: "fleet-sites"),
+)
+
+
+class _StubSim:
+    """World construction always succeeds; the mesh is what is under test.
+
+    Only the calls the builders make are answered, so an unexpected one fails
+    loudly rather than being absorbed by a catch-all.
+    """
+
+    tool_name_str = "stub-sim"
+
+    def __init__(self) -> None:
+        self.mesh: Any = None
+        self.peer_id: str | None = None
+        self.destroyed = 0
+
+    def _ok(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    create_world = add_robot = add_object = add_camera = start_policy = stop_policy = _ok
+
+    def destroy(self) -> None:
+        self.destroyed += 1
+
+
+def _load(filename: str) -> Any:
+    """Import a fleet example as a module, as the example tests do."""
+    name = f"_fleet_example_{filename.split('_')[0]}"
+    spec = importlib.util.spec_from_file_location(name, _FLEET_DIR / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def fleet_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mesh enabled, audit confined, world construction stubbed out.
+
+    The suite sets ``STRANDS_MESH=false`` process-wide so tests never touch a
+    real mesh, and that kill switch makes ``init_mesh`` return ``None`` before it
+    reaches a session -- the deliberate-opt-out branch, not the one under test.
+    """
+    monkeypatch.delenv("STRANDS_MESH", raising=False)
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path / "audit"))
+    monkeypatch.setenv("STRANDS_MESH_LOCAL_DEV", "1")
+    monkeypatch.syspath_prepend(str(_FLEET_DIR))
+    monkeypatch.setattr("strands_robots.simulation.Simulation", _StubSim)
+
+
+def _build_with_no_session(module: Any, builder: str) -> BaseException:
+    """Run one builder with no session available; return what it raised."""
+    with patch("strands_robots.mesh.core.get_session", return_value=None):
+        try:
+            getattr(module, builder)()
+        except BaseException as exc:  # noqa: BLE001 - the refusal is the subject
+            return exc
+    raise AssertionError(f"{builder} returned a fleet whose peers are not on the mesh")
+
+
+class TestEachLiveBuilderRefusesAMeshThatDidNotStart:
+    """The refusal happens where the cause is known, not at the next wait."""
+
+    @pytest.mark.parametrize(("script", "builder", "expected_peer"), _BUILDERS, ids=[b[1] for b in _BUILDERS])
+    def test_the_builder_refuses_and_names_the_remedy(
+        self, script: str, builder: str, expected_peer: Any, fleet_env: None
+    ) -> None:
+        module = _load(script)
+        peer = expected_peer(module)
+
+        exc = _build_with_no_session(module, builder)
+
+        message = str(exc)
+        assert isinstance(exc, RuntimeError), f"{builder} raised {type(exc).__name__}: {message}"
+        assert "mesh.alive is False" in message, f"the refusal does not name the observable it read: {message}"
+        assert peer in message, f"the refusal does not name the peer that failed ({peer!r}): {message}"
+        assert "strands-robots[mesh]" in message, f"the refusal does not name the remedy: {message}"
+        assert "--dry-run" in message, f"the refusal does not offer the simulator-free alternative: {message}"
+
+    @pytest.mark.parametrize(("script", "builder", "expected_peer"), _BUILDERS, ids=[b[1] for b in _BUILDERS])
+    def test_the_builder_leaves_no_world_behind(
+        self, script: str, builder: str, expected_peer: Any, fleet_env: None
+    ) -> None:
+        """Refusing mid-construction still tears the sim down.
+
+        The refusal is asserted first so a builder that fails for some other
+        reason reports that, rather than reporting an undestroyed world.
+        """
+        module = _load(script)
+        built: list[_StubSim] = []
+        original = _StubSim.__init__
+
+        def record(self: _StubSim) -> None:
+            original(self)
+            built.append(self)
+
+        with patch.object(_StubSim, "__init__", record):
+            exc = _build_with_no_session(module, builder)
+
+        assert "mesh.alive is False" in str(exc), (
+            f"{builder} did not refuse on the alive observable, so this proves nothing about its "
+            f"cleanup path: {type(exc).__name__}: {exc}"
+        )
+        assert built, "premise: the builder constructed no world, so there is nothing to release"
+        assert all(sim.destroyed for sim in built), (
+            f"{builder} refused but left {sum(not s.destroyed for s in built)} world(s) undestroyed"
+        )
+
+
+class TestTheDeliberateOptOutKeepsItsOwnAdvice:
+    """Mesh switched off on purpose and a mesh that would not start differ."""
+
+    @pytest.mark.parametrize(("script", "builder", "expected_peer"), _BUILDERS, ids=[b[1] for b in _BUILDERS])
+    def test_a_disabled_mesh_still_reports_the_switch(
+        self, script: str, builder: str, expected_peer: Any, fleet_env: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STRANDS_MESH", "false")
+        module = _load(script)
+
+        exc = _build_with_no_session(module, builder)
+
+        message = str(exc)
+        assert "STRANDS_MESH=0" in message, f"the opt-out refusal no longer names the switch: {message}"
+        assert "strands-robots[mesh]" not in message, (
+            f"an install remedy cannot fix a mesh that was switched off on purpose: {message}"
+        )
+
+
+def _peer_starting_functions(tree: ast.AST) -> list[ast.FunctionDef]:
+    """Functions that call ``init_mesh``."""
+    found: list[ast.FunctionDef] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for call in ast.walk(node):
+            if isinstance(call, ast.Call):
+                func = call.func
+                if (func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")) == "init_mesh":
+                    found.append(node)
+                    break
+    return found
+
+
+def _guards_none(fn: ast.FunctionDef) -> bool:
+    """The function compares something against ``None``."""
+    return any(
+        isinstance(node, ast.Compare) and any(isinstance(c, ast.Constant) and c.value is None for c in node.comparators)
+        for node in ast.walk(fn)
+    )
+
+
+def _refuses_on_alive(fn: ast.FunctionDef) -> bool:
+    """The function has an ``if`` that reads ``.alive`` and raises."""
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.If):
+            continue
+        reads_alive = any(isinstance(t, ast.Attribute) and t.attr == "alive" for t in ast.walk(node.test))
+        raises = any(isinstance(b, ast.Raise) for b in ast.walk(node))
+        if reads_alive and raises:
+            return True
+    return False
+
+
+def _unguarded_peer_starts(sources: dict[str, str]) -> list[str]:
+    """``"<script>:<function>"`` for every peer start that only checks ``None``."""
+    offenders = []
+    for name, source in sources.items():
+        for fn in _peer_starting_functions(ast.parse(source)):
+            if _guards_none(fn) and not _refuses_on_alive(fn):
+                offenders.append(f"{name}:{fn.name}")
+    return offenders
+
+
+def _shipped_sources() -> dict[str, str]:
+    return {name: (_FLEET_DIR / name).read_text(encoding="utf-8") for name in _PEER_SCRIPTS}
+
+
+class TestEveryPeerStartRefusesOnAlive:
+    """Derived from the scripts, so a sixth peer start is graded on arrival."""
+
+    def test_no_peer_start_checks_only_none(self) -> None:
+        offenders = _unguarded_peer_starts(_shipped_sources())
+
+        assert offenders == [], (
+            "these start a mesh peer and only check `is None`, so a peer whose mesh did not "
+            f"start passes the guard and the next wait expires instead: {offenders}"
+        )
+
+    def test_the_scan_found_the_peer_starts(self) -> None:
+        """A clean result must mean the rule was applied, not that nothing was read."""
+        counted = sum(len(_peer_starting_functions(ast.parse(src))) for src in _shipped_sources().values())
+
+        assert counted >= len(_BUILDERS) + 1, f"the scan reached only {counted} peer starts across {_PEER_SCRIPTS}"
+
+    def test_the_scan_reports_a_none_only_guard(self) -> None:
+        planted = """
+def _build():
+    mesh = init_mesh(sim, peer_id="a")
+    if mesh is None:
+        raise RuntimeError("mesh is disabled (STRANDS_MESH=0); rerun with --dry-run")
+    return mesh
+"""
+        assert _unguarded_peer_starts({"planted.py": planted}) == ["planted.py:_build"]
+
+    def test_the_scan_accepts_the_dashboard_shape(self) -> None:
+        """The shape the dashboard already ships is what the rule asks for."""
+        clean = """
+def main():
+    mesh = init_mesh(owner, peer_id="d")
+    if mesh is None:
+        raise SystemExit("mesh is disabled (STRANDS_MESH=0)")
+    if not mesh.alive:
+        raise SystemExit('mesh did not start (pip install "strands-robots[mesh]")')
+    return mesh
+"""
+        assert _unguarded_peer_starts({"clean.py": clean}) == []


### PR DESCRIPTION
Closes #2505.

## Problem

`init_mesh` returns `None` **only** when the mesh is switched off on purpose. When the
mesh is enabled but no session opens - `eclipse-zenoh` absent, or any of the other paths
on which `get_session` yields nothing - it returns a `Mesh` whose `alive` is `False`.
That peer publishes no presence and discovers none, so it is not a slow peer: every wait
below it can only expire.

The four live-fleet builders checked only `is None`, so a dead peer passed the guard.
`mesh.alive` is the observable `docs/troubleshooting.md` documents for this state, and
`examples/fleet/dashboard.py` already refuses on it with the remedy named - one of five
peer starts in `examples/fleet/` got it right.

## Measured

With `import zenoh` failing and nothing else changed. Both columns come from one capture
script run against each tree, so the numbers are comparable; a cold process adds ~2.5 s
of world construction to both sides.

| example | `upstream/main` | this branch |
|---|---|---|
| 02 cross-zone | presence wait, **15.84 s**: `timed out after 15s waiting for presence discovery of both zone peers` | builder, **0.49 s**: names peer `'zone-a'`, `mesh.alive is False`, the extra, `--dry-run` |
| 03 failover | presence wait, **15.49 s**: `timed out after 15s waiting for presence discovery of all robots` | builder, **0.34 s**: names peer `'go2-a1'` + remedy |
| 04 evacuation | presence wait, **15.97 s**: `timed out after 15s waiting for presence discovery of the fleet sim peer` | builder, 15.84 s: names peer `'evac-fleet-sim'` + remedy |
| 05 work orders | **not stopped - exit 0** after 0.55 s | builder, 0.63 s: names peer `'fleet-sites'` + remedy |

None of the three timeout messages mentions a dependency.

**05 is the worst case, not the mildest.** It has no presence wait, so every RPC came back
`{'status': 'error', 'error': 'mesh not running'}`, the whole queue ran, and it wrote four
events - three `work_order_failed`, one `work_order_nacked` - whose first reason is
`code='dispatch_failed' robot='so101-a1'`. It then printed a plausible audit
reconstruction, reported `audit integrity: ok=True`, and **exited 0**. An operator reads
that as a fleet that refused every order; automation reads a successful run.

## Change

Each builder checks `mesh.alive` after `init_mesh` returns and refuses, naming the peer,
`mesh.alive`, `pip install "strands-robots[mesh]"` and the `--dry-run` alternative. The
deliberate `STRANDS_MESH=0` guard keeps its own distinct message: an install remedy cannot
fix a switch, so the two states need different advice.

Cleanup is preserved on the new path - 02/03/04 raise inside the existing
`try/except BaseException: cleanup(); raise`, and 05 (which has no such wrapper) repeats
the explicit teardown its neighbouring guards already do.

The test helper that drives those builders returns the refusal itself rather than handing
back whatever it caught, so its own leak-catching clause ends in
`raise AssertionError(...) from exc` - the shape the tree's two other leak-catching test
helpers use, and the shape those `cleanup(); raise` wrappers use. Every refusal here is a
`RuntimeError`, on the `mesh.alive` path and on the opt-out alike, so a builder that raises
anything else is reported where the diagnosis is built instead of being handed back for an
`isinstance` assertion to classify.

## Scope

- **Examples 04 and 05 are included** because the guard was a verbatim copy: the string
  `"mesh is disabled (STRANDS_MESH=0); rerun with --dry-run"` appeared in all four files.
- **04's wall time is essentially unchanged** (15.97 s -> 15.84 s) and the table says so.
  Its refusal is raised ~1.3 s in, but the builder starts five policies before it touches
  the mesh, so tearing those down costs about what the presence wait did. What changes for
  04 is the diagnosis, not the duration.
- **03's mid-run orchestrator restart is guarded too.** It is not only reachable via an
  absent extra: `get_session` has six paths that yield no session, so a restart can return
  a dead peer on a host where zenoh is installed, and the wait below it is the same 15 s
  presence wait. Its message omits `--dry-run` (you cannot switch mid-run), matching the
  distinct message that site already had.
- No library change. The reporting side is already done and quiet-off remains the library
  contract.

## Tests

`tests/test_examples_refuse_a_mesh_that_did_not_start.py`, **9 failed / 7 passed against
`upstream/main`, 16 pass here**.

Behavioural: each real builder is driven with `get_session` returning `None` and must
refuse actionably. World construction is stubbed (only the mesh is under test), which is
why 04's base failure reports `raised AttributeError (...) instead of refusing` rather
than a returned fleet - the end-to-end measurement above covers 04's timeout, and the
structural rule below names it directly.

Structural, derived from the scripts rather than hand-listed so a sixth peer start is
graded on arrival: every function that starts a peer and guards it for `None` must also
refuse on `alive`. On `upstream/main` it reports all five offenders
(`02:_build_live_zones`, `03:_build_live_fleet`, `03:_run_live`, `04:_build_live_world`,
`05:_build_live_transport`); here it reports none. It ships with a non-vacuity test, a
planted `None`-only guard, and a clean control that is the shape `dashboard.py` already
uses.

The 7 tests that pass on both trees are the controls: the `STRANDS_MESH=0` refusal still
names the switch and must not offer an install remedy.

## Verification

78-file selection (every test that reads `examples/`, walks the test tree, names the fleet
examples, `init_mesh` or `BaseException`, plus the repo-wide docs/changelog/docstring/ASCII
guards), re-measured at `e0de1cbc`:

- branch **2275 passed, 0 failed**, 54 skipped
- base `14f49f41` with the new test file copied in: 2266 passed, **9 failed**, 54 skipped
- `2266 + 9 == 2275`, 2329 collected on both, no branch-only failure, and no pre-existing
  failure in the selection
- the same selection on the previously reviewed head reports 2275 passed / 0 failed too, so
  the helper's rewrite changes no verdict anywhere
- `mypy strands_robots tests tests_integ`: 24 == 24 against `main`, none in the changed files
- `ruff check` / `ruff format --check` clean; `scripts/assemble_changelog.py --check` OK

Based on `14f49f41` so the diff is exactly these seven files - `main` is one CI-only
commit ahead.

## Artifact

![fleet examples refuse a mesh that did not start](https://raw.githubusercontent.com/cagataycali/robots/media-fleet-mesh-refusal/fleet-mesh-refusal.png)

Both columns are real program output from the capture script above; the figure asserts its
own headline claims against the captured JSON.

