### PR TITLE
test(training): a shared-domain guard must see a table-driven read of its field

### DIFF
--- a/changelog.d/2519-shared-domain-scan-table-driven-read.md
+++ b/changelog.d/2519-shared-domain-scan-table-driven-read.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **training**: the four field-scoped shared-domain guards (`_seed_problems`,
+  `_validation_episodes_problems`, `_lora_hyperparameter_problems`,
+  `_launch_topology_problems`) derive their scope from the tree, and now
+  recognize a table-driven read (`getattr(spec, field)` over a tuple of field
+  names) as well as a read by name. A provider that forwards a spec on names no
+  field in an attribute access, so it sat outside all four derived scopes: three
+  guards certified a `readers == {...}` sweep that omitted a real reader, and all
+  four were blind to a backend that forwards a gated field and skips the gate.
+  One shared rule now defines both forms for every guard.

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -239,6 +239,15 @@ class Trainer(ABC):
     NOT reimplement training and do NOT shell out to a subprocess. Multi-GPU is
     driven via torch's programmatic ``elastic_launch`` (the engine behind
     ``torchrun``), still in-process.
+
+    The field-scoped shared domains below (:meth:`_seed_problems` and its
+    siblings) are each obliged of "a backend that reads the field", and a
+    backend reads a field by any means: naming it (``spec.seed``) or forwarding
+    it through a table (``getattr(spec, field)`` over a tuple of field names,
+    which is how a provider that passes a spec on serializes every field
+    without naming any). The second form is a read for this rule exactly as the
+    first is - what obliges the gate is that the value reaches the run, not the
+    syntax that fetched it.
     """
 
     @property

--- a/tests/training/_spec_field_reads.py
+++ b/tests/training/_spec_field_reads.py
@@ -1,0 +1,84 @@
+"""Discovery rule shared by the field-scoped shared-domain guards.
+
+Each shared numeric domain on :class:`~strands_robots.training.base.Trainer`
+(:meth:`~strands_robots.training.base.Trainer._seed_problems` and its siblings)
+documents a biconditional: a backend that *reads* the field MUST route it
+through the gate, and one that ignores the field MUST NOT report on it. The
+guards that pin the first half derive their scope from the tree rather than
+from a list, so that a new backend which starts reading the field fails them
+until it routes through the gate.
+
+That derivation is only as wide as its notion of "reads the field". A backend
+may read a spec field two ways:
+
+* by name, ``spec.seed`` - an :class:`ast.Attribute` on ``spec``; or
+* through a forwarding table, ``getattr(spec, field)`` over a tuple of field
+  names - which is how a transport-only provider serializes every field it
+  passes on without naming any of them in an attribute access.
+
+A rule that recognizes only the first form reports a complete sweep while a
+table-driven reader sits outside it, so the guards' promise ("a new backend
+that starts reading the field fails this test") does not hold for that backend
+and the biconditional goes unenforced for it. :func:`reads_spec_field`
+recognizes both, and is the one place the two forms are defined so the
+field-scoped guards cannot drift apart on what counts as a read.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Collection
+
+
+def _reads_a_field_by_name(tree: ast.AST, fields: Collection[str]) -> bool:
+    """Does *tree* contain ``spec.<field>`` for one of *fields*?"""
+    return any(
+        isinstance(node, ast.Attribute) and node.attr in fields and getattr(node.value, "id", None) == "spec"
+        for node in ast.walk(tree)
+    )
+
+
+def _forwards_spec_fields_by_name(tree: ast.AST) -> bool:
+    """Does *tree* read spec fields through ``getattr(spec, ...)``?
+
+    The marker of a forwarding table: the field being read is a value rather
+    than an attribute name, so no attribute access mentions it.
+    """
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "spec"
+        for node in ast.walk(tree)
+    )
+
+
+def _names_a_field_as_a_string(tree: ast.AST, fields: Collection[str]) -> bool:
+    """Does *tree* carry one of *fields* as a string constant (a table entry)?"""
+    return any(
+        isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in fields
+        for node in ast.walk(tree)
+    )
+
+
+def reads_spec_field(source: str, fields: Collection[str]) -> bool:
+    """Does *source* read any of *fields* off a ``spec``, by either form?
+
+    Args:
+        source: Python source of one backend module.
+        fields: The :class:`~strands_robots.training.base.TrainSpec` field names
+            one shared domain owns.
+
+    Returns:
+        True when the module reads such a field by name (``spec.seed``) or
+        forwards it through a table (``getattr(spec, field)`` over a tuple that
+        names the field). The table form requires both halves, so a module that
+        merely mentions the field name in a message - or one that uses
+        ``getattr(spec, ...)`` for unrelated fields - is not a reader.
+    """
+    tree = ast.parse(source)
+    if _reads_a_field_by_name(tree, fields):
+        return True
+    return _forwards_spec_fields_by_name(tree) and _names_a_field_as_a_string(tree, fields)

--- a/tests/training/test_launch_topology_domain.py
+++ b/tests/training/test_launch_topology_domain.py
@@ -49,6 +49,7 @@ from strands_robots.training.cosmos3 import Cosmos3Trainer
 from strands_robots.training.groot import Gr00tTrainer
 from strands_robots.training.lerobot import LerobotTrainer
 from strands_robots.training.mock import MockTrainer
+from tests.training._spec_field_reads import reads_spec_field
 
 # The two fields, and the backends that launch from them.
 TOPOLOGY_FIELDS = ("num_gpus", "num_nodes")
@@ -240,11 +241,14 @@ def _trainer_modules() -> list[pathlib.Path]:
 
 
 def _reads_a_topology_field(source: str) -> bool:
-    """Does *source* read ``spec.num_gpus`` / ``spec.num_nodes``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr in TOPOLOGY_FIELDS and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read either field, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, TOPOLOGY_FIELDS)
 
 
 def _calls_the_gate(source: str) -> bool:
@@ -262,7 +266,7 @@ class TestOneOwnerForTheLaunchTopologyDomain:
 
     The set of backends in scope is derived from the tree rather than listed:
     a module that *reads* either field must route it through the shared gate, so
-    a fourth backend that starts launching from ``num_gpus`` fails this test
+    a fifth backend that starts launching from ``num_gpus`` fails this test
     until it does.
     """
 
@@ -297,6 +301,17 @@ class TestOneOwnerForTheLaunchTopologyDomain:
     def test_the_scanners_detect_a_planted_defect(self) -> None:
         """A scanner that silently matched nothing would look like a clean tree."""
         planted = "def validate(self, spec):\n    return [] if spec.num_gpus > 1 else []\n"
+        assert _reads_a_topology_field(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards either field by name is a reader too.
+
+        The form a transport-only provider takes: no attribute access mentions
+        either field, so a scan keyed on ``spec.num_gpus`` alone reports a clean
+        sweep while this backend skips the gate.
+        """
+        planted = 'F = ("num_gpus",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in F]\n'
         assert _reads_a_topology_field(planted)
         assert not _calls_the_gate(planted)
 

--- a/tests/training/test_lora_hyperparameter_domain.py
+++ b/tests/training/test_lora_hyperparameter_domain.py
@@ -45,6 +45,7 @@ from strands_robots.training.cosmos3 import Cosmos3Trainer
 from strands_robots.training.groot import Gr00tTrainer
 from strands_robots.training.lerobot import LerobotTrainer
 from strands_robots.training.mock import MockTrainer
+from tests.training._spec_field_reads import reads_spec_field
 
 TOTAL_EPISODES = 10
 
@@ -442,11 +443,14 @@ def _trainer_modules() -> list[pathlib.Path]:
 
 
 def _reads_a_hyperparameter(source: str) -> bool:
-    """Does *source* read ``spec.lora_r`` or ``spec.lora_alpha``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr in FIELDS and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read either field, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, FIELDS)
 
 
 def _calls_the_gate(source: str) -> bool:
@@ -464,14 +468,14 @@ class TestOneOwnerForTheAdapterHyperparameterDomain:
 
     The set of backends in scope is derived from the tree rather than listed: a
     module that *reads* either field must route it through the shared gate, so a
-    second backend that starts building a LoRA adapter fails this test until it
+    third backend that starts building a LoRA adapter fails this test until it
     does.
     """
 
     def test_the_scan_finds_the_backend_that_reads_the_fields(self) -> None:
         """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
         readers = {p.name for p in _trainer_modules() if _reads_a_hyperparameter(p.read_text())}
-        assert readers == {"lerobot.py"}
+        assert readers == {"lerobot.py", "sagemaker.py"}
 
     def test_every_backend_that_reads_them_routes_through_the_shared_gate(self) -> None:
         adrift = sorted(
@@ -493,6 +497,17 @@ class TestOneOwnerForTheAdapterHyperparameterDomain:
     def test_the_scanners_detect_a_planted_defect(self) -> None:
         """A scanner that silently matched nothing would look like a clean tree."""
         planted = "def validate(self, spec):\n    return [] if spec.lora_alpha > 0 else ['bad']\n"
+        assert _reads_a_hyperparameter(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards either field by name is a reader too.
+
+        The form a transport-only provider takes: no attribute access mentions
+        either field, so a scan keyed on ``spec.lora_r`` alone reports a clean
+        sweep while this backend skips the gate.
+        """
+        planted = 'F = ("lora_alpha",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in F]\n'
         assert _reads_a_hyperparameter(planted)
         assert not _calls_the_gate(planted)
 

--- a/tests/training/test_seed_domain.py
+++ b/tests/training/test_seed_domain.py
@@ -1,9 +1,10 @@
 """The reproducibility seed a TrainSpec asks for is one shared non-negative-count domain.
 
 :attr:`~strands_robots.training.base.TrainSpec.seed` is the field a caller sets
-to make a run reproducible, and four backends read it - LeRobot (``cfg.seed`` and
-a ``--seed=`` argv token), Cosmos (a ``trainer.seed=`` Hydra override) and the two
-RL trainers (``torch.manual_seed``). Before this contract none of them checked it,
+to make a run reproducible, and five backends read it - LeRobot (``cfg.seed`` and
+a ``--seed=`` argv token), Cosmos (a ``trainer.seed=`` Hydra override), the two
+RL trainers (``torch.manual_seed``) and SageMaker (a string hyperparameter the
+job's container seeds from). Before this contract none of them checked it,
 and the appliers do not agree about a single value:
 
 * ``torch.manual_seed`` reduces the value modulo ``2**64``, so a negative seed is
@@ -41,6 +42,7 @@ from strands_robots.training.cosmos3 import Cosmos3Trainer
 from strands_robots.training.groot import Gr00tTrainer
 from strands_robots.training.lerobot import LerobotTrainer
 from strands_robots.training.mock import MockTrainer
+from tests.training._spec_field_reads import reads_spec_field
 
 # The backends that seed from the field. The RL trainers are exercised through
 # their own spec type further down (their validate() needs an RLTrainSpec).
@@ -242,11 +244,14 @@ def _trainer_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_seed(source: str) -> bool:
-    """Does *source* read ``spec.seed``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "seed" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.seed``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("seed",))
 
 
 def _calls_the_gate(source: str) -> bool:
@@ -268,7 +273,7 @@ class TestOneOwnerForTheSeedDomain:
     def test_the_scan_finds_the_seeding_backends(self) -> None:
         """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
         readers = {p.name for p in _trainer_modules() if _reads_the_seed(p.read_text())}
-        assert readers == {"cosmos3.py", "lerobot.py", "fast_sac.py", "ppo.py"}
+        assert readers == {"cosmos3.py", "lerobot.py", "fast_sac.py", "ppo.py", "sagemaker.py"}
 
     def test_every_backend_that_seeds_routes_through_the_shared_gate(self) -> None:
         adrift = sorted(
@@ -290,6 +295,17 @@ class TestOneOwnerForTheSeedDomain:
     def test_the_scanners_detect_a_planted_defect(self) -> None:
         """A scanner that silently matched nothing would look like a clean tree."""
         planted = "def validate(self, spec):\n    return [] if spec.seed is None else []\n"
+        assert _reads_the_seed(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards the field by name is a reader too.
+
+        The form a transport-only provider takes: no attribute access mentions
+        the field, so a scan keyed on ``spec.seed`` alone reports a clean sweep
+        while this backend skips the gate.
+        """
+        planted = 'FIELDS = ("seed",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in FIELDS]\n'
         assert _reads_the_seed(planted)
         assert not _calls_the_gate(planted)
 

--- a/tests/training/test_spec_field_read_discovery.py
+++ b/tests/training/test_spec_field_read_discovery.py
@@ -1,0 +1,155 @@
+"""Every field-scoped shared-domain guard sees a table-driven read of its field.
+
+Each shared numeric domain on :class:`~strands_robots.training.base.Trainer`
+documents a biconditional - a backend that reads the field MUST route it
+through the gate, one that ignores it MUST NOT report on it - and the guard for
+each domain pins the first half with a scope *derived from the tree*, so that
+"a new backend that starts reading the field fails this test until it does".
+
+That promise rests entirely on the guard's notion of "reads the field". A
+backend can read a spec field two ways: by name (``spec.seed``) or through a
+forwarding table (``getattr(spec, field)`` over a tuple of field names, which
+is how a transport-only provider serializes every field it passes on). A scan
+keyed on the first form alone certifies a complete sweep while a table-driven
+reader sits outside it, and the biconditional is then unenforced for exactly
+that backend - silently, because the guard reports a clean tree.
+
+This grades the guards from the outside rather than trusting each to grade
+itself: the set of field-scoped guards is discovered structurally, so a new
+domain guard is held to the same rule the moment it lands.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training.base import Trainer
+from strands_robots.training.sagemaker import _FORWARDED_FIELDS
+from tests.training._spec_field_reads import reads_spec_field
+
+# The gates whose scope is a field rather than every backend, mapped to the
+# TrainSpec fields each owns. The learning-rate gate is deliberately absent: no
+# backend may skip it, so its guard scans Trainer subclasses rather than field
+# reads and needs no notion of "reads the field" at all.
+FIELD_SCOPED_GATES: dict[str, tuple[str, ...]] = {
+    "_seed_problems": ("seed",),
+    "_validation_episodes_problems": ("val_episodes",),
+    "_lora_hyperparameter_problems": ("lora_r", "lora_alpha"),
+    "_launch_topology_problems": ("num_gpus", "num_nodes"),
+}
+
+
+def _guard_modules() -> dict[str, Any]:
+    """The field-scoped domain guards, discovered by structure not by name.
+
+    A guard qualifies when it scans the backend tree (``_trainer_modules``),
+    tests membership of one gate (``_calls_the_gate``) and derives its scope
+    from a reader scan (a ``_reads...`` helper). Discovering them rather than
+    listing them means a new domain guard is held to this rule on arrival.
+    """
+    here = pathlib.Path(__file__).parent
+    guards: dict[str, Any] = {}
+    for path in sorted(here.glob("test_*_domain.py")):
+        source = path.read_text()
+        names = {node.name for node in ast.parse(source).body if isinstance(node, ast.FunctionDef)}
+        readers = sorted(n for n in names if n.startswith("_reads"))
+        if not readers or "_trainer_modules" not in names or "_calls_the_gate" not in names:
+            continue
+        guards[path.name] = importlib.import_module(f"tests.training.{path.stem}")
+    return guards
+
+
+def _reader_helper(module: Any) -> Any:
+    """The single ``_reads...`` helper a field-scoped guard derives its scope from."""
+    helpers = [
+        getattr(module, name) for name in dir(module) if name.startswith("_reads") and callable(getattr(module, name))
+    ]
+    assert len(helpers) == 1, f"{module.__name__} has {len(helpers)} reader helpers"
+    return helpers[0]
+
+
+def _table_driven_reader(field: str) -> str:
+    """A backend that reads *field* only through a forwarding table."""
+    return f'FIELDS = ("{field}",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in FIELDS]\n'
+
+
+class TestEveryFieldScopedGuardSeesBothFormsOfARead:
+    """The headline: a reader scan must recognize a table-driven read."""
+
+    def test_the_scan_finds_the_field_scoped_guards(self) -> None:
+        """Non-vacuity: a scan that matched nothing would grade nothing."""
+        assert set(_guard_modules()) == {
+            "test_launch_topology_domain.py",
+            "test_lora_hyperparameter_domain.py",
+            "test_seed_domain.py",
+            "test_validation_episodes_domain.py",
+        }
+
+    @pytest.mark.parametrize("guard_name", sorted(_guard_modules()))
+    def test_it_sees_a_table_driven_read(self, guard_name: str) -> None:
+        module = _guard_modules()[guard_name]
+        reads = _reader_helper(module)
+        gate = next(g for g in FIELD_SCOPED_GATES if any(g in line for line in inspect.getsource(module).splitlines()))
+        for field in FIELD_SCOPED_GATES[gate]:
+            assert reads(_table_driven_reader(field)), (
+                f"{guard_name} does not see a table-driven read of spec.{field}, "
+                "so a backend that forwards the field by name is outside its derived scope"
+            )
+
+    @pytest.mark.parametrize("guard_name", sorted(_guard_modules()))
+    def test_it_still_sees_a_read_by_name(self, guard_name: str) -> None:
+        """The form it already recognized must keep being recognized."""
+        module = _guard_modules()[guard_name]
+        reads = _reader_helper(module)
+        gate = next(g for g in FIELD_SCOPED_GATES if any(g in line for line in inspect.getsource(module).splitlines()))
+        for field in FIELD_SCOPED_GATES[gate]:
+            assert reads(f"def validate(self, spec):\n    return [spec.{field}]\n")
+
+
+class TestTheForwardingProviderIsInScopeForEveryGateItReads:
+    """The reader the literal-only scans could not see, on the real tree."""
+
+    @pytest.mark.parametrize(("gate", "fields"), sorted(FIELD_SCOPED_GATES.items()))
+    def test_it_is_discovered_as_a_reader(self, gate: str, fields: tuple[str, ...]) -> None:
+        source = pathlib.Path(inspect.getfile(Trainer)).parent.joinpath("sagemaker.py").read_text()
+        forwarded = [f for f in fields if f in _FORWARDED_FIELDS]
+        assert forwarded, f"{gate}'s fields are no longer forwarded: {fields}"
+        assert reads_spec_field(source, forwarded)
+
+    @pytest.mark.parametrize(("gate", "fields"), sorted(FIELD_SCOPED_GATES.items()))
+    def test_it_routes_that_read_through_the_shared_gate(self, gate: str, fields: tuple[str, ...]) -> None:
+        """Being in scope is only useful if the gate is then enforced on it."""
+        source = pathlib.Path(inspect.getfile(Trainer)).parent.joinpath("sagemaker.py").read_text()
+        calls = {
+            node.func.attr
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert gate in calls, f"sagemaker.py forwards {fields} without calling {gate}"
+
+
+class TestTheSharedRuleIsPrecise:
+    """Both halves of the table form are required, so the rule cannot over-reach."""
+
+    def test_a_field_name_in_a_string_alone_is_not_a_read(self) -> None:
+        """A message or a docstring naming the field reads nothing."""
+        source = 'def validate(self, spec):\n    return ["seed must be positive"]\n'
+        assert not reads_spec_field(source, ("seed",))
+
+    def test_a_getattr_on_spec_for_other_fields_is_not_a_read(self) -> None:
+        """Forwarding a table that does not contain the field reads nothing."""
+        source = 'FIELDS = ("steps",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in FIELDS]\n'
+        assert not reads_spec_field(source, ("seed",))
+
+    def test_a_getattr_on_something_else_is_not_a_read(self) -> None:
+        source = 'def validate(self, spec):\n    return [getattr(self, "seed")]\n'
+        assert not reads_spec_field(source, ("seed",))
+
+    def test_an_unrelated_module_reads_nothing(self) -> None:
+        assert not reads_spec_field("x = 1\n", ("seed",))

--- a/tests/training/test_validation_episodes_domain.py
+++ b/tests/training/test_validation_episodes_domain.py
@@ -49,6 +49,7 @@ from strands_robots.training.groot import Gr00tTrainer
 from strands_robots.training.lerobot import LerobotTrainer
 from strands_robots.training.mock import MockTrainer
 from strands_robots.utils import validation_split_fraction
+from tests.training._spec_field_reads import reads_spec_field
 
 TOTAL_EPISODES = 10
 
@@ -428,11 +429,14 @@ def _trainer_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_count(source: str) -> bool:
-    """Does *source* read ``spec.val_episodes``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "val_episodes" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.val_episodes``, by name or through a table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("val_episodes",))
 
 
 def _calls_the_gate(source: str) -> bool:
@@ -450,14 +454,14 @@ class TestOneOwnerForTheValidationEpisodesDomain:
 
     The set of backends in scope is derived from the tree rather than listed: a
     module that *reads* ``spec.val_episodes`` must route it through the shared
-    gate, so a second backend that starts reserving a validation set fails this
+    gate, so a third backend that starts reserving a validation set fails this
     test until it does.
     """
 
     def test_the_scan_finds_the_backend_that_reads_the_field(self) -> None:
         """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
         readers = {p.name for p in _trainer_modules() if _reads_the_count(p.read_text())}
-        assert readers == {"lerobot.py"}
+        assert readers == {"lerobot.py", "sagemaker.py"}
 
     def test_every_backend_that_reads_it_routes_through_the_shared_gate(self) -> None:
         adrift = sorted(
@@ -479,6 +483,17 @@ class TestOneOwnerForTheValidationEpisodesDomain:
     def test_the_scanners_detect_a_planted_defect(self) -> None:
         """A scanner that silently matched nothing would look like a clean tree."""
         planted = "def validate(self, spec):\n    return [] if spec.val_episodes is None else []\n"
+        assert _reads_the_count(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards the field by name is a reader too.
+
+        The form a transport-only provider takes: no attribute access mentions
+        the field, so a scan keyed on ``spec.val_episodes`` alone reports a clean
+        sweep while this backend skips the gate.
+        """
+        planted = 'F = ("val_episodes",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in F]\n'
         assert _reads_the_count(planted)
         assert not _calls_the_gate(planted)
 


### PR DESCRIPTION
## Problem

Four of the shared numeric domains on `Trainer` are scoped to a **field** rather than to every backend: `_seed_problems`, `_validation_episodes_problems`, `_lora_hyperparameter_problems`, `_launch_topology_problems`. Each states a biconditional - a backend that *reads* the field MUST route it through the gate, one that ignores it MUST NOT report on it - and each guard derives its scope from the tree rather than from a list, precisely so that:

> "The set of backends in scope is derived from the tree rather than listed: a module that *reads* `spec.seed` must route it through the shared gate, so **a fifth backend that starts seeding from the field fails this test until it does**."

That promise is only as wide as the guard's notion of "reads the field", and all four scan for a literal `spec.<field>` attribute access. A provider that **passes a spec on** rather than consuming it reads every field through a forwarding table - `getattr(spec, field)` over a tuple of names - and names none of them in an attribute access. It is therefore outside all four derived scopes, and the guards report a clean, complete tree while saying nothing about it.

Measured on the backend tree:

| gate | `readers` the shipped scan reports | the field-forwarding reader | sees a planted table-driven reader |
|---|---|---|---|
| `_seed_problems` | `cosmos3, fast_sac, lerobot, ppo` | **missing** | **no** |
| `_validation_episodes_problems` | `lerobot` | **missing** | **no** |
| `_lora_hyperparameter_problems` | `lerobot` | **missing** | **no** |
| `_launch_topology_problems` | `cosmos3, groot, lerobot, sagemaker` | present | **no** |

Three guards assert a `readers == {...}` non-vacuity set that does not contain a real reader of the field, so the assertion certifies a sweep it has not made. The fourth sees the module only *incidentally* - through an `int(spec.num_nodes)` in its request builder - so its scope is accidental rather than derived, and it is equally blind to the form: a planted backend that forwards the field by name and skips the gate is invisible to all four.

The consequence is not a wrong verdict today - the forwarding provider already calls all four gates. It is that the enforcement is off for that shape of backend: a further field added to its forwarding table, or a second provider of the same shape, would skip a shared domain with every guard green.

## Change

`tests/training/_spec_field_reads.py` holds one `reads_spec_field(source, fields)` rule that recognizes both forms, so the four guards cannot drift apart on what counts as a read. The table form requires **both** halves - a `getattr(spec, ...)` read AND the field named as a string constant - so a module that merely mentions the field in a message, or forwards a table that does not contain it, is not a reader. Measured over the backend tree the rule adds exactly one module and no others (the module that *defines* the gates is already excluded by each guard, derived from the gate itself).

The four guards delegate their reader scan to it; their `readers ==` sets gain the reader they were missing; and each gains a planted **table-driven** defect beside the planted read-by-name one it already had.

`tests/training/test_spec_field_read_discovery.py` grades the guards from the outside rather than trusting each to grade itself. The set of field-scoped guards is **discovered structurally** (a guard that scans the backend tree, tests membership of one gate, and derives its scope from a reader helper), so a new domain guard is held to the same rule the moment it lands. The learning-rate gate is deliberately out of scope and the reason is stated: no backend may skip it, so its guard scans `Trainer` subclasses rather than field reads and needs no notion of "reads the field" at all.

The `Trainer` docstring states the rule the gates are read against: a backend reads a field by any means, and what obliges the gate is that the value reaches the run, not the syntax that fetched it.

## Tests

Pre-fix, against the **shipped** guards (the new file grades them from outside, so it needs no change to them to fail): **4 failed / 17 passed**, one per guard, each naming the guard and the field:

```
FAILED ...::test_it_sees_a_table_driven_read[test_seed_domain.py] - AssertionError:
  test_seed_domain.py does not see a table-driven read of spec.seed, so a backend
  that forwards the field by name is outside its derived scope
```

The 17 that pass pre-fix are the controls, and each fails for a specific wrong fix: every guard must **keep** seeing a read by name (a rule that only recognized the table form would pass the headline and break the scope that already worked); a field name in a string alone is not a read; a `getattr(spec, ...)` over a table that lacks the field is not a read; a `getattr` on something other than `spec` is not a read. Two more pin that being in scope is only useful if the gate is then enforced, so the provider must both be discovered *and* call each gate.

## Verification

Measured at `a84cdfa0`, `/tmp` worktrees of `upstream/main`, 122-file selection (all of `tests/training` plus every guard that walks the test tree and the repo-wide docs/changelog/docstring guards), run in parallel:

- branch **3 failed / 4682 passed / 58 skipped**, base **7 failed / 4674 passed / 58 skipped**; both totals reconcile (`7-3 = 4` = the pre-fix failures, `4682-4674 = 8` = those 4 plus the 4 new planted-defect tests).
- branch-only failures: **none**. The 3 shared failures are pre-existing locally (`draccus 0.8.0` against lerobot's `>=0.11.6` floor in `test_lerobot.py::TestInProcessTrainerCorrectness` and `test_lerobot_e2e.py`).
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` **24 == 24** against a pristine `upstream/main` worktree, none in the changed files.

![discovery matrix](https://raw.githubusercontent.com/cagataycali/robots/media-shared-domain-table-read/spec-field-read-discovery.png)

Both panels are produced by one script that imports each tree's **own** guard helpers and runs them against the real backend tree; only the guards differ. The bottom row is the derived scope each tree computes. The topology row is the counter-evidence: it already listed the provider, and it was blind to the form all the same.
