### PR TITLE
fix(sim/mujoco): a render REFUSAL is not a camera that is merely "cold"

### DIFF
--- a/changelog.d/2605-no-gl-refusal-is-not-coldness.md
+++ b/changelog.d/2605-no-gl-refusal-is-not-coldness.md
@@ -1,0 +1,37 @@
+### Fixed
+
+The no-OpenGL-context error now answers for the host reading it, and the camera
+recorder no longer reports a render REFUSAL as a camera that is merely "cold".
+
+`render`, `render_depth` and `get_frame` each carried their own copy of one
+sentence for every host: "Install EGL or OSMesa for offscreen rendering:
+apt-get install libosmesa6-dev". macOS has neither EGL nor OSMesa -- MuJoCo
+renders through CGL there, and there is no apt -- so a Mac operator was sent to
+install a package that does not exist for their machine while the real cause
+kept its cover. Measured on one tree with `sys.platform` set each way, the text
+`render` returns is byte-identical: the platform is never consulted.
+`no_gl_context_message` now owns the sentence and names the two macOS causes,
+which need opposite actions -- a CGL context needs a window-server session,
+which a process started by launchd, cron or a bare ssh login does not have; and
+a context that worked earlier in the same process was lost rather than missing,
+which a fresh process fixes and no install does. Linux keeps the packages, where
+they are exactly right, and the advice now lives in one place instead of three.
+
+The recorder thread's warmup had one verdict for every camera that never
+produced usable output: "still cold after 30 attempts ... first captured frames
+may show gradient artifact". A render can instead come back as a structured
+error RESULT rather than a frame, and because that is a returned dict and not a
+raised exception the warmup loop's `except` branch never saw it -- so the reason
+was dropped at every log level and the recording finished as `status="success"`
+with zero frames, no MP4, and an artifact whose only hint was an error count.
+No number of attempts fixes a missing GL context, so "cold" is not a slower
+version of the same story and its stated consequence understates a recording in
+which every frame is missing. Warmup now records the refusal per camera, reports
+refused cameras apart from genuinely cold ones, and carries the reason out
+through the artifact as `render_refused` and a line in the result text, so
+`frames: 0` arrives with its cause attached.
+
+A host that cannot render still cannot record: `status` and `frames` are
+unchanged. What changes is that the operator learns why. A genuinely cold camera
+keeps the message it always had, and a batch containing both kinds gets both
+lines.

--- a/strands_robots/simulation/mujoco/rendering.py
+++ b/strands_robots/simulation/mujoco/rendering.py
@@ -45,6 +45,45 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MAX_RENDER_BYTES = 50 * 1024 * 1024  # 50 MB
 
 
+def no_gl_context_message(*, depth: bool = False, platform: str | None = None) -> str:
+    """The one sentence every renderer consumer says when there is no GL context.
+
+    The advice was a Linux package install on every host. macOS has neither EGL
+    nor OSMesa - MuJoCo renders through CGL there - so on a Mac the reader was
+    sent to install a package that does not exist for their machine while the
+    real cause kept its cover: a CGL context needs a window-server session,
+    which a process started by launchd, cron or a bare ssh login does not have.
+    The Linux advice is kept, because on Linux it is exactly right.
+
+    Args:
+        depth: ``True`` when the caller is the depth renderer, so the sentence
+            names depth rendering rather than rendering.
+        platform: Platform to answer for, spelled as ``sys.platform`` spells it.
+            Defaults to the running platform; a caller passes it explicitly to
+            answer for a host it is not running on.
+
+    Returns:
+        One stripped sentence naming the failure and a fix that exists on
+        ``platform``.
+    """
+    import sys as _sys
+
+    system = platform or _sys.platform
+    head = (
+        "Depth rendering unavailable (no OpenGL context). " if depth else "Rendering unavailable (no OpenGL context). "
+    )
+    if system == "darwin":
+        return head + (
+            "macOS has no EGL or OSMesa - MuJoCo renders through CGL - so installing "
+            "Linux GL packages cannot help here. A CGL context needs a window-server "
+            "session, which a process started by launchd, cron or a bare ssh login does "
+            "not have; run it from a terminal on the logged-in desktop. If rendering "
+            "worked EARLIER in this same process, the context was lost rather than "
+            "missing, and a fresh process is the fix."
+        )
+    return head + ("Install EGL or OSMesa for offscreen rendering: apt-get install libosmesa6-dev")
+
+
 def _is_pixel_count(value: Any) -> bool:
     """True when ``value`` is usable as a pixel dimension (an int, not a bool)."""
     return isinstance(value, int) and not isinstance(value, bool)
@@ -1071,15 +1110,7 @@ class RenderingMixin:
             if renderer is None:
                 return {
                     "status": "error",
-                    "content": [
-                        {
-                            "text": (
-                                "Rendering unavailable (no OpenGL context). "
-                                "Install EGL or OSMesa for offscreen rendering: "
-                                "apt-get install libosmesa6-dev"
-                            )
-                        }
-                    ],
+                    "content": [{"text": no_gl_context_message()}],
                 }
             # strict camera validation - no silent fallback to default.
             # Special 'default' / 'free' tokens route to the free camera; any
@@ -1223,14 +1254,7 @@ class RenderingMixin:
             if renderer is None:
                 return {
                     "status": "error",
-                    "content": [
-                        {
-                            "text": (
-                                "Depth rendering unavailable (no OpenGL context). "
-                                "Install EGL or OSMesa for offscreen rendering."
-                            )
-                        }
-                    ],
+                    "content": [{"text": no_gl_context_message(depth=True)}],
                 }
             # Reading mjData (update_scene copies xpos/xquat/xmat/geom poses)
             # races a concurrent mj_step from a policy worker or the step()
@@ -1421,10 +1445,7 @@ class RenderingMixin:
         with self._lock:
             renderer = self._get_renderer(w, h)
             if renderer is None:
-                raise RuntimeError(
-                    "Rendering unavailable (no OpenGL context). "
-                    "Install EGL or OSMesa for offscreen rendering: apt-get install libosmesa6-dev"
-                )
+                raise RuntimeError(no_gl_context_message())
             if camera_name in FREE_CAMERA_TOKENS:
                 cam_id = -1
             else:
@@ -2173,6 +2194,13 @@ class RenderingMixin:
             _max_warmup_attempts = 30
             _cold_std_threshold = 5.0
             _warm: dict[str, bool] = dict.fromkeys(names, False)
+            # A render can come back as a structured ERROR RESULT rather than a
+            # frame ("Rendering unavailable (no OpenGL context)"). That is not a
+            # cold context that will settle with more attempts, and because it is
+            # a returned dict and not a raised exception, the ``except`` branch
+            # below never sees it: without this capture the reason is lost at
+            # every log level and the operator is told the camera is merely cold.
+            _refusals: dict[str, str] = {}
             for _attempt in range(_max_warmup_attempts):
                 if all(_warm.values()):
                     break
@@ -2186,6 +2214,14 @@ class RenderingMixin:
                         logger.debug("recorder thread warmup render failed for %s: %s", cam, e)
                         continue
                     if arr is None:
+                        if isinstance(r, dict) and r.get("status") == "error":
+                            # The narrowest superset the read can raise: a
+                            # missing key, an empty content list, and a
+                            # non-subscriptable content or block.
+                            try:
+                                _refusals[cam] = str(r["content"][0]["text"])
+                            except (IndexError, KeyError, TypeError):
+                                _refusals[cam] = "render returned an error result with no text"
                         continue
                     # arr.std(axis=0) is per-column std-dev; .mean()
                     # collapses to a scalar. Cold gradients have
@@ -2201,13 +2237,31 @@ class RenderingMixin:
                         )
             if not all(_warm.values()):
                 cold = [c for c, w in _warm.items() if not w]
-                logger.warning(
-                    "recorder thread warmup: %d cameras still cold after %d attempts: %s. "
-                    "First captured frames may show gradient artifact.",
-                    len(cold),
-                    _max_warmup_attempts,
-                    cold,
-                )
+                refused = {c: _refusals[c] for c in cold if c in _refusals}
+                if refused:
+                    # Rendering REFUSED, so "cold" would be a lie: no number of
+                    # attempts fixes a missing GL context, every capture will be
+                    # empty, and stop_cameras_recording would otherwise report
+                    # success with 0 frames and an empty MP4 - the failure the
+                    # preflight guards exist to make impossible.
+                    state["refusals"] = refused
+                    logger.warning(
+                        "recorder thread warmup: rendering REFUSED for %d of %d cameras: %s. "
+                        "This is not a cold context that settles - every captured frame will be "
+                        "empty. First reason: %s",
+                        len(refused),
+                        len(names),
+                        list(refused),
+                        next(iter(refused.values())),
+                    )
+                if [c for c in cold if c not in refused]:
+                    logger.warning(
+                        "recorder thread warmup: %d cameras still cold after %d attempts: %s. "
+                        "First captured frames may show gradient artifact.",
+                        len([c for c in cold if c not in refused]),
+                        _max_warmup_attempts,
+                        [c for c in cold if c not in refused],
+                    )
 
             # Warmup done (or capped) - capture loop is about to run. Unblock
             # the caller waiting in start_cameras_recording so the success
@@ -2392,6 +2446,14 @@ class RenderingMixin:
                 artifact["frames_skipped_size_mismatch"] = frames_skipped
             if flush_error:
                 artifact["flush_error"] = flush_error
+            # A render refusal caught during warmup is WHY this camera has no
+            # frames. Without it the caller sees frames=0 next to status
+            # "success" and has to guess between an empty scene, a too-short
+            # window and a machine that cannot render at all.
+            refusal = (state.get("refusals") or {}).get(cam)
+            if refusal:
+                artifact["render_refused"] = refusal
+                lines.append(f"   {cam:20s} rendering refused: {refusal}")
             artifacts.append(artifact)
 
         return {

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -62,6 +62,7 @@ _EXPECTED_FUNCTIONS = {
     "backend.py::capture_stderr_fd",
     "backend.py::filter_mujoco_attach_noise",
     "backend.py::mj_name_to_id",
+    "rendering.py::no_gl_context_message",
     "scene_ops.py::actuate_robot_in_scene",
     "scene_ops.py::actuator_driven_joint_ids",
     "scene_ops.py::actuator_joint_id",

--- a/tests/simulation/mujoco/test_recorder_warmup_refusal_is_not_coldness.py
+++ b/tests/simulation/mujoco/test_recorder_warmup_refusal_is_not_coldness.py
@@ -1,0 +1,237 @@
+"""A render the renderer REFUSED is not a camera that is merely "cold".
+
+The recorder thread warms each camera's GL context before the timing loop, and
+until now it had one verdict for every camera that never produced usable
+output: still cold after 30 attempts, first frames may show gradient artifact.
+That reads as a context that has not settled yet.
+
+A render can instead come back as a structured ERROR RESULT - the
+``status="error"`` envelope :meth:`render` returns when ``_get_renderer`` yields
+no renderer at all. Two things follow, and both were invisible:
+
+* No number of attempts fixes a missing GL context, so "cold" is not a slower
+  version of the same story - every captured frame will be empty.
+* Because the refusal is a *returned dict* and not a raised exception, the
+  warmup loop's ``except`` branch never sees it, so the reason was dropped at
+  every log level and the recording finished as ``status="success"`` with zero
+  frames, an empty MP4, and nothing in the artifact saying why.
+
+These tests drive the real daemon recorder. ``start_cameras_recording`` waits on
+``state["ready"]``, which ``_loop`` sets only after warmup finishes, so the call
+returning IS the synchronisation point: no sleeps and no thread patching, and
+every assertion below reads state the warmup has already written.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import numpy as np  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from strands_robots.simulation.mujoco.simulation import MuJoCoSimEngine  # noqa: E402
+
+_LOGGER = "strands_robots.simulation.mujoco.rendering"
+
+
+@pytest.fixture
+def sim():
+    s = MuJoCoSimEngine(tool_name="warmup_refusal_test", mesh=False)
+    s.create_world()
+    s.add_camera(name="cam_a", position=[0.6, -0.5, 0.4], target=[0.0, 0.0, 0.1])
+    s.add_camera(name="cam_b", position=[-0.6, 0.5, 0.4], target=[0.0, 0.0, 0.1])
+    yield s
+    try:
+        s.stop_cameras_recording()
+    finally:
+        s.cleanup()
+
+
+def _png(arr: np.ndarray) -> bytes:
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+#: A frame with real per-column variance: ``arr.std(axis=0).mean()`` well over
+#: the warmup's 5.0 threshold, so the camera reports warm on the first attempt.
+_WARM_PNG = _png(np.concatenate([np.full((12, 32, 3), 255, np.uint8), np.zeros((12, 32, 3), np.uint8)]))
+#: A uniform frame: per-column std-dev is exactly 0, which is what "cold" means
+#: here - a real frame that carries no geometry yet.
+_COLD_PNG = _png(np.full((24, 32, 3), 128, np.uint8))
+
+
+def _frame(png: bytes) -> dict:
+    return {
+        "status": "success",
+        "content": [{"image": {"format": "png", "source": {"bytes": png, "media_type": "image/png"}}}],
+    }
+
+
+def _refusal(text: str = "Rendering unavailable (no OpenGL context). Install EGL or OSMesa") -> dict:
+    """What :meth:`render` returns when ``_get_renderer`` yields no renderer."""
+    return {"status": "error", "content": [{"text": text}]}
+
+
+def _record(sim, tmp_path, per_camera: dict[str, dict], cameras: list[str], caplog):
+    """Run one real recording whose renders are dictated by ``per_camera``.
+
+    Returns ``(warnings, stop_result)``. ``caplog`` is cleared after
+    ``start_cameras_recording`` returns so the unrelated "not ready" notice
+    cannot be mistaken for a warmup verdict.
+    """
+
+    def stub_render(camera_name, width=None, height=None, **kwargs):
+        return per_camera[camera_name]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        sim.render = stub_render  # type: ignore[method-assign]
+        started = sim.start_cameras_recording(cameras=cameras, output_dir=str(tmp_path), fps=10, width=32, height=24)
+        assert started["status"] == "success", started
+        warnings = [r.getMessage() for r in caplog.records if r.name == _LOGGER]
+        stopped = sim.stop_cameras_recording()
+    return warnings, stopped
+
+
+def _artifacts(stopped: dict) -> dict[str, dict]:
+    payload = next(b["json"] for b in stopped["content"] if "json" in b)
+    return {a["camera"]: a for a in payload["artifacts"]}
+
+
+class TestARefusalIsNotColdness:
+    """The warmup verdict has to name the failure the operator actually has."""
+
+    def test_a_refused_render_is_reported_as_refused_not_as_a_cold_camera(self, sim, tmp_path, caplog):
+        """The headline: 30 attempts against a missing GL context are not warmup.
+
+        Reporting this as "cold" tells the operator to wait for something that
+        will never settle, and its suggested consequence - a gradient artifact
+        on the first frames - understates a recording in which every frame is
+        missing.
+        """
+        warnings, _ = _record(sim, tmp_path, {"cam_a": _refusal()}, ["cam_a"], caplog)
+
+        assert any("REFUSED" in w for w in warnings), (
+            f"a refused render was not reported as a refusal; warmup said: {warnings}"
+        )
+        assert not any("still cold after" in w for w in warnings), (
+            f"a refused render was reported as a camera that is merely cold: {warnings}"
+        )
+
+    def test_the_refusal_reason_reaches_the_operator(self, sim, tmp_path, caplog):
+        """The renderer already said why; the warmup loop has to carry it."""
+        warnings, _ = _record(sim, tmp_path, {"cam_a": _refusal()}, ["cam_a"], caplog)
+
+        assert any("no OpenGL context" in w for w in warnings), f"the reason the renderer gave was dropped: {warnings}"
+
+    def test_the_warning_says_the_frames_will_be_empty_not_merely_degraded(self, sim, tmp_path, caplog):
+        warnings, _ = _record(sim, tmp_path, {"cam_a": _refusal()}, ["cam_a"], caplog)
+
+        refused = [w for w in warnings if "REFUSED" in w]
+        assert refused, warnings
+        assert "empty" in refused[0]
+        assert "gradient artifact" not in refused[0]
+
+    def test_the_artifact_names_why_the_camera_has_no_frames(self, sim, tmp_path, caplog):
+        """``frames: 0`` beside ``status: success`` is not a diagnosis.
+
+        Without the reason the caller has to guess between an empty scene, a
+        window too short to catch a frame, and a machine that cannot render at
+        all - and only the last one is worth acting on.
+        """
+        _, stopped = _record(sim, tmp_path, {"cam_a": _refusal()}, ["cam_a"], caplog)
+
+        artifact = _artifacts(stopped)["cam_a"]
+        assert artifact["frames"] == 0, artifact
+        assert "no OpenGL context" in artifact.get("render_refused", ""), artifact
+        text = next(b["text"] for b in stopped["content"] if "text" in b)
+        assert "rendering refused" in text
+
+    def test_a_mixed_batch_separates_the_refused_from_the_cold(self, sim, tmp_path, caplog):
+        """Two cameras, two different failures, two different verdicts.
+
+        A single "cold" line covering both would hide the one that cannot be
+        waited out behind the one that can.
+        """
+        warnings, stopped = _record(
+            sim,
+            tmp_path,
+            {"cam_a": _refusal(), "cam_b": _frame(_COLD_PNG)},
+            ["cam_a", "cam_b"],
+            caplog,
+        )
+
+        refused = [w for w in warnings if "REFUSED" in w]
+        cold = [w for w in warnings if "still cold after" in w]
+        assert len(refused) == 1, warnings
+        assert len(cold) == 1, warnings
+        assert "cam_a" in refused[0] and "cam_b" not in refused[0]
+        assert "cam_b" in cold[0] and "cam_a" not in cold[0]
+        # Only the refused camera carries a reason; the cold one has none to give.
+        arts = _artifacts(stopped)
+        assert "render_refused" in arts["cam_a"]
+        assert "render_refused" not in arts["cam_b"]
+
+    def test_an_error_result_with_no_readable_text_still_records_a_placeholder(self, sim, tmp_path, caplog):
+        """A refusal whose envelope carries no text must not lose the fact of it.
+
+        The reason is read out of a caller-shaped dict, so the read can fail on
+        a missing key, an empty content list or a non-subscriptable block. That
+        must not cost the recorder thread, and it must not silently downgrade
+        the camera back to "cold".
+        """
+        warnings, stopped = _record(sim, tmp_path, {"cam_a": {"status": "error", "content": []}}, ["cam_a"], caplog)
+
+        assert any("REFUSED" in w for w in warnings), warnings
+        assert not any("still cold after" in w for w in warnings), warnings
+        assert _artifacts(stopped)["cam_a"]["render_refused"]
+
+
+class TestTheColdPathIsUnchanged:
+    """Cold is still a real state, and it still reads the way it always did."""
+
+    def test_a_genuinely_cold_camera_is_still_reported_as_cold(self, sim, tmp_path, caplog):
+        """A frame that arrives but carries no geometry is the original case.
+
+        This is what fails if the two paths are ever collapsed into one: a
+        camera that really is warming up must not be told its renders were
+        refused, because waiting is exactly the right thing for it.
+        """
+        warnings, stopped = _record(sim, tmp_path, {"cam_a": _frame(_COLD_PNG)}, ["cam_a"], caplog)
+
+        assert any("still cold after" in w for w in warnings), warnings
+        assert any("gradient artifact" in w for w in warnings), warnings
+        assert not any("REFUSED" in w for w in warnings), warnings
+        assert "render_refused" not in _artifacts(stopped)["cam_a"]
+
+    def test_a_camera_that_warms_reports_neither(self, sim, tmp_path, caplog):
+        warnings, stopped = _record(sim, tmp_path, {"cam_a": _frame(_WARM_PNG)}, ["cam_a"], caplog)
+
+        assert not any("still cold after" in w for w in warnings), warnings
+        assert not any("REFUSED" in w for w in warnings), warnings
+        assert "render_refused" not in _artifacts(stopped)["cam_a"]
+
+    def test_the_synchronous_path_flushes_without_a_refusals_key(self, sim, tmp_path):
+        """Only the daemon recorder warms up, so only it can record a refusal.
+
+        ``start_cameras_recording_synchronous`` renders on the caller's thread
+        and has no warmup loop, so its state never carries the key at all - the
+        shared flush has to read it as absent rather than assume it is there.
+        """
+        sim.render = lambda camera_name, width=None, height=None, **kw: _frame(_WARM_PNG)  # type: ignore[method-assign]
+        started = sim.start_cameras_recording_synchronous(
+            cameras=["cam_a"], output_dir=str(tmp_path), fps=10, width=32, height=24
+        )
+        assert started["status"] == "success", started
+        handles = next(b["json"] for b in started["content"] if "json" in b)
+        handles["on_frame"](0, {}, {})
+        stopped = handles["finalize"]()
+
+        assert stopped["status"] == "success", stopped
+        assert "refusals" not in (sim._cams_rec_state or {})
+        assert "render_refused" not in _artifacts(stopped)["cam_a"]

--- a/tests/simulation/mujoco/test_render_no_gl_context_message.py
+++ b/tests/simulation/mujoco/test_render_no_gl_context_message.py
@@ -208,3 +208,74 @@ def test_every_renderer_consumer_has_a_pinned_no_gl_channel():
         f"stale={sorted(set(_NO_GL_CHANNEL) - consumers)}. "
         "Decide what the new consumer does without a GL context, pin it, and record it here."
     )
+
+
+# ---------------------------------------------------------------------------
+# The advice has to be true on the host that is reading it
+# ---------------------------------------------------------------------------
+
+
+class TestTheFixIsPlatformCorrect:
+    """``apt-get install libosmesa6-dev`` is right on Linux and false on macOS.
+
+    macOS ships neither EGL nor OSMesa (MuJoCo renders through CGL there), so
+    the old single-sentence advice sent a Mac operator to install a package that
+    does not exist for their machine - and while they chased it, the real cause
+    kept its cover. This pins both halves: Linux keeps the packages, darwin gets
+    a cause it can actually act on.
+
+    ``platform=`` is injected rather than read from the host, so both halves are
+    graded on every runner - nothing here skips on a Linux CI box.
+    """
+
+    def test_linux_keeps_the_package_advice(self):
+        text = rendering.no_gl_context_message(platform="linux")
+        assert "apt-get install libosmesa6-dev" in text
+        assert "macOS" not in text
+
+    def test_macos_is_not_told_to_apt_get(self):
+        text = rendering.no_gl_context_message(platform="darwin")
+        assert "apt-get" not in text, "there is no apt on macOS"
+        assert "CGL" in text, "name the API that actually renders there"
+        assert "launchd" in text, "the daemon-with-no-window-server case is the common one"
+
+    def test_macos_names_the_lost_context_case_no_install_can_fix(self):
+        """A context that worked and then vanished is not a missing install.
+
+        The two macOS causes need opposite actions: no window-server session is
+        fixed by where the process is started from, a context that worked
+        EARLIER in this same process is fixed by starting a fresh one. Naming
+        only the first sends the second case chasing a session it already had.
+        """
+        text = rendering.no_gl_context_message(platform="darwin")
+        assert "EARLIER" in text and "fresh process" in text
+
+    def test_both_platforms_stay_within_the_shared_contract(self):
+        for plat in ("linux", "darwin", "win32"):
+            for depth in (False, True):
+                text = rendering.no_gl_context_message(depth=depth, platform=plat)
+                assert text == text.strip()
+                assert "OpenGL" in text
+                # The existing consumers' assertions: EGL/OSMesa is named either
+                # as the fix (Linux) or as the thing that does not exist (macOS).
+                assert ("EGL" in text) or ("OSMesa" in text)
+                head = "Depth rendering unavailable" if depth else "Rendering unavailable"
+                assert text.startswith(head)
+
+    def test_the_running_platform_is_the_default(self):
+        """Every consumer calls the helper with no ``platform=``.
+
+        The injected argument exists for the tests; the shipped call sites pass
+        nothing, so the default has to be the host actually reading the message.
+        """
+        import sys
+
+        assert rendering.no_gl_context_message() == rendering.no_gl_context_message(platform=sys.platform)
+
+    def test_every_consumer_goes_through_the_helper(self):
+        """No consumer may keep its own hardcoded sentence and drift."""
+        src = inspect.getsource(rendering)
+        assert src.count("apt-get install libosmesa6-dev") == 1, (
+            "the Linux advice lives in no_gl_context_message and nowhere else"
+        )
+        assert src.count("no_gl_context_message(") >= 4  # def + 3 call sites


### PR DESCRIPTION
## Problem

Two reporting defects on the same path: the renderer could not build a GL context.

**1. The advice was one sentence for every host.** `render`, `render_depth` and `get_frame` each carried their own copy of *"Install EGL or OSMesa for offscreen rendering: apt-get install libosmesa6-dev"*. macOS has neither EGL nor OSMesa - MuJoCo renders through CGL there, and there is no apt - so a Mac operator was sent to install a package that does not exist for their machine, and while they chased it the real cause kept its cover. Measured by asking the same tree twice with `sys.platform` set each way:

| `sys.platform` | text `render` returns on `upstream/main` |
|---|---|
| `linux` | `Rendering unavailable (no OpenGL context). Install EGL or OSMesa ... apt-get install libosmesa6-dev` |
| `darwin` | byte-identical |

The platform is never consulted. The real macOS cause is that a CGL context needs a window-server session, which a process started by launchd, cron or a bare ssh login does not have; and a context that worked EARLIER in the same process was lost rather than missing, which a fresh process fixes and an install does not.

**2. A refusal was reported as coldness.** The recorder thread warms each camera before the timing loop and had one verdict for every camera that never produced usable output. A render can instead come back as a structured error RESULT rather than a frame - and because that is a *returned dict* and not a raised exception, the warmup loop's `except` branch never sees it, so the reason was dropped at every log level. Measured end to end by making `_get_renderer` return `None` for one real recording:

| | `upstream/main` | this branch |
|---|---|---|
| warmup verdict | `1 cameras still cold after 30 attempts ... First captured frames may show gradient artifact.` | `rendering REFUSED for 1 of 1 cameras ... This is not a cold context that settles - every captured frame will be empty. First reason: Rendering unavailable (no OpenGL context) ...` |
| artifact keys | `camera, errors, frames, path, size_kb` | the same **plus `render_refused`** |
| reason recorded anywhere | no | log and artifact |

No number of attempts fixes a missing GL context, so "cold" is not a slower version of the same story, and its stated consequence - a gradient artifact on the first frames - understates a recording in which *every* frame is missing. The recording reported `status="success"` with 0 frames and no MP4, and the artifact said only `errors: 12`, which does not say why.

## Change

`no_gl_context_message(*, depth=False, platform=None)` becomes the one owner of the sentence and answers for the host reading it: darwin gets CGL, the window-server session and the lost-context case; every other platform keeps the package advice, which on Linux is exactly right. The three inline copies in `render`, `render_depth` and `get_frame` now call it, so `apt-get install libosmesa6-dev` appears once in the module.

The warmup loop captures the refusal per camera in a `_refusals` map, and the verdict splits: refused cameras are reported as refused, genuinely cold ones keep the message they always had, and a batch containing both gets both lines. The reason travels into `state["refusals"]` and out through the artifact as `render_refused` plus a line in the result text, so `frames: 0` arrives with its cause attached.

`platform=` is injected rather than read from the host, so both halves are graded on every runner - nothing in the new tests skips on a Linux CI box.

**What this does not change:** a host that cannot render still cannot record. `status` is still `success` and `frames` is still `0` in both columns. What changes is that the operator learns why, instead of being told to wait for a context that will never settle.

## Deviations from the source of the two commits

Three, each deliberate:

- The helper's docstring stated the mechanism in terms of a specific deployment; rewritten to state the mechanism itself, with `Args:`/`Returns:`.
- The refusal-text read was wrapped in `except Exception`. AGENTS.md forbids that for a non-recovery path and asks for the smallest superset, so I enumerated what the read can actually raise - a missing key, an empty content list, and a non-subscriptable content or block - and narrowed it to `(IndexError, KeyError, TypeError)`.
- One test named an internal tracking id; renamed for the behaviour it pins.

`import sys as _sys` stays at function scope because that is the one pre-existing spelling in this same module (`rendering.py:1273` on `main`); hoisting it would leave the file with two conventions.

## Scope

`backend.py` names `libosmesa6-dev` twice more and is deliberately untouched: both sites sit behind `_is_headless()`, which returns `False` on macOS by design - its own docstring says the EGL/OSMesa fallback is Linux-specific - so neither is reachable on the host this fixes.

`render_refused` is added to the artifact without a docstring entry because its two sibling optional keys, `frames_skipped_size_mismatch` and `flush_error`, are equally undocumented there; documenting one of three would be the odd one out.

## Tests

`tests/simulation/mujoco/test_recorder_warmup_refusal_is_not_coldness.py` is new - there was no test for the refusal path anywhere. It drives the real daemon recorder: `start_cameras_recording` waits on `state["ready"]`, which `_loop` sets only after warmup finishes, so the call returning IS the synchronisation point. No sleeps and no thread patching.

`TestTheFixIsPlatformCorrect` joins the existing `test_render_no_gl_context_message.py`, whose module docstring already pins the four renderer consumers and their channels.

Pre-fix, both files copied onto `upstream/main`: **12 failed / 10 passed**. Six failures are behavioural in the refusal file, each quoting the real message:

```
AssertionError: a refused render was reported as a camera that is merely cold:
["recorder thread warmup: 1 cameras still cold after 30 attempts: ['cam_a'].
  First captured frames may show gradient artifact."]
```

A seventh is behavioural in the platform file (`the Linux advice lives in no_gl_context_message and nowhere else` - it counts two copies on `main`). The remaining five can only report that the helper does not exist yet, so they pin the contract rather than the regression.

The 10 that pass on both trees are the controls. Three matter most, and each fails for a specific wrong fix:

- a genuinely cold camera is still reported as cold, with `gradient artifact` and no `REFUSED` - fails if the two paths are ever collapsed into one
- a camera that warms reports neither
- the synchronous recorder, which has no warmup loop and so never carries the key, still flushes - pins that the shared flush reads `refusals` as absent rather than assuming it

## Verification

Measured at `18bc0cf6`, against `upstream/main` at `71735507`, on one host with `MUJOCO_GL=egl`.

**Control - a recording on a host that CAN render**, driven with real GL through the same code: 19 frames captured, 45.7 KB MP4, and **19 frames decoded back out of the file** on both trees. Normal recording is untouched.

**Gate.** 268 test files - the mujoco suite, every test naming the changed symbols, and the repo-wide docstring / string / changelog guards - run on both trees with the identical selection, the new file excluded so any difference is the source change alone:

| tree | failed | passed | skipped |
|---|---|---|---|
| this branch | 0 | 7405 | 52 |
| `upstream/main` | 0 | 7399 | 52 |

Branch-only failures: none. The `+6` is exactly the six tests in `TestTheFixIsPlatformCorrect`; the new refusal file's own 9 tests pass separately.

`ruff check` and `ruff format --check` clean. `mypy strands_robots tests tests_integ`: 24 errors on the branch and 24 on `upstream/main`, identical sets, none in the changed files. The two `py/empty-except` sites an AST pre-flight reports in `rendering.py` are byte-identical on `main` and none of the eight hunks here is near them.

`rendering.py::no_gl_context_message` is registered in the mujoco public-member inventory, which is what a new public module-level function is required to do.

![no-GL render refusal vs coldness](https://raw.githubusercontent.com/cagataycali/robots/media-render-refusal-not-coldness/refusal-not-coldness.png)

The figure is three measurements from one script run against each tree: the control recording with its decoded frames, the same recording on a GL-free host, and the advice each tree gives a Mac. Both columns run identical package code except `rendering.py`.
