### PR TITLE
fix(mesh): a refused teleop frame is counted under the guard that refused it

### DIFF
--- a/changelog.d/2624-teleop-refusal-cause-accounting.md
+++ b/changelog.d/2624-teleop-refusal-cause-accounting.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **A refused teleop frame is now counted under the guard that refused it, and each guard's
+  rate-limited log line is spent on its own budget.**
+  `InputReceiver` refuses a frame for six reasons; the apply-rate ceiling and the per-joint slew bound
+  each reported themselves in `rate_dropped` and `slew_rejected`, while an E-stop lockout, a stale or
+  missing frame timestamp, and a frame `validate_input_frame` refused all shared `rejected`. Beyond
+  leaving a report unable to say which guard refused a stream, the warning each guard emits was
+  rate-limited against that shared counter, so a follower that had already refused a few frames for
+  one reason -- an ordinary clock-skewed start -- refused the next reason in complete silence, and the
+  log line is the only place a refusal names the value it refused and the bound it exceeded. `stats`
+  now reports `rejected_lockout`, `rejected_freshness` and `rejected_invalid` beside the unchanged
+  `rejected` total, which always equals their sum, and the budget is spent per cause. No refusal
+  condition changes: the same frames are refused, and the two causes that already had their own
+  counter keep it. The `stats` docstring also enumerated an ACL check this path never makes while
+  omitting the frame-validation refusal, and now names the causes it reports.

--- a/strands_robots/mesh/input.py
+++ b/strands_robots/mesh/input.py
@@ -73,6 +73,19 @@ _MAX_LOGGED_LOOP_ERRORS = 5
 INPUT_MAX_HZ_DEFAULT = 100.0
 
 
+#: How many refused frames of ONE cause are logged before that cause goes quiet.
+#: Spent per cause rather than per receiver: a cause that keeps refusing must not
+#: silence the FIRST refusal of a different one, because the log line is the only
+#: place a refusal states which value it refused and against which bound.
+_REFUSAL_LOG_BUDGET = 5
+
+#: The refusal causes that share the ``rejected`` total, in the order
+#: :meth:`InputReceiver._on_input` checks them. Each is reported as
+#: ``rejected_<cause>`` in :attr:`InputReceiver.stats` and spends its own share of
+#: :data:`_REFUSAL_LOG_BUDGET`.
+_REJECTION_CAUSES: tuple[str, ...] = ("lockout", "freshness", "invalid")
+
+
 def _input_max_hz() -> float:
     """Resolve ``STRANDS_MESH_INPUT_MAX_HZ`` (lazy, restart-free).
 
@@ -401,6 +414,10 @@ class InputReceiver:
         self._last_seq = -1
         self._drops = 0
         self._rejected = 0
+        # Per-cause breakdown of ``_rejected``. Every cause that shares the total
+        # keeps its own count, so a report can say WHICH guard refused the stream
+        # and each cause spends its own log budget.
+        self._rejected_by_cause: dict[str, int] = dict.fromkeys(_REJECTION_CAUSES, 0)
         self._rate_dropped = 0
         self._slew_rejected = 0
         self._last_rate_gate_mono = 0.0
@@ -432,11 +449,20 @@ class InputReceiver:
         """Live receive counters: the ``source`` peer and device, whether the
         subscription is ``running``, ``frames_received``, ``errors``, and the
         loss/back-pressure breakdown - out-of-order ``drops``, ``rejected``
-        frames (E-stop lockout, replay-freshness, or ACL checks), and
-        ``rate_dropped`` frames (shed to hold the apply-rate cap), and
-        ``slew_rejected`` frames (refused for commanding a joint faster
+        frames, and ``rate_dropped`` frames (shed to hold the apply-rate cap),
+        and ``slew_rejected`` frames (refused for commanding a joint faster
         than the per-joint slew bound) -
         plus the achieved ``hz_actual``.
+
+        ``rejected`` is the total of a breakdown that names which guard refused
+        the frame, so a report does not have to recover the reason from the
+        log: ``rejected_lockout`` (arrived during an E-stop lockout),
+        ``rejected_freshness`` (the frame's ``t`` is missing, non-numeric, stale
+        or too far in the future - the replay defence), and ``rejected_invalid``
+        (``validate_input_frame`` refused the frame's shape or a value: too many
+        keys, an illegal key, or a value that is non-scalar, non-numeric,
+        non-finite or past the magnitude bound). ``rejected`` always equals
+        their sum.
         """
         elapsed = time.monotonic() - self._start_mono if self._start_mono else 0
         return {
@@ -447,6 +473,9 @@ class InputReceiver:
             "errors": self._error_count,
             "drops": self._drops,
             "rejected": self._rejected,
+            # Derived from the declared causes, so a cause added to the
+            # vocabulary is reported without a second list to update here.
+            **{f"rejected_{cause}": n for cause, n in self._rejected_by_cause.items()},
             "rate_dropped": self._rate_dropped,
             "slew_rejected": self._slew_rejected,
             "hz_actual": self._frame_count / elapsed if elapsed > 0 else 0,
@@ -487,6 +516,29 @@ class InputReceiver:
         )
         return self.stats
 
+    def _refuse(self, cause: str, message: str, *args: Any) -> None:
+        """Count one refused frame under ``cause`` and log the first few of it.
+
+        The one place refusals on this path are accounted for. ``cause`` is a
+        member of :data:`_REJECTION_CAUSES`; the frame is counted under it and in
+        the ``rejected`` total, and :data:`_REFUSAL_LOG_BUDGET` is spent per
+        cause. Reasons this path refuses a frame outnumber the counters that
+        carried them, so a stream refused for one reason used to exhaust the
+        shared budget and leave the next reason -- stated nowhere else -- unlogged.
+
+        Args:
+            cause: Which guard refused the frame. Must be in
+                :data:`_REJECTION_CAUSES`; an unknown cause raises ``KeyError``
+                rather than being counted under a name no report enumerates.
+            message: ``logger.warning`` format string for this refusal.
+            *args: Interpolated into ``message`` only if the budget allows.
+        """
+        seen = self._rejected_by_cause[cause] + 1
+        self._rejected_by_cause[cause] = seen
+        self._rejected = getattr(self, "_rejected", 0) + 1
+        if seen <= _REFUSAL_LOG_BUDGET:
+            logger.warning(message, *args)
+
     def _on_input(self, topic: str, data: dict[str, Any]) -> None:
         if not self._running:
             return
@@ -501,12 +553,11 @@ class InputReceiver:
         # via the ``rejected`` stat and a rate-limited warning.
         lockout = getattr(self.mesh, "_estop_lockout", None)
         if lockout is not None and lockout.is_set():
-            self._rejected = getattr(self, "_rejected", 0) + 1
-            if self._rejected <= 5:
-                logger.warning(
-                    "[mesh] input frame rejected during E-stop lockout from %s",
-                    self.source_peer_id,
-                )
+            self._refuse(
+                "lockout",
+                "[mesh] input frame rejected during E-stop lockout from %s",
+                self.source_peer_id,
+            )
             return
 
         # Cross-session teleop replay defence. The CMD path got
@@ -532,22 +583,20 @@ class InputReceiver:
 
         _frame_t = data.get("t")
         if not isinstance(_frame_t, (int, float)) or isinstance(_frame_t, bool):
-            self._rejected = getattr(self, "_rejected", 0) + 1
-            if self._rejected <= 5:
-                logger.warning(
-                    "[mesh] input frame rejected (missing/invalid timestamp) from %s",
-                    self.source_peer_id,
-                )
+            self._refuse(
+                "freshness",
+                "[mesh] input frame rejected (missing/invalid timestamp) from %s",
+                self.source_peer_id,
+            )
             return
         _age = time.time() - float(_frame_t)
         if _age > _resume_freshness_window_s() or _age < -_resume_forward_skew_s():
-            self._rejected = getattr(self, "_rejected", 0) + 1
-            if self._rejected <= 5:
-                logger.warning(
-                    "[mesh] input frame rejected (stale/future t=%.1fs) from %s",
-                    _age,
-                    self.source_peer_id,
-                )
+            self._refuse(
+                "freshness",
+                "[mesh] input frame rejected (stale/future t=%.1fs) from %s",
+                _age,
+                self.source_peer_id,
+            )
             return
 
         try:
@@ -589,13 +638,12 @@ class InputReceiver:
             try:
                 safe_action = validate_input_frame(action)
             except ValidationError as verr:
-                self._rejected = getattr(self, "_rejected", 0) + 1
-                if self._rejected <= 5:
-                    logger.warning(
-                        "[mesh] input frame rejected from %s: %s",
-                        self.source_peer_id,
-                        verr,
-                    )
+                self._refuse(
+                    "invalid",
+                    "[mesh] input frame rejected from %s: %s",
+                    self.source_peer_id,
+                    verr,
+                )
                 return
             # Per-joint slew bound. The guards above bound each frame in
             # isolation - who sent it, how fresh it is, how densely frames

--- a/tests/mesh/test_input_refusal_causes.py
+++ b/tests/mesh/test_input_refusal_causes.py
@@ -1,0 +1,267 @@
+"""A refused teleop frame is counted under the guard that refused it.
+
+:meth:`~strands_robots.mesh.input.InputReceiver._on_input` refuses a frame for
+six distinct reasons, and four of them shared one ``rejected`` counter while the
+other two (the apply-rate ceiling and the per-joint slew bound) each kept their
+own. Two consequences followed from the sharing, and only the second is visible
+from the counters:
+
+* a report reading ``rejected`` cannot say which guard refused the stream, so
+  the reason has to be recovered from the follower's log, and
+* the log itself is rate-limited per counter, so a stream refused for one reason
+  spends the shared budget and the FIRST refusal of a different reason -- the
+  only place a refusal names the value it refused and the bound it exceeded --
+  is never written.
+
+The second is what makes the first unrecoverable rather than merely awkward.
+These tests pin the per-cause accounting, that the budget is spent per cause,
+and that the two causes which already had their own counter keep it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import textwrap
+import threading
+import time
+
+import pytest
+
+from strands_robots.mesh import input as mesh_input
+from strands_robots.mesh.input import InputReceiver
+from tests.mesh.test_input_stream_lifecycle import _make_receiver, _RecvMesh
+
+_LOGGER = "strands_robots.mesh.input"
+
+#: The causes this path refuses for, and the per-cause log budget, stated here as
+#: well as in the module so a rename cannot quietly narrow what this file grades.
+_CAUSES = ("lockout", "freshness", "invalid")
+_BUDGET = 5
+
+
+def _locked_out_receiver():
+    mesh = _RecvMesh()
+    mesh._estop_lockout = threading.Event()
+    mesh._estop_lockout.set()
+    return _make_receiver(mesh)
+
+
+def _fresh(action, seq=0):
+    return {"action": action, "seq": seq, "t": time.time()}
+
+
+def _stale(seq=0):
+    return {"action": {"j0": 0.1}, "seq": seq, "t": time.time() - 9999.0}
+
+
+def _over_the_value_bound(seq=0):
+    # |1500| is past DEFAULT_INPUT_VALUE_ABS (720 frame units), so
+    # validate_input_frame refuses it and names both numbers.
+    return _fresh({"j0": 1500.0}, seq)
+
+
+#: One frame per cause, and how that cause is reported.
+_CASES = (
+    pytest.param("lockout", _locked_out_receiver, lambda: _fresh({"j0": 0.1}), id="lockout"),
+    pytest.param("freshness", _make_receiver, _stale, id="freshness"),
+    pytest.param("invalid", _make_receiver, _over_the_value_bound, id="invalid"),
+)
+
+
+class TestARefusalNamesTheGuardThatRefusedIt:
+    @pytest.mark.parametrize(("cause", "make", "frame"), _CASES)
+    def test_only_that_cause_and_the_total_advance(self, cause, make, frame, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")  # isolate from the rate gate
+        recv, applied = make()
+        recv._on_input(recv.topic, frame())
+        stats = recv.stats
+        assert applied == [], "a refused frame must never reach the robot"
+        assert stats["rejected"] == 1
+        key = f"rejected_{cause}"
+        assert key in stats, (
+            f"a frame refused by the {cause} guard is counted only in the shared total, so "
+            f"nothing reports which guard refused it: {stats}"
+        )
+        assert stats[key] == 1, f"{cause} did not report itself: {stats}"
+        others = [f"rejected_{other}" for other in _CAUSES if other != cause]
+        assert all(stats[key] == 0 for key in others), f"a {cause} refusal was counted under another cause too: {stats}"
+
+    def test_the_total_is_the_sum_of_the_causes(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        recv, _ = _make_receiver()
+        for seq in range(3):
+            recv._on_input(recv.topic, _stale(seq))
+        for seq in range(2):
+            recv._on_input(recv.topic, _over_the_value_bound(10 + seq))
+        stats = recv.stats
+        missing = [f"rejected_{c}" for c in _CAUSES if f"rejected_{c}" not in stats]
+        assert missing == [], f"the total is reported with no breakdown behind it: {missing}"
+        breakdown = {c: stats[f"rejected_{c}"] for c in _CAUSES}
+        assert breakdown == {"lockout": 0, "freshness": 3, "invalid": 2}
+        assert stats["rejected"] == sum(breakdown.values()) == 5
+
+
+class TestTheLogBudgetIsSpentPerCause:
+    def test_a_refusal_is_still_stated_after_another_cause_spent_the_budget(self, monkeypatch, caplog):
+        """The regression: an unrelated cause must not silence the next one.
+
+        A refusal states the offending value and the bound it exceeded in its log
+        line and nowhere else, so a consumer diagnosing "the leader streams
+        degrees into a radian envelope" reads that line. Sharing one budget with
+        the replay-freshness guard meant a follower that had already refused a
+        few stale frames -- an ordinary clock-skew start -- refused the
+        out-of-range frame in complete silence.
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        caplog.set_level(logging.WARNING, logger=_LOGGER)
+        recv, applied = _make_receiver()
+        for seq in range(_BUDGET):
+            recv._on_input(recv.topic, _stale(seq))
+        assert recv.stats["rejected"] == _BUDGET, "premise: the budget is spent"
+        caplog.clear()
+
+        recv._on_input(recv.topic, _over_the_value_bound(99))
+
+        assert applied == []
+        stated = [r.getMessage() for r in caplog.records if "out of range" in r.getMessage()]
+        assert stated, (
+            "the value refusal was counted and never stated: rejected="
+            f"{recv.stats['rejected']} with no line naming the value or the bound, so the "
+            "budget spent by the replay-freshness guard silenced a different guard's "
+            "only report"
+        )
+        assert "1500" in stated[0] and "720" in stated[0], (
+            f"the refusal must name the value and the bound: {stated[0]!r}"
+        )
+        # and the counters now say which guard refused it, without reading the log
+        assert recv.stats["rejected_invalid"] == 1
+        assert recv.stats["rejected_freshness"] == _BUDGET
+
+    def test_one_cause_still_goes_quiet_once_its_own_budget_is_spent(self, monkeypatch, caplog):
+        """Control: the budget still exists, it is just no longer shared.
+
+        Passes on both trees - one cause refusing ``_BUDGET + 4`` times still goes
+        quiet after ``_BUDGET`` lines. It fails for the tempting over-fix of
+        logging every refusal, which would flood a 50 Hz loop.
+        """
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "0")
+        caplog.set_level(logging.WARNING, logger=_LOGGER)
+        recv, _ = _make_receiver()
+        over = _BUDGET + 4
+        for seq in range(over):
+            recv._on_input(recv.topic, _stale(seq))
+        assert recv.stats["rejected"] == over
+        assert len(caplog.records) == _BUDGET
+
+
+class TestTheAccountingHasOneOwner:
+    """Structural: the fix cannot be undone one refusal site at a time."""
+
+    def test_every_rejected_increment_goes_through_the_helper(self):
+        src = textwrap.dedent(inspect.getsource(InputReceiver))
+        cls = ast.parse(src).body[0]
+        outside: list[str] = []
+        for fn in cls.body:
+            if not isinstance(fn, ast.FunctionDef) or fn.name in {"__init__", "_refuse"}:
+                continue
+            for node in ast.walk(fn):
+                targets = (
+                    node.targets
+                    if isinstance(node, ast.Assign)
+                    else [node.target]
+                    if isinstance(node, ast.AugAssign)
+                    else []
+                )
+                for target in targets:
+                    if ast.unparse(target) == "self._rejected":
+                        outside.append(f"{fn.name}:{node.lineno}")
+        assert outside == [], (
+            "a refusal counted the total directly instead of through _refuse, so it "
+            f"reports no cause and shares another cause's log budget: {outside}"
+        )
+
+    def test_the_budget_is_measured_against_the_cause_not_the_total(self):
+        refuse = textwrap.dedent(inspect.getsource(InputReceiver._refuse))
+        fn = ast.parse(refuse).body[0]
+        gates = [
+            ast.unparse(node.test)
+            for node in ast.walk(fn)
+            if isinstance(node, ast.If) and any("logger.warning" in ast.unparse(child) for child in ast.walk(node))
+        ]
+        assert gates, "the helper no longer gates its log line"
+        for gate in gates:
+            assert "self._rejected" not in gate, f"the log budget is measured against the shared total again: {gate!r}"
+
+    def test_every_refusal_site_names_a_declared_cause(self):
+        src = textwrap.dedent(inspect.getsource(InputReceiver._on_input))
+        fn = ast.parse(src).body[0]
+        causes = [
+            node.args[0].value
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and ast.unparse(node.func) == "self._refuse"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ]
+        assert len(causes) >= 4, f"the scan found no refusal sites to grade: {causes}"
+        unknown = sorted(set(causes) - set(mesh_input._REJECTION_CAUSES))
+        assert unknown == [], f"refusal sites name causes no report enumerates: {unknown}"
+        assert set(causes) == set(mesh_input._REJECTION_CAUSES), (
+            "a declared cause is never used, so nothing reports it: "
+            f"{sorted(set(mesh_input._REJECTION_CAUSES) - set(causes))}"
+        )
+
+
+class TestTheGradedVocabularyMatchesTheModule:
+    def test_the_causes_and_the_budget_are_the_ones_the_module_declares(self):
+        """This file states both independently, so a rename cannot narrow the sweep."""
+        assert tuple(mesh_input._REJECTION_CAUSES) == _CAUSES
+        assert mesh_input._REFUSAL_LOG_BUDGET == _BUDGET
+
+
+class TestTheReportedShapeIsDocumented:
+    def test_the_docstring_names_every_reported_cause(self):
+        doc = inspect.getdoc(InputReceiver.stats) or ""
+        missing = [f"rejected_{c}" for c in _CAUSES if f"rejected_{c}" not in doc]
+        assert missing == [], f"stats reports keys its docstring does not name: {missing}"
+
+    def test_the_docstring_does_not_claim_a_cause_this_path_has_no_check_for(self):
+        """It named an ACL check the receive path does not make, and omitted the
+        frame-validation refusal that a consumer's own diagnosis is built on."""
+        doc = (inspect.getdoc(InputReceiver.stats) or "").lower()
+        checks = [line for line in inspect.getsource(InputReceiver._on_input).splitlines() if "acl" in line.lower()]
+        assert checks == [], f"an ACL check appeared on the receive path: {checks}"
+        assert "acl" not in doc, "the docstring names a cause this path never checks"
+
+
+class TestTheCausesWithTheirOwnCounterKeepIt:
+    """Controls: the two guards that already reported themselves are untouched."""
+
+    def test_a_rate_capped_frame_is_not_counted_as_rejected(self, monkeypatch):
+        monkeypatch.setenv("STRANDS_MESH_INPUT_MAX_HZ", "10")
+        recv, applied = _make_receiver()
+        recv._on_input(recv.topic, _fresh({"j0": 0.1}, 0))
+        recv._on_input(recv.topic, _fresh({"j0": 0.2}, 1))
+        stats = recv.stats
+        assert len(applied) == 1
+        assert stats["rate_dropped"] == 1
+        assert stats["rejected"] == 0
+        assert all(stats.get(f"rejected_{c}", 0) == 0 for c in _CAUSES)
+
+    def test_the_breakdown_does_not_absorb_the_separately_counted_causes(self):
+        recv, _ = _make_receiver()
+        stats = recv.stats
+        for key in ("rate_dropped", "slew_rejected"):
+            assert key in stats
+            assert f"rejected_{key}" not in stats, (
+                f"{key} was folded into the rejected breakdown, changing what rejected totals"
+            )
+
+    def test_a_single_lockout_refusal_still_totals_one(self):
+        """The pre-existing contract: ``rejected`` is still the total."""
+        recv, applied = _locked_out_receiver()
+        recv._on_input(recv.topic, _fresh({"j0": 0.1}))
+        assert applied == []
+        assert recv._rejected == 1


### PR DESCRIPTION
## Problem

`InputReceiver._on_input` refuses a teleop frame for six distinct reasons. Two of them keep their
own counter -- `rate_dropped` (the apply-rate ceiling) and `slew_rejected` (the per-joint slew
bound). The other four shared `rejected`:

| refusal | counter before |
|---|---|
| arrived during an E-stop lockout | `rejected` |
| frame `t` missing or non-numeric | `rejected` |
| frame `t` stale or too far in the future | `rejected` |
| `validate_input_frame` refused the shape or a value | `rejected` |
| over the apply-rate ceiling | `rate_dropped` |
| over the per-joint slew bound | `slew_rejected` |

Two things followed from the sharing, and the second is what makes the first unrecoverable rather
than merely awkward.

**A report cannot say which guard refused the stream.** `rejected: 8` is the whole answer, and the
reason exists only in the follower's log line.

**Each guard's log line is rate-limited against the shared counter**, so a stream refused for one
reason spends the budget and the *first* refusal of a different reason is never written. Measured on
one receiver, same frame both times:

| the stream | `rejected` | lines written | is the value refusal stated? |
|---|---|---|---|
| the out-of-range frame arrives first | 1 | 1 | yes -- `value for '1' out of range: \|1500.0\| > 720.0` |
| five stale-`t` frames, then the same frame | 6 | 5 | **no** |

Both rows refuse the same frame for the same reason. Only the second is undiagnosable, and the
difference is how many *unrelated* frames preceded it -- an ordinary clock-skewed start.

The `stats` docstring also enumerated causes that did not match the code. It named "ACL checks"
(the string `acl` appears nowhere else in the module, and neither `_on_input` nor
`validate_input_frame` makes such a check) and omitted the frame-validation refusal, which is the
one that names an offending value and its bound.

## Change

`_refuse(cause, message, *args)` becomes the single place a refusal on this path is accounted for.
It counts the frame under its cause, adds it to the `rejected` total, and spends
`_REFUSAL_LOG_BUDGET` **per cause**. `stats` reports the breakdown beside the total, derived from
the declared causes so a cause added later is reported without a second list to update:

```
rejected            8      <- unchanged: still the total
rejected_lockout    0
rejected_freshness  5
rejected_invalid    3
```

`rejected` always equals their sum, so nothing that reads it today changes. The two guards that
already had their own counter are untouched, and no refusal decision moves: both trees refuse the
same eight frames in the measurement above.

The docstring now names the three causes it reports and drops the ACL claim.

## Not in scope

* **A stable code vocabulary.** The breakdown keys are counter names, not an error-code taxonomy;
  `_REJECTION_CAUSES` stays module-private so it cannot become one by accident.
* **`last_refusal` / `last_frame_t` / publisher timestamps.** Each adds a new reported field with a
  freshness contract of its own; this change only makes the counters already reported carry which
  guard produced them.
* **Narrowing any of the four guards.** Their refusal conditions are unchanged.
* The reported shape is documented at its owner, `InputReceiver.stats`, rather than duplicated into
  `TeleopMixin.get_teleop_status`, which forwards `rcv.stats` verbatim.

## Tests

`tests/mesh/test_input_refusal_causes.py`, 15 tests. Against `upstream/main`: **11 failed / 4
passed**. The headline reads

```
AssertionError: the value refusal was counted and never stated: rejected=6 with no line naming
the value or the bound, so the budget spent by the replay-freshness guard silenced a different
guard's only report
```

Nine of the eleven fail behaviourally or structurally with the offending state in the message (the
full `stats` dict, the four call sites, the ACL claim); two can only report that the new symbols are
absent, and pin the root cause rather than the regression.

Every guard is load-bearing -- each break fires exactly its own:

| break | fires |
|---|---|
| revert `input.py` | all 11 |
| log budget measured against the shared total again | headline + the budget's structural pin |
| docstring names ACL again | the ACL pin |
| docstring stops naming the reported keys | the key-naming pin |
| one site counts the total directly again | lockout attribution + single-owner + cause coverage |
| a declared cause is never used (both freshness sites mislabelled) | freshness attribution + the sum + headline + cause coverage |
| breakdown absorbs `slew_rejected` | cause coverage + the vocabulary pin + the separate-counter control |
| control (restored) | 0 of 15 |

Four tests pass on both trees and are the no-overreach controls: a rate-capped frame is still not
`rejected`, the breakdown does not absorb the two separately-counted causes, one cause still goes
quiet once *its own* budget is spent (so the fix is not "log every refusal" in a 50 Hz loop), and
`rejected == 1` for a single lockout refusal -- the contract
`test_input_stream_lifecycle.py::test_estop_lockout_rejects_frame` already pins.

## Verification

Measured at `9e01c20c`; the head is now `ebe9c6d2`, which adds only the changelog fragment (`git diff 9e01c20c..ebe9c6d2 -- '*.py'` is empty), so the numbers below still stand.

Identical 446-file selection on both trees, with the new test file excluded from each so the
comparison measures the source change alone:

| tree | failed | passed | skipped | errors |
|---|---|---|---|---|
| branch | 50 | 14794 | 149 | 24 |
| `upstream/main` | 48 | 14796 | 149 | 24 |

70 failing ids are shared and all dep-absent locally: 45 `tests/mesh/test_iot_*`
(`No module named 'awsiot'`), 23 across `test_robot_mesh_dc_dispatch_errors.py` and
`test_device_connect_hardening.py` (`device_connect_agent_tools`), 2 in `tests/training/test_lerobot.py`
(installed draccus 0.10.0 against lerobot 0.6.2's `draccus>=0.11.6` floor). All three are declared
extras that CI installs.

The six ids that differ are contention, proven by isolation on both trees:
`tests/mesh/test_zenoh_transport_security.py` fails with a *different* subset on each tree (3 on the
branch, 2 different ones on `upstream/main`) because it opens real localhost Zenoh sessions while
several suites run in parallel -- run alone it is `9 passed, 2 skipped` on **both** trees. And
`test_eval_async_rtc_masks_inference_latency` is wall-clock sensitive: 3/3 isolated runs pass on both
trees. Neither file is touched by this change.

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24
against a pristine `upstream/main` worktree with no branch-only error.

## Artifact

The shipped receiver driven against a real MuJoCo SO-101 (`MUJOCO_GL=egl`) with the stream above --
five stale-`t` frames, then three the leader reports in degrees into a 720-unit envelope. Both trees
refuse all eight (`frames_received: 0`, the follower never moves, and the render is identical to
within `5.4e-05` mean level). What changes is what a consumer reading the counters and the log can
conclude: on `upstream/main` the refusal is unrecoverable and the verdict stops at "every frame is
being refused"; after the change the same consumer reaches "the envelope is 720 units, and this
leader reported joint 1 at 1500 -- the arm reports DEGREES while the envelope assumes radians".

![teleop refusal causes](https://raw.githubusercontent.com/cagataycali/robots/media-teleop-refusal-causes/teleop-refusal-causes.png)

