### PR TITLE
fix(hardware): the health probe names which camera is down

### DIFF
--- a/changelog.d/2629-health-probe-names-the-camera.md
+++ b/changelog.d/2629-health-probe-names-the-camera.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **`Robot.get_status()` now reports each camera's own connection reading, so an unhealthy arm names
+  which stream is down.**
+  The probe's `cameras` field was built from `robot.config.cameras` -- the camera names the device was
+  asked for -- while the measured reading sat one attribute away on `robot.cameras[name].is_connected`.
+  Because `is_connected` on a lerobot arm is `bus and all(cameras)`, it collapses N+1 independent facts
+  into one boolean, and with only the configured enumeration beside it four physically distinct faults
+  produced one identical report: a single dropped camera, every camera dropped, the motor bus down, and
+  a camera whose probe raises all answered `is_connected=False` with the same `cameras` list. A new
+  `cameras_connected` maps each live camera to its own reading, so a camera reading `False` is the
+  culprit and every camera reading `True` leaves the motor bus as the one by elimination. `cameras`
+  keeps answering which streams the device is configured for, unfiltered, so the difference between the
+  two names exactly the cameras whose state could not be read: a camera whose probe raises is omitted
+  rather than reported as `False` -- which would claim a measurement the device never made -- mirroring
+  the observation path, and the rest of the status still arrives.

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -2655,17 +2655,64 @@ class Robot(TeleopMixin, AgentTool):
             pass  # Ignore errors in destructor
 
     async def get_status(self) -> dict[str, Any]:
-        """Get robot status including connection and task state."""
+        """Report the device's measured state plus this robot's task state.
+
+        Two fields answer different questions about cameras, and the pair is
+        what makes an unhealthy device attributable:
+
+        * ``cameras`` enumerates the camera names the device is *configured*
+          for - which image streams exist at all.
+        * ``cameras_connected`` maps each live camera to its own
+          ``is_connected`` reading - which of those streams are actually up.
+
+        ``is_connected`` on a lerobot arm is ``bus and all(cameras)``, so a
+        single dropped camera pulls it to ``False`` without naming which of the
+        N+1 facts fell. Reported beside the per-camera readings, a ``False``
+        becomes attributable: a camera reading ``False`` is the culprit, and
+        every camera reading ``True`` leaves the motor bus as the one by
+        elimination.
+
+        Best-effort per camera, mirroring the observation path: a camera whose
+        ``is_connected`` probe raises is omitted from ``cameras_connected``
+        rather than failing the whole probe, so a name present in ``cameras``
+        and absent from ``cameras_connected`` is one whose state could not be
+        read. A device exposing no live camera objects reports an empty map.
+
+        Returns:
+            Status dict of measured facts. An unexpected failure anywhere in
+            the probe degrades to ``{"robot_name", "error", "is_connected":
+            False, "task_status": "error"}`` rather than propagating, so a
+            supervising agent reads a verdict instead of taking an exception.
+        """
         try:
             # Get robot connection status
             is_connected = self.robot.is_connected if hasattr(self.robot, "is_connected") else False
             is_calibrated = self.robot.is_calibrated if hasattr(self.robot, "is_calibrated") else True
 
-            # Get camera status
+            # The configured enumeration: which image streams the device was
+            # asked for. Says nothing about whether any of them came up.
             camera_status = []
             if hasattr(self.robot, "config") and hasattr(self.robot.config, "cameras"):
                 for name in self.robot.config.cameras.keys():
                     camera_status.append(name)
+
+            # The measured reading, one entry per live camera. The camera
+            # objects hang off the device beside the config, and each carries
+            # the ``is_connected`` that the device's own aggregate is built
+            # from - so reading them here is what turns an aggregate ``False``
+            # into a named culprit instead of a set to guess from.
+            cameras_connected: dict[str, bool] = {}
+            live_cameras = getattr(self.robot, "cameras", None)
+            if isinstance(live_cameras, dict):
+                for name, camera in live_cameras.items():
+                    try:
+                        cameras_connected[name] = bool(camera.is_connected)
+                    except Exception as e:  # noqa: BLE001 - a camera that cannot answer is omitted, not fatal
+                        # Breadth is the camera backend's, not ours: the default
+                        # OpenCV camera answers through ``cv2.VideoCapture``, and
+                        # ``cv2.error`` subclasses ``Exception`` directly, so any
+                        # narrower tuple would let the shipped camera through.
+                        logger.debug("camera %r on %s could not report is_connected: %s", name, self.tool_name_str, e)
 
             # Build status dict
             status_data = {
@@ -2676,6 +2723,7 @@ class Robot(TeleopMixin, AgentTool):
                 "is_connected": is_connected,
                 "is_calibrated": is_calibrated,
                 "cameras": camera_status,
+                "cameras_connected": cameras_connected,
                 "ros2_bridge": bool(getattr(self, "_ros_bridge", None) is not None),
                 "ros2_transport": getattr(self, "_ros2_transport", "rclpy")
                 if getattr(self, "_ros_bridge", None) is not None

--- a/tests/test_hardware_robot_lifecycle.py
+++ b/tests/test_hardware_robot_lifecycle.py
@@ -785,6 +785,207 @@ class TestStatusSurface:
 
 
 # ---------------------------------------------------------------------------
+# Camera health: which stream is down, not just that something is
+# ---------------------------------------------------------------------------
+
+
+class _Cam:
+    """Stand-in for a lerobot ``Camera``; only ``is_connected`` is read here."""
+
+    def __init__(self, connected: bool) -> None:
+        self._connected = connected
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+
+class _CamThatCannotAnswer:
+    """A camera whose probe raises, the way a yanked USB device can.
+
+    ``OpenCVCamera.is_connected`` answers through ``cv2.VideoCapture.isOpened()``,
+    and ``cv2.error`` subclasses ``Exception`` directly, so a real backend can
+    raise something outside the usual attribute/value families.
+    """
+
+    @property
+    def is_connected(self) -> bool:
+        raise RuntimeError("VIDIOC_QUERYCAP: Inappropriate ioctl for device")
+
+
+class _ArmWithCameras:
+    """Mirrors a lerobot SO-arm: ``is_connected`` is ``bus and all(cameras)``.
+
+    The live camera objects hang off ``cameras`` and the requested ones off
+    ``config.cameras``, which is the split the status probe reads.
+    """
+
+    name = "so101_follower"
+    robot_type = "so101_follower"
+
+    def __init__(self, cameras: dict[str, Any], *, bus_connected: bool = True) -> None:
+        self.cameras = dict(cameras)
+        self.config = types.SimpleNamespace(cameras={name: object() for name in cameras})
+        self._bus_connected = bus_connected
+
+    @property
+    def is_connected(self) -> bool:
+        try:
+            cameras_up = all(cam.is_connected for cam in self.cameras.values())
+        except Exception:  # noqa: BLE001 - the device aggregate is fail-closed too
+            cameras_up = False
+        return self._bus_connected and cameras_up
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def __str__(self) -> str:
+        return "SOFollower(so101)"
+
+
+def _status_of(arm: Any) -> dict[str, Any]:
+    hw = _make_robot()
+    hw.robot = arm
+    try:
+        return asyncio.run(hw.get_status())
+    finally:
+        hw.cleanup()
+
+
+class TestCameraHealthIsAttributable:
+    """``get_status`` is the operator's health probe, so an unhealthy device
+    must say *which* fact fell.
+
+    ``is_connected`` on a lerobot arm is ``bus and all(cameras)``: it collapses
+    N+1 independent facts into one boolean. ``cameras`` answers a different
+    question - which streams the device was configured for - so on its own it
+    is identical whether every camera is streaming or every one is dead. These
+    pin the per-camera readings that make the aggregate attributable.
+    """
+
+    def test_each_live_camera_reports_its_own_measured_connection(self):
+        """A dropped camera is named, not merely counted.
+
+        The device is configured for two cameras and one of them is down. The
+        probe must report each camera's own ``is_connected`` reading, so the
+        operator learns it is ``front_cam`` rather than "something in this set".
+        """
+        status = _status_of(_ArmWithCameras({"wrist_cam": _Cam(True), "front_cam": _Cam(False)}))
+        assert status["is_connected"] is False
+        readings = status.get("cameras_connected")
+        if readings is None:
+            pytest.fail(
+                "the health probe answered is_connected=False with cameras="
+                f"{status['cameras']} and no per-camera reading, so which of the "
+                "motor bus and the two cameras fell is not in the report"
+            )
+        assert readings == {"wrist_cam": True, "front_cam": False}
+
+    def test_a_partial_camera_failure_is_distinguishable_from_a_total_one(self):
+        """One camera down and both cameras down are different faults.
+
+        Both pull the device aggregate to ``False`` and both leave the
+        configured enumeration untouched, so without the per-camera readings
+        the two reports are identical.
+        """
+        partial = _status_of(_ArmWithCameras({"wrist_cam": _Cam(True), "front_cam": _Cam(False)}))
+        total = _status_of(_ArmWithCameras({"wrist_cam": _Cam(False), "front_cam": _Cam(False)}))
+
+        # The two facts that cannot tell them apart, pinned so the reason the
+        # per-camera map is needed stays visible.
+        assert partial["is_connected"] == total["is_connected"] is False
+        assert partial["cameras"] == total["cameras"]
+
+        if partial.get("cameras_connected") == total.get("cameras_connected"):
+            pytest.fail(
+                "one dropped camera and two dropped cameras produce the same report: "
+                f"is_connected={partial['is_connected']}, cameras={partial['cameras']}, "
+                f"cameras_connected={partial.get('cameras_connected')!r}"
+            )
+        assert partial["cameras_connected"] == {"wrist_cam": True, "front_cam": False}
+        assert total["cameras_connected"] == {"wrist_cam": False, "front_cam": False}
+
+    def test_every_camera_up_leaves_the_motor_bus_as_the_only_culprit(self):
+        """A ``False`` aggregate with every camera reading ``True`` isolates the bus.
+
+        The probe has no direct reading for the motor bus, so the per-camera
+        readings are what turn "one of bus-plus-two-cameras fell" into "the bus
+        fell" by elimination.
+        """
+        status = _status_of(_ArmWithCameras({"wrist_cam": _Cam(True), "front_cam": _Cam(True)}, bus_connected=False))
+        assert status["is_connected"] is False
+        assert status["cameras_connected"] == {"wrist_cam": True, "front_cam": True}
+
+    def test_a_camera_that_cannot_answer_is_omitted_rather_than_guessed(self):
+        """An unreadable probe is absent from the map, not reported as ``False``.
+
+        Reporting ``False`` would claim a measurement the device never made and
+        make an unreadable camera indistinguishable from a disconnected one.
+        Omitting it mirrors the observation path, where a camera that cannot
+        answer is left out rather than failing the whole read; the name is still
+        in ``cameras``, so the difference between the two sets is exactly the
+        cameras whose state could not be read.
+        """
+        status = _status_of(_ArmWithCameras({"wrist_cam": _Cam(True), "front_cam": _CamThatCannotAnswer()}))
+        assert status["cameras_connected"] == {"wrist_cam": True}
+        assert "front_cam" not in status["cameras_connected"]
+        assert set(status["cameras"]) - set(status["cameras_connected"]) == {"front_cam"}
+
+    def test_a_device_with_no_live_camera_objects_reports_an_empty_map(self):
+        """An arm with no cameras reports an empty map, not a missing field.
+
+        A caller reading ``cameras_connected`` must not have to distinguish
+        "this arm has no cameras" from "this build does not report them".
+        """
+        status = _status_of(_ArmWithCameras({}))
+        assert status["cameras"] == []
+        assert status["cameras_connected"] == {}
+
+    # -- the probe's existing guarantees, which the per-camera reads must keep --
+
+    def test_the_probe_survives_a_camera_that_cannot_answer(self):
+        """A raising camera must not blank the health probe.
+
+        The fail-soft contract is that a device read which raises degrades to a
+        structured error rather than propagating; a *per-camera* failure is
+        narrower still and must not cost the caller the rest of the status.
+        """
+        status = _status_of(_ArmWithCameras({"wrist_cam": _Cam(True), "front_cam": _CamThatCannotAnswer()}))
+        assert "error" not in status
+        assert status["task_status"] == "idle"
+        assert status["robot_name"] == "test_arm"
+        assert status["robot_type"] == "so101_follower"
+
+    def test_the_configured_enumeration_still_names_every_camera(self):
+        """``cameras`` keeps answering "which streams exist", unfiltered.
+
+        It must not become a health field: a camera that is down, or one whose
+        state could not be read, is still a stream the device is configured
+        for, and filtering it out would lose the set difference that identifies
+        the unreadable ones.
+        """
+        status = _status_of(
+            _ArmWithCameras({"wrist_cam": _Cam(False), "front_cam": _CamThatCannotAnswer(), "top_cam": _Cam(True)})
+        )
+        assert status["cameras"] == ["wrist_cam", "front_cam", "top_cam"]
+
+    def test_a_device_whose_cameras_attribute_is_not_a_mapping_is_left_alone(self):
+        """A non-mapping ``cameras`` attribute yields an empty map, not an error.
+
+        ``Robot`` wraps whatever lerobot hands it, and the health probe must not
+        be the thing that breaks on an unfamiliar shape: the rest of the status
+        still has to arrive.
+        """
+        arm = _ArmWithCameras({})
+        arm.cameras = ["wrist_cam", "front_cam"]  # type: ignore[assignment]
+        status = _status_of(arm)
+        assert "error" not in status
+        assert status["cameras_connected"] == {}
+        assert status["task_status"] == "idle"
+
+
+# ---------------------------------------------------------------------------
 # Robot construction: input validation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`Robot.get_status()` is the operator's health probe -- the module's own test says so ("`get_status` is the operator's health probe; a raising serial/USB backend must never propagate out of it"). Every field in it is a fact read off the device at call time, except one. `cameras` was built from `robot.config.cameras` -- the names the device was *asked* for -- while the measured reading sat one attribute away, on `robot.cameras[name].is_connected`.

That matters because of what `is_connected` is on a lerobot arm:

```python
# lerobot src/lerobot/robots/so_follower/so_follower.py:89
return self.bus.is_connected and all(cam.is_connected for cam in self.cameras.values())
```

It collapses N+1 independent facts into one boolean, and 15 lerobot robot classes build it that way. With only the configured enumeration beside it, four physically distinct faults produced **one identical report**. Measured by driving `get_status()` on a two-camera arm shaped like `SOFollower`:

| fault | `is_connected` | `cameras` | `cameras_connected` (before) |
| --- | --- | --- | --- |
| `front_cam` dropped | `False` | `['wrist_cam', 'front_cam']` | field absent |
| both cameras dropped | `False` | `['wrist_cam', 'front_cam']` | field absent |
| motor bus down, cameras fine | `False` | `['wrist_cam', 'front_cam']` | field absent |
| `front_cam` probe raises | `False` | `['wrist_cam', 'front_cam']` | field absent |

**4 distinct faults, 1 distinct report.** An operator reading it learns that something in the set fell, and the field that enumerates the set answers a different question, so it is byte-identical whether every camera is streaming or every one is dead.

## Change

Report each live camera's own `is_connected` reading under `cameras_connected`. After: **4 faults, 4 reports.**

| fault | `is_connected` | `cameras_connected` (after) |
| --- | --- | --- |
| `front_cam` dropped | `False` | `{'wrist_cam': True, 'front_cam': False}` |
| both cameras dropped | `False` | `{'wrist_cam': False, 'front_cam': False}` |
| motor bus down, cameras fine | `False` | `{'wrist_cam': True, 'front_cam': True}` |
| `front_cam` probe raises | `False` | `{'wrist_cam': True}` |

Row 3 is the one worth noting: the probe has no direct reading for the motor bus, so every camera reading `True` under a `False` aggregate isolates the bus by elimination.

Three deliberate boundaries:

- **`cameras` is unchanged, and unfiltered.** It keeps answering "which streams exist" -- a camera that is down is still a stream the device is configured for. The existing `test_get_status_lists_the_devices_configured_cameras` passes untouched, and filtering it would destroy the set difference below.
- **A camera whose probe raises is omitted, not reported as `False`.** Reporting `False` would claim a measurement the device never made and make an unreadable camera indistinguishable from a disconnected one. Omission mirrors the observation path, which already says "a camera whose RTX product hasn't warmed up is omitted rather than failing the whole observation". Because `cameras` stays unfiltered, `set(cameras) - set(cameras_connected)` is exactly the cameras whose state could not be read.
- **The per-camera probe is guarded per camera**, so one bad camera costs its own entry rather than the whole status. The breadth is the camera backend's, not ours: the default `OpenCVCamera` answers through `cv2.VideoCapture.isOpened()`, and `cv2.error`'s MRO is `['error', 'Exception', 'BaseException', 'object']` -- a direct `Exception` subclass -- so the narrower tuple the observation path uses (`RuntimeError, ValueError, AttributeError, TypeError, IndexError`) would let the shipped camera through. The handler mirrors `mujoco/rendering.py`'s per-camera best-effort (`# noqa: BLE001`) and the reason is stated at the site.

## Scope

This is the existing probe reporting the fact it already reaches for; it adds no new method and changes no existing field's shape or meaning. A `readiness()`/`wait_ready()` lifecycle API and a fatal-exit log convention are separate surfaces and separate decisions, not touched here.

## Tests

`tests/test_hardware_robot_lifecycle.py::TestCameraHealthIsAttributable`, 8 cases. Pre-fix on `upstream/main`: **6 failed / 71 passed**; after: **77 passed**.

Two failures are behavioural and name the consequence:

```
Failed: the health probe answered is_connected=False with cameras=['wrist_cam', 'front_cam']
and no per-camera reading, so which of the motor bus and the two cameras fell is not in the report

Failed: one dropped camera and two dropped cameras produce the same report:
is_connected=False, cameras=['wrist_cam', 'front_cam'], cameras_connected=None
```

The other four pin the field's contract shape rather than the regression. Two cases pass on both trees and are the controls: the probe survives a camera that cannot answer, and the configured enumeration still names every camera.

Six breaks, six distinct firing sets:

| break | fails | which |
| --- | --- | --- |
| revert the source | 6 | the two measurements plus the four contract pins |
| probe the config instead of the live camera objects | 3 | partial and total failure report identically again |
| drop the per-camera guard | 3 | the fail-soft control fires -- one bad camera blanks the whole probe (`KeyError: 'cameras'`) |
| a raising probe reports `False` instead of being omitted | 1 | only the omission case |
| filter `cameras` to the connected ones | 4 | including the **pre-existing** `test_get_status_lists_the_devices_configured_cameras` |
| drop the non-mapping guard | 1 | only the unfamiliar-shape case |
| control (restored) | 0 of 77 | |

The fifth row is the one that shows the original field's contract survived rather than being replaced.

## Verification

Measured at `52e82502`, against `upstream/main` `58b9a793`.

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 errors on both trees**, none in the changed files, branch-only set empty.
- Blast radius: the 87 test files naming the status surface, `hardware_robot`, `is_connected`, or a repo-wide guard, run with the **identical** selection on both trees with the file this PR modifies excluded from each: **2814 passed, 5 skipped, 0 failed** on the branch and byte-identically on `upstream/main` (171.7s vs 173.4s). No pre-existing failures in the selection.
- `scripts/assemble_changelog.py --check`: OK.

![get_status camera health, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-health-probe-camera-2629/health-probe-names-the-camera.png)

The columns are one capture script run against each tree: the same two-camera arm, the same four faults, and only `strands_robots` different between them. Asserted from the captured payloads rather than read off the picture: the device aggregate `is_connected`, the configured `cameras` list, the healthy and no-camera rows, and the probe's survival of a camera that cannot answer are **identical in both columns** -- what changes is only whether the report names the camera.
