### PR TITLE
docs(examples/fleet): the fleet dashboard is named, not promised

### DIFF
--- a/changelog.d/2642-fleet-examples-name-the-shipped-dashboard.md
+++ b/changelog.d/2642-fleet-examples-name-the-shipped-dashboard.md
@@ -1,0 +1,11 @@
+### Fixed: two fleet examples no longer promise a dashboard that already ships
+
+`examples/fleet/03_failover_and_degraded_ops.py` and
+`04_emergency_evacuation.py` described the read-only Rerun fleet dashboard as
+future work ("shows the safety events live once it lands", referencing #2181),
+but it landed in `examples/fleet/dashboard.py`. A reader working through the
+fleet suite in order was told to wait for a file sitting in the same directory.
+Both docstrings now name the artifact in the present tense, which is also the
+spelling that cannot go stale again: prose naming a path stops depending on
+issue state. The still-accurate forward reference to the Isaac adapter (#2123,
+open) is unchanged. (#2642)

--- a/examples/fleet/03_failover_and_degraded_ops.py
+++ b/examples/fleet/03_failover_and_degraded_ops.py
@@ -30,8 +30,9 @@ Note: The live estop drill leaves the surviving robots in safety lockout by
       Set STRANDS_MESH_LOCAL_DEV=1 (defaulted below) to skip TLS locally.
 
 Part of the fleet suite (epic #2179); the shared manifest schema lives in
-``capabilities.py``. The read-only Rerun fleet dashboard (#2181) attaches to
-the same mesh and shows the peer loss and the recovery live once it lands.
+``capabilities.py``. The read-only Rerun fleet dashboard
+(``examples/fleet/dashboard.py``) attaches to the same mesh and shows the peer
+loss and the recovery live.
 """
 
 from __future__ import annotations

--- a/examples/fleet/04_emergency_evacuation.py
+++ b/examples/fleet/04_emergency_evacuation.py
@@ -44,8 +44,8 @@ Note: The live lockout drill needs `STRANDS_MESH_OVERRIDE_CODE`; when unset,
 
 Part of the fleet suite (epic #2179). The retreat sits behind the small
 ``EvacuationWorld`` seam so the Isaac adapter (#2123) drops in later; the
-read-only Rerun fleet dashboard (#2181) attaches to the same mesh and shows
-the safety events live once it lands.
+read-only Rerun fleet dashboard (``examples/fleet/dashboard.py``) attaches to
+the same mesh and shows the safety events live.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Towards #2642 (the immediate-fix half; the gate stays open there, and see "Why there is no test" for why it cannot be offline).

## The defect

Two examples in the fleet suite describe the read-only Rerun fleet dashboard as future work:

```
examples/fleet/03_failover_and_degraded_ops.py:34
  The read-only Rerun fleet dashboard (#2181) attaches to
  the same mesh and shows the peer loss and the recovery live once it lands.

examples/fleet/04_emergency_evacuation.py:48
  the read-only Rerun fleet dashboard (#2181) attaches to the same mesh and
  shows the safety events live once it lands.
```

It landed four days ago:

| fact | value |
|---|---|
| artifact | `examples/fleet/dashboard.py` - "Read-only fleet dashboard: a subscribe-only mesh peer rendered in Rerun" |
| added by | `ae57b3fa` - `feat(examples/fleet): 02_cross_zone_transport + read-only Rerun fleet dashboard (#2198)` |
| issue #2181 | CLOSED 2026-08-19T04:48:25Z, title matching the PR exactly |

The reader who hits this is the one working through the fleet suite in order: they are inside `examples/fleet/`, `dashboard.py` is sitting next to the file they are reading, and its docstring tells them to wait for it.

## The change

Both docstrings name the artifact in the present tense instead of promising a ticket:

> The read-only Rerun fleet dashboard (``examples/fleet/dashboard.py``) attaches to the same mesh and shows the safety events live.

That is also the spelling that cannot go stale again, which is the reason to prefer it over merely flipping the tense: prose that names a path is checkable against the tree, while prose that names a ticket depends on state no in-tree check can read.

`04_emergency_evacuation.py`'s other forward reference - "the Isaac adapter (#2123) drops in later" - is deliberately **unchanged**: #2123 is still open, so that sentence is still true. This PR corrects what is false and leaves what is accurate alone.

## Why there is no test

Docstring-only, and I can state that precisely rather than assert it. For both files, with the module docstring removed the AST is identical to `main`, and every changed byte lies inside the docstring:

```
examples/fleet/03_failover_and_degraded_ops.py
  AST identical with module docstring removed : True
  every changed byte lies inside the docstring: True
examples/fleet/04_emergency_evacuation.py
  AST identical with module docstring removed : True
  every changed byte lies inside the docstring: True
```

I did try to ship a pin with this, and I am reporting the result because it changes the design on #2642 rather than being something I quietly dropped. I wrote a corpus-wide offline check - find forward-looking prose, resolve the path it names, fail if that path already exists - and ran it against the tree. It produced **two false positives and could not see the actual defect**:

1. `examples/libero/README.md` - the sentence names two paths, `libero_backend_matrix.py` (exists; it is the thing doing the printing) and `run_isaac_fleet.py` (absent; the thing actually promised). Proximity picks the wrong one.
2. `04_emergency_evacuation.py` - "drops in later" refers to the Isaac adapter **#2123**, while the nearest path token belongs to a different clause across a semicolon.
3. Decisive: the drifted sentences named **#2181 - a ticket, not a path**. A path-resolving check is structurally incapable of catching the shape that motivated it.

So the discriminating signal for this defect class is issue state, and a check for it cannot be a unit test. Shipping the offline version would have added a grader whose corpus is clean and which cannot detect the bug it was written for. Recorded on #2642 so the gate is scoped correctly there.

## Gates

- `ruff check` and `ruff format --check` on both files: clean.
- `scripts/assemble_changelog.py --check`: `changelog fragments OK`.
- Changelog recorded as a fragment (`changelog.d/2642-...md`), not appended to `CHANGELOG.md`.
- No runtime surface: `git diff --name-only main...HEAD -- strands_robots/ tests/` is empty.

## Round changelog

**Round 1** - initial submission.