### PR TITLE
fix(transforms): every input the determinism key is spread from is held to its domain

### DIFF
--- a/changelog.d/2617-determinism-key-input-domain.md
+++ b/changelog.d/2617-determinism-key-input-domain.md
@@ -1,0 +1,41 @@
+### Fixed: every input the determinism key is spread from is held to its domain
+
+`derive_variant_seed` spreads the triple `(seed, source_episode, variant)` through one
+`numpy.random.SeedSequence`, so all three name the stream a generated variant is rendered
+from. Only `source_episode` was checked, and the other two degraded exactly the way that
+function's own `Raises:` block already warns about for the one that was.
+
+Measured on mid-grey frames through `MockTransform`: `variant=True` derived pixel 110,
+byte-identical to `variant=1`; `variant="1"` the same, because NumPy coerces a str spelling
+of a whole number; `variant=False` matched `variant=0`; and `seed=True` and `seed="1"` both
+derived `seed=1`'s key. Two "distinct" variants of one episode were therefore written into
+the augmented dataset as two episodes whose pixels are identical, under provenance records
+naming different `variant` counters - so the data-multiplication factor the transform
+surface exists for was silently 1 for that pair, with no refusal anywhere.
+
+The values NumPy refuses on its own were no better placed: `-1`, `2.5` and `None` arrived as
+its internal `expected non-negative integer` / `seed must be integer` /
+`object of type 'NoneType' has no len()`, naming neither the parameter nor the surface, and
+two of those are `TypeError` rather than the `ValueError` these surfaces document as their
+refusal channel.
+
+All three inputs now go through the shared `non_negative_whole_number_error` rule, with
+`seed=None` kept as the documented opt-out from determinism rather than a stream name. The
+`int()` coercion moves after the guard, never before, which is the ordering that rule's own
+docstring asks for. Every triple accepted before derives the identical key; the only change
+on the accepted side is that an integral float is honored on `variant` and `seed` exactly as
+it already was on `source_episode`.
+
+Both backend seams refuse the counter too, for the reason their `source_episode` guards
+already exist. A backend need never reach `derive_variant_seed` at all - `mock`'s explicit
+`pixel_shift` mode derives no key, so it shifted the pixels without reading the counter once
+for any value above - and the refusal should name the counter rather than whatever the
+pipeline seam reaches first: unbound, `cosmos_transfer` reported an unusable counter as "no
+video2video pipeline is bound", a wiring diagnosis for the one thing the caller had got
+right.
+
+`transform()` is unaffected either way: it derives `variant` from
+`range(int(spec.variants_per_episode))` and the shared spec preflight already holds
+`variants_per_episode`, `episodes[]` and `seed` to their domains, so the reachable surface is
+a direct caller of the public helper or of the backend seam - the same reachability the
+shipped `source_episode` guard is justified by.

--- a/docs/data/transforms.md
+++ b/docs/data/transforms.md
@@ -147,3 +147,24 @@ register_transform("my_v2v", lambda: MyTransform)
 
 The base class owns the dataset plumbing, pass-through, provenance and
 re-validation gate, so a backend cannot accidentally weaken them.
+
+`transform_frames` is called with the determinism key's two per-call inputs,
+`source_episode` and `variant`, and owns one obligation of its own: refuse a
+value either is not. Both are non-negative whole numbers - together with
+`spec.seed` they are spread through one `SeedSequence` by `derive_variant_seed`,
+so an unusable value on any of the three names a stream another variant already
+owns rather than failing:
+
+```python
+from strands_robots.utils import non_negative_whole_number_error
+
+for name, value in (("source_episode", source_episode), ("variant", variant)):
+    if text := non_negative_whole_number_error(value, name, "my_v2v.transform_frames"):
+        raise ValueError(text)
+```
+
+`derive_variant_seed` applies the same rule to all three, so a backend that
+always derives a key inherits it - but refuse in `transform_frames` too, because
+a backend need not derive one at all (`mock`'s explicit `pixel_shift` mode reads
+no key), and because the refusal should name the counter rather than whatever
+the pipeline seam happens to complain about first.

--- a/strands_robots/transforms/base.py
+++ b/strands_robots/transforms/base.py
@@ -196,26 +196,42 @@ def derive_variant_seed(seed: int | None, source_episode: int, variant: int) -> 
     same spec always reproduces the same output.
 
     Args:
-        seed: The spec's base seed (:attr:`TransformSpec.seed`).
+        seed: The spec's base seed (:attr:`TransformSpec.seed`), a non-negative
+            whole number or ``None`` to opt out of determinism.
         source_episode: Source episode index the variant is generated from.
         variant: Variant counter within that episode
-            (``0 .. variants_per_episode - 1``).
+            (``0 .. variants_per_episode - 1``), a non-negative whole number.
 
     Returns:
         A 32-bit seed, or ``None`` when ``seed`` is ``None``.
 
     Raises:
-        ValueError: ``source_episode`` is outside the non-negative
-            whole-number domain every episode-resolving surface shares.
-            ``True`` is the value worth naming: unrefused it derives episode
-            1's seed, so a variant of episode ``True`` silently collides with
-            a variant of episode 1.
+        ValueError: Any of the three inputs is outside the non-negative
+            whole-number domain the key needs (``seed=None`` excepted - that
+            spelling opts out of determinism rather than naming a stream).
+            Each is checked because each spreads into the same
+            :class:`~numpy.random.SeedSequence`, so an unusable value on any
+            of them yields a key some other triple already owns: ``True`` is
+            the value worth naming, since unrefused it is ``1`` to NumPy, and
+            a str spelling of a whole number is coerced to it. Episode
+            ``True`` therefore silently collided with episode 1, variant
+            ``True`` (or ``"1"``) with variant 1, and ``seed=True`` with
+            ``seed=1`` - two "distinct" variants generated from one stream,
+            written as two episodes whose pixels are byte-identical. The
+            values NumPy refuses on its own reached here as its internal
+            ``TypeError``/``ValueError`` naming neither the parameter nor this
+            surface.
     """
-    if text := non_negative_whole_number_error(source_episode, "source_episode", "derive_variant_seed"):
-        raise ValueError(text)
+    for name, value in (("seed", seed), ("source_episode", source_episode), ("variant", variant)):
+        if name == "seed" and value is None:
+            continue  # documented opt-out, not a stream name
+        if text := non_negative_whole_number_error(value, name, "derive_variant_seed"):
+            raise ValueError(text)
     if seed is None:
         return None
-    return int(np.random.SeedSequence([seed, int(source_episode), variant]).generate_state(1)[0])
+    # int() after the guard, never before: the shared rule has already
+    # compared the coercion back against the value it was given.
+    return int(np.random.SeedSequence([int(seed), int(source_episode), int(variant)]).generate_state(1)[0])
 
 
 class DatasetTransform(ABC):
@@ -290,6 +306,13 @@ class DatasetTransform(ABC):
             variant: Variant counter within that episode. Together with
                 :attr:`TransformSpec.seed` and ``source_episode`` this is the
                 determinism key - see :func:`derive_variant_seed`.
+                Implementations refuse a value outside the same non-negative
+                whole-number domain, for the same reason they refuse one on
+                ``source_episode``: an unusable counter names a stream another
+                variant already owns. The guard lives in each implementation
+                because a backend may never reach
+                :func:`derive_variant_seed` (a fixed shift reads no key), and
+                this abstract declaration carries no body.
 
         Returns:
             Transformed pixels with the SAME shape and dtype as ``frames``.

--- a/strands_robots/transforms/cosmos_transfer.py
+++ b/strands_robots/transforms/cosmos_transfer.py
@@ -204,19 +204,20 @@ class CosmosTransferTransform(DatasetTransform):
             refuses anything else loudly).
 
         Raises:
-            ValueError: ``source_episode`` is outside the non-negative
-                whole-number domain shared by every episode-resolving surface
+            ValueError: ``source_episode`` or ``variant`` is outside the
+                non-negative whole-number domain the determinism key needs
                 (see :func:`~strands_robots.transforms.base.derive_variant_seed`).
+                Both are refused ahead of the pipeline-binding check, so an
+                unusable counter is not reported as a wiring problem.
             RuntimeError: No pipeline is bound. Unreachable through
                 :meth:`~strands_robots.transforms.base.DatasetTransform.transform`,
                 which validates first; raised for a direct caller so the
                 refusal names the remedy instead of surfacing as an
                 ``AttributeError`` on ``None``.
         """
-        if text := non_negative_whole_number_error(
-            source_episode, "source_episode", "cosmos_transfer.transform_frames"
-        ):
-            raise ValueError(text)
+        for name, value in (("source_episode", source_episode), ("variant", variant)):
+            if text := non_negative_whole_number_error(value, name, "cosmos_transfer.transform_frames"):
+                raise ValueError(text)
         if self._pipeline is None and self._pipeline_problems():
             raise RuntimeError(f"cosmos_transfer.transform_frames: no video2video pipeline is bound - {_PIPELINE_HELP}")
         pipeline = self._pipeline

--- a/strands_robots/transforms/mock.py
+++ b/strands_robots/transforms/mock.py
@@ -82,14 +82,18 @@ class MockTransform(DatasetTransform):
             Shifted pixels, same shape and dtype.
 
         Raises:
-            ValueError: ``source_episode`` is outside the non-negative
-                whole-number domain shared by every episode-resolving surface
+            ValueError: ``source_episode`` or ``variant`` is outside the
+                non-negative whole-number domain the determinism key needs
                 (see :func:`~strands_robots.transforms.base.derive_variant_seed`).
-                Refused before the explicit ``pixel_shift`` short-circuit, so
-                the two constructor modes agree on the accepted domain.
+                Both are refused before the explicit ``pixel_shift``
+                short-circuit, so the two constructor modes agree on the
+                accepted domain - and ``variant`` has to be refused here as
+                well as there, because that short-circuit never derives a key
+                to be refused by.
         """
-        if text := non_negative_whole_number_error(source_episode, "source_episode", "mock.transform_frames"):
-            raise ValueError(text)
+        for name, value in (("source_episode", source_episode), ("variant", variant)):
+            if text := non_negative_whole_number_error(value, name, "mock.transform_frames"):
+                raise ValueError(text)
         if self._pixel_shift is not None:
             shift = self._pixel_shift
         else:

--- a/tests/transforms/test_frame_surface_episode_domain.py
+++ b/tests/transforms/test_frame_surface_episode_domain.py
@@ -1,15 +1,48 @@
-"""The frame-level transform surfaces refuse an unusable source-episode value.
+"""The frame-level transform surfaces refuse an unusable determinism-key input.
 
-The structural sweep in ``tests/simulation/test_replay_episode_index_domain.py``
-pins that :func:`~strands_robots.transforms.base.derive_variant_seed` and each
-backend's ``transform_frames`` apply the shared non-negative whole-number rule
-to ``source_episode``. This file drives the real functions, because what the
-sweep protects is behaviour: ``derive_variant_seed(seed, True, 0)`` is
-``derive_variant_seed(seed, 1, 0)`` unrefused, so a variant of episode ``True``
-would silently share its determinism key - and therefore its pixels - with a
-variant of episode 1. ``transform_frames`` is the documented seam a backend
-author calls directly, so it refuses the same domain rather than disagreeing
-with the orchestration that validated ``spec.episodes`` upstream.
+:func:`~strands_robots.transforms.base.derive_variant_seed` spreads the triple
+``(seed, source_episode, variant)`` through one
+:class:`~numpy.random.SeedSequence`, so all three name the stream a generated
+variant is rendered from. The structural sweep in
+``tests/simulation/test_replay_episode_index_domain.py`` pins the
+``source_episode`` half - that sweep's scope is the episode-index quantity - and
+this file drives the real functions, because what is protected is behaviour:
+``derive_variant_seed(seed, True, 0)`` is ``derive_variant_seed(seed, 1, 0)``
+unrefused, so a variant of episode ``True`` would silently share its
+determinism key - and therefore its pixels - with a variant of episode 1.
+
+The other two inputs to that one expression reached NumPy unchecked and
+degraded exactly the same way, measured on mid-grey frames through
+``MockTransform``:
+
+==================  ==============================  =====================
+input               pre-fix outcome                 collided with
+==================  ==============================  =====================
+``variant=True``    pixel 110, no refusal           ``variant=1``
+``variant=False``   pixel 121, no refusal           ``variant=0``
+``variant="1"``     pixel 110, no refusal           ``variant=1``
+``seed=True``       key 1835504127, no refusal      ``seed=1``
+``seed="1"``        key 1835504127, no refusal      ``seed=1``
+``variant=-1``      ``ValueError`` from NumPy       -
+``variant=2.5``     ``TypeError`` from NumPy        -
+``variant=None``    ``TypeError`` from NumPy        -
+==================  ==============================  =====================
+
+Three classes in one parameter, the same three the episode-index sweep records:
+a **bool named a stream another variant already owned** (and so did a str
+spelling of a whole number, which NumPy coerces), leaving two "distinct"
+variants of one episode written as two episodes whose pixels are
+byte-identical; the values NumPy refuses on its own **named neither the
+parameter nor the surface**; and two of them raised ``TypeError``, which is not
+the ``ValueError`` these surfaces document as their refusal channel.
+
+``transform_frames`` is the documented seam a backend author calls directly, so
+it refuses the same domain rather than disagreeing with the orchestration that
+validated ``spec.episodes`` / ``spec.variants_per_episode`` upstream - and
+``variant`` has to be refused there as well as inside ``derive_variant_seed``,
+because a backend need never reach that function: ``MockTransform``'s explicit
+``pixel_shift`` mode derives no key at all, so pre-fix it accepted every value
+in the table above without reading the counter once.
 """
 
 import numpy as np
@@ -29,7 +62,26 @@ UNUSABLE = [
     pytest.param(None, id="None"),
 ]
 
+#: ``seed`` alone admits ``None`` - the documented opt-out from determinism,
+#: not a stream name - so it is graded by its own control test instead.
+UNUSABLE_SEED = [param for param in UNUSABLE if param.values[0] is not None]
+
 _FRAMES = np.zeros((2, 4, 4, 3), dtype=np.uint8)
+
+
+class _RecordingPipeline:
+    """Minimal video2video pipeline that records whether it saw pixels at all."""
+
+    version = "recording"
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.seeds: list[int | None] = []
+
+    def generate(self, video, prompt="", seed=None):
+        self.calls += 1
+        self.seeds.append(seed)
+        return video
 
 
 class TestDeriveVariantSeed:
@@ -89,3 +141,144 @@ class TestTransformFramesRefusesTheSameDomain:
         )
         assert out.shape == _FRAMES.shape and out.dtype == _FRAMES.dtype
         assert (out == 3).all()
+
+
+class TestTheWholeDeterminismKeyIsHeldToTheDomain:
+    """Every input the key is spread from, not one of the three."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_an_unusable_variant_is_refused_with_the_shared_verdict(self, value):
+        expected = non_negative_whole_number_error(value, "variant", "derive_variant_seed")
+        assert expected is not None
+        with pytest.raises(ValueError) as excinfo:
+            derive_variant_seed(7, 0, value)
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize("value", UNUSABLE_SEED)
+    def test_an_unusable_seed_is_refused_with_the_shared_verdict(self, value):
+        expected = non_negative_whole_number_error(value, "seed", "derive_variant_seed")
+        assert expected is not None
+        with pytest.raises(ValueError) as excinfo:
+            derive_variant_seed(value, 0, 0)
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_variant_refusal_does_not_depend_on_a_seed_being_set(self, value):
+        """``seed=None`` opts out of determinism, not of the value domain."""
+        with pytest.raises(ValueError):
+            derive_variant_seed(None, 0, value)
+
+    @pytest.mark.parametrize("unusable,peer", [(True, 1), (False, 0), ("1", 1), ("0", 0)])
+    def test_a_variant_no_longer_names_another_variants_stream(self, unusable, peer):
+        """The load-bearing rows: pre-fix these two derived one key."""
+        with pytest.raises(ValueError):
+            derive_variant_seed(7, 0, unusable)
+        assert derive_variant_seed(7, 0, peer) is not None
+
+    @pytest.mark.parametrize("unusable,peer", [(True, 1), (False, 0), ("1", 1)])
+    def test_a_seed_no_longer_names_another_seeds_stream(self, unusable, peer):
+        with pytest.raises(ValueError):
+            derive_variant_seed(unusable, 0, 0)
+        assert derive_variant_seed(peer, 0, 0) is not None
+
+    def test_none_seed_is_still_the_documented_opt_out(self):
+        """Control: the one spelling that is absence rather than a stream."""
+        assert derive_variant_seed(None, 0, 0) is None
+        assert derive_variant_seed(None, 3, 2) is None
+
+    @pytest.mark.parametrize(
+        "triple,key",
+        [
+            ((7, 0, 0), 2083679832),
+            ((7, 0, 1), 2028854884),
+            ((7, 0, 2), 3835300069),
+            ((7, 2, 1), 1060258595),
+            ((11, 2, 1), 2549836301),
+        ],
+    )
+    def test_an_accepted_triple_derives_the_key_it_derived_before(self, triple, key):
+        """Control: widening the guard did not move any accepted stream.
+
+        The values are the pre-fix outputs, so this fails if the coercion
+        moved to before the guard (or changed what is spread into the
+        sequence) rather than after it.
+        """
+        assert derive_variant_seed(*triple) == key
+
+    @pytest.mark.parametrize("integral_float,whole", [(2.0, 2), (0.0, 0)])
+    def test_an_integral_float_is_honored_on_every_input(self, integral_float, whole):
+        """The shared rule accepts one, so all three inputs do - as ``source_episode`` already did."""
+        assert derive_variant_seed(7, 0, integral_float) == derive_variant_seed(7, 0, whole)
+        assert derive_variant_seed(integral_float, 0, 0) == derive_variant_seed(whole, 0, 0)
+
+    def test_accepted_variants_still_name_distinct_streams(self):
+        """Control: the guard refuses the domain, not the variance the key exists for."""
+        keys = {derive_variant_seed(7, 0, v) for v in range(4)}
+        assert len(keys) == 4
+
+
+class TestTransformFramesRefusesAnUnusableVariant:
+    """The backend seam agrees with the orchestration on the counter too."""
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_mock_backend_refuses_before_any_pixel_work(self, value):
+        with pytest.raises(ValueError, match="variant must be a non-negative whole number"):
+            MockTransform().transform_frames("cam", _FRAMES, TransformSpec(seed=7), source_episode=0, variant=value)
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_explicit_shift_mode_refuses_too(self, value):
+        """The row that needs a guard here rather than in the shared helper.
+
+        A fixed ``pixel_shift`` derives no key, so pre-fix this path shifted
+        the pixels without reading the counter for any value in the table.
+        """
+        with pytest.raises(ValueError, match="variant must be a non-negative whole number"):
+            MockTransform(pixel_shift=3).transform_frames(
+                "cam", _FRAMES, TransformSpec(), source_episode=0, variant=value
+            )
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_cosmos_backend_refuses_before_the_pipeline_binding_check(self, value):
+        """The domain refusal outranks the unbound-pipeline RuntimeError.
+
+        Pre-fix an unusable counter was reported as a wiring problem: "no
+        video2video pipeline is bound", naming the seam the caller had got right.
+        """
+        with pytest.raises(ValueError, match="variant must be a non-negative whole number"):
+            CosmosTransferTransform().transform_frames(
+                "cam", _FRAMES, TransformSpec(seed=7), source_episode=0, variant=value
+            )
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_a_bound_pipeline_never_sees_pixels_for_an_unusable_variant(self, value):
+        pipeline = _RecordingPipeline()
+        with pytest.raises(ValueError, match="variant must be a non-negative whole number"):
+            CosmosTransferTransform(pipeline=pipeline).transform_frames(
+                "cam", _FRAMES, TransformSpec(seed=7), source_episode=0, variant=value
+            )
+        assert pipeline.calls == 0
+
+    def test_an_accepted_variant_still_transforms(self):
+        """Control: the guard refuses the domain, not the callers."""
+        out = MockTransform(pixel_shift=3).transform_frames(
+            "cam", _FRAMES, TransformSpec(), source_episode=0, variant=2
+        )
+        assert out.shape == _FRAMES.shape and out.dtype == _FRAMES.dtype
+        assert (out == 3).all()
+
+    def test_two_accepted_variants_of_one_episode_still_differ(self):
+        """Control: two variants are two renderings, which is the point of the key."""
+        grey = np.full((2, 4, 4, 3), 128, dtype=np.uint8)
+        spec = TransformSpec(seed=7)
+        first = MockTransform().transform_frames("cam", grey, spec, source_episode=0, variant=0)
+        second = MockTransform().transform_frames("cam", grey, spec, source_episode=0, variant=1)
+        assert not np.array_equal(first, second)
+
+    def test_a_bound_pipeline_still_sees_an_accepted_variants_pixels(self):
+        pipeline = _RecordingPipeline()
+        out = CosmosTransferTransform(pipeline=pipeline).transform_frames(
+            "cam", _FRAMES, TransformSpec(seed=7), source_episode=0, variant=1
+        )
+        assert pipeline.calls == 1
+        assert out.shape == _FRAMES.shape
+        assert pipeline.seeds == [derive_variant_seed(7, 0, 1)]


### PR DESCRIPTION
## Problem

`derive_variant_seed` spreads the triple `(seed, source_episode, variant)` through one
`numpy.random.SeedSequence`, so all three inputs name the stream a generated variant is
rendered from. Only one of the three was checked.

The consequence is the one the function's own `Raises:` block already names for
`source_episode` - "unrefused it derives episode 1's seed, so a variant of episode `True`
silently collides with a variant of episode 1" - reached through the other two inputs.
Measured on mid-grey frames through `MockTransform`, and on the raw key:

| input | pre-fix outcome | collided with |
| --- | --- | --- |
| `variant=True` | pixel 110, no refusal | `variant=1` (pixel 110) |
| `variant=False` | pixel 121, no refusal | `variant=0` (pixel 121) |
| `variant="1"` | pixel 110, no refusal | `variant=1` |
| `seed=True` | key `1835504127`, no refusal | `seed=1` |
| `seed="1"` | key `1835504127`, no refusal | `seed=1` |
| `variant=-1` | `ValueError: expected non-negative integer` (NumPy) | - |
| `variant=2.5` | `TypeError: seed must be integer` (NumPy) | - |
| `variant=None` | `TypeError: object of type 'NoneType' has no len()` | - |

`np.array_equal` on the two renderings is `True` for the collision rows: two "distinct"
variants of one episode were written into the augmented dataset as two episodes whose
pixels are byte-identical, under provenance records naming different `variant` counters -
so the data-multiplication factor the transform surface exists for was silently 1 for that
pair. NumPy coerces a str spelling of a whole number, which is why `"1"` behaves as `1`.

The three rows NumPy refuses on its own are the other two classes the neighbouring
episode-index sweep records: the message named neither the parameter nor the surface, and
two of them are `TypeError`, which is not the `ValueError` these surfaces document as their
refusal channel.

At the backend seams the same counter degraded twice over:

| surface | pre-fix, unusable `variant` |
| --- | --- |
| `mock.transform_frames(pixel_shift=3)` | accepted every value, shifted the pixels - that path derives no key, so the counter was never read at all |
| `cosmos_transfer.transform_frames`, no pipeline | `RuntimeError: no video2video pipeline is bound` - a wiring diagnosis for a bad counter, naming the seam the caller had got right |
| `cosmos_transfer.transform_frames`, pipeline bound | `True` / `"1"` accepted and handed to `generate`; `-1` / `2.5` / `None` raised NumPy's internals |

## Change

Apply the shared `non_negative_whole_number_error` rule to all three inputs of the key in
`derive_variant_seed`, keeping `seed=None` as the documented opt-out from determinism
rather than a stream name. The `int()` coercion moves *after* the guard, never before,
which is the ordering that shared rule's own docstring asks for ("the caller coerces the
accepted value with `int()`; that coercion is safe *because* this guard has already
performed it and compared the result back").

Both backend seams refuse the counter too, for the reason their `source_episode` guards
already exist:

- a backend need never reach `derive_variant_seed` - `mock`'s explicit `pixel_shift` mode
  derives no key - so a guard only in the shared helper leaves that path unchecked;
- the refusal should name the counter rather than whatever the pipeline seam complains
  about first, which is what `test_the_cosmos_backend_refuses_before_the_pipeline_binding_check`
  already pins for the episode index.

Docs: `docs/data/transforms.md` "Custom backends" now states the one obligation
`transform_frames` owns beyond the pixels, with the two-line loop to copy, and says why it
is needed in the backend as well as in the shared helper.

## Scope

`transform()` is unaffected: it derives `variant` from `range(int(spec.variants_per_episode))`
and `_spec_problems` already holds `variants_per_episode`, `episodes[]` and `seed` to their
domains, so every value reaching the key through the orchestration was already clean. The
reachable surface is a direct caller of the public `derive_variant_seed` or of
`transform_frames` - which is exactly the reachability the shipped `source_episode` guard
is justified by ("`transform_frames` is the documented seam a backend author calls
directly, so it refuses the same domain rather than disagreeing with the orchestration
that validated `spec.episodes` upstream").

The structural sweep in `tests/simulation/test_replay_episode_index_domain.py` is untouched:
its scope is the episode-index quantity, and a variant counter is a different one.

## Tests

`tests/transforms/test_frame_surface_episode_domain.py`, extended from the
`source_episode` half to the whole key, with the measurement table in its module docstring.

Copied onto `upstream/main`: **50 failed / 47 passed**, all behavioural - the file imports
only pre-existing public symbols, so nothing fails on a missing name. Sharpest lines:
`DID NOT RAISE <class 'ValueError'>` for the collision rows, and
`TypeError: seed must be integer` / `object of type 'NoneType' has no len()` escaping a
surface documented to raise `ValueError`.

The 47 that pass on both trees are the controls, and each fails for a specific wrong fix:

| control | fails if |
| --- | --- |
| `test_an_accepted_triple_derives_the_key_it_derived_before` | the coercion moves before the guard, or what is spread into the sequence changes |
| `test_none_seed_is_still_the_documented_opt_out` | `seed=None` is read as a value rather than as absence |
| `test_accepted_variants_still_name_distinct_streams` | the guard narrows the variance the key exists for |
| `test_two_accepted_variants_of_one_episode_still_differ` | as above, at the pixel level |
| `test_an_integral_float_is_honored_on_every_input` | the new inputs are held to a narrower domain than `source_episode` |
| `test_a_bound_pipeline_still_sees_an_accepted_variants_pixels` | the guard refuses a legitimate call, or stops forwarding the derived key |

Break table on the fixed tree - each break fires exactly and only its own guards:

| break | fails | which |
| --- | --- | --- |
| revert all three files to `upstream/main` | 50 | the whole regression set |
| drop the `variant` guard from `derive_variant_seed` | 16 | the key + derived-shift mock cases |
| drop the `seed` guard from `derive_variant_seed` | 8 | only the two `seed` tests |
| drop the inline `variant` guard from `mock.transform_frames` | 6 | only `test_the_explicit_shift_mode_refuses_too` |
| drop the inline `variant` guard from `cosmos_transfer.transform_frames` | 6 | only `test_the_cosmos_backend_refuses_before_the_pipeline_binding_check` |
| coerce with `int()` before the guard instead of after | 19 | the shared-verdict and accepted-key controls |
| control (fixed tree) | 0 of 97 | - |

The last two rows of the first block are the reason both inline guards exist rather than
only the shared one. Dropping the mock guard fails **only** the explicit-shift class - the
derived-shift path still reaches `derive_variant_seed` and is still covered - and dropping
the cosmos guard fails **only** the unbound-pipeline class, where the `RuntimeError` would
otherwise answer first. They are complementary, not redundant.

## Artifact

The change is to which values the pixel-producing seam accepts, so the artifact is the
renderings themselves: `MockTransform` on a uniform mid-grey source at `seed=29`,
`source_episode=0`, one tile per variant counter (the mock adds a per-variant constant, so
each tile is that variant's whole frame).

![per-variant renderings before and after](https://raw.githubusercontent.com/cagataycali/robots/media-determinism-key-2617/determinism-key-variant-renderings.png)

Before, `variant=False` renders pixel 71 - variant 0's frame - and `variant=True` and
`variant="1"` both render pixel 192, variant 1's. Each is an extra generated episode
duplicating one already written. After, those three are refused and variants 0/1/2 are
unmoved at 71/192/134.

The console below the strip is the control: the same real end-to-end run - a recorded
LeRobotDataset in, an augmented LeRobotDataset out - on both trees. `status=success`,
`episodes_read=2`, `episodes_written=4`, `episodes_discarded=0`, the four
`meta/provenance.json` records identical field for field including their derived seeds, and
the first pixel of every written episode read back out of the produced dataset identical at
`[51, 39, 102, 80]`. The figure script asserts each of those from the captured JSON.

## Verification

Measured at `cc9ba885`.

- `tests/transforms/test_frame_surface_episode_domain.py`: **97 passed**, up from 37 collected.
- Blast radius, the identical 85-file selection (every test naming the transform surfaces,
  the shared rule, `variants_per_episode`, or reading the docs tree) run on this branch and
  on a pristine `upstream/main` worktree, with this file excluded from both so the
  comparison measures the source change alone: **3276 passed / 55 skipped / 0 failed,
  byte-identical on both**, 200.66s vs 202.33s.
- Every triple accepted before derives the identical key after: `(7,0,0) 2083679832`,
  `(7,0,1) 2028854884`, `(7,0,2) 3835300069`, `(7,2,1) 1060258595`, `(11,2,1) 2549836301`,
  `(None,0,0) None`, and `np.int64` unchanged. The one behaviour change on the accepted
  side is that an integral float is now honored on `variant`/`seed` exactly as it already
  was on `source_episode`.
- The mock's derived shift on accepted variants is unchanged in both trees:
  `variant 0/1/2 -> pixel 121/110/187`.
- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
  `mypy`: 24 == 24 against the pristine base, branch-only empty.
