### PR TITLE
fix(examples/fleet): classify a --serve-web bind by address class, not by equality with the default

### DIFF
--- a/changelog.d/2524-dashboard-loopback-bind-class.md
+++ b/changelog.d/2524-dashboard-loopback-bind-class.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **examples/fleet**: the `--serve-web` startup message classifies the bind
+  address by class rather than by equality with the default, so any loopback
+  address (`127.0.0.0/8`, not only `127.0.0.1`) gets the SSH tunnel recipe
+  instead of a network-exposure warning, and the recipe forwards to the address
+  the server is actually on. A hostname stays unclassified, matching the Rerun
+  CLI's own IP-literal-only `--bind` domain, and an IPv6 literal is bracketed
+  wherever a port follows it. The default bind is byte-identical.

--- a/examples/fleet/README.md
+++ b/examples/fleet/README.md
@@ -206,6 +206,12 @@ STRANDS_MESH_MULTICAST=true python examples/fleet/dashboard.py --serve-web
 ssh -N -L 9090:127.0.0.1:9090 -L 9876:127.0.0.1:9876 user@remote-box
 ```
 
+Any loopback address gets that tunnel recipe, not just the default one:
+`--bind` takes an IP literal, and the whole `127.0.0.0/8` block is reachable
+only from the host, so `--bind 127.0.0.2` (isolating the viewer on its own
+loopback address) prints the recipe forwarded to `127.0.0.2`. The
+network-exposure warning is for a bind that really is wider.
+
 The web viewer is a view, not a surface: it changes only the render
 transport, and the mesh peer stays subscribe-only exactly as above. With
 rerun-sdk absent, `--serve-web` fails with the install hint rather than

--- a/examples/fleet/dashboard.py
+++ b/examples/fleet/dashboard.py
@@ -57,6 +57,7 @@ import os
 os.environ.setdefault("STRANDS_MESH_LOCAL_DEV", "1")
 
 import argparse
+import ipaddress
 import subprocess
 import sys
 import tempfile
@@ -319,6 +320,50 @@ def serve_connect_host(bind: str) -> str:
     return "127.0.0.1" if bind == "0.0.0.0" else bind
 
 
+def is_loopback_bind(bind: str) -> bool:
+    """Whether a server bound to ``bind`` is reachable only from this host.
+
+    Membership in the loopback class, not equality with one spelling of it:
+    ``127.0.0.1`` is the default, but the whole ``127.0.0.0/8`` block is
+    loopback too, and the Rerun CLI accepts it - measured on rerun-sdk 0.26.2,
+    ``--bind 127.0.0.2`` binds both listeners and serves. An operator who
+    isolates the viewer on its own loopback address is still on loopback, so
+    the startup message owes them the tunnel recipe rather than a network-
+    exposure warning.
+
+    A hostname is deliberately not classified. ``--bind`` takes an IP literal
+    only (measured: ``--bind localhost`` is refused with "invalid IP address
+    syntax"), so parsing the address here means this classification and the
+    server's own accepted domain cannot disagree - a name the server refuses
+    never reaches the message at all.
+    """
+    try:
+        return ipaddress.ip_address(bind).is_loopback
+    except ValueError:
+        # Not an IP literal, so not an address the server would bind either.
+        return False
+
+
+def url_host(host: str) -> str:
+    """``host`` as a URL authority: an IPv6 literal is bracketed (RFC 3986).
+
+    Unbracketed, an IPv6 address runs into the port separator and the result
+    parses as neither (``http://::1:9090``), so the URL the message prints
+    would not open and the ``ssh -L`` forward would not parse. The bracket
+    keeps whatever :func:`is_loopback_bind` classifies spellable; no IPv6
+    bind is reachable on rerun-sdk 0.26.2 (measured: the gRPC listener binds
+    ``[::1]`` and the process then exits ``Could not parse address``), so this
+    is what keeps the two halves consistent rather than a reachable fix.
+    """
+    try:
+        if ipaddress.ip_address(host).version == 6:
+            return f"[{host}]"
+    except ValueError:
+        # Not an IP literal, so not a form that collides with the port separator.
+        pass
+    return host
+
+
 def rerun_binary() -> str:
     """Resolve the native rerun-cli binary that ships inside the rerun-sdk wheel.
 
@@ -379,14 +424,20 @@ def web_viewer_lines(*, bind: str, web_port: int, grpc_port: int) -> list[str]:
     the viewer from the web port and then dials the gRPC port itself. Any
     wider bind says so explicitly instead: opting into network exposure is
     the caller's deliberate act and the output should read like one.
+
+    Which posture a bind has is :func:`is_loopback_bind`'s class membership,
+    not equality with the default spelling, and the recipe forwards to the
+    address the server is actually on: ``--bind 127.0.0.2`` serves on
+    loopback, so a warning about who can reach it would be false and a
+    forward to ``127.0.0.1`` would reach nothing.
     """
-    host = serve_connect_host(bind)
+    host = url_host(serve_connect_host(bind))
     grpc_uri = f"rerun+http://{host}:{grpc_port}/proxy"
     url = f"http://{host}:{web_port}/?url={urllib.parse.quote(grpc_uri, safe='')}"
     lines = [f"Rerun web viewer: {url}"]
-    if bind == DEFAULT_BIND:
-        lines.append("bound to 127.0.0.1 (loopback only). From a remote machine, tunnel both ports first:")
-        lines.append(f"  ssh -N -L {web_port}:127.0.0.1:{web_port} -L {grpc_port}:127.0.0.1:{grpc_port} user@this-host")
+    if is_loopback_bind(bind):
+        lines.append(f"bound to {bind} (loopback only). From a remote machine, tunnel both ports first:")
+        lines.append(f"  ssh -N -L {web_port}:{host}:{web_port} -L {grpc_port}:{host}:{grpc_port} user@this-host")
         lines.append("then open the URL above in your local browser.")
     else:
         lines.append(

--- a/tests/test_fleet_cross_zone_transport.py
+++ b/tests/test_fleet_cross_zone_transport.py
@@ -476,6 +476,89 @@ def test_web_viewer_lines_say_so_when_bound_wider_than_loopback(dash):
     assert not any("ssh -N" in line for line in lines)  # the recipe is for the loopback posture
 
 
+@pytest.mark.parametrize("bind", ["127.0.0.2", "127.1.2.3", "::1"])
+def test_a_loopback_bind_other_than_the_default_is_not_network_exposure(dash, bind):
+    """The posture is the address's class, not equality with one spelling of it.
+
+    ``127.0.0.0/8`` is loopback in its entirety and the Rerun CLI binds it:
+    measured on rerun-sdk 0.26.2, ``--bind 127.0.0.2`` passes the dashboard's
+    own readiness gate with both listeners serving. Reported as network
+    exposure, that startup message makes a false claim about who can reach
+    the dashboard AND withholds the tunnel recipe - on the headless remote
+    host this flag exists for, the recipe is the actionable half.
+    """
+    lines = dash.web_viewer_lines(bind=bind, web_port=9090, grpc_port=9876)
+    assert not any("network exposure" in line for line in lines), (
+        f"bind={bind} is loopback, but the startup message calls it network exposure: {lines[1]}"
+    )
+    assert any("ssh -N" in line for line in lines), (
+        f"bind={bind} is loopback and reachable only through a tunnel, but no recipe was printed: {lines}"
+    )
+
+
+def test_the_tunnel_recipe_forwards_to_the_address_the_server_is_on(dash):
+    """A forward to the default address would reach nothing on a bind that is not it."""
+    lines = dash.web_viewer_lines(bind="127.0.0.2", web_port=9090, grpc_port=9876)
+    tunnel = next((line for line in lines if "ssh -N" in line), None)
+    assert tunnel is not None, f"no tunnel recipe was printed for a loopback bind: {lines}"
+    assert "-L 9090:127.0.0.2:9090" in tunnel
+    assert "-L 9876:127.0.0.2:9876" in tunnel
+    assert "127.0.0.1" not in tunnel
+
+
+def test_an_ipv6_literal_is_bracketed_wherever_a_port_follows_it(dash):
+    """Unbracketed, the address runs into the port separator and parses as neither."""
+    lines = dash.web_viewer_lines(bind="::1", web_port=9090, grpc_port=9876)
+    assert "http://[::1]:9090/" in lines[0]
+    assert "%5B%3A%3A1%5D%3A9876" in lines[0]  # the quoted rerun+http://[::1]:9876 stream URI
+    assert "http://::1:9090" not in lines[0]
+    tunnel = next(line for line in lines if "ssh -N" in line)
+    assert "-L 9090:[::1]:9090" in tunnel
+
+
+def test_a_hostname_is_not_classified_because_the_server_refuses_one(dash):
+    """Control: the classification and the CLI's accepted domain must not diverge.
+
+    ``--bind`` takes an IP literal only - measured, ``--bind localhost`` is
+    refused with "invalid IP address syntax" - so a name never reaches a
+    serving process. Parsing the address keeps the two in step; a fixed set of
+    loopback spellings would print a tunnel recipe for a bind the server will
+    not accept.
+    """
+    lines = dash.web_viewer_lines(bind="localhost", web_port=9090, grpc_port=9876)
+    assert any("network exposure" in line for line in lines)
+    assert not any("ssh -N" in line for line in lines)
+
+
+def test_the_default_bind_message_is_unchanged(dash):
+    """Control: the posture that already worked reads exactly as before."""
+    assert dash.web_viewer_lines(bind=dash.DEFAULT_BIND, web_port=9090, grpc_port=9876) == [
+        "Rerun web viewer: http://127.0.0.1:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A9876%2Fproxy",
+        "bound to 127.0.0.1 (loopback only). From a remote machine, tunnel both ports first:",
+        "  ssh -N -L 9090:127.0.0.1:9090 -L 9876:127.0.0.1:9876 user@this-host",
+        "then open the URL above in your local browser.",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("bind", "loopback"),
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.2", True),
+        ("127.1.2.3", True),
+        ("::1", True),
+        ("0.0.0.0", False),  # binds every interface; not itself loopback
+        ("::", False),
+        ("10.0.0.5", False),
+        ("localhost", False),  # a name, which --bind refuses
+        ("", False),
+        ("not-an-address", False),
+    ],
+)
+def test_is_loopback_bind_is_class_membership(dash, bind, loopback):
+    assert dash.is_loopback_bind(bind) is loopback
+
+
 def test_serve_web_with_rerun_absent_raises_the_install_hint(dash, monkeypatch):
     """--serve-web is an explicit ask: no silent terminal fall-through."""
 


### PR DESCRIPTION
## Problem

`--serve-web` decides its network posture with an exact comparison against one
spelling of loopback:

```python
if bind == DEFAULT_BIND:   # DEFAULT_BIND == "127.0.0.1"
    ... tunnel recipe ...
else:
    ... "WARNING: bound to {bind} (network exposure beyond loopback); ..."
```

`127.0.0.0/8` is loopback in its entirety, and the Rerun CLI binds it. Measured
on rerun-sdk 0.26.2, driving the dashboard's own `_start_web_server` readiness
gate with `--bind 127.0.0.2`:

| measured | value |
| --- | --- |
| readiness gate | served, child alive |
| listeners (`ss -ltn`) | `127.0.0.2:43010`, `127.0.0.2:43011` |
| connect from loopback | reachable (both ports) |
| connect from this host's LAN address | **refused (ConnectionRefusedError), both ports** |
| GET the printed URL | HTTP 200, serves the Rerun viewer |
| what the dashboard printed | `WARNING: bound to 127.0.0.2 (network exposure beyond loopback); anyone who can reach ports 43010 and 43011 can watch this dashboard.` |

So the message makes a claim about who can reach the dashboard that is
measurably false, and - because the recipe is gated on the same comparison -
withholds the SSH tunnel lines. On a headless remote host, which is the case
`--serve-web` exists for, that recipe is the actionable half of the output: the
operator is told they are exposed and not told how to reach the viewer.

Two spellings that look affected are not, and both stay out of scope for a
measured reason: `--bind localhost` is refused by the CLI itself
(`error: invalid value 'localhost' for '--bind <BIND>': invalid IP address
syntax`), and no IPv6 bind serves on 0.26.2 (the gRPC listener binds `[::1]`
and the process then exits `Could not parse address`, so the readiness gate
refuses it).

## Change

`is_loopback_bind()` asks the address instead of comparing it to the default, so
the whole loopback class is recognised, and the loopback branch now forwards to
the address the server is actually on - a forward to `127.0.0.1` would reach
nothing on a bind that is not it.

A hostname is deliberately not classified. `--bind` takes an IP literal only, so
parsing the address keeps this classification and the server's own accepted
domain in step; a fixed set of loopback spellings (`localhost`, `127.0.0.1`,
`::1`) would instead print a tunnel recipe for a bind the server refuses.

`url_host()` brackets an IPv6 literal wherever a port follows it. Unbracketed,
`http://::1:9090` parses as neither address nor port, so a classified-loopback
`::1` would have been handed an unopenable URL and an unparseable `ssh -L`
forward. No IPv6 bind is reachable today, so this is not a reachable fix - it is
what keeps the classification and the spelling consistent, and it also removes
the malformed `http://:::9090` the wildcard produced.

The default bind is byte-identical, so the posture that already worked reads
exactly as before.

The README gains the same statement it now makes in output: any loopback
address gets the recipe, and the warning is for a bind that really is wider.

## Tests

`tests/test_fleet_cross_zone_transport.py`, in the existing `--serve-web`
section. Against `upstream/main`: **15 failed / 46 passed** -> 61 passed.

Five failures are behavioural, quoting the measurement:

```
E  AssertionError: bind=127.0.0.2 is loopback, but the startup message calls it
   network exposure: WARNING: bound to 127.0.0.2 (network exposure beyond
   loopback); anyone who can reach ports 9090 and 9876 can watch this dashboard.
E  AssertionError: assert 'http://[::1]:9090/' in 'Rerun web viewer:
   http://::1:9090/?url=rerun%2Bhttp%3A%2F%2F%3A%3A1%3A9876%2Fproxy'
E  AssertionError: no tunnel recipe was printed for a loopback bind: [...]
```

The remaining ten are the classifier's truth table, which names the new helper
and so fails pre-fix on the attribute rather than on behaviour - a root-cause pin
rather than regression evidence.

The 46 both-tree passes are the controls, and each fails for a specific wrong fix:

- `test_the_default_bind_message_is_unchanged` pins all four lines of the default
  output, so widening the classification cannot change the posture that worked.
- `test_a_hostname_is_not_classified_because_the_server_refuses_one` fails for the
  fixed-spelling-set fix, which would classify `localhost`.
- `test_web_viewer_lines_say_so_when_bound_wider_than_loopback` (existing) keeps
  `0.0.0.0` on the warning branch.

## Verification

- 233-file selection (all `tests/test_fleet_*`, every test touching the dashboard
  or reading `examples/`, plus the repo-wide guards), same selection both trees:
  branch **8 failed / 9493 passed / 101 skipped**, base **23 / 9478 / 101**, both
  collecting 9602. Failed delta == passed delta == 15 == the pre-fix count, and
  the branch-only failure set is empty. The 8 shared failures are
  `tests/mesh/test_iot_connect_timeout_domain.py` needing `awsiotsdk`.
- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`
  clean; `mypy` 24 == 24 against a pristine `upstream/main`, none in the changed
  files.
- Measured at `ee4b6b2`; the head has since moved to `2a0ff9e`, which adds
  only the changelog fragment (no `.py` or docs change), so the numbers above
  still describe the tree.

## Artifact

The real Rerun web server on `--bind 127.0.0.2`, started through the dashboard's
own readiness gate, under both trees. Every measured field - the listeners, the
loopback and off-host probes, the HTTP status of the printed URL - is identical
in the two runs; only the message differs, which is the control.

![--serve-web loopback bind classification](https://raw.githubusercontent.com/cagataycali/robots/media-dashboard-loopback-bind/loopback-bind-class.png)
