### PR TITLE
ci(checks): detect a pull request whose recorded head is not its branch tip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -749,6 +749,93 @@ hatch run format            # ruff check --fix, ruff format
      `require_last_push_approval` then disqualifies the pushing account from
      re-supplying it, turning a one-approval merge into one that needs a second
      reviewer.
+   - *And that the head it names is the branch's tip.* A pull request has two
+     answers to "what is the head commit" and they can disagree for hours.
+     `headRefOid` is the value the pull request *records*; the tip of the branch
+     in the head repository is the value that exists. GitHub normally reconciles
+     them within a second of a push, and when it does not, nothing on the pull
+     request says so - because every gate this step tells you to poll resolves
+     the head *through the pull request's own view of it*, so they all agree
+     with each other and all of them are answering about a commit that is no
+     longer the tip.
+
+     #2508 sat approved, green and unmergeable for over five hours that way:
+
+     | | commit | pushed | check suites |
+     |---|---|---|---|
+     | `headRefOid` as reported | `21ea097e` | 07:56:47 | 8, all green |
+     | actual tip of the head branch | `271ec912` | 13:58:16 | **0** |
+
+     What that costs is the diagnosis, because the refusal names a gate this
+     repository does not have:
+
+     ```
+     mergePullRequest       ->  Head branch is out of date. Review and try the merge again.
+     PUT /pulls/2508/merge  ->  409  Head branch is out of date. ...
+     ```
+
+     There is no staleness requirement here to satisfy. The `default` ruleset
+     sets `strict_required_status_checks_policy: false` and `main` has no
+     classic protection (`GET /branches/main/protection` -> `404 Branch not
+     protected`), and the branch was not in conflict either -
+     `git merge-tree --write-tree --messages main <head>` returned a tree and
+     zero conflict messages. So the message invites the one action that makes
+     things worse: pushing a refresh onto a contributor's branch consumes the
+     approval of whoever owns the pushing token under
+     `require_last_push_approval`, which is the state #1035 cannot leave. On
+     #2508 the branch needed nothing - the author had already merged the base
+     cleanly.
+
+     `mergeable` / `mergeStateStatus` pinned at `UNKNOWN` is the only anomaly,
+     and it is the weakest signal available, because this step already documents
+     `mergeable` as lazily computed - it "reads `unknown` first and the settled
+     value second". A single `UNKNOWN` is therefore both expected and benign,
+     and "read it once more" is indistinguishable from that benign case for as
+     long as you are willing to keep reading. Five consecutive reads on #2508
+     returned `UNKNOWN` across both the GraphQL and REST shapes; every other
+     signal - `reviewDecision: APPROVED`, `call-test-lint` `SUCCESS`, no
+     unresolved thread, and *both* `--all-open` sweeps below - read ready.
+
+     Ask the head repository, which is the one side not under suspicion:
+
+     ```graphql
+     repository(owner: $headOwner, name: $headName) {
+       ref(qualifiedName: "refs/heads/<headRefName>") { target { oid } }
+     }
+     ```
+
+     resolved from `pullRequest { headRepository { nameWithOwner } headRefName }`
+     and compared against `headRefOid`. Reading the tip through the pull request
+     cannot work by construction - that is the field being checked.
+
+     **Reopen it; do not push it.** A close/reopen reconciles the record without
+     touching the branch, and on #2508 it moved `headRefOid` to `271ec912` and
+     queued the nine check suites that commit had never had. Same remedy and
+     nearly the same reason as the no-check-suite case above (#1987):
+     `reopened` recomputes with no commit, therefore no push, therefore neither
+     `dismiss_stale_reviews_on_push` nor a new last pusher. Read the flip
+     history first and count `nodes`, per the *Before* bullet - #2508 had zero.
+
+     Expect `reviewDecision` to move to `REVIEW_REQUIRED` once the record
+     catches up, and read that as bookkeeping rather than lost review: the
+     approval was already attributed to a commit that was not the tip. Check
+     whether the new head moved the pull request's *own* diff before asking for
+     a re-review - `271ec912` was a clean base merge, `git show --cc` 0 lines,
+     old head an ancestor of the new one, diff against the merge base
+     byte-identical at `3 files, +438`, which is the #1821 shape.
+
+     The lag is not only a merge blocker. It is also a window in which
+     `APPROVED` names the wrong commit, so a record reconciled while the head
+     carries *new* content leaves an approval covering a tree nobody read.
+     Sweep it when reporting repository health, alongside the two `--all-open`
+     checks above:
+
+     ```
+     python3 scripts/check_pr_head_is_current.py --repo <owner/name> --all-open
+     ```
+
+     It agreed with `git ls-remote` on all 10 open pull requests, so it needs no
+     clone. Pinned by tests/test_pr_head_is_current.py. See #2538.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    the **required** contexts' own conclusions and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.

--- a/changelog.d/2538-stale-pr-head-record.md
+++ b/changelog.d/2538-stale-pr-head-record.md
@@ -1,0 +1,28 @@
+### Added: a check for a pull request whose recorded head is not its branch's tip
+
+`scripts/check_pr_head_is_current.py` compares `pullRequest { headRefOid }`
+against the tip of the branch in the head repository, per pull request or across
+the whole open set with `--all-open`.
+
+The two are meant to be the same commit and can disagree for hours. #2508 sat
+approved, green and unmergeable for over five hours recording `21ea097e` -
+pushed 07:56:47, eight green check suites - while its branch tip was `271ec912`,
+pushed 13:58:16 and carrying no check suite at all. Every gate resolves the head
+through the pull request's own view of it, so `reviewDecision` read `APPROVED`,
+`call-test-lint / Test and Lint` read `SUCCESS`, no thread was unresolved, and
+both existing `--all-open` sweeps reported no finding - each of them correctly,
+about a commit that was no longer the tip.
+
+Both merge APIs refuse such a pull request with `Head branch is out of date`,
+which names a gate this repository does not have: the `default` ruleset sets
+`strict_required_status_checks_policy: false` and `main` carries no classic
+protection. The one field that moves, `mergeable` at `UNKNOWN`, is also the
+weakest available signal, since a first `UNKNOWN` is the documented and benign
+result of lazy computation - so "read it again" is indistinguishable from the
+ordinary case for as long as one keeps reading.
+
+The check reads the head repository's ref rather than the pull request's own
+answer, because that answer is the value under suspicion. It reports and does
+not gate: the remedy is a close/reopen, which reconciles the record without a
+commit and therefore without spending the approval, and is not something a
+branch author clears by pushing.

--- a/scripts/check_pr_head_is_current.py
+++ b/scripts/check_pr_head_is_current.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Report a pull request whose recorded head commit is not its branch's tip.
+
+Why this exists
+---------------
+A pull request has two answers to "what is the head commit", and they can
+disagree for hours. ``pullRequest { headRefOid }`` is the value the pull request
+*records*; the tip of the branch in the head repository is the value that
+exists. GitHub normally reconciles the two within a second of a push, and when
+it does not, nothing on the pull request says so.
+
+Measured on #2508, which sat approved, green and unmergeable for over five
+hours::
+
+    headRefOid reported by the API      21ea097e   pushed 07:56:47   8 check suites, green
+    tip of yinsong1986:docs/...         271ec912   pushed 13:58:16   0 check suites
+
+Every merge attempt against it refused, by both APIs, with one message::
+
+    mergePullRequest         ->  Head branch is out of date. Review and try the merge again.
+    PUT /pulls/2508/merge    ->  409  Head branch is out of date. ...
+
+That message names a gate this repository does not have, which is what makes it
+so expensive to act on. The ``default`` ruleset sets
+``strict_required_status_checks_policy: false`` and ``main`` carries no classic
+protection (``GET /branches/main/protection`` -> ``404 Branch not protected``),
+so being behind the base is not a merge requirement here at all. The branch was
+not in conflict either: ``git merge-tree --write-tree --messages`` against
+``main`` returned a tree and zero conflict messages. Nothing about the *branch*
+was stale. The pull request's record was.
+
+Why every other check agrees the pull request is ready
+------------------------------------------------------
+Each gate AGENTS.md tells you to poll resolves the head through the pull
+request's own view of it, so they all answer correctly about a commit that is no
+longer the tip, and they all agree with each other:
+
+==========================================  ============================  ==============================
+signal                                      value during the lag          true of ``21ea097e``?
+==========================================  ============================  ==============================
+``reviewDecision``                          ``APPROVED``                  yes
+``call-test-lint / Test and Lint``          ``SUCCESS``                   yes
+``reviewThreads``                           none unresolved               yes
+``check_last_push_approval.py --all-open``  ``satisfied``                 yes
+``check_merge_base_overlap.py --all-open``  no finding                    yes
+``mergeable`` / ``mergeStateStatus``        ``UNKNOWN``                   the only anomaly
+==========================================  ============================  ==============================
+
+So the presentation is a pull request that has cleared every gate and is waiting
+for somebody to press merge. That is the same presentation #1905 records for
+``pusher-only-approval`` and #1917 for a workflow-touching ``BLOCKED`` read, and
+this is a third cause of it. Unlike those two it does not resolve with time:
+nothing about waiting reconciles the record.
+
+``UNKNOWN`` is the one field that moves, and it is the weakest signal available.
+AGENTS.md already documents ``mergeable`` as lazily computed -- it "reads
+``unknown`` first and the settled value second" -- so a single ``UNKNOWN`` is
+both expected and benign, and is normally cleared by reading again. Here it
+never settles, and "read it once more" is indistinguishable from the documented
+benign case for as long as one is willing to keep reading. Five consecutive
+reads on #2508 returned ``UNKNOWN``, across both the GraphQL and REST shapes.
+
+What this reads instead
+-----------------------
+The head repository's own ref, which is the value under suspicion read from the
+side that is not suspected::
+
+    query($owner:String!,$name:String!,$ref:String!){
+      repository(owner:$owner,name:$name){ ref(qualifiedName:$ref){ target { oid } } }
+    }
+
+resolved from ``pullRequest { headRepository { nameWithOwner } headRefName }``.
+Reading the head through the pull request cannot work here by construction: that
+is the field being checked.
+
+The ``ref`` read is sound and needs no clone. Swept across all 10 open
+non-draft pull requests in this repository it agreed with ``git ls-remote`` on
+every one, and it named #2508 as the only stale record before the
+reconciliation and none afterwards.
+
+Outcomes
+--------
+``current``
+    The record matches the tip. Nothing to say, and the ordinary state.
+
+``stale-head-record``
+    The finding. The pull request's gates, its checks and its approval all
+    describe a commit that is not the branch tip, and a merge will refuse.
+
+``unresolvable-head``
+    The head repository or its branch could not be read -- a deleted fork, a
+    deleted branch. Reported as its own outcome rather than folded into a pass,
+    so a permissions change or an API shape change cannot quietly turn this
+    check into one that always agrees. It is not a finding: a pull request whose
+    fork is gone has a different problem with a different remedy.
+
+The remedy is a reopen, not a push
+----------------------------------
+A close/reopen reconciles the record without touching the branch. On #2508 it
+moved ``headRefOid`` to ``271ec912`` and queued the nine check suites that
+commit had never had. This is the same remedy as the no-check-suite case in
+AGENTS.md step 8 (#1987) and for a closely related reason: ``pull_request``
+takes the default types, so ``reopened`` recomputes with no commit, therefore no
+push, therefore neither ``dismiss_stale_reviews_on_push`` nor a new last pusher.
+
+Do not push the branch, even though "out of date" reads like a request to
+refresh it. On a contributor's branch a push consumes the approval of whoever
+owns the pushing token under ``require_last_push_approval``, converting a pull
+request one maintainer could merge into one that needs a second approver -- the
+state #1035 has been in since 2026-08-01. On #2508 the branch also needed
+nothing: the author had already merged the base cleanly.
+
+Read the close/reopen history first, per AGENTS.md step 8, counting ``nodes``
+rather than ``totalCount``. #2508 had zero, so a single flip was safe. An
+alternating run means something is undoing you and another flip only lengthens
+it.
+
+Why there is a sweep mode
+-------------------------
+The same reason ``check_last_push_approval.py`` has one. A stale record produces
+no event -- that *is* the defect, that the push was not registered against the
+pull request -- so a workflow driven by ``pull_request`` cannot fire on the
+population this is written for. ``--all-open`` is the caller a scheduled health
+scan needs. Draft pull requests are excluded: a draft cannot merge whatever its
+record says, so a finding on one does not mean what a finding here means.
+
+This reports and does not gate. Its remedy is a reopen by someone with write
+access, which is not something a branch clears by pushing, and a check a branch
+cannot turn green by doing anything belongs in a report.
+
+Usage
+-----
+::
+
+    python3 scripts/check_pr_head_is_current.py --repo strands-labs/robots --pr 2508
+    python3 scripts/check_pr_head_is_current.py --repo strands-labs/robots --all-open
+
+Exit 1 when at least one evaluated pull request has a stale head record.
+
+Pinned by tests/test_pr_head_is_current.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# Pagination ceiling for the open-pull-request listing, matching
+# check_last_push_approval.py. A repository with more open pull requests than
+# this at once has a different problem, and an unbounded loop over a paginated
+# endpoint is how a transient API shape change becomes a hang rather than an
+# error.
+_MAX_PAGES = 20
+
+CURRENT = "current"
+STALE_HEAD_RECORD = "stale-head-record"
+UNRESOLVABLE_HEAD = "unresolvable-head"
+
+_API = "https://api.github.com/graphql"
+
+# The remedy text, shared by the single-pull-request report and the sweep so the
+# two cannot drift into describing different remedies for one rule.
+WHAT_CLEARS_THIS: tuple[str, ...] = (
+    "",
+    "### What clears this",
+    "",
+    "Close and reopen the pull request. That reconciles the record without",
+    "touching the branch: `reopened` recomputes the same head, so there is no",
+    "commit, no push, and therefore neither `dismiss_stale_reviews_on_push`",
+    "nor a new last pusher.",
+    "",
+    "Read the close/reopen history first and count `nodes`, not `totalCount`.",
+    "An alternating run means something is undoing you and a further flip only",
+    "lengthens it.",
+    "",
+    "Do **not** push the branch to refresh it, however much `Head branch is out",
+    "of date` reads like a request to. There is no staleness gate on this",
+    "repository to satisfy -- the `default` ruleset sets",
+    "`strict_required_status_checks_policy: false` and `main` has no classic",
+    "protection -- and on a contributor's branch a push consumes the approval of",
+    "whoever owns the pushing token under `require_last_push_approval`, which",
+    "turns a pull request one maintainer could merge into one needing a second",
+    "approver.",
+    "",
+    "Expect `reviewDecision` to move to `REVIEW_REQUIRED` once the record",
+    "catches up, and read that as bookkeeping rather than lost review: the",
+    "approval was already attributed to a commit that was not the tip. Check",
+    "whether the new head changed the pull request's own diff before asking for",
+    "a re-review -- a clean base merge leaves it byte-identical.",
+)
+
+
+# Named rather than inlined: as a list element it would be two adjacent string
+# parts, which a reader cannot tell from a dropped comma.
+_UNRESOLVABLE_PREAMBLE = (
+    "Unresolvable (named rather than counted as clean, because a head this"
+    + " check could not read is not a head it cleared):"
+)
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome and the two commits it was computed from."""
+
+    outcome: str
+    recorded: str | None
+    tip: str | None
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == STALE_HEAD_RECORD
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == CURRENT:
+            return f"The recorded head {_short(self.recorded)} is the branch tip. Nothing to report."
+        if self.outcome == UNRESOLVABLE_HEAD:
+            return (
+                "Could not read the head repository's branch, so the recorded head "
+                f"{_short(self.recorded)} could not be compared against anything. Not treated "
+                "as a finding: a deleted fork or branch is a different problem."
+            )
+        return (
+            f"The pull request records its head as {_short(self.recorded)}, but the branch tip "
+            f"is {_short(self.tip)}. Its checks, its approval and every merge gate describe "
+            f'{_short(self.recorded)}, and a merge will refuse with "Head branch is out of '
+            'date" naming a staleness gate this repository does not have. Reopen the pull '
+            "request to reconcile the record; do not push the branch."
+        )
+
+
+@dataclass(frozen=True)
+class Row:
+    """One evaluated pull request, for the sweep report."""
+
+    pr: int
+    verdict: Verdict
+    head_repo: str
+    head_ref: str
+    mergeable: str
+    merge_state_status: str
+    review_decision: str
+
+
+def _short(oid: str | None) -> str:
+    """Render a commit for a human without pretending an absent one is a commit."""
+    if not oid:
+        return "(unknown)"
+    return f"`{oid[:8]}`"
+
+
+def classify(recorded: str | None, tip: str | None) -> Verdict:
+    """Decide whether a pull request's recorded head is its branch's tip.
+
+    ``tip`` of ``None`` means the head repository's ref could not be read, and
+    ``recorded`` of ``None`` means the pull request did not report a head at
+    all. Either way there is nothing to compare, which is reported as its own
+    outcome rather than as a pass -- an unreadable head is not a head that
+    matches, and folding the two together is how this check would become a
+    no-op that always agrees.
+    """
+    if not recorded or not tip:
+        return Verdict(UNRESOLVABLE_HEAD, recorded, tip)
+    if recorded == tip:
+        return Verdict(CURRENT, recorded, tip)
+    return Verdict(STALE_HEAD_RECORD, recorded, tip)
+
+
+def _graphql(query: str, variables: dict[str, object], token: str) -> dict:
+    request = urllib.request.Request(
+        _API,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "strands-robots-check-pr-head-is-current",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise ValueError(f"GraphQL errors: {payload['errors']}")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("GraphQL response carried no data object")
+    return data
+
+
+_PR_FIELDS = """
+  number isDraft headRefName headRefOid
+  headRepository { nameWithOwner }
+  mergeable mergeStateStatus reviewDecision
+"""
+
+_FIELDS_PLACEHOLDER = "__PR_FIELDS__"
+
+
+def _with_pr_fields(query: str) -> str:
+    """Substitute the shared field list into a query document.
+
+    Neither an f-string nor ``%`` formatting: a GraphQL document is almost all
+    braces, so both spellings would require escaping every one of them and the
+    query would stop being copy-pasteable into the API explorer. The two shapes
+    share one field list so a field added for the sweep cannot go missing from
+    the single-pull-request path.
+    """
+    return query.replace(_FIELDS_PLACEHOLDER, _PR_FIELDS)
+
+
+_ONE_PR = _with_pr_fields(
+    """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){ __PR_FIELDS__ }
+  }
+}
+"""
+)
+
+_OPEN_PRS = _with_pr_fields(
+    """
+query($owner:String!,$name:String!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequests(states: OPEN, first: 50, after: $cursor){
+      pageInfo { hasNextPage endCursor }
+      nodes { __PR_FIELDS__ }
+    }
+  }
+}
+"""
+)
+
+_REF_TIP = """
+query($owner:String!,$name:String!,$ref:String!){
+  repository(owner:$owner,name:$name){
+    ref(qualifiedName:$ref){ target { oid } }
+  }
+}
+"""
+
+
+def _split_repo(repo: str) -> tuple[str, str]:
+    if repo.count("/") != 1 or not all(repo.split("/")):
+        raise ValueError(f"--repo must be owner/name, got {repo!r}")
+    owner, name = repo.split("/")
+    return owner, name
+
+
+def branch_tip(head_repo: str, head_ref: str, token: str) -> str | None:
+    """Return the tip of ``head_ref`` in ``head_repo``, or ``None`` if unreadable.
+
+    Deliberately reads the head *repository*, not the pull request. The pull
+    request's own answer is the value being checked, so consulting it here would
+    compare a field against itself and agree every time.
+    """
+    try:
+        owner, name = _split_repo(head_repo)
+    except ValueError:
+        return None
+    try:
+        data = _graphql(
+            _REF_TIP,
+            {"owner": owner, "name": name, "ref": f"refs/heads/{head_ref}"},
+            token,
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError):
+        return None
+    repository = data.get("repository") or {}
+    ref = repository.get("ref") or {}
+    target = ref.get("target") or {}
+    oid = target.get("oid")
+    return oid if isinstance(oid, str) else None
+
+
+def evaluate(node: dict, token: str) -> Row:
+    """Evaluate one pull request node from either query shape."""
+    head_repository = node.get("headRepository") or {}
+    head_repo = head_repository.get("nameWithOwner") or ""
+    head_ref = node.get("headRefName") or ""
+    recorded = node.get("headRefOid")
+    tip = branch_tip(head_repo, head_ref, token) if head_repo and head_ref else None
+    return Row(
+        pr=int(node["number"]),
+        verdict=classify(recorded, tip),
+        head_repo=head_repo or "(unknown)",
+        head_ref=head_ref or "(unknown)",
+        mergeable=str(node.get("mergeable")),
+        merge_state_status=str(node.get("mergeStateStatus")),
+        review_decision=str(node.get("reviewDecision")),
+    )
+
+
+def fetch_one(repo: str, number: int, token: str) -> dict:
+    owner, name = _split_repo(repo)
+    data = _graphql(_ONE_PR, {"owner": owner, "name": name, "number": number}, token)
+    repository = data.get("repository") or {}
+    node = repository.get("pullRequest")
+    if not isinstance(node, dict):
+        raise ValueError(f"{repo}#{number} did not resolve to a pull request")
+    return node
+
+
+def fetch_open(repo: str, token: str) -> list[dict]:
+    owner, name = _split_repo(repo)
+    nodes: list[dict] = []
+    cursor: str | None = None
+    for _ in range(_MAX_PAGES):
+        data = _graphql(_OPEN_PRS, {"owner": owner, "name": name, "cursor": cursor}, token)
+        connection = (data.get("repository") or {}).get("pullRequests") or {}
+        nodes.extend(connection.get("nodes") or [])
+        page = connection.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            break
+        cursor = page.get("endCursor")
+    return nodes
+
+
+def render_sweep(repo: str, rows: Sequence[Row], skipped: Sequence[int]) -> str:
+    findings = [r for r in rows if r.verdict.is_finding]
+    unresolvable = [r for r in rows if r.verdict.outcome == UNRESOLVABLE_HEAD]
+    lines = [
+        "## Pull-request head record sweep",
+        "",
+        f"Evaluated {len(rows)} open non-draft pull request(s) in {repo}.",
+        "",
+    ]
+    if findings:
+        named = ", ".join(f"#{r.pr}" for r in findings)
+        lines += [
+            f"**{len(findings)} record(s) a commit that is not the branch tip:** {named}.",
+            "",
+            "Every merge gate on these describes the recorded commit, so all of them",
+            "read ready while the merge refuses. This does not resolve with time.",
+            "",
+        ]
+    else:
+        lines += ["Every recorded head is its branch's tip.", ""]
+
+    lines += [
+        "| pull request | recorded head | branch tip | outcome | mergeable | mergeStateStatus | review |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| #{row.pr} | {_short(row.verdict.recorded)} | {_short(row.verdict.tip)} | "
+            f"{row.verdict.outcome} | {row.mergeable} | {row.merge_state_status} | "
+            f"{row.review_decision} |"
+        )
+    if unresolvable:
+        lines += ["", _UNRESOLVABLE_PREAMBLE, ""]
+        lines += [f"- #{r.pr}: `{r.head_repo}` `{r.head_ref}` could not be read" for r in unresolvable]
+    if skipped:
+        lines += ["", "Skipped: " + ", ".join(f"#{n}" for n in skipped) + "."]
+    if findings:
+        lines += list(WHAT_CLEARS_THIS)
+    return "\n".join(lines)
+
+
+def render_one(repo: str, row: Row) -> str:
+    lines = [
+        "## Pull-request head record",
+        "",
+        f"Outcome: **{row.verdict.outcome}**",
+        "",
+        row.verdict.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| pull request | {repo}#{row.pr} |",
+        f"| head repository | `{row.head_repo}` |",
+        f"| head branch | `{row.head_ref}` |",
+        f"| recorded head | {_short(row.verdict.recorded)} |",
+        f"| branch tip | {_short(row.verdict.tip)} |",
+        f"| mergeable | {row.mergeable} |",
+        f"| mergeStateStatus | {row.merge_state_status} |",
+        f"| reviewDecision | {row.review_decision} |",
+    ]
+    if row.verdict.is_finding:
+        lines += list(WHAT_CLEARS_THIS)
+    return "\n".join(lines)
+
+
+def _publish(report: str) -> None:
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def _annotate(repo: str, row: Row) -> None:
+    print(f"::warning title=Recorded head is not the branch tip::{repo}#{row.pr}: {row.verdict.summary}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Evaluate every open non-draft pull request instead of one.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        print("check_pr_head_is_current: --repo is required", file=sys.stderr)
+        return 0
+    if not args.token:
+        print("check_pr_head_is_current: no token; set --token or GITHUB_TOKEN", file=sys.stderr)
+        return 0
+
+    if args.all_open:
+        try:
+            nodes = fetch_open(args.repo, args.token)
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+            # Listing is the one lookup with no partial result to report, so it
+            # fails open rather than failing the caller's run.
+            print(f"check_pr_head_is_current: could not list open pull requests: {exc}", file=sys.stderr)
+            return 0
+        rows: list[Row] = []
+        skipped: list[int] = []
+        for node in nodes:
+            if node.get("isDraft"):
+                continue
+            try:
+                rows.append(evaluate(node, args.token))
+            except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+                # One unreadable pull request must not suppress a finding on the
+                # others, so it is named and skipped rather than fatal.
+                number = node.get("number")
+                print(f"check_pr_head_is_current: skipped #{number}: {exc}", file=sys.stderr)
+                if isinstance(number, int):
+                    skipped.append(number)
+        rows.sort(key=lambda r: r.pr)
+        _publish(render_sweep(args.repo, rows, skipped))
+        findings = [r for r in rows if r.verdict.is_finding]
+        for row in findings:
+            _annotate(args.repo, row)
+        return 1 if findings else 0
+
+    if not args.pr:
+        print("check_pr_head_is_current: --pr or --all-open is required", file=sys.stderr)
+        return 0
+    try:
+        row = evaluate(fetch_one(args.repo, int(args.pr), args.token), args.token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+        print(f"check_pr_head_is_current: could not evaluate {args.repo}#{args.pr}: {exc}", file=sys.stderr)
+        return 0
+    _publish(render_one(args.repo, row))
+    if row.verdict.is_finding:
+        _annotate(args.repo, row)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -90,6 +90,7 @@ _NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
     "check_duplicate_claim.py": ("--repo", None),
     "check_last_push_approval.py": ("--repo", None),
     "check_merge_base_overlap.py": ("--github-repo", "--all-open"),
+    "check_pr_head_is_current.py": ("--repo", None),
 }
 
 

--- a/tests/test_pr_head_is_current.py
+++ b/tests/test_pr_head_is_current.py
@@ -1,0 +1,294 @@
+"""Pins the head-record classifier against the pull request that produced it.
+
+The interesting property of this check is not that it compares two strings. It
+is that the two strings are meant to be the same string, and every other signal
+on the pull request is derived from the one that can be wrong. Measured on
+#2508, which sat approved, green and unmergeable for over five hours:
+
+    recorded ``headRefOid``   21ea097e   pushed 07:56:47   8 check suites, green
+    tip of the head branch    271ec912   pushed 13:58:16   0 check suites
+
+While that lag stood, ``reviewDecision`` read ``APPROVED``, the required check
+read ``SUCCESS``, no thread was unresolved, and both sweep scripts reported no
+finding -- each of them correctly, about ``21ea097e``. The merge refused with
+``Head branch is out of date``, naming a staleness gate this repository does not
+have: the ``default`` ruleset sets ``strict_required_status_checks_policy:
+false`` and ``main`` has no classic branch protection.
+
+So the fixtures below are the real observation and its control, and the control
+is what carries the argument: the *same* pull request after a close/reopen
+reconciled the record reads ``current`` on identical code, with the only change
+being that the recorded head caught up to the tip.
+
+The unresolvable cases are pinned for the opposite reason. A head this check
+could not read must not be reported as a head that matches, because that is the
+one failure mode that would silently turn the check into a no-op agreeing with
+everything.
+
+See scripts/check_pr_head_is_current.py, issue #2538, and the "PR Workflow"
+section of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_pr_head_is_current.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_pr_head_is_current", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+# The two heads #2508 carried, verbatim.
+RECORDED = "21ea097e470a63002f9d0e63b22d2b1838770d21"
+TIP = "271ec912b97857d8264a748d85d8f33eb3c2de5a"
+
+
+class TestTheMeasuredPullRequest:
+    """#2508 before and after the record was reconciled."""
+
+    def test_a_recorded_head_behind_the_tip_is_the_finding(self) -> None:
+        verdict = mod.classify(RECORDED, TIP)
+        assert verdict.outcome == mod.STALE_HEAD_RECORD
+        assert verdict.is_finding
+
+    def test_the_same_pull_request_reads_current_once_reconciled(self) -> None:
+        """The control. Only the recorded head moved; the branch tip did not."""
+        verdict = mod.classify(TIP, TIP)
+        assert verdict.outcome == mod.CURRENT
+        assert not verdict.is_finding
+
+    def test_the_finding_names_both_commits_and_refuses_the_push_remedy(self) -> None:
+        """The summary has to carry the two facts that stop the expensive reflex.
+
+        A reader who sees only "out of date" refreshes the branch, which on a
+        contributor's branch spends the approval under
+        ``require_last_push_approval``. So the summary names the remedy and names
+        what not to do.
+        """
+        summary = mod.classify(RECORDED, TIP).summary
+        assert RECORDED[:8] in summary
+        assert TIP[:8] in summary
+        assert "Reopen" in summary
+        assert "do not push" in summary
+
+
+class TestAnUnreadableHeadIsNotAMatch:
+    """An unresolvable head is its own outcome, never a pass."""
+
+    @pytest.mark.parametrize(
+        ("recorded", "tip"),
+        [
+            (RECORDED, None),  # deleted fork or branch, or an unreadable ref
+            (None, TIP),  # the pull request reported no head at all
+            (None, None),
+            ("", ""),  # both absent must not compare equal into ``current``
+        ],
+    )
+    def test_missing_either_side_is_unresolvable(self, recorded, tip) -> None:
+        verdict = mod.classify(recorded, tip)
+        assert verdict.outcome == mod.UNRESOLVABLE_HEAD
+        assert not verdict.is_finding
+
+    def test_two_absent_heads_do_not_read_as_current(self) -> None:
+        """The specific way this check would become a no-op that always agrees."""
+        assert mod.classify(None, None).outcome != mod.CURRENT
+        assert mod.classify("", "").outcome != mod.CURRENT
+
+
+class TestTheTipIsReadFromTheHeadRepository:
+    """The pull request's own view of its head cannot be the source here.
+
+    That field is the value under suspicion, so a tip read through it would
+    compare a field against itself and report ``current`` on exactly the
+    pull requests this check exists to find.
+    """
+
+    def test_branch_tip_queries_the_head_repository_ref(self, monkeypatch) -> None:
+        seen: dict[str, object] = {}
+
+        def fake_graphql(query, variables, token):
+            seen["query"] = query
+            seen["variables"] = variables
+            return {"repository": {"ref": {"target": {"oid": TIP}}}}
+
+        monkeypatch.setattr(mod, "_graphql", fake_graphql)
+        assert mod.branch_tip("yinsong1986/robots", "docs/data-augmentation-notebook", "t") == TIP
+
+        # The ref is read off the head repository, by owner and name written out,
+        # and never through pullRequest { headRefOid }.
+        assert seen["variables"] == {
+            "owner": "yinsong1986",
+            "name": "robots",
+            "ref": "refs/heads/docs/data-augmentation-notebook",
+        }
+        assert "headRefOid" not in str(seen["query"])
+        assert "ref(qualifiedName:" in str(seen["query"]).replace(" ", "")
+
+    def test_an_unreadable_ref_returns_none_rather_than_raising(self, monkeypatch) -> None:
+        """A deleted fork must not abort a sweep over the other pull requests."""
+
+        def boom(query, variables, token):
+            raise ValueError("Could not resolve to a Repository")
+
+        monkeypatch.setattr(mod, "_graphql", boom)
+        assert mod.branch_tip("gone/robots", "some-branch", "t") is None
+
+    def test_a_malformed_head_repository_is_unresolvable(self, monkeypatch) -> None:
+        def unreached(query, variables, token):  # pragma: no cover - must not run
+            raise AssertionError("a malformed repository must not reach the API")
+
+        monkeypatch.setattr(mod, "_graphql", unreached)
+        assert mod.branch_tip("not-a-repo", "branch", "t") is None
+
+
+class TestEvaluateAndReport:
+    """The node shapes both queries return, and what the reports must say."""
+
+    @staticmethod
+    def _node(**over):
+        node = {
+            "number": 2508,
+            "isDraft": False,
+            "headRefName": "docs/data-augmentation-notebook",
+            "headRefOid": RECORDED,
+            "headRepository": {"nameWithOwner": "yinsong1986/robots"},
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
+            "reviewDecision": "APPROVED",
+        }
+        node.update(over)
+        return node
+
+    def test_the_lag_is_a_finding_even_though_every_other_field_reads_ready(self, monkeypatch) -> None:
+        """The whole point: APPROVED plus UNKNOWN plus a moved tip is the finding."""
+        monkeypatch.setattr(mod, "branch_tip", lambda *a, **k: TIP)
+        row = mod.evaluate(self._node(), "t")
+        assert row.verdict.is_finding
+        assert row.review_decision == "APPROVED"
+        assert row.mergeable == "UNKNOWN"
+
+    def test_a_null_head_repository_is_unresolvable_not_a_finding(self, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "branch_tip", lambda *a, **k: TIP)
+        row = mod.evaluate(self._node(headRepository=None), "t")
+        assert row.verdict.outcome == mod.UNRESOLVABLE_HEAD
+
+    def test_the_sweep_report_names_every_finding_and_the_remedy(self) -> None:
+        stale = mod.Row(
+            pr=2508,
+            verdict=mod.classify(RECORDED, TIP),
+            head_repo="yinsong1986/robots",
+            head_ref="docs/data-augmentation-notebook",
+            mergeable="UNKNOWN",
+            merge_state_status="UNKNOWN",
+            review_decision="APPROVED",
+        )
+        report = mod.render_sweep("strands-labs/robots", [stale], [])
+        assert "#2508" in report
+        assert "### What clears this" in report
+        assert "Close and reopen" in report
+
+    def test_a_clean_sweep_says_so_without_the_remedy_block(self) -> None:
+        """A remedy printed under a clean report trains the reader to skip it."""
+        current = mod.Row(
+            pr=2536,
+            verdict=mod.classify(TIP, TIP),
+            head_repo="cagataycali/robots",
+            head_ref="fix/benchmark-refused-default-robot",
+            mergeable="MERGEABLE",
+            merge_state_status="BLOCKED",
+            review_decision="REVIEW_REQUIRED",
+        )
+        report = mod.render_sweep("strands-labs/robots", [current], [])
+        assert "Every recorded head is its branch's tip." in report
+        assert "### What clears this" not in report
+
+    def test_an_unresolvable_row_is_named_rather_than_counted_clean(self) -> None:
+        row = mod.Row(
+            pr=1234,
+            verdict=mod.classify(RECORDED, None),
+            head_repo="gone/robots",
+            head_ref="lost-branch",
+            mergeable="UNKNOWN",
+            merge_state_status="UNKNOWN",
+            review_decision="REVIEW_REQUIRED",
+        )
+        report = mod.render_sweep("strands-labs/robots", [row], [])
+        assert "#1234" in report
+        assert "Unresolvable" in report
+
+
+class TestExitStatus:
+    """Exit 1 only on a finding, so a red run means one specific thing."""
+
+    def test_a_missing_token_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "strands-labs/robots", "--pr", "2508", "--token", ""]) == 0
+
+    def test_a_missing_repo_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "", "--all-open", "--token", "t"]) == 0
+
+    def test_neither_pr_nor_all_open_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "strands-labs/robots", "--token", "t"]) == 0
+
+    def test_a_stale_record_exits_one(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(mod, "fetch_one", lambda *a, **k: TestEvaluateAndReport._node())
+        monkeypatch.setattr(mod, "branch_tip", lambda *a, **k: TIP)
+        code = mod.main(["--repo", "strands-labs/robots", "--pr", "2508", "--token", "t"])
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "::warning title=Recorded head is not the branch tip::" in out
+
+    def test_a_current_record_exits_zero_and_annotates_nothing(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(mod, "fetch_one", lambda *a, **k: TestEvaluateAndReport._node(headRefOid=TIP))
+        monkeypatch.setattr(mod, "branch_tip", lambda *a, **k: TIP)
+        code = mod.main(["--repo", "strands-labs/robots", "--pr", "2508", "--token", "t"])
+        assert code == 0
+        assert "::warning" not in capsys.readouterr().out
+
+    def test_a_draft_is_excluded_from_the_sweep(self, monkeypatch) -> None:
+        """A draft cannot merge whatever its record says."""
+        monkeypatch.setattr(
+            mod,
+            "fetch_open",
+            lambda *a, **k: [TestEvaluateAndReport._node(isDraft=True)],
+        )
+        monkeypatch.setattr(mod, "branch_tip", lambda *a, **k: TIP)
+        assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+
+    def test_one_unreadable_pull_request_does_not_suppress_a_finding(self, monkeypatch, capsys) -> None:
+        """A sweep's value is the population, so one bad row must not end it."""
+        good = TestEvaluateAndReport._node()
+        bad = TestEvaluateAndReport._node(number=9999)
+
+        def flaky(node, token):
+            if node["number"] == 9999:
+                raise ValueError("rate limited")
+            return mod.Row(
+                pr=node["number"],
+                verdict=mod.classify(RECORDED, TIP),
+                head_repo="yinsong1986/robots",
+                head_ref="docs/data-augmentation-notebook",
+                mergeable="UNKNOWN",
+                merge_state_status="UNKNOWN",
+                review_decision="APPROVED",
+            )
+
+        monkeypatch.setattr(mod, "fetch_open", lambda *a, **k: [bad, good])
+        monkeypatch.setattr(mod, "evaluate", flaky)
+        code = mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"])
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "#2508" in out
+        assert "#9999" in out


### PR DESCRIPTION
Closes #2538

## The finding

A pull request has two answers to "what is the head commit", and they can disagree for hours. `headRefOid` is the value the pull request **records**; the tip of the branch in the head repository is the value that **exists**. GitHub normally reconciles them within a second of a push, and when it does not, nothing on the pull request says so.

Measured on #2508, which sat approved, green and unmergeable for over five hours:

| | commit | pushed | check suites |
|---|---|---|---|
| `headRefOid` as reported | `21ea097e` | 07:56:47 | 8, all green |
| actual tip of the head branch | `271ec912` | 13:58:16 | **0** |

## Why nothing already here could see it

Every gate AGENTS.md step 8 tells you to poll resolves the head *through the pull request's own view of it*. So they all agree with each other, and all of them are answering correctly about a commit that is no longer the tip:

| signal | value during the lag | true of `21ea097e`? |
|---|---|---|
| `reviewDecision` | `APPROVED` | yes |
| `call-test-lint / Test and Lint` | `SUCCESS` | yes |
| `reviewThreads` | none unresolved | yes |
| `check_last_push_approval.py --all-open` | `satisfied` | yes |
| `check_merge_base_overlap.py --all-open` | no finding | yes |
| `mergeable` / `mergeStateStatus` | `UNKNOWN` | the only anomaly |

So it presents as a pull request that has cleared every gate and is waiting for somebody to press merge - the same presentation #1905 records for `pusher-only-approval` and #1917 for a workflow-touching `BLOCKED` read. This is a third cause of it, and unlike those two it does not resolve with time.

The refusal actively misdirects, which is what makes it expensive:

```
mergePullRequest       ->  Head branch is out of date. Review and try the merge again.
PUT /pulls/2508/merge  ->  409  Head branch is out of date. ...
```

There is no staleness gate here to satisfy. The `default` ruleset sets `strict_required_status_checks_policy: false`, `main` has no classic protection (`GET /branches/main/protection` -> `404 Branch not protected`), and the branch was not in conflict either - `git merge-tree --write-tree --messages` returned a tree and zero conflict messages. The message therefore invites the one action that makes things worse: pushing a refresh onto a contributor's branch consumes the approval of whoever owns the pushing token under `require_last_push_approval`, which is the state #1035 cannot leave.

And the one field that does move is the weakest signal available. AGENTS.md already documents `mergeable` as lazily computed - it "reads `unknown` first and the settled value second" - so a first `UNKNOWN` is both expected and benign, and "read it once more" is indistinguishable from that benign case for as long as one is willing to keep reading. Five consecutive reads returned `UNKNOWN`, across both the GraphQL and REST shapes.

## What this adds

`scripts/check_pr_head_is_current.py`, with `--pr` and `--all-open`. It reads the head repository's own ref:

```graphql
repository(owner: $headOwner, name: $headName) {
  ref(qualifiedName: "refs/heads/<headRefName>") { target { oid } }
}
```

resolved from `pullRequest { headRepository { nameWithOwner } headRefName }`, and compares it against `headRefOid`. Reading the tip *through* the pull request cannot work by construction - that is the field being checked.

Three outcomes, for the same reason the sibling check has three: `current`, `stale-head-record` (the finding), and `unresolvable-head` for a deleted fork or branch. The last one is deliberately not folded into a pass, because a head the check could not read is not a head that matches, and that is the single failure mode that would quietly turn this into a check agreeing with everything.

It **reports and does not gate**, on the same grounds as `check_last_push_approval.py`: the remedy is a close/reopen by someone with write access, and a check a branch cannot turn green by pushing belongs in a report.

## Why `--all-open` is the caller

A stale record produces no event - that *is* the defect, that the push was never registered against the pull request - so a workflow driven by `pull_request` cannot fire on the population this is written for. That is the same gap `check_last_push_approval.py` grew `--all-open` to close. AGENTS.md now lists it beside the other two sweeps under "reporting repository health".

## Verification

Run against the live open set, all 11 open non-draft pull requests, the `ref` read agreed with `git ls-remote` on **every one** - so no clone is needed. It named #2508 as the only stale record before the reconciliation, and `none` after it:

```
## Pull-request head record sweep
Evaluated 11 open non-draft pull request(s) in strands-labs/robots.
Every recorded head is its branch's tip.
```

The remedy is also verified rather than argued: a close/reopen on #2508 moved `headRefOid` to `271ec912` and queued the nine check suites that commit had never had, and `mergeable` moved from `UNKNOWN` to `MERGEABLE`. No push was made to that branch.

## Tests

`tests/test_pr_head_is_current.py`, 23 cases. The fixtures are the two real commits, and the control is the same pull request after reconciliation - identical code, `current`, because only the recorded head moved. It also pins that the tip is read from the head repository and never from `headRefOid`, that two absent heads do not compare equal into `current`, that a draft is excluded, and that one unreadable pull request does not suppress a finding on the rest.

The suite earned its place during authoring: it caught `branch_tip` calling `_graphql` without its `token` argument, which would have made every sweep report `unresolvable-head`.

`tests/test_duplicate_claim_check.py` gains one line. That test derives the set of scripts able to infer their repository from `$GITHUB_REPOSITORY` and requires each to declare how it names one, so a new inferring script has to be declared there - and that in turn is what grades the invocation added to AGENTS.md for naming `--repo`.

```
131 passed   # the check scripts' own tests, plus the repo-wide scanners
ruff check / ruff format / mypy   clean
```

The 8 failures in `tests/test_robot_factory.py` in my scratch environment are missing optional modules (`strands`, `serial`) and are identical on the unmodified base - a delta, not an absolute.

## Scope

No behaviour under `strands_robots/` changes. New script, new test, one line in an existing test, one AGENTS.md entry under step 8, one changelog fragment.