### PR TITLE
fix(simulation): scope a bare joint name to robot_name on a joint write

### DIFF
--- a/changelog.d/2453-joint-write-scopes-a-bare-name-to-robot-name.md
+++ b/changelog.d/2453-joint-write-scopes-a-bare-name-to-robot-name.md
@@ -1,0 +1,29 @@
+### Fixed
+
+`set_joint_positions` / `set_joint_velocities` now resolve an unqualified joint
+name inside `robot_name`'s namespace before the cross-robot fallback, so a write
+lands on the robot the caller addressed. Two robots that each declare a joint
+named `j1` compile to `alice/j1` and `bob/j1`, and a bare `{"j1": 0.9}` was
+resolved by a lookup that tries every robot namespace in turn and returns the
+first hit -- so `robot_name="bob"` moved `alice`, left `bob` at rest, and
+reported `Set 2/2 joint positions` for the robot that never moved. Robots
+sharing joint names is the ordinary case (two instances of one arm, or any two
+`robot_descriptions` models that both call a joint `elbow`), and the docstring
+already recommended the dict form as the safest in multi-robot scenes while
+naming `robot_name` as what "resolves an unqualified joint name" -- so the
+documented contract was the one that silently crossed robots.
+
+The ordered (list) form shared the defect rather than escaping it.
+`SimRobot.joint_names` holds *short* names, so the `dict(zip(joint_names,
+values))` normalisation produced the same bare keys: measured, a 3-vector
+addressed to `bob` wrote `alice/j1`, `alice/j2` and `bob/shoulder` -- bound to
+bob's joint order, written to alice's addresses. Scoping in the shared joint-write
+resolver repairs both forms at once.
+
+No call that worked is now refused: a bare name that is not a joint of
+`robot_name`, or a call that passes no `robot_name` at all, reaches the same
+cross-robot lookup as before. Scoping is applied in the joint-write resolver
+only; the shared `_resolve_mj_name` keeps its deliberate "unambiguous or
+explicit" first-match contract for the read paths (`get_body_state`,
+`get_jacobian`, sites, geoms and sensors) that share it. The dict-form docstring
+now states the resolution order instead of an unqualified safety claim.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from strands_robots.simulation.base import _BOOLEAN_STATE_REASON, close_match_hint
-from strands_robots.simulation.models import registered
+from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.mujoco.backend import (
     _NO_WORLD_MSG,
     _ensure_mujoco,
@@ -1357,7 +1357,7 @@ class PhysicsMixin:
         # that is not a joint of this robot still reaches the shared lookup.
         ns = ""
         if robot_name is not None and self._world is not None:
-            robot = self._world.robots.get(robot_name)
+            robot = registry_entry(self._world.robots, robot_name)
             if robot is not None:
                 ns = robot.namespace or ""
 

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1304,6 +1304,7 @@ class PhysicsMixin:
         values: dict[str, float],
         name: str,
         method: str,
+        robot_name: str | None = None,
     ) -> tuple[dict[str, int], dict[str, Any] | None]:
         """Resolve every joint name to a MuJoCo joint id before any state write.
 
@@ -1320,6 +1321,10 @@ class PhysicsMixin:
             values: The ``{joint_name: value}`` mapping about to be written.
             name: Parameter name (``"positions"`` / ``"velocities"``), used in error text.
             method: Calling method name, used in error text.
+            robot_name: The robot an unqualified key belongs to. Its namespace is
+                tried first, so a bare name reaches that robot's joint even when
+                a sibling robot declares the same short name. ``None`` (or a name
+                no robot in the world carries) leaves resolution as it was.
 
         Returns:
             ``({joint_name: joint_id}, None)`` when every name resolves, else
@@ -1342,10 +1347,28 @@ class PhysicsMixin:
                 ],
             }
 
+        # An unqualified key is resolved inside ``robot_name``'s namespace before
+        # the shared lookup gets it. ``_resolve_mj_name`` tries a bare name
+        # verbatim and then under every robot namespace in turn, returning the
+        # first hit - deliberately, for the read paths that share it - so with
+        # two robots declaring ``j1`` the first one attached wins and the write
+        # lands on a robot the caller never addressed (#2453). Scoping first
+        # keeps that fallback for everything it already resolved: a bare name
+        # that is not a joint of this robot still reaches the shared lookup.
+        ns = ""
+        if robot_name is not None and self._world is not None:
+            robot = self._world.robots.get(robot_name)
+            if robot is not None:
+                ns = robot.namespace or ""
+
         resolved: dict[str, int] = {}
         unresolved: list[str] = []
         for jnt_name in values:
-            jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, jnt_name)
+            jnt_id = -1
+            if ns and isinstance(jnt_name, str) and "/" not in jnt_name:
+                jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, ns + jnt_name)
+            if jnt_id < 0:
+                jnt_id = self._resolve_mj_name(mj.mjtObj.mjOBJ_JOINT, jnt_name)
             if jnt_id >= 0:
                 resolved[jnt_name] = jnt_id
             else:
@@ -1419,7 +1442,15 @@ class PhysicsMixin:
 
         Accepts EITHER form:
 
-        * dict: {joint_name: value, ...} - explicit per-joint, safest in multi-robot scenes.
+        * dict: {joint_name: value, ...} - explicit per-joint, and the form to
+          reach for in a multi-robot scene *provided the key names one robot*.
+          An unqualified key is resolved inside ``robot_name``'s namespace
+          first, so ``{"j1": 0.9}`` with ``robot_name="bob"`` writes ``bob/j1``
+          even when a sibling robot also declares ``j1``. Without
+          ``robot_name`` a bare key falls back to a first-match-wins lookup
+          across robots, so pass ``robot_name`` or the qualified
+          ``"<robot>/<joint>"`` spelling when more than one robot declares the
+          name.
         * list/tuple: [v0, v1, ...] - ordered positional. Must match a single robot's
           joint count (when ``robot_name`` is given, that robot's joints; otherwise the
           world must contain exactly one robot, or the call errors).
@@ -1538,7 +1569,9 @@ class PhysicsMixin:
         if err:
             return err
 
-        joint_ids, err = self._resolve_joint_write_targets(positions, "positions", "set_joint_positions")
+        joint_ids, err = self._resolve_joint_write_targets(
+            positions, "positions", "set_joint_positions", robot_name=robot_name
+        )
         if err:
             return err
 
@@ -1606,6 +1639,10 @@ class PhysicsMixin:
         The write is all-or-nothing on the same terms as
         :meth:`set_joint_positions`: an unresolvable joint name (or an empty
         mapping) returns ``status="error"`` and leaves ``qvel`` untouched.
+
+        Joint names are scoped on the same terms too: an unqualified key is
+        resolved inside ``robot_name``'s namespace before the cross-robot
+        fallback, so a bare name reaches the robot the caller addressed.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1680,7 +1717,9 @@ class PhysicsMixin:
         if err:
             return err
 
-        joint_ids, err = self._resolve_joint_write_targets(velocities, "velocities", "set_joint_velocities")
+        joint_ids, err = self._resolve_joint_write_targets(
+            velocities, "velocities", "set_joint_velocities", robot_name=robot_name
+        )
         if err:
             return err
 

--- a/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
+++ b/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
@@ -224,3 +224,52 @@ def test_list_form_writes_the_addressed_robot(sim):
         assert _qpos(sim, joint) == pytest.approx(0.1), joint
     for joint in ("alice/j1", "alice/j2"):
         assert _qpos(sim, joint) == pytest.approx(0.0), joint
+
+
+# A robot_name that cannot key the robot registry, one per unhashable builtin a
+# caller might plausibly pass by mistake, mirroring the set in
+# tests/simulation/test_unhashable_entity_name_is_reported.py.
+UNHASHABLE_ROBOT_NAMES = [(t.__name__, t(["bob"]) if t is not dict else {"bob": 1}) for t in (list, set, dict)]
+
+
+@pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
+def test_dict_form_reports_a_robot_name_that_cannot_be_a_key(sim, kind, robot_name):
+    """Scoping made robot_name a registry lookup, which must stay total.
+
+    The namespace lookup here is the dict form's *first* use of ``robot_name``:
+    before scoping, the dict form ignored the argument outright, so no lookup
+    existed to be partial. A bare ``self._world.robots.get(robot_name)`` is not
+    total -- for a name that cannot be a key (a list, a dict, a set) the lookup
+    itself raises ``TypeError: unhashable type``, which escapes the
+    ``{"status", "content"}`` envelope this method documents as its only failure
+    channel. Measured on the unscoped-lookup tree: all three names raised out of
+    the dict form while the list form reported each one, so one argument had two
+    answers depending on the form. Routing through
+    :func:`~strands_robots.simulation.models.registry_entry` makes the name
+    resolve to "no such robot", which is the fall-back path
+    :func:`test_unknown_robot_name_falls_back_rather_than_raising` already pins.
+    """
+    result = sim.set_joint_positions({"j1": 0.4}, robot_name=robot_name)
+    assert isinstance(result, dict) and "status" in result, f"{kind} name escaped the envelope: {result!r}"
+    assert result["status"] == "success", result
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.4)
+
+
+@pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
+def test_the_list_form_still_refuses_such_a_name(sim, kind, robot_name):
+    """The control: the ordered form already reported it, and still must.
+
+    Without this, the test above could be satisfied by making both forms raise.
+    """
+    result = sim.set_joint_positions([0.1, 0.2, 0.3], robot_name=robot_name)
+    assert result["status"] == "error", result
+    assert "not found" in result["content"][0]["text"], result
+
+
+@pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
+def test_velocities_share_the_total_lookup(sim, kind, robot_name):
+    """The sibling setter shares the resolver, so it shares the contract."""
+    result = sim.set_joint_velocities({"j1": 1.0}, robot_name=robot_name)
+    assert isinstance(result, dict) and "status" in result, f"{kind} name escaped the envelope: {result!r}"
+    assert result["status"] == "success", result
+    assert _qvel(sim, "alice/j1") == pytest.approx(1.0)

--- a/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
+++ b/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
@@ -1,0 +1,226 @@
+"""Regression tests: a bare joint name is scoped to ``robot_name``.
+
+``set_joint_positions`` / ``set_joint_velocities`` resolve each dict key through
+:meth:`~strands_robots.simulation.mujoco.physics.PhysicsMixin._resolve_mj_name`,
+which tries a name verbatim and then under every robot namespace in turn,
+returning the first hit. That is deliberate for the read paths that share it, but
+for a *write* it meant a bare key ignored ``robot_name`` entirely: two robots
+each declaring ``j1`` / ``j2`` compile to ``alice/j1`` ... ``bob/j2``, and::
+
+    sim.set_joint_positions({"j1": 0.9, "j2": -0.9}, robot_name="bob")
+    # -> success: "Set 2/2 joint positions, FK updated"
+
+moved *alice* (the first robot attached), left ``bob`` at rest, and reported the
+requested count for the robot that never moved. The method's own docstring
+recommended the dict form as "safest in multi-robot scenes" and named
+``robot_name`` as whose namespace "resolves an unqualified joint name", so the
+documented safe form was the one that crossed robots (#2453).
+
+The ordered (list) form shares the defect rather than escaping it, contrary to
+what #2453 assumed: it normalises to ``dict(zip(robot.joint_names, values))``
+and ``SimRobot.joint_names`` holds *short* names, so a 3-vector addressed to
+``bob`` wrote ``alice/j1``, ``alice/j2`` and ``bob/shoulder`` - bound to bob's
+joint order, written to alice's addresses. Scoping in the resolver repairs both
+forms at once.
+
+These pin the repair and its blast radius: an unqualified key resolves inside
+``robot_name``'s namespace first, and every spelling that resolved before still
+resolves - a qualified key, a bare key with no ``robot_name``, and a bare key
+that names no joint of ``robot_name`` but does name one elsewhere in the scene.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+mj = pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Two robots that both declare ``j1`` / ``j2``. ``alice`` carries a freejoint so
+# the two robots do not share a qpos layout, which is what makes a cross-robot
+# write land at a visibly wrong address rather than a coincidentally equal one.
+ALICE_XML = """
+<mujoco model="alice">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.5">
+      <freejoint name="root"/>
+      <geom name="g0" type="box" size="0.05 0.05 0.05"/>
+      <body name="l1" pos="0 0 0.1">
+        <joint name="j1" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+        <geom name="g1" type="capsule" size="0.02 0.05"/>
+        <body name="l2" pos="0 0 0.1">
+          <joint name="j2" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom name="g2" type="capsule" size="0.02 0.05"/>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# ``shoulder`` is declared by ``bob`` only, so it exercises the fallback: a bare
+# name that is not a joint of the addressed robot must still resolve.
+BOB_XML = """
+<mujoco model="bob">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0.5 0 0.1">
+      <body name="l1" pos="0 0 0.1">
+        <joint name="j1" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+        <geom name="g1" type="capsule" size="0.02 0.05"/>
+        <body name="l2" pos="0 0 0.1">
+          <joint name="j2" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+          <geom name="g2" type="capsule" size="0.02 0.05"/>
+          <body name="l3" pos="0 0 0.1">
+            <joint name="shoulder" type="hinge" axis="1 0 0" range="-3.14 3.14"/>
+            <geom name="g3" type="capsule" size="0.02 0.05"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+def _write(xml: str, name: str) -> str:
+    path = os.path.join(tempfile.mkdtemp(), f"{name}.xml")
+    with open(path, "w") as handle:
+        handle.write(xml)
+    return path
+
+
+@pytest.fixture
+def sim():
+    s = Simulation(tool_name="test_joint_write_robot_scoping", mesh=False)
+    s.create_world()
+    # ``alice`` is attached first, so it is the robot the unscoped first-match
+    # lookup used to hand a bare ``j1`` to.
+    assert s.add_robot(name="alice", urdf_path=_write(ALICE_XML, "alice"))["status"] == "success"
+    assert s.add_robot(name="bob", urdf_path=_write(BOB_XML, "bob"))["status"] == "success"
+    yield s
+    s.cleanup()
+
+
+def _qpos(sim, joint: str) -> float:
+    model, data = sim._world._model, sim._world._data
+    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, joint)
+    assert jid >= 0, f"fixture must compile a joint named {joint!r}"
+    return float(data.qpos[model.jnt_qposadr[jid]])
+
+
+def _qvel(sim, joint: str) -> float:
+    model, data = sim._world._model, sim._world._data
+    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, joint)
+    assert jid >= 0, f"fixture must compile a joint named {joint!r}"
+    return float(data.qvel[model.jnt_dofadr[jid]])
+
+
+def test_fixture_shares_short_joint_names(sim):
+    """Guard the premise: without a shared short name nothing below is a test."""
+    names = {mj.mj_id2name(sim._world._model, mj.mjtObj.mjOBJ_JOINT, i) for i in range(sim._world._model.njnt)}
+    assert {"alice/j1", "alice/j2", "bob/j1", "bob/j2"} <= names
+
+
+def test_bare_name_writes_the_addressed_robot(sim):
+    """The reported robot is the one that moves."""
+    result = sim.set_joint_positions({"j1": 0.9, "j2": -0.9}, robot_name="bob")
+    assert result["status"] == "success", result
+    assert _qpos(sim, "bob/j1") == pytest.approx(0.9)
+    assert _qpos(sim, "bob/j2") == pytest.approx(-0.9)
+
+
+def test_bare_name_leaves_the_unaddressed_robot_alone(sim):
+    """The bug wrote alice; a robot nobody addressed must not move."""
+    result = sim.set_joint_positions({"j1": 0.9, "j2": -0.9}, robot_name="bob")
+    assert result["status"] == "success", result
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.0)
+    assert _qpos(sim, "alice/j2") == pytest.approx(0.0)
+
+
+def test_reported_count_is_honest_for_the_addressed_robot(sim):
+    """A reported 2/2 has to mean two of bob's joints, not two writes anywhere."""
+    result = sim.set_joint_positions({"j1": 0.9, "j2": -0.9}, robot_name="bob")
+    assert "2/2" in result["content"][0]["text"]
+    moved = [j for j in ("bob/j1", "bob/j2") if _qpos(sim, j) != 0.0]
+    assert len(moved) == 2, f"count claimed 2 but only {moved} moved"
+
+
+def test_the_other_robot_is_reachable_by_name_too(sim):
+    """Scoping must not pin every bare name to one robot."""
+    assert sim.set_joint_positions({"j1": 0.4}, robot_name="alice")["status"] == "success"
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.4)
+    assert _qpos(sim, "bob/j1") == pytest.approx(0.0)
+
+
+def test_qualified_key_still_wins(sim):
+    """An explicit ``<robot>/<joint>`` spelling is not re-scoped."""
+    result = sim.set_joint_positions({"alice/j1": 0.5}, robot_name="bob")
+    assert result["status"] == "success", result
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.5)
+    assert _qpos(sim, "bob/j1") == pytest.approx(0.0)
+
+
+def test_bare_name_absent_from_the_addressed_robot_still_resolves(sim):
+    """The cross-robot fallback is preserved, so no working call is refused."""
+    # ``shoulder`` is bob's; addressing alice must still reach it rather than
+    # becoming an error the moment scoping is tried first.
+    result = sim.set_joint_positions({"shoulder": 0.3}, robot_name="alice")
+    assert result["status"] == "success", result
+    assert _qpos(sim, "bob/shoulder") == pytest.approx(0.3)
+
+
+def test_bare_name_without_robot_name_is_unchanged(sim):
+    """No ``robot_name`` means the pre-existing first-match lookup, untouched."""
+    result = sim.set_joint_positions({"j1": 0.7})
+    assert result["status"] == "success", result
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.7)
+
+
+def test_unknown_robot_name_falls_back_rather_than_raising(sim):
+    """A robot_name no robot carries cannot scope, and must not crash the write."""
+    result = sim.set_joint_positions({"j1": 0.2}, robot_name="nobody")
+    assert result["status"] == "success", result
+    assert _qpos(sim, "alice/j1") == pytest.approx(0.2)
+
+
+def test_unresolvable_name_is_still_all_or_nothing(sim):
+    """Scoping must not weaken the all-or-nothing guard."""
+    before = sim._world._data.qpos.copy()
+    result = sim.set_joint_positions({"j1": 0.5, "nope": 0.1}, robot_name="bob")
+    assert result["status"] == "error", result
+    assert np.array_equal(sim._world._data.qpos, before), "partial write leaked into qpos"
+
+
+def test_velocities_scope_to_the_addressed_robot(sim):
+    """The sibling setter shares the resolver, so it shares the contract."""
+    result = sim.set_joint_velocities({"j1": 1.5}, robot_name="bob")
+    assert result["status"] == "success", result
+    assert _qvel(sim, "bob/j1") == pytest.approx(1.5)
+    assert _qvel(sim, "alice/j1") == pytest.approx(0.0)
+
+
+def test_list_form_writes_the_addressed_robot(sim):
+    """The ordered form shared the defect, because it binds to short names.
+
+    ``SimRobot.joint_names`` holds unqualified names (``['j1', 'j2',
+    'shoulder']``), so the ordered form's ``dict(zip(joint_names, positions))``
+    normalisation produced exactly the bare keys the resolver then sent to
+    whichever robot declared them first. Measured on the unfixed tree, a
+    3-vector for ``bob`` wrote ``alice/j1``, ``alice/j2`` and ``bob/shoulder``
+    -- positionally bound to bob's joint *order* and then written to alice's
+    joint *addresses*. Binding to ``robot_name`` in the resolver fixes both
+    forms at once, which is why this is asserted rather than assumed.
+    """
+    joints = sim.robot_joint_names("bob")
+    assert joints == ["j1", "j2", "shoulder"], joints
+    result = sim.set_joint_positions([0.1] * len(joints), robot_name="bob")
+    assert result["status"] == "success", result
+    for joint in ("bob/j1", "bob/j2", "bob/shoulder"):
+        assert _qpos(sim, joint) == pytest.approx(0.1), joint
+    for joint in ("alice/j1", "alice/j2"):
+        assert _qpos(sim, joint) == pytest.approx(0.0), joint

--- a/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
+++ b/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
@@ -31,6 +31,7 @@ that names no joint of ``robot_name`` but does name one elsewhere in the scene.
 
 import os
 import tempfile
+from typing import Any
 
 import numpy as np
 import pytest
@@ -227,9 +228,17 @@ def test_list_form_writes_the_addressed_robot(sim):
 
 
 # A robot_name that cannot key the robot registry, one per unhashable builtin a
-# caller might plausibly pass by mistake, mirroring the set in
+# caller might plausibly pass by mistake (a single-element list is what wrapping
+# a name in brackets produces; a dict is what a half-built kwargs mapping looks
+# like). Spelled out rather than derived from the types so the values are the
+# ones a caller would actually pass, and to cover the same set as
 # tests/simulation/test_unhashable_entity_name_is_reported.py.
-UNHASHABLE_ROBOT_NAMES = [(t.__name__, t(["bob"]) if t is not dict else {"bob": 1}) for t in (list, set, dict)]
+UNHASHABLE_ROBOT_NAMES: list[tuple[str, Any]] = [
+    ("list", ["bob"]),
+    ("dict", {"bob": 1}),
+    ("set", {"bob"}),
+    ("bytearray", bytearray(b"bob")),
+]
 
 
 @pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])


### PR DESCRIPTION
## What

A joint write resolves an unqualified joint name inside `robot_name`'s namespace before the cross-robot fallback, so `set_joint_positions` / `set_joint_velocities` move the robot the caller addressed.

One behavioural change in `strands_robots/simulation/mujoco/physics.py` (+43/-4), one pinned regression file, one changelog fragment.

Closes #2453

## Why

Both setters resolved every dict key through `_resolve_mj_name`, which tries a bare name verbatim and then under every robot namespace in turn, returning the first hit. That is deliberate for the read paths that share it, but on a write it meant `robot_name` was never consulted. Measured on two robots that each declare `j1` / `j2`:

```python
sim.set_joint_positions({"j1": 0.9, "j2": -0.9}, robot_name="bob")
# -> success | "Set 2/2 joint positions, FK updated"
```

```
qpos [0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0,  0.9, -0.9,  0.0, 0.0]
                                          ^^^^^^^^^   ^^^^^^^^
  alice/j1, alice/j2 = 0.9, -0.9   <- written, and alice was not addressed
  bob/j1,   bob/j2   = 0.0,  0.0   <- bob was addressed and did not move
```

`bob` never moved and the call reported `2/2` for it.

## The contract question #2453 raised is already answered in the source

#2453 filed this rather than patching it because the repair looked like a contract choice between three options. It is narrower than that: the `robot_name` parameter's own docstring already says it is

> Which robot the ordered form binds to, **and whose namespace resolves an unqualified joint name.**

and the dict form is recommended as "safest in multi-robot scenes". So option 1 (namespace-first, falling back to the bare lookup) is not a new meaning for a public argument -- it is the documented one, and the code did not implement it. That makes this a bug fix, not a contract change, which is why it is patched here.

## A correction to the issue

#2453 states the list form "is scoped correctly (it binds positionally to `robot_name`'s joints), which is what makes this an asymmetry inside one call". Measured, that is not so: `SimRobot.joint_names` holds **short** names (`['j1', 'j2', 'shoulder']`), so the ordered form's `dict(zip(joint_names, values))` normalisation produces exactly the same bare keys. On the unfixed tree a 3-vector addressed to `bob` wrote `alice/j1`, `alice/j2` and `bob/shoulder` -- bound to bob's joint *order*, written to alice's joint *addresses*. There was no asymmetry; both forms crossed robots, and scoping in the shared resolver repairs both at once.

## Blast radius

Scoping is applied in `_resolve_joint_write_targets` only. `_resolve_mj_name` is shared by eight read/write call sites (bodies, sites, geoms, sensors) and documents a deliberate "unambiguous or explicit" first-match contract, so it is left exactly as it was.

No call that worked is now refused -- the namespace attempt is tried *first* and falls through:

- a bare name that is not a joint of `robot_name` still reaches the cross-robot lookup (pinned: `shoulder` is bob's, addressed via `robot_name="alice"`, still resolves);
- a call with no `robot_name` is unchanged (pinned);
- a `robot_name` no robot carries falls back rather than raising (pinned);
- a qualified `"<robot>/<joint>"` key is not re-scoped (pinned);
- the all-or-nothing guard is unweakened (pinned).

## Tests

`tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py` -- 12 tests, no assets or downloads (two inline MJCFs, `mujoco` 3.12.0). Non-vacuity measured: **5 of the 12 fail on the unfixed tree** and all 12 pass with the fix.

The fixture's premise is itself asserted (`test_fixture_shares_short_joint_names`), so the file cannot silently stop being a test if namespacing changes.

## Verification

- new file: `12 passed`; reverting only `physics.py`: `5 failed, 7 passed`
- sibling resolver suite `test_joint_setter_unknown_names_rejected.py`: `18 passed, 1 skipped` together with the new file
- `tests/test_args_docstring_completeness.py`, `test_docstring_xref_roles_resolve.py`, `test_docstrings_no_dangling_doc_refs.py`, `test_asset_docstring_module_xrefs.py`: `444 passed` (the xref gate caught an incorrect `MujocoPhysics` citation in an earlier draft; the class is `PhysicsMixin`)
- `tests/simulation/test_replay_episode_index_domain.py`, `test_joint_state_domain_is_shared_across_backends.py`: `287 passed`
- changelog: `scripts/assemble_changelog.py --check` OK; fragment gate suites `89 passed`
- `ruff check` / `ruff format --check` clean; `mypy` reports **0** errors in `physics.py`

Pre-existing on this box and unrelated: `test_joint_discovery_hint_is_followable.py` fails `7 failed, 4 passed` identically on unmodified `main` (no network for `robot_descriptions`, so `so101` assets are absent).

## Docs

The dict-form docstring stated an unqualified "safest in multi-robot scenes"; it now states the resolution order, since that is what makes it safe and what the caller needs in order to choose between passing `robot_name` and qualifying the key. `set_joint_velocities` gains the same note, and the resolver's new parameter is documented in its `Args:` block.

## What it looks like

The same call, the same scene, the same reported text -- rendered headless in MuJoCo (EGL). Two arms both
declare `j1` / `j2`; `alice` (orange) is attached first, so it is the one that wins a first-match-wins
bare-name lookup. `bob` (green) is the robot the call names.

![which robot a bare joint key reaches](https://raw.githubusercontent.com/cagataycali/robots/media-joint-write-namespace-scope/joint_write_scope.png)

| | `alice/j1` | `alice/j2` | `bob/j1` | `bob/j2` | reported |
|---|---|---|---|---|---|
| `upstream/main` | **+0.90** | **-0.90** | 0.00 | 0.00 | `success` / "Set 2/2 joint positions, FK updated" |
| this branch | 0.00 | 0.00 | **+0.90** | **-0.90** | `success` / "Set 2/2 joint positions, FK updated" |

The reported text is byte-identical in both rows, which is the point: nothing in the result distinguishes the
run that moved the addressed robot from the run that moved its neighbour. Measured on the frames, the orange
arm shifts 3988 px and the green arm 0 px on `main`; on this branch the green arm shifts 6295 px and the
orange arm 0 px. The at-rest frames are identical across the two trees (mean |delta| 0.000001), so the only
difference the images carry is which arm the write reached.

## Out of scope

In the dict form a `robot_name` that names no robot is still accepted and simply cannot scope anything (the list form errors via `_unknown_robot_msg`). Refusing it would change the accepted call set, which is a separate concern from this one and is deliberately not bundled here. Filed as #2549.

## Project board

#2453 should move to "In review" on the Strands Labs - Robots board.

---

## Round 2 — CI: the new namespace lookup was not total

`call-test-lint` failed on `44f72d1` with a real defect this PR introduced, not a flake:

```
FAILED tests/simulation/test_unhashable_entity_name_is_reported.py::test_every_backend_lookup_uses_the_shared_rule
  AssertionError: these registry lookups are not total:
      physics.py:1360 in _resolve_joint_write_targets()
1 failed, 21635 passed, 216 skipped
```

**What it caught.** The namespace lookup added in round 1 was a bare `self._world.robots.get(robot_name)`. That is not total: for a `robot_name` that cannot be a registry key the lookup itself raises `TypeError: unhashable type`, so it escapes the `{"status", "content"}` envelope both setters document as their only failure channel. Measured on `44f72d1`:

| `robot_name` | dict form | list form |
|---|---|---|
| `["bob"]` | **raised** `TypeError: unhashable type: 'list'` | `error: Robot '['bob']' not found.` |
| `{"bob": 1}` | **raised** `TypeError: unhashable type: 'dict'` | `error: Robot '{'bob': 1}' not found.` |
| `{"bob"}` | **raised** `TypeError: unhashable type: 'set'` | `error: Robot '{'bob'}' not found.` |

So one argument had two answers depending on the form — and the raising one was the form this PR's docstring recommends. Same shape as #2549, reached by a different route.

**This PR is what made it a defect.** Before scoping, the dict form ignored `robot_name` outright, so there was no lookup to be partial. The guard's companion `test_the_creation_exemption_still_describes_real_code` failed alongside it, reporting `_resolve_joint_write_targets` as a fourth entry in a three-function creation exemption — which is the check refusing to let the new lookup hide inside a hole meant for entity creation.

**Fix** (`30c71ee`, +1/-1 in `physics.py` plus the import): route through `registry_entry`, the shared total counterpart already used by 20 lookups across the three backends. An unhashable name now resolves to "no such robot", landing on the existing fall-back that `test_unknown_robot_name_falls_back_rather_than_raising` pins — so the round-1 blast-radius claim ("no call that worked is now refused") still holds, and nothing that was refused became accepted.

**Pins** (+12, so the file is 24 tests, not 12), each parametrised over the four unhashable builtins a caller plausibly passes by mistake:

- `test_dict_form_reports_a_robot_name_that_cannot_be_a_key` — reports rather than raises;
- `test_velocities_share_the_total_lookup` — the sibling setter shares the resolver, so it shares the contract;
- `test_the_list_form_still_refuses_such_a_name` — the **control**: without it the first could be satisfied by making both forms raise.

**Verification, measured at `530d43a`.** The two suites together: `75 passed`. Against `upstream/main` with the new tests copied in: `5 failed, 70 passed` -- the five behavioural scoping pins. Against `44f72d1`, this PR's own first commit, where the namespace lookup was still partial: `10 failed, 65 passed` -- the eight dict/velocity totality pins plus both backend-scan guards. The four list-form controls pass in every one of the three trees, which is what makes them controls. `ruff check` / `ruff format --check` clean.

No changelog change: the escape was introduced and repaired inside this unmerged PR, so the fragment's account of the net user-visible change is unaltered.

**The lint gate then caught how that set was built** (`530d43a`, test-only). The four cases were derived with a comprehension over `(list, set, dict)` whose value is `t(["bob"]) if t is not dict else {"bob": 1}`. mypy cannot narrow a `type[...]` union through `is not`, so it checks `dict(["bob"])` against the mapping overload and reports the list item as an incompatible `str` -- which fails `Run lint` before `Run tests` executes at all. The cases are now spelled out, annotated `list[tuple[str, Any]]`, the way `test_unhashable_entity_name_is_reported.py` already spells the same set. That also makes the comment true: the derived version covered three builtins while claiming to mirror a set of four, so `bytearray` went ungraded -- and it reaches the same partial lookup (`TypeError: unhashable type: 'bytearray'` on `44f72d1`), so it is a case worth having rather than a fourth spelling of the same one.

