### PR TITLE
docs(policies/curobo): number every rung the joint-space dispatch probes

### DIFF
--- a/changelog.d/2607-curobo-joint-space-ladder.md
+++ b/changelog.d/2607-curobo-joint-space-ladder.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **policies/curobo**: the documented joint-space dispatch ladder now numbers a rung
+  per planner entry point, in the order `_plan_and_cache` probes them. It numbered two
+  rungs for a ladder of three and folded the other probes into the first rung's
+  parenthetical, so `plan_single_js` read as both rung one's second probe and rung
+  two's subject, and `plan_single` - the entry point the code actually ends on - was
+  numbered nowhere. A reader sizing a stub planner from the list was told a planner
+  exposing only `plan_single` has no joint-space path, when it is the rung that plans
+  the goal. The Cartesian ladder in the same docstring already numbered exactly the two
+  entry points it probes, and the joint-space branch's own comment already stated the
+  fallback condition correctly, so no behaviour changes: the probe order and every
+  dispatch outcome are identical. Both ladders are now graded against the AST rather
+  than against other prose - a rung per entry point in probe order, one entry point per
+  rung - and the last resort is driven through the real dispatch for the first time.

--- a/strands_robots/policies/curobo/policy.py
+++ b/strands_robots/policies/curobo/policy.py
@@ -685,10 +685,14 @@ class CuroboPolicy(Policy):
         Dispatch order for joint-space goals:
 
         1. New API: ``MotionPlanner.plan_js(JointState, JointState)``
-           (or any other goal-aware joint-space entry point cuRobo
-           lands; we probe ``plan_js`` first, then ``plan_single_js``,
-           then ``plan_single`` as a last resort).
-        2. Legacy / stub API: ``plan_single_js(JointState, JointState)``.
+        2. Legacy / stub API: ``plan_single_js(JointState, JointState)``
+        3. Last resort: ``plan_single(JointState, JointState)`` - a planner
+           exposing neither joint-space entry point still plans a joint-space
+           goal through its Cartesian-shaped entry point.
+
+        Both joint-space names exist because cuRobo renamed that entry point
+        between its legacy and ``main`` surfaces, so a planner is free to
+        expose either one and the first it has is the one used.
         """
         # Refresh the collision scene if requested.
         if world_update is not None:

--- a/tests/policies/curobo/test_dispatch_ladder_is_documented_in_probe_order.py
+++ b/tests/policies/curobo/test_dispatch_ladder_is_documented_in_probe_order.py
@@ -1,0 +1,241 @@
+"""The documented dispatch ladders name the entry points, in the order probed.
+
+``CuroboPolicy._plan_and_cache`` probes several planner entry points per goal
+type and takes the first one the planner exposes, because cuRobo renamed them
+between the legacy ``MotionGen`` surface and the ``main`` ``MotionPlanner``
+surface. Its docstring publishes that ladder as a numbered list, and a reader
+sizing a stub planner - or a maintainer adding a fourth entry point - works
+from the list rather than from the ``getattr`` chain.
+
+Two properties keep the list usable, and both are graded against the code
+rather than against other prose:
+
+* **Same rungs, same order.** The numbered list is the probe order, so a rung
+  the code tries is a rung the list numbers.
+* **One rung, one entry point.** A rung that also names the entry points below
+  it collapses the ladder into itself: the same name then reads as both this
+  rung's probe and the next rung's subject, and the count of rungs stops
+  matching the count of things tried.
+
+The joint-space ladder failed both: it numbered two rungs for a ladder of
+three, and its first rung named all three in a parenthetical while its second
+rung named the middle one again. The Cartesian ladder in the same docstring
+numbered exactly the two entry points it probes, which is why the pair is
+graded together - the passing half shows the rule is the file's own convention.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import re
+import textwrap
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.curobo import policy as curobo_policy
+from strands_robots.policies.curobo.policy import CuroboPolicy
+
+from .test_policy import _StubMotionGen, _StubMotionGenResult
+
+#: Heading of each documented ladder, and the branch of the goal-type ``if``
+#: whose probes it describes. ``"body"`` is the Cartesian branch (the ``if``
+#: suite), ``"orelse"`` the joint-space one.
+_LADDERS: tuple[tuple[str, str], ...] = (
+    ("Dispatch order for Cartesian goals:", "body"),
+    ("Dispatch order for joint-space goals:", "orelse"),
+)
+
+#: ``_LADDERS`` as parametrize cases, named for the goal type they describe.
+_LADDER_CASES = [
+    pytest.param(heading, branch, id="cartesian" if branch == "body" else "joint-space") for heading, branch in _LADDERS
+]
+
+#: A ladder names at least this many rungs. Without a floor, a docstring
+#: reflow that hides the numbered lists would satisfy every rule below by
+#: grading nothing.
+_MINIMUM_RUNGS = 2
+
+
+def _plan_and_cache_ast() -> ast.FunctionDef:
+    """Return the parsed ``_plan_and_cache`` definition."""
+    src = textwrap.dedent(inspect.getsource(CuroboPolicy._plan_and_cache))
+    node = ast.parse(src).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    return node
+
+
+def _goal_type_branch(which: str) -> list[ast.stmt]:
+    """Return the statements of one branch of the goal-type dispatch ``if``."""
+    for node in ast.walk(_plan_and_cache_ast()):
+        if isinstance(node, ast.If) and "target_pose is not None" in ast.unparse(node.test):
+            return node.body if which == "body" else node.orelse
+    raise AssertionError("the goal-type dispatch 'if' is no longer recognisable")
+
+
+def _probe_order(statements: list[ast.stmt]) -> list[str]:
+    """Planner entry points *statements* reaches for, in source order.
+
+    Both spellings count: the ``getattr(self._motion_planner, "name", None)``
+    probe that asks whether an entry point exists, and the
+    ``self._motion_planner.name(...)`` call that reaches for one directly.
+    """
+    found: list[tuple[int, int, str]] = []
+    seen: set[str] = set()
+    for statement in statements:
+        for node in ast.walk(statement):
+            name: str | None = None
+            # ``ast.walk`` yields ``ast.AST``; the position is read off the
+            # narrowed expression so the type checker can see it carries one.
+            located: ast.expr | None = None
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr":
+                probed = node.args[1] if len(node.args) >= 2 else None
+                if (
+                    isinstance(probed, ast.Constant)
+                    and isinstance(probed.value, str)
+                    and "_motion_planner" in ast.unparse(node.args[0])
+                ):
+                    name = probed.value
+                    located = node
+            elif isinstance(node, ast.Attribute) and "_motion_planner" in ast.unparse(node.value):
+                name = node.attr
+                located = node
+            if name is not None and located is not None and name not in seen:
+                seen.add(name)
+                found.append((located.lineno, located.col_offset, name))
+    return [name for _line, _col, name in sorted(found)]
+
+
+def _rung_texts(heading: str) -> list[str]:
+    """Return each numbered rung under *heading* as one whitespace-normalised line."""
+    doc = inspect.getdoc(CuroboPolicy._plan_and_cache) or ""
+    lines = doc.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == heading)
+    except StopIteration:
+        raise AssertionError(f"the docstring no longer carries the heading {heading!r}") from None
+
+    rungs: list[list[str]] = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.match(r"^\d+\.\s", stripped):
+            rungs.append([stripped])
+        elif rungs and line[:1].isspace():
+            # An indented line continues the rung above it.
+            rungs[-1].append(stripped)
+        else:
+            # A new heading, an ``Args:`` block, or unindented prose: the
+            # numbered list is over.
+            break
+    return [" ".join(parts) for parts in rungs]
+
+
+def _entry_points_named(rung: str) -> list[str]:
+    """Entry-point names a rung's text carries, in order, deduplicated.
+
+    A rung writes its subject as a double-backticked reference, optionally
+    qualified (``MotionPlanner.plan_js``) and optionally with the signature
+    (``plan_js(JointState, JointState)``); only the callable name matters here.
+    """
+    names: list[str] = []
+    for raw in re.findall(r"``([A-Za-z_][\w.]*)(?:\([^`]*\))?``", rung):
+        name = raw.split(".")[-1]
+        if name.startswith("plan_") and name not in names:
+            names.append(name)
+    return names
+
+
+def _documented_order(heading: str) -> list[str]:
+    """The entry point each numbered rung under *heading* names, in rung order."""
+    order: list[str] = []
+    for rung in _rung_texts(heading):
+        named = _entry_points_named(rung)
+        if named:
+            order.append(named[0])
+    return order
+
+
+class TestTheLadderIsDocumentedInProbeOrder:
+    @pytest.mark.parametrize(("heading", "branch"), _LADDER_CASES)
+    def test_the_numbered_rungs_are_the_entry_points_the_code_probes(self, heading: str, branch: str) -> None:
+        """Every entry point the branch probes is numbered, in probe order."""
+        probed = _probe_order(_goal_type_branch(branch))
+        documented = _documented_order(heading)
+        assert probed, f"premise: no planner entry point found for {heading!r}"
+        assert documented == probed, (
+            f"{heading!r} numbers {len(documented)} rung(s) {documented} for a ladder of "
+            f"{len(probed)}: the code probes {probed}. A reader sizing a stub planner from "
+            "the numbered list is told the entry points it does not name are unsupported."
+        )
+
+    @pytest.mark.parametrize(("heading", "branch"), _LADDER_CASES)
+    def test_a_rung_names_one_entry_point(self, heading: str, branch: str) -> None:
+        """No rung describes the probes belonging to the rungs below it."""
+        offenders = {rung: named for rung in _rung_texts(heading) if len(named := _entry_points_named(rung)) > 1}
+        assert not offenders, (
+            f"{heading!r} has a rung naming several entry points, so the same name reads as "
+            f"both this rung's probe and another rung's subject: {offenders}"
+        )
+
+
+class TestEveryDocumentedRungPlansAJointSpaceGoal:
+    """Drive each rung of the joint-space ladder through the real dispatch.
+
+    Rungs one and two are pinned elsewhere by the new-API and legacy stubs;
+    the last resort - a planner exposing neither joint-space entry point -
+    had no test, which is how it came to be absent from the numbered list.
+    """
+
+    @staticmethod
+    def _plan(planner: Any) -> str:
+        policy = CuroboPolicy(motion_gen=planner, action_horizon=4)
+        asyncio.run(
+            policy.get_actions(
+                {"observation.state": [0.0, 0.0, 0.0]},
+                "",
+                target_joints={"j0": 0.5, "j1": -0.3, "j2": 0.2},
+            )
+        )
+        assert planner.plan_calls, "the planner was never reached"
+        return str(planner.plan_calls[0][0])
+
+    def test_a_planner_exposing_plan_js_uses_it(self) -> None:
+        class _WithPlanJs(_StubMotionGen):
+            def plan_js(self, start_state: object, goal: object) -> _StubMotionGenResult:
+                self.plan_calls.append(("plan_js", start_state, goal))
+                return _StubMotionGenResult(ndof=self.ndof, horizon=self.horizon, success=True, status="ok")
+
+        landed = self._plan(_WithPlanJs(ndof=3, horizon=4))
+        assert landed == "plan_js"
+
+    def test_a_planner_exposing_only_plan_single_js_uses_it(self) -> None:
+        landed = self._plan(_StubMotionGen(ndof=3, horizon=4))
+        assert landed == "plan_single_js"
+
+    def test_a_planner_exposing_neither_joint_space_entry_point_uses_plan_single(self) -> None:
+        """The last resort: the Cartesian-shaped legacy entry point still plans."""
+
+        class _OnlyPlanSingle(_StubMotionGen):
+            plan_single_js = None  # type: ignore[assignment]
+
+        landed = self._plan(_OnlyPlanSingle(ndof=3, horizon=4))
+        assert landed == "plan_single"
+
+
+class TestTheScanIsNotVacuous:
+    def test_every_ladder_names_rungs(self) -> None:
+        for heading, _branch in _LADDERS:
+            rungs = _rung_texts(heading)
+            assert len(rungs) >= _MINIMUM_RUNGS, f"{heading!r} yielded {len(rungs)} rung(s): {rungs}"
+
+    def test_every_ladder_probes_entry_points(self) -> None:
+        for _heading, branch in _LADDERS:
+            probed = _probe_order(_goal_type_branch(branch))
+            assert len(probed) >= _MINIMUM_RUNGS, f"branch {branch!r} probes {probed}"
+
+    def test_the_policy_module_is_the_one_under_test(self) -> None:
+        assert curobo_policy.CuroboPolicy is CuroboPolicy


### PR DESCRIPTION
## Problem

`CuroboPolicy._plan_and_cache` takes the first planner entry point a planner exposes, because cuRobo renamed those entry points between its legacy `MotionGen` surface and the `main` `MotionPlanner` surface. For a joint-space goal it probes three of them:

```python
plan_js_fn = getattr(self._motion_planner, "plan_js", None) or getattr(
    self._motion_planner, "plan_single_js", None
)
if plan_js_fn is not None:
    result = plan_js_fn(start_state, goal_js)
else:
    result = self._motion_planner.plan_single(start_state, goal_js)
```

Its docstring published that ladder as **two** numbered rungs, and folded the other two probes into the first rung's parenthetical:

```
1. New API: ``MotionPlanner.plan_js(JointState, JointState)``
   (or any other goal-aware joint-space entry point cuRobo
   lands; we probe ``plan_js`` first, then ``plan_single_js``,
   then ``plan_single`` as a last resort).
2. Legacy / stub API: ``plan_single_js(JointState, JointState)``.
```

So the list disagreed with itself and with the code in two ways. `plan_single_js` was named both as rung one's second probe and as rung two's subject, which collapses the ladder into itself - the count of rungs stopped matching the count of things tried. And `plan_single`, the rung the code actually ends on, was numbered nowhere: a reader sizing a stub planner from the numbered list is told a planner exposing only `plan_single` has no joint-space path at all, when it is in fact the rung that plans the goal.

Three pieces of in-file evidence say the code is the correct half:

- The **Cartesian** ladder eight lines above numbers exactly the two entry points it probes (`plan_pose`, then `plan_single`) - the same rule, already met by the sibling ladder in the same docstring.
- The code comment inside the joint-space branch already names all three and states the fallback condition correctly ("Fall back to `plan_single` only if neither joint-space entry point is exposed").
- The dispatch is pinned by tests at rungs one and two.

Measured through the real dispatch, one planner shape per rung:

| goal | planner exposes | lands on |
| --- | --- | --- |
| joint-space | `plan_js` + `plan_single_js` + `plan_single` | `plan_js` |
| joint-space | `plan_single_js` + `plan_single` | `plan_single_js` |
| joint-space | `plan_single` only | `plan_single` |
| Cartesian | `plan_pose` + `plan_single` | `plan_pose` |
| Cartesian | `plan_single` only | `plan_single` |

That third row had no test. `_NewApiStubMotionPlanner` removes the legacy pair to pin rung one, and `_StubMotionGen` exposes both legacy entry points to pin rung two, so no stub reached a planner exposing `plan_single` without `plan_single_js` - which is how the last resort came to be missing from the numbered list.

Both the numbered list and the parenthetical were written in the same commit (#442, 2026-06-15), so the list has never matched the ladder.

## Change

The joint-space ladder now numbers a rung per entry point, in probe order, with the forward-looking note kept as prose rather than as a competing order inside rung one:

```
1. New API: ``MotionPlanner.plan_js(JointState, JointState)``
2. Legacy / stub API: ``plan_single_js(JointState, JointState)``
3. Last resort: ``plan_single(JointState, JointState)`` - a planner
   exposing neither joint-space entry point still plans a joint-space
   goal through its Cartesian-shaped entry point.
```

No behaviour changes: the probe order and every dispatch outcome are identical before and after.

`tests/policies/curobo/test_dispatch_ladder_is_documented_in_probe_order.py` grades both ladders against the code rather than against other prose, so neither can drift again:

- **Same rungs, same order.** The numbered rungs must equal the entry points the branch probes, derived from the AST (both the `getattr(self._motion_planner, "name", None)` probe and the `self._motion_planner.name(...)` call). A fourth entry point is graded on arrival, with no list to update.
- **One rung, one entry point.** A rung may not name the probes belonging to the rungs below it.
- Each rung of the joint-space ladder is driven through the real dispatch, which pins the last resort for the first time.
- A rung floor and a probe floor keep a docstring reflow that hides the numbered lists from satisfying every rule by grading nothing.

Both rules are parametrized over the two ladders, so the Cartesian half is the control: it passes on both trees and shows the rule is the file's own convention rather than a new one.

## Verification

Measured at `ff8673c`, on the branch and on a pristine `upstream/main`.

Pre-fix split, with the new file copied onto `upstream/main`: **2 failed / 8 passed** (10 passed after). Both failures are semantic and quote the sequences:

```
'Dispatch order for joint-space goals:' numbers 2 rung(s) ['plan_js', 'plan_single_js']
for a ladder of 3: the code probes ['plan_js', 'plan_single_js', 'plan_single'].

'Dispatch order for joint-space goals:' has a rung naming several entry points, so the
same name reads as both this rung's probe and another rung's subject:
{'1. New API: ``MotionPlanner.plan_js(...)`` (or any other ... we probe ``plan_js``
first, then ``plan_single_js``, then ``plan_single`` as a last resort).':
 ['plan_js', 'plan_single_js', 'plan_single']}
```

The eight that pass on both trees are the controls: both Cartesian cases, the three behavioural rungs, and the three non-vacuity checks.

Blast radius - 342 test files (everything naming the curobo policy or a planner entry point, plus every guard that walks docstrings or sources), the new file excluded so the two runs are comparable:

| tree | failed | passed | skipped |
| --- | --- | --- | --- |
| branch | 17 | 15897 | 85 |
| pristine `upstream/main` | 17 | 15897 | 85 |

Failing-ID sets identical in both directions (`comm` empty each way). All 17 are `tests/mesh/test_iot_*` needing `awsiotsdk`, a declared extra CI installs.

`tests/policies/curobo/` 172 passed. `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 errors on the branch and 24 on a pristine worktree, none in the changed files.

## Artifact

The ladder each tree documents beside the ladder the code probes, both columns produced by one script that reads its own tree's docstring and then drives the real dispatch. The dispatch table is the control: identical in both trees, because no behaviour changed.

![curobo joint-space dispatch ladder, documented vs probed](https://raw.githubusercontent.com/cagataycali/robots/media-curobo-ladder/curobo-ladder.png)
