### PR TITLE
fix(hardware): a leader arm is named as a teleoperator, not listed among the followers

### DIFF
--- a/changelog.d/2628-leader-named-as-a-teleoperator.md
+++ b/changelog.d/2628-leader-named-as-a-teleoperator.md
@@ -1,0 +1,26 @@
+### Fixed: a leader arm is named as a teleoperator, not listed among the followers
+
+`Robot()`'s registry guard refuses an unregistered `*_leader` name and names
+`Teleoperator()` instead, deliberately without listing the registry - its own
+comment says a listing "invites the caller to retry with the follower name on the
+leader's port - the exact mistake that torque-enables the arm a human is holding".
+That guard sits behind `get_robot(canonical) is None and not has_hardware(canonical)`,
+so registering the leader arm makes it unreachable.
+
+Registering it is not misuse: `hardware={"lerobot_type": "so101_leader"}` is the
+honest registration for a leader arm, and it satisfies the invariant that a leader
+name may never name the follower it drives. The request fell through to lerobot's
+`RobotConfig` lookup instead, which answered `Unsupported robot type: 'so101_leader'.
+Known lerobot robot types: [...]` - sixteen names, every one a follower. That is the
+listing the first guard exists to remove, offered by the refusal a registered rig
+actually reaches. Following it and retrying with `so101_follower` on the leader's
+port builds an `SOFollowerRobotConfig` bound to the arm a human is holding.
+
+lerobot is not confused about the device: `so101_leader` is one of nine `*_leader`
+entries in `TeleoperatorConfig`. The refusal never asked the other registry. Both
+config sites now consult one shared rule first, so a name that is a device of the
+other kind is named as that kind together with the entry point that builds it -
+`Teleoperator(...)` for a leader handed to `Robot()`, and `Robot(...)` for a follower
+handed to `Teleoperator()`. Neither cross-kind refusal lists the choices of the kind
+that was asked for, because a caller whose name is a known device has not made a
+typo. A name neither registry knows is a typo, and keeps its listing unchanged.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -1079,6 +1079,17 @@ class Robot(TeleopMixin, AgentTool):
         try:
             ConfigClass = RobotConfig.get_choice_class(robot_type)
         except KeyError:
+            # A leader arm is a teleoperator, not a robot, and lerobot keeps the
+            # two in separate registries. Listing the robot types for a leader
+            # name is the retry that torque-enables the arm a human is holding,
+            # so name the kind it really is instead. ``Robot()``'s own registry
+            # guard does this for an unregistered ``*_leader`` name; a leader
+            # that IS registered -- as itself, which is the honest thing to
+            # register -- reaches this site instead.
+            from strands_robots.teleoperator import _other_lerobot_kind_refusal
+
+            if other := _other_lerobot_kind_refusal(robot_type, wanted="robot"):
+                raise ValueError(other) from None
             available = sorted(RobotConfig.get_known_choices().keys())
             # ``from None`` -- the KeyError is an internal detail of
             # lerobot's draccus registry; suppress the chained traceback

--- a/strands_robots/teleoperator.py
+++ b/strands_robots/teleoperator.py
@@ -144,6 +144,67 @@ def _ensure_lerobot_teleoperators_registered() -> None:
             logger.warning("[teleoperator] third-party plugin registration failed: %s", exc)
 
 
+def _other_lerobot_kind_refusal(requested: str, *, wanted: str) -> str | None:
+    """Name ``requested`` as the OTHER kind of lerobot device, or ``None``.
+
+    lerobot keeps two ChoiceRegistries: ``RobotConfig`` for the arm that is
+    driven and ``TeleoperatorConfig`` for the one a human holds. A leader and
+    the follower it drives carry the same servo bus and the same USB-serial
+    shape, so a request for one kind that names a device of the other kind is a
+    wrong entry point, not a typo -- and answering it with the names of the kind
+    it is not answers the wrong question. For ``Robot("so101_leader")`` that
+    list is every follower type, which is exactly the retry that torque-enables
+    the arm a human is holding; :func:`strands_robots.robot.Robot` already
+    refuses an unregistered ``*_leader`` name without listing the registry for
+    that reason, and this is the same refusal for a name lerobot knows.
+
+    Args:
+        requested: The device type string the caller asked to build.
+        wanted: The kind the caller asked for -- ``"robot"`` or
+            ``"teleoperator"``.
+
+    Returns:
+        A refusal naming the kind ``requested`` really is and the entry point
+        that builds it, or ``None`` when the other registry does not know
+        ``requested`` either. ``None`` means the name is genuinely unknown, so
+        the caller keeps its own listing of the kind that was asked for.
+
+    Raises:
+        ValueError: If ``wanted`` is neither ``"robot"`` nor
+            ``"teleoperator"``.
+    """
+    if wanted == "robot":
+        from lerobot.teleoperators.config import TeleoperatorConfig
+
+        _ensure_lerobot_teleoperators_registered()
+        if requested not in TeleoperatorConfig.get_known_choices():
+            return None
+        return (
+            f"Unsupported robot type: {requested!r}. That is a lerobot teleoperator "
+            f"(leader) device, not a robot: build it with "
+            f"``Teleoperator({requested!r}, port=...)`` and attach it to the follower "
+            f"it drives. Passing a leader to ``Robot()`` would drive the arm a human "
+            f"is holding as a position servo."
+        )
+    if wanted == "teleoperator":
+        from lerobot.robots.config import RobotConfig
+
+        # Imported here, not at module scope: this module is deliberately
+        # stdlib-only so it stays import-safe, and the robot registry is only
+        # needed on a refusal path.
+        from strands_robots.hardware_robot import _ensure_lerobot_robots_registered
+
+        _ensure_lerobot_robots_registered()
+        if requested not in RobotConfig.get_known_choices():
+            return None
+        return (
+            f"Unsupported teleoperator type: {requested!r}. That is a lerobot robot "
+            f"(follower) device, not a teleoperator: build it with "
+            f"``Robot({requested!r}, mode='real', port=...)``."
+        )
+    raise ValueError(f"wanted must be 'robot' or 'teleoperator', got {wanted!r}")
+
+
 def _build_teleop_config(teleop_type: str, **kwargs: Any) -> Any:
     """Resolve + construct a lerobot ``TeleoperatorConfig`` for ``teleop_type``.
 
@@ -161,6 +222,8 @@ def _build_teleop_config(teleop_type: str, **kwargs: Any) -> Any:
     try:
         ConfigClass = TeleoperatorConfig.get_choice_class(teleop_type)
     except KeyError:
+        if other := _other_lerobot_kind_refusal(teleop_type, wanted="teleoperator"):
+            raise ValueError(other) from None
         available = sorted(TeleoperatorConfig.get_known_choices().keys())
         raise ValueError(
             f"Unsupported teleoperator type: {teleop_type!r}. Known lerobot teleoperator types: {available}"

--- a/tests/test_leader_arm_is_not_a_robot.py
+++ b/tests/test_leader_arm_is_not_a_robot.py
@@ -6,11 +6,23 @@
 SO101Follower driver on the leader's motor bus - torque-enabling the arm a
 human is holding and turning it into a rigid position servo. These tests pin
 the refusal and the registry invariant behind it.
+
+That refusal is reachable only while the leader name is *unregistered*: it sits
+behind ``get_robot(canonical) is None and not has_hardware(canonical)``. An
+operator who registers their leader arm -- as itself, with
+``hardware.lerobot_type="so101_leader"``, which is the honest thing to register
+and satisfies the invariant above -- makes it unreachable, and the request fell
+through to lerobot's ``RobotConfig`` lookup instead. That answered
+``Unsupported robot type: 'so101_leader'. Known lerobot robot types: [...]``,
+whose list is every follower type: the retry this refusal exists to remove.
+lerobot knows ``so101_leader`` perfectly well -- as a *teleoperator* -- so the
+deeper site names the kind it really is, in both directions.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -114,3 +126,196 @@ def test_an_unknown_non_leader_name_keeps_the_registry_listing(monkeypatch: pyte
 
     with pytest.raises(ValueError, match="Unknown robot 'so101_leaderr'"):
         Robot("so101_leaderr", mode="sim")
+
+
+# --- The deeper site: a name lerobot knows, as the other kind of device -------
+#
+# ``Robot()``'s registry guard above only sees an UNREGISTERED ``*_leader``
+# name. These pin the refusal a registered leader actually receives, and the
+# mirror-image refusal on the teleoperator side.
+
+
+LEROBOT_LEADERS = [
+    "so100_leader",
+    "so101_leader",
+    "koch_leader",
+    "bi_so_leader",
+]
+
+LEROBOT_FOLLOWERS = [
+    "so100_follower",
+    "so101_follower",
+    "koch_follower",
+]
+
+
+@pytest.fixture
+def isolated_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Point the user registry + asset paths at temp dirs.
+
+    Mirrors ``tests/registry/conftest.py``'s autouse fixture so registering a
+    probe robot here cannot touch the developer's ``~/.strands_robots``.
+    """
+    from strands_robots.registry.user_registry import _invalidate_cache
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    monkeypatch.setenv("STRANDS_BASE_DIR", str(tmp_path))
+    monkeypatch.setenv("STRANDS_ASSETS_DIR", str(assets))
+    _invalidate_cache()
+    yield assets
+    _invalidate_cache()
+
+
+def _register_leader(assets: Path, name: str, lerobot_type: str) -> None:
+    """Register ``name`` as the leader device it is, the way an operator would."""
+    from strands_robots.registry import register_robot
+
+    model = assets / name / "so101"
+    model.mkdir(parents=True, exist_ok=True)
+    (model / "so101.xml").write_text(
+        '<mujoco model="stub"><worldbody><body name="link">'
+        '<joint name="j1" type="hinge" axis="0 0 1"/>'
+        '<geom type="capsule" size="0.02 0.1"/></body></worldbody></mujoco>'
+    )
+    register_robot(
+        name=name,
+        model_xml="so101/so101.xml",
+        description="SO-101 leader arm on this rig",
+        category="arm",
+        joints=6,
+        hardware={"lerobot_type": lerobot_type, "port": "/dev/ttyACM0"},
+        overwrite=True,
+    )
+
+
+def test_a_registered_leader_is_named_as_a_teleoperator(isolated_registry: Path) -> None:
+    """The reachability half: registering the leader must not lose the refusal.
+
+    ``Robot()``'s registry guard cannot fire once the name is registered, so
+    this is the path a real rig takes. It has to arrive at the same verdict.
+    """
+    _register_leader(isolated_registry, "probe_rig_leader", "so101_leader")
+
+    with pytest.raises(ValueError) as exc:
+        Robot("probe_rig_leader", mode="real")
+
+    msg = str(exc.value)
+    assert "teleoperator" in msg, msg
+    assert "Teleoperator('so101_leader', port=...)" in msg, msg
+    assert "drive the arm a human is holding" in msg, msg
+
+
+def test_the_registered_leader_refusal_never_offers_the_follower_types(
+    isolated_registry: Path,
+) -> None:
+    """The safety half, and the whole reason this refusal is special.
+
+    A list of robot types is a list of followers, and retrying with one of them
+    on the leader's port is the mistake being prevented. A caller whose name IS
+    a known teleoperator has not made a typo, so there is nothing a listing
+    could usefully offer.
+    """
+    _register_leader(isolated_registry, "probe_rig_leader", "so101_leader")
+
+    with pytest.raises(ValueError) as exc:
+        Robot("probe_rig_leader", mode="real")
+
+    msg = str(exc.value)
+    assert "Known lerobot robot types" not in msg, msg
+    assert "so101_follower" not in msg, msg
+
+
+@pytest.mark.parametrize("leader", LEROBOT_LEADERS)
+def test_every_lerobot_leader_type_is_refused_as_a_teleoperator(leader: str) -> None:
+    """Not just ``so101_leader``: every leader lerobot ships behaves the same.
+
+    Driven at the config site so the assertion is about the refusal rather than
+    about any one registry entry.
+    """
+    pytest.importorskip("lerobot")
+    inst = hardware_robot.Robot.__new__(hardware_robot.Robot)
+
+    with pytest.raises(ValueError) as exc:
+        inst._create_minimal_config(leader, None)
+
+    msg = str(exc.value)
+    assert "teleoperator" in msg, msg
+    assert f"Teleoperator({leader!r}, port=...)" in msg, msg
+    assert "Known lerobot robot types" not in msg, msg
+
+
+@pytest.mark.parametrize("follower", LEROBOT_FOLLOWERS)
+def test_a_follower_handed_to_teleoperator_is_named_as_a_robot(follower: str) -> None:
+    """The mirror image: the other entry point is equally blind on its own.
+
+    Not a safety case -- driving a follower is the normal thing -- but the same
+    wrong-entry-point answer, so it gets the same treatment.
+    """
+    pytest.importorskip("lerobot")
+    from strands_robots.teleoperator import _build_teleop_config
+
+    with pytest.raises(ValueError) as exc:
+        _build_teleop_config(follower, port="/dev/null")
+
+    msg = str(exc.value)
+    assert "robot" in msg, msg
+    assert f"Robot({follower!r}, mode='real', port=...)" in msg, msg
+    assert "Known lerobot teleoperator types" not in msg, msg
+
+
+def test_an_unknown_robot_type_keeps_its_listing() -> None:
+    """Control: a genuinely unknown name is a typo, and a listing helps.
+
+    Fails if the cross-kind branch widens into every refusal.
+    """
+    pytest.importorskip("lerobot")
+    inst = hardware_robot.Robot.__new__(hardware_robot.Robot)
+
+    with pytest.raises(ValueError) as exc:
+        inst._create_minimal_config("not_a_real_robot", None)
+
+    msg = str(exc.value)
+    assert "Unsupported robot type: 'not_a_real_robot'" in msg, msg
+    assert "Known lerobot robot types" in msg, msg
+    assert "teleoperator" not in msg, msg
+
+
+def test_an_unknown_teleoperator_type_keeps_its_listing() -> None:
+    """Control: the same, on the teleoperator side."""
+    pytest.importorskip("lerobot")
+    from strands_robots.teleoperator import _build_teleop_config
+
+    with pytest.raises(ValueError) as exc:
+        _build_teleop_config("not_a_real_teleoperator", port="/dev/null")
+
+    msg = str(exc.value)
+    assert "Unsupported teleoperator type: 'not_a_real_teleoperator'" in msg, msg
+    assert "Known lerobot teleoperator types" in msg, msg
+
+
+def test_a_follower_type_still_builds_a_config() -> None:
+    """Control: the accepted path is untouched -- only refusals changed."""
+    pytest.importorskip("lerobot")
+    inst = hardware_robot.Robot.__new__(hardware_robot.Robot)
+    # The accepted path reads ``tool_name_str`` to namespace lerobot's
+    # calibration files; the refusal path above never gets that far.
+    inst.tool_name_str = "probe"
+
+    config = inst._create_minimal_config("so101_follower", None, port="/dev/null")
+
+    assert config.port == "/dev/null"
+    assert config.id == "probe"
+
+
+def test_the_rule_refuses_a_kind_it_does_not_know() -> None:
+    """A ``wanted`` that names neither kind is a caller error, not a silent None.
+
+    The helper answers a question about two registries; asked about a third it
+    has no honest answer, so it says so rather than reporting "not the other
+    kind".
+    """
+    from strands_robots.teleoperator import _other_lerobot_kind_refusal
+
+    with pytest.raises(ValueError, match="wanted must be 'robot' or 'teleoperator'"):
+        _other_lerobot_kind_refusal("so101_leader", wanted="gripper")


### PR DESCRIPTION
## Problem

`Robot()`'s registry guard refuses an **unregistered** `*_leader` name and names `Teleoperator()` instead, deliberately *without* listing the registry. Its own comment says why:

> Answering it with the generic registry listing invites the caller to retry with the follower name on the leader's port - the exact mistake that torque-enables the arm a human is holding.

That guard sits behind `get_robot(canonical) is None and not (has_sim(canonical) or has_hardware(canonical)) and not is_discoverable(canonical)`. Registering the leader arm makes every one of those false, so the guard cannot fire.

Registering it is not misuse. `hardware={"lerobot_type": "so101_leader", ...}` is the honest registration for a leader arm, and it satisfies `tests/test_leader_arm_is_not_a_robot.py::test_no_leader_name_resolves_to_a_follower_entry` (a leader name may name a leader device; only naming the *follower* it drives is forbidden). Measured on a registered SO-101 leader:

```
Robot('so101_rig_leader', mode='real')
ValueError: Unsupported robot type: 'so101_leader'. Known lerobot robot types:
  ['bi_openarm_follower', 'bi_rebot_b601_follower', 'bi_so_follower',
   'earthrover_mini_plus', 'hope_jr_arm', 'hope_jr_hand', 'koch_follower',
   'lekiwi', 'lekiwi_client', 'omx_follower', 'openarm_follower', 'reachy2',
   'rebot_b601_follower', 'so100_follower', 'so101_follower', 'unitree_g1']
```

All 16 names are followers. That is the listing the first guard exists to remove, offered by the refusal a real rig actually reaches.

lerobot is not confused about the device: `so101_leader` is one of 9 `*_leader` entries in `TeleoperatorConfig.get_known_choices()` (20 choices). The refusal simply never asked the other registry.

## Consequence

Following each refusal to the driver it directs the caller to build, for the same registered leader on the same physical port:

| tree | offers | a caller who follows it builds | on the leader's port |
|---|---|---|---|
| `upstream/main` | the 16 robot types | `SOFollowerRobotConfig` | torque-drives it |
| this branch | `Teleoperator('so101_leader', port=...)` | `SOLeaderTeleopConfig` | reads it |

## Change

`teleoperator._other_lerobot_kind_refusal(requested, *, wanted=)` is the one owner of the rule: lerobot keeps robots and teleoperators in two `ChoiceRegistries`, a leader and its follower share a servo bus and a USB-serial shape, so a request naming a device of the other kind is a **wrong entry point, not a typo** -  and the names of the kind it is not answer the wrong question. Both refusal sites consult it before listing their own choices:

- `hardware_robot._create_minimal_config` -  a known teleoperator is named as one, pointing at `Teleoperator(...)`, and no robot types are listed (matching the decision `Robot()`'s guard already made).
- `teleoperator._build_teleop_config` -  the mirror image: a known robot is named as one, pointing at `Robot(...)`. Not a safety case (driving a follower is the normal thing) but the same wrong-entry-point answer, so it gets the same treatment.

A name neither registry knows is a genuine typo, and it keeps its listing byte-identical. `wanted` outside `{"robot", "teleoperator"}` raises rather than reporting "not the other kind".

The helper is private and lives in `teleoperator.py` because that module is stdlib-only at import scope; the robot registry is reached by a function-scope import, on a refusal path only. No public surface changes; no accepted call changes.

## Tests

`tests/test_leader_arm_is_not_a_robot.py` is the existing home for this contract -  its module docstring already states the harm -  so the reachability half is pinned beside the registry invariant it slips past. Pre-fix, with the file copied onto `upstream/main`: **10 failed / 21 passed**, 9 of them behavioural (each failure prints the follower list). Post-fix **31 passed**.

The 21 that pass on both trees are the controls, and each fails for a specific wrong fix: an unknown robot type keeps its listing (fails if the cross-kind branch widens into every refusal); an unknown teleoperator type keeps its listing; a valid follower type still builds a config with its `id` intact (the accepted path is untouched); and the pre-existing unregistered-leader and registry-invariant tests are unchanged.

## Verification

Measured at `2ad1abd6` on Linux/py3.12, lerobot 0.6.2.

- **Gate** -  65 test files (every test naming the changed symbols, the hardware/teleoperator/registry suites, and the repo-wide docstring/string/changelog guards), the identical selection run on this branch and on a pristine `upstream/main` worktree with the changed test file excluded from both: **2463 passed, 1 skipped, 0 failed on each**, failing-ID sets identical, 81.1s vs 82.4s.
- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`.
- `mypy strands_robots tests tests_integ`: **24 errors on this branch and 24 on pristine `upstream/main`**, branch-only set empty, none in the changed files.

## Scope

Issue context: this is the name-based half. A physics-based check (reading each servo's `Present_Voltage` to tell a 7.4V leader pack from a 12V follower supply) is a separate change with open contract questions -  whether a probe given a port string may share a bus with a live robot, and what a voltage verdict's schema is -  so it is deliberately not here.

![leader arm named as a teleoperator](https://raw.githubusercontent.com/cagataycali/robots/media-leader-kind/leader_kind.png)
