### PR TITLE
docs(architecture): derive the orientation page's counts from the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ AgentTool returning `{"status", "content"}`.
 | `start` | `instruction`, `policy_port`, `duration` | Non-blocking async start |
 | `status` | - | Current task status |
 | `stop` | - | Interrupt running task (emergency stop) |
-In sim mode the same tool exposes the 67 Simulation actions - see Simulation (MuJoCo).
+In sim mode the same tool exposes the 77 Simulation actions - see Simulation (MuJoCo).
 </details>
 
 <details>
@@ -924,7 +924,7 @@ the library.
 ## Simulation (MuJoCo)
 
 `Robot("so100")` (sim mode) returns a `Simulation` - a MuJoCo-backed AgentTool
-exposing **67 actions** for world composition, physics, rendering, policy
+exposing **77 actions** for world composition, physics, rendering, policy
 execution, and dataset recording. Build it directly when you want full control:
 
 ```python

--- a/changelog.d/2583-architecture-counts-derived-from-the-code.md
+++ b/changelog.d/2583-architecture-counts-derived-from-the-code.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **docs**: `docs/architecture.md`'s module table and `Policy` contract paragraph, plus README's Simulation action count, are now derived from the code by a guard rather than restated by hand. The page had claimed 4 policy providers for 14, 8 `@tool` helpers for 20, and four `Policy` implementations of fifteen; README quoted 67 published actions for 77. The `Policy` paragraph also named only one of the three "policy declares, runtime supplies" seams, so a policy conforming to the documented contract received no body pose at all - `base_quat` is the pelvis, which diverges from `torso_link` by 34.4 degrees at 0.6 rad of waist yaw.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,17 +79,17 @@ graph TB
 |--------|--------------|-----------|
 | `strands_robots/robot.py` | Factory `Robot(name, mode, backend, **kwargs)`. Name resolution, sim/real dispatch, mesh attach. | `Robot()` function |
 | `strands_robots/registry/` | 72 robots, 119 aliases, 8 categories. `robots.json` is source of truth. | `list_robots()`, `resolve_name()`, `get_robot()` |
-| `strands_robots/simulation/` | MuJoCo `AgentTool` - 60+ actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
+| `strands_robots/simulation/` | MuJoCo `AgentTool` - 77 actions. | `Simulation`, `SimWorld`, `SimRobot`, `SimObject`, `SimCamera` |
 | `strands_robots/simulation/base.py` | Backend ABC for future Isaac/Newton backends. | `SimEngine` |
 | `strands_robots/hardware_robot.py` | Real-servo path. Async task execution + status. | `Robot` (class), `TaskStatus`, `RobotTaskState` |
-| `strands_robots/policies/` | ABC + 4 providers + factory + JSON registry. | `Policy`, `create_policy()` |
+| `strands_robots/policies/` | ABC + 14 providers + factory + JSON registry. | `Policy`, `create_policy()` |
 | `strands_robots/dataset_recorder.py` | LeRobot v3 writer. | `DatasetRecorder` |
-| `strands_robots/tools/` | 8 `@tool`-decorated helpers. | `lerobot_calibrate`, `serial_tool`, etc. |
+| `strands_robots/tools/` | 20 `@tool`-decorated helpers. | `lerobot_calibrate`, `serial_tool`, etc. |
 | `strands_robots/benchmarks/libero/` | LIBERO benchmark adapter. | `LiberoSuite` |
 
 ## ABCs
 
-**`Policy`** - `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, `provider_name` property, `requires_images` property (default `True`), `reset(seed)` (default no-op). Four implementations: `MockPolicy`, `Gr00tPolicy`, `LerobotLocalPolicy`, `Cosmos3Policy`.
+**`Policy`** - three abstract members every implementation supplies: `get_actions(observation_dict, instruction) -> list[dict]` (async), `set_robot_state_keys(keys)`, and the `provider_name` property. The rest of the contract is *declared* rather than implemented - the runtime reads the declaration and supplies what it names: `requires_images` (default `True`), `required_bodies` (default `()`; the only way to receive a body pose beyond the floating base - a tracker that skips it gets `base_quat`, the pelvis) and `children` (default `()`; what a wrapper returns so a capability probe reaches the policy inside it). `reset(seed)` (default no-op) is called per episode. 15 implementations ship; [Policies](policies/overview.md) is the provider table.
 
 **`SimEngine`** - `create_world()`, `step()`, 30+ abstract actions. Today: MuJoCo CPU. Roadmap: Isaac Sim, Newton.
 

--- a/tests/test_docs_architecture_counts_match_the_code.py
+++ b/tests/test_docs_architecture_counts_match_the_code.py
@@ -1,0 +1,306 @@
+"""Repo hygiene: the orientation page's counts are the code's counts.
+
+``docs/architecture.md`` is the map a contributor reads to size each subsystem,
+and its "ABCs" paragraph is read as the contract a new implementation conforms
+to. Both restate the code in prose, and nothing tied most of that prose to the
+code, so it drifted: the module table claimed 4 policy providers for a package
+shipping 14 and 8 ``@tool`` helpers for 20, while the ``Policy`` paragraph named
+four implementations of fifteen and two of the contract's three declaration
+seams. README quoted 67 Simulation actions for a published enum of 77 - a number
+someone had already corrected once by hand, which is exactly the drift a guard
+prevents and prose does not.
+
+One row of that same table *was* graded, by
+``test_docs_robot_catalog_coverage.py``, and it is exact. This module extends
+that idea to the rest of the page, deriving every number from the code so a
+count cannot be right on the day it is written and wrong a month later:
+
+* The module-table counts come from ``registry/policies.json`` and from an AST
+  walk of ``strands_robots/tools/``.
+* The Simulation action count comes from the published ``tool_spec.json`` enum,
+  and is graded wherever either document states one.
+* The ``Policy`` paragraph is graded against ``Policy.__abstractmethods__`` (what
+  an implementation must supply) and against the *declaration seams* - the
+  "policy declares, runtime supplies" family, itself derived from the base
+  class's own docstrings rather than listed here.
+
+The seam half is the one with teeth. A policy conforming to the five members the
+paragraph used to name receives no body pose at all: the runtime supplies one
+only for a body ``required_bodies`` names, so a whole-body tracker that skips it
+reads ``base_quat`` - the pelvis, which diverges from ``torso_link`` by tens of
+degrees once the waist turns. Every implementation the paragraph named is one for
+which that omission is invisible, and every implementation that uses a seam was
+absent, so the enumeration was self-consistently incomplete.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from strands_robots.policies.base import Policy
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = REPO_ROOT / "strands_robots"
+ARCHITECTURE = REPO_ROOT / "docs" / "architecture.md"
+README = REPO_ROOT / "README.md"
+
+#: Documents that restate the Simulation action surface as a number.
+ACTION_COUNT_SITES = (ARCHITECTURE, README)
+
+#: The phrase the base class uses to mark a member of the declaration family.
+_SEAM_PHRASE = "policy declares, runtime supplies"
+
+
+def _architecture() -> str:
+    return ARCHITECTURE.read_text(encoding="utf-8")
+
+
+def _policy_paragraph() -> str:
+    """The ABCs paragraph describing ``Policy``, whitespace-normalised."""
+    for block in _architecture().split("\n\n"):
+        if block.lstrip().startswith("**`Policy`**"):
+            return " ".join(block.split())
+    raise AssertionError("docs/architecture.md has no '**`Policy`**' paragraph in its ABCs section")
+
+
+def _module_table_row(module: str) -> str:
+    """The ``| `<module>` | ... |`` row of the Modules table."""
+    prefix = f"| `{module}` |"
+    for line in _architecture().splitlines():
+        if line.startswith(prefix):
+            return line
+    raise AssertionError(f"docs/architecture.md has no Modules row for {module!r}")
+
+
+def _tool_count() -> int:
+    """``@tool``-decorated module-level helpers under ``strands_robots/tools/``."""
+    total = 0
+    for path in sorted((PACKAGE / "tools").glob("*.py")):
+        for node in ast.parse(path.read_text(encoding="utf-8")).body:
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            if any(ast.unparse(d).split("(")[0].strip() == "tool" for d in node.decorator_list):
+                total += 1
+    return total
+
+
+def _shipped_providers() -> list[str]:
+    """Providers ``registry/policies.json`` ships.
+
+    The shipped registry rather than ``list_providers()``: the row describes what
+    the package contains, and ``list_providers()`` also reports providers a caller
+    registered at runtime - which in a test session includes every throwaway
+    ``register_policy`` a sibling module left behind.
+    """
+    registry = json.loads((PACKAGE / "registry" / "policies.json").read_text(encoding="utf-8"))
+    return sorted(registry["providers"])
+
+
+def _published_action_count() -> int:
+    """Actions the MuJoCo tool schema publishes to a model."""
+    spec = json.loads((PACKAGE / "simulation" / "mujoco" / "tool_spec.json").read_text(encoding="utf-8"))
+    return len(spec["properties"]["action"]["enum"])
+
+
+def _policy_implementations() -> frozenset[str]:
+    """Concrete ``Policy`` implementations, resolved transitively without importing.
+
+    An AST walk rather than ``issubclass`` so an optional dependency missing
+    locally cannot silently shrink the set and let a stale number pass.
+    """
+    bases: dict[str, set[str]] = {}
+    for path in sorted((PACKAGE / "policies").rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.ClassDef):
+                bases[node.name] = {ast.unparse(b).split(".")[-1] for b in node.bases}
+    reached = {"Policy"}
+    grew = True
+    while grew:
+        grew = False
+        for name, parents in bases.items():
+            if name not in reached and parents & reached:
+                reached.add(name)
+                grew = True
+    return frozenset(reached - {"Policy"})
+
+
+def _member_doc(name: str) -> str:
+    attr = getattr(Policy, name)
+    target = attr.fget if isinstance(attr, property) else attr
+    return inspect.getdoc(target) or ""
+
+
+def _declaration_seams() -> frozenset[str]:
+    """The "policy declares, runtime supplies" members, derived from the base class.
+
+    A member is in the family when its own docstring names the contract, or when
+    a member that does cites it with an ``:attr:`` role - which is how the base
+    class records that ``requires_images`` is the precedent the later two follow.
+    Deriving it means a fourth seam is graded the day it is added.
+    """
+    public = {name for name in dir(Policy) if not name.startswith("_")}
+    marked: set[str] = set()
+    cited: set[str] = set()
+    for name in sorted(public):
+        doc = _member_doc(name)
+        if _SEAM_PHRASE.split(" supplies")[0] in doc:
+            marked.add(name)
+            cited |= set(re.findall(r":attr:`(?:~[\w.]*\.)?(\w+)`", doc))
+    return frozenset(marked | (cited & public))
+
+
+def _names(paragraph: str, member: str) -> bool:
+    """Whether ``paragraph`` names ``member`` as a whole token.
+
+    A dotted path names the thing to import, which is a different fact from the
+    member a paragraph is telling an implementer about, so the boundary matters.
+    """
+    return re.search(rf"(?<![\w.]){re.escape(member)}(?![\w.])", paragraph) is not None
+
+
+def test_the_module_table_states_the_number_of_providers_that_ship() -> None:
+    """The policies row quotes ``list_providers()``, not a number from its past."""
+    providers = _shipped_providers()
+    row = _module_table_row("strands_robots/policies/")
+    stated = re.findall(r"\b(\d+)\s+providers\b", row)
+    assert stated == [str(len(providers))], (
+        f"docs/architecture.md's policies row states {stated or 'no'} providers; "
+        f"registry/policies.json ships {len(providers)}: {providers}"
+    )
+
+
+def test_the_module_table_states_the_number_of_tools_that_ship() -> None:
+    """The tools row quotes the ``@tool``-decorated helpers that exist."""
+    expected = _tool_count()
+    row = _module_table_row("strands_robots/tools/")
+    stated = re.findall(r"\b(\d+)\s+`@tool`", row)
+    assert stated == [str(expected)], (
+        f"docs/architecture.md's tools row states {stated or 'no'} @tool helpers; "
+        f"strands_robots/tools/ defines {expected}"
+    )
+
+
+@pytest.mark.parametrize("path", ACTION_COUNT_SITES, ids=lambda p: p.name)
+def test_a_documented_simulation_action_count_is_the_published_enum(path: Path) -> None:
+    """Every action count either document states is the count a model is offered.
+
+    Graded wherever a number qualifies "actions" rather than at fixed lines, so a
+    fresh claim added elsewhere in the file is held to the same enum.
+    """
+    expected = _published_action_count()
+    text = path.read_text(encoding="utf-8")
+    stated = {int(n) for n in re.findall(r"\b(\d+)\s+(?:\*\*)?(?:Simulation )?actions\b", text)}
+    wrong = sorted(n for n in stated if n != expected)
+    assert not wrong, (
+        f"{path.relative_to(REPO_ROOT)} states {wrong} Simulation actions; tool_spec.json publishes {expected}"
+    )
+
+
+def test_the_policy_paragraph_names_every_abstract_member() -> None:
+    """A member an implementation *must* supply is a member the paragraph names."""
+    paragraph = _policy_paragraph()
+    missing = sorted(m for m in Policy.__abstractmethods__ if not _names(paragraph, m))
+    assert not missing, (
+        f"docs/architecture.md's Policy paragraph does not name {missing}, which "
+        f"Policy declares abstract, so an implementer reading it learns an incomplete "
+        f"must-implement set: {paragraph[:160]}..."
+    )
+
+
+def test_the_policy_paragraph_claims_nothing_abstract_that_is_not() -> None:
+    """The converse: a member the paragraph presents as abstract really is one."""
+    paragraph = _policy_paragraph()
+    claimed = set(re.findall(r"`(\w+)\(", paragraph)) | set(re.findall(r"`(\w+)` property", paragraph))
+    optional = {name for name in claimed if hasattr(Policy, name) and name not in Policy.__abstractmethods__}
+    intro = paragraph.split(":")[0] if ":" in paragraph else paragraph
+    wrong = sorted(name for name in optional if _names(intro, name))
+    assert not wrong, (
+        f"docs/architecture.md's Policy paragraph introduces {wrong} alongside the "
+        f"abstract members, but Policy supplies a default for each: "
+        f"{sorted(Policy.__abstractmethods__)} are the abstract ones"
+    )
+
+
+def test_the_policy_paragraph_names_every_declaration_seam() -> None:
+    """A seam the runtime reads is a seam the contract paragraph names.
+
+    ``requires_images`` alone was named. ``required_bodies`` is the only route to
+    a body pose, and ``children`` the only route into a wrapped policy, so a
+    paragraph naming one of the three teaches a contract whose two silent halves
+    are the ones a policy cannot recover from by trying harder.
+    """
+    seams = _declaration_seams()
+    paragraph = _policy_paragraph()
+    missing = sorted(s for s in seams if not _names(paragraph, s))
+    assert not missing, (
+        f"docs/architecture.md's Policy paragraph does not name {missing}; the base "
+        f"class marks {sorted(seams)} as the 'policy declares, runtime supplies' "
+        f"family, and a policy that skips one is not told it exists"
+    )
+
+
+def test_the_policy_paragraph_states_the_number_of_implementations_that_ship() -> None:
+    """An implementation count in the paragraph is the number of implementations."""
+    expected = len(_policy_implementations())
+    paragraph = _policy_paragraph()
+    stated = {int(n) for n in re.findall(r"\b(\d+)\s+implementations\b", paragraph)}
+    wrong = sorted(n for n in stated if n != expected)
+    assert not wrong, (
+        f"docs/architecture.md's Policy paragraph states {wrong} implementations; "
+        f"strands_robots/policies/ defines {expected}"
+    )
+
+
+def test_the_paragraph_does_not_enumerate_a_strict_subset_as_the_implementations() -> None:
+    """Naming implementations is fine; naming some of them as *the* set is not.
+
+    The paragraph previously read "Four implementations: MockPolicy, Gr00tPolicy,
+    LerobotLocalPolicy, Cosmos3Policy" - a closed list of four of fifteen, and
+    the four for which the omitted seams happen to be invisible.
+    """
+    paragraph = _policy_paragraph()
+    implementations = _policy_implementations()
+    named = {n for n in re.findall(r"`(\w+)`", paragraph) if n in implementations}
+    total = len(implementations)
+    assert not (0 < len(named) < total), (
+        f"docs/architecture.md's Policy paragraph names {sorted(named)} - "
+        f"{len(named)} of {total} implementations - which reads as the complete set. "
+        f"State the count and point at the provider table instead."
+    )
+
+
+def test_the_seam_family_is_derived_from_the_base_class() -> None:
+    """Non-vacuity: the derived family is real members, and it spans all three.
+
+    Without this a refactor that stopped matching the base class's phrasing would
+    make the seam guard grade an empty set and report a clean page.
+    """
+    seams = _declaration_seams()
+    assert seams == {"requires_images", "required_bodies", "children"}, (
+        f"derived seam family is {sorted(seams)}; expected the three the base class "
+        f"marks. Update this pin deliberately if a seam is added or removed."
+    )
+    for name in seams:
+        assert hasattr(Policy, name), f"{name} is not a Policy member"
+
+
+@pytest.mark.parametrize(
+    ("paragraph", "expected_missing"),
+    [
+        ("**`Policy`** - `get_actions()`, `set_robot_state_keys()`, `provider_name` property.", "children"),
+        ("**`Policy`** - `requires_images`, `required_bodies`, `children`.", "get_actions"),
+    ],
+    ids=["seam-omitted", "abstract-omitted"],
+)
+def test_the_graders_report_a_planted_omission(paragraph: str, expected_missing: str) -> None:
+    """The rules fire on prose that omits a member, not merely on the real page."""
+    seams = _declaration_seams()
+    wanted = set(Policy.__abstractmethods__) | set(seams)
+    missing = sorted(m for m in wanted if not _names(paragraph, m))
+    assert expected_missing in missing, f"planted omission of {expected_missing} not reported: {missing}"


### PR DESCRIPTION
## Problem

`docs/architecture.md` is the map a contributor reads to size each subsystem, and its "ABCs"
paragraph is read as the contract a new implementation conforms to. Both restate the code in
prose. One row of that table is graded - `test_docs_robot_catalog_coverage.py` ties the registry
row to `robots.json`, and it is exact. Nothing graded the rest, and the rest drifted.

Measured against the code on `upstream/main`:

| claim | page states | code says |
|---|---|---|
| policies row: providers | `4` | **14** (`registry/policies.json`) |
| tools row: `@tool` helpers | `8` | **20** (AST walk of `strands_robots/tools/`) |
| README: Simulation actions (x2 sites) | `67` | **77** (published `tool_spec.json` enum) |
| `Policy` para: declaration seams named | 1 of 3 | 3 of 3 |
| `Policy` para: implementations named | 4 of 15, by name | 15 |
| registry row: robots / aliases / categories | 72 / 119 / 8 | 72 / 119 / 8 - **already graded, already exact** |

Every module-table count and the ABCs paragraph date from the original docs site (#160,
2026-06-11) and never moved while the package grew. README's action count is the exception that
proves the point: #1374 corrected it `65 -> 67` by hand on 2026-07-14, which is how a number
becomes authoritative, and it drifted again by the same mechanism - because nothing ties it to
the enum.

## The seam half is the one with teeth

The paragraph enumerated the `Policy` contract as five members, naming `requires_images` and
omitting `required_bodies` and `children`. Those are not incidental: `Policy.children`'s own
docstring calls all three "the same `policy declares, runtime supplies` contract", so the code
marks a three-member family and the page named one of it.

Driven in MuJoCo on a `unitree_g1`:

- A policy implementing **exactly the five members the paragraph named** receives `base_quat`
  and **no body pose at all** - `status="success"`, nothing reports it. The runtime supplies a
  body pose only for a body `required_bodies` names.
- Declaring the seam adds `body.torso_link.{pos,quat,lin_vel,ang_vel}`.
- `base_quat` is the *pelvis*. At `waist_yaw = 0.6 rad` it diverges from `torso_link` by
  **34.38 deg**, so a whole-body tracker written against the documented contract feeds its
  network the wrong frame whenever the waist is not neutral.

And the enumeration was self-consistently incomplete: **0 of the 4 implementations it named
override either seam**, while **all 3 that do** (`CompositePolicy`, `PersistentPolicy`,
`ProtoMotionsPolicy`) were absent. It named the subset for which the omission is invisible.

## Change

`docs/architecture.md` and `README.md`, plus a guard that derives each number from the code so a
count cannot be right the day it is written and wrong a month later:

- module-table counts from `registry/policies.json` and an AST walk of `strands_robots/tools/`;
- the Simulation action count from the published `tool_spec.json` enum, graded wherever either
  document states one rather than at fixed lines, so a fresh claim elsewhere in the file is held
  to the same enum;
- the `Policy` paragraph against `Policy.__abstractmethods__` (what an implementation must
  supply) and against the declaration-seam family, itself derived from the base class's own
  docstrings - so a fourth seam is graded the day it is added;
- the paragraph now states the implementation count and points at the provider table instead of
  closing a list of four.

The provider count reads `policies.json` rather than `list_providers()` on purpose: the row
describes what the package *contains*, and `list_providers()` also reports runtime registrations,
which in a test session includes every throwaway `register_policy` a sibling module left behind
(23 mid-suite here).

## Verification

Measured at `641d113b`, `upstream/main` at `b96412ad`, mujoco 3.12.0.

**Pre-fix split** - the new guard on `upstream/main`'s pages: **6 failed / 6 passed**, each
failure naming the claim and the code count, e.g.

```
docs/architecture.md's Policy paragraph does not name ['children', 'required_bodies'];
the base class marks ['children', 'required_bodies', 'requires_images'] as the
'policy declares, runtime supplies' family, and a policy that skips one is not told it exists
```

After: **12 passed**. The 6 that pass on both trees are the controls - the three abstract members
were already named; `docs/architecture.md`'s own `60+ actions` was not a false claim, so the
action grader correctly did not flag it (it is now the exact number for consistency); the seam
family derivation is pinned non-vacuously; and two planted-prose cases prove the rules fire on an
omission rather than only on the real page.

**Every guard is load-bearing** - reverting one claim at a time fails exactly one test, and only
its own:

| break | tests failed |
|---|---|
| revert provider count to 4 | `..._number_of_providers_that_ship` |
| revert tool count to 8 | `..._number_of_tools_that_ship` |
| revert README action count to 67 | `..._is_the_published_enum[README.md]` |
| drop the `children` seam | `..._names_every_declaration_seam` |
| drop an abstract member | `..._names_every_abstract_member` |
| re-enumerate four implementations | `..._does_not_enumerate_a_strict_subset...` |

**Zero regressions** - 77 test files (every guard that reads `docs/architecture.md`, README or a
docs page, walks a source tree, grades docstrings/exports/changelog fragments, plus
`tests/policies/`), identical selection on both trees, run in parallel:

| tree | failed | passed | skipped |
|---|---|---|---|
| this branch | 0 | 1908 | 1 |
| `upstream/main` | 0 | 1908 | 1 |

Failing-ID sets identical (empty both ways). `ruff check` + `ruff format --check` clean over
`strands_robots tests tests_integ`; `mypy` 24 == 24 against a pristine `upstream/main` worktree
with none in the changed files.

## Artifact

Both columns run the same package - only `docs/architecture.md` and `README.md` differ, and each
row is read from that column's own page. The code-side measurement and the sim divergence are
asserted identical across trees inside the figure script, so the picture cannot drift from the
claim: **5 of 6 claims disagree with the code before, 0 after.** The strip below is the same
`unitree_g1` at `waist_yaw` 0.0 and 0.6 rad (13.3% of pixels differ), with the observation a
documented-contract-only policy actually receives.

![architecture counts graded against the code](https://raw.githubusercontent.com/cagataycali/robots/media-architecture-counts-32529916400/architecture-counts.png)

## Scope

Left alone, with the measurement:

- The `SimEngine` line's "30+ abstract actions" - 14 `__abstractmethods__` against 38 public
  members, so which reading it takes is genuinely ambiguous and "30+" is true for the surface one.
- README's "70+ robots" and the `docs/robots/` and `docs/policies/` counts, all measured correct.
- The registry row, which `test_docs_robot_catalog_coverage.py` owns. Two guards on one claim can
  disagree about the wording.
