### PR TITLE
fix(simulation): name a refused field by a spelling the schema publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,11 @@ for action Y. Valid: [...]"*, missing required params produce *"Action X
 requires parameter Y."*, a field the schema publishes as a string is refused
 unless it is one (*"Action X: 'Y' must be a string, got 7 (int)"*), and
 vectors/dtypes are validated before MuJoCo sees them - so the agent learns the
-contract without crashing the process.
+contract without crashing the process. Every one of those refusals names the
+field by the spelling you sent, or by the one this schema publishes: the router
+rewrites a few wire names to their method parameter (`torque_vec` -> `torque`)
+before validating, and a refusal naming the rewritten name would point at a
+field the schema does not carry.
 
 **Third-party backends.** `create_simulation(name)` discovers backends beyond
 the built-in `mujoco`/`newton`/`isaac` registry via Python

--- a/changelog.d/2566-refusal-names-a-published-spelling.md
+++ b/changelog.d/2566-refusal-names-a-published-spelling.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **simulation/mujoco**: a router refusal now names the field by a spelling the tool schema publishes. The dispatcher rewrites `_FIELD_ALIASES` to method parameter names before validating, and `apply_force`'s torque - published as `torque_vec`, validated as `torque` - has no property of its own, so the vector arity check, the per-component check and the unknown-parameter `Valid:` list all reported a field a schema-constrained caller cannot emit. The resolution the string-type check already performed is now one owner consulted by every site that names a field; a parameter with no published spelling at all keeps its own name, so the dispatcher's deliberate width for Python callers is unchanged.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -50,7 +50,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import AsyncGenerator, Callable, Sequence
+from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -356,6 +356,55 @@ def _published_string_params(field_aliases: dict[str, str]) -> frozenset[str]:
         field_aliases.get(wire, wire)
         for wire, prop in props.items()
         if wire != "action" and prop.get("type") == "string"
+    )
+
+
+# Every field name the schema publishes. Derived from the schema for the same
+# reason ``_PUBLISHED_ACTIONS`` is, and used to decide which spelling a refusal
+# may name: a model constrained to this schema can emit no other.
+_PUBLISHED_PARAMS: frozenset[str] = frozenset(_TOOL_SPEC_SCHEMA["properties"]) - {"action"}
+
+
+def _reported_param_name(param: str, field_aliases: Mapping[str, str], received: Mapping[str, Any]) -> str:
+    """The spelling a refusal names when it is about method parameter *param*.
+
+    The dispatcher rewrites ``_FIELD_ALIASES`` to method parameter names before
+    validating, so a refusal that echoes the parameter it validated can name a
+    field no caller ever wrote. ``apply_force``'s torque is the case with no way
+    back: it arrives as the schema's ``torque_vec``, is validated as ``torque``,
+    and ``torque`` is not a published property at all -- so a model told
+    "Parameter 'torque' must be a list of 3 numbers" was sent to a field it
+    cannot emit.
+
+    Preference order, most specific first:
+
+    1. *param* itself when the payload carries it, since that is what the caller
+       wrote.
+    2. The alias for *param* that the payload carries, for a field that arrived
+       under a wire name.
+    3. The spelling the schema publishes, for a name the payload does not carry
+       at all -- an entry in a ``Valid:`` list, or a missing required parameter.
+
+    Args:
+        param: The method parameter name the dispatcher validated.
+        field_aliases: The dispatcher's wire-name to parameter-name map.
+        received: The payload as the caller sent it, before alias rewriting.
+
+    Returns:
+        The field name to put in the refusal. Falls back to *param* when no
+        published spelling exists, which keeps a Python-only parameter reportable
+        under the only name it has.
+    """
+    if param in received:
+        return param
+    for wire, target in field_aliases.items():
+        if target == param and wire in received:
+            return wire
+    if param in _PUBLISHED_PARAMS:
+        return param
+    return next(
+        (wire for wire, target in field_aliases.items() if target == param and wire in _PUBLISHED_PARAMS),
+        param,
     )
 
 
@@ -5728,7 +5777,9 @@ class MuJoCoSimEngine(
         # 1) Unknown kwargs (skipped for **kwargs methods which legitimately passthrough)
         unknown = [] if method_has_var_keyword else [k for k in remapped if k not in accepted_field_names]
         if unknown:
-            valid_sorted = sorted(method_param_names - {"action"})
+            valid_sorted = sorted(
+                _reported_param_name(param, self._FIELD_ALIASES, received) for param in method_param_names - {"action"}
+            )
             return None, {
                 "status": "error",
                 "content": [
@@ -5750,14 +5801,7 @@ class MuJoCoSimEngine(
             # alias (``checkpoint_name`` -> ``name``), and reporting the
             # canonical parameter would send them looking for a key their
             # payload does not contain.
-            reported = (
-                sparam
-                if sparam in received
-                else next(
-                    (wire for wire, param in self._FIELD_ALIASES.items() if param == sparam and wire in received),
-                    sparam,
-                )
-            )
+            reported = _reported_param_name(sparam, self._FIELD_ALIASES, received)
             smsg = published_string_error(svalue, reported, f"Action '{action}'")
             if smsg is not None:
                 return None, {"status": "error", "content": [{"text": smsg}]}
@@ -5770,11 +5814,12 @@ class MuJoCoSimEngine(
             if val is None:
                 continue
             expected_len = " or ".join(str(n) for n in accepted_lens)
+            reported_vparam = _reported_param_name(vparam, self._FIELD_ALIASES, received)
             n_components = sequence_length(val)
             if n_components is None:
                 return None, {
                     "status": "error",
-                    "content": [{"text": f"Parameter '{vparam}' must be a list of {expected_len} numbers."}],
+                    "content": [{"text": f"Parameter '{reported_vparam}' must be a list of {expected_len} numbers."}],
                 }
             if n_components not in accepted_lens:
                 return None, {
@@ -5782,7 +5827,8 @@ class MuJoCoSimEngine(
                     "content": [
                         {
                             "text": (
-                                f"Parameter '{vparam}' must be a list of {expected_len} numbers, got {n_components}."
+                                f"Parameter '{reported_vparam}' must be a list of {expected_len} numbers, "
+                                f"got {n_components}."
                             )
                         }
                     ],
@@ -5799,7 +5845,12 @@ class MuJoCoSimEngine(
                     return None, {
                         "status": "error",
                         "content": [
-                            {"text": (f"Parameter '{vparam}'[{i}] must be numeric, got {type(component).__name__}.")}
+                            {
+                                "text": (
+                                    f"Parameter '{reported_vparam}'[{i}] must be numeric, "
+                                    f"got {type(component).__name__}."
+                                )
+                            }
                         ],
                     }
 
@@ -5813,9 +5864,10 @@ class MuJoCoSimEngine(
             elif param_name in remapped:
                 kwargs[param_name] = remapped[param_name]
             elif param.default is inspect.Parameter.empty:
+                reported_missing = _reported_param_name(param_name, self._FIELD_ALIASES, received)
                 return None, {
                     "status": "error",
-                    "content": [{"text": f"Action '{action}' requires parameter '{param_name}'."}],
+                    "content": [{"text": f"Action '{action}' requires parameter '{reported_missing}'."}],
                 }
 
         # 5) Residual keys for **kwargs methods. The unknown-key check above is
@@ -5838,7 +5890,12 @@ class MuJoCoSimEngine(
           * a field the schema publishes as a string is refused unless it is
             one, before the method body assumes it,
           * vector params have length + numeric dtype checked before the
-            value reaches numpy / MuJoCo.
+            value reaches numpy / MuJoCo,
+          * and every one of those refusals names the field by the spelling the
+            caller sent, or by the one the schema publishes - see
+            :func:`_reported_param_name`, since the alias rewriting above runs
+            first and a refusal echoing the rewritten name can point at a field
+            the schema does not carry.
 
         Policy-provider kwargs are nested under ``policy_config`` (never
         top-level) so the dispatcher stays backend-agnostic.

--- a/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
+++ b/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
@@ -75,6 +75,31 @@ _VAR_KEYWORD_ACTIONS: frozenset[str] = frozenset(
 )
 
 
+def _required_parameters(action: str) -> list[str]:
+    """Named parameters of *action*'s method that carry no default."""
+    method = getattr(MuJoCoSimEngine, MuJoCoSimEngine._ACTION_ALIASES.get(action, action), None)
+    if method is None:  # pragma: no cover - every published action resolves today
+        return []
+    return [
+        name
+        for name, p in inspect.signature(method).parameters.items()
+        if name != "self"
+        and p.default is inspect.Parameter.empty
+        and p.kind not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    ]
+
+
+# Actions the router refuses before the method body runs, because the payload is
+# missing a parameter the signature requires. Only these may be dispatched bare:
+# an action whose parameters all carry defaults BINDS, so ``sim(action=X)``
+# executes it on the live world instead of producing the refusal under test --
+# which for ``start_recording`` means creating a dataset in the shared cache
+# (rule 15) and for ``open_viewer`` means reaching ``launch_passive``.
+_REQUIRED_PARAM_ACTIONS: frozenset[str] = frozenset(
+    action for action in _SPEC["properties"]["action"]["enum"] if _required_parameters(action)
+)
+
+
 @pytest.fixture
 def sim() -> Generator[Simulation, None, None]:
     """A world holding one body, so a refusal is the only thing under test."""
@@ -187,6 +212,77 @@ class TestAVectorRefusalNamesTheFieldTheCallerSent:
         assert "Parameter 'torque' must be a list of 3 numbers, got 2." in _text(result)
 
 
+class TestTheBareDispatchSweepCannotExecuteAnAction:
+    """A sweep that dispatches bare may only name actions the router refuses.
+
+    ``sim(action=X)`` with no other key is a refusal probe, but it is only a
+    probe for an action whose signature requires something: when every parameter
+    carries a default the payload BINDS, and the method runs against the live
+    world. Two of those reach outside the test process -- ``start_recording``
+    resolves ``repo_id="local/sim_recording"`` with no ``root`` and creates it
+    under ``$HF_LEROBOT_HOME`` (AGENTS.md rule 15, whose measured cost is one
+    planted dataset turning 133 passes into 22 ``FileExistsError`` failures in
+    unrelated modules), and ``open_viewer`` reaches
+    ``mujoco.viewer.launch_passive`` on any host that is not headless. Neither is
+    visible on CI, where ``DISPLAY`` is unset and no dataset exists yet.
+
+    So the filter is a property of the sweep, not a convenience, and these tests
+    fail if it is widened back to the published enum.
+    """
+
+    def test_no_graded_action_can_be_called_with_no_arguments(self) -> None:
+        """The mechanical form of "the router refuses it before the body runs".
+
+        Binding the signature with nothing but ``self`` is what
+        ``_dispatch_action`` effectively attempts for a bare payload; a method
+        that binds is a method that executes.
+        """
+        bindable = []
+        for action in sorted(_REQUIRED_PARAM_ACTIONS):
+            method = getattr(MuJoCoSimEngine, MuJoCoSimEngine._ACTION_ALIASES.get(action, action))
+            try:
+                inspect.signature(method).bind(object())
+            except TypeError:
+                continue
+            bindable.append(action)
+        assert not bindable, f"bare dispatch would execute these on the live world: {bindable}"
+
+    @pytest.mark.parametrize(
+        ("action", "effect"),
+        [
+            ("start_recording", "creates a dataset under $HF_LEROBOT_HOME (rule 15)"),
+            ("open_viewer", "reaches mujoco.viewer.launch_passive on a host with a display"),
+        ],
+    )
+    def test_an_action_with_a_side_effect_outside_the_process_is_not_swept(self, action: str, effect: str) -> None:
+        """Named individually, because these are the two the filter exists for."""
+        assert action in _SPEC["properties"]["action"]["enum"], f"premise: {action} is published"
+        assert action not in _REQUIRED_PARAM_ACTIONS, (
+            f"{action} would be dispatched bare by the sweep above, which {effect}"
+        )
+
+    def test_the_bare_dispatch_sweep_is_parametrized_over_the_filtered_set(self) -> None:
+        """Pins the decorator, not just the set it is derived from.
+
+        The two tests above grade what :data:`_REQUIRED_PARAM_ACTIONS` contains,
+        which stays true if the sweep is widened back to the published enum
+        beside them. This reads the sweep's own parametrization, so that edit is
+        what fails rather than the next developer's cache.
+        """
+        suite = TestARefusalAdvertisesOnlyPublishedSpellings
+        sweep = suite.test_a_missing_required_parameter_is_named_by_a_published_spelling
+        marks = [m for m in getattr(sweep, "pytestmark", []) if m.name == "parametrize"]
+        assert len(marks) == 1, marks
+        argnames, argvalues = marks[0].args
+        assert argnames == "action", argnames
+        assert sorted(argvalues) == sorted(_REQUIRED_PARAM_ACTIONS), sorted(argvalues)
+
+    def test_the_filter_still_grades_most_of_the_published_surface(self) -> None:
+        """Non-vacuity: a derivation that collapsed to nothing would report clean."""
+        assert len(_REQUIRED_PARAM_ACTIONS) >= 20, sorted(_REQUIRED_PARAM_ACTIONS)
+        assert _REQUIRED_PARAM_ACTIONS <= set(_SPEC["properties"]["action"]["enum"])
+
+
 class TestARefusalAdvertisesOnlyPublishedSpellings:
     """Whatever a refusal offers as a remedy, a model has to be able to emit it."""
 
@@ -226,21 +322,23 @@ class TestARefusalAdvertisesOnlyPublishedSpellings:
         assert {"bucket", "run_id"} <= offered, sorted(offered)
         assert not ({"bucket", "run_id"} & _PUBLISHED), "premise: neither may be a published property"
 
-    @pytest.mark.parametrize("action", sorted(_SPEC["properties"]["action"]["enum"]))
+    @pytest.mark.parametrize("action", sorted(_REQUIRED_PARAM_ACTIONS))
     def test_a_missing_required_parameter_is_named_by_a_published_spelling(self, sim: Simulation, action: str) -> None:
         """The required-parameter refusal reports a signature name too.
 
         No required parameter is aliased away today, so this sweep passes either
         way - it is here so that the day one is, the refusal names a field the
         caller can supply rather than the day the report is read.
+
+        Dispatched bare, so it is parametrized over the actions the router
+        refuses before the method body runs; see :data:`_REQUIRED_PARAM_ACTIONS`
+        for why the rest are not swept here.
         """
         result = sim(action=action)
-        if result["status"] != "error":
-            pytest.skip(f"action {action!r} needs no required parameter")
+        assert result["status"] == "error", result
         text = _text(result)
         match = re.search(r"requires parameter '([A-Za-z_][A-Za-z0-9_]*)'", text)
-        if match is None:
-            pytest.skip(f"action {action!r} was refused for another reason: {text}")
+        assert match is not None, f"action {action!r} was refused for another reason: {text}"
         assert match.group(1) not in _ALIASED_AWAY, text
 
 

--- a/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
+++ b/tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py
@@ -1,0 +1,291 @@
+"""A router refusal names the field by a spelling the schema publishes.
+
+``_dispatch_action`` rewrites ``_FIELD_ALIASES`` to method parameter names
+*before* validating, so every refusal downstream of that rewrite reports the
+parameter it validated rather than the field the caller wrote. One of those
+canonical names has no property of its own: ``apply_force``'s torque is
+published as ``torque_vec`` and validated as ``torque``, and the schema has no
+``torque`` property at all.
+
+The consequence is a refusal a schema-constrained model cannot act on. Sending
+``torque_vec="up"`` was answered ``Parameter 'torque' must be a list of 3
+numbers``, and an unknown field on the same action was answered ``Valid:
+['body_name', 'force', 'point', 'torque']`` -- both naming a property the model
+is not permitted to emit, so its only route back was to guess that ``torque``
+and ``torque_vec`` are one field.
+
+The string-type check, thirty lines above the vector one in the same function,
+already resolved the spelling back to what the caller sent; its comment records
+why ("reporting the canonical parameter would send them looking for a key their
+payload does not contain"). ``test_tool_spec.py`` independently keeps a
+``_schema_name`` helper for the same mapping, to grade the very table these
+refusals report from. What was missing was one owner for the rule, consulted by
+every site that names a field.
+
+The sweeps below are derived from ``_FIELD_ALIASES`` and from the schema, so an
+alias added later is graded without a second list to keep true.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation.mujoco.simulation import (  # noqa: E402
+    MuJoCoSimEngine,
+    Simulation,
+)
+
+_SPEC = json.loads((Path(inspect.getfile(MuJoCoSimEngine)).parent / "tool_spec.json").read_text())
+_PUBLISHED: frozenset[str] = frozenset(_SPEC["properties"]) - {"action"}
+
+# Method parameters the schema reaches only under a different name. The
+# dispatcher is deliberately wider than the schema - ``stop_recording`` accepts
+# ``bucket`` / ``run_id`` from Python without publishing either - so an
+# unpublished name is not by itself a defect. What a refusal may not do is name
+# THESE, because the same field has a published spelling the caller can supply.
+_ALIASED_AWAY: frozenset[str] = frozenset(
+    param for wire, param in MuJoCoSimEngine._FIELD_ALIASES.items() if wire in _PUBLISHED and param not in _PUBLISHED
+)
+
+# A bad value for each published JSON type, chosen so the router refuses before
+# the method body runs. These sweeps measure the refusal, not the action.
+_BAD_BY_TYPE: dict[str, Any] = {
+    "array": [1, 2],  # short vector: refused by the arity check
+    "string": 7,
+    "object": "notadict",
+}
+
+# Actions whose method takes ``**kwargs``: the unknown-parameter check is
+# skipped for them by design (they forward or reject the residual keys
+# themselves), so they publish no "Valid:" list to grade.
+_VAR_KEYWORD_ACTIONS: frozenset[str] = frozenset(
+    action
+    for action in _SPEC["properties"]["action"]["enum"]
+    if (method := getattr(MuJoCoSimEngine, MuJoCoSimEngine._ACTION_ALIASES.get(action, action), None)) is not None
+    and any(p.kind is inspect.Parameter.VAR_KEYWORD for p in inspect.signature(method).parameters.values())
+)
+
+
+@pytest.fixture
+def sim() -> Generator[Simulation, None, None]:
+    """A world holding one body, so a refusal is the only thing under test."""
+    engine = Simulation(tool_name="refusal_spelling")
+    try:
+        assert engine(action="create_world")["status"] == "success"
+        built = engine(action="add_object", name="cube", shape="box", position=[0.2, 0.0, 0.1], size=[0.05] * 3)
+        assert built["status"] == "success", built
+        yield engine
+    finally:
+        engine.destroy()
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The refusal text of a structured tool result."""
+    return " ".join(block.get("text", "") for block in result.get("content", []))
+
+
+def _valid_list(text: str) -> list[str]:
+    """The names advertised by an ``Unknown parameter ... Valid: [...]`` refusal."""
+    match = re.search(r"Valid: \[(.*?)\]", text)
+    assert match is not None, f"refusal carried no Valid: list: {text}"
+    return re.findall(r"'([^']+)'", match.group(1))
+
+
+def _aliases_by_kind(kind: str) -> list[tuple[str, str]]:
+    """``(wire, param)`` alias pairs whose published property has JSON type *kind*."""
+    return sorted(
+        (wire, param)
+        for wire, param in MuJoCoSimEngine._FIELD_ALIASES.items()
+        if _SPEC["properties"].get(wire, {}).get("type") == kind
+    )
+
+
+class TestTheAliasMapIsWhatMakesThisReachable:
+    """Premise: the sweeps below are graded against a real asymmetry."""
+
+    def test_at_least_one_canonical_parameter_name_is_unpublished(self) -> None:
+        """Without one, every sweep here would hold for a router that ignores aliases.
+
+        ``torque`` is that name today. If the schema ever publishes it, this test
+        is the one that says the sweeps have gone vacuous.
+        """
+        unpublished = sorted(set(MuJoCoSimEngine._FIELD_ALIASES.values()) - _PUBLISHED)
+        assert unpublished, (
+            "premise: some _FIELD_ALIASES target must be absent from the schema, "
+            "or a refusal naming the target is indistinguishable from one naming the wire field"
+        )
+        assert "torque" in unpublished, unpublished
+        assert _ALIASED_AWAY == frozenset({"torque"}), sorted(_ALIASED_AWAY)
+
+    def test_every_alias_wire_name_is_itself_published(self) -> None:
+        """A wire name is what a model emits, so the spelling reported must exist.
+
+        The fallback in the reporting rule keeps a Python-only parameter
+        reportable under its own name; this pins that the aliases in play today
+        never need it.
+        """
+        unpublished_wires = sorted(set(MuJoCoSimEngine._FIELD_ALIASES) - _PUBLISHED)
+        assert unpublished_wires == ["camera_names", "joint_positions"], unpublished_wires
+        for wire, param in MuJoCoSimEngine._FIELD_ALIASES.items():
+            assert wire in _PUBLISHED or param in _PUBLISHED, (wire, param)
+
+
+class TestAVectorRefusalNamesTheFieldTheCallerSent:
+    """The arity and element checks report the spelling the payload carried."""
+
+    @pytest.mark.parametrize(("wire", "param"), _aliases_by_kind("array"))
+    def test_a_short_vector_sent_under_a_wire_name_is_refused_under_that_name(
+        self, sim: Simulation, wire: str, param: str
+    ) -> None:
+        """Pre-fix ``torque_vec=[1, 2]`` was answered "Parameter 'torque' ...".
+
+        The caller's payload has no ``torque`` key and the schema has no
+        ``torque`` property, so neither the request nor the contract offered a
+        way to act on that name.
+        """
+        result = sim(action="apply_force", body_name="cube", **{wire: _BAD_BY_TYPE["array"]})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert f"'{wire}'" in text, text
+        assert f"'{param}'" not in text or param == wire, text
+
+    @pytest.mark.parametrize(("wire", "param"), _aliases_by_kind("array"))
+    def test_a_non_numeric_component_sent_under_a_wire_name_is_refused_under_that_name(
+        self, sim: Simulation, wire: str, param: str
+    ) -> None:
+        """The per-component refusal reports from the same table, so it needs the same rule."""
+        result = sim(action="apply_force", body_name="cube", **{wire: [1, 2, "up"]})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert f"'{wire}'[2]" in text, text
+        assert f"'{param}'" not in text or param == wire, text
+
+    def test_a_vector_with_no_alias_keeps_its_own_name(self, sim: Simulation) -> None:
+        """Most vectors are spelled the same on both sides; that path is unchanged."""
+        result = sim(action="apply_force", body_name="cube", force=[1, 2])
+        assert result["status"] == "error"
+        assert "Parameter 'force' must be a list of 3 numbers, got 2." in _text(result)
+
+    def test_a_python_caller_who_writes_the_canonical_name_is_named_by_it(self, sim: Simulation) -> None:
+        """The rule reports what the caller wrote, not what the schema prefers.
+
+        ``torque`` is reachable from Python even though the schema does not
+        publish it, and rewriting that refusal to ``torque_vec`` would name a key
+        the payload does not carry - the same mistake in the other direction.
+        """
+        result = sim(action="apply_force", body_name="cube", torque=[1, 2])
+        assert result["status"] == "error"
+        assert "Parameter 'torque' must be a list of 3 numbers, got 2." in _text(result)
+
+
+class TestARefusalAdvertisesOnlyPublishedSpellings:
+    """Whatever a refusal offers as a remedy, a model has to be able to emit it."""
+
+    @pytest.mark.parametrize(
+        "action",
+        sorted(set(_SPEC["properties"]["action"]["enum"]) - _VAR_KEYWORD_ACTIONS),
+    )
+    def test_the_valid_list_names_only_fields_the_schema_publishes(self, sim: Simulation, action: str) -> None:
+        """Pre-fix ``apply_force`` advertised ``torque``, which is not a property.
+
+        The list is built from the method signature, so a parameter whose
+        published spelling differs reached the caller under a name the schema
+        does not carry - while the spelling that works went unmentioned.
+        """
+        payload: dict[str, Any] = {"action": action, "definitely_not_a_field": 1}
+        result = sim(**payload)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "Unknown parameter" in text, text
+        offered = set(_valid_list(text))
+        assert not (offered & _ALIASED_AWAY), (
+            f"action {action!r} advertised {sorted(offered & _ALIASED_AWAY)}, which the schema "
+            f"reaches only under another name: {text}"
+        )
+
+    def test_a_parameter_with_no_published_spelling_is_still_advertised(self, sim: Simulation) -> None:
+        """The dispatcher's deliberate width is not what this narrows.
+
+        ``stop_recording`` takes ``bucket`` / ``run_id`` from Python and publishes
+        neither, and rewriting the reporting rule to name only schema properties
+        would drop them from the list of what the action accepts. Only a
+        parameter the schema reaches under ANOTHER name is substituted.
+        """
+        result = sim(action="stop_recording", definitely_not_a_field=1)
+        assert result["status"] == "error"
+        offered = set(_valid_list(_text(result)))
+        assert {"bucket", "run_id"} <= offered, sorted(offered)
+        assert not ({"bucket", "run_id"} & _PUBLISHED), "premise: neither may be a published property"
+
+    @pytest.mark.parametrize("action", sorted(_SPEC["properties"]["action"]["enum"]))
+    def test_a_missing_required_parameter_is_named_by_a_published_spelling(self, sim: Simulation, action: str) -> None:
+        """The required-parameter refusal reports a signature name too.
+
+        No required parameter is aliased away today, so this sweep passes either
+        way - it is here so that the day one is, the refusal names a field the
+        caller can supply rather than the day the report is read.
+        """
+        result = sim(action=action)
+        if result["status"] != "error":
+            pytest.skip(f"action {action!r} needs no required parameter")
+        text = _text(result)
+        match = re.search(r"requires parameter '([A-Za-z_][A-Za-z0-9_]*)'", text)
+        if match is None:
+            pytest.skip(f"action {action!r} was refused for another reason: {text}")
+        assert match.group(1) not in _ALIASED_AWAY, text
+
+
+class TestTheStringCheckKeepsTheBehaviourItAlreadyHad:
+    """The one site that already resolved the spelling now shares the rule."""
+
+    @pytest.mark.parametrize(("wire", "param"), _aliases_by_kind("string"))
+    def test_a_non_string_sent_under_a_wire_name_is_refused_under_that_name(
+        self, sim: Simulation, wire: str, param: str
+    ) -> None:
+        """``checkpoint_name`` was already reported correctly; it still is."""
+        result = sim(action="save_state", **{wire: 7})
+        assert result["status"] == "error"
+        text = _text(result)
+        assert f"'{wire}' must be a string" in text, text
+
+    def test_a_string_with_no_alias_keeps_its_own_name(self, sim: Simulation) -> None:
+        """Folding the two sites into one rule must not move the common case."""
+        result = sim(action="load_scene", scene_path=7)
+        assert result["status"] == "error"
+        assert "'scene_path' must be a string" in _text(result)
+
+
+class TestOneOwnerForTheReportingRule:
+    """Root cause: five refusal sites, one of which resolved the spelling."""
+
+    def test_no_refusal_in_the_validator_formats_a_raw_parameter_name(self) -> None:
+        """Every site names the field through the shared rule, not the loop variable.
+
+        A site that interpolates the parameter it is iterating over reports the
+        post-rewrite name, which is what made ``torque`` reachable in four
+        messages at once.
+        """
+        source = inspect.getsource(MuJoCoSimEngine._validate_and_build_kwargs)
+        for raw in ("{vparam}", "{param_name}'."):
+            assert raw not in source, f"a refusal still formats the raw name {raw!r}"
+        assert source.count("_reported_param_name(") >= 4, source.count("_reported_param_name(")
+
+    def test_the_reported_spelling_prefers_the_payload_then_the_schema(self) -> None:
+        """The rule's three branches, stated directly on the helper."""
+        from strands_robots.simulation.mujoco.simulation import _reported_param_name
+
+        aliases = {"torque_vec": "torque"}
+        assert _reported_param_name("torque", aliases, {"torque": [1]}) == "torque"
+        assert _reported_param_name("torque", aliases, {"torque_vec": [1]}) == "torque_vec"
+        assert _reported_param_name("torque", aliases, {}) == "torque_vec"
+        assert _reported_param_name("force", aliases, {}) == "force"
+        assert _reported_param_name("bucket", aliases, {}) == "bucket"


### PR DESCRIPTION
## Problem

`_dispatch_action` rewrites `_FIELD_ALIASES` to method parameter names **before** validating, so every refusal downstream of that rewrite reports the parameter it validated rather than the field the caller wrote. One of those canonical names has no property of its own: `apply_force`'s torque is published as `torque_vec` and validated as `torque`, and `tool_spec.json` has no `torque` property at all.

Four refusals reached the caller naming it. Measured on a live world holding one body:

| sent | refusal on `main` | names a published property |
| --- | --- | --- |
| `torque_vec="up"` | `Parameter 'torque' must be a list of 3 numbers, got 8.` | no |
| `torque_vec=[1, 2]` | `Parameter 'torque' must be a list of 3 numbers, got 2.` | no |
| `torque_vec=[1, 2, "a"]` | `Parameter 'torque'[2] must be numeric, got str.` | no |
| an unknown field on `apply_force` | `Valid: ['body_name', 'force', 'point', 'torque']` | no |

A model constrained to this schema cannot emit `torque`, so it was told to fix a field it is not permitted to send, and the spelling that works went unmentioned. Its only route back was to guess that `torque` and `torque_vec` are one field.

The string-type check thirty lines above the vector one, in the same function, already resolved the spelling back to what the caller sent - its comment records why ("reporting the canonical parameter would send them looking for a key their payload does not contain"). `tests/simulation/mujoco/test_tool_spec.py` independently keeps a `_schema_name` helper for the same mapping, in order to grade the very table these refusals report from. What was missing was one owner for the rule, consulted by every site that names a field.

## Change

`_reported_param_name(param, field_aliases, received)` is that owner. It prefers, most specific first: the spelling the payload carries, then the alias for it that the payload carries, then the one the schema publishes. All five refusal sites in `_validate_and_build_kwargs` now go through it - the unknown-parameter `Valid:` list, the string-type check (which loses its inline copy of the same logic), the vector arity check, the per-component check, and the missing-required check.

`_PUBLISHED_PARAMS` is derived from `tool_spec.json`, for the same reason `_PUBLISHED_ACTIONS` and `_PUBLISHED_STRING_PARAMS` are: a second list would be a second thing to keep true.

**Scope.** The dispatcher is deliberately wider than the schema for Python callers - `stop_recording` accepts `bucket` / `run_id` without publishing either - so an unpublished name is not by itself a defect, and the rule leaves such a parameter under its own name. Only a parameter the schema reaches under **another** name is substituted. Sweeping all 77 actions that publish a `Valid:` list, **1 changed**:

```
apply_force: ['torque'] -> ['torque_vec']
stop_recording: ['bucket', 'output_path', 'push_to_hub', 'run_id']  (unchanged)
```

Narrowing the reporting rule to "name only schema properties" would have been the obvious wrong fix: it drops `bucket` / `run_id` from the list of what `stop_recording` accepts. `test_a_parameter_with_no_published_spelling_is_still_advertised` fails for it.

## Tests

`tests/simulation/mujoco/test_router_refusals_name_a_published_spelling.py`, 115 items. The sweeps are derived from `_FIELD_ALIASES` and from the schema, so an alias added later is graded without a second list.

| tree | failed | passed |
| --- | --- | --- |
| `upstream/main` + this test file | 5 | 110 |
| this branch | 0 | 115 |

The three behavioural failures name the offending spelling in the assertion (`AssertionError: Parameter 'torque' must be a list of 3 numbers, got 2.`); the fourth is the root-cause pin (`a refusal still formats the raw name '{vparam}'`) and the fifth is the helper's own unit test. The 110 both-tree passes are the controls: a vector with no alias keeps its own name, a Python caller who writes `torque` is still named by it, the string refusal keeps the behaviour it already had, the deliberate Python-only width survives, and no action advertises a substituted field it should not.

The bare-dispatch sweep is a special case. `sim(action=X)` with no other key is a refusal probe only for an action whose signature requires something: when every parameter carries a default the payload **binds**, and the method runs against the live world. Measured over the published enum, 53 of 77 bound and 36 reached a success status - `render`, `save_state`, `export_xml` among them, and two with effects outside the test process:

| action | dispatched bare | why it is not visible on CI |
| --- | --- | --- |
| `start_recording` | resolves `repo_id="local/sim_recording"` with no `root` and **creates** `$HF_LEROBOT_HOME/local/sim_recording/meta/info.json` (rule 15) | no dataset exists there yet on a fresh runner |
| `open_viewer` | reaches `mujoco.viewer.launch_passive` wherever `_is_headless()` is false - unconditionally on macOS/Windows, and on Linux whenever `DISPLAY` is set | runners set no `DISPLAY`, so `mujoco.viewer` is unimportable and the call is a clean error dict |

So it is parametrized over `_REQUIRED_PARAM_ACTIONS`, derived from the signatures the way `_VAR_KEYWORD_ACTIONS` already is - an action with a named parameter carrying no default. All 24 are refused at the router with a named required parameter and zero writes, and both skip branches become unreachable, so the sweep now asserts the refusal instead of skipping past it:

| sweep parametrized over | HF root after the run | pytest | wall |
| --- | --- | --- | --- |
| sweep over the published enum | `local/sim_recording/meta/info.json` created | 110 passed, **53 skipped** | 15.06 s |
| sweep over `_REQUIRED_PARAM_ACTIONS` | empty | **115 passed, 0 skipped** | 2.40 s |

`TestTheBareDispatchSweepCannotExecuteAnAction` keeps that true, and its two halves are complementary - neither alone catches both ways of losing it:

| regression | bind pin | `start_recording` pin | `open_viewer` pin | parametrize pin |
| --- | --- | --- | --- | --- |
| sweep widened back to the enum (the set untouched) | pass | pass | pass | **fail** |
| derivation stops reading `p.default` | **fail** | **fail** | pass | pass |

`open_viewer` takes no parameters at all, so it stays outside the set even under a broken derivation - which is why the parametrize pin, read off the sweep's own `pytestmark`, is what protects it.

## Verification

Measured at `ac13fdbf`, blast radius = 280 files (all of `tests/simulation/mujoco`, every guard that walks a source or test tree, every test naming a recording root or `$HF_LEROBOT_HOME`, and the repo-wide docstring / string / changelog guards). Both trees run with `MUJOCO_GL=egl`, in parallel and in lockstep at 443 s.

| tree | failed | passed | skipped |
| --- | --- | --- | --- |
| this branch | 0 | 8414 | 73 |
| the previous head `d92e403a` | 0 | 8409 | 126 |

The branch-only failure set is empty and the selection has no pre-existing failures. The counts reconcile exactly: 8487 collected against 8535, i.e. 53 sweep parameters dropped less 5 new guard items; passed `+5` is those items, and skipped `-53` is the bare-executing actions that used to be skipped past.

Regression evidence for the reporting rule itself, `upstream/main` + this test file: **5 failed / 110 passed**, the same five as before (the new guards grade the sweep's own shape, so they hold on `main` too). `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 == 24 against a pristine `upstream/main` worktree, nothing branch-only and nothing in the changed file.

## Rollout

Same scene, same request, same 676-step headless MuJoCo rollout in both columns - only which field the refusal names differs. A caller that follows the refusal it is given recovers on the right and is stuck on the left; the bar's yaw travel is **0.00 deg** against **36.77 deg**. Frame 0 is pixel-identical across trees (mean |px| = 0.000), so the two runs are the same rollout until the refusal is acted on.

![refusal names a published spelling](https://raw.githubusercontent.com/cagataycali/robots/media-refusal-spelling/refusal-spelling.png)

