### PR TITLE
fix(scripts): name an uncomputed mergeability instead of reading it as clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1011,10 +1011,21 @@ hatch run format            # ruff check --fix, ruff format
    unresolved thread or a failing check (the author), a missing approval (any
    reviewer), an approval only its own pusher supplied (a different reviewer,
    per #1905), a required check absent because a fork run is held at
-   `action_required` (a maintainer), a check still running (nobody), or no
-   unsatisfied rule at all, which is the #2574 case and the one worth saying out
-   loud. A conflict or a draft is reported as *gating*: the rules behind it
-   cannot be assessed, so an approval there is necessary but not sufficient.
+   `action_required` (a maintainer), a check still running (nobody), a
+   mergeability GitHub has not finished computing (nobody, until a re-read), or
+   no unsatisfied rule at all, which is the #2574 case and the one worth saying
+   out loud. A conflict, a draft, or an uncomputed mergeability is reported as
+   *gating*: the rules behind it cannot be assessed, so an approval there is
+   necessary but not sufficient.
+
+   That last one is why the sweep is worth re-reading rather than trusting once.
+   `mergeable` is `bool | None`, and a merge into `main` invalidates the cached
+   value for **every** open pull request -- so a sweep run just after a merge is
+   exactly when the null appears, which is also when a health pass is most likely
+   to run. #1035 was measured reading `pusher-only-approval` (owed by a reviewer)
+   while it was in fact `CONFLICTING`/`DIRTY`, and an otherwise-satisfied pull
+   request in the same state read `no-unsatisfied-rule`, whose printed remedy is
+   to attempt the merge. Both are now `merge-state-unknown`. See #2585.
 
    It composes `check_last_push_approval.py` rather than restating it, so what
    counts as a current approval has one owner. Neither script gates a merge.

--- a/changelog.d/2585-merge-state-unknown-is-not-clean.md
+++ b/changelog.d/2585-merge-state-unknown-is-not-clean.md
@@ -1,0 +1,18 @@
+### Fixed: an uncomputed mergeability is no longer reported as a clean merge
+
+`scripts/check_merge_blockers.py` modelled `mergeable` as `bool | None` but
+classified only two of those three states. GitHub computes mergeability on
+demand and returns null while it works, and a merge into the base invalidates
+the cached value for every open pull request -- so a sweep run just after a
+merge is exactly when the null appears. Falling through the conflict branch
+reported it as if the branch merged cleanly, and the rules underneath it then
+owned the next action: #1035 was measured reporting `pusher-only-approval`,
+owed by a reviewer, while it was in fact `CONFLICTING`/`DIRTY`. An otherwise
+satisfied pull request in the same state reported `no-unsatisfied-rule`, whose
+printed remedy is to attempt the merge.
+
+The third state is now named: a `merge-state-unknown` outcome, owed by nobody,
+carrying the re-read that resolves it. It is reported as *gating*, so an
+approval underneath it reads as necessary but not sufficient rather than as the
+next action, and it is deliberately not a finding, so the exit status keeps its
+meaning. A null is still never reported as a conflict.

--- a/scripts/check_merge_blockers.py
+++ b/scripts/check_merge_blockers.py
@@ -78,6 +78,16 @@ is*, so the outcomes group that way rather than by severity:
 ``required-check-pending``
     Nobody. The answer is not in yet.
 
+``merge-state-unknown``
+    Nobody, for now, and the same shape as the entry above one field over.
+    ``mergeable`` is ``bool | None``: GitHub computes it on demand and returns
+    null while it works, which is neither "conflicts" nor "merges cleanly". A
+    merge into the base invalidates it for every open pull request, so a sweep
+    run just after a merge is precisely when it is null. Reported as *gating*,
+    because reading the null as clean is how a conflicted branch is reported as
+    owed by a reviewer -- measured on #1035, which read
+    ``pusher-only-approval`` while it was ``DIRTY``. Re-read to resolve it.
+
 ``required-check-absent``
     A **maintainer**, by authorising or re-running the workflow. A fork pull
     request whose runs are held at ``action_required`` reports ``completed``
@@ -176,6 +186,7 @@ resolve_reviews = _approval.resolve_reviews
 # order they are reported in: a conflict makes the approval question moot, and
 # an unresolved thread makes it moot for a different reason.
 MERGE_CONFLICT = "merge-conflict"
+MERGE_STATE_UNKNOWN = "merge-state-unknown"
 DRAFT = "draft"
 REQUIRED_CHECK_FAILING = "required-check-failing"
 REQUIRED_CHECK_PENDING = "required-check-pending"
@@ -195,6 +206,7 @@ ANYONE = "anyone, by attempting the merge"
 
 _OWED_BY: dict[str, str] = {
     MERGE_CONFLICT: AUTHOR,
+    MERGE_STATE_UNKNOWN: NOBODY,
     DRAFT: AUTHOR,
     REQUIRED_CHECK_FAILING: AUTHOR,
     REQUIRED_CHECK_PENDING: NOBODY,
@@ -211,7 +223,13 @@ _OWED_BY: dict[str, str] = {
 # that would merge. Distinguished so the report names one next action instead
 # of a set the reader has to order, which is the mistake #1905 records as
 # "necessary but no longer sufficient".
-_GATING: frozenset[str] = frozenset({MERGE_CONFLICT, DRAFT})
+#
+# An unknown mergeability gates for the weaker reason that the conflict question
+# is still open: it may turn out to gate nothing at all. It is grouped here
+# because the cost is asymmetric -- reporting the approval rule as the next
+# action on a branch that turns out to be conflicted burns an approval, and
+# reporting it as necessary-but-not-sufficient costs one re-read (#2585).
+_GATING: frozenset[str] = frozenset({MERGE_CONFLICT, MERGE_STATE_UNKNOWN, DRAFT})
 
 
 # The outcomes a scheduled author-side pass can act on without anyone else.
@@ -332,6 +350,13 @@ def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
     # Upstream of every rule below: a branch that does not merge cleanly cannot
     # be merged by satisfying anything else, and the required check that is
     # green is green on a head that predates the conflict.
+    #
+    # Three states, not two. GitHub computes mergeability on demand and returns
+    # null while it works, and a merge into the base invalidates it for every
+    # open pull request -- so a sweep run just after a merge is exactly when the
+    # null shows up. Falling through to the rules below would report it as
+    # cleanly mergeable, which is how #1035 came back as owed by a reviewer
+    # while it was in fact DIRTY (#2585).
     if state.mergeable is False:
         found.append(
             Blocker(
@@ -341,6 +366,20 @@ def evaluate(state: PullRequestState, rules: Ruleset) -> tuple[Blocker, ...]:
                 f"{state.merge_state or 'dirty'}. No approval can merge it while "
                 f"this stands, and the required check's green describes a head "
                 f"that predates the conflict.",
+            )
+        )
+    elif state.mergeable is None:
+        found.append(
+            Blocker(
+                MERGE_STATE_UNKNOWN,
+                "(not a ruleset rule)",
+                f"GitHub has not finished computing whether this branch merges "
+                f"cleanly into {state.base_ref}; merge state is "
+                f"{state.merge_state or 'unknown'}. No conflict is alleged and "
+                f"none is ruled out -- the question is open, so the rules below "
+                f"are reported as necessary rather than sufficient. Re-read the "
+                f"pull request: mergeability is computed on demand and settles "
+                f"on a later read.",
             )
         )
 

--- a/tests/test_merge_blockers.py
+++ b/tests/test_merge_blockers.py
@@ -364,6 +364,69 @@ def test_an_unknown_mergeability_is_not_reported_as_a_conflict() -> None:
     assert mod.MERGE_CONFLICT not in outcomes(mod.evaluate(state(mergeable=None), MAIN))
 
 
+def test_an_unknown_mergeability_is_named_rather_than_passed_over() -> None:
+    """Silence is not neutral here: it reads identically to ``mergeable: true``.
+
+    The assertion above pins that ``None`` is not called a conflict. This pins the
+    other half -- that it is not called nothing either, which is what let the
+    rules underneath it own the next action.
+    """
+    blockers = mod.evaluate(state(mergeable=None), MAIN)
+    assert mod.MERGE_STATE_UNKNOWN in outcomes(blockers)
+    assert mod.NO_UNSATISFIED_RULE not in outcomes(blockers)
+    unknown = next(b for b in blockers if b.outcome == mod.MERGE_STATE_UNKNOWN)
+    assert "Re-read" in unknown.detail
+
+
+def test_an_unknown_mergeability_is_owed_by_nobody_and_is_not_a_finding() -> None:
+    """The answer is not in yet, so there is nobody to route it to.
+
+    Not a finding for the same reason ``required-check-pending`` is not one: the
+    exit status is for what a scheduled author-side pass can act on alone, and a
+    value the caller can only wait for is not that.
+    """
+    blocker = mod.primary(mod.evaluate(state(mergeable=None), MAIN))
+    assert blocker.outcome == mod.MERGE_STATE_UNKNOWN
+    assert blocker.owed_by == mod.NOBODY
+    assert blocker.is_finding is False
+    assert blocker.is_gating is True
+
+
+def test_an_unknown_mergeability_does_not_hand_a_conflicted_branch_to_a_reviewer() -> None:
+    """The measured regression: #1035 read ``pusher-only-approval`` while it was DIRTY.
+
+    Identical inputs to the conflict case above except the one field GitHub had
+    not finished computing. Measured 2026-08-21 23:07 UTC, a minute after two
+    merges moved ``main`` and invalidated the cached value for every open pull
+    request -- so the sweep named a reviewer, and #1905 records that an approval
+    there is dismissed by the resolving push rather than merging anything.
+    """
+    st = state(
+        mergeable=None,
+        merge_state="unknown",
+        approvers=("cagataycali",),
+        pusher="cagataycali",
+    )
+    blockers = mod.evaluate(st, MAIN)
+    assert outcomes(blockers) == [mod.MERGE_STATE_UNKNOWN, mod.PUSHER_ONLY_APPROVAL]
+    assert mod.primary(blockers).owed_by == mod.NOBODY
+    rendered = mod.render(st, MAIN, blockers, "o/r")
+    assert "necessary but not sufficient" in rendered
+    # The reviewer must not be offered as the next action while the question is open.
+    assert f"Next action is owed by {mod.OTHER_REVIEWER}" not in rendered
+
+
+def test_an_unknown_mergeability_does_not_read_as_the_stale_state_case() -> None:
+    """#2574's remedy is a merge attempt; an uncomputed mergeability's is a re-read.
+
+    Attempting the merge on a branch whose conflict status is still being
+    computed is how a null gets resolved as a failed mutation instead of a read.
+    """
+    st = state(mergeable=None)
+    rendered = mod.render(st, MAIN, mod.evaluate(st, MAIN), "o/r")
+    assert "Attempt the merge" not in rendered
+
+
 def test_the_next_action_line_names_one_owner_when_a_gating_blocker_is_present() -> None:
     blockers = mod.evaluate(state(mergeable=False, approvers=()), MAIN)
     rendered = mod.render(state(mergeable=False, approvers=()), MAIN, blockers, "o/r")


### PR DESCRIPTION
`scripts/check_merge_blockers.py` models `mergeable` as `bool | None` and classifies only two of those three states. GitHub computes mergeability on demand and returns null while it works, so the third state fell through the conflict branch and was reported as a clean merge -- letting the rules underneath it own the next action.

Closes #2585

## How this was found

Not by reading the code. By running the sweep AGENTS.md mandates for repository health, about a minute after merging #2577 and #2583 -- which is what made `main` move and invalidated the cached value for every open pull request.

The sweep split two equally-conflicted branches into two different owners:

| pull request | sweep said | true state |
|---|---|---|
| #1722 | `merge-conflict, missing-approval` -- owed by **the author** | `CONFLICTING` / `DIRTY` |
| #1035 | `pusher-only-approval` -- owed by **a reviewer other than the pusher** | `CONFLICTING` / `DIRTY` |

The only difference was which value happened to be warm in REST's cache. Read again minutes later, both agree, and the patched sweep on the same live data now reports #1035 as `merge-conflict, pusher-only-approval` owed by the author.

## Two manifestations, not one

1. **A conflicted branch is handed to a reviewer.** #1035 above. #1905 records what that approval buys: nothing today, because the branch needs an author-side rebase first, and the approval is then dismissed by the resolving push -- a burned approval, the cost #2017 tracks.
2. **An otherwise satisfied branch is told to merge.** With every other rule satisfied and mergeability uncomputed, the outcome was `no-unsatisfied-rule`, owed by `anyone, by attempting the merge`, and the report printed the `Attempt the merge` remedy. So the tool advised attempting a merge on a branch whose conflict status was still being computed. Measured directly against the pre-fix module:

```
PRE-FIX outcome: ['no-unsatisfied-rule']
PRE-FIX owed by: anyone, by attempting the merge
```

## This is not "guess it is a conflict"

`test_an_unknown_mergeability_is_not_reported_as_a_conflict` is right, and it still passes unchanged -- *"Guessing turns a wait into an accusation."* A null is never reported as a conflict here.

The gap was that it was not reported **at all**, and silence is not neutral: it reads identically to `mergeable: true`.

The script already had the vocabulary one field over. A required check whose conclusion is `None` gets its own outcome -- `required-check-pending`, owed by `NOBODY`, *"the answer is not in yet."* An unknown mergeability is the same shape and had none.

## The change

- `merge-state-unknown`, owed by **nobody**, detail carrying the re-read that resolves it.
- **Gating**, so the approval rule underneath reads as *necessary but not sufficient* rather than as the next action. The comment says why it gates on a weaker basis than a conflict does: the cost is asymmetric -- a wrong reviewer hand-off burns an approval, a re-read costs one round trip.
- **Not a finding**, so the exit status keeps its current meaning, matching `required-check-pending`.

## Why report and not poll

Deliberate, and it matches the script's existing idiom rather than introducing a new one: it prints `Attempt the merge` for the stale-state case instead of attempting it, and `Neither script gates a merge`. A bounded re-poll would put a sleep inside a sweep over N pull requests to answer a question the caller resolves by reading again.

## Verification

- The 4 new tests **fail on pre-fix code** and pass after: `4 failed, 59 passed` before, `63 passed` after. One fails behaviourally rather than on the missing symbol, which is the `Attempt the merge` case above.
- 334 passed across the merge-blocker, sibling-check, changelog and string-hygiene suites.
- `ruff check` clean, `ruff format --check` clean, `mypy scripts/check_merge_blockers.py` clean, `assemble_changelog.py --check` OK.
- End-to-end `--all-open` against live data: 10 pull requests, normal path unchanged.

## Doc drift

AGENTS.md described the outcome list and said *"A conflict or a draft is reported as gating"*, which this change makes incomplete. Updated in the same diff, with the reason the null is correlated with the moment a health sweep runs.