### PR TITLE
fix(sim/isaac): refuse a render whose camera_name no camera carries

### DIFF
--- a/changelog.d/2575-isaac-render-refuses-an-uncarried-camera-name.md
+++ b/changelog.d/2575-isaac-render-refuses-an-uncarried-camera-name.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **sim/isaac**: `render` refuses a `camera_name` that names a camera the scene does not carry, with the same `Camera '<name>' not found. Available: [...]` verdict its own `get_frame` raises and the MuJoCo and Newton `render` give. It previously reported `status="success"` with an all-black frame sized from the config default, `pixel_mean` `0.0` as a measurement, the missing name in the `camera` field, and the PNG block the shared frame extractor reads - so a rollout recording a mistyped camera wrote an all-black video and reported success. A `camera_name` that names no camera at all (`None`, `""`, `"default"`, `"free"`) keeps that blank frame unchanged: this backend has no free camera to fall back to, and `"default"` is `render`'s own signature default.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -237,6 +237,22 @@ membership test itself raised `TypeError: unhashable type` for a list or dict
 name, so the miss escaped the envelope those methods document as their only
 failure channel - reachable with no entities registered at all.
 
+`render` is the one lookup that cannot answer with a frame, so it reports the
+same verdict as its raw sibling. Given a `camera_name` that *names* a camera the
+scene does not carry it returns `{"status": "error"}` with
+`Camera '<name>' not found. Available: [...]` - the message `get_frame` raises
+for the identical name, and the one the MuJoCo and Newton `render` give. It used
+to report `status="success"` with an all-black frame instead, tagged
+`Rendered (no camera)`, plus `pixel_mean` `0.0` as a measurement and the missing
+name in the `camera` field; because that envelope carries the PNG block the
+shared frame extractor reads, a rollout recording a mistyped camera wrote an
+all-black video and reported success. A `camera_name` that names *no* camera -
+`None`, `""`, `"default"` (the signature default) or `"free"` - still gets that
+blank frame: Isaac has no free camera to fall back to, unlike the two backends
+whose render entry points resolve those tokens to one, so for them it is a
+degradation rather than a mistake. Registering a camera under one of those names
+is accepted here and renders normally, since nothing on this backend routes them.
+
 ## Fleet (IsaacLab-style) preview
 
 ```python

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -45,6 +45,7 @@ from strands_robots.simulation.isaac.recording import IsaacRecordingMixin
 from strands_robots.simulation.models import registered, registry_entry
 from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
+    FREE_CAMERA_TOKENS,
     camera_fov_error,
     coerce_pose_vector,
     coerce_rgba,
@@ -4009,9 +4010,19 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         * ``Rendered (headless, no RTX)`` -- ``IsaacConfig.render_mode``
           is ``"headless"``; RTX path-tracing is unavailable. Most CI
           and GR00T server flows hit this path.
-        * ``Rendered (no camera)`` -- ``camera_name`` is unknown to
-          ``self._cameras``. Caller probably forgot to call ``add_camera``
-          (or typo'd the name).
+        * ``Rendered (no camera)`` -- no camera was *named*: ``camera_name``
+          is one of :data:`~strands_robots.utils.FREE_CAMERA_TOKENS` (this
+          method's own ``"default"`` signature default, ``None``, ``""`` or
+          ``"free"``) and this scene carries no camera under it. Caller
+          probably forgot to call ``add_camera``. Isaac has no free camera to
+          fall back to, unlike the backends whose render entry points resolve
+          those tokens to one, so a blank frame is the degradation. A
+          ``camera_name`` that *names* a camera this scene does not carry is a
+          caller mistake rather than a degradation and is refused with
+          ``Camera '<name>' not found. Available: [...]`` - the same verdict
+          :meth:`get_frame` gives for the identical name, and that the MuJoCo
+          and Newton ``render`` give too, so a typo cannot read as a
+          successful render of black pixels.
         * ``Rendered (Phase-1 camera, no RTX handle)`` -- the camera
           exists in ``self._cameras`` but its ``handle`` is ``None``.
           Happens when the camera was added before the
@@ -4099,7 +4110,8 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             ``(H, W, 3)`` array, ``depth`` a float32 ``(H, W)`` array, and
             ``meta`` carries ``text`` plus (RTX path) a ``json`` sub-dict. On
             failure ``rgb`` / ``depth`` are ``None`` and ``meta["error"]``
-            holds the human-readable reason.
+            holds the human-readable reason - an unusable pixel count, or a
+            ``camera_name`` that names a camera this scene does not carry.
         """
         with self._lock:
             if not self._world_created:
@@ -4131,8 +4143,34 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
                 )
 
             if not registered(self._cameras, camera_name):
-                # No camera configured - return blank. Caller probably
-                # forgot to call add_camera or typo'd the name.
+                # Two causes reach here and they need different answers. A
+                # caller who *named* a camera this scene does not carry made a
+                # mistake this method can name: refuse it with the same verdict
+                # this backend's own ``get_frame`` gives for the identical
+                # name, and that the MuJoCo and Newton ``render`` give too. A
+                # black frame under ``status="success"`` is not an answer to it
+                # - the json block reports ``pixel_mean`` 0.0 as a measurement
+                # and ``camera`` as the name that does not exist, the frame is
+                # sized from the config default rather than any camera, and the
+                # PNG block above it feeds the shared
+                # ``PolicyRunner._extract_frame_ndarray``, so a rollout
+                # recording that camera writes an all-black video and reports
+                # success.
+                #
+                # A caller who named *no* camera is the other cause, and the
+                # blank frame is this backend's documented degradation for it:
+                # Isaac has no free camera to fall back to, unlike the two
+                # backends whose render entry points resolve every
+                # ``FREE_CAMERA_TOKENS`` member to one, and ``"default"`` is
+                # this method's own signature default. Membership in that
+                # shared token set is the test, so the tuple's ``==`` per
+                # element keeps it total for an unhashable name.
+                if camera_name not in FREE_CAMERA_TOKENS:
+                    return (
+                        None,
+                        None,
+                        {"error": f"Camera '{camera_name}' not found. Available: {sorted(self._cameras)}"},
+                    )
                 return (
                     np.zeros((h, w, 3), dtype=np.uint8),
                     np.zeros((h, w), dtype=np.float32),

--- a/tests/simulation/isaac/test_render_refuses_a_camera_the_scene_does_not_carry.py
+++ b/tests/simulation/isaac/test_render_refuses_a_camera_the_scene_does_not_carry.py
@@ -1,0 +1,327 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests: Isaac's ``render`` refuses a camera the scene does not carry.
+
+:meth:`~strands_robots.simulation.isaac.simulation.IsaacSimulation.render`
+documents four blank-frame fallback paths, and one of them named *two* causes
+with one answer: "``camera_name`` is unknown to ``self._cameras``. Caller
+probably forgot to call ``add_camera`` (or typo'd the name)." Those two causes
+need different answers, and the typo half was answered with success.
+
+Measured on the pre-fix branch, one camera named ``wrist`` registered and
+``render_mode="rtx_realtime"``:
+
+* ``render("wrst")`` returned ``status="success"``, text ``Rendered (no
+  camera): 640x480``, ``pixel_mean`` **0.0**, and a ``json`` block naming
+  ``camera: "wrst"`` - a measurement of a camera that does not exist, sized
+  from the config default rather than from any camera.
+* the PNG block above that json feeds the shared
+  ``PolicyRunner._extract_frame_ndarray`` (``_rgb_png_block``'s own docstring
+  says so), so a rollout recording that camera writes an all-black video and
+  reports success.
+* the same name through this same class's :meth:`get_frame` raised ``KeyError:
+  Camera 'wrst' not found. Available: ['wrist']`` - one registry, one lock, one
+  question, two answers.
+* the MuJoCo and Newton ``render`` refuse it too, each with that same sentence,
+  so Isaac was the one cell of six (three backends x two readback surfaces)
+  that succeeded.
+
+The fix splits the branch by the docstring's own two causes.
+:data:`~strands_robots.utils.FREE_CAMERA_TOKENS` is the shared spelling of "no
+camera was *named*" - ``None``, ``""``, ``"default"`` and ``"free"``, one of
+which is this method's own signature default - and Isaac has no free camera to
+fall back to, so for those the blank frame stays exactly as documented. A name
+outside that set is a caller mistake this method can name, and it is refused
+with the verdict its own ``get_frame`` already gives.
+
+What each class pins:
+
+* ``TestRenderRefusesACameraTheSceneDoesNotCarry`` - the headline: a named
+  camera nothing carries is an error, and the message names the alternatives.
+* ``TestBothSurfacesGiveOneVerdictForOneName`` - the root cause: ``render`` and
+  ``get_frame`` report the *same* sentence for the same name, so the two cannot
+  drift into locally reworded copies again.
+* ``TestARefusalCarriesNoFrame`` - a refusal carries no PNG block and no pixel
+  statistics, so nothing downstream can mistake it for a frame.
+* ``TestTheRefusalIsTotal`` - a name that is not a string, and one that is not
+  even hashable, are refused rather than raising past the envelope.
+* ``TestTheDocumentedDegradationsAreUnchanged`` - the over-reach control, and
+  the reason the fix is scoped to a *named* camera: every one of the four
+  documented fallbacks still answers exactly as before, byte-for-byte, on both
+  the token path and in ``headless`` mode.
+* ``TestEveryBackendGivesTheSameVerdict`` - the parity pin: all three backends'
+  render path carry the one refusal sentence.
+* ``TestTheContractIsDocumented`` - the docstring states the split, so a caller
+  can discover which half of the old bullet they are in.
+
+None of this needs Isaac Sim or a GPU: the camera lookup runs before any RTX
+handle is read, and the handle itself is duck-typed - the skeleton-via-``__new__``
+fixture shape the sibling ``test_camera_readback_pixel_domain.py`` uses.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.config import IsaacConfig
+from strands_robots.simulation.isaac.simulation import IsaacSimulation, _CameraState
+from strands_robots.utils import FREE_CAMERA_TOKENS
+
+#: The registered camera's own render size, deliberately different from the
+#: config default below so a frame sized from the wrong source is visible.
+NATIVE_W, NATIVE_H = 64, 48
+
+#: The config's blank-frame size, which the pre-fix miss branch used.
+CONFIG_W, CONFIG_H = 640, 480
+
+#: The registered camera's name. Every "not carried" probe below is a name this
+#: scene does not hold.
+CAM = "wrist"
+
+#: Names that *name* a camera this scene does not carry: a typo of the
+#: registered one, a plausible camera name from another scene, and a name that
+#: differs only in case.
+NOT_CARRIED = ["wrst", "front", "agentview", "Wrist"]
+
+
+class _FakeCameraHandle:
+    """Duck-typed stand-in for the Isaac ``Camera`` sensor handle.
+
+    ``get_rgba`` returns a constant, distinctly non-black frame so a real
+    render is never confused with a blank fallback.
+    """
+
+    def __init__(self) -> None:
+        self.reads: list[str] = []
+
+    def get_rgba(self) -> np.ndarray:
+        self.reads.append("rgba")
+        return np.full((NATIVE_H, NATIVE_W, 4), 200, dtype=np.uint8)
+
+    def get_depth(self) -> np.ndarray:
+        self.reads.append("depth")
+        return np.full((NATIVE_H, NATIVE_W), 1.5, dtype=np.float32)
+
+
+def _engine(
+    *,
+    render_mode: str = "rtx_realtime",
+    handle: _FakeCameraHandle | None = None,
+    with_handle: bool = True,
+) -> IsaacSimulation:
+    """Skeleton ``IsaacSimulation`` carrying only what the render path reads.
+
+    ``render_mode`` must not be ``"headless"`` for the camera lookup to be
+    reached: that mode returns its own documented blank frame first.
+    """
+    engine = IsaacSimulation.__new__(IsaacSimulation)
+    engine._config = IsaacConfig(render_mode=render_mode, camera_width=CONFIG_W, camera_height=CONFIG_H)
+    engine._lock = threading.RLock()
+    engine._world = None
+    engine._world_created = True
+    engine._robots = {}
+    engine._objects = {}
+    engine._cameras = {}
+    engine._prim_registry = []
+    engine._cam_out_size = {}
+    engine._camera_warmup_steps = 0
+    engine._sim_time = 0.0
+    engine._step_count = 0
+    engine._main_tid = threading.get_ident()
+
+    cam = _CameraState(CAM, f"/World/cameras/{CAM}", NATIVE_W, NATIVE_H)
+    if with_handle:
+        cam.handle = handle if handle is not None else _FakeCameraHandle()
+    engine._cameras[CAM] = cam
+    return engine
+
+
+def _text(result: dict[str, Any]) -> str:
+    """The result's first text block, or ``""`` when it carries none."""
+    return next((b["text"] for b in result.get("content", []) if "text" in b), "")
+
+
+def _json(result: dict[str, Any]) -> dict[str, Any]:
+    """The result's json block, or ``{}`` when it carries none."""
+    return next((b["json"] for b in result.get("content", []) if "json" in b), {})
+
+
+def _get_frame_verdict(engine: IsaacSimulation, name: Any) -> str:
+    """The message ``get_frame`` reports for ``name``, as the sibling surface."""
+    try:
+        engine.get_frame(name)
+    except KeyError as refused:
+        # ``KeyError``'s ``str()`` quotes its argument; the message itself is arg 0.
+        return str(refused.args[0])
+    raise AssertionError(f"get_frame({name!r}) did not refuse a camera the scene does not carry")
+
+
+class TestRenderRefusesACameraTheSceneDoesNotCarry:
+    """A named camera nothing carries is an error, and the message names the alternatives."""
+
+    @pytest.mark.parametrize("name", NOT_CARRIED)
+    def test_the_result_is_an_error(self, name: str) -> None:
+        result = _engine().render(camera_name=name)
+        assert result["status"] == "error", (
+            f"render({name!r}) reported {result['status']!r} for a camera this scene does not "
+            f"carry, with text {_text(result)!r} and json {_json(result)!r}"
+        )
+
+    @pytest.mark.parametrize("name", NOT_CARRIED)
+    def test_the_message_names_the_cameras_that_are_carried(self, name: str) -> None:
+        text = _text(_engine().render(camera_name=name))
+        assert f"Camera '{name}' not found" in text, text
+        assert f"Available: ['{CAM}']" in text, text
+
+
+class TestBothSurfacesGiveOneVerdictForOneName:
+    """``render`` and ``get_frame`` report the same sentence for the same name.
+
+    They read the same registry under the same lock, so a name one refuses the
+    other cannot answer - and a locally reworded copy of the verdict is how the
+    two drifted apart in the first place.
+    """
+
+    @pytest.mark.parametrize("name", NOT_CARRIED)
+    def test_the_two_verdicts_are_identical(self, name: str) -> None:
+        engine = _engine()
+        rendered = _text(engine.render(camera_name=name))
+        raw = _get_frame_verdict(engine, name)
+        assert rendered == raw, f"render said {rendered!r}; get_frame said {raw!r}"
+
+
+class TestARefusalCarriesNoFrame:
+    """A refusal carries no PNG block and no pixel statistics.
+
+    ``render``'s success envelope carries a PNG block precisely so the shared
+    ``PolicyRunner._extract_frame_ndarray`` can pull frames for video
+    recording. A refusal that still carried one would put black pixels into a
+    recording under an error.
+    """
+
+    def test_no_image_block_is_emitted(self) -> None:
+        result = _engine().render(camera_name="wrst")
+        images = [b for b in result.get("content", []) if "image" in b]
+        assert images == [], f"a refusal carried {len(images)} image block(s)"
+
+    def test_no_pixel_statistics_are_reported(self) -> None:
+        payload = _json(_engine().render(camera_name="wrst"))
+        assert "pixel_mean" not in payload, payload
+        assert "pixel_variance" not in payload, payload
+
+    def test_the_refused_name_is_not_reported_as_the_camera(self) -> None:
+        payload = _json(_engine().render(camera_name="wrst"))
+        assert payload.get("camera") != "wrst", (
+            "the json block attributed the frame to a camera the scene does not carry"
+        )
+
+
+class TestTheRefusalIsTotal:
+    """A name of any type reaches a verdict rather than raising past the envelope.
+
+    ``registered`` is total by contract, and the token test is membership in a
+    *tuple*, whose ``==``-per-element comparison stays total for a name that is
+    not hashable at all.
+    """
+
+    @pytest.mark.parametrize("name", [7, 0, ["wrist"], {"name": "wrist"}, 1.5], ids=["7", "0", "list", "dict", "1.5"])
+    def test_a_non_string_name_is_refused(self, name: Any) -> None:
+        result = _engine().render(camera_name=name)
+        assert result["status"] == "error", f"render({name!r}) reported {result['status']!r}"
+        assert "not found" in _text(result), _text(result)
+
+
+class TestTheDocumentedDegradationsAreUnchanged:
+    """Every documented blank-frame fallback still answers exactly as before.
+
+    This is the over-reach control and the reason the fix is scoped to a
+    *named* camera: broadening it to every registry miss would turn Isaac's own
+    signature default into an error.
+    """
+
+    def test_a_carried_camera_still_renders_its_own_frame(self) -> None:
+        result = _engine().render(camera_name=CAM)
+        assert result["status"] == "success", _text(result)
+        assert _text(result) == "Rendered (RTX rtx_realtime): 64x48"
+        assert _json(result)["pixel_mean"] == pytest.approx(200.0 * 3 / 3)
+        assert _json(result)["camera"] == CAM
+
+    @pytest.mark.parametrize("token", list(FREE_CAMERA_TOKENS), ids=["None", "empty", "default", "free"])
+    def test_a_token_that_names_no_camera_keeps_the_blank_frame(self, token: str | None) -> None:
+        result = _engine().render(camera_name=token)  # type: ignore[arg-type]
+        assert result["status"] == "success", _text(result)
+        assert _text(result) == f"Rendered (no camera): {CONFIG_W}x{CONFIG_H}"
+
+    def test_the_signature_default_is_one_of_those_tokens(self) -> None:
+        default = inspect.signature(IsaacSimulation.render).parameters["camera_name"].default
+        assert default in FREE_CAMERA_TOKENS, f"render's default camera_name is {default!r}, which the fix would refuse"
+
+    @pytest.mark.parametrize("name", [CAM, "wrst"])
+    def test_headless_mode_answers_first_as_documented(self, name: str) -> None:
+        result = _engine(render_mode="headless").render(camera_name=name)
+        assert result["status"] == "success", _text(result)
+        assert _text(result) == f"Rendered (headless, no RTX): {CONFIG_W}x{CONFIG_H}"
+
+    def test_a_carried_camera_without_a_handle_keeps_its_blank_frame(self) -> None:
+        result = _engine(with_handle=False).render(camera_name=CAM)
+        assert result["status"] == "success", _text(result)
+        assert _text(result) == f"Rendered (Phase-1 camera, no RTX handle): {NATIVE_W}x{NATIVE_H}"
+
+    def test_a_refused_name_costs_no_render(self) -> None:
+        handle = _FakeCameraHandle()
+        engine = _engine(handle=handle)
+        engine.render(camera_name="wrst")
+        assert handle.reads == [], f"the refused name reached the RTX handle: {handle.reads}"
+
+
+#: The function on each backend that resolves ``render``'s ``camera_name``, and
+#: therefore owns the verdict for a name the scene does not carry. Isaac's
+#: ``render`` forwards to a private helper; the other two resolve inline.
+_RENDER_NAME_RESOLVERS = [
+    ("isaac", "strands_robots.simulation.isaac.simulation", "IsaacSimulation", "_render_frame"),
+    ("newton", "strands_robots.simulation.newton.simulation", "NewtonSimEngine", "render"),
+    ("mujoco", "strands_robots.simulation.mujoco.rendering", "RenderingMixin", "render"),
+]
+
+
+class TestEveryBackendGivesTheSameVerdict:
+    """All three backends' render path carry the one refusal sentence.
+
+    ``camera_fov_error``'s docstring states the invariant these backends share:
+    a camera configuration one refuses must be refused by the others. The name
+    of a camera is the same kind of fact, and this was the entry point that
+    answered a name nothing carries with a frame.
+    """
+
+    @pytest.mark.parametrize(("label", "module", "cls", "func"), _RENDER_NAME_RESOLVERS, ids=lambda p: str(p))
+    def test_the_resolver_refuses_an_uncarried_name(self, label: str, module: str, cls: str, func: str) -> None:
+        import importlib
+
+        owner = getattr(importlib.import_module(module), cls)
+        source = inspect.getsource(getattr(owner, func))
+        assert "not found. Available" in source, (
+            f"the {label} backend's render name resolver ({cls}.{func}) carries no "
+            "refusal for a camera name the scene does not carry"
+        )
+
+    def test_the_scan_reached_all_three_backends(self) -> None:
+        assert {row[0] for row in _RENDER_NAME_RESOLVERS} == {"isaac", "newton", "mujoco"}
+
+
+class TestTheContractIsDocumented:
+    """``render``'s docstring states the split, so a caller can find their half."""
+
+    def test_the_blank_frame_bullet_is_scoped_to_an_unnamed_camera(self) -> None:
+        doc = inspect.getdoc(IsaacSimulation.render) or ""
+        bullet = doc[doc.index("``Rendered (no camera)``") :]
+        bullet = bullet[: bullet.index("``Rendered (Phase-1")]
+        assert "FREE_CAMERA_TOKENS" in bullet, bullet
+
+    def test_the_docstring_names_the_refusal(self) -> None:
+        doc = inspect.getdoc(IsaacSimulation.render) or ""
+        assert "not found. Available" in doc, "render's docstring does not state the refusal it produces"

--- a/tests/simulation/isaac/test_render_refuses_a_camera_the_scene_does_not_carry.py
+++ b/tests/simulation/isaac/test_render_refuses_a_camera_the_scene_does_not_carry.py
@@ -298,7 +298,7 @@ class TestEveryBackendGivesTheSameVerdict:
     answered a name nothing carries with a frame.
     """
 
-    @pytest.mark.parametrize(("label", "module", "cls", "func"), _RENDER_NAME_RESOLVERS, ids=lambda p: str(p))
+    @pytest.mark.parametrize(("label", "module", "cls", "func"), _RENDER_NAME_RESOLVERS, ids=str)
     def test_the_resolver_refuses_an_uncarried_name(self, label: str, module: str, cls: str, func: str) -> None:
         import importlib
 


### PR DESCRIPTION
## Problem

`IsaacSimulation.render` documents four blank-frame fallback paths, and one of them named **two causes with one answer**:

> `Rendered (no camera)` -- `camera_name` is unknown to `self._cameras`. Caller probably forgot to call `add_camera` (or typo'd the name).

The typo half was answered with success. Measured with one camera named `wrist` registered and `render_mode="rtx_realtime"`:

```
render("wrst") -> status='success'
                  text='Rendered (no camera): 640x480'
                  json={'pixel_mean': 0.0, 'pixel_variance': 0.0, 'camera': 'wrst'}
                  image=PNG block present
```

Three things follow from that envelope:

- `pixel_mean` `0.0` is reported as a **measurement**, and `camera` names a camera that does not exist.
- the frame is `640x480` - the config default - rather than any camera's resolution.
- the PNG block above that json is emitted precisely so the shared `PolicyRunner._extract_frame_ndarray` can pull frames for video recording (`_rgb_png_block`'s own docstring says so). A rollout recording a mistyped camera therefore **writes an all-black video and reports success**.

The same name through this same class's `get_frame` raised `KeyError: Camera 'wrst' not found. Available: ['wrist']` - one registry, one lock, one question, two answers. And the sibling backends refuse it too, so Isaac's `render` was the one cell of six that succeeded:

| backend | `render(<name nothing carries>)` | `get_frame(<same name>)` |
| --- | --- | --- |
| MuJoCo | `status=error`, `Camera 'x' not found. Available: [...]` | `KeyError`, same sentence |
| Newton | `status=error`, same sentence | `KeyError`, same sentence |
| **Isaac** | **`status=success`**, black frame, `pixel_mean 0.0` | `KeyError`, same sentence |

## Change

Split the branch by the docstring's own two causes.

`FREE_CAMERA_TOKENS` is the shared spelling of "no camera was *named*" - `None`, `""`, `"default"` and `"free"`. A `camera_name` outside that set **names** a camera the scene does not carry: that is a caller mistake this method can name, and it is now refused with the verdict `get_frame` already gives. A token that names no camera keeps the blank frame **byte for byte**: Isaac has no free camera to fall back to, unlike the two backends whose render entry points resolve those tokens to one, and `"default"` is this method's own signature default - so broadening the refusal to every registry miss would turn a bare `render()` into an error.

The token test is membership in a *tuple*, whose `==`-per-element comparison stays total for a name that is not hashable at all, matching `registered`'s own totality contract.

Scope notes:

- `render_mode="headless"` answers before the camera lookup and is untouched: RTX produces no frames there at all, which is a degradation rather than a mistake.
- `reserved_camera_name_error` is deliberately **not** applied on this backend, and that stays true: its docstring records that Isaac routes no tokens, so `"default"` is an ordinary addressable name here. The token set is consulted only on a registry *miss*, so `add_camera("default", ...)` is still accepted and `render("default")` still renders it.
- the documented usage example in `docs/simulation/isaac.md` registers `front` via `add_camera` before rendering it, so it is unaffected.

`docs/simulation/isaac.md` already carried the paragraph enumerating the lookup surfaces and how each reports a miss - naming `get_frame` / `get_camera_params` but not `render`. It now names `render` too.

## Verification

Pre-fix split, the new test file copied onto `upstream/main`: **23 failed / 13 passed**, 36 passed after. Every behavioural failure carries the measurement, e.g.

```
AssertionError: render('wrst') reported 'success' for a camera this scene does not carry,
  with text 'Rendered (no camera): 640x480' and json {'pixel_mean': 0.0, 'pixel_variance': 0.0, 'camera': 'wrst'}
```

The 13 that pass on both trees are the controls, and each fails for a specific wrong fix: all four `FREE_CAMERA_TOKENS` members keep the blank frame byte for byte; the signature default is one of them; both `headless` cases answer first as documented; a carried camera with no RTX handle keeps its Phase-1 frame; a carried camera still renders its own frame; a refused name costs no handle read; and the MuJoCo and Newton parity rows were already green - only the Isaac row of that parity test flips.

Blast radius, 79 files (all of `tests/simulation/isaac` plus every test naming the shared camera domains or reading `AGENTS.md` / a docs page, plus the repo-wide guards), same selection on both trees:

| tree | failed | passed | skipped | collected |
| --- | --- | --- | --- | --- |
| this branch | 0 | 4101 | 29 | 4130 |
| `upstream/main` + the new test file | 23 | 4078 | 29 | 4130 |

Branch-only failing ids: empty. Base-only: exactly the 23 from the new file, none foreign. No failure is shared by the two trees. `mypy strands_robots tests tests_integ`: 24 errors on a pristine `upstream/main` worktree and 24 on the branch, none in the changed files. `ruff check` / `ruff format --check` clean.

## Artifact

Isaac Sim is not needed to see this: the camera lookup runs before any RTX handle is read, and the handle is duck-typed. Both columns below run the **same** capture script against a stand-in engine whose handle hands back a real 6-frame MuJoCo rollout - only `strands_robots` differs.

![Isaac render refuses an uncarried camera name](https://raw.githubusercontent.com/cagataycali/robots/media-isaac-render-uncarried-camera/isaac-render-uncarried-camera.png)

The `wrist` strip is the control: identical in both columns, byte for byte (mean `110.92003942418981`). The mistyped `wrst` name is where they diverge - on `upstream/main` six all-black frames (`mean 0.00`) each carrying a PNG block, so six frames reach a recording under success; on this branch the call is refused and nothing is recorded.
