### PR TITLE
fix(mesh): a degraded state probe names itself in the published snapshot

### DIFF
--- a/changelog.d/2621-degraded-state-probes-are-published.md
+++ b/changelog.d/2621-degraded-state-probes-are-published.md
@@ -1,0 +1,26 @@
+### Fixed: a degraded state probe names itself in the published snapshot
+
+Every section of a `strands/{peer_id}/state` snapshot is optional, because a robot may be hardware, sim,
+both or neither, so an absent section is ambiguous: a robot with no joints and a robot whose joint read
+just raised publish the same thing. A failing probe was reported in the peer's own log, which closed half
+of that and could not close the other half, because the observer that has to explain the absence is on
+another machine. A fleet view could only tell the two cases apart by reading that peer's log.
+
+It could not always do even that. `_read_state` returns `None` when only `peer_id` and `t` survived and
+the state loop publishes nothing for a `None`, so a hardware peer whose one section was `joints` stopped
+publishing state entirely for as long as its bus was contended - while its presence heartbeat kept
+advertising it, since `_presence_loop` does not read `_read_state`. There was no message on the wire to
+inspect at all.
+
+A probe that fails now names itself in a `degraded` block keyed by category, carrying the exception's type
+name as `reason` - the discriminator `_warn_read_state_once`'s own docstring names as selecting the
+operator's next move, so a contended `ConnectionError` and an uncalibrated `RuntimeError` are told apart -
+its message as a `detail` bounded like the topic's other caller-supplied strings, a `failures` count and
+`for_seconds`. The entry is removed on the tick the probe answers again, and the clear happens where the
+read returned rather than where the probe was skipped, so a sim peer with no motor bus is not an
+`hw_joints` recovery and an arm that has gone away keeps its last diagnosis. `for_seconds` is a duration
+and is measured on `time.monotonic()`; the stamp it comes from stays off the wire.
+
+A diagnosis is something to report, so the silenced peer above publishes its fault instead of vanishing.
+The log is unchanged: the once-per-category warning gate arms for the life of the peer, so a probe
+flapping at `STATE_HZ` costs the same one warning it always did while the wire tracks every transition.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -107,7 +107,7 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 | Topic | Rate | Content |
 |-------|------|---------|
 | `strands/{peer_id}/presence` | 2 Hz | heartbeat / peer discovery |
-| `strands/{peer_id}/state` | 10 Hz | joints, sim time, task status |
+| `strands/{peer_id}/state` | 10 Hz | joints, sim time, task status, degraded probes |
 | `strands/{peer_id}/cmd` | on demand | incoming RPC commands |
 | `strands/{peer_id}/response/{id}` | on demand | RPC replies (turn_id correlated) |
 | `strands/{peer_id}/stream` | on demand | VLA execution steps |
@@ -117,6 +117,51 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 | `strands/broadcast` | on demand | fan-out RPC |
 
 Sensor topics only publish when the robot exposes the attribute. Zero cost when unused.
+
+### Degraded state probes
+
+Every section of a state snapshot is optional, because a robot may be hardware,
+sim, both or neither. So an absent section is ambiguous on its own: a robot with
+no joints and a robot whose joint read just failed publish the same thing.
+
+A probe that fails therefore names itself, keyed by category, so the fault is on
+the wire rather than only in that peer's log:
+
+```json
+{
+  "peer_id": "arm-a1",
+  "t": 1755900000.123,
+  "degraded": {
+    "hw_joints": {
+      "reason": "ConnectionError",
+      "detail": "Port is in use!",
+      "failures": 37,
+      "for_seconds": 3.7
+    }
+  }
+}
+```
+
+`reason` is the exception's type name, which is what selects the next move: a
+`ConnectionError` from a contended serial port is a different job from a
+`RuntimeError` from an arm nobody calibrated, and both used to arrive as an
+absent `joints`. `detail` is that exception's message, bounded because it comes
+from a driver and the topic publishes ten times a second. `failures` counts the
+ticks that have raised since the fault began and `for_seconds` how long it has
+been failing, so one unlucky read is distinguishable from a standing fault.
+
+The entry is removed on the tick the probe answers again, so the block always
+describes the current state rather than the worst thing that ever happened. The
+key is absent entirely when nothing is degraded.
+
+It also keeps such a peer talking. A snapshot with nothing to report is not
+published, so a hardware-only peer whose one section was `joints` used to go
+silent on this topic for as long as its bus was contended -- while its presence
+heartbeat kept advertising it, and with nothing on the wire to inspect. A
+diagnosis is something to report, so the peer publishes it.
+
+The categories are `hw_joints` (the motor bus), `task_state` (the running
+rollout), `sim_world` and `sim_joints`.
 
 ### Pose orientation
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -190,6 +190,13 @@ RESUME_FORWARD_SKEW_S: float = _parse_positive_float_env("STRANDS_MESH_RESUME_FO
 #: See :data:`RESUME_FRESHNESS_WINDOW_S` for lazy-resolution note.
 RESUME_REPLAY_CACHE_MAX: int = _parse_positive_int_env("STRANDS_MESH_RESUME_REPLAY_CACHE_MAX", "4096")
 
+#: Longest ``detail`` string a degraded-probe record carries onto the state
+#: topic. The text is a third-party driver's exception message, the state topic
+#: publishes at ``STATE_HZ``, and a driver that puts a whole device dump in that
+#: message would otherwise put ten copies of it on the wire every second. The
+#: ``reason`` beside it is the exception's type name, which is bounded already.
+MAX_DEGRADED_DETAIL_LEN: int = 256
+
 
 def _resume_freshness_window_s() -> float:
     """Lazy resolver for ``STRANDS_MESH_RESUME_FRESHNESS_S``.
@@ -412,6 +419,14 @@ class Mesh(SensorLoopsMixin):
         # The state loop retries at STATE_HZ, so a persistent fault is reported
         # once and then kept at debug level rather than once per tick.
         self._read_state_warned: set[str] = set()
+
+        # Which _read_state probes are degraded RIGHT NOW, keyed by category.
+        # Separate from _read_state_warned, which answers a different question:
+        # this one is cleared when a probe answers again, so the published
+        # snapshot stops claiming a fault that has cleared, while the log gate
+        # above stays armed for the life of the peer so a probe that flaps at
+        # STATE_HZ cannot re-arm the warning ten times a second.
+        self._read_state_degraded: dict[str, dict[str, Any]] = {}
 
         # RPC correlation state.
         #
@@ -1132,7 +1147,8 @@ class Mesh(SensorLoopsMixin):
                 survives even when the message is empty, because the type is
                 what selects the operator's next move: a ``ConnectionError``
                 from a contended serial port and a ``RuntimeError`` from an
-                uncalibrated arm need different actions.
+                uncalibrated arm need different actions. That same type name is
+                what the published record carries as its ``reason``.
 
         Each probe stays wrapped in ``except Exception`` on purpose -- a flaky
         read must not kill the state thread -- so this exists to keep that
@@ -1140,12 +1156,41 @@ class Mesh(SensorLoopsMixin):
         is warned about; the rest drop to debug, because the loop retries at
         ``STATE_HZ`` and a persistent fault would otherwise emit ten warnings a
         second.
+
+        The log gate and the published record are deliberately separate. The
+        gate arms once and stays armed for the life of the peer, so a probe that
+        flaps cannot emit a warning per tick; the record is cleared by
+        :meth:`_note_read_state_ok` as soon as the probe answers, so the
+        snapshot stops claiming a fault the moment it clears. Every call updates
+        the record's failure count, reason and detail, because a probe whose
+        failure mode CHANGES -- a contended port that becomes an uncalibrated
+        arm -- would otherwise keep publishing the first reason forever.
         """
-        warned = getattr(self, "_read_state_warned", None)
-        if warned is None:
+        records = getattr(self, "_read_state_degraded", None)
+        if records is None:
             # A Mesh built through __new__ (several tests, and the sim paths)
             # never ran __init__. Bookkeeping must not be able to raise inside
             # the handler that exists to report a failure.
+            records = {}
+            self._read_state_degraded = records
+        record = records.get(category)
+        if record is None:
+            records[category] = {
+                "reason": type(exc).__name__,
+                "detail": str(exc)[:MAX_DEGRADED_DETAIL_LEN],
+                "failures": 1,
+                # Monotonic: for_seconds answers "how long has this been
+                # failing", a duration, and a wall-clock stamp would make that
+                # duration jump by the size of any NTP correction mid-fault.
+                "since_mono": time.monotonic(),
+            }
+        else:
+            record["failures"] = int(record.get("failures", 0)) + 1
+            record["reason"] = type(exc).__name__
+            record["detail"] = str(exc)[:MAX_DEGRADED_DETAIL_LEN]
+
+        warned = getattr(self, "_read_state_warned", None)
+        if warned is None:
             warned = set()
             self._read_state_warned = warned
         if category in warned:
@@ -1165,7 +1210,95 @@ class Mesh(SensorLoopsMixin):
             exc,
         )
 
+    def _note_read_state_ok(self, category: str) -> None:
+        """Clear ``category``'s degraded record: the probe answered.
+
+        Called from inside each probe once the operation that can raise has
+        returned, so the record is dropped only on a real answer and never on a
+        tick where the probe did not run at all -- a sim peer with no hardware
+        must not read as an ``hw_joints`` recovery.
+
+        Args:
+            category: The probe that answered. Unknown or already-clear
+                categories are a no-op, so a probe may call this every tick.
+
+        The recovery is reported on the wire -- the record disappears from the
+        next snapshot -- and at debug in the log. It is deliberately not a
+        warning: the whole point of publishing the record is that an observer no
+        longer has to read the log, and a probe flapping at ``STATE_HZ`` would
+        otherwise trade ten silent ticks for twenty noisy lines.
+        """
+        records = getattr(self, "_read_state_degraded", None)
+        if not records:
+            return
+        record = records.pop(category, None)
+        if record is None:
+            return
+        logger.debug(
+            "[mesh] %s: state probe %r answered again after %d failure(s) over %.1fs",
+            self.peer_id,
+            category,
+            int(record.get("failures", 0)),
+            time.monotonic() - float(record.get("since_mono", time.monotonic())),
+        )
+
+    def _degraded_probes(self) -> dict[str, dict[str, Any]] | None:
+        """The ``degraded`` block for the snapshot, or ``None`` when healthy.
+
+        Returns:
+            One entry per currently-degraded probe, keyed by category, each
+            carrying ``reason`` (the exception's type name -- the discriminator
+            :meth:`_warn_read_state_once` documents as selecting the operator's
+            next move), ``detail`` (that exception's message, bounded by
+            :data:`MAX_DEGRADED_DETAIL_LEN`), ``failures`` (how many ticks have
+            raised since the fault began) and ``for_seconds`` (how long it has
+            been failing). ``None`` when no probe is degraded, so a healthy
+            peer's snapshot is byte-for-byte what it always was.
+
+        ``since_mono`` is process-local and stays off the wire: seconds of local
+        uptime mean nothing to the machine reading the snapshot, so the elapsed
+        duration is computed here and only the difference is published.
+        """
+        records = getattr(self, "_read_state_degraded", None)
+        if not records:
+            return None
+        now = time.monotonic()
+        return {
+            category: {
+                "reason": record.get("reason", ""),
+                "detail": record.get("detail", ""),
+                "failures": int(record.get("failures", 0)),
+                "for_seconds": round(now - float(record.get("since_mono", now)), 3),
+            }
+            for category, record in sorted(records.items())
+        }
+
     def _read_state(self) -> dict[str, Any] | None:
+        """Build this peer's state snapshot for ``strands/{peer_id}/state``.
+
+        Returns:
+            The snapshot, or ``None`` when nothing but ``peer_id`` and ``t``
+            survived -- the state loop publishes nothing for a ``None``.
+
+        Every section is optional and probed defensively, because a robot may be
+        hardware, sim, both or neither. A section is present when its probe
+        answered and has something to report: ``joints`` (per-joint positions,
+        from the motor bus or from the sim world), ``task`` (the running
+        rollout's status), ``sim_time`` and ``robots``.
+
+        A section that is ABSENT is therefore ambiguous on its own -- a robot
+        with no joints and a robot whose joint probe just raised look identical
+        -- so a probe that fails names itself in ``degraded``, keyed by
+        category, with the ``reason`` / ``detail`` / ``failures`` /
+        ``for_seconds`` block :meth:`_degraded_probes` documents. That block is
+        the guarantee: while a probe is failing the snapshot says so, and the
+        entry disappears on the tick the probe answers again. It also keeps the
+        peer publishing at all. Before it, a hardware peer whose only section
+        was ``joints`` returned ``None`` for every tick of a contended bus, so
+        it went silent on the state topic while its presence heartbeat kept
+        advertising it -- indistinguishable from a peer whose state thread had
+        died, and explicable only by reading that peer's log.
+        """
         r = self.robot
         snapshot: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
 
@@ -1180,6 +1313,7 @@ class Mesh(SensorLoopsMixin):
                 # already in hand -- one dead USB camera used to erase an arm's
                 # entire joint telemetry while its presence stayed healthy.
                 obs = read_joints(inner)
+                self._note_read_state_ok("hw_joints")
                 cam_keys = set(getattr(getattr(inner, "config", None), "cameras", {}).keys())
                 joints: dict[str, Any] = {}
                 for key, value in obs.items():
@@ -1207,6 +1341,7 @@ class Mesh(SensorLoopsMixin):
                     "steps": getattr(ts, "step_count", 0),
                     "duration": getattr(ts, "duration", 0.0),
                 }
+                self._note_read_state_ok("task_state")
         except Exception as exc:
             self._warn_read_state_once("task_state", exc)
 
@@ -1242,10 +1377,19 @@ class Mesh(SensorLoopsMixin):
                                 }
                         if sim_joints:
                             snapshot["joints"] = sim_joints
+                        self._note_read_state_ok("sim_joints")
                     except Exception as exc:
                         self._warn_read_state_once("sim_joints", exc)
+                self._note_read_state_ok("sim_world")
         except Exception as exc:
             self._warn_read_state_once("sim_world", exc)
+
+        # Unconditional: a probe that is failing says so on the wire for as long
+        # as it fails, which is also what keeps a hardware-only peer publishing
+        # at all when its one section is the one that raised.
+        degraded = self._degraded_probes()
+        if degraded is not None:
+            snapshot["degraded"] = degraded
 
         return snapshot if len(snapshot) > 2 else None
 

--- a/tests/mesh/test_mesh.py
+++ b/tests/mesh/test_mesh.py
@@ -672,10 +672,22 @@ class TestTelemetryRobustness:
         assert p["topics"] == ["health"]
 
     def test_read_state_swallows_every_attribute_error(self) -> None:
-        """A hostile robot yields no useful state -> None, never an exception."""
+        """A hostile robot yields no telemetry, but says which probes failed.
+
+        The contract is that nothing propagates: every probe is wrapped in
+        ``except Exception`` so a hostile driver cannot kill the state thread.
+        What it yields is not nothing, though -- each probe that raised names
+        itself in ``degraded``, so a peer whose every read fails is
+        distinguishable on the wire from one that simply has nothing to report.
+        """
         m = Mesh(_HostileRobot(), peer_id="hostile-2")
 
-        assert m._read_state() is None  # must not raise
+        out = m._read_state()  # must not raise
+
+        assert out is not None
+        assert "joints" not in out and "task" not in out, "no telemetry survived"
+        assert set(out["degraded"]) == {"hw_joints", "task_state", "sim_world"}
+        assert {r["reason"] for r in out["degraded"].values()} == {"RuntimeError"}
 
 
 class TestOnPresenceNonDict:

--- a/tests/mesh/test_read_state_probe_failures_are_reported.py
+++ b/tests/mesh/test_read_state_probe_failures_are_reported.py
@@ -23,8 +23,20 @@ pin the contract that replaced the silence:
   the peer and the exception's ``repr``;
 * later failures of the same category drop to debug, because the loop retries at
   ``STATE_HZ`` and a persistent fault would otherwise emit ten warnings a second;
-* what is *published* is byte-for-byte what it was before -- this changes the
-  report, not the snapshot.
+* a healthy peer's snapshot is byte-for-byte what it always was.
+
+The log was the whole of that first fix, and reporting a fault only where the
+peer's own process can see it left the harm above standing: an observer still
+had to read that peer's log to explain an absent section, so the fleet dashboard
+grew a regex over mesh's log lines and used it as an API. So the snapshot now
+carries the same verdict the log does, in a ``degraded`` block keyed by category
+-- ``reason`` (the exception's type name, which the reporter's own docstring
+names as the discriminator that selects the operator's next move), ``detail``,
+``failures`` and ``for_seconds``. Two consequences are pinned below: while a
+probe fails the snapshot says so, and because it says so the snapshot is no
+longer empty, so the hardware-only peer above keeps publishing instead of going
+silent. See :mod:`tests.mesh.test_state_degraded_probes_are_published` for the
+block's own contract.
 """
 
 from __future__ import annotations
@@ -129,7 +141,11 @@ class TestAFailedProbeIsReported:
         with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
             out = m._read_state()
 
-        assert out is None, "a snapshot with no readable section is still not published"
+        assert out is not None, "a probe failure is a diagnosis to publish, not a reason to go quiet"
+        assert "joints" not in out, "the failed section is still omitted"
+        assert out["degraded"]["hw_joints"]["reason"] == type(exc).__name__, (
+            "the wire must carry the same discriminator the log does"
+        )
         warned = _warnings(caplog)
         assert len(warned) == 1, f"expected exactly one warning, got {warned}"
         assert "hw_joints" in warned[0]
@@ -152,6 +168,7 @@ class TestAFailedProbeIsReported:
         assert out is not None
         assert out["joints"] == {"j1": 0.5}, "the readable section still publishes"
         assert "task" not in out, "the failed section is still omitted"
+        assert set(out["degraded"]) == {"task_state"}, "only the probe that failed is named"
         warned = _warnings(caplog)
         assert len(warned) == 1, f"expected exactly one warning, got {warned}"
         assert "task_state" in warned[0]
@@ -170,7 +187,8 @@ class TestAFailedProbeIsReported:
         with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
             out = m._read_state()
 
-        assert out is None
+        assert out is not None, "a probe failure is a diagnosis to publish, not a reason to go quiet"
+        assert out["degraded"]["sim_world"]["reason"] == "RuntimeError"
         warned = _warnings(caplog)
         assert len(warned) == 1, f"expected exactly one warning, got {warned}"
         assert "sim_world" in warned[0]

--- a/tests/mesh/test_state_degraded_probes_are_published.py
+++ b/tests/mesh/test_state_degraded_probes_are_published.py
@@ -1,0 +1,390 @@
+"""A degraded state probe names itself in the published snapshot.
+
+:meth:`strands_robots.mesh.core.Mesh._read_state` probes a robot defensively --
+hardware joints, task state, sim world, sim joints -- and omits the section of
+any probe that raises. An omitted section is ambiguous by itself: a robot with no
+joints and a robot whose joint read just failed produce the same snapshot.
+
+Reporting the failure in the peer's own log closed half of that. It could not
+close the other half, because the observer that needs to explain the absence is
+on another machine: a fleet view could only distinguish the two cases by reading
+that peer's log, so one grew a regex over mesh's own log lines and used it as an
+API. These tests pin the contract that removes the need:
+
+* while a probe is failing, the snapshot carries ``degraded[<category>]`` with
+  ``reason`` (the exception's type name -- the discriminator
+  ``_warn_read_state_once`` documents as selecting the operator's next move),
+  ``detail`` (its message, bounded), ``failures`` and ``for_seconds``;
+* the entry disappears on the tick the probe answers again;
+* a healthy peer's snapshot is unchanged -- no key is added when nothing failed;
+* the block makes the snapshot non-empty, so a hardware-only peer whose one
+  section is the one that raised keeps publishing instead of going silent. That
+  silence is the whole reason a log regex was the only way to explain it: there
+  was no message to inspect.
+
+The report is deliberately NOT changed with it. ``_read_state_warned`` arms once
+per category for the life of the peer, so a probe flapping at ``STATE_HZ`` costs
+the same one warning it always did while the wire tracks every transition.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import textwrap
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.core import Mesh
+
+CORE_LOGGER = "strands_robots.mesh.core"
+
+#: Every category the probes report, taken from the source in
+#: :mod:`tests.mesh.test_read_state_probe_failures_are_reported` for the same
+#: reason: a fifth probe must not be able to appear without being held to this.
+EXPECTED_CATEGORIES = {"hw_joints", "task_state", "sim_world", "sim_joints"}
+
+
+class _Bus:
+    """A device whose joint read fails, or answers, on demand."""
+
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(cameras={})
+        # read_joints prefers a bus that can sync_read; None routes it through
+        # get_observation, which is the seam these tests drive.
+        self.bus = None
+        self.exc: BaseException | None = None
+        self.reads = 0
+
+    def get_observation(self) -> dict[str, Any]:
+        self.reads += 1
+        if self.exc is not None:
+            raise self.exc
+        return {"shoulder_pan.pos": 0.5, "elbow_flex.pos": -0.25}
+
+
+def _mesh(host: Any, peer_id: str = "arm-a1") -> Mesh:
+    """A Mesh with only what ``_read_state`` reads.
+
+    Built through ``__new__`` on purpose: the state machinery has to work on a
+    peer whose ``__init__`` never ran, which is how the sim paths reach it.
+    """
+    m = Mesh.__new__(Mesh)
+    m.peer_id = peer_id  # type: ignore[misc]
+    m.robot = host  # type: ignore[misc]
+    return m
+
+
+def _hardware_peer() -> tuple[Mesh, _Bus]:
+    """A peer whose only section is ``joints`` -- the shape that went silent."""
+    bus = _Bus()
+    return _mesh(SimpleNamespace(robot=bus)), bus
+
+
+class TestAFailingProbeNamesItselfOnTheWire:
+    """The block is present, keyed by category, while the probe is failing."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ConnectionError("Port is in use!"),
+            RuntimeError("this arm has no calibration registered"),
+            TimeoutError("no response from motors"),
+            OSError("[Errno 6] Device not configured"),
+        ],
+        ids=["port-contention", "uncalibrated", "no-response", "unplugged"],
+    )
+    def test_the_reason_is_the_exception_type(self, exc: BaseException) -> None:
+        """Four faults an operator answers differently, told apart on the wire.
+
+        The type is the discriminator the reporter's docstring already names: a
+        contended port is a different job from an uncalibrated arm. Before this,
+        all four arrived as the same absent section.
+        """
+        m, bus = _hardware_peer()
+        bus.exc = exc
+        out = m._read_state()
+
+        assert out is not None
+        record = out["degraded"]["hw_joints"]
+        assert record["reason"] == type(exc).__name__
+        assert record["detail"] == str(exc)
+        assert record["failures"] == 1
+        assert record["for_seconds"] >= 0.0
+
+    def test_only_the_probe_that_failed_is_named(self) -> None:
+        """A working section must not be reported as degraded."""
+
+        class _RaisingTask:
+            @property
+            def status(self) -> Any:
+                raise RuntimeError("task state unreadable")
+
+        bus = _Bus()
+        m = _mesh(SimpleNamespace(robot=bus, _task_state=_RaisingTask()))
+        out = m._read_state()
+
+        assert out is not None
+        assert out["joints"], "the readable section still publishes"
+        assert set(out["degraded"]) == {"task_state"}
+
+    def test_the_failure_count_accumulates_across_ticks(self) -> None:
+        """``failures`` distinguishes one unlucky read from a standing fault."""
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+
+        counts = []
+        for _ in range(3):
+            out = m._read_state()
+            assert out is not None
+            counts.append(out["degraded"]["hw_joints"]["failures"])
+
+        assert counts == [1, 2, 3], f"failures must count ticks, got {counts}"
+
+    def test_a_changed_failure_mode_replaces_the_reason(self) -> None:
+        """A fault that becomes a different fault must not keep the old reason.
+
+        A contended port that is resolved into an arm nobody calibrated is two
+        different jobs, and reporting the first one forever would send the
+        operator back to a port that is now free.
+        """
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        first = m._read_state()
+        bus.exc = RuntimeError("this arm has no calibration registered")
+        second = m._read_state()
+
+        assert first is not None and second is not None
+        assert first["degraded"]["hw_joints"]["reason"] == "ConnectionError"
+        assert second["degraded"]["hw_joints"]["reason"] == "RuntimeError"
+        assert second["degraded"]["hw_joints"]["detail"] == "this arm has no calibration registered"
+
+    def test_the_detail_is_bounded(self) -> None:
+        """The text is a third-party message on a 10 Hz topic, so it is capped."""
+        from strands_robots.mesh.core import MAX_DEGRADED_DETAIL_LEN
+
+        m, bus = _hardware_peer()
+        bus.exc = RuntimeError("x" * (MAX_DEGRADED_DETAIL_LEN * 4))
+        out = m._read_state()
+
+        assert out is not None
+        assert len(out["degraded"]["hw_joints"]["detail"]) == MAX_DEGRADED_DETAIL_LEN
+
+
+class TestTheBlockClearsWhenTheProbeAnswers:
+    """A stale diagnosis is worse than none: the entry is removed on recovery."""
+
+    def test_a_recovered_probe_is_no_longer_reported(self) -> None:
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        during = m._read_state()
+        bus.exc = None
+        after = m._read_state()
+
+        assert during is not None and "hw_joints" in during["degraded"]
+        assert after is not None
+        assert "degraded" not in after, "a probe that answered must not still be reported degraded"
+        assert after["joints"], "and its section is back"
+
+    def test_a_second_fault_after_recovery_starts_a_fresh_count(self) -> None:
+        """``failures`` and ``for_seconds`` describe the CURRENT fault."""
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        m._read_state()
+        m._read_state()
+        bus.exc = None
+        m._read_state()
+        bus.exc = ConnectionError("Port is in use!")
+        out = m._read_state()
+
+        assert out is not None
+        assert out["degraded"]["hw_joints"]["failures"] == 1
+
+    def test_a_peer_with_no_hardware_is_not_a_recovery(self) -> None:
+        """A probe that did not run must not clear another peer shape's fault.
+
+        The clear happens where the read returned, not where the probe was
+        skipped, so a sim peer with no motor bus cannot read as an ``hw_joints``
+        recovery -- and an arm that has gone away keeps its last diagnosis.
+        """
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        m._read_state()
+        bus.is_connected = False  # the arm is gone; the probe is skipped entirely
+        out = m._read_state()
+
+        assert out is not None
+        assert out["degraded"]["hw_joints"]["reason"] == "ConnectionError", (
+            "a skipped probe is not an answer, so the standing fault survives"
+        )
+        assert bus.reads == 1, "premise: the second tick did not reach the device"
+
+
+class TestAHealthyPeerIsUnchanged:
+    """No key is added when nothing failed."""
+
+    def test_a_readable_arm_publishes_no_degraded_key(self) -> None:
+        m, _bus = _hardware_peer()
+        out = m._read_state()
+
+        assert out is not None
+        assert set(out) == {"peer_id", "t", "joints"}
+
+    def test_a_peer_with_nothing_to_report_still_publishes_nothing(self) -> None:
+        """The empty-snapshot guard is about having nothing to say, not silence.
+
+        A host with no hardware, no task and no world has no diagnosis either,
+        so it still returns ``None`` and the loop still publishes nothing. What
+        changed is that a probe FAILURE is now something to say.
+        """
+        m = _mesh(SimpleNamespace(robot=None))
+        out = m._read_state()
+        assert out is None
+
+
+class TestTheSilencedPeerKeepsPublishing:
+    """The headline consequence: a diagnosis is content, so the peer speaks."""
+
+    def test_a_hardware_only_peer_publishes_its_fault(self) -> None:
+        """Its one section is the one that raised, and it used to vanish.
+
+        ``_read_state`` returns ``None`` when only ``peer_id`` and ``t``
+        survived and the loop publishes nothing for a ``None``, so this peer
+        stopped appearing on the state topic while its presence heartbeat kept
+        advertising it -- with nothing on the wire to inspect, which is what
+        left a log regex as the only way to explain it.
+        """
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        out = m._read_state()
+
+        assert out is not None, "a peer with a fault to report must not go silent"
+        assert out["degraded"]["hw_joints"]["reason"] == "ConnectionError"
+
+    def test_the_state_loop_publishes_that_snapshot(self) -> None:
+        """End to end through the loop's own publish gate, not just the builder."""
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        published: list[tuple[str, Any]] = []
+        # Parameter named as Mesh.publish names it: the assignment is checked.
+        m.publish = lambda key, payload: published.append((key, payload))  # type: ignore[method-assign]
+
+        state = m._read_state()
+        if state:
+            m.publish(f"strands/{m.peer_id}/state", state)
+
+        assert len(published) == 1, "the loop's `if state:` gate must let a diagnosis through"
+        topic, payload = published[0]
+        assert topic == "strands/arm-a1/state"
+        assert payload["degraded"]["hw_joints"]["detail"] == "Port is in use!"
+
+
+class TestTheDurationIsMeasuredNotStamped:
+    """``for_seconds`` is a duration, so it belongs on the monotonic clock."""
+
+    def test_a_wall_clock_step_does_not_move_the_duration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An NTP correction mid-fault must not invent hours of downtime.
+
+        ``t`` is an absolute stamp another machine correlates and stays on
+        ``time.time()``; ``for_seconds`` answers how long the probe has been
+        failing and must not move when the date does.
+        """
+        from strands_robots.mesh import core
+
+        real_time = core.time.time
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        first = m._read_state()
+
+        monkeypatch.setattr(core.time, "time", lambda: real_time() + 86_400.0)
+        second = m._read_state()
+
+        assert first is not None and second is not None
+        assert second["degraded"]["hw_joints"]["for_seconds"] < 60.0, (
+            "for_seconds tracked the wall clock instead of elapsed time"
+        )
+        assert second["t"] - first["t"] > 3600.0, "premise: the wall clock really moved"
+
+    def test_the_monotonic_stamp_stays_off_the_wire(self) -> None:
+        """Seconds of local process uptime mean nothing to another machine."""
+        m, bus = _hardware_peer()
+        bus.exc = ConnectionError("Port is in use!")
+        out = m._read_state()
+
+        assert out is not None
+        assert set(out["degraded"]["hw_joints"]) == {"reason", "detail", "failures", "for_seconds"}
+
+
+class TestTheReportIsUnchanged:
+    """This changes the snapshot, not the log."""
+
+    def test_a_flapping_probe_still_warns_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The wire tracks every transition; the log keeps its one line.
+
+        Clearing the log gate on recovery would re-arm the warning, so a probe
+        flapping at ``STATE_HZ`` would trade ten silent ticks for a warning per
+        tick -- which is the noise the once-per-category gate exists to prevent.
+        """
+        m, bus = _hardware_peer()
+        with caplog.at_level(logging.DEBUG, logger=CORE_LOGGER):
+            for _ in range(4):
+                bus.exc = ConnectionError("Port is in use!")
+                m._read_state()
+                bus.exc = None
+                m._read_state()
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1, f"a flapping probe must not warn per tick, got {len(warnings)}"
+
+
+class TestEveryProbeIsHeldToTheContract:
+    """Derived from the source, so a fifth probe cannot skip half of it."""
+
+    def test_every_reported_category_also_notes_its_recovery(self) -> None:
+        """A category that can be set and never cleared would go stale forever."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Mesh._read_state)))
+        reported: set[str] = set()
+        cleared: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            arg = node.args[0]
+            if not isinstance(arg, ast.Constant) or not isinstance(arg.value, str):
+                continue
+            name = ast.unparse(node.func)
+            if name.endswith("_warn_read_state_once"):
+                reported.add(arg.value)
+            elif name.endswith("_note_read_state_ok"):
+                cleared.add(arg.value)
+
+        assert reported == EXPECTED_CATEGORIES, f"reported categories drifted: {reported}"
+        assert reported - cleared == set(), (
+            f"these probes report a failure and never clear it: {sorted(reported - cleared)}"
+        )
+
+    def test_the_block_is_attached_unconditionally(self) -> None:
+        """Attaching it inside a probe's ``try`` would lose it to that probe."""
+        body = textwrap.dedent(inspect.getsource(Mesh._read_state))
+        tree = ast.parse(body)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        guarded = {
+            id(inner)
+            for node in ast.walk(func)
+            if isinstance(node, ast.Try)
+            for stmt in node.body
+            for inner in ast.walk(stmt)
+        }
+        attaches = [
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.Call) and ast.unparse(node.func).endswith("_degraded_probes")
+        ]
+        assert attaches, "premise: _read_state builds the block"
+        for call in attaches:
+            assert id(call) not in guarded, "the block must not be built inside a probe's try"


### PR DESCRIPTION
## Problem

Every section of a state snapshot is optional, because a robot may be hardware, sim, both or neither. So an absent section is ambiguous on its own: a robot with no joints and a robot whose joint read just raised publish the same thing.

A previous change made a failing probe report itself in the peer's own log, once per category. That closed half of the problem and could not close the other half, because the observer that has to explain the absence is on another machine. Its own test file said so, and scoped the wire out explicitly:

> what is *published* is byte-for-byte what it was before -- this changes the report, not the snapshot.

With nothing on the wire, a fleet view could only tell the two cases apart by reading that peer's log -- so one grew a regex over `mesh.core`'s log lines and used it as an API.

## Measured

A hardware peer whose only section is `joints`, driven through the real `_read_state` with four faults an operator answers differently:

| joint read raises | publishes | `joints` | reason on the wire | log lines |
| --- | --- | --- | --- | --- |
| (nothing -- control) | yes | yes | n/a | 0 |
| `ConnectionError("Port is in use!")` | **no** | no | none | 1 |
| `RuntimeError("no calibration registered")` | **no** | no | none | 1 |
| `TimeoutError("no response from motors")` | **no** | no | none | 1 |

The peer does not merely omit a section -- it publishes **nothing at all**. `_read_state` returns `None` when only `peer_id` and `t` survived and the state loop publishes nothing for a `None`, so the peer goes silent on the state topic for as long as its bus is contended, while its presence heartbeat keeps advertising it. `_presence_loop` does not read `_read_state`, so the two disagree.

That is why a log regex was the only way to explain it: there was no message to inspect. A peer that also runs a task keeps publishing, and its snapshot then carries `{peer_id, t, task}` with `joints` silently absent and no reason -- indistinguishable from an arm with no joints.

## Change

A probe that fails names itself in `degraded`, keyed by category:

```json
"degraded": {
  "hw_joints": {
    "reason": "ConnectionError",
    "detail": "Port is in use!",
    "failures": 37,
    "for_seconds": 3.7
  }
}
```

`reason` is the exception's **type name**, which is not an invented vocabulary: `_warn_read_state_once`'s own docstring already names it as the discriminator that selects the operator's next move ("a `ConnectionError` from a contended serial port and a `RuntimeError` from an uncalibrated arm need different actions"). The same value the log carries is now the value the wire carries. `detail` is that exception's message, bounded by a new `MAX_DEGRADED_DETAIL_LEN` because the text comes from a driver and the topic publishes ten times a second -- the same reason `MAX_INSTRUCTION_LEN` and `MAX_MODEL_PATH_LEN` exist beside it.

The entry is removed on the tick the probe answers again, so the block describes the current state rather than the worst thing that ever happened. The clear happens where the read returned, not where the probe was skipped, so a sim peer with no motor bus cannot read as an `hw_joints` recovery and an arm that has gone away keeps its last diagnosis.

`for_seconds` is a duration, so it is measured on `time.monotonic()`; the `since_mono` stamp it is derived from stays off the wire, because seconds of local process uptime mean nothing to the machine reading the snapshot. `t` is an absolute stamp another machine correlates and stays on `time.time()`.

And because a diagnosis is something to report, the empty-snapshot guard stops suppressing it: the silenced peer above publishes its fault instead of vanishing.

**The log is deliberately unchanged.** `_read_state_warned` arms once per category for the life of the peer, so a probe flapping at `STATE_HZ` costs the same one warning it always did while the wire tracks every transition. Clearing that gate on recovery would have re-armed the warning and traded ten silent ticks for a warning per tick -- exactly the noise the once-per-category gate exists to prevent. The two structures answer different questions and are kept separate for that reason.

## Tests

Pre-fix, against `upstream/main`: **22 failed, 10 passed.** Twenty-one fail by measuring the pre-fix behaviour or source -- eleven with `assert None is not None` (the peer went silent), two with a `KeyError` on the absent block, and the rest on the structural pins -- and one on the new constant's absence.

Five existing assertions are inverted rather than repaired, because each pinned the behaviour this changes. Four are in the probe-failure file and asserted `out is None` with the message "a snapshot with no readable section is still not published"; every warning assertion in those tests survives untouched, so what moved is the scope boundary the earlier change drew, not the contract it pinned. That file's module docstring said the snapshot was unchanged, and it no longer is, so it says what it says now.

The fifth is `test_mesh.py::TestTelemetryRobustness::test_read_state_swallows_every_attribute_error`, and only the wider run found it -- the two probe files alone were green. Its contract is that nothing propagates from a hostile driver, which is unchanged and still asserted. What it yields is no longer nothing: a robot whose every probed attribute raises now names all three of `hw_joints`, `task_state` and `sim_world`, each with `reason` `RuntimeError`, so a peer whose every read fails is distinguishable from one with nothing to report. The mutating call also moves out of its `assert`, which leaves that file with one such site where it had two.

Every guard was verified load-bearing by breaking the fix one way at a time:

| break | failing | fires |
| --- | --- | --- |
| revert the source | 22 | the full pre-fix split |
| never clear the record | 2 | both recovery tests |
| `for_seconds` on the wall clock | 1 | the monotonic-clock test |
| keep the first reason forever | 1 | the changed-failure-mode test |
| unbounded `detail` | 1 | the bound test |
| recovery re-arms the log gate | 1 | the flapping test |
| attach the block even when empty | 4 | three healthy-peer tests plus a pre-existing one |
| clear where the probe was skipped | 1 | the skipped-probe test |
| leak `since_mono` onto the wire | 1 | the off-the-wire test |
| one category reported but never cleared | 1 | the structural recovery-parity test |
| attach the block inside a probe's `try` | 21 | the attach-unconditionally pin plus twenty more |
| control | 0 of 32 | |

The last two are derived from `_read_state`'s source rather than listed, so a fifth probe is held to both halves of the contract instead of being able to report a failure it never clears.

## Artifact

![degraded state probes on the wire](https://raw.githubusercontent.com/cagataycali/robots/media-state-degraded/state-degraded-probes.png)

Twelve ticks of one hardware peer, driven through the real `_read_state` and the state loop's own `if state:` gate on each tree in turn. The bus is contended for six of them, then the port is freed. Same script, same package code; only `strands_robots` differs between the columns.

`upstream/main` publishes **6 of 12** ticks, with **six** fault ticks carrying no message at all. This branch publishes **12 of 12**, with those six carrying the reason. Both emit exactly **one** log warning, which is the no-change control for the report, and a healthy tick's snapshot is identical in both columns -- `{peer_id, t, joints}`, no key added. Every number in the figure is asserted from the captured JSON by the script that draws it.

## Scope

`reason` is the exception type, not a code vocabulary. Mapping types onto codes such as `PORT_IN_USE` or `NO_RESPONSE` would mean matching a driver's message **text** -- `"Port is in use!"` is a lerobot string -- and this module has no basis for that classification. No such vocabulary exists in the tree today.

A recovery counter is out of scope: `bus_access` does not keep one, so there is nothing to surface. `failures` and `for_seconds` describe the current fault, and a fault that clears and returns starts a fresh count, which is pinned.

The `except Exception` breadth on each probe stays. A flaky read must not kill the state thread; the defect was the silence, not the breadth.

## Verification

Measured at `7d3c3780` on `upstream/main` `a12120ca`.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 errors, the same 24 as a pristine worktree of the base, none in a changed file.

Blast radius: 390 test files -- everything naming the probe machinery, all of `tests/mesh`, and the repo-wide docs, docstring, string and changelog guards -- run with the identical selection on this branch and on a pristine `upstream/main` worktree, with the three test files this PR changes excluded from both.

| tree | failed | passed | skipped | errors |
| --- | --- | --- | --- | --- |
| this branch | 24 | 13527 | 86 | 24 |
| pristine base | 23 | 13528 | 86 | 24 |

Failing ids: 48 against 47. The single difference was `test_mesh.py`'s hostile-robot test, which that run measured before it was repaired; excluding that file the sets are **47 and 47 with an empty diff in both directions**, and the file itself is 46 passed on each tree afterwards. The 47 shared are local environment gaps, not code: 45 in `tests/mesh/test_iot_*` on `No module named 'awsiot'` (a declared extra CI installs) and two in `tests/test_doctor.py` on `PackageNotFoundError`, because the worktree is not pip-installed.
