### PR TITLE
fix(transforms): the pipeline seam reports a failed probe instead of raising it

### DIFF
--- a/changelog.d/2618-pipeline-seam-probe-reports.md
+++ b/changelog.d/2618-pipeline-seam-probe-reports.md
@@ -1,0 +1,22 @@
+### Fixed: a failed pipeline resolution is reported by the transform preflight, not raised at the caller
+
+`CosmosTransferTransform` binds a caller-supplied video2video pipeline, so resolving the seam runs the
+caller's code at three points: the module import and attribute lookup, the zero-arg construction of a
+class or factory target, and the read of the object's `generate` surface. `validate()` is documented to
+return a list of problems and `transform()` to return `status="error"` for anything but a backend
+shape/dtype bug, but only `ImportError`, `AttributeError` and `TypeError` were reported - 51 of 52 builtin
+exception classes raised out of both surfaces.
+
+The classes that escaped are the ones a real generation stack raises, because constructing one loads
+weights and touches a device: `ImportError` from an optional dependency imported inside a factory body
+(so `ModuleNotFoundError` escaped a handler written for exactly that case, which wrapped only the module
+import), `RuntimeError` with no driver, `OSError` with the weights absent, and `ValueError` on a malformed
+config - the last indistinguishable from the shape/dtype `ValueError` that `transform()` documents as its
+only raise. A lazy handle whose `generate` is a property raised at the third point, where `getattr`'s
+default absorbs only `AttributeError`.
+
+Each probe point now reports, with the cause named accurately: a factory that raised is constructible, so
+it is not folded into the "not constructible zero-arg" wording, which would name the wrong remedy. The
+`generate` read has one guarded owner. `Exception`, not `BaseException` - an operator's Ctrl-C during a
+multi-gigabyte load is not a bad spec and still propagates. Every spelling that already reached a verdict
+keeps it, wording included.

--- a/docs/data/transforms.md
+++ b/docs/data/transforms.md
@@ -148,6 +148,17 @@ spec = TransformSpec(
 Without a pipeline, `validate()` names the missing seam (and the licensing
 caveat) instead of crashing; nothing is read or written.
 
+The same holds for a pipeline that is named but cannot be loaded. Resolving the
+seam runs your code at three points - the module import and attribute lookup,
+the zero-arg construction of a class or factory target, and the read of the
+object's `generate` surface - and constructing a real generation pipeline loads
+weights and touches a device. So a missing optional dependency imported inside
+a factory body, an absent driver, absent weights or a malformed config are
+reported by `validate()` as problems, and by `transform()` as
+`status="error"`, each naming the class and message the pipeline raised. An
+operator interrupt (`KeyboardInterrupt`, `SystemExit`) is not a spec problem
+and still propagates.
+
 ## Custom backends
 
 Subclass `DatasetTransform`, implement `provider_name`, `validate` (call

--- a/strands_robots/transforms/cosmos_transfer.py
+++ b/strands_robots/transforms/cosmos_transfer.py
@@ -89,6 +89,38 @@ _PIPELINE_HELP = (
     "wiring it in."
 )
 
+#: Sentinel for "the pipeline exposes no ``generate`` attribute at all", kept
+#: distinct from a ``generate`` that is present but ``None`` so the probe below
+#: classifies both exactly as ``hasattr`` / ``getattr`` did.
+_UNSET: Any = object()
+
+
+def _generate_surface(obj: Any, subject: str) -> tuple[Any, str | None]:
+    """Read ``obj.generate`` for the probe, or report why the read failed.
+
+    The pipeline is caller-supplied, so reading an attribute off it runs the
+    caller's code: a lazy handle that initialises a CUDA context on first
+    access raises here, and ``getattr``'s default only absorbs
+    ``AttributeError``. Reporting keeps this probe inside
+    :meth:`~strands_robots.transforms.base.DatasetTransform.validate`'s
+    "return problems" contract.
+
+    Args:
+        obj: The candidate pipeline - an injected object or a resolved import
+            target.
+        subject: How the caller named it, for the problem text.
+
+    Returns:
+        ``(surface, None)`` where ``surface`` is the attribute or :data:`_UNSET`
+        when absent, or ``(_UNSET, problem)`` when the read itself raised.
+    """
+    try:
+        return getattr(obj, "generate", _UNSET), None
+    except Exception as exc:  # noqa: BLE001 - never fatal while probing a caller's object
+        return _UNSET, (
+            f"{subject} raised {type(exc).__name__} while its generate() surface was read ({exc}) - {_PIPELINE_HELP}"
+        )
+
 
 class CosmosTransferTransform(DatasetTransform):
     """Video2video episode augmentation behind a vendor-neutral pipeline seam.
@@ -143,10 +175,12 @@ class CosmosTransferTransform(DatasetTransform):
         instance validate approved.
         """
         if self._pipeline is not None:
-            if not callable(getattr(self._pipeline, "generate", None)):
-                return [
-                    f"pipeline object {type(self._pipeline).__name__} has no callable generate() - {_PIPELINE_HELP}"
-                ]
+            subject = f"pipeline object {type(self._pipeline).__name__}"
+            surface, problem = _generate_surface(self._pipeline, subject)
+            if problem:
+                return [problem]
+            if not callable(surface):
+                return [f"{subject} has no callable generate() - {_PIPELINE_HELP}"]
             return []
         if self._pipeline_spec is None:
             return [f"no video2video pipeline is bound - {_PIPELINE_HELP}"]
@@ -156,20 +190,39 @@ class CosmosTransferTransform(DatasetTransform):
         module_name, _, attr_name = path.partition(":") if ":" in path else path.rpartition(".")
         if not module_name or not attr_name:
             return [f"pipeline import path {path!r} is not 'pkg.mod:attr' or 'pkg.mod.attr' - {_PIPELINE_HELP}"]
+        subject = f"pipeline import path {path!r}"
         try:
             candidate = getattr(importlib.import_module(module_name), attr_name)
-        except (ImportError, AttributeError) as exc:
-            return [f"pipeline import path {path!r} did not resolve ({exc}) - {_PIPELINE_HELP}"]
+        except Exception as exc:  # noqa: BLE001 - never fatal during name resolution
+            # Not only ``ImportError`` / ``AttributeError``: a module body runs
+            # arbitrary caller code on first import, and a module-level
+            # ``__getattr__`` runs it again on the attribute lookup.
+            return [f"{subject} did not resolve ({type(exc).__name__}: {exc}) - {_PIPELINE_HELP}"]
+        surface, problem = _generate_surface(candidate, subject)
+        if problem:
+            return [problem]
         # A class target (or a factory with no generate of its own) is
         # constructed zero-arg; an unconstructed class would otherwise pass the
         # generate() probe and then receive the video as its ``self``.
-        if isinstance(candidate, type) or (callable(candidate) and not hasattr(candidate, "generate")):
+        if isinstance(candidate, type) or (callable(candidate) and surface is _UNSET):
             try:
                 candidate = candidate()
             except TypeError as exc:
-                return [f"pipeline import path {path!r} is not constructible zero-arg ({exc}) - {_PIPELINE_HELP}"]
-        if not callable(getattr(candidate, "generate", None)):
-            return [f"pipeline import path {path!r} resolves to no generate() surface - {_PIPELINE_HELP}"]
+                return [f"{subject} is not constructible zero-arg ({exc}) - {_PIPELINE_HELP}"]
+            except Exception as exc:  # noqa: BLE001 - never fatal during name resolution
+                # Constructing a real generation pipeline loads weights and
+                # touches a device, so the failures are the deployment's, not
+                # the signature's: no driver (``RuntimeError``), weights absent
+                # (``OSError``), an optional dep imported inside the factory
+                # body (``ImportError``), a malformed config (``ValueError``).
+                # Reported with an accurate subject rather than folded into the
+                # zero-arg wording above, which would name the wrong cause.
+                return [f"{subject} raised {type(exc).__name__} while being constructed ({exc}) - {_PIPELINE_HELP}"]
+            surface, problem = _generate_surface(candidate, subject)
+            if problem:
+                return [problem]
+        if not callable(surface):
+            return [f"{subject} resolves to no generate() surface - {_PIPELINE_HELP}"]
         self._pipeline = candidate
         return []
 

--- a/tests/transforms/test_cosmos_transfer.py
+++ b/tests/transforms/test_cosmos_transfer.py
@@ -9,11 +9,18 @@ exercise the seam with a fake pipeline, the same dependency-injection shape
 none of this needs a generation model installed.
 """
 
+import ast
+import inspect
+import pathlib
+import sys
+import textwrap
+import types
+
 import numpy as np
 import pytest
 
-from strands_robots.transforms import TransformSpec, derive_variant_seed, load_provenance
-from strands_robots.transforms.cosmos_transfer import CosmosTransferTransform
+from strands_robots.transforms import TransformSpec, cosmos_transfer, derive_variant_seed, load_provenance
+from strands_robots.transforms.cosmos_transfer import _PIPELINE_HELP, CosmosTransferTransform
 
 
 class FakePipeline:
@@ -73,6 +80,204 @@ class TestPipelineSeam:
     def test_direct_frames_call_without_pipeline_raises_with_remedy(self):
         with pytest.raises(RuntimeError, match="no video2video pipeline"):
             CosmosTransferTransform().transform_frames("cam", _frames(), TransformSpec(), source_episode=0, variant=0)
+
+
+class TestEveryProbePointReportsInsteadOfRaising:
+    """A caller-supplied pipeline runs the caller's code at three probe points.
+
+    ``validate`` is documented to *return* a list of problems, and
+    :meth:`~strands_robots.transforms.base.DatasetTransform.transform` to
+    return ``status="error"`` for anything but a backend shape / dtype bug - so
+    a failure at any of the seam's three probe points (the module import and
+    attribute lookup, the zero-arg construction, the ``generate`` read) is a
+    problem, not an exception handed to the caller.
+
+    Constructing a real generation pipeline loads weights and touches a device,
+    so the classes are the deployment's: ``ImportError`` from an optional dep
+    imported inside a factory body, ``RuntimeError`` with no driver, ``OSError``
+    with the weights absent, ``ValueError`` on a malformed config. Only
+    ``TypeError`` (a factory that needs arguments) was reported before.
+    """
+
+    # (probe-point label, pipeline= spelling built from a raising class)
+    POINTS = ("import", "construct", "generate_read")
+    CLASSES = (ImportError, ModuleNotFoundError, RuntimeError, OSError, FileNotFoundError, ValueError, KeyError)
+
+    @staticmethod
+    def _transform(point: str, exc: BaseException, monkeypatch) -> CosmosTransferTransform:
+        """Build a transform whose seam raises ``exc`` at ``point``."""
+        mod = types.ModuleType("fake_pipeline_mod")
+        if point == "import":
+            # A module-level ``__getattr__`` runs caller code on the lookup the
+            # import handler wraps. Scoped to the target name: a module whose
+            # every attribute raises also breaks the caller's own introspection
+            # (``inspect.getmodule`` reads ``__file__``), which is not the
+            # behaviour under test.
+            def module_getattr(name: str):
+                if name == "target":
+                    raise exc
+                raise AttributeError(name)
+
+            mod.__getattr__ = module_getattr  # type: ignore[method-assign]
+        elif point == "construct":
+
+            def factory():
+                raise exc
+
+            mod.target = factory  # type: ignore[attr-defined]
+        else:
+
+            class LazyHandle:
+                @property
+                def generate(self):
+                    raise exc
+
+            mod.target = LazyHandle()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "fake_pipeline_mod", mod)
+        return CosmosTransferTransform(pipeline="fake_pipeline_mod:target")
+
+    @pytest.mark.parametrize("point", POINTS)
+    @pytest.mark.parametrize("exc_type", CLASSES, ids=lambda c: c.__name__)
+    def test_a_raising_probe_point_is_a_problem(self, point, exc_type, monkeypatch):
+        transform = self._transform(point, exc_type("deployment says no"), monkeypatch)
+        problems = transform.validate(TransformSpec(source_root="/nope", output_root="/out"))
+        assert any("deployment says no" in p for p in problems), problems
+        assert any(_PIPELINE_HELP[:40] in p for p in problems), "the refusal must still carry the remedy"
+
+    @pytest.mark.parametrize("point", POINTS)
+    def test_the_documented_run_path_reports_error_rather_than_raising(self, point, monkeypatch, tmp_path):
+        """The package docstring's own usage: validate, then transform."""
+        source = tmp_path / "src"
+        (source / "meta").mkdir(parents=True)
+        (source / "meta" / "info.json").write_text('{"codebase_version": "v3.0"}')
+        transform = self._transform(point, RuntimeError("Found no NVIDIA driver"), monkeypatch)
+        spec = TransformSpec(source_root=source, output_root=tmp_path / "out")
+        assert transform.validate(spec), "the seam failure must be reported by validate"
+        result = transform.transform(spec)
+        assert result.status == "error"
+        assert "Found no NVIDIA driver" in result.message
+
+    @pytest.mark.parametrize("point", POINTS)
+    @pytest.mark.parametrize("exc_type", (KeyboardInterrupt, SystemExit, GeneratorExit), ids=lambda c: c.__name__)
+    def test_an_operator_interrupt_is_not_downgraded_to_a_spec_problem(self, point, exc_type, monkeypatch):
+        """Ctrl-C while a multi-gigabyte pipeline loads is not a bad spec.
+
+        Fails if the handlers widen to ``BaseException``: the caller asked to
+        stop, and reporting that as a validation problem would keep going.
+        """
+        transform = self._transform(point, exc_type(), monkeypatch)
+        with pytest.raises(exc_type):
+            transform.validate(TransformSpec(source_root="/nope", output_root="/out"))
+
+    def test_a_construction_failure_is_not_reported_as_a_bad_signature(self, monkeypatch):
+        """A factory that raised is constructible; only the deployment failed.
+
+        Folding every construction failure into the zero-arg wording would name
+        the wrong cause - the remedy for "no driver" is not a different factory
+        signature.
+        """
+        transform = self._transform("construct", RuntimeError("Found no NVIDIA driver"), monkeypatch)
+        problem = transform._pipeline_problems()[0]
+        assert "raised RuntimeError while being constructed" in problem
+        assert "not constructible zero-arg" not in problem
+
+    def test_a_factory_needing_arguments_keeps_its_wording(self, monkeypatch):
+        """The one class already reported keeps the message it already had."""
+        mod = types.ModuleType("argful_mod")
+
+        def needs_args(cfg):  # zero-arg construction cannot satisfy this
+            return cfg
+
+        mod.target = needs_args  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "argful_mod", mod)
+        problems = CosmosTransferTransform(pipeline="argful_mod:target")._pipeline_problems()
+        assert any("is not constructible zero-arg" in p for p in problems), problems
+
+    def test_an_injected_object_with_a_raising_generate_read_is_a_problem(self):
+        """The third probe point is also reached with no import path at all."""
+
+        class LazyHandle:
+            @property
+            def generate(self):
+                raise RuntimeError("CUDA context not initialised")
+
+        problems = CosmosTransferTransform(pipeline=LazyHandle())._pipeline_problems()
+        assert any("while its generate() surface was read" in p for p in problems), problems
+        assert any("CUDA context not initialised" in p for p in problems), problems
+
+    @pytest.mark.parametrize(
+        ("spelling", "expected"),
+        [
+            ("tests.transforms.test_cosmos_transfer:FAKE_PIPELINE", None),
+            ("tests.transforms.test_cosmos_transfer.FakePipeline", None),
+            ("justoneword", "is not 'pkg.mod:attr'"),
+            ("no.such.module:thing", "did not resolve"),
+            ("tests.transforms.test_cosmos_transfer:_frames", "resolves to no generate() surface"),
+        ],
+    )
+    def test_the_verdict_on_every_previously_accepted_spelling_is_unchanged(self, spelling, expected):
+        """Widening the handlers changes no verdict that was already reached."""
+        problems = CosmosTransferTransform(pipeline=spelling)._pipeline_problems()
+        if expected is None:
+            assert problems == []
+        else:
+            assert any(expected in p for p in problems), problems
+
+
+class TestTheSeamHasOneGuardedProbeRule:
+    """Structural: a probe point added later cannot re-derive an unguarded read.
+
+    The behavioural tests above cover the three probe points the seam has
+    today; these pin the rule itself, so a fourth one is held to it.
+    """
+
+    @staticmethod
+    def _func(name: str) -> ast.FunctionDef:
+        source = textwrap.dedent(inspect.getsource(getattr(cosmos_transfer, name, None) or CosmosTransferTransform))
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        raise AssertionError(f"{name} not found")
+
+    def test_the_generate_read_has_a_single_owner(self):
+        """No other function reads ``generate`` off the caller's object."""
+        tree = ast.parse(pathlib.Path(cosmos_transfer.__file__).read_text(encoding="utf-8"))
+        owners = set()
+        for func in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+            for call in [n for n in ast.walk(func) if isinstance(n, ast.Call)]:
+                if ast.unparse(call.func) != "getattr":
+                    continue
+                if any(isinstance(a, ast.Constant) and a.value == "generate" for a in call.args):
+                    owners.add(func.name)
+        assert owners == {"_generate_surface"}, f"the generate read must have one guarded owner, found {owners}"
+
+    @pytest.mark.parametrize("func_name", ["_generate_surface", "_pipeline_problems"])
+    def test_every_probe_handler_reports_rather_than_raises(self, func_name):
+        """Each ``try`` in the resolution names ``Exception`` in some handler."""
+        func = self._func(func_name)
+        tries = [n for n in ast.walk(func) if isinstance(n, ast.Try)]
+        assert tries, f"premise: {func_name} guards at least one probe"
+        for node in tries:
+            named = set()
+            for handler in node.handlers:
+                if handler.type is None:
+                    named.add("bare")
+                elif isinstance(handler.type, ast.Tuple):
+                    named.update(ast.unparse(e) for e in handler.type.elts)
+                else:
+                    named.add(ast.unparse(handler.type))
+            assert "Exception" in named, f"{func_name}:{node.lineno} reports only {sorted(named)}"
+
+    def test_the_module_import_is_guarded(self):
+        """``import_module`` runs a caller's module body; never outside a try."""
+        func = self._func("_pipeline_problems")
+        guarded = {id(n) for t in ast.walk(func) if isinstance(t, ast.Try) for n in ast.walk(t)}
+        imports = [
+            n for n in ast.walk(func) if isinstance(n, ast.Call) and ast.unparse(n.func).endswith("import_module")
+        ]
+        assert imports, "premise: the seam resolves a dotted path by importing it"
+        for call in imports:
+            assert id(call) in guarded, f"import_module at line {call.lineno} is not inside a try"
 
 
 class TestHandOff:


### PR DESCRIPTION
## Problem

`CosmosTransferTransform` binds a caller-supplied video2video pipeline, so resolving the seam runs the caller's code at three points: the module import and attribute lookup, the zero-arg construction of a class / factory target, and the read of the object's `generate` surface.

`DatasetTransform.validate` is documented as a *"Pure, side-effect-free preflight. Return a list of human-readable problems"*, and `transform()` documents exactly one raise (a shape / dtype `ValueError` from `transform_frames`), `status="error"` otherwise. `_pipeline_problems`' own docstring says *"return problems instead of raising"*.

It reported three classes: `ImportError` and `AttributeError` around the import, `TypeError` around the construction. Driving every builtin exception class through a raising factory, **51 of 52 escaped `validate()` - and therefore `transform()`.** Only `TypeError` was reported.

The classes that escaped are the ones a real generation stack raises, because constructing one loads weights and touches a device:

| probe point | raised | `validate()` | `transform()` |
| --- | --- | --- | --- |
| module import + attribute lookup | `ImportError` | 1 problem | `status="error"` |
| zero-arg construction | `ImportError` (a factory body's `import torch`) | **RAISED** | **RAISED** |
| zero-arg construction | `RuntimeError` (no NVIDIA driver) | **RAISED** | **RAISED** |
| zero-arg construction | `OSError` (weights absent) | **RAISED** | **RAISED** |
| `generate()` surface read | `RuntimeError` (lazy handle, CUDA context) | **RAISED** | **RAISED** |

Row 1 is the control - the import point already handled the one class its handler named. Row 2 is **the same class**, raised one frame lower: a factory whose body imports an optional dependency raises `ModuleNotFoundError`, an `ImportError` subclass, straight past a handler written for exactly that case, because the handler wrapped only the module import and not the factory call.

Two further consequences worth naming:

- The `ValueError` case is indistinguishable from the shape / dtype `ValueError` that `transform()` documents as its only raise, so a malformed checkpoint config reads as a backend bug.
- `getattr(obj, "generate", None)`'s default absorbs only `AttributeError`, so a lazy pipeline handle whose `generate` is a property raised at the third point - reachable with no import path at all, by injecting the object directly.

The package's own module docstring teaches the shape where this lands: `problems = transform.validate(spec)` / `if not problems: result = transform.transform(spec)`.

## Change

Each of the three probe points now reports, and the cause is named accurately.

- The import and attribute lookup catch `Exception`: a module body runs arbitrary caller code on first import, and a module-level `__getattr__` (PEP 562, which this package uses in its own `__init__.py`) runs it again on the lookup.
- The zero-arg construction keeps `except TypeError` with its existing wording, and adds a sibling handler for everything else. A factory that raised **is** constructible zero-arg, so folding it into that wording would name the wrong remedy - "no driver" is not fixed by a different factory signature.
- The `generate` read moves into one guarded owner, `_generate_surface`, used at both the injected-object and resolved-candidate sites. It returns `(surface, problem)` and distinguishes "absent" from "present but `None`" with a sentinel, so the construct decision is byte-equivalent to the `hasattr` it replaces.

`Exception`, not `BaseException`: an operator's Ctrl-C while a multi-gigabyte pipeline loads is not a bad spec, and `KeyboardInterrupt` / `SystemExit` / `GeneratorExit` still propagate.

Every spelling that already reached a verdict keeps it, wording included.

The in-repo precedent for resolving a caller-supplied dotted path is a wide handler: `tools/use_lerobot.py::_import_from_lerobot` catches `Exception` with the comment *"non-Import errors during import are real too"*, and `policies/lerobot_local/resolution.py` pairs `except ImportError` with `except (AttributeError, RuntimeError, TypeError)` so a failure means *"this strategy cannot resolve the class here"* rather than *"leaking lerobot's internal exception type to the caller"*.

`docs/data/transforms.md` documented only the missing-pipeline case; it now states the same contract for a pipeline that is named but cannot be loaded.

## Out of scope

`_pipeline_problems` resolves and constructs *inside* `validate()`, which the ABC says MUST NOT allocate GPUs. Whether the resolution should move out of the preflight (and what `transform_frames`' existing direct-caller `RuntimeError` then means) is a design decision, not a reporting one, so it is left alone here.

## Tests

`tests/transforms/test_cosmos_transfer.py`, extended in place. Pre-fix (the new tests against `upstream/main` source): **27 failed / 33 passed**. Of the 27, **24 fail by the third-party exception escaping** (`RuntimeError` 8, `ValueError` 3, `OSError` 3, `KeyError` 3, `FileNotFoundError` 3, `ModuleNotFoundError` 2, `ImportError` 2) and 3 by assertion.

Each break below was applied to the fixed tree and fires exactly and only its own guards:

| break | failed of 60 | guards fired |
| --- | --- | --- |
| control | 0 | - |
| `git checkout upstream/main -- cosmos_transfer.py` | 27 | the headline, the documented run path, the accurate-cause test, the injected-object test, both structural |
| widen the handlers to `BaseException` | 11 | **only** the operator-interrupt controls + the handler pin |
| fold construction failures into the zero-arg wording | 1 | **only** the accurate-cause test |
| re-derive the `generate` read inline | 1 | **only** the single-owner pin |
| revert just the import handler | 7 | **only** the import-point cases + the handler pin |
| move `import_module` outside its `try` | 3 | the guarded-import pin, and the **pre-existing** `test_unresolvable_dotted_path_is_a_problem_not_a_raise` |

The last row is the one worth reading: the existing test whose name already states this contract (*"is a problem not a raise"*) still holds, because it exercised the module import - the one path that already worked. The fix extends that contract to the other two points rather than replacing it.

## Verification

Measured at `b6cff7f7`, on `mujoco 3.5.0` / `lerobot 0.6.2`. The branch was merged with `main` after #2617 landed in the two files this touches; the merge was clean, and every number below was re-measured at that head (the pre-fix split is unchanged).

- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `upstream/main` worktree, branch-only set empty.
- 77-file blast radius (all of `tests/transforms`, every test naming the transform surface, and the repo-wide docs / docstring / string / changelog guards), the identical selection run on both trees with the changed test file excluded from both: **2303 passed, 1 skipped, 0 failed on each**, failing-ID sets empty in both directions.
- `tests/transforms/test_cosmos_transfer.py`: 60 passed.

## Artifact

Produced by one capture script run against each tree, with only `strands_robots` differing. Section 1 is the control: a working pipeline, a real recorded `LeRobotDataset` in and a provenance-marked one out - 2 episodes read, 2 written, 1 MP4, and the written pixels read back **out** of the produced dataset. That whole section is byte-identical across the two trees (asserted in the figure script, along with every number quoted here), so the only thing that changes is what a caller is handed when the seam fails.

![pipeline seam probe reporting](https://raw.githubusercontent.com/cagataycali/robots/media-pipeline-seam-probe/pipeline-seam-probe.png)
