### PR TITLE
fix(simulation): match a MuJoCo enum by value, not by operand order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1350,6 +1350,32 @@ Corrections from code review that apply to all future contributions:
   `ctrlrange` is authoritative and already in the drive's own units, so only the
   *substitution* of a driven joint's limits needs the drive to be a servo.
 
+### MuJoCo enums are matched by value, never by operand order
+
+`mjModel` / `mjData` expose their type fields as numpy integer arrays, while the
+matching vocabulary is a pybind11 enum. Whether the two compare equal depends on
+which side the enum is on.
+
+- **Compare `int()` to `int()`.** `int(model.geom_type[i]) in (int(mjGEOM_PLANE),
+  int(mjGEOM_HFIELD))`, `int(model.actuator_trntype[a]) != int(mjTRN_TENDON)`.
+- **`x in (enum, ...)` is the trap, not a hand-written reversed `==`.** CPython
+  compares `element == needle`, so membership puts the ENUM on the left. That is
+  `True` on mujoco 3.9.0 / 3.10.0 / 3.11.0 and `False` on 3.12.0 - all inside the
+  declared `mujoco>=3.5.0,<4.0.0` range. A `set` of enum members degrades the
+  same way: the hashes still collide and the confirming equality is the failing
+  direction.
+- **The failure is silent.** The membership test simply answers `False` for every
+  element. Measured: a heightfield ground geom stopped being recognised as
+  ground, so a "lowest robot geom" scan returned the ground's own `z=0.0`; and an
+  example's home-pose helper matched 0 of 3 joints, writing no `qpos` and no
+  `ctrl` while logging that the pose had been set.
+- **The rule is uniform, with no exemption for a spec-side value.** `MjsGeom.type`
+  really is an enum, so `in` works there - but a reader cannot tell an `MjsGeom`
+  attribute from an `MjModel` array element at the call site, so both are written
+  by value.
+- Pinned by `tests/test_mujoco_enum_comparisons_are_value_based.py`, which grades
+  `strands_robots`, `tests`, `tests_integ` and `examples`.
+
 ### Clocks: a duration is measured, a stamp is recorded
 - **A duration belongs on `time.monotonic()`.** Anything that decides *how long to keep
   waiting* - a timeout, a deadline, a TTL, a retry window, a rate window, a frame pacer -

--- a/changelog.d/2528-mujoco-enum-value-comparison.md
+++ b/changelog.d/2528-mujoco-enum-value-comparison.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation**: match a MuJoCo `mjt*` enum by value rather than by operand order. A model field is a numpy integer and `x in (enum, ...)` puts the enum on the *left* of `==`, where a pybind11 enum stops matching a numpy integer on mujoco 3.12.0 - inside the declared `mujoco>=3.5.0,<4.0.0` range. The membership test then answers `False` for every element with nothing raised: a heightfield ground geom was no longer recognised as ground, and an example's home-pose helper matched 0 of 3 joints and wrote neither `qpos` nor `ctrl` while logging that the pose had been set. Every such comparison now reads `int(...)` on both sides, and a new guard grades `strands_robots`, `tests`, `tests_integ` and `examples` so a new site fails CI instead of degrading silently.

--- a/examples/mujoco_gs/scene.py
+++ b/examples/mujoco_gs/scene.py
@@ -210,17 +210,20 @@ def _erect_arm(sim, robot_name: str = "arm") -> bool:
 
         kq = m.key_qpos[key_id]
         ns = f"{robot_name}/"
-        hinge_slide = (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_SLIDE)
+        # Joint types are compared BY VALUE: ``m.jnt_type[j]`` is a numpy integer and
+        # ``x in (enum, ...)`` puts the enum on the left of ``==``, where a pybind11
+        # enum does not match a numpy integer on every mujoco build.
+        hinge_slide = (int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE))
         # 1) qpos for the arm's own actuated joints.
         for j in range(m.njnt):
             jn = mujoco.mj_id2name(m, mujoco.mjtObj.mjOBJ_JOINT, j) or ""
-            if jn.startswith(ns) and m.jnt_type[j] in hinge_slide:
+            if jn.startswith(ns) and int(m.jnt_type[j]) in hinge_slide:
                 adr = m.jnt_qposadr[j]
                 d.qpos[adr] = kq[adr]
         # 2) actuator targets so position actuators hold the pose.
         for a in range(m.nu):
             jid = int(m.actuator_trnid[a, 0])
-            if jid >= 0 and m.jnt_type[jid] in hinge_slide:
+            if jid >= 0 and int(m.jnt_type[jid]) in hinge_slide:
                 d.ctrl[a] = kq[m.jnt_qposadr[jid]]
         mujoco.mj_forward(m, d)
         logger.info("Arm set to 'home' pose (erected on benchtop).")

--- a/examples/so101_curobo/scene.py
+++ b/examples/so101_curobo/scene.py
@@ -544,14 +544,17 @@ def _erect_arm(sim, robot_name: str) -> bool:
             return False
         kq = m.key_qpos[key_id]
         ns = f"{robot_name}/"
-        hinge_slide = (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_SLIDE)
+        # Joint types are compared BY VALUE: ``m.jnt_type[j]`` is a numpy integer and
+        # ``x in (enum, ...)`` puts the enum on the left of ``==``, where a pybind11
+        # enum does not match a numpy integer on every mujoco build.
+        hinge_slide = (int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE))
         for j in range(m.njnt):
             jn = mujoco.mj_id2name(m, mujoco.mjtObj.mjOBJ_JOINT, j) or ""
-            if jn.startswith(ns) and m.jnt_type[j] in hinge_slide:
+            if jn.startswith(ns) and int(m.jnt_type[j]) in hinge_slide:
                 d.qpos[m.jnt_qposadr[j]] = kq[m.jnt_qposadr[j]]
         for a in range(m.nu):
             jid = int(m.actuator_trnid[a, 0])
-            if jid >= 0 and m.jnt_type[jid] in hinge_slide:
+            if jid >= 0 and int(m.jnt_type[jid]) in hinge_slide:
                 d.ctrl[a] = kq[m.jnt_qposadr[jid]]
         mujoco.mj_forward(m, d)
         return True

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -1118,9 +1118,8 @@ class SpecBuilder:
         #      angled/elevated plane, e.g. a ramp or wall, which must survive).
         #   3. Debug log -- record which geoms were stripped so a disappearing
         #      (or surviving) robot floor is diagnosable.
-        world_has_ground = any(
-            g.type in (mujoco.mjtGeom.mjGEOM_PLANE, mujoco.mjtGeom.mjGEOM_HFIELD) for g in scene_spec.geoms
-        )
+        ground_types = (int(mujoco.mjtGeom.mjGEOM_PLANE), int(mujoco.mjtGeom.mjGEOM_HFIELD))
+        world_has_ground = any(int(g.type) in ground_types for g in scene_spec.geoms)
         stripped: list[str] = []
         if world_has_ground:
             for plane in [

--- a/tests/simulation/test_add_robot_seats_on_terrain.py
+++ b/tests/simulation/test_add_robot_seats_on_terrain.py
@@ -83,6 +83,12 @@ def _write(xml: str) -> str:
     return p
 
 
+# ``model.geom_type[i]`` is a numpy integer, so it is compared to the geom-type
+# enum BY VALUE: ``x in (enum, ...)`` puts the enum on the left of ``==``, where a
+# pybind11 enum does not match a numpy integer on every mujoco build.
+_GROUND_GEOM_TYPES = (int(mujoco.mjtGeom.mjGEOM_HFIELD), int(mujoco.mjtGeom.mjGEOM_PLANE))
+
+
 def _lowest_collision_geom_z(sim) -> float:
     """World z of the lowest collidable robot geom (skips the ground plane / hfield)."""
     model, data = sim._world._model, sim._world._data
@@ -90,7 +96,7 @@ def _lowest_collision_geom_z(sim) -> float:
     for gid in range(model.ngeom):
         if model.geom_contype[gid] == 0 and model.geom_conaffinity[gid] == 0:
             continue
-        if model.geom_type[gid] in (mujoco.mjtGeom.mjGEOM_HFIELD, mujoco.mjtGeom.mjGEOM_PLANE):
+        if int(model.geom_type[gid]) in _GROUND_GEOM_TYPES:
             continue
         zs.append(float(data.geom_xpos[gid][2]))
     assert zs, "no collidable robot geoms found"

--- a/tests/test_mujoco_enum_comparisons_are_value_based.py
+++ b/tests/test_mujoco_enum_comparisons_are_value_based.py
@@ -1,0 +1,184 @@
+"""A MuJoCo ``mjt*`` enum is matched by VALUE, never by operand order.
+
+``mjModel`` / ``mjData`` expose their type fields as numpy integer arrays
+(``model.geom_type[i]`` is an ``np.int32``), while the matching vocabulary is a
+pybind11 enum (``mujoco.mjtGeom.mjGEOM_HFIELD``). Whether those two compare
+equal depends on WHICH SIDE the enum is on:
+
+* ``np.int32(1) == mjGEOM_HFIELD`` - numpy on the left - is ``True`` on every
+  build measured.
+* ``mjGEOM_HFIELD == np.int32(1)`` - the enum on the left - is ``True`` on
+  3.9.0, 3.10.0 and 3.11.0 and ``False`` on 3.12.0 (measured on released
+  wheels; the declared range is ``mujoco>=3.5.0,<4.0.0``, so both answers are
+  in-range).
+
+That second form is not usually written by hand: it is what ``in`` produces.
+CPython's ``tuple.__contains__`` compares ``element == needle``, so
+``model.geom_type[i] in (mjGEOM_HFIELD, mjGEOM_PLANE)`` puts the ENUM on the
+left and silently stops matching - the membership test just answers ``False``
+for every geom, with nothing raised and no warning. A hash-based ``in`` over a
+``set`` of enum members degrades the same way: the hashes still collide, and the
+equality that confirms the hit is the failing direction.
+
+Measured consequence of one such site (mujoco 3.12.0, the shipped
+terrain-seat helper): a heightfield ground geom stopped being recognised as
+ground, so the "lowest robot geom" it computes returned the ground's own
+``z=0.0`` and three ``create_world(terrain=...)`` regression tests failed with
+``assert 0.0 >= 0.16``. Another (``examples/*/scene.py``): the home-pose helper
+matched 0 of 3 joints and wrote no ``qpos`` and no ``ctrl``, leaving the arm at
+its compiled default pose while logging that the home pose had been set.
+
+So the rule is to compare integers on both sides - ``int(model.geom_type[i]) in
+(int(mjGEOM_HFIELD), int(mjGEOM_PLANE))`` - which is what the MuJoCo backend
+already does at its own type checks (``int(model.actuator_trntype[act_id]) !=
+int(mj.mjtTrn.mjTRN_TENDON)``). This guard is structural rather than
+behavioural on purpose: the defect only manifests from mujoco 3.12.0 on, so a
+test that merely exercised the installed build would pass on an older one and
+pin nothing.
+"""
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_TREES = ("strands_robots", "tests", "tests_integ", "examples")
+
+# ``mj.mjtGeom.mjGEOM_HFIELD`` / ``mujoco.mjtJoint.mjJNT_HINGE`` and friends.
+_ENUM_MEMBER = re.compile(r"^(?:mj|mujoco)\.mjt[A-Za-z]+\.[A-Za-z_]+$")
+
+_MINIMUM_GRADED_FILES = 40
+
+
+def _is_enum_member(node: ast.expr) -> bool:
+    """Whether ``node`` spells a ``mjt*`` enum member access."""
+    return bool(_ENUM_MEMBER.match(ast.unparse(node)))
+
+
+def _enum_collection_names(tree: ast.Module) -> set[str]:
+    """Names bound to a tuple/set/list whose every element is a bare enum member."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Tuple | ast.Set | ast.List):
+            continue
+        elements = node.value.elts
+        if not elements or not all(_is_enum_member(e) for e in elements):
+            continue
+        names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+def _order_dependent_comparisons(source: str) -> list[tuple[int, str, str]]:
+    """Return ``[(lineno, kind, snippet)]`` for every enum-on-the-left comparison."""
+    tree = ast.parse(source)
+    collections = _enum_collection_names(tree)
+    found: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        for op, comparator in zip(node.ops, node.comparators, strict=True):
+            kind = None
+            if isinstance(op, ast.In | ast.NotIn):
+                if (
+                    isinstance(comparator, ast.Tuple | ast.Set | ast.List)
+                    and comparator.elts
+                    and all(_is_enum_member(e) for e in comparator.elts)
+                ):
+                    kind = "membership in a collection of enum members"
+                elif isinstance(comparator, ast.Name) and comparator.id in collections:
+                    kind = f"membership in {comparator.id}, a collection of enum members"
+            elif isinstance(op, ast.Eq | ast.NotEq) and _is_enum_member(node.left):
+                kind = "an enum member on the left of =="
+            if kind:
+                found.append((node.lineno, kind, ast.unparse(node)))
+    return found
+
+
+def _graded_files() -> list[pathlib.Path]:
+    """Every python file in the graded trees that names the enum vocabulary."""
+    out: list[pathlib.Path] = []
+    for tree in _TREES:
+        for path in sorted((_REPO_ROOT / tree).rglob("*.py")):
+            if "mjt" in path.read_text(encoding="utf-8"):
+                out.append(path)
+    return out
+
+
+class TestEveryEnumComparisonIsValueBased:
+    """No source compares a ``mjt*`` enum from the left, where numpy stops matching."""
+
+    def test_no_source_puts_a_mujoco_enum_on_the_left_of_a_comparison(self) -> None:
+        offenders: list[str] = []
+        for path in _graded_files():
+            for lineno, kind, snippet in _order_dependent_comparisons(path.read_text(encoding="utf-8")):
+                rel = path.relative_to(_REPO_ROOT)
+                offenders.append(f"{rel}:{lineno} ({kind}): {snippet}")
+        assert not offenders, (
+            "these comparisons put a mujoco enum on the left, where a numpy model/data "
+            "field stops matching it on mujoco 3.12.0; compare int() to int() instead:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_the_scan_reaches_every_tree(self) -> None:
+        """A refactor that stops reaching the sources must fail, not report clean."""
+        graded = _graded_files()
+        assert len(graded) >= _MINIMUM_GRADED_FILES, f"only {len(graded)} files graded"
+        reached = {p.relative_to(_REPO_ROOT).parts[0] for p in graded}
+        assert reached == set(_TREES), f"trees reached: {sorted(reached)}"
+
+
+class TestTheScanFindsBothOrderDependentShapes:
+    """Planted sources: a clean result means the sources are right, not that anything passes."""
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "x = model.geom_type[0] in (mujoco.mjtGeom.mjGEOM_PLANE, mujoco.mjtGeom.mjGEOM_HFIELD)",
+            "x = model.geom_type[0] not in (mj.mjtGeom.mjGEOM_PLANE,)",
+            "x = model.geom_type[0] in {mujoco.mjtGeom.mjGEOM_PLANE}",
+            "GROUND = (mujoco.mjtGeom.mjGEOM_PLANE, mujoco.mjtGeom.mjGEOM_HFIELD)\nx = m.geom_type[0] in GROUND",
+            "x = mujoco.mjtGeom.mjGEOM_PLANE == model.geom_type[0]",
+            "x = mj.mjtJoint.mjJNT_FREE != model.jnt_type[0]",
+        ],
+        ids=["in-tuple", "not-in-tuple", "in-set", "in-named-collection", "enum-left-eq", "enum-left-neq"],
+    )
+    def test_an_order_dependent_comparison_is_reported(self, snippet: str) -> None:
+        assert _order_dependent_comparisons(snippet), f"not reported: {snippet}"
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "x = int(model.geom_type[0]) in (int(mujoco.mjtGeom.mjGEOM_PLANE),)",
+            "GROUND = (int(mujoco.mjtGeom.mjGEOM_PLANE),)\nx = int(m.geom_type[0]) in GROUND",
+            "x = model.geom_type[0] == mujoco.mjtGeom.mjGEOM_PLANE",
+            "x = int(model.actuator_trntype[0]) != int(mj.mjtTrn.mjTRN_TENDON)",
+            "x = name in ('a', 'b')",
+        ],
+        ids=["int-in-tuple", "int-in-named", "enum-on-the-right", "int-vs-int", "unrelated"],
+    )
+    def test_a_value_based_comparison_is_not_reported(self, snippet: str) -> None:
+        assert not _order_dependent_comparisons(snippet), f"falsely reported: {snippet}"
+
+
+class TestTheValueBasedFormMatchesOnThisBuild:
+    """The convention selects the right geoms on whichever mujoco is installed."""
+
+    def test_int_membership_selects_the_ground_geom_types(self) -> None:
+        mujoco = pytest.importorskip("mujoco")
+        model = mujoco.MjModel.from_xml_string(
+            "<mujoco>"
+            '<asset><hfield name="hf" nrow="4" ncol="4" size="1 1 .2 .1"/></asset>'
+            "<worldbody>"
+            '<geom name="pl" type="plane" size="1 1 .1"/>'
+            '<geom name="hg" type="hfield" hfield="hf"/>'
+            '<geom name="bx" type="box" size=".1 .1 .1"/>'
+            "</worldbody></mujoco>"
+        )
+        ground = (int(mujoco.mjtGeom.mjGEOM_PLANE), int(mujoco.mjtGeom.mjGEOM_HFIELD))
+        selected = {
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if int(model.geom_type[g]) in ground
+        }
+        assert selected == {"pl", "hg"}, f"selected {sorted(selected)}"

--- a/tests_integ/simulation/test_builtin_benchmark_load.py
+++ b/tests_integ/simulation/test_builtin_benchmark_load.py
@@ -163,6 +163,11 @@ _TERRAIN = "pyramid"
 _DIFFICULTY = 2.0
 
 
+# ``model.geom_type[i]`` is a numpy integer, so it is compared to the geom-type
+# enum BY VALUE (see the note in tests/simulation/test_add_robot_seats_on_terrain.py).
+_GROUND_GEOM_TYPES = (int(mujoco.mjtGeom.mjGEOM_HFIELD), int(mujoco.mjtGeom.mjGEOM_PLANE))
+
+
 def _lowest_collision_geom_z(sim: Any) -> float:
     """World z of the lowest collidable robot geom (skips the ground plane / hfield)."""
     model, data = sim._world._model, sim._world._data
@@ -170,7 +175,7 @@ def _lowest_collision_geom_z(sim: Any) -> float:
         float(data.geom_xpos[g][2])
         for g in range(model.ngeom)
         if not (model.geom_contype[g] == 0 and model.geom_conaffinity[g] == 0)
-        and model.geom_type[g] not in (mujoco.mjtGeom.mjGEOM_HFIELD, mujoco.mjtGeom.mjGEOM_PLANE)
+        and int(model.geom_type[g]) not in _GROUND_GEOM_TYPES
     ]
     assert zs, "no collidable robot geoms found"
     return min(zs)


### PR DESCRIPTION
## Problem

`mjModel` / `mjData` expose their type fields as numpy integer arrays
(`model.geom_type[i]` is an `np.int32`), while the matching vocabulary is a
pybind11 enum (`mujoco.mjtGeom.mjGEOM_HFIELD`). Whether the two compare equal
depends on which side the enum is on, and that changed inside the declared
`mujoco>=3.5.0,<4.0.0` range:

| comparison, on a numpy model field | 3.9.0 / 3.10.0 / 3.11.0 | 3.12.0 |
| --- | --- | --- |
| `np.int32(1) == mjGEOM_HFIELD` (numpy left) | True | True |
| `mjGEOM_HFIELD == np.int32(1)` (enum left) | True | **False** |
| `geom_type[i] in (HFIELD, PLANE)` | True | **False** |
| `int(geom_type[i]) in (int(HFIELD), int(PLANE))` | True | True |

The enum-on-the-left form is not usually written by hand: it is what `in`
produces. CPython's `tuple.__contains__` compares `element == needle`, so
`model.geom_type[i] in (mjGEOM_HFIELD, mjGEOM_PLANE)` puts the enum on the left
and the membership test simply answers `False` for every element - nothing
raised, nothing logged. A `set` of enum members degrades identically: the hashes
still collide and the equality that confirms the hit is the failing direction.

Two measured consequences on 3.12.0:

- `tests/simulation/test_add_robot_seats_on_terrain.py` - the heightfield ground
  geom stopped being recognised as ground, so the helper that computes "the
  lowest collidable robot geom" returned the ground's own `z=0.0`. Three
  `create_world(terrain=...)` regression tests failed with `assert 0.0 >= 0.16`
  (**6 passed on 3.10.0, 3 failed on 3.12.0**, same tree).
- `examples/mujoco_gs/scene.py::_erect_arm` and its `examples/so101_curobo`
  twin - the home-pose helper matched **0 of 4** hinge/slide joints and wrote
  neither `qpos` nor `ctrl`, leaving the arm in its compiled zero pose while
  reporting success and logging that the home pose had been set.

## Change

Every comparison that put a `mjt*` enum on the left now reads `int()` on both
sides - the convention the MuJoCo backend already uses at its own type checks
(`int(model.actuator_trntype[act_id]) != int(mj.mjtTrn.mjTRN_TENDON)`, six such
sites today). Seven call sites across `strands_robots`, `tests`, `tests_integ`
and `examples`.

The rule is applied uniformly rather than with an exemption. The one shipped
site, `spec_builder.attach_robot`'s ground detection, was measured **not**
broken - `MjsGeom.type` really is an enum, so `in` works there - but a reader
cannot tell an `MjsGeom` attribute from an `MjModel` array element at the call
site, so it is written by value too. Comparisons with the enum on the *right*
(`geom_type[i] == mjGEOM_PLANE`) still match on every build measured and are
left alone.

`tests/test_mujoco_enum_comparisons_are_value_based.py` closes the class: it
grades all four trees for a `mjt*` enum on the left of `==`, whether that comes
from a literal collection, a named collection of enum members, or a
hand-written reversed comparison. It is structural rather than behavioural on
purpose - the defect only manifests from 3.12.0 on, so a test that merely
exercised the installed build would pass on an older one and pin nothing.

## Verification

Measured at `d6cc7e9`, mujoco 3.12.0 unless stated.

Pre-fix, the new guard against `upstream/main` sources: **1 failed / 13
passed**, naming all seven offenders. Pre-fix, the terrain-seat tests on
`upstream/main`: **6 passed on mujoco 3.10.0**, **3 failed on 3.12.0**.

Post-fix the new guard and the terrain-seat tests are **20 passed on mujoco
3.10.0 and 20 passed on 3.12.0** - the fix is a no-op on the builds where the
old form already worked.

Blast radius (all of `tests/simulation`, every test that scans a source tree or
`AGENTS.md`, and the repo-wide guards - 179 paths, 17275 collected), branch vs
an `upstream/main` worktree, same interpreter:

| measure | branch | upstream/main |
| --- | --- | --- |
| passed | 16956 | 16951 |
| failed | 35 | 40 |
| errors | 126 | 126 |

Branch-only failing ids: none. The two ids that appear branch-only are in
`tests/mesh/test_zenoh_transport_security.py`, which opens real localhost Zenoh
sessions; base fails three *different* ids in that same file, and the file is
**9 passed on both trees** when run alone. Base-only ids are exactly the three
terrain-seat tests and the new guard. The 126 errors and the remaining shared
failures are the same on both trees (optional deps absent from this
interpreter).

`ruff check` / `ruff format --check` clean over `strands_robots tests
tests_integ`; `mypy` 24 errors on the branch and 24 on a pristine
`upstream/main` worktree, none in the changed files.

## Artifact

mujoco 3.12.0 in both columns, same scene, each column executing that tree's
own `_erect_arm` verbatim. Left: 0 of 4 joints matched, no `qpos` and no `ctrl`
written, arm still in its zero pose. Right: 4 of 4 matched, arm in its `home`
pose.

![enum matched by value](https://raw.githubusercontent.com/cagataycali/robots/media-mujoco-enum-value/enum-value-comparison.png)
