### PR TITLE
fix(simulation): refuse a joint write whose robot_name no robot carries

### DIFF
--- a/changelog.d/2549-joint-write-refuses-an-unknown-robot-name.md
+++ b/changelog.d/2549-joint-write-refuses-an-unknown-robot-name.md
@@ -1,0 +1,43 @@
+### Fixed: a dict-form joint write refuses a `robot_name` no robot carries
+
+`set_joint_positions` / `set_joint_velocities` now refuse a `robot_name` that
+names no robot in the world in the dict form, with the message the ordered
+(list) form already used. Previously the two accepted forms answered the same
+bad argument differently, and the dict form's answer was success:
+
+```python
+sim.set_joint_positions([0.1, 0.2], robot_name="nobody")
+# -> error: Robot 'nobody' not found. Available robots: [...]
+
+sim.set_joint_positions({"j1": 0.1}, robot_name="nobody")
+# -> success: "Set 1/1 joint positions, FK updated"   (before)
+```
+
+Tolerating it was harmless while the dict form ignored `robot_name` outright --
+there was nothing for a wrong value to be wrong about. Scoping an unqualified
+key to `robot_name`'s namespace made the argument load-bearing: it now selects
+the namespace a bare joint name resolves in, so a misspelled robot name means
+"scope this write to a namespace that does not exist". That fell through to the
+pre-existing cross-robot first-match lookup and wrote *some* robot's joint --
+whichever declared the name first -- while the caller believed they had
+addressed a specific one, and the success text reported the requested count for
+a robot that never moved. It is the wrong-robot write already fixed for an
+unqualified name, reached instead through an unchecked scope.
+
+The refusal lives in the shared joint-write resolver, so it covers both setters
+and both call forms from one place, and it covers two kinds of bad name at
+once: one no robot carries, and one that cannot be a registry key at all (a
+list, a dict, a set -- what wrapping a name in brackets or passing a half-built
+kwargs mapping produces). The lookup is routed through the total
+`registry_entry`, so the second kind resolves to "no such robot" and is
+reported rather than raising `TypeError: unhashable type` past the
+`{"status", "content"}` contract.
+
+Blast radius: this refuses calls that previously succeeded, which is the point
+-- each one was writing a joint on a robot the caller did not name. Nothing
+that resolved correctly changes. A bare key with no `robot_name` at all, a
+fully qualified `<robot>/<joint>` key, and a bare key that names no joint of
+`robot_name` but does name one elsewhere in the scene all reach the same lookup
+as before. The one in-tree caller that passes `robot_name` (the LIBERO
+adapter's init-state arm-qpos apply) takes it from `list_robots()`, so it
+cannot trip the new refusal.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -1323,8 +1323,9 @@ class PhysicsMixin:
             method: Calling method name, used in error text.
             robot_name: The robot an unqualified key belongs to. Its namespace is
                 tried first, so a bare name reaches that robot's joint even when
-                a sibling robot declares the same short name. ``None`` (or a name
-                no robot in the world carries) leaves resolution as it was.
+                a sibling robot declares the same short name. ``None`` leaves
+                resolution as it was; a name no robot in the world carries is
+                refused, on the same terms as the list form.
 
         Returns:
             ``({joint_name: joint_id}, None)`` when every name resolves, else
@@ -1355,11 +1356,28 @@ class PhysicsMixin:
         # lands on a robot the caller never addressed (#2453). Scoping first
         # keeps that fallback for everything it already resolved: a bare name
         # that is not a joint of this robot still reaches the shared lookup.
+        #
+        # A ``robot_name`` no robot carries is refused rather than read as "no
+        # namespace". Once the namespace is load-bearing, a misspelling means
+        # "scope this write to a namespace that does not exist", which falls
+        # through to the cross-robot first-match lookup and writes some other
+        # robot's joint while the caller believes they addressed a specific one -
+        # the defect #2453 reported, reached through an unchecked scope instead of
+        # an unqualified name. The list form already refuses the same value here,
+        # so this deletes a divergence rather than adding a rule: one argument had
+        # two answers, and in the dict form the answer was success (#2549).
+        # ``registry_entry`` keeps the lookup total, so a name that cannot be a
+        # registry key at all is refused by this same branch rather than raising
+        # ``TypeError`` past the structured-error contract.
         ns = ""
         if robot_name is not None and self._world is not None:
             robot = registry_entry(self._world.robots, robot_name)
-            if robot is not None:
-                ns = robot.namespace or ""
+            if robot is None:
+                return {}, {
+                    "status": "error",
+                    "content": [{"text": self._unknown_robot_msg(robot_name)}],
+                }
+            ns = robot.namespace or ""
 
         resolved: dict[str, int] = {}
         unresolved: list[str] = []
@@ -1450,7 +1468,10 @@ class PhysicsMixin:
           ``robot_name`` a bare key falls back to a first-match-wins lookup
           across robots, so pass ``robot_name`` or the qualified
           ``"<robot>/<joint>"`` spelling when more than one robot declares the
-          name.
+          name. A ``robot_name`` no robot carries is refused: because it selects
+          the namespace, a misspelling would otherwise scope the write to a
+          namespace that does not exist and fall back to that cross-robot
+          lookup, landing on a robot the caller never addressed.
         * list/tuple: [v0, v1, ...] - ordered positional. Must match a single robot's
           joint count (when ``robot_name`` is given, that robot's joints; otherwise the
           world must contain exactly one robot, or the call errors).
@@ -1474,7 +1495,10 @@ class PhysicsMixin:
                 ordered vector (see the two accepted forms above).
             robot_name: Which robot the ordered form binds to, and whose
                 namespace resolves an unqualified joint name. Optional when the
-                world holds exactly one robot.
+                world holds exactly one robot. When given it must name a robot
+                in the world, in either form: a name no robot carries returns
+                ``status="error"`` and writes nothing, rather than widening the
+                lookup back across every robot.
             hold: Also write the matching position-servo setpoints, so the servos
                 hold the pose written instead of pulling it back to wherever they
                 were last commanded. Must be a boolean. Joints with no position
@@ -1642,7 +1666,8 @@ class PhysicsMixin:
 
         Joint names are scoped on the same terms too: an unqualified key is
         resolved inside ``robot_name``'s namespace before the cross-robot
-        fallback, so a bare name reaches the robot the caller addressed.
+        fallback, so a bare name reaches the robot the caller addressed, and a
+        ``robot_name`` no robot carries is refused in both call forms.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}

--- a/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
+++ b/tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
@@ -27,6 +27,20 @@ These pin the repair and its blast radius: an unqualified key resolves inside
 ``robot_name``'s namespace first, and every spelling that resolved before still
 resolves - a qualified key, a bare key with no ``robot_name``, and a bare key
 that names no joint of ``robot_name`` but does name one elsewhere in the scene.
+
+They also pin the consequence of making the namespace load-bearing: a
+``robot_name`` no robot carries is refused rather than read as "no namespace"
+(#2549). While the dict form ignored the argument there was nothing for a wrong
+value to be wrong about, so tolerating it cost nothing; once it selects the
+namespace, a misspelling means "scope this write to a namespace that does not
+exist" and falls through to the cross-robot first-match lookup - writing some
+other robot's joint while the caller believes they addressed a specific one,
+which is #2453's defect reached through an unchecked scope. The list form
+refused that value all along, so the two accepted forms gave one argument two
+answers and the dict form's answer was ``status="success"``. Refusing in the
+shared resolver deletes the divergence for both forms and both setters at once;
+``test_the_two_forms_agree_on_an_unknown_robot_name`` is the pin on the
+agreement itself, rather than on each form separately.
 """
 
 import os
@@ -182,18 +196,67 @@ def test_bare_name_without_robot_name_is_unchanged(sim):
     assert _qpos(sim, "alice/j1") == pytest.approx(0.7)
 
 
-def test_unknown_robot_name_falls_back_rather_than_raising(sim):
-    """A robot_name no robot carries cannot scope, and must not crash the write."""
+def test_unknown_robot_name_is_refused(sim):
+    """A robot_name no robot carries is an error, not a scope that silently widens.
+
+    This asserts the flip #2549 decided. The previous pin here recorded the
+    tolerant behaviour: the lookup missed, ``ns`` stayed empty, and the write
+    proceeded through the cross-robot first-match lookup reporting success -- so
+    ``robot_name="nobody"`` wrote *alice*, the first robot attached. That is the
+    same wrong-robot write #2453 reported, reached through an unchecked scope
+    rather than an unqualified name, and it is the reason tolerating the value
+    stopped being free once the namespace became load-bearing.
+
+    ``nobody`` is refused with the list form's own message, and nothing is
+    written -- the all-or-nothing contract covers a refused scope too, not just
+    an unresolvable joint name.
+    """
+    before = sim._world._data.qpos.copy()
     result = sim.set_joint_positions({"j1": 0.2}, robot_name="nobody")
+    assert result["status"] == "error", result
+    assert "not found" in result["content"][0]["text"], result
+    assert np.array_equal(sim._world._data.qpos, before), "refused write leaked into qpos"
+
+
+def test_the_two_forms_agree_on_an_unknown_robot_name(sim):
+    """The claim #2549 is about: one argument, one answer, whichever form.
+
+    Asserting the two refusals are the *same string* rather than merely both
+    errors is deliberate -- the defect was not that the dict form lacked an
+    error, it was that the two accepted spellings of one call disagreed about
+    whether ``robot_name`` must name a real robot. Equality is what a future
+    change cannot satisfy by inventing a second, differently-worded refusal.
+    """
+    dict_form = sim.set_joint_positions({"j1": 0.2}, robot_name="nobody")
+    list_form = sim.set_joint_positions([0.1, 0.2, 0.3], robot_name="nobody")
+    assert dict_form["status"] == list_form["status"] == "error", (dict_form, list_form)
+    assert dict_form["content"][0]["text"] == list_form["content"][0]["text"]
+
+
+def test_a_known_robot_name_is_still_accepted(sim):
+    """Non-vacuity: the refusal must key on the name, not refuse every name."""
+    result = sim.set_joint_positions({"j1": 0.2}, robot_name="alice")
     assert result["status"] == "success", result
     assert _qpos(sim, "alice/j1") == pytest.approx(0.2)
 
 
 def test_unresolvable_name_is_still_all_or_nothing(sim):
-    """Scoping must not weaken the all-or-nothing guard."""
+    """Scoping must not weaken the all-or-nothing guard.
+
+    The message assertion pins refusal *precedence*: a real ``robot_name`` with
+    an unresolvable joint key must still be diagnosed as the joint problem it
+    is. Refusing an unknown ``robot_name`` (#2549) put a second refusal ahead of
+    this one in the same resolver, and a robot lookup that fired too eagerly
+    would replace the joint hint -- which names the key and the joints the model
+    does have -- with "Robot 'bob' not found", sending the caller after the
+    wrong argument.
+    """
     before = sim._world._data.qpos.copy()
     result = sim.set_joint_positions({"j1": 0.5, "nope": 0.1}, robot_name="bob")
     assert result["status"] == "error", result
+    text = result["content"][0]["text"]
+    assert "nope" in text, text
+    assert "not found" not in text.split("Joint")[0], f"robot refusal pre-empted the joint refusal: {text}"
     assert np.array_equal(sim._world._data.qpos, before), "partial write leaked into qpos"
 
 
@@ -242,7 +305,7 @@ UNHASHABLE_ROBOT_NAMES: list[tuple[str, Any]] = [
 
 
 @pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
-def test_dict_form_reports_a_robot_name_that_cannot_be_a_key(sim, kind, robot_name):
+def test_dict_form_refuses_a_robot_name_that_cannot_be_a_key(sim, kind, robot_name):
     """Scoping made robot_name a registry lookup, which must stay total.
 
     The namespace lookup here is the dict form's *first* use of ``robot_name``:
@@ -253,22 +316,32 @@ def test_dict_form_reports_a_robot_name_that_cannot_be_a_key(sim, kind, robot_na
     ``{"status", "content"}`` envelope this method documents as its only failure
     channel. Measured on the unscoped-lookup tree: all three names raised out of
     the dict form while the list form reported each one, so one argument had two
-    answers depending on the form. Routing through
-    :func:`~strands_robots.simulation.models.registry_entry` makes the name
-    resolve to "no such robot", which is the fall-back path
-    :func:`test_unknown_robot_name_falls_back_rather_than_raising` already pins.
+    answers depending on the form.
+
+    Routing through :func:`~strands_robots.simulation.models.registry_entry`
+    makes such a name resolve to "no such robot" instead of raising, and #2549
+    then decided what "no such robot" means for a write: a refusal. So this
+    asserts an error rather than the tolerated success an earlier revision
+    pinned, and the envelope check stays -- it is the part that distinguishes a
+    refusal from a ``TypeError``, which is the escape this case exists for.
+    Both subsets reach the one branch: a name no robot carries, and a name that
+    cannot be a registry key at all.
     """
+    before = sim._world._data.qpos.copy()
     result = sim.set_joint_positions({"j1": 0.4}, robot_name=robot_name)
     assert isinstance(result, dict) and "status" in result, f"{kind} name escaped the envelope: {result!r}"
-    assert result["status"] == "success", result
-    assert _qpos(sim, "alice/j1") == pytest.approx(0.4)
+    assert result["status"] == "error", result
+    assert "not found" in result["content"][0]["text"], result
+    assert np.array_equal(sim._world._data.qpos, before), "refused write leaked into qpos"
 
 
 @pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
 def test_the_list_form_still_refuses_such_a_name(sim, kind, robot_name):
     """The control: the ordered form already reported it, and still must.
 
-    Without this, the test above could be satisfied by making both forms raise.
+    Now that both forms refuse, this is what keeps "both refuse" from being
+    satisfied by both *raising*: the ordered form has to answer through the
+    ``{"status", "content"}`` envelope, naming the robot it could not find.
     """
     result = sim.set_joint_positions([0.1, 0.2, 0.3], robot_name=robot_name)
     assert result["status"] == "error", result
@@ -278,7 +351,17 @@ def test_the_list_form_still_refuses_such_a_name(sim, kind, robot_name):
 @pytest.mark.parametrize("kind,robot_name", UNHASHABLE_ROBOT_NAMES, ids=[k for k, _ in UNHASHABLE_ROBOT_NAMES])
 def test_velocities_share_the_total_lookup(sim, kind, robot_name):
     """The sibling setter shares the resolver, so it shares the contract."""
+    before = sim._world._data.qvel.copy()
     result = sim.set_joint_velocities({"j1": 1.0}, robot_name=robot_name)
     assert isinstance(result, dict) and "status" in result, f"{kind} name escaped the envelope: {result!r}"
-    assert result["status"] == "success", result
-    assert _qvel(sim, "alice/j1") == pytest.approx(1.0)
+    assert result["status"] == "error", result
+    assert np.array_equal(sim._world._data.qvel, before), "refused write leaked into qvel"
+
+
+def test_velocities_refuse_an_unknown_robot_name(sim):
+    """The sibling setter shares the refusal for a plain misspelling too."""
+    before = sim._world._data.qvel.copy()
+    result = sim.set_joint_velocities({"j1": 1.0}, robot_name="nobody")
+    assert result["status"] == "error", result
+    assert "not found" in result["content"][0]["text"], result
+    assert np.array_equal(sim._world._data.qvel, before), "refused write leaked into qvel"


### PR DESCRIPTION
Closes #2549

## What

The dict form of `set_joint_positions` / `set_joint_velocities` accepted a `robot_name` that names no robot in the world and reported success. The list form refused the same value:

```python
sim.set_joint_positions([0.1, 0.2], robot_name="nobody")
# -> error: Robot 'nobody' not found. Available robots: [...]

sim.set_joint_positions({"j1": 0.1}, robot_name="nobody")
# before -> success | "Set 1/1 joint positions, FK updated"
# now    -> error: Robot 'nobody' not found. Available robots: [...]
```

One argument had two answers, and in the dict form the answer was a successful write. This implements option 1 of the three the issue set out (refuse, reusing the list form's `_unknown_robot_msg`), which is the option the issue and its follow-up both favoured.

## Why it had to change

Tolerating the value was inert while the dict form ignored `robot_name` outright -- there was nothing for a wrong value to be wrong about. Scoping an unqualified key to `robot_name`'s namespace made the argument load-bearing: it now selects the namespace a bare joint name resolves in. So a misspelled robot name means "scope this write to a namespace that does not exist", which fell through to the pre-existing cross-robot first-match lookup and wrote **whichever robot declared the name first** -- while the success text reported the requested count for a robot that never moved.

That is the same wrong-robot write already fixed for an unqualified name, reached through an unchecked *scope* rather than an unqualified *name*.

## How

One branch in the shared joint-write resolver, so it covers both setters and both call forms from one place:

- It reuses the list form's own message rather than writing a second one, so the two forms now answer a bad `robot_name` **identically** -- the divergence is deleted, not papered over.
- The lookup already routes through the total `registry_entry`, so the same branch also refuses a name that cannot be a registry key at all (a list, a dict, a set -- what wrapping a name in brackets or passing a half-built kwargs mapping produces) instead of raising `TypeError: unhashable type` past the `{"status", "content"}` contract.
- The list form validates `robot_name` before normalising to a dict, so for that form the new branch is unreachable and behaviour is unchanged.

Production change is 4 lines of logic; the rest is the docstrings that state the contract and the pins.

## Blast radius

This refuses calls that previously succeeded -- which is the point: each one was writing a joint on a robot the caller did not name. **Nothing that resolved correctly changes.** All still reach the same lookup as before, and are pinned:

| call | behaviour |
|---|---|
| bare key, no `robot_name` | unchanged (first-match lookup) |
| qualified `<robot>/<joint>` key | unchanged, not re-scoped |
| bare key naming no joint of `robot_name` but one elsewhere | unchanged (cross-robot fallback) |
| known `robot_name` | unchanged |

The one in-tree caller that passes `robot_name` -- the LIBERO adapter's init-state arm-qpos apply -- takes it from `list_robots()`, i.e. a name the code produced, so it cannot trip the refusal.

**Refusal precedence is pinned too.** A real `robot_name` with an unresolvable joint key must still be diagnosed as the joint problem it is; a robot lookup firing too eagerly would replace the joint hint (which names the key and the joints the model does have) with "Robot 'bob' not found", sending the caller after the wrong argument.

## Pins

The three cases that recorded the tolerated behaviour are flipped **deliberately** rather than incidentally, as the issue asked:

- `test_unknown_robot_name_falls_back_rather_than_raising` -> `test_unknown_robot_name_is_refused` (renamed for the behaviour it now asserts)
- `test_dict_form_reports_a_robot_name_that_cannot_be_a_key` -> `test_dict_form_refuses_...` (4 parametrised cases; the envelope check stays, since that is what separates a refusal from a `TypeError`)
- `test_velocities_share_the_total_lookup` (4 parametrised cases)

Added:

- `test_the_two_forms_agree_on_an_unknown_robot_name` -- asserts the two refusals are the *same string*, not merely both errors. That is the actual claim of the issue, and it is what a future change cannot satisfy by inventing a second, differently-worded refusal.
- `test_a_known_robot_name_is_still_accepted` -- non-vacuity: the refusal must key on the name, not refuse every name.
- `test_velocities_refuse_an_unknown_robot_name` -- the sibling setter for a plain misspelling.
- refusal-precedence and no-leak-into-`qpos`/`qvel` assertions on the refused paths.

No references to the two renamed cases survive anywhere in the tree (checked across `*.py`, `*.md`, `*.ipynb`).

## Verification

```
tests/simulation/mujoco/test_joint_write_scopes_a_bare_name_to_robot_name.py
  27 passed

with the production change reverted:
  11 failed, 16 passed      <- the pins grade the fix; the 16 are the
                               blast-radius cases, which pass either way

guards + neighbours (624 + 643 selected):
  tests/test_changelog_{format,fragments,fragment_gate}.py
  tests/test_test_case_names_describe_behaviour.py
  tests/test_docstring_xref_roles_resolve.py
  tests/test_docstrings_no_dangling_doc_refs.py
  tests/test_args_docstring_completeness.py
  tests/test_source_no_implicit_string_concatenation_in_lists.py
  tests/simulation/test_unhashable_entity_name_is_reported.py
  tests/simulation/mujoco/test_joint_setter_unknown_names_rejected.py
  tests/simulation/test_sim_engine_describe_discovery.py
  -> all pass except two pre-existing environment failures, verified
     identical on a clean `main` checkout in the same runner:
       test_sim_engine_describe_discovery: 'so100' in []        (asset absent)
       test_joint_discovery_hint_is_followable: 7 failed        (so101 absent)
     Same test IDs, same cause (model file not on disk); this branch changes
     only the message text on an already-red path.

ruff check / ruff format --check: clean
mypy strands_robots/simulation/mujoco/physics.py: no issues
python scripts/assemble_changelog.py --check: OK
scripts/check_duplicate_claim.py --issue 2549: unique-claim
```

## Changelog

`changelog.d/2549-joint-write-refuses-an-unknown-robot-name.md` -- a behavioural change, so it is recorded as `Fixed` with the blast radius spelled out.

## §13 Review rounds

- **round 0** (initial): the refusal in the shared resolver, three pins flipped, three added, the precedence pin, public docstrings updated, changelog fragment.
