### PR TITLE
fix(mesh): a human's approval is recorded even when the gate then refuses the action

### DIFF
--- a/changelog.d/2630-hitl-approval-recorded-before-a-later-refusal.md
+++ b/changelog.d/2630-hitl-approval-recorded-before-a-later-refusal.md
@@ -1,0 +1,26 @@
+### Fixed
+
+The mesh tool now records the operator's human-in-the-loop verdict once, as soon
+as it is known, so a later refusal cannot return past the row. The rate limit is
+deliberately re-checked under the lock *after* the operator approves -- the
+pre-interrupt check does not consume a slot, so a concurrent invocation can take
+the last one while the human is deciding -- and that re-check can refuse an action
+the operator approved. The row was written per branch (`approved=False` in the
+decline branch, `approved=True` after the re-check), so the raced refusal returned
+between the two and the verdict went unrecorded: the audit log carried only
+`rate_limit_race`, which says why the action was refused and nothing about who
+authorised it. Measured, an approval whose slot was taken while the operator was
+deciding left zero operator rows, on the one gate that reaches physical actuation.
+
+An incident audit asks "did a human approve this?" first, which is what
+`log_operator_response` already documented ("Call this on BOTH outcomes"), and the
+two sibling gates already had the right shape: `use_ros` and `lerobot_train`
+compute the verdict and record it unconditionally before branching. The raced path
+now leaves two rows for two facts -- `operator approved: 'y'` and
+`rate_limit_race: ...` -- and a structural guard derived from the tree's
+`interrupt()` call sites holds every gate, including a fourth added later, to one
+site no return can bypass.
+
+The accepted grammar is unchanged: a non-string reply, including `True` and
+`{"approve": True}`, still fails closed as its own tests and `docs/security.md`
+require. Only the accounting on the path where the operator did approve is fixed.

--- a/strands_robots/tools/_hitl_audit.py
+++ b/strands_robots/tools/_hitl_audit.py
@@ -49,9 +49,16 @@ def log_operator_response(
 ) -> None:
     """Record an operator's HITL interrupt reply in the local audit log.
 
-    Call this on BOTH outcomes. A decline is the row that carries the operator's
-    reason; an approval is the record that a human authorised an agent to reach a
-    physical surface, which is the question an audit of an incident asks first.
+    Call this on BOTH outcomes, from ONE site the gate reaches as soon as the
+    verdict is known and before any later refusal can return. A decline is the row
+    that carries the operator's reason; an approval is the record that a human
+    authorised an agent to reach a physical surface, which is the question an audit
+    of an incident asks first - and a gate may still refuse an APPROVED action for
+    its own reasons (the mesh tool re-checks its rate limit under the lock, and a
+    concurrent invocation can take the last slot while the operator is deciding).
+    Recording per-branch after such a check leaves that path with no operator row
+    at all, so the log says only why the action was refused and nothing about who
+    authorised it.
 
     Args:
         source: Which tool asked, e.g. ``"use_ros_tool"``. Recorded as the event

--- a/strands_robots/tools/robot_mesh.py
+++ b/strands_robots/tools/robot_mesh.py
@@ -1223,17 +1223,25 @@ def robot_mesh(
                 f"action '{action}' requires a human-in-the-loop interrupt. Interrupts are not available here: {exc}"
             )
 
-        if not _interrupt_approves(response):
+        approved = _interrupt_approves(response)
+        # Record the human's verdict as soon as it is known, before any later
+        # refusal can return. The rate-limit re-check below can reject an
+        # APPROVED action (a concurrent invocation took the last slot while the
+        # operator was deciding), and recording after it left that path with no
+        # operator row at all: the audit log carried only ``rate_limit_race``,
+        # which does not say a human authorised a physical actuation. One
+        # unconditional site, matching use_ros and lerobot_train.
+        #
+        # #322: the operator's literal interrupt response is recorded in
+        # the LOCAL audit row (full fidelity for forensics) but MUST NOT be
+        # echoed back to the LLM. Echoing it turns the human operator into a
+        # content side-channel: a prompt-injected agent could phrase the
+        # approval reason so the operator's typed reply leaks data back into
+        # the model context. Return a flat, fixed sentinel instead.
+        log_operator_response(_AUDIT_SOURCE, action, target, approved=approved, response=response)
+        if not approved:
             # Declined approval does NOT consume a rate-limit slot -
             # see _rate_limit_check docstring for the safety rationale.
-            #
-            # #322: the operator's literal interrupt response is recorded in
-            # the LOCAL audit row (full fidelity for forensics) but MUST NOT be
-            # echoed back to the LLM. Echoing it turns the human operator into a
-            # content side-channel: a prompt-injected agent could phrase the
-            # approval reason so the operator's typed reply leaks data back into
-            # the model context. Return a flat, fixed sentinel instead.
-            log_operator_response(_AUDIT_SOURCE, action, target, approved=False, response=response)
             return _err(f"action '{action}' was declined by the operator interrupt.")
         # Approval granted. Re-check under the lock and consume the
         # slot atomically -- a concurrent invocation that ALSO passed
@@ -1244,7 +1252,6 @@ def robot_mesh(
         if rl_race_err is not None:
             _audit_tool_action(action, target, False, f"rate_limit_race: {rl_race_err}")
             return _err(rl_race_err)
-        log_operator_response(_AUDIT_SOURCE, action, target, approved=True, response=response)
     else:
         # No interrupt required for this action - reserve the slot with the
         # same atomic check+record the approved path uses above. The pre-gate

--- a/tests/tools/test_hitl_operator_response_audit.py
+++ b/tests/tools/test_hitl_operator_response_audit.py
@@ -33,7 +33,7 @@ import strands_robots
 import strands_robots.tools.lerobot_train as train_mod
 import strands_robots.tools.robot_mesh as mesh_mod
 import strands_robots.tools.use_ros as ros_mod
-from strands_robots.mesh.audit import read_audit_log
+from strands_robots.mesh.audit import audit_log_path, read_audit_log
 
 # A reply that carries a reason. Every gate accepts a canonical affirmative only,
 # so this is always a decline - which is exactly why the audit row is the only
@@ -143,6 +143,29 @@ def audit_rows(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict[str
 
     monkeypatch.setattr("strands_robots.mesh.audit.log_safety_event", _record)
     return recorded
+
+
+@pytest.fixture(autouse=True)
+def audit_dir_is_this_tests_own(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep every gate driven in this file off the developer's real audit trail.
+
+    ``audit_log_path()`` falls back to ``~/.strands_robots`` when
+    ``STRANDS_MESH_AUDIT_DIR`` is unset, so a test that drives a real gate
+    reaches the real writer. Measured before this fixture existed: one run of
+    the rate-limit-race control appended an ``operator approved: 'y'`` row for
+    action ``tell`` with ``success: true`` to the developer's own
+    ``mesh_audit.jsonl`` and advanced the signed ``mesh_audit.seq.json``
+    sidecar beside it. That row is indistinguishable from a genuine human
+    authorisation to exactly the incident reader this file exists to serve, and
+    it accumulates on every local run.
+
+    Autouse rather than one line in the offending test, because the hole is
+    structural: capturing ``log_safety_event`` is a choice each test makes, so a
+    gate-driving test added later re-grows the same contamination in silence and
+    nothing fails. A test that wants a directory it can read back still names one
+    itself - its own ``setenv`` runs after this one and wins.
+    """
+    monkeypatch.setenv("STRANDS_MESH_AUDIT_DIR", str(tmp_path / "audit"))
 
 
 class TestEveryGateRecordsTheOperatorReply:
@@ -463,3 +486,33 @@ class TestAnApprovedActionRefusedForAnotherReasonStillRecordsTheHuman:
                 },
             )
         ]
+
+
+class TestTheAuditTrailATestWritesIsItsOwn:
+    """A gate driven by this suite must not write where an incident audit reads.
+
+    AGENTS.md item 16 exempts ``tests/`` from whole-log attestation *because* a
+    test redirects the audit directory. That exemption is only sound while the
+    redirect actually holds, so it is pinned here rather than assumed.
+    """
+
+    def test_the_resolved_audit_log_is_not_the_real_home(self, tmp_path: Path) -> None:
+        """The fallback in ``audit_log_path()`` is never the path under test."""
+        resolved = audit_log_path()
+
+        assert resolved.parent != Path.home() / ".strands_robots", (
+            "a gate driven by this suite would write to the developer's real audit trail at "
+            f"{resolved}, where a fabricated 'operator approved' row is indistinguishable "
+            "from a genuine human authorisation"
+        )
+        assert tmp_path in resolved.parents, f"the audit log is not this test's own: {resolved}"
+
+    def test_driving_a_real_gate_writes_only_under_this_tests_directory(self, tmp_path: Path) -> None:
+        """The row the rate-limit-race control used to plant lands in tmp_path."""
+        _drive_robot_mesh_racing_the_rate_limit(APPROVAL)
+
+        details = [str(rec.get("payload", {}).get("detail", "")) for rec in read_audit_log(since=0)]
+        assert any(detail.startswith("operator approved") for detail in details), (
+            f"premise: driving the gate left no operator row to locate: {details}"
+        )
+        assert tmp_path in audit_log_path().parents, "the operator row was written outside this test"

--- a/tests/tools/test_hitl_operator_response_audit.py
+++ b/tests/tools/test_hitl_operator_response_audit.py
@@ -272,6 +272,50 @@ class TestTheGatedSetIsDerivedFromTheInterruptSites:
             f"{gate.label}'s gate does not record the operator's reply through the shared owner"
         )
 
+    @pytest.mark.parametrize("gate", _GATES, ids=_GATE_IDS)
+    def test_each_gate_records_from_one_site_no_later_refusal_can_return_past(self, gate: _Gate) -> None:
+        """One site, reached as soon as the verdict is known.
+
+        Two per-branch sites are what let a third exit skip both: the mesh tool
+        recorded ``approved=False`` in its decline branch and ``approved=True``
+        after its post-approval rate-limit re-check, so the raced refusal between
+        them returned with the operator's verdict unrecorded. A single site the
+        gate reaches before it can return again cannot be bypassed that way, and
+        it is the shape the other two gates already had.
+        """
+        fn_src = textwrap.dedent(inspect.getsource(getattr(gate.module, gate.function)))
+        fn = next(
+            node
+            for node in ast.walk(ast.parse(fn_src))
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == gate.function
+        )
+        calls = self._own_calls(fn)
+
+        sites = [call.lineno for call in calls if ast.unparse(call.func) == "log_operator_response"]
+        assert len(sites) == 1, (
+            f"{gate.label} records the operator's verdict at {len(sites)} sites {sites}; want one that every "
+            "path reaches once the verdict is known, so a later refusal cannot return past all of them"
+        )
+
+        verdicts = [
+            call
+            for call in calls
+            if "approve" in ast.unparse(call.func) and ast.unparse(call.func) != "log_operator_response"
+        ]
+        assert len(verdicts) == 1, (
+            f"{gate.label} computes the operator verdict at {len(verdicts)} sites; the rule below reads the first"
+        )
+
+        escapes = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Return) and verdicts[0].lineno < node.lineno < sites[0]
+        ]
+        assert not escapes, (
+            f"{gate.label} can return at lines {escapes} between computing the operator's verdict and recording "
+            "it, so that path leaves no row saying whether a human authorised the action"
+        )
+
 
 class TestTheMeshToolRowIsUnchanged:
     """Control: the tool that already recorded keeps writing the same row."""
@@ -312,3 +356,110 @@ class TestAnUnwritableAuditLogDoesNotChangeTheVerdict:
         assert (result is not None and result.get("status") == "error") is declined, (
             f"{gate.label} changed its verdict when the audit write failed: {result}"
         )
+
+
+def _drive_robot_mesh_racing_the_rate_limit(response: object) -> tuple[dict[str, Any] | None, MagicMock]:
+    """A ``tell`` that a concurrent invocation out-races while the operator decides.
+
+    The pre-interrupt rate-limit check deliberately does not consume a slot, so a
+    second invocation can take the last one while the human is deciding; the
+    re-check under the lock then refuses an action the operator APPROVED. Draining
+    the bucket from inside ``interrupt()`` is that concurrency, made deterministic
+    without threads: the slot goes while the gate is blocked on the human.
+    """
+    fn = getattr(mesh_mod.robot_mesh, "__wrapped__", None) or mesh_mod.robot_mesh
+    mesh = MagicMock()
+    mesh.tell.return_value = {"status": "ok"}
+    mesh_mod._reset_rate_limits()
+    mesh_mod._reset_interrupt_actions_cache()
+
+    taken = 0
+
+    def _interrupt(*_a: object, **_k: object) -> object:
+        nonlocal taken
+        while mesh_mod._rate_limit_check_and_record("tell") is None and taken < 500:
+            taken += 1
+        return response
+
+    ctx = MagicMock(name="ToolContext")
+    ctx.interrupt.side_effect = _interrupt
+    with (
+        patch.object(mesh_mod, "_gateway_mesh", lambda: None),
+        patch.object(mesh_mod, "_resolve_mesh", return_value=mesh),
+    ):
+        result = fn(action="tell", tool_context=ctx, target="peer-a", instruction="go")
+
+    assert taken, "premise: no slot was taken while the operator was deciding, so nothing raced"
+    return result, mesh
+
+
+class TestAnApprovedActionRefusedForAnotherReasonStillRecordsTheHuman:
+    """The verdict is recorded even when the gate then refuses the action itself.
+
+    A gate can refuse an action the operator approved: the mesh tool re-checks its
+    rate limit under the lock, and a concurrent invocation can take the last slot
+    while the human is deciding. Recording per-branch after that check left the
+    raced path with no operator row at all - the audit log carried only
+    ``rate_limit_race``, which says why the action was refused and nothing about
+    who authorised it, so an incident audit asking "did a human approve this?"
+    found no answer for the one gate that reaches physical actuation.
+    """
+
+    def test_the_human_verdict_is_recorded_even_though_the_action_was_refused(
+        self, audit_rows: list[tuple[str, str, dict[str, Any]]]
+    ) -> None:
+        result, mesh = _drive_robot_mesh_racing_the_rate_limit(APPROVAL)
+
+        assert result is not None and result["status"] == "error", f"premise: the race did not refuse: {result}"
+        assert "rate limit" in result["content"][0]["text"].lower(), (
+            f"premise: the refusal was not the rate-limit race: {result['content'][0]['text']}"
+        )
+        mesh.tell.assert_not_called()
+
+        rows = _operator_rows(audit_rows)
+        assert len(rows) == 1, (
+            "a human approved a physical actuation and the audit log has no row saying so; "
+            f"rows a forensic reader would find: {audit_rows}"
+        )
+        source, payload = rows[0]
+        assert source == "robot_mesh_tool"
+        assert payload["success"] is True, f"the operator's approval was recorded as a non-approval: {payload}"
+        assert repr(APPROVAL) in str(payload["detail"]), f"the recorded row does not carry the reply: {payload}"
+
+    def test_the_reason_the_action_was_refused_is_recorded_alongside_it(
+        self, audit_rows: list[tuple[str, str, dict[str, Any]]]
+    ) -> None:
+        """Two rows, two facts: a human authorised it, and it was refused anyway."""
+        _drive_robot_mesh_racing_the_rate_limit(APPROVAL)
+
+        raced = [p for _e, _s, p in audit_rows if "rate_limit_race" in str(p.get("detail", ""))]
+        assert len(raced) == 1, f"the refusal reason is not recorded: {audit_rows}"
+        assert raced[0]["success"] is False
+
+    def test_the_model_is_told_the_rate_limit_refused_it_not_the_operator(self) -> None:
+        """Control: the operator approved, so the text must not blame a human."""
+        result, _mesh = _drive_robot_mesh_racing_the_rate_limit(APPROVAL)
+
+        assert result is not None
+        text = result["content"][0]["text"].lower()
+        assert "declined by the operator" not in text, (
+            f"an approved action was reported to the model as an operator decline: {text}"
+        )
+
+    def test_an_unraced_approval_records_the_same_row_it_always_did(
+        self, audit_rows: list[tuple[str, str, dict[str, Any]]]
+    ) -> None:
+        """Control: moving the site changes nothing on the path that already worked."""
+        _drive_robot_mesh(APPROVAL)
+
+        assert _operator_rows(audit_rows) == [
+            (
+                "robot_mesh_tool",
+                {
+                    "action": "emergency_stop",
+                    "target": "",
+                    "success": True,
+                    "detail": f"operator approved: {APPROVAL!r}",
+                },
+            )
+        ]


### PR DESCRIPTION
## Problem

The mesh tool re-checks its rate limit **under the lock after** the operator approves, because the pre-interrupt check deliberately does not consume a slot. So a concurrent invocation can take the last slot while the human is deciding, and the re-check then refuses an action the operator **approved**.

The operator row was written per branch -- `approved=False` in the decline branch, `approved=True` after that re-check -- so the raced refusal returned *between* them and the verdict went unrecorded:

| measured | operator rows | what the audit log carries |
|---|---|---|
| plain approval | 1 | `success=True  "operator approved: 'y'"` |
| approval, slot taken while deciding | **0** | `success=False "rate_limit_race: rate limit exceeded for action 'tell' between check and record ..."` |

A human authorised a physical actuation and the trail has no row saying so. The one surviving row attributes the refusal to a rate limit and says nothing about who authorised it, so an incident audit asking "did a human approve this?" finds no answer -- on the one gate that reaches physical actuation (`tell`, `send`, `stop`, `broadcast`, `emergency_stop`, `rpc`).

`log_operator_response`'s own docstring already asks for the opposite:

> Call this on BOTH outcomes. A decline is the row that carries the operator's reason; an approval is the record that a human authorised an agent to reach a physical surface, **which is the question an audit of an incident asks first.**

And the two sibling gates already had the right shape: `use_ros._gate_command` and `lerobot_train._gate_extra_flags` both compute the verdict and record it **unconditionally**, then branch. `robot_mesh` was the one gate of three that recorded per branch.

## Change

Record the verdict once, as soon as it is known, before any later refusal can return -- the shape the other two gates already used:

```python
approved = _interrupt_approves(response)
log_operator_response(_AUDIT_SOURCE, action, target, approved=approved, response=response)
if not approved:
    return _err(f"action '{action}' was declined by the operator interrupt.")
rl_race_err = _rate_limit_check_and_record(action)
if rl_race_err is not None:
    _audit_tool_action(action, target, False, f"rate_limit_race: {rl_race_err}")
    return _err(rl_race_err)
```

The raced path now leaves **two rows, two facts**: `operator approved: 'y'` (a human authorised it) and `rate_limit_race: ...` (why it was refused anyway).

`log_operator_response`'s docstring gains the requirement the fix satisfies -- one site, reached before any later refusal can return -- so a fourth gate is told the shape rather than inferring it from a sibling.

Nothing else moves: the grammar, the model-visible text, and the "a decline does not consume a rate-limit slot" contract are untouched.

## Tests

`2 failed / 29 passed` against `upstream/main`, both failures behavioural or structural:

```
FAILED ...::test_the_human_verdict_is_recorded_even_though_the_action_was_refused
  a human approved a physical actuation and the audit log has no row saying so;
  rows a forensic reader would find: [(... 'success': False,
  'detail': "rate_limit_race: rate limit exceeded for action 'tell' ...")]
FAILED ...::test_each_gate_records_from_one_site_no_later_refusal_can_return_past[robot_mesh]
  robot_mesh records the operator's verdict at 2 sites [252, 241]; want one that every
  path reaches once the verdict is known, so a later refusal cannot return past all of them
```

The behavioural test drives the real race deterministically without threads: the stand-in `interrupt()` drains the bucket while the gate is blocked on the human, which is exactly the concurrency the re-check exists for. A premise assert fails loudly if no slot was taken.

The structural test is the root cause, and it is derived rather than listed -- the graded set comes from the tree's `interrupt()` call sites, so a fourth gate is held to the rule on arrival. Two clauses, measured complementary:

| break | fires |
|---|---|
| control (this branch) | 0 of 31 |
| exact pre-fix source | **2** -- the behavioural race test + the `one site` clause |
| one site, but placed after the race check | **6** -- incl. **4 pre-existing** tests (the decline row, its verb/target, the echo contract, the byte-identical payload) + the `no return between` clause |
| same, with the `no return between` clause disabled | **5** -- the structural test now passes, so both clauses carry weight |

The third row is the no-overreach evidence: four tests that already pinned the decline row pass on this branch and fire the moment it is lost, so the reorder preserved the contract they pin. The `use_ros` and `lerobot_train` parameters of the structural rule pass on both trees -- they already had the shape.

## Scope

The **grammar** is deliberately unchanged. A non-string reply (including `True` and `{"approve": True}`) still fails closed, because that is a tested, documented posture rather than drift:

- `_interrupt_approves`' docstring: "We accept the canonical short forms only - defence in depth against accidental approval from a typo."
- `tests/mesh/test_robot_mesh_hitl_approval_contract.py::test_non_string_payloads_never_approve` names `{"approve": True}` and `True` explicitly as cases that must not approve, and a dispatch-level test pins that they return a `declined` error without reaching the mesh.
- `docs/security.md`: "Only `y` / `yes` / `approve` / `approved` count as approval; anything else (including an empty response) is treated as a decline."

Widening it would invert that safety test, which is a contract decision and not this PR's. This PR only fixes the accounting on the path where the operator *did* approve in the accepted grammar.

## Verification

Measured at `4bfaf7b0`, on the identical 274-file selection (every test naming the changed symbols, the three HITL
gates, or a repo-wide guard) run on both trees with the changed test file excluded from each:

| tree | result |
|---|---|
| this branch | `25 failed, 8929 passed, 14 skipped, 24 errors` |
| `upstream/main` | `25 failed, 8922 passed, 14 skipped, 24 errors` |

49 failing ids, the **same set on both trees** (`comm` empty in both directions), and `+7 passed` is exactly the
seven items this PR adds (four tests plus the structural rule's three gate parameters). Every one of the 49 is a
dependency absent from this machine and installed by CI's `.[all,dev]`: 45 `tests/mesh/test_iot_*` on
`No module named 'awsiot'` (the `[mesh-iot]` extra), 2 `tests/test_device_connect_hardening.py` on
`device_connect_agent_tools`, and 2 `tests/training/test_lerobot.py::TestInProcessTrainerCorrectness` on
`draccus 0.10.0` against lerobot 0.6.2's `draccus>=0.11.6` floor (`encode() takes 1 positional argument but 2 were
given`).

`ruff check` and `ruff format --check` are clean over `strands_robots tests tests_integ`; `mypy` reports the same
24 pre-existing errors on both trees, none in the changed files.

## Artifact

The change is to what an auditor reads, so the artifact is the audit log itself. One script per tree drives the
real gate twice against a real `STRANDS_MESH_AUDIT_DIR` -- once with nothing racing, once with a concurrent call
taking the last slot while the operator decides -- and reads the rows back with `read_audit_log`:

![HITL approval accounting, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-hitl-approval-accounting/hitl-approval-accounting.png)

Both columns run the same session and reach the same verdict: `status="error"`, the byte-identical rate-limit text,
the action dispatched 0 times, and 30 slots taken while the operator was deciding. The unraced approval records the
identical row in both trees. The only difference is that the raced path now carries the row saying a human
authorised it.


## Review rounds

**Round 1** - `c39b713`, one concern: a unit test in this PR reached the real audit writer.

`test_the_model_is_told_the_rate_limit_refused_it_not_the_operator` took neither the `audit_rows`
fixture nor an audit directory, so it drove the real gate onto the developer's own trail. Reproduced
under a scratch `HOME` before fixing: one run appended `operator approved: 'y'` for action `tell` with
`success: true` to `~/.strands_robots/mesh_audit.jsonl`, advanced the signed `mesh_audit.seq.json`
sidecar and left a lockfile. A fabricated approval row is indistinguishable from a genuine human
authorisation to exactly the reader this PR exists to serve, and it accumulates per run.

Fixed by naming the audit directory **autouse at module scope** rather than in the one offending test.
The hole is structural: capturing `log_safety_event` is a choice each test makes, so a gate-driving test
added later re-grows the contamination with nothing failing. An AST sweep found two tests taking
neither -- this one, and `test_the_table_covers_every_interrupt_site`, a pure `interrupt()` call-site
scan that drives no gate. `test_a_declined_use_ros_publish_lands_on_disk` is unaffected; its own
`setenv` runs after the fixture and wins.

Pinned both directions by `TestTheAuditTrailATestWritesIsItsOwn`, which fails without the redirect and
names the real trail when it does. Read as a delta, since this box lacks several optional deps:

| tree | failed | passed | files written under `HOME` |
|---|---|---|---|
| `4bfaf7b0` | 62 | 2053 | 3, including the fabricated approval row |
| `c39b713` | 62 | 2055 | none |

The 62 are pre-existing and identical on both sides; the whole effect is +2 (the new pins) and the
pollution gone. Lint clean on the file.

This round also recorded a dependency nothing was checking: AGENTS.md item 16 exempts `tests/` from
whole-log attestation *because* a test redirects the audit dir, so that exemption rests on a property
no test asserted. The new class states it in its docstring.
