### PR TITLE
fix(policies/lerobot_local): refuse a norm_tag the checkpoint's stats do not declare

### DIFF
--- a/changelog.d/2543-unknown-norm-tag-is-reported.md
+++ b/changelog.d/2543-unknown-norm-tag-is-reported.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **policies/lerobot_local**: a `norm_tag` the checkpoint's `norm_stats.json` does not declare is now refused instead of absorbed. It previously shared the `(None, None)` verdict used for "this checkpoint ships no stats", so the processor bridge became a full passthrough while usable stats sat in the payload - state reaching the policy un-normalized and actions reaching the motors un-unnormalized - and the load report blamed a missing `policy_postprocessor.json` the checkpoint was never going to ship. The refusal names the requested tag, the declared tags and the consequence, and that reason reaches the load report in place of the generic message.

--- a/docs/policies/lerobot-local.md
+++ b/docs/policies/lerobot-local.md
@@ -294,6 +294,14 @@ action_unnorm = (clip(action, -1, 1) + 1) * (q99 - q01) / 2 + q01
 When a stats file declares multiple embodiment tags, pass `norm_tag=` to select
 one; a single-tag file is auto-detected.
 
+A `norm_tag` the stats file does not declare is refused rather than absorbed. The
+tag is a free-form string, so a misspelling would otherwise skip normalization
+entirely - state reaching the policy un-normalized and actions reaching the robot
+un-unnormalized, with usable stats sitting unused in the payload. The load report
+names the tag that was asked for and the tags the checkpoint declares, instead of
+blaming a missing `policy_postprocessor.json` the checkpoint was never going to
+ship.
+
 ### Device-pinned checkpoints
 
 A checkpoint trained on GPU bakes `device_processor.device = "cuda"` into its

--- a/strands_robots/policies/lerobot_local/norm_stats.py
+++ b/strands_robots/policies/lerobot_local/norm_stats.py
@@ -54,6 +54,22 @@ OBS_STATE = "observation.state"
 _EPS = 1e-6
 
 
+class UnknownNormTagError(ValueError):
+    """An explicitly requested ``norm_tag`` the checkpoint's stats do not carry.
+
+    Distinct from the two benign reasons a norm-stats fallback yields no
+    pipelines - no recognized stats file, or a multi-tag file the caller left
+    unresolved. Here the stats ARE present and usable and the caller named a tag
+    that is not among them, which is a caller error: the reference implementation
+    (``_RobotStats.validate_tag`` in
+    ``lerobot.policies.molmoact2.molmoact2_hf_model.modeling_molmoact2``) raises
+    for exactly this input rather than proceeding un-normalized.
+
+    Subclasses :class:`ValueError` so a caller narrowing on the loader's existing
+    exception contract keeps catching it.
+    """
+
+
 def _to_array(value: Any) -> np.ndarray | None:
     """Coerce a stats value to a float32 ndarray (mirrors the reference helper).
 
@@ -450,7 +466,24 @@ def build_norm_stats_processors(
     Returns:
         ``(preprocessor, postprocessor)`` pipelines, or ``(None, None)`` when the
         tag is unresolved, the stats are unusable, or LeRobot is unavailable.
+
+    Raises:
+        UnknownNormTagError: If ``norm_tag`` is given but the payload carries no
+            such tag. Degrading to ``(None, None)`` there would make the bridge a
+            passthrough while usable stats sit in the payload - the
+            un-normalized-state / un-unnormalized-action failure this module
+            exists to prevent - and the caller could not tell that verdict apart
+            from "this checkpoint ships no stats".
     """
+    declared = payload.get("metadata_by_tag")
+    if norm_tag and isinstance(declared, dict) and declared and norm_tag not in declared:
+        raise UnknownNormTagError(
+            f"norm_tag={norm_tag!r} is not declared by this checkpoint's norm stats. "
+            f"Declared tags: {sorted(declared)}. Normalization would be skipped "
+            "entirely: observation.state would reach the policy un-normalized and "
+            "predicted actions would reach the motors un-unnormalized. Pass one of "
+            "the declared tags, or omit norm_tag to auto-resolve a single-tag file."
+        )
     tag = select_norm_tag(payload, norm_tag)
     if tag is None:
         return None, None
@@ -489,6 +522,7 @@ def build_norm_stats_processors(
 
 __all__ = [
     "MOLMOACT2_NORM_STATS_FORMAT",
+    "UnknownNormTagError",
     "DEFAULT_SO_NORM_TAG",
     "FeatureNormalizer",
     "load_norm_stats",

--- a/strands_robots/policies/lerobot_local/policy.py
+++ b/strands_robots/policies/lerobot_local/policy.py
@@ -557,6 +557,7 @@ class LerobotLocalPolicy(Policy):
         # embodiment / image_keys were incompatible with the model's declared
         # features, so the bridge was discarded (see _load_processor_bridge).
         self._embodiment_config_failed = False
+        self._processor_inert_reason: str | None = None
         self._tokenizer: Any = None
         # Refused where the caller's value arrives, and before any checkpoint is
         # downloaded: the tokenizer reads this as a slice bound over the encoded
@@ -1113,6 +1114,7 @@ class LerobotLocalPolicy(Policy):
         caller error that should abort the load loudly.
         """
         self._embodiment_config_failed = False
+        self._processor_inert_reason = None
         if not (self.use_processor and self.pretrained_name_or_path):
             return
 
@@ -1167,6 +1169,12 @@ class LerobotLocalPolicy(Policy):
                     self._processor_bridge = None
                     self._embodiment_config_failed = True
             else:
+                # An inactive bridge is normally benign - the checkpoint ships no
+                # processor configs and no recognized stats file. When it instead
+                # carries a reason (a caller argument put reachable pipelines out
+                # of reach), keep that reason so the report below can name it; the
+                # bridge itself is still discarded, it applies nothing either way.
+                self._processor_inert_reason = self._processor_bridge.inert_reason
                 self._processor_bridge = None
                 logger.debug("No processor configs found, using raw obs/action flow")
 
@@ -1181,7 +1189,23 @@ class LerobotLocalPolicy(Policy):
         # misleading "no policy_postprocessor.json" message for that case.
         if self.use_processor and not self._embodiment_config_failed:
             bridge = self._processor_bridge
-            if bridge is None or not bridge.has_postprocessor:
+            inert_reason = self._processor_inert_reason
+            if inert_reason:
+                # The pipelines were within reach and a caller-supplied argument
+                # put them out of reach. Report THAT, not the generic missing-
+                # postprocessor message below, whose remedy (supply the
+                # checkpoint's postprocessor) does not address it - the same
+                # accurate-cause rule the embodiment-config failure follows.
+                logger.warning(
+                    "lerobot_local: %s loaded WITHOUT normalization: %s "
+                    "Until it is corrected, observation.state reaches the policy "
+                    "un-normalized and predicted actions reach the robot without "
+                    "unnormalization -- if the arm barely moves or reaches an "
+                    "out-of-distribution pose, this is why.",
+                    self.pretrained_name_or_path or "<model>",
+                    inert_reason,
+                )
+            elif bridge is None or not bridge.has_postprocessor:
                 logger.warning(
                     "lerobot_local: %s loaded WITHOUT an action postprocessor "
                     "(no policy_postprocessor.json). Actions are emitted in the "

--- a/strands_robots/policies/lerobot_local/processor.py
+++ b/strands_robots/policies/lerobot_local/processor.py
@@ -255,6 +255,7 @@ class ProcessorBridge:
         preprocessor: Any | None = None,
         postprocessor: Any | None = None,
         device: str | None = None,
+        inert_reason: str | None = None,
     ):
         """Initialize with optional pre/post processor pipelines.
 
@@ -262,10 +263,14 @@ class ProcessorBridge:
             preprocessor: LeRobot DataProcessorPipeline for observation preprocessing.
             postprocessor: LeRobot DataProcessorPipeline for action postprocessing.
             device: Target device for tensor operations (auto-detected if None).
+            inert_reason: Why this bridge carries no pipelines, when the cause is
+                a nameable caller error rather than a checkpoint that ships none.
+                ``None`` for every other bridge.
         """
         self._preprocessor = preprocessor
         self._postprocessor = postprocessor
         self._device = device
+        self._inert_reason = inert_reason
         # The embodiment's obs_rename map ({runtime_key: model_feature}),
         # latched by apply_embodiment. Used to enrich the 'image_keys
         # missing' preprocessor failure with the expected camera source
@@ -392,10 +397,22 @@ class ProcessorBridge:
         # both pipelines are None and the bridge silently passes data through
         # un-normalized -- the single biggest cause of off-policy arm motion on
         # such checkpoints. Build quantile/min-max/mean-std normalizers instead.
+        inert_reason: str | None = None
         if preprocessor is None and postprocessor is None:
-            preprocessor, postprocessor = cls._load_norm_stats_fallback(
-                pretrained_name_or_path, norm_tag=norm_tag, revision=revision
-            )
+            from .norm_stats import UnknownNormTagError
+
+            try:
+                preprocessor, postprocessor = cls._load_norm_stats_fallback(
+                    pretrained_name_or_path, norm_tag=norm_tag, revision=revision
+                )
+            except UnknownNormTagError as exc:
+                # The stats file IS present and usable; the caller named a tag it
+                # does not declare. Record the cause instead of propagating: the
+                # policy narrows on ValueError to treat an absent bridge as
+                # benign, so a raise here degrades to the same passthrough with
+                # its reason at debug, and the load report then blames a missing
+                # postprocessor the checkpoint was never going to ship.
+                inert_reason = str(exc)
 
         # Third fallback: an OLD-FORMAT checkpoint ships no processor configs and
         # no norm_stats.json, but carries in-model normalization buffers that
@@ -411,6 +428,7 @@ class ProcessorBridge:
             preprocessor=preprocessor,
             postprocessor=postprocessor,
             device=device,
+            inert_reason=inert_reason,
         )
 
     @classmethod
@@ -595,6 +613,11 @@ class ProcessorBridge:
 
         Returns:
             ``(preprocessor, postprocessor)`` pipelines or ``(None, None)``.
+
+        Raises:
+            UnknownNormTagError: If ``norm_tag`` names a tag the recognized stats
+                file does not declare - a caller error, not an absence, so it does
+                not share the ``(None, None)`` verdict.
         """
         from . import norm_stats as _norm_stats
 
@@ -839,6 +862,22 @@ class ProcessorBridge:
         """Whether any processing pipeline is active."""
         return self.has_preprocessor or self.has_postprocessor
 
+    @property
+    def inert_reason(self) -> str | None:
+        """Why this bridge carries no pipelines, when the cause is a caller error.
+
+        A bridge with neither pipeline is normally benign - the checkpoint ships
+        no processor configs and no recognized stats file, so there is genuinely
+        nothing to apply. When instead the pipelines were WITHIN REACH and a
+        caller-supplied argument put them out of reach, that reason is recorded
+        here so the load report can name the actual cause rather than the generic
+        "this checkpoint ships no postprocessor" one, whose remedy (supply the
+        checkpoint's postprocessor) does not address it.
+
+        ``None`` whenever the bridge is active, or inert for a benign reason.
+        """
+        return self._inert_reason
+
     def inert_normalization_features(self) -> list[str]:
         """Declared normalization features that will silently pass through.
 
@@ -1058,6 +1097,7 @@ class ProcessorBridge:
             "has_preprocessor": self.has_preprocessor,
             "has_postprocessor": self.has_postprocessor,
             "is_active": self.is_active,
+            "inert_reason": self.inert_reason,
             "repr": repr(self),
         }
 

--- a/tests/policies/lerobot_local/test_unknown_norm_tag_is_reported.py
+++ b/tests/policies/lerobot_local/test_unknown_norm_tag_is_reported.py
@@ -1,0 +1,228 @@
+"""A ``norm_tag`` the checkpoint's stats do not declare is reported, not absorbed.
+
+A checkpoint that ships only ``norm_stats.json`` gets its normalization from
+:mod:`strands_robots.policies.lerobot_local.norm_stats`, keyed by an embodiment
+*tag*. ``norm_tag`` is a documented ``config_keys`` knob, so the tag is a
+free-form caller string and a misspelling is the ordinary mistake.
+
+That misspelling used to be absorbed. ``build_norm_stats_processors`` answered a
+requested-but-undeclared tag with the same ``(None, None)`` it uses for "this
+checkpoint ships no stats", so the bridge became a full passthrough while usable
+stats sat in the payload: ``observation.state`` reached the policy un-normalized
+and predicted actions reached the motors un-unnormalized - the exact failure the
+norm-stats fallback exists to prevent (a mid-range SO-101 action collapses from
+~150 degrees to the raw 0.5 the model emitted). The load report then blamed a
+missing ``policy_postprocessor.json`` and told the caller to supply a
+postprocessor the checkpoint was never going to ship, so the one-character
+remedy appeared nowhere.
+
+The reference implementation refuses the same input:
+``_RobotStats.validate_tag`` in
+``lerobot.policies.molmoact2.molmoact2_hf_model.modeling_molmoact2`` raises
+``ValueError`` naming the allowed tags rather than proceeding un-normalized.
+
+These tests pin the two halves and the boundary:
+
+* a requested tag the payload does not declare raises ``UnknownNormTagError``
+  naming the tag, the declared tags and the consequence, and that reason reaches
+  the load report instead of the missing-postprocessor message;
+* a benign absence (no stats file at all) keeps the old ``(None, None)`` verdict,
+  a ``None`` reason and the existing missing-postprocessor message, and the
+  ambiguous multi-tag case is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.lerobot_local import norm_stats as ns
+from strands_robots.policies.lerobot_local.policy import LerobotLocalPolicy
+from strands_robots.policies.lerobot_local.processor import ProcessorBridge
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "molmoact2_norm_stats.json"
+
+
+def _payload() -> dict[str, Any]:
+    return json.loads(_FIXTURE.read_text())
+
+
+def _real_tag(payload: dict[str, Any]) -> str:
+    return next(iter(payload["metadata_by_tag"]))
+
+
+def _checkpoint(tmp_path: Path, payload: dict[str, Any]) -> str:
+    """A checkpoint dir carrying only ``norm_stats.json`` (the MolmoAct2 shape)."""
+    (tmp_path / "norm_stats.json").write_text(json.dumps(payload))
+    return str(tmp_path)
+
+
+def _lerobot_pipeline_importable() -> bool:
+    try:
+        from lerobot.processor.pipeline import DataProcessorPipeline  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+_requires_pipeline = pytest.mark.skipif(
+    not _lerobot_pipeline_importable(),
+    reason="lerobot processor pipeline framework not installed",
+)
+
+
+class TestAnUndeclaredTagIsRefused:
+    """The resolver refuses a tag the payload does not carry."""
+
+    def test_requested_tag_absent_from_the_payload_raises(self):
+        payload = _payload()
+        with pytest.raises(ns.UnknownNormTagError) as exc:
+            ns.build_norm_stats_processors(payload, norm_tag="so101")
+        message = str(exc.value)
+        # Names what was asked for, what exists, and what would otherwise happen.
+        assert "so101" in message
+        assert _real_tag(payload) in message
+        assert "un-normalized" in message
+
+    def test_the_refusal_is_a_value_error(self):
+        """Callers narrowing on the loader's existing exception contract still catch it."""
+        assert issubclass(ns.UnknownNormTagError, ValueError)
+
+    def test_a_declared_tag_named_by_the_refusal_actually_works(self):
+        """The remedy the message offers is not a second dead end."""
+        payload = _payload()
+        with pytest.raises(ns.UnknownNormTagError) as exc:
+            ns.build_norm_stats_processors(payload, norm_tag="so101")
+        offered = re.search(r"Declared tags: \[([^\]]*)\]", str(exc.value))
+        assert offered is not None, str(exc.value)
+        tags = [t.strip().strip("'\"") for t in offered.group(1).split(",") if t.strip()]
+        assert tags, str(exc.value)
+        # Applying the offered tag resolves; no exception, a real tag back.
+        assert ns.select_norm_tag(payload, tags[0]) == tags[0]
+
+
+@_requires_pipeline
+class TestTheBridgeRecordsWhyItIsInert:
+    """A caller error puts the reason on the bridge; a benign absence does not.
+
+    The three control cases read the reason defensively (``getattr``), so "no
+    reason is recorded" is an assertion about behaviour rather than about the
+    attribute existing - they hold on a tree without it too.
+    """
+
+    def test_undeclared_tag_leaves_the_reason_on_the_bridge(self, tmp_path):
+        ckpt = _checkpoint(tmp_path, _payload())
+        bridge = ProcessorBridge.from_pretrained(ckpt, norm_tag="so101")
+        assert bridge.is_active is False
+        assert bridge.inert_reason is not None
+        assert "so101" in bridge.inert_reason
+        assert bridge.get_info()["inert_reason"] == bridge.inert_reason
+
+    def test_a_checkpoint_with_no_stats_has_no_reason(self, tmp_path):
+        """The benign absence keeps its quiet verdict - nothing was within reach."""
+        bridge = ProcessorBridge.from_pretrained(str(tmp_path), norm_tag="so101")
+        assert bridge.is_active is False
+        assert getattr(bridge, "inert_reason", None) is None
+
+    def test_a_declared_tag_still_builds_both_pipelines(self, tmp_path):
+        """Control: the path that already worked is untouched."""
+        payload = _payload()
+        ckpt = _checkpoint(tmp_path, payload)
+        bridge = ProcessorBridge.from_pretrained(ckpt, norm_tag=_real_tag(payload))
+        assert bridge.has_preprocessor and bridge.has_postprocessor
+        assert getattr(bridge, "inert_reason", None) is None
+
+    def test_an_omitted_tag_still_auto_resolves(self, tmp_path):
+        """Control: single-tag auto-detection is untouched."""
+        bridge = ProcessorBridge.from_pretrained(_checkpoint(tmp_path, _payload()))
+        assert bridge.has_preprocessor and bridge.has_postprocessor
+        assert getattr(bridge, "inert_reason", None) is None
+
+    def test_the_undeclared_tag_is_what_costs_the_unnormalization(self, tmp_path):
+        """The measured consequence: the action stays in the model's raw space."""
+        payload = _payload()
+        ckpt = _checkpoint(tmp_path, payload)
+        stats = payload["metadata_by_tag"][_real_tag(payload)]["action_stats"]
+        emitted = np.full(len(stats["q01"]), 0.5, dtype=np.float32)
+
+        good = ProcessorBridge.from_pretrained(ckpt, norm_tag=_real_tag(payload))
+        applied = np.asarray(good.postprocess(emitted.copy()), dtype=np.float32)
+        # Unnormalized into robot units, far from the raw 0.5 the model emitted.
+        assert np.max(np.abs(applied)) > 10.0 * float(np.max(np.abs(emitted)))
+
+        typo = ProcessorBridge.from_pretrained(ckpt, norm_tag="so101")
+        assert typo.has_postprocessor is False  # nothing would unnormalize it
+
+
+class TestTheLoadReportNamesTheAccurateCause:
+    """The report blames the tag, not a postprocessor the checkpoint never had."""
+
+    @staticmethod
+    def _policy(**kwargs) -> LerobotLocalPolicy:
+        with patch.object(LerobotLocalPolicy, "_load_model"):
+            return LerobotLocalPolicy(pretrained_name_or_path="fake/ckpt", **kwargs)
+
+    @staticmethod
+    def _bridge(inert_reason: str | None) -> MagicMock:
+        bridge = MagicMock(name="ProcessorBridge")
+        bridge.is_active = False
+        bridge.has_postprocessor = False
+        bridge.inert_reason = inert_reason
+        bridge.inert_normalization_features.return_value = []
+        return bridge
+
+    def _load(self, monkeypatch, bridge) -> None:
+        monkeypatch.setattr(
+            "strands_robots.policies.lerobot_local.policy.ProcessorBridge.from_pretrained",
+            classmethod(lambda cls, *a, **k: bridge),
+        )
+
+    def test_an_inert_reason_replaces_the_missing_postprocessor_message(self, monkeypatch, caplog):
+        reason = "norm_tag='so101' is not declared by this checkpoint's norm stats."
+        self._load(monkeypatch, self._bridge(reason))
+        pol = self._policy()
+
+        with caplog.at_level(logging.WARNING):
+            pol._load_processor_bridge()
+
+        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any(reason in m for m in msgs), msgs
+        # NOT the misleading message: the checkpoint was never going to ship one,
+        # and supplying a postprocessor does not fix a misspelled tag.
+        assert not any("policy_postprocessor.json" in m for m in msgs), msgs
+
+    def test_a_reasonless_inert_bridge_keeps_the_existing_message(self, monkeypatch, caplog):
+        """Control: the benign absence still reports exactly what it used to."""
+        self._load(monkeypatch, self._bridge(None))
+        pol = self._policy()
+
+        with caplog.at_level(logging.WARNING):
+            pol._load_processor_bridge()
+
+        msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("policy_postprocessor.json" in m for m in msgs), msgs
+
+
+class TestTheBoundaryIsUnchanged:
+    """Verdicts that are not caller errors keep their existing behaviour."""
+
+    def test_an_ambiguous_multi_tag_payload_still_degrades_quietly(self):
+        """Nothing to blame the caller for: no tag was requested."""
+        payload = {"format": ns.MOLMOACT2_NORM_STATS_FORMAT, "metadata_by_tag": {"x": {}, "y": {}}}
+        assert ns.build_norm_stats_processors(payload) == (None, None)
+
+    def test_the_public_tag_resolver_still_returns_none(self):
+        """``select_norm_tag`` keeps its documented "resolve or None" contract."""
+        assert ns.select_norm_tag({"metadata_by_tag": {"a": {}}}, "missing") is None
+
+    def test_an_empty_tag_mapping_does_not_raise(self):
+        """Nothing is declared, so there is no declared set to have missed."""
+        payload = {"format": ns.MOLMOACT2_NORM_STATS_FORMAT, "metadata_by_tag": {}}
+        assert ns.build_norm_stats_processors(payload, norm_tag="so101") == (None, None)


### PR DESCRIPTION
## Problem

A LeRobot checkpoint that ships only `norm_stats.json` (the MolmoAct2 SO-100/101 family) gets its normalization from `norm_stats.py`, keyed by an embodiment *tag*. `norm_tag` is a documented `config_keys` knob, so the tag is a free-form caller string and a misspelling is the ordinary mistake.

That misspelling was absorbed. `build_norm_stats_processors` answered a requested-but-undeclared tag with the same `(None, None)` it uses for "this checkpoint ships no stats", so the bridge became a full passthrough while usable stats sat in the payload - `observation.state` reaching the policy un-normalized and predicted actions reaching the motors un-unnormalized, the exact failure that module exists to prevent. Measured against the bundled SO-100/101 fixture, a mid-range action collapses from **150.88 degrees to the raw 0.5** the model emitted.

The load report then named the wrong cause. With the pipelines absent it emitted the generic message, so the operator was told `(no policy_postprocessor.json)` and advised to *"Provide the checkpoint's postprocessor"* - a postprocessor this checkpoint was never going to ship, while the one-character remedy appeared nowhere.

The reference implementation refuses the same input: `_RobotStats.validate_tag` in `lerobot.policies.molmoact2.molmoact2_hf_model.modeling_molmoact2` raises `ValueError` naming the allowed tags rather than proceeding un-normalized.

| requested `norm_tag` | pipelines | action for an emitted `0.5` | operator is told |
|---|---|---|---|
| declared tag | built | `150.88` (robot units) | nothing (correct) |
| omitted (single-tag file) | built | `150.88` | nothing (correct) |
| **`'so101'` (a typo)** | **none** | **`0.5`** | **"no policy_postprocessor.json"** |
| no stats file at all | none | `0.5` | "no policy_postprocessor.json" (correct) |

## Change

`build_norm_stats_processors` raises `UnknownNormTagError` when `norm_tag` names a tag the payload does not declare, quoting the tag, the declared tags and the consequence. It subclasses `ValueError`, so a caller narrowing on the loader's existing exception contract still catches it.

Propagating alone would not have reached the operator: `LerobotLocalPolicy._load_processor_bridge` narrows on `ValueError` to treat an absent bridge as benign, so a raise degrades to the same passthrough with its reason at debug. `ProcessorBridge` therefore records the reason, and the load report names it in place of the generic message - the same accurate-cause rule the embodiment-config failure already follows (*"already warned with the accurate cause, so we do not emit the misleading `no policy_postprocessor.json` message for that case"*). `get_info()` reports it too.

Scoped to the caller error. A payload with several tags and no requested one keeps its quiet `(None, None)` verdict - nothing to blame the caller for - and the public `select_norm_tag` keeps its documented resolve-or-`None` contract.

## Sim artifact

MuJoCo SO-101, headless. The same policy output is driven through the real `ProcessorBridge` twice; the only difference is the requested tag. Peak per-frame motion **0.164 (undeclared) vs 20.728 (declared)** - a 127x difference in what reaches the arm, from one character. The consoles below are the real load reports from each tree.

![norm_tag not declared](https://raw.githubusercontent.com/cagataycali/robots/media-unknown-norm-tag/norm_tag.png)

The commanded values are byte-identical in both trees (asserted in the capture): this change alters what is reported, not what is computed.

## Tests

`tests/policies/lerobot_local/test_unknown_norm_tag_is_reported.py` - **5 failed / 8 passed** against `upstream/main`, 13 pass after. Four of the five failures are behavioural (the refusal is not raised, the reason is absent, the report is misleading); the fifth pins the new symbol.

The eight both-tree passes are the controls, and each fails for a specific wrong fix: a declared tag and an omitted tag still build both pipelines; a checkpoint with no stats keeps a `None` reason and the existing message; the ambiguous multi-tag case still degrades quietly; `select_norm_tag` still returns `None`; and an empty tag mapping does not raise. One control parses a declared tag back out of the refusal and applies it, so the remedy the message offers is not a second dead end.

## Verification

Measured at `815c3cca` with `MUJOCO_GL=egl`, lerobot 0.6.2, mujoco 3.12.0.

- 100-file blast radius (every test naming the changed symbols, all of `tests/policies/lerobot_local`, the docs and repo-wide guards): branch **1 failed / 2392 passed / 3 skipped**, base **6 failed / 2387 passed / 3 skipped**, 2396 collected on both. Branch-only failures: none. Base-only: exactly the 5 pre-fix cases.
- The one shared failure, `test_vla_jepa.py::test_vla_jepa_processor_steps_register_via_strands_path`, reproduces identically on a pristine `upstream/main` in isolation - a lerobot step-registration artifact of this environment, untouched by this diff.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 errors on both trees, none in the changed files.
