### PR TITLE
docs(registry): the documented resolution ladder names the URL forms the registry ships

### DIFF
--- a/changelog.d/2594-resolution-order-names-shipped-url-forms.md
+++ b/changelog.d/2594-resolution-order-names-shipped-url-forms.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **registry**: `resolve_policy`'s documented stage-1 rung now names the URL forms
+  the shipped registry actually matches. Stage 1 has no vocabulary of its own - it
+  matches the `url_patterns` providers declare in `policies.json` - and the rung was
+  wrong in both directions: it listed a scheme-less `host:port`, which no shipped
+  pattern matches (all five require a scheme), and omitted `cosmos3://` and
+  `vera://`, which they do. A caller following the rung with `localhost:5555` got no
+  reason from `policy_provider_error`, then a raise out of `run_policy` diagnosing a
+  broken HuggingFace checkpoint - `config.json had no usable 'type'` - for a network
+  address, having reached stage 5 and been forwarded to `lerobot_local` as a
+  checkpoint id. `policy_provider_error`'s own enumeration of resolvable spellings
+  carried the same claim and is corrected too. The generic scheme-less branch keeps
+  its behaviour: it is a tested extension point, reached when a provider declares a
+  scheme-less pattern, and which provider should own the form is a contract choice
+  left open. A new bidirectional guard grades both surfaces against the registry, so
+  a scheme added to one cannot drift from the other.

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -313,9 +313,11 @@ def policy_provider_error(provider: str, **kwargs) -> str | None:
 
     Probes the SAME resolution path :func:`create_policy` uses, without
     instantiating anything, so every spelling that provider accepts -- a
-    registered name, a HuggingFace model ID, a ``zmq://`` / ``ws://`` URL, a
-    ``host:port`` pair -- resolves here too. Only a name no spelling can reach
-    yields a reason.
+    registered name, a HuggingFace model ID, a ``zmq://`` / ``ws://`` URL --
+    resolves here too. Only a name no spelling can reach yields a reason. A
+    scheme-less ``host:port`` is not among them: no shipped provider declares a
+    scheme-less ``url_patterns`` entry, so such a string is resolvable only as a
+    checkpoint id and this preflight reports no reason for it.
 
     This is the agent-tool companion to :func:`preflight_policy`, which
     deliberately swallows resolution failures on the stated grounds that

--- a/strands_robots/registry/policies.py
+++ b/strands_robots/registry/policies.py
@@ -131,11 +131,21 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
     and returns the canonical provider + ready-to-use kwargs.
 
     Resolution order:
-        1. URL patterns (ws://, zmq://, grpc://, host:port)
+        1. URL patterns declared in ``policies.json`` (ws://, wss://, zmq://,
+           grpc://, cosmos3://, vera://)
         2. Shorthand names (mock, groot, lerobot_local, ...)
         3. HuggingFace model IDs (org/model)
         4. Registered provider name
         5. Fallback to lerobot_local
+
+    Stage 1 recognises exactly the forms the registry declares: the
+    ``url_patterns`` entries providers carry are the whole vocabulary, so a
+    scheme this package does not ship is not a URL here. A scheme-less
+    ``host:port`` address is matched only by a provider that declares a
+    scheme-less pattern -- the generic ``server_address`` branch below exists
+    for that -- and none of the shipped providers declares one, so with the
+    shipped registry such a string reaches stage 5 and is forwarded to
+    ``lerobot_local`` as a checkpoint id rather than dialled as an address.
 
     Every stage matches case-insensitively. A URL scheme is folded per RFC 3986
     section 3.1 (``ZMQ://gpu:5555`` resolves exactly as ``zmq://gpu:5555``, and
@@ -216,6 +226,13 @@ def resolve_policy(policy: str, **extra_kwargs) -> tuple[str, dict[str, Any]]:
                 elif pattern.startswith("^grpc://"):
                     kwargs["server_address"] = url.removeprefix("grpc://")
                 elif ":" in url and "/" not in url:
+                    # Generic scheme-less ``host:port``. Reached only when a
+                    # provider declares a scheme-less ``url_patterns`` entry
+                    # (e.g. ``^[^/]+:[0-9]+$``). None of the shipped providers
+                    # does, so against the shipped registry this is an
+                    # extension point rather than a live path, and a bare
+                    # ``host:port`` falls through to stage 5 instead. It is
+                    # exercised by injecting a provider that declares one.
                     kwargs["server_address"] = url
                 kwargs.update(extra_kwargs)
                 return prov_name, kwargs

--- a/tests/registry/test_resolution_order_names_the_shipped_url_forms.py
+++ b/tests/registry/test_resolution_order_names_the_shipped_url_forms.py
@@ -1,0 +1,163 @@
+"""The documented resolution ladder names the URL forms the registry ships.
+
+``strands_robots.registry.policies.resolve_policy`` opens with a five-stage
+``Resolution order:`` block whose first rung enumerates the URL forms stage 1
+recognises. That stage has no vocabulary of its own: it matches the
+``url_patterns`` entries providers declare in ``policies.json``, so the forms it
+recognises are exactly the ones the shipped registry carries. A rung that names
+a form no shipped pattern matches sends the reader after a spelling that reaches
+stage 5 instead, where it is forwarded to ``lerobot_local`` as a checkpoint id;
+a rung that omits a shipped pattern hides a transport a caller could have used.
+
+Both directions are graded here against one relation - does some shipped
+``url_patterns`` entry match a probe of this form - so the rung and the registry
+cannot drift apart in either direction. The same relation grades
+:func:`strands_robots.policies.factory.policy_provider_error`, whose docstring
+enumerates the spellings it treats as resolvable in a ``--`` aside.
+
+In both cases only the enumerating construct is graded - the numbered rung, and
+the aside - never the prose around it. That prose exists to explain the forms
+stage 1 does *not* match, so a form named there is a qualification rather than a
+claim, and grading it would make an accurate docstring fail.
+"""
+
+import inspect
+import re
+
+import pytest
+
+import strands_robots.registry.policies as policies_mod
+from strands_robots.policies.factory import policy_provider_error
+from strands_robots.registry.policies import resolve_policy
+
+# A URL form as the prose spells one: a scheme with its separator, or the
+# scheme-less ``host:port`` shape.
+_FORM = re.compile(r"[A-Za-z][A-Za-z0-9+.\-]*://|host:port")
+
+# The rung-1 text: everything between the ``1.`` marker and the ``2.`` marker of
+# the ``Resolution order:`` block.
+_RUNG_ONE = re.compile(r"^Resolution order:\s*$(.*?)\n\s*2\.", re.M | re.S)
+
+# The enumerating aside in ``policy_provider_error``'s docstring: the spellings
+# it lists between the ``--`` pair as ones that resolve.
+_PREFLIGHT_ASIDE = re.compile(r"every spelling that provider accepts\s*--(.*?)--", re.S)
+
+
+def _inject_registry(monkeypatch, providers: dict) -> None:
+    """Force resolve_policy to see a synthetic provider registry.
+
+    Mirrors the shim the URL-scheme coverage tests use; kept local so this
+    module reads standalone.
+    """
+    real_load = policies_mod._load
+
+    def fake_load(name: str):
+        if name == "policies":
+            return {"providers": providers}
+        return real_load(name)
+
+    monkeypatch.setattr(policies_mod, "_load", fake_load)
+
+
+def _rung_one_text() -> str:
+    """The first rung of ``resolve_policy``'s documented resolution order."""
+    doc = inspect.getdoc(resolve_policy) or ""
+    match = _RUNG_ONE.search(doc)
+    assert match, "resolve_policy no longer opens with a numbered 'Resolution order:' block"
+    return match.group(1)
+
+
+def _preflight_enumerated_text() -> str:
+    """The aside in ``policy_provider_error``'s docstring that enumerates spellings."""
+    doc = inspect.getdoc(policy_provider_error) or ""
+    match = _PREFLIGHT_ASIDE.search(doc)
+    assert match, "policy_provider_error no longer enumerates the spellings that resolve"
+    return match.group(1)
+
+
+def _url_forms(text: str) -> list[str]:
+    """The URL forms ``text`` names, in order, deduplicated."""
+    return list(dict.fromkeys(_FORM.findall(text)))
+
+
+def _shipped_url_patterns() -> list[tuple[str, str]]:
+    """Every ``(provider, url_pattern)`` pair the shipped registry declares."""
+    providers = policies_mod._load("policies").get("providers", {})
+    return [(name, pattern) for name, info in providers.items() for pattern in info.get("url_patterns", [])]
+
+
+def _probe(form: str) -> str:
+    """A minimal address of ``form``, for matching against a declared pattern."""
+    return "h:1" if form == "host:port" else f"{form}h:1"
+
+
+def _unmatched(forms: list[str]) -> list[str]:
+    """The named forms no shipped ``url_patterns`` entry matches."""
+    patterns = [pattern for _name, pattern in _shipped_url_patterns()]
+    return [f for f in forms if not any(re.match(p, _probe(f)) for p in patterns)]
+
+
+class TestTheLadderAndTheRegistryNameTheSameUrlForms:
+    """Stage 1's documented vocabulary is the registry's, in both directions."""
+
+    def test_every_url_form_the_ladder_names_is_one_the_registry_matches(self):
+        """A named form no pattern matches reaches stage 5, not stage 1."""
+        forms = _url_forms(_rung_one_text())
+        unsound = _unmatched(forms)
+        assert not unsound, (
+            f"resolve_policy's stage-1 rung names {unsound}, which no shipped url_patterns entry "
+            f"matches; such a string falls through to stage 5 and is forwarded to lerobot_local as "
+            f"a checkpoint id. Declared patterns: {_shipped_url_patterns()}"
+        )
+
+    def test_every_url_pattern_the_registry_ships_is_named_in_the_ladder(self):
+        """A shipped pattern the rung omits is a transport the reader cannot find."""
+        probes = [_probe(f) for f in _url_forms(_rung_one_text())]
+        unnamed = [
+            f"{name} ({pattern})"
+            for name, pattern in _shipped_url_patterns()
+            if not any(re.match(pattern, p) for p in probes)
+        ]
+        assert not unnamed, (
+            f"the shipped registry declares url_patterns that resolve_policy's stage-1 rung does not name: {unnamed}"
+        )
+
+    def test_the_preflight_docstring_names_no_form_the_registry_cannot_match(self):
+        """``policy_provider_error`` enumerates the spellings it calls resolvable."""
+        forms = _url_forms(_preflight_enumerated_text())
+        unsound = _unmatched(forms)
+        assert not unsound, (
+            f"policy_provider_error's docstring names {unsound} among the spellings that resolve, "
+            f"but no shipped url_patterns entry matches it"
+        )
+
+    def test_the_ladder_and_the_registry_are_both_non_empty(self):
+        """A parse that reached nothing would make the two rules above vacuous."""
+        forms = _url_forms(_rung_one_text())
+        assert len(forms) >= 3, f"only parsed {forms} out of the stage-1 rung"
+        assert len(_shipped_url_patterns()) >= 3, "the shipped registry declares almost no url_patterns"
+        assert _url_forms(_preflight_enumerated_text()), "parsed no form out of the preflight's aside"
+
+
+class TestTheSchemeLessAddressIsAnExtensionPointNotAShippedForm:
+    """A bare ``host:port`` is matched only by a declared scheme-less pattern."""
+
+    @pytest.mark.parametrize("address", ["gpu-box:8080", "localhost:5555"])
+    def test_a_scheme_less_address_reaches_the_fallback_with_the_shipped_registry(self, address):
+        """No shipped pattern matches it, so stage 5 forwards it as a checkpoint id."""
+        provider, kwargs = resolve_policy(address)
+        assert provider == "lerobot_local"
+        assert kwargs["pretrained_name_or_path"] == address
+        assert "server_address" not in kwargs
+        assert "host" not in kwargs
+
+    def test_the_preflight_reports_no_reason_for_a_scheme_less_address(self):
+        """It resolves - as a checkpoint id - so the preflight has nothing to report."""
+        assert policy_provider_error("gpu-box:8080") is None
+
+    def test_a_declared_scheme_less_pattern_still_maps_to_server_address(self, monkeypatch):
+        """The generic branch is a live extension point, just not a shipped form."""
+        _inject_registry(monkeypatch, {"hostport": {"url_patterns": [r"^[^/]+:[0-9]+$"]}})
+        provider, kwargs = resolve_policy("myserver:8080")
+        assert provider == "hostport"
+        assert kwargs["server_address"] == "myserver:8080"

--- a/tests/registry/test_resolve_policy_url_schemes.py
+++ b/tests/registry/test_resolve_policy_url_schemes.py
@@ -2,10 +2,11 @@
 
 ``strands_robots.registry.policies.resolve_policy`` documents a five-step
 resolution order (URL patterns -> shorthands -> HF model IDs -> registered
-provider name -> lerobot_local fallback). The shipped ``policies.json`` only
-declares ``zmq://`` and ``cosmos3://`` URL patterns, so the generic parser
-branches for ``ws(s)://``, ``grpc://`` and bare ``host:port`` addresses - part
-of the public resolution contract - had no exercising input.
+provider name -> lerobot_local fallback). The shipped ``policies.json`` declares
+five URL patterns - ``^zmq://``, ``^grpc://``, ``^cosmos3://``, ``^vera://`` and
+``^wss?://`` - so only the generic scheme-less ``host:port`` branch, part of the
+public resolution contract and reachable by a provider that declares a
+scheme-less pattern, has no exercising input from the shipped registry.
 
 These tests inject a synthetic provider registry (via ``monkeypatch``) so the
 generic parser branches run, plus cover the HF-org routing, canonical-name


### PR DESCRIPTION
## Problem

`resolve_policy`'s docstring opens with a five-stage `Resolution order:` block whose first rung enumerates the URL forms stage 1 recognises:

```
1. URL patterns (ws://, zmq://, grpc://, host:port)
```

Stage 1 has no vocabulary of its own. It matches the `url_patterns` entries providers declare in `policies.json`, so the forms it recognises are exactly the ones the shipped registry carries. That list is wrong in both directions:

- **`host:port` is not one of them.** All five shipped patterns require a scheme (`^zmq://`, `^grpc://`, `^cosmos3://`, `^vera://`, `^wss?://`), so a scheme-less address matches nothing at stage 1 and falls through all five stages to the fallback, where it is forwarded to `lerobot_local` as a checkpoint id.
- **`cosmos3://` and `vera://` are missing.** Both are shipped patterns the rung never names, so two transports a caller could have used are undiscoverable from the ladder.

The rung dates from #54 (2026-03-17). `cosmos3://` arrived in #317 (2026-06-08) and `vera://` in #663 (2026-06-25); neither was added to the list, and `host:port` has never been true of the shipped registry.

`policy_provider_error` carries the same claim, listing "a `host:port` pair" among the spellings it treats as resolvable and promising that "only a name no spelling can reach yields a reason".

## What a caller following the rung gets

Measured on a MuJoCo `so101` sim, with `STRANDS_TRUST_REMOTE_CODE=1` set so the trust gate is not the first thing hit:

| step | result |
| --- | --- |
| `policy_provider_error("localhost:5555")` | `None` - the preflight reports no reason |
| `run_policy(policy_provider="localhost:5555")` | **escapes** the documented `status=error` envelope |
| the raise | `ValueError: Could not determine policy type from 'localhost:5555'. config.json had no usable 'type', 'model_type', or recognized 'auto_map' entry` |

A checkpoint diagnosis for a network address. With the trust gate closed instead, the same string reports that `lerobot_local` "loads HuggingFace models with `trust_remote_code=True`" and offers `export STRANDS_TRUST_REMOTE_CODE=1` - so the remedy on offer for a hostname is to enable remote code execution.

Escaping the envelope is the specific harm `policy_provider_error` exists to prevent; its own docstring says a raise out of `run_policy` "escapes the `status=error` envelope those tools are documented to return". It returns `None` here because the string *does* resolve - as a checkpoint id.

## Change

Docstrings only; no code path moves.

- **`resolve_policy`** - the stage-1 rung now names the shipped schemes (`ws://`, `wss://`, `zmq://`, `grpc://`, `cosmos3://`, `vera://`). A new paragraph below the ladder states that stage 1's vocabulary *is* the registry's, and that a scheme-less `host:port` is matched only by a provider declaring a scheme-less pattern - none of the shipped ones does, so such a string reaches stage 5 and is forwarded as a checkpoint id rather than dialled as an address.
- **`policy_provider_error`** - drops `host:port` from the enumerating aside and says why it is not among them.
- **the generic scheme-less branch** keeps its behaviour and gains a comment: it is reached only when a provider declares a scheme-less `url_patterns` entry, so against the shipped registry it is an extension point rather than a live path.

Routing a bare `host:port` to a transport provider is deliberately **not** attempted: which provider owns the scheme-less form is a contract choice (`server_address` suggests gRPC, but zmq and ws are equally plausible), and the branch itself does not decide - it returns whichever provider declared the matching pattern.

The branch is a tested extension point, not dead code: `tests/registry/test_resolve_policy_url_schemes.py` exercises it by injecting a provider that declares `^[^/]+:[0-9]+$`. That file's module docstring also carried a stale census - "only declares `zmq://` and `cosmos3://`" against five shipped patterns, and listing `ws(s)://` and `grpc://` as lacking an exercising input when both are now shipped - corrected here.

## Guard

`tests/registry/test_resolution_order_names_the_shipped_url_forms.py` grades the rung against the registry in **both** directions using one relation - does some shipped `url_patterns` entry match a probe of this form:

- every form the rung names must be matched by a shipped pattern (soundness)
- every shipped pattern must match a form the rung names (completeness)

The same relation grades `policy_provider_error`'s aside, so a third surface cannot drift either. Only the enumerating constructs are graded - the numbered rung and the `--` aside - never the prose around them, since that prose exists to explain the forms stage 1 does *not* match; grading it would make an accurate docstring fail.

## Verification

Pre-fix split, the new guard copied onto `upstream/main`: **3 failed / 5 passed** -> 8 passed. Each failure names its offender:

```
resolve_policy's stage-1 rung names ['host:port'], which no shipped url_patterns
entry matches; such a string falls through to stage 5 and is forwarded to
lerobot_local as a checkpoint id.

the shipped registry declares url_patterns that resolve_policy's stage-1 rung
does not name: ['cosmos3 (^cosmos3://)', 'vera (^vera://)']

policy_provider_error's docstring names ['host:port'] among the spellings that
resolve, but no shipped url_patterns entry matches it
```

Every guard is load-bearing - six injected regressions, each failing exactly and only its own:

| injected regression | fails |
| --- | --- |
| rung names `host:port` again | soundness + completeness |
| rung omits `cosmos3://`, `vera://` | completeness |
| preflight aside names `host:port` again | preflight |
| generic scheme-less branch deleted | the extension-point control |
| the form parse matches nothing | completeness + non-vacuity |
| aside scoping widened to the whole docstring | preflight, on the accurate qualification |

The fifth row is why the non-vacuity test exists: with nothing parsed, soundness and the preflight rule pass vacuously.

Gate over 87 files (every test touching the resolver, the registry, or a docstring/string/changelog guard), the identical selection run on both trees with the new guard excluded, so any difference is the source change alone:

| tree | result |
| --- | --- |
| this branch (`47cd3d1c`) | 3 failed, 3245 passed, 1 skipped |
| pristine `upstream/main` (`bdfe49a`) | 3 failed, 3245 passed, 1 skipped |

The failing-ID sets are byte-identical - `comm` empty in both directions. All three are environment-dependent locally and unrelated to the diff: two are
`tests/training/test_lerobot.py::TestInProcessTrainerCorrectness` on a `draccus` older than lerobot's declared `>=0.11.6` floor, and one is `test_vla_jepa.py`'s lerobot lazy step registration, which fails identically on a pristine tree in isolation.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24 against a pristine worktree with no branch-only error.

## Artifact

Each column reads **its own tree's** rung, extracts the forms it names, and follows them. Package code is identical in both columns - only the docstring differs - so the console block at the bottom, which is what a caller who writes the scheme-less form actually gets, is byte-identical in both trees. Asserted in the figure script alongside every headline number.

![documented stage-1 URL vocabulary vs the shipped registry](https://raw.githubusercontent.com/cagataycali/robots/media-resolution-order-url-forms/resolution-order-url-forms.png)
