### PR TITLE
fix(mesh): a subscription never silently fails to exist

### DIFF
--- a/changelog.d/2626-a-subscription-never-silently-fails-to-exist.md
+++ b/changelog.d/2626-a-subscription-never-silently-fails-to-exist.md
@@ -1,0 +1,33 @@
+### Fixed: a mesh subscription never silently fails to exist
+
+`Mesh.subscribe` has three `None` returns. One - a raising `declare_subscriber` -
+has always logged a WARNING naming the topic, in line with the six other
+client-side refusals in `strands_robots/mesh/core.py`: `send`, `broadcast`, the
+invalid-command and lockout rejections, the startup declare failure, and
+`declare_publisher`. The other two, the peer not being on the mesh and there
+being no session, answered `None` with no record at all.
+
+Those two are the pair a caller meets on the only rejoin the class offers.
+`stop()` drops every subscription `subscribe` records and clears `inbox`;
+`start()` re-declares only the peer's own built-in topics, and the
+`(topic, callback)` pairs behind a user subscription are not retained anywhere,
+so a consumer that leaves and rejoins after a config change or a hub restart
+re-subscribes. If the mesh has not come back up, that re-subscribe answered
+`None` and said nothing - and `stop()` had not said the subscription was gone in
+the first place, so an empty `_user_subs` was the only evidence either had
+happened.
+
+Both refusals now say why at WARNING, naming the topic and which of the three it
+was, and `stop()` reports at INFO how many subscriptions it dropped and their
+names when there were any, so a rejoining caller is told what it has to
+re-declare. `subscribe`'s docstring gains a `Returns:` block accounting for all
+three refusals and states that a subscription does not survive `stop()`;
+`stop`'s states what it drops and why `start()` cannot restore it, and
+`docs/mesh.md` says the same to a consumer under **Rejoining the mesh**.
+
+Nothing about the round trip changes. Measured end to end against a live Zenoh
+session, the subscription attaches and fires once, `stop()` empties `user_subs`
+and `inbox`, the early re-subscribe answers `None`, and the rejoin restores the
+`peer_id` and leaves an engaged e-stop lockout engaged - identically before and
+after. A network blip was never a way to forget a stop; what it was is a way to
+lose a subscription without being told.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -129,6 +129,30 @@ always agree: both describe the full rotation for every orientation, including
 the half of SO(3) past 120 degrees that a robot turning back the way it came
 lands in.
 
+### Rejoining the mesh
+
+`stop()` then `start()` is how a peer leaves and rejoins - after a config
+change, or a hub that went away and came back. The peer keeps its identity
+across it: the `peer_id` is unchanged, and an engaged e-stop lockout stays
+engaged, so a network blip is not a way to forget a stop.
+
+What does not survive is your own `subscribe()` topics. `start()` re-declares
+the peer's built-in topics from the table above; the subscribers `subscribe()`
+returned are undeclared with the session reference and their callbacks are not
+retained, so a rejoining consumer re-declares its own. `stop()` reports at INFO
+how many it dropped and their names, and `subscribe()` says at WARNING when it
+refuses - naming the topic and whether the peer is off the mesh, has no session,
+or had the declare itself fail - so a rejoin that has not finished is visible
+rather than a silent `None`.
+
+```python
+sim.mesh.stop()
+sim.mesh.start()
+name = sim.mesh.subscribe("strands/*/state", callback=on_state)
+if name is None:
+    ...  # the WARNING says which of the three refusals it was
+```
+
 ## Agent-driven mesh
 
 ```python

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -825,7 +825,15 @@ class Mesh(SensorLoopsMixin):
             logger.info("[mesh] %s on mesh (%s)", self.peer_id, self.peer_type)
 
     def stop(self) -> None:
-        """Stop all loops and release the session reference."""
+        """Stop all loops and release the session reference.
+
+        Drops every :meth:`subscribe` subscription and clears :attr:`inbox`:
+        the subscribers are undeclared with the session reference, and the
+        ``(topic, callback)`` pairs behind them are not retained, so
+        :meth:`start` re-declares only this peer's built-in topics. A rejoining
+        caller re-declares its own subscriptions; the count dropped is reported
+        at INFO so that is visible rather than inferred.
+        """
         with self._lifecycle_lock:
             if not self._running:
                 return
@@ -837,10 +845,23 @@ class Mesh(SensorLoopsMixin):
 
         with self._subs_lock:
             subs_to_drop = list(self._subs)
+            user_sub_names = sorted(self._user_subs)
             self._subs.clear()
             self._user_subs.clear()
         with self._inbox_lock:
             self.inbox.clear()
+
+        # The peer's own built-in topics are re-declared by ``start()``; a
+        # caller's :meth:`subscribe` topics are not, and their callbacks are
+        # not retained anywhere, so this is the only notice that a rejoin
+        # leaves them to be re-declared.
+        if user_sub_names:
+            logger.info(
+                "[mesh] %s: dropped %d subscription(s) on leaving the mesh (%s); re-declare after start()",
+                self.peer_id,
+                len(user_sub_names),
+                ", ".join(user_sub_names),
+            )
 
         for sub in subs_to_drop:
             try:
@@ -3124,11 +3145,40 @@ class Mesh(SensorLoopsMixin):
     def subscribe(
         self, topic: str, callback: Callable[[str, dict[str, Any]], None] | None = None, name: str | None = None
     ) -> str | None:
-        """Subscribe to any Zenoh topic and receive parsed JSON dicts."""
+        """Subscribe to any Zenoh topic and receive parsed JSON dicts.
+
+        Returns:
+            The subscription name (``name`` when given, else *topic*) once the
+            subscriber is declared, or ``None`` when it was not. Every
+            ``None`` says why at WARNING, matching how the rest of this class
+            reports a client-side refusal: the peer is not on the mesh, there
+            is no session to declare against, or ``declare_subscriber`` itself
+            failed.
+
+        A subscription does not survive :meth:`stop`. That method drops every
+        subscription this one records and :meth:`start` re-declares only the
+        peer's own built-in topics, so a caller that rejoins the mesh
+        re-declares its own subscriptions - which is what the WARNING above
+        makes visible when a rejoin has not happened yet.
+        """
         if not self._running:
+            # Silent until now, unlike the declare_subscriber failure below and
+            # every other client-side refusal in this class. A caller
+            # re-subscribing after a stop()/start() round trip reads the
+            # ``None`` as "subscribed" unless it checks, so name the reason.
+            logger.warning(
+                "[mesh] %s: subscribe(%s) refused: peer is not on the mesh (start() first)",
+                self.peer_id,
+                topic,
+            )
             return None
         session = current_session()
         if session is None:
+            logger.warning(
+                "[mesh] %s: subscribe(%s) refused: no mesh session",
+                self.peer_id,
+                topic,
+            )
             return None
         sub_name = name or topic
         with self._inbox_lock:

--- a/tests/mesh/test_subscribe_publish_step_resilience.py
+++ b/tests/mesh/test_subscribe_publish_step_resilience.py
@@ -11,10 +11,16 @@ future refactor cannot silently regress them:
   failure as well as a subscriber already absent from the tracking list.
 - ``publish_step`` serializes list/tuple observation and action values into
   JSON-safe lists before publishing the VLA execution step.
+- A user subscription never silently fails to exist: every ``subscribe``
+  refusal says why, and ``stop`` says how many it dropped. The cases above
+  pinned the ``None`` *return* for two of the three refusal paths and nothing
+  about the report, so the two that answered without a word - not on the mesh,
+  no session - were the ones a caller re-subscribing after a ``stop()`` hit.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -193,3 +199,148 @@ class TestPublishStepSerialization:
 
         mesh.publish_step(step=0, observation={}, action={})
         assert published == []
+
+
+_CORE_LOGGER = "strands_robots.mesh.core"
+
+
+def _refusals(caplog, topic: str) -> list[str]:
+    """Every WARNING naming *topic*, i.e. what the caller is told about it.
+
+    Keyed on the topic rather than a call spelling: the three refusal paths
+    word themselves differently (``subscribe(...) refused`` for the two this
+    class added, ``declare_subscriber(...) failed`` for the pre-existing one)
+    and the contract is that the caller learns which topic did not attach.
+    """
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING and topic in r.getMessage()]
+
+
+class TestASubscriptionNeverSilentlyFailsToExist:
+    """Each way a subscription fails to exist reports itself.
+
+    ``subscribe`` has three ``None`` returns. One - a raising
+    ``declare_subscriber`` - has always logged a WARNING naming the topic, in
+    line with the six other client-side refusals in
+    :mod:`strands_robots.mesh.core`. The other two answered ``None`` with no
+    record at all, and they are the pair a caller meets on the only rejoin the
+    class offers: ``stop()`` drops every subscription this method records, so
+    the re-subscribe that follows a ``start()`` is exactly where a caller needs
+    to be told why nothing was declared.
+    """
+
+    def test_a_subscribe_before_start_says_why(self, caplog):
+        """Not on the mesh is a refusal, so it names itself and the topic."""
+        mesh = Mesh(_FakeRobot(), peer_id="quiet-peer")
+
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            result = mesh.subscribe("strands/quiet/topic")
+
+        assert result is None
+        said = _refusals(caplog, "strands/quiet/topic")
+        assert said, "subscribe answered None and said nothing"
+        assert "not on the mesh" in said[0], said
+
+    def test_a_subscribe_after_a_stop_says_why(self, caplog, monkeypatch):
+        """The rejoin path: a subscription dropped by stop() cannot be replaced silently."""
+        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        mesh = _running_mesh("rejoin-peer")
+        assert mesh.subscribe("strands/rejoin/topic", name="t") == "t", "premise: it subscribes while running"
+
+        mesh.stop()
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            result = mesh.subscribe("strands/rejoin/topic", name="t")
+
+        assert result is None
+        said = _refusals(caplog, "strands/rejoin/topic")
+        assert said, "a re-subscribe after stop() answered None and said nothing"
+        assert "not on the mesh" in said[0], said
+
+    def test_a_subscribe_without_a_session_says_why(self, caplog, monkeypatch):
+        """No session is a refusal too, and it is distinguishable from the others."""
+        monkeypatch.setattr(mesh_core, "current_session", lambda: None)
+        mesh = _running_mesh("sessionless-peer")
+
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            result = mesh.subscribe("strands/sessionless/topic")
+
+        assert result is None
+        said = _refusals(caplog, "strands/sessionless/topic")
+        assert said, "subscribe answered None and said nothing"
+        assert "no mesh session" in said[0], said
+
+    def test_the_declare_failure_still_says_why(self, caplog, monkeypatch):
+        """Control: the one path that always reported still reports, unchanged."""
+        session = MagicMock()
+        session.declare_subscriber.side_effect = RuntimeError("router unreachable")
+        monkeypatch.setattr(mesh_core, "current_session", lambda: session)
+        mesh = _running_mesh("declare-fail-peer")
+
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            assert mesh.subscribe("strands/declare/topic") is None
+
+        said = _refusals(caplog, "strands/declare/topic")
+        assert said, "the pre-existing declare_subscriber WARNING was lost"
+        assert "router unreachable" in said[0], said
+
+    def test_a_successful_subscribe_says_nothing_about_refusing(self, caplog, monkeypatch):
+        """Control: the accepted path is not made noisy by the refusals above."""
+        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        mesh = _running_mesh("accepted-peer")
+
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            assert mesh.subscribe("strands/accepted/topic", name="ok") == "ok"
+
+        assert _refusals(caplog, "strands/accepted/topic") == []
+
+    def test_stop_reports_the_subscriptions_it_dropped(self, caplog, monkeypatch):
+        """A rejoining caller is told what it has to re-declare."""
+        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        mesh = _running_mesh("dropping-peer")
+        assert mesh.subscribe("strands/a", name="a") == "a"
+        assert mesh.subscribe("strands/b", name="b") == "b"
+
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            mesh.stop()
+
+        dropped = [r.getMessage() for r in caplog.records if "dropped" in r.getMessage()]
+        assert dropped, "stop() discarded two subscriptions and said nothing"
+        assert "2 subscription" in dropped[0], dropped
+        assert "a" in dropped[0] and "b" in dropped[0], dropped
+        assert mesh._user_subs == {}, "premise: they really are gone"
+
+    def test_a_stop_with_no_subscriptions_says_nothing_about_dropping(self, caplog):
+        """Control: ordinary teardown stays quiet, so the notice means something."""
+        mesh = _running_mesh("undropping-peer")
+
+        with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
+            mesh.stop()
+
+        assert [r.getMessage() for r in caplog.records if "dropped" in r.getMessage()] == []
+
+    def test_a_stop_keeps_the_peer_id_and_the_lockout(self, monkeypatch):
+        """Control: leaving the mesh is not a way to forget an e-stop.
+
+        The lockout and the peer's identity are what a rejoin has to preserve,
+        and both already survive ``stop()``. Pinned here so the reporting added
+        beside them cannot be mistaken for - or grow into - a reset.
+        """
+        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        mesh = _running_mesh("latched-peer")
+        mesh._estop_lockout.set()
+        mesh._last_estop_ts = 12345.0
+
+        mesh.stop()
+
+        assert mesh.peer_id == "latched-peer"
+        assert mesh._estop_lockout.is_set(), "stop() forgot an engaged e-stop"
+        assert mesh._last_estop_ts == 12345.0
+
+    def test_the_return_contract_names_every_refusal(self):
+        """The docstring accounts for all three ways it answers None."""
+        doc = Mesh.subscribe.__doc__ or ""
+        assert "Returns:" in doc, "subscribe documents no return"
+        for reason in ("not on the mesh", "no session", "declare_subscriber"):
+            assert reason in doc, f"the {reason!r} refusal is undocumented: {doc!r}"
+        assert "does not survive" in doc, "the stop() interaction is undocumented"

--- a/tests/mesh/test_subscribe_publish_step_resilience.py
+++ b/tests/mesh/test_subscribe_publish_step_resilience.py
@@ -242,7 +242,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
 
     def test_a_subscribe_after_a_stop_says_why(self, caplog, monkeypatch):
         """The rejoin path: a subscription dropped by stop() cannot be replaced silently."""
-        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        session = MagicMock()
+        monkeypatch.setattr(mesh_core, "current_session", lambda: session)
         mesh = _running_mesh("rejoin-peer")
         attached = mesh.subscribe("strands/rejoin/topic", name="t")
         assert attached == "t", "premise: it subscribes while running"
@@ -287,7 +288,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
 
     def test_a_successful_subscribe_says_nothing_about_refusing(self, caplog, monkeypatch):
         """Control: the accepted path is not made noisy by the refusals above."""
-        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        session = MagicMock()
+        monkeypatch.setattr(mesh_core, "current_session", lambda: session)
         mesh = _running_mesh("accepted-peer")
 
         with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
@@ -298,7 +300,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
 
     def test_stop_reports_the_subscriptions_it_dropped(self, caplog, monkeypatch):
         """A rejoining caller is told what it has to re-declare."""
-        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        session = MagicMock()
+        monkeypatch.setattr(mesh_core, "current_session", lambda: session)
         mesh = _running_mesh("dropping-peer")
         first = mesh.subscribe("strands/a", name="a")
         second = mesh.subscribe("strands/b", name="b")
@@ -330,7 +333,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
         and both already survive ``stop()``. Pinned here so the reporting added
         beside them cannot be mistaken for - or grow into - a reset.
         """
-        monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
+        session = MagicMock()
+        monkeypatch.setattr(mesh_core, "current_session", lambda: session)
         mesh = _running_mesh("latched-peer")
         mesh._estop_lockout.set()
         mesh._last_estop_ts = 12345.0

--- a/tests/mesh/test_subscribe_publish_step_resilience.py
+++ b/tests/mesh/test_subscribe_publish_step_resilience.py
@@ -244,7 +244,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
         """The rejoin path: a subscription dropped by stop() cannot be replaced silently."""
         monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
         mesh = _running_mesh("rejoin-peer")
-        assert mesh.subscribe("strands/rejoin/topic", name="t") == "t", "premise: it subscribes while running"
+        attached = mesh.subscribe("strands/rejoin/topic", name="t")
+        assert attached == "t", "premise: it subscribes while running"
 
         mesh.stop()
         caplog.clear()
@@ -277,7 +278,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
         mesh = _running_mesh("declare-fail-peer")
 
         with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
-            assert mesh.subscribe("strands/declare/topic") is None
+            refused = mesh.subscribe("strands/declare/topic")
+        assert refused is None
 
         said = _refusals(caplog, "strands/declare/topic")
         assert said, "the pre-existing declare_subscriber WARNING was lost"
@@ -289,7 +291,8 @@ class TestASubscriptionNeverSilentlyFailsToExist:
         mesh = _running_mesh("accepted-peer")
 
         with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):
-            assert mesh.subscribe("strands/accepted/topic", name="ok") == "ok"
+            accepted = mesh.subscribe("strands/accepted/topic", name="ok")
+        assert accepted == "ok"
 
         assert _refusals(caplog, "strands/accepted/topic") == []
 
@@ -297,8 +300,9 @@ class TestASubscriptionNeverSilentlyFailsToExist:
         """A rejoining caller is told what it has to re-declare."""
         monkeypatch.setattr(mesh_core, "current_session", lambda: MagicMock())
         mesh = _running_mesh("dropping-peer")
-        assert mesh.subscribe("strands/a", name="a") == "a"
-        assert mesh.subscribe("strands/b", name="b") == "b"
+        first = mesh.subscribe("strands/a", name="a")
+        second = mesh.subscribe("strands/b", name="b")
+        assert (first, second) == ("a", "b"), "premise: two subscriptions to drop"
 
         caplog.clear()
         with caplog.at_level(logging.DEBUG, logger=_CORE_LOGGER):


### PR DESCRIPTION
## Problem

`Mesh.subscribe` has three `None` returns. One of them - a raising `declare_subscriber` - has always logged a WARNING naming the topic, in line with the six other client-side refusals in `strands_robots/mesh/core.py` (`send`, `broadcast`, the invalid-cmd and lockout rejections, the startup declare failure, `declare_publisher`). The other two answered `None` with no record at all:

```python
if not self._running:
    return None
session = current_session()
if session is None:
    return None
```

Those two are the pair a caller meets on the only rejoin the class offers. `stop()` drops every subscription `subscribe` records and clears `inbox`; `start()` re-declares only the peer's own built-in topics, and the `(topic, callback)` pairs behind a user subscription are not retained anywhere, so a consumer that leaves and rejoins re-subscribes. If the mesh has not come back up, that re-subscribe answers `None` and says nothing - and `stop()` never said the subscription had gone in the first place.

Measured end to end against a live Zenoh session (`STRANDS_MESH_LOCAL_DEV=1`), one peer, one topic:

| phase | `upstream/main` | this branch |
| --- | --- | --- |
| join, subscribe, publish | `subscribe -> "state"`, 1 callback fire | identical |
| `stop()` | `Zenoh mesh session closed` / `off mesh` - **no mention of the subscription** | + `dropped 1 subscription(s) on leaving the mesh (state); re-declare after start()` |
| state after `stop()` | `user_subs=[]  inbox=[]` | identical |
| re-subscribe before the rejoin finishes | `None`, **0 log records** | `None`, `WARNING ... subscribe(strands/*/state) refused: peer is not on the mesh (start() first)` |
| rejoin + re-declare | `subscribe -> "state"`, 1 fire, `peer_id` kept, lockout still engaged (`last_estop_ts 1755900000.0`) | identical |

## Change

The two silent refusals now say why at WARNING, naming the topic and which refusal it was, so all three `None` returns report themselves. `stop()` reports at INFO how many subscriptions it dropped and their names, only when there were any - a rejoining caller is told what it has to re-declare rather than inferring it from an empty `_user_subs`.

`subscribe`'s docstring gains a `Returns:` block accounting for all three refusals and states that a subscription does not survive `stop()`; `stop`'s states what it drops and why `start()` cannot restore it. `docs/mesh.md` gains a **Rejoining the mesh** subsection saying the same thing to a consumer: what the round trip keeps (`peer_id`, an engaged lockout) and what it does not.

No behaviour changes. The accepted path, the pre-existing declare-failure WARNING, the `peer_id` and an engaged e-stop lockout are all unchanged across `stop()`, and each is a control test.

## Scope

A public `Mesh.reconnect()` verb is **not** in this PR, and measuring the round trip is why. Of what such a verb would have to guarantee, the peer identity and the safety lockout already survive `stop()`/`start()` unchanged, and presence resumes; the one thing that does not is the user's own subscriptions. Restoring those needs `subscribe` to retain the `(topic, callback)` pair it currently discards, and a default for whether a reconnect preserves or drops them - a new public surface plus a contract choice, not a report. Worth noting too that the raw-session consumers that hand-roll this dance today call `get_session()` / `release_session()` and declare their own subscribers directly, so a `Mesh`-level verb would not serve them; a session-level one is a separate question again.

What this PR does is make the existing round trip honest, which is the part that needs no decision.

## Tests

`tests/mesh/test_subscribe_publish_step_resilience.py` already pinned this surface - including the `None` *return* for two of the three refusal paths - and said nothing about the report, which is why the two that answered without a word were never noticed. Extended there rather than in a new file, so its ten existing cases are controls.

Pre-fix (this file on `upstream/main` source): **5 failed / 14 passed**, four of them behavioural -

```
subscribe answered None and said nothing
a re-subscribe after stop() answered None and said nothing
stop() discarded two subscriptions and said nothing
subscribe documents no return
```

Post-fix: 19 passed. Each break fires exactly and only its own guard:

| break | fires |
| --- | --- |
| control (unmodified) | 0 of 19 |
| revert `core.py` to `upstream/main` | all 5 |
| drop only the two `subscribe` reports | 3 (before start / after stop / no session) |
| drop only the `stop()` report | 1 |
| make the `stop()` report unconditional | 1 - the no-noise control |
| drop only the `Returns:` block | 1 |
| report at DEBUG instead of WARNING | 3 |

## Verification

Measured at `80e69b73`, base `58b9a793`. Head is now `fa7bbe6a`, which adds two test-only commits: the `subscribe()` calls hoisted out of their asserts (the call is the premise, and `python -O` strips an assert wholesale), and the stand-in session bound to a local as the three pre-existing cases in that file already do - `lambda: MagicMock()` was four `py/unnecessary-lambda` notes and the odd one out. `strands_robots/` is untouched by both; the pre-fix split and the break table re-measured unchanged at the new head.

- Gate: 234 files (all of `tests/mesh`, every test naming `subscribe` / `_user_subs` / `docs/mesh.md`, plus the repo-wide docs, changelog, ASCII, docstring-xref and dependency guards), the identical selection on both trees with the changed test file excluded from each: **`21 failed, 6162 passed, 8 skipped, 24 errors` byte-identical**, 45 failing ids each, `comm` empty in both directions. All 45 are `tests/mesh/test_iot_*` on `No module named 'awsiot'` (88 occurrences), a declared extra CI installs.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `upstream/main` worktree, none in the changed files.
- `ruff check` / `ruff format --check` clean over the CI scope.

## Artifact

The rejoin driven end to end against a live Zenoh session, once per tree - same script, same topic, same timings, only `strands_robots` differs. Every measured value is identical in the two columns; what changes is what the peer says.

![rejoin](https://raw.githubusercontent.com/cagataycali/robots/media-rejoin-refusals/rejoin.png)
