### PR TITLE
fix(sim): the static-geom filter is expressible on both ray surfaces

### DIFF
--- a/changelog.d/2639-static-filter-on-both-ray-surfaces.md
+++ b/changelog.d/2639-static-filter-on-both-ray-surfaces.md
@@ -1,0 +1,5 @@
+### Fixed: the static-geom filter is expressible on both ray surfaces, and checked on both
+
+`include_static` decides whether a geom on a body with no degrees of freedom - the ground plane, a wall, a fixed fixture - can be the answer to a clearance question. `raycast` exposed it; `multi_raycast` hardcoded the include, so a lidar fan could not ask the question a single ray can ask, and passing the flag refused the call as an unknown parameter even though the tool schema publishes `include_static` for both actions. A 72-ray fan around a walled scene holding one movable crate answered 72 of 72 bearings with the wall where the caller had asked for the movable scene only; it now answers the 6 the crate occupies.
+
+Both surfaces now hold the flag to the shared boolean domain the module already applies to `set_joint_positions`' `hold`. Read by truthiness the filter inverted for exactly the spellings a caller opting out reaches for, since `"false"`, `"no"` and `"0"` are all truthy: each of them selected the include it names the opposite of. A boolean caller is unaffected and a caller who omits the flag gets the identical fan; a non-boolean value is now refused by name.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -928,7 +928,14 @@ class PhysicsMixin:
                 model defines - an id outside ``[0, model.nbody)`` matches no
                 body, so the geoms the caller asked to skip would be included
                 and could be reported as the obstacle.
-            include_static: Whether to include static geoms.
+            include_static: Whether the ray sees static geoms (a geom on a body
+                with no degrees of freedom - the ground plane, a wall, a fixed
+                fixture). ``False`` casts against the movable scene only, so a
+                clearance check can ask about dynamic obstacles without the
+                static world answering first. Must be a boolean: read by
+                truthiness this flag inverts for exactly the spellings a caller
+                opting out reaches for, since ``"false"``, ``"no"`` and ``"0"``
+                are all truthy.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -974,6 +981,15 @@ class PhysicsMixin:
         if err is not None:
             return err
 
+        # The static filter is a posture flag, so it is held to the shared boolean
+        # domain rather than read by truthiness (the rule ``set_joint_positions``
+        # states for ``hold``): "false", "no" and "0" are all truthy, so every
+        # string spelling of an opt-out would select the include it asks to skip.
+        # Resolved once here so the batch entry point can apply the same value.
+        if text := boolean_flag_error(include_static, "include_static", "raycast"):
+            return {"status": "error", "content": [{"text": text}]}
+        static_filter = 1 if include_static else 0
+
         pnt = np.array(origin_f, dtype=np.float64)
         vec = np.array(direction_f, dtype=np.float64)
         # Normalize direction
@@ -1002,7 +1018,7 @@ class PhysicsMixin:
                 pnt,
                 vec,
                 None,  # geom group filter (None = all)
-                1 if include_static else 0,
+                static_filter,
                 exclusion,
                 geomid,
             )
@@ -2253,6 +2269,7 @@ class PhysicsMixin:
         origin: list[float],
         directions: list[list[float]],
         exclude_body: int = -1,
+        include_static: bool = True,
     ) -> dict[str, Any]:
         """Cast multiple rays from a single origin (e.g., for LIDAR simulation).
 
@@ -2279,6 +2296,14 @@ class PhysicsMixin:
                 string is refused rather than read as one ray per character).
             exclude_body: Body ID whose geoms every ray passes through (``-1`` =
                 exclude nothing); see :meth:`raycast`.
+            include_static: Whether the ray sees static geoms (a geom on a body
+                with no degrees of freedom - the ground plane, a wall, a fixed
+                fixture). ``False`` casts against the movable scene only, so a
+                clearance check can ask about dynamic obstacles without the
+                static world answering first. Must be a boolean: read by
+                truthiness this flag inverts for exactly the spellings a caller
+                opting out reaches for, since ``"false"``, ``"no"`` and ``"0"``
+                are all truthy.
 
         Returns:
             Standard status dict. On success the ``{"json": ...}`` block carries
@@ -2316,6 +2341,14 @@ class PhysicsMixin:
         exclusion, err = _coerce_excluded_body(exclude_body, "multi_raycast", int(model.nbody))
         if err is not None:
             return err
+
+        # Same shared boolean domain :meth:`raycast` applies to this flag and
+        # ``set_joint_positions`` applies to ``hold``, rather than a truthiness
+        # read: "false", "no" and "0" are all truthy, so every string spelling of
+        # an opt-out would select the include the caller asked to switch off.
+        if text := boolean_flag_error(include_static, "include_static", "multi_raycast"):
+            return {"status": "error", "content": [{"text": text}]}
+        static_filter = 1 if include_static else 0
 
         # Validate and normalize EVERY direction before casting anything, so a
         # batch that cannot be cast in full is refused rather than half-cast. The
@@ -2366,7 +2399,7 @@ class PhysicsMixin:
             mj.mj_kinematics(model, data)
             for vec in vectors:
                 geomid = np.array([-1], dtype=np.int32)
-                dist = mj.mj_ray(model, data, pnt, vec, None, 1, exclusion, geomid)
+                dist = mj.mj_ray(model, data, pnt, vec, None, static_filter, exclusion, geomid)
                 results.append(
                     {
                         "distance": float(dist) if dist >= 0 else None,

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -2926,7 +2926,8 @@ class MuJoCoSimEngine(
         )
         base["methods"]["multi_raycast"] = (
             "(origin: list[float], directions: list[list[float]], "
-            "exclude_body=-1) -> dict  # batch raycast from one origin (e.g. a lidar fan); "
+            "exclude_body=-1, include_static=True) -> dict  # batch raycast from one origin "
+            "(e.g. a lidar fan); "
             "all-or-nothing - a direction it cannot cast refuses the batch instead of "
             "reporting that bearing as a miss"
         )

--- a/strands_robots/simulation/mujoco/tool_spec.json
+++ b/strands_robots/simulation/mujoco/tool_spec.json
@@ -453,7 +453,7 @@
     },
     "include_static": {
       "type": "boolean",
-      "description": "Include static geoms in raycast"
+      "description": "Whether a ray sees static geoms - a geom on a body with no degrees of freedom, such as the ground plane or a wall. Read by both raycast and multi_raycast; false casts against the movable scene only, so a clearance check can ask about dynamic obstacles without the static world answering first"
     },
     "positions": {
       "type": "object",

--- a/tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py
+++ b/tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py
@@ -16,7 +16,16 @@ produce that answer without casting anything:
   ``nan`` raised ``TypeError`` out of the pybind11 signature, and an id outside
   ``[0, model.nbody)`` matched no body - so the geoms the caller asked the ray to
   pass through were included and could be reported as the obstacle.
+* ``include_static`` - the filter that decides whether the static world answers a
+  clearance question - was a parameter of ``raycast`` only. ``multi_raycast``
+  hardcoded the include, so a lidar fan could not ask about dynamic obstacles the
+  way a single ray could, and passing the flag refused the call as an unknown
+  parameter even though the tool schema publishes it for both actions. On the one
+  surface that did accept it the flag was read by truthiness, so ``"false"``,
+  ``"no"`` and ``"0"`` all selected the include they name the opposite of.
 """
+
+import inspect
 
 import numpy as np
 import pytest
@@ -24,6 +33,14 @@ import pytest
 pytest.importorskip("mujoco")
 
 from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# Rays the ``sim`` fixture below makes meaningful. Straight down from above:
+# ``OFF_CUBE`` clears the cube so only the static ground can answer, which is what
+# makes the static filter observable; ``OVER_CUBE`` hits the dynamic cube, which
+# the filter must not touch.
+DOWN = [0.0, 0.0, -1.0]
+OFF_CUBE = [0.5, 0.0, 1.0]
+OVER_CUBE = [0.0, 0.0, 1.0]
 
 # Directions that name no castable ray. Each must be refused identically by the
 # single-ray and the batch entry point - a caller must not get two contracts for
@@ -47,6 +64,23 @@ UNHONORABLE_EXCLUSIONS = [
     pytest.param(2.7, id="fractional"),
     pytest.param("1", id="string"),
     pytest.param(True, id="bool"),
+    pytest.param(float("nan"), id="nan"),
+]
+
+# Static-filter values that are not booleans. The string spellings are the ones
+# worth naming: read by truthiness every one of them selects the include it asks
+# to switch off, so a clearance check would be answered by the static world after
+# the caller told it not to be.
+NON_BOOLEAN_STATIC_FILTERS = [
+    pytest.param("false", id="str-false"),
+    pytest.param("no", id="str-no"),
+    pytest.param("0", id="str-zero"),
+    pytest.param("true", id="str-true"),
+    pytest.param(0, id="int-zero"),
+    pytest.param(1, id="int-one"),
+    pytest.param(None, id="none"),
+    pytest.param([], id="empty-list"),
+    pytest.param(2.7, id="fractional"),
     pytest.param(float("nan"), id="nan"),
 ]
 
@@ -171,3 +205,96 @@ class TestCastableBatchStillResolves:
         result = sim.multi_raycast(origin=[0, 0, 1.0], directions=np.array([[0.0, 0.0, -1.0]]))
         assert result["status"] == "success"
         assert _json(result)["hits"] == 1
+
+
+class TestStaticFilterIsExpressibleOnBothRaySurfaces:
+    """A lidar fan can ask the question a single ray can ask.
+
+    ``include_static`` decides whether a geom on a body with no degrees of freedom
+    - the ground plane, a wall - can be the answer to a clearance question. The
+    batch entry point hardcoded the include, so the two surfaces disagreed about a
+    ray semantic while ``multi_raycast``'s own docstring points at ``raycast`` for
+    the sibling ``exclude_body`` parameter.
+    """
+
+    @pytest.mark.parametrize("method", ["raycast", "multi_raycast"])
+    def test_the_filter_is_a_parameter_of_both_surfaces(self, method):
+        """Neither surface may leave the caller unable to name the filter."""
+        signature = inspect.signature(getattr(Simulation, method))
+        assert "include_static" in signature.parameters, (
+            f"{method} cannot express the static filter its sibling exposes, so a "
+            "clearance check cannot ask about dynamic obstacles here"
+        )
+        assert signature.parameters["include_static"].default is True
+
+    @pytest.mark.parametrize("include_static", [True, False])
+    def test_single_and_batch_report_the_same_distance(self, sim, include_static):
+        """One filter value, one answer - a caller must not get two contracts."""
+        single = _json(sim.raycast(origin=OFF_CUBE, direction=DOWN, include_static=include_static))
+        batch = _json(sim.multi_raycast(origin=OFF_CUBE, directions=[DOWN], include_static=include_static))
+        assert batch["rays"][0]["distance"] == single["distance"]
+
+    def test_excluding_statics_is_actually_applied_by_the_batch(self, sim):
+        """The ground stops answering, so the fan reports the free space it found."""
+        included = _json(sim.multi_raycast(origin=OFF_CUBE, directions=[DOWN], include_static=True))
+        excluded = _json(sim.multi_raycast(origin=OFF_CUBE, directions=[DOWN], include_static=False))
+        assert included["hits"] == 1
+        assert included["rays"][0]["distance"] == pytest.approx(1.0, abs=1e-6)
+        assert excluded["hits"] == 0
+        assert excluded["rays"][0]["distance"] is None
+
+    @pytest.mark.parametrize("include_static", [True, False])
+    def test_a_dynamic_hit_is_unaffected_by_the_filter(self, sim, include_static):
+        """The filter selects statics only; the movable scene answers either way."""
+        for payload in (
+            _json(sim.raycast(origin=OVER_CUBE, direction=DOWN, include_static=include_static)),
+            _json(sim.multi_raycast(origin=OVER_CUBE, directions=[DOWN], include_static=include_static)),
+        ):
+            distance = payload.get("distance", (payload.get("rays") or [{}])[0].get("distance"))
+            assert distance == pytest.approx(0.8, abs=1e-6)
+
+    @pytest.mark.parametrize("action", ["raycast", "multi_raycast"])
+    def test_the_agent_surface_accepts_the_published_flag(self, sim, action):
+        """``include_static`` is a published tool_spec property, so both actions take it."""
+        rays = {"direction": DOWN} if action == "raycast" else {"directions": [DOWN]}
+        result = sim(action=action, origin=OFF_CUBE, include_static=False, **rays)
+        assert result["status"] == "success", _text(result)
+
+
+class TestStaticFilterDomain:
+    """The filter is checked on both surfaces, not read by truthiness."""
+
+    @pytest.mark.parametrize("method", ["raycast", "multi_raycast"])
+    @pytest.mark.parametrize("include_static", NON_BOOLEAN_STATIC_FILTERS)
+    def test_a_non_boolean_filter_is_refused_by_both(self, sim, method, include_static):
+        if method == "raycast":
+            result = sim.raycast(origin=OFF_CUBE, direction=DOWN, include_static=include_static)
+        else:
+            result = sim.multi_raycast(origin=OFF_CUBE, directions=[DOWN], include_static=include_static)
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "include_static" in text
+        assert method in text
+
+    @pytest.mark.parametrize("method", ["raycast", "multi_raycast"])
+    @pytest.mark.parametrize("include_static", [True, False, np.bool_(True), np.bool_(False)])
+    def test_a_boolean_filter_is_accepted_by_both(self, sim, method, include_static):
+        """The domain accepts a numpy boolean, so a mask element is a usable value."""
+        if method == "raycast":
+            result = sim.raycast(origin=OFF_CUBE, direction=DOWN, include_static=include_static)
+        else:
+            result = sim.multi_raycast(origin=OFF_CUBE, directions=[DOWN], include_static=include_static)
+        assert result["status"] == "success", _text(result)
+
+    def test_a_malformed_direction_outranks_a_malformed_filter(self, sim):
+        """The vector refusals keep the precedence they had before the filter check.
+
+        A caller who passes both a bad direction and a bad filter got the direction
+        message before this parameter was checked at all, so it still does: adding
+        a guard must not change which refusal an existing caller reads.
+        """
+        result = sim.raycast(origin=OFF_CUBE, direction=[0.0, 1.0], include_static="false")
+        assert result["status"] == "error"
+        text = _text(result)
+        assert "'direction' must be 3 elements" in text
+        assert "include_static" not in text


### PR DESCRIPTION
## Problem

`raycast` and `multi_raycast` are the two ray surfaces of the MuJoCo backend, and `multi_raycast`'s own docstring points at `raycast` for the sibling `exclude_body` parameter. They disagreed about a third ray semantic.

`include_static` decides whether a geom on a body with no degrees of freedom - the ground plane, a wall, a fixed fixture - can be the answer to a clearance question. `raycast` exposed it; `multi_raycast` hardcoded the include, so a lidar fan could not ask the question a single ray can ask. Measured on one scene, one origin, one direction:

| call | answer |
| --- | --- |
| `raycast(include_static=True)` | `wall_geom` @ 0.475 m |
| `raycast(include_static=False)` | `crate_geom` @ 0.900 m |
| `multi_raycast(...)` | `wall_geom` @ 0.475 m, no way to ask otherwise |
| `multi_raycast(include_static=False)` | `TypeError: multi_raycast() got an unexpected keyword argument` |

The tool schema publishes `include_static` as a `boolean` property, and the property dict is flat and shared across actions, so a schema-constrained caller can emit it for either action. Through the agent surface it was refused:

```
{"action": "multi_raycast", "origin": [...], "directions": [...], "include_static": false}
-> status=error  Unknown parameter 'include_static' for action 'multi_raycast'.
                 Valid: ['directions', 'exclude_body', 'origin']
```

On the one surface that did accept the flag it was read by truthiness, so every string spelling of an opt-out selected the include it names the opposite of:

| value | geom reported |
| --- | --- |
| `False` | `crate_geom` @ 0.900 |
| `"false"` | `wall_geom` @ 0.475 |
| `"no"` | `wall_geom` @ 0.475 |
| `"0"` | `wall_geom` @ 0.475 |

`physics.py` already states that rule, 500 lines from the site that broke it. `set_joint_positions` guards `hold` with the shared boolean domain under the comment *"Read by truthiness this flag would invert for exactly the spellings a caller opting out reaches for: `"false"`, `"no"` and `"0"` are all truthy"*, and `boolean_flag_error` is already imported in this module.

## Change

One contract: **the static-geom filter is expressible on both ray surfaces, and checked on both.**

- `multi_raycast` gains `include_static: bool = True` - the same name, type, default and meaning its documented sibling exposes. The default is the value the batch loop hardcoded, so a caller who does not name the flag gets the identical fan.
- Both surfaces route the flag through `boolean_flag_error` and resolve the C-level filter once. Adding an unchecked flag beside a checked sibling would have shipped the defect the module already guards against for `hold`, and a flag the schema publishes is agent-reachable.
- The `describe()` signature string for `multi_raycast` and the shared `include_static` schema description now name both actions - the description previously read "Include static geoms in raycast", singular, for a property both actions consume.

Not a pure no-op, and worth stating precisely: a boolean caller is unaffected, and a non-boolean value that previously selected a branch by truthiness is now refused by name. Nothing in the tree passes a non-boolean (`include_static` appeared in four places, all inside `physics.py`).

Message precedence is preserved: a caller who passes both a malformed direction and a malformed filter still reads the direction refusal, which is what they read before this parameter was checked at all.

## Tests

Extended `tests/simulation/mujoco/test_raycast_uncastable_ray_refused.py`, which already pins the two ray surfaces against each other for `directions` and `exclude_body` and whose module docstring states this exact contract - *"refused identically by the single-ray and the batch entry point - a caller must not get two contracts for one malformed vector"*. Nothing pinned the static filter.

Pre-fix, with only the test file copied onto `upstream/main`: **31 failed / 40 passed** (12 `AssertionError`, 19 `TypeError: unexpected keyword argument`). The two headline failures read:

```
multi_raycast cannot express the static filter its sibling exposes, so a
clearance check cannot ask about dynamic obstacles here

Unknown parameter 'include_static' for action 'multi_raycast'.
Valid: ['directions', 'exclude_body', 'origin']
```

The 40 that pass on both trees are the existing suite plus the new controls. Each guard was checked by breaking exactly one thing:

| break | fires |
| --- | --- |
| revert `strands_robots/`, keep the tests | 31 - the whole regression set |
| batch keeps the parameter but hardcodes the include | 2 - both parity behaviour tests |
| both surfaces read the flag by truthiness again | 20 - the domain test, both methods |
| only the batch surface loses its domain check | 10 - the domain test, batch only |
| the `raycast` check moves above the vector validation | 1 - the precedence control only |
| control (no break) | 0 of 71 |

The third and fourth rows are complementary, so each surface's check is independently pinned, and the last row is the only thing that fires the precedence control.

## Verification

Measured at `eac7726`; the head is now `a31c628`, which adds only the changelog fragment, on `mujoco 3.12.0` (the version this repo's range resolves).

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `upstream/main` worktree, none in the changed files.
- 250-file selection (every test naming the ray surfaces, the shared boolean domain, `tool_spec` or `describe()`, plus all of `tests/simulation/mujoco/` and the repo-wide docs/docstring/string guards), run with the changed test file excluded from **both** trees so the comparison measures collateral damage only:

  | tree | result |
  | --- | --- |
  | this branch | 6221 passed, 125 skipped, 0 failed |
  | pristine `upstream/main` | 6221 passed, 125 skipped, 0 failed |

  Byte-identical summary lines, zero failures on either side, so there is no passed-delta arithmetic to reconcile.
- The changed test file itself: 71 passed.
- `changelog.d/2639-...`: `scripts/assemble_changelog.py --check` OK, and the 85 fragment-gate tests pass.

## Artifact

A 72-ray fan from one origin, MuJoCo headless. A static wall rings the robot; one movable crate sits inside it. The caller asks the batch surface for the movable scene only.

![static filter on both ray surfaces](https://raw.githubusercontent.com/cagataycali/robots/media-static-filter-both-ray-surfaces/static_filter.png)

- `upstream/main`: the parameter does not exist on that surface, so no fan is cast.
- this branch: **6 of 72** bearings answered, all by the movable crate.
- Control, top-down: the same fan with the filter omitted answers **72 of 72** - the wall on every bearing - and the 72 distances are byte-identical on both trees.
- Control: `raycast(include_static=False)` returns `crate_geom @ 0.6278648857607881` on both trees. The single-ray surface is unchanged, and that is the answer the fan could not produce.

Both scene renders and every control are asserted from the captured JSON inside the figure script, so the picture cannot drift from these numbers.

