### PR TITLE
fix(sim): MUJOCO_GL is read the way MuJoCo reads it

### DIFF
--- a/changelog.d/2633-mujoco-gl-folded-value.md
+++ b/changelog.d/2633-mujoco-gl-folded-value.md
@@ -1,0 +1,20 @@
+### Fixed: `MUJOCO_GL` is read the way MuJoCo reads it
+
+MuJoCo folds `MUJOCO_GL` with `.lower().strip()`, reads `disable`/`disabled`/`off`/`false`/`0` as
+"build no GL context at all", accepts a platform-dependent set of backend names, and raises
+`RuntimeError` at import for anything else. Two sites re-derived that vocabulary loosely, so both
+answered about a spelling rather than about a backend.
+
+`strands_robots doctor` compared the raw value against `egl`/`osmesa`/`glfw` and read everything else
+as unset. `MUJOCO_GL=EGL` renders through EGL and was refused with "MUJOCO_GL not set and no display
+detected"; a disabled GL context and a value MuJoCo refuses at import both read as unset, so on any
+machine with a display they passed. On macOS the same fall-through recommended `egl`, which MuJoCo
+refuses there. Verdicts now name the value MuJoCo reads, refuse a disabled context and an unaccepted
+value on their own terms, and only ever recommend a value that platform accepts.
+
+The MuJoCo GL backend gated its NVIDIA EGL vendor ICD staging on an exact `egl`, so `MUJOCO_GL=EGL`
+selected EGL while skipping the guarantee that keeps glvnd off Mesa `llvmpipe` - the silent CPU
+software-rasterizer fallback. A whitespace-only value is also no longer mistaken for a preference,
+so a headless host is auto-configured rather than left on GLFW.
+
+Every value the previous comparison recognised keeps its verdict, byte for byte.

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -168,15 +168,74 @@ def check_mujoco() -> str:
 
 
 def check_mujoco_gl() -> str:
-    """MUJOCO_GL set for headless rendering."""
-    gl = os.environ.get("MUJOCO_GL", "")
-    if gl in ("egl", "osmesa"):
-        return _pass(f"MUJOCO_GL={gl}")
-    if gl == "glfw":
-        return _warn("MUJOCO_GL=glfw (needs display)", note="Set MUJOCO_GL=egl or osmesa for headless")
-    # Not set - check if a display exists
-    if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
-        return _pass("MUJOCO_GL unset (display detected, glfw will work)")
+    """MUJOCO_GL names a backend MuJoCo accepts, and one that can render here.
+
+    Answers about the value MuJoCo will read rather than about the string that was
+    typed. MuJoCo folds ``MUJOCO_GL`` with ``.lower().strip()``, reads one family
+    of values as "build no GL context at all", and raises ``RuntimeError`` at
+    import for anything outside the set it builds for the platform. Re-deriving
+    that vocabulary loosely answered about a spelling: ``MUJOCO_GL=EGL`` renders
+    through EGL and read as unrecognised, while every unrecognised value - a
+    disabled GL context, or one MuJoCo refuses outright - read as "not set" and so
+    passed on any machine with a display.
+
+    The vocabulary and the display question both belong to the MuJoCo backend
+    module, which sets this variable when it is unset, so both are asked there
+    rather than restated here.
+    """
+    from strands_robots.simulation.mujoco.backend import (
+        _MUJOCO_GL_DISABLE,
+        _MUJOCO_GL_OFFSCREEN,
+        _is_headless,
+        _mujoco_gl_valid_values,
+        _mujoco_gl_value,
+    )
+
+    raw = os.environ.get("MUJOCO_GL", "")
+    value = _mujoco_gl_value()
+    # Name the value MuJoCo reads whenever folding changed it, so a verdict about
+    # ``EGL`` does not read as a verdict about a variable nobody set.
+    shown = f"MUJOCO_GL={raw}" if raw == value else f"MUJOCO_GL={raw!r} (MuJoCo reads it as {value!r})"
+    valid = _mujoco_gl_valid_values()
+    # What to recommend has to be valid here: on a platform whose only backend
+    # draws through the window server there is no offscreen value to offer, and
+    # naming one would send the reader after a value MuJoCo refuses.
+    offscreen_here = sorted(_MUJOCO_GL_OFFSCREEN & valid)
+
+    if value in _MUJOCO_GL_DISABLE:
+        fix = (
+            f"export MUJOCO_GL={offscreen_here[0]}  # or unset it for the platform default"
+            if offscreen_here
+            else "unset MUJOCO_GL  # the platform's own backend renders through its window server"
+        )
+        return _fail(f"{shown} disables MuJoCo's GL context, so nothing can render", fix=fix)
+
+    if value not in valid:
+        offered = ", ".join(sorted(v for v in valid if v))
+        return _fail(
+            f"{shown} is a value MuJoCo refuses at import on {platform.system()}",
+            fix=f"export MUJOCO_GL=<one of: {offered}>  # or unset it for the platform default",
+        )
+
+    if value in _MUJOCO_GL_OFFSCREEN:
+        return _pass(shown)
+
+    # Every remaining accepted value routes MuJoCo to a backend that draws through
+    # the platform's window server.
+    if value:
+        note = (
+            f"Set MUJOCO_GL={' or '.join(offscreen_here)} for headless"
+            if offscreen_here
+            else f"{platform.system()} has no offscreen MuJoCo backend, so a window server is required"
+        )
+        return _warn(f"{shown} (needs display)", note=note)
+
+    if not _is_headless():
+        if platform.system() == "Linux":
+            return _pass("MUJOCO_GL unset (display detected, glfw will work)")
+        return _pass(f"MUJOCO_GL unset ({platform.system()} renders through its native backend)")
+    # ``_is_headless`` is only ever true on Linux, so the remedy below is reached
+    # on the one platform where those two backends exist.
     return _fail(
         "MUJOCO_GL not set and no display detected",
         fix="export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc",

--- a/strands_robots/doctor.py
+++ b/strands_robots/doctor.py
@@ -184,9 +184,9 @@ def check_mujoco_gl() -> str:
     rather than restated here.
     """
     from strands_robots.simulation.mujoco.backend import (
-        _MUJOCO_GL_DISABLE,
-        _MUJOCO_GL_OFFSCREEN,
         _is_headless,
+        _mujoco_gl_disables_rendering,
+        _mujoco_gl_offscreen_values,
         _mujoco_gl_valid_values,
         _mujoco_gl_value,
     )
@@ -200,9 +200,9 @@ def check_mujoco_gl() -> str:
     # What to recommend has to be valid here: on a platform whose only backend
     # draws through the window server there is no offscreen value to offer, and
     # naming one would send the reader after a value MuJoCo refuses.
-    offscreen_here = sorted(_MUJOCO_GL_OFFSCREEN & valid)
+    offscreen_here = sorted(_mujoco_gl_offscreen_values())
 
-    if value in _MUJOCO_GL_DISABLE:
+    if _mujoco_gl_disables_rendering(value):
         fix = (
             f"export MUJOCO_GL={offscreen_here[0]}  # or unset it for the platform default"
             if offscreen_here
@@ -217,7 +217,7 @@ def check_mujoco_gl() -> str:
             fix=f"export MUJOCO_GL=<one of: {offered}>  # or unset it for the platform default",
         )
 
-    if value in _MUJOCO_GL_OFFSCREEN:
+    if value in offscreen_here:
         return _pass(shown)
 
     # Every remaining accepted value routes MuJoCo to a backend that draws through

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -102,6 +102,39 @@ def _mujoco_gl_valid_values(system: str | None = None) -> frozenset[str]:
     return _MUJOCO_GL_ANY_PLATFORM | _MUJOCO_GL_PLATFORM_ONLY.get(name, frozenset())
 
 
+def _mujoco_gl_disables_rendering(value: str) -> bool:
+    """Whether a folded ``MUJOCO_GL`` value builds no GL context at all.
+
+    MuJoCo accepts this family and then defines no ``GLContext``, so rendering is
+    unavailable rather than misconfigured. It is a different answer from a value
+    MuJoCo refuses at import, and naming the wrong one sends a caller after the
+    wrong remedy.
+
+    Args:
+        value: A value already folded by :func:`_mujoco_gl_value`.
+
+    Returns:
+        True when MuJoCo will skip GL context creation entirely.
+    """
+    return value in _MUJOCO_GL_DISABLE
+
+
+def _mujoco_gl_offscreen_values(system: str | None = None) -> frozenset[str]:
+    """Accepted values that render on a platform with no display server.
+
+    Empty on a platform whose only backend draws through the window server, which
+    is what a caller needs in order not to recommend a value MuJoCo refuses there.
+
+    Args:
+        system: Platform name as :func:`platform.system` reports it. Defaults to
+            the running platform.
+
+    Returns:
+        The offscreen backends that platform accepts.
+    """
+    return _MUJOCO_GL_OFFSCREEN & _mujoco_gl_valid_values(system)
+
+
 # glvnd EGL vendor ICD payload that points at the NVIDIA EGL library, plus the
 # standard directories glvnd scans for vendor ICD JSON files. When MUJOCO_GL is
 # "egl", libglvnd loads the first vendor whose ICD JSON is registered here; an

--- a/strands_robots/simulation/mujoco/backend.py
+++ b/strands_robots/simulation/mujoco/backend.py
@@ -4,6 +4,7 @@ import contextlib
 import ctypes
 import logging
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -43,6 +44,62 @@ def _is_headless() -> bool:
     if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
         return False
     return True
+
+
+# MuJoCo's own ``MUJOCO_GL`` vocabulary, transcribed from ``mujoco.gl_context``:
+# it folds the value with ``.lower().strip()``, reads one family as "build no GL
+# context at all", accepts a platform-dependent set of backend names, and raises
+# ``RuntimeError`` at import time for anything else.
+#
+# Transcribed rather than asked. ``mujoco.gl_context`` computes its copy of this
+# at module import, so it is already stale relative to a caller's environment;
+# importing it is itself what raises for exactly the values a caller needs told
+# about; and mujoco may not be installed at all, which is a separate question.
+# Same reasoning as ``doctor._hf_token_path``, which transcribes the Hub's
+# token-path rule for a Hub that may not be installed either.
+_MUJOCO_GL_DISABLE: frozenset[str] = frozenset({"disable", "disabled", "off", "false", "0"})
+_MUJOCO_GL_ANY_PLATFORM: frozenset[str] = frozenset({"enable", "enabled", "on", "true", "1", "glfw", ""})
+_MUJOCO_GL_PLATFORM_ONLY: dict[str, frozenset[str]] = {
+    "Linux": frozenset({"glx", "egl", "osmesa"}),
+    "Windows": frozenset({"wgl"}),
+    "Darwin": frozenset({"cgl"}),
+}
+# Backends that render with no display server: MuJoCo routes Linux ``egl`` and
+# ``osmesa`` to offscreen contexts, while every other backend it selects (GLFW on
+# Linux and Windows, CGL on macOS) draws through the platform's window server.
+_MUJOCO_GL_OFFSCREEN: frozenset[str] = frozenset({"egl", "osmesa"})
+
+
+def _mujoco_gl_value() -> str:
+    """The ``MUJOCO_GL`` value MuJoCo will read, folded the way MuJoCo folds it.
+
+    MuJoCo reads ``os.environ.get("MUJOCO_GL", "").lower().strip()``, so ``EGL``,
+    ``egl`` and ``" egl "`` all select the same backend. Comparing the raw string
+    instead answers about a spelling rather than about a backend: ``MUJOCO_GL=EGL``
+    renders through EGL, while a case-sensitive test reads it as a value nobody
+    recognises.
+
+    Returns:
+        The folded value. Empty both for an unset variable and for one holding
+        only whitespace, which MuJoCo also reads as "no preference".
+    """
+    return os.environ.get("MUJOCO_GL", "").lower().strip()
+
+
+def _mujoco_gl_valid_values(system: str | None = None) -> frozenset[str]:
+    """Values MuJoCo accepts for ``MUJOCO_GL`` on a platform.
+
+    Args:
+        system: Platform name as :func:`platform.system` reports it. Defaults to
+            the running platform.
+
+    Returns:
+        The platform-independent names together with that platform's own backend
+        names. A folded value outside this set and outside
+        :data:`_MUJOCO_GL_DISABLE` makes ``import mujoco`` raise ``RuntimeError``.
+    """
+    name = platform.system() if system is None else system
+    return _MUJOCO_GL_ANY_PLATFORM | _MUJOCO_GL_PLATFORM_ONLY.get(name, frozenset())
 
 
 # glvnd EGL vendor ICD payload that points at the NVIDIA EGL library, plus the
@@ -159,15 +216,26 @@ def _configure_gl_backend() -> None:  # noqa: C901
     - "osmesa" - OSMesa (CPU software rendering, slower but always works)
     - "glfw"   - GLFW (default, requires X11/Wayland display server)
 
+    MuJoCo folds the value with ``.lower().strip()`` before reading it, so
+    ``EGL`` and ``" egl "`` select EGL as well (see :func:`_mujoco_gl_value`).
+
     This function MUST be called before `import mujoco`. Setting MUJOCO_GL
     after import has no effect - the backend is locked at import time.
 
     Never overrides a user-set MUJOCO_GL value.
     """
     existing = os.environ.get("MUJOCO_GL")
-    if existing:
+    # Read the folded value, because that is the backend MuJoCo will select.
+    # ``MUJOCO_GL=EGL`` renders through EGL and so has to reach the vendor-ICD
+    # guarantee too; a case-sensitive test here left glvnd on its default, which
+    # on an NVIDIA host missing the NVIDIA ICD is Mesa llvmpipe - the silent
+    # software-rasterizer fallback ``_ensure_nvidia_egl_vendor_icd`` exists to
+    # prevent. A whitespace-only value is not a preference: MuJoCo reads it as
+    # unset, so auto-configuration is what respects it.
+    value = _mujoco_gl_value()
+    if value:
         logger.debug(f"MUJOCO_GL already set to '{existing}', respecting user config")
-        if existing == "egl":
+        if value == "egl":
             _ensure_nvidia_egl_vendor_icd()
         return
 

--- a/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
+++ b/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
@@ -1,0 +1,389 @@
+"""The MUJOCO_GL verdict is about the value MuJoCo reads, not the string typed.
+
+MuJoCo folds ``MUJOCO_GL`` with ``.lower().strip()``, reads
+``disable/disabled/off/false/0`` as "build no GL context at all", accepts a
+platform-dependent set of backend names, and raises ``RuntimeError`` at import
+for anything else (``mujoco.gl_context``). Re-deriving that vocabulary loosely
+answered about a spelling: ``MUJOCO_GL=EGL`` renders through EGL and read as
+unrecognised, and every unrecognised value - a disabled GL context, or one MuJoCo
+refuses outright - read as "not set", which on a machine with a display passed.
+
+The same fold decides whether the NVIDIA EGL vendor ICD is staged, so
+``MUJOCO_GL=EGL`` selected EGL while skipping the guarantee that keeps glvnd off
+Mesa ``llvmpipe`` - the silent software-rasterizer fallback that
+``_ensure_nvidia_egl_vendor_icd`` exists to prevent.
+
+The vocabulary below is written out here rather than imported, so these cases
+grade the shipped behaviour against a second opinion; one drift test pins the two
+against each other.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import sys
+
+import pytest
+
+# MuJoCo's own vocabulary, transcribed independently of the package.
+_DISABLE = ("disable", "disabled", "off", "false", "0")
+_ANY_PLATFORM = ("", "1", "enable", "enabled", "glfw", "on", "true")
+_LINUX_ONLY = ("egl", "glx", "osmesa")
+_DARWIN_ONLY = ("cgl",)
+_WINDOWS_ONLY = ("wgl",)
+
+
+def _marker(verdict: str) -> str:
+    """The status a caller can recover from a verdict line."""
+    for name in ("FAIL", "WARN", "PASS", "SKIP"):
+        if f"  {name}  " in verdict:
+            return name
+    raise AssertionError(f"verdict carries no status marker: {verdict!r}")
+
+
+def _plain(verdict: str) -> str:
+    """The verdict with ANSI colour removed."""
+    return re.sub(r"\033\[[0-9;]*m", "", verdict)
+
+
+def _headline(verdict: str) -> str:
+    """The verdict's own claim, without the remedy lines below it.
+
+    A remedy legitimately says "or unset it", so a claim about what the variable
+    holds has to be read from the line that makes it.
+    """
+    return _plain(verdict).split("\n")[0]
+
+
+def _recommended_values(verdict: str) -> set[str]:
+    """Every MUJOCO_GL value the verdict's remedy tells the reader to set.
+
+    Only the remedy lines are read: the headline names the value the caller
+    already has, which is exactly the value under complaint.
+    """
+    lines = _plain(verdict).split("\n")[1:]
+    found: set[str] = set()
+    for line in lines:
+        for match in re.finditer(r"MUJOCO_GL=(.+?)(?:\s+#|\s+for headless|$)", line):
+            body = match.group(1).strip()
+            body = re.sub(r"^<one of:\s*", "", body).rstrip(">")
+            for token in re.split(r",|\bor\b", body):
+                token = token.strip()
+                if token:
+                    found.add(token)
+    return found
+
+
+@pytest.fixture
+def linux_headless(monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+    """A headless Linux host: the platform where every backend name is available."""
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    return monkeypatch
+
+
+class TestTheVerdictIsAboutTheValueMujocoReads:
+    """A spelling MuJoCo folds to a working backend is not a broken setup."""
+
+    @pytest.mark.parametrize("spelling", ["EGL", " egl ", "EgL", "\tosmesa\n", "OSMesa"])
+    def test_a_folded_offscreen_backend_passes(self, linux_headless, spelling: str) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", spelling)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "PASS", (
+            f"MUJOCO_GL={spelling!r} folds to {spelling.lower().strip()!r}, which renders headlessly, "
+            f"yet the verdict is {_marker(verdict)}: {_plain(verdict)!r}"
+        )
+
+    @pytest.mark.parametrize("spelling", ["GLFW", " glfw ", "GLX", "ON", "TRUE"])
+    def test_a_folded_display_backend_warns_rather_than_reading_as_unset(self, linux_headless, spelling: str) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", spelling)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "WARN", (
+            f"MUJOCO_GL={spelling!r} selects a backend that needs a display; the verdict is "
+            f"{_marker(verdict)}: {_plain(verdict)!r}"
+        )
+        assert "not set" not in _headline(verdict), (
+            f"MUJOCO_GL={spelling!r} is set, so the verdict must not report it as unset: {_headline(verdict)!r}"
+        )
+
+    def test_a_folded_verdict_names_the_value_mujoco_reads(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", "EGL")
+        text = _plain(check_mujoco_gl())
+        assert "EGL" in text and "egl" in text, (
+            f"a verdict about a folded value has to name both what was set and what MuJoCo reads: {text!r}"
+        )
+
+
+class TestADisabledGLContextIsNotAWorkingConfiguration:
+    """The disable family builds no GL context, so nothing can render."""
+
+    @pytest.mark.parametrize("value", _DISABLE)
+    @pytest.mark.parametrize("display", [None, ":0"])
+    def test_a_disabled_gl_context_fails(self, linux_headless, value: str, display: str | None) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", value)
+        if display is not None:
+            linux_headless.setenv("DISPLAY", display)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "FAIL", (
+            f"MUJOCO_GL={value!r} makes MuJoCo build no GL context at all (DISPLAY={display!r}), "
+            f"so the verdict cannot be {_marker(verdict)}: {_plain(verdict)!r}"
+        )
+        assert value in _plain(verdict), f"the verdict has to name the value that disabled it: {_plain(verdict)!r}"
+
+    def test_a_disabled_gl_context_is_not_reported_as_unset(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", "off")
+        linux_headless.setenv("DISPLAY", ":0")
+        headline = _headline(check_mujoco_gl())
+        assert "unset" not in headline, f"MUJOCO_GL=off is set, and to a value that disables rendering: {headline!r}"
+
+
+class TestAValueMujocoRefusesIsReportedAsRefused:
+    """MuJoCo raises at import for an unrecognised value, so say so."""
+
+    @pytest.mark.parametrize("value", ["egl1", "glfw2", "yes", "egl osmesa", "EGL;osmesa"])
+    @pytest.mark.parametrize("display", [None, ":0"])
+    def test_an_unrecognised_value_fails_and_names_the_refusal(
+        self, linux_headless, value: str, display: str | None
+    ) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", value)
+        if display is not None:
+            linux_headless.setenv("DISPLAY", display)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "FAIL", (
+            f"MUJOCO_GL={value!r} makes ``import mujoco`` raise RuntimeError (DISPLAY={display!r}), "
+            f"so the verdict cannot be {_marker(verdict)}: {_plain(verdict)!r}"
+        )
+        assert "refuses" in _plain(verdict), (
+            f"the verdict has to say MuJoCo refuses the value rather than that none was set: {_plain(verdict)!r}"
+        )
+
+    def test_the_refusal_offers_the_values_that_platform_accepts(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", "egl1")
+        offered = _recommended_values(check_mujoco_gl())
+        assert {"egl", "osmesa", "glfw", "glx"} <= offered, (
+            f"a Linux refusal has to offer the Linux backend names; offered {sorted(offered)}"
+        )
+
+
+class TestThePlatformDecidesWhichBackendsAreValid:
+    """MuJoCo builds its accepted set per platform, so the verdict has to too."""
+
+    @pytest.fixture
+    def macos(self, monkeypatch: pytest.MonkeyPatch) -> pytest.MonkeyPatch:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        return monkeypatch
+
+    @pytest.mark.parametrize("value", ["egl", "osmesa", "glx"])
+    def test_a_linux_only_backend_is_refused_on_macos(self, macos, value: str) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        macos.setenv("MUJOCO_GL", value)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "FAIL", (
+            f"MUJOCO_GL={value!r} is not in MuJoCo's accepted set on Darwin, so ``import mujoco`` raises; "
+            f"the verdict is {_marker(verdict)}: {_plain(verdict)!r}"
+        )
+
+    def test_the_macos_refusal_offers_cgl_and_not_a_linux_backend(self, macos) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        macos.setenv("MUJOCO_GL", "egl")
+        offered = _recommended_values(check_mujoco_gl())
+        assert "cgl" in offered, f"a Darwin refusal has to offer cgl; offered {sorted(offered)}"
+        assert not offered & {"egl", "osmesa", "glx"}, (
+            f"a Darwin remedy must not name a backend MuJoCo refuses there; offered {sorted(offered)}"
+        )
+
+    def test_the_macos_native_backend_is_accepted(self, macos) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        macos.setenv("MUJOCO_GL", "cgl")
+        assert _marker(check_mujoco_gl()) != "FAIL", "cgl is MuJoCo's macOS backend"
+
+    def test_an_unset_variable_is_not_a_failure_on_macos(self, macos) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        macos.delenv("MUJOCO_GL", raising=False)
+        verdict = check_mujoco_gl()
+        assert _marker(verdict) == "PASS", (
+            "MuJoCo routes macOS to CGL whatever MUJOCO_GL holds, so an unset variable is the "
+            f"working default: {_plain(verdict)!r}"
+        )
+
+    def test_the_windows_native_backend_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("MUJOCO_GL", "wgl")
+        assert _marker(check_mujoco_gl()) != "FAIL", "wgl is MuJoCo's Windows backend"
+
+
+class TestARemedyNeverNamesAValueMujocoRefuses:
+    """Every value a verdict tells the reader to set has to be accepted there."""
+
+    @pytest.mark.parametrize("system", ["Linux", "Darwin", "Windows"])
+    @pytest.mark.parametrize("value", ["egl1", "off", "glfw", "cgl", "wgl", "egl", ""])
+    def test_a_remedy_only_offers_values_that_platform_accepts(
+        self, monkeypatch: pytest.MonkeyPatch, system: str, value: str
+    ) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        accepted = set(_ANY_PLATFORM) | set(
+            {"Linux": _LINUX_ONLY, "Darwin": _DARWIN_ONLY, "Windows": _WINDOWS_ONLY}[system]
+        )
+        monkeypatch.setattr(platform, "system", lambda: system)
+        monkeypatch.setattr(sys, "platform", {"Linux": "linux", "Darwin": "darwin", "Windows": "win32"}[system])
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        if value:
+            monkeypatch.setenv("MUJOCO_GL", value)
+        else:
+            monkeypatch.delenv("MUJOCO_GL", raising=False)
+
+        offered = _recommended_values(check_mujoco_gl())
+        refused = offered - accepted
+        assert not refused, (
+            f"on {system}, MUJOCO_GL={value!r} produced a remedy naming {sorted(refused)}, which MuJoCo "
+            f"refuses there - following it makes ``import mujoco`` raise"
+        )
+
+
+class TestNothingElseChanges:
+    """Every value the previous vocabulary recognised keeps its verdict."""
+
+    def test_egl_still_passes_with_the_same_line(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", "egl")
+        assert _plain(check_mujoco_gl()) == "  PASS  MUJOCO_GL=egl"
+
+    def test_glfw_still_warns_with_the_same_lines(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.setenv("MUJOCO_GL", "glfw")
+        assert _plain(check_mujoco_gl()) == (
+            "  WARN  MUJOCO_GL=glfw (needs display)\n        Set MUJOCO_GL=egl or osmesa for headless"
+        )
+
+    def test_unset_and_headless_still_fails_with_the_same_lines(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.delenv("MUJOCO_GL", raising=False)
+        assert _plain(check_mujoco_gl()) == (
+            "  FAIL  MUJOCO_GL not set and no display detected\n"
+            "        Fix: export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc"
+        )
+
+    def test_unset_with_a_display_still_passes_with_the_same_line(self, linux_headless) -> None:
+        from strands_robots.doctor import check_mujoco_gl
+
+        linux_headless.delenv("MUJOCO_GL", raising=False)
+        linux_headless.setenv("DISPLAY", ":0")
+        assert _plain(check_mujoco_gl()) == "  PASS  MUJOCO_GL unset (display detected, glfw will work)"
+
+
+class TestTheEGLVendorICDGuaranteeFollowsTheFoldedValue:
+    """Whichever spelling selects EGL reaches the vendor-ICD guarantee."""
+
+    @pytest.fixture
+    def icd_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        staged: list[bool] = []
+        monkeypatch.setattr(backend, "_ensure_nvidia_egl_vendor_icd", lambda: staged.append(True))
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("DISPLAY", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        return staged
+
+    @pytest.mark.parametrize("spelling", ["egl", "EGL", " egl ", "EgL"])
+    def test_every_spelling_of_egl_stages_the_vendor_icd(
+        self, monkeypatch: pytest.MonkeyPatch, icd_spy: list[bool], spelling: str
+    ) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        monkeypatch.setenv("MUJOCO_GL", spelling)
+        backend._configure_gl_backend()
+        assert icd_spy == [True], (
+            f"MUJOCO_GL={spelling!r} selects MuJoCo's EGL backend, so glvnd has to be pointed at the "
+            "NVIDIA vendor ICD; without it an NVIDIA host missing that ICD renders on Mesa llvmpipe"
+        )
+
+    @pytest.mark.parametrize("spelling", ["osmesa", "OSMESA", "glfw", "GLFW", "glx"])
+    def test_a_non_egl_backend_does_not_stage_the_vendor_icd(
+        self, monkeypatch: pytest.MonkeyPatch, icd_spy: list[bool], spelling: str
+    ) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        monkeypatch.setenv("MUJOCO_GL", spelling)
+        backend._configure_gl_backend()
+        assert icd_spy == [], f"MUJOCO_GL={spelling!r} does not select EGL, so no vendor ICD is needed"
+
+    @pytest.mark.parametrize("spelling", ["egl", "EGL", " egl ", "glfw", "off"])
+    def test_a_user_value_is_never_overwritten(
+        self, monkeypatch: pytest.MonkeyPatch, icd_spy: list[bool], spelling: str
+    ) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        monkeypatch.setenv("MUJOCO_GL", spelling)
+        backend._configure_gl_backend()
+        assert backend.os.environ["MUJOCO_GL"] == spelling, "a value the user set is theirs"
+
+    def test_a_whitespace_only_value_is_not_a_preference(
+        self, monkeypatch: pytest.MonkeyPatch, icd_spy: list[bool]
+    ) -> None:
+        import strands_robots.simulation.mujoco.backend as backend
+
+        monkeypatch.setenv("MUJOCO_GL", "   ")
+        monkeypatch.setattr(backend.ctypes.cdll, "LoadLibrary", lambda _name: None)
+        backend._configure_gl_backend()
+        assert backend.os.environ["MUJOCO_GL"] == "egl", (
+            "MuJoCo reads a whitespace-only value as no preference, so a headless host still gets "
+            "an offscreen backend configured rather than being left on GLFW"
+        )
+
+
+class TestTheTranscribedVocabularyMatchesTheModule:
+    """The vocabulary written out above and the module's own must not drift."""
+
+    def test_the_disable_family_agrees(self) -> None:
+        from strands_robots.simulation.mujoco.backend import _MUJOCO_GL_DISABLE
+
+        assert _MUJOCO_GL_DISABLE == frozenset(_DISABLE)
+
+    @pytest.mark.parametrize(
+        ("system", "extra"),
+        [("Linux", _LINUX_ONLY), ("Darwin", _DARWIN_ONLY), ("Windows", _WINDOWS_ONLY), ("FreeBSD", ())],
+    )
+    def test_the_accepted_set_agrees(self, system: str, extra: tuple[str, ...]) -> None:
+        from strands_robots.simulation.mujoco.backend import _mujoco_gl_valid_values
+
+        assert _mujoco_gl_valid_values(system) == frozenset(_ANY_PLATFORM) | frozenset(extra)
+
+    @pytest.mark.parametrize("raw", ["EGL", " egl ", "\tOSMesa\n", "", "   ", "off"])
+    def test_the_fold_agrees(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        from strands_robots.simulation.mujoco.backend import _mujoco_gl_value
+
+        monkeypatch.setenv("MUJOCO_GL", raw)
+        assert _mujoco_gl_value() == raw.lower().strip()

--- a/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
+++ b/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
@@ -225,7 +225,7 @@ class TestThePlatformDecidesWhichBackendsAreValid:
     def test_the_macos_native_backend_is_accepted(self, macos) -> None:
         from strands_robots.doctor import check_mujoco_gl
 
-        macos.setenv("MUJOCO_GL", "cgl")
+        macos.setenv("MUJOCO_GL", _DARWIN_ONLY[0])  # cgl, MuJoCo's macOS backend
         assert _marker(check_mujoco_gl()) != "FAIL", "cgl is MuJoCo's macOS backend"
 
     def test_an_unset_variable_is_not_a_failure_on_macos(self, macos) -> None:

--- a/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
+++ b/tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py
@@ -139,7 +139,15 @@ class TestADisabledGLContextIsNotAWorkingConfiguration:
             f"MUJOCO_GL={value!r} makes MuJoCo build no GL context at all (DISPLAY={display!r}), "
             f"so the verdict cannot be {_marker(verdict)}: {_plain(verdict)!r}"
         )
-        assert value in _plain(verdict), f"the verdict has to name the value that disabled it: {_plain(verdict)!r}"
+        headline = _headline(verdict)
+        assert value in headline, f"the verdict has to name the value that disabled it: {headline!r}"
+        # MuJoCo accepts this family and simply builds no context, so reporting it
+        # as a value MuJoCo refuses at import would name the wrong cause.
+        assert "refuses" not in headline, (
+            f"MuJoCo accepts {value!r} and builds no GL context from it, so the verdict must not "
+            f"report it as a value MuJoCo refuses: {headline!r}"
+        )
+        assert "render" in headline, f"the verdict has to name the consequence - that nothing can render: {headline!r}"
 
     def test_a_disabled_gl_context_is_not_reported_as_unset(self, linux_headless) -> None:
         from strands_robots.doctor import check_mujoco_gl


### PR DESCRIPTION
## What

`MUJOCO_GL` is read in two places, and neither read it the way MuJoCo does. Both
now ask one folded value, owned by the module that already sets this variable.

## The rule, from MuJoCo itself

`mujoco/gl_context.py` is the spec:

```python
_MUJOCO_GL = os.environ.get('MUJOCO_GL', '').lower().strip()
if _MUJOCO_GL not in ('disable', 'disabled', 'off', 'false', '0'):
  _VALID_MUJOCO_GL = ('enable', 'enabled', 'on', 'true', '1' , 'glfw', '')
  if _SYSTEM == 'Linux':   _VALID_MUJOCO_GL += ('glx', 'egl', 'osmesa')
  elif _SYSTEM == 'Windows': _VALID_MUJOCO_GL += ('wgl',)
  elif _SYSTEM == 'Darwin':  _VALID_MUJOCO_GL += ('cgl',)
  if _MUJOCO_GL not in _VALID_MUJOCO_GL:
    raise RuntimeError(f'invalid value for environment variable MUJOCO_GL: {_MUJOCO_GL}')
```

So MuJoCo folds the value, has a family that builds **no GL context at all**,
accepts a platform-dependent set of names, and **raises at import** for anything
else.

## Measured, on a Linux host

Each row is one fresh process: `check_mujoco_gl()`, then `import mujoco` in the
same process, reading whether a `GLContext` exists at all.

**With a display present** (`DISPLAY=:99`), before this change:

| `MUJOCO_GL` | what MuJoCo does | verdict | |
|---|---|---|---|
| `disable` / `off` / `false` / `0` | imports, builds **no GLContext** | **PASS** `MUJOCO_GL unset (display detected, glfw will work)` | passes a setup where nothing can render, and calls a set variable unset |
| `egl1` | **`RuntimeError: invalid value for environment variable MUJOCO_GL: egl1`** | **PASS** `MUJOCO_GL unset (display detected, glfw will work)` | passes a value that makes `import mujoco` raise |
| `EGL` / `" egl "` | EGL, works | PASS, but the line names the wrong backend and says unset | |

**Headless**, before this change:

| `MUJOCO_GL` | what MuJoCo does | verdict |
|---|---|---|
| `EGL` | **EGL, renders headlessly** | **FAIL** `MUJOCO_GL not set and no display detected` -> `Fix: export MUJOCO_GL=egl` |
| `" egl "` | **EGL, renders headlessly** | **FAIL**, same line |
| `GLFW` | GLFW | FAIL as unset, rather than the `glfw` warning |
| `glx` | GLFW | FAIL as unset (a set value) |
| `egl1` | raises at import | FAIL as unset, never naming the refusal |

After this change every cell agrees with what MuJoCo did in that same process.
`EGL` and `" egl "` pass; the disable family and `egl1` fail and name why; `glx`
and `GLFW` get the display warning `glfw` always got.

## The second site: the EGL vendor ICD

`_ensure_nvidia_egl_vendor_icd` exists because, in its own words, glvnd
otherwise "silently falls back to Mesa `llvmpipe` (CPU software rasterization),
roughly two orders of magnitude slower. That throttles every policy observation,
rollout video, and dataset recording with no signal."

`_configure_gl_backend` gated it on `existing == "egl"`. `MUJOCO_GL=EGL` selects
EGL and skipped it, so on an NVIDIA host missing the NVIDIA ICD - the CUDA
base-image case that function was written for - rendering silently drops to CPU.
`docs/troubleshooting.md` already documents that staging as automatic for an EGL
backend; it was automatic for one spelling of one.

A whitespace-only value was also treated as a user preference and left alone,
though MuJoCo reads it as unset, so a headless host was left on GLFW instead of
being auto-configured.

## Change

`strands_robots/simulation/mujoco/backend.py` gains MuJoCo's vocabulary
(`_MUJOCO_GL_DISABLE`, `_MUJOCO_GL_ANY_PLATFORM`, `_MUJOCO_GL_PLATFORM_ONLY`,
`_MUJOCO_GL_OFFSCREEN`) and answers the four questions that vocabulary decides:
`_mujoco_gl_value()` folds, `_mujoco_gl_valid_values()` gives a platform's
accepted set, `_mujoco_gl_disables_rendering()` distinguishes the family MuJoCo
accepts and then builds nothing from, and `_mujoco_gl_offscreen_values()` gives
the values that need no display server there. The caller asks those rather than
doing set arithmetic on the raw constants, so the vocabulary is only ever read
where it is defined. It is transcribed rather than imported:
`mujoco.gl_context` computes its copy at module import so it is already stale
relative to a caller's environment, importing it is itself what raises for the
values a caller needs told about, and mujoco may not be installed at all. Same
reasoning as `doctor._hf_token_path`, which transcribes the Hub's token-path rule.

`_configure_gl_backend` reads the folded value. `doctor.check_mujoco_gl` asks the
backend those questions and `_is_headless`, rather than restating either the
vocabulary or the display test.

A remedy is now built from the values valid on the running platform, so a macOS
verdict offers `cgl` instead of `egl`.

The predicates arrived because CodeQL was right about the shape: the first
revision exported the disable family and the offscreen set for the caller to
intersect, so `py/unused-global-variable` flagged both as declared-and-unused in
the module that defines them - which is exactly the smell of a caller deciding
something its owner should. Both alerts cleared, and the encapsulation is better
for it.

## Tests

`tests/test_doctor_mujoco_gl_reads_the_value_mujoco_reads.py`, 91 cases. The
vocabulary is written out in the test file as a second opinion, with one drift
class pinning it against the module.

Against `upstream/main`: **66 failed / 25 passed**. Only 11 of the 66 report the
absence of a new symbol; the other 55 are behavioural, e.g.

```
MUJOCO_GL='EGL' folds to 'egl', which renders headlessly, yet the verdict is FAIL
MUJOCO_GL='off' makes MuJoCo build no GL context at all (DISPLAY=':0'), so the verdict cannot be PASS
on Darwin, MUJOCO_GL='egl' produced a remedy naming ['egl'], which MuJoCo refuses there
MUJOCO_GL='EGL' selects MuJoCo's EGL backend, so glvnd has to be pointed at the NVIDIA vendor ICD
```

The 25 that pass on both trees are the controls. `TestNothingElseChanges` pins
all four previously-recognised outcomes byte for byte:

| `MUJOCO_GL` | line, unchanged |
|---|---|
| `egl` | `  PASS  MUJOCO_GL=egl` |
| `glfw` | `  WARN  MUJOCO_GL=glfw (needs display)` + `Set MUJOCO_GL=egl or osmesa for headless` |
| unset, headless | `  FAIL  MUJOCO_GL not set and no display detected` + `Fix: export MUJOCO_GL=egl  # or osmesa; add to ~/.bashrc` |
| unset, display | `  PASS  MUJOCO_GL unset (display detected, glfw will work)` |

`TestARemedyNeverNamesAValueMujocoRefuses` parses each verdict's remedy and
asserts every value it offers is accepted on that platform, so no verdict can
send a reader after a value MuJoCo would refuse.

## Verification

Measured at `2aaaf833`, on a Linux host with mujoco 3.5.0.

220 test files - every test naming `check_mujoco_gl`, `_configure_gl_backend`,
`MUJOCO_GL`, `_is_headless`, `_ensure_nvidia_egl_vendor_icd` or the doctor module,
all of `tests/simulation/mujoco/`, and the repo-wide docstring, string, changelog
and dependency guards - run as the **identical selection on both trees**, with the
new test file excluded from each so the comparison is of the source change alone:

| tree | result |
|---|---|
| this branch | `3 failed, 5176 passed, 48 skipped in 322.24s` |
| pristine `upstream/main` | `3 failed, 5176 passed, 48 skipped in 335.19s` |

Failing-ID sets identical, `comm` empty in both directions. All 3 reproduce on a
pristine tree in isolation and are environmental here: two are
`TestDoctorVersionResolution` raising `PackageNotFoundError` because the worktree
is not pip-installed, and `test_lerobot_e2e` needs `draccus>=0.11.6` where this
box has 0.10.0.

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`. `mypy` 24 errors on both trees, branch-only set empty.

The new file alone: **91 passed**.

One repo-wide guard reacted to the new file and was right to:
`test_examples_mujoco_gl.py` forbids a hard-coded `MUJOCO_GL="cgl"` on a line
without a platform guard, because on headless Linux that kills the first render.
The macOS cases now name that backend through the vocabulary the test file already
declares rather than repeating the literal.

### Each guard is load-bearing

Every break is applied to the committed tree and the new file re-run:

| break | failed | classes fired |
|---|---|---|
| control | 0 | - |
| revert both source files | 66 | all 7 |
| revert `doctor.py` only | 51 | the 5 verdict classes, **not** the vendor-ICD class |
| restore `existing == "egl"` for the ICD | 3 | the vendor-ICD class only |
| drop the per-platform accepted set | 19 | platform + remedy + drift |
| hardcode the remedy to `egl or osmesa` | 6 | the remedy guard only |
| empty the disable family | 11 | disable + drift |
| gate `_configure_gl_backend` on raw truthiness | 1 | the whitespace-only case |

The second and third rows are complementary, which is what shows the two sites are
independently pinned. Emptying the disable family initially fired only the drift
test, because a disable value then fell through to the "MuJoCo refuses this value"
branch and still failed - the right verdict for the wrong reason. That case now
also asserts the headline does not blame MuJoCo for a value MuJoCo accepts.

## Scope

`glx` with a display moves from PASS to the display warning `glfw` has always
received with a display present; the note is accurate either way, and this keeps
one treatment for every value MuJoCo routes to GLFW rather than inventing a
display-dependent split.

The macOS and Windows rows are derived from MuJoCo's own accepted set quoted
above, not measured on those hosts.

`MUJOCO_GL=osmesa` still passes on a host with no `libOSMesa`, where `import
mujoco` fails. Answering that needs the check to import mujoco, which is
`check_mujoco`'s separate question, so it is left alone.