### PR TITLE
fix(hardware): a missing required parameter is refused by name, with the bus

### DIFF
--- a/changelog.d/2631-missing-hardware-parameter-names-the-bus.md
+++ b/changelog.d/2631-missing-hardware-parameter-names-the-bus.md
@@ -1,0 +1,30 @@
+### Fixed: a missing required hardware parameter is refused by name, with the bus
+
+Eight of lerobot's sixteen robot types declare `port` with no default, so
+forgetting it is the commonest caller mistake on the hardware path.
+`_create_minimal_config` let the resolved dataclass raise and wrapped whatever it
+said, so the refusal read `SOFollowerRobotConfig.__init__() missing 1 required
+positional argument: 'port'` -- a lerobot internal, naming neither the parameter
+the caller supplies nor a single device on the host. `mode="auto"` had already
+enumerated the candidate ports one frame up, logged them, and returned only the
+string `"real"`, so `mode="auto"` and `mode="real"` produced the identical message
+and the probe's work was invisible.
+
+The mirror-image mistake was already reported properly: a kwarg the dataclass
+does not declare is refused with the accepted field names, and the docstring says
+why -- it catches a typo like `prot=` at config-build time rather than as a
+delayed connection failure with no kwarg in sight. Both halves of "the caller got
+a kwarg wrong" now report the same way. A missing port additionally names this
+host's servo-bus candidates and their USB serial numbers, because a port path is
+a position on the bus that the kernel may renumber across a replug while the
+serial number does not move. The scan answers a missing `port` only: naming
+serial devices for a missing `remote_ip` would point a network robot's caller at
+the wrong bus entirely.
+
+Which serial device is a robot's motor bus is now decided once, in
+`strands_robots._serial_discovery`. That rule was inline in `_auto_detect_mode`
+-- the keyword list, the WCH CH34x / FTDI vendor ids, the exclusions -- and the
+refusal needs the same answer, so a second copy would let the two disagree about
+what a robot is. Enumeration there is best-effort, because pyserial is not a
+declared dependency of this package: an absent import or a libusb hub glitch
+reports no devices rather than replacing a precise refusal with an `ImportError`.

--- a/strands_robots/_serial_discovery.py
+++ b/strands_robots/_serial_discovery.py
@@ -1,0 +1,197 @@
+"""Sole owner of the servo-bus recognition rule.
+
+A USB port path -- ``/dev/ttyACM0`` on Linux, ``/dev/cu.usbmodem58FA0826181`` on
+macOS -- is a POSITION on the bus, not an identity. Unplug an arm and plug it
+back in and the kernel may hand it a different number; plug a second arm in
+first and it may take the number the first one had. The USB serial number does
+not move, so a report that names a port should name the serial number beside it.
+
+Two callers in different layers need the same answer to "which of this host's
+serial devices look like a robot's motor bus":
+
+- :func:`strands_robots.robot._auto_detect_mode`, deciding sim vs real for
+  ``mode="auto"``.
+- :meth:`strands_robots.hardware_robot.Robot._create_minimal_config`, naming the
+  candidates when the caller did not supply the ``port`` its robot requires.
+
+:mod:`strands_robots.robot` defers importing :mod:`strands_robots.hardware_robot`
+(it is the heavy hardware layer, and a sim-only caller must not pay for it), so
+neither can own the rule for the other. It lives here, once, as
+:data:`SERVO_BUS_VIDS` plus :func:`matches_servo_bus`.
+
+``pyserial`` is not a declared dependency of this package -- it arrives with
+lerobot -- so enumeration is best-effort throughout: :func:`scan_serial_devices`
+answers with an empty list rather than raising, and every caller treats "no
+devices" and "cannot enumerate" the same way.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Servo-bus USB bridge vendor IDs. Feetech/SO-10x controller boards carry WCH
+#: CH34x chips that enumerate with the generic description ``USB Single Serial``
+#: (observed on macOS with SO-101, vid ``0x1a86`` pid ``0x55d3``), so keyword
+#: matching alone misses them entirely and ``mode="auto"`` silently falls back
+#: to sim with hardware attached.
+SERVO_BUS_VIDS: frozenset[int] = frozenset({0x1A86, 0x0403})  # WCH CH34x, FTDI
+
+#: Substrings that identify a servo bus by name, matched against the device
+#: description and manufacturer.
+SERVO_BUS_KEYWORDS: tuple[str, ...] = (
+    "feetech",
+    "dynamixel",
+    "sts3215",
+    "xl430",
+    "xl330",
+    "ch340",
+    "ch343",
+)
+
+#: Substrings that disqualify a device however it matched: an internal UART, a
+#: debug port or a Bluetooth bridge is not a robot even on a matching vid.
+NON_SERVO_BUS_KEYWORDS: tuple[str, ...] = (
+    "bluetooth",
+    "internal",
+    "debug",
+    "apple",
+    "modem",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class SerialCandidate:
+    """One serial device on this host, as discovery sees it.
+
+    Attributes:
+        port: The device path, e.g. ``/dev/ttyACM0``. This is a position on the
+            bus and may differ the next time the same hardware is plugged in.
+        stable_id: The USB serial number when the device reports one, else a
+            ``vid:pid`` (optionally ``:location``) fallback, else ``None`` for a
+            device that carries no USB identity at all (an on-board UART). Two
+            devices of the same model report different serial numbers, so this
+            is what survives a replug.
+        likely_servo_bus: Whether :func:`matches_servo_bus` recognised it as a
+            robot's motor bus.
+    """
+
+    port: str
+    stable_id: str | None
+    likely_servo_bus: bool
+
+
+def matches_servo_bus(port_info: Any) -> bool:
+    """Return whether ``port_info`` looks like a robot's motor bus.
+
+    Recognised by name (:data:`SERVO_BUS_KEYWORDS` against the description and
+    manufacturer) or by vendor id (:data:`SERVO_BUS_VIDS`), and disqualified by
+    :data:`NON_SERVO_BUS_KEYWORDS` however it matched.
+
+    Args:
+        port_info: A ``serial.tools.list_ports_common.ListPortInfo``, or
+            anything exposing the same ``description`` / ``manufacturer`` /
+            ``vid`` attributes. Read with ``getattr`` defaults so a partial
+            stand-in is answered rather than raising.
+
+    Returns:
+        ``True`` when the device is a servo-bus candidate.
+    """
+    description = (getattr(port_info, "description", None) or "").lower()
+    manufacturer = (getattr(port_info, "manufacturer", None) or "").lower()
+    named = any(keyword in description + manufacturer for keyword in SERVO_BUS_KEYWORDS)
+    by_vid = getattr(port_info, "vid", None) in SERVO_BUS_VIDS
+    if not (named or by_vid):
+        return False
+    return not any(keyword in description for keyword in NON_SERVO_BUS_KEYWORDS)
+
+
+def stable_device_id(port_info: Any) -> str | None:
+    """Return the identity of ``port_info`` that survives a replug.
+
+    The USB serial number when the device reports one. Devices that report none
+    fall back to ``vid:pid`` plus the bus ``location`` when it is available:
+    that still distinguishes two different models, and distinguishes two
+    identical models on different bus positions, but it is a weaker identity
+    than a serial number because it moves when the cable does.
+
+    Args:
+        port_info: A ``ListPortInfo``, or anything exposing ``serial_number`` /
+            ``vid`` / ``pid`` / ``location``.
+
+    Returns:
+        The identity, or ``None`` for a device with no USB identity at all
+        (an on-board UART reports neither a serial number nor a vid).
+    """
+    serial_number = getattr(port_info, "serial_number", None)
+    if serial_number:
+        return str(serial_number)
+    vid = getattr(port_info, "vid", None)
+    pid = getattr(port_info, "pid", None)
+    if vid is None or pid is None:
+        return None
+    fallback = f"{vid:04x}:{pid:04x}"
+    location = getattr(port_info, "location", None)
+    return f"{fallback}:{location}" if location else fallback
+
+
+def scan_serial_devices() -> list[SerialCandidate]:
+    """Enumerate this host's serial devices, best-effort.
+
+    Returns:
+        One :class:`SerialCandidate` per device, in the order pyserial reports
+        them. An empty list when there are no devices AND when enumeration
+        could not be performed at all: ``pyserial`` is not a declared
+        dependency of this package, and USB enumeration fails for reasons that
+        are none of the caller's business (a permission error on the device
+        node, a libusb hub glitch). Callers treat both the same way, so this
+        never raises -- the failure is logged at debug for diagnosis.
+    """
+    try:
+        import serial.tools.list_ports
+
+        ports = list(serial.tools.list_ports.comports())
+    except Exception as exc:  # noqa: BLE001 - see Returns: enumeration is best-effort
+        # pyserial usually raises OSError (incl. PermissionError,
+        # SerialException) but libusb backends have been observed to raise
+        # RuntimeError on hub glitches, and the import itself raises
+        # ImportError when pyserial is absent.
+        logger.debug("USB enumeration failed (%s: %s); reporting no devices", type(exc).__name__, exc)
+        return []
+    return [
+        SerialCandidate(
+            port=port_info.device,
+            stable_id=stable_device_id(port_info),
+            likely_servo_bus=matches_servo_bus(port_info),
+        )
+        for port_info in ports
+    ]
+
+
+def describe_serial_candidates(devices: list[SerialCandidate]) -> str:
+    """Describe ``devices`` for a refusal that could not name a port.
+
+    Args:
+        devices: The result of :func:`scan_serial_devices`.
+
+    Returns:
+        One sentence naming the servo-bus candidates and their stable ids, or
+        naming what was present instead when none of them looks like a robot,
+        or saying that nothing is present. Never empty, so a refusal can append
+        it unconditionally.
+    """
+    servo = [device for device in devices if device.likely_servo_bus]
+    if servo:
+        listed = ", ".join(
+            f"{device.port} (usb id {device.stable_id})" if device.stable_id else device.port for device in servo
+        )
+        return f"Candidate servo-bus device(s) on this host: {listed}."
+    if devices:
+        return (
+            f"None of this host's {len(devices)} serial device(s) looks like a servo bus: "
+            f"{', '.join(device.port for device in devices)}."
+        )
+    return "No serial devices are present on this host."

--- a/strands_robots/hardware_robot.py
+++ b/strands_robots/hardware_robot.py
@@ -36,6 +36,7 @@ from strands.tools.tools import AgentTool
 from strands.types._events import ToolResultEvent
 from strands.types.tools import ToolResult, ToolSpec, ToolUse
 
+from strands_robots._serial_discovery import describe_serial_candidates, scan_serial_devices
 from strands_robots.bus_access import read_observation, write_action
 from strands_robots.ros_telemetry import ROS2_SYSTEM_INSTALL_HINT
 from strands_robots.teleop_mixin import TeleopMixin
@@ -1023,6 +1024,18 @@ class Robot(TeleopMixin, AgentTool):
         rather than as a delayed connection failure with no kwarg in
         sight.
 
+        The mirror-image mistake -- a required field that no forwarded kwarg
+        supplied -- is refused here too, naming the parameter the caller
+        supplies rather than letting the dataclass report
+        ``SOFollowerRobotConfig.__init__() missing 1 required positional
+        argument: 'port'``. A missing port additionally names this host's
+        servo-bus candidates and their USB serial numbers, because a port path
+        is a position on the bus while the serial number is what survives a
+        replug -- see :func:`strands_robots._serial_discovery.scan_serial_devices`.
+        The scan answers a missing ``port`` only: naming serial devices for a
+        missing ``remote_ip`` would point a network robot's caller at the wrong
+        bus entirely.
+
         Each entry of ``cameras`` follows the same contract, resolved against
         the fields of lerobot's ``OpenCVCameraConfig`` -- see
         :func:`_build_camera_config`.
@@ -1037,7 +1050,9 @@ class Robot(TeleopMixin, AgentTool):
             ValueError: If a kwarg is unknown to both the cross-robot allowlist
                 and the resolved dataclass, if a ``cameras`` entry is malformed,
                 if ``max_relative_target`` is not a limit the driver can honor,
-                or if the resolved config class refuses the assembled values.
+                if the resolved dataclass declares a required field that no
+                forwarded kwarg supplied, or if the resolved config class
+                refuses the assembled values.
             TypeError: If lerobot resolves ``robot_type`` to a non-dataclass
                 config class, which would make kwarg filtering unsafe.
         """
@@ -1194,6 +1209,46 @@ class Robot(TeleopMixin, AgentTool):
         if "max_relative_target" in config_data:
             config_data["max_relative_target"] = _normalize_max_relative_target(
                 config_data["max_relative_target"], robot_type
+            )
+
+        # A required field no forwarded kwarg satisfied is the commonest caller
+        # mistake on this path -- 8 of lerobot's serial robot types declare
+        # ``port`` with no default -- and letting the dataclass raise reports it
+        # as ``SOFollowerRobotConfig.__init__() missing 1 required positional
+        # argument: 'port'``: a lerobot internal, naming neither the parameter
+        # the caller supplies nor the devices this host has. The unknown-kwarg
+        # gate above already refuses the mirror-image mistake (a typo like
+        # ``prot=``) by naming the accepted fields, so the two halves of "the
+        # caller got a kwarg wrong" are reported the same way. Detected here
+        # rather than from the exception because the answer is on the bus, and
+        # by the time the dataclass raises nobody is looking at it: the same
+        # values would reach the same dataclass either way, so this changes
+        # which sentence a refused call gets, not which calls are refused.
+        missing_required = [
+            field.name
+            for field in dataclasses.fields(ConfigClass)
+            if field.default is dataclasses.MISSING
+            and field.default_factory is dataclasses.MISSING
+            and field.name not in config_data
+        ]
+        if missing_required:
+            remedy = ", ".join(f"{name}=..." for name in missing_required)
+            hint = (
+                f"missing required parameter(s) {missing_required}, which the caller supplies -- e.g. "
+                f"Robot({self.tool_name_str!r}, mode='real', {remedy})."
+            )
+            # Only a port-shaped parameter is answered by a serial scan. Naming
+            # this host's serial devices for a missing ``remote_ip`` would point
+            # a network robot's caller at the wrong bus entirely.
+            if any(name == "port" or name.endswith("_port") for name in missing_required):
+                hint += (
+                    f" {describe_serial_candidates(scan_serial_devices())}"
+                    " A port path is a position on the bus, not an identity: it can change when the device is"
+                    " replugged, while the usb id does not."
+                )
+            raise ValueError(
+                f"Failed to construct {ConfigClass.__name__} for robot type {robot_type!r}: "
+                f"{hint} Config: {config_data}"
             )
 
         try:

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -46,6 +46,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from strands_robots._mesh_switch import mesh_env_request
+from strands_robots._serial_discovery import scan_serial_devices
 from strands_robots.registry import (
     get_hardware_type,
     get_robot,
@@ -89,44 +90,20 @@ def _auto_detect_mode(canonical: str) -> str:
     elif env_mode:
         logger.warning("STRANDS_ROBOT_MODE=%r ignored (expected 'sim', 'real', or 'auto')", env_mode)
 
-    # Only probe USB if the robot actually has hardware support
+    # Only probe USB if the robot actually has hardware support. Which serial
+    # device is a robot's motor bus is decided once, by
+    # :func:`~strands_robots._serial_discovery.matches_servo_bus`: the hardware
+    # layer needs the same answer to name the candidates when the caller did not
+    # supply the ``port`` its robot requires, and a second copy of the vendor-id
+    # table would let the two disagree about what a robot is. Enumeration there
+    # is best-effort (pyserial is not a declared dependency of this package), so
+    # a host that cannot enumerate reports no devices and falls back to sim,
+    # which is always safe.
     if has_hardware(canonical):
-        try:
-            import serial.tools.list_ports
-
-            ports = list(serial.tools.list_ports.comports())
-            servo_keywords = ["feetech", "dynamixel", "sts3215", "xl430", "xl330", "ch340", "ch343"]
-            # Servo-bus USB bridge vendor IDs. Feetech/SO-10x controller boards
-            # carry WCH CH34x chips that enumerate with the generic description
-            # "USB Single Serial" (observed on macOS with SO-101, vid 0x1a86
-            # pid 0x55d3), so keyword matching alone misses them entirely and
-            # mode="auto" silently falls back to sim with hardware attached.
-            servo_vids = {0x1A86, 0x0403}  # WCH CH34x, FTDI
-            exclude = ["bluetooth", "internal", "debug", "apple", "modem"]
-            robot_ports = [
-                p
-                for p in ports
-                if (
-                    any(
-                        kw in ((p.description or "") + (getattr(p, "manufacturer", None) or "")).lower()
-                        for kw in servo_keywords
-                    )
-                    or (getattr(p, "vid", None) in servo_vids)
-                )
-                and not any(s in (p.description or "").lower() for s in exclude)
-            ]
-            if robot_ports:
-                logger.info(
-                    "Auto-detected robot hardware: %s",
-                    [p.device for p in robot_ports],
-                )
-                return "real"
-        except Exception as e:
-            # USB enumeration is best-effort. pyserial usually raises OSError
-            # (incl. PermissionError, SerialException) but libusb backends have
-            # been observed to raise RuntimeError on hub glitches. Falling back
-            # to sim is always safe; we log at debug for diagnosis.
-            logger.debug("USB probe failed (%s: %s); falling back to sim", type(e).__name__, e)
+        servo_ports = [device.port for device in scan_serial_devices() if device.likely_servo_bus]
+        if servo_ports:
+            logger.info("Auto-detected robot hardware: %s", servo_ports)
+            return "real"
 
     return "sim"
 

--- a/tests/test_missing_hardware_parameter_names_the_bus.py
+++ b/tests/test_missing_hardware_parameter_names_the_bus.py
@@ -1,0 +1,410 @@
+"""A required hardware parameter the caller did not supply is refused by name.
+
+Eight of lerobot's serial robot types declare ``port`` with no default, so
+forgetting it is the commonest caller mistake on the hardware path. Letting the
+resolved dataclass raise reported it as ``SOFollowerRobotConfig.__init__()
+missing 1 required positional argument: 'port'`` -- a lerobot internal, naming
+neither the parameter the caller supplies nor the devices this host has, while
+the port list needed to answer it had already been enumerated one frame up by
+``mode="auto"`` and discarded.
+
+The mirror-image mistake was already reported properly: a kwarg the dataclass
+does not declare (a typo like ``prot=``) is refused with the accepted field
+names. These tests pin the other half, and pin that the rule deciding "which
+serial device is a robot's motor bus" has one owner -- the hardware layer and
+``_auto_detect_mode`` both consult it, and a second copy of the vendor-id table
+would let them disagree about what a robot is.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import pathlib
+from typing import Any
+
+import pytest
+
+import strands_robots
+
+_PACKAGE_DIR = pathlib.Path(strands_robots.__file__).parent
+_OWNER = _PACKAGE_DIR / "_serial_discovery.py"
+
+# The vendor ids, restated here rather than imported: this is the value the
+# one-owner guard pins, and a guard that reads it from the module it is checking
+# cannot fail when that module is absent.
+_SERVO_BUS_VIDS = (0x1A86, 0x0403)  # WCH CH34x, FTDI
+
+# A WCH CH34x servo bridge as an SO-101 enumerates: a generic description that
+# no keyword matches, so only the vendor id recognises it.
+_ARM_VID, _ARM_PID = 0x1A86, 0x55D3
+
+
+class _FakePort:
+    """A stand-in for pyserial's ``ListPortInfo``."""
+
+    def __init__(
+        self,
+        device: str,
+        description: str = "n/a",
+        vid: int | None = None,
+        pid: int | None = None,
+        serial_number: str | None = None,
+        manufacturer: str | None = None,
+        location: str | None = None,
+    ) -> None:
+        self.device = device
+        self.name = device.rsplit("/", 1)[-1]
+        self.description = description
+        self.manufacturer = manufacturer
+        self.vid = vid
+        self.pid = pid
+        self.serial_number = serial_number
+        self.location = location
+
+
+def _arm(device: str, serial_number: str | None, location: str | None = None) -> _FakePort:
+    return _FakePort(device, "USB Single Serial", _ARM_VID, _ARM_PID, serial_number, location=location)
+
+
+def _uart(device: str) -> _FakePort:
+    """An on-board UART: no vid, no pid, no serial number."""
+    return _FakePort(device)
+
+
+@pytest.fixture
+def bus(monkeypatch: pytest.MonkeyPatch):
+    """Return a callable that makes ``comports()`` report the given devices."""
+    serial_tools = pytest.importorskip("serial.tools.list_ports")
+
+    def _set(*ports: Any) -> None:
+        monkeypatch.setattr(serial_tools, "comports", lambda: list(ports))
+
+    return _set
+
+
+def _config_for(robot_type: str, tool_name: str, **kwargs: Any) -> Any:
+    """Build a config through the real hardware path, returning it or raising."""
+    pytest.importorskip("lerobot")
+    from strands_robots.hardware_robot import Robot as HwRobot
+
+    hw = HwRobot.__new__(HwRobot)
+    hw.tool_name_str = tool_name
+    return hw._create_minimal_config(robot_type, None, **kwargs)
+
+
+def _refusal_for(robot_type: str, tool_name: str, **kwargs: Any) -> str:
+    """Return the refusal text, failing loudly if the call is not refused."""
+    try:
+        built = _config_for(robot_type, tool_name, **kwargs)
+    except ValueError as refused:
+        return str(refused)
+    raise AssertionError(f"{robot_type} built {type(built).__name__} instead of refusing a missing required parameter")
+
+
+class TestAMissingRequiredParameterIsNamed:
+    """The refusal names the parameter the caller supplies, not a lerobot internal."""
+
+    def test_the_refusal_names_the_missing_parameter(self, bus) -> None:
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "port" in text, text
+        assert "missing required parameter" in text, text
+
+    def test_the_refusal_does_not_leak_the_dataclass_initialiser(self, bus) -> None:
+        """``SOFollowerRobotConfig.__init__()`` is lerobot's business, not the caller's."""
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "__init__()" not in text, text
+        assert "positional argument" not in text, text
+
+    def test_the_refusal_offers_the_call_that_supplies_it(self, bus) -> None:
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "Robot('so101', mode='real', port=...)" in text, text
+
+    def test_every_missing_parameter_is_named_not_just_the_first(self, bus) -> None:
+        """``hope_jr_hand`` requires both ``port`` and ``side``."""
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("hope_jr_hand", "hope_jr_hand")
+
+        assert "port" in text and "side" in text, text
+        assert "port=..., side=..." in text, text
+
+    def test_the_refusal_still_names_the_config_class_and_the_assembled_values(self, bus) -> None:
+        """The wrapper's existing contract: name the class and what was assembled."""
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "Failed to construct SOFollowerRobotConfig for robot type 'so101_follower'" in text, text
+        assert "Config: {" in text, text
+
+
+class TestThePortRefusalNamesTheBus:
+    """A missing port is answered with the devices this host actually has."""
+
+    def test_a_servo_bus_candidate_is_named_with_its_stable_id(self, bus) -> None:
+        bus(_arm("/dev/ttyACM0", "5AB0181806"), _arm("/dev/ttyACM3", "5AB0158428"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "/dev/ttyACM0 (usb id 5AB0181806)" in text, text
+        assert "/dev/ttyACM3 (usb id 5AB0158428)" in text, text
+
+    def test_devices_that_are_not_a_servo_bus_are_named_as_such(self, bus) -> None:
+        """Two on-board UARTs are present but neither is a robot -- say so."""
+        bus(_uart("/dev/ttyS0"), _uart("/dev/ttyAMA10"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "looks like a servo bus" in text, text
+        assert "/dev/ttyS0" in text and "/dev/ttyAMA10" in text, text
+
+    def test_an_empty_bus_is_reported_as_empty(self, bus) -> None:
+        bus()
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "No serial devices are present on this host." in text, text
+
+    def test_the_refusal_says_a_port_is_not_an_identity(self, bus) -> None:
+        """The reason to name the usb id: the path is what moves across a replug."""
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "position on the bus, not an identity" in text, text
+
+    def test_an_unusable_bus_still_produces_the_parameter_refusal(self, monkeypatch) -> None:
+        """Enumeration is best-effort: a hub glitch must not replace the refusal."""
+        serial_tools = pytest.importorskip("serial.tools.list_ports")
+
+        def boom() -> list[Any]:
+            raise RuntimeError("libusb hub glitch")
+
+        monkeypatch.setattr(serial_tools, "comports", boom)
+        text = _refusal_for("so101_follower", "so101")
+
+        assert "missing required parameter" in text and "port" in text, text
+        assert "No serial devices are present on this host." in text, text
+
+
+class TestOnlyAPortIsAnsweredByASerialScan:
+    """A missing network address is not answered with this host's serial devices."""
+
+    def test_a_missing_remote_ip_names_the_parameter_but_not_the_serial_bus(self, bus) -> None:
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        text = _refusal_for("lekiwi_client", "lekiwi")
+
+        assert "remote_ip" in text, text
+        assert "/dev/ttyACM0" not in text, text
+        assert "servo bus" not in text, text
+
+
+class TestTheServoBusRecognitionRule:
+    """The rule is pure and testable without a bus."""
+
+    def test_a_generic_description_is_recognised_by_vendor_id(self) -> None:
+        """An SO-101 enumerates as ``USB Single Serial``, which no keyword matches."""
+        from strands_robots._serial_discovery import matches_servo_bus
+
+        assert matches_servo_bus(_arm("/dev/ttyACM0", "5AB0181806")) is True
+
+    def test_an_onboard_uart_is_not_a_servo_bus(self) -> None:
+        from strands_robots._serial_discovery import matches_servo_bus
+
+        assert matches_servo_bus(_uart("/dev/ttyS0")) is False
+
+    def test_a_named_servo_bus_is_recognised_without_a_vendor_id(self) -> None:
+        from strands_robots._serial_discovery import matches_servo_bus
+
+        assert matches_servo_bus(_FakePort("/dev/ttyUSB0", "Feetech STS3215 bus")) is True
+
+    def test_an_excluded_device_is_refused_however_it_matched(self) -> None:
+        """A matching vendor id does not make a Bluetooth bridge a robot."""
+        from strands_robots._serial_discovery import matches_servo_bus
+
+        assert matches_servo_bus(_FakePort("/dev/cu.Bluetooth", "Bluetooth-Incoming-Port", _ARM_VID, _ARM_PID)) is False
+
+    def test_a_partial_stand_in_is_answered_rather_than_raising(self) -> None:
+        """The rule reads its inputs with defaults, so a bare object is answered."""
+        from strands_robots._serial_discovery import matches_servo_bus
+
+        assert matches_servo_bus(object()) is False
+
+
+class TestTheStableIdentity:
+    """What survives a replug, and what stands in when nothing does."""
+
+    def test_a_serial_number_is_the_identity(self) -> None:
+        from strands_robots._serial_discovery import stable_device_id
+
+        assert stable_device_id(_arm("/dev/ttyACM0", "5AB0181806")) == "5AB0181806"
+
+    def test_the_same_hardware_keeps_its_identity_when_the_port_moves(self) -> None:
+        """The point of the whole exercise: the path changes, the id does not."""
+        from strands_robots._serial_discovery import stable_device_id
+
+        before = _arm("/dev/ttyACM0", "5AB0181806")
+        after = _arm("/dev/ttyACM3", "5AB0181806")
+
+        assert before.device != after.device
+        assert stable_device_id(before) == stable_device_id(after)
+
+    def test_a_device_without_a_serial_number_falls_back_to_vid_pid(self) -> None:
+        from strands_robots._serial_discovery import stable_device_id
+
+        no_serial = _FakePort("/dev/ttyUSB0", "USB Serial", 0x0403, 0x6001)
+
+        assert stable_device_id(no_serial) == "0403:6001"
+
+    def test_the_fallback_carries_the_bus_location_when_there_is_one(self) -> None:
+        """Two identical serial-less devices are still told apart by position."""
+        from strands_robots._serial_discovery import stable_device_id
+
+        left = _FakePort("/dev/ttyUSB0", "USB Serial", 0x0403, 0x6001, location="1-2:1.0")
+        right = _FakePort("/dev/ttyUSB1", "USB Serial", 0x0403, 0x6001, location="1-3:1.0")
+
+        assert stable_device_id(left) == "0403:6001:1-2:1.0"
+        assert stable_device_id(left) != stable_device_id(right)
+
+    def test_a_device_with_no_usb_identity_at_all_has_none(self) -> None:
+        from strands_robots._serial_discovery import stable_device_id
+
+        assert stable_device_id(_uart("/dev/ttyS0")) is None
+
+    def test_a_candidate_with_no_identity_is_still_named_by_port(self, bus) -> None:
+        """A serial-less servo bus is reported without inventing an id for it."""
+        from strands_robots._serial_discovery import describe_serial_candidates, scan_serial_devices
+
+        bus(_FakePort("/dev/ttyUSB0", "Feetech bus"))
+        described = describe_serial_candidates(scan_serial_devices())
+
+        assert "/dev/ttyUSB0" in described
+        assert "usb id" not in described
+
+
+class TestTheRuleHasOneOwner:
+    """A second copy of the vendor-id table would let the two callers disagree."""
+
+    def test_only_the_owner_module_carries_the_vendor_id_table(self) -> None:
+        carriers = sorted(
+            path.relative_to(_PACKAGE_DIR).as_posix()
+            for path in _PACKAGE_DIR.rglob("*.py")
+            if path != _OWNER
+            and any(f"{vid:#06x}" in path.read_text(encoding="utf-8").lower() for vid in _SERVO_BUS_VIDS)
+        )
+
+        assert carriers == [], (
+            f"the servo-bus vendor ids are named outside {_OWNER.name} by {carriers}; "
+            "route those call sites through matches_servo_bus() instead"
+        )
+
+    def test_the_mode_probe_consults_the_owner(self) -> None:
+        """``_auto_detect_mode`` must not re-derive what a robot's bus looks like."""
+        source = (_PACKAGE_DIR / "robot.py").read_text(encoding="utf-8")
+
+        assert "scan_serial_devices" in source, "robot.py no longer consults the owner"
+        assert "comports" not in source, "robot.py enumerates the bus itself instead of asking the owner"
+
+    def test_the_hardware_refusal_consults_the_owner(self) -> None:
+        source = (_PACKAGE_DIR / "hardware_robot.py").read_text(encoding="utf-8")
+
+        assert "scan_serial_devices" in source
+        assert "describe_serial_candidates" in source
+
+    def test_the_owner_is_reachable_without_pyserial(self, monkeypatch) -> None:
+        """pyserial is not a declared dependency, so its absence reports no devices."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def refuse_serial(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name.startswith("serial"):
+                raise ImportError("no pyserial")
+            return real_import(name, *args, **kwargs)
+
+        from strands_robots._serial_discovery import scan_serial_devices
+
+        monkeypatch.setattr(builtins, "__import__", refuse_serial)
+
+        assert scan_serial_devices() == []
+
+
+class TestNothingElseChanges:
+    """Which calls are refused is unchanged -- only what a refused call is told."""
+
+    def test_a_supplied_port_still_builds(self, bus) -> None:
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+        config = _config_for("so101_follower", "so101", port="/dev/ttyACM0")
+
+        assert config.port == "/dev/ttyACM0"
+
+    def test_a_config_that_refuses_its_own_values_keeps_the_generic_wrapper(self, monkeypatch, bus) -> None:
+        """A ``__post_init__`` refusal is not a missing parameter -- it still wraps."""
+        pytest.importorskip("lerobot")
+        from lerobot.robots.config import RobotConfig
+
+        @dataclasses.dataclass
+        class ExplodingConfig:
+            id: str = ""
+            cameras: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+            def __post_init__(self) -> None:
+                raise ValueError("post-init rejected the assembled config")
+
+        monkeypatch.setattr(RobotConfig, "get_choice_class", lambda robot_type: ExplodingConfig)
+        bus(_arm("/dev/ttyACM0", "5AB0181806"))
+
+        with pytest.raises(ValueError, match="post-init rejected the assembled config"):
+            _config_for("so101_follower", "so101")
+
+    @pytest.mark.parametrize(
+        ("label", "devices", "expected"),
+        [
+            ("a servo bus is present", (_arm("/dev/ttyACM0", "5AB0181806"),), "real"),
+            ("only on-board uarts", (_uart("/dev/ttyS0"), _uart("/dev/ttyAMA10")), "sim"),
+            ("nothing at all", (), "sim"),
+        ],
+    )
+    def test_the_mode_probe_reaches_the_same_verdict(self, bus, label, devices, expected) -> None:
+        pytest.importorskip("lerobot")
+        from strands_robots.robot import _auto_detect_mode
+
+        bus(*devices)
+
+        assert _auto_detect_mode("so101") == expected, label
+
+    def test_an_unusable_bus_still_falls_back_to_sim(self, monkeypatch) -> None:
+        serial_tools = pytest.importorskip("serial.tools.list_ports")
+        from strands_robots.robot import _auto_detect_mode
+
+        def boom() -> list[Any]:
+            raise RuntimeError("libusb hub glitch")
+
+        monkeypatch.setattr(serial_tools, "comports", boom)
+
+        assert _auto_detect_mode("so101") == "sim"
+
+
+class TestTheScanIsNotVacuous:
+    """A rule that recognises nothing would satisfy every assertion above."""
+
+    def test_the_owner_declares_the_vendor_ids_this_file_pins(self) -> None:
+        """The restated literal above must be the set the owner really declares."""
+        from strands_robots._serial_discovery import SERVO_BUS_VIDS
+
+        assert set(_SERVO_BUS_VIDS) == set(SERVO_BUS_VIDS)
+        assert 0x1A86 in SERVO_BUS_VIDS, "the WCH CH34x bridge every SO-10x carries"
+
+    def test_the_one_owner_scan_reaches_the_package(self) -> None:
+        scanned = [path for path in _PACKAGE_DIR.rglob("*.py")]
+
+        assert len(scanned) > 100, f"only {len(scanned)} modules scanned"
+        assert _OWNER in scanned
+
+    def test_the_owner_module_parses_as_the_source_the_guards_read(self) -> None:
+        """The structural guards read source text; confirm it is the real module."""
+        tree = ast.parse(_OWNER.read_text(encoding="utf-8"))
+        names = {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
+
+        assert {"matches_servo_bus", "stable_device_id", "scan_serial_devices"} <= names


### PR DESCRIPTION
## Problem

Eight of lerobot's sixteen robot types declare `port` with no default, so forgetting it is the commonest caller mistake on the hardware path. `_create_minimal_config` let the resolved dataclass raise and wrapped whatever it said:

```
ValueError: Failed to construct SOFollowerRobotConfig for robot type 'so101_follower':
SOFollowerRobotConfig.__init__() missing 1 required positional argument: 'port'.
Config: {'id': 'so101', 'cameras': {}}
```

That names `SOFollowerRobotConfig.__init__()`, a lerobot internal. It does not name `port=` as the thing the caller supplies, and it does not name a single device on the host - even though `mode="auto"` had enumerated the candidate ports one frame up, logged them, and returned only the string `"real"`. `Robot('so101', mode='auto')` and `Robot('so101', mode='real')` produced the identical message, so the probe's work was invisible.

The mirror-image mistake was already reported properly. A kwarg the dataclass does not declare is refused by name with the accepted field list, and `_create_minimal_config`'s own docstring says why: it "catches typos like `prot=` (instead of `port=`) at config-build time rather than as a delayed connection failure with no kwarg in sight." A required kwarg the caller omitted is the same class of mistake and got the third-party internal.

`tests/test_robot_factory.py::test_config_construction_failure_wrapped_as_value_error` already used a `_RequiresArg` config with a no-default field, and its docstring asks for a refusal "not a raw TypeError leaking the dataclass internals" - while the wrapper it pins interpolates exactly that TypeError.

## Change

A required field no forwarded kwarg supplied is detected before construction and refused by name. The prefix and the `Config: {...}` tail are unchanged, so the wrapper's existing contract (name the class, name the assembled values) still holds:

```
ValueError: Failed to construct SOFollowerRobotConfig for robot type 'so101_follower':
missing required parameter(s) ['port'], which the caller supplies -- e.g.
Robot('so101', mode='real', port=...). Candidate servo-bus device(s) on this host:
/dev/ttyACM0 (usb id 5AB0181806), /dev/ttyACM3 (usb id 5AB0158428). A port path is a
position on the bus, not an identity: it can change when the device is replugged,
while the usb id does not. Config: {'id': 'so101', 'cameras': {}}
```

The USB serial number is named beside the path because the path is what moves: unplug an arm and plug it back in and the kernel may hand it a different number, and plug a second arm in first and it may take the number the first one had. `pyserial` already reports the serial number; nothing was reading it.

The serial scan answers a missing `port` only. `lekiwi_client` requires `remote_ip`, and naming this host's serial devices there would point a network robot's caller at the wrong bus entirely.

Which serial device is a robot's motor bus is now decided once, in `strands_robots/_serial_discovery.py`. `_auto_detect_mode` had that rule inline - the keyword list, the WCH CH34x / FTDI vendor ids, the exclusions - and the refusal needs the same answer, so a second copy would let the two disagree about what a robot is. Enumeration there is best-effort: `pyserial` is not a declared dependency of this package (it arrives with lerobot), so an absent import or a libusb hub glitch reports no devices rather than replacing a precise refusal with an `ImportError`.

## Scope

Refusing by name is decision-free: the same values reach the same dataclass either way, so this changes which sentence a refused call gets, not which calls are refused.

Deliberately not included, because each is a public-surface decision this does not need to make: a public `list_serial_devices()`, a `Robot(stable_id=)` parameter that resolves a serial number to its current port at connect time, and any on-disk `stable_id -> last_port` persistence. The rule and the identity are now in one place should any of those be wanted later.

## Verification

Both trees run the identical selection with this PR's new test file excluded, so any difference would be the source change alone.

| tree | failed | passed | skipped |
| --- | --- | --- | --- |
| this branch | 0 | 1288 | 1 |
| `upstream/main` | 0 | 1287 | 1 |

The selection is 33 files: every test naming `_create_minimal_config`, `_auto_detect_mode`, the port enumeration or the construct-failure text, plus the repo-wide guards. Zero failures on either side, and the `comm` of the failing-id sets is empty in both directions. The one extra passing item on this branch is `test_attributes_docstring_completeness.py::test_every_field_has_an_attributes_entry[strands_robots/_serial_discovery.py::SerialCandidate]`, which that guard parametrized over the new dataclass on its own.

Pre-fix split of the new file against `upstream/main`: **27 failed / 8 passed** -> 35 passed. Eleven of the 27 are behavioural or structural (nine drive the real refusal, two pin that both call sites consult the owner); the other sixteen report the new module's absence, which is weaker evidence and is labelled as such. The 8 that pass on `upstream/main` are the controls: a supplied port still builds, a `__post_init__` refusal still routes to the generic wrapper, the refusal still names the config class and the assembled values, the serial scan still does not answer a missing `remote_ip`, and all four `_auto_detect_mode` verdicts are unchanged.

Every guard is load-bearing - each break fires exactly its own set:

| break | tests that fail |
| --- | --- |
| revert the hardware refusal | 9 (the refusal tests) |
| drop the port-shaped gate, always append the bus | 1 (only the `remote_ip` control) |
| revert `robot.py` to its own inline vendor-id table | 2 (one-owner guard, mode-probe pin) |
| make the scan raise instead of reporting nothing | 3 (the best-effort tests) |
| make `matches_servo_bus` recognise everything | 5 (rule tests, uart verdict, "not a servo bus") |
| drop the `vid:pid` identity fallback | 2 (the fallback tests) |
| control | 0 of 35 |

`mypy strands_robots tests tests_integ`: 24 errors on both trees, none branch-only. `ruff check` and `ruff format --check` clean on CI's scope. 753 repo-wide guard tests pass (docstring xrefs, ASCII, `Args:`/`Attributes:`/`Raises:` completeness, exception clauses, exports, dependency audit, changelog).

## Artifact

`Robot('so101', mode='real')` with two SO-101 arms attached, run against each tree. The capture script reads whichever refusal its own tree produces, extracts the device paths that refusal names, and retries with the first one - so the bottom row is what a caller who obeys the message actually gets, with nothing hardcoded per column.

![the refusal a caller who forgot port= is given, per tree](https://raw.githubusercontent.com/cagataycali/robots/media-missing-hardware-parameter/refusal-names-the-bus.png)

On `upstream/main` the refusal names no device, so there is nothing to retry with. On this branch it names `/dev/ttyACM0` and `/dev/ttyACM3` with their USB serial numbers `5AB0181806` and `5AB0158428`, and the retry builds the config. The controls are identical on both trees: `mode="auto"` reaches `real` either way, and a call that supplies `port=` builds either way.
