### PR TITLE
ci: name the ruleset rule a blocked pull request has left unsatisfied

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -948,6 +948,52 @@ hatch run format            # ruff check --fix, ruff format
    still `APPROVED`, nine suites queued including the required one. #1988 has the
    full account.
 
+   **Two further causes need no second token, and one needs nothing at all.**
+   `mergeStateStatus` is one word for at least six situations and names none of
+   them, so the rule that is actually unsatisfied has to be read separately.
+   Measured 2026-08-21, both approved and green, both idle after approval because
+   a scheduled pass read `BLOCKED` and concluded the next move was a reviewer's:
+
+   | PR | approved | merged | idle | actually unsatisfied | who could clear it |
+   |---|---|---|---|---|---|
+   | #2566 | 16:39 | 17:10 | 31 min | one unresolved review thread | the author |
+   | #2574 | 16:25 | 17:10 | 45 min | nothing - a stale computation | anyone, by retrying |
+
+   #2566 sat on `required_review_thread_resolution`, which the ruleset carries:
+   one thread was open, its fix had already landed, and the reviewer had approved
+   *past* it. Resolving it flipped `blocked` to `clean` on the next read. #2574 had
+   zero threads and twelve green checks, and `blocked` was simply stale -
+   `mergePullRequest` refused with `Pull Request is not mergeable`, naming nothing,
+   and `PUT /repos/{owner}/{repo}/pulls/{n}/merge` then succeeded on the first
+   attempt with no state having changed in between.
+
+   Two consequences worth keeping. **A merge attempt is cheap and self-verifying**,
+   so `BLOCKED` on a pull request with no unsatisfied rule is not a reason to wait;
+   and **prefer REST for the attempt**, because its refusal names the requirement
+   that is unmet while the GraphQL mutation's does not.
+
+   Rather than infer which of these is operating, read it:
+
+   ```
+   python3 scripts/check_merge_blockers.py --repo strands-labs/robots --pr <N>
+   python3 scripts/check_merge_blockers.py --repo strands-labs/robots --all-open
+   ```
+
+   It reads the branch ruleset - so a rule that is changed in settings cannot
+   drift from this file - and names every rule the pull request leaves
+   unsatisfied together with the party who can clear it: a conflict or an
+   unresolved thread or a failing check (the author), a missing approval (any
+   reviewer), an approval only its own pusher supplied (a different reviewer,
+   per #1905), a required check absent because a fork run is held at
+   `action_required` (a maintainer), a check still running (nobody), or no
+   unsatisfied rule at all, which is the #2574 case and the one worth saying out
+   loud. A conflict or a draft is reported as *gating*: the rules behind it
+   cannot be assessed, so an approval there is necessary but not sufficient.
+
+   It composes `check_last_push_approval.py` rather than restating it, so what
+   counts as a current approval has one owner. Neither script gates a merge.
+   Pinned by tests/test_merge_blockers.py.
+
    This is worth the words because the failure mode is silent and expensive in the
    opposite direction from the usual one. Treating an advisory red as a merge
    blocker does not look like a mistake; it looks like diligence, and it costs a

--- a/changelog.d/2578-name-the-unsatisfied-merge-rule.md
+++ b/changelog.d/2578-name-the-unsatisfied-merge-rule.md
@@ -1,0 +1,15 @@
+### Added: a blocked pull request's report names the rule it left unsatisfied
+
+`scripts/check_merge_blockers.py` reads the branch ruleset and names every rule a
+pull request leaves unsatisfied, together with the party who can clear it -- a
+conflict, an unresolved review thread or a failing check (the author), a missing
+approval (any reviewer), an approval only its own pusher supplied (a different
+reviewer), a required check held at `action_required` (a maintainer), a check
+still running (nobody), or no unsatisfied rule at all, which means the state is
+stale and the merge is worth attempting.
+
+`mergeStateStatus: BLOCKED` is one word for all of these and names none of them,
+so two approved and green pull requests sat idle after approval on obligations
+their own authors could have cleared. Takes `--pr` for one pull request or
+`--all-open` to sweep the queue; composes `check_last_push_approval.py` so what
+counts as a current approval keeps one owner, and gates nothing.

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -1,0 +1,882 @@
+#!/usr/bin/env python3
+"""Name the branch-ruleset rule a blocked pull request has left unsatisfied.
+
+Why this exists
+---------------
+``mergeStateStatus: BLOCKED`` is one word for at least six unrelated
+situations, and it names none of them. The rule that is actually unsatisfied
+decides who owes the next action, so collapsing them loses the only fact a
+triage pass needs. Three cases measured in this repository on 2026-08-21, all
+reading ``blocked``, all needing different people:
+
+===========  ==========================================  ====================
+pull request what was actually unsatisfied               who could clear it
+===========  ==========================================  ====================
+#2566        one unresolved review thread, whose fix     **the author**
+             had already landed and which the reviewer
+             had approved past
+#2574        nothing at all -- the ``blocked`` was a      anyone, by retrying
+             stale computation, and the merge succeeded
+             on the first attempt with no state change
+#2497        no approving review yet                     any reviewer
+===========  ==========================================  ====================
+
+#2566 and #2574 both sat idle after approval (31 and 45 minutes) because a
+scheduled author-side pass read ``APPROVED`` plus green checks plus ``BLOCKED``
+and concluded the remaining obligation was somebody else's. It was not. That
+conclusion is the same one issue #1905 documents under the heading "it presents
+as reviewer bandwidth", reached through a different door: #1905's door is the
+``require_last_push_approval`` topology, and these two are not that, so nothing
+built for #1905 detects them.
+
+The missing read is cheap. The ruleset is published, every input it refers to
+is queryable, and no new policy or gate is needed to say which of its rules is
+unmet.
+
+Why the ruleset is read rather than inferred
+--------------------------------------------
+The rules in force are a property of the branch, not of this file, so hardcoding
+them would drift the moment one is changed in the repository settings. Read from::
+
+    GET /repos/{owner}/{repo}/rules/branches/{base_ref}
+
+which on this repository's ``main`` returns, among others::
+
+    pull_request.required_approving_review_count:    1
+    pull_request.required_review_thread_resolution:  true
+    pull_request.require_last_push_approval:         true
+    pull_request.require_extra_approval_for_unattributed_changes: true
+    required_status_checks.required_status_checks:   ["call-test-lint / Test and Lint"]
+
+Reading it also bounds the report honestly: a rule the branch does not carry is
+never named as a blocker, and a rule this file cannot evaluate is listed as
+such rather than silently passed. ``require_code_owner_review`` is the standing
+example of the first -- it is set on this branch and vacuous, because the
+repository has no CODEOWNERS file.
+
+What this reports, and what it deliberately does not
+----------------------------------------------------
+Each blocker carries the rule that produced it and the party who can clear it.
+The distinction that matters is not blocked-versus-clean, it is *whose move it
+is*, so the outcomes group that way rather than by severity:
+
+``merge-conflict``, ``draft``, ``required-check-failing``, ``unresolved-threads``
+    The **author** owes the next action. These are the misfiled class: each one
+    is indistinguishable from waiting on a reviewer in every field a status
+    sweep reads, and each is clearable without anyone else.
+
+``missing-approval``
+    A **reviewer** owes the next action. The ordinary, honest state, and
+    reported as passing for the same reason the sibling check reports
+    ``awaiting-first-review`` as passing: if the common case is a finding, the
+    finding means nothing.
+
+``pusher-only-approval``
+    A reviewer **other than the pusher** owes it. Not re-derived here; see the
+    sibling note below.
+
+``required-check-pending``
+    Nobody. The answer is not in yet.
+
+``required-check-absent``
+    A **maintainer**, by authorising or re-running the workflow. A fork pull
+    request whose runs are held at ``action_required`` reports ``completed``
+    with a null-ish rollup, which reads identically to "never ran".
+
+``no-unsatisfied-rule``
+    Every rule the branch carries is satisfied and it still reads blocked. This
+    is the #2574 case and the one most worth saying out loud, because the
+    remedy is to attempt the merge: ``mergePullRequest`` refuses with ``Pull
+    Request is not mergeable``, which names nothing, while ``PUT
+    /repos/{owner}/{repo}/pulls/{n}/merge`` either succeeds or names the
+    unsatisfied requirement. A merge attempt is cheap and self-verifying.
+
+    One caveat is deliberately printed with it rather than left to be
+    rediscovered: an Actions installation token reads ``BLOCKED`` on any pull
+    request that touches ``.github/workflows/**`` regardless of the rules, so
+    on such a pull request this outcome may be an artifact of the token that
+    asked. Re-read with a personal access token before concluding the state is
+    stale. See the "PR Workflow" section of AGENTS.md.
+
+This does not merge anything, does not gate anything, and is not in the
+required set. It answers one question and exits.
+
+Why it composes the sibling rather than re-deriving it
+-----------------------------------------------------
+``require_last_push_approval`` already has an owner:
+``scripts/check_last_push_approval.py``, which carries the measured evidence
+for it and the semantics of what a "current" approval is -- per author, their
+most recent review that expresses a position, so ``COMMENTED`` is not a
+retraction. Those semantics are subtle enough that a second copy would drift,
+and this file needs the same primitive to count approvals at all. So it imports
+``current_approvers`` and the two resolvers from that module instead of
+restating them, which is the repository's own rule for a guard that acquires a
+second caller (AGENTS.md, Key Conventions 11). ``scripts`` is not a package, so
+the import goes by path.
+
+Usage
+-----
+::
+
+    python3 scripts/check_merge_blockers.py --repo strands-labs/robots --pr 2574
+    python3 scripts/check_merge_blockers.py --repo strands-labs/robots --all-open
+
+Exit status follows the sibling's contract, so the two can be run side by side
+and read the same way: ``1`` is a finding, ``0`` is clean or undeterminable,
+and ``2`` means the check could not compute an answer -- red here never means
+"this branch needs another human".
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+API_ROOT = "https://api.github.com"
+
+_MAX_PAGES = 20
+_TIMEOUT = 30
+
+
+# --------------------------------------------------------------------------
+# The sibling check owns "who currently approves" and "who pushed the head".
+# Imported by path because ``scripts`` is not a package; see the module
+# docstring for why this is a shared primitive rather than a copy.
+# --------------------------------------------------------------------------
+_SIBLING = Path(__file__).resolve().parent / "check_last_push_approval.py"
+
+
+def _load_sibling() -> Any:
+    spec = importlib.util.spec_from_file_location("check_last_push_approval", _SIBLING)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load {_SIBLING}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_approval = _load_sibling()
+current_approvers = _approval.current_approvers
+resolve_pusher = _approval.resolve_pusher
+resolve_reviews = _approval.resolve_reviews
+
+
+# Outcome names. Ordered here the way they bind in practice, which is also the
+# order they are reported in: a conflict makes the approval question moot, and
+# an unresolved thread makes it moot for a different reason.
+MERGE_CONFLICT = "merge-conflict"
+DRAFT = "draft"
+REQUIRED_CHECK_FAILING = "required-check-failing"
+REQUIRED_CHECK_PENDING = "required-check-pending"
+REQUIRED_CHECK_ABSENT = "required-check-absent"
+UNRESOLVED_THREADS = "unresolved-threads"
+MISSING_APPROVAL = "missing-approval"
+PUSHER_ONLY_APPROVAL = "pusher-only-approval"
+NO_UNSATISFIED_RULE = "no-unsatisfied-rule"
+
+# Who owes the next action. The whole point of the report.
+AUTHOR = "the author"
+REVIEWER = "any reviewer"
+OTHER_REVIEWER = "a reviewer other than the pusher"
+MAINTAINER = "a maintainer"
+NOBODY = "nobody"
+ANYONE = "anyone, by attempting the merge"
+
+_OWED_BY: dict[str, str] = {
+    MERGE_CONFLICT: AUTHOR,
+    DRAFT: AUTHOR,
+    REQUIRED_CHECK_FAILING: AUTHOR,
+    REQUIRED_CHECK_PENDING: NOBODY,
+    REQUIRED_CHECK_ABSENT: MAINTAINER,
+    UNRESOLVED_THREADS: AUTHOR,
+    MISSING_APPROVAL: REVIEWER,
+    PUSHER_ONLY_APPROVAL: OTHER_REVIEWER,
+    NO_UNSATISFIED_RULE: ANYONE,
+}
+
+# A gating blocker makes every rule after it unanswerable rather than merely
+# also-unsatisfied: a conflicted or draft branch cannot have its approval
+# question settled, because the diff a reviewer would approve is not the diff
+# that would merge. Distinguished so the report names one next action instead
+# of a set the reader has to order, which is the mistake #1905 records as
+# "necessary but no longer sufficient".
+_GATING: frozenset[str] = frozenset({MERGE_CONFLICT, DRAFT})
+
+
+# The outcomes a scheduled author-side pass can act on without anyone else.
+# These are the ones that get misread as reviewer bandwidth, so these are the
+# ones worth an exit status. MISSING_APPROVAL is excluded deliberately: it is
+# the ordinary state, and a finding that fires on the ordinary state is noise.
+_FINDINGS: frozenset[str] = frozenset(
+    {
+        MERGE_CONFLICT,
+        DRAFT,
+        REQUIRED_CHECK_FAILING,
+        UNRESOLVED_THREADS,
+        NO_UNSATISFIED_RULE,
+    }
+)
+
+_STALE_STATE_REMEDY: tuple[str, ...] = (
+    "",
+    "### What clears this",
+    "",
+    "Attempt the merge. `mergeStateStatus` is a cached computation and is not",
+    "authoritative: #2574 read `blocked` from both GraphQL and REST with zero",
+    "review threads and every check green, and `PUT /pulls/{n}/merge` then",
+    "succeeded on the first attempt with no state having changed in between.",
+    "",
+    "Prefer REST for the attempt. GraphQL's `mergePullRequest` refuses with",
+    "`Pull Request is not mergeable`, which names nothing; the REST refusal",
+    "names the requirement that is unmet.",
+    "",
+    "Before concluding the state is stale, check the token: an Actions",
+    "installation token reads `blocked` on any pull request touching",
+    "`.github/workflows/**` whatever the rules say. Re-read with a personal",
+    "access token.",
+)
+
+
+@dataclass(frozen=True)
+class Blocker:
+    """One unsatisfied rule, the party who can clear it, and the detail."""
+
+    outcome: str
+    rule: str
+    detail: str
+
+    @property
+    def owed_by(self) -> str:
+        return _OWED_BY.get(self.outcome, NOBODY)
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome in _FINDINGS
+
+    @property
+    def is_gating(self) -> bool:
+        """Whether the rules after this one cannot be assessed until it clears."""
+        return self.outcome in _GATING
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    """The subset of the branch ruleset this check can evaluate."""
+
+    required_approving_review_count: int = 0
+    required_review_thread_resolution: bool = False
+    require_last_push_approval: bool = False
+    required_contexts: tuple[str, ...] = ()
+    # Named so the report can say a rule is carried but not evaluated here,
+    # rather than implying the branch does not carry it.
+    unevaluated: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PullRequestState:
+    """Everything about one pull request the rules are evaluated against."""
+
+    number: int
+    head_sha: str
+    base_ref: str
+    draft: bool
+    mergeable: bool | None
+    merge_state: str
+    unresolved_threads: int
+    check_conclusions: dict[str, str | None] = field(default_factory=dict)
+    approvers: tuple[str, ...] = ()
+    pusher: str | None = None
+
+
+# --------------------------------------------------------------------------
+# Rule evaluation. Pure, so the fixtures in the tests are the real
+# observations rather than a mock of the transport.
+# --------------------------------------------------------------------------
+
+
+def _plural(count: int, noun: str) -> str:
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
+    """Return every rule the pull request leaves unsatisfied, in binding order.
+
+    A rule the branch does not carry is never evaluated, so the report cannot
+    name a blocker that is not in force. When nothing is unsatisfied the result
+    is a single ``no-unsatisfied-rule`` blocker rather than an empty tuple: the
+    caller asked why a pull request is blocked, and "no reason found" is an
+    answer with a remedy, not an absence of one.
+    """
+    found: list[Blocker] = []
+
+    if state.draft:
+        found.append(
+            Blocker(
+                DRAFT,
+                "pull_request",
+                "The pull request is a draft, so no rule can be satisfied yet.",
+            )
+        )
+
+    # Upstream of every rule below: a branch that does not merge cleanly cannot
+    # be merged by satisfying anything else, and the required check that is
+    # green is green on a head that predates the conflict.
+    if state.mergeable is False:
+        found.append(
+            Blocker(
+                MERGE_CONFLICT,
+                "(not a ruleset rule)",
+                f"The branch conflicts with {state.base_ref}; merge state is "
+                f"{state.merge_state or 'dirty'}. No approval can merge it while "
+                f"this stands, and the required check's green describes a head "
+                f"that predates the conflict.",
+            )
+        )
+
+    for context in rules.required_contexts:
+        if context not in state.check_conclusions:
+            found.append(
+                Blocker(
+                    REQUIRED_CHECK_ABSENT,
+                    "required_status_checks",
+                    f"Required check {context!r} has not reported on "
+                    f"{state.head_sha[:8] or '(unknown head)'}. A fork run held at "
+                    f"action_required reads the same as one that never started.",
+                )
+            )
+            continue
+        conclusion = state.check_conclusions[context]
+        if conclusion is None:
+            found.append(
+                Blocker(
+                    REQUIRED_CHECK_PENDING,
+                    "required_status_checks",
+                    f"Required check {context!r} is still running.",
+                )
+            )
+        elif conclusion.lower() not in ("success", "neutral", "skipped"):
+            found.append(
+                Blocker(
+                    REQUIRED_CHECK_FAILING,
+                    "required_status_checks",
+                    f"Required check {context!r} concluded {conclusion}.",
+                )
+            )
+
+    if rules.required_review_thread_resolution and state.unresolved_threads:
+        found.append(
+            Blocker(
+                UNRESOLVED_THREADS,
+                "required_review_thread_resolution",
+                f"{_plural(state.unresolved_threads, 'review thread')} unresolved. "
+                f"This blocks an approved pull request with every check green, and "
+                f"it is clearable by the author alone -- including when the fix has "
+                f"already landed and the reviewer approved past the thread.",
+            )
+        )
+
+    if rules.required_approving_review_count:
+        # The pusher's own approval is discounted only when the branch actually
+        # carries require_last_push_approval. Filtering unconditionally would
+        # invent a blocker on a branch that permits a self-approved head.
+        eligible = (
+            [a for a in state.approvers if a != state.pusher]
+            if rules.require_last_push_approval
+            else list(state.approvers)
+        )
+        if not state.approvers:
+            found.append(
+                Blocker(
+                    MISSING_APPROVAL,
+                    "required_approving_review_count",
+                    f"{len(state.approvers)} of {rules.required_approving_review_count} "
+                    f"required approvals. Waiting on a first review, which is the "
+                    f"ordinary state.",
+                )
+            )
+        elif rules.require_last_push_approval and not eligible:
+            found.append(
+                Blocker(
+                    PUSHER_ONLY_APPROVAL,
+                    "require_last_push_approval",
+                    f"Every current approval is from {state.pusher}, the account that "
+                    f"pushed the head, so none of them counts. See "
+                    f"scripts/check_last_push_approval.py and issue #1905.",
+                )
+            )
+        elif len(eligible) < rules.required_approving_review_count:
+            found.append(
+                Blocker(
+                    MISSING_APPROVAL,
+                    "required_approving_review_count",
+                    f"{len(eligible)} of {rules.required_approving_review_count} "
+                    f"required approvals from an account that did not push the head.",
+                )
+            )
+
+    if not found:
+        return (
+            Blocker(
+                NO_UNSATISFIED_RULE,
+                "(none)",
+                "Every rule this check can evaluate is satisfied. If the pull "
+                "request still reads blocked, the state is stale or the token "
+                "asking cannot see past a workflow change.",
+            ),
+        )
+    return tuple(found)
+
+
+def parse_ruleset(payload: object) -> Ruleset:
+    """Reduce the branch-rules payload to the rules this check evaluates.
+
+    Unknown rule types are ignored rather than refused: a ruleset gaining a
+    rule must not turn this check red, and a rule it cannot evaluate is named
+    in ``unevaluated`` so the report does not imply the branch is without it.
+    """
+    rules = payload if isinstance(payload, list) else []
+    count = 0
+    threads = False
+    last_push = False
+    contexts: list[str] = []
+    unevaluated: list[str] = []
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        kind = rule.get("type")
+        params = rule.get("parameters") or {}
+        if not isinstance(params, dict):
+            params = {}
+        if kind == "pull_request":
+            count = int(params.get("required_approving_review_count") or 0)
+            threads = bool(params.get("required_review_thread_resolution"))
+            last_push = bool(params.get("require_last_push_approval"))
+            # Carried by the branch and not answerable here. Named for the
+            # reason the docstring gives: silence would read as absence.
+            if params.get("require_code_owner_review"):
+                unevaluated.append("require_code_owner_review")
+            if params.get("require_extra_approval_for_unattributed_changes"):
+                unevaluated.append("require_extra_approval_for_unattributed_changes")
+        elif kind == "required_status_checks":
+            for entry in params.get("required_status_checks") or []:
+                if isinstance(entry, dict) and entry.get("context"):
+                    contexts.append(str(entry["context"]))
+
+    return Ruleset(
+        required_approving_review_count=count,
+        required_review_thread_resolution=threads,
+        require_last_push_approval=last_push,
+        required_contexts=tuple(contexts),
+        unevaluated=tuple(unevaluated),
+    )
+
+
+# --------------------------------------------------------------------------
+# Transport
+# --------------------------------------------------------------------------
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "strands-robots-check-merge-blockers",
+    }
+
+
+def _get(url: str, token: str) -> object:
+    request = urllib.request.Request(url, headers=_headers(token))
+    with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:  # noqa: S310 - fixed API host
+        return json.load(response)
+
+
+_THREAD_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) { nodes { isResolved isOutdated } }
+    }
+  }
+}
+"""
+
+
+def resolve_unresolved_threads(repo: str, pr: int, token: str) -> int:
+    """Count review threads that are neither resolved nor outdated.
+
+    GraphQL only: REST exposes review comments but not whether the thread they
+    belong to has been resolved, and resolution is the whole question. An
+    outdated thread does not block a merge, so it is not counted -- the rule is
+    about threads the ruleset considers live.
+    """
+    owner, _, name = repo.partition("/")
+    body = json.dumps({"query": _THREAD_QUERY, "variables": {"owner": owner, "name": name, "number": pr}}).encode()
+    headers = _headers(token)
+    headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(f"{API_ROOT}/graphql", data=body, headers=headers)
+    with urllib.request.urlopen(request, timeout=_TIMEOUT) as response:  # noqa: S310 - fixed API host
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise ValueError(f"reviewThreads query failed: {payload['errors']}")
+    threads = (
+        (((payload.get("data") or {}).get("repository") or {}).get("pullRequest") or {}).get("reviewThreads") or {}
+    ).get("nodes") or []
+    return sum(1 for t in threads if not t.get("isResolved") and not t.get("isOutdated"))
+
+
+def resolve_check_conclusions(repo: str, head_sha: str, token: str) -> dict[str, str | None]:
+    """Map check name to conclusion on the head, plus legacy commit statuses.
+
+    A check that is queued or in progress has a ``None`` conclusion, which is
+    kept as ``None`` rather than coerced: "still running" and "failed" ask for
+    different things. Both surfaces are read because a required context can be
+    supplied by either, and the ruleset names a context without saying which.
+    """
+    conclusions: dict[str, str | None] = {}
+
+    payload = _get(f"{API_ROOT}/repos/{repo}/commits/{head_sha}/check-runs?per_page=100", token)
+    runs = payload.get("check_runs", []) if isinstance(payload, dict) else []
+    for run in runs:
+        name = run.get("name")
+        if not name:
+            continue
+        conclusion = run.get("conclusion")
+        # A context appearing twice keeps its worst answer: a re-run that
+        # succeeded does not retire a sibling that did not.
+        if name in conclusions and conclusions[name] not in (None, "success"):
+            continue
+        conclusions[str(name)] = conclusion
+
+    status = _get(f"{API_ROOT}/repos/{repo}/commits/{head_sha}/status", token)
+    if isinstance(status, dict):
+        for entry in status.get("statuses") or []:
+            context = entry.get("context")
+            if context and context not in conclusions:
+                state = entry.get("state")
+                conclusions[str(context)] = None if state == "pending" else state
+
+    return conclusions
+
+
+def resolve_ruleset(repo: str, base_ref: str, token: str) -> Ruleset:
+    quoted = urllib.parse.quote(base_ref, safe="")
+    return parse_ruleset(_get(f"{API_ROOT}/repos/{repo}/rules/branches/{quoted}", token))
+
+
+def resolve_state(repo: str, pr: int, token: str) -> PullRequestState:
+    """Read one pull request and everything the rules are evaluated against."""
+    payload = _get(f"{API_ROOT}/repos/{repo}/pulls/{pr}", token)
+    if not isinstance(payload, dict):
+        raise ValueError(f"unexpected payload for {repo}#{pr}")
+    head_sha = ((payload.get("head") or {}).get("sha")) or ""
+    base_ref = ((payload.get("base") or {}).get("ref")) or ""
+    reviews = resolve_reviews(repo, pr, token)
+    return PullRequestState(
+        number=pr,
+        head_sha=head_sha,
+        base_ref=base_ref,
+        draft=bool(payload.get("draft")),
+        mergeable=payload.get("mergeable"),
+        merge_state=str(payload.get("mergeable_state") or ""),
+        unresolved_threads=resolve_unresolved_threads(repo, pr, token),
+        check_conclusions=resolve_check_conclusions(repo, head_sha, token) if head_sha else {},
+        approvers=current_approvers(reviews),
+        pusher=resolve_pusher(repo, head_sha, token) if head_sha else None,
+    )
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def primary(blockers: Sequence[Blocker]) -> Blocker:
+    """Return the blocker that owns the next action.
+
+    A gating blocker wins outright, because nothing after it is answerable. Then
+    a finding, because that is the class a scheduled pass can act on alone. Then
+    the first blocker somebody actually owes, so a rule that is merely waiting
+    on a clock cannot mask one that is waiting on a person: a pull request whose
+    required check is still running and which has no approval is answerable by a
+    reviewer now, and reporting it as owed by nobody would park it. Only if no
+    blocker is owed by anyone does the earliest-binding one stand.
+
+    Both renderers and both warning paths route through this, so precedence
+    cannot be applied to one report and not the other.
+    """
+    return next(
+        (b for b in blockers if b.is_gating),
+        next(
+            (b for b in blockers if b.is_finding),
+            next((b for b in blockers if b.owed_by != NOBODY), blockers[0]),
+        ),
+    )
+
+
+def _next_action(blockers: Sequence[Blocker]) -> list[str]:
+    """Render the one next action, honouring precedence between blockers.
+
+    A gating blocker is reported alone. Listing it beside the approval rule it
+    sits upstream of is what produced the misreading #1905 records: the reader
+    sees two owners, picks the reviewer, and supplies an approval that cannot
+    merge anything. Non-gating blockers genuinely are parallel -- a pending
+    check and a missing approval wait on different people at once -- so those
+    are listed together.
+    """
+    gating = primary(blockers) if any(b.is_gating for b in blockers) else None
+    if gating is not None:
+        trailing = [b for b in blockers if b is not gating]
+        lines = [f"Next action is owed by {gating.owed_by}, on `{gating.outcome}`."]
+        if trailing:
+            counted = "rule" if len(trailing) == 1 else f"{len(trailing)} rules"
+            lines.append(
+                f"The {counted} below it cannot be assessed until that clears: an"
+                " approval is necessary but not sufficient while it stands."
+            )
+        return lines
+    owed = sorted({b.owed_by for b in blockers if b.owed_by != NOBODY})
+    if owed:
+        return [f"Next action is owed by {_join(owed)}."]
+    return ["No party owes an action; the answer is not in yet."]
+
+
+def render(state: PullRequestState, rules: Ruleset, blockers: Sequence[Blocker], repo: str) -> str:
+    """Render one pull request's blockers, the party owing each named first."""
+    lines = [
+        "## Merge blockers",
+        "",
+        f"Outcome: **{', '.join(b.outcome for b in blockers)}**",
+        "",
+        *_next_action(blockers),
+        "",
+    ]
+    lines += [
+        "| field | value |",
+        "|---|---|",
+        f"| pull request | {repo}#{state.number} |",
+        f"| head | `{state.head_sha[:8] or '(unknown)'}` |",
+        f"| base | {state.base_ref or '(unknown)'} |",
+        f"| merge state (cached, not authoritative) | {state.merge_state or '(unknown)'} |",
+        f"| unresolved review threads | {state.unresolved_threads} |",
+        f"| current approvals | {_join(state.approvers)} |",
+        f"| head pushed by | {state.pusher or '(undetermined)'} |",
+        "",
+        "| unsatisfied rule | owed by | detail |",
+        "|---|---|---|",
+    ]
+    for blocker in blockers:
+        lines.append(f"| `{blocker.rule}` | {blocker.owed_by} | {blocker.detail} |")
+
+    if rules.unevaluated:
+        lines += [
+            "",
+            "Carried by the branch and not evaluated here: "
+            + ", ".join(f"`{name}`" for name in rules.unevaluated)
+            + ". Named so their absence from the table above does not read as the"
+            " branch not carrying them.",
+        ]
+    if any(b.outcome == NO_UNSATISFIED_RULE for b in blockers):
+        lines += list(_STALE_STATE_REMEDY)
+    return "\n".join(lines)
+
+
+def _join(names: Sequence[str]) -> str:
+    names = list(names)
+    if not names:
+        return "nobody"
+    if len(names) == 1:
+        return names[0]
+    return ", ".join(names[:-1]) + " and " + names[-1]
+
+
+@dataclass(frozen=True)
+class SweepRow:
+    """One open pull request and the blockers computed for it."""
+
+    pr: int
+    blockers: tuple[Blocker, ...]
+
+    @property
+    def is_finding(self) -> bool:
+        return any(b.is_finding for b in self.blockers)
+
+    @property
+    def primary(self) -> Blocker:
+        return primary(self.blockers)
+
+
+def sweep(repo: str, token: str) -> tuple[list[SweepRow], list[int], Ruleset]:
+    """Evaluate every open non-draft pull request against its base ruleset.
+
+    One unreadable pull request is skipped and named, never allowed to take the
+    rest of the report with it. Rulesets are cached per base branch, because a
+    sweep of thirty pull requests onto one branch asks the same question thirty
+    times otherwise.
+    """
+    rows: list[SweepRow] = []
+    skipped: list[int] = []
+    cache: dict[str, Ruleset] = {}
+    last = Ruleset()
+
+    for pr in resolve_open_pull_requests(repo, token):
+        try:
+            state = resolve_state(repo, pr, token)
+            if state.base_ref not in cache:
+                cache[state.base_ref] = resolve_ruleset(repo, state.base_ref, token)
+            rules = cache[state.base_ref]
+            last = rules
+            rows.append(SweepRow(pr, evaluate(state, rules)))
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+            print(
+                f"check_merge_blockers: {repo}#{pr} lookup failed, not evaluated: {exc}",
+                file=sys.stderr,
+            )
+            skipped.append(pr)
+    return rows, skipped, last
+
+
+def resolve_open_pull_requests(repo: str, token: str) -> list[int]:
+    """Return every open non-draft pull request number, ascending.
+
+    Sorted so two reports differ by changed verdicts rather than by ordering.
+    """
+    found: list[int] = []
+    for _ in range(_MAX_PAGES):
+        page = len(found) // 100 + 1
+        payload = _get(f"{API_ROOT}/repos/{repo}/pulls?state=open&per_page=100&page={page}", token)
+        rows = payload if isinstance(payload, list) else []
+        for row in rows:
+            if row.get("draft"):
+                continue
+            number = row.get("number")
+            if isinstance(number, int):
+                found.append(number)
+        if len(rows) < 100:
+            break
+    return sorted(found)
+
+
+def render_sweep(rows: Sequence[SweepRow], skipped: Sequence[int], repo: str) -> str:
+    """Render the sweep, separating what the author owes from what a reviewer does."""
+    findings = [row for row in rows if row.is_finding]
+    lines = [
+        "## Merge blocker sweep",
+        "",
+        f"Evaluated {len(rows)} open non-draft pull request(s) in {repo}.",
+        "",
+    ]
+    if findings:
+        named = ", ".join(f"#{row.pr}" for row in findings)
+        lines += [
+            f"**{len(findings)} blocked on something no reviewer can clear:** {named}.",
+            "",
+            "Each of these reads the same as waiting on a reviewer and is not.",
+            "",
+        ]
+    else:
+        lines += [
+            "No pull request is blocked on an author-clearable rule. Anything",
+            "blocked here is waiting on review, which is the ordinary state.",
+            "",
+        ]
+    lines += [
+        "| pull request | unsatisfied rule(s) | owed by |",
+        "|---|---|---|",
+    ]
+    for row in rows:
+        outcomes = ", ".join(b.outcome for b in row.blockers)
+        lines.append(f"| #{row.pr} | {outcomes} | {row.primary.owed_by} |")
+    if skipped:
+        lines += [
+            "",
+            "Not evaluated (lookup failed): " + ", ".join(f"#{pr}" for pr in skipped) + ".",
+            "Named rather than omitted, so a gap in coverage cannot read as a clean sweep.",
+        ]
+    return "\n".join(lines)
+
+
+def _emit(report: str) -> None:
+    """Print the report, and append it to the step summary when there is one."""
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def _describe(blockers: Iterable[Blocker]) -> str:
+    """One line naming each blocker, its rule, and who owes the next action."""
+    return "; ".join(f"{b.outcome} ({b.rule}), owed by {b.owed_by}" for b in blockers)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Sweep every open non-draft pull request instead of one.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.token:
+        parser.error("--token is required (or set GITHUB_TOKEN)")
+    if not args.repo:
+        parser.error("--repo is required (or set GITHUB_REPOSITORY)")
+    # Refused rather than resolved, for the reason the sibling gives: silently
+    # ignoring either flag reads as a successful run of the other thing.
+    if args.all_open and args.pr:
+        parser.error("--all-open and --pr are mutually exclusive")
+    if not args.all_open and not args.pr:
+        parser.error("--pr is required (or set PR_NUMBER), or pass --all-open")
+
+    if args.all_open:
+        try:
+            rows, skipped, rules = sweep(args.repo, args.token)
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+            print(f"check_merge_blockers: could not list open pull requests: {exc}", file=sys.stderr)
+            return 0
+        _emit(render_sweep(rows, skipped, args.repo))
+        findings = [row for row in rows if row.is_finding]
+        for row in findings:
+            print(
+                f"::warning title=Blocked on something no reviewer can clear::"
+                f"{args.repo}#{row.pr}: {_describe([row.primary])}"
+            )
+        return 1 if findings else 0
+
+    pr = int(args.pr)
+    try:
+        state = resolve_state(args.repo, pr, args.token)
+        rules = resolve_ruleset(args.repo, state.base_ref, args.token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+        # A lookup failure is not a finding: say so on stderr and pass, rather
+        # than accusing a branch of a blocker this run could not observe.
+        print(f"check_merge_blockers: lookup failed, reporting nothing: {exc}", file=sys.stderr)
+        return 0
+
+    blockers = evaluate(state, rules)
+    _emit(render(state, rules, blockers, args.repo))
+    if any(b.is_finding for b in blockers):
+        print(f"::warning title=Blocked on something no reviewer can clear::{_describe([primary(blockers)])}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -90,6 +90,7 @@ _NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
     "check_duplicate_claim.py": ("--repo", None),
     "check_last_push_approval.py": ("--repo", None),
     "check_merge_base_overlap.py": ("--github-repo", "--all-open"),
+    "check_merge_blockers.py": ("--repo", None),
     "check_pr_head_is_current.py": ("--repo", None),
 }
 

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -1,0 +1,717 @@
+"""Pins the merge-blocker classifier against pull requests measured in this repo.
+
+The property under test is not that a pull request is blocked -- ``mergeStateStatus``
+already says that, and says nothing else. It is that the *rule* which is
+unsatisfied is named, because that is what decides who owes the next action. Three
+pull requests measured on 2026-08-21 all read ``blocked`` and needed three
+different people:
+
+===========  ==============================  ==========================
+pull request unsatisfied                     who could clear it
+===========  ==============================  ==========================
+#2566        one unresolved review thread    the author
+#2574        nothing -- a stale computation   anyone, by retrying
+#2497        no approving review yet         any reviewer
+===========  ==============================  ==========================
+
+#2566 and #2574 each sat idle after approval (31 and 45 minutes) because a
+scheduled pass read APPROVED plus green plus BLOCKED and concluded the next move
+was somebody else's. So the fixtures below are those observations, and the
+control triple is what carries the argument: the three differ in exactly one
+input each and produce three different owners.
+
+See scripts/check_merge_blockers.py, issue #1905, and the "PR Workflow" section
+of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_merge_blockers.py"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_merge_blockers", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+# Reached through the importlib load above, so these are module attributes at
+# runtime rather than names mypy can resolve. The script itself is fully typed
+# and checked (mypy scripts/check_merge_blockers.py); ``hatch run lint`` covers
+# only the package and its tests.
+Ruleset: Any = mod.Ruleset
+PullRequestState: Any = mod.PullRequestState
+Blocker: Any = mod.Blocker
+
+REQUIRED = "call-test-lint / Test and Lint"
+
+
+# The ruleset this repository's ``main`` actually carries, as returned by
+# GET /repos/strands-labs/robots/rules/branches/main on 2026-08-21. Trimmed to
+# the rule types the payload contains, values verbatim.
+MEASURED_RULES_PAYLOAD: list[dict[str, Any]] = [
+    {"type": "deletion", "parameters": {}},
+    {
+        "type": "pull_request",
+        "parameters": {
+            "required_approving_review_count": 1,
+            "dismiss_stale_reviews_on_push": True,
+            "required_reviewers": [],
+            "require_code_owner_review": True,
+            "require_last_push_approval": True,
+            "required_review_thread_resolution": True,
+            "require_extra_approval_for_unattributed_changes": True,
+            "allowed_merge_methods": ["squash"],
+        },
+    },
+    {"type": "non_fast_forward", "parameters": {}},
+    {
+        "type": "required_status_checks",
+        "parameters": {
+            "strict_required_status_checks_policy": False,
+            "required_status_checks": [{"context": REQUIRED, "integration_id": 15368}],
+        },
+    },
+]
+
+MAIN = mod.parse_ruleset(MEASURED_RULES_PAYLOAD)
+
+
+def state(**overrides: Any) -> Any:
+    """A pull request that satisfies every rule, so each test varies one input."""
+    base: dict[str, Any] = {
+        "number": 1,
+        "head_sha": "0123456789abcdef",
+        "base_ref": "main",
+        "draft": False,
+        "mergeable": True,
+        "merge_state": "blocked",
+        "unresolved_threads": 0,
+        "check_conclusions": {REQUIRED: "success"},
+        "approvers": ("a-reviewer",),
+        "pusher": "the-author",
+    }
+    base.update(overrides)
+    return PullRequestState(**base)
+
+
+def outcomes(blockers: Any) -> list[str]:
+    return [b.outcome for b in blockers]
+
+
+# --------------------------------------------------------------------------
+# The ruleset is read, not assumed.
+# --------------------------------------------------------------------------
+
+
+def test_the_measured_ruleset_parses_to_the_rules_in_force() -> None:
+    assert MAIN.required_approving_review_count == 1
+    assert MAIN.required_review_thread_resolution is True
+    assert MAIN.require_last_push_approval is True
+    assert MAIN.required_contexts == (REQUIRED,)
+
+
+def test_a_rule_the_branch_carries_but_this_check_cannot_answer_is_named() -> None:
+    """Silence about a rule in force would read as the branch not having it.
+
+    Both of these are set on ``main``. ``require_code_owner_review`` is vacuous
+    here because the repository has no CODEOWNERS file, and
+    ``require_extra_approval_for_unattributed_changes`` is not answerable from
+    the fields this check reads. Neither may be silently dropped.
+    """
+    assert MAIN.unevaluated == (
+        "require_code_owner_review",
+        "require_extra_approval_for_unattributed_changes",
+    )
+
+
+def test_an_unknown_rule_type_does_not_break_the_parse() -> None:
+    """A ruleset gaining a rule must not turn this check red."""
+    rules = mod.parse_ruleset([*MEASURED_RULES_PAYLOAD, {"type": "future_rule", "parameters": {"x": 1}}])
+    assert rules.required_contexts == (REQUIRED,)
+    assert rules.required_approving_review_count == 1
+
+
+def test_a_rule_the_branch_does_not_carry_is_never_named_as_a_blocker() -> None:
+    """With thread resolution off, an unresolved thread is not a blocker."""
+    without = Ruleset(required_approving_review_count=1, required_review_thread_resolution=False)
+    assert mod.UNRESOLVED_THREADS not in outcomes(mod.evaluate(state(unresolved_threads=3), without))
+
+
+def test_a_malformed_ruleset_payload_yields_no_rules_rather_than_raising() -> None:
+    assert mod.parse_ruleset({"unexpected": "shape"}) == Ruleset()
+    assert mod.parse_ruleset([None, "junk"]) == Ruleset()
+
+
+# --------------------------------------------------------------------------
+# The three measured pull requests: one input each, three owners.
+# --------------------------------------------------------------------------
+
+
+def test_2566_an_unresolved_thread_blocks_an_approved_green_pull_request() -> None:
+    """The author owes this, and nothing on the pull request said so.
+
+    #2566 was APPROVED with every check SUCCESS and read ``blocked`` purely
+    because one thread was open -- a thread whose fix had already landed and
+    which the reviewer had approved past.
+    """
+    blockers = mod.evaluate(state(unresolved_threads=1), MAIN)
+    assert outcomes(blockers) == [mod.UNRESOLVED_THREADS]
+    assert blockers[0].rule == "required_review_thread_resolution"
+    assert blockers[0].owed_by == mod.AUTHOR
+    assert blockers[0].is_finding is True
+
+
+def test_2574_every_rule_satisfied_and_still_blocked_is_its_own_answer() -> None:
+    """The #2574 case: APPROVED, 12 checks SUCCESS, zero threads, still ``blocked``.
+
+    ``mergePullRequest`` refused with "Pull Request is not mergeable" and the
+    REST merge then succeeded on the first attempt with no state having changed.
+    So "no rule is unsatisfied" is a finding with a remedy, not an absence of
+    one, and must not render as an empty report.
+    """
+    blockers = mod.evaluate(state(), MAIN)
+    assert outcomes(blockers) == [mod.NO_UNSATISFIED_RULE]
+    assert blockers[0].owed_by == mod.ANYONE
+    assert blockers[0].is_finding is True
+
+
+def test_2497_a_missing_first_review_is_reported_but_is_not_a_finding() -> None:
+    """The ordinary state. A finding that fires on it would mean nothing."""
+    blockers = mod.evaluate(state(approvers=()), MAIN)
+    assert outcomes(blockers) == [mod.MISSING_APPROVAL]
+    assert blockers[0].owed_by == mod.REVIEWER
+    assert blockers[0].is_finding is False
+
+
+def test_the_measured_triple_produces_three_different_owners() -> None:
+    """The control: one varied input each, three parties owing the next action."""
+    owners = [
+        mod.primary(mod.evaluate(state(unresolved_threads=1), MAIN)).owed_by,
+        mod.primary(mod.evaluate(state(), MAIN)).owed_by,
+        mod.primary(mod.evaluate(state(approvers=()), MAIN)).owed_by,
+    ]
+    assert owners == [mod.AUTHOR, mod.ANYONE, mod.REVIEWER]
+    assert len(set(owners)) == 3
+
+
+# --------------------------------------------------------------------------
+# Two further pull requests measured live on 2026-08-21.
+# --------------------------------------------------------------------------
+
+
+def test_1035_names_the_conflict_ahead_of_the_approval_it_sits_upstream_of() -> None:
+    """#1035: CONFLICTING/DIRTY, one approval, from the account that pushed the head.
+
+    Both rules are unsatisfied, but only one is actionable: #1905 records that an
+    approval here is "necessary but no longer sufficient". So the conflict must
+    own the next action, and the author must own the conflict.
+    """
+    blockers = mod.evaluate(
+        state(mergeable=False, merge_state="dirty", approvers=("cagataycali",), pusher="cagataycali"),
+        MAIN,
+    )
+    assert outcomes(blockers) == [mod.MERGE_CONFLICT, mod.PUSHER_ONLY_APPROVAL]
+    assert mod.primary(blockers).outcome == mod.MERGE_CONFLICT
+    assert mod.primary(blockers).owed_by == mod.AUTHOR
+
+
+def test_2480_a_pending_check_does_not_mask_a_reviewer_who_can_act_now() -> None:
+    """#2480: required check still running, no approval.
+
+    The check is owed by nobody and binds first. Reporting that as the next
+    action would park a pull request a reviewer could approve immediately.
+    """
+    blockers = mod.evaluate(state(approvers=(), check_conclusions={REQUIRED: None}), MAIN)
+    assert outcomes(blockers) == [mod.REQUIRED_CHECK_PENDING, mod.MISSING_APPROVAL]
+    assert blockers[0].owed_by == mod.NOBODY
+    assert mod.primary(blockers).outcome == mod.MISSING_APPROVAL
+    assert mod.primary(blockers).owed_by == mod.REVIEWER
+
+
+# --------------------------------------------------------------------------
+# The required check: three states, three owners.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("conclusions", "expected", "owner"),
+    [
+        ({REQUIRED: "failure"}, "required-check-failing", mod.AUTHOR),
+        ({REQUIRED: "timed_out"}, "required-check-failing", mod.AUTHOR),
+        ({REQUIRED: "cancelled"}, "required-check-failing", mod.AUTHOR),
+        ({REQUIRED: None}, "required-check-pending", mod.NOBODY),
+        ({}, "required-check-absent", mod.MAINTAINER),
+        ({"some other check": "failure"}, "required-check-absent", mod.MAINTAINER),
+    ],
+)
+def test_the_required_check_states_are_separated_by_who_clears_them(
+    conclusions: dict[str, str | None], expected: str, owner: str
+) -> None:
+    blockers = mod.evaluate(state(check_conclusions=conclusions), MAIN)
+    assert outcomes(blockers) == [expected]
+    assert blockers[0].owed_by == owner
+
+
+@pytest.mark.parametrize("conclusion", ["success", "neutral", "skipped"])
+def test_a_check_that_did_not_fail_is_not_a_blocker(conclusion: str) -> None:
+    """CodeQL reports NEUTRAL and ``deploy`` reports SKIPPED on a green head."""
+    assert outcomes(mod.evaluate(state(check_conclusions={REQUIRED: conclusion}), MAIN)) == [mod.NO_UNSATISFIED_RULE]
+
+
+def test_an_absent_required_check_names_the_held_fork_run() -> None:
+    """A fork run held at ``action_required`` reads the same as never having run.
+
+    #1722 carried nine such runs, and three passes over #1905 described it as a
+    missing run rather than a held one. The remedy differs: authorisation, not a
+    push, and it consumes no approval.
+    """
+    blockers = mod.evaluate(state(check_conclusions={}), MAIN)
+    assert "action_required" in blockers[0].detail
+
+
+# --------------------------------------------------------------------------
+# Approvals, composed from the sibling rather than re-derived.
+# --------------------------------------------------------------------------
+
+
+def test_the_approval_semantics_come_from_the_sibling_check() -> None:
+    """One owner for what a "current" approval is, so the two cannot drift.
+
+    ``require_last_push_approval`` and the position-state rules belong to
+    scripts/check_last_push_approval.py. This check needs the same primitive to
+    count approvals at all, so it imports it. If that import is ever replaced by
+    a copy, this fails.
+    """
+    # Asserted by defining module rather than by object identity: another test
+    # file loading the sibling replaces the sys.modules entry, so identity is a
+    # statement about import order and this is a statement about where the code
+    # lives.
+    for shared in (mod.current_approvers, mod.resolve_pusher, mod.resolve_reviews):
+        assert shared.__module__ == "check_last_push_approval", shared
+    assert mod._SIBLING.name == "check_last_push_approval.py"
+    assert mod._SIBLING.is_file()
+
+
+def test_a_commented_review_does_not_retract_an_approval_here_either() -> None:
+    """The behaviour the shared primitive exists to keep identical."""
+    review = mod._approval.Review
+    reviews = [
+        review("a-reviewer", "APPROVED", "2026-08-01T00:00:00Z"),
+        review("a-reviewer", "COMMENTED", "2026-08-02T00:00:00Z"),
+    ]
+    assert mod.current_approvers(reviews) == ("a-reviewer",)
+
+
+def test_an_approval_from_a_third_party_satisfies_the_last_push_rule() -> None:
+    blockers = mod.evaluate(state(approvers=("someone-else",), pusher="the-author"), MAIN)
+    assert outcomes(blockers) == [mod.NO_UNSATISFIED_RULE]
+
+
+def test_two_approvals_where_only_one_is_eligible_still_satisfies_a_count_of_one() -> None:
+    blockers = mod.evaluate(state(approvers=("the-author", "someone-else"), pusher="the-author"), MAIN)
+    assert outcomes(blockers) == [mod.NO_UNSATISFIED_RULE]
+
+
+def test_a_higher_required_count_is_honoured() -> None:
+    rules = Ruleset(required_approving_review_count=2, require_last_push_approval=True)
+    blockers = mod.evaluate(state(approvers=("someone-else",), pusher="the-author"), rules)
+    assert outcomes(blockers) == [mod.MISSING_APPROVAL]
+    assert "1 of 2" in blockers[0].detail
+
+
+def test_the_last_push_rule_is_not_applied_when_the_branch_does_not_carry_it() -> None:
+    rules = Ruleset(required_approving_review_count=1, require_last_push_approval=False)
+    blockers = mod.evaluate(state(approvers=("the-author",), pusher="the-author"), rules)
+    # The pusher's own approval counts here, so the count is met and nothing is
+    # unsatisfied. Discounting it unconditionally invented a blocker; this is the
+    # regression that caught it.
+    assert outcomes(blockers) == [mod.NO_UNSATISFIED_RULE]
+
+
+# --------------------------------------------------------------------------
+# Precedence.
+# --------------------------------------------------------------------------
+
+
+def test_a_draft_gates_every_rule_after_it() -> None:
+    blockers = mod.evaluate(state(draft=True, approvers=(), unresolved_threads=2), MAIN)
+    assert outcomes(blockers)[0] == mod.DRAFT
+    assert mod.primary(blockers).outcome == mod.DRAFT
+    assert mod.primary(blockers).is_gating is True
+
+
+def test_a_conflict_gates_the_thread_and_approval_rules() -> None:
+    blockers = mod.evaluate(state(mergeable=False, unresolved_threads=2, approvers=()), MAIN)
+    assert mod.primary(blockers).outcome == mod.MERGE_CONFLICT
+    assert set(outcomes(blockers)) == {mod.MERGE_CONFLICT, mod.UNRESOLVED_THREADS, mod.MISSING_APPROVAL}
+
+
+def test_an_unknown_mergeability_is_not_reported_as_a_conflict() -> None:
+    """GitHub returns ``None`` while it computes. Guessing turns a wait into an accusation."""
+    assert mod.MERGE_CONFLICT not in outcomes(mod.evaluate(state(mergeable=None), MAIN))
+
+
+def test_the_next_action_line_names_one_owner_when_a_gating_blocker_is_present() -> None:
+    blockers = mod.evaluate(state(mergeable=False, approvers=()), MAIN)
+    rendered = mod.render(state(mergeable=False, approvers=()), MAIN, blockers, "o/r")
+    assert f"Next action is owed by {mod.AUTHOR}" in rendered
+    assert "necessary but not sufficient" in rendered
+    # The reviewer must not be offered as an alternative next action.
+    assert f"owed by {mod.AUTHOR} and {mod.REVIEWER}" not in rendered
+
+
+def test_parallel_blockers_are_reported_together() -> None:
+    """A pending check and a missing approval wait on different parties at once."""
+    st = state(approvers=(), check_conclusions={REQUIRED: None})
+    rendered = mod.render(st, MAIN, mod.evaluate(st, MAIN), "o/r")
+    assert "necessary but not sufficient" not in rendered
+
+
+# --------------------------------------------------------------------------
+# Review threads.
+# --------------------------------------------------------------------------
+
+
+def test_the_thread_count_is_named_not_merely_flagged() -> None:
+    blockers = mod.evaluate(state(unresolved_threads=1), MAIN)
+    assert "1 review thread unresolved" in blockers[0].detail
+    blockers = mod.evaluate(state(unresolved_threads=3), MAIN)
+    assert "3 review threads unresolved" in blockers[0].detail
+
+
+def test_an_outdated_thread_is_not_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An outdated thread does not block a merge, so it is not a blocker.
+
+    #1722 carries four threads, all resolved, and reads DIRTY for an unrelated
+    reason -- counting them would have named the wrong rule.
+    """
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {"isResolved": False, "isOutdated": False},
+                            {"isResolved": False, "isOutdated": True},
+                            {"isResolved": True, "isOutdated": False},
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen(payload))
+    assert mod.resolve_unresolved_threads("o/r", 1, "t") == 1
+
+
+def test_a_graphql_error_raises_rather_than_reporting_zero_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero would be a silent pass on the exact rule #2566 was blocked by."""
+    monkeypatch.setattr(mod.urllib.request, "urlopen", _fake_urlopen({"errors": [{"message": "nope"}]}))
+    with pytest.raises(ValueError, match="reviewThreads"):
+        mod.resolve_unresolved_threads("o/r", 1, "t")
+
+
+def test_a_null_pull_request_node_yields_zero_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GraphQL returns null, not {}, for an absent node."""
+    monkeypatch.setattr(
+        mod.urllib.request,
+        "urlopen",
+        _fake_urlopen({"data": {"repository": {"pullRequest": None}}}),
+    )
+    assert mod.resolve_unresolved_threads("o/r", 1, "t") == 0
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        import json
+
+        return json.dumps(self._payload).encode()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def _fake_urlopen(payload: Any) -> Any:
+    def opener(request: Any, timeout: int = 0) -> _FakeResponse:
+        return _FakeResponse(payload)
+
+    return opener
+
+
+# --------------------------------------------------------------------------
+# Check-run parsing.
+# --------------------------------------------------------------------------
+
+
+def test_a_rerun_that_succeeded_does_not_retire_a_failing_sibling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1035's head carried the required context twice. The worst answer stands."""
+    calls: list[str] = []
+
+    def fake_get(url: str, token: str) -> Any:
+        calls.append(url)
+        if "check-runs" in url:
+            return {
+                "check_runs": [
+                    {"name": REQUIRED, "conclusion": "failure"},
+                    {"name": REQUIRED, "conclusion": "success"},
+                ]
+            }
+        return {"statuses": []}
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: "failure"}
+
+
+def test_a_legacy_commit_status_can_supply_a_required_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ruleset names a context without saying which surface reports it."""
+
+    def fake_get(url: str, token: str) -> Any:
+        if "check-runs" in url:
+            return {"check_runs": []}
+        return {"statuses": [{"context": REQUIRED, "state": "success"}]}
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: "success"}
+
+
+def test_a_pending_commit_status_is_kept_pending_not_coerced_to_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get(url: str, token: str) -> Any:
+        if "check-runs" in url:
+            return {"check_runs": []}
+        return {"statuses": [{"context": REQUIRED, "state": "pending"}]}
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_check_conclusions("o/r", "abc", "t") == {REQUIRED: None}
+
+
+# --------------------------------------------------------------------------
+# Reports.
+# --------------------------------------------------------------------------
+
+
+def test_the_stale_state_report_names_the_remedy_and_the_token_caveat() -> None:
+    """The #2574 remedy is a merge attempt, and the caveat prevents a false one.
+
+    An Actions installation token reads ``blocked`` on any pull request touching
+    ``.github/workflows/**`` whatever the rules say, so this outcome must carry
+    the instruction to re-read before concluding the state is stale.
+    """
+    rendered = mod.render(state(), MAIN, mod.evaluate(state(), MAIN), "o/r")
+    assert "Attempt the merge" in rendered
+    assert "not authoritative" in rendered
+    assert ".github/workflows/**" in rendered
+    assert "personal" in rendered
+
+
+def test_the_report_calls_the_cached_merge_state_what_it_is() -> None:
+    rendered = mod.render(state(), MAIN, mod.evaluate(state(), MAIN), "o/r")
+    assert "merge state (cached, not authoritative)" in rendered
+
+
+def test_a_satisfied_pull_request_report_does_not_carry_the_stale_remedy() -> None:
+    st = state(approvers=())
+    rendered = mod.render(st, MAIN, mod.evaluate(st, MAIN), "o/r")
+    assert "Attempt the merge" not in rendered
+
+
+def test_the_conflict_detail_says_the_green_check_describes_an_older_head() -> None:
+    """#1035's required check is SUCCESS on a head that predates the conflict."""
+    st = state(mergeable=False, merge_state="dirty")
+    rendered = mod.render(st, MAIN, mod.evaluate(st, MAIN), "o/r")
+    assert "predates the conflict" in rendered
+
+
+def test_no_report_string_carries_a_non_ascii_character() -> None:
+    """AGENTS.md: no emojis in user-facing strings, plain ASCII only."""
+    reports = [
+        mod.render(state(), MAIN, mod.evaluate(state(), MAIN), "o/r"),
+        mod.render(state(approvers=()), MAIN, mod.evaluate(state(approvers=()), MAIN), "o/r"),
+        mod.render(
+            state(mergeable=False),
+            MAIN,
+            mod.evaluate(state(mergeable=False), MAIN),
+            "o/r",
+        ),
+        mod.render_sweep([mod.SweepRow(1, mod.evaluate(state(unresolved_threads=1), MAIN))], [2], "o/r"),
+        mod.render_sweep([], [], "o/r"),
+        "\n".join(mod._STALE_STATE_REMEDY),
+    ]
+    for report in reports:
+        report.encode("ascii")
+
+
+# --------------------------------------------------------------------------
+# Sweep.
+# --------------------------------------------------------------------------
+
+
+def test_the_sweep_separates_the_author_clearable_rows(capsys: pytest.CaptureFixture[str]) -> None:
+    rows = [
+        mod.SweepRow(1035, mod.evaluate(state(mergeable=False), MAIN)),
+        mod.SweepRow(2497, mod.evaluate(state(approvers=()), MAIN)),
+    ]
+    rendered = mod.render_sweep(rows, [], "o/r")
+    assert "1 blocked on something no reviewer can clear:** #1035" in rendered
+    assert f"| #1035 | {mod.MERGE_CONFLICT} | {mod.AUTHOR} |" in rendered
+    assert f"| #2497 | {mod.MISSING_APPROVAL} | {mod.REVIEWER} |" in rendered
+
+
+def test_a_clean_sweep_says_so_rather_than_printing_a_bare_table() -> None:
+    rendered = mod.render_sweep([], [], "o/r")
+    assert "No pull request is blocked on an author-clearable rule" in rendered
+
+
+def test_an_unevaluated_pull_request_is_named_rather_than_omitted() -> None:
+    """A silent gap in coverage must not read as a clean sweep."""
+    rendered = mod.render_sweep([], [2497], "o/r")
+    assert "#2497" in rendered
+    assert "Not evaluated" in rendered
+
+
+def test_a_draft_pull_request_is_not_swept(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_get",
+        lambda url, token: [{"number": 1, "draft": True}, {"number": 2, "draft": False}],
+    )
+    assert mod.resolve_open_pull_requests("o/r", "t") == [2]
+
+
+def test_the_sweep_rows_are_ordered_by_pull_request_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_get",
+        lambda url, token: [{"number": 9}, {"number": 3}, {"number": 7}],
+    )
+    assert mod.resolve_open_pull_requests("o/r", "t") == [3, 7, 9]
+
+
+def test_the_listing_stops_on_a_short_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages: list[str] = []
+
+    def fake_get(url: str, token: str) -> Any:
+        pages.append(url)
+        return [{"number": 1}]
+
+    monkeypatch.setattr(mod, "_get", fake_get)
+    assert mod.resolve_open_pull_requests("o/r", "t") == [1]
+    assert len(pages) == 1
+
+
+def test_one_unreadable_pull_request_does_not_suppress_the_others(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(mod, "resolve_open_pull_requests", lambda repo, token: [1, 2])
+
+    def fake_state(repo: str, pr: int, token: str) -> Any:
+        if pr == 1:
+            raise ValueError("unreadable")
+        return state(number=2, approvers=())
+
+    monkeypatch.setattr(mod, "resolve_state", fake_state)
+    monkeypatch.setattr(mod, "resolve_ruleset", lambda repo, ref, token: MAIN)
+    rows, skipped, _ = mod.sweep("o/r", "t")
+    assert [r.pr for r in rows] == [2]
+    assert skipped == [1]
+
+
+def test_the_ruleset_is_read_once_per_base_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sweep of thirty pull requests onto one branch asks once, not thirty times."""
+    monkeypatch.setattr(mod, "resolve_open_pull_requests", lambda repo, token: [1, 2, 3])
+    monkeypatch.setattr(mod, "resolve_state", lambda repo, pr, token: state(number=pr))
+    calls: list[str] = []
+
+    def fake_rules(repo: str, ref: str, token: str) -> Any:
+        calls.append(ref)
+        return MAIN
+
+    monkeypatch.setattr(mod, "resolve_ruleset", fake_rules)
+    mod.sweep("o/r", "t")
+    assert calls == ["main"]
+
+
+# --------------------------------------------------------------------------
+# Exit status. Same contract as the sibling, so the two read alike.
+# --------------------------------------------------------------------------
+
+
+def test_a_finding_exits_one_and_the_ordinary_state_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mod, "resolve_ruleset", lambda repo, ref, token: MAIN)
+
+    monkeypatch.setattr(mod, "resolve_state", lambda repo, pr, token: state(unresolved_threads=1))
+    assert mod.main(["--repo", "o/r", "--pr", "1", "--token", "t"]) == 1
+
+    monkeypatch.setattr(mod, "resolve_state", lambda repo, pr, token: state(approvers=()))
+    assert mod.main(["--repo", "o/r", "--pr", "1", "--token", "t"]) == 0
+
+
+def test_a_lookup_failure_reports_nothing_rather_than_a_blocker(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Red must never mean "this branch needs another human"."""
+
+    def boom(repo: str, pr: int, token: str) -> Any:
+        raise ValueError("no")
+
+    monkeypatch.setattr(mod, "resolve_state", boom)
+    assert mod.main(["--repo", "o/r", "--pr", "1", "--token", "t"]) == 0
+    assert "lookup failed" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["--repo", "o/r", "--token", "t"], "--pr is required"),
+        (["--repo", "o/r", "--token", "t", "--pr", "1", "--all-open"], "mutually exclusive"),
+        (["--repo", "o/r", "--pr", "1"], "--token is required"),
+        (["--pr", "1", "--token", "t"], "--repo is required"),
+    ],
+)
+def test_an_ambiguous_invocation_is_refused_rather_than_resolved(
+    argv: list[str], expected: str, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Silently ignoring either flag reads as a successful run of the other thing."""
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+    with pytest.raises(SystemExit):
+        mod.main(argv)
+    assert expected in capsys.readouterr().err
+
+
+def test_the_step_summary_receives_the_report(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    mod._emit("## a report")
+    assert "## a report" in summary.read_text(encoding="utf-8")


### PR DESCRIPTION
## What this changes

Adds `scripts/check_merge_blockers.py`, which reads the branch ruleset and names every rule a pull request leaves unsatisfied, together with the party who can clear it. Nothing is gated and no policy changes.

Closes #2578.

## Why

`mergeStateStatus: BLOCKED` is one word for at least six unrelated situations and names none of them. The rule that is actually unsatisfied is what decides *who owes the next action*, so collapsing them loses the only fact a triage pass needs. Two pull requests measured 2026-08-21, both approved and green, both idle after approval on obligations that were not a reviewer's:

| PR | approved | merged | idle | actually unsatisfied | who could clear it |
|---|---|---|---|---|---|
| #2566 | 16:39 | 17:10 | 31 min | one unresolved review thread | the author |
| #2574 | 16:25 | 17:10 | 45 min | nothing - a stale computation | anyone, by retrying |

#2566 sat on `required_review_thread_resolution`, on a thread whose fix had already landed and which the reviewer had approved *past*. #2574 had zero threads and twelve green checks; `mergePullRequest` refused with `Pull Request is not mergeable`, naming nothing, and the REST merge then succeeded on the first attempt with no state having changed in between.

This repository has now recorded four causes of the same presentation - #1905 (pusher-only approval), #1917 (viewer-scoped token), #1988 (zero check suites), and these two. Each was diagnosed by hand. `check_last_push_approval.py` answers exactly one of them, deliberately, and reports `satisfied` on both cases above: right shape, wrong scope.

## Verdicts on the live queue

Run against all open pull requests, which is the discrimination the change exists for:

```
| pull request | unsatisfied rule(s)                      | owed by      |
| #1035        | merge-conflict, pusher-only-approval     | the author   |
| #1722        | merge-conflict, missing-approval          | the author   |
| #2480        | required-check-pending, missing-approval  | any reviewer |
| #2497        | missing-approval                         | any reviewer |
| #2534        | missing-approval                         | any reviewer |
```

This matches the independent measurement recorded on #1905 on 2026-08-21 (seven awaiting first review, two `DIRTY`), and separates the two rows that no amount of reviewing clears from the seven that a single reviewer clears each.

## Design notes

**The ruleset is read, not hardcoded.** A rule changed in repository settings cannot drift from the report, a rule the branch does not carry is never named as a blocker, and a rule the branch *does* carry but this check cannot answer is named as unevaluated rather than silently dropped. `require_code_owner_review` (vacuous here - there is no CODEOWNERS file) and `require_extra_approval_for_unattributed_changes` are both set on `main` today and neither is answerable from pull request fields.

**Precedence is explicit.** A conflict or a draft is *gating*: the rules behind it cannot be assessed, so the report names one next action instead of a set the reader has to order. #1905 records losing that distinction as its own failure ("an approving review is necessary but no longer sufficient"). Conversely a blocker owed by nobody, such as a check still running, never masks one owed by a person - #2480 is answerable by a reviewer now, and reporting it as owed by nobody would park it.

**`require_last_push_approval` is not re-derived.** That rule, and the semantics of what counts as a current approval (per author, their most recent review that expresses a position, so `COMMENTED` is not a retraction), belong to `check_last_push_approval.py`. This check needs the same primitive to count approvals at all, so it imports it rather than restating it - the repository's own rule for a guard that acquires a second caller (Key Conventions 11). A test asserts the functions are defined in that module, so a future copy-paste fails rather than drifting.

**Not a gate, and not in the required set.** The remedy for most outcomes is somebody else's action, and a gate whose remedy is "find another human" sits red on a branch that has done nothing wrong. No workflow is added either: a report-only check in the same rollup as the required set makes a branch read as broken, which #1905 already complains about. This is a scan-time caller, the same shape as `--all-open` on the sibling.

**The stale-state outcome carries its own caveat.** An Actions installation token reads `blocked` on any pull request touching `.github/workflows/**` whatever the rules say (#1917), so `no-unsatisfied-rule` prints the instruction to re-read with a personal access token before concluding the state is stale. Without that, this check would manufacture the very false reading it exists to prevent.

## Testing

`tests/test_merge_blockers.py`, 59 tests. Fixtures are the real observations, not invented ones: the measured ruleset payload verbatim, and the three-case control where one varied input each produces three different owners. Also pinned - the required check's failing/pending/absent split by who clears it, an outdated thread not being counted, a GraphQL error raising rather than reporting zero threads (which would be a silent pass on the exact rule #2566 was blocked by), a re-run that succeeded not retiring a failing sibling, ASCII-only report strings, and the exit-status contract.

Two bugs were caught by these tests while writing them and are fixed here: the pusher's own approval was discounted even when the branch does not carry `require_last_push_approval`, which invented a blocker; and the sweep applied precedence in one renderer and not the other.

`check_merge_blockers.py` is registered in `_NAMES_REPOSITORY` in `tests/test_duplicate_claim_check.py`, since it reads `$GITHUB_REPOSITORY` and so must declare the flag that names one.

```
pytest tests/test_merge_blockers.py                                             59 passed
pytest <all AGENTS.md-reading process graders>                                 388 passed
pytest tests/test_{merge_blockers,last_push_approval,duplicate_claim_check}.py 171 passed
mypy scripts/check_merge_blockers.py                                           no issues
ruff check / ruff format --check                                               clean
python3 scripts/assemble_changelog.py --check                                  OK
```

The remaining suite failures in this environment are missing optional heavy dependencies (`lerobot`, `mujoco`, `psutil`, `serial`). Verified pre-existing by running the same subset on a clean checkout of `main`: 37 failed / 127 passed both with and without this change.

AGENTS.md records the two new causes and the invocation in the PR Workflow step that already enumerates the others, since a decision recorded only in a comment is not durable.