### PR TITLE
fix(tools): hold lerobot_train's device to torch's own device-string domain

### DIFF
--- a/changelog.d/2560-lerobot-train-device-domain.md
+++ b/changelog.d/2560-lerobot-train-device-domain.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **tools/lerobot_train**: `device` is now held to torch's own device-string domain at the dispatch boundary, like the run-size numerics beside it in the same detached argv. `device="gpu"` (or `"CUDA"`, or `"cuda:x"`) is refused up front, naming the parameter and a spelling to use instead, rather than aborting the detached run after the tool has already reported it started with a pid. The admitted set is torch's own - the value is handed to `torch.device` rather than compared against a copied list - and only the spelling is graded, so naming a device the dispatching machine does not currently have still builds an argv. A resumed run, whose argv carries no `--policy.device`, is not refused for one.

--- a/strands_robots/tools/lerobot_train.py
+++ b/strands_robots/tools/lerobot_train.py
@@ -368,6 +368,55 @@ def _has_resumable_checkpoint(output_dir: str) -> Path | None:
     return last if last.exists() else None
 
 
+def _torch_device_error(device: Any) -> str | None:
+    """Error text for a ``device`` no torch build can parse, or ``None``.
+
+    ``device`` is interpolated into ``--policy.device=`` in the argv of a
+    DETACHED process, so an unusable value is not refused where the caller can
+    see it: the tool reports a started run with a PID and a log path, and only
+    the training log records that lerobot aborted before the first step. That is
+    the reason the run-size numerics in the same argv are refused up front, and
+    ``device`` is the one token beside them that was carried through unchecked.
+
+    The admitted domain is torch's own, read by handing the value to
+    ``torch.device`` rather than by comparing against a copied list of device
+    types - the same "source the domain live" shape as
+    :func:`_expert_only_policy_types` and :func:`_policy_config_field_names`
+    above. A torch build that gains a backend is admitted here with no change,
+    and torch's own exception enumerates the types it accepts, so the refusal
+    names the admitted set without restating it.
+
+    Only the spelling is graded, never availability: ``torch.device("cuda")``
+    constructs on a CPU-only box and must keep building an argv there, because a
+    queued or containerised run legitimately names a device the dispatching
+    machine does not currently have. A non-``str`` is refused before torch is
+    consulted for that reason - ``torch.device(0)`` reads the accelerator
+    inventory (``Cannot access accelerator device when none is available``),
+    which would make the same request build here and refuse there.
+
+    When torch is not importable the domain is unknown and the value passes
+    through unguarded, as :func:`_policy_config_field_names` documents for its
+    own field set.
+    """
+    if not isinstance(device, str):
+        return (
+            f"lerobot_train: device must be a torch device string, got {type(device).__name__}. "
+            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
+        )
+    try:
+        import torch
+    except Exception:  # noqa: BLE001 - torch missing -> domain unknown, pass through
+        return None
+    try:
+        torch.device(device)
+    except (RuntimeError, ValueError) as e:
+        return (
+            f"lerobot_train: device={device!r} is not a torch device string ({e}). "
+            "Pass a device type, optionally with an index (e.g. 'cuda', 'cuda:0', 'cpu', 'mps')."
+        )
+    return None
+
+
 def build_train_command(
     dataset_root: str,
     policy_type: str = "act",
@@ -412,7 +461,8 @@ def build_train_command(
             freeze the VLM and are mutually exclusive), if ``train_expert_only``
             is requested for a non-expert policy, if ``num_gpus < 1``, or if a
             supplied ``steps`` / ``batch_size`` - or, under ``lora``, a supplied
-            ``lora_r`` / ``lora_alpha`` - is not a positive integer.
+            ``lora_r`` / ``lora_alpha`` - is not a positive integer, or if a
+            fresh run's ``device`` is not a device string torch can parse.
     """
     if lora and train_expert_only:
         raise ValueError(
@@ -459,6 +509,14 @@ def build_train_command(
         # only honors --config_path + --resume. Other flags are ignored on resume.
         cmd.extend([f"--config_path={resume_config}", "--resume=true"])
         return cmd
+
+    # The one selector string in the fresh-run argv. Checked here rather than
+    # beside the size guards above so a resumed run - which returned already, with
+    # only --config_path + --resume and no --policy.device - is never refused for a
+    # value its argv does not carry.
+    device_error = _torch_device_error(device)
+    if device_error:
+        raise ValueError(device_error)
 
     # Fresh-run flags.
     cmd.extend(
@@ -648,7 +706,10 @@ def lerobot_train(
         steps: Number of training steps.
         batch_size: Training batch size.
         save_freq: Checkpoint save frequency in steps.
-        device: Torch device (cuda, cuda:0, cpu, mps).
+        device: Torch device type, optionally with an index (cuda, cuda:0,
+            cpu, mps). Refused before launch if torch cannot parse it; only
+            the spelling is graded, so naming a device this machine does not
+            have is allowed.
         dtype: Policy dtype (bfloat16, float32) for policies whose lerobot
             config declares a dtype field (e.g. the pi0 family, xvla). Default
             None lets lerobot pick; ACT and most policies have no dtype field,

--- a/tests/tools/test_lerobot_train_device_domain.py
+++ b/tests/tools/test_lerobot_train_device_domain.py
@@ -1,0 +1,252 @@
+"""``lerobot_train`` refuses a device torch cannot parse, before launching it.
+
+``build_train_command`` writes ``--policy.device`` into the argv of a process
+the tool then launches DETACHED, so an unusable value was not reported to the
+caller at all: the tool returned ``status="success"`` with a pid and a log path,
+and only the training log recorded that lerobot aborted before the first step.
+``device`` was the one token in that fresh-run argv with no domain - the run-size
+numerics beside it (``steps``, ``batch_size``, ``lora_r``, ``lora_alpha``,
+``val_episodes``) are refused up front for exactly this reason, and ``dtype`` /
+``gradient_checkpointing`` / ``policy_type`` are each gated against a live
+lerobot registry.
+
+``device="gpu"`` is the ordinary mistake: it is the word the rest of the world
+uses and it is not a torch device type, so it aborted the detached run while the
+tool reported it started.
+
+The admitted domain is torch's own, read by handing the value to
+``torch.device`` rather than by comparing against a copied list, so a torch build
+that gains a backend is admitted here with no change. These tests pin that only
+the *spelling* is graded and never availability - ``cuda`` on a CPU-only box, and
+the exotic-but-valid types below, must keep building an argv, because a queued or
+containerised run legitimately names a device the dispatching machine lacks - and
+that the scope is no wider than the defect: the resume path never emits
+``--policy.device``, so a resumed run is not refused for a value its argv does
+not carry.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.lerobot_train as train_mod
+from tests.tools.test_lerobot_train import _FakeProc, _write_dataset
+
+build_train_command = train_mod.build_train_command
+
+# Spellings no torch build can parse, and why each one matters.
+UNUSABLE_DEVICES: tuple[Any, ...] = (
+    "gpu",  # the ordinary mistake: the word everyone else uses
+    "GPU",
+    "CUDA",  # torch device types are lowercase
+    "nvidia",
+    "cuda:x",  # a non-numeric index
+    "cuda:-1",
+    "cuda:",  # an index promised and not given
+    "cuda:0:1",
+    "cuda 0",  # a space instead of the separator
+    "",  # names nothing
+    "   ",
+    "cpu; rm -rf /",  # injection shapes, defended even though the argv is argv-style
+    "$(whoami)",
+    "`id`",
+    "cpu\nInjected",
+    0,  # a non-str: torch would read the accelerator inventory for this one
+    None,
+    True,
+    3.5,
+    ["cuda"],
+)
+
+# Spellings torch parses. The first four are what the tool's own docstring names;
+# ``cpu:0`` is an explicitly indexed host device; the rest are valid device types
+# that essentially no test machine has, and are here to prove availability is not
+# what is being graded.
+USABLE_DEVICES: tuple[str, ...] = ("cuda", "cuda:0", "cpu", "mps", "cpu:0", "xla", "vulkan", "hpu", "meta", "xpu")
+
+
+def _build(**kwargs: Any) -> list[str]:
+    """Build an argv with a minimal usable base, overridden by ``kwargs``.
+
+    Funnelled so the deliberately off-type values above reach the runtime guard
+    the way an agent supplies them, without a type checker objecting at each
+    call site.
+    """
+    base: dict[str, Any] = {"dataset_root": "/data/cubes", "policy_type": "act"}
+    base.update(kwargs)
+    return build_train_command(**base)
+
+
+def _write_resumable_checkpoint(output_dir: Path) -> Path:
+    """Write the ``train_config.json`` ``--resume`` requires, and return the dir."""
+    pretrained = output_dir / "checkpoints" / "last" / "pretrained_model"
+    pretrained.mkdir(parents=True, exist_ok=True)
+    (pretrained / "train_config.json").write_text(json.dumps({"steps": 20000}))
+    return output_dir
+
+
+@pytest.fixture(autouse=True)
+def _isolated_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Keep the on-disk session store inside the test's own tmp_path."""
+    session_dir = tmp_path / ".sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(train_mod, "SESSION_DIR", session_dir)
+    return session_dir
+
+
+class TestADeviceTorchCannotParseIsRefused:
+    """The spelling is graded against torch's own parser before the argv is built."""
+
+    @pytest.mark.parametrize("device", UNUSABLE_DEVICES)
+    def test_an_unusable_device_never_reaches_the_argv(self, device: Any) -> None:
+        pytest.importorskip("torch")
+        with pytest.raises(ValueError) as excinfo:
+            _build(device=device)
+        assert "device" in str(excinfo.value)
+
+    def test_the_refusal_names_the_parameter_the_tool_and_the_value(self) -> None:
+        pytest.importorskip("torch")
+        with pytest.raises(ValueError) as excinfo:
+            _build(device="gpu")
+        message = str(excinfo.value)
+        assert "device" in message
+        assert "lerobot_train" in message
+        assert "gpu" in message
+
+    def test_the_refusal_names_a_spelling_the_caller_can_use_instead(self) -> None:
+        """A refusal that does not say what to pass costs the caller a round trip."""
+        pytest.importorskip("torch")
+        with pytest.raises(ValueError) as excinfo:
+            _build(device="gpu")
+        assert "cuda" in str(excinfo.value)
+
+    def test_a_non_string_is_refused_for_its_type_not_by_torch(self) -> None:
+        """The type gate runs first, so the verdict cannot vary by machine.
+
+        ``torch.device(0)`` reads the accelerator inventory rather than a
+        spelling, so consulting torch for a non-string would build this argv on a
+        GPU box and refuse it on a CPU box.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _build(device=0)
+        message = str(excinfo.value)
+        assert "must be a torch device string" in message
+        assert "int" in message
+
+
+class TestOnlyTheSpellingIsGradedNeverAvailability:
+    """A run may name a device the dispatching machine does not have."""
+
+    @pytest.mark.parametrize("device", USABLE_DEVICES)
+    def test_a_parseable_device_still_reaches_the_argv(self, device: str) -> None:
+        assert f"--policy.device={device}" in _build(device=device)
+
+    def test_cuda_builds_on_a_machine_without_cuda(self) -> None:
+        """The premise the whole guard rests on, asserted where it is false."""
+        torch = pytest.importorskip("torch")
+        if torch.cuda.is_available():
+            pytest.skip("this machine has CUDA, so it cannot witness the CPU-only case")
+        assert "--policy.device=cuda" in _build(device="cuda")
+
+    def test_the_default_device_is_accepted(self) -> None:
+        """``device`` defaults to ``"cuda"``; the guard must not refuse the default."""
+        assert "--policy.device=cuda" in _build()
+
+
+class TestTheDomainIsSourcedLiveRatherThanCopied:
+    """Executable premises, so the reasoning cannot silently become wrong."""
+
+    @pytest.mark.parametrize("device", [value for value in UNUSABLE_DEVICES if isinstance(value, str)])
+    def test_torch_really_rejects_every_unusable_spelling(self, device: str) -> None:
+        """Non-vacuity: the probe set is refused by torch, not by a local list."""
+        torch = pytest.importorskip("torch")
+        with pytest.raises((RuntimeError, ValueError)):
+            torch.device(device)
+
+    @pytest.mark.parametrize("device", USABLE_DEVICES)
+    def test_torch_really_accepts_every_usable_spelling(self, device: str) -> None:
+        """So the admitted half is torch's verdict too, not a copied allow-list."""
+        torch = pytest.importorskip("torch")
+        assert torch.device(device) is not None
+
+    def test_torchs_own_message_enumerates_the_admitted_device_types(self) -> None:
+        """Which is why the refusal quotes it instead of restating the set."""
+        torch = pytest.importorskip("torch")
+        with pytest.raises(RuntimeError) as excinfo:
+            torch.device("gpu")
+        assert "cuda" in str(excinfo.value)
+
+    def test_an_unimportable_torch_leaves_the_value_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no torch the domain is unknown, so the value passes through.
+
+        The same contract ``_policy_config_field_names`` documents for its own
+        field set: an absent source of truth must not become a refusal.
+        """
+        real_import = builtins.__import__
+
+        def _no_torch(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "torch" or name.startswith("torch."):
+                raise ImportError("torch is not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_torch)
+        assert "--policy.device=gpu" in _build(device="gpu")
+
+
+class TestTheRefusalReachesTheCallerBeforeAnyProcessStarts:
+    """A rejected device must be reported, not launched and then discovered."""
+
+    def test_the_tool_reports_an_error_envelope_rather_than_raising(self, tmp_path: Path) -> None:
+        pytest.importorskip("torch")
+        dataset = _write_dataset(tmp_path / "cubes")
+        result = train_mod.lerobot_train(action="start", dataset_root=str(dataset), device="gpu")
+        assert result["status"] == "error"
+        text = "\n".join(item["text"] for item in result["content"] if "text" in item)
+        assert "device" in text
+
+    def test_a_refused_device_launches_no_process(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("torch")
+        dataset = _write_dataset(tmp_path / "cubes")
+        launched: list[Any] = []
+
+        def _fail_if_launched(*args: Any, **kwargs: Any) -> _FakeProc:
+            launched.append(args)
+            return _FakeProc()
+
+        monkeypatch.setattr(train_mod.subprocess, "Popen", _fail_if_launched)
+        result = train_mod.lerobot_train(action="start", dataset_root=str(dataset), device="gpu")
+        assert result["status"] == "error"
+        assert launched == [], "a refused device still spawned a training process"
+
+
+class TestTheScopeIsNoWiderThanTheDefect:
+    """A resumed run's argv carries no device, so it must not be refused for one."""
+
+    def test_a_resumed_run_is_not_refused_for_an_unusable_device(self, tmp_path: Path) -> None:
+        output_dir = _write_resumable_checkpoint(tmp_path / "train_out")
+        cmd = _build(device="gpu", output_dir=str(output_dir), resume=True)
+        assert "--resume=true" in cmd
+
+    def test_a_resumed_run_really_emits_no_device_flag(self, tmp_path: Path) -> None:
+        """Non-vacuity for the scoping decision above."""
+        output_dir = _write_resumable_checkpoint(tmp_path / "train_out")
+        cmd = _build(device="cuda", output_dir=str(output_dir), resume=True)
+        assert not [flag for flag in cmd if flag.startswith("--policy.device=")]
+
+    def test_the_other_argv_guards_are_untouched(self) -> None:
+        with pytest.raises(ValueError, match="num_gpus must be >= 1"):
+            _build(num_gpus=0)
+        with pytest.raises(ValueError, match="steps must be a positive integer"):
+            _build(steps=0)
+
+
+def test_the_probe_sets_are_disjoint_and_cover_both_kinds() -> None:
+    """Guards the probe sets themselves against a future edit collapsing them."""
+    assert not set(USABLE_DEVICES) & {value for value in UNUSABLE_DEVICES if isinstance(value, str)}
+    assert any(not isinstance(value, str) for value in UNUSABLE_DEVICES), "no non-string probe"
+    assert any(isinstance(value, str) for value in UNUSABLE_DEVICES), "no unparseable-string probe"


### PR DESCRIPTION
Fixes #2558

## What

`build_train_command` interpolates `device` into `--policy.device=` in the argv of
a process `lerobot_train(action="start")` launches **detached**, then returns
`status="success"` with a pid and a log path. `device` was the one
caller-supplied token in that fresh-run argv with no domain.

Everything beside it is already held to one before the dispatch: `steps`,
`batch_size`, `lora_r`, `lora_alpha` and `val_episodes` against the shared
positive-count domain; `dtype`, `gradient_checkpointing` and `policy_type`
against a live lerobot registry; `num_gpus` against `>= 1`. The comment beside
the size guards already states the reason those exist:

> An unusable value here is not merely rejected downstream: it is written into
> the argv of a DETACHED process, so the caller is told the run started and only
> the training log records that it could not be honored.

`device="gpu"` is the ordinary mistake - it is the word the rest of the world
uses and it is not a torch device type - so the run aborted before its first step
while the tool reported it started. `"CUDA"` and `"cuda:x"` fail the same way.

## How

A local `_torch_device_error` refuses the value at the dispatch boundary, naming
the parameter. Per AGENTS.md #11 this stays local and the domain is stated in the
field's docstring - one field, one caller, so nothing is lifted into `utils.py`.

The admitted domain is **torch's own**, read by handing the value to
`torch.device` rather than by comparing against a copied list of device types.
That mirrors how `_expert_only_policy_types` and `_policy_config_field_names` in
the same file source their domains live from lerobot: a torch build that gains a
backend is admitted here with no change, and torch's own exception already
enumerates the types it accepts, so the refusal quotes it instead of restating
the set.

## Three scoping decisions worth reviewing

**Only the spelling is graded, never availability.** `torch.device("cuda")`
constructs on a CPU-only box and must keep building an argv there - a queued or
containerised run legitimately names a device the dispatching machine does not
currently have, and a machine's device inventory is not a property of the argv.
Pinned by `test_cuda_builds_on_a_machine_without_cuda`, plus four
valid-but-essentially-never-present device types (`xla`, `vulkan`, `hpu`, `meta`)
in the admitted probe set.

**A non-`str` is refused before torch is consulted.** `torch.device(0)` reads the
accelerator inventory (`RuntimeError: Cannot access accelerator device when none
is available`), so routing an int through torch would build one request on a GPU
box and refuse it on a CPU box. The type gate keeps the verdict
machine-independent.

**Scoped to the fresh-run path.** The resume branch has already returned with
only `--config_path` + `--resume=true` and never emits `--policy.device`, so a
resumed run is not refused for a value its argv does not carry - the same "never
refuse a value this action ignores" contract #2555 encodes. Pinned both ways: the
refusal does not fire on resume, and a non-vacuity test asserts the resume argv
really carries no device flag.

When torch is not importable the domain is unknown and the value passes through
unguarded, as `_policy_config_field_names` documents for its own field set.

## Tests

`tests/tools/test_lerobot_train_device_domain.py`, 68 cases, mirroring the shape
of its sibling `test_lerobot_train_size_knob_domain.py`:

* 20 unusable spellings refused and never reaching the argv, including the
  injection shapes and the non-strings.
* 10 parseable spellings still reaching it.
* The refusal names the parameter, the tool, the value, **and a spelling the
  caller can use instead**.
* The domain is torch's verdict, not a local list: every probe in both halves is
  asserted against `torch.device` directly, so the probe sets cannot drift from
  the guard.
* The refusal reaches the caller as an error envelope and launches no process
  (asserted through a `Popen` spy, so a guard that ran after the dispatch could
  not pass).
* The other argv guards are asserted untouched.

## Not in scope

`strands_robots/training/lerobot.py` carries the same unvalidated string into
`--policy.device=` and `--reward_model.device=` from `LerobotTrainer.__init__`.
Different entry point, different validation owner (`training/_validate.py`'s spec
gates, where `device` is not a `TrainSpec` field at all), so it is left for a
separate change rather than folded in here. `training/reward.py`'s `device` is
in-process and raises where the caller sees it, so it is not part of this class.

## Verification

`ruff check` and `ruff format --check` clean on both files; `mypy` reports
nothing in the changed file. The new test file passes 67/68 locally - the single
failure is `test_the_tool_reports_an_error_envelope_rather_than_raising`, which
needs `lerobot` importable for the tool's `start` action to get past its first
check. The pre-existing sibling test of identical shape fails identically in the
same minimal environment, and CI installs `features = ["all"]`.
