### PR TITLE
fix(policies/protomotions): a body index is refused unless it addresses a body

### DIFF
--- a/changelog.d/2619-body-index-addresses-a-body.md
+++ b/changelog.d/2619-body-index-addresses-a-body.md
@@ -1,0 +1,42 @@
+### Fixed: a tracker body index is refused unless it addresses a body
+
+`ProtoMotionsConfig.anchor_body_index` and `root_body_index` are offsets into
+`body_names` - the tracker reads a body out of the reference-motion cache by row
+index, never by name. `load_config_from_yaml` documents its result as "validated for
+consistent dimensions" and promises `ValueError` for "an inconsistent dimension", and
+the module docstring promises such an error "surfaces at policy build time with a
+clean message". It checked the `stiffness` and `damping` lengths against the joint
+count, and neither index.
+
+A negative index is a valid tuple lookup, so it was the silent case. `body_names[-1]`
+is `right_rubber_hand`, a real link: an `anchor_body_index: -1` sidecar loaded, and
+the whole chain then agreed on the hand - `required_bodies` declared it, the runtime
+resolved it once per rollout and merged `body.right_rubber_hand.quat` into every
+observation, `_extract_anchor_rot` found exactly that key, and the future-reference
+window sliced the same row. Measured on the tracker's own G1 embodiment, that link's
+world orientation is 0.01, 10.37 and 20.20 degrees from `torso_link` across a
+waist-turn pose set - an anchor orientation the network consumes every tick, with
+nothing anywhere reporting it. An index past the end instead deferred `IndexError:
+tuple index out of range` to whichever property read the name first, naming neither
+the field, the value, the range, nor the sidecar.
+
+The loader's `int()` coercion widened the same hole by running before anything looked
+at the value: a yaml `anchor_body_index: true` became row 1 (`head`, 34.4 degrees out)
+and a `2.7` became row 2 (`left_hip_pitch_link`), so the sidecar route and a
+hand-built `ProtoMotionsConfig(anchor_body_index=True)` disagreed about the same value.
+
+Both indices now go through the shared `non_negative_whole_number_error` rule and then
+the row count of the body list they index, in `ProtoMotionsConfig.__post_init__` so a
+sidecar and a hand-built config report the same value the same way. The domain runs
+before the `int()` normalisation, never after, which is the ordering
+`MotionBricksConfig.__post_init__` already states the reason for; the four sibling
+policy configs validate in `__post_init__` too, and `protomotions` was the one that did
+not. An integral float such as `16.0` still addresses a row and is kept, normalised to
+the row number both consumers index with, and the refusal quotes the range it was
+checked against. `anchor_body_name` and `root_body_name` documented
+`Raises: IndexError`, which is now unreachable, so both say so instead.
+
+This is the config-side mirror of a hole the package already refuses on the model side:
+a G1 MJCF missing bodies is rejected precisely because reading positionally hands the
+tracker `left_shoulder_pitch_link` where it asked for `torso_link`. The sidecar that
+named the same wrong row was not.

--- a/docs/policies/protomotions.md
+++ b/docs/policies/protomotions.md
@@ -244,6 +244,34 @@ sidecar; omit it to use the defaults, which match the shipped export.
 | `control_dt` | `0.02` | Seconds per control tick (50 Hz) |
 | `future_step_indices` | `(1, 2, 4, 8)` | Lookahead offsets, in control steps |
 
+### A body index has to address a body
+
+The two body indices are offsets into `body_names`, so an index that misses is
+the config-side mirror of the model-side row shift above - and it is refused the
+same way, when the config is built rather than when something reads it:
+
+```text
+ValueError: ProtoMotionsConfig.anchor_body_index must be a row of body_names
+(0..32), got 99 for 33 bodies. The index is an offset into body_names, so one
+that misses cannot resolve the body it names.
+```
+
+Both directions are checked, because they fail differently. A negative index is
+a valid tuple lookup: `body_names[-1]` is `right_rubber_hand`, so an
+`anchor_body_index: -1` sidecar resolves a real link and the tracker anchors on
+it consistently - `required_bodies` declares that link, the runtime supplies its
+quaternion, and the future-reference window slices the same row. Nothing
+disagrees, and on the tracker's own embodiment that link's world orientation is
+20 degrees from `torso_link` with the waist turned and an arm raised. An index
+past the end used to surface only as `IndexError: tuple index out of range` from
+whichever property read the name first.
+
+The index also goes through the shared whole-number domain, so a yaml
+`anchor_body_index: true` is refused instead of being read as row 1 (`head`),
+and a hand-built `ProtoMotionsConfig(...)` reports the same value the same way a
+sidecar does. An integral float such as `16.0` addresses a row and is kept,
+normalised to the row number both consumers index with.
+
 ## Testing without weights
 
 `session=` injects anything satisfying the `ProtoMotionsSession` protocol

--- a/strands_robots/policies/protomotions/config.py
+++ b/strands_robots/policies/protomotions/config.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from strands_robots.utils import require_optional
+from strands_robots.utils import non_negative_whole_number_error, require_optional
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +264,45 @@ class ProtoMotionsConfig:
     )
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        """Refuse a body index that cannot address :attr:`body_names`.
+
+        The two indices are the only fields this config resolves a body NAME
+        from, and an index that misses is not a value the control path can
+        report: :attr:`anchor_body_name` and :attr:`root_body_name` index a
+        tuple, so a negative index silently names a real but different link,
+        and the tracker then anchors on it consistently -
+        :attr:`~strands_robots.policies.base.Policy.required_bodies` declares
+        that link, the runtime supplies its quaternion, and the future-reference
+        window reads the same row. Every stage agrees, and every stage is wrong.
+
+        Each index goes through the shared whole-number domain BEFORE the
+        ``int()`` normalisation, not after: that conversion is what laundered a
+        yaml ``anchor_body_index: true`` into row 1 (``head``) and a ``2.7``
+        into row 2 (``left_hip_pitch_link``).
+
+        Raises:
+            ValueError: If either body index is not a non-negative whole number,
+                or is not a row of :attr:`body_names`.
+        """
+        num_bodies = len(self.body_names)
+        for name in ("anchor_body_index", "root_body_index"):
+            raw = getattr(self, name)
+            if error := non_negative_whole_number_error(raw, name, "ProtoMotionsConfig"):
+                raise ValueError(error)
+            index = int(raw)
+            if index >= num_bodies:
+                raise ValueError(
+                    f"ProtoMotionsConfig.{name} must be a row of body_names "
+                    f"(0..{num_bodies - 1}), got {index} for {num_bodies} bodies. "
+                    "The index is an offset into body_names, so one that misses "
+                    "cannot resolve the body it names."
+                )
+            # Normalise to a plain int (frozen -> object.__setattr__) so an
+            # integral float the domain admits is stored as the row number the
+            # observation lookup and the future-reference slice both index with.
+            object.__setattr__(self, name, index)
+
     # ------------------------------------------------------------------
     # Derived properties - computed on read, never stored, so a frozen
     # dataclass with a single source of truth for each field stays that way.
@@ -293,9 +332,9 @@ class ProtoMotionsConfig:
         :attr:`~strands_robots.policies.base.Policy.required_bodies` and the
         observation lookup reading one source of truth.
 
-        Raises:
-            IndexError: If :attr:`anchor_body_index` is out of range for
-                :attr:`body_names`.
+        Always resolves: :meth:`__post_init__` refuses an
+        :attr:`anchor_body_index` that is not a row of :attr:`body_names`, so
+        the lookup here cannot miss.
         """
         return self.body_names[self.anchor_body_index]
 
@@ -303,9 +342,8 @@ class ProtoMotionsConfig:
     def root_body_name(self) -> str:
         """Name of the root (floating-base) body - ``pelvis`` on the G1.
 
-        Raises:
-            IndexError: If :attr:`root_body_index` is out of range for
-                :attr:`body_names`.
+        Always resolves: :meth:`__post_init__` refuses a
+        :attr:`root_body_index` that is not a row of :attr:`body_names`.
         """
         return self.body_names[self.root_body_index]
 
@@ -337,8 +375,12 @@ def load_config_from_yaml(path: str | Path) -> ProtoMotionsConfig:
     Raises:
         FileNotFoundError: If ``path`` does not exist.
         ImportError: If ``pyyaml`` is not installed.
-        ValueError: If the yaml contains an inconsistent dimension (e.g.
-            ``stiffness`` length != number of joints).
+        ValueError: If the yaml contains an inconsistent dimension: a
+            ``stiffness`` or ``damping`` length that is not the joint count, or
+            an ``anchor_body_index`` / ``root_body_index`` that is not a row of
+            ``body_names`` (refused by
+            :meth:`ProtoMotionsConfig.__post_init__`, so a config built by hand
+            reports the same value the same way).
     """
     yaml = require_optional(
         "yaml",
@@ -358,8 +400,12 @@ def load_config_from_yaml(path: str | Path) -> ProtoMotionsConfig:
     body_names = tuple(data.get("body_names", GTP_G1_BODY_NAMES))
 
     robot = data.get("robot", {})
-    anchor_idx = int(robot.get("anchor_body_index", GTP_G1_ANCHOR_BODY_INDEX))
-    root_idx = int(robot.get("root_body_index", GTP_G1_ROOT_BODY_INDEX))
+    # Handed through raw, not through int(): ProtoMotionsConfig.__post_init__ is
+    # the single owner of what a body index may be, and coercing here first is
+    # what turned a yaml ``anchor_body_index: true`` into row 1 before the
+    # domain could see it.
+    anchor_idx = robot.get("anchor_body_index", GTP_G1_ANCHOR_BODY_INDEX)
+    root_idx = robot.get("root_body_index", GTP_G1_ROOT_BODY_INDEX)
 
     control = data.get("control", {})
     stiffness = tuple(control.get("stiffness", data.get("default_joint_stiffness", _G1_STIFFNESS)))

--- a/tests/policies/protomotions/test_body_index_addresses_a_body.py
+++ b/tests/policies/protomotions/test_body_index_addresses_a_body.py
@@ -1,0 +1,288 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A tracker body index is refused unless it addresses a row of ``body_names``.
+
+:attr:`~strands_robots.policies.protomotions.config.ProtoMotionsConfig.anchor_body_index`
+and ``root_body_index`` are the only two fields the config resolves a body NAME
+from, and both are offsets into ``body_names``. An offset that misses is a
+dimension error the control path cannot report, because the tracker consumes the
+resolved body CONSISTENTLY: ``required_bodies`` declares that link, the runtime
+merges its ``body.<name>.quat`` into every observation, and the future-reference
+window slices the same row out of the motion cache. Every stage agrees on a link
+that is not the anchor.
+
+The two ways an offset misses are not symmetric, which is why the guard covers
+both:
+
+* A NEGATIVE index wraps. ``body_names[-1]`` is ``right_rubber_hand`` - a real
+  link name, so nothing raises anywhere and the tracker anchors on the hand.
+  Measured on the tracker's own G1 embodiment, that link's world orientation is
+  20.2 degrees from ``torso_link`` with the waist turned and an arm raised.
+* A POSITIVE out-of-range index raises ``IndexError: tuple index out of range``
+  from the property that resolves the name, naming neither the field, the value,
+  the valid range, nor the sidecar it came from - and only once something reads
+  the property, not when the config was built.
+
+``load_config_from_yaml`` documents the returned config as "validated for
+consistent dimensions" and promises ``ValueError`` for "an inconsistent
+dimension"; the module docstring promises such an error "surfaces at policy build
+time with a clean message". Both indices are checked here so those hold for the
+two dimensions that were unchecked.
+
+The domain runs BEFORE the ``int()`` normalisation, which is what the four
+sibling policy configs (``kimodo``, ``motionbricks``, ``vera``, ``wbc``) already
+do - ``MotionBricksConfig.__post_init__`` states the reason in as many words.
+Coercing first laundered a yaml ``anchor_body_index: true`` into row 1 (``head``)
+and a ``2.7`` into row 2 (``left_hip_pitch_link``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.policies.protomotions.config import (
+    GTP_G1_ANCHOR_BODY_INDEX,
+    GTP_G1_BODY_NAMES,
+    GTP_G1_JOINT_NAMES,
+    GTP_G1_ROOT_BODY_INDEX,
+    ProtoMotionsConfig,
+    load_config_from_yaml,
+)
+
+_INDEX_FIELDS = ("anchor_body_index", "root_body_index")
+
+# Values that name no row of ``body_names``. The wrapping negatives are the
+# reachable slip (a 1-based sidecar, or an index copied from a list that counted
+# from the end); ``True``/``2.7`` are the values the removed ``int()`` used to
+# turn into a different, in-range row.
+_UNADDRESSABLE: list[Any] = [
+    pytest.param(-1, id="minus_one_wraps_to_the_last_body"),
+    pytest.param(-17, id="negative_wrap_that_lands_on_the_right_body_by_accident"),
+    pytest.param(len(GTP_G1_BODY_NAMES), id="one_past_the_end"),
+    pytest.param(99, id="far_out_of_range"),
+    pytest.param(True, id="boolean_reads_as_row_one"),
+    pytest.param(2.7, id="non_integral_float_truncates_to_row_two"),
+    pytest.param("16", id="string_spelling_of_a_valid_row"),
+    pytest.param(None, id="none"),
+    pytest.param(float("nan"), id="nan"),
+    pytest.param(float("inf"), id="inf"),
+]
+
+
+def _built(**overrides: Any) -> ProtoMotionsConfig:
+    """Build a config with ``overrides`` applied.
+
+    Deliberately typed loose: half the cases below pass values the signature
+    refuses, which is the point, and splatting a ``dict[str, Any]`` through the
+    real constructor is what a type checker reports rather than what the guard
+    reports.
+    """
+    return ProtoMotionsConfig(**overrides)
+
+
+def _sidecar(tmp_path: Path, **robot: Any) -> Path:
+    """Write a minimal but complete ``unified_pipeline.yaml`` sidecar."""
+    yaml = pytest.importorskip("yaml")
+    body = {
+        "joint_names": list(GTP_G1_JOINT_NAMES),
+        "body_names": list(GTP_G1_BODY_NAMES),
+        "robot": {
+            "anchor_body_index": GTP_G1_ANCHOR_BODY_INDEX,
+            "root_body_index": GTP_G1_ROOT_BODY_INDEX,
+            **robot,
+        },
+    }
+    path = tmp_path / "unified_pipeline.yaml"
+    path.write_text(yaml.safe_dump(body))
+    return path
+
+
+class TestABodyIndexMustAddressABody:
+    """Both indices are refused unless they name a row of ``body_names``."""
+
+    @pytest.mark.parametrize("field_name", _INDEX_FIELDS)
+    @pytest.mark.parametrize("value", _UNADDRESSABLE)
+    def test_an_unaddressable_index_is_refused_at_construction(self, field_name: str, value: Any) -> None:
+        """A config carrying an index that names no body must not be built.
+
+        Pre-fix every one of these built a config. The wrapping negatives then
+        resolved a real but different link and nothing raised at all; the rest
+        either resolved a different in-range row or deferred an ``IndexError``
+        to whoever first read the name.
+        """
+        with pytest.raises(ValueError, match=field_name):
+            _built(**{field_name: value})
+
+    @pytest.mark.parametrize("field_name", _INDEX_FIELDS)
+    def test_the_refusal_names_the_body_count_it_was_checked_against(self, field_name: str) -> None:
+        """An out-of-range refusal quotes the range, so it is actionable.
+
+        The pre-fix report was ``IndexError: tuple index out of range`` from a
+        property read, which names neither the field nor the bound.
+        """
+        with pytest.raises(ValueError) as refused:
+            _built(**{field_name: 99})
+        message = str(refused.value)
+        assert field_name in message
+        assert "body_names" in message
+        assert f"0..{len(GTP_G1_BODY_NAMES) - 1}" in message
+        assert str(len(GTP_G1_BODY_NAMES)) in message
+
+    @pytest.mark.parametrize("field_name", _INDEX_FIELDS)
+    @pytest.mark.parametrize("value", [-1, 99, True, 2.7])
+    def test_a_yaml_sidecar_is_refused_the_same_way(self, tmp_path: Path, field_name: str, value: Any) -> None:
+        """The loader reports the same verdict as a hand-built config.
+
+        ``load_config_from_yaml`` used to coerce the two indices with ``int()``
+        before the dataclass saw them, so the yaml route and the direct route
+        disagreed about ``true`` and ``2.7``.
+        """
+        with pytest.raises(ValueError, match=field_name):
+            load_config_from_yaml(_sidecar(tmp_path, **{field_name: value}))
+
+    def test_a_negative_index_no_longer_resolves_a_real_but_wrong_body(self) -> None:
+        """The headline: -1 named ``right_rubber_hand`` and the tracker used it.
+
+        Guards against a fix that only bounded the upper end: ``body_names[-1]``
+        is a valid tuple lookup, so an upper-bound-only check leaves the silent
+        case in place. The assertion states what the wrong answer WAS, so it
+        fails with that name rather than only with "did not raise".
+        """
+        assert GTP_G1_BODY_NAMES[-1] == "right_rubber_hand"
+        assert GTP_G1_BODY_NAMES[GTP_G1_ANCHOR_BODY_INDEX] == "torso_link"
+        with pytest.raises(ValueError, match="anchor_body_index"):
+            built = _built(anchor_body_index=-1)
+            pytest.fail(
+                "ProtoMotionsConfig accepted anchor_body_index=-1 and resolved "
+                f"{built.anchor_body_name!r} as the anchor, where the config's own "
+                f"index 16 is {GTP_G1_BODY_NAMES[GTP_G1_ANCHOR_BODY_INDEX]!r}."
+            )
+
+    def test_an_empty_body_list_cannot_carry_an_anchor(self) -> None:
+        """No row exists, so the shipped default index addresses nothing."""
+        with pytest.raises(ValueError, match="body_names"):
+            ProtoMotionsConfig(body_names=())
+
+    def test_a_yaml_boolean_no_longer_becomes_the_head_row(self) -> None:
+        """A yaml ``anchor_body_index: true`` used to load as row 1.
+
+        ``bool`` is an ``int`` subclass, so the loader's ``int()`` turned it into
+        a row that addresses ``head`` - 34.4 degrees from ``torso_link`` with the
+        waist turned. Stated as its own case because it is the value the removed
+        coercion laundered, not one a range check alone would catch.
+        """
+        assert GTP_G1_BODY_NAMES[int(True)] == "head"
+        with pytest.raises(ValueError, match="anchor_body_index"):
+            built = _built(anchor_body_index=True)
+            pytest.fail(
+                "ProtoMotionsConfig accepted anchor_body_index=True and resolved "
+                f"{built.anchor_body_name!r} as the anchor."
+            )
+
+    def test_the_bound_is_the_configs_own_body_list(self) -> None:
+        """A trimmed embodiment bounds the index to ITS rows, not the G1's.
+
+        Fails for a fix that hard-codes ``len(GTP_G1_BODY_NAMES)`` instead of
+        reading the config's own list.
+        """
+        trimmed = GTP_G1_BODY_NAMES[:20]
+        with pytest.raises(ValueError, match=r"0\.\.19"):
+            _built(body_names=trimmed, anchor_body_index=20)
+
+    @pytest.mark.parametrize("field_name", _INDEX_FIELDS)
+    def test_an_integral_float_is_normalised_to_the_row_number(self, field_name: str) -> None:
+        """``3.0`` addresses a row, so it is normalised rather than refused.
+
+        The shared whole-number domain admits an integral float; storing it as an
+        ``int`` matters because both consumers index with it - a tuple lookup for
+        the name and a numpy slice for the future-reference window.
+        """
+        cfg = _built(**{field_name: 3.0})
+        assert getattr(cfg, field_name) == 3
+        assert isinstance(getattr(cfg, field_name), int)
+        assert not isinstance(getattr(cfg, field_name), bool)
+
+
+class TestTheAddressableIndicesAreUnchanged:
+    """Controls: nothing that could address a body before is refused now."""
+
+    def test_the_shipped_defaults_still_build(self) -> None:
+        """The default config is the pinned G1 tracker embodiment."""
+        cfg = ProtoMotionsConfig()
+        assert cfg.anchor_body_index == GTP_G1_ANCHOR_BODY_INDEX
+        assert cfg.root_body_index == GTP_G1_ROOT_BODY_INDEX
+        assert cfg.anchor_body_name == "torso_link"
+        assert cfg.root_body_name == "pelvis"
+
+    @pytest.mark.parametrize("field_name", _INDEX_FIELDS)
+    @pytest.mark.parametrize("value", [0, 1, 16, len(GTP_G1_BODY_NAMES) - 1])
+    def test_every_row_of_body_names_is_accepted(self, field_name: str, value: int) -> None:
+        """Every in-range row stays addressable, including both endpoints."""
+        cfg = _built(**{field_name: value})
+        assert getattr(cfg, field_name) == value
+        assert cfg.body_names[value] == GTP_G1_BODY_NAMES[value]
+
+    def test_dataclasses_replace_still_repoints_the_anchor(self) -> None:
+        """The runtime-contract suite repoints the anchor onto the root."""
+        base = ProtoMotionsConfig()
+        root_anchored = dataclasses.replace(base, anchor_body_index=base.root_body_index)
+        assert root_anchored.anchor_is_root
+        assert root_anchored.anchor_body_name == base.root_body_name
+
+    def test_a_shorter_embodiment_still_addresses_its_own_rows(self) -> None:
+        """The bound is the config's own ``body_names``, not the G1 constant.
+
+        A fingerless or otherwise trimmed embodiment is a legitimate config and
+        index 16 addresses a body there too; only where the range ENDS changes.
+        """
+        trimmed = GTP_G1_BODY_NAMES[:20]
+        cfg = _built(body_names=trimmed, anchor_body_index=16)
+        assert cfg.anchor_body_name == trimmed[16]
+
+    def test_the_shipped_sidecar_shape_loads_unchanged(self, tmp_path: Path) -> None:
+        """A well-formed sidecar is unaffected by the widened check."""
+        cfg = load_config_from_yaml(_sidecar(tmp_path))
+        assert cfg.anchor_body_name == "torso_link"
+        assert cfg.root_body_name == "pelvis"
+        assert cfg.num_bodies == len(GTP_G1_BODY_NAMES)
+        assert cfg.num_dofs == len(GTP_G1_JOINT_NAMES)
+
+    def test_the_existing_joint_count_refusal_is_untouched(self, tmp_path: Path) -> None:
+        """The two dimensions the loader already checked report as before."""
+        yaml = pytest.importorskip("yaml")
+        path = tmp_path / "unified_pipeline.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "joint_names": list(GTP_G1_JOINT_NAMES),
+                    "body_names": list(GTP_G1_BODY_NAMES),
+                    "control": {"stiffness": [1.0, 2.0, 3.0]},
+                }
+            )
+        )
+        with pytest.raises(ValueError, match=r"stiffness length \(3\) != joint count \(29\)"):
+            load_config_from_yaml(path)
+
+
+class TestTheResolvedNameIsWhatTheTrackerConsumes:
+    """The index reaches the policy's declared body and its cache slice."""
+
+    def test_required_bodies_is_the_resolved_anchor_name(self) -> None:
+        """A wrong index would have propagated through this declaration.
+
+        ``required_bodies`` is what the runtime resolves once per rollout to
+        merge ``body.<name>.quat``, so the index and the observation key cannot
+        disagree - which is exactly why a wrong index is silent.
+        """
+        pytest.importorskip("numpy")
+        from strands_robots.policies.protomotions.policy import ProtoMotionsPolicy
+
+        cfg = ProtoMotionsConfig()
+        policy = ProtoMotionsPolicy.__new__(ProtoMotionsPolicy)
+        policy._config = cfg  # noqa: SLF001 - reading the property, not building a session
+        assert policy.required_bodies == (cfg.anchor_body_name,)
+        assert policy.required_bodies == ("torso_link",)


### PR DESCRIPTION
## Problem

`ProtoMotionsConfig.anchor_body_index` and `root_body_index` are offsets into
`body_names` - the tracker reads a body out of the reference-motion cache by row
index, never by name. `load_config_from_yaml` documents its result as "validated
for consistent dimensions" and promises `ValueError` for "an inconsistent
dimension"; the module docstring promises such an error "surfaces at policy build
time with a clean message". It checked two dimensions - the `stiffness` and
`damping` lengths against the joint count - and neither index.

The two ways an index misses are not symmetric, and the silent one is a valid
Python lookup:

* A **negative** index wraps. `body_names[-1]` is `right_rubber_hand`, a real
  link, so nothing raises anywhere and the tracker anchors on the hand. The whole
  chain agrees: `required_bodies` declares that link, the runtime resolves it once
  per rollout and merges `body.right_rubber_hand.quat` into every observation,
  `_extract_anchor_rot` finds exactly that key, and the future-reference window
  slices the same row out of the cache. Every stage is consistent, and every stage
  is wrong.
* A **positive out-of-range** index deferred `IndexError: tuple index out of
  range` to whichever property read the name first - naming neither the field, the
  value, the valid range, nor the sidecar it came from.

Measured on the tracker's own G1 embodiment (`g1_holo_compat.xml`, whose 33 bodies
are `GTP_G1_BODY_NAMES` in order), the anchor orientation a `-1` sidecar feeds the
network, against the one index 16 declares:

| pose | resolved anchor | degrees from `torso_link` |
| --- | --- | --- |
| waist 0.0 | `right_rubber_hand` | 0.01 |
| waist 0.3, arm raised | `right_rubber_hand` | 10.37 |
| waist 0.6, arm raised | `right_rubber_hand` | 20.20 |

The `int()` coercion in the loader widened the same hole: it ran *before* anything
looked at the value, so a yaml `anchor_body_index: true` became row 1 (`head`,
34.4 degrees out at waist 0.6) and a `2.7` became row 2
(`left_hip_pitch_link`). Both loaded, reported nothing, and disagreed with a
hand-built `ProtoMotionsConfig(anchor_body_index=True)`, which took the same
value through a different path.

This is the config-side mirror of a hole the package already documents and
refuses on the model side: `docs/policies/protomotions.md` explains that a
30-body G1 shifts every row after the gap, so "the tracker asks for `torso_link`
at row 16 and is handed `left_shoulder_pitch_link` - on a walking clip, an anchor
orientation some 20 degrees out, with nothing in the cache to say so." The model
that produces that shift is refused. The sidecar that names the same wrong row
was not.

## Change

`ProtoMotionsConfig.__post_init__` now holds both indices to the shared
`non_negative_whole_number_error` domain and then to the row count of the body
list they index, raising `ValueError` either way:

```text
ValueError: ProtoMotionsConfig.anchor_body_index must be a row of body_names
(0..32), got 99 for 33 bodies. The index is an offset into body_names, so one
that misses cannot resolve the body it names.
```

Validating in `__post_init__` rather than in the loader makes it one owner for
both routes - a sidecar and a hand-built config now report the same value the same
way - and matches the four sibling policy configs (`kimodo`, `motionbricks`,
`vera`, `wbc`) that already validate there; `protomotions` was the one that did
not. The domain runs **before** the `int()` normalisation, which is the ordering
`MotionBricksConfig.__post_init__` states the reason for in as many words
("Before the `float()` below, not after: that conversion is what used to launder
..."). The loader therefore hands the raw yaml value through instead of coercing
it first, and an integral float such as `16.0` still addresses a row and is kept,
normalised to the row number both consumers index with.

`anchor_body_name` and `root_body_name` documented `Raises: IndexError`. That is
now unreachable, so both docstrings say so instead.

**Scope.** Only the two indices, because they are the only fields this config
resolves a body NAME from and the only unvalidated inputs whose wrongness is
silent. Measured and deliberately left alone: `future_step_indices` accepts `[]`,
`[0]` and `[-1, 2]`; `decimation` is documented as `control_dt / physics_dt` and a
sidecar may disagree with its own timing; `control_dt = 0.0` surfaces as
`ZeroDivisionError` from the load log line and `-0.02` is accepted;
`action_ema_alpha` is unbounded. Each of those is a value-domain or
derived-relation question rather than "an index that cannot address a body", and
each wants its own decision. The sidecar also carries `robot.anchor_body_name`
beside the index, which the loader ignores; cross-checking the two would refuse a
disagreement, but which of them wins is a contract choice, not a range.

## Visual

Same sidecar slip, same embodiment, same three poses, run through each tree's own
`ProtoMotionsConfig`. The red frame marks the link the config resolved as the
anchor - the orientation the tracker consumes - and the green frame marks the
declared anchor, `torso_link`. On the left they separate as the waist turns; on
the right the sidecar is refused, so the corrected config anchors where it
declares. The shipped index 16 resolves `torso_link` in both columns, which is the
control.

![anchor body index](https://raw.githubusercontent.com/cagataycali/robots/media-protomotions-anchor-index/anchor_index.png)

## Tests

`tests/policies/protomotions/test_body_index_addresses_a_body.py`, 50 cases.

| tree | failed | passed |
| --- | --- | --- |
| `upstream/main` | 36 | 14 |
| this branch | 0 | 50 |

All 36 pre-fix failures are in the regression class; both control classes are
green on `upstream/main` and here. The headline two fail with the wrong answer
rather than only "did not raise":

```text
Failed: ProtoMotionsConfig accepted anchor_body_index=-1 and resolved
'right_rubber_hand' as the anchor, where the config's own index 16 is 'torso_link'.
Failed: ProtoMotionsConfig accepted anchor_body_index=True and resolved 'head'
as the anchor.
```

Each guard was broken one at a time; every break fires a distinct set and none is
redundant:

| break | failed | fires |
| --- | --- | --- |
| revert the fix | 36 | every regression case |
| upper bound only (drop the shared domain) | 24 | both wrapping negatives, `True`, `2.7`, `"16"`, `None`, nan, inf, and the headline |
| range against `GTP_G1_BODY_NAMES` instead of the config's own list | 2 | trimmed embodiment, empty body list |
| loader coerces with `int()` first | 4 | the yaml route for `true` / `2.7` only |
| drop the `object.__setattr__` normalisation | 2 | the integral-float row-number cases |
| guard `anchor_body_index` only | 16 | every `root_body_index` case |
| control (as shipped here) | 0 of 50 | - |

## Verification

Measured at `25bcf10e` on `upstream/main` @ `1ab3af1d`.

* Identical 114-file selection on both trees, with the new test file excluded from
  each so it measures collateral only (every test naming the changed symbols, all
  of `tests/policies/protomotions`, and the repo-wide docstring / string /
  changelog / source guards): **3986 passed, 56 skipped, 0 failed on both**,
  219.4s vs 216.1s.
* `tests/policies/protomotions` alone: 159 passed.
* The shipped `unified_pipeline.yaml` from
  `cagataydev/protomotions-gtp-unitree-g1` loads unchanged - `anchor_body_index`
  16 -> `torso_link`, `root_body_index` 0 -> `pelvis`, 33 bodies, 29 joints - and
  both values are plain ints there, so the domain is a no-op on the shipped
  artifact.
* `ruff check` / `ruff format --check` clean over `strands_robots tests
  tests_integ`; `mypy` 24 errors on both this branch and a pristine
  `upstream/main` worktree, none in the changed files.
