### PR TITLE
fix(tools): confine a caller-named file to the directory that was validated

### DIFF
--- a/changelog.d/2567-output-path-confined-to-validated-directory.md
+++ b/changelog.d/2567-output-path-confined-to-validated-directory.md
@@ -1,0 +1,16 @@
+### Fixed: a caller-named capture or pose file cannot be written outside the directory that was validated
+
+`validate_save_path` guards the directory a tool writes into, but the file was
+composed afterwards from separate caller-supplied parameters and joined onto it,
+and `os.path.join` walks back out of its first argument whenever the second asks
+it to. So the `..` traversal that guard refuses in `save_path` was reachable
+through `lerobot_camera`'s `filename` or `format`, or `pose_tool`'s `robot_id` --
+the halves of the path nothing checked -- and the write reported success at
+whatever location it had reached.
+
+A new `resolve_output_path` helper beside `validate_save_path` resolves the
+composed name and refuses one that does not land inside the resolved directory,
+which also means a symlink inside it cannot be used to step outside. It is a
+containment check rather than a character allowlist, so every name that worked
+before still works: an unlisted extension such as `tiff` stays honored, per the
+decision recorded in #2559, and so does a filename containing a space.

--- a/strands_robots/tools/_path_validation.py
+++ b/strands_robots/tools/_path_validation.py
@@ -1,7 +1,15 @@
 """Shared path validation utilities for tools that write to the filesystem.
 
-Provides a consistent ``validate_save_path`` helper that all tool modules
-can import to reject dangerous path values before any I/O occurs.
+Provides two helpers all tool modules can import to reject dangerous path values
+before any I/O occurs, one per half of a write target:
+
+* :func:`validate_save_path` validates the *directory* a tool writes into.
+* :func:`resolve_output_path` resolves the *file name* a caller asks for inside
+  that directory, and refuses a name that leaves it.
+
+Both are needed because a tool composes its write target from the two, and
+validating only the directory leaves the composition unchecked - the defect
+:func:`resolve_output_path` exists to close.
 
 Cross-platform: blocks sensitive directories on Linux, macOS, and Windows.
 """
@@ -108,5 +116,74 @@ def validate_save_path(path: str, *, label: str = "path") -> str:
     for prefix in BLOCKED_PREFIXES:
         if check_path.startswith(prefix):
             raise ValueError(f"{label} resolves to a protected system directory ({prefix}): {resolved}")
+
+    return resolved
+
+
+def resolve_output_path(directory: str, name: str, *, label: str = "filename") -> str:
+    """Resolve ``name`` as a file inside the already-validated ``directory``.
+
+    :func:`validate_save_path` validates the directory a tool was told to write
+    into. It cannot validate the *file*, because the file name is composed
+    afterwards from separate caller-supplied parts - a ``filename`` and often an
+    extension - and ``os.path.join`` happily walks back out of the directory it
+    was given. So a tool that validated its ``save_path`` and then joined a name
+    onto it wrote wherever the name pointed:
+
+    ``os.path.join("/captures", "../../etc/x" + ".jpg")`` -> ``/etc/x.jpg``
+
+    which is the traversal ``validate_save_path`` refuses in its own argument,
+    reached through the part that was never checked. This helper is the second
+    half of that pair, and it is deliberately a *containment* check rather than a
+    character allowlist: an allowlist has to guess which spellings are dangerous
+    on which platform, and it would refuse working requests. What is actually
+    required is narrower and exactly statable - the resolved write target must lie
+    inside the resolved directory - so that is what is asserted, after resolution,
+    on the composed path. Resolving with :func:`os.path.realpath` also means a
+    symlink inside the directory cannot be used to step outside it.
+
+    A name that stays inside the directory is accepted whatever it is spelled
+    with, including one that names a subdirectory (``"a/b.jpg"``). That is not an
+    oversight: such a name is contained, so it is not this function's concern, and
+    if the subdirectory does not exist the write fails loudly at the call site
+    rather than silently landing somewhere else.
+
+    Args:
+        directory: The directory to resolve within. Pass the value returned by
+            :func:`validate_save_path`, not the raw caller-supplied one.
+        name: The file name to resolve, composed of whatever caller-supplied
+            parts the tool builds it from.
+        label: A human-readable name for error messages (e.g. ``"filename"``).
+
+    Returns:
+        The resolved absolute path of the file, guaranteed to be inside
+        ``directory``.
+
+    Raises:
+        ValueError: If ``name`` is empty, contains a null byte, or resolves to a
+            location that is not inside ``directory``.
+    """
+    if not name:
+        raise ValueError(f"{label} must not be empty")
+
+    if _DANGEROUS_CHARS.search(name):
+        raise ValueError(f"{label} contains invalid characters")
+
+    root = os.path.realpath(directory)
+    resolved = os.path.realpath(os.path.join(root, name))
+
+    # ``commonpath`` rather than ``startswith``: the latter matches a sibling
+    # directory that merely shares a prefix ("/captures2" against "/captures").
+    # Both operands are absolute here, so it cannot raise on mixed forms.
+    if os.path.commonpath([root, resolved]) != root:
+        raise ValueError(
+            f"{label}: {name!r} resolves to {resolved}, which is outside the directory it must be written into ({root})"
+        )
+
+    # Reported separately: this one *is* inside the directory, so the message
+    # above would have to say it is outside it, which is a contradiction rather
+    # than a diagnosis.
+    if resolved == root:
+        raise ValueError(f"{label}: {name!r} names the directory {root} itself, not a file inside it")
 
     return resolved

--- a/strands_robots/tools/lerobot_camera.py
+++ b/strands_robots/tools/lerobot_camera.py
@@ -36,7 +36,7 @@ except ImportError as e:
 
 from strands import tool
 
-from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
 from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
 
 # Configure logging
@@ -286,7 +286,9 @@ def lerobot_camera(
         camera_type: Camera type ("opencv" or "realsense")
         camera_id: Camera device ID (int for index, str for path like "/dev/video0")
         save_path: Directory to save captured images/videos
-        filename: Custom filename (without extension)
+        filename: Custom filename (without extension). Resolved inside
+            save_path; a value naming a location outside it is refused rather
+            than written there.
         camera_ids: List of camera IDs for batch operations
         width: Frame width in pixels (a positive whole number)
         height: Frame height in pixels (a positive whole number)
@@ -296,7 +298,9 @@ def lerobot_camera(
         rotation: Image rotation; one of "NO_ROTATION", "ROTATE_90", "ROTATE_180"
             or "ROTATE_270", compared case-insensitively. Any other value is
             refused rather than silently read as "NO_ROTATION".
-        format: Image format ("jpg", "png", "bmp")
+        format: Image format ("jpg", "png", "bmp"). Becomes the saved file's
+            extension, so like filename it is resolved inside save_path and
+            refused if it names a location outside it.
         capture_duration: Duration for video recording (positive seconds)
         preview_duration: Duration for preview display (positive seconds)
         async_mode: Use async reading for better performance
@@ -608,7 +612,7 @@ def _capture_single_image(
             cam_name = str(camera_id).replace("/dev/", "").replace("/", "_")
             filename = f"lerobot_{camera_type}_{cam_name}_{timestamp}"
 
-        file_path = os.path.join(save_path, f"{filename}.{format}")
+        file_path = resolve_output_path(save_path, f"{filename}.{format}", label="filename and format")
 
         # Create camera configuration
         camera = _create_camera(camera_type, camera_id, width, height, fps, color_mode, rotation)
@@ -701,7 +705,7 @@ def _capture_batch_images(
                 else:
                     cam_filename = f"batch_{camera_type}_{cam_name}_{timestamp}"
 
-                file_path = os.path.join(save_path, f"{cam_filename}.{format}")
+                file_path = resolve_output_path(save_path, f"{cam_filename}.{format}", label="filename and format")
 
                 # Create and use camera
                 camera = _create_camera(camera_type, cam_id, width, height, fps, color_mode, rotation)
@@ -822,7 +826,7 @@ def _record_video_sequence(
             cam_name = str(camera_id).replace("/dev/", "").replace("/", "_")
             filename = f"lerobot_video_{camera_type}_{cam_name}_{timestamp}"
 
-        video_path = os.path.join(save_path, f"{filename}.mp4")
+        video_path = resolve_output_path(save_path, f"{filename}.mp4", label="filename")
 
         # Create camera
         camera = _create_camera(camera_type, camera_id, width, height, fps, color_mode, rotation)

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -21,7 +21,7 @@ import serial
 import serial.tools.list_ports
 from strands import tool
 
-from strands_robots.tools._path_validation import validate_save_path
+from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
 from strands_robots.utils import finite_number_error, positive_count_error, positive_finite_number_error
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ class PoseManager:
         raw_dir = str(storage_dir) if storage_dir else str(Path.cwd() / ".strands_robots" / "poses")
         self.storage_dir = Path(validate_save_path(raw_dir, label="storage_dir"))
         self.storage_dir.mkdir(parents=True, exist_ok=True)
-        self.pose_file = self.storage_dir / f"{robot_id}_poses.json"
+        self.pose_file = Path(resolve_output_path(str(self.storage_dir), f"{robot_id}_poses.json", label="robot_id"))
         self.poses: dict[str, RobotPose] = {}
         self._load_poses()
 
@@ -669,7 +669,9 @@ def pose_tool(
 
     Args:
         action: Action to perform
-        robot_id: Robot identifier for pose storage
+        robot_id: Robot identifier for pose storage. Becomes part of the pose
+            file's name, so a value resolving outside the storage directory is
+            refused rather than written there.
         port: Serial port for robot communication
         pose_name: Name for pose operations
         motor_name: Motor name for single motor operations
@@ -723,8 +725,15 @@ def pose_tool(
     ):
         return {"status": "error", "content": [{"text": target_error}]}
 
-    # Initialize managers
-    pose_manager = PoseManager(robot_id)
+    # Initialize managers. PoseManager composes its pose file name from
+    # robot_id, so an id that resolves outside the storage directory is refused
+    # there rather than here. This construction sits outside the try below, so
+    # the refusal is caught explicitly - otherwise it would leave this tool as
+    # an exception instead of the error envelope every other refusal here uses.
+    try:
+        pose_manager = PoseManager(robot_id)
+    except ValueError as e:
+        return {"status": "error", "content": [{"text": str(e)}]}
 
     try:
         if action == "list_poses":

--- a/tests/tools/test_output_path_is_confined_to_its_directory.py
+++ b/tests/tools/test_output_path_is_confined_to_its_directory.py
@@ -1,0 +1,316 @@
+"""A caller-named file must land in the directory that was validated.
+
+``validate_save_path`` is the guard every filesystem-writing tool here runs on the
+directory it was told to write into. It rejects a ``..`` component explicitly, and
+resolves the result to check it does not land in a protected system directory. What
+it cannot do is validate the *file*, because the file name is composed afterwards,
+from different caller-supplied parameters, and joined onto the directory it
+returned::
+
+    save_path = validate_save_path(save_path, label="save_path")   # checked
+    file_path = os.path.join(save_path, f"{filename}.{format}")    # not checked
+
+``os.path.join`` walks back out of its first argument whenever the second asks it
+to, so the traversal ``validate_save_path`` refuses in ``save_path`` was reachable
+through ``filename`` or ``format`` instead - the halves of the path nothing looked
+at. Both are agent-supplied ``@tool`` parameters with no domain of their own, and
+the write reported ``status="success"`` at whatever location it had reached.
+
+``resolve_output_path`` closes that by asserting the property that was actually
+wanted: the resolved write target lies inside the resolved directory. It is
+deliberately not a character allowlist. ``format`` is documented as a closed
+vocabulary but #2559 decided it is not held to one, because an unlisted extension
+is *honored* rather than replaced - OpenCV writes a ``tiff`` if it can - so
+narrowing the spelling would refuse working requests. Containment is orthogonal to
+that decision, and these tests pin both halves: a traversal is refused, and every
+value that worked before still works, ``tiff`` included.
+
+The sites covered are the ones where a caller-supplied component reaches a path:
+``capture`` and ``capture_batch`` (``filename`` and ``format``), ``record``
+(``filename``; the ``.mp4`` extension is fixed), and ``PoseManager``
+(``robot_id``). ``configure`` is deliberately absent - it composes its name from
+``camera_type``, which ``_create_camera`` refuses before the name is built, and a
+``camera_id`` whose separators are already stripped.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.lerobot_camera as cam_mod
+from strands_robots.tools._path_validation import resolve_output_path, validate_save_path
+
+# Names that resolve outside the directory they are joined onto. The first two are
+# the realistic shapes - a traversal in the name, and a traversal reached through
+# the extension after a legitimate-looking stem. ``/etc/passwd`` covers the
+# absolute name, which ``os.path.join`` honors by discarding its first argument
+# entirely.
+ESCAPING_NAMES = (
+    "../escaped.jpg",
+    "../../../../tmp/escaped.jpg",
+    "shot.jpg/../../escaped.jpg",
+    "/etc/passwd",
+    "sub/../../escaped.jpg",
+)
+
+# Names that stay inside and must keep working. ``a/b.jpg`` names a subdirectory:
+# it is contained, so containment is not what should refuse it.
+CONTAINED_NAMES = (
+    "shot.jpg",
+    "shot.tiff",
+    "my capture.jpg",
+    "shot..jpg",
+    ".hidden.jpg",
+    "a/b.jpg",
+)
+
+
+class TestResolveOutputPath:
+    """The helper itself."""
+
+    @pytest.mark.parametrize("name", ESCAPING_NAMES)
+    def test_a_name_resolving_outside_the_directory_is_refused(self, tmp_path: Path, name: str) -> None:
+        root = validate_save_path(str(tmp_path / "captures"))
+        os.makedirs(root, exist_ok=True)
+        with pytest.raises(ValueError) as excinfo:
+            resolve_output_path(root, name, label="filename")
+        # The refusal names the value, where it landed and the directory it had to
+        # stay in, because a caller cannot correct the name from "invalid" alone.
+        message = str(excinfo.value)
+        assert "filename" in message
+        assert repr(name) in message
+        assert root in message
+
+    @pytest.mark.parametrize("name", CONTAINED_NAMES)
+    def test_a_contained_name_is_returned_resolved(self, tmp_path: Path, name: str) -> None:
+        root = validate_save_path(str(tmp_path / "captures"))
+        os.makedirs(root, exist_ok=True)
+        resolved = resolve_output_path(root, name)
+        assert os.path.isabs(resolved)
+        assert os.path.commonpath([root, resolved]) == root
+
+    def test_a_sibling_directory_sharing_a_prefix_is_outside(self, tmp_path: Path) -> None:
+        """``startswith`` would accept this; ``commonpath`` must not.
+
+        ``/x/captures2`` shares a string prefix with ``/x/captures`` while being a
+        different directory, so a prefix comparison is the wrong relation here.
+        """
+        root = str(tmp_path / "captures")
+        os.makedirs(root, exist_ok=True)
+        os.makedirs(str(tmp_path / "captures2"), exist_ok=True)
+        with pytest.raises(ValueError, match="outside the directory it must be written into"):
+            resolve_output_path(root, "../captures2/shot.jpg")
+
+    def test_a_symlink_cannot_be_used_to_step_outside(self, tmp_path: Path) -> None:
+        """Resolution follows symlinks, so a link inside the directory is not a hole."""
+        root = tmp_path / "captures"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (root / "link").symlink_to(outside, target_is_directory=True)
+        with pytest.raises(ValueError, match="outside the directory it must be written into"):
+            resolve_output_path(str(root), "link/escaped.jpg")
+
+    def test_naming_the_directory_itself_is_refused_as_such(self, tmp_path: Path) -> None:
+        """Reported as naming the directory, not as being outside it.
+
+        This name resolves *to* the directory, so the out-of-bounds wording would
+        have to claim it is outside itself.
+        """
+        root = str(tmp_path / "captures")
+        os.makedirs(root, exist_ok=True)
+        with pytest.raises(ValueError, match="itself, not a file inside it"):
+            resolve_output_path(root, ".")
+
+    @pytest.mark.parametrize("name", ["", "shot\x00.jpg"])
+    def test_an_unusable_name_is_refused_before_resolution(self, tmp_path: Path, name: str) -> None:
+        root = str(tmp_path / "captures")
+        os.makedirs(root, exist_ok=True)
+        with pytest.raises(ValueError):
+            resolve_output_path(root, name)
+
+
+class _Recorder:
+    """A camera stand-in: connects, yields one frame, records nothing else."""
+
+    def __init__(self) -> None:
+        self.width = 8
+        self.height = 6
+        self.fps = 30
+        self.color_mode = type("_M", (), {"value": "RGB"})()
+
+    def connect(self, warmup: bool = True) -> None:
+        return None
+
+    def disconnect(self) -> None:
+        return None
+
+    def read(self) -> np.ndarray:
+        return np.zeros((6, 8, 3), dtype=np.uint8)
+
+    def async_read(self, timeout_ms: float = 1000) -> np.ndarray:
+        return self.read()
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    """Install the stand-in for every camera the tool opens."""
+    cam = _Recorder()
+    monkeypatch.setattr(cam_mod, "_create_camera", lambda *a, **k: cam)
+    return cam
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(block["text"] for block in result["content"] if "text" in block)
+
+
+def _recording_imwrite(written: list[str]) -> Callable[[str, Any], bool]:
+    """A ``cv2.imwrite`` stand-in that records its path and reports success.
+
+    Named rather than a lambda because the one-line form would have to be
+    ``written.append(path) or True``, and ``list.append`` returns ``None``.
+    """
+
+    def imwrite(path: str, img: Any) -> bool:
+        written.append(path)
+        return True
+
+    return imwrite
+
+
+class TestTheCameraToolRefusesAnEscapingName:
+    """``filename`` and ``format`` are agent-supplied and both reach the path."""
+
+    @pytest.mark.parametrize("action", ["capture", "record"])
+    @pytest.mark.parametrize("filename", ["../escaped", "../../../../tmp/escaped"])
+    def test_an_escaping_filename_is_refused(
+        self, recorder: _Recorder, tmp_path: Path, action: str, filename: str
+    ) -> None:
+        result = cam_mod.lerobot_camera(
+            action=action,
+            camera_id=0,
+            save_path=str(tmp_path / "captures"),
+            filename=filename,
+            capture_duration=0.01,
+        )
+        assert result["status"] == "error", result
+        assert "outside the directory it must be written into" in _text(result)
+
+    def test_an_escaping_format_is_refused(self, recorder: _Recorder, tmp_path: Path) -> None:
+        """The extension is the other half of the same composed name."""
+        result = cam_mod.lerobot_camera(
+            action="capture",
+            camera_id=0,
+            save_path=str(tmp_path / "captures"),
+            filename="shot",
+            format="jpg/../../../../tmp/escaped.jpg",
+        )
+        assert result["status"] == "error", result
+        assert "outside the directory it must be written into" in _text(result)
+
+    def test_an_escaping_filename_is_refused_for_a_batch(self, recorder: _Recorder, tmp_path: Path) -> None:
+        result = cam_mod.lerobot_camera(
+            action="capture_batch",
+            camera_ids=[0],
+            save_path=str(tmp_path / "captures"),
+            filename="../escaped",
+        )
+        # Batch renders each camera's outcome into the summary text and reports
+        # "error" only when no camera succeeded, which is the case here.
+        assert result["status"] == "error", result
+        assert "outside the directory it must be written into" in _text(result)
+
+    def test_nothing_is_written_outside_the_directory(self, recorder: _Recorder, tmp_path: Path) -> None:
+        """The property under test, asserted on the filesystem rather than the message."""
+        root = tmp_path / "captures"
+        before = sorted(p.name for p in tmp_path.iterdir())
+        cam_mod.lerobot_camera(
+            action="capture",
+            camera_id=0,
+            save_path=str(root),
+            filename="../escaped",
+        )
+        # ``captures`` itself is created by the tool before the name is resolved,
+        # so it is the only permissible addition.
+        after = sorted(p.name for p in tmp_path.iterdir())
+        assert [n for n in after if n not in before] == ["captures"]
+        assert not (tmp_path / "escaped.jpg").exists()
+
+
+class TestTheCameraToolStillHonorsEveryWorkingName:
+    """Containment must not become a vocabulary, which #2559 decided against."""
+
+    @pytest.mark.parametrize("format", ["jpg", "png", "bmp", "tiff"])
+    def test_an_unlisted_extension_is_still_honored(
+        self, recorder: _Recorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, format: str
+    ) -> None:
+        written: list[str] = []
+        monkeypatch.setattr(cam_mod.cv2, "imwrite", _recording_imwrite(written))
+        monkeypatch.setattr(os.path, "getsize", lambda path: 1)
+
+        result = cam_mod.lerobot_camera(
+            action="capture",
+            camera_id=0,
+            save_path=str(tmp_path / "captures"),
+            filename="shot",
+            format=format,
+        )
+
+        assert result["status"] == "success", result
+        assert written and written[0].endswith(f"shot.{format}")
+
+    def test_a_filename_with_a_space_is_still_honored(
+        self, recorder: _Recorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A containment check has no reason to refuse this; an allowlist would."""
+        written: list[str] = []
+        monkeypatch.setattr(cam_mod.cv2, "imwrite", _recording_imwrite(written))
+        monkeypatch.setattr(os.path, "getsize", lambda path: 1)
+
+        result = cam_mod.lerobot_camera(
+            action="capture",
+            camera_id=0,
+            save_path=str(tmp_path / "captures"),
+            filename="my capture",
+            format="jpg",
+        )
+
+        assert result["status"] == "success", result
+        assert written and written[0].endswith("my capture.jpg")
+
+
+class TestThePoseToolRefusesAnEscapingRobotId:
+    """``robot_id`` becomes part of the pose file's name."""
+
+    @pytest.mark.parametrize("robot_id", ["../escaped", "../../../../tmp/escaped"])
+    def test_an_escaping_robot_id_is_refused(self, tmp_path: Path, robot_id: str) -> None:
+        from strands_robots.tools.pose_tool import PoseManager
+
+        with pytest.raises(ValueError, match="outside the directory it must be written into"):
+            PoseManager(robot_id, storage_dir=tmp_path / "poses")
+
+    def test_a_normal_robot_id_still_resolves_inside(self, tmp_path: Path) -> None:
+        from strands_robots.tools.pose_tool import PoseManager
+
+        manager = PoseManager("so101_follower", storage_dir=tmp_path / "poses")
+        root = os.path.realpath(str(tmp_path / "poses"))
+        assert os.path.commonpath([root, str(manager.pose_file)]) == root
+        assert manager.pose_file.name == "so101_follower_poses.json"
+
+    def test_the_tool_reports_the_refusal_in_its_own_envelope(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Not as an exception: every other refusal in this tool is an error dict."""
+        from strands_robots.tools import pose_tool as pose_mod
+
+        monkeypatch.chdir(tmp_path)
+        result = pose_mod.pose_tool(action="list_poses", robot_id="../escaped")
+
+        assert result["status"] == "error", result
+        assert "outside the directory it must be written into" in _text(result)


### PR DESCRIPTION
## What

`validate_save_path` guards the directory a tool writes into. The *file* is composed afterwards, from separate caller-supplied parameters, and joined onto the directory that guard returned:

```python
save_path = validate_save_path(save_path, label="save_path")   # checked
file_path = os.path.join(save_path, f"{filename}.{format}")    # not checked
```

`os.path.join` walks back out of its first argument whenever the second asks it to, so the `..` traversal that guard refuses in `save_path` was reachable through `filename` or `format` instead -- the halves of the path nothing looked at -- and the write reported `status="success"` at whatever location it had reached.

## Measurement

Composition only, on the resolved directory a *passing* `validate_save_path` returns:

```
validated save_path: /tmp/robots_probe/captures

 filename='shot' format='jpg'
   realpath : /tmp/robots_probe/captures/shot.jpg          escapes: False

 filename='../../../../tmp/robots_probe/escaped_via_filename' format='jpg'
   realpath : /tmp/robots_probe/escaped_via_filename.jpg   escapes: True

 filename='shot' format='jpg/../../../../tmp/robots_probe/escaped_via_format.jpg'
   realpath : /tmp/robots_probe/escaped_via_format.jpg     escapes: True
```

The third row is the one worth noting: the stem is legitimate and the escape is carried entirely by the extension -- a parameter whose documented role is to pick an image format.

## Why containment, and not the allowlist already in the tree

`lerobot_calibrate.get_calibration_path` already guards this exact class with a function-local `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` and the comment "Security hardening: restrict path components to prevent traversal". Reusing it would have been the smaller-looking change, and it was measured and rejected, because it decides more than is needed and collides with a decision already on record.

#2559 held `color_mode` and `rotation` to closed vocabularies and **deliberately left `format` out**, pinned in `test_lerobot_camera_vocabulary_options.py`:

> `format` is deliberately outside this domain. Unlike the two selectors, an unlisted `format` is *honored* rather than replaced -- it becomes the saved file's extension and OpenCV writes it if it can -- so narrowing it to the three names the docstring lists would refuse working requests.

That reasoning is sound, and it is what makes this defect possible: `format` reaching the path is the feature, and nothing confined it to a single component. An allowlist would also have refused `my capture.jpg`, which works today.

So what is asserted is narrower and exactly statable -- **the resolved write target lies inside the resolved directory** -- checked after resolution, on the composed path. That is orthogonal to which extensions are allowed, so it closes the traversal without reopening #2559's decision, and it needs no guess about which characters are dangerous on which platform. Resolving with `realpath` also means a symlink inside the directory cannot be used to step outside it.

A name that stays inside is accepted whatever it is spelled with, including one naming a subdirectory (`a/b.jpg`). That is not an oversight: it is contained, and if the subdirectory does not exist the write fails loudly rather than landing somewhere else.

## Changes

- `strands_robots/tools/_path_validation.py` -- new `resolve_output_path(directory, name, *, label)`. Added here because this module's stated job is the path guards every tool imports, and it owned only the directory half of a write target. The out-of-bounds and names-the-directory-itself cases are reported separately, because the first message would otherwise have to say a path inside the directory is outside it.
- `strands_robots/tools/lerobot_camera.py` -- the three composition sites (`capture`, `capture_batch`, `record`) resolve through it; `filename` and `format` docstrings state the refusal.
- `strands_robots/tools/pose_tool.py` -- `PoseManager` resolves its pose file through it. `PoseManager` is constructed *outside* the tool's own `try`, so the refusal is caught explicitly there -- otherwise it would leave the tool as an exception instead of the error envelope every other refusal in it uses.
- `tests/tools/test_output_path_is_confined_to_its_directory.py`
- `changelog.d/2567-output-path-confined-to-validated-directory.md`

## Scope

Two sites are deliberately **not** touched, both already correct:

- `_configure_camera_settings` composes its name from `camera_type`, which `_create_camera` refuses before the name is built, and a `camera_id` whose separators are already stripped.
- `lerobot_calibrate.get_calibration_path` is not defective, so its local allowlist is left alone rather than migrated for symmetry.

No vocabulary is narrowed, added or reweighted, and no accepted value becomes refused except one that resolves outside its directory.

## Verification

```
tests/tools/test_output_path_is_confined_to_its_directory.py    32 passed
tests/tools/test_path_validation.py
tests/tools/test_lerobot_camera.py
tests/tools/test_lerobot_camera_vocabulary_options.py
tests/tools/test_lerobot_camera_numeric_options.py
tests/tools/test_lerobot_camera_async_read_budget.py
tests/tools/test_pose_tool*.py
tests/tools/test_lerobot_calibrate.py                         652 passed
tests/tools/test_agent_tool_parameter_descriptions.py
tests/tools/test_public_member_docstrings.py
tests/tools/test_docstring_module_xrefs.py
tests/test_log_strings_are_ascii.py
tests/test_except_tuples_state_their_real_scope.py              77 passed
ruff check / ruff format --check                              clean
mypy on the changed files, tests included                    no errors
non-ASCII in changed files                                   none
```

The local environment could not resolve lerobot 0.6's CUDA wheel set, so `lerobot.cameras` was supplied by a stub. Five tests in `test_lerobot_camera.py` depend on the real package (`OpenCVCamera.find_cameras`, the RealSense config dataclass) and fail under it. They fail **identically on a pristine `main` with the same stub**, so they are an artifact of that environment rather than of this change; CI exercises them against the real dependency.

Both halves are pinned: a traversal is refused at each site and nothing lands outside the directory (asserted on the filesystem, not only on the message), and every value that worked before still works -- `jpg`, `png`, `bmp`, `tiff`, and a filename containing a space.

Closes #2567

## Round changelog

- **Round 0** -- initial submission. The first push failed `hatch run lint`: mypy rejected a `cv2.imwrite` stand-in written as `lambda path, img: written.append(path) or True`, because `list.append` returns `None`. Replaced with a named, typed helper, and mypy re-run over the test file as well as the source -- which is what the table above now reports, and what the local run had checked only for the source. That gate runs before the test step, so no test result had been produced yet. No behaviour in the change itself was affected, and the branch is still a single commit.