### PR TITLE
docs(policies): document the fields a config dataclass declares, and grade it

### DIFF
--- a/changelog.d/2587-attributes-block-names-every-declared-field.md
+++ b/changelog.d/2587-attributes-block-names-every-declared-field.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **policies**: a config dataclass's `Attributes:` block now names every field it
+  declares. `EmbodimentMap` documented five of ten, omitting the unit-conversion
+  group (`state_units`, `action_units`, `gripper_index`, `gripper_joint_range`,
+  `joint_mids`), so an embodiment written from that block converted nothing and a
+  degrees-trained SO-arm checkpoint's values reached the sim unconverted;
+  `PackStateProcessorStep`, which receives four of them, and `ProtoMotionsConfig`
+  had the same gap. Graded for every dataclass with such a block by
+  `tests/test_attributes_docstring_completeness.py`, the attribute-list counterpart
+  to the existing `Args:` completeness guard.

--- a/strands_robots/policies/lerobot_local/embodiment.py
+++ b/strands_robots/policies/lerobot_local/embodiment.py
@@ -626,6 +626,21 @@ def register_pack_state_step() -> type | None:
             state_keys: Ordered robot/sim scalar keys composing the state vector.
             expected_dim: Model's declared ``observation.state`` dimension.
             dim_policy: ``"strict"`` | ``"pad"`` | ``"truncate"``.
+            state_units: ``"native"`` (the default - pack the sim's own values)
+                or ``"degrees"`` (convert the sim's radian joints to the model's
+                training units before packing). Mirrors
+                :attr:`EmbodimentMap.state_units`, which is where this step's
+                value comes from.
+            gripper_index: Column of the gripper inside ``state_keys``, which
+                speaks ``RANGE_0_100`` rather than degrees. ``-1`` (the default)
+                = no distinct gripper column.
+            gripper_joint_range: The sim gripper joint's ``[min, max]`` radians,
+                used to map that column onto 0..100. Empty (the default) =
+                convert the gripper like an arm joint.
+            joint_mids: Per-joint calibration mid-points in degrees, aligned to
+                ``state_keys``, subtracted from the arm columns so the packed
+                state is mid-centered like LeRobot's ``DEGREES`` mode. Empty
+                (the default) = mid 0.
         """
 
         state_keys: list[str] = field(default_factory=list)
@@ -777,6 +792,26 @@ class EmbodimentMap:
         action_keys: Ordered robot actuator names for the action tensor's
             index→name mapping (output side).
         dim_policy: ``"strict"`` | ``"pad"`` | ``"truncate"`` for state dim.
+        state_units: Unit convention of the sim state vector this map packs:
+            ``"native"`` (the default - no conversion) or ``"degrees"`` (arm
+            columns in degrees, gripper column in ``RANGE_0_100``), which is
+            what :meth:`sim_state_to_model` converts from.
+        action_units: Unit convention of the model's action vector, same
+            vocabulary as ``state_units``. On ``"degrees"``
+            :meth:`model_action_to_sim` converts the model's degrees back to sim
+            radians; left ``"native"`` for a degrees-trained SO-arm checkpoint,
+            the raw degree values reach the sim unconverted and saturate its
+            radian joint limits.
+        gripper_index: Column of the gripper inside ``state_keys`` /
+            ``action_keys``, which speaks ``RANGE_0_100`` rather than degrees.
+            ``-1`` (the default) = no distinct gripper column; SO arms use ``5``.
+        gripper_joint_range: The sim gripper joint's ``[min, max]`` radians, used
+            to map that column's 0..100 command onto the joint and back. Empty
+            (the default) = convert the gripper like an arm joint.
+        joint_mids: Per-joint calibration mid-points in degrees, aligned to
+            ``state_keys`` / ``action_keys``, because LeRobot's ``DEGREES`` mode
+            is mid-point-centered. Empty (the default) = mid 0, i.e. sim
+            ``qpos=0`` is assumed to be the calibration mid.
     """
 
     name: str = ""

--- a/strands_robots/policies/protomotions/config.py
+++ b/strands_robots/policies/protomotions/config.py
@@ -221,6 +221,16 @@ class ProtoMotionsConfig:
             steps.
         action_ema_alpha: Optional exponential-moving-average smoothing on the
             joint target output (``1.0`` = passthrough, upstream default).
+        onnx_in_names: Input tensor names in the order the exported session
+            declares them, so the session's ``get_inputs()`` order can be
+            validated against this tuple at load.
+        onnx_out_names: Output tensor names requested from the session. Outputs
+            are paired to these names rather than by position, so a config that
+            declares the checkpoint's outputs in a different order still reads
+            the right tensor.
+        metadata: Free-form provenance carried alongside the config, populated
+            from a sidecar's own ``metadata`` key. Never read by the control
+            path.
     """
 
     joint_names: tuple[str, ...] = GTP_G1_JOINT_NAMES

--- a/tests/test_attributes_docstring_completeness.py
+++ b/tests/test_attributes_docstring_completeness.py
@@ -1,0 +1,423 @@
+"""A documented ``Attributes:`` block is the only field list a caller reads.
+
+A configuration dataclass in this package is a caller-facing surface, not an
+internal record: :class:`~strands_robots.policies.lerobot_local.embodiment.EmbodimentMap`
+is exported and is built straight from a caller-supplied dict, and
+:class:`~strands_robots.policies.protomotions.config.ProtoMotionsConfig` is
+resolved from a checkpoint's sidecar. So the class's ``Attributes:`` block is
+where a caller learns which keys that dict may carry - and a field missing from
+it is a field the caller does not know to set.
+
+That is not a cosmetic gap. ``EmbodimentMap`` documented five of its ten fields,
+and the five it omitted were the unit-conversion group: ``state_units`` /
+``action_units`` decide whether the map converts at all, and ``gripper_index`` /
+``gripper_joint_range`` / ``joint_mids`` parameterise the conversion. Their
+defaults are ``"native"`` / ``-1`` / empty, so a caller writing an embodiment
+from that block got a map that converts nothing, ``validate()`` accepted it, and
+a degrees-trained SO-arm checkpoint's raw ``90.0`` reached a sim joint whose
+range is ``+/-1.9199`` radians. ``ProtoMotionsConfig`` omitted ``onnx_in_names``
+- while another docstring in the same package cites
+``:attr:`ProtoMotionsConfig.onnx_in_names``` as where its shapes are documented.
+
+``tests/test_args_docstring_completeness.py`` pins exactly this comparison for
+``Args:`` blocks, and its scope is a function signature, so an attribute list
+was graded by nothing. These tests close that: for every dataclass whose
+docstring *already* has an ``Attributes:`` block, every field it declares must
+have an entry. A class with no ``Attributes:`` block at all is out of scope -
+this checks a block that exists for completeness rather than demanding one,
+which is the same boundary the ``Args:`` guard draws.
+
+A field documented on a base class counts, so a subclass may document only what
+it adds; and one entry may name several fields that share a description
+(``actor_obs_keys / critic_obs_keys: ...``), matching the ``Args:`` guard's own
+label handling. The scan is AST-only, so no optional backend has to be
+importable for a config dataclass behind one to be graded.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+import strands_robots as package
+
+# Derived from an imported symbol rather than a path literal, so a moved package
+# cannot leave this scanning an empty tree while reporting success.
+_PACKAGE_ROOT = Path(inspect.getfile(package)).parent
+
+# Same entry / label conventions as the ``Args:`` guard, so the two blocks are
+# read the same way: ``name (type):`` / ``name:`` / ``a / b:``.
+_ENTRY = re.compile(r"^\s*([A-Za-z_][\w ,/]*?)\s*(\([^)]*\))?\s*:")
+_LABEL_SPLIT = re.compile(r"\s*(?:/|,|\bor\b)\s*")
+
+# A block that follows ``Attributes:`` ends at the next section header.
+_OTHER_SECTIONS = frozenset(
+    {
+        "Args:",
+        "Arguments:",
+        "Parameters:",
+        "Returns:",
+        "Raises:",
+        "Yields:",
+        "Example:",
+        "Examples:",
+        "Note:",
+        "Notes:",
+    }
+)
+
+# Fewer than this many graded dataclasses means the scan stopped reaching the
+# package rather than that the package stopped documenting its fields.
+_MINIMUM_GRADED_DATACLASSES = 15
+_MINIMUM_GRADED_FIELDS = 120
+
+
+def documented_attributes(doc: str) -> tuple[frozenset[str], bool]:
+    """Names documented in ``doc``'s ``Attributes:`` section, and whether it has one.
+
+    Args:
+        doc: A dedented docstring (as :func:`ast.get_docstring` returns).
+
+    Returns:
+        ``(names, has_section)``. ``names`` is empty when there is no
+        ``Attributes:`` section, so callers must consult ``has_section`` to tell
+        "documents nothing" from "has no block to check". Combined labels are
+        split on ``/``, ``,`` and ``or``.
+    """
+    lines = doc.splitlines()
+    header_indent = None
+    body: list[str] = []
+    for index, line in enumerate(lines):
+        if line.strip() == "Attributes:":
+            header_indent = len(line) - len(line.lstrip())
+            body = lines[index + 1 :]
+            break
+    if header_indent is None:
+        return frozenset(), False
+
+    names: set[str] = set()
+    entry_indent = None
+    for line in body:
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= header_indent:
+            break  # section ended (a dedented paragraph)
+        if line.strip() in _OTHER_SECTIONS:
+            break  # section ended (the next header, at the entry indent)
+        if entry_indent is None:
+            entry_indent = indent
+        if indent != entry_indent:
+            continue  # continuation line of the entry above
+        match = _ENTRY.match(line)
+        if not match:
+            continue
+        for part in _LABEL_SPLIT.split(match.group(1)):
+            cleaned = part.strip()
+            if cleaned:
+                names.add(cleaned)
+    return frozenset(names), True
+
+
+def _is_dataclass(cls: ast.ClassDef) -> bool:
+    """Whether ``cls`` carries a ``@dataclass`` decorator, bare or called."""
+    for decorator in cls.decorator_list:
+        node = decorator.func if isinstance(decorator, ast.Call) else decorator
+        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
+        if name == "dataclass":
+            return True
+    return False
+
+
+def declared_fields(cls: ast.ClassDef) -> list[str]:
+    """Public fields ``cls`` declares in its own body, in declaration order.
+
+    ``ClassVar`` annotations are class-level constants rather than fields, so
+    they are excluded the way :func:`dataclasses.fields` excludes them.
+    """
+    names = []
+    for node in cls.body:
+        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
+            continue
+        if node.target.id.startswith("_"):
+            continue
+        if "ClassVar" in ast.unparse(node.annotation):
+            continue
+        names.append(node.target.id)
+    return names
+
+
+def documented_dataclasses(root: Path) -> list[tuple[str, list[str], frozenset[str]]]:
+    """Every dataclass under ``root`` whose docstring has an ``Attributes:`` block.
+
+    Args:
+        root: Package directory to walk. Every ``*.py`` beneath it is parsed by
+            AST, so no optional backend needs to be importable.
+
+    Returns:
+        ``(surface_id, declared_fields, documented_names)`` triples, where
+        ``surface_id`` is ``"<relative path>::<Class>"`` and ``documented_names``
+        includes the names any base class documents, so a subclass may document
+        only the fields it adds.
+    """
+    by_name: dict[str, frozenset[str]] = {}
+    classes: list[tuple[str, ast.ClassDef]] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            doc = ast.get_docstring(cls)
+            documented, has_section = documented_attributes(doc) if doc else (frozenset(), False)
+            if has_section:
+                by_name[cls.name] = documented | by_name.get(cls.name, frozenset())
+            if _is_dataclass(cls) and has_section:
+                classes.append((str(path.relative_to(root.parent)), cls))
+
+    surfaces = []
+    for rel, cls in classes:
+        credited: set[str] = set(by_name.get(cls.name, frozenset()))
+        for base in cls.bases:
+            base_name = base.attr if isinstance(base, ast.Attribute) else getattr(base, "id", "")
+            credited |= by_name.get(base_name, frozenset())
+        surfaces.append((f"{rel}::{cls.name}", declared_fields(cls), frozenset(credited)))
+    return surfaces
+
+
+_DATACLASSES = documented_dataclasses(_PACKAGE_ROOT)
+
+
+@pytest.mark.parametrize(
+    ("surface", "fields", "documented"),
+    _DATACLASSES,
+    ids=[surface for surface, _, _ in _DATACLASSES],
+)
+def test_every_field_has_an_attributes_entry(surface: str, fields: list[str], documented: frozenset[str]) -> None:
+    """A dataclass documenting its attributes documents every field it declares."""
+    missing = [name for name in fields if name not in documented]
+    assert not missing, (
+        f"{surface} has an Attributes: block that omits {missing}. A caller "
+        "building this config reads that block for the keys it may set, so an "
+        "omitted field is one they do not know exists - and its default decides "
+        "the behaviour instead. Document it, or document it on a base class."
+    )
+
+
+class TestTheScanIsNonVacuous:
+    """A clean sweep has to mean the package is documented, not that nothing was read."""
+
+    def test_the_scan_reaches_the_package(self) -> None:
+        assert len(_DATACLASSES) >= _MINIMUM_GRADED_DATACLASSES, (
+            f"only {len(_DATACLASSES)} dataclasses carry an Attributes: block; the scan "
+            "is no longer reaching the package"
+        )
+
+    def test_the_scan_grades_real_fields(self) -> None:
+        total = sum(len(fields) for _, fields, _ in _DATACLASSES)
+        assert total >= _MINIMUM_GRADED_FIELDS, (
+            f"only {total} declared fields were graded across {len(_DATACLASSES)} dataclasses"
+        )
+
+    def test_the_unit_conversion_group_is_graded(self) -> None:
+        """The fields whose omission started this are in scope, by name."""
+        embodiment = next(
+            (entry for entry in _DATACLASSES if entry[0].endswith("::EmbodimentMap")),
+            None,
+        )
+        assert embodiment is not None, "EmbodimentMap is no longer graded"
+        _, fields, _ = embodiment
+        for name in ("state_units", "action_units", "gripper_index", "gripper_joint_range", "joint_mids"):
+            assert name in fields, f"EmbodimentMap.{name} is no longer a graded field"
+
+
+class TestABaseClassEntryCounts:
+    """A subclass may document only the fields it adds."""
+
+    def test_an_inherited_field_documented_on_the_base_is_accepted(self) -> None:
+        source = "\n".join(
+            [
+                "from dataclasses import dataclass",
+                "",
+                "@dataclass",
+                "class Base:",
+                '    """Base.',
+                "",
+                "    Attributes:",
+                "        shared: Documented here.",
+                '    """',
+                "",
+                "    shared: int = 0",
+                "",
+                "@dataclass",
+                "class Child(Base):",
+                '    """Child.',
+                "",
+                "    Attributes:",
+                "        extra: Documented here.",
+                '    """',
+                "",
+                "    shared: int = 1",
+                "    extra: int = 2",
+            ]
+        )
+        surfaces = self._scan(source)
+        child = next(entry for entry in surfaces if entry[0].endswith("::Child"))
+        _, fields, documented = child
+        assert fields == ["shared", "extra"]
+        assert set(fields) <= documented, "a base-documented field was not credited to the subclass"
+
+    def test_a_field_documented_nowhere_is_still_reported(self) -> None:
+        source = "\n".join(
+            [
+                "from dataclasses import dataclass",
+                "",
+                "@dataclass",
+                "class Solo:",
+                '    """Solo.',
+                "",
+                "    Attributes:",
+                "        documented: Yes.",
+                '    """',
+                "",
+                "    documented: int = 0",
+                "    forgotten: int = 1",
+            ]
+        )
+        _, fields, documented = self._scan(source)[0]
+        missing = [name for name in fields if name not in documented]
+        assert missing == ["forgotten"]
+
+    @staticmethod
+    def _scan(source: str) -> list[tuple[str, list[str], frozenset[str]]]:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "pkg"
+            root.mkdir()
+            (root / "mod.py").write_text(source, encoding="utf-8")
+            return documented_dataclasses(root)
+
+
+class TestCombinedEntryLabelsCount:
+    """One entry may name several fields that share a description."""
+
+    @pytest.mark.parametrize(
+        "label",
+        ["lora_r / lora_alpha", "lora_r, lora_alpha", "lora_r or lora_alpha"],
+    )
+    def test_both_names_are_credited(self, label: str) -> None:
+        doc = "\n".join(["Summary.", "", "Attributes:", f"    {label}: Shared description."])
+        names, has_section = documented_attributes(doc)
+        assert has_section
+        assert {"lora_r", "lora_alpha"} <= names
+
+    def test_the_shipped_combined_entry_is_read(self) -> None:
+        """``TrainSpec`` documents three LoRA fields in one entry."""
+        surface = next(entry for entry in _DATACLASSES if entry[0].endswith("::TrainSpec"))
+        _, _, documented = surface
+        assert {"lora_r", "lora_alpha", "lora_target_modules"} <= documented
+
+
+class TestTheParserBoundsTheSection:
+    """An ``Attributes:`` block ends where the next section begins."""
+
+    def test_a_following_section_is_not_read_as_entries(self) -> None:
+        doc = "\n".join(
+            [
+                "Summary.",
+                "",
+                "Attributes:",
+                "    documented: Yes.",
+                "",
+                "Args:",
+                "    not_a_field: A parameter.",
+            ]
+        )
+        names, has_section = documented_attributes(doc)
+        assert has_section
+        assert names == frozenset({"documented"})
+
+    def test_a_continuation_line_is_not_read_as_an_entry(self) -> None:
+        doc = "\n".join(
+            [
+                "Summary.",
+                "",
+                "Attributes:",
+                "    documented: A description that wraps and whose",
+                "        continuation: contains a colon.",
+            ]
+        )
+        names, _ = documented_attributes(doc)
+        assert names == frozenset({"documented"})
+
+    def test_a_docstring_with_no_block_is_out_of_scope(self) -> None:
+        names, has_section = documented_attributes("Summary only.")
+        assert not has_section
+        assert names == frozenset()
+
+
+class TestTheScannerDetectsAPlantedDefect:
+    """A clean result must mean the fields are documented, not that nothing is checked."""
+
+    def test_a_planted_undocumented_field_is_reported(self) -> None:
+        source = "\n".join(
+            [
+                "from dataclasses import dataclass",
+                "",
+                "@dataclass(frozen=True)",
+                "class Planted:",
+                '    """Planted.',
+                "",
+                "    Attributes:",
+                "        named: Documented.",
+                '    """',
+                "",
+                "    named: int = 0",
+                "    unnamed: int = 1",
+            ]
+        )
+        surfaces = TestABaseClassEntryCounts._scan(source)
+        assert len(surfaces) == 1
+        _, fields, documented = surfaces[0]
+        with pytest.raises(AssertionError, match="unnamed"):
+            test_every_field_has_an_attributes_entry(surfaces[0][0], fields, documented)
+
+    def test_a_class_that_is_not_a_dataclass_is_out_of_scope(self) -> None:
+        """The field list of a plain class is not an annotation list."""
+        source = "\n".join(
+            [
+                "class Plain:",
+                '    """Plain.',
+                "",
+                "    Attributes:",
+                "        documented: Yes.",
+                '    """',
+                "",
+                "    documented: int = 0",
+                "    undocumented: int = 1",
+            ]
+        )
+        assert TestABaseClassEntryCounts._scan(source) == []
+
+    def test_a_classvar_is_not_graded_as_a_field(self) -> None:
+        source = "\n".join(
+            [
+                "from dataclasses import dataclass",
+                "from typing import ClassVar",
+                "",
+                "@dataclass",
+                "class WithConstant:",
+                '    """WithConstant.',
+                "",
+                "    Attributes:",
+                "        value: Documented.",
+                '    """',
+                "",
+                "    LIMIT: ClassVar[int] = 5",
+                "    value: int = 0",
+            ]
+        )
+        _, fields, _ = TestABaseClassEntryCounts._scan(source)[0]
+        assert fields == ["value"]


### PR DESCRIPTION
## Problem

An `Attributes:` block is where a caller learns which keys a config dict may carry.
`EmbodimentMap` is exported from `strands_robots.policies.lerobot_local.embodiment`
and is built straight from a caller-supplied dict, so that block is its API - and it
documented **five of its ten fields**.

The five it omitted are the unit-conversion group. `state_units` / `action_units`
decide whether the map converts at all, and `gripper_index` / `gripper_joint_range` /
`joint_mids` parameterise the conversion. Their defaults are `"native"` / `-1` /
empty, so a caller writing an embodiment from that block gets a map that converts
nothing - and `validate()` accepts it:

```
spec built from the documented fields -> state_units='native' action_units='native' gripper_index=-1
validate() -> ACCEPTED (no refusal)
```

The consequence is the one `LerobotLocalPolicy` already names in a comment at the
conversion site: *"feeding the raw degree values straight in saturates the radian
joint limits"*. Driving a MuJoCo SO-101 with a degrees-trained SO-arm checkpoint's
action stream through each spec:

| | 5 documented fields | 10 documented fields |
| --- | --- | --- |
| largest value commanded | **70.0000 rad** | 1.2217 rad |
| joint 1 range | +/-1.9199 rad | +/-1.9199 rad |
| final pose vs the one requested | **-0.2782 vs +1.2217** (off by 1.4999) | +1.0222 vs +1.2217 (off by 0.1995) |
| mean tracking error over the sweep | 1.1171 rad | 0.4115 rad |

The arm does not stall - it is driven to its limit and unwinds, ending 1.50 rad from
the requested pose and on the wrong side of zero.

Two more surfaces had the same shape:

- `PackStateProcessorStep`, the registered pipeline step that **receives** four of
  those five fields (`processor.py` passes `state_units=`, `gripper_index=`,
  `gripper_joint_range=`, `joint_mids=` into it), documented three of its seven.
  The same field group was undocumented at both ends of the handoff.
- `ProtoMotionsConfig` omitted `onnx_in_names`, `onnx_out_names` and `metadata` -
  while `ProtoMotionsPolicy._run_session`'s own docstring cites
  `ProtoMotionsConfig.onnx_in_names` as where its shapes are documented.

In every case the semantics were already written down as inline comments beside the
field declarations, just not where a caller reads.

## Change

Each of the three blocks now names every field its class declares, including what the
default means and - for the unit group - what happens when it is left at that default.
No code changes: the diff is docstrings plus a new guard.

`tests/test_args_docstring_completeness.py` pins exactly this comparison for `Args:`
blocks, and its scope is a function signature, so an attribute list was graded by
nothing. `tests/test_attributes_docstring_completeness.py` closes that: for every
dataclass whose docstring **already** has an `Attributes:` block, every field it
declares must have an entry. A class with no such block is out of scope, which is the
same boundary the `Args:` guard draws.

Two conventions the shipped tree already uses are honoured, so the rule needs no
exemptions:

- a field documented on a **base class** counts, so a subclass may document only what
  it adds (`RLTrainSpec` relies on `TrainSpec` for `learning_rate`);
- one entry may name **several fields** that share a description
  (`TrainSpec`'s `lora_r / lora_alpha / lora_target_modules:`,
  `RLTrainSpec`'s `actor_obs_keys / critic_obs_keys:`), matching the `Args:` guard's
  own label handling.

The scan is AST-only, so a config dataclass behind an optional backend is still graded
with that backend absent.

## Scope

21 dataclasses carry an `Attributes:` block and declare 192 fields between them.
Three were incomplete; the other 18 were already exact, and the guard reports them
clean. The converse direction - an entry naming something that is not a field - was
measured across all 189 pre-existing entries and had no offenders, so it is not part
of this change.

## Verification

Measured at `284677f3` against `upstream/main` at `578e3674`.

Pre-fix, the new guard against unmodified sources: **3 failed / 34 passed**, one
failure per class naming its omitted fields, e.g.

```
EmbodimentMap has an Attributes: block that omits
['state_units', 'action_units', 'gripper_index', 'gripper_joint_range', 'joint_mids']
```

After: 37 passed. Every control is load-bearing - each of six planted regressions
fails exactly and only its own guard:

| planted regression | headline | combined labels | base class | dataclass only | ClassVar | non-vacuity |
| --- | --- | --- | --- | --- | --- | --- |
| drop the five `EmbodimentMap` entries | FAIL | | | | | |
| stop splitting `a / b:` labels | FAIL | FAIL | | | | |
| stop crediting a base class's entries | FAIL | | FAIL | | | |
| treat every class as a dataclass | FAIL | | | FAIL | | |
| drop the `ClassVar` exclusion | | | | | FAIL | |
| make the scan reach nothing | | FAIL | | | | FAIL |

Gate: `ruff check` / `ruff format --check` clean over `strands_robots tests
tests_integ`; `mypy` 24 == 24 against a pristine `upstream/main` worktree with no
branch-only error.

Blast radius - every test that walks a source tree, inspects a docstring, reads
`AGENTS.md` or names the changed modules (319 files), run on this branch and on
`upstream/main` with the new test file excluded so the two selections are identical:
**21 failed / 12474 passed / 56 skipped on both**, with the failing-ID sets matching
and nothing on either side alone. All 21 are dependency-absent in this environment and
green on CI: 17 `tests/mesh/test_iot_*` needing `awsiotsdk`, 3 in `tests/training`
from an older `draccus`, and one `lerobot` lazy-registration case.

## Artifact

The capture script reads whichever tree it runs against for `EmbodimentMap`'s own
`Attributes:` block, builds an embodiment from exactly the fields that block names,
and drives a real MuJoCo SO-101 headless with the checkpoint's action stream. Package
code is identical in both rows - only the docstring differs. The first frames of the
two rollouts agree to 0.027 mean abs level (same starting pose); they end 25.76 apart.

![Attributes-block completeness](https://raw.githubusercontent.com/cagataycali/robots/media-attributes-block-completeness/attributes-block-completeness.png)
