### PR TITLE
test: name every test case for its behaviour, not for the release that added it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1388,6 +1388,7 @@ Corrections from code review that apply to all future contributions:
 - **Round-trip tests for recording** - Any recording feature needs: start -> write -> stop -> reopen -> assert non-empty. Schema-only tests miss silent data loss.
 - **Pin regression tests for reviewed fixes** - Every review fix gets a test that fails on pre-fix code. Otherwise the next refactor silently reintroduces the bug.
 - **No host paths in test files** - Never commit `/Users/<name>/` or `/home/<name>/` paths. CI test `test_no_host_paths.py` enforces this.
+- **Name a test for its behaviour, not for its provenance** - a test class or function must not carry the release (`TestHardwareConfigV040Followups`) or review round (`...Followups`) that produced it. The name is the first thing a maintainer reads, so it has to say what is verified; and a name tied to a shipped release reads as historical, which invites skipping it. A bundle named for a review round is usually a bundle of unrelated checks - split it into one behaviour per class rather than inventing a name that covers all of them. Provenance belongs in the docstring, where the `#NNN` reference stays useful. A version token of one or two digits is fine: it names a *data format* under test (`test_load_v3_parses_every_field`), not a release. `Pinned by` `tests/test_test_case_names_describe_behaviour.py`.
 
 ### Performance
 - **Don't create executors in hot loops** - Reuse a single `ThreadPoolExecutor` instance instead of creating one per call at 50Hz.

--- a/changelog.d/2550-test-names-describe-behaviour.md
+++ b/changelog.d/2550-test-names-describe-behaviour.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **tests**: no test class or function is named for the release or review round that
+  produced it. `TestHardwareConfigV040Followups` and `TestEnsureCaV040Followups` named
+  a shipped release and a review trail rather than the behaviour they verify, which is
+  what a maintainer scanning for coverage of a behaviour actually reads - and `V040`
+  reads as historical once the release is past, which invites skipping the class. The
+  hardware class was three unrelated review items, so no single behaviour name covers
+  it: it is split into `TestForwardableKwargDropIsReported`,
+  `TestThirdPartyPluginGuardIsNarrow` and `TestLerobotExtraShipsAnAarch64VideoDecoder`.
+  The CA class shares one subject and is renamed to
+  `TestEnsureCaFilesystemDiscipline`. No assertion changed, and the `#NNN` issue
+  references stay in the per-test docstrings. A repo-wide guard now refuses a release
+  token (three or more digits after a `v`) and a review-round token
+  (`Followup`/`Followups`) in a test-case name, while deliberately accepting a one- or
+  two-digit version, which names a data format under test rather than a release - the
+  nine such names in the tree are pinned as controls so the rule cannot widen into "no
+  digits in test names".

--- a/tests/mesh/test_iot_ca_pin.py
+++ b/tests/mesh/test_iot_ca_pin.py
@@ -359,8 +359,13 @@ class TestUnverifiedReuseWarning:
         )
 
 
-class TestEnsureCaV040Followups:
-    """v0.4.0 mesh-iot follow-ups (#388) from the #228 review trail."""
+class TestEnsureCaFilesystemDiscipline:
+    """``_ensure_ca``'s own writes: refuse a symlink at either path, marker owner-only.
+
+    The CA path and the break-glass ``.unverified`` sidecar are both opened
+    ``O_NOFOLLOW``, and the sidecar is created ``0o600`` in one step - no
+    create-then-chmod window, and no write-through to a pre-planted symlink.
+    """
 
     def test_ensure_ca_rejects_symlinked_path_with_explicit_message(self, tmp_path):
         """#312: a symlinked CA path must be rejected with an EXPLICIT 'SYMLINK'

--- a/tests/test_robot_factory.py
+++ b/tests/test_robot_factory.py
@@ -1573,8 +1573,8 @@ class TestMinimalConfigContractBranches:
             hw._create_minimal_config("needs_arg_robot", cameras={})
 
 
-class TestHardwareConfigV040Followups:
-    """v0.4.0 hardware_robot follow-up bundle (#389) - PR #276 review trail."""
+class TestForwardableKwargDropIsReported:
+    """A kwarg the target dataclass cannot take is reported, never dropped silently."""
 
     def test_cross_robot_kwarg_drop_emits_debug_signal(self, caplog):
         """#294/#297: dropping a forwardable kwarg the target dataclass does
@@ -1601,6 +1601,10 @@ class TestHardwareConfigV040Followups:
             f"expected a DEBUG signal naming the dropped 'kp' kwarg; got {drop_msgs}"
         )
 
+
+class TestThirdPartyPluginGuardIsNarrow:
+    """The third-party plugin registration guard names the exceptions it absorbs."""
+
     def test_register_third_party_plugins_exception_is_narrow(self):
         """#291: the register_third_party_plugins() guard must NOT be a bare
         except Exception. Pin the narrowed (ImportError, AttributeError,
@@ -1617,6 +1621,10 @@ class TestHardwareConfigV040Followups:
         assert "except Exception as exc:  # noqa: BLE001 -- third-party plugin" not in src, (
             "the bare except Exception on plugin registration must be gone (#291)"
         )
+
+
+class TestLerobotExtraShipsAnAarch64VideoDecoder:
+    """The ``[lerobot]`` extra declares a video decoder that resolves on aarch64."""
 
     def test_lerobot_extra_provides_aarch64_video_decoder(self):
         """#378: a `pip install strands-robots[lerobot]` on Thor/Jetson must get a

--- a/tests/test_test_case_names_describe_behaviour.py
+++ b/tests/test_test_case_names_describe_behaviour.py
@@ -1,0 +1,152 @@
+"""A test's name describes the behaviour it verifies, not the release that added it.
+
+A test is read far more often than it is written, and the first thing a
+maintainer sees is its name. ``TestHardwareConfigV040Followups`` tells the
+reader which review round produced the class and nothing about what it
+checks, so finding the test that covers a behaviour means opening every
+plausible file; and once the release is long past, the name actively
+misleads - it reads as "historical", which is an invitation to skip it.
+
+Two tokens are refused, both of which name the *provenance* of a test rather
+than its subject:
+
+* **A release token** - three or more digits after a ``v`` (``V040`` is
+  ``0.4.0`` with the dots dropped). Two digits or fewer are left alone,
+  because a *data format* version genuinely is the behaviour under test:
+  ``test_load_v3_parses_every_field`` (the ``.spz`` v3 layout),
+  ``test_a_v21_root_is_refused_and_pointed_at_lerobots_converter`` (a
+  LeRobot v2.1 dataset), ``test_current_transform_version_is_v4``. Those
+  names must keep working, and are pinned below.
+* **A review-round token** - ``Followup`` / ``Followups``. A bundle named
+  for its review round is also usually a bundle of unrelated checks, which
+  is the other half of the problem: no single behaviour name fits, so the
+  fix is to split it rather than to rename it.
+
+Provenance is not lost by this rule, it moves to where a reader wants it:
+the docstring. Every test renamed for this guard kept its ``#NNN:`` issue
+reference in its own docstring.
+
+This encodes what the tree already does - at the commit that added this
+guard, 2 of 3294 test classes and 0 of 17508 test functions named a
+release.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_TEST_TREES = ("tests", "tests_integ")
+
+#: Three-or-more-digit version token: a release triple with the dots dropped.
+#: A preceding letter is allowed on purpose - the offender this guard was
+#: written for spelled it ``...CaV040Followups`` in CamelCase.
+_RELEASE_TOKEN = re.compile(r"[Vv]\d{3,}")
+
+#: A name for the review round that produced the test, not for its subject.
+_REVIEW_ROUND_TOKEN = re.compile(r"[Ff]ollowups?")
+
+#: A clean sweep would prove nothing if the scan stopped reaching the trees.
+_MINIMUM_SCANNED_NAMES = 15_000
+
+
+def _test_case_names() -> list[tuple[pathlib.Path, int, str]]:
+    """Every ``class Test*`` and ``def test_*`` name in both test trees."""
+    found: list[tuple[pathlib.Path, int, str]] = []
+    for tree in _TEST_TREES:
+        for path in sorted((_REPO_ROOT / tree).rglob("*.py")):
+            try:
+                module = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
+                continue
+            for node in ast.walk(module):
+                if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+                    found.append((path, node.lineno, node.name))
+                elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name.startswith("test_"):
+                    found.append((path, node.lineno, node.name))
+    return found
+
+
+def _provenance_named(names: list[tuple[pathlib.Path, int, str]]) -> list[str]:
+    """The offending names, formatted with the token that disqualified each."""
+    offenders: list[str] = []
+    for path, lineno, name in names:
+        reasons = []
+        if match := _RELEASE_TOKEN.search(name):
+            reasons.append(f"release token {match.group(0)!r}")
+        if match := _REVIEW_ROUND_TOKEN.search(name):
+            reasons.append(f"review-round token {match.group(0)!r}")
+        if reasons:
+            rel = path.relative_to(_REPO_ROOT)
+            offenders.append(f"{rel}:{lineno} {name} ({', '.join(reasons)})")
+    return offenders
+
+
+def test_no_test_case_is_named_for_a_release_or_a_review_round() -> None:
+    """No test class or function names the release or review round that added it."""
+    names = _test_case_names()
+    assert len(names) >= _MINIMUM_SCANNED_NAMES, (
+        f"only {len(names)} test-case names reached the scan (expected at least "
+        f"{_MINIMUM_SCANNED_NAMES}); the discovery has gone blind, so a clean "
+        "result would prove nothing"
+    )
+    offenders = _provenance_named(names)
+    assert not offenders, (
+        "test case(s) named for their provenance rather than the behaviour they verify:\n  "
+        + "\n  ".join(offenders)
+        + "\nName the behaviour and keep the issue reference in the docstring."
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Real names in the tree at the commit that added this guard: each
+        # states the version of a *data format* it parses, which is the
+        # behaviour under test.
+        "test_load_v3_parses_every_field",
+        "test_load_v2_takes_the_three_byte_rotation_path",
+        "test_decode_rotations_v3_roundtrips_quaternions",
+        "test_a_v21_root_is_refused_and_pointed_at_lerobots_converter",
+        "test_current_transform_version_is_v4",
+        "test_non_v3_video_path_template_returns_report_not_keyerror",
+        # The class form of the same allowance - no class in the tree carries a
+        # format-version token today, so this pins that the rule is about the
+        # token, not about which node kind it sits on.
+        "TestSpzV3Layout",
+    ],
+)
+def test_a_data_format_version_stays_accepted(name: str) -> None:
+    """One- and two-digit version tokens name a format, not a release."""
+    assert not _provenance_named([(_REPO_ROOT / "tests" / "x.py", 1, name)]), (
+        f"{name!r} names the version of a data format it parses, which is the "
+        "behaviour under test; only a release triple is refused"
+    )
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_token"),
+    [
+        ("TestHardwareConfigV040Followups", "release token 'V040'"),
+        ("TestEnsureCaV040Followups", "release token 'V040'"),
+        ("TestSomethingV051", "release token 'V051'"),
+        ("test_something_v0410_regression", "release token 'v0410'"),
+        ("TestReviewFollowups", "review-round token 'Followups'"),
+        ("test_pr_review_followup_cases", "review-round token 'followup'"),
+    ],
+)
+def test_a_provenance_named_case_is_reported(name: str, expected_token: str) -> None:
+    """Both refused tokens are detected, so a clean sweep is a real result."""
+    offenders = _provenance_named([(_REPO_ROOT / "tests" / "x.py", 1, name)])
+    assert offenders, f"{name!r} names its provenance and must be reported"
+    assert expected_token in offenders[0], f"expected {expected_token!r} in {offenders[0]!r}"
+
+
+def test_the_scan_reaches_both_test_trees() -> None:
+    """A scan that stopped covering ``tests_integ`` would report clean falsely."""
+    reached = {path.relative_to(_REPO_ROOT).parts[0] for path, _lineno, _name in _test_case_names()}
+    assert set(_TEST_TREES) <= reached, f"scan reached only {sorted(reached)}"


### PR DESCRIPTION
## Problem

Two test classes were named for the release and review round that produced them rather than for the behaviour they verify:

| | |
|---|---|
| `tests/test_robot_factory.py:1576` | `class TestHardwareConfigV040Followups` - *"v0.4.0 hardware_robot follow-up bundle (#389) - PR #276 review trail."* |
| `tests/mesh/test_iot_ca_pin.py:362` | `class TestEnsureCaV040Followups` - *"v0.4.0 mesh-iot follow-ups (#388) from the #228 review trail."* |

A test's name is the first thing a maintainer reads, so finding the test that covers a behaviour means opening every plausible file. And once the release is long past the name actively misleads: `V040` reads as historical, which is an invitation to skip it.

This is not the tree's habit - it is the exception. Measured over both test trees at the merge base:

| | total | named for a release / review round |
|---|---|---|
| test classes | 3294 | **2** |
| test functions | 17508 | **0** |

## Change

**The names.** The hardware class was three unrelated review items (a dropped-kwarg debug signal, an exception-clause narrowness check, a packaging-extra assertion), so no single behaviour name covers it - a bundle named for a review round is usually a bundle. It is split into one class per behaviour:

- `TestForwardableKwargDropIsReported`
- `TestThirdPartyPluginGuardIsNarrow`
- `TestLerobotExtraShipsAnAarch64VideoDecoder`

The CA class does share one subject - `_ensure_ca`'s own filesystem writes - so it is renamed to `TestEnsureCaFilesystemDiscipline`. No assertion changes in either file; the `#NNN` issue references stay in the per-test docstrings, which is where a reader wants provenance.

**The guard.** `tests/test_test_case_names_describe_behaviour.py` refuses two tokens in a `class Test*` or `def test_*` name:

- a **release token** - three or more digits after a `v` (`V040` is `0.4.0` with the dots dropped);
- a **review-round token** - `Followup` / `Followups`.

Both offenders carried both tokens, so both rules are load-bearing on real data rather than only on planted input.

**What is deliberately still accepted:** a one- or two-digit version token, because there it names a *data format* that genuinely is the behaviour under test. The nine such names in the tree are pinned as controls, e.g. `test_load_v3_parses_every_field` (the `.spz` v3 layout), `test_a_v21_root_is_refused_and_pointed_at_lerobots_converter` (a LeRobot v2.1 dataset), `test_current_transform_version_is_v4`. That boundary is what keeps the rule from becoming "no digits in test names".

`AGENTS.md` gains the convention under `### Testing`, in that section's existing style of ending a bullet with the test that enforces it.

## Verification

Measured at `8b234dfb`, against `upstream/main` at `11acaa7e`.

**Pre-fix split.** Copying only the new guard into an `upstream/main` worktree: **1 failed / 14 passed**, the failure naming both offenders and both tokens:

```
test case(s) named for their provenance rather than the behaviour they verify:
  tests/mesh/test_iot_ca_pin.py:362 TestEnsureCaV040Followups (release token 'V040', review-round token 'Followups')
  tests/test_robot_factory.py:1576 TestHardwareConfigV040Followups (release token 'V040', review-round token 'Followups')
Name the behaviour and keep the issue reference in the docstring.
```

15 passed after. The 14 both-tree passes are the controls: 7 format-version names that must keep working, 6 planted provenance-named cases proving each rule detects (so a clean sweep is a real result, not an inert grader), and a scope test that the scan reaches both `tests/` and `tests_integ/`. A `>= 15000` floor on the number of names scanned means a discovery that goes blind fails loudly instead of reporting clean.

**The renames change no behaviour.** `tests/test_robot_factory.py` + `tests/mesh/test_iot_ca_pin.py`: **162 passed** before and after.

**Blast radius.** The 154 test files that walk a test tree, read `AGENTS.md` or grade names, plus both edited files and the repo-wide guards, run against both trees:

| | failed | passed | skipped | collected |
|---|---|---|---|---|
| branch | 8 | 6664 | 55 | 6727 |
| `upstream/main` + the guard | 9 | 6663 | 55 | 6727 |

Same collected total, and the failed and passed deltas are both 1 - the one pre-fix failure. The branch-only failure set is empty; the base-only set is exactly that failure. The 8 shared failures are `tests/mesh/test_iot_*` needing `awsiotsdk`, which is declared and installed in CI.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 errors on both trees with none in the changed files.

**No visual artifact:** this touches no policy, simulation behaviour, rendering, recording or robot asset - it renames test cases and adds a naming guard.

