### PR TITLE
fix(transforms): a provenance record that cannot answer is refused, not read as recorded

### DIFF
--- a/changelog.d/2616-provenance-record-that-cannot-answer.md
+++ b/changelog.d/2616-provenance-record-that-cannot-answer.md
@@ -1,0 +1,25 @@
+### Fixed: a provenance record that cannot answer is refused, not read as recorded
+
+The provenance sidecar exists so generated and recorded episodes stay
+distinguishable, and `synthetic_episode_indices()` is the one call that separates
+them: everything it returns was generated, everything outside it was recorded. It
+read the verdict with `synthetic is True`, so a record whose field was present but
+not a boolean landed outside the set - i.e. was reported as recorded, with nothing
+raised. `write_provenance()` is public and documents its record shape in full, and
+required only that the key be present, so `synthetic=1` or `synthetic="true"` was
+stored and then read as a recorded episode.
+
+The two keys a reader turns into a verdict are now held to the shared domains -
+`episode_index` on `non_negative_whole_number_error`, `synthetic` on
+`boolean_flag_error` - by one rule both `write_provenance()` and
+`load_provenance()` consult, so a record the writer refuses is a record the reader
+refuses. `synthetic` is refused rather than coerced, because every non-empty string
+and every non-zero number is truthy; `synthetic=false` remains a readable answer
+that is simply outside the set. The writer also stores both keys in the type the
+schema documents, which lets a NumPy verdict round-trip as JSON `true` instead of
+failing to serialise, and an `episode_index` that cannot name an episode is now
+named in the refusal rather than surfacing as `int()`'s own complaint.
+
+That split - validate the keys a reader turns into a verdict, carry the descriptive
+keys through untouched - is the one `record_deterministic_verdicts` already makes
+for the other per-episode sidecar.

--- a/docs/data/transforms.md
+++ b/docs/data/transforms.md
@@ -28,7 +28,15 @@ record (strands-robots)  ->  transform (this page)  ->  train (create_trainer)
    episode index, and the transform's name and version. Training filters and
    evaluation read it via `load_provenance()` / `synthetic_episode_indices()`,
    so generated pixels are treated honestly - silent mixing of generated and
-   recorded data is the failure mode this field exists to prevent.
+   recorded data is the failure mode this field exists to prevent. A record that
+   cannot answer what it is read for is refused rather than stored or trusted:
+   `episode_index` must be a non-negative whole number and `synthetic` must be a
+   boolean, checked by one rule that both `write_provenance()` and
+   `load_provenance()` consult. `synthetic` is not coerced, because every
+   non-empty string and every non-zero number is truthy - guessing which of them
+   meant "generated" is how a generated episode ends up counted as recorded. The
+   descriptive keys (`transform_version`, `prompt`, `seed`) are carried through
+   untouched; nothing reads them as a verdict.
 3. **Re-validation is the acceptance gate.** Supply a deterministic verdict
    function and every generated episode is re-scored against its source
    episode's verdict; a generated episode that flips the verdict is discarded
@@ -93,6 +101,12 @@ from strands_robots.transforms import synthetic_episode_indices
 synthetic = synthetic_episode_indices("/data/augmented")
 # everything in `synthetic` was generated; everything outside it was recorded
 ```
+
+An empty set is that statement, not a shrug: a dataset with no
+`meta/provenance.json` declares no synthetic episodes (the ordinary state of a
+recorded dataset), while a file that is present but unreadable raises. Absence
+and corruption are different verdicts, so "outside the set" always means
+recorded.
 
 ## Backends
 

--- a/strands_robots/transforms/provenance.py
+++ b/strands_robots/transforms/provenance.py
@@ -23,10 +23,58 @@ import json
 from pathlib import Path
 from typing import Any
 
+from strands_robots.utils import boolean_flag_error, non_negative_whole_number_error
+
 #: Location of the provenance sidecar, relative to a dataset root. Lives under
 #: ``meta/`` beside LeRobot's own ``info.json`` so dataset tooling that copies
 #: metadata copies the honesty record with it.
 PROVENANCE_RELPATH = "meta/provenance.json"
+
+
+#: The provenance keys a reader turns into a verdict, and the shared domain each
+#: is held to. ``episode_index`` is the index the reader returns and
+#: ``synthetic`` is the boolean it classifies on, so both are validated rather
+#: than merely required to be present - the same split
+#: :func:`~strands_robots.episode_labels.record_deterministic_verdicts` makes for
+#: the other per-episode sidecar, which validates the index and the verdict
+#: booleans it reads and carries its descriptive keys through untouched.
+#: ``transform`` stays a presence check for that reason: it labels a record, and
+#: no reader branches on it.
+_VERDICT_KEY_DOMAINS = {
+    "episode_index": non_negative_whole_number_error,
+    "synthetic": boolean_flag_error,
+}
+
+#: Keys every record must carry, whatever their type.
+_MANDATORY_KEYS = ("episode_index", "synthetic", "transform")
+
+
+def _record_problem(position: int, record: dict[str, Any], context: str) -> str | None:
+    """Error text when a provenance record cannot answer what it is read for.
+
+    The one owner of "is this record readable as provenance?", so
+    :func:`write_provenance` and :func:`load_provenance` cannot disagree about
+    which records are: a record the writer refuses is a record the reader
+    refuses, and vice versa.
+
+    Args:
+        position: Index of the record within the list, for the message.
+        record: The record to grade.
+        context: Surface name for the message (the caller's own function).
+
+    Returns:
+        The error text, or ``None`` when the record is readable.
+    """
+    missing = [key for key in _MANDATORY_KEYS if key not in record]
+    if missing:
+        return (
+            f"{context}: record {position} is missing mandatory provenance key(s) {missing} - "
+            "a record that cannot say which episode is synthetic and what generated it is not provenance"
+        )
+    for key, domain in _VERDICT_KEY_DOMAINS.items():
+        if msg := domain(record[key], f"record {position} {key!r}", context):
+            return msg
+    return None
 
 
 def provenance_path(root: str | Path) -> Path:
@@ -58,24 +106,33 @@ def write_provenance(root: str | Path, records: list[dict[str, Any]]) -> Path:
         The path written.
 
     Raises:
-        ValueError: ``records`` is not a list of dicts, or a record omits the
-            mandatory keys (``episode_index``, ``synthetic``, ``transform``) -
-            a provenance file that cannot answer "is episode N synthetic, and
-            what generated it?" defeats its purpose, so it is refused rather
-            than written incomplete.
+        ValueError: ``records`` is not a list of dicts, or a record cannot
+            answer what it is read for - it omits a mandatory key
+            (``episode_index``, ``synthetic``, ``transform``), or its
+            ``episode_index`` is not a non-negative whole number, or its
+            ``synthetic`` is not a boolean. A provenance file that cannot answer
+            "is episode N synthetic, and what generated it?" defeats its
+            purpose, so it is refused rather than written unreadable. A
+            non-boolean ``synthetic`` in particular is refused rather than
+            coerced: every non-empty string is truthy and every non-zero number
+            is, so guessing which of them meant "generated" is how a generated
+            episode gets counted as recorded.
     """
     if not isinstance(records, list) or any(not isinstance(r, dict) for r in records):
         raise ValueError(f"write_provenance: records must be a list of dicts (got {type(records).__name__})")
+    written: list[dict[str, Any]] = []
     for i, record in enumerate(records):
-        missing = [key for key in ("episode_index", "synthetic", "transform") if key not in record]
-        if missing:
-            raise ValueError(
-                f"write_provenance: record {i} is missing mandatory provenance key(s) {missing} - "
-                "a record that cannot say which episode is synthetic and what generated it is not provenance"
-            )
+        if msg := _record_problem(i, record, "write_provenance"):
+            raise ValueError(msg)
+        # Store the verdict keys in the type the schema documents, so the file a
+        # reader loads holds the same answer the writer graded. The guard
+        # round-tripped both, and the caller's dict is left untouched.
+        written.append(
+            {**record, "episode_index": int(record["episode_index"]), "synthetic": bool(record["synthetic"])}
+        )
     path = provenance_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"version": 1, "episodes": records}
+    payload = {"version": 1, "episodes": written}
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return path
 
@@ -92,10 +149,14 @@ def load_provenance(root: str | Path) -> list[dict[str, Any]]:
         state of a recorded dataset.
 
     Raises:
-        ValueError: The file exists but cannot be parsed or does not hold the
-            documented shape. A present-but-unreadable honesty record is
-            corruption, not absence, so it is never read as "no synthetic
-            episodes".
+        ValueError: The file exists but cannot be parsed, does not hold the
+            documented shape, or holds a record that cannot answer what it is
+            read for (see :func:`write_provenance` for the per-record rule -
+            both ends apply the same one, so a record this refuses is a record
+            the writer would have refused). A present-but-unreadable honesty
+            record is corruption, not absence, so it is never read as "no
+            synthetic episodes" - which is what a record whose ``synthetic``
+            field is not a boolean would otherwise be read as.
     """
     path = provenance_path(root)
     if not path.is_file():
@@ -109,6 +170,9 @@ def load_provenance(root: str | Path) -> list[dict[str, Any]]:
         raise ValueError(
             f'provenance file {path} does not hold the documented shape ({{"version": ..., "episodes": [record, ...]}})'
         )
+    for i, record in enumerate(episodes):
+        if msg := _record_problem(i, record, f"provenance file {path}"):
+            raise ValueError(msg)
     return episodes
 
 
@@ -123,8 +187,18 @@ def synthetic_episode_indices(root: str | Path) -> set[int]:
 
     Returns:
         The set of ``episode_index`` values whose record carries a true
-        ``synthetic`` field; empty for a dataset with no provenance file.
+        ``synthetic`` field; empty for a dataset with no provenance file. A
+        record declaring ``synthetic=false`` is a readable answer and is simply
+        outside the set; a record whose ``synthetic`` is not a boolean cannot
+        answer at all and is refused by :func:`load_provenance` rather than
+        landing outside it.
+
+    Raises:
+        ValueError: Propagated from :func:`load_provenance` when the file is
+            present but unreadable. Never swallowed: an empty set means "this
+            dataset declares no synthetic episodes", so returning it for a file
+            that could not be read would be the silent mixing of generated and
+            recorded data this sidecar exists to prevent.
     """
-    return {
-        int(r["episode_index"]) for r in load_provenance(root) if r.get("synthetic") is True and "episode_index" in r
-    }
+    # ``load_provenance`` round-tripped both keys through the shared domains.
+    return {int(r["episode_index"]) for r in load_provenance(root) if bool(r["synthetic"])}

--- a/tests/transforms/test_provenance.py
+++ b/tests/transforms/test_provenance.py
@@ -8,6 +8,8 @@ reading it as "no synthetic episodes" would be exactly the silent mixing of
 generated and recorded data the file exists to prevent.
 """
 
+import json
+
 import pytest
 
 from strands_robots.transforms.provenance import (
@@ -74,3 +76,149 @@ class TestRefusals:
         path.write_text('{"episodes": "all of them"}', encoding="utf-8")
         with pytest.raises(ValueError, match="documented shape"):
             load_provenance(tmp_path)
+
+
+def _write_file(root, records: list[dict]) -> None:
+    """Plant a provenance file directly, as a hand edit or another tool would."""
+    meta = root / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "provenance.json").write_text(json.dumps({"version": 1, "episodes": records}), encoding="utf-8")
+
+
+#: Values a caller reaches for instead of a boolean ``synthetic``. Every one is
+#: truthy, so reading the field by truthiness would classify them as generated;
+#: reading it with ``is True`` classifies them as recorded. Both are guesses, and
+#: the second one is silent.
+_NON_BOOLEAN_SYNTHETIC = [1, 1.0, "true", "yes"]
+
+#: Values that cannot name an episode. ``int()`` raises on both, and one of the
+#: two raises ``TypeError``, outside anything this module documents.
+_UNUSABLE_EPISODE_INDEX = [None, "abc", -1]
+
+
+class TestARecordThatCannotAnswerIsRefusedNotReadAsRecorded:
+    """A verdict key present but unreadable is corruption, not a "no".
+
+    The sidecar exists to keep generated and recorded episodes distinguishable,
+    and :func:`~strands_robots.transforms.provenance.synthetic_episode_indices`
+    is the one call that distinguishes them: everything it returns was
+    generated, everything outside it was recorded. So a record whose
+    ``synthetic`` field is present but is not a boolean has exactly one wrong
+    outcome available - landing outside the set, i.e. being reported as recorded
+    - and that is the silent mixing the file exists to prevent. It is refused at
+    both ends instead, by one shared rule.
+    """
+
+    @pytest.mark.parametrize("synthetic", _NON_BOOLEAN_SYNTHETIC)
+    def test_the_writer_refuses_a_non_boolean_synthetic(self, tmp_path, synthetic):
+        record = {**_record(0, 3), "synthetic": synthetic}
+        try:
+            write_provenance(tmp_path, [record])
+        except ValueError as refused:
+            assert "synthetic" in str(refused)
+            return
+        pytest.fail(
+            f"write_provenance accepted synthetic={synthetic!r}, and synthetic_episode_indices then "
+            f"reports {synthetic_episode_indices(tmp_path)} - the generated episode reads as recorded"
+        )
+
+    @pytest.mark.parametrize("synthetic", _NON_BOOLEAN_SYNTHETIC)
+    def test_the_reader_refuses_a_non_boolean_synthetic(self, tmp_path, synthetic):
+        _write_file(tmp_path, [{**_record(0, 3), "synthetic": synthetic}])
+        try:
+            got = synthetic_episode_indices(tmp_path)
+        except ValueError as refused:
+            assert "synthetic" in str(refused)
+            return
+        pytest.fail(
+            f"a record carrying synthetic={synthetic!r} was read as {got} - the episode it declares "
+            "generated is reported as recorded, with nothing raised"
+        )
+
+    def test_a_missing_synthetic_field_is_refused_by_the_reader_too(self, tmp_path):
+        """The writer already refused this; a planted file must not slip past it."""
+        _write_file(tmp_path, [{"episode_index": 0, "transform": "mock"}])
+        with pytest.raises(ValueError, match="missing mandatory provenance key"):
+            synthetic_episode_indices(tmp_path)
+
+    @pytest.mark.parametrize("index", _UNUSABLE_EPISODE_INDEX)
+    def test_an_unusable_episode_index_is_named_rather_than_crashing_the_read(self, tmp_path, index):
+        """The refusal names the file and the field, not ``int()``'s own complaint."""
+        _write_file(tmp_path, [{**_record(0, 3), "episode_index": index}])
+        with pytest.raises(ValueError, match="episode_index"):
+            synthetic_episode_indices(tmp_path)
+
+
+class TestBothEndsApplyOneRule:
+    """The writer and the reader cannot disagree about which records are readable.
+
+    A record the writer refuses to store must be a record the reader refuses to
+    trust, or the surface has two notions of provenance and a file can be
+    unreadable only after it exists.
+    """
+
+    @pytest.mark.parametrize(
+        "record",
+        [
+            _record(0, 3),
+            {**_record(0, 3), "synthetic": False},
+            {**_record(0, 3), "synthetic": "true"},
+            {**_record(0, 3), "synthetic": 1},
+            {**_record(0, 3), "episode_index": None},
+            {**_record(0, 3), "episode_index": "abc"},
+            {"episode_index": 0, "transform": "mock"},
+            {"synthetic": True, "transform": "mock"},
+        ],
+        ids=str,
+    )
+    def test_the_writer_and_the_reader_reach_the_same_verdict(self, tmp_path, record):
+        writer_refused = False
+        try:
+            write_provenance(tmp_path / "w", [record])
+        except ValueError:
+            writer_refused = True
+
+        _write_file(tmp_path / "r", [record])
+        reader_refused = False
+        try:
+            load_provenance(tmp_path / "r")
+        except ValueError:
+            reader_refused = True
+
+        assert writer_refused == reader_refused, (
+            f"writer {'refused' if writer_refused else 'accepted'} but reader "
+            f"{'refused' if reader_refused else 'accepted'} {record!r}"
+        )
+
+
+class TestTheStoredRecordHoldsTheTypeTheSchemaDocuments:
+    """What the writer graded is what a reader loads."""
+
+    def test_a_numpy_boolean_verdict_round_trips_as_json_true(self, tmp_path):
+        """A verdict computed with NumPy is a boolean, and must reach the file as one."""
+        numpy = pytest.importorskip("numpy")
+        write_provenance(tmp_path, [{**_record(0, 3), "synthetic": numpy.True_}])
+        on_disk = json.loads(provenance_path(tmp_path).read_text(encoding="utf-8"))
+        assert on_disk["episodes"][0]["synthetic"] is True
+        assert synthetic_episode_indices(tmp_path) == {0}
+
+    def test_the_shipped_records_are_stored_unchanged(self, tmp_path):
+        """The transform surface's own records already hold the documented types."""
+        records = [_record(0, 3), _record(1, 3)]
+        before = json.dumps(records, sort_keys=True)
+        write_provenance(tmp_path, records)
+        on_disk = json.loads(provenance_path(tmp_path).read_text(encoding="utf-8"))
+        assert json.dumps(on_disk["episodes"], sort_keys=True) == before
+        assert json.dumps(records, sort_keys=True) == before  # the caller's list is untouched
+
+    def test_a_descriptive_key_is_carried_through_whatever_its_type(self, tmp_path):
+        """Only the keys a reader turns into a verdict are graded."""
+        write_provenance(tmp_path, [{**_record(0, 3), "transform_version": 3, "prompt": None}])
+        loaded = load_provenance(tmp_path)
+        assert loaded[0]["transform_version"] == 3
+        assert loaded[0]["prompt"] is None
+
+    def test_synthetic_false_is_a_readable_answer_outside_the_set(self, tmp_path):
+        """``false`` says "recorded"; that is an answer, not a failure to answer."""
+        write_provenance(tmp_path, [{**_record(0, 3), "synthetic": False}, _record(1, 3)])
+        assert synthetic_episode_indices(tmp_path) == {1}


### PR DESCRIPTION
## Problem

The provenance sidecar exists so generated and recorded episodes stay
distinguishable. Its module docstring, the `docs/data/transforms.md` contract
bullet and the test file's own docstring all name the same failure mode - *silent
mixing of generated and recorded data* - and `synthetic_episode_indices()` is the
one call that separates them. The documented consumer is:

```python
synthetic = synthetic_episode_indices("/data/augmented")
# everything in `synthetic` was generated; everything outside it was recorded
```

It read the verdict with `r.get("synthetic") is True`, so a record whose field
was present but not a boolean landed **outside** the set - i.e. was reported as
recorded, with nothing raised. `write_provenance()` is public and documents its
record shape in full, and required only that the key be *present*, so the whole
path is reachable through public API:

| record a caller supplies | `write_provenance` | `synthetic_episode_indices` |
|---|---|---|
| `synthetic=True` | accepted | `{0}` |
| `synthetic=1` | **accepted** | **`set()`** - reported recorded |
| `synthetic=1.0` | **accepted** | **`set()`** - reported recorded |
| `synthetic="true"` | **accepted** | **`set()`** - reported recorded |
| `synthetic=np.True_` | `TypeError: Object of type bool is not JSON serializable` | - |
| `episode_index=None` | accepted | `TypeError` from `int()` |
| `episode_index="abc"` | accepted | `ValueError: invalid literal for int()` |

Two further consequences of the same gap. A verdict computed with NumPy is a
`numpy.bool_`, which is not `True` and is not JSON-serialisable, so the most
natural way to *produce* a verdict could not be stored at all. And an
`episode_index` that cannot name an episode surfaced as `int()`'s own complaint -
naming neither the file nor the field, and as a `TypeError`, outside anything
this module documents.

`load_provenance()`'s own `Raises:` block already promises this cannot happen:
*"A present-but-unreadable honesty record is corruption, not absence, so it is
never read as 'no synthetic episodes'."* That held for a JSON parse error and for
the top-level shape, and not for a record.

## Change

One rule, consulted by both ends, holding the two keys a reader turns into a
verdict to the shared domains:

- `episode_index` -> `non_negative_whole_number_error` (the domain
  `PolicyRunner.replay` and `record_deterministic_verdicts` already use for an
  episode index)
- `synthetic` -> `boolean_flag_error`
- `transform` keeps its presence-only check

`synthetic` is refused rather than coerced. Every non-empty string and every
non-zero number is truthy, so guessing which of them meant "generated" is how a
generated episode gets counted as recorded; and `synthetic=false` stays a
readable answer that is simply outside the set.

`write_provenance` also stores the two verdict keys in the type the schema
documents (`bool()` / `int()`, on a copy - the caller's dict is untouched), so
the file a reader loads holds the same answer the writer graded. That is what
lets a NumPy verdict round-trip as JSON `true`.

That split - validate the keys a reader turns into a verdict, carry the
descriptive keys through untouched - is the one
`strands_robots.episode_labels.record_deterministic_verdicts` already makes for
the other per-episode sidecar: it validates `episode` on
`non_negative_whole_number_error` and `success` / `failure` on
`boolean_flag_error`, then carries `steps` / `cumulative_reward` / `seed`
through. The two sidecars now agree on what an episode index and a boolean
verdict are.

**Narrowing:** an `episode_index` spelled `"0"` used to be accepted and now
refuses, because that is the same domain's verdict for the same field on every
other episode-index surface in the tree.

## Verification

Measured at `627c794f`.

Real end-to-end run of the shipped transform, then the same records supplied
through the public writer and planted on disk:

![provenance record refusal](https://raw.githubusercontent.com/cagataycali/robots/media-provenance-record-refusal/provenance-record-refusal.png)

The control is the whole top half: the shipped transform reads 2 episodes, writes
2, discards 0, and the produced dataset is **byte-identical on both trees** -
`meta/provenance.json` bytes and all 12 generated frames read back out
(`np.array_equal` True). Three rows reported *recorded* before, none after; the
NumPy verdict now stores instead of failing to serialise.

Regression tests (`tests/transforms/test_provenance.py`, extending the file whose
docstring already states this contract): **15 failed / 16 passed** against
`upstream/main`, all 31 pass after. Every pre-fix failure is behavioural and
carries the measurement, e.g.

```
Failed: write_provenance accepted synthetic=1, and synthetic_episode_indices
        then reports set() - the generated episode reads as recorded
Failed: a record carrying synthetic='true' was read as set() - the episode it
        declares generated is reported as recorded, with nothing raised
AssertionError: Regex pattern did not match.
  Expected regex: 'episode_index'
  Actual message: "invalid literal for int() with base 10: 'abc'"
```

Each guard is load-bearing, one break each:

| break | failed | which guards fire |
|---|---|---|
| revert the source | 15 | the whole new set (the pre-fix split) |
| drop the reader half only | 14 | the 5 reader refusals + 6 writer/reader parity cases |
| drop the writer half only | 10 | the 4 writer refusals + 5 parity cases + the **pre-existing** `test_write_refuses_record_missing_mandatory_keys` |
| store the caller's value verbatim | 1 | the NumPy round-trip |
| coerce truthiness instead of refusing | 8 | both non-boolean refusal families |
| also validate the descriptive keys | 1 | the descriptive-key-carried-through control |
| control | 0 of 31 | - |

The writer-half break firing the *pre-existing* writer test is the evidence the
shared rule preserved the original refusal rather than replacing it.

Blast radius: 132 files (every test naming the provenance surface or the shared
domains, all of `tests/transforms`, plus the docs / docstring / string /
changelog guards), the identical selection on both trees with the changed test
file excluded from each:

| tree | result |
|---|---|
| this branch | `2 failed, 5632 passed, 83 skipped in 294.53s` |
| `upstream/main` | `2 failed, 5632 passed, 83 skipped in 294.58s` |

Byte-identical, with the failing-ID sets identical in both directions. The two
shared failures are a local environment artifact, not the diff:
`tests/training/test_lerobot.py::TestInProcessTrainerCorrectness::{test_base_model_warm_start_reads_checkpoint_config,
test_lora_base_model_does_not_preset_use_peft}` fail with `encode() takes 1
positional argument but 2 were given` on draccus 0.10.0, below the
`draccus>=0.11.6` floor lerobot 0.6.2 declares.

`ruff check` and `ruff format --check` clean on the CI scope; `mypy strands_robots
tests tests_integ` reports the same 24 pre-existing errors as a pristine
`upstream/main` worktree, none of them in the changed files. The PR is 4 files:
the module, its test file, the docs contract bullet and a changelog fragment.

Measured at `e24cd82a` (the fragment added the PR number after the PR was
opened; the source and test diff is unchanged from `627c794f`).

