### PR TITLE
fix(sim): the empty-recording refusal names the loops that can record

### DIFF
--- a/changelog.d/2627-empty-recording-refusal-names-the-recording-loops.md
+++ b/changelog.d/2627-empty-recording-refusal-names-the-recording-loops.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **simulation/recording**: the empty-recording refusal now classifies each loop by
+  whether it takes an `on_frame` hook. `stop_recording` refuses a session that
+  captured nothing, and that refusal is the only thing a caller whose dataset came out
+  empty reads, but it was wrong in two opposite directions. It said frames "are written
+  only by `run_policy(...)`" and that "eval_policy / evaluate / replay_episode and bare
+  step loops do NOT feed the recorder" - denying a documented, working route, since
+  `eval_policy` and `evaluate_benchmark` both take an `on_frame` hook and
+  `eval_policy`'s own docstring recommends it for exactly this ("Use it to record
+  frames"). Measured, a hook calling `add_frame` over a 20-step eval writes 20 frames
+  and `stop_recording` then saves the episode. Meanwhile `teleoperate` - the apply loop
+  a caller recording a teleoperated demonstration reaches for, and the one that
+  genuinely has no such hook - was absent from the list entirely, so a caller who drove
+  30 leader frames into an open recording read a "does not feed" list that never
+  mentioned the loop they had just used. The old text also named `evaluate`, which is
+  not a method on the simulation surface. The refusal now names `run_policy` as the
+  loop that feeds the recorder on its own, `eval_policy` / `evaluate_benchmark` as the
+  ones that record when the caller passes a hook, and `replay_episode` / `teleoperate`
+  / bare `step` loops as the ones that cannot. No behaviour changes: the refusal fires
+  on the same condition and still carries the phrases its existing assertions pin. The
+  classification is derived from the signatures in the new guard rather than restated,
+  so an apply loop that gains an `on_frame` parameter fails until the refusal moves it.

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -650,11 +650,14 @@ class DatasetRecordingMixin:
                     {
                         "text": (
                             "stop_recording captured no frames - dataset would be empty "
-                            "(0 frames). Frames are written only by run_policy(...) while "
-                            "recording is active (its on_frame hook calls add_frame). "
-                            "eval_policy / evaluate / replay_episode and bare step loops do "
-                            "NOT feed the recorder. To record a dataset: start_recording -> "
-                            "run_policy (once per episode) -> stop_recording."
+                            "(0 frames). run_policy(...) feeds the recorder on its own: it "
+                            "installs the per-step on_frame hook that calls add_frame. "
+                            "eval_policy / evaluate_benchmark take an on_frame hook, so they "
+                            "record only when the caller passes one that calls add_frame. "
+                            "replay_episode, teleoperate and bare step loops have no such "
+                            "hook and cannot feed the recorder. To record a dataset: "
+                            "start_recording -> run_policy (once per episode) -> "
+                            "stop_recording."
                         )
                     }
                 ],

--- a/tests/simulation/mujoco/test_stop_recording_finalize.py
+++ b/tests/simulation/mujoco/test_stop_recording_finalize.py
@@ -288,9 +288,9 @@ class TestStopRecordingEmptyDataset:
     NOT fail a dataset that was filled via per-episode save_episode.
 
     Regression for the silent empty-dataset bug. A recording driven by a path
-    that never feeds the dataset recorder (eval_policy / evaluate /
-    replay_episode / a bare step loop - only run_policy's on_frame hook calls
-    add_frame) leaves the recorder with zero frames. Previously stop_recording
+    that never fed the dataset recorder (replay_episode, teleoperate or a bare
+    step loop - none of which takes an on_frame hook, while run_policy installs
+    one itself) leaves the recorder with zero frames. Previously stop_recording
     called save_episode unconditionally, discarded its error return, and
     reported success with "0 frames, 0 episode(s)", producing a dataset with
     only meta/info.json (no parquet/video).
@@ -311,7 +311,7 @@ class TestStopRecordingEmptyDataset:
         text = result["content"][0]["text"]
         assert "captured no frames" in text
         assert "0 frames" in text
-        # actionable guidance: point to the only path that records frames.
+        # actionable guidance: name the path that records frames on its own.
         assert "run_policy" in text
         # save_episode must NOT be called on the empty buffer.
         assert rec.calls == []

--- a/tests/simulation/test_empty_recording_refusal_classifies_the_loops.py
+++ b/tests/simulation/test_empty_recording_refusal_classifies_the_loops.py
@@ -1,0 +1,189 @@
+"""The empty-recording refusal classifies each loop by whether it takes a hook.
+
+``stop_recording`` refuses a session that captured nothing, and that refusal is
+the only thing a caller whose dataset came out empty reads. It therefore has to
+be right about *which* loops can fill a recording, and there are three kinds:
+
+* :meth:`~strands_robots.simulation.base.SimEngine.run_policy` feeds the
+  recorder on its own - it installs the per-step ``on_frame`` hook that calls
+  ``add_frame``, so a caller passes nothing.
+* :meth:`~strands_robots.simulation.base.SimEngine.eval_policy` and
+  :meth:`~strands_robots.simulation.base.SimEngine.evaluate_benchmark` *accept*
+  an ``on_frame`` hook. They record when the caller supplies one, and
+  ``eval_policy``'s own docstring recommends exactly that ("Use it to record
+  frames"). Measured: a hook calling ``add_frame`` over a 20-step eval writes 20
+  frames and ``stop_recording`` then saves the episode.
+* :meth:`~strands_robots.simulation.base.SimEngine.replay_episode`,
+  :meth:`~strands_robots.teleop_mixin.TeleopMixin.teleoperate` and a bare
+  ``step`` loop take no such hook, so nothing a caller does makes them record.
+
+The refusal used to say frames "are written only by ``run_policy``" and that
+"eval_policy / evaluate / replay_episode and bare step loops do NOT feed the
+recorder" - denying a route two of the named entry points do have, while
+omitting ``teleoperate``, the loop a caller recording a teleoperated
+demonstration reaches for and the one that genuinely cannot record.
+
+The classification is derived from the signatures rather than listed here, so
+the day an apply-loop gains an ``on_frame`` parameter this test fails until the
+refusal moves it out of the cannot-record sentence.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+
+import pytest
+
+from strands_robots.simulation import recording as _recording
+from strands_robots.simulation.base import SimEngine
+from strands_robots.teleop_mixin import TeleopMixin
+
+# Every loop the refusal speaks about, and where its signature lives. ``step``
+# stands for the "bare step loops" phrasing rather than a named method.
+_LOOPS: dict[str, type] = {
+    "run_policy": SimEngine,
+    "eval_policy": SimEngine,
+    "evaluate_benchmark": SimEngine,
+    "replay_episode": SimEngine,
+    "teleoperate": TeleopMixin,
+}
+
+# run_policy installs the recording hook itself, so it is not a caller-supplied
+# route even though it is the one entry point that always records.
+_SELF_FEEDING = "run_policy"
+
+
+def _takes_on_frame(name: str) -> bool:
+    owner = _LOOPS[name]
+    fn = getattr(owner, name, None)
+    if fn is None:  # pragma: no cover - guarded by the inventory test below
+        return False
+    return "on_frame" in inspect.signature(fn).parameters
+
+
+def _hook_bearing() -> set[str]:
+    """Loops a caller can make record by passing ``on_frame``."""
+    return {n for n in _LOOPS if n != _SELF_FEEDING and _takes_on_frame(n)}
+
+
+def _hookless() -> set[str]:
+    """Loops that cannot record however the caller calls them."""
+    return {n for n in _LOOPS if n != _SELF_FEEDING and not _takes_on_frame(n)}
+
+
+def _refusal_text() -> str:
+    """The empty-recording refusal, read from the source it is raised from.
+
+    Read as a literal rather than by driving ``stop_recording`` so the
+    classification is graded without a backend, a dataset stack or a GL context.
+    """
+    tree = ast.parse(inspect.getsource(_recording))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and "captured no frames" in node.value:
+            return " ".join(node.value.split())
+        # The message is assembled from adjacent string literals, which the
+        # parser folds into one JoinedStr/Constant only when it is not an
+        # f-string; handle the concatenated form too.
+        if isinstance(node, ast.BinOp):  # pragma: no cover - defensive
+            continue
+    raise AssertionError(f"no empty-recording refusal literal found in {_recording.__name__}")
+
+
+def _names(text: str) -> set[str]:
+    """Loop names the text mentions, matched as whole tokens.
+
+    A bare substring test would let ``eval_policy`` be answered by an unrelated
+    dotted path, so each name is bounded the way the rest of this suite bounds a
+    prose-graded identifier.
+    """
+    return {n for n in _LOOPS if re.search(rf"(?<![\w.]){re.escape(n)}(?![\w.])", text)}
+
+
+# The clause is located by what it *says* rather than by one phrasing, so this
+# grades any wording that denies a loop the ability to record. Keyed on a single
+# spelling it would only ever pass judgement on the sentence it was written
+# against, and a reworded refusal would read as having no such clause at all.
+_DENIAL_MARKERS = (
+    "cannot feed",
+    "cannot fill",
+    "do not feed",
+    "does not feed",
+    "never feed",
+    "no such hook",
+)
+
+
+def _cannot_sentence(text: str) -> str:
+    """The clause that says which loops cannot feed the recorder."""
+    lowered = text.lower()
+    for part in re.split(r"(?<=[.])\s+", text):
+        if any(m in part.lower() for m in _DENIAL_MARKERS):
+            return part
+    raise AssertionError(f"refusal names no clause denying a loop the ability to record: {lowered!r}")
+
+
+class TestTheRefusalIsRightAboutWhichLoopsCanRecord:
+    def test_no_hook_bearing_loop_is_called_unable_to_record(self) -> None:
+        """A loop that takes ``on_frame`` must not be listed as unable to feed.
+
+        This is the half that was wrong: the refusal told a caller whose dataset
+        was empty that ``eval_policy`` does not feed the recorder, while
+        ``eval_policy(on_frame=...)`` is a documented and measured way to fill
+        one - so the message denied the route it should have pointed at.
+        """
+        text = _refusal_text()
+        denied = _names(_cannot_sentence(text)) & _hook_bearing()
+        assert not denied, (
+            f"the refusal says {sorted(denied)} cannot feed the recorder, but each takes an "
+            f"on_frame hook a caller can use to record. Clause: {_cannot_sentence(text)!r}"
+        )
+
+    def test_every_hook_bearing_loop_is_named(self) -> None:
+        """The routes a caller *can* record through are worth naming."""
+        text = _refusal_text()
+        missing = _hook_bearing() - _names(text)
+        assert not missing, (
+            f"{sorted(missing)} accept an on_frame hook and can fill a recording, but the "
+            f"empty-recording refusal does not name them: {text!r}"
+        )
+
+    def test_every_hookless_loop_is_named_as_unable(self) -> None:
+        """Including ``teleoperate``, which the refusal used to omit entirely."""
+        text = _refusal_text()
+        clause = _cannot_sentence(text)
+        missing = _hookless() - _names(clause)
+        assert not missing, (
+            f"{sorted(missing)} take no on_frame hook, so no caller can make them record, but "
+            f"the refusal does not say so: {clause!r}"
+        )
+
+    def test_the_self_feeding_loop_is_still_the_headline_remedy(self) -> None:
+        """``run_policy`` records with no hook from the caller, so it leads."""
+        text = _refusal_text()
+        assert _SELF_FEEDING in _names(text), f"refusal no longer names {_SELF_FEEDING}: {text!r}"
+        assert not _takes_on_frame(_SELF_FEEDING), (
+            f"{_SELF_FEEDING} now takes an on_frame parameter, so it is a caller-supplied route "
+            "like eval_policy and this refusal's split needs revisiting"
+        )
+
+
+class TestTheScanFoundSomethingToGrade:
+    """Without these, every rule above passes over an empty set."""
+
+    def test_the_refusal_was_located(self) -> None:
+        text = _refusal_text()
+        assert "captured no frames" in text
+        assert "0 frames" in text
+
+    def test_both_groups_are_populated(self) -> None:
+        assert len(_hook_bearing()) >= 2, f"expected >=2 hook-bearing loops, got {sorted(_hook_bearing())}"
+        assert len(_hookless()) >= 2, f"expected >=2 hookless loops, got {sorted(_hookless())}"
+
+    @pytest.mark.parametrize("name", sorted(_LOOPS))
+    def test_every_graded_loop_still_exists(self, name: str) -> None:
+        assert getattr(_LOOPS[name], name, None) is not None, (
+            f"{name} is no longer a method of {_LOOPS[name].__name__}; the refusal's "
+            "classification is graded against it"
+        )


### PR DESCRIPTION
## The refusal this is about

`stop_recording` refuses a session that captured nothing. That refusal is the only
thing a caller whose dataset came out empty reads, so it has to be right about
*which* loops can fill a recording. On `main` it says:

```
stop_recording captured no frames - dataset would be empty (0 frames). Frames are
written only by run_policy(...) while recording is active (its on_frame hook calls
add_frame). eval_policy / evaluate / replay_episode and bare step loops do NOT feed
the recorder. To record a dataset: start_recording -> run_policy (once per episode)
-> stop_recording.
```

## What is wrong, measured

The message is wrong in two opposite directions. `eval_policy` and
`evaluate_benchmark` both take an `on_frame` hook, and `eval_policy`'s own docstring
recommends it for exactly this purpose ("Use it to record frames or stream telemetry
synchronously on the eval thread"). Meanwhile `teleoperate` -- the apply loop a caller
recording a teleoperated demonstration reaches for, and one that genuinely has no
hook -- is absent from the list entirely.

Measured on a MuJoCo `so101`, each with `start_recording` open and
`HF_LEROBOT_HOME` pointed at a scratch directory:

| entry point | takes `on_frame`? | the refusal said | measured |
| --- | --- | --- | --- |
| `run_policy` | no, installs its own | writes frames | 30 frames, 1 episode, `success` |
| `eval_policy` | **yes** | "do NOT feed the recorder" | **20 frames, 1 episode, `success`** |
| `evaluate_benchmark` | **yes** | not named at all | -- |
| `replay_episode` | no | "do NOT feed the recorder" | correct |
| bare `step` loops | no | "do NOT feed the recorder" | correct |
| `teleoperate` | no | **not named at all** | 30 frames applied, 0 recorded |

The `eval_policy` row is the one that costs a caller time: a hook of
`lambda step, obs, action: recorder.add_frame(obs, action, task=...)` over a 20-step
eval writes 20 frames and `stop_recording` then reports
`Episode saved to LeRobotDataset ... 20 frames, 1 episode(s)`. So the refusal denied
a documented, working route while naming only one remedy.

The `teleoperate` row is the omission: 30 leader frames reached `send_action`,
`teleoperate` reported `success` ("30 frames, 0 errors, 30.0Hz over 1.0s"), and the
recorder saw nothing -- which `stop_recording` correctly refuses, but with a
"does not feed" list that never mentions the loop the caller just used.

One smaller point: the old text names `evaluate`, which is not a method on the
simulation surface (`PolicyRunner.evaluate` is internal), so a caller cannot act on it.

## Change

`strands_robots/simulation/recording.py` -- the refusal now splits the loops the way
their signatures do:

- `run_policy` feeds the recorder on its own (it installs the per-step `on_frame`
  hook that calls `add_frame`), so it stays the headline remedy;
- `eval_policy` / `evaluate_benchmark` take an `on_frame` hook and record when the
  caller passes one;
- `replay_episode`, `teleoperate` and bare `step` loops have no such hook and cannot
  feed the recorder.

No behaviour changes: the refusal still fires on exactly the same condition, still
returns `status="error"`, and still contains `captured no frames`, `0 frames` and
`run_policy`, which are what the existing assertions pin.

`tests/simulation/mujoco/test_stop_recording_finalize.py` -- that suite's class
docstring and one comment restated the same inaccurate claim ("only run_policy's
on_frame hook calls add_frame", "the only path that records frames"), so they are
corrected alongside it. Its assertions are untouched.

`tests/simulation/test_empty_recording_refusal_classifies_the_loops.py` (new) --
grades the refusal against the signatures rather than against a restated list. The
hook-bearing and hookless groups are derived with `inspect.signature`, and the clause
that denies a loop the ability to record is located by what it says rather than by one
phrasing, so a reworded refusal is still graded. The day an apply loop gains an
`on_frame` parameter, this fails until the refusal moves it out of the cannot-record
sentence.

## Scope: what this does not do

This does not add a per-tick hook to `teleoperate`, which is the capability the
refusal's `teleoperate` row now names honestly. That is a public API decision rather
than a message correction, and one input to it is not uniform today: `TeleopMixin`
documents `send_action` as the only contract a host must satisfy, and while the
simulation hosts have `get_observation`, the hardware `Robot` does not -- it reads
through `bus_access.read_observation`. So where the observation in an
`(observation, action)` pair comes from in a host-agnostic mixin is a contract choice,
not an implementation detail, and it is left to a maintainer.

## Verification

Measured at `893066a1`.

Pre-fix split, this file copied onto `upstream/main`: **3 failed / 8 passed**, each
failure naming its own finding rather than a wording difference:

```
test_no_hook_bearing_loop_is_called_unable_to_record
  the refusal says ['eval_policy'] cannot feed the recorder, but each takes an
  on_frame hook a caller can use to record.
test_every_hook_bearing_loop_is_named
  ['evaluate_benchmark'] accept an on_frame hook and can fill a recording, but the
  empty-recording refusal does not name them
test_every_hookless_loop_is_named_as_unable
  ['teleoperate'] take no on_frame hook, so no caller can make them record, but the
  refusal does not say so
```

After: 11 passed. Each guard is load-bearing -- six breaks, each firing only its own:

| break | fires |
| --- | --- |
| the exact pre-fix message | all three semantic guards |
| `teleoperate` dropped from the cannot-clause | hookless-named only |
| `eval_policy` put back into the cannot-clause | no-hook-bearing-denied only |
| `evaluate_benchmark` never named | hook-bearing-named only |
| the derivation loses `run_policy` | the self-feeding pin only |
| nothing reads as hook-bearing | non-vacuity + hookless-named |
| control (restored) | 0 of 11 |

Gate: the identical 117-file selection (every test touching `start_recording` /
`stop_recording` / `on_frame` / `add_frame` / `teleoperate`, plus the repo-wide
docstring, string and changelog guards) run on this branch and on a pristine
`upstream/main` worktree, with the new file excluded from both:

| tree | result |
| --- | --- |
| this branch | 5 failed, 4859 passed in 265.59s |
| pristine `upstream/main` | 5 failed, 4859 passed in 265.62s |

Failing-ID sets identical, `comm` empty in both directions. The five are
pre-existing and not in this diff: four in
`tests/simulation/test_recording_frame_loss_is_not_tolerated.py`, which pass 29/29
when that file runs alone on the pristine tree (import-order dependent in a wide
selection), and `tests/training/test_lerobot_e2e.py::test_record_train_load_loop`,
which needs `draccus>=0.11.6` where this box resolves 0.10.0.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`.
`mypy` 24 errors on both this branch and the pristine base, none in the changed files.

No visual artifact: this changes the text of one refusal. The rollouts either side of
it are byte-identical, and the recorded dataset in the `run_policy` row above is the
round trip that shows the path it points at works.
