### PR TITLE
fix(mesh): broadcast reports the cmd-topic size cap it shares with send

### DIFF
--- a/changelog.d/2622-broadcast-cmd-size-cap.md
+++ b/changelog.d/2622-broadcast-cmd-size-cap.md
@@ -1,0 +1,14 @@
+### Fixed: broadcast reports the cmd-topic size cap it shares with send
+
+The transport's `low_pass_filter` caps `**/cmd` and `**/broadcast` with one rule
+(`strands_cmd_size_cap`, 16 KiB, ingress and egress) while the command validator admits a
+`world_update` up to `MAX_WORLD_UPDATE_BYTES` (64 KiB). `Mesh.send` pre-checked that gap and
+answered with a structured error naming the cap and the env var that raises it.
+`Mesh.broadcast` publishes on the other key expression of the same rule and did not, so a
+validator-valid command four times the wire limit was handed to the filter and returned the
+empty list a broadcast nobody answered also returns.
+
+`Mesh._cmd_topic_size_problem` is now the one owner of that cap and both publishers ask it, so
+the two key expressions of one filter rule cannot come to disagree about the limit they share.
+`broadcast` reports the reason the way it already reports a client-side rejection: log it and
+return no responses. `send`'s error wording is unchanged.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -2972,6 +2972,43 @@ class Mesh(SensorLoopsMixin):
                 )
 
     # RPC -- outgoing
+    def _cmd_topic_size_problem(self, msg: dict[str, Any]) -> str | None:
+        """Report why *msg* would be dropped by the cmd-topic byte cap.
+
+        The transport's ``low_pass_filter`` caps ``**/cmd`` AND
+        ``**/broadcast`` with one rule (``strands_cmd_size_cap``, default
+        16 KiB, ingress and egress) while the command validator admits a
+        ``world_update`` up to :data:`~strands_robots.mesh.security.MAX_WORLD_UPDATE_BYTES`
+        (64 KiB). A valid command in that gap is silently dropped, so both
+        publishers on that rule ask this before handing the payload over.
+
+        One owner rather than a copy per publisher: a second inline check is
+        how the two topics come to disagree about the cap they share.
+
+        Returns:
+            A reason naming the encoded size, the cap and the env var that
+            raises it, or ``None`` when the message fits -- and also ``None``
+            when the cap cannot be read at all. The check is a diagnostic, not
+            part of publishing: it turns a silent transport drop into a
+            reported one. If the config helper cannot be imported there is no
+            cap to compare against, so the caller publishes and an over-cap
+            message behaves as it did before this check existed. Failing every
+            command because an optional module is missing would be worse.
+        """
+        try:
+            from strands_robots.mesh._zenoh_config import cmd_bytes_cap
+        except ImportError:
+            return None
+        encoded_len = len(json.dumps(msg).encode("utf-8"))
+        cap = cmd_bytes_cap()
+        if encoded_len <= cap:
+            return None
+        return (
+            f"command message is {encoded_len} bytes; the transport drops "
+            f"cmd messages over {cap} bytes (STRANDS_MESH_MAX_CMD_BYTES). "
+            "Shrink world_update/instruction or raise the cap on BOTH peers."
+        )
+
     def send(self, target: str, cmd: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
         """Send a command to a single peer and return the first response.
 
@@ -3029,39 +3066,15 @@ class Mesh(SensorLoopsMixin):
                 raise ValueError("send: target may not equal BROADCAST_RESPONDER or contain NUL")
             self._expected_responders[turn] = target
         msg = {"sender_id": self.peer_id, "turn_id": turn, "command": cmd, "timestamp": time.time()}
-        # The transport's low-pass filter silently drops cmd-topic
-        # messages above its byte cap (default 16 KiB) BOTH ways, while the
-        # validator admits world_update payloads up to 64 KiB - a valid
-        # command in that gap timed out with zero diagnostics. Check the
-        # encoded size here and answer with a structured error instead.
-        try:
-            from strands_robots.mesh._zenoh_config import cmd_bytes_cap as _cmd_cap
-
-            _encoded_len = len(json.dumps(msg).encode("utf-8"))
-            _cap = _cmd_cap()
-            if _encoded_len > _cap:
-                with self._rpc_lock:
-                    self._pending.pop(turn, None)
-                    self._responses.pop(turn, None)
-                    self._expected_responders.pop(turn, None)
-                return {
-                    "status": "error",
-                    "error": (
-                        f"command message is {_encoded_len} bytes; the transport drops "
-                        f"cmd messages over {_cap} bytes (STRANDS_MESH_MAX_CMD_BYTES). "
-                        "Shrink world_update/instruction or raise the cap on BOTH peers."
-                    ),
-                }
-        except ImportError:
-            # The size pre-check is a diagnostic, not part of sending: it turns
-            # a silent transport drop into a structured error naming the cap.
-            # If the config helper cannot be imported there is no cap to read,
-            # so skip the check and publish. An over-cap message then behaves as
-            # it did before the check existed - dropped by the low-pass filter,
-            # surfacing as the {"status": "timeout"} below - which is worse
-            # diagnostics but still a correct send. Raising instead would let a
-            # missing optional module fail every command on this path.
-            pass
+        # An over-cap command is dropped by the transport with no diagnostics,
+        # so report it here instead of publishing into the filter.
+        size_problem = self._cmd_topic_size_problem(msg)
+        if size_problem is not None:
+            with self._rpc_lock:
+                self._pending.pop(turn, None)
+                self._responses.pop(turn, None)
+                self._expected_responders.pop(turn, None)
+            return {"status": "error", "error": size_problem}
         try:
             self.publish(f"strands/{target}/cmd", msg)
             event.wait(timeout=timeout)
@@ -3099,6 +3112,19 @@ class Mesh(SensorLoopsMixin):
             # Sentinel -- broadcast accepts responses from any peer.
             self._expected_responders[turn] = BROADCAST_RESPONDER
         msg = {"sender_id": self.peer_id, "turn_id": turn, "command": cmd, "timestamp": time.time()}
+        # ``strands/broadcast`` shares the cmd-topic byte cap with ``**/cmd``
+        # (one ``strands_cmd_size_cap`` rule), so an over-cap broadcast is
+        # dropped by the filter and returns the same empty list a broadcast
+        # nobody answered returns. Report it the way this method already
+        # reports a client-side rejection: log the reason, return no responses.
+        size_problem = self._cmd_topic_size_problem(msg)
+        if size_problem is not None:
+            logger.warning("[mesh] %s: broadcast rejected client-side: %s", self.peer_id, size_problem)
+            with self._rpc_lock:
+                self._pending.pop(turn, None)
+                self._responses.pop(turn, None)
+                self._expected_responders.pop(turn, None)
+            return []
         try:
             self.publish("strands/broadcast", msg)
             # A broadcast has no single expected responder, so collect acks for

--- a/tests/mesh/test_cmd_topic_size_cap_is_reported.py
+++ b/tests/mesh/test_cmd_topic_size_cap_is_reported.py
@@ -1,0 +1,196 @@
+"""Both publishers on the cmd-topic byte cap report an over-cap payload.
+
+The transport's ``low_pass_filter`` caps ``**/cmd`` and ``**/broadcast`` with
+one rule (``strands_cmd_size_cap``, ingress and egress) while the command
+validator admits a ``world_update`` four times that size
+(:data:`~strands_robots.mesh.security.MAX_WORLD_UPDATE_BYTES` is 64 KiB against
+a 16 KiB cap). A validator-valid command in that gap is dropped by the filter,
+which cannot say why nothing arrived.
+
+:meth:`~strands_robots.mesh.core.Mesh.send` pre-checked the encoded size and
+answered with a structured error naming the cap.
+:meth:`~strands_robots.mesh.core.Mesh.broadcast` publishes on the other key
+expression of the same rule and did not, so an over-cap broadcast was handed to
+the filter and returned the empty list a broadcast nobody answered also
+returns -- indistinguishable, on a method ``robot_mesh`` exposes as a fleet-wide
+action. Both now ask one helper, so the two topics cannot come to disagree
+about the cap they share.
+"""
+
+import ast
+import inspect
+import json
+import logging
+import sys
+import textwrap
+
+import pytest
+
+from strands_robots.mesh import core
+from strands_robots.mesh import security as _security
+from strands_robots.mesh._zenoh_config import cmd_bytes_cap
+
+#: A validator-VALID execute command whose ``world_update`` sits in the gap
+#: between the validator's bound and the transport's cap.
+_OVER_CAP_CMD: dict[str, object] = {
+    "action": "execute",
+    "instruction": "go",
+    "policy_provider": "mock",
+    "world_update": {"blob": "x" * 20000},
+}
+_SMALL_CMD: dict[str, object] = {"action": "stop"}
+
+
+def _mesh() -> core.Mesh:
+    m = core.Mesh(robot=object(), peer_id="op")
+    m._running = True
+    return m
+
+
+def _drive(m: core.Mesh, publisher: str, cmd: dict[str, object]) -> tuple[object, list[tuple[str, int]]]:
+    """Run *publisher* with *cmd*, returning ``(result, what reached the wire)``."""
+    reached: list[tuple[str, int]] = []
+    m.publish = lambda key, payload: reached.append(  # type: ignore[method-assign]
+        (key, len(json.dumps(payload).encode("utf-8")))
+    )
+    if publisher == "send":
+        return m.send("r1", cmd, timeout=0.05), reached
+    return m.broadcast(cmd, timeout=0.05), reached
+
+
+class TestTheOverCapPayloadIsWithinTheValidatorsBound:
+    """Premise: the fixture is a command the validator accepts."""
+
+    def test_the_validator_admits_the_over_cap_command(self) -> None:
+        # Without this the tests below would measure a validation refusal
+        # rather than the size cap.
+        _security.validate_command(dict(_OVER_CAP_CMD))
+
+    def test_the_fixture_exceeds_the_cap_it_is_about(self) -> None:
+        encoded = len(json.dumps(_OVER_CAP_CMD).encode("utf-8"))
+        assert encoded > cmd_bytes_cap(), f"fixture is {encoded} bytes, cap is {cmd_bytes_cap()}"
+
+
+class TestNeitherPublisherHandsAnOverCapPayloadToTheFilter:
+    """The headline. ``send`` passes on both trees; ``broadcast`` is the fix."""
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_an_over_cap_command_does_not_reach_the_transport(self, publisher: str) -> None:
+        m = _mesh()
+        _result, reached = _drive(m, publisher, dict(_OVER_CAP_CMD))
+        assert reached == [], (
+            f"{publisher}() handed a {len(json.dumps(_OVER_CAP_CMD).encode('utf-8'))}-byte command to the "
+            f"transport, whose cmd-topic rule caps it at {cmd_bytes_cap()} bytes and drops it silently: {reached}"
+        )
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_the_reason_names_the_actual_size_the_cap_and_the_env_var(
+        self, publisher: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        m = _mesh()
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            result, _reached = _drive(m, publisher, dict(_OVER_CAP_CMD))
+        # ``send`` reports in its return value, ``broadcast`` in the log --
+        # each uses the shape its own return type already has for a
+        # client-side rejection. Read whichever this publisher offers.
+        reported = json.dumps(result) + " " + caplog.text
+        cap = cmd_bytes_cap()
+        for expected in (str(cap), "STRANDS_MESH_MAX_CMD_BYTES", "bytes"):
+            assert expected in reported, f"{publisher}() did not name {expected!r}: {reported[:400]}"
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_the_refused_turn_leaves_no_pending_state(self, publisher: str) -> None:
+        m = _mesh()
+        _drive(m, publisher, dict(_OVER_CAP_CMD))
+        assert m._pending == {}, m._pending
+        assert m._responses == {}, m._responses
+        assert m._expected_responders == {}, m._expected_responders
+
+
+class TestABroadcastRejectionIsReportedTheWayThisMethodAlreadyReportsOne:
+    """``broadcast`` returns ``list``, so its rejection slot is the log."""
+
+    def test_the_over_cap_broadcast_is_logged_as_a_client_side_rejection(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        m = _mesh()
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            result = m.broadcast(dict(_OVER_CAP_CMD), timeout=0.05)
+        assert result == []
+        assert "broadcast rejected client-side" in caplog.text, caplog.text
+
+    def test_a_validation_rejection_still_uses_that_same_shape(self, caplog: pytest.LogCaptureFixture) -> None:
+        # The wording this fix reuses is not new: an invalid command has been
+        # reported this way. Both rejections must stay one shape.
+        m = _mesh()
+        with caplog.at_level(logging.WARNING, logger="strands_robots.mesh.core"):
+            result = m.broadcast({"action": "execute", "instruction": "go"}, timeout=0.05)
+        assert result == []
+        assert "broadcast rejected client-side" in caplog.text, caplog.text
+
+
+class TestNothingElseChanges:
+    """Controls -- each fails for a specific over-reaching fix."""
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_a_payload_under_the_cap_still_reaches_the_transport(self, publisher: str) -> None:
+        m = _mesh()
+        _result, reached = _drive(m, publisher, dict(_SMALL_CMD))
+        assert len(reached) == 1, f"{publisher}() did not publish an in-cap command: {reached}"
+        assert reached[0][1] <= cmd_bytes_cap()
+
+    def test_sends_over_cap_error_wording_is_unchanged(self) -> None:
+        # Operators and forks match on this text; the refactor moved where it
+        # is built, not what it says.
+        m = _mesh()
+        result, _reached = _drive(m, "send", dict(_OVER_CAP_CMD))
+        assert isinstance(result, dict)
+        assert result["status"] == "error"
+        encoded = len(
+            json.dumps({"sender_id": "op", "turn_id": "x" * 32, "command": _OVER_CAP_CMD, "timestamp": 0.0}).encode(
+                "utf-8"
+            )
+        )
+        assert result["error"].startswith("command message is "), result["error"]
+        assert result["error"].endswith("Shrink world_update/instruction or raise the cap on BOTH peers."), result[
+            "error"
+        ]
+        # The reported size is the encoded message, not the bare command.
+        assert abs(int(result["error"].split()[3]) - encoded) < 64, result["error"]
+
+    def test_an_unreadable_cap_publishes_rather_than_refusing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The check is a diagnostic. If the config helper cannot be imported
+        # there is no cap to compare against, so the payload goes out as it did
+        # before the check existed rather than every command failing.
+        m = _mesh()
+        # A None entry makes the import raise ImportError from the import
+        # machinery itself, which is what a missing optional module looks like.
+        monkeypatch.setitem(sys.modules, "strands_robots.mesh._zenoh_config", None)
+        assert m._cmd_topic_size_problem({"blob": "x" * 20000}) is None
+
+
+class TestOneOwnerForTheSharedCap:
+    """Structural: both publishers ask the helper, neither re-derives the cap."""
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_the_publisher_consults_the_shared_helper(self, publisher: str) -> None:
+        src = textwrap.dedent(inspect.getsource(getattr(core.Mesh, publisher)))
+        called = {
+            ast.unparse(node.func).split(".")[-1] for node in ast.walk(ast.parse(src)) if isinstance(node, ast.Call)
+        }
+        assert "_cmd_topic_size_problem" in called, (
+            f"{publisher}() does not ask the shared cmd-size helper; a second inline check is how the "
+            "two key expressions of one filter rule come to disagree about the cap."
+        )
+
+    @pytest.mark.parametrize("publisher", ["send", "broadcast"])
+    def test_the_publisher_does_not_re_derive_the_cap(self, publisher: str) -> None:
+        src = textwrap.dedent(inspect.getsource(getattr(core.Mesh, publisher)))
+        assert "cmd_bytes_cap" not in src, (
+            f"{publisher}() reads the cap itself instead of delegating; the helper owns it."
+        )
+
+    def test_the_helper_is_the_only_place_the_cap_is_read_on_this_path(self) -> None:
+        src = textwrap.dedent(inspect.getsource(core.Mesh._cmd_topic_size_problem))
+        assert "cmd_bytes_cap" in src
+        assert "STRANDS_MESH_MAX_CMD_BYTES" in src, "the reason must name the knob that raises the cap"


### PR DESCRIPTION
## Problem

The transport's `low_pass_filter` caps two key expressions with **one** rule:

```json
{"id": "strands_cmd_size_cap", "key_exprs": ["**/cmd", "**/broadcast"],
 "flows": ["ingress", "egress"], "size_limit": cmd_bytes}
```

`DEFAULT_MAX_CMD_BYTES` is 16 KiB. The command validator admits a `world_update` up to
`MAX_WORLD_UPDATE_BYTES`, which is **64 KiB** -  so a validator-valid command can be four
times the size the transport will carry, and the filter drops it with no diagnostics.

`Mesh.send` already pre-checks that gap and answers with a structured error naming the cap.
`Mesh.broadcast` publishes on the *other* key expression of the *same* rule and did not, so an
over-cap broadcast was handed to the filter and returned `[]` -  which is exactly what a
broadcast nobody answered returns. `broadcast` is a fleet-wide action the `robot_mesh` tool
exposes and one of `_DEFAULT_INTERRUPT_ACTIONS`.

Measured on `a12120ca`, driving both publishers with the same validator-valid command
(`{"action": "execute", "instruction": "go", "policy_provider": "mock", "world_update": {"blob": "x"*20000}}`,
20257 bytes encoded, cap 16384):

| publisher | result | reached the transport |
| --- | --- | --- |
| `send` | `{"status": "error", "error": "command message is 20257 bytes; the transport drops cmd messages over 16384 bytes (STRANDS_MESH_MAX_CMD_BYTES). ..."}` | no |
| `broadcast` | `[]` | **yes -  `('strands/broadcast', 20257)`** |
| `broadcast`, in-cap (control) | `[]` | yes -  `('strands/broadcast', 130)` |

Rows 2 and 3 are byte-identical to the caller. That is the "the sender only ever sees a
timeout" failure mode, one method over from where it was already fixed.

## Change

`Mesh._cmd_topic_size_problem(msg)` is now the one owner of the cmd-topic cap, and both
publishers on that filter rule ask it. A second inline check is how two key expressions of one
rule come to disagree about the cap they share, so `send`'s inline block moved into the helper
rather than being copied.

`broadcast` reports the reason the way it **already** reports a client-side rejection -  its
return type is `list[dict]`, so a rejection has no structured slot, and the existing
`ValidationError` path logs and returns `[]`. The size rejection reuses that shape and wording
(`"broadcast rejected client-side: ..."`), so the method has one rejection shape rather than two.

`send`'s error text is unchanged, byte for byte -  pinned by a control test. The helper keeps
`send`'s documented `ImportError` behaviour: if the config helper cannot be imported there is no
cap to compare against, so the payload is published as it was before the check existed rather
than every command failing on a missing optional module.

## Scope

Only the cmd-topic rule. The filter has two other rules with **different** caps, and neither is
the same contract:

- `**/camera/**` is capped at 1 MiB **ingress only** -  the comment says "publisher trusts own
  frames", so a publisher-side check is not what that rule asks for.
- `**/safety/**` is capped at 4 KiB ingress and egress. Its publishers have no pre-check either,
  but a safety envelope cannot simply be refused (the e-stop must proceed), so what to do instead
 -  truncate, split, or report locally -  is a design decision rather than a mirror of an existing
  one. Reported separately with the measurement rather than guessed at here.

## Tests

`tests/mesh/test_cmd_topic_size_cap_is_reported.py`, 19 cases. Against `a12120ca`:
**8 failed / 11 passed** -> 19 passed. Three of the eight are behavioural and all name
`broadcast`:

```
FAILED ...::test_an_over_cap_command_does_not_reach_the_transport[broadcast]
  AssertionError: broadcast() handed a 20099-byte command to the transport, whose cmd-topic
  rule caps it at 16384 bytes and drops it silently: [('strands/broadcast', 20257)]
FAILED ...::test_the_reason_names_the_actual_size_the_cap_and_the_env_var[broadcast]
  AssertionError: broadcast() did not name '16384': []
FAILED ...::test_the_over_cap_broadcast_is_logged_as_a_client_side_rejection
```

Three more are the single-owner pins and two report the helper's absence; those pin the
contract's shape rather than the regression, and I have labelled them that way.

The eleven that pass on both trees are the controls -  including the whole `[send]` half of the
parametrized headline, which is what makes "`send` is unchanged" a measurement.

Each guard is load-bearing (6 breaks, 6 distinct firing sets, zero dead guards):

| break | tests that fire | n |
| --- | --- | --- |
| revert the whole change | all of them | 8 |
| revert `broadcast`'s check only | the 3 behavioural + `broadcast`'s consult pin | 4 |
| `broadcast` checks but does not log | reason[broadcast] + the log-shape test | 2 |
| the reason omits the env var | reason[send] + reason[broadcast] + the helper pin | 3 |
| `send` re-derives the cap inline | reason[send] + the wording control + both `send` pins | 4 |
| the helper refuses a payload that fits | both in-cap controls | 2 |
| unmodified | -  | 0 of 19 |

## Artifact

The same validator-valid command driven through both publishers on each tree. Row 2 is the
change; rows 3 and 4 are in-cap controls, and row 1 is `send`, whose result is byte-identical
across the two columns.

![over-cap broadcast reached the filter that drops it](https://raw.githubusercontent.com/cagataycali/robots/media-broadcast-cmd-size-cap/broadcast-cmd-size-cap.png)

No robot behaves differently either way: on `main` the over-cap broadcast is eaten by the filter
and on this branch it is refused before the wire, so in both cases no peer receives it. What
changes is whether the caller is told, which is the whole point of the pre-check `send` already
had.

## Verification

Measured at `a43d33ac`, against `upstream/main` `a12120ca`.

- `tests/mesh/test_cmd_topic_size_cap_is_reported.py`: 19 passed (8 failed / 11 passed on `a12120ca`).
- Blast radius: the 207 test files naming the changed symbols, plus all of `tests/mesh` and the
  repo-wide docstring / string / changelog guards, run as the identical selection on both trees
  with the new file excluded from each. Both report `23 failed, 5463 passed, 5 skipped, 24 errors`
  as byte-identical summary lines, and the 47 failing ids are the same set in both directions
  (`comm` empty each way). All 47 need optional extras this environment lacks: 45 want `awsiot`
  and 2 want `device_connect_agent_tools`, both of which CI installs.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: 24 errors on the branch and 24 on a pristine
  `upstream/main` worktree, identical sets, none in the changed files.
