### PR TITLE
fix(training): resolve a runtime-registered trainer through the public resolver

### DIFF
--- a/changelog.d/2526-trainer-resolver-runtime-registry.md
+++ b/changelog.d/2526-trainer-resolver-runtime-registry.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **training**: `import_trainer_class` now resolves a provider registered with
+  `register_trainer`, so it serves every name `list_trainers()` advertises.
+  It consulted only the `policies.json` `"trainer"` block and auto-discovery on
+  `strands_robots.training.<provider>`, which refused the runtime-registered
+  providers - including `ppo` and `fast_sac`, whose modules live in the
+  `training.rl` subpackage - while `create_trainer` resolved them; the refusal
+  it raised also listed those providers as available. The runtime lookup now
+  lives once in `import_trainer_class`, which `create_trainer` delegates to,
+  and keeps its precedence over a shipped `trainer` block.

--- a/strands_robots/training/factory.py
+++ b/strands_robots/training/factory.py
@@ -17,6 +17,13 @@ Mirrors ``strands_robots.policies.factory`` exactly, but resolves the
 so a single provider name owns BOTH the inference class
 (``create_policy("lerobot_local")``) and the training class
 (``create_trainer("lerobot_local")``).
+
+A provider can also be declared at runtime with :func:`register_trainer`, which
+is how the ``training.rl`` backends (``ppo``, ``fast_sac``) and the ``sagemaker``
+transport are wired without a paired inference provider to hang a JSON block
+off. Both routes resolve through :func:`import_trainer_class`, so
+:func:`list_trainers`, :func:`import_trainer_class` and :func:`create_trainer`
+answer for the same set of names.
 """
 
 from __future__ import annotations
@@ -78,15 +85,38 @@ def list_trainers() -> list[str]:
 def import_trainer_class(provider: str) -> type[Trainer]:
     """Import and return the :class:`Trainer` subclass for a provider.
 
-    Resolution order:
-      1. The provider's ``"trainer"`` block in policies.json.
-      2. Auto-discovery fallback: ``strands_robots.training.<provider>`` with a
+    The one resolver behind :func:`create_trainer`, which adds nothing but the
+    constructor call - so a name either function can resolve is a name both can.
+    Resolution order mirrors ``policies.factory._resolve_policy_class``:
+
+      1. The runtime registry (:func:`register_trainer`), resolving an alias to
+         its provider first. This rung comes first so re-registering a name
+         overrides a shipped ``trainer`` block rather than being ignored by it.
+      2. The provider's ``"trainer"`` block in policies.json.
+      3. Auto-discovery fallback: ``strands_robots.training.<provider>`` with a
          class named ``<Provider>Trainer`` or the first ``Trainer`` subclass.
 
+    Rung 1 is not optional for the shipped providers either: ``ppo`` and
+    ``fast_sac`` register at runtime because their modules live in the
+    ``training.rl`` subpackage, which neither of the other two rungs reaches.
+
+    Args:
+        provider: Provider name or a runtime-registered alias.
+
+    Returns:
+        The :class:`Trainer` subclass, not an instance.
+
     Raises:
-        ValueError: If no trainer can be resolved for the provider.
+        ValueError: If no trainer can be resolved for the provider. The message
+            names the providers this resolver can serve, which is the same set
+            :func:`list_trainers` advertises.
         ImportError: If the declared module can't be imported.
     """
+    # 1. Runtime registry (register_trainer), alias first.
+    resolved = _runtime_aliases.get(provider, provider)
+    if resolved in _runtime_registry:
+        return _runtime_registry[resolved]()
+
     cfg = get_policy_provider(provider)
     if cfg and "trainer" in cfg:
         tcfg = cfg["trainer"]
@@ -131,11 +161,5 @@ def create_trainer(provider: str, **kwargs: Any) -> Trainer:
     Raises:
         ValueError: If no trainer is registered for the provider.
     """
-    # 1. Runtime registry first (user-registered trainers).
-    resolved = _runtime_aliases.get(provider, provider)
-    if resolved in _runtime_registry:
-        return _runtime_registry[resolved]()(**kwargs)
-
-    # 2. Registry / auto-discovery.
     TrainerClass = import_trainer_class(provider)
     return TrainerClass(**kwargs)

--- a/tests/training/test_factory.py
+++ b/tests/training/test_factory.py
@@ -1,7 +1,9 @@
 """Tests for the Trainer abstraction: ABC contract, factory, mock lifecycle."""
 
+import ast
 import json
 import os
+import re
 
 import pytest
 
@@ -14,6 +16,7 @@ from strands_robots.training import (
     list_trainers,
     register_trainer,
 )
+from strands_robots.training.factory import _runtime_registry
 from strands_robots.training.mock import MockTrainer
 
 
@@ -195,9 +198,10 @@ class TestSpecTolerance:
 
 
 class TestAutoDiscoveryFallback:
-    """Resolution-order step 2 of ``import_trainer_class``: when a provider has
-    no ``trainer`` block in policies.json, the factory falls back to importing
-    ``strands_robots.training.<provider>`` and resolving a Trainer subclass.
+    """Last resolution rung of ``import_trainer_class``: when a provider is in
+    neither the runtime registry nor a ``trainer`` block in policies.json, the
+    factory falls back to importing ``strands_robots.training.<provider>`` and
+    resolving a Trainer subclass.
     """
 
     def test_resolves_named_provider_trainer_class(self, monkeypatch):
@@ -242,3 +246,124 @@ class TestAutoDiscoveryFallback:
 
         with pytest.raises(ValueError, match="No trainer registered"):
             import_trainer_class("emptyprov")
+
+
+class TestBothResolversServeEveryListedTrainer:
+    """``import_trainer_class`` resolves every name ``list_trainers`` advertises.
+
+    The factory has two entry points onto one question - which ``Trainer``
+    subclass a provider name means. :func:`create_trainer` answers it to build
+    an instance; :func:`import_trainer_class` is the public answer for a caller
+    that wants the class without paying for construction. A name only one of
+    them can serve makes the pair a coin flip on which door the caller used,
+    and the refusal ``import_trainer_class`` raises builds its available list
+    from ``list_trainers()`` - so a name it cannot serve is advertised by the
+    very message that rejects it.
+    """
+
+    def test_every_listed_trainer_resolves(self):
+        """No advertised provider is refused by the public resolver."""
+        refused = {}
+        for name in list_trainers():
+            try:
+                import_trainer_class(name)
+            except Exception as e:  # noqa: BLE001 - report every failure, not the first
+                refused[name] = f"{type(e).__name__}: {e}"
+        assert not refused, f"list_trainers() advertises providers import_trainer_class refuses: {refused}"
+
+    def test_the_refusal_advertises_only_names_it_can_serve(self):
+        """A refusal must not enumerate the provider it just rejected."""
+        with pytest.raises(ValueError) as exc:
+            import_trainer_class("no_such_trainer_xyz")
+        message = str(exc.value)
+        advertised = ast.literal_eval(re.search(r"Available trainers: (\[[^\]]*\])", message).group(1))
+        assert advertised, "premise: the refusal names an available-trainers list to grade"
+        unservable = []
+        for name in advertised:
+            try:
+                import_trainer_class(name)
+            except Exception:  # noqa: BLE001 - any failure means the list over-promises
+                unservable.append(name)
+        assert not unservable, f"the refusal offers providers it cannot resolve: {unservable}\n  message: {message}"
+
+    def test_the_two_entry_points_agree_on_every_listed_name(self):
+        """Resolving a class and building an instance answer the same question."""
+        disagree = []
+        for name in list_trainers():
+            try:
+                import_trainer_class(name)
+                imports = True
+            except Exception:  # noqa: BLE001
+                imports = False
+            try:
+                create_trainer(name)
+                creates = True
+            except Exception:  # noqa: BLE001
+                creates = False
+            if imports is not creates:
+                disagree.append((name, imports, creates))
+        assert not disagree, f"(name, import_trainer_class, create_trainer) disagree: {disagree}"
+
+    def test_the_builtin_rl_trainers_are_reachable_through_the_public_resolver(self):
+        """``ppo`` and ``fast_sac`` register at runtime, not in policies.json.
+
+        Their modules live in the ``training.rl`` subpackage, so neither the
+        JSON rung nor auto-discovery on ``strands_robots.training.<provider>``
+        finds them - the runtime registry is the only rung that can.
+        """
+        from strands_robots.training.rl.fast_sac import FastSacTrainer
+        from strands_robots.training.rl.ppo import PpoTrainer
+
+        assert import_trainer_class("ppo") is PpoTrainer
+        assert import_trainer_class("fast_sac") is FastSacTrainer
+
+    def test_a_runtime_registered_trainer_and_its_alias_resolve(self):
+        """The documented ``register_trainer`` route reaches the public resolver."""
+
+        class ResolverProbeTrainer(MockTrainer):
+            pass
+
+        register_trainer("resolver_probe", lambda: ResolverProbeTrainer, aliases=["rp"])
+        assert import_trainer_class("resolver_probe") is ResolverProbeTrainer
+        assert import_trainer_class("rp") is ResolverProbeTrainer
+
+    def test_at_least_one_listed_trainer_is_runtime_only(self):
+        """Non-vacuity: the graded set spans both registries.
+
+        Were every provider declared in policies.json, the properties above
+        would hold for a resolver that consults only the JSON rung.
+        """
+        from strands_robots.registry.policies import get_policy_provider
+
+        runtime_only = [name for name in list_trainers() if not (get_policy_provider(name) or {}).get("trainer")]
+        assert runtime_only, "expected at least one provider registered outside policies.json"
+
+
+class TestTheRuntimeRungKeepsItsPrecedence:
+    """A runtime registration shadows a JSON ``trainer`` block, as before.
+
+    ``create_trainer`` consulted the runtime registry ahead of the registry
+    lookup, so a caller could already override a shipped provider's trainer by
+    re-registering the name. Sharing one resolver has to keep that ordering:
+    demoting the runtime rung below the JSON rung would silently ignore such an
+    override instead of honoring it.
+    """
+
+    def test_a_runtime_registration_overrides_a_json_trainer_block(self):
+        class ShadowingTrainer(MockTrainer):
+            pass
+
+        register_trainer("mock", lambda: ShadowingTrainer)
+        try:
+            assert import_trainer_class("mock") is ShadowingTrainer
+            assert isinstance(create_trainer("mock"), ShadowingTrainer)
+        finally:
+            _runtime_registry.pop("mock", None)
+        # The JSON rung answers again once the override is gone.
+        assert import_trainer_class("mock") is MockTrainer
+
+    def test_an_unknown_provider_is_still_refused(self):
+        with pytest.raises(ValueError, match="No trainer registered"):
+            import_trainer_class("definitely_not_a_trainer_xyz")
+        with pytest.raises(ValueError, match="No trainer registered"):
+            create_trainer("definitely_not_a_trainer_xyz")


### PR DESCRIPTION
## Problem

`list_trainers()` advertises seven providers. `create_trainer` resolves all seven.
`import_trainer_class` - the public answer for a caller that wants the `Trainer`
class without paying for construction - refuses four of them:

```
provider        declared in         create_trainer   import_trainer_class
cosmos3         policies.json       resolves         resolves
fast_sac        register_trainer    resolves         ValueError: No trainer registered for provider 'fast_sac'
groot           policies.json       resolves         resolves
lerobot_local   policies.json       resolves         resolves
mock            policies.json       resolves         resolves
ppo             register_trainer    resolves         ValueError: No trainer registered for provider 'ppo'
sagemaker       register_trainer    resolves         resolves
```

`import_trainer_class` consults the `"trainer"` block in `policies.json` and then
auto-discovery on `strands_robots.training.<provider>`. Neither rung reaches the
runtime registry, so every provider declared with `register_trainer` is refused -
including two the package registers itself in `training/__init__.py`. `ppo` and
`fast_sac` live in the `training.rl` subpackage, so auto-discovery on
`strands_robots.training.ppo` finds nothing. `sagemaker` resolves only because its
module happens to sit at `strands_robots.training.sagemaker`, which the registration
comment already notes ("Auto-discovery would resolve `create_trainer("sagemaker")`
from the module name alone").

The same gap hits the documented user route. `register_trainer`'s own docstring
example registers `"my_vla"` with the alias `"mv"`; neither spelling resolves
through `import_trainer_class`.

The refusal then over-promises, because it builds its list from `list_trainers()`:

```
ValueError: No trainer registered for provider 'fast_sac'.
Available trainers: ['cosmos3', 'fast_sac', 'groot', 'lerobot_local', 'mock', 'ppo', 'sagemaker']
```

The message enumerates the provider it has just rejected, so the one list a caller
has to recover from the failure names four providers this resolver cannot serve.

## Change

`import_trainer_class` gains the runtime rung as step 1 - alias resolved first, and
ahead of the `policies.json` block so re-registering a name still overrides a
shipped `trainer` block rather than being ignored by it. `create_trainer` then
delegates wholly to it, dropping its own copy of the same lookup.

The runtime lookup now exists once. That is what the module docstring already
promised (`"Mirrors strands_robots.policies.factory exactly"`) and how the policy
side is built: `create_policy` adds nothing but the constructor call and the
trust-remote-code gate on top of a single resolver whose first rung is the runtime
registry.

`create_trainer`'s behaviour is unchanged - it consulted the runtime registry first
before, and the shared resolver keeps that precedence. Verified: it returns the
identical class for all seven providers on both sides.

Docstrings updated in the same change: `import_trainer_class`'s stated resolution
order listed two rungs where the resolver behind `create_trainer` had three, and the
module docstring described only the `policies.json` route. No prose page documents
this resolver, so the docstrings are its documentation surface.

## Evidence

![trainer resolver, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-trainer-resolver-runtime-registry/trainer-resolver-runtime-registry.png)

One probe script run against `upstream/main` and against this branch. Package code
is the only variable; the probe registers `my_vla`/`mv` exactly as the factory's own
docstring example does.

| | `upstream/main` | this branch |
|---|---|---|
| listed providers `import_trainer_class` refuses | `fast_sac`, `ppo`, `my_vla`, `mv` | none |
| names the refusal advertises but cannot resolve | `fast_sac`, `ppo`, `my_vla`, `mv` | none |
| `create_trainer` class per provider | identical | identical |

The last row is the control: this branch changes which rungs
`import_trainer_class` consults, not what any provider resolves to. There is no
simulation behaviour in the diff, so there is no rollout to film.

## Tests

Extended `tests/training/test_factory.py`. Against `upstream/main`: **6 failed,
32 passed**; after: **38 passed**, and unchanged under random ordering.

The failures are behavioural and name the providers:

```
test_every_listed_trainer_resolves
  list_trainers() advertises providers import_trainer_class refuses:
  {'custom_x': ..., 'cx': ..., 'fast_sac': ..., 'ppo': ...}

test_the_refusal_advertises_only_names_it_can_serve
  the refusal offers providers it cannot resolve: ['custom_x', 'cx', 'fast_sac', 'ppo']

test_the_two_entry_points_agree_on_every_listed_name
  (name, import_trainer_class, create_trainer) disagree:
  [('custom_x', False, True), ('cx', False, True), ('fast_sac', False, True), ('ppo', False, True)]
```

The properties are derived from `list_trainers()` at run time rather than from a
literal, so a provider added later is graded without editing the test.
`test_at_least_one_listed_trainer_is_runtime_only` keeps that from going vacuous -
were every provider declared in `policies.json`, the properties would hold for a
resolver that consults only the JSON rung.

Two tests pass on both sides and are the no-overreach controls:
`test_an_unknown_provider_is_still_refused` (the fix must not make the resolver
permissive) and `test_at_least_one_listed_trainer_is_runtime_only`.

`test_a_runtime_registration_overrides_a_json_trainer_block` pins the rung
*ordering*, which the two shapes of a wrong fix are measured against:

- rung removed entirely -> 9 failed (the three pre-existing tests that reach
  `ppo`/`fast_sac`/a runtime alias through `create_trainer` fail too, which is what
  shows the delegation is real)
- rung merely demoted below the JSON rung -> exactly 1 failed, that test

`TestAutoDiscoveryFallback`'s docstring named its rung by number
("Resolution-order step 2"); it is now the last rung, and the docstring says so
instead of counting.

## Verification

Measured at `44cbd63e` on `/tmp` worktrees of `upstream/main` (`4e2e89f1`).

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine
  `upstream/main` worktree, none in the changed files
- 71-file selection (every test naming the factory surface, all of
  `tests/training`, `tests/tools/test_train_policy.py`, and the repo-wide
  docstring / changelog / source-string guards), both trees, same selection:

  | | failed | passed | skipped | collected |
  |---|---|---|---|---|
  | this branch | 3 | 3547 | 5 | 3550 |
  | `upstream/main` + this test file | 9 | 3541 | 5 | 3550 |

  Branch-only failures: none. The six base-only failures are exactly the pre-fix
  ones above. The three shared failures are pre-existing and environmental -
  `test_lerobot_e2e.py::test_record_train_load_loop` and two
  `TestInProcessTrainerCorrectness` cases need `draccus>=0.11.6`, and this
  machine resolves 0.8.0.
