### PR TITLE
ci: report which review threads are still owed an author reply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,9 +291,15 @@ hatch run format            # ruff check --fix, ruff format
    - Thread's last non-bot comment is **yours** -> do not reply. You have
      already said it. If there is code to push, push it; the push is the
      message.
-   - Thread is **`isResolved` or `isOutdated`** -> do not reply. Resolution is
-     terminal. Reopening it to restate a landed fix reads as noise, not
-     diligence.
+   - Thread is **`isResolved`** -> do not reply. Resolution is a reviewer action
+     and terminal. Reopening it to restate a landed fix reads as noise, not
+     diligence. `isOutdated` is **not** terminal, measured: it describes the diff
+     rather than the conversation, and a thread keeps accepting comments after it
+     flips - #2577's took two more after `d04a8969` moved its lines. It is also
+     `false` on threads that *are* answered, when the fix adds lines elsewhere
+     (#2480, still `false` after `e83cf51` fixed it). Decide an outdated thread on
+     authorship like any other, or a reviewer's new demand on a moved line is
+     filed as settled.
    - Last comment is **someone else's** and your existing replies do not answer
      it -> reply once, then resolve.
 
@@ -301,6 +307,26 @@ hatch run format            # ruff check --fix, ruff format
    those twelve comments on its own: no semantic comparison, just the author of
    the last comment. Both `isResolved` and the comment authors are already in
    the context payload - they were fetched and not read.
+
+   **Ask for the verdict rather than re-deriving it.** "Fetched and not read" is
+   the whole failure, and it recurred after this rule was written: #2511 took
+   four author replies to one question and #2577 took two, with every field
+   needed to refuse them present in the payload each time. Re-deriving one
+   boolean from a payload that also contains a reviewer's question addressed to
+   you is the part that does not survive a context rebuild, so ask a command:
+
+   ```
+   python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --pr <N>
+   python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --all-open
+   ```
+
+   `settled` and `answered` are not work. `awaiting-the-author` is, and it is the
+   only outcome that exits 1 - so the sweep answers "which of my open pull
+   requests actually need me" in one read. The report also names the commit each
+   thread was written against beside the pull request's head, which is what tells
+   "already fixed at `<oid>`" apart from "not yet fixed" without re-deriving the
+   fix (#2520). It reports and does not gate: what an author should do next is not
+   something a branch can turn green.
 
    What makes this worth writing down is that the previous rule was *satisfied*
    by all twelve. "Address all review comments", and "reply when a thread asks

--- a/changelog.d/2581-thread-answered-check.md
+++ b/changelog.d/2581-thread-answered-check.md
@@ -1,0 +1,32 @@
+### Added: a command that says which review threads are still owed an author reply
+
+`scripts/check_thread_is_answered.py` reports, per review thread on a pull request,
+whether anything is owed: `settled` (a reviewer resolved it), `answered` (the last
+non-bot comment is the author's, so the next move is the reviewer's), or
+`awaiting-the-author` - the only outcome that is work, and the only one that exits
+`1`. `--all-open` sweeps every open non-draft pull request, answering "which of
+these actually need me" in one read.
+
+One rule decides it: whoever spoke last owes the next move, unless a reviewer
+resolved the thread. A thread is append-only, so a reviewer's question stays in it
+verbatim after it is answered and its presence is not evidence that anything is
+outstanding - #2511 collected four author replies to one question in 27 minutes and
+#2577 collected two, each announcing a commit the previous reply had already named.
+
+`isOutdated` is reported but not consulted, because it describes the diff rather
+than the conversation and is unreliable in both directions: it stays `false` on an
+answered thread whose fix added lines elsewhere (#2480 after `e83cf51`), and a
+thread goes on accepting comments after it flips to `true` (#2577 took two more),
+so reading it as terminal files a reviewer's new demand on a moved line as settled.
+The AGENTS.md rule that called it terminal is corrected to match.
+
+Whether the pull request's head has moved past the commit a thread was written
+against is reported beside each thread but decides nothing - an author reply that
+explains rather than changes is a complete answer. It is reported because
+`originalCommit` belongs to the thread and not to the comment (identical on all
+four comments of #2511, across two pushes), so `headRefOid` is the only commit a
+thread can be keyed to when telling "already fixed at `<oid>`" from "not yet
+fixed".
+
+Reports and does not gate, and is wired to no workflow: what an author should do
+next is not something a branch can turn green.

--- a/scripts/check_thread_is_answered.py
+++ b/scripts/check_thread_is_answered.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Report which of a pull request's review threads are still owed an author reply.
+
+Why this exists
+---------------
+A review thread is append-only, and an agent that rebuilds its context each run
+cannot tell "this question is unanswered" from "this question is answered and the
+answer is sitting in the payload I just read". The reviewer's question is still
+there verbatim either way. Nothing in the serialised thread says *answered*.
+
+So the same thread gets answered repeatedly. Measured on two threads in this
+repository:
+
+============  ==========================  ===============  =========================
+pull request  thread                       author replies   what the replies after
+                                                            the first one added
+============  ==========================  ===============  =========================
+#2511         ``PRRT_kwDORUMiZs6arq8z``    3                nothing -- the same fix,
+                                                            the same commit
+                                                            (``c2969d4``), the same
+                                                            6 failures reproduced
+                                                            three more times, over
+                                                            27 minutes
+#2577         ``PRRT_kwDORUMiZs6bQMZz``    2                nothing -- ``d04a8969``
+                                                            was already named by the
+                                                            first reply, 10 minutes
+                                                            earlier
+============  ==========================  ===============  =========================
+
+The cost is not the wasted run. It is that a duplicate reply is permanent: every
+later reviewer and every later run has to read it, and reading it is itself what
+makes the next run likely to add one more. #2520 records the loop.
+
+Why the rule that already exists did not stop it
+------------------------------------------------
+AGENTS.md is not silent here. It already says a thread that ``isResolved`` or
+``isOutdated`` is terminal and must not be replied to, and that a thread whose
+last non-bot comment is yours has already been answered. #2577's thread was
+**both** ``isResolved: true`` and ``isOutdated: true`` when it received its third
+comment at 19:28:20Z, and its second and third comments were both the author's.
+Every field needed to refuse that reply was in the payload, and had been fetched.
+
+That is the argument for a command rather than another paragraph. The rule asks a
+reader to re-derive one boolean from a payload that also contains a reviewer's
+question addressed to them; the command asks for a pull request number and prints
+a verdict. The same reasoning put ``check_duplicate_claim.py`` in ``scripts/``
+after prose alone failed to prevent three duplicate claims.
+
+Why a reply cannot be keyed to the commit that answers it
+---------------------------------------------------------
+The obvious implementation is to read the commit a reply was written against and
+compare it to the branch head. It cannot work: ``originalCommit`` is a property of
+the **thread**, not of the comment. On #2511 all four comments -- one reviewer
+comment and three author replies spanning 04:19 to 04:46 -- report the same
+``originalCommit`` ``ee3e4526``, while the branch head by the last reply was
+``0a69634d``:
+
+===================  =========================  ==========================
+comment              author                     ``originalCommit``
+===================  =========================  ==========================
+1 (04:19 reviewer)   ``yinsong1986``            ``ee3e4526``
+2 (04:19 reply)      ``cagataycali``            ``ee3e4526``
+3 (04:31 reply)      ``cagataycali``            ``ee3e4526``
+4 (04:46 reply)      ``cagataycali``            ``ee3e4526``
+===================  =========================  ==========================
+
+So a reply carries no record of the commit it was verified against, and the only
+commit a thread can be keyed to is the pull request's own ``headRefOid``. This
+reads that, reports it beside every thread, and says whether the head has moved
+off the commit the thread was written against -- which is what a second run needs
+in order to tell "already fixed at ``d04a8969``" from "not yet fixed" (#2520).
+
+What decides the outcome, and what is only reported
+---------------------------------------------------
+One rule decides it: **whoever spoke last owes the next move, unless a reviewer
+resolved the thread.** Resolution is terminal because it is a reviewer action.
+Everything else is the authorship test.
+
+Two fields that look like they belong in that decision are reported beside it
+instead, and both exclusions are deliberate.
+
+``isOutdated`` is not consulted. It describes the diff, not the conversation: it
+says the lines the thread was written against have moved. As a stand-in for "this
+has been answered" it is wrong in both directions, and each direction is measured
+here.
+
+It can be ``false`` on a thread that *is* answered. #2480's thread still reads
+``isOutdated: false`` after ``e83cf51`` fixed the finding it raised, because the
+fix added a method rather than rewriting the commented line. So outdated is not
+evidence of an answer.
+
+And a thread keeps accepting comments after it flips to ``true``. #2577's thread
+is ``isOutdated: true`` -- ``d04a8969`` moved those lines -- and it took two
+further comments at 19:17:50Z and 19:28:20Z regardless. Both happened to be the
+author's, but nothing about the flag prevents a reviewer's from arriving the same
+way, and a rule that reads outdated as terminal would file that demand as settled.
+Authorship subsumes what the proxy was reaching for: if the last word is yours
+there is nothing to say, however the diff moved -- and if it is not, there is.
+Pinned by ``test_a_reviewer_demand_on_an_outdated_thread_is_owed``.
+
+Whether the head has moved is not consulted either. An author reply that explains
+rather than changes -- "this is intentional, here is why" -- is a complete answer
+that leaves the head exactly where the thread was written, and folding the head
+comparison into the verdict would call it unanswered and invite the duplicate
+reply this exists to prevent. Pinned by
+``test_an_answer_with_no_commit_after_it_is_still_answered``.
+
+What the steady state looks like, and why that is the point
+-----------------------------------------------------------
+Swept over the 150 most recently updated closed pull requests here, every one of
+the 26 review threads found is ``isResolved: true`` and therefore ``settled``, and
+all 150 report ``nothing-owed``. The same sweep over the 11 currently open pull
+requests also reports ``nothing-owed`` throughout.
+
+That is the expected result, not a broken check: threads in this repository do get
+resolved, so on a finished pull request ``settled`` is the only outcome left. The
+two discriminating outcomes exist only in the window between a reviewer's comment
+and its resolution -- which is exactly the window a scheduled run reads in, and
+exactly when the wrong answer costs a permanent duplicate reply. Their coverage
+therefore comes from ``tests/test_thread_is_answered.py``, which replays the
+measured payloads of the two incidents above with the flags as they stood in that
+window, rather than from a historical sweep that cannot contain them.
+
+The incidents are attributable on timestamped fields alone, which is why
+authorship carries the rule. Thread resolution has no timestamp in the API, so
+"was it resolved yet" is not answerable after the fact -- but at 19:28:20Z on
+#2577 the last non-bot comment was the author's own reply from 19:17:50Z, and at
+04:31 and 04:46 on #2511 the last non-bot comment was the author's reply from
+04:19. The authorship test alone returns ``answered`` for all three, with no
+appeal to a field whose history cannot be read back.
+
+The last *non-bot* comment decides, because ``github-advanced-security`` posts
+directly into review threads -- measured on #2480 and on all four threads of
+#1722 -- and a bot commenting after the author's reply would otherwise flip an
+answered thread back to owed. AGENTS.md already words its rule as "last non-bot
+comment", so this implements the documented rule rather than inventing one. A
+thread carrying only bot comments has no author answer and is owed.
+
+Outcomes
+--------
+Per thread:
+
+``settled``
+    ``isResolved``. Terminal; a reviewer has closed the business, and reopening it
+    to restate a landed fix reads as noise.
+``answered``
+    Open, and the last non-bot comment is the pull request author's. The author
+    has had the last word; the next move is the reviewer's.
+``awaiting-the-author``
+    Open, and the last non-bot comment belongs to someone other than the author
+    (or there is no non-bot comment). This is the only outcome that is work.
+
+Per pull request: ``nothing-owed``, or ``author-owes-a-reply`` when at least one
+thread is ``awaiting-the-author``.
+
+What this deliberately does not do
+----------------------------------
+It does not read comment bodies. A reply naming a commit and a reply naming
+nothing are the same to this check, because judging whether an answer is adequate
+is the reviewer's job and a check that attempted it would be wrong in the
+direction of arguing with a reviewer.
+
+It does not gate, and is wired to no workflow. Its answer is about what an author
+should do next, which is not something a branch can turn green, and this
+repository already keeps that kind of check out of CI
+(``check_pr_head_is_current.py``, ``check_duplicate_claim.py``,
+``check_merge_blockers.py``).
+
+Usage
+-----
+::
+
+    python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --pr 2577
+    python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --all-open
+
+Exit 1 when at least one evaluated pull request has a thread awaiting its author.
+
+Pinned by tests/test_thread_is_answered.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# Pagination ceiling for the open-pull-request listing, matching
+# check_pr_head_is_current.py and check_last_push_approval.py.
+_MAX_PAGES = 20
+
+# Read ceilings, chosen against the GraphQL node budget rather than by taste:
+# the sweep multiplies all three, and 25 x 100 x 20 stays an order of magnitude
+# under the 500,000-node limit that 50 x 100 x 100 would sit exactly on.
+#
+# Threads are read from the *start* and the shortfall is named in the report,
+# because the unread tail of a long thread list is its newest threads and those
+# are the likeliest to be owed -- silently dropping them would report
+# nothing-owed for the one case that is work. Comments are read from the *end*,
+# because only the last non-bot comment decides and a thread's early history
+# cannot change it.
+_PRS_PER_PAGE = 25
+_THREADS_PER_PR = 100
+_COMMENTS_PER_THREAD = 20
+
+SETTLED = "settled"
+ANSWERED = "answered"
+AWAITING_THE_AUTHOR = "awaiting-the-author"
+
+NOTHING_OWED = "nothing-owed"
+AUTHOR_OWES_A_REPLY = "author-owes-a-reply"
+
+_API = "https://api.github.com/graphql"
+
+# The remedy text, shared by the single-pull-request report and the sweep so the
+# two cannot drift into describing different remedies for one outcome.
+WHAT_TO_DO: tuple[str, ...] = (
+    "",
+    "### What clears this",
+    "",
+    "Answer each `awaiting-the-author` thread **once**, then resolve it. One",
+    "concern, one commit, one reply -- and the reply is owed only because the",
+    "last word is not yours yet.",
+    "",
+    "Threads reported `answered` or `settled` are not work. Do not reply to them",
+    "to restate a fix that has landed: the reviewer's question stays in the",
+    "thread verbatim after it is answered, so its presence is not evidence that",
+    "anything is outstanding. If code is owed, push it -- the push is the",
+    "message.",
+    "",
+    "`head moved` beside an `answered` thread says a commit followed the thread,",
+    "not that the commit fixed it. It is there so a later run can tell",
+    '"already fixed at <oid>" from "not yet fixed" without re-deriving the fix.',
+)
+
+
+def _short(oid: str | None) -> str:
+    """Render a commit for a human without pretending an absent one is a commit."""
+    if not oid:
+        return "(unknown)"
+    return f"`{oid[:8]}`"
+
+
+@dataclass(frozen=True)
+class Thread:
+    """One review thread, and the two facts its outcome was computed from."""
+
+    thread_id: str
+    path: str
+    outcome: str
+    last_author: str | None
+    comments: int
+    original_commit: str | None
+    head_moved: bool
+    outdated: bool
+
+    @property
+    def is_owed(self) -> bool:
+        return self.outcome == AWAITING_THE_AUTHOR
+
+
+@dataclass(frozen=True)
+class Row:
+    """One evaluated pull request."""
+
+    pr: int
+    author: str
+    head: str | None
+    threads: tuple[Thread, ...]
+    unread_threads: int
+
+    @property
+    def owed(self) -> tuple[Thread, ...]:
+        return tuple(t for t in self.threads if t.is_owed)
+
+    @property
+    def outcome(self) -> str:
+        return AUTHOR_OWES_A_REPLY if self.owed else NOTHING_OWED
+
+    @property
+    def is_finding(self) -> bool:
+        return bool(self.owed)
+
+    @property
+    def summary(self) -> str:
+        if self.owed:
+            named = ", ".join(f"`{t.path}`" for t in self.owed)
+            return (
+                f"{len(self.owed)} of {len(self.threads)} thread(s) are awaiting @{self.author}: "
+                f"{named}. Answer each once, then resolve it."
+            )
+        if not self.threads:
+            return "No review threads. Nothing is owed here."
+        return (
+            f"All {len(self.threads)} thread(s) are settled or already answered by @{self.author}. "
+            "Nothing is owed here; the next move belongs to a reviewer."
+        )
+
+
+def last_non_bot_author(comments: Sequence[dict]) -> str | None:
+    """Return the login of the last comment not written by a bot.
+
+    ``None`` when every comment is a bot's, which is not the same as an empty
+    thread and is treated the same way by the caller: neither carries an answer
+    from the author.
+    """
+    for comment in reversed(list(comments)):
+        author = comment.get("author") or {}
+        if author.get("__typename") == "Bot":
+            continue
+        login = author.get("login")
+        if isinstance(login, str) and login:
+            return login
+    return None
+
+
+def classify(node: dict, pr_author: str, head: str | None) -> Thread:
+    """Decide whether one review thread is owed a reply from ``pr_author``.
+
+    ``head`` is the pull request's recorded head commit. It is used only to
+    compute ``head_moved`` for the report -- never to choose the outcome. See the
+    module docstring: an answer that explains rather than changes leaves the head
+    where the thread was written, and is still an answer.
+    """
+    comments = ((node.get("comments") or {}).get("nodes")) or []
+    first = comments[0] if comments else {}
+    original = ((first.get("originalCommit") or {}).get("oid")) or None
+    last_author = last_non_bot_author(comments)
+    head_moved = bool(head and original and head != original)
+
+    if node.get("isResolved"):
+        outcome = SETTLED
+    elif last_author is not None and last_author == pr_author:
+        outcome = ANSWERED
+    else:
+        outcome = AWAITING_THE_AUTHOR
+
+    return Thread(
+        thread_id=str(node.get("id") or "(unknown)"),
+        path=str(node.get("path") or "(unknown)"),
+        outcome=outcome,
+        last_author=last_author,
+        comments=int((node.get("comments") or {}).get("totalCount") or len(comments)),
+        original_commit=original,
+        head_moved=head_moved,
+        outdated=bool(node.get("isOutdated")),
+    )
+
+
+def evaluate(node: dict) -> Row:
+    """Evaluate one pull request node from either query shape."""
+    author = ((node.get("author") or {}).get("login")) or "(unknown)"
+    head = node.get("headRefOid")
+    connection = node.get("reviewThreads") or {}
+    nodes = connection.get("nodes") or []
+    total = connection.get("totalCount")
+    unread = max(0, int(total) - len(nodes)) if isinstance(total, int) else 0
+    return Row(
+        pr=int(node["number"]),
+        author=author,
+        head=head if isinstance(head, str) else None,
+        threads=tuple(classify(t, author, head if isinstance(head, str) else None) for t in nodes),
+        unread_threads=unread,
+    )
+
+
+def _graphql(query: str, variables: dict[str, object], token: str) -> dict:
+    request = urllib.request.Request(
+        _API,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "strands-robots-check-thread-is-answered",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise ValueError(f"GraphQL errors: {payload['errors']}")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("GraphQL response carried no data object")
+    return data
+
+
+_PR_FIELDS = """
+  number isDraft headRefOid
+  author { login }
+  reviewThreads(first: __THREADS__) {
+    totalCount
+    nodes {
+      id isResolved isOutdated path
+      comments(last: __COMMENTS__) {
+        totalCount
+        nodes { author { login __typename } originalCommit { oid } }
+      }
+    }
+  }
+"""
+
+_FIELDS_PLACEHOLDER = "__PR_FIELDS__"
+
+
+def _with_pr_fields(query: str) -> str:
+    """Substitute the shared field list into a query document.
+
+    Neither an f-string nor ``%`` formatting: a GraphQL document is almost all
+    braces, so both spellings would require escaping every one of them and the
+    query would stop being copy-pasteable into the API explorer. The two shapes
+    share one field list so a field added for the sweep cannot go missing from
+    the single-pull-request path.
+    """
+    fields = _PR_FIELDS.replace("__THREADS__", str(_THREADS_PER_PR)).replace("__COMMENTS__", str(_COMMENTS_PER_THREAD))
+    return query.replace(_FIELDS_PLACEHOLDER, fields)
+
+
+_ONE_PR = _with_pr_fields(
+    """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){ __PR_FIELDS__ }
+  }
+}
+"""
+)
+
+_OPEN_PRS = _with_pr_fields(
+    """
+query($owner:String!,$name:String!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequests(states: OPEN, first: __PAGE__, after: $cursor){
+      pageInfo { hasNextPage endCursor }
+      nodes { __PR_FIELDS__ }
+    }
+  }
+}
+""".replace("__PAGE__", str(_PRS_PER_PAGE))
+)
+
+
+def _split_repo(repo: str) -> tuple[str, str]:
+    if repo.count("/") != 1 or not all(repo.split("/")):
+        raise ValueError(f"--repo must be owner/name, got {repo!r}")
+    owner, name = repo.split("/")
+    return owner, name
+
+
+def fetch_one(repo: str, number: int, token: str) -> dict:
+    owner, name = _split_repo(repo)
+    data = _graphql(_ONE_PR, {"owner": owner, "name": name, "number": number}, token)
+    node = (data.get("repository") or {}).get("pullRequest")
+    if not isinstance(node, dict):
+        raise ValueError(f"{repo}#{number} did not resolve to a pull request")
+    return node
+
+
+def fetch_open(repo: str, token: str) -> list[dict]:
+    owner, name = _split_repo(repo)
+    nodes: list[dict] = []
+    cursor: str | None = None
+    for _ in range(_MAX_PAGES):
+        data = _graphql(_OPEN_PRS, {"owner": owner, "name": name, "cursor": cursor}, token)
+        connection = (data.get("repository") or {}).get("pullRequests") or {}
+        nodes.extend(connection.get("nodes") or [])
+        page = connection.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            break
+        cursor = page.get("endCursor")
+    return nodes
+
+
+def _thread_rows(row: Row) -> list[str]:
+    lines = [
+        "| thread | outcome | last non-bot comment | comments | thread commit | head moved | outdated |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for thread in row.threads:
+        who = f"@{thread.last_author}" if thread.last_author else "(only bots)"
+        lines.append(
+            f"| `{thread.path}` | {thread.outcome} | {who} | {thread.comments} | "
+            f"{_short(thread.original_commit)} | {'yes' if thread.head_moved else 'no'} | "
+            f"{'yes' if thread.outdated else 'no'} |"
+        )
+    return lines
+
+
+def _unread_note(row: Row) -> list[str]:
+    if not row.unread_threads:
+        return []
+    return [
+        "",
+        f"{row.unread_threads} thread(s) beyond the first {_THREADS_PER_PR} were not read, so this "
+        "report is silent about them rather than clearing them.",
+    ]
+
+
+def render_one(repo: str, row: Row) -> str:
+    lines = [
+        "## Review threads owed a reply",
+        "",
+        f"Outcome: **{row.outcome}**",
+        "",
+        row.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| pull request | {repo}#{row.pr} |",
+        f"| author | @{row.author} |",
+        f"| recorded head | {_short(row.head)} |",
+        f"| threads | {len(row.threads)} |",
+        f"| awaiting the author | {len(row.owed)} |",
+    ]
+    if row.threads:
+        lines += [""] + _thread_rows(row)
+    lines += _unread_note(row)
+    if row.is_finding:
+        lines += list(WHAT_TO_DO)
+    return "\n".join(lines)
+
+
+def render_sweep(repo: str, rows: Sequence[Row], skipped: Sequence[int]) -> str:
+    findings = [r for r in rows if r.is_finding]
+    lines = [
+        "## Review threads owed a reply -- sweep",
+        "",
+        f"Evaluated {len(rows)} open non-draft pull request(s) in {repo}.",
+        "",
+    ]
+    if findings:
+        named = ", ".join(f"#{r.pr}" for r in findings)
+        lines += [f"**{len(findings)} pull request(s) have a thread awaiting their author:** {named}.", ""]
+    else:
+        lines += ["Every review thread is settled or already answered by its author.", ""]
+
+    lines += [
+        "| pull request | author | outcome | threads | awaiting | answered | settled |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        answered = sum(1 for t in row.threads if t.outcome == ANSWERED)
+        settled = sum(1 for t in row.threads if t.outcome == SETTLED)
+        lines.append(
+            f"| #{row.pr} | @{row.author} | {row.outcome} | {len(row.threads)} | "
+            f"{len(row.owed)} | {answered} | {settled} |"
+        )
+    for row in findings:
+        lines += ["", f"### #{row.pr}", ""] + _thread_rows(row)
+    for row in rows:
+        note = _unread_note(row)
+        if note:
+            lines += [note[0], f"#{row.pr}: {note[1]}"]
+    if skipped:
+        lines += ["", "Skipped: " + ", ".join(f"#{n}" for n in skipped) + "."]
+    if findings:
+        lines += list(WHAT_TO_DO)
+    return "\n".join(lines)
+
+
+def _publish(report: str) -> None:
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def _annotate(repo: str, row: Row) -> None:
+    print(f"::warning title=A review thread is awaiting its author::{repo}#{row.pr}: {row.summary}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    parser.add_argument(
+        "--all-open",
+        action="store_true",
+        help="Evaluate every open non-draft pull request instead of one.",
+    )
+    args = parser.parse_args(argv)
+
+    # Refused rather than resolved, for the reason the siblings give: silently
+    # ignoring either flag reads as a successful run of the other thing.
+    if args.all_open and args.pr:
+        parser.error("--all-open and --pr are mutually exclusive")
+
+    if not args.repo:
+        print("check_thread_is_answered: --repo is required", file=sys.stderr)
+        return 0
+    if not args.token:
+        print("check_thread_is_answered: no token; set --token or GITHUB_TOKEN", file=sys.stderr)
+        return 0
+
+    if args.all_open:
+        try:
+            nodes = fetch_open(args.repo, args.token)
+        except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+            # Listing is the one lookup with no partial result to report, so it
+            # fails open rather than failing the caller's run.
+            print(f"check_thread_is_answered: could not list open pull requests: {exc}", file=sys.stderr)
+            return 0
+        rows: list[Row] = []
+        skipped: list[int] = []
+        for node in nodes:
+            if node.get("isDraft"):
+                continue
+            try:
+                rows.append(evaluate(node))
+            except (ValueError, KeyError, TypeError) as exc:
+                # One unreadable pull request must not suppress a finding on the
+                # others, so it is named and skipped rather than fatal.
+                number = node.get("number")
+                print(f"check_thread_is_answered: skipped #{number}: {exc}", file=sys.stderr)
+                if isinstance(number, int):
+                    skipped.append(number)
+        rows.sort(key=lambda r: r.pr)
+        _publish(render_sweep(args.repo, rows, skipped))
+        findings = [r for r in rows if r.is_finding]
+        for row in findings:
+            _annotate(args.repo, row)
+        return 1 if findings else 0
+
+    if not args.pr:
+        print("check_thread_is_answered: --pr or --all-open is required", file=sys.stderr)
+        return 0
+    try:
+        row = evaluate(fetch_one(args.repo, int(args.pr), args.token))
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError, TypeError) as exc:
+        # A lookup failure is not a finding: say so on stderr and pass, rather
+        # than accusing an author of a reply this run could not observe.
+        print(f"check_thread_is_answered: could not evaluate {args.repo}#{args.pr}: {exc}", file=sys.stderr)
+        return 0
+    _publish(render_one(args.repo, row))
+    if row.is_finding:
+        _annotate(args.repo, row)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -92,6 +92,9 @@ _NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
     "check_merge_base_overlap.py": ("--github-repo", "--all-open"),
     "check_merge_blockers.py": ("--repo", None),
     "check_pr_head_is_current.py": ("--repo", None),
+    # Both modes reach the API, so both owe the flag and there is no marker to
+    # scope it to: --pr resolves one pull request and --all-open sweeps them.
+    "check_thread_is_answered.py": ("--repo", None),
 }
 
 

--- a/tests/test_review_thread_reply_gate.py
+++ b/tests/test_review_thread_reply_gate.py
@@ -75,11 +75,18 @@ _GATE = "Check whether you are already the thread's last author before replying.
 #: rule gets "simplified" back into the loop it exists to stop.
 _PER_CONCERN = "per-*concern* obligation, not a per-*cycle* one"
 
-#: The two dispositions, each paired with its directive. The pairing is the
-#: point: naming the fields without "do not reply" documents a payload, not a
-#: rule.
+#: The dispositions, each paired with its directive. The pairing is the point:
+#: naming the fields without a directive documents a payload, not a rule.
 _OWN_REPLY_DIRECTIVE = "is **yours** -> do not reply"
-_TERMINAL_STATE_DIRECTIVE = "`isResolved` or `isOutdated`** -> do not reply"
+
+#: Resolution is terminal, and it is now the *only* state that is. ``isOutdated``
+#: was paired with it in one directive until the pairing was measured false, so
+#: the correction is pinned from both sides - the terminal directive, the explicit
+#: denial, and the disposition that replaces it. Re-merging the two fields into
+#: one "do not reply" reads as a tightening and fails here.
+_RESOLVED_DIRECTIVE = "`isResolved`** -> do not reply"
+_OUTDATED_NOT_TERMINAL = "`isOutdated` is **not** terminal"
+_OUTDATED_DISPOSITION = "Decide an outdated thread on authorship like any other"
 
 #: The single-reply case, so the gate cannot be read as "never reply".
 _REPLY_ONCE = "reply once, then resolve"
@@ -156,11 +163,38 @@ def test_both_do_not_reply_dispositions_survive_with_their_directive() -> None:
         "author of the last comment - and on its own it would have prevented ten "
         "of the twelve replies on #1899."
     )
-    assert _TERMINAL_STATE_DIRECTIVE in prose, (
-        "AGENTS.md > PR Workflow step 5 no longer treats isResolved / isOutdated "
-        "as terminal. Both fields are already in the context payload; on #1899 "
-        "they were fetched and not read, and ten replies landed on a thread "
-        "carrying both."
+    assert _RESOLVED_DIRECTIVE in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer treats isResolved as terminal. "
+        "The field is already in the context payload; on #1899 it was fetched and "
+        "not read, and ten replies landed on a thread carrying it."
+    )
+
+
+def test_outdated_is_denied_terminality_and_given_a_disposition() -> None:
+    """``isOutdated`` is the one payload field the gate must NOT read as terminal.
+
+    It was paired with ``isResolved`` in a single "do not reply" directive, and the
+    pairing is false in both directions: a thread keeps accepting comments after it
+    flips, and it reads ``false`` on threads that are genuinely answered when the
+    fix adds its lines elsewhere. So the denial and its replacement disposition are
+    pinned together - a denial that removes the rule without supplying one leaves an
+    outdated thread undecided, which is how a reviewer's new demand on a moved line
+    gets filed as settled.
+    """
+    prose = _step_5_prose()
+    assert _OUTDATED_NOT_TERMINAL in prose, (
+        "AGENTS.md > PR Workflow step 5 no longer denies that isOutdated is "
+        "terminal. It describes the diff rather than the conversation, so a thread "
+        "keeps accepting comments after it flips, and it is false on threads that "
+        "ARE answered when the fix adds lines elsewhere. Reading it as terminal "
+        "files a reviewer's new demand on a moved line as settled - the opposite "
+        "failure to #1899's, and the one a reviewer pays for."
+    )
+    assert _OUTDATED_DISPOSITION in prose, (
+        "AGENTS.md > PR Workflow step 5 denies that isOutdated is terminal without "
+        "saying what to do instead. The denial alone removes a rule and leaves no "
+        "rule; an outdated thread is decided on authorship like any other, and "
+        "that sentence is the whole replacement."
     )
 
 

--- a/tests/test_thread_is_answered.py
+++ b/tests/test_thread_is_answered.py
@@ -1,0 +1,432 @@
+"""Pins for scripts/check_thread_is_answered.py.
+
+The payloads here are not invented. Each one is the shape measured from a real
+review thread in this repository, with the resolution flag set to what it was
+during the window the check is meant to be run in -- which is the only window in
+which a thread is not yet ``isResolved``. A sweep of the 150 most recently updated
+closed pull requests finds 26 review threads and every one of them is resolved, so
+the two discriminating outcomes cannot be covered by real closed data and are
+covered here instead.
+
+Measured sources:
+
+- #2577, thread ``PRRT_kwDORUMiZs6bQMZz``: one reviewer comment plus two author
+  replies (19:17:50Z, 19:28:20Z), head ``d04a8969``, thread commit ``b966ce64``,
+  ``isOutdated: true``.
+- #2511, thread ``PRRT_kwDORUMiZs6arq8z``: one reviewer comment plus three author
+  replies (04:19, 04:31, 04:46), head ``0a69634d``, thread commit ``ee3e4526``.
+- #2480, thread ``PRRT_kwDORUMiZs6aqPJ-``: a ``github-advanced-security`` comment
+  answered by the author, ``isOutdated: false`` even after ``e83cf51`` fixed it.
+- #1722: four threads carrying a single bot comment each.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_thread_is_answered.py"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_thread_is_answered", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+# Measured on the pull requests named in the module docstring.
+AUTHOR = "cagataycali"
+REVIEWER = "yinsong1986"
+BOT = "github-advanced-security"
+
+HEAD_2577 = "d04a896937dbec1281e39eaa31eeffecf950889d"
+COMMIT_2577 = "b966ce64b75edfe69e4f8ba73bfc391306703b1e"
+HEAD_2511 = "0a69634d7f0d037b3c1d587744acb92e9f99bf59"
+COMMIT_2511 = "ee3e452681fe4f649b87f50bdba40a07e706a192"
+
+
+def _comment(login: str, *, bot: bool = False, oid: str = COMMIT_2577) -> dict:
+    """One review-thread comment, in the shape the GraphQL query returns."""
+    return {
+        "author": {"login": login, "__typename": "Bot" if bot else "User"},
+        "originalCommit": {"oid": oid},
+    }
+
+
+def _thread(
+    comments: list[dict],
+    *,
+    resolved: bool = False,
+    outdated: bool = False,
+    path: str = "tests/simulation/mujoco/test_randomize_persistence_boundary.py",
+    thread_id: str = "PRRT_kwDORUMiZs6bQMZz",
+) -> dict:
+    return {
+        "id": thread_id,
+        "isResolved": resolved,
+        "isOutdated": outdated,
+        "path": path,
+        "comments": {"totalCount": len(comments), "nodes": comments},
+    }
+
+
+def _pr(threads: list[dict], *, number: int = 2577, author: str = AUTHOR, head: str = HEAD_2577) -> dict:
+    return {
+        "number": number,
+        "isDraft": False,
+        "headRefOid": head,
+        "author": {"login": author},
+        "reviewThreads": {"totalCount": len(threads), "nodes": threads},
+    }
+
+
+# --------------------------------------------------------------------------
+# The two incidents this check was written for.
+# --------------------------------------------------------------------------
+
+
+def test_the_2577_thread_is_answered_when_its_third_comment_was_posted() -> None:
+    """The reply that should not have been sent.
+
+    At 19:28:20Z the thread held a reviewer comment and the author's own reply
+    from 19:17:50Z, which already named ``d04a8969``. The check has to call that
+    answered, because the reviewer's question is still sitting in the payload
+    verbatim and is not evidence that anything is outstanding.
+    """
+    thread = _thread(
+        [_comment(REVIEWER), _comment(AUTHOR)],
+        outdated=True,
+    )
+    verdict = mod.classify(thread, AUTHOR, HEAD_2577)
+    assert verdict.outcome == mod.ANSWERED
+    assert verdict.is_owed is False
+    assert verdict.last_author == AUTHOR
+
+
+@pytest.mark.parametrize("replies", [1, 2, 3])
+def test_the_2511_thread_is_answered_from_the_first_reply_onwards(replies: int) -> None:
+    """One reviewer comment, then N author replies -- answered at every N.
+
+    #2511 collected three author replies over 27 minutes, all announcing the same
+    commit. The check must return the same verdict after the first as after the
+    third, or it would license the second.
+    """
+    comments = [_comment(REVIEWER, oid=COMMIT_2511)]
+    comments += [_comment(AUTHOR, oid=COMMIT_2511) for _ in range(replies)]
+    verdict = mod.classify(
+        _thread(comments, thread_id="PRRT_kwDORUMiZs6arq8z"),
+        AUTHOR,
+        HEAD_2511,
+    )
+    assert verdict.outcome == mod.ANSWERED
+
+
+# --------------------------------------------------------------------------
+# The authorship rule, and that it is what decides.
+# --------------------------------------------------------------------------
+
+
+def test_a_reviewer_comment_with_no_reply_is_owed() -> None:
+    """The case that is work: the last word is the reviewer's."""
+    verdict = mod.classify(_thread([_comment(REVIEWER)]), AUTHOR, HEAD_2577)
+    assert verdict.outcome == mod.AWAITING_THE_AUTHOR
+    assert verdict.is_owed is True
+
+
+def test_flipping_only_the_last_comments_author_flips_the_outcome() -> None:
+    """Non-vacuity: the authorship test is doing the deciding, not the payload shape.
+
+    Same thread, same head, same commit, same comment count -- only the login on
+    the final comment differs. A check that always agreed would not move here.
+    """
+    answered = mod.classify(_thread([_comment(REVIEWER), _comment(AUTHOR)]), AUTHOR, HEAD_2577)
+    owed = mod.classify(_thread([_comment(AUTHOR), _comment(REVIEWER)]), AUTHOR, HEAD_2577)
+    assert (answered.outcome, owed.outcome) == (mod.ANSWERED, mod.AWAITING_THE_AUTHOR)
+
+
+def test_a_resolved_thread_is_settled_whoever_spoke_last() -> None:
+    """Resolution is a reviewer action, so it outranks the authorship test.
+
+    A resolved thread whose last comment is the reviewer's is closed business, not
+    a demand: the reviewer had the last word and then resolved it anyway.
+    """
+    verdict = mod.classify(_thread([_comment(AUTHOR), _comment(REVIEWER)], resolved=True), AUTHOR, HEAD_2577)
+    assert verdict.outcome == mod.SETTLED
+    assert verdict.is_owed is False
+
+
+def test_a_reviewer_demand_on_an_outdated_thread_is_owed() -> None:
+    """The direction the ``isOutdated`` proxy gets wrong.
+
+    #2577's thread went on taking comments after ``d04a8969`` flipped it to
+    ``isOutdated: true``. A rule that read outdated as terminal would file a
+    reviewer's demand arriving that way as settled; the authorship test does not.
+    """
+    verdict = mod.classify(_thread([_comment(AUTHOR), _comment(REVIEWER)], outdated=True), AUTHOR, HEAD_2577)
+    assert verdict.outcome == mod.AWAITING_THE_AUTHOR
+    assert verdict.outdated is True
+
+
+# --------------------------------------------------------------------------
+# Bots.
+# --------------------------------------------------------------------------
+
+
+def test_a_bot_comment_after_the_authors_reply_does_not_reopen_the_thread() -> None:
+    """``github-advanced-security`` posts into threads (#2480, all four on #1722).
+
+    A bot speaking after the author must not turn an answered thread back into
+    work, which is why the *last non-bot* comment decides.
+    """
+    thread = _thread([_comment(REVIEWER), _comment(AUTHOR), _comment(BOT, bot=True)])
+    verdict = mod.classify(thread, AUTHOR, HEAD_2577)
+    assert verdict.outcome == mod.ANSWERED
+    assert verdict.last_author == AUTHOR
+
+
+def test_a_thread_of_only_bot_comments_is_owed() -> None:
+    """#1722's four threads are one bot comment each, and nobody has answered them."""
+    verdict = mod.classify(_thread([_comment(BOT, bot=True)]), "Vivek0712", HEAD_2577)
+    assert verdict.outcome == mod.AWAITING_THE_AUTHOR
+    assert verdict.last_author is None
+
+
+def test_last_non_bot_author_skips_a_run_of_trailing_bots() -> None:
+    assert mod.last_non_bot_author([_comment(AUTHOR), _comment(BOT, bot=True), _comment(BOT, bot=True)]) == AUTHOR
+    assert mod.last_non_bot_author([]) is None
+    assert mod.last_non_bot_author([_comment(BOT, bot=True)]) is None
+
+
+# --------------------------------------------------------------------------
+# What is reported rather than decided on.
+# --------------------------------------------------------------------------
+
+
+def test_an_answer_with_no_commit_after_it_is_still_answered() -> None:
+    """An author reply that explains rather than changes is a complete answer.
+
+    Here the head is still the commit the thread was written against, so no commit
+    followed the reply. Folding that into the verdict would call the thread
+    unanswered and license exactly the duplicate reply this check exists to stop.
+    """
+    verdict = mod.classify(_thread([_comment(REVIEWER), _comment(AUTHOR)]), AUTHOR, COMMIT_2577)
+    assert verdict.outcome == mod.ANSWERED
+    assert verdict.head_moved is False
+
+
+def test_head_moved_is_reported_and_changes_no_verdict() -> None:
+    """The same thread under two heads: the column moves, the outcome does not."""
+    thread = _thread([_comment(REVIEWER), _comment(AUTHOR)])
+    moved = mod.classify(thread, AUTHOR, HEAD_2577)
+    unmoved = mod.classify(thread, AUTHOR, COMMIT_2577)
+    assert moved.head_moved is True
+    assert unmoved.head_moved is False
+    assert moved.outcome == unmoved.outcome == mod.ANSWERED
+
+
+def test_an_unreadable_head_reports_no_movement_rather_than_movement() -> None:
+    """``None`` is not a commit that differs from the thread's."""
+    verdict = mod.classify(_thread([_comment(REVIEWER)]), AUTHOR, None)
+    assert verdict.head_moved is False
+
+
+def test_the_thread_commit_is_read_from_the_thread_not_from_a_reply() -> None:
+    """``originalCommit`` is a property of the thread, measured identical on all four
+    comments of #2511 across 27 minutes and two pushes.
+
+    So it is read from the thread's first comment. A payload whose last comment
+    carried a different oid must not change the reported thread commit -- if it
+    ever did, the field would be describing the reply instead.
+    """
+    thread = _thread([_comment(REVIEWER, oid=COMMIT_2511), _comment(AUTHOR, oid=HEAD_2511)])
+    assert mod.classify(thread, AUTHOR, HEAD_2511).original_commit == COMMIT_2511
+
+
+# --------------------------------------------------------------------------
+# Pull-request level aggregation.
+# --------------------------------------------------------------------------
+
+
+def test_a_pull_request_with_no_threads_owes_nothing() -> None:
+    row = mod.evaluate(_pr([]))
+    assert row.outcome == mod.NOTHING_OWED
+    assert row.is_finding is False
+    assert "No review threads" in row.summary
+
+
+def test_one_owed_thread_among_settled_ones_is_still_a_finding() -> None:
+    """A single unanswered thread is not diluted by its resolved neighbours."""
+    row = mod.evaluate(
+        _pr(
+            [
+                _thread([_comment(REVIEWER), _comment(AUTHOR)], resolved=True),
+                _thread([_comment(REVIEWER)], path="strands_robots/utils.py"),
+            ]
+        )
+    )
+    assert row.outcome == mod.AUTHOR_OWES_A_REPLY
+    assert row.is_finding is True
+    assert [t.path for t in row.owed] == ["strands_robots/utils.py"]
+    assert "strands_robots/utils.py" in row.summary
+
+
+def test_threads_beyond_the_read_ceiling_are_named_rather_than_cleared() -> None:
+    """The unread tail is the newest threads, which are the likeliest to be owed.
+
+    Reporting ``nothing-owed`` while silently dropping them would be wrong in the
+    one direction that costs work, so the shortfall is stated.
+    """
+    node = _pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])])
+    node["reviewThreads"]["totalCount"] = 103
+    row = mod.evaluate(node)
+    assert row.unread_threads == 102
+    assert "were not read" in mod.render_one("strands-labs/robots", row)
+
+
+def test_an_absent_thread_total_is_not_read_as_a_shortfall() -> None:
+    node = _pr([_thread([_comment(REVIEWER)])])
+    del node["reviewThreads"]["totalCount"]
+    assert mod.evaluate(node).unread_threads == 0
+
+
+# --------------------------------------------------------------------------
+# Reporting and exit status.
+# --------------------------------------------------------------------------
+
+
+def test_the_remedy_appears_only_when_something_is_owed() -> None:
+    owed = mod.evaluate(_pr([_thread([_comment(REVIEWER)])]))
+    answered = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])]))
+    assert "### What clears this" in mod.render_one("strands-labs/robots", owed)
+    assert "### What clears this" not in mod.render_one("strands-labs/robots", answered)
+
+
+def test_the_single_report_names_the_outcome_and_both_commits() -> None:
+    row = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])]))
+    report = mod.render_one("strands-labs/robots", row)
+    assert f"Outcome: **{mod.NOTHING_OWED}**" in report
+    assert "`d04a8969`" in report
+    assert "`b966ce64`" in report
+
+
+def test_the_sweep_names_every_pull_request_and_only_findings_in_detail() -> None:
+    rows = [
+        mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])], number=2577)),
+        mod.evaluate(_pr([_thread([_comment(REVIEWER)])], number=2511)),
+    ]
+    report = mod.render_sweep("strands-labs/robots", rows, [])
+    assert "#2577" in report and "#2511" in report
+    assert "### #2511" in report
+    assert "### #2577" not in report
+
+
+@pytest.mark.parametrize(
+    ("threads", "expected"),
+    [
+        ([_thread([_comment(REVIEWER), _comment(AUTHOR)])], 0),
+        ([_thread([_comment(REVIEWER), _comment(AUTHOR)], resolved=True)], 0),
+        ([], 0),
+        ([_thread([_comment(REVIEWER)])], 1),
+    ],
+)
+def test_exit_status_is_one_only_when_a_thread_awaits_its_author(
+    threads: list[dict], expected: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mod, "fetch_one", lambda *_a, **_k: _pr(threads))
+    assert mod.main(["--repo", "strands-labs/robots", "--pr", "2577", "--token", "t"]) == expected
+
+
+def test_the_sweep_skips_drafts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A draft is not waiting on its author in the sense this reports."""
+    draft = _pr([_thread([_comment(REVIEWER)])], number=9999)
+    draft["isDraft"] = True
+    monkeypatch.setattr(mod, "fetch_open", lambda *_a, **_k: [draft])
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+
+
+def test_a_lookup_failure_is_not_a_finding(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    """Never accuse an author of a reply this run could not observe."""
+
+    def boom(*_a: object, **_k: object) -> dict:
+        raise ValueError("GraphQL errors: [{'message': 'nope'}]")
+
+    monkeypatch.setattr(mod, "fetch_one", boom)
+    assert mod.main(["--repo", "strands-labs/robots", "--pr", "2577", "--token", "t"]) == 0
+    assert "could not evaluate" in capsys.readouterr().err
+
+
+def test_a_failed_listing_is_not_a_finding(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    def boom(*_a: object, **_k: object) -> list[dict]:
+        raise ValueError("nope")
+
+    monkeypatch.setattr(mod, "fetch_open", boom)
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 0
+    assert "could not list open pull requests" in capsys.readouterr().err
+
+
+def test_one_unreadable_pull_request_does_not_suppress_a_finding_on_another(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broken = _pr([_thread([_comment(REVIEWER)])], number=1)
+    del broken["number"]
+    good = _pr([_thread([_comment(REVIEWER)])], number=2511)
+    monkeypatch.setattr(mod, "fetch_open", lambda *_a, **_k: [broken, good])
+    assert mod.main(["--repo", "strands-labs/robots", "--all-open", "--token", "t"]) == 1
+
+
+def test_all_open_and_pr_are_refused_together() -> None:
+    """Silently ignoring either flag reads as a successful run of the other thing."""
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(["--repo", "strands-labs/robots", "--pr", "2577", "--all-open", "--token", "t"])
+    assert excinfo.value.code == 2
+
+
+@pytest.mark.parametrize("argv", [["--pr", "2577"], ["--all-open"]])
+def test_a_missing_token_reports_nothing_rather_than_failing(argv: list[str], capsys: pytest.CaptureFixture) -> None:
+    assert mod.main(["--repo", "strands-labs/robots", *argv, "--token", ""]) == 0
+    assert "no token" in capsys.readouterr().err
+
+
+def test_neither_a_pull_request_nor_a_sweep_was_asked_for(capsys: pytest.CaptureFixture) -> None:
+    assert mod.main(["--repo", "strands-labs/robots", "--token", "t"]) == 0
+    assert "--pr or --all-open is required" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# Query shape.
+# --------------------------------------------------------------------------
+
+
+def test_both_query_shapes_carry_the_whole_field_list() -> None:
+    """The two documents share one field list, so the sweep cannot drift from the
+    single-pull-request path -- and neither may ship an unsubstituted placeholder.
+    """
+    for document in (mod._ONE_PR, mod._OPEN_PRS):
+        assert mod._FIELDS_PLACEHOLDER not in document
+        assert "__THREADS__" not in document and "__COMMENTS__" not in document
+        for field in ("headRefOid", "isResolved", "isOutdated", "originalCommit", "__typename", "totalCount"):
+            assert field in document, field
+
+
+def test_the_comment_window_is_the_tail_and_the_thread_window_is_the_head() -> None:
+    """Only the last non-bot comment decides, so comments are read from the end;
+    the newest threads are the likeliest to be owed, so threads are read from the
+    start and the shortfall is reported rather than dropped.
+    """
+    assert f"comments(last: {mod._COMMENTS_PER_THREAD})" in mod._ONE_PR
+    assert f"reviewThreads(first: {mod._THREADS_PER_PR})" in mod._ONE_PR
+
+
+@pytest.mark.parametrize("repo", ["", "owner", "owner/", "/name", "a/b/c"])
+def test_a_repository_that_is_not_owner_slash_name_is_refused(repo: str) -> None:
+    with pytest.raises(ValueError, match="must be owner/name"):
+        mod._split_repo(repo)


### PR DESCRIPTION
## Problem

A review thread is append-only, so a run that rebuilds its context each cycle cannot tell
*unanswered* from *answered, and the answer is in the payload I just read*. The reviewer's
question sits there verbatim either way. Nothing in the serialised thread says "answered".

So the same thread gets answered repeatedly:

| pull request | thread | author replies | what the replies after the first added |
|---|---|---|---|
| #2511 | `PRRT_kwDORUMiZs6arq8z` | 3 | nothing - same fix, same commit (`c2969d4`), the same 6 failures reproduced three more times, over 27 minutes |
| #2577 | `PRRT_kwDORUMiZs6bQMZz` | 2 | nothing - `d04a8969` was already named by the first reply, 10 minutes earlier |

The cost is not the wasted run. A duplicate reply is **permanent**: every later reviewer and
every later run has to read it, and reading it is what makes the next run add one more.
#2520 records the loop.

## Why the rule that already exists did not stop it

AGENTS.md is not silent here - it already says a resolved/outdated thread is terminal, and
that a thread whose last non-bot comment is yours has been answered. #2577's thread was
**both** `isResolved: true` and `isOutdated: true` when it took its third comment at
19:28:20Z, and its second and third comments were both the author's. Every field needed to
refuse that reply was in the payload, and had been fetched.

That is the argument for a command rather than another paragraph: the rule asks a reader to
re-derive one boolean from a payload that also contains a reviewer's question addressed to
them. The same reasoning put `check_duplicate_claim.py` in `scripts/` after prose alone
failed to prevent three duplicate claims.

## Change

`scripts/check_thread_is_answered.py` - one outcome per thread, one exit code per pull
request, no clone:

```
python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --pr 2577
python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --all-open
```

| outcome | meaning |
|---|---|
| `settled` | `isResolved`. A reviewer closed the business. |
| `answered` | Open, last non-bot comment is the author's. Next move is the reviewer's. |
| `awaiting-the-author` | Open, last non-bot comment is someone else's (or only bots). **The only outcome that is work, and the only one that exits 1.** |

It reports and does not gate, wired to no workflow, like its three agent-invoked siblings:
what an author should do next is not something a branch can turn green.

## One rule decides it; two tempting fields are reported instead

**Whoever spoke last owes the next move, unless a reviewer resolved the thread.**

**`isOutdated` is not consulted**, and both directions of its unreliability are measured
here. It describes the diff, not the conversation:

- It is `false` on threads that *are* answered. #2480's still reads `isOutdated: false`
  after `e83cf51` fixed the finding, because the fix added a method rather than rewriting
  the commented line.
- A thread keeps taking comments after it flips to `true`. #2577's is `isOutdated: true` and
  took two more comments anyway. Both happened to be the author's, but nothing about the
  flag stops a reviewer's arriving the same way - and a rule reading outdated as terminal
  would file that demand as settled.

Authorship subsumes what the proxy was reaching for. The AGENTS.md bullet calling outdated
terminal is corrected in place rather than contradicted by a second rule.

**Whether the head moved is reported, not decided on.** An author reply that explains rather
than changes is a complete answer that leaves the head exactly where the thread was written;
folding that into the verdict would call it unanswered and license the duplicate reply this
exists to prevent.

It is reported because of a measurement that kills the obvious implementation:
`originalCommit` is a property of the **thread**, not of the comment. All four comments on
#2511 - one reviewer comment and three author replies spanning 04:19 to 04:46 - report the
same `originalCommit` `ee3e4526`, while the head by the last reply was `0a69634d`:

| comment | author | `originalCommit` |
|---|---|---|
| 1 (04:19, reviewer) | reviewer | `ee3e4526` |
| 2 (04:19, reply) | author | `ee3e4526` |
| 3 (04:31, reply) | author | `ee3e4526` |
| 4 (04:46, reply) | author | `ee3e4526` |

So a reply carries no record of the commit it was verified against, and `headRefOid` is the
only commit a thread can be keyed to - which is what #2520 asks for, to tell "already fixed
at `<oid>`" apart from "not yet fixed".

## Tests

`tests/test_thread_is_answered.py`, **41 passed**. Every payload is the measured shape of a
real thread with the resolution flag set to what it was in the window the check runs in.

Coverage comes from replayed incidents rather than a historical sweep, deliberately - see
Verification: on a finished pull request `settled` is the only reachable outcome, so a
historical sweep *cannot* contain the two discriminating ones.

The non-vacuity pin is `test_flipping_only_the_last_comments_author_flips_the_outcome`: same
thread, same head, same commit, same comment count, only the final login differs. A check
that always agreed would not move there. Also pinned: a reviewer demand on an outdated
thread is owed; a resolved thread is settled whoever spoke last; a bot comment after the
author's reply does not reopen it (`github-advanced-security` posts into threads on #2480
and all four of #1722); a bot-only thread is owed; an answer with no commit after it is
still answered; `head_moved` changes no verdict; the thread commit is read from the thread
and not from a reply; unread threads past the ceiling are named rather than cleared; a
lookup failure is never a finding.

## Verification

**Driven against live data, not only fixtures.**

`--pr 2577` -> `nothing-owed`, exit 0, naming the thread `settled`, head `d04a8969`, thread
commit `b966ce64`, head moved `yes`.

`--all-open` over all 11 open pull requests -> `nothing-owed` throughout, exit 0.

**Steady state, and why the sweep is quiet.** Over the 150 most recently updated closed pull
requests: 26 review threads found, **all 26 `isResolved`** and therefore `settled`, all 150
`nothing-owed`. That is the expected result rather than a broken check - threads here do get
resolved, so the two discriminating outcomes exist only in the window between a reviewer's
comment and its resolution. That window is exactly when a scheduled run reads, and exactly
when the wrong answer costs a permanent duplicate reply.

**The incidents are attributable on timestamped fields alone**, which is why authorship
carries the rule: thread resolution has no timestamp in the API, so "was it resolved yet" is
not answerable after the fact. But at 19:28:20Z on #2577 the last non-bot comment was the
author's own reply from 19:17:50Z, and at 04:31 and 04:46 on #2511 it was the author's reply
from 04:19. The authorship test returns `answered` for all three with no appeal to a field
whose history cannot be read back.

**Gate.** `ruff check` and `ruff format --check` clean on both new files. Repo-wide graders
that walk the source or test tree: **530 passed, 1 failed**, and the failure is
`test_docstring_xref_roles_resolve.py::test_qualified_strands_robots_xref_roles_resolve`
with `ImportError: No module named 'cv2'` - reproduced identically on a pristine
`origin/main` worktree, so it is this box lacking an optional dep rather than a branch
finding. CI installs `.[all,dev]`.

**Duplication check before writing any of it.** `check_merge_blockers.py` is the only
existing reader of `reviewThreads` and it collapses them to a scalar count of live threads
(`resolve_unresolved_threads`), discarding every per-thread field. `originalCommit`, thread
comments and comment authors are read **nowhere** in the repository.

## Scope - why #2520 stays open

#2520 has two halves. This lands the read: a thread's state as a verdict instead of a
re-derivation. It does **not** address the other half its second comment records - two
parallel runs each independently deriving the same fix (#2566), where both would correctly
see `awaiting-the-author` and both would still do the work. That needs something about
claiming a thread rather than reading one, so the issue stays open and this only
cross-references it.

Towards #2520.

<sub>An earlier revision of this description phrased that heading with a closing keyword in
front of the issue number, which GitHub linked as a closing reference - it does not read the
surrounding negation. Reworded so merging this cannot auto-close an issue it only half
answers.</sub>


## Round 1

Two graders on `main` pinned premises this branch invalidates, and both failed on `acc21ea`.
Found by running them against the branch tree rather than by reading the rollup -
`call-test-lint` was still in flight, so the branch was never green.

| grader | what it pinned | why this branch broke it |
|---|---|---|
| `tests/test_review_thread_reply_gate.py` | `` `isResolved` or `isOutdated`** -> do not reply `` as a single directive | step 5 now separates the two fields, so that literal is absent |
| `tests/test_duplicate_claim_check.py` | derived `_INFERS_REPOSITORY` == declared `_NAMES_REPOSITORY` | the new script reads `$GITHUB_REPOSITORY`, so it joined the derived set only |

- `1b5c05e` replaces the invalidated premise rather than deleting it. The terminal directive
  is pinned on `isResolved` alone, and the `isOutdated` correction gets its own test
  asserting the two halves that must travel together: the explicit denial, and the
  disposition that replaces it. A denial that removes the rule without supplying one leaves
  an outdated thread undecided - the failure the correction exists to prevent. All three
  literals are absent from the pre-correction prose, so none is vacuous and re-merging the
  fields fails here.
- `d5cf250` declares `check_thread_is_answered.py` as `("--repo", None)`: both modes reach
  the API, so both owe the flag and there is no argv marker to scope it to. Verified
  load-bearing rather than decorative - dropping `--repo` from the documented sweep
  invocation fails naming that invocation.

Regression sweep: the 33 top-level AGENTS.md graders plus this branch's own tests ->
**892 passed**. The only failures need `serial` / `torch` / `strands` optional deps this box
lacks and reproduce identically on a pristine `origin/main`, per the base-first comparison
AGENTS.md requires.
