### PR TITLE
fix(sim): the symlink refusal names where the link points

### DIFF
--- a/changelog.d/2603-symlink-refusal-names-destination.md
+++ b/changelog.d/2603-symlink-refusal-names-destination.md
@@ -1,0 +1,30 @@
+### Fixed
+
+The symlink refusal in `validate_output_path` now names where the link points,
+and hands over that path when this same call would accept it. Refusing to follow
+a link planted at an output target is right -- it is an arbitrary-write vector --
+but the refusal named no way forward, and on macOS the single most reachable
+scratch path IS a symlink: `/tmp` points at `/private/tmp`. A caller that asked
+for the most ordinary directory on the machine got a dead end that read like an
+attack had been detected. The reachable surface is the two `label="output_dir"`
+sinks, where the target is a directory rather than a file inside one: measured
+through `start_cameras_recording(output_dir=<a directory reached through a
+symlink>)`, the call refused and wrote nothing, and following the corrected
+message writes the recording (1 MP4, 16 frames).
+
+The link itself is still never followed; `resolve()` is a read.
+
+Two properties the hint holds. It does not raise: naming the destination means
+resolving it while a refusal is being built, and `Path.resolve(strict=False)` is
+not total -- CPython 3.12 raises `RuntimeError("Symlink loop from ...")` for a
+cycle while 3.13 returns the link unresolved, and `requires-python = ">=3.12"`
+admits both. A handler naming only `OSError` would catch neither, letting 3.12's
+`RuntimeError` escape a function documented to raise `ValueError`, past the
+`except ValueError` every sink maps to a structured tool error. And it does not
+advertise a path this same call would refuse: under active confinement a link
+pointing outside the sandbox has its destination named as a diagnosis rather than
+offered, so a caller who follows the message cannot land in a second refusal.
+
+A dangling link still gets a hint. `resolve(strict=False)` returns its target
+without raising, and a not-yet-existing path is exactly what an output sink is
+about to create.

--- a/strands_robots/simulation/safe_output.py
+++ b/strands_robots/simulation/safe_output.py
@@ -128,6 +128,60 @@ def _confinement_refusal(
     )
 
 
+def _symlink_destination_hint(raw: Path, *, sandbox_root: Path | None, allow_abs: bool) -> str:
+    """Return a suffix naming where a refused symlink points, or ``""``.
+
+    Refusing to follow a link planted at the target is right - it is an
+    arbitrary-write vector - but the refusal has to leave the caller somewhere
+    to go, and on macOS the single most reachable scratch path IS a symlink:
+    ``/tmp`` points at ``/private/tmp``. A caller (often an LLM) that asked for
+    the most ordinary directory on the machine got a refusal that read like an
+    attack had been detected and named no way forward. Naming the destination is
+    the missing step; the link itself is still never followed.
+
+    Two things this must not do.
+
+    It must not raise. Building a refusal is part of answering the caller, and
+    ``Path.resolve(strict=False)`` is not total: on CPython 3.12 a symlink cycle
+    raises ``RuntimeError("Symlink loop from ...")`` (3.13 returns the link
+    unresolved instead), and both are inside this package's supported range. A
+    handler naming only ``OSError`` would therefore catch neither, letting a
+    ``RuntimeError`` escape a function documented to raise ``ValueError`` - past
+    the ``except ValueError`` every sink maps to a structured tool error.
+
+    It must not advertise a path this same call would refuse. Under active
+    confinement a link pointing outside the sandbox has its destination named as
+    a diagnosis rather than offered as a remedy, so a caller who follows the
+    message cannot land in a second refusal.
+
+    Args:
+        raw: The symlink the caller supplied, already ``expanduser()``-expanded.
+        sandbox_root: Directory the path must resolve under, or ``None`` for
+            guards-only mode.
+        allow_abs: Whether the absolute-path opt-in is in force for this sink.
+
+    Returns:
+        A suffix beginning ``" - it points at ..."``, or ``""`` when there is
+        nothing honest to say: a link this call cannot resolve, or one that
+        resolves to itself.
+    """
+    try:
+        dest = raw.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return ""
+    if dest == raw:
+        return ""
+    if sandbox_root is not None and not allow_abs:
+        try:
+            dest.relative_to(sandbox_root)
+        except ValueError:
+            return (
+                f" - it points at {str(dest)!r}, which is outside the sandbox "
+                f"{sandbox_root} (pass a path under the sandbox instead)"
+            )
+    return f" - it points at {str(dest)!r}, pass that path instead"
+
+
 def validate_output_path(
     output_path: str,
     *,
@@ -191,7 +245,10 @@ def validate_output_path(
         raw = sandbox_root / raw
     # Refuse to follow a symlink planted at the target (arbitrary-write vector).
     if raw.is_symlink():
-        raise ValueError(f"{label} {output_path!r} is a symlink - refusing to follow")
+        raise ValueError(
+            f"{label} {output_path!r} is a symlink - refusing to follow"
+            f"{_symlink_destination_hint(raw, sandbox_root=sandbox_root, allow_abs=allow_abs)}"
+        )
 
     # resolve() normalizes "..", expands the chain, and follows any intermediate
     # symlinks, so the confinement check below sees the true on-disk destination.

--- a/tests/simulation/test_output_path_sandbox.py
+++ b/tests/simulation/test_output_path_sandbox.py
@@ -75,11 +75,18 @@ def _macos_tmp_shape(tmp_path):
 
 
 def test_symlink_refusal_names_the_destination_it_will_not_follow(tmp_path):
-    """The refusal names where the link points, not just that it is a link."""
+    """The refusal names where the link points, not just that it is a link.
+
+    The verdict must not soften into advice either: naming a way forward is an
+    addition to the refusal, not a replacement for it, so "refusing to follow"
+    still has to be in the message a caller reads.
+    """
     link, real = _macos_tmp_shape(tmp_path)
     with pytest.raises(ValueError, match="symlink") as excinfo:
         validate_output_path(str(link), sandbox_root=None, allow_abs=True, label="output_dir")
-    assert str(real) in str(excinfo.value), str(excinfo.value)
+    message = str(excinfo.value)
+    assert "refusing to follow" in message, message
+    assert str(real) in message, message
 
 
 def test_the_path_the_symlink_refusal_offers_is_one_this_call_accepts(tmp_path):

--- a/tests/simulation/test_output_path_sandbox.py
+++ b/tests/simulation/test_output_path_sandbox.py
@@ -9,7 +9,9 @@ context and on both Linux and macOS.
 """
 
 import os
+import re
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -51,6 +53,134 @@ def test_rejects_symlink_target(tmp_path):
     link.symlink_to(victim)
     with pytest.raises(ValueError, match="symlink"):
         validate_output_path(str(link), sandbox_root=None, allow_abs=True)
+
+
+# --- the symlink refusal names where the link points (issue #327) ---
+#
+# Refusing is right, but the refusal has to leave the caller somewhere to go.
+# On macOS the single most reachable scratch path IS a symlink (/tmp ->
+# /private/tmp), so a caller that asked for the most ordinary directory on the
+# machine got a refusal that read like an attack had been detected and named no
+# way forward. These pin both halves of the fix: the destination is named, and
+# every path the message *offers* is one this same call accepts.
+
+
+def _macos_tmp_shape(tmp_path):
+    """Build the /tmp -> /private/tmp shape: a real dir reached through a link."""
+    real = tmp_path / "private_tmp"
+    real.mkdir()
+    link = tmp_path / "tmp"
+    link.symlink_to(real)
+    return link, real
+
+
+def test_symlink_refusal_names_the_destination_it_will_not_follow(tmp_path):
+    """The refusal names where the link points, not just that it is a link."""
+    link, real = _macos_tmp_shape(tmp_path)
+    with pytest.raises(ValueError, match="symlink") as excinfo:
+        validate_output_path(str(link), sandbox_root=None, allow_abs=True, label="output_dir")
+    assert str(real) in str(excinfo.value), str(excinfo.value)
+
+
+def test_the_path_the_symlink_refusal_offers_is_one_this_call_accepts(tmp_path):
+    """Follow the remedy verbatim: an offered path must not hit a second refusal.
+
+    Parses the destination back out of the message and passes it, which is what
+    a caller acting on the refusal does. A message that offers a path this same
+    call would reject is a dead end wearing a remedy.
+    """
+    link, real = _macos_tmp_shape(tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        validate_output_path(str(link), sandbox_root=None, allow_abs=True, label="output_dir")
+    offered = re.search(r"it points at '([^']+)', pass that path instead", str(excinfo.value))
+    assert offered, f"no path offered: {excinfo.value}"
+    resolved = validate_output_path(offered.group(1), sandbox_root=None, allow_abs=True, label="output_dir")
+    assert resolved == real.resolve()
+
+
+@pytest.mark.parametrize("unresolvable", [RuntimeError("Symlink loop from 'x'"), OSError("ELOOP")])
+def test_a_symlink_the_call_cannot_resolve_is_still_a_value_error(tmp_path, monkeypatch, unresolvable):
+    """Naming the destination must not change which exception class escapes.
+
+    ``Path.resolve(strict=False)`` is not total, and which class it raises for a
+    cycle depends on the interpreter: CPython 3.12 raises ``RuntimeError``
+    ("Symlink loop from ...") while 3.13 returns the link unresolved. Both are
+    inside ``requires-python = ">=3.12"``, so a handler naming only ``OSError``
+    would let 3.12's ``RuntimeError`` escape a function documented to raise
+    ``ValueError`` - past the ``except ValueError`` every sink maps to a
+    structured tool error. Both classes are driven here so the guard holds on
+    either interpreter rather than only the one running it.
+    """
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "target")
+
+    def boom(self, strict=False):
+        raise unresolvable
+
+    monkeypatch.setattr(Path, "resolve", boom)
+    with pytest.raises(ValueError, match="symlink"):
+        validate_output_path(str(link), sandbox_root=None, allow_abs=True, label="output_dir")
+
+
+def test_a_real_symlink_loop_is_refused_without_a_hint(tmp_path):
+    """A cycle has no destination to name, so the refusal stays bare."""
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+    with pytest.raises(ValueError, match="symlink") as excinfo:
+        validate_output_path(str(a), sandbox_root=None, allow_abs=True, label="output_dir")
+    assert "it points at" not in str(excinfo.value), str(excinfo.value)
+
+
+def test_a_broken_symlink_still_names_its_destination(tmp_path):
+    """A dangling link resolves fine, and its destination is a usable target.
+
+    ``resolve(strict=False)`` does not raise for a link whose target is absent -
+    it returns the target path - and a not-yet-existing path is exactly what an
+    output sink is about to create. So this case gets a hint like any other.
+    """
+    link = tmp_path / "broken"
+    target = tmp_path / "not_created_yet"
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="symlink") as excinfo:
+        validate_output_path(str(link), sandbox_root=None, allow_abs=True, label="output_dir")
+    assert str(target) in str(excinfo.value), str(excinfo.value)
+    assert validate_output_path(str(target), sandbox_root=None, allow_abs=True) == target.resolve()
+
+
+def test_a_confined_symlink_pointing_outside_is_named_but_not_offered(tmp_path):
+    """Under confinement, an outside destination is a diagnosis, not a remedy.
+
+    Offering it would send the caller straight into the confinement refusal, so
+    the message names where the link goes and then points back into the sandbox.
+    """
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = sandbox / "escape"
+    link.symlink_to(outside)
+    with pytest.raises(ValueError, match="symlink") as excinfo:
+        validate_output_path(str(link), sandbox_root=sandbox, allow_abs=False)
+    message = str(excinfo.value)
+    assert str(outside) in message, message
+    assert "pass that path instead" not in message, message
+    assert "outside the sandbox" in message, message
+
+
+def test_a_confined_symlink_pointing_inside_the_sandbox_is_offered(tmp_path):
+    """A destination confinement would accept is offered as the way forward."""
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    inner = sandbox / "inner"
+    inner.mkdir()
+    link = sandbox / "shortcut"
+    link.symlink_to(inner)
+    with pytest.raises(ValueError, match="symlink") as excinfo:
+        validate_output_path(str(link), sandbox_root=sandbox, allow_abs=False)
+    offered = re.search(r"it points at '([^']+)', pass that path instead", str(excinfo.value))
+    assert offered, f"no path offered: {excinfo.value}"
+    assert validate_output_path(offered.group(1), sandbox_root=sandbox, allow_abs=False) == inner.resolve()
 
 
 @pytest.mark.parametrize("bad", ["../escape.mp4", "../../etc/x.mp4", "sub/../../etc/x.mp4"])


### PR DESCRIPTION
## Problem

`validate_output_path` refuses to follow a symlink planted at an output target, which is right: it is an arbitrary-write vector. But the refusal named no way forward:

```
output_dir '/tmp' is a symlink - refusing to follow
```

On macOS the single most reachable scratch path IS a symlink - `/tmp` points at `/private/tmp` - so a caller that asked for the most ordinary directory on the machine got a dead end that read like an attack had been detected. The reachable surface is the two `label="output_dir"` sinks (`start_cameras_recording` / `..._synchronous`), where the target is a directory rather than a file inside one.

Measured through the real sinks (a directory reached through a symlink, guards-only mode, which is the recording default):

| sink | before |
| --- | --- |
| `render(output_path=)` | refused, no path named, 0 bytes written |
| `start_cameras_recording(output_dir=)` | refused, no path named, 0 MP4 |

## Change

The refusal names the destination, and when this same call would accept that destination it is offered as the path to pass. The link itself is still never followed - `resolve()` is a read.

Two properties the hint has to hold, both of which a naive version of this fix gets wrong.

**It must not raise.** Naming the destination means resolving it while a refusal is being built, and `Path.resolve(strict=False)` is not total. Measured on both supported interpreters:

| link | CPython 3.12.3 | CPython 3.13.12 |
| --- | --- | --- |
| dangling target | returns the target, no raise | returns the target, no raise |
| cycle | raises `RuntimeError("Symlink loop from ...")` | returns the link unresolved, no raise |

`requires-python = ">=3.12"` admits both, so a handler naming only `OSError` catches neither, and on 3.12 a `RuntimeError` escapes a function documented to raise `ValueError` - past the `except ValueError` every sink maps to a structured tool error. The handler names `(OSError, RuntimeError)`, and the reasoning is in the helper's docstring rather than left to be re-derived.

**It must not advertise a path this same call would refuse.** Under active confinement (the `render` sink's default) a link inside the sandbox pointing outside resolves to a path the confinement check then rejects, so offering it would send the caller straight into a second refusal. That case names the destination as a diagnosis and points back into the sandbox instead. Naming a resolved path in a refusal is already this function's convention - the confinement refusal one branch below does the same.

After, through the same two sinks, following the remedy the message gives:

| sink | mode | after |
| --- | --- | --- |
| `render(output_path=)` | confined | offered `.../shots/frame.png`, retry `success`, PNG 46089 bytes |
| `start_cameras_recording(output_dir=)` | guards-only | offered the real directory, retry `success`, 1 MP4 / 40513 bytes / 16 frames |

Also measured and left as-is: a dangling link does get a hint, because `resolve(strict=False)` returns its target and a not-yet-existing path is exactly what an output sink is about to create - verified accepted on retry.

## Tests

Extends `tests/simulation/test_output_path_sandbox.py` beside the existing `test_rejects_symlink_target`. Split against `upstream/main` with only the test file copied in: **5 failed / 54 passed** -> 59 passed.

The value of the other four is what they do to a naive form of this fix (catch `OSError` only, always offer the destination). Applied verbatim to `upstream/main` and run against these tests:

| tree | failing | which |
| --- | --- | --- |
| `upstream/main` | 5 | the five that need a destination named |
| naive form | 3 | `..._cannot_resolve_is_still_a_value_error[RuntimeError]`, `..._real_symlink_loop_is_refused_without_a_hint`, `..._pointing_outside_is_named_but_not_offered` |
| this branch | 0 | - |

`test_a_symlink_the_call_cannot_resolve_is_still_a_value_error` drives `RuntimeError` and `OSError` through a patched `resolve`, so it holds on either interpreter rather than only the one running it. `test_the_path_the_symlink_refusal_offers_is_one_this_call_accepts` parses the destination back out of the message and passes it, which is what a caller acting on the refusal does.

## Verification

Measured at `aad8f2d9`. The head has since moved to `df1674e`, which adds two assertions to the headline test (that `refusing to follow` still appears, so naming a way forward is an addition to the verdict rather than a replacement) and changes no source line; the file still reports 59 passed and the pre-fix split is unchanged at 5 failed / 54 passed.

Blast radius: 108 test files (every test touching the sandbox helpers or the two sinks, plus the repo-wide docstring / string / changelog guards), the changed test file excluded from both trees so any difference is the source change alone.

| tree | result |
| --- | --- |
| this branch | 4 failed, 4812 passed, 4 skipped |
| `upstream/main` (pristine) | 4 failed, 4812 passed, 4 skipped |

Failing ID sets identical, `comm` empty in both directions. All 4 are pre-existing and environmental: `test_rendering_pacers_survive_a_clock_step[forward_30s]` passes 16/16 when that file runs alone on the pristine tree (order-dependent), and the three `tests/training` failures are `draccus 0.10.0` against `lerobot 0.6.2`'s `draccus>=0.11.6` floor.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`. `mypy` 24 errors on this branch and 24 on a pristine `upstream/main`, identical sets, none in the changed files.

## Artifact

Both columns run the same capture script against the same two real sinks; only `strands_robots` differs. Each column follows whatever remedy its own tree's message gives, so the right-hand frame is the one a caller obtains by acting on the refusal, and the left-hand panel is what the call produced instead.

![symlink refusal names its destination](https://raw.githubusercontent.com/cagataycali/robots/media-symlink-hint-32560286419/symlink-hint.png)
