### PR TITLE
fix(ci): refuse a local-checkout flag in the mode that reads no checkout

### DIFF
--- a/changelog.d/2570-all-open-refuses-a-local-checkout-flag.md
+++ b/changelog.d/2570-all-open-refuses-a-local-checkout-flag.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **ci**: `check_merge_base_overlap.py --all-open` now refuses `--repo` instead of
+  silently accepting it. The sweep reads the open set from the API and is handed
+  none of `--repo`, so a caller who named the repository that way - the spelling
+  the four sibling gate scripts use for `owner/name` - had it read as a filesystem
+  path while the sweep read `$GITHUB_REPOSITORY`, reporting cleanly and exiting `0`
+  for a repository nobody asked about. The refusal names `--github-repo`, which is
+  the flag that does name the repository the sweep reads. `--head` was already
+  refused for the same reason; neither flag's meaning changes, so the
+  single-branch path and the CI invocation are untouched.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -156,10 +156,17 @@ Usage
                 landed does not carry that gate's script (issue #1791). Sound
                 because every input below is read from the object database and
                 never from the working tree.
-``--repo``      repository root (default: the current working directory).
+``--repo``      repository root (default: the current working directory). One
+                branch only: the sweep reads no checkout, so ``--all-open``
+                refuses it rather than ignoring it. The sibling gate scripts
+                spell ``owner/name`` ``--repo``, so a caller who reaches for it
+                here names a path, the sweep reads ``$GITHUB_REPOSITORY``
+                instead, and the report describes a repository nobody asked
+                about (issue #2569).
 
 ``--all-open``  Sweep the open set instead of one branch (see above). Mutually
-                exclusive with ``--head``, which names one commit.
+                exclusive with ``--head`` and ``--repo``, which name a local
+                commit and a local checkout.
 ``--github-repo``
                 ``owner/name`` for ``--all-open`` (default:
                 ``$GITHUB_REPOSITORY``). Deliberately not ``--repo``: in this
@@ -818,11 +825,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    # Mutually exclusive rather than ignored: --head names one commit and the
-    # sweep reads none, so honouring both would answer a question the caller did
-    # not ask while looking like it had.
+    # Mutually exclusive rather than ignored: --head names one commit and --repo
+    # one checkout, and the sweep reads neither, so honouring either would answer
+    # a question the caller did not ask while looking like it had. --repo is the
+    # one a caller is most likely to pass by mistake, because the sibling gate
+    # scripts spell owner/name --repo: accepted as a path, it leaves the sweep
+    # reading $GITHUB_REPOSITORY and reporting on a repository nobody asked about
+    # (issue #2569). Every value-bearing flag the sweep does read is passed to
+    # _run_sweep below, which is what pins this partition rather than a list.
     if args.all_open and args.head is not None:
         parser.error("--all-open sweeps the open set and reads no local commit; --head names one branch")
+    if args.all_open and args.repo is not None:
+        parser.error(
+            "--all-open sweeps the open set from the API and reads no local checkout; --repo names one. "
+            "To name the repository the sweep reads, pass --github-repo owner/name."
+        )
     if args.all_open:
         if not args.github_repo:
             parser.error("--all-open needs --github-repo owner/name (or $GITHUB_REPOSITORY)")

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -25,7 +25,9 @@ CI, pinned by ``test_a_merge_commit_head_defeats_the_check``.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import inspect
 import subprocess
 import sys
 from collections.abc import Callable
@@ -950,6 +952,161 @@ def test_all_open_and_head_are_mutually_exclusive(tmp_path: Path) -> None:
     with pytest.raises(SystemExit) as raised:
         check.main(["--all-open", "--head", "abc123", "--github-repo", "owner/name", "--token", "t"])
     assert raised.value.code == 2
+
+
+def _flag_partition() -> tuple[dict[str, str], set[str]]:
+    """Split ``main``'s value-bearing flags into what the sweep reads and what it does not.
+
+    Derived from the source rather than listed. Every value the sweep reads is
+    passed to ``_run_sweep``, so its complement is exactly the set of flags only
+    the single-branch path consults -- which is the partition the mutual-exclusion
+    checks have to cover. A flag added later lands on one side or the other
+    without this test being edited.
+
+    ``store_true`` flags are skipped: they select the mode rather than carry an
+    input it could read.
+    """
+    options: dict[str, str] = {}
+    swept: set[str] = set()
+    for node in ast.walk(ast.parse(inspect.getsource(check.main))):
+        if not isinstance(node, ast.Call):
+            continue
+        called = ast.unparse(node.func)
+        if called.endswith("add_argument") and node.args and isinstance(node.args[0], ast.Constant):
+            option = str(node.args[0].value)
+            if not option.startswith("--"):
+                continue
+            if any(
+                keyword.arg == "action"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value == "store_true"
+                for keyword in node.keywords
+            ):
+                continue
+            options[option.removeprefix("--").replace("-", "_")] = option
+        elif called == "_run_sweep":
+            swept.update(
+                argument.attr
+                for argument in node.args
+                if isinstance(argument, ast.Attribute) and ast.unparse(argument).startswith("args.")
+            )
+    return options, swept
+
+
+_FLAG_OPTIONS, _SWEEP_READS = _flag_partition()
+
+#: Flags the sweep is handed none of, so passing one to ``--all-open`` describes a
+#: run that is not happening.
+_SWEEP_IGNORES = tuple(sorted(set(_FLAG_OPTIONS) - _SWEEP_READS))
+
+
+def _refusal(argv: list[str], captured: pytest.CaptureFixture[str]) -> str:
+    """Run ``main`` expecting an argparse refusal and return the message it gave.
+
+    Only the text after ``error:`` -- argparse prints the whole usage line first,
+    and the usage line names every flag, so asserting against the full stderr
+    would pass whatever the refusal said.
+
+    An accepted call is reported as what it did rather than as a missing raise:
+    the run went ahead reading a value it was never handed, which is the thing
+    being pinned.
+    """
+    try:
+        code = check.main(argv)
+    except SystemExit as refused:
+        assert refused.code == 2, f"expected an argparse refusal, got exit {refused.code}"
+        return captured.readouterr().err.split("error:", 1)[1].strip()
+    raise AssertionError(
+        f"argparse accepted {' '.join(argv)} and the run went ahead (exit {code}): the sweep is handed "
+        "none of that flag, so the value named nothing and the report describes whatever "
+        "$GITHUB_REPOSITORY names instead"
+    )
+
+
+def test_all_open_and_repo_are_mutually_exclusive(capsys: pytest.CaptureFixture[str]) -> None:
+    """``--repo`` names one checkout and the sweep reads none, so it is refused too.
+
+    The same reasoning as ``--head`` above, on the flag a caller is far more
+    likely to reach for: the sibling gate scripts spell ``owner/name`` ``--repo``,
+    so ``--repo strands-labs/robots --all-open`` reads as naming the repository.
+    Accepted as a path it named nothing -- the sweep read ``$GITHUB_REPOSITORY``
+    and reported on whatever repository the command happened to be running in,
+    exiting ``0`` with a report shaped exactly like the right one. Measured before
+    this refusal, run from a checkout of a fork: the same command reported ``0 open
+    non-draft pull request(s)`` for the fork, where naming the intended repository
+    reports 10.
+
+    So the refusal also names ``--github-repo``: a caller who passed ``--repo``
+    wanted the repository named, and that is the flag that names it.
+    """
+    message = _refusal(
+        ["--all-open", "--repo", "strands-labs/robots", "--github-repo", "owner/name", "--token", "t"],
+        capsys,
+    )
+    assert "--repo" in message
+    assert "--github-repo" in message, f"the refusal must name the flag that does name a repository: {message!r}"
+
+
+@pytest.mark.parametrize("dest", _SWEEP_IGNORES)
+def test_a_flag_the_sweep_is_handed_none_of_is_refused_rather_than_ignored(
+    dest: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Every flag outside ``_run_sweep``'s arguments is refused by ``--all-open``.
+
+    The root-cause form of the two named tests around it: the rule is a property
+    of the partition, not of the two flags that happen to be on the local side
+    today, so a third one is graded on arrival rather than silently ignored.
+    """
+    option = _FLAG_OPTIONS[dest]
+    message = _refusal(
+        ["--all-open", option, "placeholder", "--github-repo", "owner/name", "--token", "t"],
+        capsys,
+    )
+    assert option in message, f"the refusal must name the flag it refused: {message!r}"
+
+
+def test_the_partition_is_derived_and_finds_both_sides() -> None:
+    """Non-vacuity: a derivation that found nothing would grade nothing.
+
+    Pinned as the two sets rather than a count, because each side carries a
+    different obligation -- the sweep's own inputs are refused when *missing*
+    (above), and the local ones when *present*.
+    """
+    assert _SWEEP_READS == {"github_repo", "base_ref", "token"}, _SWEEP_READS
+    assert set(_SWEEP_IGNORES) == {"head", "repo"}, _SWEEP_IGNORES
+
+
+def test_the_flag_both_modes_read_is_not_refused_by_the_sweep(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``--base-ref`` is handed to the sweep, so naming it is not a mistake.
+
+    The boundary: the refusal is scoped to flags the sweep is handed none of, not
+    to every flag the single-branch path also happens to read.
+    """
+    monkeypatch.setattr(check, "_get", _api([], {}, base="release"))
+    monkeypatch.chdir(tmp_path)
+    assert check.main(["--all-open", "--base-ref", "release", "--github-repo", "owner/name", "--token", "t"]) == 0
+
+
+def test_one_branch_still_reads_the_checkout_path(repo: Path) -> None:
+    """``--repo`` is refused by the sweep only; it stays the single-branch input.
+
+    Which is what makes the refusal a scoping statement rather than a removal.
+    """
+    _branch_editing_shared(repo)
+    assert check.main(["--repo", str(repo), "--base-ref", "main", "--head", "HEAD"]) == 0
+
+
+def test_the_head_refusal_is_unchanged(capsys: pytest.CaptureFixture[str]) -> None:
+    """Each refusal stays specific to the flag it refused.
+
+    Collapsing them into one message would lose the ``--github-repo`` pointer,
+    which is the half a caller who reached for ``--repo`` needs.
+    """
+    message = _refusal(
+        ["--all-open", "--head", "abc123", "--github-repo", "owner/name", "--token", "t"],
+        capsys,
+    )
+    assert message == "--all-open sweeps the open set and reads no local commit; --head names one branch"
 
 
 @pytest.mark.parametrize("missing", ["--github-repo", "--token"])


### PR DESCRIPTION
`--all-open` sweeps the open set from the API. Every value it reads is handed to `_run_sweep`: `--github-repo`, `--base-ref`, `--token`. `--head` and `--repo` name local git inputs it reads none of, and the script already refuses `--head` for exactly that reason:

> Mutually exclusive rather than ignored: `--head` names one commit and the sweep reads none, so honouring both would answer a question the caller did not ask while looking like it had.

`--repo` was silently accepted. It is also the flag a caller reaches for, because the four sibling gate scripts spell `owner/name` `--repo` (`check_duplicate_claim`, `check_pr_head_is_current`, `check_last_push_approval`, `check_closing_reference`). Accepted here as a filesystem path it named nothing: the sweep read `$GITHUB_REPOSITORY` instead, and the report described whatever repository the command happened to be running in.

Measured on `d464c04`, run from a checkout of a fork:

| command | exit | report |
| --- | --- | --- |
| `--all-open --repo strands-labs/robots` | **0** | `cagataycali/robots`, base `main`: **0 open** non-draft pull request(s), 0 pair(s) compared |
| `--all-open --github-repo strands-labs/robots` | 1 | `strands-labs/robots`, base `main`: **10 open** non-draft pull request(s), 45 pair(s) compared |

A clean report for a repository nobody asked about, exiting `0` - which is the harm AGENTS.md step 1 records for the sibling intake check ("a wrong answer shaped exactly like the right one"), and the reason that one refuses an inferred repository. `--github-repo`'s own docstring already anticipates the ambiguity ("one flag that means a filesystem path in one mode and a slug in the other is the kind of ambiguity a caller discovers by getting a wrong answer") - the flag was separated, the refusal was not added.

## Change

Extend the existing mutual exclusion to `--repo`, and name `--github-repo` in the refusal: a caller who passed `--repo` wanted the repository named, and that is the flag that names it.

```
error: --all-open sweeps the open set from the API and reads no local checkout; --repo names one.
       To name the repository the sweep reads, pass --github-repo owner/name.
```

No rename, and no change to what either flag means, so the single-branch path and the CI invocation (`--base-ref ... --head ...`, no `--repo`) are untouched. The `--repo` docstring entry now says it is single-branch only.

The test derives the partition from the source rather than listing it - every value-bearing flag outside `_run_sweep`'s arguments must be refused - so a third local-only flag is graded on arrival instead of silently ignored. Derived today: the sweep reads `{base_ref, github_repo, token}` and is handed none of `{head, repo}`.

## Verification

Measured at `cd46bb1`.

Pre-fix split, the new tests against `d464c04`: **2 failed / 54 passed** -> 56 passed. Both failures name what happened rather than a missing raise:

```
AssertionError: argparse accepted --all-open --repo strands-labs/robots --github-repo owner/name
--token t and the run went ahead (exit 1): the sweep is handed none of that flag, so the value
named nothing and the report describes whatever $GITHUB_REPOSITORY names instead
```

The five tests that pass on both trees are the boundary, and each fails for a specific wrong fix: `--base-ref` is handed to the sweep so naming it is **not** refused; the single-branch path still reads `--repo`; `--head`'s refusal stays byte-identical (collapsing the two messages would lose the `--github-repo` pointer); and the derivation is pinned non-vacuously in both directions.

Blast radius, 117 files - every test naming a gate script or `AGENTS.md`, every guard that walks the test tree or grades sources, plus the repo-wide guards:

| tree | failed | passed | skipped | collected |
| --- | --- | --- | --- | --- |
| this branch | 0 | 4138 | 82 | 4220 |
| `d464c04` + the new tests | 2 | 4136 | 82 | 4220 |

Branch-only failures: none. Base-only: exactly the two pre-fix failures above, no others. No failure is shared by the two trees. `mypy strands_robots tests tests_integ` is 24 errors on both, none in the changed files; `ruff check` and `ruff format --check` clean.

## The report the two spellings produce

Same command, same environment, both trees. The control is the second block of each panel: the documented spelling is byte-identical on both trees, so what changes is only which spelling is allowed to describe a run that is not happening.

![--all-open refuses a local-checkout flag](https://raw.githubusercontent.com/cagataycali/robots/media-all-open-local-flag/all-open-refuses-a-local-flag.png)

Closes #2569.

### Scope

The issue also asked whether `--repo` should be renamed so the two scripts teach one vocabulary. That question is already answered in this script and against the rename: `--github-repo` exists precisely so the slug meaning has its own spelling, with the reasoning in the docstring. Renaming `--repo` would break every existing caller of the single-branch path to restate a decision already made, so this change adds the refusal the separation was missing and leaves both flags' meanings alone.
