### PR TITLE
fix(tools): refuse a protected directory under every name that reaches it

### DIFF
--- a/changelog.d/2604-blocklist-resolved-on-both-sides.md
+++ b/changelog.d/2604-blocklist-resolved-on-both-sides.md
@@ -1,0 +1,25 @@
+### Fixed
+
+`gr00t_inference` now refuses a protected host directory under every name that
+reaches it. `_check_volume_safety` resolved the candidate mount through symlinks
+and compared it against a literal blocklist, so it compared a directory against
+a name. Docker mounts the directory, so a protected directory reachable under a
+second name was refused under one spelling and admitted under the other. On a
+host whose protected directory is reached through a symlink whose target escapes
+the blocklist - macOS ships `/etc -> /private/etc`, and a Linux server with a
+separate data volume may ship `/home -> /mnt/home` - the symlink spelling was
+refused and the target spelling, along with every file beneath it, was admitted.
+
+The admitted spelling reached two sinks, and the second is the one that matters:
+`_check_hf_local_dir_safety` delegates to the same helper, and `hf_local_dir` is
+an agent-supplied string that `_download_checkpoint` writes to on the host with
+no docker mediation. So the reachable surface was an agent-named write into a
+protected directory, not only an operator bind mount.
+
+Both sides of the comparison are resolved now. A protected path that is not a
+symlink contributes one entry, so on a host whose protected paths are real
+directories the set is the blocklist and every verdict is the one it was; where
+`/bin`, `/sbin` and `/lib` are symlinks into `/usr`, the three entries they add
+were already covered by `/usr`. The invariant is stated for every entry in the
+shipped blocklist, parametrized, so an entry added later is covered without
+anyone remembering this.

--- a/strands_robots/tools/gr00t_inference.py
+++ b/strands_robots/tools/gr00t_inference.py
@@ -293,6 +293,28 @@ def _resolve_host_path(host_path: str) -> str:
     return os.path.realpath(os.path.expanduser(host_path))
 
 
+def _with_resolved(paths: tuple[str, ...]) -> set[str]:
+    """Return each protected path AND the path its symlinks resolve to.
+
+    The blocklist names a path, but docker mounts the directory that path
+    resolves to, so a protected directory reachable under two names has to be
+    blocked under both. A host that reaches a protected directory through a
+    symlink whose target escapes the blocklist is the case this covers: macOS
+    ships ``/etc -> /private/etc``, and a Linux server with a separate data
+    volume may ship ``/home -> /mnt/home``. Resolving only the candidate mount
+    (#384 item 2) refuses the symlink spelling and admits the target spelling,
+    which is the same directory.
+
+    A path that is not a symlink contributes one entry, so on a host whose
+    protected paths are all real directories the returned set is the blocklist.
+    """
+    out: set[str] = set()
+    for raw in paths:
+        out.add(os.path.normpath(raw))
+        out.add(os.path.realpath(raw))
+    return out
+
+
 def _check_volume_safety(volumes: dict[str, str] | None) -> str | None:
     """Return None if all bind-mount host paths are safe, else a reason.
 
@@ -303,8 +325,12 @@ def _check_volume_safety(volumes: dict[str, str] | None) -> str | None:
     """
     if not volumes:
         return None
-    blocked_dirs = {os.path.normpath(p) for p in _BLOCKED_VOLUME_HOST_PATHS}
-    blocked_exact = {os.path.normpath(p) for p in _BLOCKED_VOLUME_EXACT}
+    # Both sides of the comparison are resolved: the candidate mount (#384
+    # item 2) and the blocklist itself. Resolving one side only compares a
+    # directory against a name, so a protected directory reachable under a
+    # second name was refused under one spelling and admitted under the other.
+    blocked_dirs = _with_resolved(_BLOCKED_VOLUME_HOST_PATHS)
+    blocked_exact = _with_resolved(_BLOCKED_VOLUME_EXACT)
     for host_path in volumes:
         norm = _normalize_host_path(str(host_path))
         # #384 item 2: also evaluate the symlink-resolved path so a host symlink

--- a/tests/tools/test_gr00t_container_hardening.py
+++ b/tests/tools/test_gr00t_container_hardening.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -591,3 +592,128 @@ def test_resolve_host_path_does_not_raise_on_missing_path():
     mount source (realpath resolves as far as it can, never raises)."""
     out = gi._resolve_host_path("/does/not/exist/yet/ckpt")
     assert isinstance(out, str) and out.startswith("/")
+
+
+# --------------------------------------------------------------------------- #
+# Both sides of the blocklist comparison are resolved                          #
+# --------------------------------------------------------------------------- #
+def _host_with_a_symlinked_protected_dir(tmp_path):
+    """Build a host whose protected dir is reached through an escaping symlink.
+
+    ``<host>/etc -> <host>/private/etc``, and the blocklist names ``<host>/etc``
+    -- the shape macOS ships (``/etc -> /private/etc``) and that a Linux server
+    with a separate data volume ships (``/home -> /mnt/home``). The target
+    spelling is deliberately outside the blocklist, which is what makes the two
+    names distinguishable to a comparison that resolves only one side.
+    """
+    root = os.path.realpath(str(tmp_path))
+    os.makedirs(f"{root}/private/etc", exist_ok=True)
+    os.makedirs(f"{root}/safe", exist_ok=True)
+    with open(f"{root}/private/etc/shadow", "w"):
+        pass
+    os.symlink(f"{root}/private/etc", f"{root}/etc")
+    return root
+
+
+class TestTheBlocklistIsResolvedOnBothSides:
+    """A protected directory is refused under every name that reaches it.
+
+    ``_check_volume_safety`` resolves the candidate mount through symlinks
+    (#384 item 2) and used to compare it against a literal blocklist, so it
+    compared a directory against a name. Docker mounts the directory, so a
+    protected directory reachable under a second name was refused under one
+    spelling and admitted under the other -- and the admitted spelling reaches
+    the same files.
+    """
+
+    def test_the_layout_under_test_really_escapes_the_blocklist(self, tmp_path):
+        """Premise: the symlink exists and its target is not a blocklist entry."""
+        root = _host_with_a_symlinked_protected_dir(tmp_path)
+        assert os.path.islink(f"{root}/etc")
+        assert os.path.realpath(f"{root}/etc") == f"{root}/private/etc"
+        literal = {os.path.normpath(p) for p in (f"{root}/etc",)}
+        assert f"{root}/private/etc" not in literal
+
+    def test_the_resolved_spelling_of_a_protected_directory_is_refused(self, monkeypatch, tmp_path):
+        """The target spelling names the same directory, so it is refused too."""
+        root = _host_with_a_symlinked_protected_dir(tmp_path)
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", (f"{root}/etc",))
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", ())
+        by_name = gi._check_volume_safety({f"{root}/etc": "/data/checkpoints"})
+        by_target = gi._check_volume_safety({f"{root}/private/etc": "/data/checkpoints"})
+        assert by_name is not None, "premise: the symlink spelling was already refused"
+        assert by_target is not None, (
+            f"{root}/private/etc is the directory {root}/etc resolves to, and docker mounts "
+            f"that directory, but the blocklist admitted it: {by_target!r}"
+        )
+
+    def test_a_child_of_the_resolved_spelling_is_refused(self, monkeypatch, tmp_path):
+        """The files the blocklist exists to protect are under the target name."""
+        root = _host_with_a_symlinked_protected_dir(tmp_path)
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", (f"{root}/etc",))
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", ())
+        reason = gi._check_volume_safety({f"{root}/private/etc/shadow": "/data/checkpoints"})
+        assert reason is not None, "a file inside the protected directory was admitted by its other name"
+
+    def test_an_agent_supplied_hf_local_dir_cannot_name_the_resolved_spelling(self, monkeypatch, tmp_path):
+        """``hf_local_dir`` is agent-supplied and reaches a host write directly.
+
+        ``_download_checkpoint`` writes the snapshot to it on the host with no
+        docker mediation, so this sink turns the admitted spelling into an
+        agent-reachable write into a protected directory.
+        """
+        root = _host_with_a_symlinked_protected_dir(tmp_path)
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", (f"{root}/etc",))
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", ())
+        assert gi._check_hf_local_dir_safety(f"{root}/private/etc") is not None
+
+    def test_an_exact_match_entry_is_refused_under_its_resolved_name(self, monkeypatch, tmp_path):
+        """A socket reachable under two names is refused under both."""
+        root = os.path.realpath(str(tmp_path))
+        os.makedirs(f"{root}/run", exist_ok=True)
+        os.symlink(f"{root}/run", f"{root}/var_run")
+        with open(f"{root}/run/docker.sock", "w"):
+            pass
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", ())
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", (f"{root}/var_run/docker.sock",))
+        assert gi._check_volume_safety({f"{root}/run/docker.sock": "/x"}) is not None
+
+    @pytest.mark.parametrize("blocked", gi._BLOCKED_VOLUME_HOST_PATHS, ids=str)
+    def test_every_shipped_blocklist_entry_refuses_its_own_resolved_path(self, blocked):
+        """Stated for every entry, so an entry added later is covered too.
+
+        On a host whose protected paths are real directories, or whose symlinks
+        resolve inside another blocked prefix, this already held -- it is the
+        invariant that makes the blocklist about directories rather than names.
+        """
+        resolved = os.path.realpath(blocked)
+        if resolved == os.sep:
+            pytest.skip("root is matched exactly, not by prefix")
+        assert gi._check_volume_safety({resolved: "/data/checkpoints"}) is not None
+
+    def test_a_blocklist_of_real_directories_changes_no_verdict(self, monkeypatch, tmp_path):
+        """No-op where nothing is a symlink: resolution adds no entry.
+
+        A protected path that is a real directory resolves to itself, so on a
+        host whose blocklist holds no symlink every verdict is the one it was.
+        """
+        root = os.path.realpath(str(tmp_path))
+        os.makedirs(f"{root}/etc", exist_ok=True)
+        os.makedirs(f"{root}/elsewhere", exist_ok=True)
+        with open(f"{root}/etc/shadow", "w"):
+            pass
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", (f"{root}/etc",))
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", ())
+        assert gi._check_volume_safety({f"{root}/etc": "/x"}) is not None
+        assert gi._check_volume_safety({f"{root}/etc/shadow": "/x"}) is not None
+        assert gi._check_volume_safety({f"{root}/elsewhere": "/x"}) is None
+
+    def test_a_symlink_into_a_safe_directory_is_still_allowed(self, monkeypatch, tmp_path):
+        """Resolving the blocklist must not refuse an unprotected target."""
+        root = _host_with_a_symlinked_protected_dir(tmp_path)
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_HOST_PATHS", (f"{root}/etc",))
+        monkeypatch.setattr(gi, "_BLOCKED_VOLUME_EXACT", ())
+        link = f"{root}/models_link"
+        os.symlink(f"{root}/safe", link)
+        assert gi._check_volume_safety({link: "/data/checkpoints"}) is None
+        assert gi._check_volume_safety({f"{root}/safe": "/data/checkpoints"}) is None


### PR DESCRIPTION
## Problem

`_check_volume_safety` resolves the candidate mount through symlinks (#384 item 2) and compared it against a **literal** blocklist, so it compared a *directory* against a *name*. Docker mounts the directory, so a protected directory reachable under a second name was refused under one spelling and admitted under the other.

Measured on a host whose protected directory is reached through a symlink whose target escapes the blocklist (`<host>/etc -> <host>/private/etc`, blocklist naming `<host>/etc`) - the shape macOS ships as `/etc -> /private/etc`, and that a Linux server with a separate data volume ships as `/home -> /mnt/home`:

| mount | before | after |
| --- | --- | --- |
| `<host>/etc` | refused | refused |
| `<host>/etc/shadow` | refused | refused |
| `<host>/private/etc` | **allowed** | refused |
| `<host>/private/etc/shadow` | **allowed** | refused |
| `<host>/safe` | allowed | allowed |

The admitted spelling is the same directory, so row 4 is the file the blocklist exists to protect, reached under the name it does not check.

`_check_hf_local_dir_safety` delegates to this helper, and `hf_local_dir` is an **agent-supplied** string that reaches a host write with no docker mediation (`_download_checkpoint` writes the snapshot there directly). Driven through that path on the same layout, the resolved spelling and its children were admitted before and are refused after, so the reachable surface was an agent-named write into a protected directory rather than only an operator bind mount.

## Change

Resolve both sides of the comparison:

```python
blocked_dirs = _with_resolved(_BLOCKED_VOLUME_HOST_PATHS)
blocked_exact = _with_resolved(_BLOCKED_VOLUME_EXACT)
```

`_with_resolved` contributes each protected path **and** the path its symlinks resolve to. A path that is not a symlink contributes one entry, so on a host whose protected paths are real directories the returned set is the blocklist and every verdict is the one it was.

Measured on this Linux host: 15 literal entries become 18, the three added being `/usr/bin`, `/usr/sbin`, `/usr/lib` from `/bin`, `/sbin`, `/lib` - **each already covered by the literal `/usr`** - while `/var/run -> /run` adds nothing because `/run` is already an entry, and the exact-match set is unchanged. So the effective coverage here is identical; what changes is a host where a protected path resolves outside every prefix.

## Notes on scope

The issue this came from reported the headline as a mount of `/etc` being allowed because it resolves to `/private/etc`. That is **not** what happens: `candidates` holds both `norm` and `resolved`, so the symlink spelling matches the blocklist by name and is refused (row 1 above, before and after). The defect is the *target* spelling, which the issue mentions only in passing, and its children.

The same issue proposed a second piece - carving the per-user temp root out of the blocklist, because macOS resolves `tempfile.gettempdir()` to `/private/var/folders/<...>/T`, i.e. under `/var`. That is deliberately **not** here. It is a widening of a security blocklist rather than a fix to a one-sided comparison, it is a no-op on a host where `gettempdir()` is `/tmp` (not under any protected prefix), and `gettempdir()` reads `TMPDIR`/`TMP`/`TEMP` and honours any *writable* candidate: measured, `TMPDIR=/dev/shm`, `TMPDIR=/var/tmp` and `TMPDIR=/run/user/<uid>` are all honoured on this host, each of which would unblock a subtree of a protected prefix (`/dev`, `/var`, `/run`) through an environment variable that is not the documented opt-out. Whether an operator-facing carve-out should exist, and what should name it, is a contract choice rather than a defect - worth its own change with its own justification.

## Tests

New `TestTheBlocklistIsResolvedOnBothSides` in the existing hardening file, so the `#384 item 2` tests beside it stay as controls.

**4 failed / 99 passed** against `upstream/main`, **103 passed / 1 skipped** after. The four are behavioural, each naming the admitted spelling:

- `test_the_resolved_spelling_of_a_protected_directory_is_refused` - `... is the directory ... resolves to, and docker mounts that directory, but the blocklist admitted it: None`
- `test_a_child_of_the_resolved_spelling_is_refused`
- `test_an_agent_supplied_hf_local_dir_cannot_name_the_resolved_spelling`
- `test_an_exact_match_entry_is_refused_under_its_resolved_name`

Five pass on both trees and are the controls, each failing for a specific wrong fix:

- `test_a_blocklist_of_real_directories_changes_no_verdict` - the no-op guarantee; fails if resolution ever adds an entry where nothing is a symlink.
- `test_a_symlink_into_a_safe_directory_is_still_allowed` - fails if resolving the blocklist starts refusing an unprotected target.
- `test_every_shipped_blocklist_entry_refuses_its_own_resolved_path` - parametrized over the shipped blocklist, so an entry added later is covered without anyone remembering this. It already held on a host whose symlinks resolve inside another blocked prefix, which is this host; it is the invariant statement rather than regression evidence here.
- `test_the_layout_under_test_really_escapes_the_blocklist` - premise, so the headline cannot pass vacuously.
- The pre-existing `test_check_volume_safety_allows_symlink_into_safe_dir` and `..._resolves_symlink_into_protected_dir`.

## Artifact

The agent-supplied sink, driven end to end on the synthetic host. Both columns run the same capture script against the same layout, with `huggingface_hub.snapshot_download` stood in by a function that writes into `local_dir` exactly as the real one does - `local_dir.mkdir(parents=True, exist_ok=True)` and the guard call above it are shipped code, and only `strands_robots` differs between the columns.

![the blocklist compared a directory against a name](https://raw.githubusercontent.com/cagataycali/robots/media-blocklist-both-sides/blocklist-both-sides.png)

Before, `hf_local_dir=<host>/private/etc` returns `status="success"` with `Downloaded nvidia/GR00T-N1.5-3B -> <host>/private/etc`, and `model.safetensors` lands **inside the protected directory, beside `shadow`**. After, it is refused and the directory is untouched. Row 1 is the control: the symlink spelling was refused in both columns and wrote nothing.

## Verification

Measured at `df9a436`.

Blast radius - every test naming the volume/`hf_local_dir` guards or the blocklist, all of `tests/tools`, and the repo-wide docstring, string, changelog and dependency guards. 68 files, run on this branch and on a pristine `upstream/main` with the changed test file excluded from both, so any difference is caused by the source change alone:

| tree | passed | failed | skipped |
| --- | --- | --- | --- |
| this branch | 3324 | 0 | 9 |
| `upstream/main` | 3324 | 0 | 9 |

Identical, and zero failures on either side.

`tests/tools/test_gr00t_container_hardening.py` separately: **4 failed / 99 passed / 1 skipped** on `upstream/main` with this file copied in, **103 passed / 1 skipped** here.

`mypy strands_robots tests tests_integ`: 24 pre-existing on both trees, branch-only empty, none in the changed files. `ruff check` and `ruff format --check` clean over the CI scope.
