### PR TITLE
fix(mesh): report a payload that can never reach the wire, at a level an operator sees

### DIFF
--- a/changelog.d/2638-unencodable-mesh-payload-is-reported.md
+++ b/changelog.d/2638-unencodable-mesh-payload-is-reported.md
@@ -1,0 +1,25 @@
+### Fixed: a mesh payload that can never reach the wire is reported, not dropped at DEBUG
+
+`Mesh.publish_safety_event` writes one event to two sinks, and on a payload the
+JSON encoder refuses the two disagreed. The audit half recorded a
+`sig="SERIALISE_FAILED"` poison record and logged at ERROR; the wire half
+published nothing and said so only at DEBUG. At the default log level an operator
+therefore had a forensic trail asserting a `critical` collision event had been
+raised, with no peer having received it.
+
+Both encode sites absorbed the encode into the handler that absorbs a wire
+failure, so a permanent failure and a transient one were reported identically.
+`MeshTransport.put` already scoped its tolerance to a transient failure - a closed
+session, a dropped broker, a socket-level write - which the caller's next tick
+retries. A payload the encoder refuses is not transient: it fails the same way
+forever, and 8 of 9 realistic payload shapes are affected, including a
+`np.float32` sensor reading and an `np.zeros(3)` pose vector.
+
+The encode now happens outside that handler at both sites, and the permanent case
+is reported at ERROR once per topic through one shared reporter, so a bridge's two
+legs word it identically and a 50 Hz publisher with a broken payload builder emits
+one line rather than one per tick. The transient path is unchanged. Hoisting the
+encode above the `awscrt` import on the MQTT leg also separates an absent
+`[mesh-iot]` extra from a bad payload, and `BridgeTransport.put`'s docstring no
+longer cites a serialisation error as an example of something that propagates
+through it - measured with the real legs, it does not.

--- a/strands_robots/mesh/session.py
+++ b/strands_robots/mesh/session.py
@@ -70,6 +70,18 @@ _SESSION_REFS: int = 0
 # under ``_SESSION_LOCK``.
 _zenoh_missing_warned: set[str] = set()
 
+# One-shot-per-topic guard for a payload that cannot be JSON-encoded.  Unlike a
+# transient wire failure, an unencodable payload fails identically on every
+# retry, so a 50 Hz publisher would otherwise emit one report per tick forever.
+# Keyed on the topic because the payload builder is per-topic: a broken builder
+# is broken for every tick of ITS key and says nothing about any other.  A set
+# (mutated via .add, never reassigned) avoids a `global` rebind so static
+# analysis sees it as used.  Read and mutated WITHOUT ``_SESSION_LOCK``, because
+# :func:`_put_zenoh_directly` deliberately does not take it (a 50 Hz teleop loop
+# must not serialise on the session lock); the worst race is two threads each
+# reporting the same topic once.
+_unencodable_topics_warned: set[str] = set()
+
 
 # Constants
 
@@ -1071,6 +1083,53 @@ def put(key: str, data: dict[str, Any]) -> None:
     _put_zenoh_directly(key, data)
 
 
+def _report_unencodable_payload(transport: str, key: str, exc: BaseException) -> None:
+    """Report a payload that can never reach *key*, at ERROR, once per topic.
+
+    Every transport's ``put`` is fire-and-forget and
+    :meth:`strands_robots.mesh.transport.base.MeshTransport.put`
+    scopes that tolerance to a TRANSIENT failure - a closed session, a dropped broker, a
+    socket-level write - which the next tick retries. A payload the JSON encoder
+    refuses is not transient: it fails identically forever, so the message never
+    goes out at all and no retry can change that.
+
+    Reporting it at DEBUG left the two halves of one call disagreeing.
+    :meth:`strands_robots.mesh.sensors.SensorLoopsMixin.publish_safety_event`
+    writes the event to the wire AND to the local audit log; on an unencodable
+    payload the audit half records a ``sig="SERIALISE_FAILED"`` poison record and
+    logs at ERROR (naming the peer and the reason), while the wire half dropped
+    the event silently. A default-configured operator therefore saw a forensic
+    trail asserting that a safety event had been raised, with no peer having
+    received it and nothing above DEBUG to say so.
+
+    Once per topic, because a payload builder is per-topic: the same builder runs
+    on every tick of ITS key, so a 50 Hz publisher would otherwise emit one
+    report per tick, while a different key says nothing about it. Per TOPIC and
+    not per (topic, transport): under the bridge backend both legs encode the
+    same payload with the same encoder, so the second leg's report would restate
+    one fact. The leg that noticed is named in the line rather than keyed on,
+    which is why the wording does not claim the other leg is unaffected.
+
+    Args:
+        transport: Which leg could not encode, for the log line (``"Zenoh"`` /
+            ``"MQTT"``). The wording is shared so a reader grepping the log for
+            one transport's report finds the other's.
+        key: The topic the payload was addressed to; also the once-guard key.
+        exc: What the encoder raised, quoted as the reason.
+    """
+    if key in _unencodable_topics_warned:
+        return
+    _unencodable_topics_warned.add(key)
+    logger.error(
+        "put on %s: the payload cannot be JSON-encoded, so this message and every "
+        "later one built the same way is dropped before it reaches the wire "
+        "(noticed on the %s leg; reported once for this topic): %s",
+        key,
+        transport,
+        exc,
+    )
+
+
 def _put_zenoh_directly(key: str, data: dict[str, Any]) -> None:
     """Publish to the raw Zenoh session, bypassing transport-backend routing.
 
@@ -1089,11 +1148,28 @@ def _put_zenoh_directly(key: str, data: dict[str, Any]) -> None:
     Fire-and-forget, and it reads ``_SESSION`` without taking
     ``_SESSION_LOCK`` exactly as :func:`put` always has: a 50 Hz teleop loop
     must not serialise on the session lock.
+
+    The JSON encode is attempted OUTSIDE the handler that absorbs a wire
+    failure, because the two outcomes are not the same kind of failure. A wire
+    failure is transient and the next tick retries it, so it stays at DEBUG. A
+    payload the encoder refuses can never be published, so it is reported
+    through :func:`_report_unencodable_payload` instead of being absorbed by the
+    same DEBUG line. Neither raises: the ``put`` contract is fire-and-forget
+    either way. The encode catch is deliberately wide because an arbitrary
+    payload object can carry an arbitrary ``__reduce__`` / ``keys`` / ``default``
+    hook, so the encoder's raise set is not enumerable here (``json.dumps``
+    itself raises ``TypeError`` for an unsupported type and ``ValueError`` for a
+    circular reference).
     """
     if _SESSION is None:
         return
     try:
-        _SESSION.put(key, json.dumps(data).encode())
+        encoded = json.dumps(data).encode()
+    except Exception as exc:  # noqa: BLE001 - see the encode note in the docstring
+        _report_unencodable_payload("Zenoh", key, exc)
+        return
+    try:
+        _SESSION.put(key, encoded)
     except Exception as exc:
         logger.debug("Zenoh put error on %s: %s", key, exc)
 

--- a/strands_robots/mesh/transport/base.py
+++ b/strands_robots/mesh/transport/base.py
@@ -91,8 +91,21 @@ class MeshTransport(Protocol):
     def put(self, key: str, data: dict[str, Any]) -> None:
         """Publish a JSON-serialisable payload to the wire.
 
-        Fire-and-forget. MUST NOT raise on transient failure. Implementations
-        should log at debug and continue, matching the Zenoh behaviour today.
+        Fire-and-forget: MUST NOT raise, whatever goes wrong.
+
+        The tolerance is scoped by WHETHER A RETRY COULD SUCCEED, because the two
+        cases are not equally reportable:
+
+        * A TRANSIENT failure - a closed session, a dropped broker, a
+          socket-level write error - is retried by the caller's next tick.
+          Implementations log at debug and continue, matching the Zenoh
+          behaviour today.
+        * A payload the JSON encoder refuses can NEVER reach the wire, and no
+          retry changes that. Implementations report it at ERROR once per topic
+          via :func:`~strands_robots.mesh.session._report_unencodable_payload`,
+          which owns the wording so one grep finds every transport's report.
+          Absorbing it into the transient DEBUG line made a permanently
+          undeliverable message indistinguishable from a delivered one.
 
         Args:
             key: The topic / Zenoh key expression. For MQTT-backed transports

--- a/strands_robots/mesh/transport/bridge_transport.py
+++ b/strands_robots/mesh/transport/bridge_transport.py
@@ -681,8 +681,19 @@ class BridgeTransport:
         an ``OSError`` subclass). Both names are class trees rather than
         single classes, so the absorbed surface is wider than the two:
         ``NotImplementedError`` and ``RecursionError`` are ``RuntimeError``
-        subclasses and are swallowed here too. An exception outside both
-        trees - a serialisation ``ValueError``, say - propagates.
+        subclasses and are swallowed here too.
+
+        These handlers cover a leg that raises, which no shipped leg does: both
+        :meth:`~strands_robots.mesh.transport.zenoh_transport.ZenohTransport.put`
+        and :meth:`~strands_robots.mesh.transport.iot_transport.IotMqttTransport.put`
+        honour the fire-and-forget contract themselves. In particular an
+        unencodable payload - once cited here as an example of something that
+        propagates - does not: each leg encodes on its own and reports the
+        permanent failure through
+        :func:`~strands_robots.mesh.session._report_unencodable_payload`, once
+        per topic across both legs, then returns. So this method raises nothing
+        for a bad payload, and the operator gets one ERROR naming the topic
+        rather than an exception the mesh's publish paths do not expect.
         """
         # AWS IoT reserved topics ($aws/..., e.g. named-shadow updates) are
         # cloud-plane only. They are meaningless on the Zenoh LAN (and would

--- a/strands_robots/mesh/transport/iot_transport.py
+++ b/strands_robots/mesh/transport/iot_transport.py
@@ -53,6 +53,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from strands_robots.mesh.session import _report_unencodable_payload
 from strands_robots.utils import positive_finite_number_error
 
 logger = logging.getLogger(__name__)
@@ -527,6 +528,13 @@ class IotMqttTransport:
         Per-topic QoS and retain flags come from :data:`_TOPIC_POLICY`.
         Topics in :data:`_NEVER_BRIDGE_PREFIXES` (camera/input/hand) are
         silently dropped - they belong on Zenoh-LAN, not MQTT-WAN.
+
+        A broker or client failure stays at DEBUG: it is transient and the next
+        tick retries it. A payload the JSON encoder refuses is not, so it is
+        reported at ERROR once per topic through
+        :func:`~strands_robots.mesh.session._report_unencodable_payload` - the
+        same report the Zenoh leg emits, so a reader grepping the log for one
+        transport's wording finds the other's.
         """
         if self._client is None or not self._connected.is_set():
             return
@@ -538,6 +546,18 @@ class IotMqttTransport:
         if qos < 0:
             return  # explicit DROP
 
+        # Encoded BEFORE the publish attempt, and outside its handler: a payload
+        # the encoder refuses can never be published, whereas a broker failure is
+        # transient and the next tick retries it. Absorbing both in one DEBUG line
+        # made a permanently-undeliverable message indistinguishable from a
+        # dropped one. Hoisting the encode above the ``awscrt`` import also keeps
+        # the two apart: an absent [mesh-iot] extra is not a bad payload.
+        try:
+            encoded = json.dumps(data).encode()
+        except Exception as exc:  # noqa: BLE001 - the encoder's raise set is payload-defined
+            _report_unencodable_payload("MQTT", key, exc)
+            return
+
         try:
             from awscrt import mqtt5
 
@@ -545,7 +565,7 @@ class IotMqttTransport:
             self._client.publish(
                 mqtt5.PublishPacket(
                     topic=key,
-                    payload=json.dumps(data).encode(),
+                    payload=encoded,
                     qos=qos_enum,
                     retain=retain,
                 )

--- a/tests/mesh/test_unencodable_payload_is_reported_not_dropped.py
+++ b/tests/mesh/test_unencodable_payload_is_reported_not_dropped.py
@@ -1,0 +1,293 @@
+"""A payload that can never reach the wire is reported, not dropped at DEBUG.
+
+Every transport's ``put`` is fire-and-forget, and
+:meth:`strands_robots.mesh.transport.base.MeshTransport.put`
+scopes that tolerance to a TRANSIENT failure - a closed session, a dropped broker, a socket-level write -
+which the caller's next tick retries. A payload the JSON encoder refuses is not
+transient: it fails identically forever, so the message never goes out and no
+retry can change that.
+
+Both encode sites absorbed the two into one ``logger.debug`` line, which left the
+two halves of ONE call disagreeing.
+:meth:`~strands_robots.mesh.sensors.SensorLoopsMixin.publish_safety_event` writes
+its event to the wire AND to the local audit log; on an unencodable payload the
+audit half records a ``sig="SERIALISE_FAILED"`` poison record and logs at ERROR,
+while the wire half dropped the event with nothing above DEBUG. A
+default-configured operator saw a forensic trail asserting a safety event had
+been raised, with no peer having received it.
+
+The tests below are grouped so a reader can tell regression evidence from a
+boundary:
+
+* :class:`TestAnUnencodablePayloadIsReported` is the regression - the report did
+  not exist, so every case fails on the pre-fix tree.
+* :class:`TestTheReportIsBounded` also fails pre-fix, for the same reason (there
+  was no report to bound). It is separate because what it pins is the SHAPE of
+  the report rather than its existence: one line per broken payload builder, and
+  a second topic on its own terms. That is what fails if the guard is dropped or
+  keyed process-wide.
+* :class:`TestTheTransientContractIsUnchanged` is the only group that passes on
+  both trees, and it is the no-overreach evidence: a retryable wire failure keeps
+  its DEBUG tolerance, an encodable payload is published silently and
+  byte-identically on both legs, and a closed mesh is still a silent no-op. These
+  fail if the escalation is applied to the publish attempt instead of the encode.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.mesh import session as mesh_session
+from strands_robots.mesh.transport.iot_transport import IotMqttTransport
+
+#: A payload shape a robot safety event naturally carries. ``np.float32`` is what
+#: a sensor reading is, and ``np.zeros(3)`` is what a pose or joint vector is;
+#: neither is JSON-serialisable, and both reach the encoder through the public
+#: ``publish_safety_event`` / ``publish`` surfaces.
+UNENCODABLE: list[Any] = [
+    pytest.param({"distance_m": np.float32(0.02)}, id="numpy-scalar-sensor-reading"),
+    pytest.param({"pose": np.zeros(3)}, id="numpy-array-pose-vector"),
+    pytest.param({"raw": b"\x01\x02"}, id="bytes"),
+    pytest.param({"seen": {1, 2}}, id="set"),
+]
+
+#: The topic a safety event rides, used so the assertions read as the operator's
+#: case rather than an abstract key.
+SAFETY_TOPIC = "strands/arm-a/safety/event"
+
+
+class _StubZenohSession:
+    """Stands in for an open ``zenoh.Session``, recording what reached the wire."""
+
+    def __init__(self) -> None:
+        self.puts: list[tuple[str, bytes]] = []
+
+    def put(self, key: str, payload: bytes) -> None:
+        self.puts.append((key, payload))
+
+
+class _StubMqttClient:
+    """Stands in for the awscrt MQTT5 client, recording published packets."""
+
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+
+    def publish(self, packet: Any) -> None:
+        self.published.append(packet)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_once_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give every test an empty once-per-topic guard.
+
+    The guard is module state that deliberately outlives a single publish, so a
+    sibling test's report would otherwise silence this one's.
+    """
+    monkeypatch.setattr(mesh_session, "_unencodable_topics_warned", set(), raising=False)
+
+
+@pytest.fixture
+def zenoh_wire(monkeypatch: pytest.MonkeyPatch) -> _StubZenohSession:
+    """An open session on the legacy Zenoh path - the default backend's encode site."""
+    stub = _StubZenohSession()
+    monkeypatch.setattr(mesh_session, "_SESSION", stub)
+    return stub
+
+
+@pytest.fixture
+def mqtt_leg() -> IotMqttTransport:
+    """A connected MQTT transport.
+
+    Constructed without ``__init__`` because that opens a real mTLS connection.
+    ``put`` reads only the client and the connected flag, and the encode now
+    happens before the ``awscrt`` import, so this needs no ``[mesh-iot]`` extra.
+    """
+    transport = IotMqttTransport.__new__(IotMqttTransport)
+    transport._client = _StubMqttClient()
+    transport._connected = threading.Event()
+    transport._connected.set()
+    return transport
+
+
+def _publish_on_each_leg(zenoh_wire: _StubZenohSession, mqtt_leg: IotMqttTransport, payload: dict[str, Any]) -> None:
+    """Publish *payload* through both encode sites the mesh ships."""
+    mesh_session._put_zenoh_directly(SAFETY_TOPIC, payload)
+    mqtt_leg.put(SAFETY_TOPIC, payload)
+
+
+class TestAnUnencodablePayloadIsReported:
+    """The regression: a permanently-undeliverable message reaches the operator."""
+
+    @pytest.mark.parametrize("payload", UNENCODABLE)
+    def test_the_zenoh_leg_reports_at_a_level_a_default_operator_sees(
+        self, payload: dict[str, Any], zenoh_wire: _StubZenohSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Nothing reaches the wire, and the drop is stated at WARNING or above.
+
+        ``caplog.set_level(WARNING)`` is the operator's default: a report below it
+        is invisible to a consumer that has configured nothing.
+        """
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, payload)
+
+        assert not zenoh_wire.puts, "premise: an unencodable payload cannot reach the wire"
+        assert caplog.records, (
+            f"the payload {payload!r} can never be published, and the drop was not "
+            "reported at any level a default-configured operator sees"
+        )
+
+    @pytest.mark.parametrize("payload", UNENCODABLE)
+    def test_the_mqtt_leg_reports_the_same_condition(
+        self, payload: dict[str, Any], mqtt_leg: IotMqttTransport, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The second encode site answers the same way, so the rule is not per-leg."""
+        with caplog.at_level(logging.WARNING):
+            mqtt_leg.put(SAFETY_TOPIC, payload)
+
+        client = mqtt_leg._client
+        assert isinstance(client, _StubMqttClient), "premise: the stub client is installed"
+        assert not client.published, "premise: nothing was published"
+        assert caplog.records, f"the MQTT leg dropped {payload!r} without reporting it above DEBUG"
+
+    def test_the_report_names_the_topic_and_the_reason(
+        self, zenoh_wire: _StubZenohSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A report an operator can act on names WHICH topic and WHY.
+
+        Without the topic the operator cannot find the payload builder at fault,
+        and without the encoder's own reason they cannot tell an unencodable
+        value from a wire problem.
+        """
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, {"distance_m": np.float32(0.02)})
+
+        text = "\n".join(record.getMessage() for record in caplog.records)
+        assert SAFETY_TOPIC in text, f"the report does not name the topic: {text!r}"
+        assert "float32" in text, f"the report does not carry the encoder's reason: {text!r}"
+
+    def test_the_wire_and_the_audit_halves_of_one_call_agree(
+        self, zenoh_wire: _StubZenohSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The two sinks of ``publish_safety_event`` report at the same level.
+
+        The audit half already records a ``SERIALISE_FAILED`` poison record and
+        logs at ERROR. A wire half that reported lower is what let a forensic
+        trail assert an event no peer received.
+        """
+        from strands_robots.mesh import audit
+
+        payload = {"distance_m": np.float32(0.02)}
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, payload)
+        wire_levels = {record.levelno for record in caplog.records}
+
+        assert wire_levels, "the wire half reported nothing"
+        assert max(wire_levels) >= logging.ERROR, (
+            "the audit half of the same call reports an unencodable payload at ERROR "
+            f"(see {audit.__name__}'s SERIALISE_FAILED poison record); the wire half "
+            f"reported only {sorted(logging.getLevelName(lv) for lv in wire_levels)}, so "
+            "the forensic trail and the fleet disagree about whether the event went out"
+        )
+
+
+class TestTheTransientContractIsUnchanged:
+    """Boundary: a retryable failure keeps its DEBUG-and-continue tolerance."""
+
+    def test_a_wire_failure_stays_below_the_operator_default(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A session that refuses the write is transient, so it is not escalated.
+
+        This is what fails if the fix is applied to the publish attempt rather
+        than to the encode.
+        """
+
+        class _RefusingSession:
+            def put(self, key: str, payload: bytes) -> None:
+                raise ConnectionError("broker went away")
+
+        monkeypatch.setattr(mesh_session, "_SESSION", _RefusingSession())
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, {"distance_m": 0.02})
+
+        assert not caplog.records, (
+            "a transient wire failure must keep its DEBUG tolerance - the next tick "
+            f"retries it: {[r.getMessage() for r in caplog.records]}"
+        )
+
+    def test_an_encodable_payload_reaches_the_wire_untouched(
+        self, zenoh_wire: _StubZenohSession, mqtt_leg: IotMqttTransport, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The happy path is byte-identical and silent on both legs."""
+        payload = {"distance_m": 0.02, "peer_id": "arm-a"}
+        with caplog.at_level(logging.WARNING):
+            _publish_on_each_leg(zenoh_wire, mqtt_leg, payload)
+
+        assert [key for key, _ in zenoh_wire.puts] == [SAFETY_TOPIC]
+        assert json.loads(zenoh_wire.puts[0][1]) == payload
+        assert not caplog.records, "an encodable payload must be published silently"
+
+    def test_no_session_is_still_a_silent_no_op(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A closed mesh publishes nothing and says nothing, as documented."""
+        monkeypatch.setattr(mesh_session, "_SESSION", None)
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, {"distance_m": np.float32(0.02)})
+
+        assert not caplog.records, "a closed mesh is a no-op, not an unencodable payload"
+
+
+class TestTheReportIsBounded:
+    """Boundary: the report cannot flood a control-rate publisher."""
+
+    def test_one_report_per_topic_however_many_ticks(
+        self, zenoh_wire: _StubZenohSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A 50 Hz publisher with a broken builder reports once, not per tick.
+
+        A permanent failure repeats on every tick by definition, so an unbounded
+        report would make the log unusable - the outcome the report exists to
+        avoid.
+        """
+        payload = {"distance_m": np.float32(0.02)}
+        with caplog.at_level(logging.WARNING):
+            for _ in range(250):
+                mesh_session._put_zenoh_directly(SAFETY_TOPIC, payload)
+
+        assert len(caplog.records) == 1, f"250 ticks on one topic produced {len(caplog.records)} reports"
+
+    def test_a_second_topic_is_reported_on_its_own_terms(
+        self, zenoh_wire: _StubZenohSession, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The bound is per topic: a different builder is a different fact.
+
+        This is what fails if the guard is keyed process-wide, which would hide
+        every topic after the first.
+        """
+        payload = {"distance_m": np.float32(0.02)}
+        with caplog.at_level(logging.WARNING):
+            mesh_session._put_zenoh_directly(SAFETY_TOPIC, payload)
+            mesh_session._put_zenoh_directly("strands/arm-a/input/frame", payload)
+
+        reported = {record.getMessage() for record in caplog.records}
+        assert len(reported) == 2, f"a second topic was not reported: {reported}"
+
+    def test_both_legs_of_a_bridge_report_one_topic_once(
+        self, zenoh_wire: _StubZenohSession, mqtt_leg: IotMqttTransport, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Under the bridge backend one broken builder is one fact, not two.
+
+        Both legs encode the same payload with the same encoder, so a per-leg
+        report would restate it.
+        """
+        with caplog.at_level(logging.WARNING):
+            _publish_on_each_leg(zenoh_wire, mqtt_leg, {"distance_m": np.float32(0.02)})
+
+        assert len(caplog.records) == 1, f"two legs on one topic produced {len(caplog.records)} reports"


### PR DESCRIPTION
## Problem

`Mesh.publish_safety_event` writes ONE event to two sinks - the wire and the local
audit log. On a payload the JSON encoder refuses, the two disagreed:

| sink | outcome | what an operator at the default log level saw |
| --- | --- | --- |
| audit log | `sig="SERIALISE_FAILED"` poison record written | one ERROR naming the peer and the reason |
| wire | **0 messages** | nothing - the drop was a `logger.debug` line |

So a forensic trail asserted that a `critical` collision event had been raised,
while no peer received it and nothing above DEBUG said so. The audit half already
reports this exact condition at ERROR; the wire half is what made the two
disagree.

Both encode sites absorbed a permanent encode failure into the same handler that
absorbs a transient wire failure:

```python
# strands_robots/mesh/session.py, before
try:
    _SESSION.put(key, json.dumps(data).encode())   # encode INSIDE the wire handler
except Exception as exc:
    logger.debug("Zenoh put error on %s: %s", key, exc)
```

`strands_robots/mesh/transport/base.py` already scopes that tolerance - "MUST NOT
raise on **transient** failure. Implementations should log at debug and continue" -
and a payload the encoder refuses is not transient. It fails identically on every
retry, so the message never goes out at all.

## Reachability

`publish_safety_event(event_type, severity, payload)` is public, and the payload is
the caller's. Measured against the real encode site, 8 of 9 realistic payload
shapes are dropped, including the two most natural things in a robot safety
payload:

| payload | on the wire | reported at WARNING+ (before) |
| --- | --- | --- |
| `{"distance_m": np.float32(0.019)}` - a sensor reading | 0 | no |
| `{"obstacle_pose": np.zeros(3)}` - a pose vector | 0 | no |
| `bytes`, `set`, `datetime`, `Path`, `Decimal`, `np.int64` | 0 | no |
| `{"distance_m": 0.019}` - plain floats (control) | 1 | n/a |

`json.dumps` raises exactly `TypeError` (unsupported type) and `ValueError`
(circular reference) for these; `nan`/`inf` and deep nesting encode fine, so they
are not in this class.

## Change

The encode now happens OUTSIDE the handler that absorbs a wire failure, at both
encode sites, and a permanently-undeliverable payload is reported at ERROR once
per topic through one shared reporter so both transports word it identically:

- `mesh/session.py` - `_put_zenoh_directly` (the default backend's encode site)
  encodes first, and a refusal goes to the new `_report_unencodable_payload`.
- `mesh/transport/iot_transport.py` - `put` encodes before the `awscrt` import, so
  an absent `[mesh-iot]` extra is no longer indistinguishable from a bad payload.
- `mesh/transport/base.py` - the `MeshTransport.put` contract now scopes its
  tolerance by whether a retry could succeed, and names the permanent case.
- `mesh/transport/bridge_transport.py` - its `put` docstring cited "a
  serialisation `ValueError`" as an example of something that propagates. Measured
  with the real legs, it does not and never did: both legs handle it themselves.
  Corrected in the same change, since it is a claim about this case.

The transient path is untouched: a closed session, a dropped broker and a
socket-level write still log at debug and continue.

**Bounded once per topic**, because a permanent failure repeats on every tick by
definition - 250 ticks on one topic produce one report, a second topic is reported
on its own terms, and under the bridge backend both legs on one topic produce one
report (they share an encoder, so the second would restate one fact).

## Tests

`tests/mesh/test_unencodable_payload_is_reported_not_dropped.py`, 16 cases in
three groups. Against `upstream/main`: **13 failed / 3 passed**, every failure
semantic - e.g.

```
AssertionError: the payload {'distance_m': np.float32(0.02)} can never be
published, and the drop was not reported at any level a default-configured
operator sees
```

- `TestAnUnencodablePayloadIsReported` (10) - the regression.
- `TestTheReportIsBounded` (3) - also fails pre-fix (there was no report to
  bound); it pins the report's shape rather than its existence.
- `TestTheTransientContractIsUnchanged` (3) - the only group that passes on both
  trees, and the no-overreach evidence: a retryable wire failure keeps its DEBUG
  tolerance, an encodable payload is published silently and byte-identically on
  both legs, and a closed mesh is still a silent no-op.

Each guard was checked to be load-bearing by breaking the fix six ways; every
break fires a distinct set and none is dead:

| break | fires |
| --- | --- |
| revert both source files to `upstream/main` | 13 (the whole regression set) |
| revert the Zenoh leg only | the Zenoh + bounded cases |
| revert the MQTT leg only | 4 - only the MQTT cases |
| escalate the transient publish failure too | **1** - only the transient control |
| drop the once-per-topic guard | 2 - only the bound cases |
| key the guard process-wide instead of per topic | **1** - only the second-topic case |
| control (no change) | 0 of 16 |

## Verification

Measured at `e06d2a7b` on Python 3.12 (`ruff` clean, `mypy` clean).

- `mypy strands_robots tests tests_integ`: 24 pre-existing errors on both trees, branch-only set empty (measured against a third pristine `upstream/main` worktree, so the base count is not inflated by a copied-in test file).
- Blast radius (210 files - all of `tests/mesh`, every test naming
  the transports or `mesh.session`, plus the repo-wide docstring / string /
  changelog guards), the identical selection on both trees with the new test file
  excluded from each: `21 failed, 4499 passed, 4 skipped, 24 errors` - the SAME summary line on both trees, 45 failing ids each, `comm` empty in both directions. All 45 are `tests/mesh/test_iot_*` on `No module named 'awsiot'` (88 occurrences), the declared `[mesh-iot]` extra CI installs.

## Artifact

The real `publish_safety_event` driven on both trees with the same collision
payload. The wire and audit OUTCOMES are byte-identical in both columns and the
control row is identical too; what changes is whether a default-configured
operator is told the event never went out.

![the wire and the audit trail on an unencodable safety payload](https://raw.githubusercontent.com/cagataycali/robots/media-unencodable-mesh-payload/unencodable-mesh-payload.png)
