### PR TITLE
fix(simulation): collect a stop_when name list whatever sequence shape it is spelled as

### DIFF
--- a/changelog.d/2518-stop-when-collects-every-name-list-shape.md
+++ b/changelog.d/2518-stop-when-collects-every-name-list-shape.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **simulation**: collect every name in a `stop_when` clause's `particles` /
+  `containers` kwarg whatever sequence shape it is spelled as. `run_policy` probes a
+  clause's entity names against the live scene before arming it, because a typo'd name
+  compiles clean, degrades to a constant `False`, and lets the rollout burn its whole
+  step budget reporting `stopped_reason="budget"` - what an honest miss reports too.
+  The walker collected the list-valued kwargs only when the value was a `list`, while
+  the pour predicates take their shape contract from `name_list_error`, which accepts
+  any `Sequence` that is not a `str`/`bytes` - the same domain under which
+  `render_all(cameras=("default",))` and `set_robot_state_keys` already accept a tuple.
+  A clause spelling its beads as a tuple therefore compiled, armed, and never probed a
+  single bead name: with one bead misspelled it ran all 200 steps and reported success.
+  The walker now accepts the shapes the factories accept, so both spellings of the same
+  clause reach the same refusal at step 0.

--- a/strands_robots/simulation/benchmark_spec.py
+++ b/strands_robots/simulation/benchmark_spec.py
@@ -67,7 +67,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -316,9 +316,14 @@ def compile_stop_when(stop_when: Any, *, context: str = "stop_when") -> Callable
 # to a constant False at evaluation time, and burn the whole step budget
 # reporting stopped_reason="budget" - indistinguishable from an honest miss.
 _BODY_NAME_KWARGS = frozenset({"body", "body_a", "body_b", "container"})
-# Kwargs that carry a LIST of body names (the particle-proxy pour predicates).
-# Collected element-wise so every particle / container in a stop_when clause is
-# probed against the live sim exactly like a singular body kwarg.
+# Kwargs that carry a SEQUENCE of body names (the particle-proxy pour
+# predicates). Collected element-wise so every particle / container in a
+# stop_when clause is probed against the live sim exactly like a singular body
+# kwarg. The accepted container shape is the one the predicate factories accept
+# - name_list_error's, i.e. any Sequence that is not a str/bytes (a bare string
+# is a name-per-character mistake, not a name list). This walker only ever sees
+# a clause compile_stop_when already accepted, so a shape a factory takes and
+# this misses is a clause whose names are silently never probed.
 _BODY_LIST_KWARGS = frozenset({"particles", "containers"})
 _JOINT_NAME_KWARGS = frozenset({"joint"})
 
@@ -329,8 +334,10 @@ def stop_when_referenced_entities(stop_when: Any) -> tuple[list[str], list[str]]
     Walks the same shapes :func:`compile_stop_when` accepts (a single
     predicate call or an ``all``/``any`` group) and gathers the values of the
     entity-naming kwargs (``body`` / ``body_a`` / ``body_b`` / ``container``
-    for bodies, plus each element of the list-valued ``particles`` /
-    ``containers``, and ``joint`` for joints) so the caller can probe each one
+    for bodies, plus each element of the sequence-valued ``particles`` /
+    ``containers`` - every shape the predicate factories accept for them, which
+    is :func:`~strands_robots.utils.name_list_error`'s domain rather than
+    ``list`` alone - and ``joint`` for joints) so the caller can probe each one
     against the live sim before arming the clause. Geom names
     (``contact_between``) are not collected - there is no generic geom
     lookup on the engine ABC to probe them with.
@@ -355,7 +362,7 @@ def stop_when_referenced_entities(stop_when: Any) -> tuple[list[str], list[str]]
                     bodies.setdefault(value)
                 elif key in _JOINT_NAME_KWARGS:
                     joints.setdefault(value)
-            elif key in _BODY_LIST_KWARGS and isinstance(value, list):
+            elif key in _BODY_LIST_KWARGS and isinstance(value, Sequence) and not isinstance(value, str | bytes):
                 for entry in value:
                     if isinstance(entry, str) and entry:
                         bodies.setdefault(entry)

--- a/tests/simulation/mujoco/test_pour_task_smoke.py
+++ b/tests/simulation/mujoco/test_pour_task_smoke.py
@@ -163,6 +163,48 @@ def test_scripted_pour_flips_the_predicates(sim):
     assert spilled(sim) is False
 
 
+@pytest.mark.parametrize("shape", [list, tuple], ids=["list", "tuple"])
+def test_a_typod_bead_is_refused_before_the_rollout_whatever_the_sequence_shape(tmp_path, shape):
+    """A pour clause naming a bead that is not in the scene is refused at step 0.
+
+    ``run_policy`` probes a ``stop_when`` clause's entity names against the live
+    scene before arming it, because a typo'd name compiles clean and degrades to
+    a constant False: the rollout would run its whole step budget and report
+    ``stopped_reason="budget"``, which is what an honest miss reports too. The
+    bead names reach that probe through the sequence-valued ``particles`` kwarg,
+    so every shape the predicate factory accepts for it has to arrive there -
+    otherwise the spelling of the name list decides whether the typo is caught.
+    """
+    arm = tmp_path / "arm.xml"
+    arm.write_text(ARM_MJCF)
+    engine = create_simulation(backend="mujoco", tool_name="pour_probe", mesh=False)
+    try:
+        assert engine.create_world(ground_plane=True)["status"] == "success"
+        assert engine.add_robot(name="arm", urdf_path=str(arm))["status"] == "success"
+        _build_pour_scene(engine)
+        result = engine.run_policy(
+            robot_name="arm",
+            policy_provider="mock",
+            n_steps=40,
+            control_frequency=50.0,
+            stop_when={
+                "predicate": "particles_inside",
+                "particles": shape([*BEADS, "bead_typo"]),
+                "container": "tray",
+            },
+        )
+        payload = next(c["json"] for c in result["content"] if "json" in c)
+        text = result["content"][0]["text"]
+        assert result["status"] == "error", (
+            f"the clause was armed with an unresolvable bead and the rollout ran anyway: "
+            f"stopped_reason={payload.get('stopped_reason')!r} steps_used={payload.get('steps_used')!r}"
+        )
+        assert "bead_typo" in text, f"the refusal does not name the unresolvable bead: {text}"
+        assert payload["steps_used"] == 0
+    finally:
+        engine.destroy()
+
+
 def test_the_closed_cap_is_a_stable_state(sim):
     """The failure mode this asset choice exists for: the cap must not creep open."""
     _build_pour_scene(sim)

--- a/tests/simulation/test_pour_predicates.py
+++ b/tests/simulation/test_pour_predicates.py
@@ -16,6 +16,7 @@ uses.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -29,6 +30,7 @@ from strands_robots.simulation.predicates import (
     make_predicate,
     predicate_kind,
 )
+from strands_robots.utils import name_list_error
 
 
 class _BodySim:
@@ -186,28 +188,106 @@ class TestParticlesInsideFraction:
             make_predicate("particles_inside_fraction", particles=[], container="tray")
 
 
+class _FrozenNames(Sequence[str]):
+    """A ``Sequence`` that is neither ``list`` nor ``tuple``.
+
+    The shape a caller gets from an immutable name-set wrapper. It is here so
+    the collector is graded against the domain's rule rather than against the
+    two builtin spellings that happen to be easy to type.
+    """
+
+    def __init__(self, *names: str) -> None:
+        self._names = tuple(names)
+
+    def __getitem__(self, index: int) -> str:  # type: ignore[override]
+        return self._names[index]
+
+    def __len__(self) -> int:
+        return len(self._names)
+
+
+# Container shapes a caller can spell a name list as. The verdict on each is
+# name_list_error's - the domain the pour factories delegate their shape
+# contract to - so this table needs no hand-maintained expectation.
+_SHAPE_BUILDERS = {
+    "list": list,
+    "tuple": tuple,
+    "custom-sequence": lambda names: _FrozenNames(*names),
+    "bare-str": "".join,
+    "mapping": lambda names: dict.fromkeys(names),
+    "iterator": iter,
+}
+_SHAPES = [pytest.param(builder, id=name) for name, builder in _SHAPE_BUILDERS.items()]
+
+
 class TestStopWhenCollection:
-    def test_list_kwargs_are_collected_for_probing(self):
+    """Every name in a list-valued kwarg is collected for the pre-rollout probe.
+
+    ``stop_when_referenced_entities`` runs on a clause ``compile_stop_when``
+    has already accepted, so a container shape a predicate factory takes and
+    this walker skips is a clause whose particle names are never probed against
+    the live scene - the silent never-fires the probe exists to turn into an
+    up-front error.
+    """
+
+    @pytest.mark.parametrize("shape", [list, tuple], ids=["list", "tuple"])
+    def test_particles_are_collected_for_probing(self, shape):
         bodies, joints = stop_when_referenced_entities(
             {
                 "predicate": "particles_inside",
-                "particles": ["bead_a", "bead_b"],
+                "particles": shape(["bead_a", "bead_b"]),
                 "container": "tray",
             }
         )
         assert bodies == ["bead_a", "bead_b", "tray"]
         assert joints == []
 
-    def test_containers_list_is_collected(self):
+    @pytest.mark.parametrize("shape", [list, tuple], ids=["list", "tuple"])
+    def test_containers_are_collected(self, shape):
         bodies, _ = stop_when_referenced_entities(
             {
                 "predicate": "particles_spilled",
-                "particles": ["bead_a"],
-                "containers": ["tray", "carton"],
+                "particles": shape(["bead_a"]),
+                "containers": shape(["tray", "carton"]),
                 "max_spilled": 0,
             }
         )
         assert bodies == ["bead_a", "tray", "carton"]
+
+    @pytest.mark.parametrize("builder", _SHAPES)
+    def test_the_collector_collects_exactly_the_shapes_the_factories_accept(self, builder):
+        """The walker and the factories agree on what a name list is.
+
+        The factories delegate their shape contract to ``name_list_error``, so
+        that function is the oracle here rather than a second list of accepted
+        types this test would have to keep in step.
+        """
+        names = ["bead_a", "bead_b"]
+        accepted = name_list_error(builder(names), "particles", "particles_inside") is None
+        bodies, _ = stop_when_referenced_entities(
+            {
+                "predicate": "particles_inside",
+                "particles": builder(names),
+                "container": "tray",
+            }
+        )
+        collected = [b for b in bodies if b != "tray"]
+        if accepted:
+            assert collected == names, (
+                f"the factories accept this shape but the walker collected {collected} from it, "
+                "so its names are never probed against the live scene"
+            )
+        else:
+            assert collected == [], f"the factories refuse this shape yet the walker read {collected} out of it"
+
+    def test_the_shape_table_spans_both_verdicts(self):
+        """Premise: the table above only grades anything if it holds shapes the
+        domain accepts AND shapes it refuses."""
+        verdicts = {
+            name_list_error(builder(["bead_a", "bead_b"]), "particles", "ctx") is None
+            for builder in _SHAPE_BUILDERS.values()
+        }
+        assert verdicts == {True, False}
 
 
 class TestDeclarativeSpecIntegration:


### PR DESCRIPTION
## Problem

`run_policy` probes a `stop_when` clause's entity names against the live scene before arming it. The reason is in the comment above the kwarg tables: a typo'd name compiles clean, degrades to a constant `False` (predicates never raise), and lets the rollout burn its whole step budget reporting `stopped_reason="budget"` - which is what an honest miss reports too.

`stop_when_referenced_entities` collected the sequence-valued `particles` / `containers` kwargs only when the value was a `list`:

```python
elif key in _BODY_LIST_KWARGS and isinstance(value, list):
```

The pour predicates take their shape contract from `name_list_error`, which accepts any `Sequence` that is not a `str`/`bytes`. So a clause spelling its beads as a tuple compiles, arms, and has not one bead name probed. Measured on the bundled pour task, one bead misspelled:

| clause spelling | before | after |
|---|---|---|
| `particles=(...)` tuple, one bead misspelled | ran all 40 steps, reported `success` / `budget`, refusal never mentioned the typo | refused at step 0, names `bead_typo` |
| `particles=[...]` list, one bead misspelled | refused at step 0, names `bead_typo` | unchanged |
| `particles=(...)` tuple, every bead correct | armed, clause fired at step 1 | unchanged |

A tuple is not an exotic spelling on this path: `name_list_error` is the shared domain for every name-list parameter in the package, and under it `render_all(cameras=("default",))` returns one image today and `set_robot_state_keys` accepts a tuple. It is also why `list[str]` is the house annotation for such a parameter - `Policy.set_robot_state_keys(robot_state_keys: list[str])` validates through the same domain.

The walker runs only on a clause `compile_stop_when` has already accepted, so a container shape a factory takes and the walker misses is a clause whose names are silently never probed.

## Change

`stop_when_referenced_entities` now tests the container shape the way the domain does - any `Sequence` that is not a `str`/`bytes` - instead of `list` alone. One line of logic; the walk, the dedup and the singular-kwarg branch are untouched. The comment above `_BODY_LIST_KWARGS` and the function's `Args` now name the accepted shape and why it is that one.

Widening the collector rather than narrowing the factories is the direction that keeps one source of truth: `name_list_error` is shared by ~10 surfaces, so it cannot be narrowed for one caller, and re-checking for `list` inside these three factories would make the pour predicates the only name-list surface in the package that refuses a tuple.

## Tests

`TestStopWhenCollection` gains the shape dimension it was missing - its two existing cases become the `list` half of a parametrized pair - plus a guard that grades the walker against the domain rather than against a second list of accepted types this test would have to keep in step:

```python
accepted = name_list_error(builder(names), "particles", "particles_inside") is None
...
if accepted:
    assert collected == names   # else assert collected == []
```

It runs over `list`, `tuple`, a `Sequence` subclass that is neither, a bare `str`, a `Mapping` and a one-shot iterator, with a premise test that the table spans both verdicts so it cannot go vacuous. A `Sequence` shape added to the domain later is graded without editing this file.

The MuJoCo smoke suite gains the end-to-end consequence: a pour clause naming a bead that is not in the scene is refused at step 0 whichever way the bead list is spelled.

Against `upstream/main` (`6d8b4d3c`): **5 failed / 44 passed**, every failure behavioural -

```
test_particles_are_collected_for_probing[tuple]                          assert ['tray'] == ['bead_a', 'bead_b', 'tray']
test_containers_are_collected[tuple]                                     assert [] == ['bead_a', 'tray', 'carton']
test_the_collector_..._factories_accept[tuple]                           the factories accept this shape but the walker collected []
test_the_collector_..._factories_accept[custom-sequence]                 the factories accept this shape but the walker collected []
test_a_typod_bead_is_refused_...[tuple]                                  the clause was armed ... stopped_reason='budget' steps_used=40
```

49 pass after. The 44 that pass on both trees are the controls: the `list` spelling of every case, and the three shapes the domain refuses staying uncollected - that half fails if the collector is widened too far.

## Verification

Measured at `9a35571`, against `upstream/main` `6d8b4d3c`.

- `tests/simulation` plus every test touching the walker, the pour predicates, `name_list_error` or a name-list surface, and the repo-wide docstring/string/changelog guards - 22 paths, 13061 items: **branch 13061 passed / 0 failed**, base with the new tests copied in **13056 passed / 5 failed**. `13056 + 5 == 13061`, the five are exactly the new tests, no other test changed verdict, and the selection has no pre-existing failures.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24 against a pristine base worktree, none in the changed files.

## Artifact

The pour the clause scores, rendered headless, above what `run_policy` did with each spelling of it. Rows 2 and 3 are byte-identical across the two trees - the figure asserts that from the captured data rather than by eye.

![stop_when name-list shape](https://raw.githubusercontent.com/cagataycali/robots/media-stop-when-name-list-shape/stop_when_name_list_shape.png)

## Scope

Only the container shape changes. The singular body/joint kwargs already tested for exactly what they accept (`str`), the predicate annotations stay `list[str]` to match the house spelling for a parameter validated by this domain, and no factory's accepted set moves.
