### PR TITLE
fix(tools): name the step that fits a train result, not a load of an absent artifact

### DIFF
--- a/changelog.d/2521-train-report-next-step.md
+++ b/changelog.d/2521-train-report-next-step.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tools/train_policy**: `action="train"` names the step that fits the result it got instead of always naming a checkpoint load. A run with no artifact - a `running` result from the managed-job backend, or a `success` result whose `latest_checkpoint` found nothing - was reported with `Load the result with: create_policy('None')`, which raises `Unknown policy provider: 'None'`. An unfinished run now names the `status` poll for its `job_id`; the tool-level status and the run status in the `{"json": ...}` block are unchanged.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -122,6 +122,16 @@ agent("Record 50 cube-pick episodes, then post-tune lerobot ACT on the dataset "
 
 `train_policy` actions: `train`, `validate`, `status`, `export`, `list`.
 
+`train` reports the step that fits the run it got. A finished run names the
+checkpoint to load; a run that has not finished - the managed-job backend
+whose job outlives the submitting process, which returns `running` once its
+local poll budget expires - names the `status` poll for its `job_id` instead,
+and a run that wrote no discoverable checkpoint says so. The tool never offers
+`create_policy(<checkpoint_dir>)` for a result whose `checkpoint_dir` is
+`None`, because that renders as `create_policy('None')` and raises
+`Unknown policy provider: 'None'`. The run's own status always travels verbatim
+in the result's `{"json": ...}` block.
+
 ## Provider-specific knobs
 
 ### LeRobot (`lerobot_local`)

--- a/strands_robots/tools/train_policy.py
+++ b/strands_robots/tools/train_policy.py
@@ -44,6 +44,37 @@ def _err(text: str) -> dict[str, Any]:
     return {"status": "error", "content": [{"text": text}]}
 
 
+def _next_step_after_train(provider: str, res: Any) -> str:
+    """Name the step that fits a train result, never a load of an absent artifact.
+
+    A non-error ``train`` result does not always carry a loadable checkpoint.
+    ``status="running"`` is the backend whose job outlives the submitting
+    process reporting that the job is still going (the SageMaker provider
+    returns it when its local poll budget expires, pollable by ``job_id``), and
+    even ``status="success"`` carries whatever
+    :meth:`~strands_robots.training.base.Trainer.latest_checkpoint` found -
+    which is ``None`` when the run wrote no discoverable checkpoint tree.
+
+    Interpolating that value into a load instruction prints the ``None``
+    sentinel and sends the caller to ``create_policy('None')``, which raises
+    ``Unknown policy provider: 'None'`` - the dead end
+    ``docs/training/overview.md`` warns about when it notes that an unchecked
+    call "hands whatever consumes ``checkpoint_dir`` a ``None`` instead". So the
+    load instruction is named only when there is an artifact to load; a run that
+    has not finished gets the step that does apply, which is polling it through
+    this same tool's ``status`` action.
+    """
+    if res.status == "running":
+        unfinished = "The run has not finished, so there is no artifact to load yet."
+        if not res.job_id:
+            return unfinished
+        poll = f"train_policy(action='status', provider='{provider}', job_id='{res.job_id}')"
+        return f"{unfinished}\nPoll it with: {poll}"
+    if res.checkpoint_dir:
+        return f"Load the result with: create_policy('{res.checkpoint_dir}')"
+    return "The run finished but reported no checkpoint path, so there is nothing to load yet."
+
+
 @tool
 def train_policy(
     action: str = "train",
@@ -274,7 +305,7 @@ def train_policy(
                             f"job_id: {res.job_id}\n"
                             f"checkpoint_dir: {res.checkpoint_dir}\n"
                             f"metrics: {res.metrics}\n"
-                            f"Load the result with: create_policy('{res.checkpoint_dir}')"
+                            f"{_next_step_after_train(provider, res)}"
                         )
                     },
                     {

--- a/tests/tools/test_train_policy.py
+++ b/tests/tools/test_train_policy.py
@@ -21,6 +21,9 @@ Covered contracts:
   stub and returns a loadable artifact path.
 * The tool boundary never raises: an unknown provider is reported as a
   structured error, not an exception.
+* A non-error ``train`` result is not always a loadable one: a ``running`` run
+  and a ``success`` run that wrote no checkpoint are both reported with the step
+  that applies to them, never with the completed-run load instruction.
 """
 
 from __future__ import annotations
@@ -251,3 +254,154 @@ def test_backend_training_failure_is_shaped_as_error(tmp_path: Path) -> None:
     text = result["content"][0]["text"]
     assert "training failed" in text
     assert "cuda OOM" in text
+
+
+# --------------------------------------------------------------------------
+# train: a non-error result is not always a loadable one
+# --------------------------------------------------------------------------
+# ``train`` returns three statuses, not two. Its sibling above pins that an
+# ``error`` run is never shaped as a success; these pin the other non-success
+# status. A ``running`` result is the managed-job backend reporting that the job
+# outlived the submitting process (``SagemakerTrainer.train`` returns it when
+# its local poll budget expires - pinned by
+# ``test_exhausted_poll_budget_reports_running_not_success``), and a ``success``
+# result carries whatever ``latest_checkpoint`` found, which is ``None`` when
+# the run wrote no discoverable checkpoint tree (``LerobotTrainer.train`` passes
+# that value straight through). Neither has an artifact to load, so neither may
+# be reported with the completed-run load instruction.
+_RUNNING_JOB_ID = "strands-train-abc123"
+
+
+def _register_trainer_returning(name: str, result: Any) -> None:
+    """Register a trainer whose ``train`` returns exactly ``result``."""
+    from strands_robots.training import register_trainer
+    from strands_robots.training.mock import MockTrainer
+
+    class _FixedResultTrainer(MockTrainer):
+        @property
+        def provider_name(self) -> str:
+            return name
+
+        def validate(self, spec: Any) -> list[str]:  # passes preflight
+            return []
+
+        def train(self, spec: Any) -> Any:
+            return result
+
+        def status(self, job_id: str) -> Any:
+            return result
+
+    register_trainer(name, lambda: _FixedResultTrainer)
+
+
+def _running_result() -> Any:
+    from strands_robots.training.base import TrainResult
+
+    return TrainResult(
+        status="running",
+        job_id=_RUNNING_JOB_ID,
+        checkpoint_dir=None,
+        metrics={"sagemaker_status": "InProgress"},
+        message=f"training job '{_RUNNING_JOB_ID}' is still running after the local poll budget",
+    )
+
+
+def _train_text(tmp_path: Path, provider: str) -> tuple[dict[str, Any], str]:
+    kwargs = _valid_kwargs(tmp_path)
+    kwargs["provider"] = provider
+    result = train_policy(action="train", **kwargs)
+    _assert_canonical(result)
+    return result, result["content"][0]["text"]
+
+
+def test_the_load_instruction_names_a_provider_create_policy_refuses() -> None:
+    """Premise: the value an artifact-less result interpolates is a dead end.
+
+    Passes on both sides of the fix - it is a property of ``create_policy``, and
+    it is what makes naming ``checkpoint_dir`` unconditionally a defect rather
+    than a wording preference.
+    """
+    import pytest
+
+    from strands_robots.policies import create_policy
+
+    with pytest.raises(ValueError, match="Unknown policy provider"):
+        create_policy(str(None))
+
+
+def test_a_still_running_run_is_not_offered_as_a_loadable_checkpoint(tmp_path: Path) -> None:
+    _register_trainer_returning("mock_running", _running_result())
+    _, text = _train_text(tmp_path, "mock_running")
+    assert "create_policy(" not in text, (
+        "a run that has not finished has no artifact, but the report offered one: " + text
+    )
+    assert "has not finished" in text
+
+
+def test_a_still_running_run_names_the_poll_step_for_its_job(tmp_path: Path) -> None:
+    _register_trainer_returning("mock_running_poll", _running_result())
+    _, text = _train_text(tmp_path, "mock_running_poll")
+    assert "action='status'" in text and _RUNNING_JOB_ID in text, (
+        "the result carries a job_id this tool's status action polls; the report must name it: " + text
+    )
+
+
+def test_the_poll_step_a_running_run_names_is_one_this_tool_answers(tmp_path: Path) -> None:
+    """Follow the offered remedy verbatim - it must not be a second dead end."""
+    import re
+
+    _register_trainer_returning("mock_running_followed", _running_result())
+    _, text = _train_text(tmp_path, "mock_running_followed")
+    offered = re.search(r"train_policy\(action='status', provider='([^']+)', job_id='([^']+)'\)", text)
+    assert offered is not None, f"no runnable poll step in: {text}"
+    polled = train_policy(action="status", provider=offered.group(1), job_id=offered.group(2))
+    _assert_canonical(polled)
+    assert polled["status"] == "success", polled
+    assert _json_block(polled)["status"] == "running"
+
+
+def test_a_success_without_a_checkpoint_is_not_offered_as_a_loadable_one(tmp_path: Path) -> None:
+    from strands_robots.training.base import TrainResult
+
+    _register_trainer_returning(
+        "mock_no_ckpt",
+        TrainResult(status="success", job_id="j1", checkpoint_dir=None, message="run complete"),
+    )
+    _, text = _train_text(tmp_path, "mock_no_ckpt")
+    assert "create_policy(" not in text, "no checkpoint was written, but a load was offered: " + text
+    assert "no checkpoint path" in text
+
+
+def test_a_completed_run_with_a_checkpoint_still_names_the_load(tmp_path: Path) -> None:
+    """Control: the reported-completed path is unchanged."""
+    from strands_robots.training.base import TrainResult
+
+    _register_trainer_returning(
+        "mock_done",
+        TrainResult(
+            status="success",
+            job_id="j2",
+            checkpoint_dir="/tmp/ft/checkpoints/last/pretrained_model",
+            message="run complete",
+        ),
+    )
+    _, text = _train_text(tmp_path, "mock_done")
+    assert "Load the result with: create_policy('/tmp/ft/checkpoints/last/pretrained_model')" in text
+
+
+def test_the_run_status_is_reported_verbatim_whatever_the_next_step(tmp_path: Path) -> None:
+    """Control: only the next-step line is state-dependent.
+
+    The tool-level ``status`` stays ``success`` for a submitted-but-unfinished
+    run - the action is documented as "validate + launch training", and the
+    sibling ``status`` action likewise maps a running job onto a successful poll
+    - and the run's own status travels verbatim in the json block. Changing that
+    vocabulary is a separate contract; this pins that this fix does not.
+    """
+    _register_trainer_returning("mock_running_status", _running_result())
+    result, _ = _train_text(tmp_path, "mock_running_status")
+    assert result["status"] == "success"
+    payload = _json_block(result)
+    assert payload["status"] == "running"
+    assert payload["checkpoint_dir"] is None
+    assert payload["job_id"] == _RUNNING_JOB_ID


### PR DESCRIPTION
## Problem

`train_policy(action="train")` rendered the completed-run report for **every** non-error
result, so a run with no artifact was reported as a loadable one.

`TrainResult` documents three statuses (`"success" | "running" | "error"`), and two of them
arrive without a checkpoint:

* `running` is the managed-job backend reporting that its job outlived the submitting
  process. `SagemakerTrainer.train` returns it when the local poll budget expires - pinned
  by `test_exhausted_poll_budget_reports_running_not_success`.
* even `success` carries whatever `Trainer.latest_checkpoint` found, which is `None` when the
  run wrote no discoverable checkpoint tree. `LerobotTrainer.train` passes that value
  straight through (`checkpoint_dir=self.latest_checkpoint(spec.output_dir)`), so the default
  provider reaches it too.

Both were reported with the completed-run load instruction, which interpolates the `None`
sentinel:

```
[sagemaker] SageMaker training job 'strands-train-7f3c1a' still running after the 600s local poll budget
job_id: strands-train-7f3c1a
checkpoint_dir: None
metrics: {'sagemaker_status': 'InProgress', 'secondary_status': 'Training'}
Load the result with: create_policy('None')
```

Following that instruction is a measured dead end:

```
>>> create_policy("None")
ValueError: Unknown policy provider: 'None'. Available: ['cosmos3', 'curobo', 'groot', ...]
```

This is the failure `docs/training/overview.md` already warns about - "An unchecked call
hands whatever consumes `checkpoint_dir` a `None` instead" - and the tool was the in-tree
consumer doing it. Meanwhile the result carries the `job_id` this same tool's `status`
action reads, and that step was never named, so the one line an agent acts on pointed at a
provider that does not exist instead of at the poll that does.

The tool already describes an unfinished run correctly on its other path: `action="status"`
emits no load instruction for the same `running` result. The two paths of one tool disagreed
about what a running job means.

## Change

`train` now names the step that fits the result it got:

| result | next step named |
|---|---|
| `success` with a checkpoint | `Load the result with: create_policy('<checkpoint_dir>')` (unchanged) |
| `running` | `The run has not finished ... Poll it with: train_policy(action='status', provider='<p>', job_id='<id>')` |
| `success`, no checkpoint | `The run finished but reported no checkpoint path, so there is nothing to load yet.` |

A private `_next_step_after_train` holds the rule so the three renderings cannot drift, and
its docstring records why the load line is conditional.

**Out of scope, deliberately:** the tool-level `status` key still reports `success` for a
submitted-but-unfinished run. The action is documented as "validate + **launch** training",
and the sibling `action="status"` path likewise maps a running job onto a successful poll
(`"success" if res.status != "error"`). Changing that vocabulary is a separate contract; a
control test pins that this change does not.

## Verification

Measured at `592ee784`.

Pre-fix split - the new tests copied onto `upstream/main` (`db955ff0`): **4 failed / 17
passed**, every failure behavioural and naming the offender:

```
AssertionError: a run that has not finished has no artifact, but the report offered one:
  ... Load the result with: create_policy('None')
AssertionError: no runnable poll step in: ... Load the result with: create_policy('None')
AssertionError: no checkpoint was written, but a load was offered: ... create_policy('None')
```

After the fix: **21 passed**.

Four of the tests pass on both sides and are the boundary:

* the value an artifact-less result interpolates really is a provider `create_policy` refuses
  (the premise that makes this a defect rather than a wording preference);
* a completed run with a checkpoint still names `create_policy('<dir>')` verbatim;
* the run's own status and `checkpoint_dir` still travel verbatim in the `{"json": ...}`
  block, and the tool-level status is still `success`;
* the offered poll step is followed verbatim and answered by this same tool - so the new
  remedy is not a second dead end.

Local gate, 115 test files (everything naming `train_policy` / `TrainResult` /
`checkpoint_dir` / a trainer factory, all of `tests/training` and `tests/tools`, plus the
repo-wide docstring / xref / ASCII / changelog guards), both trees run in lockstep
(217.6 s each):

| | failed | passed | collected |
|---|---|---|---|
| this branch | 3 | 5617 | 5620 |
| `upstream/main` + the new tests | 7 | 5613 | 5620 |

Branch-only failures: **none**. The 4 base-only ids are exactly the pre-fix failures above.
The 3 shared failures are pre-existing and environmental (`tests/training/test_lerobot*.py`
needs `draccus>=0.11.6`; this box resolves 0.8.0).

`ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` = 24
pre-existing errors on both trees, none in the changed files.

## Report, before and after

Same request, same still-running job, same `checkpoint_dir: None`. The capture script parses
whatever next step each tree offers out of the report and **follows it verbatim**, so the
bottom line of each panel is what an agent obeying that report actually gets.

![train_policy next-step report](https://raw.githubusercontent.com/cagataycali/robots/media-train-next-step/train_next_step.png)

The completed-run report is byte-identical between the two trees - only the artifact-less
case changes.
