### PR TITLE
docs(training): describe the interpreter a trainer actually imports its backend in

### DIFF
--- a/changelog.d/2525-trainer-interpreter-docs.md
+++ b/changelog.d/2525-trainer-interpreter-docs.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **docs/training**: the dependency table and interpreter callout described a subprocess execution model the trainers do not have, and advertised a `python_executable=` constructor argument none of them declares - every trainer's `**kwargs` absorbed it silently, so following the guidance installed the backend into an interpreter the trainer never consults. The `groot` and `cosmos3` rows now state that the backend is imported in the calling interpreter, and a new guard grades a documented `name=` argument against the class's real parameters.

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -476,8 +476,8 @@ on an L40S GPU:
 | `lerobot_local` + ACT / diffusion | `pip install 'strands-robots[lerobot]' 'lerobot[training]'` | `[lerobot]` supplies torch + torchcodec + datasets; it does **not** supply `accelerate` |
 | `lerobot_local` + `smolvla` | `pip install 'strands-robots[lerobot]' 'lerobot[training]' 'lerobot[smolvla]'` | lerobot 0.6's `[smolvla]` extra layers `transformers>=5.4.0,<5.6.0` + num2words on top. Do **not** pin `transformers==5.3.0` - it conflicts with lerobot 0.6's transformers floor. |
 | `lerobot_local` + `pi0` / `pi05` | `pip install 'strands-robots[lerobot]' 'lerobot[training]' 'lerobot[pi]'` | lerobot 0.6's `[pi]` extra (same `transformers>=5.4.0,<5.6.0` range + scipy) |
-| `groot` | Isaac-GR00T checkout + its own venv (`omegaconf`, `tyro`, …); point `extra["groot_root"]` / `GR00T_ROOT` at it | launched as a subprocess, so it uses GR00T's interpreter, not ours |
-| `cosmos3` | cosmos-framework checkout (`uv sync --group=cu130-train`); point `extra["cosmos_root"]` / `COSMOS_ROOT` at it | torchrun-driven; same subprocess-interpreter rule |
+| `groot` | Isaac-GR00T checkout, installed with `pip install -e` into the **same** environment as `strands_robots` (it pulls `omegaconf`, `tyro`, …); point `extra["groot_root"]` / `GR00T_ROOT` at the checkout | `gr00t` is imported in the calling interpreter, so it has to be importable there; `GR00T_ROOT` resolves relative configs, not the interpreter |
+| `cosmos3` | cosmos-framework checkout (`uv sync --group=cu130-train`), installed into the **same** environment as `strands_robots`; point `extra["cosmos_root"]` / `COSMOS_ROOT` at the checkout | `cosmos_framework` is imported in the calling interpreter; multi-GPU goes through torch's programmatic `elastic_launch`, not a `torchrun` binary |
 
 > **torchcodec / torch ABI:** the lerobot training dataloader decodes video via
 > `torchcodec`, whose compiled `.so` must match the **exact** installed torch
@@ -487,10 +487,15 @@ on an L40S GPU:
 > training fails with a generic non-zero exit. Pin `torch` + `torchcodec`
 > together (verified-good combo: `torch==2.10.0+cu128` + `torchcodec==0.10.0`).
 
-> **Subprocess interpreter:** `LerobotTrainer` / `Gr00tTrainer` / `Cosmos3Trainer`
-> accept a `python_executable=` argument (defaults to `sys.executable`). Set it
-> to a venv that has the provider's deps if your agent process runs in a
-> different environment — the training pipeline runs in that interpreter.
+> **One interpreter:** `LerobotTrainer` / `Gr00tTrainer` / `Cosmos3Trainer` call their
+> backend as a library in the **same** interpreter that imports `strands_robots`, so
+> there is no second interpreter to point them at. There is no `python_executable=`
+> argument either, and because each constructor absorbs unknown keywords, passing one
+> is silently a no-op rather than an error. Install the provider's deps into the
+> environment your agent process runs in; otherwise `train()` reports
+> `<package> is not importable from this interpreter` in `TrainResult.message`.
+> `GR00T_ROOT` / `COSMOS_ROOT` (and `extra["groot_root"]` / `extra["cosmos_root"]`)
+> resolve the checkout so relative configs load - they are not interpreter paths.
 
 ## See also
 

--- a/tests/training/test_documented_trainer_interpreter_contract.py
+++ b/tests/training/test_documented_trainer_interpreter_contract.py
@@ -1,0 +1,285 @@
+"""A documented trainer constructor argument has to be one the constructor declares.
+
+Every in-package :class:`~strands_robots.training.base.Trainer` takes ``**kwargs``,
+so an undeclared keyword is *absorbed* rather than refused. That makes a prose claim
+about a constructor argument unfalsifiable at the call site: the caller passes it, the
+constructor accepts it, and the value is dropped without a log line. The docs then also
+describe the execution model the argument would have selected, so a stale claim comes in
+pairs - a knob that does nothing, plus install guidance built on top of it.
+
+The assertions here grade the prose against the code:
+
+* an ``accept ... `name=` ... argument`` claim about a trainer class must name an
+  *explicit* parameter of that class, and ``**kwargs`` absorption does not count;
+* a provider whose backend is imported in the calling interpreter (measured: its module
+  references neither ``sys.executable`` nor ``subprocess``, so it has no interpreter to
+  select) must have its dependency row say so, because that is what decides which
+  environment an operator installs the backend into.
+
+Both are derived from the trainer registry and from ``inspect`` rather than from a table
+listed here, so a provider added later is graded on arrival.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from strands_robots.training.base import Trainer
+from strands_robots.training.factory import import_trainer_class, list_trainers
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOCS = _REPO_ROOT / "docs"
+_TRAINING_OVERVIEW = _DOCS / "training" / "overview.md"
+
+# Providers the dependency table has to speak about. Their backends are third-party
+# checkouts, so *which interpreter imports them* is the operator-visible question.
+_THIRD_PARTY_BACKENDS = ("groot", "cosmos3")
+
+# An acceptance claim: a verb of acceptance and a `name=` token in one sentence.
+_ACCEPTS_ARGUMENT = re.compile(
+    r"(?:accepts?|takes?|supports?)\b[^.]{0,200}?`(?P<arg>[a-z_][a-z0-9_]*)=`[^.]{0,80}?\bargument",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# The dependency table, addressed by its own header so the capability table further
+# up the page - whose "Launcher" column describes the *upstream* project, not this
+# one - is not graded as if it were install guidance.
+_DEPENDENCY_TABLE_HEADER = "| Provider / policy | Install | Notes |"
+
+
+def _doc_pages() -> list[Path]:
+    """Every user-facing markdown page, plus the README."""
+    pages = sorted(_DOCS.rglob("*.md"))
+    readme = _REPO_ROOT / "README.md"
+    if readme.exists():
+        pages.append(readme)
+    return pages
+
+
+def _trainer_classes() -> dict[str, type[Trainer]]:
+    """Registered trainer classes this package defines, keyed by provider name.
+
+    A provider whose class lives outside ``strands_robots`` (a runtime registration
+    from a caller) is skipped: its constructor is not this package's contract.
+    """
+    resolved: dict[str, type[Trainer]] = {}
+    for provider in sorted(list_trainers()):
+        try:
+            cls = import_trainer_class(provider)
+        except Exception:  # noqa: BLE001 - an unresolvable provider is not this contract
+            continue
+        if cls.__module__.startswith("strands_robots."):
+            resolved[provider] = cls
+    return resolved
+
+
+def _explicit_parameters(cls: type) -> set[str]:
+    """The parameter names *cls* declares, excluding the variadic sinks.
+
+    ``**kwargs`` is deliberately excluded: absorbing a keyword is not accepting it,
+    and treating it as acceptance is what let a documented argument that no
+    constructor declares read as supported.
+    """
+    variadic = (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    return {p.name for p in inspect.signature(cls).parameters.values() if p.kind not in variadic}
+
+
+def _absorbs_unknown_keywords(cls: type) -> bool:
+    """Whether *cls* has a ``**kwargs`` sink that swallows an undeclared keyword."""
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in inspect.signature(cls).parameters.values())
+
+
+def _selects_an_interpreter(cls: type) -> list[str]:
+    """Interpreter-spawning references in the module that defines *cls*.
+
+    A trainer that never reads ``sys.executable`` and never calls into
+    ``subprocess`` has no second interpreter to run its backend in, so its backend
+    has to be importable from the one that imports ``strands_robots``.
+    """
+    source = Path(inspect.getsourcefile(cls) or "").read_text(encoding="utf-8")
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Attribute) and ast.unparse(node) == "sys.executable":
+            found.add("sys.executable")
+        elif isinstance(node, ast.Call):
+            call = ast.unparse(node.func)
+            if call.startswith("subprocess.") or call.endswith(".Popen"):
+                found.add(call)
+    return sorted(found)
+
+
+def _dependency_table_row(provider: str) -> str:
+    """The install/notes row for *provider*, from the dependency table only.
+
+    The page carries an earlier capability table keyed on the same provider names;
+    its columns describe each upstream project rather than how this package drives
+    it, so only rows under the dependency-table header are install guidance.
+    """
+    lines = _TRAINING_OVERVIEW.read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index(_DEPENDENCY_TABLE_HEADER)
+    except ValueError:  # pragma: no cover - guarded by the non-vacuity test
+        return ""
+    for line in lines[start:]:
+        if not line.startswith("|"):
+            break
+        if line.startswith(f"| `{provider}` |"):
+            return line
+    return ""
+
+
+def _page_label(page: Path) -> str:
+    """A repository-relative label for *page*, falling back to its absolute path."""
+    try:
+        return str(page.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(page)
+
+
+def _paragraph_around(text: str, index: int) -> str:
+    """The blank-line-delimited block of *text* containing *index*.
+
+    A multi-line blockquote is one such block, which keeps the subject of a claim
+    and the claim itself together however the prose is wrapped.
+    """
+    start = text.rfind("\n\n", 0, index)
+    start = 0 if start < 0 else start + 2
+    end = text.find("\n\n", index)
+    end = len(text) if end < 0 else end
+    return text[start:end]
+
+
+def _unbacked_argument_claims(pages: list[Path]) -> dict[str, list[str]]:
+    """Documented ``name=`` arguments that no named trainer class declares."""
+    classes = _trainer_classes()
+    by_class_name = {cls.__name__: cls for cls in classes.values()}
+    offenders: dict[str, list[str]] = {}
+    for page in pages:
+        text = page.read_text(encoding="utf-8")
+        for match in _ACCEPTS_ARGUMENT.finditer(text):
+            arg = match.group("arg")
+            # The subject usually precedes the verb ("A / B / C accept a `x=` argument"),
+            # so resolve names over the whole paragraph rather than the matched span.
+            named = [name for name in by_class_name if name in _paragraph_around(text, match.start())]
+            if not named:
+                continue
+            undeclared = [name for name in named if arg not in _explicit_parameters(by_class_name[name])]
+            if undeclared:
+                offenders.setdefault(_page_label(page), []).append(f"{arg}= on {', '.join(sorted(undeclared))}")
+    return offenders
+
+
+# --- the claim has to match the constructor ---
+
+
+def test_no_document_claims_a_trainer_argument_the_constructor_does_not_declare() -> None:
+    """A documented ``name=`` argument is a real parameter of the class it names."""
+    offenders = _unbacked_argument_claims(_doc_pages())
+    assert not offenders, (
+        "documentation promises trainer constructor arguments that are not declared "
+        f"(each is absorbed by **kwargs and dropped): {offenders}"
+    )
+
+
+@pytest.mark.parametrize("provider", _THIRD_PARTY_BACKENDS)
+def test_absorbing_a_keyword_is_not_accepting_it(provider: str) -> None:
+    """An undeclared keyword is taken and dropped, so prose cannot lean on ``**kwargs``.
+
+    This is the premise behind excluding ``**kwargs`` from the declared set: the
+    constructor call a reader would make succeeds and leaves nothing behind.
+    """
+    cls = _trainer_classes()[provider]
+    assert _absorbs_unknown_keywords(cls), f"premise: {cls.__name__} no longer has a **kwargs sink"
+    sentinel = "not_a_declared_trainer_argument"
+    assert sentinel not in _explicit_parameters(cls)
+    instance = cls(**{sentinel: "/some/venv/bin/python"})
+    assert not hasattr(instance, sentinel), (
+        f"{cls.__name__} now records {sentinel}; the absorption premise needs re-checking"
+    )
+
+
+# --- the execution model the install guidance rests on ---
+
+
+@pytest.mark.parametrize("provider", _THIRD_PARTY_BACKENDS)
+def test_no_in_package_trainer_can_select_an_interpreter(provider: str) -> None:
+    """No trainer spawns an interpreter, so none can run its backend in another one."""
+    cls = _trainer_classes()[provider]
+    spawns = _selects_an_interpreter(cls)
+    assert not spawns, (
+        f"{cls.__name__} now reaches for {spawns}; if a trainer can select an interpreter "
+        "again the dependency table's same-environment guidance needs revisiting"
+    )
+
+
+@pytest.mark.parametrize("provider", _THIRD_PARTY_BACKENDS)
+def test_the_dependency_row_states_which_interpreter_imports_the_backend(provider: str) -> None:
+    """The row tells an operator the backend is imported in the calling interpreter.
+
+    Stated positively on purpose: the row has to carry the requirement, so it cannot
+    be satisfied by dropping a phrase, and a correctly qualified mention of the
+    alternative does not trip it.
+    """
+    row = _dependency_table_row(provider)
+    assert row, f"no dependency-table row for `{provider}` in {_TRAINING_OVERVIEW.name}"
+    lowered = row.lower()
+    assert "calling interpreter" in lowered or "same environment" in lowered.replace("**", ""), (
+        f"the `{provider}` dependency row does not say which interpreter imports the backend, "
+        f"so an operator cannot tell which environment to install it into: {row}"
+    )
+
+
+def test_the_runtime_refusal_asks_for_the_same_interpreter(caplog: pytest.LogCaptureFixture) -> None:
+    """The failure an operator actually hits names the calling interpreter.
+
+    This is the message the dependency guidance has to agree with; if the runtime
+    ever starts accepting a separately installed backend, this is the assertion that
+    should be revisited first.
+    """
+    del caplog
+    for provider in _THIRD_PARTY_BACKENDS:
+        module = inspect.getmodule(_trainer_classes()[provider])
+        hint = getattr(module, "_INSTALL_HINT", "")
+        assert "this interpreter" in hint, f"{provider} install hint no longer names the interpreter: {hint!r}"
+        assert "same" in hint, f"{provider} install hint no longer asks for the same environment: {hint!r}"
+
+
+# --- non-vacuity ---
+
+
+def test_the_sweep_reaches_the_training_documentation() -> None:
+    """The graded corpus really contains the page that carries this guidance."""
+    pages = _doc_pages()
+    assert _TRAINING_OVERVIEW in pages
+    assert len(pages) >= 20, f"only {len(pages)} documentation pages discovered"
+    assert set(_THIRD_PARTY_BACKENDS) <= set(_trainer_classes()), (
+        f"graded providers missing from the registry: {sorted(_trainer_classes())}"
+    )
+
+
+def test_a_planted_claim_is_reported_and_a_denial_is_not(tmp_path: Path) -> None:
+    """An acceptance claim is graded; saying the argument does not exist is not a claim."""
+    claim = tmp_path / "claim.md"
+    claim.write_text(
+        "`Gr00tTrainer` accepts a `python_executable=` argument (defaults to `sys.executable`).\n",
+        encoding="utf-8",
+    )
+    reported = _unbacked_argument_claims([claim])
+    assert reported, "a planted claim about an undeclared argument was not reported"
+    assert "python_executable= on Gr00tTrainer" in next(iter(reported.values()))
+
+    denial = tmp_path / "denial.md"
+    denial.write_text(
+        "`Gr00tTrainer` calls its backend in the same interpreter. There is no `python_executable=` argument to set.\n",
+        encoding="utf-8",
+    )
+    assert not _unbacked_argument_claims([denial]), "a denial was mistaken for a claim"
+
+    real = tmp_path / "real.md"
+    real.write_text("`Gr00tTrainer` accepts a `groot_root=` argument.\n", encoding="utf-8")
+    assert not _unbacked_argument_claims([real]), "a declared argument was reported"


### PR DESCRIPTION
## Problem

`docs/training/overview.md` still describes the execution model the branch that
introduced the page refactored away before it merged. Inside that branch the
trainers were moved to driving their backends as libraries - `7b315ce2`
("run LeRobot training in-process (no subprocess)"), `ca53727a` ("run GR00T +
Cosmos3 in-process too (drop subprocess/torchrun)") - and `b0d24aaf` then
"drop[ped] python_executable + runpy". The whole branch squashed into #628, so
the shipped code has never had either. The page kept the pre-refactor guidance:

| Surface | Says | Reality |
|---|---|---|
| `groot` dependency row | "Isaac-GR00T checkout + **its own venv**"; "launched as a subprocess, so it uses GR00T's interpreter, not ours" | `gr00t` is `importlib.import_module`'d in the calling interpreter |
| `cosmos3` dependency row | "torchrun-driven; same subprocess-interpreter rule" | `cosmos_framework` likewise; multi-GPU uses torch's programmatic `elastic_launch` |
| interpreter callout | "`LerobotTrainer` / `Gr00tTrainer` / `Cosmos3Trainer` accept a `python_executable=` argument (defaults to `sys.executable`)" | no trainer declares it, and `python_executable` appears nowhere in `strands_robots/training/` in the entire history |

The argument is not merely absent - it is **absorbed**. Every trainer takes
`**kwargs`, so the constructor call a reader would make succeeds and the value is
dropped with no raise and no log line:

```
Gr00tTrainer(python_executable="/venv/bin/python")  -> constructed OK, attribute ABSENT
```

Following the page end to end, with the checkout in its own venv as instructed:

```
validate() -> []                                  # clean preflight, no mention
train()    -> status="error"
              "Isaac-GR00T is not importable from this interpreter. Install it
               from source ... into the *same* Python that imports strands_robots"
```

So the page sends an operator to a second interpreter, the runtime asks for the
same one, and the knob the page offers to bridge them is silently a no-op.

Five surfaces in the package already say the opposite, which is why this is a
documentation correction rather than a design question:

- `Gr00tTrainer.__init__` docstring: "`GR00T_ROOT` is for runtime config resolution, **not the interpreter path**"
- `groot._INSTALL_HINT` / `cosmos3._INSTALL_HINT`: "into the ***same*** Python that imports strands_robots"
- `groot.py` module docstring: "same interpreter, no argv, no nested `python`"
- `lerobot.py` module docstring: "**directly in this interpreter**"
- `training/base.py`: "NOT shell out to a subprocess"

Adding the parameter instead would resurrect an execution model that branch
deliberately removed, so the code stays as it is.

## Change

`docs/training/overview.md` only.

- The `groot` and `cosmos3` dependency rows now state that the backend is imported
  in the calling interpreter and has to be installed into the same environment,
  and that `GR00T_ROOT` / `COSMOS_ROOT` resolve the checkout for relative configs
  rather than selecting an interpreter.
- The **Subprocess interpreter** callout becomes **One interpreter**: there is no
  second interpreter to point at and no `python_executable=` argument, the
  absorption is named so a reader who tried it knows why nothing happened, and the
  refusal `train()` actually reports is quoted.

The capability table higher up the page is deliberately untouched: its columns
describe each *upstream* project ("Upstream entry point", "Launcher"), and the
prose directly beneath it already states that the three local backends drive
their libraries in-process. The new guard is scoped to the dependency table by
that table's own header so it does not grade the upstream one as install
guidance.

## Guard

`tests/training/test_documented_trainer_interpreter_contract.py` grades the prose
against the code, in two directions, both derived rather than listed:

1. **A documented `name=` argument is an explicit parameter of the class the prose
   names.** `**kwargs` is excluded from the declared set on purpose - absorbing a
   keyword is not accepting it, and counting it is what let an argument no
   constructor declares read as supported. Class names are resolved over the
   containing paragraph, because the subject precedes the verb
   ("A / B / C accept a `x=` argument").
2. **A provider whose module can select no interpreter says so in its install
   row.** "Can select no interpreter" is measured from the AST - the module
   references neither `sys.executable` nor anything in `subprocess` - not from
   other prose. Stated positively so the row has to carry the requirement, and so
   a correctly qualified mention of the alternative does not trip it.

Both walk the trainer registry, so a provider added later is graded on arrival
with no edit here.

## Verification

Measured at `2a4acb26`, `upstream/main` = `227faf14`.

Pre-fix (both files copied onto `upstream/main`): **3 failed / 7 passed**. The
headline names all three classes:

```
documentation promises trainer constructor arguments that are not declared
(each is absorbed by **kwargs and dropped):
{'docs/training/overview.md': ['python_executable= on Cosmos3Trainer, Gr00tTrainer, LerobotTrainer']}
```

Post-fix: **10 passed**. The seven that pass on both trees are the controls, and
each one fails for a specific wrong fix:

- the absorption premise (`groot`, `cosmos3`) - fails if a constructor starts
  refusing unknown keywords, which would make `**kwargs` exclusion the wrong rule;
- no trainer reaches for `sys.executable` or `subprocess` - fails if a trainer can
  select an interpreter again, which is when the same-environment guidance needs
  revisiting;
- the runtime install hints still ask for the same interpreter - the message the
  guidance has to agree with;
- a planted acceptance claim is reported, a denial of the same argument is not, and
  a *declared* argument (`groot_root=`) is not - so the rule cannot be satisfied by
  rewording, and the corrected page's own explicit denial is correctly not a claim;
- non-vacuity: the graded corpus really contains the page and the providers.

Blast radius (160 files: all of `tests/training`, every test naming the trainer
classes / the registry helpers / a docs page, plus the repository-wide docstring,
source-string and changelog guards), the identical selection on both trees:

| | failed | passed | skipped | collected |
|---|---|---|---|---|
| this branch | 3 | 6202 | 33 | 6205 |
| `upstream/main` + both files | 6 | 6199 | 33 | 6205 |

Branch-only failures: **none**. Base-only: exactly the 3 above. The 3 shared are
pre-existing on `upstream/main` (`TestInProcessTrainerCorrectness` x2 plus
`test_lerobot_e2e`, all the locally installed draccus predating lerobot's
`>=0.11.6` floor).

`ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ`
= 24 errors on both trees, none in the changed file.

## What it looks like

One capture script, run against each tree, reading **that tree's own page**,
extracting the guidance, following it, and recording the outcome. The package code
is identical in both columns - `interpreter consulted`, `validate()` and the
`train()` refusal are byte-identical, which is the control - so the only variable
is what the page told the operator to do.

![trainer interpreter guidance, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-trainer-interpreter/trainer-interpreter.png)

## Scope

Refusing unknown constructor keywords across the seven trainers would turn this
class of mistake into an error rather than a silent drop, but it changes behaviour
for existing callers (`_groot_worker` constructs `Gr00tTrainer(groot_root=...)`)
and is a decision for all seven at once, so it is left alone here and the guard
pins the absorption as a measured premise instead.
