### PR TITLE
fix(training): a single-node elastic launch rendezvouses on an address a peer can reach

### DIFF
--- a/changelog.d/2600-single-node-rendezvous-address.md
+++ b/changelog.d/2600-single-node-rendezvous-address.md
@@ -1,0 +1,32 @@
+### Fixed: a single-node elastic launch rendezvouses on an address a peer can reach
+
+`elastic_launch_callable` left two rendezvous values for torch to resolve, and both of
+torch's fallbacks are addresses no peer can dial.
+
+`RendezvousStoreInfo.build` resolves `MASTER_ADDR` itself when `local_addr` is None, as
+`addr = local_addr or socket.getfqdn()`. On a host whose `getfqdn()` answers with a
+reverse-DNS PTR name - the name of an address rather than a hostname - that name has no
+forward lookup, so the agent publishes an address the worker store's client can never
+resolve. The endpoint fell back to the literal `localhost:0`, whose port is not an
+address a client can dial and whose host resolves to two different stacks wherever both
+are configured. Both resolutions happen inside libtorch's C++ socket code, so a wrong
+value there is a wait that no Python timeout, `pytest-timeout` signal or rendezvous
+budget can end: the run parks on "Rendezvous'ing worker group" with no error at all.
+
+Both are derived now. A single-node launch pins `127.0.0.1` and picks a concrete free
+port; a multi-node launch with no endpoint is refused with the reason rather than falling
+back to a loopback address that can only rendezvous with itself; a multi-node launch
+keeps torch's own resolution, because the address really must be reachable from the other
+nodes, but says so when the resolved name is a reverse-DNS artifact instead of leaving
+the operator to watch a silent hang. `STRANDS_TRAIN_LOCAL_ADDR` and
+`STRANDS_TRAIN_RDZV_TIMEOUT_S` are the operator overrides.
+
+Each rendezvous phase now carries a bound in the unit the backend reading it expects:
+`read_timeout` for the c10d store, `join_timeout` for its handler, and `timeout` for the
+static backend. Previously only the last of the three was set, leaving the two the c10d
+path reads at torch's own 60 and 600 second defaults.
+
+Every unusable spelling of the timeout env var falls back to the default rather than
+raising, including the non-finite `inf` and `1e999`: converting with `int(float(raw))`
+raises `OverflowError`, which a `(TypeError, ValueError)` handler does not catch, so an
+operator's typo would have turned a training launch into a traceback.

--- a/strands_robots/training/_inproc.py
+++ b/strands_robots/training/_inproc.py
@@ -34,8 +34,11 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
+import math
+import os
+import socket
 import sys
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -160,6 +163,179 @@ def call_callable(
         return fn(*args, **kwargs)
 
 
+#: Seconds a rendezvous may take before the launch FAILS instead of waiting. torch's
+#: own defaults are minutes long (600s to join, 60s per store read) and they are spent
+#: inside libtorch's C++ socket code, where a Python-level timeout cannot reach them -
+#: so the bound has to be handed TO torch rather than wrapped around it.
+DEFAULT_RDZV_TIMEOUT_S = 120
+RDZV_TIMEOUT_ENV = "STRANDS_TRAIN_RDZV_TIMEOUT_S"
+
+#: Operator override for the address the elastic agent publishes as ``MASTER_ADDR``.
+LOCAL_ADDR_ENV = "STRANDS_TRAIN_LOCAL_ADDR"
+
+#: Reverse-DNS zones. A name ending in one of these is a PTR record, not a hostname:
+#: it answers "what is called this address" and has no forward lookup, so a peer told
+#: to dial it can never resolve it.
+_REVERSE_DNS_SUFFIXES = ("ip6.arpa", "in-addr.arpa")
+
+
+def free_local_port() -> int:
+    """A port that is free on the loopback interface right now.
+
+    Binding port 0 and reading back the assignment is the only way to learn a free
+    port without guessing. The gap between closing this socket and torch binding it
+    is a race, but a small and well-understood one - and the alternative, handing
+    torch port 0 itself, is what :func:`rendezvous_endpoint` exists to avoid.
+
+    Returns:
+        The port number the kernel assigned.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def rendezvous_endpoint(rdzv_endpoint: str, nnodes: int, *, port_picker: Callable[[], int] = free_local_port) -> str:
+    """The ``host:port`` torch should rendezvous on.
+
+    An explicit endpoint always wins: that is the multi-node case, where the address
+    has to be one every node can reach.
+
+    A single-node launch gets a CONCRETE free port on ``127.0.0.1`` rather than
+    ``localhost:0``, because neither half of that literal is usable:
+
+    * **Port 0 is not an address a client can dial.** Whether torch's c10d backend
+      hosts the store or dials it is decided by ``_matches_machine_hostname(host)``;
+      when it decides to dial, ``_create_tcp_store`` retries the connect twice with a
+      ``read_timeout`` that defaults to 60 seconds, and that wait happens inside
+      ``TCPStore``'s C++ connect.
+    * **``localhost`` is ambiguous** wherever it resolves to both ``::1`` and
+      ``127.0.0.1``, which lets the store server and its client bind different
+      stacks and miss each other. A loopback literal cannot be mis-resolved.
+
+    A multi-node launch with no endpoint is refused rather than silently falling back
+    to a loopback address that can only ever rendezvous with itself.
+
+    Args:
+        rdzv_endpoint: Caller-supplied ``host:port``, or ``""`` to derive one.
+        nnodes: Number of nodes in the launch.
+        port_picker: Returns a free local port. Injectable so the single-node
+            endpoint can be asserted without binding a real socket.
+
+    Returns:
+        The endpoint to hand to ``LaunchConfig``.
+
+    Raises:
+        ValueError: If ``nnodes > 1`` and no explicit endpoint was given, since no
+            address this function could derive would be reachable from another node.
+    """
+    if rdzv_endpoint:
+        return rdzv_endpoint
+    if nnodes > 1:
+        raise ValueError(
+            f"a {nnodes}-node launch needs an explicit rdzv_endpoint (host:port reachable by every "
+            "node); a loopback address only rendezvouses with itself"
+        )
+    return f"127.0.0.1:{port_picker()}"
+
+
+def rdzv_timeout_s(env: Mapping[str, str] | None = None) -> int:
+    """Seconds a rendezvous may spend before the launch gives up.
+
+    Every unusable spelling - junk, zero, negative, and the non-finite values
+    ``inf``/``nan`` - falls back to :data:`DEFAULT_RDZV_TIMEOUT_S` rather than
+    raising or disabling the bound. An operator's typo in an env var must not be
+    able to restore the unbounded wait this bound exists to prevent, and must not
+    turn a training launch into a traceback either.
+
+    Args:
+        env: Environment mapping to read. Defaults to ``os.environ``.
+
+    Returns:
+        A positive number of seconds.
+    """
+    raw = (env if env is not None else os.environ).get(RDZV_TIMEOUT_ENV, "")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_RDZV_TIMEOUT_S
+    if not math.isfinite(value) or value < 1:
+        return DEFAULT_RDZV_TIMEOUT_S
+    return int(value)
+
+
+def looks_like_reverse_dns(name: str) -> bool:
+    """Is this "hostname" actually a reverse-DNS pointer name?
+
+    Args:
+        name: The name to classify, with or without a trailing root dot.
+
+    Returns:
+        True if the name sits in a reverse-DNS zone and therefore has no forward
+        lookup.
+    """
+    return name.strip(".").lower().endswith(_REVERSE_DNS_SUFFIXES)
+
+
+def launch_local_addr(
+    nnodes: int,
+    explicit: str = "",
+    *,
+    env: Mapping[str, str] | None = None,
+    fqdn: Callable[[], str] = socket.getfqdn,
+) -> str | None:
+    """The address the agent should publish as ``MASTER_ADDR``, or None to let torch resolve it.
+
+    Worth spelling out, because the failure this avoids is invisible from Python.
+    When ``local_addr`` is None, torch's ``RendezvousStoreInfo.build`` resolves the
+    address itself with ``addr = local_addr or socket.getfqdn()``. On a host whose
+    ``getfqdn()`` answers with a reverse-DNS PTR name - the name of an address rather
+    than a hostname - that name has no forward lookup, so the agent publishes an
+    address the worker store's client can never resolve. libtorch then retries with
+    backoff inside its C++ socket code, where no Python timeout, no ``pytest-timeout``
+    signal and no rendezvous budget can end the wait: the run parks on
+    "Rendezvous'ing worker group" with no error at all.
+
+    So a SINGLE-NODE launch is pinned to ``127.0.0.1``. Nothing outside this machine
+    needs to reach it, and a loopback literal cannot be mis-resolved.
+
+    A multi-node launch keeps torch's own resolution, because the address really must
+    be reachable from the other nodes and a value guessed here would be worse. If the
+    resolved name is a reverse-DNS artifact, that is said out loud instead of leaving
+    the operator to watch a silent hang.
+
+    Args:
+        nnodes: Number of nodes in the launch.
+        explicit: Caller-supplied address, which wins over everything else.
+        env: Environment mapping to read the override from. Defaults to
+            ``os.environ``.
+        fqdn: Resolves this host's name. Injectable so the reverse-DNS branch can be
+            asserted without depending on the runner's own DNS.
+
+    Returns:
+        The address to publish, or None to leave the resolution to torch.
+    """
+    override = (explicit or (env if env is not None else os.environ).get(LOCAL_ADDR_ENV, "")).strip()
+    if override:
+        return override
+    if nnodes <= 1:
+        return "127.0.0.1"
+    resolved = ""
+    try:
+        resolved = fqdn()
+    except OSError as exc:
+        logger.warning("could not resolve this host's name for MASTER_ADDR (%r)", exc)
+    if resolved and looks_like_reverse_dns(resolved):
+        logger.warning(
+            "this host's fqdn resolves to the reverse-DNS name %r, which has no forward lookup; "
+            "a %d-node launch will hang waiting on it. Set %s to an address the other nodes can reach.",
+            resolved,
+            nnodes,
+            LOCAL_ADDR_ENV,
+        )
+    return None
+
+
 def elastic_launch_callable(
     fn: Callable[..., Any],
     *,
@@ -168,6 +344,7 @@ def elastic_launch_callable(
     rdzv_endpoint: str = "",
     rdzv_backend: str = "c10d",
     run_id: str = "",
+    local_addr: str = "",
     fn_args: tuple[Any, ...] = (),
 ) -> Any:
     """Multi-process launch via torch's programmatic elastic launcher (no torchrun).
@@ -177,16 +354,33 @@ def elastic_launch_callable(
     objects, so there is no command line to inject into - the shell-free
     replacement for ``torchrun --nproc_per_node=N``. For ``nnodes > 1`` a shared
     ``rdzv_endpoint`` (host:port reachable by every node) is required.
+
+    Two values are derived rather than left to torch, because torch's own fallbacks
+    for them are addresses no peer can reach: the rendezvous endpoint comes from
+    :func:`rendezvous_endpoint` and the published ``MASTER_ADDR`` from
+    :func:`launch_local_addr`, which ``local_addr`` overrides. Each rendezvous phase
+    is bounded by :func:`rdzv_timeout_s`.
     """
     from torch.distributed.launcher.api import LaunchConfig, elastic_launch
 
+    timeout_s = rdzv_timeout_s()
     config = LaunchConfig(
         min_nodes=nnodes,
         max_nodes=nnodes,
         nproc_per_node=nproc_per_node,
         run_id=run_id or "strands-train",
         rdzv_backend=rdzv_backend,
-        rdzv_endpoint=rdzv_endpoint or "localhost:0",
+        rdzv_endpoint=rendezvous_endpoint(rdzv_endpoint, nnodes),
+        # Bound the rendezvous in the units each backend actually reads: the c10d
+        # handler reads ``join_timeout`` and its store reads ``read_timeout``, while
+        # the static backend reads ``timeout``. Left at their defaults the wait
+        # happens inside libtorch's C++ socket code, out of reach of any Python-level
+        # timeout, so the bound has to travel with the config.
+        rdzv_configs={"timeout": timeout_s, "read_timeout": timeout_s, "join_timeout": timeout_s},
+        # The address published to workers as MASTER_ADDR. Left to torch it becomes
+        # ``socket.getfqdn()``, which on some hosts is a reverse-DNS name with no
+        # forward lookup - an address the workers can never resolve.
+        local_addr=launch_local_addr(nnodes, local_addr),
         max_restarts=0,
         start_method="spawn",
     )

--- a/tests/training/test_inproc_rendezvous.py
+++ b/tests/training/test_inproc_rendezvous.py
@@ -1,0 +1,195 @@
+"""What address, what port and what patience a single-node elastic launch gets.
+
+These are pure: they never construct a store or spawn a worker, so they run in
+milliseconds. The address and port a launch rendezvouses on are derived rather than
+left to torch, because torch's own fallbacks for both are addresses no peer can
+reach - ``socket.getfqdn()`` for ``MASTER_ADDR`` and ``localhost:0`` for the
+endpoint. Both resolutions happen inside libtorch's C++ socket code, so a wrong
+value there is a silent wait that no Python-level timeout can interrupt; the only
+way to test the decision is to make it in Python first, which is what these
+functions exist for.
+
+``fqdn`` and ``port_picker`` are injected throughout, so no assertion here depends
+on the runner's own DNS or on a real bind.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+
+from strands_robots.training._inproc import (
+    DEFAULT_RDZV_TIMEOUT_S,
+    LOCAL_ADDR_ENV,
+    RDZV_TIMEOUT_ENV,
+    elastic_launch_callable,
+    free_local_port,
+    launch_local_addr,
+    looks_like_reverse_dns,
+    rdzv_timeout_s,
+    rendezvous_endpoint,
+)
+
+
+def _worker() -> int:
+    return 0
+
+
+class TestRendezvousEndpoint:
+    """The endpoint is a dialable address, never port 0 and never an ambiguous name."""
+
+    def test_an_explicit_endpoint_always_wins(self) -> None:
+        assert rendezvous_endpoint("head-node:29500", 4) == "head-node:29500"
+        assert rendezvous_endpoint("head-node:29500", 1) == "head-node:29500"
+
+    def test_a_single_node_launch_gets_a_concrete_loopback_port(self) -> None:
+        assert rendezvous_endpoint("", 1, port_picker=lambda: 45678) == "127.0.0.1:45678"
+
+    def test_never_port_zero_and_never_the_ambiguous_localhost(self) -> None:
+        # Port 0 is not an address a client can dial, and ``localhost`` can resolve to
+        # both ::1 and 127.0.0.1, which lets the store server and its client bind
+        # different stacks and miss each other inside libtorch.
+        host, _, port = rendezvous_endpoint("", 1).rpartition(":")
+        assert host == "127.0.0.1"
+        assert int(port) > 0
+
+    def test_a_multi_node_launch_without_an_endpoint_is_refused_with_the_reason(self) -> None:
+        with pytest.raises(ValueError, match="rdzv_endpoint"):
+            rendezvous_endpoint("", 3)
+
+    def test_the_picked_port_is_actually_free(self) -> None:
+        port = free_local_port()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", port))  # would raise if anything still held it
+
+
+class TestRdzvTimeout:
+    """The bound handed to torch, and what an operator's typo may not do to it."""
+
+    def test_default_when_unset(self) -> None:
+        assert rdzv_timeout_s({}) == DEFAULT_RDZV_TIMEOUT_S
+
+    def test_an_operator_can_raise_it_for_a_slow_cluster(self) -> None:
+        assert rdzv_timeout_s({RDZV_TIMEOUT_ENV: "900"}) == 900
+
+    @pytest.mark.parametrize("junk", ["", "soon", "0", "-5", "None", "0x10"])
+    def test_junk_and_non_positive_fall_back_rather_than_disabling_the_bound(self, junk: str) -> None:
+        # An unparseable or non-positive value must not be able to restore the
+        # unbounded wait this bound exists to prevent.
+        assert rdzv_timeout_s({RDZV_TIMEOUT_ENV: junk}) == DEFAULT_RDZV_TIMEOUT_S
+
+    @pytest.mark.parametrize("value", ["inf", "-inf", "1e999", "nan"])
+    def test_a_non_finite_value_falls_back_instead_of_raising(self, value: str) -> None:
+        # ``int(float("inf"))`` raises OverflowError and ``int(float("nan"))`` raises
+        # ValueError, so reading this env var must not convert first and ask questions
+        # after: an env typo has to yield the default, not a traceback out of a
+        # training launch.
+        assert rdzv_timeout_s({RDZV_TIMEOUT_ENV: value}) == DEFAULT_RDZV_TIMEOUT_S
+
+
+class TestLocalAddr:
+    """The address published as ``MASTER_ADDR``.
+
+    Left to torch this is ``local_addr or socket.getfqdn()``. A host whose
+    ``getfqdn()`` answers with a reverse-DNS PTR name publishes a name with no
+    forward lookup, so the worker store's client dials an address it can never
+    resolve and libtorch retries inside its C++ socket code - a run parked on
+    "Rendezvous'ing worker group" with no error and no timeout that can reach it.
+    """
+
+    def test_a_single_node_launch_is_pinned_to_loopback(self) -> None:
+        # Even when this host's own name is the unresolvable kind.
+        assert launch_local_addr(1, env={}, fqdn=lambda: "1.0.0.0.ip6.arpa") == "127.0.0.1"
+
+    def test_a_broken_fqdn_cannot_reach_a_single_node_launch(self) -> None:
+        def _boom() -> str:
+            raise OSError("no resolution here")
+
+        assert launch_local_addr(1, env={}, fqdn=_boom) == "127.0.0.1"
+
+    def test_an_explicit_address_wins_everywhere(self) -> None:
+        assert launch_local_addr(1, "10.0.0.7", env={}) == "10.0.0.7"
+        assert launch_local_addr(4, "10.0.0.7", env={}) == "10.0.0.7"
+
+    def test_the_operator_can_override_by_env(self) -> None:
+        assert launch_local_addr(4, env={LOCAL_ADDR_ENV: " 10.0.0.9 "}) == "10.0.0.9"
+
+    def test_a_multi_node_launch_keeps_torchs_own_resolution(self) -> None:
+        # The address must be reachable from the OTHER nodes, so a value guessed here
+        # would be worse than letting torch resolve one.
+        assert launch_local_addr(4, env={}, fqdn=lambda: "head.cluster.local") is None
+
+    def test_a_multi_node_launch_with_a_reverse_dns_fqdn_is_warned_about(self, caplog: Any) -> None:
+        with caplog.at_level("WARNING"):
+            assert launch_local_addr(4, env={}, fqdn=lambda: "1.0.0.0.0.ip6.arpa") is None
+        assert LOCAL_ADDR_ENV in caplog.text
+        assert "hang" in caplog.text, "a silent hang deserves to be named as one"
+
+    @pytest.mark.parametrize(
+        "name,is_reverse",
+        [
+            ("1.0.0.0.0.0.0.0.ip6.arpa", True),
+            ("1.0.0.0.0.0.0.0.ip6.arpa.", True),
+            ("4.3.2.1.in-addr.arpa", True),
+            # The zone apex itself, in any case: not a name anyone can dial either.
+            ("IP6.ARPA", True),
+            ("head.cluster.local", False),
+            ("127.0.0.1", False),
+            # A hostname that merely starts with the zone's letters is a real name.
+            ("arpa-node.example.com", False),
+        ],
+    )
+    def test_reverse_dns_names_are_recognised(self, name: str, is_reverse: bool) -> None:
+        assert looks_like_reverse_dns(name) is is_reverse
+
+
+class TestTheLaunchCarriesTheseDecisions:
+    """The derived values reach ``LaunchConfig``, not just the helpers that make them.
+
+    A helper that returns the right address is worth nothing if the launch config is
+    still built from torch's defaults, so the config is captured and read here rather
+    than trusting that the wiring exists.
+    """
+
+    def _captured_config(self, monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> Any:
+        from torch.distributed.launcher.api import elastic_launch as real_launch
+
+        seen: dict[str, Any] = {}
+
+        def _capture(config: Any, entrypoint: Any) -> Any:
+            seen["config"] = config
+            return lambda *a, **k: {0: 0}
+
+        monkeypatch.setattr("torch.distributed.launcher.api.elastic_launch", _capture)
+        assert real_launch is not _capture  # the patch replaced something real
+        elastic_launch_callable(_worker, nproc_per_node=1, **kwargs)
+        return seen["config"]
+
+    def test_the_endpoint_is_a_concrete_loopback_port_not_localhost_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = self._captured_config(monkeypatch)
+        host, _, port = config.rdzv_endpoint.rpartition(":")
+        assert host == "127.0.0.1", config.rdzv_endpoint
+        assert int(port) > 0, config.rdzv_endpoint
+
+    def test_master_addr_is_pinned_rather_than_resolved_from_this_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # None here is what makes torch fall back to socket.getfqdn().
+        config = self._captured_config(monkeypatch)
+        assert config.local_addr == "127.0.0.1"
+
+    def test_an_explicit_local_addr_is_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = self._captured_config(monkeypatch, local_addr="10.0.0.7")
+        assert config.local_addr == "10.0.0.7"
+
+    def test_every_rendezvous_phase_carries_the_bound(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The c10d handler reads join_timeout, its store reads read_timeout, and the
+        # static backend reads timeout; a phase left at its default is a wait that
+        # outlives the bound.
+        configs = self._captured_config(monkeypatch).rdzv_configs
+        for key in ("timeout", "read_timeout", "join_timeout"):
+            assert configs[key] == DEFAULT_RDZV_TIMEOUT_S, (key, configs)
+
+    def test_an_explicit_endpoint_still_reaches_the_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = self._captured_config(monkeypatch, rdzv_endpoint="head-node:29500")
+        assert config.rdzv_endpoint == "head-node:29500"


### PR DESCRIPTION
## The defect

`elastic_launch_callable` left two rendezvous values for torch to resolve, and both of
torch's fallbacks are addresses no peer can dial.

**MASTER_ADDR.** `RendezvousStoreInfo.build` resolves the address itself when
`local_addr` is None. In torch 2.11 that line reads, verbatim:

```python
addr = local_addr or socket.getfqdn()
```

On a host whose `getfqdn()` answers with a reverse-DNS PTR name - the name *of an
address* rather than a hostname - that name has no forward lookup, so the agent
publishes an address the worker store's client can never resolve. Measured here, a
PTR name is unresolvable while a loopback literal is not:

| name | `gethostbyname` |
| --- | --- |
| `1.0.0.0...ip6.arpa` | `gaierror` |
| `127.0.0.1` | resolves |

**The endpoint.** `rdzv_endpoint` fell back to the literal `localhost:0`, and neither
half of that is usable. Port 0 is not an address a client can dial (measured:
`connect(("127.0.0.1", 0))` is refused). Whether the c10d backend hosts the store or
dials it is decided by `_matches_machine_hostname(host)`, and when it dials,
`_create_tcp_store` retries with a `read_timeout` defaulting to 60 seconds. `localhost`
also resolves to both `::1` and `127.0.0.1` wherever both stacks are configured, which
lets the store server and its client miss each other.

Both resolutions happen inside libtorch's C++ socket code, so a wrong value there is a
wait no Python-level timeout, `pytest-timeout` signal or rendezvous budget can end: the
run parks on "Rendezvous'ing worker group" with no error at all.

Only one `rdzv_configs` key was set, by `LaunchConfig.__post_init__`, leaving the two
the c10d path actually reads at their defaults.

## What changes

`rendezvous_endpoint` derives the endpoint: an explicit one always wins, a single-node
launch gets a concrete free port on `127.0.0.1`, and a multi-node launch with no
endpoint is **refused with the reason** rather than falling back to a loopback address
that can only rendezvous with itself. `launch_local_addr` pins a single-node launch to
`127.0.0.1` and keeps torch's own resolution for multi-node (the address really must be
reachable from the other nodes), warning when the resolved name is a reverse-DNS
artifact instead of leaving the operator to watch a silent hang. `rdzv_timeout_s` bounds
each phase in the unit each backend reads, with `STRANDS_TRAIN_RDZV_TIMEOUT_S` and
`STRANDS_TRAIN_LOCAL_ADDR` as operator overrides.

The three `rdzv_configs` keys are the ones consumed on these paths, not a guess:
`read_timeout` at `c10d_rendezvous_backend.py:148`, `join_timeout` via
`create_handler`'s `_get_timeout(params, "join")`, and `timeout` for the static backend.

Captured from the real `LaunchConfig` on each tree:

| | before | after |
| --- | --- | --- |
| `rdzv_endpoint` | `localhost:0` | `127.0.0.1:39911` |
| endpoint port dialable | no | yes |
| `local_addr` | `None` | `127.0.0.1` |
| MASTER_ADDR published | `socket.getfqdn()` | `127.0.0.1` |
| `rdzv_configs` | `{timeout: 900}` | `{timeout: 120, read_timeout: 120, join_timeout: 120}` |

![rendezvous address and bound](https://raw.githubusercontent.com/cagataycali/robots/media-single-node-rendezvous/rendezvous-address.png)

## Scope, and what was not measured

The hang itself does **not** reproduce on the runner this was developed on: its
`getfqdn()` answers `cagatay`, which forward-resolves, and the two real single-node
spawns in `tests/training/test_inproc.py` pass there in 4.56s before the change. So the
evidence offered is the torch source line that makes `local_addr=None` resolve to
`getfqdn()`, the measured unresolvability of a PTR name, the measured undialability of
port 0, and the captured `LaunchConfig` above - not a reproduced hang. The tests inject
`fqdn` and `port_picker` for exactly this reason: no assertion depends on the runner's
own DNS or on a real bind.

Multi-node behaviour is deliberately unchanged apart from the refusal: guessing an
address reachable from another node is not something this function can do.

## An env var that could not fall back

Reading `STRANDS_TRAIN_RDZV_TIMEOUT_S` is meant to fall back for every unusable
spelling, so that a typo cannot restore the unbounded wait. Converting with
`int(float(raw))` under `except (TypeError, ValueError)` does not achieve that:
`int(float("inf"))` raises **OverflowError**, which escapes that handler, so `inf`,
`-inf` and `1e999` would each turn a training launch into a traceback. Reading the
value as a float and rejecting non-finite and non-positive values covers all of them:

| value | read as |
| --- | --- |
| `900` | 900 |
| `soon`, `0`, `-5` | 120 (default) |
| `inf`, `-inf`, `1e999`, `nan` | 120 (default) |

## Tests

`tests/training/test_inproc_rendezvous.py`, 35 pure tests in 0.21s. Four classes: the
endpoint, the bound, the published address, and - because a helper returning the right
value is worth nothing if the config is still built from torch's defaults - a class that
captures the real `LaunchConfig` and reads it.

Pre-fix, against `upstream/main`: the file as shipped cannot collect, because every
helper is new. Keeping only the wiring class and stubbing the one new constant it needs
gives behavioural evidence instead - **4 failed / 1 passed**:

```
assert 'localhost' == '127.0.0.1'                                    (endpoint host)
assert None == '127.0.0.1'                                           (local_addr)
TypeError: elastic_launch_callable() got an unexpected keyword argument 'local_addr'
AssertionError: ('timeout', {'timeout': 900})  assert 900 == 120     (only one phase bound)
```

The one pass is the control: an explicit `rdzv_endpoint` already reached the config
before this change, and still does.

## Verification

Measured at `278c34b6`.

75 test files - all of `tests/training`, everything naming the changed symbols, and the
repo-wide docstring, string-hygiene, exception-clause and changelog guards - run on this
branch and on a pristine `upstream/main` worktree, with the new file excluded from both
so the comparison isolates the source change:

| tree | failed | passed | skipped |
| --- | --- | --- | --- |
| this branch | 3 | 3683 | 5 |
| `upstream/main` | 3 | 3683 | 5 |

Failing-ID sets identical, `comm` empty in both directions. The 3 are pre-existing and
dependency-related, not reached by this diff: two `TestInProcessTrainerCorrectness`
cases and `test_lerobot_e2e` fail on `encode() takes 1 positional argument but 2 were
given`, a draccus version below lerobot's declared floor in this environment.

`tests/training/test_inproc.py` is 24 passed on both trees, including the two spawns
that drive a real single-node rendezvous - the endpoint and the address change, the
launch does not. `ruff check` and `ruff format --check` clean over
`strands_robots tests tests_integ`; mypy 24 errors on both trees, identical sets, none
in either changed file.
