### PR TITLE
fix(mesh): report a state probe that fails instead of swallowing it

### DIFF
--- a/changelog.d/2597-read-state-probe-failures-are-reported.md
+++ b/changelog.d/2597-read-state-probe-failures-are-reported.md
@@ -1,0 +1,33 @@
+### Fixed
+
+A `_read_state` probe that fails is now reported instead of swallowed, once per
+category. `Mesh._read_state` probes a robot driver defensively so that a flaky
+read cannot kill the state thread, and all four probes ended in a bare
+`except Exception: pass` -- so a probe that raised left no trace at any log level.
+
+The consequence was not a missing log line. `_read_state` returns `None` when
+nothing but `peer_id` and `t` survived and the state loop publishes nothing for a
+`None`, so a peer whose joint probe raised stopped publishing state entirely
+while its presence broadcast still advertised it as `connected`: on the wire and
+in the log it was indistinguishable from a healthy peer with no joints to report.
+Measured against the real method, a joint probe raising `RuntimeError` or
+`ConnectionError` produced a `None` snapshot and zero log records, and a failing
+task probe dropped the `task` section out of an otherwise healthy snapshot in
+silence.
+
+The state loop's own report could not cover it. `_read_state`'s top-level
+statements are `Assign, AnnAssign, Try, Try, Try, Return`, so every statement
+that can raise is already inside a probe `try` and `_state_loop`'s
+`logger.debug("state tick error")` is unreachable for a probe failure -- it only
+ever sees a failure of `publish` itself.
+
+Each probe keeps `except Exception`: a flaky read must not kill the state thread,
+so this is a recovery path and the breadth is correct. The defect was the
+silence. The first failure of each category (`hw_joints`, `task_state`,
+`sim_world`, `sim_joints`) is now logged at WARNING naming the category, the peer
+and the exception's `repr` -- the type is in the line because it selects the
+operator's next move, a contended serial port being a different job from an
+uncalibrated arm. Later failures of that category drop to DEBUG, because the loop
+retries at `STATE_HZ` (10.0) and would otherwise emit ten warnings a second.
+
+What is published is unchanged; this changes the report, not the snapshot.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,6 +75,7 @@ description: Error → fix table for the most common gotchas across install, sim
 | Port already bound | Another zenoh process | Mesh auto falls back to client mode; or set `STRANDS_MESH_PORT` |
 | `mesh.alive` is `False`, `mesh.peers` stays empty | `eclipse-zenoh` missing (logged at WARNING: "eclipse-zenoh is not installed") | `uv pip install "strands-robots[mesh]"` |
 | Want mesh off | - | `STRANDS_MESH=false` or `Robot(..., mesh=False)` |
+| Peer is present and `connected`, but publishes no `state` (no joints) | A `_read_state` probe raised. Logged once per category at WARNING: "state probe 'hw_joints' failed" | Read the named probe: `hw_joints` is the motor bus (contended port, missing calibration), `sim_world` / `sim_joints` a sim back-reference, `task_state` the task record. Repeat failures are at DEBUG |
 
 ## Agent integration
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -406,6 +406,11 @@ class Mesh(SensorLoopsMixin):
         self._inbox_lock = threading.Lock()
         self._stop_event = threading.Event()
 
+        # Which _read_state probe categories have already been warned about.
+        # The state loop retries at STATE_HZ, so a persistent fault is reported
+        # once and then kept at debug level rather than once per tick.
+        self._read_state_warned: set[str] = set()
+
         # RPC correlation state.
         #
         # _expected_responders maps turn_id -> the peer_id we expect to
@@ -1093,6 +1098,49 @@ class Mesh(SensorLoopsMixin):
             if self._stop_event.wait(period):
                 break
 
+    def _warn_read_state_once(self, category: str, exc: BaseException) -> None:
+        """Report a degraded :meth:`_read_state` probe, once per category.
+
+        Args:
+            category: Which probe degraded -- ``hw_joints``, ``task_state``,
+                ``sim_world`` or ``sim_joints``.
+            exc: The exception the probe raised. Logged as ``repr`` so the type
+                survives even when the message is empty, because the type is
+                what selects the operator's next move: a ``ConnectionError``
+                from a contended serial port and a ``RuntimeError`` from an
+                uncalibrated arm need different actions.
+
+        Each probe stays wrapped in ``except Exception`` on purpose -- a flaky
+        read must not kill the state thread -- so this exists to keep that
+        recovery from also being silent. Only the FIRST failure of each category
+        is warned about; the rest drop to debug, because the loop retries at
+        ``STATE_HZ`` and a persistent fault would otherwise emit ten warnings a
+        second.
+        """
+        warned = getattr(self, "_read_state_warned", None)
+        if warned is None:
+            # A Mesh built through __new__ (several tests, and the sim paths)
+            # never ran __init__. Bookkeeping must not be able to raise inside
+            # the handler that exists to report a failure.
+            warned = set()
+            self._read_state_warned = warned
+        if category in warned:
+            logger.debug(
+                "[mesh] %s: state probe %r still failing: %r",
+                self.peer_id,
+                category,
+                exc,
+            )
+            return
+        warned.add(category)
+        logger.warning(
+            "[mesh] %s: state probe %r failed, that section of the snapshot is "
+            "omitted (further failures logged at debug): %r",
+            self.peer_id,
+            category,
+            exc,
+        )
+
     def _read_state(self) -> dict[str, Any] | None:
         r = self.robot
         snapshot: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
@@ -1115,8 +1163,8 @@ class Mesh(SensorLoopsMixin):
                         joints[key] = value
                 if joints:
                     snapshot["joints"] = joints
-        except Exception:
-            pass
+        except Exception as exc:
+            self._warn_read_state_once("hw_joints", exc)
 
         try:
             ts = getattr(r, "_task_state", None)
@@ -1128,8 +1176,8 @@ class Mesh(SensorLoopsMixin):
                     "steps": getattr(ts, "step_count", 0),
                     "duration": getattr(ts, "duration", 0.0),
                 }
-        except Exception:
-            pass
+        except Exception as exc:
+            self._warn_read_state_once("task_state", exc)
 
         try:
             world = getattr(r, "_world", None)
@@ -1163,10 +1211,10 @@ class Mesh(SensorLoopsMixin):
                                 }
                         if sim_joints:
                             snapshot["joints"] = sim_joints
-                    except Exception:
-                        pass
-        except Exception:
-            pass
+                    except Exception as exc:
+                        self._warn_read_state_once("sim_joints", exc)
+        except Exception as exc:
+            self._warn_read_state_once("sim_world", exc)
 
         return snapshot if len(snapshot) > 2 else None
 

--- a/tests/mesh/test_read_state_probe_failures_are_reported.py
+++ b/tests/mesh/test_read_state_probe_failures_are_reported.py
@@ -1,0 +1,286 @@
+"""A ``_read_state`` probe that fails is reported, exactly once per category.
+
+:meth:`strands_robots.mesh.core.Mesh._read_state` probes a robot driver
+defensively so that a flaky read cannot kill the state thread: every probe is
+wrapped in ``except Exception``. That breadth is deliberate and stays. What did
+not stay is the handler body -- each one was a bare ``pass``, so a probe that
+raised left no trace at any log level.
+
+The consequence is not a missing line in a log nobody reads. ``_read_state``
+returns ``None`` when nothing but ``peer_id`` and ``t`` survived, and the state
+loop publishes nothing for a ``None``, so a peer whose joint probe raises stops
+publishing state entirely while its presence broadcast still advertises it as
+connected. It is indistinguishable, on the wire and in the log, from a healthy
+peer that simply has no joints to report.
+
+The loop's own report cannot cover this. ``_state_loop`` wraps the call in
+``except Exception`` and logs at debug, but every statement in ``_read_state``
+that can raise is already inside one of the probe ``try`` blocks, so nothing
+reaches the loop's handler except a failure of ``publish`` itself. These tests
+pin the contract that replaced the silence:
+
+* the first failure of each category is logged at WARNING, naming the category,
+  the peer and the exception's ``repr``;
+* later failures of the same category drop to debug, because the loop retries at
+  ``STATE_HZ`` and a persistent fault would otherwise emit ten warnings a second;
+* what is *published* is byte-for-byte what it was before -- this changes the
+  report, not the snapshot.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import textwrap
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.core import Mesh
+
+CORE_LOGGER = "strands_robots.mesh.core"
+
+#: Every category :meth:`Mesh._warn_read_state_once` is called with, taken from
+#: the source rather than restated, so a fifth probe cannot be added silently.
+EXPECTED_CATEGORIES = {"hw_joints", "task_state", "sim_world", "sim_joints"}
+
+
+class _RaisingInner:
+    """A connected hardware driver whose ``get_observation`` always raises."""
+
+    is_connected = True
+
+    def __init__(self, exc: BaseException) -> None:
+        self.config = SimpleNamespace(cameras={})
+        self._exc = exc
+        self.calls = 0
+
+    def get_observation(self) -> dict[str, Any]:
+        self.calls += 1
+        raise self._exc
+
+
+class _Host:
+    """A robot-shaped host: only the attributes ``_read_state`` reads.
+
+    ``_task_state`` is declared rather than only assigned by the tests that need
+    it, because ``_read_state`` reaches it through ``getattr(r, "_task_state",
+    None)`` -- an absent attribute is a supported shape, not an error.
+    """
+
+    _task_state: Any = None
+
+    def __init__(self, inner: Any = None) -> None:
+        self.robot = inner
+
+
+class _RaisingTaskState:
+    """A task-state object whose ``status`` raises when read."""
+
+    @property
+    def status(self) -> Any:
+        raise RuntimeError("task state unavailable")
+
+
+def _mesh(host: Any, peer_id: str = "arm") -> Mesh:
+    """A ``Mesh`` wired to ``host`` without opening a session.
+
+    ``__new__`` because ``Mesh.__init__`` starts subscriber threads and wants a
+    live Zenoh session; ``_read_state`` needs only ``robot`` and ``peer_id``.
+    That also exercises the ``getattr`` default in ``_warn_read_state_once``:
+    bookkeeping must not raise inside the handler that exists to report a failure.
+    """
+    m = Mesh.__new__(Mesh)
+    m.peer_id = peer_id
+    m.robot = host
+    return m
+
+
+def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def _debugs(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+
+
+class TestAFailedProbeIsReported:
+    """A probe that raises names itself, once, at WARNING."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("this arm has no calibration registered"),
+            ConnectionError("Port is in use!"),
+            OSError("[Errno 6] Device not configured"),
+        ],
+        ids=["uncalibrated", "port-contention", "unplugged"],
+    )
+    def test_a_raising_joint_probe_is_warned_about(self, caplog: pytest.LogCaptureFixture, exc: BaseException) -> None:
+        """The joint probe is the one whose silence hid two live arms for hours.
+
+        The exception type is part of the message because it selects the
+        operator's next move: a contended port is a different job from an
+        uncalibrated arm, and both used to arrive as nothing at all.
+        """
+        m = _mesh(_Host(_RaisingInner(exc)))
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            out = m._read_state()
+
+        assert out is None, "a snapshot with no readable section is still not published"
+        warned = _warnings(caplog)
+        assert len(warned) == 1, f"expected exactly one warning, got {warned}"
+        assert "hw_joints" in warned[0]
+        assert "arm" in warned[0], "the peer id must be in the line: a fleet has many arms"
+        assert type(exc).__name__ in warned[0], f"the exception type must survive into the report, got {warned[0]!r}"
+
+    def test_a_raising_task_probe_is_warned_about_and_keeps_the_joints(self, caplog: pytest.LogCaptureFixture) -> None:
+        """One failed probe must not cost the sections that DID work."""
+        host = _Host(_RaisingInner(RuntimeError("unused")))
+        host.robot = SimpleNamespace(
+            is_connected=True,
+            config=SimpleNamespace(cameras={}),
+            get_observation=lambda: {"j1": 0.5},
+        )
+        host._task_state = _RaisingTaskState()
+        m = _mesh(host)
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            out = m._read_state()
+
+        assert out is not None
+        assert out["joints"] == {"j1": 0.5}, "the readable section still publishes"
+        assert "task" not in out, "the failed section is still omitted"
+        warned = _warnings(caplog)
+        assert len(warned) == 1, f"expected exactly one warning, got {warned}"
+        assert "task_state" in warned[0]
+
+    def test_a_raising_world_probe_is_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A sim peer's world back-reference can raise on attribute access."""
+
+        class _RaisingWorldHost:
+            robot = None
+
+            @property
+            def _world(self) -> Any:
+                raise RuntimeError("world unavailable")
+
+        m = _mesh(_RaisingWorldHost(), peer_id="sim")
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            out = m._read_state()
+
+        assert out is None
+        warned = _warnings(caplog)
+        assert len(warned) == 1, f"expected exactly one warning, got {warned}"
+        assert "sim_world" in warned[0]
+
+
+class TestTheReportIsOncePerCategory:
+    """``STATE_HZ`` is 10, so a persistent fault must not warn ten times a second."""
+
+    def test_repeat_failures_of_one_category_drop_to_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        inner = _RaisingInner(RuntimeError("joint bus read failed"))
+        m = _mesh(_Host(inner))
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            for _ in range(5):
+                m._read_state()
+
+        assert inner.calls == 5, "premise: the probe really ran five times"
+        assert len(_warnings(caplog)) == 1, "the fault is announced once, not per tick"
+        assert len(_debugs(caplog)) == 4, "the later ticks are still recorded, at debug"
+        assert all("still failing" in d for d in _debugs(caplog))
+
+    def test_two_categories_are_reported_independently(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Suppressing one category must not suppress a different fault."""
+        host = _Host(_RaisingInner(RuntimeError("joint bus read failed")))
+        host._task_state = _RaisingTaskState()
+        m = _mesh(host)
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            m._read_state()
+            m._read_state()
+
+        warned = _warnings(caplog)
+        assert len(warned) == 2, f"one warning per category, got {warned}"
+        assert {"hw_joints", "task_state"} == {c for c in ("hw_joints", "task_state") if any(c in w for w in warned)}
+
+
+class TestAHealthyProbeStaysSilent:
+    """The report exists for failures; a working arm must not grow a log line."""
+
+    def test_a_readable_arm_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        host = _Host(
+            SimpleNamespace(
+                is_connected=True,
+                config=SimpleNamespace(cameras={}),
+                get_observation=lambda: {"j1": 0.5, "j2": -0.25},
+            )
+        )
+        m = _mesh(host)
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            out = m._read_state()
+
+        assert out is not None and out["joints"] == {"j1": 0.5, "j2": -0.25}
+        assert caplog.records == [], f"a healthy probe is silent, got {caplog.records}"
+
+    def test_a_host_with_no_hardware_and_no_world_logs_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A gateway peer legitimately has neither, and must not complain.
+
+        Nothing raises on this path, so the categories are never reached -- the
+        report is keyed to a thrown exception, not to an absent section.
+        """
+        m = _mesh(_Host(None), peer_id="gateway")
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            out = m._read_state()
+
+        assert out is None
+        assert caplog.records == [], f"an armless peer is silent, got {caplog.records}"
+
+
+class TestNoProbeSwallowsItsFailure:
+    """The root cause, pinned structurally so a fifth probe cannot re-open it."""
+
+    def test_read_state_has_no_handler_that_only_passes(self) -> None:
+        """A bare ``pass`` handler is the shape that made all of this silent."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Mesh._read_state)))
+        swallowed = [
+            ast.unparse(handler.type) if handler.type else "bare except"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Try)
+            for handler in node.handlers
+            if len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
+        ]
+        assert swallowed == [], (
+            f"_read_state swallows {len(swallowed)} probe failure(s) with a bare pass "
+            f"({swallowed}); the state loop's own debug handler cannot see them, because "
+            "every statement that can raise is already inside a probe try block"
+        )
+
+    def test_every_probe_reports_through_the_one_helper(self) -> None:
+        """Each ``try`` in ``_read_state`` routes its handler to the reporter.
+
+        Derived from the source rather than counted, so a probe added later is
+        held to the same rule instead of being able to end in ``pass`` again.
+        """
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Mesh._read_state)))
+        handlers = [h for n in ast.walk(tree) if isinstance(n, ast.Try) for h in n.handlers]
+        assert handlers, "premise: _read_state still probes defensively"
+        for handler in handlers:
+            body = ast.unparse(ast.Module(body=handler.body, type_ignores=[]))
+            assert "_warn_read_state_once" in body, f"a probe handler does not report its failure: {body!r}"
+
+    def test_the_reported_categories_are_the_documented_ones(self) -> None:
+        """The categories named in the helper's docstring are the ones used."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Mesh._read_state)))
+        used = {
+            node.args[0].value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and ast.unparse(node.func).endswith("_warn_read_state_once")
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        }
+        assert used == EXPECTED_CATEGORIES, f"categories drifted: {used}"
+        doc = inspect.getdoc(Mesh._warn_read_state_once) or ""
+        for category in EXPECTED_CATEGORIES:
+            assert category in doc, f"{category} is used but not documented"


### PR DESCRIPTION
## Problem

`Mesh._read_state` probes a robot driver defensively so that a flaky read cannot kill the state thread. All four probes ended in a bare `except Exception: pass`, so a probe that raised left **no trace at any log level**.

That is not a missing line in a log nobody reads. `_read_state` returns `None` when nothing but `peer_id` and `t` survived, and the state loop publishes nothing for a `None` -- so a peer whose joint probe raises **stops publishing state entirely**, while its presence broadcast still advertises it as `connected`. On the wire and in the log it is indistinguishable from a healthy peer that simply has no joints to report.

The loop's own report cannot cover this. `_state_loop` wraps the call in `except Exception` and logs at debug, but `_read_state`'s top-level statement kinds are `Assign, AnnAssign, Try, Try, Try, Return` -- every statement that can raise is already inside a probe `try`, so **`logger.debug("state tick error")` is unreachable for a probe failure** and only ever sees a failure of `publish` itself.

`STATE_HZ` is `10.0`, so a persistent fault is ten silent decisions per second, and `mesh/iot/shadow.py` mirrors this topic to an AWS IoT named shadow.

Measured on `upstream/main`, driving the real `_read_state`:

| case | published snapshot keys | log records |
|---|---|---|
| healthy arm, 2 joints | `['joints', 'peer_id', 't']` | 0 |
| joint probe raises `RuntimeError` | **`None`** | **0** |
| joint probe raises `ConnectionError` | **`None`** | **0** |
| task probe raises, joints fine | `['joints', 'peer_id', 't']` (task silently absent) | **0** |
| both probes raise | **`None`** | **0** |

## Change

One private helper, `Mesh._warn_read_state_once(category, exc)`, and the four probe handlers routed through it.

Each probe **keeps `except Exception`** on purpose: a flaky read must not kill the state thread, so this is a recovery path and the breadth is correct. The defect was the silence, not the surface -- narrowing any of the four is a separate behaviour change, one per site.

- The **first** failure of each category (`hw_joints`, `task_state`, `sim_world`, `sim_joints`) is logged at WARNING naming the category, the peer and the exception's `repr`. The type is in the line because it selects the operator's next move: a `ConnectionError` from a contended serial port and a `RuntimeError` from an uncalibrated arm are different jobs.
- Later failures of that category drop to DEBUG, because the loop retries at `STATE_HZ` and would otherwise emit ten warnings a second.
- The category bookkeeping is read with a `getattr` default, so a `Mesh` built through `__new__` (several tests, and the sim paths) cannot make the handler that reports a failure raise one.

**What is published is unchanged** -- every row of the table above keeps its exact snapshot keys. This changes the report, not the snapshot.

`docs/troubleshooting.md`'s `## Mesh` table gains the symptom, next to the existing row that already cites a logged WARNING line for a missing `eclipse-zenoh`.

## Tests

`tests/mesh/test_read_state_probe_failures_are_reported.py`, **10 failed / 2 passed** on `upstream/main`, 12 passed after.

The headline failures are behavioural and quote the defect:

```
_read_state swallows 4 probe failure(s) with a bare pass
(['Exception', 'Exception', 'Exception', 'Exception']); the state loop's own
debug handler cannot see them, because every statement that can raise is
already inside a probe try block
```

The **2 tests that pass on both trees are the no-overreach controls** -- a readable arm logs nothing, and an armless gateway peer logs nothing. Both fail for the obvious wrong fix (reporting an absent section rather than a thrown exception).

`TestNoProbeSwallowsItsFailure` pins the root cause structurally and derives its expectations from the source, so a fifth probe added later is held to the same rule instead of being able to end in `pass` again.

## Verification

Measured at `3a4bcd2a` against `upstream/main` `71735507`:

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 == 24**, branch-only set empty (measured on a pristine `upstream/main` worktree).
- Blast radius, 436 test files (every test naming `_read_state` / `_state_loop` / `STATE_HZ`, all of `tests/mesh`, every test that reads a docs page or walks a source tree, plus the repo-wide guards). The **identical selection, excluding the new test file, was run on both trees**: branch and a pristine `upstream/main` worktree both reported `21 failed, 16869 passed, 60 skipped, 24 errors`, with **identical failing-ID sets** (the diff is empty in both directions). All 45 are `tests/mesh/test_iot_*` needing `awsiotsdk`, a declared extra that CI installs.
- The new test file on its own: 12 passed on the branch, **10 failed / 2 passed** on `upstream/main`.
- A CodeQL AST pre-flight over the changed files reports no new `py/empty-except`, `py/mixed-returns`, `py/side-effect-in-assert`, `py/file-not-closed` or `py/unnecessary-lambda` shape. The same file on `upstream/main` carries **15** bare-`pass` handlers and this branch **11**: the change clears four of them and introduces none.
