### PR TITLE
fix(mesh): forward the locomotion goal a tell() peer needs

### DIFF
--- a/changelog.d/2613-mesh-forwards-locomotion-goal.md
+++ b/changelog.d/2613-mesh-forwards-locomotion-goal.md
@@ -1,0 +1,51 @@
+### Fixed: the mesh forwards the locomotion goal it documents
+
+`SimEngine.run_policy` documents four issue #300 well-known goal keys -
+`target_pose` / `target_joints` / `target_velocity` / `world_update` - and offers
+the mesh as the remote analogue: "the local-sim analogue of the mesh `tell()`
+path, which already forwards these keys". The mesh carried three of them.
+`target_velocity` was absent from the wire validator's field allowlist and from
+`Mesh._SIM_WELL_KNOWN_POLICY_KWARGS`, so telling a peer to walk left the goal
+behind at two layers.
+
+It is the one goal key that is a whole command rather than a refinement. WBC and
+`wbc_gait` read `[vx, vy, omega]` and nothing else; with no goal they hold a
+standing balance, so a fleet operator asking a humanoid to walk got a rollout
+that reported `status="success"` and did not go anywhere. Neither layer says a
+word about it: `validate_command` builds its output key by key from an allowlist,
+so an unlisted field is dropped rather than refused, and the dispatcher then
+builds `policy_kwargs` from its own tuple.
+
+Both providers are reachable over the mesh by construction - the policy-provider
+allowlist is derived from the registry, and the comment on that set names WBC as
+the provider a hand-maintained copy had already omitted once. `docs/policies/wbc.md`
+promises the route in as many words: "sharing the non-VLA goal vocabulary so a
+command can flow through `run_policy` / mesh `tell()` without coupling to a
+backend".
+
+Dated: the three-key forward set is from #304 (2026-06-06), the first
+`target_velocity` consumer from #483 twelve days later, and the docstring that
+claims mesh parity from 2026-06-29. Correct when written, never brought along.
+
+The wire now validates `target_velocity` on `target_pose`'s per-component domain -
+finite, in range, a bool refused by name rather than read as a 1 m/s command - and
+bounds the component count purely as DoS defence, the role `MAX_TARGET_JOINTS`
+plays. It does not fix the arity, because the receivers disagree: WBC needs at
+least three components and reads the first three, MotionBricks reads a planar
+`[vx, vy]`. A fixed length here would refuse a shape a shipped receiver accepts,
+and each one already names its own requirement, so a two-component velocity
+crosses the wire and WBC answers "target_velocity must have at least 3 elements
+[vx, vy, omega], got 2".
+
+The set both layers carry is now graded against `run_policy`'s own docstring
+rather than restated, in both directions, so a fifth goal key is held to the same
+parity on arrival and an undocumented `target_`-shaped key is still dropped.
+
+One invariant needed widening rather than extending. The dispatcher has two sinks
+and no way to ask a provider which it reads, and that choice was pinned as "no
+provider names a goal key on its constructor" - true of cuRobo and MoveIt2, and
+not of WBC, whose constructor `target_velocity` is a documented static default.
+What makes `policy_kwargs` the correct sink there is precedence: a per-call value
+overrides the constructor one. Were that reversed, a peer told a new direction
+would answer with the direction it was built with, so the precedence is now pinned
+directly.

--- a/docs/policies/wbc.md
+++ b/docs/policies/wbc.md
@@ -131,6 +131,14 @@ command at all the controller holds a standing balance (zero velocity, default
 height + level orientation). Omitting a key (or passing `None`) selects the next
 source in the precedence chain, so `None` is how a kwarg spells "not supplied".
 
+`target_velocity` is one of the issue #300 well-known goal keys, so the mesh
+path forwards it the same way it forwards a planner's goal:
+`mesh.tell(peer, "walk forward", policy_provider="wbc", target_velocity=[0.5, 0.0, 0.0])`.
+It travels as a per-call kwarg, which is why it overrides the constructor
+default rather than being read as one. `target_orientation` and `height` are
+WBC's own kwargs rather than part of that shared vocabulary - set them on a
+local `run_policy(policy_kwargs=...)` call, or as constructor defaults.
+
 Each key's accepted domain is the one `WBCConfig` enforces for the field it
 overrides - `height` for `height_cmd`, `target_orientation` for `rpy_cmd` - so a
 value the config refuses is not reachable through the kwarg documented to take

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1920,12 +1920,11 @@ class Mesh(SensorLoopsMixin):
             # has neither, so this is unambiguous.
             #
             # Forwards the well-known per-call kwargs from #300
-            # (``target_pose`` / ``target_joints`` / ``world_update``) plus
-            # the existing ``extra`` set (model_path / server_address / ...)
-            # via ``policy_config``. ``create_policy(provider, **policy_config)``
-            # passes them to the Policy constructor; per the #300 contract
-            # planner-style providers consume them and VLA providers ignore
-            # unknown kwargs without raising.
+            # (``target_pose`` / ``target_joints`` / ``target_velocity`` /
+            # ``world_update``) via ``policy_kwargs``, and the ``extra`` set
+            # (model_path / server_address / ...) via ``policy_config``.
+            # Per the #300 contract a goal-conditioned provider consumes the
+            # goal keys and a VLA provider ignores them without raising.
             # Child SimRobot peer: a SimRobot dataclass carries no
             # run_policy/list_robots of its own - delegate to the parent
             # Simulation with robot_name pre-bound to this robot, so a task
@@ -2008,19 +2007,35 @@ class Mesh(SensorLoopsMixin):
             return {"error": "robot does not support stop_teleop"}
         return {"error": f"unknown action: {action}"}
 
-    # Well-known per-call policy kwargs from issue #300 - keys that planner-
-    # style providers (cuRobo, MoveIt2, MPC) consume to encode goals beyond
-    # natural-language ``instruction``. Forwarded from the ``tell()``
-    # payload into ``policy_kwargs`` -- the run_policy/start_policy parameter
-    # that reaches ``get_actions(obs, instruction, **policy_kwargs)`` -- so a
-    # ``policy_provider="curobo"`` peer sees the ``target_pose`` it needs
-    # without the dispatch layer dropping it silently.
+    # Well-known per-call policy kwargs from issue #300 - keys a goal-
+    # conditioned provider consumes to encode a goal beyond natural-language
+    # ``instruction``. Forwarded from the ``tell()`` payload into
+    # ``policy_kwargs`` -- the run_policy/start_policy parameter that reaches
+    # ``get_actions(obs, instruction, **policy_kwargs)`` -- so a
+    # ``policy_provider="curobo"`` peer sees the ``target_pose`` it needs and a
+    # ``policy_provider="wbc"`` peer sees the ``target_velocity`` it needs,
+    # without the dispatch layer dropping either silently.
+    #
+    # This is the set ``SimEngine.run_policy`` documents, because its
+    # ``policy_kwargs`` entry offers this path as the analogue of the local
+    # call ("the local-sim analogue of the mesh ``tell()`` path, which already
+    # forwards these keys"). Two directions, both mechanical: a key that
+    # docstring names and this tuple omits is dropped after the wire admits
+    # it, and a key admitted here that no provider reads is inert.
+    #
+    # ``target_velocity`` is the locomotion goal - WBC / wbc_gait read
+    # ``[vx, vy, omega]``, MotionBricks reads a planar direction. Every one of
+    # those providers is reachable over the mesh: the policy-provider
+    # allowlist is derived from the registry (see
+    # ``strands_robots.mesh.security``), so a locomotion peer can be told to
+    # walk and has to be able to receive where.
     #
     # See AGENTS.md > Public API Hygiene: "Forward all advertised kwargs
     # end-to-end. Silent drops are bugs masquerading as features."
     _SIM_WELL_KNOWN_POLICY_KWARGS: tuple[str, ...] = (
         "target_pose",
         "target_joints",
+        "target_velocity",
         "world_update",
     )
 
@@ -2053,12 +2068,16 @@ class Mesh(SensorLoopsMixin):
         ``policy_type``, ``pretrained_name_or_path``) travel in
         ``policy_config``, which ``create_policy`` hands to the Policy
         constructor. The issue #300 well-known per-call goal
-        (``target_pose``, ``target_joints``, ``world_update``) travels in
-        ``policy_kwargs``, which the runner forwards verbatim to every
-        ``get_actions(obs, instruction, **policy_kwargs)`` call: no provider
-        names a goal key on its constructor, so ``policy_config`` would hand
-        the goal to a forward-compatibility absorber that ignores it and the
-        planner would then refuse the payload the caller supplied. Per #300
+        (``target_pose``, ``target_joints``, ``target_velocity``,
+        ``world_update``) travels in ``policy_kwargs``, which the runner
+        forwards verbatim to every
+        ``get_actions(obs, instruction, **policy_kwargs)`` call. Sent as
+        ``policy_config`` instead, a goal reaches the Policy constructor,
+        where no provider reads it as a per-call goal - cuRobo and MoveIt2
+        name no goal key there at all, and WBC's constructor
+        ``target_velocity`` is a *static* default a per-call kwarg overrides -
+        so the goal would be absorbed and the provider would then refuse the
+        payload the caller supplied. Per #300
         the receiving Policy ignores unknown per-call kwargs rather than
         raising, so VLA providers stay compatible.
         """

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -220,6 +220,18 @@ MAX_INPUT_KEY_LEN: int = 64
 #: keeps a malicious payload from forcing an unbounded dict walk.
 MAX_TARGET_JOINTS: int = 256
 
+#: Bound on the number of components accepted in a sim ``execute`` /
+#: ``start`` payload's ``target_velocity`` list (issue #300 well-known
+#: kwarg). The wire cannot own the arity verdict: WBC and ``wbc_gait``
+#: require at least ``[vx, vy, omega]`` and read the first three, while
+#: MotionBricks reads ``[vx, vy]`` or ``[vx, vy, vz]`` - so a fixed
+#: length here would refuse a shape one of them accepts, and each names
+#: its own requirement when a caller gets it wrong. This cap is purely
+#: DoS defence, the same role :data:`MAX_TARGET_JOINTS` plays: 16 is well
+#: above any shipped receiver's read and keeps a malicious payload from
+#: forcing an unbounded list walk.
+MAX_TARGET_VELOCITY_COMPONENTS: int = 16
+
 #: Bound on a sim ``execute`` / ``start`` payload's ``world_update``
 #: nested dict size, in JSON-encoded bytes. Mesh does not interpret the
 #: per-call collision-world refresh payload; it forwards it to the
@@ -892,6 +904,11 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
         - ``target_joints`` (optional): dict of joint-name to float
           (issue #300 well-known kwarg). Bounded by
           :data:`MAX_TARGET_JOINTS`.
+        - ``target_velocity`` (optional): list of floats
+          ``[vx, vy, omega]`` (m/s, m/s, rad/s) for locomotion providers
+          (issue #300 well-known kwarg). Component count bounded by
+          :data:`MAX_TARGET_VELOCITY_COMPONENTS`; the arity a given
+          policy needs is that policy's verdict, not the wire's.
         - ``world_update`` (optional): opaque dict forwarded to the
           policy via ``policy_config``. Bounded by
           :data:`MAX_WORLD_UPDATE_BYTES` JSON-encoded bytes.
@@ -1062,8 +1079,17 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
             out["robot_name"] = value
 
         # Issue #300 well-known per-call policy kwargs. Forwarded into
-        # ``policy_config`` by the dispatcher; planner-style providers
-        # (cuRobo, MoveIt2, MPC) consume them, VLA providers ignore them.
+        # ``policy_kwargs`` by the dispatcher, which is what reaches
+        # ``get_actions(obs, instruction, **policy_kwargs)``. Planner-style
+        # providers (cuRobo, MoveIt2) read a Cartesian or joint-space goal;
+        # locomotion providers (WBC, wbc_gait, MotionBricks) read
+        # ``target_velocity``. VLA providers ignore all of them.
+        #
+        # Every key ``SimEngine.run_policy`` documents as a #300 goal key is
+        # admitted here, because that docstring offers the mesh ``tell()``
+        # path as the analogue of the local call. A key it names and this
+        # allowlist omits is dropped without a word - the ``out`` dict below
+        # is built key by key, so an unlisted one simply never arrives.
         if "target_pose" in cmd:
             value = cmd["target_pose"]
             if not isinstance(value, list) or len(value) != 7:
@@ -1098,6 +1124,28 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
                     f"target_joints[{joint_name}]", joint_value, lo=-1e6, hi=1e6, default=None
                 )
             out["target_joints"] = coerced_joints
+
+        if "target_velocity" in cmd:
+            value = cmd["target_velocity"]
+            if not isinstance(value, list) or not value:
+                raise ValidationError(
+                    "target_velocity must be a non-empty list of floats [vx, vy, omega] (m/s, m/s, rad/s)"
+                )
+            if len(value) > MAX_TARGET_VELOCITY_COMPONENTS:
+                raise ValidationError(
+                    f"target_velocity has {len(value)} components > "
+                    f"MAX_TARGET_VELOCITY_COMPONENTS ({MAX_TARGET_VELOCITY_COMPONENTS})."
+                )
+            # Per-component domain shared with ``target_pose``: finite, in
+            # range, and a bool is refused by name rather than read as 1.
+            # The component COUNT is not checked against any receiver's
+            # arity here - see :data:`MAX_TARGET_VELOCITY_COMPONENTS`.
+            coerced_velocity: list[float] = []
+            for i, component in enumerate(value):
+                coerced_velocity.append(
+                    _coerce_float(f"target_velocity[{i}]", component, lo=-1e6, hi=1e6, default=None)
+                )
+            out["target_velocity"] = coerced_velocity
 
         if "world_update" in cmd:
             value = cmd["world_update"]

--- a/tests/mesh/test_mesh_rpc_sim_dispatch.py
+++ b/tests/mesh/test_mesh_rpc_sim_dispatch.py
@@ -5,7 +5,8 @@ module pins the sim-peer branch added by issue #303: ``tell()`` against a
 peer whose ``robot`` is a ``Simulation`` (or any ``SimEngine``-shaped
 object) routes ``execute`` -> ``run_policy`` and ``start`` -> ``start_policy``
 with the issue #300 well-known goal payload (``target_pose`` /
-``target_joints`` / ``world_update``) forwarded into ``policy_kwargs`` - the
+``target_joints`` / ``target_velocity`` / ``world_update``) forwarded into
+``policy_kwargs`` - the
 runner parameter that reaches ``get_actions(obs, instruction, **kwargs)``,
 which is where every provider reads that goal. Constructor extras
 (``model_path`` / ``server_address`` / ...) keep travelling in
@@ -176,6 +177,7 @@ def test_planner_providers_read_the_goal_per_call_not_at_construction() -> None:
     """
     from strands_robots.policies.curobo.policy import CuroboPolicy
     from strands_robots.policies.moveit2.policy import MoveIt2Policy
+    from strands_robots.policies.wbc.policy import WBCPolicy
 
     for policy_class in (CuroboPolicy, MoveIt2Policy):
         constructor = inspect.signature(policy_class.__init__).parameters
@@ -186,10 +188,27 @@ def test_planner_providers_read_the_goal_per_call_not_at_construction() -> None:
             "filled from a different payload"
         )
 
-        per_call = inspect.signature(policy_class.get_actions).parameters
+    for goal_reader in (CuroboPolicy, MoveIt2Policy, WBCPolicy):
+        per_call = inspect.signature(goal_reader.get_actions).parameters
         assert any(p.kind is p.VAR_KEYWORD for p in per_call.values()), (
-            f"{policy_class.__name__}.get_actions takes no **kwargs, so it cannot receive the goal"
+            f"{goal_reader.__name__}.get_actions takes no **kwargs, so it cannot receive the goal"
         )
+
+    # WBC is the one provider that names a goal key in BOTH places, so
+    # "no constructor parameter" is not the invariant that covers it. What
+    # makes ``policy_kwargs`` the right sink there is precedence: the
+    # constructor value is a documented STATIC default and a per-call kwarg
+    # overrides it. Were that reversed, a mesh caller telling a walking peer
+    # a new direction would be answered with the one it was built with.
+    assert "target_velocity" in inspect.signature(WBCPolicy.__init__).parameters
+    policy = WBCPolicy(allow_missing_models=True, target_velocity=[0.1, 0.0, 0.0])
+    _, built_with = policy._resolve_command({})
+    _, told_over_the_mesh = policy._resolve_command({"target_velocity": [0.9, 0.0, 0.0]})
+    assert list(built_with) == [0.1, 0.0, 0.0]
+    assert list(told_over_the_mesh) == [0.9, 0.0, 0.0], (
+        "a per-call target_velocity must override the constructor default, or the goal the mesh "
+        "forwards is discarded in favour of the one the peer was built with"
+    )
 
 
 def test_execute_forwards_constructor_extras_via_policy_config() -> None:
@@ -371,3 +390,121 @@ def test_hardware_path_unchanged_when_run_policy_absent() -> None:
     )
     assert out == {"executed": "go"}
     assert len(hw.calls) == 1
+
+
+# The documented goal set, graded against both layers that carry it
+def _documented_goal_keys() -> list[str]:
+    """The #300 goal keys ``SimEngine.run_policy`` documents, read from its docstring.
+
+    Derived rather than listed so a key added to that contract is graded on
+    arrival. ``run_policy``'s ``policy_kwargs`` entry is the surface that
+    offers the mesh path as the analogue of the local call, which is what
+    makes it the authority on which keys the mesh has to carry.
+    """
+    import ast
+    import re
+    from pathlib import Path
+
+    import strands_robots.simulation.base as base_module
+
+    source = Path(base_module.__file__).read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_policy":
+            doc = ast.get_docstring(node) or ""
+            break
+    else:  # pragma: no cover - run_policy is defined on the ABC
+        raise AssertionError("SimEngine.run_policy not found in strands_robots.simulation.base")
+
+    start = doc.index("policy_kwargs:")
+    # The entry runs to the next same-indent Args label; ``n_episodes`` is
+    # the one that follows it. Read to there rather than to a blank line,
+    # because the entry itself wraps across several.
+    entry = " ".join(doc[start : doc.index("n_episodes:", start)].split())
+    return sorted({t for t in re.findall(r"``(\w+)``", entry) if t.startswith("target_") or t == "world_update"})
+
+
+def test_the_documented_goal_set_is_not_empty() -> None:
+    """Non-vacuity: a docstring reflow that hides the entry must not read as clean."""
+    keys = _documented_goal_keys()
+    assert len(keys) >= 3, f"only {keys} parsed out of run_policy's policy_kwargs entry"
+    assert "target_velocity" in keys
+
+
+def test_the_wire_admits_every_documented_goal_key() -> None:
+    """A key the wire validator omits is dropped, not refused.
+
+    ``validate_command`` builds its output key by key from an allowlist, so
+    an unlisted field never reaches the dispatcher and nothing says so.
+    """
+    from strands_robots.mesh import security
+
+    sample: dict[str, Any] = {
+        "target_pose": [0.3, 0.0, 0.4, 1.0, 0.0, 0.0, 0.0],
+        "target_joints": {"joint_0": 0.5},
+        "target_velocity": [0.5, 0.0, 0.2],
+        "world_update": {"obstacles": []},
+    }
+    dropped = []
+    for key in _documented_goal_keys():
+        assert key in sample, f"no probe value for {key}; extend `sample`"
+        out = security.validate_command(
+            {"action": "execute", "instruction": "go", "policy_provider": "mock", key: sample[key]}
+        )
+        if key not in out:
+            dropped.append(key)
+    assert not dropped, f"the wire validator drops documented #300 goal keys: {dropped}"
+
+
+def test_the_dispatcher_forwards_every_documented_goal_key() -> None:
+    """A key the wire admits and this tuple omits is dropped one layer later."""
+    missing = [key for key in _documented_goal_keys() if key not in Mesh._SIM_WELL_KNOWN_POLICY_KWARGS]
+    assert not missing, (
+        f"_SIM_WELL_KNOWN_POLICY_KWARGS omits documented #300 goal keys {missing}; "
+        f"it carries {list(Mesh._SIM_WELL_KNOWN_POLICY_KWARGS)}"
+    )
+
+
+def test_the_locomotion_goal_reaches_policy_kwargs() -> None:
+    """Telling a walking peer where to walk arrives as a per-call goal.
+
+    ``target_velocity`` is the whole locomotion command for WBC / wbc_gait,
+    and those providers are reachable over the mesh because the policy
+    provider allowlist is derived from the registry. Without this the peer
+    ran the rollout with no goal and reported success.
+    """
+    sim = _FakeSim(robots=["unitree_g1"])
+    m = Mesh(sim, peer_id="sim-locomotion")
+    out = m._dispatch(
+        {
+            "action": "execute",
+            "instruction": "walk forward",
+            "policy_provider": "wbc",
+            "target_velocity": [0.5, 0.0, 0.2],
+        }
+    )
+    assert out["status"] == "success"
+    _, kwargs = sim.run_policy_calls[0]
+    assert kwargs["policy_kwargs"]["target_velocity"] == [0.5, 0.0, 0.2]
+    # The goal is a per-call kwarg, never a constructor kwarg.
+    assert "target_velocity" not in kwargs.get("policy_config", {})
+
+
+def test_an_undocumented_goal_shaped_key_is_still_dropped() -> None:
+    """The allowlist is not widened generally - only the documented set travels."""
+    from strands_robots.mesh import security
+
+    out = security.validate_command(
+        {
+            "action": "execute",
+            "instruction": "go",
+            "policy_provider": "mock",
+            "target_acceleration": [1.0, 0.0, 0.0],
+        }
+    )
+    assert "target_acceleration" not in out
+
+    sim = _FakeSim(robots=["unitree_g1"])
+    m = Mesh(sim, peer_id="sim-unknown-goal")
+    m._dispatch({**out, "target_acceleration": [1.0, 0.0, 0.0]})
+    _, kwargs = sim.run_policy_calls[0]
+    assert "target_acceleration" not in kwargs["policy_kwargs"]

--- a/tests/mesh/test_validate_command_sim_fields.py
+++ b/tests/mesh/test_validate_command_sim_fields.py
@@ -4,8 +4,9 @@ The validator at ``strands_robots.mesh.security.validate_command`` now
 admits a small set of sim-peer fields used by ``Mesh._dispatch_sim_policy``:
 
 * ``robot_name`` - disambiguates which robot in a multi-robot sim
-* ``target_pose`` / ``target_joints`` / ``world_update`` - issue #300
-  well-known per-call kwargs forwarded to planner-style policies
+* ``target_pose`` / ``target_joints`` / ``target_velocity`` /
+  ``world_update`` - the issue #300 well-known per-call goal kwargs,
+  forwarded to whichever goal-conditioned policy reads them
 * ``control_frequency`` / ``action_horizon`` / ``fast_mode`` / ``n_steps``
   - sim-side runner controls
 
@@ -113,6 +114,70 @@ class TestTargetJoints:
         joints = {f"j{i}": 0.0 for i in range(sec.MAX_TARGET_JOINTS + 1)}
         with pytest.raises(sec.ValidationError, match="target_joints"):
             sec.validate_command({**_base(), "target_joints": joints})
+
+
+# target_velocity
+class TestTargetVelocity:
+    """The locomotion goal: WBC / wbc_gait ``[vx, vy, omega]``, MotionBricks a direction.
+
+    Its component domain is ``target_pose``'s - finite, in range, a bool
+    refused by name. Its component COUNT is bounded only as DoS defence
+    (:data:`~strands_robots.mesh.security.MAX_TARGET_VELOCITY_COMPONENTS`):
+    the receivers disagree on arity, so the wire cannot pick one without
+    refusing a shape one of them accepts, and each names its own
+    requirement. ``test_the_arity_verdict_belongs_to_the_receiving_policy``
+    pins that division.
+    """
+
+    def test_happy_path(self) -> None:
+        out = sec.validate_command({**_base(), "target_velocity": [0.5, 0.0, 0.2]})
+        assert out["target_velocity"] == [0.5, 0.0, 0.2]
+
+    def test_non_list_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": "0.5,0,0"})
+
+    def test_empty_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": []})
+
+    def test_nan_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": [0.5, float("nan"), 0.0]})
+
+    def test_inf_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": [0.5, 0.0, float("inf")]})
+
+    def test_bool_component_rejected(self) -> None:
+        """A bool is an ``int`` subclass; read as 1.0 it is a 1 m/s command."""
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": [True, 0.0, 0.0]})
+
+    def test_oversize_component_rejected(self) -> None:
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": [1e12, 0.0, 0.0]})
+
+    def test_too_many_components_rejected(self) -> None:
+        velocity = [0.0] * (sec.MAX_TARGET_VELOCITY_COMPONENTS + 1)
+        with pytest.raises(sec.ValidationError, match="target_velocity"):
+            sec.validate_command({**_base(), "target_velocity": velocity})
+
+    def test_the_arity_verdict_belongs_to_the_receiving_policy(self) -> None:
+        """A two-component velocity crosses the wire and the policy refuses it.
+
+        MotionBricks reads ``[vx, vy]``, so refusing two components here
+        would refuse a shape a shipped receiver accepts. WBC needs three and
+        says so itself, naming the field and the count it got.
+        """
+        out = sec.validate_command({**_base(), "target_velocity": [0.5, 0.0]})
+        assert out["target_velocity"] == [0.5, 0.0]
+
+        from strands_robots.policies.wbc.policy import WBCPolicy
+
+        policy = WBCPolicy(allow_missing_models=True)
+        with pytest.raises(ValueError, match=r"target_velocity must have at least 3 elements"):
+            policy._resolve_command({"target_velocity": out["target_velocity"]})
 
 
 # world_update


### PR DESCRIPTION
## Problem

`SimEngine.run_policy` documents four issue #300 well-known goal keys and offers the mesh as the remote analogue of the local call:

> Carries the well-known #300 goal keys (`target_pose` / `target_joints` / `target_velocity` / `world_update`) to non-VLA providers (cuRobo, MoveIt2, WBC) that read their goal from kwargs rather than the instruction. **This is the local-sim analogue of the mesh `tell()` path, which already forwards these keys.**

The mesh carried three of them. `target_velocity` was absent from `validate_command`'s field allowlist and from `Mesh._SIM_WELL_KNOWN_POLICY_KWARGS`, so a `tell()` that named it lost it at two layers, and neither says a word: `validate_command` builds its output key by key, so an unlisted field is dropped rather than refused, and the dispatcher then builds `policy_kwargs` from its own tuple.

| documented #300 goal key | admitted by the wire | in the dispatcher's forward set |
|---|---|---|
| `target_pose` | yes | yes |
| `target_joints` | yes | yes |
| `target_velocity` | **no** | **no** |
| `world_update` | yes | yes |

It is the one goal key that is a whole command rather than a refinement. WBC and `wbc_gait` read `[vx, vy, omega]` and nothing else, and with no goal they hold a standing balance - so asking a humanoid peer to walk produced a rollout that reported `status="success"` and did not go anywhere.

Both providers are reachable over the mesh by construction: the policy-provider allowlist is derived from the registry, and the comment on that set already names WBC as the provider a hand-maintained copy had omitted once. `docs/policies/wbc.md` promises the route in as many words - "sharing the non-VLA goal vocabulary so a command can flow through `run_policy` / mesh `tell()` without coupling to a backend".

Dated: the three-key forward set is #304 (2026-06-06), the first `target_velocity` consumer is #483 twelve days later, and the docstring claiming mesh parity is 2026-06-29. Correct when written, never brought along.

## Change

`validate_command` admits `target_velocity` on `target_pose`'s per-component domain - `_coerce_float` per element, so non-finite is refused, out-of-range is refused, and a `bool` is refused by name rather than read as a 1 m/s command. `_SIM_WELL_KNOWN_POLICY_KWARGS` gains it, so it lands in `policy_kwargs` and reaches `get_actions(obs, instruction, **policy_kwargs)`.

The component count is bounded by a new `MAX_TARGET_VELOCITY_COMPONENTS = 16`, purely as DoS defence - the role `MAX_TARGET_JOINTS` plays. The arity is deliberately **not** fixed, because the receivers disagree: WBC and `wbc_gait` require at least three components and read the first three, MotionBricks reads a planar `[vx, vy]`. A fixed length would refuse a shape a shipped receiver accepts, and each one already names its own requirement, so a two-component velocity crosses the wire and WBC answers `target_velocity must have at least 3 elements [vx, vy, omega], got 2`.

Three stale enumerations in the same code paths are corrected: two comments still said the goal travels via `policy_config` (it has travelled in `policy_kwargs` since #2312), and both named only the planner providers.

One invariant needed widening rather than extending. The dispatcher has two sinks and no way to ask a provider which it reads, and that choice was pinned as "no provider names a goal key on its constructor" - true of cuRobo and MoveIt2, and not of WBC, whose constructor `target_velocity` is a documented static default. What makes `policy_kwargs` the correct sink there is precedence: a per-call value overrides the constructor one. Were that reversed, a peer told a new direction would answer with the direction it was built with, so the precedence is now pinned directly.

## Rollout

`mesh tell(peer, "walk forward", policy_provider="wbc", target_velocity=[0.5, 0.0, 0.0])` against a Unitree G1 sim peer, with real GR00T-WholeBodyControl (SONIC) ONNX weights, MuJoCo headless (EGL), 300 ticks at 50 Hz. Same command, same weights, same scene; only `strands_robots` differs between the panels.

![mesh forwards the locomotion goal](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-locomotion-goal/mesh-locomotion-goal.gif)

[MP4](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-locomotion-goal/mesh-locomotion-goal.mp4) | [final frame](https://raw.githubusercontent.com/cagataycali/robots/media-mesh-locomotion-goal/mesh-locomotion-goal.png)

| measured | before | after |
|---|---|---|
| goal keys that survived the wire | `(nothing)` | `target_velocity` |
| dispatcher forward set | 3 of 4 documented | 4 of 4 |
| reported status | `success` | `success` |
| pelvis x after 6 s | `-0.064 m` | `+2.295 m` |
| travelled | **0.064 m** | **2.298 m** |
| frames with motion | 34 of 59 (balance sway) | 59 of 59 |

The rollout reports `success` in both columns, which is the point: nothing in the result distinguishes a peer that was given its goal from one that was not.

The capture binds the checkpoint by registering a `WBCPolicy` subclass and admitting its name through `STRANDS_MESH_POLICY_TYPE_ALLOW` - the documented operator extension point - because the dispatcher's constructor-extras allowlist (`model_path` / `server_address` / `policy_type` / `pretrained_name_or_path`) does not include `checkpoint`. That is orthogonal to this change and left alone; the wire validator, the dispatcher, the policy and the physics are all shipped code.

## Tests

The set both layers carry is graded against `run_policy`'s own docstring rather than restated, in both directions, so a fifth goal key is held to the same parity on arrival and an undocumented `target_`-shaped key is still dropped.

Pre-fix, with both test files copied onto `upstream/main`: **12 failed / 46 passed**. Eleven are behavioural; one names the new constant. The headline reads

```
AssertionError: _SIM_WELL_KNOWN_POLICY_KWARGS omits documented #300 goal keys
['target_velocity']; it carries ['target_pose', 'target_joints', 'world_update']
```

Every new guard fires for exactly its own regression, and nothing else:

| injected regression | guards that fail |
|---|---|
| revert both source files (exact pre-fix) | 12 |
| revert only the wire validator | 10 (wire admission + the component domain) |
| revert only the dispatcher's forward set | 2 (forward set + the dispatch behaviour) |
| the docstring-derived key set parses nothing | 1 (non-vacuity) |
| the wire admits any `target_`-prefixed key | 1 (undocumented-key control) |
| reverse WBC's per-call precedence | 1 (the constructor-sink invariant) |
| none | 0 of 58 |

The 46 both-tree passes are the existing contracts in those two files, unchanged - including the extended constructor-sink invariant, which passes on `upstream/main` too because it states a property of WBC rather than of this change.

## Verification

Measured at `2cb209cd`, `/tmp/lr6env` (mujoco 3.5.0, lerobot 0.6.2).

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 errors on the branch, 24 on a pristine `upstream/main` worktree**, branch-only set empty, none in the changed files.
- Blast radius: 237 files - everything naming `validate_command` / `_SIM_WELL_KNOWN_POLICY_KWARGS` / `_dispatch_sim_policy` / `target_velocity` / `policy_kwargs`, all of `tests/mesh`, plus the repo-wide docs, docstring, string and changelog guards. Run with the identical selection on both trees, **excluding the two test files this PR modifies**, so any difference is caused by the source change alone: branch `23 failed / 5390 passed`, base `24 failed / 5389 passed`.
- 45 of those failures are shared and pre-existing here: `tests/mesh/test_iot_*` needing `awsiotsdk`, a declared extra CI installs. The IDs that differ between the two runs are all in `tests/mesh/test_zenoh_transport_security.py`, which opens real localhost Zenoh sessions - branch failed 2 of them, base failed 3 *different* ones, and the file passes **9 passed / 2 skipped on both trees** when run alone. Contention between the two parallel suites, not a regression.
- CodeQL pre-flight over the changed files: identical hit sets on the branch and on the pristine base (line-shifted only); both test files clean.

## Scope

`target_orientation` and `height` are WBC's own per-call kwargs rather than part of the shared #300 vocabulary that `run_policy` documents, so they are out of scope here and `docs/policies/wbc.md` now says which route each takes. Widening the dispatcher's constructor-extras allowlist so a checkpoint can travel is a separate contract and is untouched.
