### PR TITLE
docs(hardware): name only actions the tools dispatch

### DIFF
--- a/changelog.d/2554-docs-tool-action-vocabulary.md
+++ b/changelog.d/2554-docs-tool-action-vocabulary.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **docs**: the hardware-tools page named nine `action` values no tool dispatches, in its "Key actions" table and in two of its runnable examples. `pose_tool`'s row advertised forward/inverse kinematics and gripper control, none of which that tool has - it is joint-space only, and Cartesian IK is `Simulation.move_to`. `serial_tool(action="list")` was the quietest: it is not reported as an unknown action at all, so a reader supplies the port the refusal asks for and fails to open it next, two steps away from `list_ports`, which needs no port. The rows and examples now name only actions the tools dispatch, and a new sweep grades every action value `docs/**/*.md` and `README.md` attribute to a `@tool` against the vocabulary that tool really dispatches.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -20,12 +20,12 @@ from strands_robots.tools import (
 
 | Tool | Key actions | What |
 |------|-------------|------|
-| `lerobot_calibrate` | `"list"`, `"info"`, `"search"`, `"compare"`, `"backup"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes - actual calibration is run via the LeRobot CLI) |
-| `lerobot_camera` | `"list"`, `"test"`, `"stream"` | Enumerate, test, stream connected cameras |
+| `lerobot_calibrate` | `"list"`, `"view"`, `"search"`, `"backup"`, `"restore"` | Manage existing calibration JSONs under `~/.cache/huggingface/lerobot/calibration/` (this tool inspects/organizes - actual calibration is run via the LeRobot CLI) |
+| `lerobot_camera` | `"list"`, `"test"`, `"capture"`, `"record"` | Enumerate, test, capture from, and record connected cameras |
 | `lerobot_teleoperate` | `"start"`, `"stop"`, `"status"`, `"replay"`, `"dagger"` | Leader-follower teleop session, episode replay, and DAgger correction collection |
 | `lerobot_train` | `"start"`, `"status"`, `"stop"`, `"list"` | Fine-tune a policy on a local dataset via `lerobot-train` |
-| `pose_tool` | `"fk"`, `"ik"`, `"set_gripper"` | Forward/inverse kinematics, gripper control |
-| `serial_tool` | `"list"`, `"send"` | Enumerate serial ports, send raw commands |
+| `pose_tool` | `"store_pose"`, `"load_pose"`, `"read_all"`, `"move_motor"` | Store, recall and replay named servo poses on a real bus, and read or move one motor at a time. This tool is joint-space only - Cartesian IK is `Simulation.move_to` |
+| `serial_tool` | `"list_ports"`, `"send"` | Enumerate serial ports, send raw commands |
 | `download_assets` | - | Pre-fetch MJCF assets to `~/.strands_robots/assets/` |
 | `gr00t_inference` | `"start_container"`, … | GR00T container lifecycle - see [GR00T](../policies/groot.md) |
 | `robot_mesh` | `"tell"`, `"broadcast"`, `"emergency_stop"` | Agent-driven mesh ops - see [Multi-robot](../mesh.md) |
@@ -127,12 +127,12 @@ caller's `timeout` is not effective there.
 ## Examples
 
 ```python
-result = serial_tool(action="list")
+result = serial_tool(action="list_ports")
 print(result["content"][0]["text"])
 
 result = lerobot_calibrate(action="list", device_type="robots")
 result = lerobot_camera(action="list", camera_type="opencv")
-result = pose_tool(action="fk", robot_id="so101_follower", port="/dev/ttyACM0")
+result = pose_tool(action="read_all", robot_id="so101_follower", port="/dev/ttyACM0")
 
 # DAgger / teleop takeover: a policy drives the follower while the leader can
 # pre-empt to record corrections (appended to the dataset as new episodes).

--- a/tests/test_docs_tool_action_values_are_dispatched.py
+++ b/tests/test_docs_tool_action_values_are_dispatched.py
@@ -1,0 +1,218 @@
+"""An ``action`` the documentation names must be one the tool dispatches.
+
+Every ``@tool`` entry point in :mod:`strands_robots.tools` takes a single
+``action`` string and dispatches on its value, so that value is an enumerated
+vocabulary rather than free text. A page that names an action outside it does
+not merely read loosely: the call is refused on the first line a reader runs.
+
+The sibling guard in ``test_docs_python_examples_are_callable`` grades the other
+half of the same example - whether the *keywords* a documented call passes are
+accepted by the callable - and a wrong action value passes it, because ``action``
+is a real parameter of every one of these tools. So
+``pose_tool(action="fk", robot_id=..., port=...)`` spends three accepted
+keywords and is still refused, and nothing graded the value.
+
+What the refusal looks like varies, and the quieter shapes are the reason this
+is worth pinning rather than left to review:
+
+* ``lerobot_calibrate(action="info")`` answers ``Unknown action: info`` and then
+  lists all eight real ones, so the reader recovers in one step.
+* ``lerobot_camera(action="stream")`` answers ``Unknown action: stream`` and
+  names no valid action at all.
+* ``serial_tool(action="list")`` does not report an unknown action - it answers
+  ``Port parameter required for this action``, so the reader supplies a port and
+  gets ``Serial error: could not open port`` next, two steps away from
+  ``list_ports``, which needs no port.
+
+The rule is one-directional. The table column is "Key actions", so naming a
+subset is correct and omission is never reported; only an action no tool
+dispatches is.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import strands_robots
+
+_REPO_ROOT = Path(strands_robots.__file__).resolve().parent.parent
+_TOOLS_DIR = _REPO_ROOT / "strands_robots" / "tools"
+
+# A documented call: ``<tool>(action="<value>"`` anywhere in a page, fenced or
+# inline. The action is the first argument at every documented call site.
+_CALL = re.compile(r"\b([a-z_][a-z0-9_]*)\s*\(\s*action\s*=\s*[\"']([^\"']+)[\"']")
+
+# A tools-table row: ``| `<tool>` | ... `"action"`, `"action"` ... |``.
+_ROW = re.compile(r"^\|\s*`([a-z0-9_]+)`\s*\|(.*?)\|")
+_QUOTED = re.compile(r'`"([^"]+)"`')
+
+# A page reflow that hides the tables would otherwise report a clean sweep.
+_MINIMUM_CLAIMS = 40
+_MINIMUM_TOOLS = 6
+_MINIMUM_DISPATCHED = 3
+
+
+@dataclass(frozen=True)
+class _Claim:
+    """One action value a page attributes to one tool."""
+
+    page: str
+    kind: str
+    tool: str
+    action: str
+
+    def __str__(self) -> str:
+        return f"{self.page} ({self.kind}): {self.tool}(action={self.action!r})"
+
+
+def _tool_modules() -> dict[str, Path]:
+    """Every public ``@tool`` module, keyed by the tool name it exports."""
+    return {p.stem: p for p in sorted(_TOOLS_DIR.glob("*.py")) if not p.stem.startswith("_")}
+
+
+def _string_literals(node: ast.AST) -> set[str]:
+    """The string constants ``node`` is, or collects if it is a literal group."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return {node.value}
+    if isinstance(node, ast.Tuple | ast.List | ast.Set):
+        return {e.value for e in node.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return set()
+
+
+def _dispatched_actions(source: Path) -> set[str]:
+    """The action values ``source`` dispatches on.
+
+    Reads both operand positions of a comparison against ``action`` so
+    ``"list" == action`` counts, the collection of an ``action in (...)``
+    membership test, and the patterns of a ``match action`` statement.
+    """
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare):
+            operands = [node.left, *node.comparators]
+            if any(isinstance(o, ast.Name) and o.id == "action" for o in operands):
+                for operand in operands:
+                    found |= _string_literals(operand)
+        if isinstance(node, ast.Match) and isinstance(node.subject, ast.Name) and node.subject.id == "action":
+            for case in node.cases:
+                for pattern in ast.walk(case.pattern):
+                    if isinstance(pattern, ast.MatchValue):
+                        found |= _string_literals(pattern.value)
+    return found
+
+
+def _graded_pages() -> list[Path]:
+    """The operator-facing prose graded here."""
+    return sorted(_REPO_ROOT.glob("docs/**/*.md")) + [_REPO_ROOT / "README.md"]
+
+
+def _claims_in(text: str, page: str, tools: dict[str, Path]) -> list[_Claim]:
+    """The action values ``text`` attributes to a known tool."""
+    claims = [_Claim(page, "call", tool, action) for tool, action in _CALL.findall(text) if tool in tools]
+    for line in text.splitlines():
+        row = _ROW.match(line)
+        if row is None or row.group(1) not in tools:
+            continue
+        claims += [_Claim(page, "table", row.group(1), a) for a in _QUOTED.findall(row.group(2))]
+    return claims
+
+
+def _documented_claims(tools: dict[str, Path]) -> list[_Claim]:
+    """Every action value the graded prose attributes to a tool."""
+    claims: list[_Claim] = []
+    for page in _graded_pages():
+        rel = page.relative_to(_REPO_ROOT).as_posix()
+        claims += _claims_in(page.read_text(encoding="utf-8"), rel, tools)
+    return claims
+
+
+def _claimed_tools() -> set[str]:
+    """The tools some graded page attributes at least one action to."""
+    return {c.tool for c in _documented_claims(_tool_modules())}
+
+
+def _undispatched(claims: list[_Claim], tools: dict[str, Path]) -> list[_Claim]:
+    """The claims naming an action the tool does not dispatch."""
+    vocabulary = {tool: _dispatched_actions(path) for tool, path in tools.items()}
+    return [c for c in claims if c.action not in vocabulary[c.tool]]
+
+
+class TestEveryDocumentedActionIsDispatched:
+    """The action vocabulary the prose names is the one the tools answer."""
+
+    def test_no_page_names_an_action_no_tool_dispatches(self) -> None:
+        """A documented action value must reach a dispatch branch."""
+        tools = _tool_modules()
+        offenders = _undispatched(_documented_claims(tools), tools)
+        assert not offenders, "documentation names actions no tool dispatches:\n" + "\n".join(
+            f"  {o}  (dispatched: {sorted(_dispatched_actions(tools[o.tool]))})" for o in offenders
+        )
+
+    def test_the_sweep_reaches_the_prose(self) -> None:
+        """A clean result must mean the prose was read, not that nothing was."""
+        tools = _tool_modules()
+        claims = _documented_claims(tools)
+        assert len(claims) >= _MINIMUM_CLAIMS, f"only {len(claims)} action claims found"
+        assert len({c.tool for c in claims}) >= _MINIMUM_TOOLS
+        assert {c.kind for c in claims} == {"call", "table"}, "both claim shapes must be reached"
+
+    @pytest.mark.parametrize("tool", sorted(_claimed_tools()))
+    def test_every_claimed_tool_dispatches_a_readable_vocabulary(self, tool: str) -> None:
+        """A vocabulary that read short would accept a claim it should report.
+
+        Only the tools the prose names are graded: a tool no page claims never
+        has its vocabulary consulted, and several ``@tool`` entry points take no
+        ``action`` at all. An empty read is already loud rather than silent -
+        every claim about such a tool becomes an offender above.
+        """
+        dispatched = _dispatched_actions(_tool_modules()[tool])
+        assert len(dispatched) >= _MINIMUM_DISPATCHED, f"{tool}: read {sorted(dispatched)}"
+
+
+class TestTheRuleIsOneDirectional:
+    """Naming a subset is correct; the column is "Key actions"."""
+
+    def test_a_documented_subset_is_not_reported(self) -> None:
+        """A tool may dispatch more actions than any page lists."""
+        tools = _tool_modules()
+        claims = [c for c in _documented_claims(tools) if c.tool == "use_ros"]
+        documented = {c.action for c in claims}
+        assert documented < _dispatched_actions(tools["use_ros"]), "premise: a strict subset is documented"
+        assert not _undispatched(claims, tools)
+
+
+class TestTheGraderIsLoadBearing:
+    """The sweep reports a planted claim, and only a wrong one."""
+
+    def test_a_planted_undispatched_action_is_reported(self) -> None:
+        """A page naming an action outside the vocabulary must fail."""
+        tools = _tool_modules()
+        planted = _claims_in('result = serial_tool(action="no_such_action")', "planted.md", tools)
+        assert [c.action for c in planted] == ["no_such_action"]
+        assert _undispatched(planted, tools) == planted
+
+    def test_a_planted_dispatched_action_is_accepted(self) -> None:
+        """A page naming a real action must not be reported."""
+        tools = _tool_modules()
+        planted = _claims_in('result = serial_tool(action="list_ports")', "planted.md", tools)
+        assert [c.action for c in planted] == ["list_ports"]
+        assert _undispatched(planted, tools) == []
+
+    def test_a_planted_table_row_is_graded_too(self) -> None:
+        """The table column is read, not only the fenced examples."""
+        tools = _tool_modules()
+        row = '| `pose_tool` | `"store_pose"`, `"no_such_action"` | What |'
+        planted = _claims_in(row, "planted.md", tools)
+        assert {c.kind for c in planted} == {"table"}
+        assert [c.action for c in _undispatched(planted, tools)] == ["no_such_action"]
+
+    def test_a_tool_the_package_does_not_ship_is_not_graded(self) -> None:
+        """A same-shaped call to something else degrades to "not graded"."""
+        tools = _tool_modules()
+        assert _claims_in('other_library(action="whatever")', "planted.md", tools) == []


### PR DESCRIPTION
## Problem

`docs/hardware/tools.md` names nine `action` values no tool dispatches - seven in
its "Key actions" table and two in its runnable examples. Every `@tool` in
`strands_robots.tools` takes a single `action` string and dispatches on its
value, so that value is an enumerated vocabulary rather than free text, and a
name outside it is refused on the first line a reader runs.

Driving each claim through the real tool:

| Documented | Refusal a reader gets |
|---|---|
| `lerobot_calibrate(action="info")` | `**Unknown action:** `info`` - then lists all eight real actions |
| `lerobot_calibrate(action="compare")` | `**Unknown action:** `compare`` - same, recoverable in one step |
| `lerobot_camera(action="stream")` | `Unknown action: stream` - and names no valid action at all |
| `pose_tool(action="fk")` / `"ik"` / `"set_gripper")` | `Unknown action: fk` - the row also promised kinematics this tool has none of |
| `serial_tool(action="list")` | `Port parameter required for this action` - not reported as an unknown action at all |

Two rows are worse than a plain refusal:

- **`serial_tool`** is the quietest. `action="list"` is not diagnosed as unknown;
  the call asks for a port, so a reader supplies one and gets
  `Serial error: could not open port /dev/ttyACM0` next - two steps away from
  `list_ports`, which needs no port. The page already names the real spelling in
  its own prose 33 lines above the example that uses the wrong one
  (``action="list_ports"`` reads none of these options).
- **`pose_tool`**'s "What" column read *Forward/inverse kinematics, gripper
  control*. That tool has no kinematics: it stores and replays named servo poses
  and moves one motor at a time. A reader who needs Cartesian IK is sent to a
  tool that cannot do it, and away from `Simulation.move_to`, which can.

`README.md` describes the same four tools correctly (`view`, "Store, recall, and
execute named robot poses", "discovery, capture, record"), and every other page
that names an action - `device-connect.md`, `policies/groot.md`,
`ros2-integration.md`, `rosbridge-integration.md`, `rtps-integration.md`,
`security.md`, `troubleshooting.md` - is accurate. The drift is confined to this
one page.

The sibling guard `test_docs_python_examples_are_callable` grades the other half
of the same example - whether the *keywords* a documented call passes are
accepted - and a wrong action value passes it, because `action` is a real
parameter of all of these tools. So `pose_tool(action="fk", robot_id=..., port=...)`
spends three accepted keywords and is still refused. On the unfixed tree that
guard reports `4 passed`.

## Change

The four affected rows and both examples now name only actions the tools
dispatch, and `pose_tool`'s description says what it does (joint-space poses and
single-motor moves) and where Cartesian IK actually lives.

`tests/test_docs_tool_action_values_are_dispatched.py` grades the value half:
every action `docs/**/*.md` and `README.md` attribute to a `@tool`, in a
`<tool>(action="...")` call or a tools-table row, must be one that tool
dispatches. The vocabulary is read from the module by AST, so a renamed action
fails the sweep rather than waiting for a reader; a new tool row is graded on
arrival.

The rule is one-directional. The column is "Key actions", so naming a subset is
correct and omission is never reported - only an action no tool dispatches is.
`use_ros` documents 5 of its 10 and is deliberately kept as the control for that.

Driving every action the corrected page names: 38 claims, **0** answered
`unknown action`. Every remaining refusal is an honest per-action requirement
(`view` needs a device id, `record` needs a camera id, `send` needs a port).

## Tests

Copying the new file onto `upstream/main`: **1 failed / 18 passed**. Exactly one
assertion flips - the headline, naming all nine offenders with each tool's real
vocabulary - and the 18 that pass on both trees are the grader's own controls:

- both claim shapes (table row and fenced call) are reached, and >= 40 claims are
  graded, so a page reflow that hid the tables could not report a clean sweep;
- every tool the prose claims dispatches a readable vocabulary, so a short read
  cannot silently accept a claim it should report;
- a documented strict subset is not reported (`use_ros`);
- a planted undispatched action is reported, a planted real one is not, a planted
  table row is graded, and a same-shaped call to something the package does not
  ship degrades to "not graded" rather than to a failure.

## Verification

Measured at `80ba1fa`, `MUJOCO_GL=egl`, mujoco 3.12.0.

| Selection: 76 paths (every test that reads a docs page or walks the test tree, `tests/tools`, and the repo-wide guards), 4553 collected | branch | `upstream/main` + the new file |
|---|---|---|
| result | **4492 passed / 0 failed** / 61 skipped, 190s | 1 failed / 4491 passed / 61 skipped, 191s |

`4491 + 1 == 4492`, so both trees collected the same total. Branch-only failures:
**none**. The single base failure is this PR's own headline. No test in the
selection fails on both trees.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`;
`mypy` identical to a pristine `upstream/main` worktree (5 errors, none in the
changed files).

## Artifact

The same probe run against each tree's own page - identical package code in both
columns, so what differs is only which actions the page names. Each tool's
dispatched vocabulary is byte-identical across the two runs
(`lerobot_calibrate` 8, `lerobot_camera` 8, `pose_tool` 13, `serial_tool` 8).

![hardware-tools action vocabulary, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-tool-action-vocabulary/tool_action_vocabulary.png)
