### PR TITLE
test(refusals): the code contract is graded by what can carry a code, not by the grants already registered

### DIFF
--- a/changelog.d/2636-refusal-code-guard-scope.md
+++ b/changelog.d/2636-refusal-code-guard-scope.md
@@ -1,0 +1,26 @@
+### Fixed: the refusal-code guard is scoped by what can carry a code, not by the grants already registered
+
+A continuable refusal carries a stable `code` so a consumer classifies it on
+identity rather than on prose, and one test exists to make sure a new one does not
+arrive without a code. That test looked for `raise` sites whose message names a
+grant from `REFUSAL_GRANTS`, so it could only ever find a refusal naming a grant
+that is already coded. The first refusal to offer a *new* grant -- the one case the
+rule exists for -- was invisible, and both the module and the test file claimed
+otherwise.
+
+Measured: a `ValidationError` refusing a value and offering "Set
+`STRANDS_MESH_SINK_ALLOW` to extend" leaves that file at 21 passed. The scan cannot
+see it, because the variable is absent from the grant table until someone adds the
+code, which is exactly the thing being forgotten.
+
+The scope now comes from the exception types that can carry a code at all -- a class
+whose `__init__` accepts one, plus anything inheriting it, derived from the package
+rather than listed. Within those, a message naming any `STRANDS_*` variable reads as
+an offer to the operator and must carry a code. The same planted refusal is now
+reported by site and by grant.
+
+No shipped refusal needed a code: of 1195 `raise` sites, 72 are of a code-carrying
+type, 6 of those name a variable, and all 6 already carry one -- so this is a scope
+fix with no behaviour change. A builtin `ValueError` has no `code` parameter, so the
+permissive-ACL, unacknowledged-`AUTH_MODE=none` and CA-pin refusals stay out of
+scope by structure rather than by exemption.

--- a/strands_robots/refusal_codes.py
+++ b/strands_robots/refusal_codes.py
@@ -22,8 +22,14 @@ message, and may be improved without breaking anyone.
 Only continuable refusals get a code. ``instruction exceeds 4096 chars`` is
 not continuable -- there is no grant that makes it succeed, so a consumer has
 nothing to offer and nothing to recognise. :data:`REFUSAL_GRANTS` records, per
-code, the operator grant that lifts it, which is also what lets the guard test
-derive the raise sites it must find instead of keeping a hand-written list.
+code, the operator grant that lifts it, so a consumer reads the variable to
+offer from here rather than hard-coding it.
+
+That table is deliberately *not* what scopes the guard test. Deriving the raise
+sites it must find from the grants already listed here would only ever find a
+refusal naming a grant this module already knows, so the first refusal to offer
+a *new* grant -- the one case the guard exists for -- would be invisible. The
+scope comes from the exception types that can carry a code at all instead.
 """
 
 from __future__ import annotations

--- a/tests/test_refusal_codes_are_the_stable_contract.py
+++ b/tests/test_refusal_codes_are_the_stable_contract.py
@@ -18,10 +18,14 @@ These tests pin the contract in three parts.
 * The message is *unchanged* by that -- the codes are additive, and the prose
   stays free to improve. ``test_the_code_does_not_come_from_the_message``
   states the half that matters: an unrecognisable message keeps its code.
-* ``test_every_refusal_naming_an_operator_grant_carries_a_code`` derives the
-  sites it must find from :data:`~strands_robots.refusal_codes.REFUSAL_GRANTS`
-  rather than a hand-written list, so a seventh grant-bearing refusal added
-  later is graded on arrival.
+* ``test_every_refusal_naming_an_operator_grant_carries_a_code`` finds the sites
+  it must grade by the *exception type* they raise -- the types whose
+  constructor accepts a ``code`` at all -- and then asks whether the message
+  names an environment variable. Scoping it by the grants already registered
+  would only ever find a refusal naming a grant that is already coded, so the
+  first refusal to offer a *new* grant would be invisible; that is the one case
+  this rule exists for, and
+  ``test_a_refusal_offering_an_unregistered_grant_is_reported`` is it.
 
 A rejection with no operator grant behind it stays code-less on purpose: a
 schema or bounds failure gives a consumer nothing to offer, so there is nothing
@@ -33,6 +37,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
+import re
 from typing import Any
 
 import pytest
@@ -41,6 +46,10 @@ from strands_robots.mesh.security import ValidationError, validate_command, vali
 from strands_robots.policies.factory import UntrustedRemoteCodeError, _check_trust_remote_code
 
 _PACKAGE = pathlib.Path(__file__).resolve().parent.parent / "strands_robots"
+
+#: Any ``STRANDS_*`` variable a refusal message names. A refusal of a
+#: code-carrying type that names one is treated as an offer to the operator.
+_ENV_VAR = re.compile(r"\bSTRANDS_[A-Z0-9_]+\b")
 
 #: Grant env vars are cleared per test so the refusals under test actually fire.
 _GRANT_ENV = (
@@ -233,37 +242,153 @@ def _coded_raise_sites() -> list[tuple[str, int, str]]:
     return found
 
 
-class TestTheContractReachesEveryGrantBearingRefusal:
-    """Derived from the registry, so a new grant-bearing refusal is graded."""
+def _package_sources() -> list[tuple[str, str]]:
+    """Every shipped module, as (path-for-messages, source)."""
+    return [
+        (str(path.relative_to(_PACKAGE.parent)), path.read_text(encoding="utf-8"))
+        for path in sorted(_PACKAGE.rglob("*.py"))
+    ]
 
-    def test_every_refusal_naming_an_operator_grant_carries_a_code(self) -> None:
-        from strands_robots import refusal_codes
 
-        grants = set(refusal_codes.REFUSAL_GRANTS.values())
-        uncoded = []
-        for rel, lineno, exc in _raise_sites():
-            text = _string_literals(exc)
-            named = sorted(g for g in grants if g in text)
+def _code_carrying_exception_types() -> frozenset[str]:
+    """Exception class names that can carry a refusal code, derived from the package.
+
+    A class whose ``__init__`` accepts a ``code`` keyword defines the contract;
+    anything inheriting one carries it. Scoping the rule below to these is what
+    keeps it honest in both directions: a builtin ``ValueError`` has nowhere to
+    put a code, so demanding one would be a ``TypeError`` rather than a finding,
+    and a class added later that does accept one is graded without an edit here.
+    """
+    defines: set[str] = set()
+    bases: dict[str, set[str]] = {}
+    for _rel, source in _package_sources():
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            named_bases = {b.id for b in node.bases if isinstance(b, ast.Name)}
+            named_bases |= {b.attr for b in node.bases if isinstance(b, ast.Attribute)}
+            bases.setdefault(node.name, set()).update(named_bases)
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef) and member.name == "__init__":
+                    params = [a.arg for a in member.args.args] + [a.arg for a in member.args.kwonlyargs]
+                    if "code" in params:
+                        defines.add(node.name)
+    carriers = set(defines)
+    while True:
+        inheriting = {name for name, parents in bases.items() if parents & carriers} - carriers
+        if not inheriting:
+            return frozenset(carriers)
+        carriers |= inheriting
+
+
+def _refusals_naming_an_env_var(sources: list[tuple[str, str]]) -> list[tuple[str, int, list[str], bool]]:
+    """Raise sites of a code-carrying type whose message names a ``STRANDS_*`` variable.
+
+    Naming one reads as an offer -- *set this and the identical request
+    succeeds* -- which is exactly what makes a refusal continuable. The match is
+    on any such variable rather than on a phrasing like ``"Set X"``, so a
+    reworded offer is still graded; a variable that is merely the *source* of a
+    bad value is caught too, and the remedy there is to reword rather than to
+    invent a code.
+    """
+    carriers = _code_carrying_exception_types()
+    found: list[tuple[str, int, list[str], bool]] = []
+    for rel, source in sources:
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Raise) or node.exc is None:
+                continue
+            exc = node.exc
+            if not isinstance(exc, ast.Call):
+                continue
+            raised = exc.func.id if isinstance(exc.func, ast.Name) else getattr(exc.func, "attr", None)
+            if raised not in carriers:
+                continue
+            named = sorted(set(_ENV_VAR.findall(_string_literals(exc))))
             if not named:
                 continue
-            has_code = isinstance(exc, ast.Call) and any(k.arg == "code" for k in exc.keywords)
-            if not has_code:
-                uncoded.append(f"{rel}:{lineno} names {named} but carries no code")
+            found.append((rel, node.lineno, named, any(k.arg == "code" for k in exc.keywords)))
+    return found
+
+
+def _uncoded_refusals_naming_an_env_var(sources: list[tuple[str, str]]) -> list[str]:
+    """The offending subset of :func:`_refusals_naming_an_env_var`, as messages."""
+    return [
+        f"{rel}:{lineno} names {named} but carries no code"
+        for rel, lineno, named, has_code in _refusals_naming_an_env_var(sources)
+        if not has_code
+    ]
+
+
+class TestTheContractReachesEveryGrantBearingRefusal:
+    """Scoped by what can carry a code, so a refusal offering a new grant is graded."""
+
+    def test_every_refusal_naming_an_operator_grant_carries_a_code(self) -> None:
+        uncoded = _uncoded_refusals_naming_an_env_var(_package_sources())
         assert not uncoded, (
-            "a refusal that tells an operator which grant lifts it is continuable, "
-            "so a consumer must be able to recognise it without reading the prose: " + "; ".join(uncoded)
+            "a refusal that tells an operator which environment variable lifts it is "
+            "continuable, so a consumer must be able to recognise it without reading "
+            "the prose. Either pass a code from strands_robots.refusal_codes, or -- if "
+            "that variable is not something an operator can set to make this identical "
+            "request succeed -- reword the message so it does not read as an offer: " + "; ".join(uncoded)
         )
 
-    def test_the_scan_found_the_grant_bearing_refusals(self) -> None:
-        """Non-vacuity: a scan reaching nothing would pass the rule above."""
-        from strands_robots import refusal_codes
+    def test_a_refusal_offering_an_unregistered_grant_is_reported(self) -> None:
+        """The case the rule exists for: a grant this package does not yet know.
 
-        grants = set(refusal_codes.REFUSAL_GRANTS.values())
-        naming = [
-            (rel, lineno) for rel, lineno, exc in _raise_sites() if any(g in _string_literals(exc) for g in grants)
-        ]
+        Scoping the scan by :data:`~strands_robots.refusal_codes.REFUSAL_GRANTS`
+        cannot see this, because the variable is absent from that table until
+        someone adds the code -- which is the very thing being forgotten.
+        """
+        planted = (
+            "def _sink_gate(value: str) -> None:\n"
+            "    raise ValidationError(\n"
+            '        f"telemetry_sink={value!r} not in allowlist. '
+            'Set STRANDS_MESH_SINK_ALLOW to extend."\n'
+            "    )\n"
+        )
+        reported = _uncoded_refusals_naming_an_env_var([("planted.py", planted)])
+        assert len(reported) == 1, reported
+        assert "STRANDS_MESH_SINK_ALLOW" in reported[0]
+
+    def test_a_coded_refusal_offering_a_new_grant_is_accepted(self) -> None:
+        """The rule asks for a code, not for membership of the grant table."""
+        planted = (
+            "def _sink_gate(value: str) -> None:\n"
+            "    raise ValidationError(\n"
+            '        f"telemetry_sink={value!r} not in allowlist. '
+            'Set STRANDS_MESH_SINK_ALLOW to extend.",\n'
+            "        code=refusal_codes.SINK_NOT_ALLOWED,\n"
+            "        subject=value,\n"
+            "    )\n"
+        )
+        assert _uncoded_refusals_naming_an_env_var([("planted.py", planted)]) == []
+
+    def test_a_refusal_that_cannot_carry_a_code_is_out_of_scope(self) -> None:
+        """A builtin has no ``code`` parameter, so requiring one would be a TypeError.
+
+        The package refuses a permissive ACL, an unacknowledged ``AUTH_MODE=none``
+        and a CA-pin timeout with a ``RuntimeError``/``ValueError``/``OSError``,
+        each naming the variable that lifts it. Giving those a code means giving
+        them a code-carrying type first, which is a separate change.
+        """
+        planted = (
+            "def _mode_gate(mode: str) -> None:\n"
+            '    raise ValueError("set STRANDS_MESH_I_KNOW_THIS_IS_INSECURE=1 to confirm")\n'
+        )
+        assert _uncoded_refusals_naming_an_env_var([("planted.py", planted)]) == []
+
+    def test_the_scan_reaches_the_package_and_the_shipped_refusals(self) -> None:
+        """Non-vacuity: a scan reaching nothing would pass the rule above."""
+        naming = _refusals_naming_an_env_var(_package_sources())
         assert len(naming) >= 6, naming
         assert len(_raise_sites()) >= 200, "the package-wide raise scan reached almost nothing"
+
+    def test_the_graded_types_are_derived_from_the_package(self) -> None:
+        """Non-vacuity for the scope: an empty carrier set grades nothing."""
+        carriers = _code_carrying_exception_types()
+        assert {"SecurityError", "ValidationError", "UntrustedRemoteCodeError"} <= carriers, carriers
+        assert "LockoutError" in carriers, "a subclass inherits the constructor, so it carries the contract"
+        assert "ValueError" not in carriers and "RuntimeError" not in carriers, carriers
 
     def test_every_code_passed_at_a_raise_site_is_a_declared_code(self) -> None:
         from strands_robots import refusal_codes


### PR DESCRIPTION
## Problem

A *continuable* refusal carries a stable `code` so a consumer classifies it on identity rather than on prose. One test exists to make sure a new continuable refusal does not arrive without one:

```python
grants = set(refusal_codes.REFUSAL_GRANTS.values())
for rel, lineno, exc in _raise_sites():
    named = sorted(g for g in grants if g in _string_literals(exc))
    if not named:
        continue          # <- a grant the table does not know exits here
```

The scope is the grant table, so the scan can only ever find a refusal naming a grant that **is already coded**. The first refusal to offer a *new* grant -- which is the one case the rule exists for -- is invisible, and both `refusal_codes` and the test file claim otherwise ("a seventh grant-bearing refusal added later is graded on arrival").

Measured. A `ValidationError` refusing a value and offering a remedy, added to `mesh/security.py`:

```python
raise ValidationError(
    f"telemetry_sink={value!r} not in allowlist. Set STRANDS_MESH_SINK_ALLOW to extend."
)
```

| guard | clean package | package + that refusal |
| --- | --- | --- |
| on `main` | 21 passed | **21 passed** -- unreported |
| this branch | 25 passed | **1 failed** -- reported by site and grant |

The shipped guard returns the identical verdict either way. `STRANDS_MESH_SINK_ALLOW` is absent from `REFUSAL_GRANTS` until someone adds the code, which is exactly the thing being forgotten.

## Change

The scope now comes from **what can carry a code at all**, derived from the package rather than listed: a class whose `__init__` accepts a `code` keyword (`SecurityError`, `UntrustedRemoteCodeError`), plus anything inheriting one (`ValidationError`, `LockoutError`). Within those, a message naming any `STRANDS_*` variable reads as an offer -- *set this and the identical request succeeds* -- and must carry a code.

Matching any such variable rather than a phrasing like `"Set X"` means a reworded offer is still graded. It can also flag a variable that is merely the *source* of a bad value; the failure message says so and names both remedies (pass a code, or reword so it does not read as an offer).

**No site needed a code.** Measured on the package:

| measured | count |
| --- | --- |
| `raise` sites | 1195 |
| ... of a type that can carry a code | 72 |
| ... of those, naming a `STRANDS_*` variable | 6 |
| ... of those, already carrying a code | **6** |

Zero false positives, so this is a scope fix with no behaviour change. `refusal_codes`' docstring no longer claims the grant table is what scopes the guard, and says why it must not be.

## Tests

`test_a_refusal_offering_an_unregistered_grant_is_reported` is the regression: it drives the scan over a planted source offering an unregistered grant and asserts it is reported. Reverting the discovery to `REFUSAL_GRANTS` fails that test **and only that test**.

| break | fails |
| --- | --- |
| discovery scoped to `REFUSAL_GRANTS` again | the planted-grant test, alone |
| drop the code-carrying-type scope | the rule + `..._cannot_carry_a_code_is_out_of_scope` |
| drop the inheritance closure (so `ValidationError` is not a carrier) | planted + both non-vacuity tests |
| package scan reaches nothing | planted + both non-vacuity tests |
| control (no change) | nothing -- 25 passed |

Four new tests beside it: a coded refusal offering a new grant is accepted (the rule asks for a code, not for table membership); a builtin-raising refusal is out of scope; and two non-vacuity tests, one for the scan and one for the derived carrier set.

## Scope

A builtin `ValueError` has no `code` parameter, so requiring one would be a `TypeError` rather than a finding. Three refusals name the variable that lifts them and raise a builtin -- a permissive ACL (`RuntimeError`), an unacknowledged `AUTH_MODE=none` (`ValueError`), a CA-pin timeout (`RuntimeError`). They are out of scope **by structure rather than by exemption**, and `..._cannot_carry_a_code_is_out_of_scope` pins that boundary. Giving them a code means giving them a code-carrying type first, which is a separate change.

## Verification

Measured at `158059b3`, merge base `88a3a45e`.

- The file: `25 passed` (was 21: one registry-keyed test replaced by five).
- Blast radius, the identical 52-file selection on this branch and on `upstream/main`, this file excluded from both: **2014 collected on each**. Every failure on either tree is `tests/mesh/test_zenoh_transport_security.py` failing to bind a fixed TCP port because both suites ran in parallel (`Address already in use`); that file is `9 passed, 2 skipped` run alone on **both** trees, and there are **zero** non-Zenoh failures on either.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` **24 == 24** against a pristine `upstream/main` worktree, none in either changed file.

## Artifact

No policy, simulation, rendering, recording or robot asset changes here, so there is no rollout to film. The measurement above is the artifact instead -- four runs of one test file over two package trees:

![refusal code guard scope, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-refusal-code-scope-32597565259/refusal-code-scope.png)
