### PR TITLE
fix(simulation): refuse to remove a reserved free-view camera name

### DIFF
--- a/changelog.d/2543-reserved-camera-name-at-removal.md
+++ b/changelog.d/2543-reserved-camera-name-at-removal.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **simulation**: `remove_camera` refuses a reserved free-view routing token (`default`, `free`, `""`) instead of deleting it. `create_world` both registers `default` and bakes a compiled MJCF camera of that name, while the render path resolves the token to the built-in free view without consulting either, so removing it reported success, permanently deleted a compiled camera the scene ships with, and left `list_cameras` still advertising the name. `start_recording(cameras=["default"])` then refused, and its remedy - `add_camera("default", ...)` - is itself refused as reserved, so nothing could restore it. Both backends now read the rule from the same `reserved_camera_name_error` owner that already guards creation.

--- a/changelog.d/2543-reserved-camera-name-at-removal.md
+++ b/changelog.d/2543-reserved-camera-name-at-removal.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation**: `remove_camera` refuses a reserved free-view routing token (`default`, `free`, `""`) instead of deleting it. `create_world` both registers `default` and bakes a compiled MJCF camera of that name, while the render path resolves the token to the built-in free view without consulting either, so removing it reported success, permanently deleted a compiled camera the scene ships with, and left `list_cameras` still advertising the name. `start_recording(cameras=["default"])` then refused, and its remedy - `add_camera("default", ...)` - is itself refused as reserved, so nothing could restore it. Both backends now read the rule from the same `reserved_camera_name_error` owner that already guards creation.

--- a/changelog.d/2544-reserved-camera-name-at-removal.md
+++ b/changelog.d/2544-reserved-camera-name-at-removal.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **simulation**: `remove_camera` on the MuJoCo and Newton backends now refuses a reserved
+  free-view camera name (`default`, `free`) on the same shared domain their `add_camera` already
+  consults. Removing the `default` camera `create_world` bakes in used to succeed, after which the
+  name could not be re-added (creation refuses it as reserved) and `start_recording(cameras=["default"])`
+  reported it as an unknown camera, while `list_cameras()` and `describe()` still advertised it.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -4055,12 +4055,24 @@ class MuJoCoSimEngine(
 
         Returns:
             A ``{status, content}`` tool result. ``status`` is ``"error"`` when
-            no world exists, ``name`` is unknown, a policy is running, or the
-            scene would not recompile without the camera -- in that last case
-            the camera is still registered and the scene is unchanged.
+            no world exists, ``name`` is a free-camera routing token, ``name`` is
+            unknown, a policy is running, or the scene would not recompile
+            without the camera -- in that last case the camera is still
+            registered and the scene is unchanged.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
+        # Same rule as ``add_camera``, at the other end of the name's life, and for
+        # the same reason: a routing token cannot be un-addressed. ``render`` /
+        # ``render_depth`` / ``get_frame`` / ``get_camera_params`` keep resolving
+        # the token past the registry, and ``list_cameras`` names it
+        # unconditionally, so dropping the entry removes no camera - it removes
+        # only the recordable/observable alias, leaving every other surface still
+        # advertising it. It precedes the existence test because that test can
+        # answer for ``"default"`` (``create_world`` registers the free view under
+        # that name) and answering it succeeds.
+        if (reserved_err := reserved_camera_name_error("remove_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": reserved_err}]}
         if not registered(self._world.cameras, name):
             return {"status": "error", "content": [{"text": self._unknown_camera_msg(name)}]}
         if err := self._require_no_running_policy("remove_camera"):

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -1488,10 +1488,18 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
 
         Returns:
             Status dict confirming removal, or an error dict when no world
-            exists or the camera is unknown.
+            exists, ``name`` is a free-camera routing token, or the camera is
+            unknown.
         """
         if self._world is None or self._model is None:
             return {"status": "error", "content": [{"text": "No world. Call create_world first."}]}
+        # Same rule as ``add_camera``, at the other end of the name's life: a
+        # routing token cannot be un-addressed, and ``list_cameras`` names it
+        # unconditionally. It precedes the existence test because that test
+        # answers "not found. Registered: [...]" for a name ``list_cameras``
+        # advertises, which reads as a bookkeeping slip rather than the rule.
+        if (reserved_err := reserved_camera_name_error("remove_camera", "name", name)) is not None:
+            return {"status": "error", "content": [{"text": reserved_err}]}
         if not registered(self._world.cameras, name):
             return {
                 "status": "error",

--- a/tests/simulation/test_reserved_camera_name_at_creation.py
+++ b/tests/simulation/test_reserved_camera_name_at_creation.py
@@ -182,13 +182,19 @@ class TestMujocoAddCamera:
         first = sim.add_camera("default", position=[1.0, 1.0, 1.0], target=[0.0, 0.0, 0.0])
         assert first["status"] == "error"
         assert "reserved" in first["content"][0]["text"]
-        # The old message's remedy, followed literally.
-        assert sim.remove_camera("default")["status"] == "success"
+        # The old message's remedy, followed literally: it is refused for the
+        # same stated reason, so the sequence cannot be completed at all.
+        removed = sim.remove_camera("default")
+        assert removed["status"] == "error", removed
+        assert "reserved" in removed["content"][0]["text"]
         second = sim.add_camera("default", position=[9.0, 9.0, 9.0], target=[0.0, 0.0, 0.0])
         assert second["status"] == "error", second
         assert "reserved" in second["content"][0]["text"]
-        assert "default" not in sim._world.cameras
-        assert _compiled_camera_names(sim) == []
+        # The advertised alias and the compiled camera both survived every
+        # step. Pre-fix the removal deleted the compiled camera the scene
+        # ships with (this assertion read ``[]``) and nothing could restore it.
+        assert "default" in sim._world.cameras
+        assert _compiled_camera_names(sim) == ["default"]
 
     def test_the_reserved_check_precedes_the_duplicate_test(self, sim) -> None:
         """Ordering is the property: "already exists" was the misleading answer.

--- a/tests/simulation/test_reserved_camera_name_at_removal.py
+++ b/tests/simulation/test_reserved_camera_name_at_removal.py
@@ -1,0 +1,180 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: ``remove_camera`` refuses a name its own ``render`` resolves past.
+
+:func:`~strands_robots.utils.reserved_camera_name_error` states one rule -- a
+free-camera routing token is not a camera *name* -- and until this fix the
+token-routing backends applied it at ``add_camera`` only. The name's other
+lifecycle end was unguarded, so the token could be surrendered but never
+reclaimed.
+
+``remove_camera`` cannot remove the free view. ``render``, ``render_depth``,
+``get_frame`` and ``get_camera_params`` resolve the token by an explicit check
+that never consults the registry, and ``list_cameras`` names it
+unconditionally -- its docstring calls it "the built-in ``default`` free view",
+"independent of whether the loaded MJCF happens to bake a camera literally
+named ``default``". What the call actually removed was the *registry entry*,
+i.e. only the recordable/observable alias. Measured on MuJoCo 3.10.0, one
+``create_world`` then ``remove_camera("default")``:
+
+* ``status="success"``, text ``Camera 'default' removed.``;
+* ``list_cameras()`` still answered ``['default']`` and ``render()`` still
+  produced a frame, so every read surface kept advertising the name;
+* ``start_recording(cameras=["default"])`` then refused it -- ``Unknown
+  camera(s) ['default'] ... Available scene cameras: []`` -- a refusal whose own
+  list contradicts ``list_cameras``;
+* and the remedy that refusal implies is ``add_camera("default", ...)``, which
+  :mod:`~strands_robots.utils`'s reserved rule refuses. There was no way back.
+
+So the reservation guard added at creation turned "ends with an unreachable
+camera" into "ends with an unrecoverable inconsistency": the advertised
+free-view alias could be destroyed permanently, and the recording surface that
+depends on it could not be restored by any public call.
+
+The fix reads the same shared domain at both ends of the name's life, so the
+side that *routes* a token and the side that *refuses* it stay in agreement. It
+precedes the existence test for the reason the creation-side check precedes the
+duplicate test: that test can answer for the token (``create_world`` registers
+the free view under ``"default"``, and Newton does not) and either answer is
+misleading -- ``"removed"`` or ``"not found. Registered: [...]"`` for a name
+``list_cameras`` advertises.
+
+The Isaac backend is deliberately unguarded: its ``get_frame`` looks the name up
+in its camera map with no token check, so ``"default"`` there is an ordinary
+addressable name and removing it is coherent.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from strands_robots.simulation.newton.simulation import NewtonSimEngine
+from strands_robots.utils import FREE_CAMERA_TOKENS
+
+pytest.importorskip("mujoco")
+
+# ``FREE_CAMERA_TOKENS`` is ``(None, "", "default", "free")``: ``None`` is the
+# "caller named no camera" sentinel rather than a name, and the shared domain
+# deliberately accepts it, so only the string spellings are reserved *names*.
+RESERVED_NAMES = sorted(t for t in FREE_CAMERA_TOKENS if isinstance(t, str))
+
+
+@pytest.fixture
+def sim() -> Any:
+    """A compiled MuJoCo world holding only the built-in free view."""
+    from strands_robots.simulation import create_simulation
+
+    engine = create_simulation(backend="mujoco", tool_name="reserved_removal")
+    engine.create_world()
+    yield engine
+    engine.destroy()
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _compiled_camera_names(sim: Any) -> list[str]:
+    """The cameras the compiled MJCF actually holds.
+
+    ``create_world`` bakes a camera literally named ``"default"`` (``ncam == 1``)
+    as well as registering it, and the render path's token check resolves that
+    name to the free view without consulting either. Removing it therefore
+    deleted a compiled camera the scene ships with.
+    """
+    import mujoco
+
+    model = sim._world._model
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_CAMERA, i) for i in range(model.ncam)]
+
+
+class TestTheFreeViewAliasCannotBeSurrendered:
+    """The token is refused at removal, so the alias survives."""
+
+    @pytest.mark.parametrize("token", RESERVED_NAMES)
+    def test_removing_a_routing_token_is_refused(self, sim, token: str) -> None:
+        """Every token the render path resolves past is refused as a name here."""
+        result = sim.remove_camera(token)
+        assert result["status"] == "error", result
+        text = _text(result)
+        assert "reserved" in text
+        assert "remove_camera" in text
+
+    def test_the_advertised_alias_survives_the_attempt(self, sim) -> None:
+        """``remove_camera('default')`` reported success and dropped the entry."""
+        assert "default" in sim._world.cameras
+        sim.remove_camera("default")
+        assert "default" in sim._world.cameras
+        assert sim.list_cameras() == ["default"]
+        assert _compiled_camera_names(sim) == ["default"]
+
+    def test_the_recordable_alias_survives_the_attempt(self, sim) -> None:
+        """The consequence: recording the advertised name stopped working.
+
+        ``list_cameras`` kept naming ``'default'`` while ``start_recording``
+        refused it, and no public call could put the entry back.
+        """
+        sim.remove_camera("default")
+        started = sim.start_recording(
+            repo_id="local/reserved_removal",
+            task="t",
+            fps=30,
+            root="/tmp/strands-reserved-removal",
+            cameras=["default"],
+        )
+        assert started["status"] == "success", started
+        sim.stop_recording()
+
+    def test_the_refusal_names_the_surface_and_the_rule(self, sim) -> None:
+        """A caller who tries gets the reason, not a bookkeeping answer."""
+        text = _text(sim.remove_camera("default"))
+        assert "removed" not in text
+        assert "not found" not in text
+
+
+class TestTheGuardDoesNotReachPastTheTokens:
+    """Controls: these hold on both sides of the fix."""
+
+    def test_an_addressable_camera_still_removes(self, sim) -> None:
+        """The rule is membership, so an ordinary camera is unaffected."""
+        sim.add_camera("cam1", position=[0.5, 0.5, 0.5], target=[0.0, 0.0, 0.0])
+        removed = sim.remove_camera("cam1")
+        assert removed["status"] == "success"
+        assert "cam1" not in sim._world.cameras
+
+    def test_a_name_that_merely_resembles_a_token_still_removes(self, sim) -> None:
+        """``'default_cam'`` is not the token ``'default'``."""
+        sim.add_camera("default_cam", position=[0.5, 0.5, 0.5], target=[0.0, 0.0, 0.0])
+        removed = sim.remove_camera("default_cam")
+        assert removed["status"] == "success"
+
+    def test_an_unknown_name_still_reports_not_found(self, sim) -> None:
+        """The existence test is still reached for every non-token name."""
+        result = sim.remove_camera("nope")
+        assert result["status"] == "error"
+        assert "not found" in _text(result)
+
+
+class TestTheRuleIsReadFromOneOwner:
+    """Both token-routing backends refuse through the same shared domain."""
+
+    @pytest.mark.parametrize("token", RESERVED_NAMES)
+    def test_newton_refuses_the_same_tokens(self, token: str) -> None:
+        """Newton registers no ``'default'`` entry, so its existence test
+        answered ``"not found. Registered: []"`` for a name its own
+        ``list_cameras`` advertises. The rule has to win there too.
+        """
+        import threading
+        from types import SimpleNamespace
+
+        stub = SimpleNamespace(
+            _world=SimpleNamespace(cameras={}),
+            _model=object(),
+            _lock=threading.RLock(),
+        )
+        # ``stub`` is a duck-typed stand-in: the method reads only ``_world``.
+        result = NewtonSimEngine.remove_camera(cast(Any, stub), token)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "reserved" in text
+        assert "not found" not in text


### PR DESCRIPTION
## Problem

`create_world()` bakes a `default` camera into the MJCF, and `render`/`get_frame` route
`camera_name in (None, "", "default", "free")` to the free camera by an explicit token check.
Because of that token check, `add_camera(name="default")` is refused as reserved -- a camera
created under the name could never be rendered from.

`remove_camera("default")` had no such check, so the one name the scene ships with could be
deleted but never restored. Measured on the MuJoCo backend:

| step | upstream/main |
|---|---|
| `create_world(); add_robot("so101")` | compiled MJCF cameras `['default']`, `list_cameras()` `['default']` |
| `remove_camera("default")` | **`success`**, "Camera 'default' removed." |
| after removal | compiled MJCF cameras **`[]`**, `list_cameras()` still **`['default']`** |
| `start_recording(cameras=["default"])` | **`error`**: "unknown camera(s) `['default']` ... Available scene cameras: `[]`" |
| `add_camera("default", ...)` to restore | **`error`**: reserved |

Three surfaces disagree after that one call: the compiled model has no camera, `list_cameras()`
and `describe()` still advertise the name, and `get_camera_params("default")` still answers from
the free view. Newton is the same shape (its `remove_camera` also deletes the registry entry the
scene starts with, `list_cameras()` `['default']` -> `[]`).

The remedy the recording refusal offers -- "Add them with `add_camera(...)` before recording" --
is itself refused for this name, so the state is not recoverable through the public surface. A
`Simulation` that has lost it can only be rebuilt.

## Change

Both backends now check `reserved_camera_name_error` in `remove_camera`, the same owner their
`add_camera` already consults, so the rule is applied at both ends of the name's life instead of
only at creation. The refusal carries the reason (the `render` token check) and the actionable
consequence, matching the creation-side message.

`add_camera` and `remove_camera` are inverse operations over one namespace; a name creation
cannot mint is a name removal cannot surrender.

## Tests

`tests/simulation/test_reserved_camera_name_at_removal.py` (new, 15 cases across both backends):

- the removal is refused for every reserved token (`default`, `free`, and the case variants the
  owner accepts), and the refusal names the parameter and the reason
- the compiled MuJoCo camera and the Newton registry entry both survive the refused call
- after a refused removal, `start_recording(cameras=["default"])` still succeeds and records
- a non-reserved camera can still be added and removed (the fix does not widen)
- an unknown name still reports "not found" rather than the reserved message, so the two
  refusals stay distinguishable
- the parameter label in the message is `remove_camera`, not the creation-side context

`tests/simulation/test_reserved_camera_name_at_creation.py` is repaired: it removed the shipped
`default` camera to set up its own premise, and that setup was the defect. It now asserts the
compiled camera survives, which is a stronger statement of what it was written to pin.

Pre-fix split on `upstream/main`: **8 failed / 7 passed**. Post-fix: **15 passed**.

## Verification

- 32-file selection (every test naming `remove_camera` / `list_cameras` /
  `reserved_camera_name_error`, plus the repo-wide changelog / docstring / ASCII guards), run on
  this branch and on a pristine `upstream/main` worktree: **1 failed / 1826 passed on both**, the
  same single pre-existing failure
  (`newton/test_multi_camera.py::TestNamedCameraRegistration::test_bad_position_shape_rejected`,
  a message-text assertion unrelated to this diff). Branch-only failures: none.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: no issues.
- Rollout artifact below produced by one script run under each tree with only `strands_robots`
  differing.

## Scope

`IsaacSimulation.remove_camera` refuses any name not in its `_cameras` registry, and its
`default` is a render-time alias rather than a created prim, so the deletion fixed here is not
reachable there by the same route. Its `add_camera` validates `entity_name_error` but not
`reserved_camera_name_error` (`simulation/isaac/simulation.py:4653`), and the comment above that
line records the same `(None, "", "default", "free")` token routing -- worth a look, but it is a
creation-side question on a backend I could not exercise, so it is left out of this change.

## Artifact

Identical script, both trees, MuJoCo backend headless. Left: the shipped camera is deleted and
the recording of it becomes impossible. Right: the removal is refused, the compiled camera
survives, and a 30-frame dataset with `observation.images.default` records normally.

![remove_camera reserved name](https://raw.githubusercontent.com/cagataycali/robots/media-reserved-camera-removal/figure.png)
