### PR TITLE
fix(assets): refuse an empty robot-name selection instead of downloading every robot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1503,6 +1503,23 @@ which side the enum is on.
 - **A selection widened to everything can also reach past the call.** `detach_teleop` stops
   the local loop once nothing is left to drive, so a detach widened from one stream to all
   of them ended a running session as a side effect of the misread.
+- **A surface that resolves the names by membership takes only the emptiness verdict.**
+  Where the selector is resolved into a dict rather than bound by position, a repeat
+  resolves to its first occurrence and a mapping and a one-shot iterator are each read
+  exactly once, so routing the shape through `name_list_error` would refuse calls that
+  are honored as written today - the same carve-out that keeps the WBC and MotionBricks
+  providers out of that domain. `download_robots(names=...)` is that case, and the
+  membership read is still owed: read by truthiness, `names=[]` downloaded 56 robots on
+  the shipped registry, and 13 - a whole category - when a `category` was also passed,
+  reporting either count as the caller's own request. Nothing had to write `[]` to get
+  there, which is what made it reachable rather than theoretical: the `download_assets`
+  tool builds the list from a comma-separated string through its own blank-field filter,
+  so the NON-empty `robots=","`, `" "` and `",,,"` each parse to zero names. Refuse the
+  empty selection ahead of the call that creates the asset cache directory, so a refused
+  selection leaves nothing behind - and refuse it again in the tool's own vocabulary, so
+  the remedy names the `robots=` that caller passed rather than the `names=` it never
+  did. Pinned by `tests/test_asset_download_selection_domain.py`, whose controls pin the
+  three tolerated spellings so the narrowing stays deliberate rather than incidental.
 - Pinned by `tests/test_teleop_device_selection_domain.py`, whose controls assert that the
   documented spellings (`names=None`, a real subset, `detach_teleop(None)`) are unchanged,
   and by the render path's `cameras` resolution, which has read the same kind of selector

--- a/changelog.d/2532-download-robots-empty-name-selection.md
+++ b/changelog.d/2532-download-robots-empty-name-selection.md
@@ -1,0 +1,27 @@
+### Fixed: an empty robot-name selection is refused, not read as "every robot"
+
+`names` on `download_robots` selects a subset of the sim robots the registry
+lists, and `None` is the documented "all of them". It was read by truthiness, so
+`names=[]` -- a selection that asks for no robot -- fell through to the branches
+that never read it. Measured on the shipped registry it downloaded 56 robots on
+its own, and 13 (the whole `humanoid` category) when a `category` was also
+passed, reporting either count as the caller's own request.
+
+Nothing had to write `[]` to reach that. The `download_assets` tool builds the
+list from a comma-separated string through its own blank-field filter, so the
+non-empty `robots=","`, `" "`, `",,,"` and `"  ,  "` each parsed to zero names --
+and an agent that emitted one of them cloned the entire registry and was told
+`status: success`.
+
+The selector is now read `is None`, and an empty selection is refused ahead of
+`get_user_assets_dir()` -- the call that creates the asset cache directory -- so
+a refused selection leaves nothing behind. The tool refuses in its own
+vocabulary, naming `robots=` rather than the `names=` its caller never passed; an
+absent or empty `robots=` still means "all", because for a single string argument
+unset and empty genuinely coincide.
+
+Only the emptiness verdict is taken locally. The shape is deliberately not routed
+through the shared `name_list_error` domain: this surface resolves each name by
+membership into a dict, so a repeat resolves to its first occurrence and a mapping
+and a one-shot iterator are each read exactly once. All three are honored as
+written today, and the tests pin them so that stays deliberate.

--- a/strands_robots/assets/download.py
+++ b/strands_robots/assets/download.py
@@ -469,21 +469,60 @@ def download_robots(
       3. Custom GitHub repos for non-Menagerie robots.
 
     Args:
-        names: Robot names to download (``None`` = all sim robots).
-        category: Filter by category (arm, humanoid, mobile, ...).
+        names: Robot names to download - a SUBSET of the sim robots the registry
+            lists. ``None`` selects all of them; an empty list selects none and
+            is refused rather than widened to all (see :exc:`ValueError` below).
+        category: Filter by category (arm, humanoid, mobile, ...). Applied only
+            when ``names`` is ``None``.
         force: Re-download even if present.
 
     Returns:
         Dict with downloaded/skipped/failed counts, names, and details.
+
+    Raises:
+        ValueError: If ``names`` is an empty selection, which asks for no robot
+            and cannot be honored as a request for every robot.
     """
+    # ``names`` selects a SUBSET of the sim robots the registry already lists, so it
+    # is read by membership - the rule ``names`` is read by on the teleoperate path
+    # and ``cameras`` on the render path, where an empty selection resolves to no
+    # camera rather than to every one. ``None`` is the documented "all sim robots";
+    # an explicitly empty selection is the opposite of that, not a spelling of it.
+    #
+    # Read by truthiness, ``names=[]`` fell through to the branches that do not read
+    # it at all. Measured on this registry it downloaded 56 robots on its own, and
+    # 13 - the whole ``humanoid`` category - when a ``category`` was passed too,
+    # reporting either as the caller's own request. An empty selection is what a
+    # filter that matched nothing produces, and the ``download_assets`` tool reaches
+    # it from a NON-empty argument: ``robots=","`` parses to no names through that
+    # tool's own ``if r.strip()`` filter, so no caller has to write ``[]`` to get here.
+    #
+    # Refused ahead of ``get_user_assets_dir()``, which creates the cache directory,
+    # so a refused selection leaves nothing behind to undo.
+    #
+    # Only the emptiness verdict is taken here; the shape is deliberately NOT routed
+    # through the shared ``name_list_error`` domain. This surface resolves each name
+    # by membership into ``robots`` below, so a repeat resolves to its first
+    # occurrence and costs nothing - the same carve-out that keeps the WBC and
+    # MotionBricks providers out of that domain - and a mapping and a one-shot
+    # iterator are each read exactly once here. Refusing them would reject calls
+    # that are honored as written today.
+    if names is not None and not names:
+        raise ValueError(
+            "download_robots(names=[]) selects no robot, so there is nothing to download. "
+            "Pass names=None to download every sim robot, or name the subset to download."
+        )
+
     dest_dir = get_user_assets_dir()
     # Filter None values - get_robot() can return None for unknown names
     all_sim: dict[str, dict[str, Any]] = {
         r["name"]: info for r in registry_list_robots(mode="sim") if (info := get_robot(r["name"])) is not None
     }
 
-    # Resolve requested robots
-    if names:
+    # Resolve requested robots. Read ``is not None``: an empty selection was
+    # refused above, so reaching the ``category``/all branches means the caller
+    # named no subset at all.
+    if names is not None:
         robots: dict[str, dict[str, Any]] = {}
         for name in names:
             canonical = resolve_robot_name(name)

--- a/strands_robots/tools/download_assets.py
+++ b/strands_robots/tools/download_assets.py
@@ -41,7 +41,9 @@ def download_assets(
     Args:
         action: ``download`` | ``list`` | ``status``.  ``status`` marks each
             robot ``[ok]`` (assets present) or ``[--]`` (missing).
-        robots: Comma-separated names (e.g. ``so100,panda``). Omit for all.
+        robots: Comma-separated names (e.g. ``so100,panda``). Omit for all. A
+            non-empty value that names no robot (``","``) is refused rather
+            than read as "all".
         category: Filter: arm, bimanual, hand, humanoid, mobile, mobile_manip
         force: Re-download even if present
     """
@@ -64,7 +66,36 @@ def download_assets(
             return {"status": "success", "content": [{"text": "\n".join(lines)}]}
 
         if action == "download":
-            robot_names = [r.strip() for r in robots.split(",") if r.strip()] if robots else None
+            # ``robots`` carries a SUBSET of the sim robots as one comma-separated
+            # string, and the parse below drops blank fields - so a non-empty
+            # argument can name nothing: ``","``, ``" "`` and ``",,,"`` each parse
+            # to zero names. Handed on as ``names=[]`` that was the opposite of what
+            # it asked for, because ``download_robots`` read the selector by
+            # truthiness and downloaded every sim robot instead.
+            #
+            # ``download_robots`` now refuses an empty selection, so this only has to
+            # not manufacture one - but the refusal is raised in terms of ``names=``,
+            # which is not the argument this caller passed. Refuse here instead, in
+            # this surface's own vocabulary, so the remedy names ``robots=`` and is
+            # actionable as written. An absent or empty ``robots`` still means "all":
+            # for a single string argument, unset and empty genuinely coincide, and
+            # only a value that carries content while naming nothing is a mistake.
+            robot_names: list[str] | None = None
+            if robots:
+                robot_names = [r.strip() for r in robots.split(",") if r.strip()]
+                if not robot_names:
+                    return {
+                        "status": "error",
+                        "content": [
+                            {
+                                "text": (
+                                    f"download_assets: robots={robots!r} names no robot - it is read as a "
+                                    "comma-separated list and every field in it is blank. Omit robots= to "
+                                    'download every sim robot, or name the subset (robots="so100,panda").'
+                                )
+                            }
+                        ],
+                    }
             result = download_robots(names=robot_names, category=category, force=force)
             parts = [
                 f"Downloaded: {result['downloaded']}, Skipped: {result['skipped']}, Failed: {result['failed']}",

--- a/tests/test_asset_download_selection_domain.py
+++ b/tests/test_asset_download_selection_domain.py
@@ -1,0 +1,209 @@
+"""An empty robot-name selection is refused, never widened to every robot.
+
+``download_robots(names=...)`` and the ``download_assets`` tool's ``robots=``
+string both carry a SUBSET of the sim robots the registry lists. ``None`` means
+"all of them"; an empty selection means *none*, which is the opposite answer
+rather than a spelling of the same one.
+
+Read by truthiness, ``names=[]`` fell through to the branches that never read it:
+measured on the shipped registry it downloaded 56 robots on its own, and 13 - the
+whole ``humanoid`` category - when a ``category`` was also passed, reporting
+either as the caller's own request. Nothing has to write ``[]`` to reach that: the
+tool's own ``if r.strip()`` filter turns the non-empty ``robots=","`` into zero
+names.
+
+The controls matter as much as the refusals here. This surface resolves each name
+by membership into a dict, so a repeat, a mapping and a one-shot iterator are all
+honored as written today - which is why the shape is deliberately NOT routed
+through the shared ``name_list_error`` domain, and why those spellings are pinned
+below rather than left to a later sweep to "tidy up".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from strands_robots.assets import download as dl
+from strands_robots.tools.download_assets import download_assets
+
+_MOD = "strands_robots.assets.download"
+_TOOL_MOD = "strands_robots.tools.download_assets"
+
+
+def _entry(name: str, category: str = "arm") -> dict[str, Any]:
+    return {"asset": {"dir": name, "model_xml": "model.xml"}, "category": category}
+
+
+@pytest.fixture
+def registry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, dict[str, Any]]:
+    """A two-category sim registry with the download side effects stubbed out."""
+    entries = {
+        "arm1": _entry("arm1", "arm"),
+        "arm2": _entry("arm2", "arm"),
+        "hum1": _entry("hum1", "humanoid"),
+    }
+    monkeypatch.setattr(f"{_MOD}.get_user_assets_dir", lambda: tmp_path)
+    monkeypatch.setattr(f"{_MOD}.registry_list_robots", lambda mode: [{"name": n} for n in entries])
+    monkeypatch.setattr(f"{_MOD}.get_robot", lambda n: entries.get(n))
+    monkeypatch.setattr(f"{_MOD}.resolve_robot_name", lambda n: n)
+    # Nothing is present, so every selected robot reaches the download partition -
+    # the count a widened selection would inflate.
+    monkeypatch.setattr(f"{_MOD}._needs_download", lambda *a, **k: True)
+    monkeypatch.setattr(f"{_MOD}._robot_descriptions_available", lambda: False)
+    return entries
+
+
+def _considered(**kwargs: Any) -> set[str]:
+    """The set of robots a call actually hands to the download partition."""
+    seen: set[str] = set()
+
+    def _git(robots: dict[str, Any], dest_dir: Path) -> dict[str, str]:
+        seen.update(robots)
+        return {n: "downloaded" for n in robots}
+
+    with (
+        patch(f"{_MOD}._download_via_git", side_effect=_git),
+        patch(f"{_MOD}._download_from_github", return_value="downloaded"),
+    ):
+        dl.download_robots(**kwargs)
+    return seen
+
+
+# The refusals
+
+
+def test_empty_name_selection_is_refused(registry: dict[str, Any]) -> None:
+    """``names=[]`` selects no robot, so it is refused rather than read as "all"."""
+    with pytest.raises(ValueError) as excinfo:
+        dl.download_robots(names=[])
+    message = str(excinfo.value)
+    assert "selects no robot" in message
+    # The remedy names both honorable alternatives, so it is actionable as written.
+    assert "names=None" in message
+
+
+def test_empty_name_selection_is_refused_and_not_read_as_the_category(registry: dict[str, Any]) -> None:
+    """``names=[]`` with a ``category`` is refused, not silently widened to it.
+
+    This is the second widening branch and the quieter one: the empty selection
+    fell through to the ``category`` filter, so the call downloaded an entire
+    category while reporting it as the caller's own named request.
+    """
+    with pytest.raises(ValueError):
+        dl.download_robots(names=[], category="humanoid")
+
+
+def test_refused_selection_downloads_nothing(registry: dict[str, Any]) -> None:
+    """The refusal lands before any download is attempted."""
+    with (
+        patch(f"{_MOD}._download_via_git") as git,
+        patch(f"{_MOD}._download_from_github") as github,
+    ):
+        with pytest.raises(ValueError):
+            dl.download_robots(names=[])
+    git.assert_not_called()
+    github.assert_not_called()
+
+
+def test_refused_selection_does_not_create_the_asset_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The refusal precedes ``get_user_assets_dir()``, which creates the cache dir.
+
+    Checked with the real directory helper rather than a stub: it is the call that
+    performs the ``mkdir``, so a guard placed after it would leave the directory
+    behind for a call that never downloaded anything.
+    """
+    cache = tmp_path / "assets-cache"
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(cache))
+    assert not cache.exists()
+
+    with pytest.raises(ValueError):
+        dl.download_robots(names=[])
+
+    assert not cache.exists(), "a refused selection created the asset cache directory"
+
+
+# The controls: every honored spelling is unchanged
+
+
+def test_none_selects_every_sim_robot(registry: dict[str, Any]) -> None:
+    assert _considered() == {"arm1", "arm2", "hum1"}
+
+
+def test_none_with_a_category_selects_that_category(registry: dict[str, Any]) -> None:
+    assert _considered(category="humanoid") == {"hum1"}
+
+
+def test_a_real_subset_selects_exactly_that_subset(registry: dict[str, Any]) -> None:
+    assert _considered(names=["arm2"]) == {"arm2"}
+
+
+@pytest.mark.parametrize(
+    "names",
+    [
+        pytest.param(["arm2", "arm2"], id="repeat"),
+        pytest.param({"arm2": 1}, id="mapping"),
+        pytest.param(iter(["arm2"]), id="one-shot-iterator"),
+    ],
+)
+def test_membership_resolution_keeps_tolerating_its_own_spellings(registry: dict[str, Any], names: Any) -> None:
+    """Spellings the shared name-list domain refuses are honored here, by design.
+
+    ``download_robots`` resolves each name by membership into a dict, so a repeat
+    collapses to its first occurrence, a mapping is read over its keys and a
+    one-shot iterator is consumed exactly once. Routing this selector through
+    ``name_list_error`` would reject all three, which is why only the emptiness
+    verdict is taken locally. Pinned so that choice is deliberate rather than
+    incidental.
+    """
+    assert _considered(names=names) == {"arm2"}
+
+
+# The tool surface refuses in its own vocabulary
+
+
+@pytest.mark.parametrize("robots", [",", " ", ",,,", " , ", ", ,"])
+def test_tool_refuses_a_non_empty_value_that_names_no_robot(robots: str) -> None:
+    """A ``robots=`` string can carry content while naming nothing.
+
+    Every field is dropped by the tool's own blank filter, so the parse yields an
+    empty selection from a non-empty argument.
+    """
+    with patch(f"{_TOOL_MOD}.download_robots") as download:
+        result = download_assets(action="download", robots=robots)
+
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    # Refused in this surface's vocabulary: the caller passed ``robots=``, not
+    # ``names=``, so that is the argument the remedy has to name.
+    assert "robots=" in text
+    assert "names=" not in text
+    download.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("robots", "expected"),
+    [
+        pytest.param(None, None, id="omitted-means-all"),
+        pytest.param("", None, id="empty-string-means-all"),
+        pytest.param("so100", ["so100"], id="one-name"),
+        pytest.param("so100,panda", ["so100", "panda"], id="two-names"),
+        pytest.param(" so100 , panda ", ["so100", "panda"], id="whitespace-stripped"),
+        pytest.param("so100,,panda", ["so100", "panda"], id="blank-field-dropped"),
+    ],
+)
+def test_tool_forwards_every_honored_value_unchanged(robots: str | None, expected: list[str] | None) -> None:
+    """An absent or empty ``robots=`` still means "all"; a named subset is forwarded.
+
+    For a single string argument, unset and empty genuinely coincide - only a value
+    that carries content while naming nothing is a caller mistake.
+    """
+    fake = {"downloaded": 0, "skipped": 0, "failed": 0, "method": "git clone"}
+    with patch(f"{_TOOL_MOD}.download_robots", return_value=fake) as download:
+        result = download_assets(action="download", robots=robots)
+
+    assert result["status"] == "success"
+    assert download.call_args.kwargs["names"] == expected


### PR DESCRIPTION
Fixes #2531

## The defect

`names` on `download_robots` selects a SUBSET of the sim robots the registry lists, and the docstring documents `None` as "all sim robots". It was read by truthiness:

```python
if names:                   # [] is falsy -> falls through
    robots = {...}          # the named subset
elif category:
    robots = {...}          # the whole category
else:
    robots = dict(all_sim)  # every sim robot
```

An empty selection asks for *no* robot, which is the opposite of "all of them", not a spelling of it.

## Measured, against the shipped registry (63 sim robots)

| call | robots downloaded |
|---|---|
| `names=None` (documented "all") | 56 (+7 failed) |
| `names=[]` (asks for nothing) | **56 (+7 failed)** |
| `names=[]`, `category="humanoid"` | **13 (+4 failed)** |
| `names=["g1"]` (a real subset) | 1 |

The empty selection is indistinguishable from the record-all branch, and with a `category` it is silently reinterpreted as that entire category. Both report the count as the caller's own request.

## Nobody has to write `[]` to reach it

The `download_assets` agent tool builds the list from a comma-separated string through its own blank filter, so a **non-empty** argument parses to zero names:

| `robots=` | parses to |
|---|---|
| `","` | `[]` |
| `" "` | `[]` |
| `",,,"` | `[]` |
| `"  ,  "` | `[]` |

So an agent emitting `robots=","` clones the entire registry and is told `status: success`. Same shape AGENTS.md already records for `teleoperate(names=[])` -- "what a filter that matched nothing produces" -- with a network side effect rather than a hardware one.

The cost is measurable in the test run itself: the new tests take **191s against the unfixed source** (real clones) and **0.48s** against the fix.

## The change

No new contract. AGENTS.md's "A subset selector is read by membership, never by truthiness" already rules on this, and `teleoperate` is the pinned precedent this mirrors.

1. **`download_robots`** reads `names is None` for the all-branch and refuses the empty selection, raising `ValueError` (already this module's convention -- see the clone-URL guard). Refused **ahead of `get_user_assets_dir()`**, which performs the cache `mkdir`, so a refused selection leaves nothing behind to undo.
2. **`download_assets`** refuses in its own vocabulary, naming `robots=` rather than the `names=` its caller never passed -- a refusal whose remedy names an argument the caller did not use is the failure mode AGENTS.md records under the posture-flag rule. An absent *or empty* `robots=` still means "all": for a single string argument unset and empty genuinely coincide, and only a value that carries content while naming nothing is a mistake.

### What is deliberately *not* changed

The shape is **not** routed through the shared `name_list_error` domain, unlike `teleoperate`. This surface resolves each name by membership into a dict, so -- measured -- a repeat resolves to its first occurrence, and a mapping and a one-shot iterator are each read exactly once. All three are honored as written today, so routing them through the shared domain would reject working calls. That is the same carve-out AGENTS.md records for the WBC and MotionBricks providers ("resolving these names by membership rather than by position ... so they are not callers of this function"). Only the emptiness verdict is taken locally, and the three tolerated spellings are **pinned by tests** so the narrowing stays deliberate rather than incidental.

A bare string (`names="g1"`, read as the two robots `"g"` and `"1"`, reported as `No matching robots found.`) is a real but separate and lower-severity defect -- it does not widen anything. Recorded in #2531 rather than folded in here.

## Tests

`tests/test_asset_download_selection_domain.py` (21 tests), named after the `test_teleop_device_selection_domain.py` precedent.

- 4 refusals: `names=[]`; `names=[]` + `category` (the quieter widening branch); nothing downloaded; **the asset cache directory is not created** -- checked with the real directory helper, since a guard placed after it would leave the dir behind.
- 5 tool refusals, parametrized over `","`, `" "`, `",,,"`, `" , "`, `", ,"`, asserting the message names `robots=` and never `names=`, and that `download_robots` is not called.
- 12 controls pinning every honored spelling unchanged: `None` -> all, `None`+`category` -> that category, a real subset, the three tolerated shapes, and the tool's six forwarding cases.

**9 of the 21 fail against the unfixed source** (4 library refusals + 5 tool refusals), verified by stashing the source change and re-running with the test file in place.

```
115 passed, 1 failed  # tests/test_asset_download*.py, tools/test_download_assets.py,
                      # test_ensure_meshes.py, assets docstrings, changelog gates
```

The single failure is `test_robot_descriptions_available_true_when_importable`, which fails identically on unmodified `main` in this environment (`robot_descriptions` not installed) -- verified by stashing the change and re-running.

`ruff check`, `ruff format --check` and `mypy` are clean on all three source files.

## Commits

| commit | concern |
|---|---|
| `7c539c3` | the fix + the pinned regression tests |
| `4a22ed1` | `changelog.d/` news fragment (per the fragment convention, not a `CHANGELOG.md` append) |
| `c68ceab` | AGENTS.md: record the membership-resolver carve-out on the existing subset-selector rule, and add this surface to its `Pinned by` list |

The AGENTS.md bullet is additive at a new anchor rather than an edit to the existing `Pinned by` line, to avoid the per-list-anchor conflict class described in #2507. Both test paths it names were verified to resolve on disk.

## How this was found

An AST sweep of the tree for optional-collection parameters read by truthiness (54 candidates), triaged against the documented rule. Worth recording that the sweep's most suspicious group was a **false positive**: `start_recording(cameras=...)` reads `cameras` by truthiness only to gate a validation call, and all three backends (MuJoCo, Newton, Isaac) resolve it `is not None`, so an empty camera selection already records no camera. That group is correct as written and is not touched here.