### PR TITLE
fix(policies): the ABC documents the locomotion goal key providers already read

### DIFF
--- a/changelog.d/2615-abc-documents-locomotion-goal-key.md
+++ b/changelog.d/2615-abc-documents-locomotion-goal-key.md
@@ -1,0 +1,45 @@
+### Fixed: the policy contract documents the locomotion goal key its providers read
+
+`Policy.get_actions` is where the issue #300 well-known `**kwargs` goal
+vocabulary is defined - the docstring a provider author reads to learn which
+keys a caller may pass without coupling to a backend, and the one
+`strands_robots.policies` points at by name for the list. It documented three
+keys.
+
+`target_velocity` was the fourth everywhere else: read by two independent
+provider families (`wbc`, including its `gait` variant, and `motionbricks`),
+forwarded by `run_policy` / `eval_policy` / `run_benchmark`, admitted by the
+mesh wire validator and forwarded by the mesh dispatcher since #2613, and named
+by `docs/policies/wbc.md` as "one of the issue #300 well-known goal keys". The
+contract's own definition was the only place it was missing, and it is the place
+a new provider author looks first.
+
+Nothing executes a docstring, which is the mechanism: the one list in the set
+that is not a consumer is the one a new key can be forgotten on while every
+consumer keeps working. No guard caught it because the guards compared the
+vocabulary against *another docstring* - #2613 graded the wire and dispatcher
+against `run_policy`, a consumer - so the tree held two competing definitions
+with the downstream pins anchored to the wrong one. The nearest thing to a
+contract test hard-coded the same three keys and therefore agreed with the
+omission.
+
+Three enumerations that each claim to be the present, whole vocabulary are
+corrected: the ABC, the package docstring that cites it, and `Cosmos3Policy`'s
+disclaimer, which restates the list in order to say none of it is read and so
+needs to keep covering every key it names. Provider-scoped lists (cuRobo reads
+pose / joints / `world_update`, which is what cuRobo reads) and historical ones
+("the contract landed in #300 (...)", true of #300 as shipped) are deliberately
+left alone, because holding either to the current vocabulary would demand a
+false statement.
+
+The new guards do not compare the ABC against another docstring. They derive
+what the vocabulary must contain from shipped provider code - the keys providers
+actually read out of `**kwargs` - and hold the ABC to it in both directions. The
+discriminator between shared vocabulary and a provider-private kwarg is the
+second-caller rule AGENTS.md convention 11 already codifies, with a provider
+family being the provider package so a provider's own variants count once
+between them. On this tree that rule separates the four vocabulary keys from 26
+private ones with no special cases, so the assertion is a set equality rather
+than a containment, and `target_orientation` / `target_heading` / `height` are
+pinned as single-family controls: they are `target_`-shaped and sit in the same
+`get_actions` bodies, so a guard keyed on name shape would have promoted them.

--- a/strands_robots/policies/__init__.py
+++ b/strands_robots/policies/__init__.py
@@ -8,7 +8,7 @@ produced, so the same interface fits VLA-style providers (consume images +
 instruction) and non-VLA providers (cuRobo, MoveIt2, MPC, pure-IK / scripted
 trajectories).  Non-VLA providers typically set ``requires_images=False`` and
 read their goal from the well-known ``**kwargs`` keys (``target_pose``,
-``target_joints``, ``world_update``) documented on
+``target_joints``, ``target_velocity``, ``world_update``) documented on
 :meth:`Policy.get_actions`.
 
 Built-in providers (see policies.json for full list):

--- a/strands_robots/policies/base.py
+++ b/strands_robots/policies/base.py
@@ -170,6 +170,15 @@ class Policy(ABC):
                 - ``target_joints: dict[str, float]`` - joint-space goal
                   keyed by joint name; values are in radians (revolute) or
                   metres (prismatic).
+                - ``target_velocity: list[float]`` - base-velocity goal as
+                  ``[vx, vy, omega]`` (linear m/s, angular rad/s, in the robot
+                  base frame), read by locomotion providers.  Unlike the keys
+                  above, the component count is deliberately NOT fixed by this
+                  contract, because shipped receivers disagree: whole-body
+                  controllers require the three components named above, while
+                  planar drivers read ``[vx, vy]``.  Each receiver states its
+                  own arity and refuses a shape it cannot use, so this key
+                  crosses a transport on the per-component domain alone.
                 - ``world_update: dict | None`` - per-call world refresh
                   for collision-aware planners (e.g. point cloud / depth
                   image / mesh updates).  ``None`` means "reuse the world

--- a/strands_robots/policies/cosmos3/policy.py
+++ b/strands_robots/policies/cosmos3/policy.py
@@ -401,8 +401,8 @@ class Cosmos3Policy(Policy):
                 than raise (:meth:`~strands_robots.policies.base.Policy.get_actions`),
                 and this provider's answer depends on the ``backend`` it was
                 constructed with. None of the well-known keys the ABC lists
-                (``target_pose``, ``target_joints``, ``world_update``) is read by
-                either backend.
+                (``target_pose``, ``target_joints``, ``target_velocity``,
+                ``world_update``) is read by either backend.
 
         Returns:
             ``list[dict]`` - one action dict per predicted timestep.

--- a/tests/policies/test_base.py
+++ b/tests/policies/test_base.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import re
 import threading
 from typing import Any
 
@@ -79,24 +80,64 @@ def test_reset_default_is_noop():
     assert p.reset(seed=42) is None
 
 
+def _documented_well_known_keys() -> list[str]:
+    """The well-known goal keys ``Policy.get_actions`` documents, from its docstring."""
+    doc = Policy.get_actions.__doc__ or ""
+    start = doc.find("are **well-known**")
+    end = doc.find("Providers MUST ignore unknown")
+    if start == -1 or end == -1 or end <= start:
+        return []
+    return re.findall(r"^\s*-\s+``([A-Za-z_][A-Za-z0-9_]*)\s*:", doc[start:end], re.MULTILINE)
+
+
+# One representative value per well-known goal key, on that key's documented
+# domain. Keyed by name so the round-trip below covers whatever
+# ``Policy.get_actions`` currently documents rather than a copy of the list that
+# can fall behind it -- this smoke test asserted only the first three for as long
+# as ``target_velocity`` was missing from the ABC, so it agreed with the omission
+# instead of catching it. A key added to the contract with no sample here fails
+# the completeness assertion rather than being silently skipped.
+_WELL_KNOWN_KWARG_SAMPLES: dict[str, Any] = {
+    "target_pose": [0.5, 0.0, 0.3, 1.0, 0.0, 0.0, 0.0],
+    "target_joints": {"j0": 0.1, "j1": -0.2},
+    "target_velocity": [0.5, 0.0, 0.0],
+    "world_update": None,
+}
+
+
 def test_well_known_kwargs_are_accepted_by_contract():
-    """Non-VLA providers receive goals via ``**kwargs`` (target_pose,
-    target_joints, world_update). The Policy contract requires get_actions
-    to ignore unknown kwargs rather than raising, so callers can pass
-    shared keys across providers without coupling to a backend."""
+    """Every well-known goal key the ABC documents must round-trip through a provider.
+
+    Non-VLA providers receive goals via the well-known ``**kwargs`` keys, and the
+    Policy contract requires ``get_actions`` to ignore unknown kwargs rather than
+    raising, so callers can pass shared keys across providers without coupling to
+    a backend.
+
+    The key set is read from the contract itself. The exact vocabulary and its
+    parity with shipped provider code are pinned in
+    ``test_well_known_goal_kwargs_have_one_definition.py``; this is the
+    behavioural half -- that passing all of them at once is actually accepted.
+    """
+    documented = set(_documented_well_known_keys())
+    assert documented, "parsed no well-known goal keys from the Policy.get_actions contract"
+    unsampled = sorted(documented - set(_WELL_KNOWN_KWARG_SAMPLES))
+    assert not unsampled, (
+        f"Policy.get_actions documents well-known goal keys with no sample value "
+        f"here: {unsampled}. Add one on that key's documented domain so this "
+        "round-trip covers the whole contract."
+    )
+
     p = MockPolicy()
     p.set_robot_state_keys(["j0", "j1"])
     obs = {"observation.state": [0.0, 0.0]}
 
-    # All three well-known kwargs together must round-trip cleanly through
-    # the sync wrapper -- this is the smoke test that pins the documented
-    # API surface for non-VLA providers.
+    # All well-known kwargs together must round-trip cleanly through the sync
+    # wrapper -- this is the smoke test that pins the documented API surface for
+    # non-VLA providers.
     actions = p.get_actions_sync(
         obs,
         instruction="",
-        target_pose=[0.5, 0.0, 0.3, 1.0, 0.0, 0.0, 0.0],
-        target_joints={"j0": 0.1, "j1": -0.2},
-        world_update=None,
+        **{key: _WELL_KNOWN_KWARG_SAMPLES[key] for key in sorted(documented)},
     )
     assert isinstance(actions, list) and actions, "Policy must return a non-empty action list"
     assert all(isinstance(a, dict) for a in actions)

--- a/tests/policies/test_well_known_goal_kwargs_have_one_definition.py
+++ b/tests/policies/test_well_known_goal_kwargs_have_one_definition.py
@@ -1,0 +1,374 @@
+"""The ABC owns the well-known goal vocabulary, and shipped providers grade it.
+
+:meth:`Policy.get_actions` is where the issue #300 ``**kwargs`` goal vocabulary is
+*defined* - it is the docstring a provider author reads to learn which keys a
+caller may pass without coupling to a backend, and every other enumeration in the
+tree (the package docstring, ``SimEngine.run_policy``, the mesh wire validator,
+the mesh dispatcher's forward set) restates it downstream.
+
+That makes the ABC the one list a new goal key can be forgotten on while every
+consumer still works, because nothing executes a docstring. ``target_velocity``
+was forgotten on it for exactly that reason: it is read by two independent
+provider families, carried by ``run_policy`` / ``eval_policy`` /
+``run_benchmark``, admitted by the mesh wire and forwarded by the mesh
+dispatcher, and named by ``docs/policies/wbc.md`` as "one of the issue #300
+well-known goal keys" - and absent from the ABC that the package docstring
+explicitly points at for the list.
+
+So these guards deliberately do NOT compare the ABC against another docstring.
+They derive what the vocabulary must contain from **shipped provider code** - the
+keys providers actually read out of ``**kwargs`` - and hold the ABC to it. A
+docstring can drift from code; it cannot drift from code that is parsed.
+
+The discriminator between a shared vocabulary key and a provider-private kwarg is
+the one AGENTS.md convention 11 already codifies for value-domain guards: a second
+independent caller is the evidence that a shared name is right, and one caller is
+evidence of nothing. Applied here, a "provider family" is the provider package
+(``policies/wbc/``, ``policies/motionbricks/``, ...), so ``wbc/policy.py`` and its
+``wbc/gait.py`` variant count once between them. Measured on this tree the rule
+separates the vocabulary from the private kwargs with no special cases at all:
+
+    read by two or more families -> target_pose, target_joints,
+                                    target_velocity, world_update
+    read by exactly one family   -> target_orientation, target_heading,
+                                    target_heading_angle, height,
+                                    gait_frequency, style, mode,
+                                    locomotion_style, speed_scale, replan,
+                                    scene_model, planning_group, seed,
+                                    text_prompt, guidance_scale, ... (26 keys)
+
+which is why the assertion below can be a set *equality* rather than a
+containment: the vocabulary is neither missing a key two families share nor
+carrying one that no two families do.
+"""
+
+from __future__ import annotations
+
+import ast
+import collections
+import pathlib
+import re
+
+from strands_robots.policies.base import Policy
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_POLICIES_ROOT = _REPO_ROOT / "strands_robots" / "policies"
+_SIM_BASE = _REPO_ROOT / "strands_robots" / "simulation" / "base.py"
+
+# A bullet in the ABC's well-known block: ``- ``name: type`` - prose``.
+_WELL_KNOWN_BULLET = re.compile(r"^\s*-\s+``(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*:", re.MULTILINE)
+
+# The sentinels bounding that block inside the ``**kwargs:`` Args entry. The
+# vocabulary is the bulleted list between "are **well-known**" and the
+# "Providers MUST ignore unknown" paragraph that closes the entry.
+_BLOCK_OPEN = "are **well-known**"
+_BLOCK_CLOSE = "Providers MUST ignore unknown"
+
+
+def _abc_well_known_keys() -> frozenset[str]:
+    """The goal keys :meth:`Policy.get_actions` documents as well-known.
+
+    Read from the live docstring rather than a copy, so this cannot pass by
+    agreeing with a stale duplicate of the list it is checking.
+    """
+    doc = Policy.get_actions.__doc__ or ""
+    start = doc.find(_BLOCK_OPEN)
+    end = doc.find(_BLOCK_CLOSE)
+    if start == -1 or end == -1 or end <= start:
+        return frozenset()
+    return frozenset(m.group("name") for m in _WELL_KNOWN_BULLET.finditer(doc[start:end]))
+
+
+def _is_kwargs_name(node: ast.expr) -> bool:
+    """True for ``kwargs`` and the locals providers derive from it.
+
+    ``motionbricks`` reads its goal off a ``call_kwargs`` copy it forwards, so
+    matching the bare name only would miss a real read - and reading a key off a
+    derived mapping is the same exposure as reading it off ``kwargs`` directly.
+    """
+    return isinstance(node, ast.Name) and node.id.endswith("kwargs")
+
+
+def _kwargs_key_read(node: ast.AST) -> str | None:
+    """The string key ``node`` reads out of a kwargs mapping, if it does."""
+    if (
+        isinstance(node, ast.Subscript)
+        and _is_kwargs_name(node.value)
+        and isinstance(node.slice, ast.Constant)
+        and isinstance(node.slice.value, str)
+    ):
+        return node.slice.value
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"get", "pop"}
+        and _is_kwargs_name(node.func.value)
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    ):
+        return node.args[0].value
+    return None
+
+
+def _goal_kwargs_by_provider_family() -> dict[str, frozenset[str]]:
+    """Map each kwarg key providers read to the provider families that read it.
+
+    A family is the provider package directory, so a provider's own variants
+    (``wbc/policy.py`` and ``wbc/gait.py``) count once between them - otherwise
+    every provider that ships two entry points would look like a consensus.
+    """
+    families: dict[str, set[str]] = collections.defaultdict(set)
+    for py in sorted(_POLICIES_ROOT.rglob("*.py")):
+        relative = py.relative_to(_POLICIES_ROOT).parts
+        if len(relative) < 2:
+            continue  # policies/*.py is shared machinery, not a provider family
+        family = relative[0]
+        for node in ast.walk(ast.parse(py.read_text(encoding="utf-8"))):
+            key = _kwargs_key_read(node)
+            if key is not None:
+                families[key].add(family)
+    return {key: frozenset(value) for key, value in families.items()}
+
+
+def _shared_goal_kwargs() -> frozenset[str]:
+    """Kwarg keys two or more independent provider families read."""
+    return frozenset(key for key, fams in _goal_kwargs_by_provider_family().items() if len(fams) >= 2)
+
+
+def _run_policy_documented_goal_keys() -> frozenset[str]:
+    """The goal keys ``SimEngine.run_policy`` names in its ``policy_kwargs`` entry.
+
+    Parsed from source rather than imported so the guard does not depend on the
+    simulation backend's optional dependencies being installed.
+    """
+    tree = ast.parse(_SIM_BASE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run_policy":
+            doc = ast.get_docstring(node) or ""
+            start = doc.find("policy_kwargs:")
+            if start == -1:
+                return frozenset()
+            # The entry ends at the next same-indent Args key (``n_episodes:``).
+            end = doc.find("n_episodes:", start)
+            block = doc[start:end] if end != -1 else doc[start:]
+            return frozenset(re.findall(r"``(target_[a-z_]+|world_update)``", block))
+    return frozenset()
+
+
+def _restated_keys(text: str, marker: str) -> frozenset[str]:
+    """The goal keys enumerated in the parenthesised run following ``marker``.
+
+    Shared by the two graded restatements so there is exactly one parser to keep
+    correct. Returns an empty set when the marker or the parentheses are absent;
+    every caller asserts non-emptiness separately, because "the prose moved" and
+    "the prose disagrees" are different failures and must not be reported as the
+    same one.
+    """
+    start = text.find(marker)
+    if start == -1:
+        return frozenset()
+    open_paren = text.find("(", start)
+    close_paren = text.find(")", open_paren)
+    if open_paren == -1 or close_paren == -1:
+        return frozenset()
+    return frozenset(re.findall(r"``(target_[a-z_]+|world_update)``", text[open_paren:close_paren]))
+
+
+def test_the_abc_documents_a_non_empty_goal_vocabulary() -> None:
+    """Non-vacuity: a docstring reflow that empties the parse must not read clean.
+
+    Every assertion below compares against this set, so a parser that silently
+    returns nothing would turn all of them green while the vocabulary went
+    undefended - the failure mode a bounding-sentinel parse actually has.
+    """
+    keys = _abc_well_known_keys()
+    assert keys, (
+        "parsed no well-known goal keys out of Policy.get_actions.__doc__; the "
+        f"block sentinels ({_BLOCK_OPEN!r} / {_BLOCK_CLOSE!r}) or the bullet "
+        "format changed, and every parity guard in this module is now vacuous"
+    )
+
+
+def test_the_scan_finds_the_provider_reads_it_grades_against() -> None:
+    """Non-vacuity for the other half: the code scan must actually find reads.
+
+    If the AST scan returned nothing, the set-equality guard would reduce to
+    "the ABC documents nothing" and pass on an empty vocabulary.
+    """
+    by_family = _goal_kwargs_by_provider_family()
+    assert by_family, "the provider scan found no kwargs reads at all under policies/"
+    assert _shared_goal_kwargs(), (
+        "no kwarg key is read by two provider families; the family grouping or "
+        f"the read patterns changed. scanned keys: {sorted(by_family)}"
+    )
+
+
+def test_the_abc_documents_every_goal_key_two_provider_families_share() -> None:
+    """A key two provider families read is shared vocabulary and must be on the ABC.
+
+    This is the direction that catches the real defect. ``target_velocity`` was
+    read by ``wbc`` and ``motionbricks`` while the ABC listed three keys, so a
+    provider author reading the contract could not discover the goal key two
+    shipped families already honoured.
+    """
+    shared = _shared_goal_kwargs()
+    documented = _abc_well_known_keys()
+    by_family = _goal_kwargs_by_provider_family()
+    missing = sorted(shared - documented)
+    assert not missing, (
+        "Policy.get_actions omits goal keys that two or more provider families "
+        f"already read: {missing} "
+        f"(read by { ({k: sorted(by_family[k]) for k in missing}) }). "
+        f"It documents {sorted(documented)}. Add the key to the well-known block "
+        "in strands_robots/policies/base.py - a caller cannot pass a goal key the "
+        "contract does not name."
+    )
+
+
+def test_the_abc_documents_nothing_no_two_provider_families_share() -> None:
+    """The vocabulary is extended by evidence, not widened by guesswork.
+
+    The converse direction: a key on the ABC that no two families read is either
+    dead vocabulary or a provider-private kwarg promoted by mistake. Keeping both
+    directions means the ABC tracks shipped behaviour exactly rather than drifting
+    in whichever direction is easier to add to.
+    """
+    shared = _shared_goal_kwargs()
+    documented = _abc_well_known_keys()
+    unshared = sorted(documented - shared)
+    by_family = _goal_kwargs_by_provider_family()
+    assert not unshared, (
+        "Policy.get_actions documents well-known goal keys that no two provider "
+        f"families read: {unshared} "
+        f"(read by { ({k: sorted(by_family.get(k, frozenset())) for k in unshared}) }). "
+        "Per AGENTS.md convention 11 a second independent caller is what makes a "
+        "name shared; one caller is evidence of nothing, so such a key belongs in "
+        "that provider's own documentation and not in the shared vocabulary."
+    )
+
+
+def test_a_single_family_kwarg_stays_out_of_the_shared_vocabulary() -> None:
+    """Negative control naming the keys the fix must NOT have swept in.
+
+    ``target_orientation`` and ``height`` are read by ``wbc`` (across its policy
+    and its gait variant, one family) and ``target_heading`` by ``motionbricks``
+    alone. They are ``target_``-shaped and sit in the same ``get_actions`` bodies
+    as the real vocabulary, so a guard keyed on the name shape rather than on the
+    second-caller rule would promote them. Pinning them here is what makes the
+    equality above evidence that the allowlist was extended by one key rather
+    than opened to everything that looks like a goal.
+    """
+    by_family = _goal_kwargs_by_provider_family()
+    documented = _abc_well_known_keys()
+    for private in ("target_orientation", "target_heading", "height"):
+        assert private in by_family, (
+            f"{private} is no longer read by any provider; this control now pins "
+            "nothing and should be re-pointed at a current single-family kwarg"
+        )
+        assert len(by_family[private]) == 1, (
+            f"{private} is now read by {sorted(by_family[private])} - two families "
+            "share it, so it has become shared vocabulary and this control is stale"
+        )
+        assert private not in documented, (
+            f"{private} is read by exactly one provider family "
+            f"({sorted(by_family[private])}) but is documented as shared "
+            "well-known vocabulary on Policy.get_actions"
+        )
+
+
+def test_the_abc_and_run_policy_document_the_same_goal_set() -> None:
+    """The ABC and its main in-tree consumer must name one vocabulary.
+
+    ``SimEngine.run_policy`` offers itself as "the local-sim analogue of the mesh
+    ``tell()`` path", and the mesh wire validator and dispatcher forward set are
+    already graded against *its* docstring. Pinning the two docstrings equal is
+    what makes those downstream guards transitively anchored to the ABC that owns
+    the vocabulary, instead of to a second copy of the list that can drift from
+    it independently - which is the state this test was written to end.
+    """
+    abc_keys = _abc_well_known_keys()
+    run_policy_keys = _run_policy_documented_goal_keys()
+    assert run_policy_keys, (
+        "parsed no goal keys out of SimEngine.run_policy's policy_kwargs entry; "
+        "this guard is vacuous until its parse is repaired"
+    )
+    assert abc_keys == run_policy_keys, (
+        "Policy.get_actions and SimEngine.run_policy document different #300 goal "
+        f"vocabularies. ABC: {sorted(abc_keys)}; run_policy: {sorted(run_policy_keys)}. "
+        f"Only on the ABC: {sorted(abc_keys - run_policy_keys)}; only on run_policy: "
+        f"{sorted(run_policy_keys - abc_keys)}. The ABC is the definition - bring the "
+        "consumer to it."
+    )
+
+
+def test_the_package_docstring_enumerates_the_same_vocabulary_as_the_abc() -> None:
+    """``strands_robots.policies``'s own docstring copies the list and cites its source.
+
+    It reads "the well-known ``**kwargs`` keys (...) documented on
+    :meth:`Policy.get_actions`" - a convenience copy that names the ABC as its
+    authority, so a reader who trusts the citation never opens the ABC and sees
+    whatever the copy last said. It carried the same three-key set the ABC did.
+
+    Only this one restatement is graded. Two other kinds deliberately are not, and
+    both are correct at three keys: a *provider-scoped* list (``curobo/__init__``
+    says cuRobo reads pose / joints / world_update, which is what cuRobo reads),
+    and a *historical* one ("the ABC contract landed in #300 (well-known ... )",
+    true of #300 as shipped). Holding either to the current vocabulary would
+    demand a false statement, so the discriminator for grading is that the
+    restatement claims to be the present, whole vocabulary.
+    """
+    import strands_robots.policies as policies_pkg
+
+    enumerated = _restated_keys(policies_pkg.__doc__ or "", "well-known")
+    assert enumerated, (
+        "parsed no goal keys out of the strands_robots.policies docstring's "
+        "well-known enumeration; the prose moved and this guard is vacuous "
+        "until it is re-pointed"
+    )
+    documented = _abc_well_known_keys()
+    assert enumerated == documented, (
+        "the strands_robots.policies docstring enumerates a different goal "
+        f"vocabulary than the Policy.get_actions ABC it cites. package: "
+        f"{sorted(enumerated)}; ABC: {sorted(documented)}. Only in the package "
+        f"docstring: {sorted(enumerated - documented)}; only on the ABC: "
+        f"{sorted(documented - enumerated)}."
+    )
+
+
+def test_the_cosmos3_restatement_of_the_abc_list_stays_accurate() -> None:
+    """``Cosmos3Policy.get_actions`` restates the ABC's list to disclaim all of it.
+
+    It says "None of the well-known keys the ABC lists (...) is read by either
+    backend" - an enumeration *and* a behavioural claim about the whole
+    vocabulary. Both halves go stale when the vocabulary grows: the list silently
+    falls behind, and the disclaimer starts covering fewer keys than it names
+    while still reading as though it covered them all.
+
+    So both halves are graded. The enumeration must equal the ABC's, and the
+    behavioural claim must actually hold - checked against the same provider scan
+    the vocabulary itself is derived from, not against the prose.
+    """
+    source = (_POLICIES_ROOT / "cosmos3" / "policy.py").read_text(encoding="utf-8")
+    marker = "well-known keys the ABC lists"
+    assert marker in source, (
+        f"cosmos3/policy.py no longer contains {marker!r}; the disclaimer was "
+        "reworded and this guard is vacuous until it is re-pointed"
+    )
+    enumerated = _restated_keys(source, marker)
+    documented = _abc_well_known_keys()
+    assert enumerated == documented, (
+        "cosmos3/policy.py restates the ABC's well-known key list but names a "
+        f"different set. cosmos3: {sorted(enumerated)}; ABC: {sorted(documented)}. "
+        f"Only in cosmos3: {sorted(enumerated - documented)}; only on the ABC: "
+        f"{sorted(documented - enumerated)}."
+    )
+
+    # The behavioural half of the same sentence.
+    read_by_cosmos3 = {key for key, fams in _goal_kwargs_by_provider_family().items() if "cosmos3" in fams}
+    contradicted = sorted(read_by_cosmos3 & documented)
+    assert not contradicted, (
+        "cosmos3/policy.py claims none of the well-known goal keys is read by "
+        f"either backend, but it reads {contradicted}. Either the provider grew a "
+        "goal-key reader or the disclaimer is now false."
+    )


### PR DESCRIPTION
## Problem

`Policy.get_actions` is where the issue #300 well-known `**kwargs` goal vocabulary is *defined*. It is the docstring a provider author reads to learn which keys a caller may pass without coupling to a backend, and `strands_robots.policies`'s own docstring points at it by name for the list: "the well-known `**kwargs` keys (...) **documented on** `Policy.get_actions`".

It listed three keys. `target_velocity` was the fourth everywhere else:

| site | role | keys |
|---|---|---|
| **`Policy.get_actions`** | **the definition** | **3** |
| **`strands_robots.policies` docstring** | **copy that cites the ABC** | **3** |
| **`Cosmos3Policy.get_actions`** | **restates the list to disclaim all of it** | **3** |
| `SimEngine.run_policy` | consumer | 4 |
| `SimEngine.eval_policy` | consumer | 4 |
| `SimEngine.run_benchmark` | consumer | 4 |
| `PolicyRunner.run` | consumer | 4 |
| mesh wire validator + dispatcher | transport | 4 (since #2613) |
| `docs/policies/wbc.md` | reference | 4 |

`docs/policies/wbc.md` says it in as many words - "`target_velocity` is one of the issue #300 well-known goal keys" - and two independent provider families read it: `wbc` (policy + its `gait` variant) and `motionbricks`. So the contract's own definition was the only place the key was missing, and it is the place a new provider author looks first.

Nothing executes a docstring. That is the mechanism: the one list in the set that is not a consumer is the one a new key can be forgotten on while every consumer keeps working, and no test noticed because the guard that existed compared the vocabulary against *another docstring*. #2613 graded the mesh wire and dispatcher against `run_policy`'s docstring - a consumer - so the tree ended up holding two competing definitions with the downstream guards anchored to the wrong one.

`tests/policies/test_base.py::test_well_known_kwargs_are_accepted_by_contract` was the closest thing to a guard and it hard-coded the same three keys, so it agreed with the omission rather than catching it.

## Change

Source is docstring-only, 15 lines across the three enumerations that each claim to be the *present, whole* vocabulary:

- **`policies/base.py`** - the ABC gains the `target_velocity` bullet, in `run_policy`'s documented order. It also records why this key alone carries no fixed arity: shipped receivers disagree (whole-body controllers require `[vx, vy, omega]`, planar drivers read `[vx, vy]`), so each states its own requirement and the key crosses a transport on the per-component domain alone. That is #2613's finding, stated where the vocabulary is defined rather than only where it is validated.
- **`policies/__init__.py`** - the copy that cites the ABC now matches it.
- **`cosmos3/policy.py`** - the disclaimer restates the ABC's list in order to say none of it is read; the restatement is brought current so the sentence keeps covering every key it names.

### Deliberately not touched

Two other kinds of three-key enumeration are **correct** and are left alone, because holding either to the current vocabulary would demand a false statement:

- **provider-scoped** - `curobo/__init__.py` says cuRobo reads pose / joints / `world_update`, which is exactly what cuRobo reads.
- **historical** - "the `Policy` ABC contract for non-VLA providers landed in #300 (well-known ... kwargs)" is true of #300 as shipped; `target_velocity` arrived later.

The discriminator for grading a restatement is therefore that it claims to be the present whole vocabulary, and that rule is written into the test module.

## Tests

The guards deliberately **do not** compare the ABC against another docstring - that is how the tree came to hold two definitions. They derive what the vocabulary must contain from **shipped provider code**, statically scanning every provider package for the keys actually read out of `**kwargs`, and hold the ABC to it in both directions.

The discriminator between shared vocabulary and a provider-private kwarg is the second-caller rule AGENTS.md convention 11 already codifies for value-domain guards: a second independent caller is the evidence a shared name is right, one caller is evidence of nothing. A "provider family" is the provider package, so `wbc/policy.py` and its `wbc/gait.py` variant count once between them - otherwise any provider shipping two entry points would look like a consensus.

Measured on this tree the rule separates the vocabulary from the private kwargs with **no special cases at all**:

```
read by >= 2 families : target_joints, target_pose, target_velocity, world_update
read by exactly 1     : target_orientation, target_heading, target_heading_angle,
                        height, gait_frequency, style, mode, locomotion_style,
                        speed_scale, replan, scene_model, planning_group, seed,
                        text_prompt, guidance_scale, diffusion_steps, video,
                        raw_actions, enable_safety_checker, execution_horizon,
                        prev_chunk_left_over, motion, dof_pos, dof_vel,
                        root_ang_vel_local, anchor_rot_xyzw          (26 keys)
```

which is why the assertion is a set **equality** rather than a containment: the vocabulary is neither missing a key two families share nor carrying one no two families do.

Every guard fires for exactly its own regression, and nothing else:

| injected regression | guards that fail |
|---|---|
| revert all three source files (exact pre-fix) | 2 |
| revert only the ABC | 4 |
| revert only the package docstring | 1 |
| revert only the cosmos3 restatement | 1 |
| falsely promote a single-family kwarg (`target_orientation`) onto the ABC | 6 |
| a second family starts reading `target_orientation` | 2 |
| reword the ABC block sentinel (parse goes vacuous) | 6 |
| none | 0 of 62 |

The pre-fix row failing **2** rather than 4 is the defect's own signature: with the package docstring and cosmos3 reverted too, all three copies agree with each other and only the two guards anchored outside the prose - the provider-code scan and the ABC/`run_policy` equivalence - can still see the omission. That is precisely why the copies were not evidence.

Both halves carry a non-vacuity guard, since a bounding-sentinel parse that silently returns nothing would turn every comparison green. `target_orientation` / `target_heading` / `height` are pinned as single-family negative controls: they are `target_`-shaped and sit in the same `get_actions` bodies as the real vocabulary, so a guard keyed on name shape rather than on the second-caller rule would promote them - pinning them is what makes the equality evidence the allowlist was extended by one key rather than opened to anything goal-shaped.

The ABC/`run_policy` equivalence guard is what makes #2613's wire and dispatcher pins transitively anchored to the ABC that owns the vocabulary, instead of to a second copy that can drift from it independently.

`test_base.py`'s round trip now reads the key set off the contract and fails on a documented key it has no sample value for, so it can no longer agree with an omission.

## Verification

Measured at `bb045f4`, `/tmp/tenv` (python 3.13.15, pytest 9.1.1).

- `ruff check` over `strands_robots tests`: clean. `ruff format --check`: clean (1423 files).
- Blast radius: `tests/policies`, `tests/mesh`, `tests/simulation`, plus the repo-wide `Args:`/attribute docstring-completeness, static-export, docs-architecture, docs-callable-example and changelog-fragment guards. Run with the identical selection on this branch and on a pristine `fc4dba37` worktree, **excluding the two test files this PR adds or modifies**, so any difference is caused by the source change alone: **branch `329 failed / 13328 passed / 731 errors`, base `329 failed / 13328 passed / 731 errors`** - branch-only failure set **empty**, base-only set **empty**, all 329 shared.
- Those 329 failures and 731 collection errors are pre-existing in this environment and identical on both trees: `mujoco`, `lerobot` and other declared extras CI installs are absent from the minimal venv.

## Scope

`target_orientation`, `height` and `gait_frequency` are WBC's own per-call kwargs rather than part of the shared #300 vocabulary, so they stay off the ABC and are pinned as such. Widening the vocabulary itself, or the mesh dispatcher's constructor-extras allowlist, are separate contracts and are untouched.