### PR TITLE
fix(mesh): a peer does not report the age this process observed of it

### DIFF
--- a/changelog.d/2625-peer-age-is-a-local-observation.md
+++ b/changelog.d/2625-peer-age-is-a-local-observation.md
@@ -1,0 +1,29 @@
+### Fixed
+
+A peer's presence payload no longer decides what this process reports having
+observed about it. `PeerInfo.to_dict()` spread the payload (`caps`) after the
+four fields the local process decides -- `peer_id`, `type`, `hostname` and
+`age` -- so a heartbeat carrying any of those names replaced the local reading.
+
+`age` is the one that is not a capability at all: `last_seen_mono`'s docstring
+calls it "a local observation, never a stamp the peer sent", and `docs/mesh.md`
+names it among the things the mesh decides from a duration on `time.monotonic()`
+"which no NTP correction, `date -s` or resume from suspend can move". A peer
+publishing `"age": 0.0` in its heartbeat reported itself perpetually fresh, so
+every staleness verdict read from that field was the sender's to choose rather
+than the reader's to measure.
+
+`peer_id` is the second, and it costs a lookup rather than a verdict: it is the
+key the registry files a peer under, the key `Mesh.peers_by_id` and
+`Mesh.get_peer` resolve by, and the key `Mesh.peers` filters *self* out by.
+Measured through `Mesh._on_presence` with two peers admitted, the second naming
+the first in its payload: the registry held both, `Mesh.peers` reported one id
+twice, `peers_by_id` resolved only one of them, `get_peer` returned `None` for a
+peer that was present, and the second peer's capabilities answered a lookup for
+the first. A payload naming the *reader's* own id disappeared from `Mesh.peers`
+entirely while staying in the registry.
+
+`caps` now merges first, so those four win a name collision. The spread's purpose
+is unchanged and no honest payload changes: of the twelve keys `_build_presence`
+emits, `hostname` is the only one that collides, and `update_peer` derives the
+local `hostname` from that same wire value.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -97,6 +97,15 @@ that peer has timed out (10s), which peer the registry evicts when it hits
 move. So bringing a robot's clock into sync to satisfy the forward bound above
 will not make the next heartbeat tick drop every peer it can still hear.
 
+**Nor are those durations the measured peer's to report.** `age` is *your*
+process's reading of when it last heard from a peer, and the `peer_id` a peer is
+filed under is the one its topic and certificate bind - not a field inside the
+payload. A presence payload is merged into what you read about a peer so you get
+its capabilities (`tool_name`, `connected`, `cameras`, ...), and those four
+locally decided keys - `peer_id`, `type`, `hostname`, `age` - win a name
+collision with it. A peer heartbeating `"age": 0` does not report itself fresh,
+and one naming another peer's id does not answer a lookup for that peer.
+
 Repeated wrong codes arm a brute-force cooldown
 (`STRANDS_MESH_RESUME_MAX_FAILS`, `STRANDS_MESH_RESUME_BACKOFF_S`): during the
 cooldown even the correct code is refused, so wait it out rather than retrying in

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -317,13 +317,26 @@ class PeerInfo:
         return time.monotonic() - self.last_seen_mono
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a plain dict (JSON-friendly)."""
+        """Serialise to a plain dict (JSON-friendly).
+
+        ``caps`` merges *first* so the four locally-decided fields win a name
+        collision. ``caps`` is the peer's own presence payload, and every field
+        below it is something this process decided about the peer rather than
+        something the peer reported about itself: ``age`` is the observation
+        described on :attr:`last_seen_mono`, and ``peer_id`` is the key the
+        registry files it under.
+
+        Spread last, a payload carrying any of those four names replaced the
+        local reading. An ``age`` the sender chooses defeats every staleness
+        verdict read from it, and a ``peer_id`` the sender chooses is the key
+        ``Mesh.peers_by_id`` and ``Mesh.get_peer`` look the peer up by.
+        """
         return {
+            **self.caps,
             "peer_id": self.peer_id,
             "type": self.peer_type,
             "hostname": self.hostname,
             "age": round(self.age, 1),
-            **self.caps,
         }
 
     def __repr__(self) -> str:

--- a/tests/mesh/test_peer_age_is_a_local_observation.py
+++ b/tests/mesh/test_peer_age_is_a_local_observation.py
@@ -1,0 +1,294 @@
+"""A peer's presence payload does not decide what this process observed about it.
+
+``PeerInfo.caps`` is the peer's own presence payload, merged into
+:meth:`~strands_robots.mesh.session.PeerInfo.to_dict` so a consumer reads a
+peer's capabilities (``tool_name``, ``connected``, ``cameras``, ...) beside its
+identity. Four of the keys in that dict are not capabilities: ``peer_id`` is the
+key the registry files the peer under, ``type`` and ``hostname`` are what
+:func:`~strands_robots.mesh.session.update_peer` derived from the wire, and
+``age`` is this process's own reading of when it last heard a heartbeat --
+described on ``last_seen_mono`` as "a local observation, never a stamp the peer
+sent", and named in ``docs/mesh.md`` among the things the mesh decides from a
+duration on ``time.monotonic()`` that no clock correction can move.
+
+Spread last, ``caps`` overrode all four. This pins that the local reading wins a
+name collision, and that every capability key still merges.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import textwrap
+import time
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import session as mesh_session
+
+# The four names ``to_dict`` decides locally rather than reading off the wire.
+LOCAL_FIELDS = ("peer_id", "type", "hostname", "age")
+
+
+def _peer(**caps: Any) -> mesh_session.PeerInfo:
+    """A peer last heard from 5s ago, carrying *caps* as its presence payload."""
+    return mesh_session.PeerInfo(
+        peer_id="arm-1",
+        peer_type="robot",
+        hostname="jetson-01",
+        last_seen_mono=time.monotonic() - 5.0,
+        caps=dict(caps),
+    )
+
+
+class _Sample:
+    """A Zenoh sample carrying *payload* as JSON, as ``_on_presence`` reads it."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._raw = json.dumps(payload).encode()
+
+    @property
+    def payload(self) -> Any:
+        return types.SimpleNamespace(to_bytes=lambda: self._raw)
+
+
+@pytest.fixture
+def registry() -> Any:
+    """The process-wide peer registry, emptied before and after."""
+    mesh_session._PEERS.clear()
+    yield mesh_session
+    mesh_session._PEERS.clear()
+
+
+class TestTheLocalObservationWinsAName:
+    """A payload key that collides with a locally decided field is not honoured."""
+
+    def test_a_payload_carrying_age_does_not_replace_the_local_reading(self) -> None:
+        peer = _peer(robot_id="arm-1", age=0.0)
+
+        reported = peer.to_dict()["age"]
+
+        assert reported == pytest.approx(5.0, abs=0.5), (
+            f"the peer last heartbeat 5s ago and its own presence payload said age=0.0; "
+            f"to_dict reported {reported!r}. An age the sender chooses is not an "
+            f"observation, and every staleness verdict is read from it."
+        )
+
+    def test_a_payload_carrying_peer_id_does_not_rekey_the_peer(self) -> None:
+        peer = _peer(robot_id="arm-1", peer_id="some-other-robot")
+
+        assert peer.to_dict()["peer_id"] == "arm-1", (
+            "peer_id is the key the registry files the peer under and the key "
+            "Mesh.peers_by_id / Mesh.get_peer look it up by."
+        )
+
+    def test_a_payload_carrying_type_does_not_relabel_the_peer(self) -> None:
+        peer = _peer(robot_id="arm-1", robot_type="robot", type="agent")
+
+        assert peer.to_dict()["type"] == "robot", (
+            "type is what update_peer derived from the payload's robot_type; a "
+            "second key spelled 'type' is not a second opinion about it."
+        )
+
+    @pytest.mark.parametrize("field", LOCAL_FIELDS)
+    def test_no_locally_decided_field_is_settable_from_the_payload(self, field: str) -> None:
+        """Whatever the payload says, the four fields keep the local answer."""
+        sentinel = "PAYLOAD-WINS" if field != "age" else -999.0
+        peer = _peer(robot_id="arm-1", **{field: sentinel})
+
+        assert peer.to_dict()[field] != sentinel, f"the payload set {field!r} to its own value"
+
+
+class TestTheRegistryAndTheSerialisedViewAgree:
+    """Every peer the registry holds is reachable under the id it is filed under."""
+
+    def test_every_registered_peer_id_survives_serialisation(self, registry: Any) -> None:
+        registry.update_peer(peer_id="arm-1", peer_type="robot", hostname="h", caps={"robot_id": "arm-1"})
+        registry.update_peer(
+            peer_id="arm-2",
+            peer_type="robot",
+            hostname="h",
+            caps={"robot_id": "arm-2", "peer_id": "arm-1"},
+        )
+
+        filed = sorted(registry._PEERS)
+        served = sorted(p["peer_id"] for p in registry.get_peers())
+
+        assert served == filed, (
+            f"the registry holds {filed} but get_peers reported {served}: a payload key "
+            f"renamed a peer, so two entries claim one id and the other peer is unreachable."
+        )
+
+    def test_a_masquerading_peer_is_still_reachable_by_its_own_id(self, registry: Any) -> None:
+        registry.update_peer(peer_id="arm-1", peer_type="robot", hostname="h", caps={"robot_id": "arm-1"})
+        registry.update_peer(
+            peer_id="arm-2",
+            peer_type="robot",
+            hostname="h",
+            caps={"robot_id": "arm-2", "peer_id": "arm-1", "type": "agent"},
+        )
+
+        by_id = {p["peer_id"]: p for p in registry.get_peers()}
+
+        assert set(by_id) == {"arm-1", "arm-2"}, f"only {sorted(by_id)} could be looked up"
+        assert by_id["arm-1"]["type"] == "robot", "arm-2's payload answered a lookup for arm-1"
+
+
+class TestWhatAMeshConsumerSees:
+    """The registry reaches ``Mesh.peers`` / ``peers_by_id`` / ``get_peer`` intact."""
+
+    @staticmethod
+    def _mesh(peer_id: str = "me") -> Any:
+        from strands_robots.mesh import core as mesh_core
+
+        mesh = mesh_core.Mesh.__new__(mesh_core.Mesh)
+        mesh.peer_id = peer_id
+        mesh.peer_type = "robot"
+        return mesh
+
+    def test_get_peer_resolves_a_peer_whose_payload_claims_another_id(self, registry: Any) -> None:
+        mesh = self._mesh()
+        now = time.time()
+        mesh._on_presence(_Sample({"robot_id": "arm-1", "robot_type": "robot", "hostname": "h", "timestamp": now}))
+        mesh._on_presence(
+            _Sample(
+                {
+                    "robot_id": "arm-2",
+                    "robot_type": "robot",
+                    "hostname": "h",
+                    "timestamp": now,
+                    "peer_id": "arm-1",
+                }
+            )
+        )
+        assert set(registry._PEERS) == {"arm-1", "arm-2"}, "premise: both peers were admitted"
+
+        assert mesh.get_peer("arm-2") is not None, (
+            "arm-2 is in the registry but get_peer could not find it: its own payload filed it under arm-1's id."
+        )
+        assert sorted(mesh.peers_by_id) == ["arm-1", "arm-2"]
+
+    def test_a_peer_claiming_our_own_id_is_still_reported(self, registry: Any) -> None:
+        """``Mesh.peers`` excludes *us* by peer_id, so a payload could hide a peer."""
+        mesh = self._mesh(peer_id="me")
+        mesh._on_presence(
+            _Sample(
+                {
+                    "robot_id": "ghost",
+                    "robot_type": "robot",
+                    "hostname": "h",
+                    "timestamp": time.time(),
+                    "peer_id": "me",
+                }
+            )
+        )
+        assert "ghost" in registry._PEERS, "premise: the peer was admitted to the registry"
+
+        assert [p["peer_id"] for p in mesh.peers] == ["ghost"], (
+            "a peer that names our own peer_id in its payload was filtered out of our "
+            "own fleet view while staying in the registry."
+        )
+
+
+class TestNothingElseChanges:
+    """Capability keys still merge, and an honest payload is untouched."""
+
+    def test_capability_keys_still_merge(self) -> None:
+        peer = _peer(tool_name="unitree_g1", connected=True, cameras=["front"])
+        served = peer.to_dict()
+
+        assert served["tool_name"] == "unitree_g1"
+        assert served["connected"] is True
+        assert served["cameras"] == ["front"]
+
+    def test_an_honest_presence_payload_reports_every_key(self) -> None:
+        """The vocabulary ``_build_presence`` emits, none of which decides a local field."""
+        honest = {
+            "robot_id": "arm-1",
+            "robot_type": "robot",
+            "hostname": "jetson-01",
+            "timestamp": time.time(),
+            "tool_name": "so101",
+            "task_status": "idle",
+            "instruction": "",
+            "connected": True,
+            "hw": "so101",
+            "cameras": ["front"],
+            "inputs": ["leader"],
+            "topics": ["state"],
+        }
+        served = _peer(**honest).to_dict()
+
+        for key, value in honest.items():
+            assert served[key] == value, f"{key} did not survive"
+        assert served["peer_id"] == "arm-1"
+        assert served["type"] == "robot"
+
+    def test_the_only_colliding_key_an_honest_payload_carries_is_hostname(self) -> None:
+        """``hostname`` is wire-derived by ``update_peer``, so the collision is a no-op."""
+        emitted = {
+            "robot_id",
+            "robot_type",
+            "hostname",
+            "timestamp",
+            "tool_name",
+            "task_status",
+            "instruction",
+            "connected",
+            "hw",
+            "cameras",
+            "inputs",
+            "topics",
+        }
+
+        assert emitted & set(LOCAL_FIELDS) == {"hostname"}
+
+    def test_a_wire_hostname_still_reaches_the_serialised_view(self, registry: Any) -> None:
+        registry.update_peer(
+            peer_id="arm-1",
+            peer_type="robot",
+            hostname="jetson-01",
+            caps={"robot_id": "arm-1", "hostname": "jetson-01"},
+        )
+
+        (served,) = registry.get_peers()
+
+        assert served["hostname"] == "jetson-01"
+
+    def test_age_is_still_a_rounded_non_negative_duration(self) -> None:
+        served = _peer(robot_id="arm-1").to_dict()
+
+        assert isinstance(served["age"], float)
+        assert served["age"] == round(served["age"], 1)
+        assert served["age"] >= 0.0
+
+
+class TestTheOrderIsTheContract:
+    """A future edit cannot reintroduce the override by moving the spread."""
+
+    def test_caps_merges_before_every_locally_decided_field(self) -> None:
+        source = textwrap.dedent(inspect.getsource(mesh_session.PeerInfo.to_dict))
+        returned = next(
+            node.value
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)
+        )
+
+        # ``{**caps, ...}`` parses as a Dict whose first key is None.
+        spread_at = [i for i, key in enumerate(returned.keys) if key is None]
+        local_at = [
+            i for i, key in enumerate(returned.keys) if isinstance(key, ast.Constant) and key.value in LOCAL_FIELDS
+        ]
+
+        assert spread_at, "to_dict no longer merges caps at all"
+        assert local_at, "to_dict reports none of the locally decided fields"
+        assert set(LOCAL_FIELDS) <= {key.value for key in returned.keys if isinstance(key, ast.Constant)}, (
+            "to_dict stopped reporting one of the locally decided fields"
+        )
+        assert max(spread_at) < min(local_at), (
+            "caps is spread after a locally decided field, so a presence payload "
+            "carrying that name replaces the local reading again."
+        )


### PR DESCRIPTION
## Problem

`PeerInfo.to_dict()` spread the peer's own presence payload **after** the four fields this
process decides about the peer, so a payload carrying `age`, `peer_id`, `type` or `hostname`
replaced the local reading:

```python
return {
    "peer_id": self.peer_id,
    "type": self.peer_type,
    "hostname": self.hostname,
    "age": round(self.age, 1),
    **self.caps,          # <- the peer's presence payload, spread last
}
```

`caps` is the parsed presence JSON, handed to `update_peer(..., caps=data)` straight from
`_on_presence`. Its purpose is capabilities - `tool_name`, `connected`, `cameras` - and
nothing validated the rest of its key space.

`age` is the field that matters most, because it is not a capability. `last_seen_mono`'s own
docstring calls it *"a local observation, never a stamp the peer sent, and it is not
serialised: `to_dict` reports `age`"*, and `docs/mesh.md` names it among the things the mesh
decides from a duration on `time.monotonic()` *"which no NTP correction, `date -s` or resume
from suspend can move"*. A peer publishing `"age": 0.0` set it anyway.

`peer_id` is the second: it is the key the registry files a peer under, the key
`Mesh.peers_by_id` and `Mesh.get_peer` look it up by, and the key `Mesh.peers` filters *self*
out by.

## Measured, through the real `Mesh._on_presence`

Two peers admitted; the second's payload also carries `age`, `peer_id` and `type`.

| tree  | registry holds | `Mesh.peers` reports | `peers_by_id` | `get_peer("evil")` |
| --- | --- | --- | --- | --- |
| before | `['evil', 'good']` | `peer_id='good'` **twice** | `['good']` | `None` |
| after | `['evil', 'good']` | `good`, `evil` | `['evil', 'good']` | the peer |

Before, `evil`'s payload answered a lookup for `good` (`type='operator'`, `age=0.0`,
`hostname='spoofed'`) and `evil` itself was unreachable. `age` read `0.0` for a peer this
process had last heard from 0.5s earlier; after, both read `0.5`.

A peer whose payload names **our own** `peer_id` is a hiding primitive - `Mesh.peers` filters
self by that key:

| tree  | registry holds | `Mesh.peers` reports |
| --- | --- | --- |
| before | `['ghost']` | `[]` |
| after | `['ghost']` | `['ghost']` |

## Change

`caps` merges **first**, so the four locally decided fields win a name collision. The
spread's purpose is unchanged.

**No honest payload changes.** Of the twelve keys `_build_presence` emits, `hostname` is the
only one that collides with a local name, and `update_peer` derives the local `hostname` from
that same wire value - so the reorder is a value no-op for it. Measured on both trees for a
full honest payload: 15 keys, and `{"age": 1.0, "hostname": "cagatay", "peer_id": "g1",
"type": "sim"}` identical.

## Why now

`**self.caps` dates from #101 (2026-05-21), the original mesh PR. **88 days later**, #2408
(2026-08-17) moved peer liveness onto `time.monotonic()`, wrote the `last_seen_mono` docstring
quoted above and the `docs/mesh.md` paragraph, and stated in its own commit message:

> `to_dict()` reports age and never the base, so no serialised surface changes.

It made `age` immune to a wall-clock step and left it settable by the peer being measured,
which is the stronger override of the two.

## Scope

The fix is the field ordering. Deliberately **not** here:

- **A `stale: bool` verdict or an `on_peer_lost` callback.** The SDK already has a verdict on
  absence - `prune_peers()` runs on every heartbeat tick and drops a peer past
  `PEER_TIMEOUT` (10s), returning the ids it dropped - and `age` is already reported. Adding
  an intermediate state or a callback is new public surface.
- **Making `PEER_TIMEOUT` operator-tunable.** Its sibling bound in the same module
  (`STRANDS_MESH_MAX_PEERS`) is, via a lazy `_max_peers()`; this one is a module constant, and
  because it is bound as `prune_peers(timeout=PEER_TIMEOUT)` the default is fixed at import,
  so reassigning the module attribute does not change it. Both are worth a decision, neither
  is this fix.

## Verification

`tests/mesh/test_peer_age_is_a_local_observation.py`, 17 items. Against `upstream/main`:
**12 failed / 5 passed**; after, 17 passed. The 5 that pass on both are the no-overreach
controls - capability keys still merge, an honest payload reports every key, `age` is still a
rounded non-negative duration.

Every guard is load-bearing (each break applied to the fixed tree):

| break | tests it fires |
| --- | --- |
| revert the order (`caps` last) | 12 - the full regression set |
| `caps` first but drop local `age` | 4 - both age tests, the rounding control, the structural pin |
| `caps` first but drop local `peer_id` | 8 - every masquerade test, the honest-payload control, the structural pin |
| drop the `caps` merge entirely | 3 - both capability controls, the structural pin |
| control (fixed tree) | 0 of 17 |

The last row of the third and fourth breaks is why the capability controls exist: they fire
for the tempting wrong fix - dropping the spread - and for nothing else.

`TestTheOrderIsTheContract` pins the ordering structurally off the AST, so a later edit cannot
reintroduce the override by moving the spread back.

Gate: the 421 test files that name the peer registry, its serialised view, `tests/mesh`, or a
repo-wide doc/docstring/changelog guard, run as the **identical selection on both trees** with
this PR's new file excluded from each:

| tree | result |
| --- | --- |
| this branch | `21 failed, 14328 passed, 86 skipped, 24 errors` |
| pristine `upstream/main` | `21 failed, 14328 passed, 86 skipped, 24 errors` |

Byte-identical, 45 failing ids each, and the id sets are equal in both directions - so nothing
else in that selection changed verdict. All 45 are `tests/mesh/test_iot_*` on
`No module named 'awsiot'`, the declared `[mesh-iot]` extra (`awsiotsdk>=1.21.0`) absent on this
box and installed in CI. `mypy strands_robots tests tests_integ` reports the same 24 errors on
both trees, none in the changed files; `ruff check` / `ruff format --check` clean.

## Fleet view

The same three heartbeats through the real `Mesh._on_presence`: two honest `so101` robots and
one whose payload also carries `age` / `peer_id` / `type`. `so101-b` stopped heartbeating 6s
ago, past a 5.0s threshold.

![fleet view before and after](https://raw.githubusercontent.com/cagataycali/robots/media-peer-age-local-observation/fleet-view.png)

`so101-b` reads `STALE` in **both** columns, and that is the point worth being precise about:
the defect is not that an honest peer's age is misjudged, it is that a peer chooses what is
judged. Before, the view carries three rows under two ids - `so101-a` appears twice, once as
`robot` and once as `operator` - `rogue-1` is in the registry while `get_peer("rogue-1")`
returns `None`, and the rogue peer reads `0.0s / fresh`. After, three rows, three ids, all
three reachable.

