### PR TITLE
fix(transforms): resolve a runtime-registered transform through the public resolver

### DIFF
--- a/changelog.d/2610-transform-resolver-runtime-registry.md
+++ b/changelog.d/2610-transform-resolver-runtime-registry.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **transforms**: `import_transform_class` now resolves a provider registered
+  with `register_transform`, so it serves every name `list_transforms()`
+  advertises. It consulted only the `policies.json` `"transform"` block and
+  auto-discovery on `strands_robots.transforms.<provider>`, which refused every
+  runtime-registered provider while `create_transform` resolved it - and the
+  refusal it raised built its available list from `list_transforms()`, so it
+  advertised the name it had just rejected, provider and alias alike. No
+  provider in `policies.json` declares a `"transform"` block, so today every
+  name this factory can serve arrives through `register_transform`; the two
+  shipped transforms resolved only because their modules happen to sit under
+  `strands_robots.transforms`, and a provider registered the documented way
+  ships no such module. The runtime lookup now lives once in
+  `import_transform_class`, which `create_transform` delegates to, and keeps
+  its precedence over a shipped `"transform"` block.

--- a/strands_robots/transforms/factory.py
+++ b/strands_robots/transforms/factory.py
@@ -9,6 +9,10 @@ exactly as trainers use a ``"trainer"`` block; the built-in transforms
 (``mock``, ``cosmos_transfer``) are registered at package import through the
 runtime registry instead, because ``cosmos_transfer`` is a generation model
 with no policy identity to hang a JSON block on.
+
+Both routes resolve through :func:`import_transform_class`, so
+:func:`list_transforms`, :func:`import_transform_class` and
+:func:`create_transform` answer for the same set of names.
 """
 
 from __future__ import annotations
@@ -77,16 +81,33 @@ def list_transforms() -> list[str]:
 def import_transform_class(provider: str) -> type[DatasetTransform]:
     """Import and return the :class:`DatasetTransform` subclass for a provider.
 
-    Resolution order:
-      1. The provider's ``"transform"`` block in policies.json.
-      2. Auto-discovery fallback: ``strands_robots.transforms.<provider>`` with
+    The one resolver behind :func:`create_transform`, which adds nothing but
+    the constructor call - so a name either function can resolve is a name both
+    can. Resolution order mirrors
+    :func:`~strands_robots.training.factory.import_trainer_class`:
+
+      1. The runtime registry (:func:`register_transform`), resolving an alias
+         to its provider first. This rung comes first so re-registering a name
+         overrides a shipped ``transform`` block rather than being ignored by
+         it.
+      2. The provider's ``"transform"`` block in policies.json.
+      3. Auto-discovery fallback: ``strands_robots.transforms.<provider>`` with
          a class named ``<Provider>Transform`` or the first
          :class:`DatasetTransform` subclass.
 
+    Rung 1 is not optional for the shipped transforms either: ``mock`` and
+    ``cosmos_transfer`` register at runtime, so without it they resolve only
+    because their modules happen to be auto-discoverable - and a provider
+    registered through the documented :func:`register_transform` route, which
+    ships no module under ``strands_robots.transforms``, has no other rung at
+    all.
+
     Raises:
-        ValueError: If no transform can be resolved for the provider - no
-            ``transform`` block in policies.json and no
-            ``strands_robots.transforms.<provider>`` module exists.
+        ValueError: If no transform can be resolved for the provider - not in
+            the runtime registry, no ``transform`` block in policies.json and
+            no ``strands_robots.transforms.<provider>`` module exists. The
+            message names the providers this resolver can serve, which is the
+            same set :func:`list_transforms` advertises.
         ImportError: If a module that DOES exist can't be imported: the
             declared policies.json module, or the auto-discovered provider
             module whose own dependency is missing. "Your dependency is
@@ -95,6 +116,11 @@ def import_transform_class(provider: str) -> type[DatasetTransform]:
             "available transforms" list and sending the caller to the
             wrong one.
     """
+    # 1. Runtime registry (register_transform), alias first.
+    resolved = _runtime_aliases.get(provider, provider)
+    if resolved in _runtime_registry:
+        return _runtime_registry[resolved]()
+
     cfg = get_policy_provider(provider)
     if cfg and "transform" in cfg:
         tcfg = cfg["transform"]
@@ -143,11 +169,5 @@ def create_transform(provider: str, **kwargs: Any) -> DatasetTransform:
     Raises:
         ValueError: If no transform is registered for the provider.
     """
-    # 1. Runtime registry first (built-ins and user-registered transforms).
-    resolved = _runtime_aliases.get(provider, provider)
-    if resolved in _runtime_registry:
-        return _runtime_registry[resolved]()(**kwargs)
-
-    # 2. Registry / auto-discovery.
     TransformClass = import_transform_class(provider)
     return TransformClass(**kwargs)

--- a/tests/transforms/test_factory.py
+++ b/tests/transforms/test_factory.py
@@ -1,6 +1,10 @@
 """Tests for the dataset-transform factory: registry, aliases, discovery."""
 
+import ast
 import importlib
+import inspect
+import re
+import textwrap
 
 import pytest
 
@@ -12,6 +16,7 @@ from strands_robots.transforms import (
     register_transform,
 )
 from strands_robots.transforms.cosmos_transfer import CosmosTransferTransform
+from strands_robots.transforms.factory import _runtime_aliases, _runtime_registry
 from strands_robots.transforms.mock import MockTransform
 
 
@@ -71,11 +76,226 @@ class TestFactory:
         with pytest.raises(ModuleNotFoundError, match="a_backend_sdk_that_is_not_installed_xyz"):
             import_transform_class("heavybackend")
 
-    def test_auto_discovery_import(self):
-        """``import_transform_class`` finds the module-per-provider layout."""
-        assert import_transform_class("mock") is MockTransform
-        assert import_transform_class("cosmos_transfer") is CosmosTransferTransform
+    def test_auto_discovery_import(self, tmp_path, monkeypatch):
+        """``import_transform_class`` finds the module-per-provider layout.
+
+        Exercised with a provider that exists ONLY as a module: the shipped
+        ``mock`` / ``cosmos_transfer`` are runtime-registered, so they are
+        answered by the runtime rung and cannot cover this one.
+        """
+        import strands_robots.transforms as transforms_pkg
+
+        (tmp_path / "discovered.py").write_text(
+            '"""Fake module-only transform provider."""\n'
+            "from strands_robots.transforms.base import DatasetTransform\n"
+            "\n"
+            "class DiscoveredTransform(DatasetTransform):\n"
+            '    """Module-only provider, reachable by auto-discovery alone."""\n'
+            "    @property\n"
+            "    def provider_name(self):\n"
+            '        return "discovered"\n'
+            "    def validate(self, spec):\n"
+            "        return self._spec_problems(spec)\n"
+            "    def transform_frames(self, camera_key, frames, spec, *, source_episode, variant):\n"
+            "        return frames\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(transforms_pkg, "__path__", [*transforms_pkg.__path__, str(tmp_path)])
+        importlib.invalidate_caches()
+        assert import_transform_class("discovered").__name__ == "DiscoveredTransform"
 
     def test_abc_cannot_instantiate(self):
         with pytest.raises(TypeError):
             DatasetTransform()  # type: ignore[abstract]
+
+
+class TestBothResolversServeEveryListedTransform:
+    """``import_transform_class`` resolves every name ``list_transforms`` advertises.
+
+    The factory has two entry points onto one question - which
+    :class:`DatasetTransform` subclass a provider name means.
+    :func:`create_transform` answers it to build an instance;
+    :func:`import_transform_class` is the public answer for a caller that wants
+    the class without paying for construction. A name only one of them can
+    serve makes the pair a coin flip on which door the caller used, and the
+    refusal ``import_transform_class`` raises builds its available list from
+    ``list_transforms()`` - so a name it cannot serve is advertised by the very
+    message that rejects it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _a_runtime_only_provider(self):
+        """Put a runtime-ONLY name in the graded set, and take it back out.
+
+        Registered here rather than relied upon from a sibling test: the three
+        sweeps below grade whatever ``list_transforms()`` returns, and both
+        shipped transforms happen to sit under ``strands_robots.transforms``,
+        so without a name that ships no module they would pass on a resolver
+        that never consults the runtime registry at all.
+        """
+
+        class SweepProbeTransform(MockTransform):
+            pass
+
+        register_transform("sweep_probe", lambda: SweepProbeTransform, aliases=["sp"])
+        try:
+            yield SweepProbeTransform
+        finally:
+            _runtime_registry.pop("sweep_probe", None)
+            _runtime_aliases.pop("sp", None)
+
+    def test_every_listed_transform_resolves(self):
+        """No advertised provider is refused by the public resolver."""
+        refused = {}
+        for name in list_transforms():
+            try:
+                import_transform_class(name)
+            except Exception as e:  # noqa: BLE001 - report every failure, not the first
+                refused[name] = f"{type(e).__name__}: {e}"
+        assert not refused, f"list_transforms() advertises providers import_transform_class refuses: {refused}"
+
+    def test_the_refusal_advertises_only_names_it_can_serve(self):
+        """A refusal must not enumerate the provider it just rejected."""
+        with pytest.raises(ValueError) as exc:
+            import_transform_class("no_such_transform_xyz")
+        message = str(exc.value)
+        match = re.search(r"Available transforms: (\[[^\]]*\])", message)
+        assert match, f"premise: the refusal names an available-transforms list to grade: {message}"
+        advertised = ast.literal_eval(match.group(1))
+        assert advertised, "premise: the available-transforms list is non-empty"
+        unservable = []
+        for name in advertised:
+            try:
+                import_transform_class(name)
+            except Exception:  # noqa: BLE001 - any failure means the list over-promises
+                unservable.append(name)
+        assert not unservable, f"the refusal offers providers it cannot resolve: {unservable}\n  message: {message}"
+
+    def test_the_two_entry_points_agree_on_every_listed_name(self):
+        """Resolving a class and building an instance answer the same question."""
+        disagree = []
+        for name in list_transforms():
+            try:
+                import_transform_class(name)
+                imports = True
+            except Exception:  # noqa: BLE001
+                imports = False
+            try:
+                create_transform(name)
+                creates = True
+            except Exception:  # noqa: BLE001
+                creates = False
+            if imports is not creates:
+                disagree.append((name, imports, creates))
+        assert not disagree, f"(name, import_transform_class, create_transform) disagree: {disagree}"
+
+    def test_the_builtin_transforms_are_reachable_through_the_public_resolver(self):
+        """``mock`` and ``cosmos_transfer`` register at runtime, not in policies.json."""
+        assert import_transform_class("mock") is MockTransform
+        assert import_transform_class("cosmos_transfer") is CosmosTransferTransform
+
+    def test_a_runtime_registered_transform_and_its_alias_resolve(self):
+        """The documented ``register_transform`` route reaches the public resolver.
+
+        This is the route ``register_transform``'s own example and the custom-
+        backend docs prescribe, and it ships no module under
+        ``strands_robots.transforms`` and no ``transform`` block - so the
+        runtime rung is the only one that can answer for it.
+        """
+
+        class ResolverProbeTransform(MockTransform):
+            pass
+
+        register_transform("resolver_probe", lambda: ResolverProbeTransform, aliases=["rp"])
+        try:
+            assert import_transform_class("resolver_probe") is ResolverProbeTransform
+            assert import_transform_class("rp") is ResolverProbeTransform
+        finally:
+            _runtime_registry.pop("resolver_probe", None)
+            _runtime_aliases.pop("rp", None)
+
+    def test_every_listed_transform_is_runtime_registered(self):
+        """Non-vacuity: today the runtime rung is the only one with any entries.
+
+        No provider in policies.json declares a ``transform`` block, so every
+        name this factory can serve arrives through :func:`register_transform`.
+        A resolver that skipped the runtime rung could therefore only ever
+        answer by the auto-discovery accident of a provider's module happening
+        to sit under ``strands_robots.transforms``.
+        """
+        from strands_robots.registry.policies import get_policy_provider
+
+        listed = list_transforms()
+        assert listed, "premise: the factory advertises at least one transform"
+        json_declared = [name for name in listed if (get_policy_provider(name) or {}).get("transform")]
+        assert not json_declared, f"expected no JSON-declared transforms yet, got {json_declared}"
+
+
+class TestTheRuntimeRungKeepsItsPrecedence:
+    """A runtime registration shadows a JSON ``transform`` block, as before.
+
+    ``create_transform`` consulted the runtime registry ahead of the registry
+    lookup, so a caller could already override a shipped provider's transform
+    by re-registering the name. Sharing one resolver has to keep that ordering:
+    demoting the runtime rung below the JSON rung would silently ignore such an
+    override instead of honoring it.
+    """
+
+    def test_a_runtime_registration_overrides_a_json_transform_block(self, monkeypatch):
+        """A re-registered name wins over a shipped ``transform`` block."""
+        import strands_robots.transforms.factory as factory_mod
+
+        providers = {
+            "jsonprov": {
+                "transform": {
+                    "module": "strands_robots.transforms.mock",
+                    "class": "MockTransform",
+                }
+            }
+        }
+        monkeypatch.setattr(factory_mod, "get_policy_provider", providers.get)
+        monkeypatch.setattr(factory_mod, "list_policy_providers", lambda: list(providers))
+
+        # The JSON rung answers on its own.
+        assert import_transform_class("jsonprov") is MockTransform
+
+        class ShadowingTransform(MockTransform):
+            pass
+
+        register_transform("jsonprov", lambda: ShadowingTransform)
+        try:
+            assert import_transform_class("jsonprov") is ShadowingTransform
+            assert isinstance(create_transform("jsonprov"), ShadowingTransform)
+        finally:
+            _runtime_registry.pop("jsonprov", None)
+        # The JSON rung answers again once the override is gone.
+        assert import_transform_class("jsonprov") is MockTransform
+
+    def test_an_unknown_provider_is_still_refused(self):
+        """Neither entry point invents a transform for an unregistered name."""
+        with pytest.raises(ValueError, match="No transform registered"):
+            import_transform_class("definitely_not_a_transform_xyz")
+        with pytest.raises(ValueError, match="No transform registered"):
+            create_transform("definitely_not_a_transform_xyz")
+
+    def test_constructor_kwargs_still_reach_the_transform(self):
+        """Delegating to one resolver must not drop ``create_transform``'s kwargs."""
+        transform = create_transform("mock", pixel_shift=7)
+        assert isinstance(transform, MockTransform)
+        assert transform._pixel_shift == 7
+
+    def test_create_transform_adds_nothing_but_the_constructor_call(self):
+        """One resolver owns the question - no second copy of the rung ladder.
+
+        Both docstrings state that the two entry points answer for the same set
+        of names, and a private copy of the runtime-registry lookup inside
+        :func:`create_transform` is precisely how they came apart: the rung
+        lived in one function and not the other, so the pair disagreed on every
+        runtime-registered name while each looked correct on its own.
+        """
+        source = textwrap.dedent(inspect.getsource(create_transform))
+        assert "import_transform_class(" in source, "create_transform must resolve through the shared resolver"
+        assert "_runtime_registry" not in source, (
+            "create_transform re-derives the runtime rung instead of delegating - "
+            "two copies of one resolution order is how the entry points diverged"
+        )


### PR DESCRIPTION
## Problem

`strands_robots.transforms.factory` has two public entry points onto one question - which
`DatasetTransform` subclass a provider name means - and they disagreed.
`create_transform` consulted the runtime registry first; `import_transform_class` never
consulted it at all, resolving only a `policies.json` `"transform"` block and then
auto-discovery of `strands_robots.transforms.<provider>`. Each function kept its own copy
of the lookup, so one had the rung and the other did not.

`register_transform`'s own docstring example, and the "Custom backends" section of
`docs/data/transforms.md`, both prescribe the route that breaks:

```python
register_transform("my_v2v", lambda: MyTransform, aliases=["mv"])

create_transform("my_v2v")          # -> MyTransform
import_transform_class("my_v2v")    # -> ValueError: No transform registered for provider
                                    #    'my_v2v'. Available transforms:
                                    #    ['cosmos_transfer', 'mock', 'mv', 'my_v2v']
```

The refusal builds its available list from `list_transforms()`, so it advertised the name
it had just rejected - the provider name and its alias alike.

Measured on `upstream/main`, with a provider registered exactly as documented:

| name | registered in | `import_transform_class` | `create_transform` |
|---|---|---|---|
| `cosmos_transfer` | runtime registry | resolves | resolves |
| `mock` | runtime registry | resolves | resolves |
| `mv` (alias) | runtime registry | **ValueError** | resolves `MyTransform` |
| `my_v2v` | runtime registry | **ValueError** | resolves `MyTransform` |

No provider in `policies.json` declares a `"transform"` block, so **every** name this
factory can serve today arrives through `register_transform` - and the two shipped
transforms resolved only because their modules happen to sit under
`strands_robots.transforms`. `cosmos_transfer` does not even match the
`<Provider>Transform` naming rung - that rung looks for
`"cosmos_transfer".capitalize() + "Transform"`, i.e. `Cosmos_transferTransform`, and the
class is `CosmosTransferTransform` - so it falls through to the "first `DatasetTransform`
subclass in `dir(mod)`" scan. A provider registered the documented way ships no such module and
therefore had no rung at all.

## Why this shape is settled

The module docstring states that this factory "Mirrors
`strands_robots.training.factory`". That sibling's resolver states the contract this PR
restores:

> The one resolver behind `create_trainer`, which adds nothing but the constructor call -
> so a name either function can resolve is a name both can.

and its first rung is the runtime registry, "so re-registering a name overrides a shipped
`trainer` block rather than being ignored by it". The fix is that rung, in that position.

## Change

`strands_robots/transforms/factory.py`:

- `import_transform_class` gains the runtime rung as rung 1, alias-resolved first, ahead
  of the `policies.json` block and auto-discovery. Its docstring now numbers all three
  rungs and states why rung 1 is not optional for the shipped transforms either.
- `create_transform` delegates wholly - `import_transform_class(provider)(**kwargs)` -
  instead of keeping a second copy of the runtime lookup. One resolution order, not two.
- The module docstring states that both registration routes resolve through
  `import_transform_class`, so `list_transforms`, `import_transform_class` and
  `create_transform` answer for the same set of names.

`create_transform`'s behaviour is unchanged: it consulted the runtime registry first
before, and the shared resolver keeps that precedence, so a re-registered name still
overrides a shipped `"transform"` block. The advertised set is identical in both trees and
every listed name resolves to the same class through `create_transform` - nothing about
what a transform *does* changes.

## Tests

`tests/transforms/test_factory.py`, mirroring the sibling module's own resolver class:

- `TestBothResolversServeEveryListedTransform` - every name `list_transforms()` advertises
  resolves; the refusal advertises only names it can serve; the two entry points agree per
  name; the documented `register_transform` route (and its alias) reaches the public
  resolver; the built-ins are reachable through it.
- `TestTheRuntimeRungKeepsItsPrecedence` - a runtime registration shadows a `"transform"`
  block (injected, since none is shipped) through both entry points and stops shadowing
  once removed; an unknown provider is still refused by both; `create_transform`'s kwargs
  still reach the constructor; and `create_transform` keeps no second copy of the rung
  ladder.

Properties are derived from `list_transforms()` **at run time**, so a provider added later
is graded without editing the test. A class fixture registers a runtime-**only** provider
and removes it again, rather than depending on a sibling test having leaked one: without
it the three sweeps grade only names whose modules sit under `strands_robots.transforms`
and pass on a resolver that never consults the runtime registry.

`test_auto_discovery_import` is repaired rather than left in place. It asserted the
built-ins resolve, and once the resolver consults the runtime registry they are answered
by rung 1 - so the test would have stopped covering the rung it is named for. It now
exercises a provider that exists *only* as a module.

**Pre-fix split: 6 failed / 13 passed** against `upstream/main` (`bd6e6333`), all six
behavioural, e.g.

```
list_transforms() advertises providers import_transform_class refuses:
  {'sp': "ValueError: No transform registered for provider 'sp'. Available transforms:
   ['cosmos_transfer', 'mock', 'sp', 'sweep_probe']", 'sweep_probe': ...}
the refusal offers providers it cannot resolve: ['sp', 'sweep_probe']
(name, import_transform_class, create_transform) disagree: [('sp', False, True), ...]
```

The same six fail with the two new classes run **alone**, so the evidence does not depend
on collection order.

Each guard is load-bearing against a distinct regression:

| break | failing guards |
|---|---|
| revert `factory.py` to `upstream/main` | all 6 |
| keep the rung but demote it below the `policies.json` rung | precedence only |
| keep the rung, restore `create_transform`'s own copy | the single-owner pin only |
| the rung ignores aliases | 4, incl. the file's pre-existing `test_runtime_register_and_alias` |
| drop the fixture's runtime-only registration (on base) | the 3 sweeps stop firing - it is what makes them non-vacuous |

## Verification

Measured at `3519b577`; the head is now `03376d03`, which differs only by the
changelog fragment's filename (`2609-` -> `2610-` once the PR number was known),
so every number above still describes this tree.

- `tests/transforms/test_factory.py` **19 passed**; whole `tests/transforms` **140 passed**.
- Order independence: `tests/transforms` + `tests/training/test_factory.py` under
  `pytest-randomly` **178 passed**.
- 211-file selection (everything naming the transform / trainer factory surface, the
  `tests/transforms` suite, and the repo-wide docs / docstring / changelog / source-string
  guards), run on this branch and on a pristine `upstream/main` worktree with the changed
  test file excluded from both so any difference is the source change alone:
  **11 failed, 9132 passed, 57 skipped on each**, 359.23s vs 358.66s, failing ID sets
  identical (`comm` empty both ways). The 11 are absent optional dependencies:
  8 `tests/mesh/test_iot_connect_timeout_domain.py` (`awsiot`) and 3 `tests/training`
  (`draccus` below `lerobot`'s `>=0.11.6` floor).
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`;
  `mypy` **24 == 24** against pristine with the branch-only set empty and none in the
  changed files.
- `scripts/assemble_changelog.py --check` OK.

## Artifact

No policy, simulation behaviour, rendering, recording or robot asset changes here - this
is name resolution in a factory, and the transform behaviour is byte-identical either way.
The figure is the resolver matrix, captured by running one script against each tree and
driving the documented `register_transform` route: same advertised set in both panels,
`create_transform` returning the same class for every listed name, and the real refusal a
caller of that route reads on `upstream/main`.

![transform factory resolver matrix](https://raw.githubusercontent.com/cagataycali/robots/media-transform-resolver/transform-resolver.png)

