### PR TITLE
feat(refusals): a continuable refusal carries a stable code and its subject

### DIFF
--- a/changelog.d/2623-refusal-codes-stable-contract.md
+++ b/changelog.d/2623-refusal-codes-stable-contract.md
@@ -1,0 +1,24 @@
+### Added: a stable code and subject on the refusals an operator can answer
+
+Some refusals are *continuable*: the request was well formed, and an operator who
+accepts the risk can grant something that makes the identical request succeed.
+Anything that offers that choice - a consent card, an approval endpoint, a
+supervising agent - has to recognise which refusal it is and what it is about,
+and the only thing on offer was the message text. So recognition meant prose
+matching: an env-var name appearing somewhere in the sentence, the subject pulled
+back out with an anchored regex. Two of the refusals name no env var at all.
+
+That made every wording improvement silently breaking, and this package could
+not detect it. Rewording the teleop refusals from "out of range" to "exceeds the
+safety envelope" - a plain improvement, and nothing in `tests/` asserts on either
+phrase - leaves the mesh suite at 270 passed while a consumer's classification of
+both refusals drops to `None`.
+
+Continuable refusals now carry a stable machine-readable `code` from the new
+`strands_robots.refusal_codes` and the `subject` they are about, so a consumer
+switches on identity and the message stays free to improve.
+`REFUSAL_GRANTS` names the environment variable that lifts each refusal, which a
+consumer otherwise hard-codes. The codes are additive: all eight measured refusal
+messages are byte-identical to before, and a rejection with no operator grant
+behind it - a schema or bounds failure - stays code-less on purpose, so
+`code is None` means "show the message and stop" rather than "unknown code".

--- a/docs/security.md
+++ b/docs/security.md
@@ -97,6 +97,32 @@ What this looks like in practice, and how to configure it:
 
 Reference: `strands_robots.tools.robot_mesh`.
 
+## Refusal codes are the stable contract; prose is not
+
+Some refusals are *continuable*: the request was well formed, and an operator who accepts the risk can grant something that makes the identical request succeed. An untrusted policy provider, a repo or host or policy type outside a mesh allowlist, a teleop frame past the value envelope - each of these has an operator answer behind it. Anything that offers that answer (a UI consent card, an approval endpoint, a supervising agent) first has to recognise *which* refusal it is looking at and *what* it is about.
+
+Recognise it by its `code`, never by its message text:
+
+```python
+from strands_robots import refusal_codes
+from strands_robots.mesh.security import ValidationError, validate_command
+
+try:
+    validate_command(cmd)
+except ValidationError as refusal:
+    if refusal.code == refusal_codes.HF_REPO_NOT_ALLOWED:
+        offer_to_allowlist(refusal.subject)          # the repo, already parsed out
+        print(refusal_codes.REFUSAL_GRANTS[refusal.code])   # STRANDS_MESH_HF_REPO_ALLOW
+```
+
+- **`code` is stable; the message is not.** `code` is a member of `refusal_codes.REFUSAL_CODES`, a closed vocabulary you may switch on. The message is an operator-facing sentence and may be reworded at any time to explain the refusal better. Matching on prose - looking for an env-var name in the sentence, or pulling the subject back out with a regex - couples you to wording that is free to change, and neither this package's tests nor yours will notice when it does.
+- **`subject` is what the refusal is about**, so you do not have to parse it back out: the repo id, the host or whole `server_address`, the policy type or provider name, the joint key, the refused provider.
+- **`REFUSAL_GRANTS` names the environment variable that lifts each refusal.** Read it from there rather than hard-coding it, so your consumer and this package cannot drift apart.
+- **A refusal with no code is not continuable.** `code` is `None` for rejections an operator cannot grant their way past - a schema failure, an over-long instruction, a lockout. There is nothing to offer, so there is nothing to recognise. Treat `code is None` as "show the message and stop", not as an unknown code.
+- **Codes are additive.** They were introduced without changing a single refusal message, and new codes may be added for refusals that become continuable later. Switch on the codes you know and fall through to the message for the rest.
+
+Reference: `strands_robots.refusal_codes`; `strands_robots.mesh.security.SecurityError`; `strands_robots.policies.factory.UntrustedRemoteCodeError`.
+
 ## HuggingFace policy code execution (`trust_remote_code`)
 
 Some policy providers load models from the HuggingFace Hub with `trust_remote_code=True`. That flag instructs the HuggingFace libraries to download and execute Python code from the model repository on your machine, with the privileges of the process running the agent. A malicious or compromised model repository can therefore achieve arbitrary code execution - read your credentials, open a reverse shell, or command your robot directly - simply by being loaded.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -57,6 +57,8 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
+from strands_robots import refusal_codes
+
 logger = logging.getLogger(__name__)
 
 # --- Constants -----------------------------------------------------------
@@ -387,7 +389,35 @@ _DEFAULT_POLICY_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::
 
 
 class SecurityError(Exception):
-    """Base class for payload-validation rejections."""
+    """Base class for payload-validation rejections.
+
+    A *continuable* rejection also carries a stable machine-readable
+    :attr:`code` from :data:`~strands_robots.refusal_codes.REFUSAL_CODES` and
+    the :attr:`subject` the refusal is about, so a consumer offering the
+    operator a choice classifies on identity instead of matching the message
+    text. Both default to ``None``: a rejection with no operator grant behind
+    it -- a schema or bounds failure -- has nothing for a consumer to offer.
+
+    The message is unchanged by this and stays free to improve. See
+    :mod:`strands_robots.refusal_codes`.
+
+    Args:
+        message: The operator-facing reason, unchanged by the code.
+        code: A member of :data:`~strands_robots.refusal_codes.REFUSAL_CODES`,
+            or ``None`` when the rejection is not continuable.
+        subject: What the refusal is about -- the repo, host, policy type or
+            joint key -- so a consumer need not parse it back out of
+            ``message``.
+
+    Attributes:
+        code: The stable identifier for this refusal, or ``None``.
+        subject: What the refusal is about, or ``None``.
+    """
+
+    def __init__(self, message: str = "", *, code: str | None = None, subject: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.subject = subject
 
 
 class ValidationError(SecurityError):
@@ -978,7 +1008,9 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
         policy_host = cmd.get("policy_host", "localhost")
         if not is_safe_policy_host(str(policy_host)):
             raise ValidationError(
-                f"policy_host={policy_host!r} not in allowlist. Set STRANDS_MESH_POLICY_HOST_ALLOW to extend."
+                f"policy_host={policy_host!r} not in allowlist. Set STRANDS_MESH_POLICY_HOST_ALLOW to extend.",
+                code=refusal_codes.POLICY_HOST_NOT_ALLOWED,
+                subject=str(policy_host),
             )
         # R7 defence-in-depth. ``is_safe_policy_host`` now applies the
         # same charset gate before its internal strip, so this
@@ -1009,7 +1041,9 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
             if not isinstance(value, str) or not is_safe_model_path(value, hf_only=True):
                 raise ValidationError(
                     f"pretrained_name_or_path={value!r} not in allowlist. Set "
-                    "STRANDS_MESH_HF_REPO_ALLOW to add an org/repo prefix."
+                    "STRANDS_MESH_HF_REPO_ALLOW to add an org/repo prefix.",
+                    code=refusal_codes.HF_REPO_NOT_ALLOWED,
+                    subject=value if isinstance(value, str) else None,
                 )
             out["pretrained_name_or_path"] = value
 
@@ -1025,7 +1059,9 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
             value = cmd["policy_type"]
             if not isinstance(value, str) or not is_safe_policy_type(value):
                 raise ValidationError(
-                    f"policy_type={value!r} not in allowlist. Set STRANDS_MESH_POLICY_TYPE_ALLOW to extend."
+                    f"policy_type={value!r} not in allowlist. Set STRANDS_MESH_POLICY_TYPE_ALLOW to extend.",
+                    code=refusal_codes.POLICY_TYPE_NOT_ALLOWED,
+                    subject=value if isinstance(value, str) else None,
                 )
             out["policy_type"] = value.strip().lower()
 
@@ -1035,7 +1071,9 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
                 raise ValidationError(
                     f"policy_provider={value!r} not in allowlist. "
                     "Set STRANDS_MESH_POLICY_TYPE_ALLOW to extend "
-                    "(provider and policy_type share one allowlist)."
+                    "(provider and policy_type share one allowlist).",
+                    code=refusal_codes.POLICY_TYPE_NOT_ALLOWED,
+                    subject=value if isinstance(value, str) else None,
                 )
             out["policy_provider"] = value.strip().lower()
         else:
@@ -1049,7 +1087,9 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
             value = cmd["server_address"]
             if not isinstance(value, str) or not is_safe_server_address(value):
                 raise ValidationError(
-                    f"server_address={value!r} host not in allowlist. Set STRANDS_MESH_POLICY_HOST_ALLOW to extend."
+                    f"server_address={value!r} host not in allowlist. Set STRANDS_MESH_POLICY_HOST_ALLOW to extend.",
+                    code=refusal_codes.POLICY_HOST_NOT_ALLOWED,
+                    subject=value if isinstance(value, str) else None,
                 )
             # Same CRLF/NUL/control-byte gate as policy_host.
             if not _SAFE_PASSTHROUGH_RE.fullmatch(value):
@@ -1365,7 +1405,11 @@ def validate_input_frame(action: Any) -> dict[str, float]:
             raise ValidationError(f"input frame value for {key!r} must be finite, got {fval}")
         _value_abs = _input_value_abs()
         if abs(fval) > _value_abs:
-            raise ValidationError(f"input frame value for {key!r} out of range: |{fval}| > {_value_abs}")
+            raise ValidationError(
+                f"input frame value for {key!r} out of range: |{fval}| > {_value_abs}",
+                code=refusal_codes.TELEOP_VALUE_OUT_OF_RANGE,
+                subject=key,
+            )
         out[key] = fval
 
     return out

--- a/strands_robots/policies/factory.py
+++ b/strands_robots/policies/factory.py
@@ -4,6 +4,7 @@ import logging
 import os
 from collections.abc import Callable, Mapping
 
+from strands_robots import refusal_codes
 from strands_robots.policies.base import Policy
 from strands_robots.registry import (
     import_policy_class,
@@ -100,7 +101,34 @@ def list_aliases() -> dict[str, str]:
 
 
 class UntrustedRemoteCodeError(RuntimeError):
-    """Raised when a HF model requires trust_remote_code but the user has not opted in."""
+    """Raised when a HF model requires trust_remote_code but the user has not opted in.
+
+    Carries a stable machine-readable :attr:`code`
+    (:data:`~strands_robots.refusal_codes.TRUST_REMOTE_CODE_REQUIRED`) and the
+    :attr:`subject` provider, so a consumer offering the operator the opt-in
+    classifies on identity instead of matching the message text. The message
+    is unchanged by this. See :mod:`strands_robots.refusal_codes`.
+
+    Args:
+        message: The operator-facing reason, unchanged by the code.
+        code: A member of :data:`~strands_robots.refusal_codes.REFUSAL_CODES`.
+        subject: The policy provider the gate refused.
+
+    Attributes:
+        code: The stable identifier for this refusal, or ``None``.
+        subject: The policy provider the gate refused, or ``None``.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        code: str | None = None,
+        subject: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.subject = subject
 
 
 # Providers whose HuggingFace model loading path calls ``trust_remote_code=True``.
@@ -136,7 +164,9 @@ def _check_trust_remote_code(provider: str) -> None:
         f"from the model repository.\n\n"
         f"Only load models from organisations you trust.\n\n"
         f"To acknowledge this risk and proceed, set the environment variable:\n"
-        f"    export STRANDS_TRUST_REMOTE_CODE=1\n"
+        f"    export STRANDS_TRUST_REMOTE_CODE=1\n",
+        code=refusal_codes.TRUST_REMOTE_CODE_REQUIRED,
+        subject=provider,
     )
 
 

--- a/strands_robots/refusal_codes.py
+++ b/strands_robots/refusal_codes.py
@@ -1,0 +1,80 @@
+"""Stable machine-readable identifiers for the refusals an operator can answer.
+
+Some refusals are *continuable*: the request was well formed, and an operator
+who accepts the risk can grant something that makes the identical request
+succeed. A consumer that wants to offer that choice -- a UI consent card, an
+approval endpoint, a supervising agent -- has to recognise which refusal it is
+looking at and what it is about.
+
+Without a code the only thing on offer is the message text, so recognition
+becomes prose matching: an env-var name appearing somewhere in the sentence,
+the subject pulled back out with an anchored regex. That makes every wording
+improvement a silent breaking change for every consumer, and nothing in this
+package can detect it -- a reworded refusal keeps the whole suite green.
+
+The codes here are that missing contract, in the shape
+:data:`~strands_robots.episode_labels.FAILURE_MODES` already uses for the same
+reason: a fixed vocabulary so consumers match on identity rather than parsing
+prose, with the free text left free. A refusal carries its code and its
+subject structurally (``exc.code`` / ``exc.subject``); the message stays a
+message, and may be improved without breaking anyone.
+
+Only continuable refusals get a code. ``instruction exceeds 4096 chars`` is
+not continuable -- there is no grant that makes it succeed, so a consumer has
+nothing to offer and nothing to recognise. :data:`REFUSAL_GRANTS` records, per
+code, the operator grant that lifts it, which is also what lets the guard test
+derive the raise sites it must find instead of keeping a hand-written list.
+"""
+
+from __future__ import annotations
+
+#: A HuggingFace-backed policy provider would execute code from a model
+#: repository. Subject: the provider name.
+TRUST_REMOTE_CODE_REQUIRED = "TRUST_REMOTE_CODE_REQUIRED"
+
+#: A model repo is outside the mesh allowlist. Subject: the repo id.
+HF_REPO_NOT_ALLOWED = "HF_REPO_NOT_ALLOWED"
+
+#: A policy type or provider is outside the mesh allowlist. Subject: the type
+#: or provider name (both share one allowlist, so both carry this code).
+POLICY_TYPE_NOT_ALLOWED = "POLICY_TYPE_NOT_ALLOWED"
+
+#: A policy host is outside the mesh allowlist. Subject: the host, or the
+#: whole ``server_address`` the host was taken from.
+POLICY_HOST_NOT_ALLOWED = "POLICY_HOST_NOT_ALLOWED"
+
+#: A teleop input frame commands a joint past the value envelope. Subject: the
+#: joint key. This refusal names no env var at all, which is why a consumer
+#: today has to recognise it by its own words.
+TELEOP_VALUE_OUT_OF_RANGE = "TELEOP_VALUE_OUT_OF_RANGE"
+
+#: Every code this package raises. Closed: a consumer may switch on it.
+REFUSAL_CODES: tuple[str, ...] = (
+    TRUST_REMOTE_CODE_REQUIRED,
+    HF_REPO_NOT_ALLOWED,
+    POLICY_TYPE_NOT_ALLOWED,
+    POLICY_HOST_NOT_ALLOWED,
+    TELEOP_VALUE_OUT_OF_RANGE,
+)
+
+#: The operator grant that lifts each refusal. This is what makes a refusal
+#: continuable, and it is the environment variable a consumer offering the
+#: choice has to set -- reading it from here rather than hard-coding it keeps
+#: the consumer and this package from drifting apart.
+REFUSAL_GRANTS: dict[str, str] = {
+    TRUST_REMOTE_CODE_REQUIRED: "STRANDS_TRUST_REMOTE_CODE",
+    HF_REPO_NOT_ALLOWED: "STRANDS_MESH_HF_REPO_ALLOW",
+    POLICY_TYPE_NOT_ALLOWED: "STRANDS_MESH_POLICY_TYPE_ALLOW",
+    POLICY_HOST_NOT_ALLOWED: "STRANDS_MESH_POLICY_HOST_ALLOW",
+    TELEOP_VALUE_OUT_OF_RANGE: "STRANDS_MESH_INPUT_VALUE_ABS",
+}
+
+__all__ = [
+    "HF_REPO_NOT_ALLOWED",
+    "POLICY_HOST_NOT_ALLOWED",
+    "POLICY_TYPE_NOT_ALLOWED",
+    "REFUSAL_CODES",
+    "REFUSAL_GRANTS",
+    "TELEOP_VALUE_OUT_OF_RANGE",
+    "TRUST_REMOTE_CODE_REQUIRED",
+]

--- a/tests/test_refusal_codes_are_the_stable_contract.py
+++ b/tests/test_refusal_codes_are_the_stable_contract.py
@@ -1,0 +1,272 @@
+"""A continuable refusal is recognised by its code, never by its prose.
+
+A refusal an operator can answer -- an untrusted provider, a repo or host or
+policy type outside an allowlist, a teleop frame past the value envelope -- has
+to be recognised by whoever offers that choice. Before the codes the only thing
+on offer was the message text, so recognition meant prose matching: an env-var
+name appearing somewhere in the sentence, the subject pulled back out with an
+anchored regex.
+
+That made every wording improvement a silent breaking change, and this package
+could not detect it: rewording the two teleop refusals leaves the whole mesh
+suite green (measured), because nothing here asserts on those phrases at all.
+
+These tests pin the contract in three parts.
+
+* Each continuable refusal carries its ``code`` and its ``subject``
+  structurally, so a consumer switches on identity.
+* The message is *unchanged* by that -- the codes are additive, and the prose
+  stays free to improve. ``test_the_code_does_not_come_from_the_message``
+  states the half that matters: an unrecognisable message keeps its code.
+* ``test_every_refusal_naming_an_operator_grant_carries_a_code`` derives the
+  sites it must find from :data:`~strands_robots.refusal_codes.REFUSAL_GRANTS`
+  rather than a hand-written list, so a seventh grant-bearing refusal added
+  later is graded on arrival.
+
+A rejection with no operator grant behind it stays code-less on purpose: a
+schema or bounds failure gives a consumer nothing to offer, so there is nothing
+to recognise. ``test_a_rejection_with_no_grant_behind_it_stays_code_less`` is
+the boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.security import ValidationError, validate_command, validate_input_frame
+from strands_robots.policies.factory import UntrustedRemoteCodeError, _check_trust_remote_code
+
+_PACKAGE = pathlib.Path(__file__).resolve().parent.parent / "strands_robots"
+
+#: Grant env vars are cleared per test so the refusals under test actually fire.
+_GRANT_ENV = (
+    "STRANDS_TRUST_REMOTE_CODE",
+    "STRANDS_MESH_HF_REPO_ALLOW",
+    "STRANDS_MESH_POLICY_TYPE_ALLOW",
+    "STRANDS_MESH_POLICY_HOST_ALLOW",
+    "STRANDS_MESH_INPUT_VALUE_ABS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_grants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse by default: an inherited grant would silence the refusal."""
+    for name in _GRANT_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _command(**overrides: Any) -> dict[str, Any]:
+    cmd: dict[str, Any] = {
+        "action": "execute",
+        "instruction": "pick up the cube",
+        "sender": "operator",
+        "policy_provider": "mock",
+    }
+    cmd.update(overrides)
+    return cmd
+
+
+def _refused(fn: Any) -> ValidationError | UntrustedRemoteCodeError:
+    """Return the refusal ``fn`` raises, or fail naming what it did instead."""
+    try:
+        result = fn()
+    except (ValidationError, UntrustedRemoteCodeError) as refusal:
+        return refusal
+    raise AssertionError(f"expected a refusal, got {result!r}")
+
+
+class TestEveryContinuableRefusalCarriesItsCodeAndSubject:
+    """The five codes, at the six sites that raise them."""
+
+    def test_an_untrusted_provider_names_itself(self) -> None:
+        refusal = _refused(lambda: _check_trust_remote_code("lerobot_local"))
+        assert refusal.code == "TRUST_REMOTE_CODE_REQUIRED"
+        assert refusal.subject == "lerobot_local"
+
+    def test_a_repo_outside_the_allowlist_names_the_repo(self) -> None:
+        refusal = _refused(lambda: validate_command(_command(pretrained_name_or_path="sketchy-org/model")))
+        assert refusal.code == "HF_REPO_NOT_ALLOWED"
+        assert refusal.subject == "sketchy-org/model"
+
+    def test_a_policy_type_outside_the_allowlist_names_the_type(self) -> None:
+        refusal = _refused(lambda: validate_command(_command(policy_type="mystery_net")))
+        assert refusal.code == "POLICY_TYPE_NOT_ALLOWED"
+        assert refusal.subject == "mystery_net"
+
+    def test_a_provider_outside_the_allowlist_shares_the_policy_type_code(self) -> None:
+        """Provider and policy_type share one allowlist, so they share one code."""
+        refusal = _refused(lambda: validate_command(_command(policy_provider="mystery_prov")))
+        assert refusal.code == "POLICY_TYPE_NOT_ALLOWED"
+        assert refusal.subject == "mystery_prov"
+
+    def test_a_host_outside_the_allowlist_names_the_host(self) -> None:
+        refusal = _refused(lambda: validate_command(_command(policy_host="10.9.9.9")))
+        assert refusal.code == "POLICY_HOST_NOT_ALLOWED"
+        assert refusal.subject == "10.9.9.9"
+
+    def test_a_server_address_outside_the_allowlist_names_the_address(self) -> None:
+        """The subject is the whole address: the host was derived from it."""
+        refusal = _refused(lambda: validate_command(_command(server_address="tcp://10.9.9.9:5555")))
+        assert refusal.code == "POLICY_HOST_NOT_ALLOWED"
+        assert refusal.subject == "tcp://10.9.9.9:5555"
+
+    def test_a_teleop_frame_past_the_envelope_names_the_joint(self) -> None:
+        """This refusal names no env var, so its code is the only handle on it."""
+        refusal = _refused(lambda: validate_input_frame({"shoulder.pos": 900.0}))
+        assert refusal.code == "TELEOP_VALUE_OUT_OF_RANGE"
+        assert refusal.subject == "shoulder.pos"
+
+
+class TestTheCodesAreAdditive:
+    """Adding a code changed no message and refused nothing new."""
+
+    def test_the_refusal_messages_are_unchanged(self) -> None:
+        host = str(_refused(lambda: validate_command(_command(policy_host="10.9.9.9"))))
+        teleop = str(_refused(lambda: validate_input_frame({"shoulder.pos": 900.0})))
+        assert host == "policy_host='10.9.9.9' not in allowlist. Set STRANDS_MESH_POLICY_HOST_ALLOW to extend."
+        assert teleop == "input frame value for 'shoulder.pos' out of range: |900.0| > 720.0"
+
+    def test_a_well_formed_command_is_still_accepted(self) -> None:
+        assert validate_command(_command())["instruction"] == "pick up the cube"
+
+    def test_a_message_only_rejection_still_constructs(self) -> None:
+        """The ~70 rejections that pass only a message keep working, code-less."""
+        refusal = ValidationError("something the operator cannot grant")
+        assert refusal.code is None
+        assert refusal.subject is None
+        assert str(refusal) == "something the operator cannot grant"
+
+    def test_the_code_does_not_come_from_the_message(self) -> None:
+        """The contract survives a message a prose matcher cannot recognise."""
+        refusal = ValidationError("", code="TELEOP_VALUE_OUT_OF_RANGE", subject="shoulder.pos")
+        assert refusal.code == "TELEOP_VALUE_OUT_OF_RANGE"
+        assert refusal.subject == "shoulder.pos"
+
+
+class TestTheBoundaryIsWhetherAnOperatorCanGrantSomething:
+    """A refusal with nothing to grant has nothing for a consumer to offer."""
+
+    def test_a_rejection_with_no_grant_behind_it_stays_code_less(self) -> None:
+        refusal = _refused(lambda: validate_command(_command(instruction="x" * 99999)))
+        assert refusal.code is None
+        assert refusal.subject is None
+
+    def test_a_lockout_is_a_security_error_and_is_not_code_less_by_accident(self) -> None:
+        """LockoutError inherits the attributes; nothing here claims a code."""
+        from strands_robots.mesh.security import LockoutError
+
+        refusal = LockoutError("estop engaged")
+        assert refusal.code is None
+
+
+class TestTheRegistryIsAClosedVocabulary:
+    """A consumer may switch on the codes, so they must be unique and complete."""
+
+    def test_the_codes_are_unique(self) -> None:
+        from strands_robots import refusal_codes
+
+        assert len(set(refusal_codes.REFUSAL_CODES)) == len(refusal_codes.REFUSAL_CODES)
+
+    def test_every_code_names_the_grant_that_lifts_it(self) -> None:
+        from strands_robots import refusal_codes
+
+        assert set(refusal_codes.REFUSAL_GRANTS) == set(refusal_codes.REFUSAL_CODES)
+        assert all(g.startswith("STRANDS_") for g in refusal_codes.REFUSAL_GRANTS.values())
+
+    def test_every_code_is_exported_under_its_own_name(self) -> None:
+        from strands_robots import refusal_codes
+
+        for code in refusal_codes.REFUSAL_CODES:
+            assert getattr(refusal_codes, code) == code, code
+            assert code in refusal_codes.__all__
+
+    def test_the_literals_the_site_tests_assert_are_the_declared_codes(self) -> None:
+        """The per-site tests spell their codes out; this is what ties them here."""
+        from strands_robots import refusal_codes
+
+        assert {
+            "TRUST_REMOTE_CODE_REQUIRED",
+            "HF_REPO_NOT_ALLOWED",
+            "POLICY_TYPE_NOT_ALLOWED",
+            "POLICY_HOST_NOT_ALLOWED",
+            "TELEOP_VALUE_OUT_OF_RANGE",
+        } == set(refusal_codes.REFUSAL_CODES)
+
+    def test_every_declared_code_is_actually_raised_somewhere(self) -> None:
+        """A code no site raises is a vocabulary entry a consumer waits for forever."""
+        from strands_robots import refusal_codes
+
+        raised = {code for _, _, code in _coded_raise_sites()}
+        assert raised == set(refusal_codes.REFUSAL_CODES)
+
+
+def _string_literals(node: ast.AST) -> str:
+    """Every string literal under ``node``, including f-string parts."""
+    return " ".join(n.value for n in ast.walk(node) if isinstance(n, ast.Constant) and isinstance(n.value, str))
+
+
+def _raise_sites() -> list[tuple[str, int, ast.expr]]:
+    """Every ``raise <expr>`` in the package, as (path, line, the expression)."""
+    sites: list[tuple[str, int, ast.expr]] = []
+    for path in sorted(_PACKAGE.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        rel = str(path.relative_to(_PACKAGE.parent))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Raise) and node.exc is not None:
+                sites.append((rel, node.lineno, node.exc))
+    return sites
+
+
+def _coded_raise_sites() -> list[tuple[str, int, str]]:
+    """Every raise passing ``code=<refusal_codes.NAME>``, with that name."""
+    found: list[tuple[str, int, str]] = []
+    for rel, lineno, exc in _raise_sites():
+        if not isinstance(exc, ast.Call):
+            continue
+        for keyword in exc.keywords:
+            if keyword.arg == "code" and isinstance(keyword.value, ast.Attribute):
+                found.append((rel, lineno, keyword.value.attr))
+    return found
+
+
+class TestTheContractReachesEveryGrantBearingRefusal:
+    """Derived from the registry, so a new grant-bearing refusal is graded."""
+
+    def test_every_refusal_naming_an_operator_grant_carries_a_code(self) -> None:
+        from strands_robots import refusal_codes
+
+        grants = set(refusal_codes.REFUSAL_GRANTS.values())
+        uncoded = []
+        for rel, lineno, exc in _raise_sites():
+            text = _string_literals(exc)
+            named = sorted(g for g in grants if g in text)
+            if not named:
+                continue
+            has_code = isinstance(exc, ast.Call) and any(k.arg == "code" for k in exc.keywords)
+            if not has_code:
+                uncoded.append(f"{rel}:{lineno} names {named} but carries no code")
+        assert not uncoded, (
+            "a refusal that tells an operator which grant lifts it is continuable, "
+            "so a consumer must be able to recognise it without reading the prose: " + "; ".join(uncoded)
+        )
+
+    def test_the_scan_found_the_grant_bearing_refusals(self) -> None:
+        """Non-vacuity: a scan reaching nothing would pass the rule above."""
+        from strands_robots import refusal_codes
+
+        grants = set(refusal_codes.REFUSAL_GRANTS.values())
+        naming = [
+            (rel, lineno) for rel, lineno, exc in _raise_sites() if any(g in _string_literals(exc) for g in grants)
+        ]
+        assert len(naming) >= 6, naming
+        assert len(_raise_sites()) >= 200, "the package-wide raise scan reached almost nothing"
+
+    def test_every_code_passed_at_a_raise_site_is_a_declared_code(self) -> None:
+        from strands_robots import refusal_codes
+
+        for rel, lineno, name in _coded_raise_sites():
+            assert getattr(refusal_codes, name, None) in refusal_codes.REFUSAL_CODES, f"{rel}:{lineno} {name}"


### PR DESCRIPTION
## Problem

Some refusals are *continuable*: the request was well formed, and an operator who accepts the risk can grant something that makes the identical request succeed. An untrusted policy provider, a repo or host or policy type outside a mesh allowlist, a teleop frame past the value envelope -- each has an operator answer behind it. Anything that offers that answer (a UI consent card, an approval endpoint, a supervising agent) first has to recognise *which* refusal it is looking at and *what* it is about.

The only thing on offer was the message text. So recognition means prose matching: an env-var name appearing somewhere in the sentence, the subject pulled back out with an anchored regex. **Two of the refusals name no env var at all** -- `input frame value for ... out of range` and its slew sibling -- so they can only be recognised by their own words.

The measured consequence is that this package cannot tell when it breaks such a consumer. Rewording the teleop refusals from `out of range` to `exceeds the safety envelope` -- a plain improvement, and nothing in `tests/` asserts on either phrase:

| after that one reword | result |
| --- | --- |
| this package's own mesh suite (`tests/mesh/test_*input* test_*slew* test_*security*`) | **270 passed** |
| a consumer's classification of the value refusal | recognised -> **`None`** |
| a consumer's classification of the slew refusal | recognised -> **`None`** |

The wording change is silently breaking and the suite stays green, because prose is the only contract on offer.

## Change

Continuable refusals now carry a stable machine-readable `code` and the `subject` they are about, structurally:

```python
from strands_robots import refusal_codes
from strands_robots.mesh.security import ValidationError, validate_command

try:
    validate_command(cmd)
except ValidationError as refusal:
    if refusal.code == refusal_codes.HF_REPO_NOT_ALLOWED:
        offer_to_allowlist(refusal.subject)                  # the repo, already parsed out
        os.environ[refusal_codes.REFUSAL_GRANTS[refusal.code]] = ...   # STRANDS_MESH_HF_REPO_ALLOW
```

`strands_robots/refusal_codes.py` is a new stdlib-only leaf holding five codes, the closed `REFUSAL_CODES` vocabulary, and `REFUSAL_GRANTS` -- the operator grant that lifts each refusal, which is what a consumer otherwise hard-codes. `SecurityError` (so `ValidationError` and `LockoutError`) and `UntrustedRemoteCodeError` gained keyword-only `code` / `subject`, defaulting to `None`.

This follows the shape `episode_labels.FAILURE_MODES` already uses for the same reason, in its own words: *"Fixed so downstream filters match on identity rather than parsing prose; the free-text goes in `note`."*

### The six sites, measured end to end

| refusal | code | subject |
| --- | --- | --- |
| `_check_trust_remote_code` | `TRUST_REMOTE_CODE_REQUIRED` | `lerobot_local` |
| `pretrained_name_or_path` not allowlisted | `HF_REPO_NOT_ALLOWED` | `sketchy-org/model` |
| `policy_type` not allowlisted | `POLICY_TYPE_NOT_ALLOWED` | `mystery_net` |
| `policy_provider` not allowlisted | `POLICY_TYPE_NOT_ALLOWED` | `mystery_prov` |
| `policy_host` not allowlisted | `POLICY_HOST_NOT_ALLOWED` | `10.9.9.9` |
| `server_address` host not allowlisted | `POLICY_HOST_NOT_ALLOWED` | `tcp://10.9.9.9:5555` |
| teleop frame past the value envelope | `TELEOP_VALUE_OUT_OF_RANGE` | `shoulder.pos` |
| *`instruction exceeds 2000 chars`* | *`None`* | *`None`* |

### Additive, measured

Driving all eight refusals on this branch and on `upstream/main`: **messages byte-identical, codes 0 -> 7**. No message was touched, and no request is refused that was not refused before.

And the property the whole change exists to provide -- applying the same reword *to this branch*:

| reworded refusal | `code` | `subject` | prose matching |
| --- | --- | --- | --- |
| `policy_host` not allowlisted | `POLICY_HOST_NOT_ALLOWED` | `10.9.9.9` | `None` |
| teleop value envelope | `TELEOP_VALUE_OUT_OF_RANGE` | `shoulder.pos` | `None` |

The code and the subject survive; only the prose matching breaks. That is the contract.

## The boundary: whether an operator can grant something

A rejection with no grant behind it stays code-less on purpose. A schema or bounds failure gives a consumer nothing to offer, so there is nothing to recognise, and `code is None` means "show the message and stop" rather than "unknown code".

`test_every_refusal_naming_an_operator_grant_carries_a_code` derives the sites it must find from `REFUSAL_GRANTS` rather than a hand-written list, so a seventh grant-bearing refusal added later is graded on arrival. It finds exactly 6 today, all coded, with no exemption -- which is why the trust-remote-code raise passes `code=` explicitly rather than relying on a class default the scan could not see.

## Scope

Deliberately out, each with the measurement:

- **A `code` field on the wire.** `mesh/core.py:1908` returns `{"error": ...}` -- a dict, not an exception -- and the command-response envelope is its own contract. This change is exception-side only.
- **`input_frame_slew_violation`.** It *returns* `str | None`, consumed as a log line by `mesh/input.py:633` and `teleop_mixin.py:842`; giving it a code needs either a return-type change or a code embedded in the message text, and the latter is exactly the prose coupling this removes.
- **The mtls and calibration refusals** (`mesh/_zenoh_config.py:286`, `hardware_robot.py:1405`). Neither is continuable in the sense above, and no measured consumer classifies them.
- **The other ~67 `ValidationError` sites.** They are schema and bounds failures with no operator grant, so they stay code-less by the boundary rule rather than by omission.

## Verification

Measured at `207afce5`.

- **Pre-fix split**: 19 failed / 2 passed, of which **11 fail behaviourally** (`AttributeError: 'ValidationError' object has no attribute 'code'` x10, plus `TypeError: ValidationError() takes no keyword arguments`). The other 8 can only report the new registry module's absence; they pin the vocabulary rather than the regression. 21 passed after. The per-site tests spell their codes as literals precisely so they fail behaviourally, with one drift test tying those literals to `REFUSAL_CODES`.
- **Break table** -- 7 breaks, 7 distinct firing sets, no dead guards:

| break | fails | guards fired |
| --- | --- | --- |
| B1 revert both source files | 19 | all |
| B2 drop the teleop `code=` | 2 | that site + every-declared-code-is-raised |
| B3 drop the trust-remote-code `code=` | 3 | that site + declared-code-is-raised + **the AST grant guard** |
| B4 drop the teleop `subject=` | 1 | that site only |
| B5 claim a code on `instruction exceeds ...` | 1 | **the boundary control only** |
| B6 point the package scan at an empty subtree | 2 | non-vacuity + declared-code-is-raised |
| B7 declare a code no site raises | 4 | registry closure |

- **Blast radius**: the identical 316-file selection on both trees (every test naming the changed
  symbols, every guard that walks the package or reads a docs page, plus the changelog guards), with the
  new test file excluded from both:

| tree | result |
| --- | --- |
| this branch | 19 failed, 14788 passed, 60 skipped |
| pristine `upstream/main` | 17 failed, 14789 passed, 60 skipped |

  The 17 shared failures are all `ModuleNotFoundError` in `tests/mesh/test_iot_*` (9 +
  8), which need the `awsiot` extra CI installs. The 2 branch-only ids are both in
  `tests/mesh/test_zenoh_transport_security.py`, which opens real localhost Zenoh sessions and
  cross-talks when two suites run in parallel: that file alone is **9 passed, 2 skipped on both
  trees**. Collected differs by exactly 1 -
  `test_no_teardown_method_imports_a_stdlib_module[refusal_codes.py]`, the package-wide guard
  enrolling the new module, which passes.
- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` **24 == 24** against a pristine `upstream/main` worktree, branch-only empty.
- Import cost: `mesh.security` already pulls +1118 modules via the package `__init__`; with this change it pulls **+1119** -- the one new leaf, no new transitive dependency.

## Artifact

There is no simulation behaviour to film: no message, no signature and no accepted-input set changed, and the figure below is the measurement instead -- each column produced by running one capture script against that tree.

![refusal codes are the stable contract](https://raw.githubusercontent.com/cagataycali/robots/media-refusal-codes-32597228569/refusal-codes.png)
