### PR TITLE
fix(tools): hold gr00t_inference's selector options to a domain, like the numerics beside them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1721,14 +1721,24 @@ Corrections from code review that apply to all future contributions:
   into `subprocess.run`, `subprocess.Popen`, MJCF / XML interpolation, or filesystem
   path construction MUST be validated up front via regex allowlist, enum match, or
   range check. Argv-style subprocess does not exempt you - defense-in-depth.
-- **Centralise validation in one function** - pattern: a `validate_inputs(...)` helper
-  at the top of the tool module that takes every user-supplied param as a keyword arg
-  and raises `ValueError` with a clear message on any rejection. Single entry-point
-  is independently testable. PR #90's `gr00t_inference.validate_inputs()` is the
-  canonical example.
+- **Group the check by what consumes the value, and run it at the dispatch
+  boundary** - one `..._option_error(action, *, <params>) -> str | None` helper per
+  *kind* of value, called before any expensive work starts, returning the reason for
+  the dispatcher to fold into its error dict. Keying it on the action means a caller
+  is never refused for a value the requested action ignores.
+  `gr00t_inference._numeric_option_error` and its enum-valued sibling
+  `_enumerable_option_error` are the shipped pair: both cover options that are
+  interpolated into a `docker exec` command line run **detached**, where a value the
+  server's own flag parser rejects surfaces minutes later in the container log
+  instead of as the call's result. Note the shape returns rather than raises, so
+  **Return error dicts, never raise** above still holds at the tool surface.
 - **Allowlist enumerable values** - `data_config`, `embodiment_tag`, dtype strings,
   container names: all match `^[a-z][a-z0-9_]+$` or an explicit `{"fp16", "fp8", ...}`
-  set. Never accept arbitrary strings into enumerable surfaces.
+  set. Never accept arbitrary strings into enumerable surfaces. Derive the
+  "refuses nothing real" half from a shipped catalogue rather than a copied list -
+  `data_configs.json` names every valid `data_config`, so a config added there is
+  admitted by construction. Pinned by
+  `tests/tools/test_gr00t_enumerable_option_guards.py`.
 - **Reject shell metacharacters in paths** - `;`, `|`, `$`, backticks, `>`, `<`,
   `\n`, `\r`, `\x00`. Also reject `..` path traversal components. Apply even when
   using argv-style subprocess.

--- a/changelog.d/2555-gr00t-enumerable-option-domain.md
+++ b/changelog.d/2555-gr00t-enumerable-option-domain.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tools/gr00t_inference**: `data_config`, `embodiment_tag` and the three TensorRT dtype flags are now held to a lowercase selector-token domain at the dispatch boundary, like the numeric options beside them in the same detached `docker exec` argv. An unusable value is refused up front, naming the parameter, instead of reporting a service that "failed to start" with the reason left in the container log. The admitted set is derived from the shipped `data_configs.json`, and options the requested action ignores (`data_config` under `protocol="n1.7"`, the dtypes without `use_tensorrt`) are left alone.

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -442,6 +442,105 @@ def _numeric_option_error(
     return None
 
 
+_ENUMERABLE_OPTION_RE = re.compile(r"^[a-z][a-z0-9_]+$")
+
+#: Per-action set of enumerable string options the action's command line reads.
+#: The keys mirror :data:`_ACTION_NUMERIC_OPTIONS` -- these five options are
+#: consumed by exactly the actions that build an inference command line, which is
+#: the same set that reads ``denoising_steps``.
+_ACTION_ENUMERABLE_OPTIONS: dict[str, tuple[str, ...]] = {
+    "start": ("data_config", "embodiment_tag", "vit_dtype", "llm_dtype", "dit_dtype"),
+    "restart": ("data_config", "embodiment_tag", "vit_dtype", "llm_dtype", "dit_dtype"),
+    "lifecycle:full": ("data_config", "embodiment_tag", "vit_dtype", "llm_dtype", "dit_dtype"),
+}
+
+
+def _is_allowed_enumerable_option(value: Any) -> bool:
+    """True iff *value* is a lowercase ``[a-z][a-z0-9_]+`` selector token.
+
+    Total over any input, like :func:`_is_allowed_image`: a non-string is refused
+    rather than carried into :mod:`re`.
+    """
+    return isinstance(value, str) and _ENUMERABLE_OPTION_RE.match(value) is not None
+
+
+def _enumerable_option_error(
+    action: str,
+    *,
+    data_config: Any,
+    embodiment_tag: Any,
+    vit_dtype: Any,
+    llm_dtype: Any,
+    dit_dtype: Any,
+    protocol: str,
+    use_tensorrt: bool,
+    lifecycle: str,
+) -> str | None:
+    """Error text for the first enumerable option ``action`` reads but cannot honor.
+
+    The enum-valued counterpart to :func:`_numeric_option_error`, and it exists for
+    the same reason that one records: these options are interpolated into the
+    ``docker exec`` command line that :func:`_build_inference_command` builds and
+    ``_start_service`` runs **detached**, so a value the server's own flag parser
+    rejects surfaces minutes later inside the container's log rather than as this
+    call's result. The numeric options in that argv were already refused here; the
+    selector strings beside them were carried through unchecked, so a mistyped
+    ``data_config`` reported a service that "failed to start" and a shell
+    metacharacter rode into the argv on the strength of it being argv-style.
+
+    Each option names a vocabulary rather than a free string -- an embodiment data
+    config, an embodiment tag, a TensorRT precision -- and every value the shipped
+    catalogue and this tool's own docstring name is a lowercase
+    ``[a-z][a-z0-9_]+`` token, so that is the domain. It is the class the
+    repository requires for exactly these fields, and holding them to it refuses
+    nothing the server would have accepted.
+
+    Only the options ``action`` actually reads are checked, so a caller is never
+    refused for a value the requested action ignores. Two carry an extra
+    condition, both read off :func:`_build_inference_command`: the N1.7 entrypoint
+    takes no ``--data-config`` flag, so under ``protocol="n1.7"`` that value is
+    genuinely inert; and the three dtype flags are only emitted when
+    ``use_tensorrt`` is set.
+
+    Args:
+        action: The requested action; decides which options are effective.
+        data_config: Embodiment data-config selector, as supplied.
+        embodiment_tag: Embodiment tag, as supplied.
+        vit_dtype: TensorRT ViT precision, as supplied.
+        llm_dtype: TensorRT LLM precision, as supplied.
+        dit_dtype: TensorRT DiT precision, as supplied.
+        protocol: The server protocol; ``"n1.7"`` ignores ``data_config``.
+        use_tensorrt: Whether the dtype flags are emitted at all.
+        lifecycle: The lifecycle phase, which selects the effective option set
+            when ``action`` is ``"lifecycle"``.
+
+    Returns:
+        An error message naming the action and the option, or ``None`` when every
+        option this call reads is usable.
+    """
+    key = f"lifecycle:{lifecycle}" if action == "lifecycle" else action
+    consumed = _ACTION_ENUMERABLE_OPTIONS.get(key, ())
+    if not consumed:
+        return None
+    candidates: list[tuple[str, Any]] = []
+    if "data_config" in consumed and protocol != "n1.7":
+        candidates.append(("data_config", data_config))
+    if "embodiment_tag" in consumed:
+        candidates.append(("embodiment_tag", embodiment_tag))
+    if use_tensorrt:
+        candidates.extend([("vit_dtype", vit_dtype), ("llm_dtype", llm_dtype), ("dit_dtype", dit_dtype)])
+    for param, value in candidates:
+        if not _is_allowed_enumerable_option(value):
+            return (
+                f"{action}: {param} must be a lowercase selector token matching "
+                f"{_ENUMERABLE_OPTION_RE.pattern} (letters, digits and underscores), "
+                f"got {value!r}. It is passed straight to the inference server's "
+                f"flag parser, which reports a value it cannot read only in the "
+                f"container log."
+            )
+    return None
+
+
 @tool
 def gr00t_inference(
     action: str,
@@ -619,8 +718,11 @@ def gr00t_inference(
             Defaults to 5555 (ZMQ) or auto-switches
             to 8000 when ``http_server=True``.
         data_config: Embodiment data config name (see Data configs above). N1.5/N1.6 only.
+            Must be a lowercase ``[a-z][a-z0-9_]+`` selector token - it is passed
+            to the server's ``--data-config`` flag, which reports a name it cannot
+            read only in the container log.
         embodiment_tag: Embodiment tag for the model (e.g., ``gr1``, ``so100``,
-            ``libero_sim``).
+            ``libero_sim``). Must be a lowercase ``[a-z][a-z0-9_]+`` selector token.
         denoising_steps: Number of denoising steps for action generation (default: 4).
             Must be a positive integer. Ignored by ``protocol="n1.7"``, whose
             entrypoint takes no ``--denoising-steps`` flag.
@@ -633,8 +735,14 @@ def gr00t_inference(
         use_tensorrt: Enable TensorRT acceleration (default: False).
         trt_engine_path: Directory for TensorRT engine cache (default: ``gr00t_engine``).
         vit_dtype: ViT precision with TensorRT - ``fp16`` or ``fp8`` (default: ``fp8``).
+            Must be a lowercase ``[a-z][a-z0-9_]+`` token; read only when
+            ``use_tensorrt=True``.
         llm_dtype: LLM precision with TensorRT - ``fp16``, ``nvfp4``, or ``fp8`` (default: ``nvfp4``).
+            Must be a lowercase ``[a-z][a-z0-9_]+`` token; read only when
+            ``use_tensorrt=True``.
         dit_dtype: DiT precision with TensorRT - ``fp16`` or ``fp8`` (default: ``fp8``).
+            Must be a lowercase ``[a-z][a-z0-9_]+`` token; read only when
+            ``use_tensorrt=True``.
         http_server: Use HTTP REST API instead of ZMQ (default: False).
         api_token: API token for authentication. Falls back to ``GROOT_API_TOKEN`` env var.
         protocol: Server protocol version - ``"n1.5"`` (default), ``"n1.6"``, or ``"n1.7"``.
@@ -794,6 +902,23 @@ def gr00t_inference(
     )
     if _numeric_reason is not None:
         return {"status": "error", "message": f"gr00t_inference: {_numeric_reason}"}
+
+    # Same boundary, same argv: the selector strings sit beside those numerics on
+    # the detached ``docker exec`` command line, so a value the server's flag
+    # parser cannot read is equally invisible to this caller.
+    _enumerable_reason = _enumerable_option_error(
+        action,
+        data_config=data_config,
+        embodiment_tag=embodiment_tag,
+        vit_dtype=vit_dtype,
+        llm_dtype=llm_dtype,
+        dit_dtype=dit_dtype,
+        protocol=protocol,
+        use_tensorrt=use_tensorrt,
+        lifecycle=lifecycle,
+    )
+    if _enumerable_reason is not None:
+        return {"status": "error", "message": f"gr00t_inference: {_enumerable_reason}"}
 
     if action == "find_containers":
         return _find_gr00t_containers()

--- a/tests/tools/test_gr00t_enumerable_option_guards.py
+++ b/tests/tools/test_gr00t_enumerable_option_guards.py
@@ -1,0 +1,273 @@
+"""``gr00t_inference`` refuses an enumerable option it cannot honor.
+
+Five agent-supplied selector strings ride the same detached ``docker exec``
+command line as the numeric options ``test_gr00t_numeric_option_guards.py``
+covers. ``data_config``, ``embodiment_tag`` and the three TensorRT dtype flags
+are interpolated into the argv that :func:`_build_inference_command` builds and
+``_start_service`` runs with ``-d``, so a value the inference server's own flag
+parser rejects surfaces minutes later inside the container's log rather than as
+the tool call's result -- the numerics beside them were refused up front for
+exactly that reason, and these were carried through unchecked.
+
+Each of the five names a vocabulary rather than a free string. Every value the
+shipped ``data_configs.json`` catalogue and this tool's own docstring name is a
+lowercase ``[a-z][a-z0-9_]+`` token, so that is the domain, and the catalogue
+test below is what keeps it non-breaking: it is derived from the shipped JSON
+rather than a copied list, so a config added there is admitted or the test says
+so.
+
+The refusal is asserted to reach neither docker nor a socket, and the
+value-reaches-the-builder half is asserted through a ``_start_service`` spy: a
+guard that ran after the container work started could not make the rejection a
+property of the request.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# The module object rather than its members, matching the numeric sibling: these
+# tests reach ``gi.subprocess`` to make a side effect fatal and ``gi._start_service``
+# to observe what the dispatch let through.
+import strands_robots.tools.gr00t_inference as gi
+
+# Values no selector flag can carry. Shell metacharacters and a newline are the
+# injection shapes the argv is defended against even though it is argv-style;
+# ``So100`` is the ordinary mistake (the catalogue is lowercase); the empty string
+# names nothing; and the non-strings cannot index a vocabulary at all.
+UNUSABLE_SELECTORS: list[Any] = [
+    "so100; rm -rf /",
+    "$(whoami)",
+    "`id`",
+    "a|b",
+    "bogus\nInjected",
+    "with space",
+    "So100",
+    "",
+    "_leading",
+    "9leading",
+    123,
+    None,
+    ["so100"],
+]
+
+# The five options and, for each, the extra request state that makes it effective.
+EFFECTIVE_SELECTORS: list[tuple[str, dict[str, Any]]] = [
+    ("data_config", {}),
+    ("embodiment_tag", {}),
+    ("vit_dtype", {"use_tensorrt": True}),
+    ("llm_dtype", {"use_tensorrt": True}),
+    ("dit_dtype", {"use_tensorrt": True}),
+]
+
+_DOMAIN_PHRASE = "must be a lowercase selector token"
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with deliberately off-type values.
+
+    Routed through one ``**kwargs`` funnel because several tests pass values the
+    signature's annotations forbid on purpose - that is the input class under
+    test - and mypy does not narrow a splatted ``dict[str, Any]``.
+    """
+    return gi.gr00t_inference(**kwargs)
+
+
+def _message(result: dict[str, Any]) -> str:
+    return str(result.get("message", ""))
+
+
+def _catalogue_values() -> list[str]:
+    """Every ``data_config`` name and alias the package ships.
+
+    Read from the shipped JSON rather than copied, so the admitted set below
+    tracks the catalogue instead of a second list to keep in sync.
+    """
+    path = Path(gi.__file__).resolve().parents[1] / "policies" / "groot" / "data_configs.json"
+    catalogue = json.loads(path.read_text(encoding="utf-8"))
+    return [*catalogue["configs"], *catalogue.get("aliases", {})]
+
+
+@pytest.fixture
+def no_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail the test if a refused call reaches docker or a socket.
+
+    A guard that runs after the container work has already started cannot make
+    the rejection a property of the request.
+    """
+
+    def _no_subprocess(*_a: Any, **_kw: Any) -> Any:
+        raise AssertionError("a refused call reached subprocess.run")
+
+    def _no_socket(_port: Any) -> bool:
+        raise AssertionError("a refused call opened a socket")
+
+    monkeypatch.setattr(gi.subprocess, "run", _no_subprocess)
+    monkeypatch.setattr(gi, "_is_service_running", _no_socket)
+
+
+@pytest.fixture
+def start_service_spy(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Record the kwargs the dispatch hands the service starter.
+
+    An accepted selector must reach it carrying the caller's value; a refused one
+    must not reach it at all. Standing in for ``_start_service`` keeps every case
+    off docker without hiding which half of the boundary the value stopped at.
+    """
+    seen: list[dict[str, Any]] = []
+
+    def _spy(**kwargs: Any) -> dict[str, Any]:
+        seen.append(kwargs)
+        return {"status": "success", "message": "stub"}
+
+    monkeypatch.setattr(gi, "_start_service", _spy)
+    return seen
+
+
+class TestAnUnusableSelectorIsRefused:
+    """Each effective selector is held to the token domain, by name."""
+
+    @pytest.mark.parametrize("param,extra", EFFECTIVE_SELECTORS)
+    @pytest.mark.parametrize("value", UNUSABLE_SELECTORS)
+    def test_refused_naming_the_parameter(
+        self,
+        param: str,
+        extra: dict[str, Any],
+        value: Any,
+        no_side_effects: None,
+    ) -> None:
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            **{param: value},
+            **extra,
+        )
+        assert result["status"] == "error", result
+        message = _message(result)
+        assert param in message, message
+        assert _DOMAIN_PHRASE in message, message
+
+    def test_the_refusal_says_where_an_unreadable_value_would_have_surfaced(self, no_side_effects: None) -> None:
+        """The message names the reason the value could not just be passed on."""
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            data_config="so100; rm -rf /",
+        )
+        assert "container log" in _message(result), _message(result)
+
+    def test_a_refused_selector_never_reaches_the_service_starter(
+        self, start_service_spy: list[dict[str, Any]]
+    ) -> None:
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            embodiment_tag="gr1 && curl evil",
+        )
+        assert result["status"] == "error", result
+        assert start_service_spy == [], start_service_spy
+
+
+class TestTheShippedCatalogueIsAdmitted:
+    """The domain refuses nothing the package itself names as a valid value."""
+
+    def test_every_catalogue_data_config_reaches_the_service_starter(
+        self, start_service_spy: list[dict[str, Any]]
+    ) -> None:
+        values = _catalogue_values()
+        assert len(values) >= 20, f"premise: catalogue looks unread ({len(values)} values)"
+        refused = []
+        for value in values:
+            start_service_spy.clear()
+            result = _call(
+                action="start",
+                checkpoint_path="/tmp/ckpt",
+                container_name="gr00t-test",
+                data_config=value,
+            )
+            if _DOMAIN_PHRASE in _message(result):
+                refused.append(value)
+            elif start_service_spy:
+                assert start_service_spy[0]["data_config"] == value
+        assert refused == [], f"the domain refuses shipped catalogue values: {refused}"
+
+    @pytest.mark.parametrize("dtype", ["fp8", "nvfp4", "fp16", "bf16", "fp32", "int8"])
+    def test_a_real_tensorrt_precision_is_admitted(self, dtype: str, start_service_spy: list[dict[str, Any]]) -> None:
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            use_tensorrt=True,
+            vit_dtype=dtype,
+            llm_dtype=dtype,
+            dit_dtype=dtype,
+        )
+        assert _DOMAIN_PHRASE not in _message(result), _message(result)
+
+
+class TestEffectiveOptionsOnly:
+    """A caller is never refused for a value the requested action ignores."""
+
+    def test_n1_7_ignores_data_config_because_its_entrypoint_drops_the_flag(
+        self, start_service_spy: list[dict[str, Any]]
+    ) -> None:
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            protocol="n1.7",
+            data_config="not; a config",
+        )
+        assert _DOMAIN_PHRASE not in _message(result), _message(result)
+
+    @pytest.mark.parametrize("param", ["vit_dtype", "llm_dtype", "dit_dtype"])
+    def test_a_dtype_is_inert_without_tensorrt(self, param: str, start_service_spy: list[dict[str, Any]]) -> None:
+        result = _call(
+            action="start",
+            checkpoint_path="/tmp/ckpt",
+            container_name="gr00t-test",
+            use_tensorrt=False,
+            **{param: "not; a dtype"},
+        )
+        assert _DOMAIN_PHRASE not in _message(result), _message(result)
+
+    @pytest.mark.parametrize("action", ["status", "stop", "list", "find_containers"])
+    def test_an_action_that_builds_no_command_line_reads_no_selector(
+        self, action: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(gi, "_find_gr00t_containers", lambda: {"status": "success", "containers": []})
+        monkeypatch.setattr(gi, "_check_service_status", lambda _p: {"status": "success"})
+        monkeypatch.setattr(gi, "_stop_service", lambda _p: {"status": "success"})
+        monkeypatch.setattr(gi, "_list_running_services", lambda: {"status": "success"})
+        result = _call(action=action, data_config="not; a config")
+        assert _DOMAIN_PHRASE not in _message(result), _message(result)
+
+
+class TestTheGuardCoversEveryCommandLineAction:
+    """The action table is the set that reaches the command builder.
+
+    Derived from the numeric table's own command-line entry rather than restated:
+    ``denoising_steps`` is a ``_build_inference_command`` argument, so the actions
+    that read it are exactly the actions that build an argv, and the selector
+    strings in that argv must be held for the same set.
+    """
+
+    def test_the_selector_table_matches_the_command_line_actions(self) -> None:
+        numeric = {key for key, options in gi._ACTION_NUMERIC_OPTIONS.items() if "denoising_steps" in options}
+        assert numeric, "premise: no action reads denoising_steps"
+        assert set(gi._ACTION_ENUMERABLE_OPTIONS) == numeric
+
+    def test_every_selector_the_command_builder_takes_is_in_the_table(self) -> None:
+        import inspect
+
+        params = set(inspect.signature(gi._build_inference_command).parameters)
+        covered = set().union(*gi._ACTION_ENUMERABLE_OPTIONS.values())
+        assert covered <= params, covered - params
+        assert covered == {"data_config", "embodiment_tag", "vit_dtype", "llm_dtype", "dit_dtype"}


### PR DESCRIPTION
## Problem

`gr00t_inference` builds one `docker exec` argv and runs it **detached** (`-d`). Nine
agent-supplied options ride that argv. Three of them - `port`, `denoising_steps`,
`timeout` - are held to a domain at the dispatch boundary, and
`_numeric_option_error` records exactly why:

> `port` and `denoising_steps` are interpolated into a `docker exec` command line that
> runs detached, so a value the server's own argument parser rejects surfaces minutes
> later inside the container's log rather than as this call's result. Refusing them
> here - before any container is built, any checkpoint is downloaded, and any socket is
> opened - is what makes the value's rejection a property of the request rather than of
> how far the orchestration got.

The five **selector strings** beside them in that same argv had no domain:
`data_config`, `embodiment_tag`, `vit_dtype`, `llm_dtype`, `dit_dtype`. Measured
through the tool, with `_start_service` stood in so nothing touches docker:

| request | before | after |
|---|---|---|
| `data_config="So100"` (ordinary typo) | `success`, reaches the starter | refused, names `data_config` |
| `data_config="so100; rm -rf /"` | `success`, reaches the starter | refused |
| `embodiment_tag="gr1\nInjected"` | `success`, reaches the starter | refused |
| `vit_dtype="not a dtype"` (`use_tensorrt=True`) | `success`, reaches the starter | refused |
| `data_config="so100_dualcam"` (**control**) | `success`, reaches the starter | `success`, reaches the starter |

Against the real argv builder the value lands as an argument:

```
argv[14] = 'so100; rm -rf /'   (preceded by '--data-config')
argv[16] = 'gr1 && curl evil'  (preceded by '--embodiment-tag')
argv[23] = 'not_a_dtype'       (preceded by '--vit-dtype')
argv[25] = ''                  (preceded by '--llm-dtype')
```

The argv is argv-style, so this is not shell injection - it is the failure mode the
numeric guard already names: the caller is told the service "failed to start", or is
told nothing at all, while the reason sits in a container log. `AGENTS.md` names these
exact fields (`data_config`, `embodiment_tag`, dtype strings) as surfaces that must be
allowlisted.

## Change

`_enumerable_option_error`, the enum-valued sibling of `_numeric_option_error`, called
from the same boundary immediately after it. It mirrors that helper's structure rather
than introducing a second shape:

- **Keyed on the action.** `_ACTION_ENUMERABLE_OPTIONS` covers `start` / `restart` /
  `lifecycle:full` - derived as the set that builds an inference command line, which is
  the same set the numeric table records for `denoising_steps`. A caller is never
  refused for a value the requested action ignores.
- **Two effectiveness conditions, both read off `_build_inference_command`.** The N1.7
  entrypoint takes no `--data-config` flag, so under `protocol="n1.7"` that value is
  genuinely inert and is left alone - the same carve-out `denoising_steps` already has.
  The three dtype flags are only emitted when `use_tensorrt` is set.
- **The domain is a lowercase `[a-z][a-z0-9_]+` token**, the class the repository
  already requires for these fields. The predicate is total over any input, like
  `_is_allowed_image`, so a non-string is refused rather than carried into `re`.
- **Returns a reason for the dispatcher to fold into its error dict**, so
  "Return error dicts, never raise" still holds at the tool surface.

The refusal names the parameter and where an unreadable value would otherwise have
surfaced, and echoes the value with `!r` so a newline cannot break up the message.

**Non-breaking, and it is derived rather than asserted.** The admitted set is read from
the shipped `strands_robots/policies/groot/data_configs.json` rather than copied, so a
config added there is admitted by construction: all **30** catalogue names and aliases
pass, as do `fp8`, `nvfp4`, `fp16`, `bf16`, `fp32`, `int8`.

`AGENTS.md`'s `### LLM Input Safety` prescribed a single `validate_inputs(...)` helper
that raises `ValueError`, and offered `gr00t_inference.validate_inputs()` as the
canonical example. That symbol exists nowhere in the package, and the module cited is
the one with the most dispersed validation in the tree - eight per-concern predicates
returning `str | None`, no single entry point - so the citation pointed at a
counter-example of its own rule. The bullet now describes the shipped shape and names
the pair that implements it.

## Tests

`tests/tools/test_gr00t_enumerable_option_guards.py`, a sibling of the numeric file,
reusing its `no_side_effects` fixture so every refusal is asserted to reach neither
`subprocess.run` nor a socket.

Against `upstream/main`: **69 failed, 15 passed**. The sharpest single line is a
refused `embodiment_tag="gr1 && curl evil"` returning
`{'message': 'stub', 'status': 'success'}` - the value reached the service starter and
the tool called it a success. After: **84 passed**.

The 15 that pass on both trees are the controls, and each fails for a specific wrong
fix:

- every shipped catalogue `data_config` still reaches the starter carrying the
  caller's value (fails if the domain is narrowed past the catalogue)
- six real TensorRT precisions are admitted
- `protocol="n1.7"` still ignores `data_config`; a dtype is still inert without
  `use_tensorrt`; `status` / `stop` / `list` / `find_containers` read no selector
  (all fail if the guard stops being action-keyed)

Two more pin the root cause structurally: the selector action table equals the set of
actions the numeric table records as reading `denoising_steps`, and every option the
table covers is a real `_build_inference_command` parameter - so a sixth selector
cannot be added to that argv and left ungraded.

## Verification

Measured at `c0d9acd`, blast radius of 132 files (`tests/tools`, every test naming the
tool or the option tables or `AGENTS.md`, plus the repo-wide guards), both trees in
parallel and in lockstep (118.95s vs 118.96s):

- branch **5379 passed, 0 failed, 36 skipped**
- base **69 failed, 5310 passed, 36 skipped** - `5310 + 69 = 5379`, same collected
  total on both
- branch-only failing ids: **empty**; base-only: exactly the new file, zero foreign;
  no pre-existing failures in the selection
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine
  `upstream/main` worktree, none in the changed files
- `ruff check` / `ruff format --check` clean

No sim behaviour, policy, rendering, recording or robot asset changes, so there is
nothing to render; the figure below is the measured before/after of what the caller is
told and where the value stopped.

![the same five requests through both trees](https://raw.githubusercontent.com/cagataycali/robots/media-gr00t-selector-domain/selector-domain.png)
