### PR TITLE
fix(ci): refuse a flag the open-set sweep cannot honour

### DIFF
--- a/changelog.d/2571-sweep-refuses-a-flag-it-cannot-honour.md
+++ b/changelog.d/2571-sweep-refuses-a-flag-it-cannot-honour.md
@@ -1,0 +1,23 @@
+### Fixed: the open-set overlap sweep refuses a `--repo` it cannot honour
+
+`scripts/check_merge_base_overlap.py --all-open` parsed `--repo` and dropped it. In
+this script `--repo` is the local checkout path and the sweep reads no checkout - it
+resolves the open set from the API, keyed on `--github-repo`. The sibling intake check
+spells the API repository exactly that way (`check_duplicate_claim.py --repo
+strands-labs/robots`), so a caller reaching for it here is reaching for the repository
+to sweep.
+
+Measured from a scheduled agent whose checkout is another repository: `--repo
+strands-labs/robots --all-open` exited `0` with a clean report naming that other
+repository. Against the repository it meant, the same command reports 11 open pull
+requests, 55 pairs and 2 blocking pairs (`#1035 + #1722`, `#2480 + #2534`), so the
+clean report was hiding findings rather than merely misattributing them - the wrong
+answer shaped exactly like the right one that AGENTS.md step 1 documents for the
+sibling, in the mode step 12 asks a scheduled agent to run.
+
+`--all-open --repo` is now refused the way `--all-open --head` already was, and the
+message names `--github-repo owner/name` so the caller gets the spelling that works
+rather than deriving it from `--help` for two flags that differ by a prefix. The
+distinct spelling was the earlier remedy for the same ambiguity and it only separates
+the two for a caller who already knows which is which. Single-branch mode does read a
+checkout and keeps the flag.

--- a/scripts/check_merge_base_overlap.py
+++ b/scripts/check_merge_base_overlap.py
@@ -157,16 +157,21 @@ Usage
                 because every input below is read from the object database and
                 never from the working tree.
 ``--repo``      repository root (default: the current working directory).
+                Refused with ``--all-open``, which reads no checkout.
 
 ``--all-open``  Sweep the open set instead of one branch (see above). Mutually
-                exclusive with ``--head``, which names one commit.
+                exclusive with ``--head`` and with ``--repo``, neither of which
+                it reads.
 ``--github-repo``
                 ``owner/name`` for ``--all-open`` (default:
                 ``$GITHUB_REPOSITORY``). Deliberately not ``--repo``: in this
                 script ``--repo`` is already a local checkout path, and one flag
                 that means a filesystem path in one mode and a slug in the other
                 is the kind of ambiguity a caller discovers by getting a wrong
-                answer.
+                answer. Distinct spellings only keep the two apart for a caller
+                who already knows which is which, so ``--all-open --repo`` is
+                refused by a message naming this flag rather than accepted and
+                dropped.
 ``--token``     API token for ``--all-open`` (default: ``$GITHUB_TOKEN``). Needs
                 ``pull-requests: read``.
 
@@ -823,6 +828,19 @@ def main(argv: Sequence[str] | None = None) -> int:
     # not ask while looking like it had.
     if args.all_open and args.head is not None:
         parser.error("--all-open sweeps the open set and reads no local commit; --head names one branch")
+    # Same rule for --repo, which the sweep reads no more than it reads --head.
+    # This one earns a message naming --github-repo because the value a caller
+    # puts after --repo is evidence of what they meant: the sibling intake check
+    # spells owner/name that way, so reaching for it here is reaching for the
+    # repository to sweep, and accepting it silently answers for whatever
+    # $GITHUB_REPOSITORY happened to be -- a clean report about another
+    # repository, which is the shape of wrong answer this mode is least able to
+    # make a reader suspicious of.
+    if args.all_open and args.repo is not None:
+        parser.error(
+            "--all-open sweeps the open set and reads no checkout; --repo is a local path. "
+            "Name the repository to sweep with --github-repo owner/name"
+        )
     if args.all_open:
         if not args.github_repo:
             parser.error("--all-open needs --github-repo owner/name (or $GITHUB_REPOSITORY)")

--- a/tests/test_merge_base_overlap.py
+++ b/tests/test_merge_base_overlap.py
@@ -952,6 +952,70 @@ def test_all_open_and_head_are_mutually_exclusive(tmp_path: Path) -> None:
     assert raised.value.code == 2
 
 
+def _refuse_all_open_with_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> SystemExit:
+    """Run ``--all-open --repo <slug>`` with the wrong answer made available.
+
+    ``GITHUB_REPOSITORY`` is set to a repository the caller did not name and the
+    API is wired to a stand-in that fails if reached, so a refusal is the only way
+    through: dropping ``--repo`` and sweeping the inferred repository trips the
+    stand-in instead of exiting 2.
+    """
+    monkeypatch.setenv("GITHUB_REPOSITORY", "someone/elsewhere")
+
+    def unreachable(url: str, token: str) -> object:
+        raise AssertionError(f"the sweep read the API for a repository the caller did not name: {url}")
+
+    monkeypatch.setattr(check, "_get", unreachable)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as raised:
+        check.main(["--all-open", "--repo", "strands-labs/robots", "--token", "t"])
+    return raised.value
+
+
+def test_all_open_and_repo_are_mutually_exclusive(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``--repo`` is a checkout path, and the sweep reads no checkout.
+
+    Accepting it was not inert, which is why this is a behavioural pin rather than
+    an argument-parsing detail. Measured in the field (#2569): a scheduled agent
+    ran ``--repo strands-labs/robots --all-open`` from a checkout of another
+    repository and got exit ``0`` and a clean report naming
+    ``cagataycali/strands-gtc-nvidia`` -- the value was dropped, the API read went
+    to ``$GITHUB_REPOSITORY``, and the sweep answered for a repository nobody
+    asked about. Re-run against the intended one, the same command reported 11
+    open pull requests and 2 blocking pairs, so the clean report was not merely
+    misattributed; it was hiding findings.
+
+    The property was already asserted in prose by
+    ``test_the_sweep_refuses_to_run_without_its_own_inputs`` ("``--repo`` is not
+    consulted ... the sweep reads no checkout") and enforced by nothing.
+
+    That the refusal is not over-broad is pinned by the single-branch tests, which
+    reach ``main`` through ``--repo`` on every call (see ``_run_at``): the mode
+    that does read a checkout keeps the flag.
+    """
+    assert _refuse_all_open_with_repo(monkeypatch, tmp_path).code == 2
+
+
+def test_the_refusal_names_the_flag_that_does_name_a_repository(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 2 alone leaves the caller where the wrong answer did: guessing a spelling.
+
+    A caller who reaches for ``--repo`` to name the repository to sweep has
+    written the *sibling* intake check's flag for ``owner/name``
+    (``check_duplicate_claim.py --repo strands-labs/robots``), so the one thing
+    they need back is the spelling that works here. A refusal that only says
+    ``--repo`` is wrong sends them to ``--help`` to re-derive it, and the two
+    flags differ by a prefix, which is exactly the confusion that produced the
+    wrong report.
+    """
+    _refuse_all_open_with_repo(monkeypatch, tmp_path)
+
+    message = capsys.readouterr().err
+    assert "--github-repo" in message, message
+
+
 @pytest.mark.parametrize("missing", ["--github-repo", "--token"])
 def test_the_sweep_refuses_to_run_without_its_own_inputs(monkeypatch: pytest.MonkeyPatch, missing: str) -> None:
     """Neither input has a local fallback, so a missing one is refused, not guessed.


### PR DESCRIPTION
## Problem

`scripts/check_merge_base_overlap.py` accepts `--repo` in `--all-open` mode and does not read it. In this script `--repo` is the local checkout path, and the sweep reads no checkout - it resolves the open set from the API, keyed on `--github-repo` (default `$GITHUB_REPOSITORY`). So the value is parsed and dropped.

That is not inert, because the *sibling* intake check spells the API repository exactly that way:

```
scripts/check_duplicate_claim.py     --repo strands-labs/robots     # owner/name, inference refused
scripts/check_merge_base_overlap.py --repo <path>                  # local checkout path, silently unread by --all-open
```

A caller who reaches for `--repo` here is reaching for the repository to sweep. Measured in the field, from a scheduled agent whose checkout is another repository:

```
$ python3 scripts/check_merge_base_overlap.py --repo strands-labs/robots --all-open

`cagataycali/strands-gtc-nvidia`, base `main`: 1 open non-draft pull request(s), 0 pair(s) compared.

No pair in the open set shares a changed path [...] Nothing here needs a merge-order decision.
exit=0
```

The report was not merely misattributed. Against the repository the caller meant, the same sweep reports:

| swept | open PRs | pairs | blocking pairs | prose-only | unevaluated | exit |
| --- | --- | --- | --- | --- | --- | --- |
| `$GITHUB_REPOSITORY` (dropped `--repo`) | 1 | 0 | 0 | 0 | 0 | 0 |
| `strands-labs/robots` (what was asked for) | 11 | 55 | **2** | 1 | 2 | 1 |

The two blocking pairs it was hiding are `#1035 + #1722` and `#2480 + #2534`. This is the failure mode AGENTS.md step 1 already documents for the sibling - "a wrong answer shaped exactly like the right one" - reached here through a flag rather than through an omission, and in the mode step 12 asks a scheduled agent to run, which is the caller whose checkout is least likely to be the repository in question.

The property was already asserted, in prose, by the test directly below the guard - `test_the_sweep_refuses_to_run_without_its_own_inputs`: "`--repo` is not consulted for either: in this script it is a checkout path, and the sweep reads no checkout." Enforced by nothing.

## Change

`--all-open --repo` is refused, the way `--all-open --head` already is thirty lines above it, and for the reason recorded there: honouring neither "would answer a question the caller did not ask while looking like it had."

The refusal names `--github-repo`:

```
check_merge_base_overlap.py: error: --all-open sweeps the open set and reads no checkout;
--repo is a local path. Name the repository to sweep with --github-repo owner/name
```

Exit `2` alone would leave the caller where the wrong answer did - deriving a spelling from `--help`, for two flags that differ by a prefix. Naming the one that works is the whole remedy for a caller who has just been told their flag is wrong.

**Scope.** Single-branch mode does read a checkout and keeps `--repo` unchanged; it is reached through that flag on every call in the git-topology tests (`_run_at`), so an over-broad refusal fails there rather than passing quietly.

This deliberately does **not** touch the `$GITHUB_REPOSITORY` default on `--github-repo`, which #2569 also raises. That is a separate decision with its own tradeoff - `tests/test_duplicate_claim_check.py` carries a reasoned scope note for the current behaviour - and it is not what produced the wrong report: the repository *was* named on the command line and dropped. Nor does it rename anything: the naming decision was already taken in #2565, and `--github-repo` is the outcome. What was missing is that a distinct spelling only separates two flags for a caller who already knows which is which.

## Tests

`tests/test_merge_base_overlap.py`, beside the `--head` pin it mirrors. The refusal is measured with the wrong answer *available*: `$GITHUB_REPOSITORY` is set to a repository the caller did not name, and `_get` is replaced by a stand-in that fails if reached - so dropping `--repo` and sweeping the inferred repository trips the stand-in instead of exiting 2.

| tree | result |
| --- | --- |
| `main` + these two tests | **2 failed**, 49 passed |
| this branch | **51 passed** |

Both failures on `main` name the incident rather than a status code:

```
AssertionError: the sweep read the API for a repository the caller did not name:
https://api.github.com/repos/someone/elsewhere/pulls?state=open&per_page=100&page=1
```

The second test pins the message content, because a refusal that only rejects is what sent the caller looking in the first place.

## Verification

Blast radius = the 58 guard files that read `scripts/`, `changelog.d/`, `AGENTS.md` or walk the tree from the repo root; nothing else can see a script, a test file and a news fragment. Same selection, same environment, both trees:

| tree | failed | passed | skipped | errors |
| --- | --- | --- | --- | --- |
| this branch | 5 | **2547** | 145 | 5 |
| `main` (`d464c04`, pristine worktree) | 5 | **2545** | 145 | 5 |

The failure and error sets are identical and named on both sides - all ten are missing optional extras in this environment (`No module named 'lerobot'` / `'serial'`), none branch-only. Passed reconciles exactly: `+2` is the two new pins. The optional-extra modules could not be installed here, so the package-level suites did not run; CI runs them.

`ruff check` / `ruff format --check` clean on both changed files. `mypy tests/test_merge_base_overlap.py` - `Success: no issues found`, identical against a pristine `main` worktree.

## Dogfood

The command that produced the wrong report, and the two modes either side of it, run against this branch:

| command | result |
| --- | --- |
| `--repo strands-labs/robots --all-open` | exit **2**, refused, message names `--github-repo` |
| `--github-repo strands-labs/robots --all-open` | exit 1, the real report: 11 PRs, 55 pairs, 2 blocking |
| `--repo . --base-ref main --head HEAD` | exit 0, `No overlap` - single-branch mode unaffected |

The middle row is also this branch's step 12 sweep. It reports no blocking pair involving this pull request.

Fixes #2569
