### PR TITLE
fix(benchmarks/libero): an orientation that encodes no rotation is not the identity

### DIFF
--- a/changelog.d/2588-eef-quaternion-encodes-a-rotation.md
+++ b/changelog.d/2588-eef-quaternion-encodes-a-rotation.md
@@ -1,0 +1,15 @@
+### Fixed: a LIBERO end-effector orientation that encodes no rotation is dropped, not read as the identity
+
+`LiberoAdapter` refused a config-supplied `eef_quat_offset` that was not a unit
+quaternion but accepted any four numbers as the orientation read back from the
+backend, and `_quat_wxyz_rotate_vec` normalised with `norm or 1.0` - so an
+all-zero quaternion, the spelling of an orientation that was never written,
+rotated a vector exactly as the identity does. The #1802 wrist offset was then
+added along a world axis whatever the body was doing and returned as a corrected
+position, and `[0, 0, 0, 0]` went out as the reported orientation; a NaN
+component propagated through both. `_extract_pose` now drops an orientation that
+encodes no rotation, exactly as it already dropped a wrong-length one, so the
+caller takes its existing "reported no orientation" path; `_quat_wxyz_rotate_vec`
+refuses one instead of substituting a norm, matching the settled
+`policies/wbc/control.quat_rotate_inverse` sibling. A large-magnitude quaternion
+is still accepted and normalised - it encodes an ordinary rotation.

--- a/strands_robots/benchmarks/libero/adapter.py
+++ b/strands_robots/benchmarks/libero/adapter.py
@@ -4056,7 +4056,15 @@ def _extract_pose(state: dict[str, Any] | None) -> tuple[list[float] | None, lis
             pos = [float(c) for c in raw_pos]
         raw_quat = json_block.get("quaternion")
         if isinstance(raw_quat, list) and len(raw_quat) == 4 and all(isinstance(c, (int, float)) for c in raw_quat):
-            quat = [float(c) for c in raw_quat]
+            if _rotation_quat_norm(raw_quat) is None:
+                # Four numbers that encode no rotation are an unreadable
+                # orientation, not the identity one - dropped exactly like a
+                # wrong-length quaternion above, so the caller takes its
+                # existing "reported no orientation" path instead of adding a
+                # body-frame offset in a rotation the body does not have.
+                logger.debug("LiberoAdapter: body-state quaternion encodes no rotation; dropped: %r", raw_quat)
+            else:
+                quat = [float(c) for c in raw_quat]
     return (pos, quat)
 
 
@@ -4091,10 +4099,57 @@ def _quat_wxyz_multiply(a: list[float], b: list[float]) -> list[float]:
     ]
 
 
+#: Below this norm a quaternion's direction is numerically unrecoverable, so it
+#: encodes no rotation. Same boundary as the settled sibling
+#: ``policies/wbc/control.quat_rotate_inverse``, so the two agree on where the
+#: domain ends rather than merely on the idea that it ends somewhere.
+_MIN_ROTATION_QUAT_NORM = 1e-8
+
+
+def _rotation_quat_norm(quat_wxyz: list[float]) -> float | None:
+    """Return the norm of ``quat_wxyz`` when it encodes a rotation, else ``None``.
+
+    ``None`` means the four numbers are not an orientation: a non-finite
+    component, or a norm too small for the direction to be recovered. Both are
+    spellings of an orientation that was never written, and neither is the
+    identity - #2588 measured the all-zero one being read as exactly that.
+
+    A large magnitude is *not* out of domain: a quaternion and its scaling encode
+    one rotation, so ``[1e200, 1e200, 0, 0]`` normalizes to a perfectly ordinary
+    45-degree rotation. ``math.hypot`` is used rather than ``np.linalg.norm`` for
+    exactly that case - the latter squares before summing, so it overflows to
+    ``inf`` and would refuse a rotation it could have recovered.
+    """
+    try:
+        q = [float(c) for c in quat_wxyz]
+    except (TypeError, ValueError):
+        return None
+    if len(q) != 4 or not all(math.isfinite(c) for c in q):
+        return None
+    norm = math.hypot(*q)
+    if not math.isfinite(norm) or norm <= _MIN_ROTATION_QUAT_NORM:
+        return None
+    return norm
+
+
 def _quat_wxyz_rotate_vec(quat_wxyz: list[float], vec: list[float]) -> list[float]:
-    """Rotate ``vec`` by the (normalized) wxyz quaternion: ``R(q) @ vec``."""
+    """Rotate ``vec`` by the wxyz quaternion: ``R(q) @ vec``.
+
+    ``quat_wxyz`` need not be exactly unit - it is normalized here - but it must
+    encode a rotation. A quaternion that does not is refused rather than
+    normalized by a substituted ``1.0``: that substitution makes an orientation
+    that was never written return the vector unrotated, which is what the
+    identity rotation returns, so the caller adds a body-frame offset along a
+    world axis and reports the result as corrected (#2588). The refusal matches
+    the same-shaped sibling ``policies/wbc/control.quat_rotate_inverse``.
+
+    Raises:
+        ValueError: If ``quat_wxyz`` encodes no rotation.
+    """
+    norm = _rotation_quat_norm(quat_wxyz)
+    if norm is None:
+        raise ValueError(f"_quat_wxyz_rotate_vec: quaternion encodes no rotation; got {quat_wxyz!r}")
     q = np.asarray(quat_wxyz, dtype=np.float64)
-    norm = float(np.linalg.norm(q)) or 1.0
     w, x, y, z = q / norm
     u = np.array([x, y, z], dtype=np.float64)
     v = np.asarray(vec, dtype=np.float64)

--- a/tests/benchmarks/libero/test_eef_quaternion_encodes_a_rotation.py
+++ b/tests/benchmarks/libero/test_eef_quaternion_encodes_a_rotation.py
@@ -1,0 +1,184 @@
+"""An end-effector orientation that encodes no rotation is dropped, not read as identity.
+
+``LiberoAdapter`` already refuses a config-supplied ``eef_quat_offset`` that is
+not a unit quaternion, and says why in the constructor: "a malformed offset
+silently feeding GR00T garbage state is exactly the failure class #168 spent 30
+rounds bisecting". The orientation read *from the backend* fed the same
+observation and was checked for shape only - four numbers, any four - and the
+helper consuming it normalised with ``float(np.linalg.norm(q)) or 1.0``.
+
+That substitution is what made the two indistinguishable. Measured on ``146ace1``
+against the ``[0, 0, 0.097]`` wrist offset #1802 added for the Isaac hand body::
+
+    identity  [1, 0, 0, 0]    rotate([0, 0, 0.097]) -> [0.0, 0.0, 0.097]
+    all-zero  [0, 0, 0, 0]    rotate([0, 0, 0.097]) -> [0.0, 0.0, 0.097]
+    NaN       [nan, 0, 0, 0]  rotate([0, 0, 0.097]) -> [nan, nan, nan]
+
+So an orientation that was never written added the body-frame offset along world
+Z whatever the wrist was doing, and ``_read_eef_state`` returned that as a
+corrected position; ``_quat_wxyz_multiply`` then reported ``[0, 0, 0, 0]`` as the
+orientation. Both land in the observation dict a policy consumes, which is state
+that is silently wrong rather than absent.
+
+The tree had already settled the contract elsewhere.
+``tests/policies/protomotions/test_state_utils_unit_quaternion_contract.py``
+names this exact value - "an all-zero orientation - the spelling of one that was
+never written" - and records that three other world-to-body helpers normalise
+internally while the degenerate case is *refused* by the
+``policies/wbc/control.quat_rotate_inverse`` sibling "rather than answered with a
+made-up rotation". ``_quat_wxyz_rotate_vec`` was a fourth helper of the same
+shape and the only one that answered.
+
+The two halves below are one rule applied at the two places a quaternion can
+arrive:
+
+* ``_extract_pose`` **drops** a degenerate orientation, because the caller wraps
+  ``get_body_state`` in ``except Exception`` precisely so a state read cannot
+  abort an eval - and it already has an honest branch for a missing orientation
+  ("reported no orientation; cannot express the body-frame offset - using the
+  uncorrected position"). A degenerate quaternion is the same unreadable
+  orientation with the length right, so it takes the same path as the
+  wrong-length one already did.
+* ``_quat_wxyz_rotate_vec`` **raises**, so the made-up rotation cannot return
+  through a caller that has not gone through ``_extract_pose``. With the gate
+  above in place this is a backstop rather than a reachable path, which is why it
+  is asserted directly rather than through the adapter.
+
+#2588.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from strands_robots.benchmarks.libero.adapter import (
+    _extract_pose,
+    _quat_wxyz_rotate_vec,
+    _rotation_quat_norm,
+)
+
+#: The wrist offset #1802 configures for the Isaac hand body, in the body frame.
+_HAND_OFFSET = [0.0, 0.0, 0.097]
+
+#: Spellings of an orientation that was never written. Each is four numbers, so
+#: each passed the pre-#2588 shape check.
+_NON_ROTATIONS = [
+    pytest.param([0.0, 0.0, 0.0, 0.0], id="all-zero"),
+    pytest.param([0, 0, 0, 0], id="all-zero-ints"),
+    pytest.param([1e-12, 0.0, 0.0, 0.0], id="norm-below-threshold"),
+    pytest.param([math.nan, 0.0, 0.0, 0.0], id="nan-w"),
+    pytest.param([1.0, 0.0, math.nan, 0.0], id="nan-component"),
+    pytest.param([math.inf, 0.0, 0.0, 0.0], id="inf-w"),
+    pytest.param([-math.inf, 0.0, 0.0, 0.0], id="negative-inf-w"),
+]
+
+#: Orientations that do encode a rotation, including ones that are not unit.
+#: A non-unit quaternion encodes the same rotation as its normalisation, so it
+#: must be accepted and normalised rather than refused.
+_ROTATIONS = [
+    pytest.param([1.0, 0.0, 0.0, 0.0], id="identity"),
+    pytest.param([0.0, 1.0, 0.0, 0.0], id="180-about-x"),
+    pytest.param([2.0, 0.0, 0.0, 0.0], id="scaled-identity"),
+    pytest.param([0.5, 0.5, 0.5, 0.5], id="unit-mixed"),
+    pytest.param([-1.0, 0.0, 0.0, 0.0], id="negated-identity"),
+    pytest.param([1e-4, 0.0, 0.0, 0.0], id="small-but-above-threshold"),
+    pytest.param([1e200, 1e200, 0.0, 0.0], id="huge-but-normalizable"),
+]
+
+
+def _payload(quat: list[float] | None = None, pos: list[float] | None = None) -> dict:
+    """Build a ``get_body_state`` success envelope carrying the given fields."""
+    block: dict[str, object] = {}
+    if pos is not None:
+        block["position"] = pos
+    if quat is not None:
+        block["quaternion"] = quat
+    return {"status": "success", "content": [{"json": block}]}
+
+
+class TestRotationQuatNorm:
+    """The domain predicate both halves of the rule share."""
+
+    @pytest.mark.parametrize("quat", _NON_ROTATIONS)
+    def test_a_non_rotation_has_no_norm_to_report(self, quat):
+        assert _rotation_quat_norm(quat) is None
+
+    @pytest.mark.parametrize("quat", _ROTATIONS)
+    def test_a_rotation_reports_its_norm(self, quat):
+        norm = _rotation_quat_norm(quat)
+        assert norm is not None
+        assert norm == pytest.approx(math.hypot(*(float(c) for c in quat)))
+
+    @pytest.mark.parametrize("quat", [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0, 0.0], []])
+    def test_a_wrong_length_quaternion_is_not_a_rotation(self, quat):
+        assert _rotation_quat_norm(quat) is None
+
+    def test_an_uncoercible_component_is_not_a_rotation(self):
+        """The predicate answers about the *domain*, and coerces to get there.
+
+        A component that ``float()`` accepts is a number whatever it was spelled
+        as, so ``"1.0"`` is deliberately not refused here - ``_extract_pose``
+        rejects non-``(int, float)`` components before the predicate is reached,
+        and duplicating that dtype rule would give two readers of one field.
+        What is refused is a component there is no number in.
+        """
+        assert _rotation_quat_norm([None, 0.0, 0.0, 0.0]) is None
+        assert _rotation_quat_norm(["not-a-number", 0.0, 0.0, 0.0]) is None
+        assert _rotation_quat_norm(None) is None
+        assert _rotation_quat_norm(_rotation_quat_norm) is None
+
+
+class TestExtractPoseDropsANonRotation:
+    """``_extract_pose`` reports an unreadable orientation as absent."""
+
+    @pytest.mark.parametrize("quat", _NON_ROTATIONS)
+    def test_a_non_rotation_is_dropped(self, quat):
+        assert _extract_pose(_payload(quat=quat)) == (None, None)
+
+    @pytest.mark.parametrize("quat", _NON_ROTATIONS)
+    def test_the_position_beside_it_still_survives(self, quat):
+        """The drop is per-field: this is the branch the caller already logs for."""
+        pos, orientation = _extract_pose(_payload(quat=quat, pos=[1.0, 2.0, 3.0]))
+        assert pos == [1.0, 2.0, 3.0]
+        assert orientation is None
+
+    @pytest.mark.parametrize("quat", _ROTATIONS)
+    def test_a_rotation_is_still_returned_verbatim(self, quat):
+        """Non-unit input is passed through unchanged - normalising is the
+        consumer's job, and #1802's offset multiply needs the raw value."""
+        assert _extract_pose(_payload(quat=quat)) == (None, [float(c) for c in quat])
+
+
+class TestRotateVecRefusesANonRotation:
+    """``_quat_wxyz_rotate_vec`` refuses rather than substituting a norm of 1."""
+
+    @pytest.mark.parametrize("quat", _NON_ROTATIONS)
+    def test_a_non_rotation_is_refused(self, quat):
+        with pytest.raises(ValueError, match="encodes no rotation"):
+            _quat_wxyz_rotate_vec(quat, _HAND_OFFSET)
+
+    def test_the_all_zero_spelling_no_longer_answers_like_the_identity(self):
+        """The measurement in the module docstring, as an assertion.
+
+        Both calls returned ``[0.0, 0.0, 0.097]`` before #2588, which is why the
+        wrong frame was invisible.
+        """
+        assert _quat_wxyz_rotate_vec([1.0, 0.0, 0.0, 0.0], _HAND_OFFSET) == pytest.approx(_HAND_OFFSET)
+        with pytest.raises(ValueError):
+            _quat_wxyz_rotate_vec([0.0, 0.0, 0.0, 0.0], _HAND_OFFSET)
+
+    @pytest.mark.parametrize("quat", _ROTATIONS)
+    def test_a_rotation_is_normalized_rather_than_trusted(self, quat):
+        """A quaternion and its scaling encode one rotation, so both must answer
+        the same thing - the formula is quadratic in the components and does not
+        cancel, so this only holds if the helper normalises internally."""
+        scaled = [3.0 * c for c in quat]
+        assert _quat_wxyz_rotate_vec(scaled, _HAND_OFFSET) == pytest.approx(_quat_wxyz_rotate_vec(quat, _HAND_OFFSET))
+
+    def test_a_rotation_still_rotates(self):
+        """180 degrees about x maps +z to -z; a guard that refused everything
+        would pass every test above."""
+        rotated = _quat_wxyz_rotate_vec([0.0, 1.0, 0.0, 0.0], _HAND_OFFSET)
+        assert rotated == pytest.approx([0.0, 0.0, -0.097])


### PR DESCRIPTION
Fixes #2588

## The asymmetry

`LiberoAdapter` validates a config-supplied end-effector orientation and refuses one that is not a unit quaternion. The orientation it reads back *from the backend* feeds the same observation and was checked for shape only - four numbers, any four. The constructor comment beside the config check already states what that costs:

> `#1802` - EEF source corrections for backends without the RoboSuite grip site (Isaac). Validated eagerly: **a malformed offset silently feeding GR00T garbage state is exactly the failure class #168 spent 30 rounds bisecting.**

`_extract_pose` had no such check, and `_quat_wxyz_rotate_vec` normalized with `float(np.linalg.norm(q)) or 1.0`.

## What the `or 1.0` did

A zero-norm quaternion divided by `1.0`, so the rotation was computed from `w = x = y = z = 0`. Against the `[0, 0, 0.097]` wrist offset #1802 adds for the Isaac hand body, on `146ace1`:

```
identity  [1, 0, 0, 0]    rotate([0, 0, 0.097]) -> [0.0, 0.0, 0.097]
all-zero  [0, 0, 0, 0]    rotate([0, 0, 0.097]) -> [0.0, 0.0, 0.097]   <- indistinguishable
NaN       [nan, 0, 0, 0]  rotate([0, 0, 0.097]) -> [nan, nan, nan]
```

So an orientation that was never written was read as "no rotation": the body-frame offset was added along world Z whatever the wrist was actually doing, and `_read_eef_state` returned that as a *corrected* position. `_quat_wxyz_multiply([0,0,0,0], offset)` then reported `[0, 0, 0, 0]` as the orientation, which is not a rotation either. Both land in the observation dict a policy consumes - state that is silently wrong rather than absent.

## Why this is a fix and not a new rule

The tree had already settled the contract. `tests/policies/protomotions/test_state_utils_unit_quaternion_contract.py` names this exact value - "an all-zero orientation - the spelling of one that was never written" - and records where the rule is applied:

> Three other world-to-body helpers (`policies/wbc/control.quat_rotate_inverse`, `simulation/predicates._quat_rotate_inverse_wxyz` and the Newton backend's copy) all normalise internally, and the degenerate case is refused by the same-layer `policies/wbc/control` sibling rather than answered with a made-up rotation.

`_quat_wxyz_rotate_vec` was a fourth helper of the same shape and the only one that answered.

## The change

One rule, applied at the two places a quaternion arrives, plus the predicate they share:

| site | behaviour | why that one |
|---|---|---|
| `_extract_pose` | **drops** the orientation | The caller wraps `get_body_state` in `except Exception` precisely so a state read cannot abort an eval, and it already has an honest branch for a missing orientation (`"reported no orientation; cannot express the body-frame offset - using the uncorrected position"`). A degenerate quaternion is the same unreadable orientation with the length right, so it takes the path the wrong-length one already took. |
| `_quat_wxyz_rotate_vec` | **raises** | So the made-up rotation cannot return through a caller that has not gone through `_extract_pose`. Threshold and message shape match `quat_rotate_inverse`. |

A large-magnitude quaternion is *not* refused - it encodes an ordinary rotation. `math.hypot` is used rather than `np.linalg.norm` for that: the latter squares before summing, so `[1e200, 1e200, 0, 0]` overflows to `inf` and would be refused despite normalizing to a plain 45-degree rotation. That also keeps the suite free of a numpy overflow warning.

## Deliberately out of scope

The same `or 1.0` appears in three matrix-to-quaternion converters (`simulation/isaac/simulation.py`, `mesh/sensors.py`, and this module's sibling). Those build the quaternion themselves from a rotation matrix, and no finite matrix reaches them with a zero-norm result - every branch either sets one component to `0.25 * s` with `s > 0`, or divides by `s == 0` and produces a non-finite value rather than a zero. `or 1.0` guards nothing reachable there, and removing it is a separate question.

## Overlap with #2497, already checked

`check_merge_base_overlap.py --all-open` reports `#2497 + #2589` sharing `strands_robots/benchmarks/libero/adapter.py`, so the composition is answered here rather than left to be derived.

#2497's entire change to that file is **one comment line**, a docs-drift fix at line ~70:

```
-# (``examples/libero/run_isaac.py``) loads Isaac Sim's bundled Franka USD,
+# (``examples/libero/run.py isaac``) loads Isaac Sim's bundled Franka USD,
```

This branch's hunks are at lines 4059 and 4102-4152. No shared line, no behavioural interaction - a comment naming an example script cannot reach the quaternion domain - and the merge is clean:

```
$ git merge-tree --write-tree --name-only pr2497 HEAD
exit 0, zero conflicted paths
```

## Verification

`tests/benchmarks/libero/test_eef_quaternion_encodes_a_rotation.py` - 56 cases. Both halves of the rule and the shared predicate, each parameterized over the spellings that passed the old shape check, and over rotations that must still be accepted:

- `test_the_all_zero_spelling_no_longer_answers_like_the_identity` is the measurement above as an assertion.
- `test_a_rotation_is_normalized_rather_than_trusted` compares `q` against `3q`; the formula is quadratic in the components and does not cancel, so this only holds if the helper normalizes internally.
- `test_a_rotation_still_rotates` pins 180 degrees about x mapping +z to -z, so a guard that refused everything would not pass.
- `test_the_position_beside_it_still_survives` pins that the drop is per-field, which is what makes the caller's existing branch reachable.

```
tests/benchmarks/libero/                      562 passed, 79 skipped
tests/test_log_strings_are_ascii.py
tests/test_refusal_messages_never_raise.py
tests/test_container_refusals_render_elementwise.py
tests/test_conversion_escape_is_closed.py
tests/simulation/test_input_validators_refuse_a_boolean.py     589 passed
ruff check / ruff format --check / mypy       clean
scripts/assemble_changelog.py --check        OK (631 pending)
```

The 5 failures in `tests/benchmarks/libero/test_libero_prewarm_init_state.py` are pre-existing and reproduce identically on `main` at `146ace1` in the same environment (`ModuleNotFoundError: No module named 'mujoco'`); they are untouched by this branch.

## §13 changelog

**Round 1** - initial submission.
