### PR TITLE
docs(policies): the documented spelling recipe is the registry, not the factory

### DIFF
--- a/changelog.d/2582-enumeration-claim-names-what-the-factory-resolves.md
+++ b/changelog.d/2582-enumeration-claim-names-what-the-factory-resolves.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **policies**: `list_providers()` and `list_aliases()` are documented as every *registered* provider spelling rather than every spelling `create_policy` accepts. `import_policy_class` also resolves a module under `strands_robots.policies` that exports a `Policy` subclass, so the union omitted `composite` - which `create_policy` builds - and `persistent`, which resolves but is constructed directly because its first parameter is named `provider`. Both are now named where enumeration is taught, and a guard derives them from the resolution path so a third such module is held to the same rule.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -122,7 +122,7 @@ from strands_robots.policies.cosmos3 import Cosmos3Policy
 | `create_policy(provider, **kw)` | Resolve + construct. Accepts `zmq://`, `cosmos3://`, HF `org/model`. |
 | `register_policy(name, loader, aliases)` | Runtime registration. |
 | `list_providers()` | Sorted canonical names of every JSON-registered provider, plus any runtime `register_policy` names and their aliases. Canonical names only for the JSON registry: pair it with `list_aliases()` for the rest. |
-| `list_aliases()` | Every provider alias and the canonical name it resolves to, across both registries. Together with `list_providers()` they are every spelling `create_policy` accepts. |
+| `list_aliases()` | Every provider alias and the canonical name it resolves to, across both registries. Together with `list_providers()` they are every *registered* spelling - not every spelling `create_policy` resolves. A module under `strands_robots.policies` exporting a `Policy` subclass also resolves under its own module name: `composite` (builds through the factory) and `persistent` (resolves; constructed directly). |
 | `list_policy_types()` | `policy_type` strings the installed lerobot resolves; `[]` without lerobot. Discovery peer of `list_providers`. |
 | `UntrustedRemoteCodeError` | Raised when `STRANDS_TRUST_REMOTE_CODE` is required but unset. |
 | `Gr00tPolicy` | GR00T N1.5/N1.6/N1.7 via ZMQ (service) or in-process. |

--- a/docs/policies/overview.md
+++ b/docs/policies/overview.md
@@ -14,7 +14,9 @@ python -c 'from strands_robots.policies import list_providers; print(list_provid
 
 `create_policy` also accepts each provider's declared aliases and shorthands,
 which `list_providers()` does not repeat. `list_aliases()` reports those, so
-the two together are every spelling `create_policy` accepts:
+the two together are every *registered* spelling. They are not every spelling
+`create_policy` resolves: `composite` and `persistent` resolve with no registry
+entry, as described under [Beyond the registry](#beyond-the-registry) below.
 
 ```bash
 python -c 'from strands_robots.policies import list_aliases; print(list_aliases())'
@@ -34,6 +36,20 @@ policy = create_policy("lerobot_local", pretrained_name_or_path="lerobot/pi0_so1
 policy = create_policy("cosmos3", embodiment="droid", port=8000)
 policy = create_policy("remote", endpoint="ws://gpu-box:8765")
 ```
+
+### Beyond the registry
+
+`import_policy_class` falls back to auto-discovery, so a module under
+`strands_robots.policies` that exports a `Policy` subclass resolves under its
+own module name with no registry entry. Two ship, and neither is a registry
+provider because each wraps a policy you already hold rather than building one
+from config:
+
+- **`composite`** ([`CompositePolicy`](wbc.md#composing-an-upper-body-manipulation-on-top-of-wbc))
+  builds through the factory: `create_policy("composite", lower=..., upper=...)`.
+- **`persistent`** ([`PersistentPolicy`](persistent-worker.md)) resolves but
+  cannot be built through `create_policy`: its first parameter is named
+  `provider`, which `create_policy` has already bound. Construct it directly.
 
 ## Providers
 

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -63,10 +63,29 @@ def list_aliases() -> dict[str, str]:
     :func:`create_policy` accepts a provider's declared aliases and
     shorthands as readily as its canonical name, but
     :func:`list_providers` reports the canonical names from the JSON
-    registry. Together the two surfaces enumerate every spelling
-    :func:`create_policy` accepts::
+    registry. Together the two surfaces enumerate every spelling the
+    registries hold::
 
-        accepted = set(list_providers()) | set(list_aliases())
+        registered = set(list_providers()) | set(list_aliases())
+
+    That is every *registered* spelling, not every spelling
+    :func:`create_policy` resolves.
+    :func:`~strands_robots.registry.policies.import_policy_class` falls back
+    to auto-discovery, so a module under ``strands_robots.policies`` that
+    exports a :class:`~strands_robots.policies.base.Policy` subclass resolves
+    under its own module name with no registry entry. Two ship, and neither is
+    a registry provider because each wraps a policy the caller already holds
+    rather than building one from config:
+
+    * ``composite``
+      (:class:`~strands_robots.policies.composite.CompositePolicy`) builds
+      through this factory -- ``create_policy("composite", lower=..., upper=...)``
+      -- and is the one spelling ``registered`` above omits.
+    * ``persistent``
+      (:class:`~strands_robots.policies.persistent.PersistentPolicy`) resolves
+      but cannot be built here: its first parameter is named ``provider``,
+      which :func:`create_policy` has already bound, so it is constructed
+      directly.
 
     Covers both registries, matching the union :func:`list_providers`
     reports: aliases declared in ``policies.json`` and aliases passed to

--- a/tests/policies/test_provider_alias_discovery.py
+++ b/tests/policies/test_provider_alias_discovery.py
@@ -12,11 +12,25 @@ The headline guard asks the question a caller actually has -- is every
 accepted spelling reported by *some* public discovery surface -- rather than
 naming one function, so it keeps holding if the surfaces are later renamed
 or split.
+
+That headline grades the *registered* spellings, which is the set the
+discovery surfaces own. ``create_policy`` resolves one more kind of spelling:
+``import_policy_class`` falls back to auto-discovery, so a module under
+``strands_robots.policies`` exporting a ``Policy`` subclass resolves under its
+own module name with no registry entry. Those cannot be reported as providers
+- one of them (``persistent``) cannot even be built through ``create_policy``,
+so listing it would advertise a provider the factory refuses - so the contract
+for them is the other half of discovery: the prose that teaches a caller how to
+enumerate must name them. The second guard here grades that, deriving the
+spellings from the resolution path rather than from a list, so a third such
+module is held to the same rule the day it lands.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -26,7 +40,13 @@ import pytest
 from strands_robots.policies import create_policy, list_providers, register_policy
 from strands_robots.registry import list_policy_providers
 
-POLICIES_JSON = Path(__file__).resolve().parents[2] / "strands_robots" / "registry" / "policies.json"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POLICIES_JSON = REPO_ROOT / "strands_robots" / "registry" / "policies.json"
+
+#: Docs that teach a caller how to enumerate accepted provider spellings.
+#: Graded as prose: a runnable snippet is a usage example, not a claim about
+#: which set is complete.
+_ENUMERATION_DOCS = ("docs/api-reference.md", "docs/policies/overview.md")
 
 #: Surfaces a caller can reach to discover provider spellings. Probed by name
 #: so this file collects (and the headline guard reports a real coverage gap)
@@ -87,6 +107,113 @@ def _reported_spellings() -> set[str]:
     for surface in _discovery_surfaces().values():
         reported |= set(surface())
     return reported
+
+
+def _resolved_outside_the_registry() -> dict[str, str]:
+    """Spellings ``create_policy`` resolves that no discovery surface reports.
+
+    ``import_policy_class`` falls back to auto-discovery, so a module under
+    ``strands_robots.policies`` exporting a ``Policy`` subclass resolves under
+    its own module name. Only names the surfaces do *not* already report are
+    probed, so this needs no optional dependency: every registry provider is
+    reported, and it is the unreported remainder that has to be documented.
+
+    Returns:
+        Mapping of module-name spelling to the dotted class it resolves to.
+    """
+    import pkgutil
+
+    import strands_robots.policies as policies_pkg
+    from strands_robots.registry.policies import import_policy_class
+
+    reported = _reported_spellings()
+    resolved: dict[str, str] = {}
+    for module in pkgutil.iter_modules(policies_pkg.__path__):
+        if module.name.startswith("_") or module.name in reported:
+            continue
+        try:
+            policy_class = import_policy_class(module.name)
+        except (ValueError, ImportError):
+            # Not a spelling create_policy resolves: either no Policy subclass
+            # to auto-discover, or its optional dependency is absent. Both are
+            # "nothing to document" rather than a gap.
+            continue
+        resolved[module.name] = f"{policy_class.__module__}.{policy_class.__name__}"
+    return resolved
+
+
+def _prose_blocks(text: str) -> list[str]:
+    """Split markdown into blank-line-delimited prose blocks.
+
+    Fenced code is dropped: a runnable snippet naming both surfaces is a usage
+    example, not a claim about which set is complete. A table row is its own
+    block, because a whole table read as one block would let any row answer for
+    a claim made in another.
+    """
+    blocks: list[str] = []
+    chunk: list[str] = []
+    in_fence = False
+
+    def flush() -> None:
+        if not chunk:
+            return
+        rows = [line for line in chunk if line.lstrip().startswith("|")]
+        if rows:
+            blocks.extend(" ".join(row.split()) for row in rows)
+        else:
+            blocks.append(" ".join(" ".join(chunk).split()))
+        chunk.clear()
+
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            flush()
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not line.strip():
+            flush()
+            continue
+        chunk.append(line)
+    flush()
+    return blocks
+
+
+def _names_the_spelling(text: str, spelling: str) -> bool:
+    """Whether ``text`` names ``spelling`` as a value a caller would pass.
+
+    Matched as a whole token, so a dotted path does not answer for it:
+    ``strands_robots.policies.persistent.PersistentPolicy`` identifies the
+    *class* to construct directly, which is a different fact from ``persistent``
+    being a spelling the factory resolves. Without the boundary the substring
+    inside that path would satisfy the rule.
+    """
+    return re.search(rf"(?<![\w.]){re.escape(spelling)}(?![\w.])", text) is not None
+
+
+def _teaches_enumeration(text: str) -> bool:
+    """Whether ``text`` tells a caller how to enumerate what the factory takes.
+
+    Both surfaces plus the factory: a block naming only one of them is
+    describing that function, not the accepted set.
+    """
+    return all(token in text for token in ("list_providers", "list_aliases", "create_policy"))
+
+
+def _enumeration_surfaces() -> dict[str, str]:
+    """Every surface that teaches a caller how to enumerate accepted spellings."""
+    from strands_robots.policies import list_aliases
+
+    found: dict[str, str] = {}
+    docstring = inspect.getdoc(list_aliases) or ""
+    if _teaches_enumeration(docstring):
+        found["strands_robots/policies/factory.py::list_aliases"] = docstring
+    for relative in _ENUMERATION_DOCS:
+        text = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        for block in _prose_blocks(text):
+            if _teaches_enumeration(block):
+                found[f"{relative}: {block[:56]}..."] = block
+    return found
 
 
 def test_the_registry_declares_aliases_to_discover() -> None:
@@ -210,3 +337,103 @@ def test_the_policy_alias_mapping_has_the_shape_the_robot_one_does() -> None:
     assert all(isinstance(k, str) and isinstance(v, str) for k, v in policy_aliases.items())
     assert not [a for a, c in robot_aliases.items() if a == c], "robot registry shape changed"
     assert not [a for a, c in policy_aliases.items() if a == c]
+
+
+def test_a_spelling_resolves_outside_the_registry() -> None:
+    """Premise: with nothing auto-discovered the documentation guard is vacuous."""
+    resolved = _resolved_outside_the_registry()
+    assert resolved, (
+        "no module under strands_robots.policies resolves outside the registry, so grading the "
+        "docs for naming them proves nothing"
+    )
+
+
+def test_the_enumeration_surfaces_are_found() -> None:
+    """Premise: a reflow that hides a surface must fail, not report clean."""
+    surfaces = _enumeration_surfaces()
+    assert "strands_robots/policies/factory.py::list_aliases" in surfaces, (
+        f"list_aliases' own docstring no longer teaches enumeration, so the guard below grades "
+        f"less than it claims; found: {sorted(surfaces)}"
+    )
+    for relative in _ENUMERATION_DOCS:
+        assert any(key.startswith(relative) for key in surfaces), (
+            f"{relative} no longer states the enumeration recipe in prose; found: {sorted(surfaces)}"
+        )
+
+
+def test_every_enumeration_surface_names_the_unregistered_spellings() -> None:
+    """A spelling the factory resolves is reported, or named where enumeration is taught.
+
+    ``list_providers()`` and ``list_aliases()`` report the registry. A caller
+    who takes their union as "every spelling ``create_policy`` accepts" - which
+    is what these surfaces told them to do - rejects ``composite``, which
+    ``create_policy`` builds. Naming it is the discovery the surfaces cannot
+    provide, since neither wrapper can be listed as a provider.
+    """
+    resolved = _resolved_outside_the_registry()
+    silent = {
+        label: sorted(name for name in resolved if not _names_the_spelling(text, name))
+        for label, text in _enumeration_surfaces().items()
+    }
+    silent = {label: missing for label, missing in silent.items() if missing}
+    assert not silent, (
+        f"create_policy resolves {sorted(resolved)} with no registry entry, and these surfaces "
+        f"teach a caller to enumerate accepted spellings without naming them: {silent}. A caller "
+        f"validating against the documented union refuses a spelling the factory accepts."
+    )
+
+
+def test_the_composite_spelling_builds_through_the_factory() -> None:
+    """Control: the spelling the docs now name really is accepted.
+
+    Passes before and after this change - the factory's behaviour is what the
+    documentation was already supposed to describe.
+    """
+    from strands_robots.policies import list_aliases
+
+    assert "composite" not in set(list_providers()) | set(list_aliases())
+    policy = create_policy("composite", lower=create_policy("mock"), upper=create_policy("mock"))
+    assert type(policy).__name__ == "CompositePolicy"
+    assert policy.provider_name == "composite"
+
+
+def test_the_persistent_spelling_resolves_but_is_not_buildable_here() -> None:
+    """Control: why the second wrapper is documented as a direct construction.
+
+    ``PersistentPolicy``'s first parameter is named ``provider``, which
+    :func:`create_policy` has already bound, so no keyword can reach it. That is
+    what makes reporting it as a provider wrong rather than merely incomplete.
+    """
+    from strands_robots.registry.policies import import_policy_class
+
+    assert import_policy_class("persistent").__name__ == "PersistentPolicy"
+    with pytest.raises(TypeError, match="provider"):
+        create_policy("persistent")
+
+
+@pytest.mark.parametrize("module_name", ["base", "factory"])
+def test_a_module_with_no_policy_subclass_is_not_a_spelling(module_name: str) -> None:
+    """Control: the auto-discovered set is not "every module in the package".
+
+    Fails if the derivation is widened to module names, which would demand the
+    docs name modules ``create_policy`` refuses.
+    """
+    from strands_robots.registry.policies import import_policy_class
+
+    with pytest.raises(ValueError, match="Unknown policy provider"):
+        import_policy_class(module_name)
+    assert module_name not in _resolved_outside_the_registry()
+
+
+def test_a_dotted_path_does_not_answer_for_the_spelling() -> None:
+    """Control: the boundary in the token match is load-bearing.
+
+    Naming ``strands_robots.policies.persistent.PersistentPolicy`` tells a
+    reader which class to construct; it does not tell them ``persistent`` is a
+    spelling the factory resolves. A substring match would treat the two as the
+    same statement, so a surface that only linked the class would pass.
+    """
+    assert not _names_the_spelling("see strands_robots.policies.persistent.PersistentPolicy", "persistent")
+    assert _names_the_spelling("the ``persistent`` spelling resolves", "persistent")
+    assert not _names_the_spelling("CompositePolicy wraps two policies", "composite")
+    assert _names_the_spelling("`composite` builds through the factory", "composite")


### PR DESCRIPTION
## Problem

`list_providers()` and `list_aliases()` report the two policy registries. Three surfaces told a
caller their union was *every spelling `create_policy` accepts*, and offered it as a recipe -
`list_aliases`' own docstring, the `docs/api-reference.md` row, and the `docs/policies/overview.md`
paragraph:

```python
accepted = set(list_providers()) | set(list_aliases())   # 28 spellings
```

`import_policy_class` also falls back to auto-discovery, so a module under `strands_robots.policies`
that exports a `Policy` subclass resolves under its own module name with no registry entry. Two ship,
and the union omits both. Measured on `aa1c5b8e`:

| spelling | in the documented union | `import_policy_class` resolves | `create_policy` builds |
|---|---|---|---|
| `random` (a registry alias) | yes | yes | yes |
| `composite` | **no** | yes -> `CompositePolicy` | **yes** |
| `persistent` | **no** | yes -> `PersistentPolicy` | no (see below) |
| `base`, `factory` | no | no - `Unknown policy provider` | no |

So a caller who validates a provider name against the documented recipe - which is what these
surfaces told them to do - rejects `composite`, and `create_policy("composite", lower=..., upper=...)`
builds a `CompositePolicy`. Both wrappers are documented in their own right
(`docs/policies/persistent-worker.md` is a whole page; `docs/policies/wbc.md` has a composite
section), so the spelling is reachable and the recipe is what hides it.

## Why the prose, and not the discovery surfaces

Reporting the two as providers would be wrong rather than merely wider:

- **`persistent` cannot be built through the factory at all.** `PersistentPolicy.__init__`'s first
  parameter is named `provider`, which `create_policy` has already bound, so no keyword can reach it -
  `create_policy("persistent")` raises `TypeError: missing 1 required positional argument: 'provider'`.
  Listing it would advertise a provider the factory refuses.
- **The package already records the property the recipe denied.** `mesh/security.py`, explaining why
  its policy-provider allowlist stays a literal: *"A provider this package can build but does not list
  here is refused on the mesh `tell()` path"*. Buildable is already a wider set than registry-listed.
- `docs/policies/overview.md`'s provider table is pinned to exactly `policies.json`'s canonical keys by
  `tests/test_docs_policy_coverage.py`, whose docstring calls it *"the human-facing catalogue of what
  `create_policy("<name>")` accepts"*.

Code, tests and the registry agree; the three prose surfaces did not. So the surfaces keep reporting
the registry, and the prose names the second route.

## Change

- `list_aliases`' docstring: the union is every **registered** spelling (the recipe's variable is
  renamed `accepted` -> `registered`), then names the auto-discovery route and both spellings it
  reaches, including why `persistent` is constructed directly.
- `docs/api-reference.md`: same correction in the `list_aliases()` row.
- `docs/policies/overview.md`: the enumeration paragraph now says *registered*, and a new
  **Beyond the registry** subsection documents the two wrappers with links to the pages that already
  cover them. Both anchors verified to resolve.

No behaviour change: `strands_robots/policies/factory.py` is docstring-only, and no other file under
`strands_robots/` is touched.

## The guard could not see this

`tests/policies/test_provider_alias_discovery.py` owns this contract - its module docstring opens
*"Every provider spelling `create_policy` accepts is discoverable"* - but its `_accepted_spellings()`
reads `policies.json`, so it grades the registry only. **On the unfixed tree the shipped guard reports
`10 passed`** with `composite` accepted and reported by nothing.

It now derives the unregistered spellings from the resolution path (probing only module names the
surfaces do *not* already report, so it needs no optional dependency) and grades every surface that
teaches enumeration for naming them. A third such module is held to the same rule the day it lands.
The match is whole-token: a dotted path like `strands_robots.policies.persistent.PersistentPolicy`
identifies the class to construct, which is a different fact from `persistent` being a spelling the
factory resolves.

The existing headline guard is unchanged - the registry is still the set the discovery surfaces own.

## Tests

`tests/policies/test_provider_alias_discovery.py`, **1 failed / 17 passed** pre-fix -> 18 passed. The
one failure names every surface and both spellings:

```
AssertionError: create_policy resolves ['composite', 'persistent'] with no registry entry, and these
surfaces teach a caller to enumerate accepted spellings without naming them:
{'strands_robots/policies/factory.py::list_aliases': ['composite', 'persistent'],
 'docs/api-reference.md: | `list_aliases()` | Every provider alias and the canoni...': [...],
 "docs/policies/overview.md: `create_policy` also accepts each provider's declared al...": [...]}.
A caller validating against the documented union refuses a spelling the factory accepts.
```

A 1-failed split is the point: one assertion flips, and the 17 that pass on both trees are the
evidence nothing else moved. Every new guard is load-bearing - each break is detected by exactly one,
naming exactly its own site:

| regression | detected by | reports |
|---|---|---|
| the derivation stops probing auto-discovery | premise | `no module ... resolves outside the registry` |
| `overview.md` stops stating the recipe | premise | `overview.md no longer states the enumeration recipe` |
| the factory docstring drops `persistent` (dotted path left in place) | headline | `{...::list_aliases: ['persistent']}` |
| the api-reference row drops both spellings | headline | `{docs/api-reference.md...: ['composite', 'persistent']}` |

Controls, all passing on both trees: `composite` really does build through the factory and reports
`provider_name == "composite"`; `persistent` resolves but raises on construction (pinning *why* it is
documented differently); `base`/`factory` do not resolve, so the derived set is not "every module in
the package"; and a dotted path alone does not satisfy the token match.

## Verification

Measured at `c33b4b8e`.

- 255-file blast radius (everything naming the factory/registry surfaces or `policies.json`, every
  guard that reads a docs page or walks a source tree, all of `tests/policies` and `tests/registry`,
  plus the repo-wide docstring/string/changelog guards), two trees in parallel and in lockstep
  (397.71s vs 397.34s): branch **11 failed / 11199 passed / 81 skipped**, `upstream/main` **11 failed
  / 11191 passed / 81 skipped**. Failing-ID sets **identical**, `comm` empty both ways; the `+8`
  passed is exactly the 8 new items. The 11 shared failures are dependency-absent locally
  (`awsiotsdk`, and a `draccus` floor below lerobot's) - both declared extras CI installs.
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `upstream/main` worktree,
  branch-only empty, none in the changed files.
- No non-ASCII added to any changed file; fence counts unchanged; no ragged table rows.

## Artifact

Same package code in both columns - only the documentation differs. The capture script reads the
recipe out of the tree it runs against, checks whether that tree's prose names any spelling beyond the
union, builds the allowlist a caller would build, then validates and dispatches. `random` (a registry
alias) is admitted, resolves and builds identically in both columns; on `upstream/main` `composite` is
refused by the caller's own allowlist while the factory builds it.

![A caller following the documented recipe refuses composite on main and admits it after](https://raw.githubusercontent.com/cagataycali/robots/media-enumeration-claim-32525124558/enumeration-claim.png)
