### PR TITLE
fix(tools): report a GR00T restart whose teardown could not free the port

### DIFF
--- a/changelog.d/2537-gr00t-restart-honours-the-teardown-verdict.md
+++ b/changelog.d/2537-gr00t-restart-honours-the-teardown-verdict.md
@@ -1,0 +1,2 @@
+### Fixed
+- **tools**: `gr00t_inference(action="restart")` now reports a teardown that could not free the port instead of reporting the new checkpoint as serving. The rebind cannot detect the collision itself - the launch is a detached `docker exec -d` and the readiness wait is a bare TCP connect that the surviving server answers - so a restart whose stop failed returned `status="success"` naming the new `checkpoint_path` while every inference request still reached the old one.

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -489,7 +489,10 @@ def gr00t_inference(
         - ``stop``: Terminate a running service on the specified ``port``.
         - ``status``: Check whether a service is running on the specified ``port``.
         - ``list``: Discover all running services across common ports (5555-5558, 8000-8003).
-        - ``restart``: Stop and re-start a service (e.g., to swap checkpoints). Requires ``checkpoint_path``.
+        - ``restart``: Stop and re-start a service (e.g., to swap checkpoints). Requires
+          ``checkpoint_path``. Refused when the running service cannot be stopped: the
+          port is still held, so the new checkpoint cannot bind it and the previous one
+          keeps serving.
         - ``find_containers``: List available Isaac-GR00T Docker containers.
         - ``build_image``: Clone Isaac-GR00T at ``repo_tag`` and run ``bash docker/build.sh``.
           Idempotent - skips the build when ``image_name`` already exists in the local
@@ -937,8 +940,34 @@ def gr00t_inference(
     elif action == "restart":
         if checkpoint_path is None:
             return {"status": "error", "message": "Checkpoint path required for restart"}
-        # Stop existing service and start new one
-        _stop_service(port)
+        # Stop the existing service, then rebind the port for the new checkpoint.
+        # The teardown verdict is the PRECONDITION for that rebind, not a
+        # progress note: ``_stop_service`` reports an error exactly when
+        # something still holds ``port`` after SIGTERM and SIGKILL, and its
+        # message says so in as many words ("a restart will fail to bind it").
+        #
+        # Discarding it sent the rebind ahead anyway, and the rebind cannot
+        # detect the collision on its own. The launch is a detached
+        # ``docker exec -d``, so ``subprocess.run`` returns 0 as soon as the
+        # daemon accepts it - it says nothing about whether the server inside
+        # bound the port - and the readiness wait is a bare TCP connect to
+        # ``port``, which the SURVIVING server answers on the first poll. The
+        # result was ``status="success"`` naming the new ``checkpoint_path`` as
+        # the one serving, byte-identical to a restart that really did swap it,
+        # while every inference request still reached the old checkpoint. Swapping
+        # checkpoints is the documented reason this action exists, so that is the
+        # one thing a caller cannot be left guessing about.
+        stop_result = _stop_service(port)
+        if stop_result["status"] == "error":
+            return {
+                "status": "error",
+                "port": port,
+                "message": (
+                    f"Restart aborted: the service on port {port} could not be stopped, so "
+                    f"{checkpoint_path!r} was not started and the previous checkpoint is still "
+                    f"serving. {stop_result.get('message', '')}"
+                ),
+            }
         time.sleep(2)  # Brief pause to allow port release before rebind
         return _start_service(
             checkpoint_path=checkpoint_path,

--- a/tests/tools/test_gr00t_inference.py
+++ b/tests/tools/test_gr00t_inference.py
@@ -1458,12 +1458,20 @@ class TestStartRestartDispatch:
 
     def test_restart_stops_then_starts_in_order(self):
         """``restart`` tears down the existing service before starting the new
-        one, with a pause in between, and returns the start result."""
+        one, with a pause in between, and returns the start result.
+
+        The ``_stop_service`` stub answers with a real success envelope because
+        ``restart`` reads the teardown verdict before it rebinds the port - a
+        stub returning ``None`` cannot express either verdict, so it could not
+        tell an honoured teardown from a discarded one.
+        """
         calls: list[str] = []
         with (
             patch(
                 "strands_robots.tools.gr00t_inference._stop_service",
-                side_effect=lambda port: calls.append("stop"),
+                side_effect=lambda port: (
+                    calls.append("stop") or {"status": "success", "port": port, "message": "stopped"}
+                ),
             ),
             patch(
                 "strands_robots.tools.gr00t_inference._start_service",

--- a/tests/tools/test_gr00t_stop_service_port_teardown.py
+++ b/tests/tools/test_gr00t_stop_service_port_teardown.py
@@ -13,8 +13,15 @@ rebinding. Two properties have to hold, and they pull in opposite directions:
   2. **The report must be true.** ``"status": "success"`` tells the caller the
      port is free. When something still holds the port after SIGTERM *and*
      SIGKILL -- a pid owned by another user, a failing ``docker exec`` -- saying
-     success sends ``restart`` on to a bind that cannot succeed, and the
-     resulting error names the wrong thing.
+     success sends ``restart`` on to a bind that cannot succeed.
+
+  3. **``restart`` has to consult that verdict.** The rebind cannot detect the
+     collision on its own: the launch is a detached ``docker exec -d`` and the
+     readiness wait is a bare TCP connect to the port, which the surviving
+     server answers. So a discarded error does not merely make the follow-on
+     failure name the wrong thing -- there is no follow-on failure at all. The
+     restart reports ``success`` naming the new checkpoint while the old one
+     keeps serving.
 
 Both branches (``docker exec`` into a GR00T container, and the host ``lsof``
 fallback) implement the same escalation, so every property is pinned on both.
@@ -77,9 +84,17 @@ class FakeHost:
         self._unkillable = set(unkillable)
         self._scans = 0
         self.signals: list[str] = []
+        # Every ``docker exec -d`` argv the tool ran, i.e. each inference server
+        # it launched. A restart that was refused must not have launched one.
+        self.launched: list[list[str]] = []
 
     def run(self, cmd: Any, *_args: Any, **kwargs: Any) -> _Result:
         argv = [str(part) for part in cmd]
+        if argv[:3] == ["docker", "exec", "-d"]:
+            # A detached exec: the daemon accepts it and returns 0 whether or not
+            # the server inside goes on to bind the port.
+            self.launched.append(argv)
+            return _Result(0, "")
         if argv[:2] == ["docker", "ps"]:
             if not self.in_container:
                 return _Result(0, "")
@@ -209,3 +224,175 @@ def test_an_unexpected_error_is_still_converted_to_an_error_tool_result() -> Non
         result = gi._stop_service(PORT)
     assert result["status"] == "error"
     assert "Failed to stop service" in result["message"]
+
+
+# --- restart consults the teardown verdict before it rebinds the port --------
+#
+# ``restart`` is the only caller that performs the bind ``_stop_service``'s
+# refusal is written for ("The port is still held, so a restart will fail to
+# bind it"). The ``stop`` action returns that verdict; ``restart`` used to
+# discard it.
+
+NEW_CHECKPOINT = "/data/checkpoints/policy-v2"
+
+
+def _restart(host: FakeHost, *, checkpoint_path: str = NEW_CHECKPOINT) -> dict[str, Any]:
+    """Drive the real ``restart`` dispatch against ``host``.
+
+    ``_is_service_running`` is forced True to model the readiness probe the tool
+    actually performs: a TCP connect to the port, which a server that survived
+    the teardown answers just as readily as one the restart launched. That is
+    exactly why the teardown verdict has to be consulted instead of re-derived
+    from the port.
+    """
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+        patch.object(gi, "_is_service_running", return_value=True),
+    ):
+        return gi.gr00t_inference(action="restart", checkpoint_path=checkpoint_path, port=PORT)
+
+
+def _launched_model_paths(host: FakeHost) -> list[str]:
+    """``--model-path`` of every inference server the tool launched."""
+    return [argv[argv.index("--model-path") + 1] for argv in host.launched if "--model-path" in argv]
+
+
+def test_a_restart_that_cannot_free_the_port_is_refused() -> None:
+    """An unkillable owner must not be reported as a completed checkpoint swap."""
+    host = FakeHost(in_container=True, unkillable=("999",))
+    result = _restart(host)
+    assert result["status"] == "error", (
+        f"reported {result.get('status')!r} ({result.get('message')!r}) while pid 999 still holds "
+        f"port {PORT}, so the new checkpoint cannot have bound it. The response is indistinguishable "
+        "from a restart that really did swap the checkpoint."
+    )
+
+
+def test_the_refusal_names_the_port_and_the_checkpoint_that_was_not_started() -> None:
+    """The caller has to learn which request was refused, not just that one was."""
+    host = FakeHost(in_container=True, unkillable=("999",))
+    message = _restart(host).get("message", "")
+    assert str(PORT) in message, f"message does not name the port: {message!r}"
+    assert NEW_CHECKPOINT in message, f"message does not name the checkpoint that was not started: {message!r}"
+
+
+def test_the_refusal_carries_the_teardown_reason() -> None:
+    """The teardown already says what to go look at; the refusal must not drop it."""
+    host = FakeHost(in_container=True, unkillable=("999",))
+    message = _restart(host).get("message", "")
+    assert "999" in message, f"message does not name the surviving pid the teardown found: {message!r}"
+    assert "SIGKILL" in message, f"message does not carry the teardown's own reason: {message!r}"
+
+
+def test_no_inference_server_is_launched_when_the_port_could_not_be_freed() -> None:
+    """A refused restart must not leave a second server racing for the port."""
+    host = FakeHost(in_container=True, unkillable=("999",))
+    _restart(host)
+    assert _launched_model_paths(host) == [], (
+        f"launched {_launched_model_paths(host)} into a port still held by pid 999. The detached exec "
+        "returns 0 regardless, so the failed bind is never reported."
+    )
+
+
+def test_a_host_side_owner_that_survives_the_escalation_is_also_refused() -> None:
+    """The host ``lsof`` fallback reaches the same refusal as the container branch.
+
+    Reached with an explicit ``container_name`` so the dispatch does not stop
+    earlier at "no running GR00T containers found" - the port owner here is a
+    process on the host, which is the case the teardown's second refusal names.
+    """
+    host = FakeHost(in_container=False, unkillable=("4242",))
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+        patch.object(gi, "_is_service_running", return_value=True),
+    ):
+        result = gi.gr00t_inference(
+            action="restart", checkpoint_path=NEW_CHECKPOINT, port=PORT, container_name=CONTAINER
+        )
+    assert result["status"] == "error", f"reported {result} while pid 4242 still holds port {PORT}"
+    assert "4242" in result.get("message", ""), result
+
+
+def test_every_stop_service_call_site_consults_the_verdict() -> None:
+    """No caller may discard ``_stop_service``'s result.
+
+    The root-cause pin. ``_stop_service`` reports an error precisely when the
+    port is still held, and every caller of it is about to act on that fact -
+    so a bare-expression call is the defect itself rather than a style point.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(gi))
+    discarded = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and ast.unparse(node.value.func) == "_stop_service"
+    ]
+    assert discarded == [], (
+        f"_stop_service result discarded at line(s) {discarded}. Its error means the port is still "
+        "held; a caller that drops it acts on a precondition it never read."
+    )
+
+
+# --- controls: the paths that already worked must keep working ---------------
+
+
+def test_a_restart_that_frees_the_port_starts_the_new_checkpoint() -> None:
+    """The ordinary restart path is unchanged, and reports the new checkpoint."""
+    host = FakeHost(in_container=True, live=("222",))
+    result = _restart(host)
+    assert result["status"] == "success", result
+    assert result["checkpoint_path"] == NEW_CHECKPOINT, result
+    assert _launched_model_paths(host) == [NEW_CHECKPOINT], (
+        f"launched {_launched_model_paths(host)}; the freed port must be rebound for the new checkpoint"
+    )
+
+
+def test_a_restart_onto_a_free_port_still_starts_the_new_checkpoint() -> None:
+    """Nothing to stop is not a failed teardown, so the restart proceeds.
+
+    ``container_name`` is explicit because with no port owner there is also no
+    running GR00T container for the launch to discover - that refusal is a
+    different one and would mask the property under test.
+    """
+    host = FakeHost(in_container=False)
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+        patch.object(gi, "_is_service_running", return_value=True),
+    ):
+        result = gi.gr00t_inference(
+            action="restart", checkpoint_path=NEW_CHECKPOINT, port=PORT, container_name=CONTAINER
+        )
+    assert result["status"] == "success", result
+    assert _launched_model_paths(host) == [NEW_CHECKPOINT], result
+
+
+def test_a_restart_without_a_checkpoint_is_refused_before_any_teardown() -> None:
+    """The pre-existing argument guard still runs first: nothing is torn down."""
+    host = FakeHost(in_container=True, live=("222",))
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+    ):
+        result = gi.gr00t_inference(action="restart", port=PORT)
+    assert result["status"] == "error"
+    assert "Checkpoint path required" in result["message"], result
+    assert host.signals == [], f"tore down the running service for a request it then refused: {host.signals}"
+
+
+def test_the_stop_action_still_returns_the_teardown_verdict_unchanged() -> None:
+    """``stop`` already returned the verdict; its response must not have moved."""
+    host = FakeHost(in_container=True, unkillable=("999",))
+    with (
+        patch.object(gi.subprocess, "run", side_effect=host.run),
+        patch.object(gi.time, "sleep"),
+    ):
+        via_action = gi.gr00t_inference(action="stop", port=PORT)
+    direct = _stop(FakeHost(in_container=True, unkillable=("999",)))
+    assert via_action == direct, f"the stop action reshaped the teardown verdict: {via_action} != {direct}"


### PR DESCRIPTION
## Problem

`gr00t_inference(action="restart")` frees a port and rebinds it for a new checkpoint - the action's documented reason for existing is "e.g., to swap checkpoints".

`_stop_service` returns an error exactly when something still holds the port after SIGTERM *and* SIGKILL, and its message says why that matters in as many words:

> GR00T service on port 5555 in container gr00t-jetson survived SIGTERM and SIGKILL: pid(s) 999 still match. **The port is still held, so a restart will fail to bind it.** Check the container with 'docker exec gr00t-jetson ps -ef'.

`restart` was the one caller that performs that bind, and it discarded the verdict.

The rebind cannot detect the collision on its own:

- the launch is a **detached** `docker exec -d`, so `subprocess.run(..., check=True)` returns 0 as soon as the daemon accepts the exec - it says nothing about whether the server inside bound the port;
- the readiness wait is `_is_service_running(port)`, a bare `socket.connect_ex(("localhost", port))`, which the **surviving** server answers on the first poll.

Measured through the real dispatch against a stubbed docker/lsof/kill process table, one pid surviving SIGKILL:

| | teardown fails | control: teardown frees the port |
|---|---|---|
| `status` | `"success"` | `"success"` |
| `checkpoint_path` | `/data/checkpoints/policy-v2` | `/data/checkpoints/policy-v2` |
| `message` | `GR00T ZMQ service started on port 5555 (server: n1.5)` | *(identical)* |
| port held by | `['999']` | none |
| actually serving | **`policy-v1` (the old checkpoint)** | `policy-v2` |

The two responses are byte-identical. A restart that could not swap the checkpoint is indistinguishable from one that did, and every subsequent inference request reaches the old policy.

## Change

`restart` reads the teardown verdict and refuses the rebind when it is an error, naming the port, the checkpoint that was **not** started, and carrying the teardown's own reason:

```
Restart aborted: the service on port 5555 could not be stopped, so
'/data/checkpoints/policy-v2' was not started and the previous checkpoint is
still serving. GR00T service on port 5555 in container gr00t-jetson survived
SIGTERM and SIGKILL: pid(s) 999 still match. ...
```

The sibling call site - the `stop` action at `gr00t_inference.py:802` - already returned that verdict unchanged; a control test pins that its response has not moved. The action's docstring now states the refusal.

An AST pin asserts no caller of `_stop_service` discards the result, so a third caller cannot drop it.

`test_restart_stops_then_starts_in_order` stubbed `_stop_service` with `side_effect=lambda port: calls.append("stop")` - `list.append` returns `None`, so the fake could express neither verdict, which is why the discard was invisible there. It now answers with a real envelope (matching the `_start_service` stub two lines below) and still passes against pre-fix source, so its stated intent is preserved rather than relaxed.

## Not in scope

`_start_container` discards `_remove_container` on its `force=True` path (`gr00t_inference.py:1804`), while the other call site (`lifecycle="teardown"`) checks it. Measured: when `docker rm -f` fails, the following `docker run --name` fails too, so the caller gets `status="error"` either way - `'docker run failed: docker: Conflict. The container name "/gr00t" is already in use.'` - identical to the control where the removal succeeded. That is a misdiagnosis (it blames the run, not the removal), not a silent success, so it is a different failure mode and left alone here.

Making `_is_service_running` verify server *identity* rather than port occupancy would close the gap from the other side, but it needs a protocol-level probe and is a design choice; this change only requires the caller to read a verdict that is already computed.

## Verification

Measured at `f49fa11f`.

Pre-fix split (both test files copied onto `upstream/main`): **6 failed / 18 passed** in the teardown module, every failure behavioural -

```
test_a_restart_that_cannot_free_the_port_is_refused
  AssertionError: reported 'success' ('GR00T ZMQ service started on port 5555
  (server: n1.5)') while pid 999 still holds port 5555, so the new checkpoint
  cannot have bound it. The response is indistinguishable from a restart that
  really did swap the checkpoint.

test_every_stop_service_call_site_consults_the_verdict
  AssertionError: _stop_service result discarded at line(s) [941].
```

Six controls pass on both trees: the ordinary restart starts the new checkpoint, a restart onto a free port proceeds, the missing-checkpoint guard still runs before any teardown, and the `stop` action's response is byte-identical to calling `_stop_service` directly.

Gate - 68 files (every test naming the service/container lifecycle helpers, all of `tests/tools`, and the repo-wide docstring / changelog / string-hygiene guards), same selection on both trees:

| | branch | `upstream/main` |
|---|---|---|
| passed | 3046 | 3040 |
| failed | 0 | 6 |
| collected | 3054 | 3054 |

Branch-only failures: none. Base-only: exactly the six above. No pre-existing failures in the selection. `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24 against a pristine `upstream/main` worktree, none in the changed files.

## Artifact

Both columns run the same capture script against the same stubbed process table; only the restart branch differs. Ground truth is port ownership - pid 999 survives SIGKILL, so the new server cannot have bound 5555.

![gr00t restart teardown verdict](https://raw.githubusercontent.com/cagataycali/robots/media-gr00t-restart-teardown/gr00t-restart-teardown-verdict.png)
