### PR TITLE
fix(simulation): hold a patch op's claimed name to the shared entity-name domain

### DIFF
--- a/changelog.d/2547-patch-op-entity-name-domain.md
+++ b/changelog.d/2547-patch-op-entity-name-domain.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation/mujoco**: the `patch_scene_mjcf` ops that claim a name (`add_body`, `add_geom`, `add_site`) now hold it to the same `entity_name_error` domain `add_object` / `add_camera` / `add_robot` apply. A name carrying a NUL used to report success and compile the entity under the truncated name, so a later op that genuinely asked for that shorter name was refused as a repeated name the caller never used; an empty `add_geom` name compiled an unnamed geom that `set_geom_properties(geom_name=...)` could not reach. Omitting `add_geom`'s name still produces an unnamed geom, and the ops that look a name up are unchanged.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -43,7 +43,7 @@ from typing import Any
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
 from strands_robots.simulation.mujoco.backend import _ensure_mujoco, filter_mujoco_attach_noise, mj_name_to_id
 from strands_robots.simulation.mujoco.spec_builder import SpecBuilder
-from strands_robots.utils import coerce_rgba, finite_vector_error, pose_vector_error
+from strands_robots.utils import coerce_rgba, entity_name_error, finite_vector_error, pose_vector_error
 
 logger = logging.getLogger(__name__)
 
@@ -2302,6 +2302,12 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
     MuJoCo compile errors surface on the enclosing ``recompile`` call.
     ``new_bodies`` is a batch-local cache of body handles added earlier
     in the same patch (see ``_find_body`` for why this is needed).
+
+    An op that CLAIMS a name holds it to the shared
+    :func:`~strands_robots.utils.entity_name_error` domain, so this door cannot
+    create an entity a name-based surface is unable to address. An op that
+    LOOKS a name UP does not: there a name addressing nothing is honestly
+    absent, which is what its own "not found" message already reports.
     """
     if not isinstance(op, dict):
         raise ValueError(f"each op must be a dict, got {type(op).__name__}")
@@ -2321,8 +2327,10 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
     if kind == "add_body":
         parent = op.get("parent", "world")
         name = op.get("name")
-        if not name:
+        if name is None:
             raise ValueError("add_body requires 'name'")
+        if (name_err := entity_name_error("add_body", "name", name)) is not None:
+            raise ValueError(name_err)
         pos = op.get("pos", [0.0, 0.0, 0.0])
         quat = op.get("quat", [1.0, 0.0, 0.0, 0.0])
         parent_body = _find_body(spec, parent, new_bodies)
@@ -2352,6 +2360,10 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
             "rgba": op.get("rgba", [0.5, 0.5, 0.5, 1.0]),
         }
         if "name" in op:
+            # Only a supplied name is a claim: omitting the key leaves the geom
+            # unnamed, which is a legal MJCF geom and stays legal here.
+            if (name_err := entity_name_error("add_geom", "name", op["name"])) is not None:
+                raise ValueError(name_err)
             geom_kwargs["name"] = op["name"]
         if "pos" in op:
             geom_kwargs["pos"] = op["pos"]
@@ -2366,8 +2378,10 @@ def _apply_patch_op(spec: Any, op: dict[str, Any], new_bodies: dict[str, Any]) -
         if body is None:
             raise ValueError(f"add_site: body '{body_name}' not found")
         name = op.get("name")
-        if not name:
+        if name is None:
             raise ValueError("add_site requires 'name'")
+        if (name_err := entity_name_error("add_site", "name", name)) is not None:
+            raise ValueError(name_err)
         site_kwargs: dict[str, Any] = {
             "name": name,
             "pos": op.get("pos", [0.0, 0.0, 0.0]),

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1107,6 +1107,24 @@ class MuJoCoSimEngine(
         keyword, and MuJoCo reports a mismatch there by dumping a C++ overload
         table that names neither the op nor the field.
 
+        The three ops that CLAIM a name - ``add_body``, ``add_geom`` and
+        ``add_site`` - hold it to the same
+        :func:`~strands_robots.utils.entity_name_error` domain that
+        ``add_object`` / ``add_camera`` / ``add_robot`` apply, so a name one
+        door refuses is refused at all of them. Supplying ``""`` or a name
+        carrying a NUL leaves an entity this API cannot then address: MuJoCo
+        reads a name only up to the first NUL, so ``{"op": "add_body", "name":
+        "a\x00b"}`` used to report success while compiling the body as ``a`` -
+        ``list_bodies`` showed only ``a``, and a later op that genuinely asked
+        for ``a`` was refused as a repeated name the caller never used. An
+        empty ``add_geom`` name compiled an unnamed geom, which
+        ``set_geom_properties(geom_name=...)`` cannot reach at all. Omitting
+        ``name`` on ``add_geom`` is unaffected and still produces an unnamed
+        geom, which is legal MJCF; the three ops that instead LOOK a name UP
+        (``set_body_pos`` / ``set_body_quat`` / ``delete_body``) are unchanged,
+        because a name that addresses nothing is honestly absent there and
+        those ops already say so.
+
         The whole batch is applied, then the spec is recompiled once. If any
         op fails, the batch is rejected and the world is rolled back to its
         pre-patch state (from a deep copy of the spec). Use this for fast

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -2266,7 +2266,10 @@ def entity_name_error(method: str, param_name: str, name: Any) -> str | None:
     does: ``add_object`` / ``add_camera`` / ``add_robot`` exist on more than one
     backend and their accepted domain must not diverge - a name one backend
     refuses must be refused by the others, and a second copy of the rule would
-    drift from the first.
+    drift from the first. The MuJoCo ``patch_scene_mjcf`` ops that claim a name
+    (``add_body`` / ``add_geom`` / ``add_site``) are a fourth door onto the same
+    spec and route through it too, because "which names may address an entity"
+    is a property of the backend, not of the call used to create one.
 
     Three values are refused, each because it produces an entity that some part
     of this API cannot address (measured on MuJoCo 3.11.0, one ``create_world``

--- a/tests/simulation/test_entity_name_domain_at_creation.py
+++ b/tests/simulation/test_entity_name_domain_at_creation.py
@@ -542,3 +542,192 @@ class TestEveryBackendGivesTheSameVerdict:
         ic = IsaacSimulation.add_camera(_isaac_stub(), name)  # type: ignore[arg-type]
         assert mj["status"] == nt["status"] == ic["status"] == "error", (mj, nt, ic)
         assert mj["content"][0]["text"] == nt["content"][0]["text"] == ic["content"][0]["text"]
+
+
+# --------------------------------------------------------------------------- #
+# MuJoCo: the fourth creation door (patch_scene_mjcf)                         #
+# --------------------------------------------------------------------------- #
+#: The ``patch_scene_mjcf`` ops that CLAIM a name, so the name has to address
+#: the entity they create.
+_CLAIMING_OPS = ("add_body", "add_geom", "add_site")
+
+#: The ops that instead LOOK a name UP. A name addressing nothing is honestly
+#: absent there, which their own "not found" message already reports, so they
+#: are deliberately outside this domain.
+_LOOKUP_OPS = ("set_body_pos", "set_body_quat", "delete_body")
+
+
+def _claim_ops(name: object) -> dict[str, list[dict[str, object]]]:
+    """A minimal batch per claiming op, each claiming ``name``."""
+    return {
+        "add_body": [{"op": "add_body", "parent": "world", "name": name}],
+        "add_geom": [
+            {"op": "add_body", "parent": "world", "name": "host"},
+            {"op": "add_geom", "body": "host", "type": "sphere", "size": [0.08], "name": name},
+        ],
+        "add_site": [
+            {"op": "add_body", "parent": "world", "name": "host"},
+            {"op": "add_site", "body": "host", "name": name},
+        ],
+    }
+
+
+def _geom_names(sim) -> list[str | None]:
+    import mujoco
+
+    model = sim._world._model
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, i) for i in range(model.ngeom)]
+
+
+def _op_branch_source(kind: str) -> str:
+    """The body of ``_apply_patch_op``'s ``if kind == "<kind>":`` branch."""
+    import ast
+    import inspect
+    import textwrap
+
+    from strands_robots.simulation.mujoco import scene_ops
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(scene_ops._apply_patch_op)))
+    fn = tree.body[0]
+    assert isinstance(fn, ast.FunctionDef)
+    for node in fn.body:
+        if isinstance(node, ast.If) and ast.unparse(node.test) == f"kind == '{kind}'":
+            return "\n".join(ast.unparse(stmt) for stmt in node.body)
+    raise AssertionError(f"no branch for op {kind!r} in _apply_patch_op")
+
+
+class TestMujocoPatchSceneMjcf:
+    """The patch ops that claim a name refuse the names the methods refuse.
+
+    ``patch_scene_mjcf`` is a published action and its ``add_body`` /
+    ``add_geom`` / ``add_site`` ops claim a name in the same spec ``add_object``
+    writes into, but they checked only that the name was truthy. So the two
+    values this domain exists to refuse were accepted at that door:
+
+    * ``{"op": "add_body", "name": "a\\x00b"}`` -> ``status="success"``, and the
+      body compiled as ``a``: ``list_bodies()`` reported ``['world', 'a']``, and
+      a later op that genuinely asked for ``a`` was refused
+      ``Error: repeated name 'a' in body`` - blaming a collision with a name the
+      caller never used.
+    * ``{"op": "add_geom", "name": ""}`` -> ``status="success"`` with the geom
+      compiled unnamed, so ``set_geom_properties(geom_name="")`` answered
+      ``Geom 'None' not found``: the caller claimed a name and got an entity the
+      only name-addressed geom surface cannot reach.
+
+    A non-string reached MuJoCo's binding instead and raised a C++ overload
+    table naming neither the op nor the field.
+    """
+
+    @pytest.mark.parametrize("kind", _CLAIMING_OPS)
+    @pytest.mark.parametrize("name", (*_NON_STRING_NAMES, "", *_NUL_NAMES))
+    def test_unaddressable_name_is_refused(self, sim, kind, name):
+        result = sim.patch_scene_mjcf(_claim_ops(name)[kind])
+        assert result["status"] == "error", (kind, name, result)
+        text = result["content"][0]["text"]
+        assert "'name'" in text, (kind, name, text)
+        assert kind in text, (kind, name, text)
+
+    @pytest.mark.parametrize("kind", _CLAIMING_OPS)
+    @pytest.mark.parametrize("name", ("", "a\x00b"))
+    def test_a_refused_batch_compiles_nothing(self, sim, kind, name):
+        """The rejected batch leaves no entity behind under any spelling."""
+        before_bodies, before_geoms = _body_names(sim), _geom_names(sim)
+        sim.patch_scene_mjcf(_claim_ops(name)[kind])
+        assert _body_names(sim) == before_bodies, (kind, name)
+        assert _geom_names(sim) == before_geoms, (kind, name)
+
+    def test_a_nul_name_does_not_reserve_its_truncation(self, sim):
+        """The collision half: the requested name and the compiled one differed.
+
+        Pre-fix ``add_body("a\\x00b")`` succeeded as ``a``, so this second
+        ``add_body("a")`` - a different name, legitimately asked for - was
+        refused ``repeated name 'a' in body``.
+        """
+        refused = sim.patch_scene_mjcf([{"op": "add_body", "parent": "world", "name": "a\x00b"}])
+        assert refused["status"] == "error", refused
+        result = sim.patch_scene_mjcf([{"op": "add_body", "parent": "world", "name": "a"}])
+        assert result["status"] == "success", result
+        assert "a" in _body_names(sim)
+
+    def test_an_empty_geom_name_compiles_no_unnamed_geom(self, sim):
+        """Pre-fix the geom compiled with ``None`` for a name."""
+        sim.patch_scene_mjcf(_claim_ops("")["add_geom"])
+        assert None not in _geom_names(sim)
+
+    @pytest.mark.parametrize("name", (7, ["x"], "", "a\x00b"))
+    def test_the_patch_door_and_add_object_agree(self, sim, name):
+        """One backend, one domain: both doors refuse with the same sentence."""
+        patched = sim.patch_scene_mjcf(_claim_ops(name)["add_body"])
+        method = sim.add_object(name, shape="box")
+        assert patched["status"] == method["status"] == "error", (patched, method)
+        assert entity_name_error("add_body", "name", name) in patched["content"][0]["text"]
+
+    # ---- controls: these pass before the fix too -------------------------- #
+
+    def test_an_omitted_geom_name_is_still_legal(self, sim):
+        """Not supplying a name is not claiming one - the geom stays unnamed."""
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "parent": "world", "name": "host"},
+                {"op": "add_geom", "body": "host", "type": "sphere", "size": [0.08]},
+            ]
+        )
+        assert result["status"] == "success", result
+        assert None in _geom_names(sim)
+
+    @pytest.mark.parametrize("kind", ("add_body", "add_site"))
+    def test_an_absent_name_keeps_its_own_message(self, sim, kind):
+        """A missing key is a different report from an unusable value."""
+        ops: list[dict[str, object]] = [{"op": "add_body", "parent": "world"}]
+        if kind == "add_site":
+            ops = [{"op": "add_body", "parent": "world", "name": "host"}, {"op": "add_site", "body": "host"}]
+        result = sim.patch_scene_mjcf(ops)
+        assert result["status"] == "error"
+        assert f"{kind} requires 'name'" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize("name", _GOOD_NAMES)
+    def test_addressable_names_still_round_trip(self, sim, name):
+        result = sim.patch_scene_mjcf(
+            [
+                {"op": "add_body", "parent": "world", "name": name, "pos": [0.0, 0.0, 0.5]},
+                {"op": "add_geom", "body": name, "type": "sphere", "size": [0.08], "name": f"{name}_g"},
+                {"op": "add_site", "body": name, "name": f"{name}_s"},
+            ]
+        )
+        assert result["status"] == "success", (name, result)
+        assert name in _body_names(sim)
+        assert sim.get_body_state(body_name=name)["status"] == "success"
+
+    @pytest.mark.parametrize("kind", _LOOKUP_OPS)
+    def test_a_lookup_op_still_reports_absence(self, sim, kind):
+        """A name that addresses nothing is absent, not refused, at a lookup."""
+        op: dict[str, object] = {"op": kind, "name": "ghost"}
+        if kind == "set_body_pos":
+            op["pos"] = [0.0, 0.0, 1.0]
+        elif kind == "set_body_quat":
+            op["quat"] = [1.0, 0.0, 0.0, 0.0]
+        result = sim.patch_scene_mjcf([op])
+        assert result["status"] == "error"
+        assert "not found" in result["content"][0]["text"]
+
+
+class TestEveryClaimingOpRoutesThroughTheDomain:
+    """The root cause, so a seventh op cannot arrive unclassified.
+
+    Derived from ``_PATCH_OP_KEYS`` rather than a list here: an op added to the
+    table is graded the moment it exists, and has to be either a claiming op
+    that consults the domain or a lookup op that does not.
+    """
+
+    def test_every_supported_op_is_classified(self):
+        from strands_robots.simulation.mujoco.scene_ops import _PATCH_OP_KEYS
+
+        assert set(_PATCH_OP_KEYS) == set(_CLAIMING_OPS) | set(_LOOKUP_OPS)
+
+    @pytest.mark.parametrize("kind", _CLAIMING_OPS)
+    def test_a_claiming_op_consults_the_shared_domain(self, kind):
+        assert "entity_name_error" in _op_branch_source(kind), kind
+
+    @pytest.mark.parametrize("kind", _LOOKUP_OPS)
+    def test_a_lookup_op_does_not(self, kind):
+        assert "entity_name_error" not in _op_branch_source(kind), kind


### PR DESCRIPTION
## Problem

`patch_scene_mjcf` is a published action, and three of its ops create an entity in the live `MjSpec`: `add_body`, `add_geom` and `add_site`. Each checked only that the supplied name was *truthy*, while `add_object` / `add_camera` / `add_robot` route the same question through the shared `entity_name_error` domain. That domain exists because a name which cannot address the entity it creates leaves something unreachable through the very API that made it, and its docstring measures the values on MuJoCo. The patch door is a fourth creation site on the same spec, so those values were accepted there.

Measured on one `create_world`, MuJoCo 3.12.0:

| op | name | before | after |
|---|---|---|---|
| `add_body` | `"a\x00b"` | **success**, body compiled as `a` | error, names the NUL |
| `add_geom` | `"a\x00b"` | **success**, geom compiled as `a` | error |
| `add_site` | `"a\x00b"` | **success**, site compiled as `a` | error |
| `add_geom` | `""` | **success**, geom compiled **unnamed** | error |
| `add_body` / `add_site` | `""` | error (`requires 'name'`) | error, now says why |
| `add_body` | `7`, `["x"]` | error, but a C++ overload table naming neither the op nor the field | error, names the op, the field and the value |
| `add_object` | any of the above | error, with the reason | unchanged |

Two consequences follow, and neither is visible to the caller:

- **Two names, one entity.** MuJoCo compares names only up to the first NUL. `add_body(name="a\x00b")` reported success, `list_bodies()` returned `['world', 'a']`, and a later op that genuinely asked for `a` was refused `Error: repeated name 'a' in body` - blaming a collision with a name the caller never used. So the door silently reserved a name nobody requested and then rejected the request for it.
- **An entity no name-based surface can reach.** `add_geom(name="")` compiled the geom with `None` for a name, and `set_geom_properties(geom_name="")` answered `Geom 'None' not found. Available geoms: ['ground']`. The caller claimed a name and got something the only name-addressed geom surface cannot touch.

## Change

`_apply_patch_op` routes the name of the three ops that **claim** one through `entity_name_error`, so the refusal names the op, the parameter, the value and the reason, and arrives before the spec is written.

Scope follows the domain's own reasoning rather than a judgement call:

- The three ops that **look a name up** (`set_body_pos`, `set_body_quat`, `delete_body`) are unchanged. A name that addresses nothing is honestly *absent* at a lookup, which is what their own `body '<name>' not found` message already reports.
- **Omitting** `add_geom`'s `name` is unchanged and still produces an unnamed geom, which is legal MJCF. Only a *supplied* name is a claim, so `""` is refused and an absent key is not.
- An absent `name` key keeps its exact `<op> requires 'name'` message, so the four existing tests that pin it are untouched.

`entity_name_error`'s docstring and `patch_scene_mjcf`'s now state that the patch ops are a fourth door onto the same domain, beside the numeric-domain paragraph they parallel.

## Tests

Added to `tests/simulation/test_entity_name_domain_at_creation.py`, the file that already owns this contract for the three methods and whose docstring says the domain lives in one shared helper so the creation sites cannot drift.

Against `upstream/main`: **59 failed / 296 passed** -> 355 pass. 56 of the failures are behavioural, e.g.

```
test_a_nul_name_does_not_reserve_its_truncation
  AssertionError: assert 'success' == 'error'

test_an_empty_geom_name_compiles_no_unnamed_geom
  AssertionError: assert None not in ['ground', None]
```

The remaining 3 are the root-cause guard: `TestEveryClaimingOpRoutesThroughTheDomain` derives the op set from `_PATCH_OP_KEYS`, so a seventh op cannot arrive unclassified - it has to be a claiming op that consults the domain or a lookup op that does not.

The 296 that pass on both trees are the controls, and each fails for a specific wrong fix:

- omitting `add_geom`'s name still yields an unnamed geom (fails if the check is made unconditional);
- `add_body` / `add_site` keep their `requires 'name'` message for an absent key (fails if the two reports are collapsed);
- all three lookup ops still report absence (fails if the domain is applied to them);
- every name in `_GOOD_NAMES` - namespaced, dotted, spaced, non-ASCII, 200 chars - still round-trips through all three ops and `get_body_state`;
- the patch door and `add_object` produce the same sentence for the same value.

## Verification

Measured at `31994f92`, against `upstream/main` `40514971`.

- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: 24 == 24 against a pristine `upstream/main` worktree, none in the changed files.
- 424-file blast radius (every test naming the changed symbols, all of `tests/simulation`, and the repo-wide docstring / string / changelog guards), same selection on both trees:

| | failed | passed | skipped | collected |
|---|---|---|---|---|
| this branch | 5 | 13524 | 81 | 13610 |
| `upstream/main` (with the new test file copied in) | 64 | 13465 | 81 | 13610 |

  Branch-only failures: **none**. The 59 base-only ids are exactly the pre-fix failures, all in the new test file. The 5 shared failures (4 in `test_recording_frame_loss_is_not_tolerated.py`, 1 in `test_rendering_pacers_survive_a_clock_step.py[forward_30s]`) are pre-existing and import-order dependent within a selection this wide - all 29 tests in those two files pass in isolation on both trees.

## Artifact

An agent places three markers with three separate `patch_scene_mjcf` calls; the second name has picked up a NUL from an untrimmed upstream string. The yellow pad marks where the third marker, `"probe"`, was asked for. Same script, same scene, MuJoCo headless (`MUJOCO_GL=egl`) - only `strands_robots` differs.

Before, the ask naming `"probe\x00tmp"` reported success and compiled the body as `probe` **0.28 m** from where `probe` was requested, so the ask that did name `probe` was refused for colliding with it. After, the NUL is refused where it is written and `probe` lands on the pad (**0.00 m**).

The green marker (1682 px) and the pad (2121 px) are pixel-identical with the same centroids in both panels, so the red marker's 167 px move is the only difference.

![patch-op entity-name domain, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-patch-op-entity-name/patch-op-entity-name-domain.png)

