### PR TITLE
docs(mesh): the command census names every action it validates a field for

### DIFF
--- a/changelog.d/2645-command-census-per-action.md
+++ b/changelog.d/2645-command-census-per-action.md
@@ -1,0 +1,28 @@
+### Fixed: the command census names every action it validates a field for
+
+`validate_command` documents its per-action work under a `Performed checks:` census. Six
+action branches validate at least one field out of `cmd`; the census named four of them, and
+for one of those four it described the check inaccurately.
+
+`resume` and `teleop_stop` were absent entirely, so nothing in the census said that
+`resume.override_code` -- the operator's second factor for clearing an e-stop lockout -- is
+bounded at 256 printable-ASCII characters, or that `teleop_stop.device_name` is checked at
+all. `teleop_receive` was named but only for one of its two fields.
+
+The inaccuracy is the sharpest of the four. The census said `source_peer_id` must be "a
+non-empty str", where the body hands it to `validate_mesh_identifier`. Measured, that
+validator refuses the Zenoh wildcards `*` and `**`, `/`, `?`, `#`, `$`, control characters and
+anything over `MAX_PEER_ID_LEN` -- every one of which the census's own words admit. A reader
+sizing an allowlist entry or a fixture from the census therefore picks a value the validator
+rejects, and the rejection names a charset the census never mentioned.
+
+The census now names all six branches, every field each one validates, and the shared
+validator the two teleop identifiers are decided by, so the admitted charset is discoverable
+from the census rather than by reading the body.
+
+`validate_command`'s docstring is the whole package diff: with that docstring removed from
+both versions the two files are byte-identical, so no verdict, message or accepted input
+moves. The existing census guard gains the per-action completeness rule, with the action set
+derived from the body's own `if action == "x"` chain and the field set from every way the body
+reads `cmd` -- `.get`, `.pop`, `cmd["x"]` and `"x" in cmd` -- so a seventh branch, or a new
+field on an existing one, is graded on arrival.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -947,7 +947,19 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
         - ``fast_mode`` (optional): boolean.
         - ``n_steps`` (optional): integer in ``[1, 10_000_000]``.
     * ``step``: ``steps`` integer in ``[1, 10_000]``, defaults to 1.
-    * ``teleop_receive``: ``source_peer_id`` non-empty str.
+    * ``teleop_receive``: both identifiers are checked by
+      :func:`validate_mesh_identifier`, so the admitted charset is
+      ``[A-Za-z0-9_.-]+`` rather than any non-empty string -- a Zenoh
+      wildcard is refused instead of silently widening the subscription
+      the follower builds out of them.
+        - ``source_peer_id``: REQUIRED.
+        - ``device_name`` (optional): defaults to ``"leader"`` downstream.
+    * ``teleop_stop``: ``device_name`` (optional) must be a str or null.
+    * ``resume``: ``override_code`` (optional, defaults to ``""``): str of at
+      most :data:`MAX_OVERRIDE_CODE_LEN` characters, printable ASCII only
+      (no C0/DEL/CRLF). The operator's second factor for clearing an e-stop
+      lockout is bounded here so it cannot carry a control character into the
+      audit trail, and cannot reach ``Mesh._resume_lockout`` as a non-string.
 
     Raises :class:`ValidationError` on any rule violation.
     """

--- a/tests/mesh/test_performed_checks_census_matches_the_code.py
+++ b/tests/mesh/test_performed_checks_census_matches_the_code.py
@@ -358,3 +358,303 @@ class TestTheValueRuleTheCensusNowStates:
         monkeypatch.setenv("STRANDS_MESH_INPUT_VALUE_ABS", "10.0")
         refusal = _refused(50.0)
         assert refusal is not None and "out of range" in refusal, refusal
+
+
+def _validated_action_fields(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, dict[str, str | None]]:
+    """Map each ``action`` branch of *fn* to the fields that branch validates.
+
+    A census enumerated *per action* is complete only when it names every
+    action branch that validates a field, and every field inside it. Both
+    halves are read off the body -- the ``if action == "x"`` chain, and the
+    ``cmd`` reads within each branch -- so a thirteenth action is graded on
+    arrival with no list here to update.
+
+    A field handed to a shared ``validate_*`` helper maps to that helper's
+    name, because the helper *is* the domain: a bullet that describes such a
+    field in its own words can describe a wider admission than the code
+    performs, which is how ``source_peer_id`` came to be documented as a
+    "non-empty str" while
+    :func:`~strands_robots.mesh.security.validate_mesh_identifier` refuses the
+    Zenoh ``**`` wildcard -- a value that, per that function's own docstring,
+    widens a point-to-point teleop subscription into a match-any one.
+
+    A validator that does not branch on an action yields ``{}``, so the rules
+    below are vacuous for it rather than needing an exemption.
+    """
+    found: dict[str, dict[str, str | None]] = {}
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.If):
+            continue
+        actions = _actions_selected_by(node.test)
+        if not actions:
+            continue
+        branch = ast.Module(body=node.body, type_ignores=[])
+        fields = _command_fields_read(branch)
+        fields.pop("action", None)
+        for action in actions:
+            found.setdefault(action, {}).update(fields)
+    return {action: fields for action, fields in found.items() if fields}
+
+
+def _actions_selected_by(test: ast.expr) -> list[str]:
+    """Action literals the ``if``/``elif`` *test* selects, in either spelling."""
+    selected: list[str] = []
+    for node in ast.walk(test):
+        if not (isinstance(node, ast.Compare) and isinstance(node.left, ast.Name)):
+            continue
+        if node.left.id != "action":
+            continue
+        for comparator in node.comparators:
+            if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+                selected.append(comparator.value)
+            elif isinstance(comparator, (ast.Tuple, ast.List, ast.Set)):
+                for element in comparator.elts:
+                    # The isinstance on ``.value`` narrows for the type checker:
+                    # ``ast.Constant.value`` is the whole literal union.
+                    if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                        selected.append(element.value)
+    return selected
+
+
+def _command_fields_read(branch: ast.Module) -> dict[str, str | None]:
+    """Fields *branch* reads out of ``cmd``, mapped to a delegate or ``None``.
+
+    All three read spellings the body uses count -- ``cmd.get("f")``,
+    ``cmd["f"]`` and ``"f" in cmd`` -- because a field guarded only behind a
+    presence test is still a field the function validates.
+    """
+    fields: dict[str, str | None] = {}
+    for node in ast.walk(branch):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            container = node.func.value
+            if (
+                node.func.attr in ("get", "pop")
+                and isinstance(container, ast.Name)
+                and container.id == "cmd"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                fields.setdefault(node.args[0].value, None)
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name) and node.value.id == "cmd":
+            if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+                fields.setdefault(node.slice.value, None)
+        if isinstance(node, ast.Compare) and isinstance(node.left, ast.Constant):
+            if isinstance(node.left.value, str) and any(isinstance(o, (ast.In, ast.NotIn)) for o in node.ops):
+                if any(isinstance(c, ast.Name) and c.id == "cmd" for c in node.comparators):
+                    fields.setdefault(node.left.value, None)
+    for field, delegate in _delegated_fields(branch).items():
+        if field in fields:
+            fields[field] = delegate
+    return fields
+
+
+def _delegated_fields(branch: ast.Module) -> dict[str, str]:
+    """Fields *branch* hands to a shared ``validate_*`` helper.
+
+    The helper is located by the dotted ``"action.field"`` label every such
+    call passes for its message prefix. The label is read off the AST rather
+    than out of the unparsed source, because :func:`ast.unparse` normalises
+    string literals to single quotes and a pattern written for the source's
+    double quotes silently matches nothing.
+    """
+    delegated: dict[str, str] = {}
+    for node in ast.walk(branch):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if not node.func.id.startswith("validate_"):
+            continue
+        for argument in node.args:
+            if isinstance(argument, ast.Constant) and isinstance(argument.value, str) and "." in argument.value:
+                delegated[argument.value.rsplit(".", 1)[1]] = node.func.id
+    return delegated
+
+
+#: Fewest action/field pairs the per-action scan must reach. Below this the
+#: rules would hold vacuously over an empty enumeration.
+_MINIMUM_ACTION_FIELD_PAIRS = 20
+
+
+def _per_action_censuses() -> list[tuple[str, str, dict[str, dict[str, str | None]]]]:
+    """Every census whose function enumerates checks per ``action``."""
+    found = []
+    for name, fn, bullets, _constants in _censuses():
+        by_action = _validated_action_fields(fn)
+        if by_action:
+            found.append((name, bullets, by_action))
+    return found
+
+
+class TestACensusEnumeratedPerActionNamesEveryActionAndField:
+    """An enumeration organised by action must be complete about both."""
+
+    def test_every_action_that_validates_a_field_is_named(self) -> None:
+        missing: dict[str, list[str]] = {}
+        for name, bullets, by_action in _per_action_censuses():
+            absent = sorted(action for action in by_action if f"``{action}``" not in bullets)
+            if absent:
+                missing[name] = absent
+        assert not missing, (
+            f"a census enumerated per action omits an action branch that validates a field: {missing}. "
+            "A reader consulting the enumeration concludes the action carries nothing to check."
+        )
+
+    def test_every_field_an_action_validates_is_named(self) -> None:
+        missing: dict[str, list[str]] = {}
+        for name, bullets, by_action in _per_action_censuses():
+            absent = sorted(
+                f"{action}.{field}"
+                for action, fields in by_action.items()
+                for field in fields
+                if f"``{field}``" not in bullets
+            )
+            if absent:
+                missing[name] = absent
+        assert not missing, (
+            f"a census names an action but not every field that action validates: {missing}. "
+            "An unnamed field reads as unvalidated, so a publisher author does not learn its bound."
+        )
+
+    def test_a_field_delegated_to_a_shared_validator_names_it(self) -> None:
+        missing: dict[str, list[str]] = {}
+        for name, bullets, by_action in _per_action_censuses():
+            absent = sorted(
+                f"{action}.{field} -> {delegate}"
+                for action, fields in by_action.items()
+                for field, delegate in fields.items()
+                if delegate is not None and delegate not in bullets
+            )
+            if absent:
+                missing[name] = absent
+        assert not missing, (
+            f"a census describes a delegated field without naming the validator that decides it: {missing}. "
+            "The helper is the domain, so describing the field in other words can state a wider admission "
+            "than the code performs."
+        )
+
+
+class TestThePerActionScanIsNotVacuous:
+    """The rules above are only worth anything over a populated enumeration."""
+
+    def test_the_scan_reaches_the_per_action_census(self) -> None:
+        names = [name for name, _bullets, _by_action in _per_action_censuses()]
+        assert "validate_command" in names, names
+
+    def test_the_scan_reaches_every_action_field_pair(self) -> None:
+        pairs = sum(len(fields) for _n, _b, by_action in _per_action_censuses() for fields in by_action.values())
+        assert pairs >= _MINIMUM_ACTION_FIELD_PAIRS, pairs
+
+    def test_the_scan_finds_the_delegated_identifier_fields(self) -> None:
+        """``validate_mesh_identifier`` is the delegate the rule exists for."""
+        delegated = {
+            delegate
+            for _n, _b, by_action in _per_action_censuses()
+            for fields in by_action.values()
+            for delegate in fields.values()
+            if delegate is not None
+        }
+        assert "validate_mesh_identifier" in delegated, delegated
+
+
+class TestThePerActionRulesDoNotOverReach:
+    """A validator with no action branches is not held to an enumeration."""
+
+    def test_a_census_that_does_not_branch_on_an_action_is_not_graded(self) -> None:
+        source = inspect.getsource(security)
+        fn = next(
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name == "validate_input_frame"
+        )
+        assert _validated_action_fields(fn) == {}
+
+    def test_every_read_spelling_counts_as_a_field(self) -> None:
+        """``cmd.get``, ``cmd[...]`` and ``"f" in cmd`` all name a field."""
+        planted = ast.parse(
+            "\n".join(
+                [
+                    "def validate_planted(cmd):",
+                    '    """Performed checks:',
+                    "",
+                    "    * ``noop``: nothing.",
+                    '    """',
+                    '    if action == "planted":',
+                    '        a = cmd.get("via_get")',
+                    '        b = cmd["via_subscript"]',
+                    '        if "via_membership" in cmd:',
+                    "            pass",
+                ]
+            )
+        )
+        fn = planted.body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _validated_action_fields(fn) == {
+            "planted": {"via_get": None, "via_subscript": None, "via_membership": None}
+        }
+
+    def test_a_delegate_label_is_read_off_the_ast_not_the_unparsed_source(self) -> None:
+        """Single-quote normalisation by ``ast.unparse`` must not hide it."""
+        planted = ast.parse(
+            "\n".join(
+                [
+                    "def validate_planted(cmd):",
+                    '    if action == "planted":',
+                    '        x = validate_thing(cmd.get("field"), "planted.field")',
+                ]
+            )
+        )
+        fn = planted.body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _validated_action_fields(fn) == {"planted": {"field": "validate_thing"}}
+
+
+class TestTheActionRulesTheCensusNowStates:
+    """The census's new bullets describe what the validator really does."""
+
+    @pytest.mark.parametrize("identifier", ["**", "*", "a/b", "with space", "semi;colon"])
+    def test_a_teleop_source_peer_id_outside_the_charset_is_refused(self, identifier: str) -> None:
+        with pytest.raises(security.ValidationError, match=r"\[A-Za-z0-9_\.-\]\+"):
+            security.validate_command({"action": "teleop_receive", "source_peer_id": identifier})
+
+    def test_a_teleop_device_name_outside_the_charset_is_refused(self) -> None:
+        with pytest.raises(security.ValidationError, match="device_name"):
+            security.validate_command({"action": "teleop_receive", "source_peer_id": "leader", "device_name": "**"})
+
+    def test_an_identifier_inside_the_charset_is_admitted(self) -> None:
+        out = security.validate_command(
+            {"action": "teleop_receive", "source_peer_id": "arm-1.left", "device_name": "leader_2"}
+        )
+        assert out["source_peer_id"] == "arm-1.left"
+        assert out["device_name"] == "leader_2"
+
+    @pytest.mark.parametrize("device", [123, [], {}, 1.5])
+    def test_a_non_string_teleop_stop_device_name_is_refused(self, device: Any) -> None:
+        with pytest.raises(security.ValidationError, match="must be a string or null"):
+            security.validate_command({"action": "teleop_stop", "device_name": device})
+
+    def test_a_null_teleop_stop_device_name_is_admitted(self) -> None:
+        assert security.validate_command({"action": "teleop_stop", "device_name": None})["device_name"] is None
+
+    @pytest.mark.parametrize("code", [123, [], {}, True])
+    def test_a_non_string_override_code_is_refused(self, code: Any) -> None:
+        with pytest.raises(security.ValidationError, match="must be a string"):
+            security.validate_command({"action": "resume", "override_code": code})
+
+    def test_an_override_code_past_the_cited_bound_is_refused(self) -> None:
+        over = "a" * (security.MAX_OVERRIDE_CODE_LEN + 1)
+        with pytest.raises(security.ValidationError, match="too long"):
+            security.validate_command({"action": "resume", "override_code": over})
+
+    @pytest.mark.parametrize("code", ["ok\ninjected", "ok\r\ninjected", "nul\x00byte", "bell\x07"])
+    def test_an_override_code_carrying_a_control_character_is_refused(self, code: str) -> None:
+        with pytest.raises(security.ValidationError, match="control characters"):
+            security.validate_command({"action": "resume", "override_code": code})
+
+    def test_a_printable_override_code_at_the_bound_is_admitted(self) -> None:
+        at_bound = "a" * security.MAX_OVERRIDE_CODE_LEN
+        assert security.validate_command({"action": "resume", "override_code": at_bound})["override_code"] == at_bound
+
+    def test_an_omitted_override_code_defaults_to_empty(self) -> None:
+        assert security.validate_command({"action": "resume"})["override_code"] == ""


### PR DESCRIPTION
## Problem

`validate_command` documents its per-action work under a `Performed checks:` census. Six action
branches validate at least one field out of `cmd`; the census named four of them, and for one of
those four it described the check inaccurately.

Derived from the body's own `if action == "x"` chain and its `cmd` reads:

| action branch | fields it validates | census names the action | names every field | names the shared validator |
| --- | --- | --- | --- | --- |
| `execute` | 18 | yes | yes | n/a |
| `start` | 18 | yes | yes | n/a |
| `step` | 1 | yes | yes | n/a |
| `teleop_receive` | 2 | yes | **no** (`device_name` absent) | **no** |
| `teleop_stop` | 1 | **no** | **no** | n/a |
| `resume` | 1 | **no** | **no** | n/a |

Three of the six branches were incompletely named. The inaccuracy in the fourth is the sharpest of
the four findings: the census said `source_peer_id` must be "a non-empty str", where the body calls
`validate_mesh_identifier`. Measured, that validator refuses the Zenoh wildcards `*` and `**`, `/`,
`?`, `#`, `$`, control characters, and anything over `MAX_PEER_ID_LEN` -- all of which the census's
own words admit. So a reader who sizes an allowlist entry or a fixture from the census picks a value
the validator rejects, and the rejection names a charset the census never mentioned.

`resume.override_code` is the omission with the most weight behind it. It is the operator's second
factor for clearing an e-stop lockout, bounded at 256 printable-ASCII characters, and the census
named neither the action nor the field.

## Change

Extend the census to name all six branches, every field each one validates, and the shared validator
the two teleop identifiers are decided by. `source_peer_id` and `device_name` now say they are
checked by `validate_mesh_identifier`, so the admitted charset is discoverable from the census rather
than by reading the body.

`validate_command`'s docstring is the entire package diff. With that docstring removed from both
versions the two files are byte-identical, so no verdict, message or accepted input moves.

## Tests

`tests/mesh/test_performed_checks_census_matches_the_code.py` is the existing guard for this census
(it already grades the value-domain bullets against the validator). It gains the per-action
completeness rule, with both halves derived rather than listed:

- the action set comes from the body's own `if action == "x"` / `in (...)` chain;
- the field set per branch comes from every way the body reads `cmd` -- `.get`, `.pop`, `cmd["x"]`
  and `"x" in cmd`;
- a field handed to a `validate_*` helper as `"<action>.<field>"` records that helper as its
  delegate, read off the AST argument rather than the unparsed source.

A seventh action branch, or a new field on an existing one, is therefore graded on arrival.

Pre-fix split, running the updated guard against `upstream/main`: **3 failed / 54 passed**. All three
failures are semantic and name their own finding -- the missing actions, the missing field, and the
undocumented delegate.

Break table, each row the whole file:

| break | failures | which |
| --- | --- | --- |
| control (this branch) | 0 of 57 | - |
| exact pre-fix census | 3 | action + field + delegate rules |
| drop the `resume` / `teleop_stop` bullets | 2 | action + field |
| name `resume` but not `override_code` | 1 | field rule only |
| describe the identifiers without naming the validator | 1 | delegate rule only |
| field scan loses the `"x" in cmd` spelling | 1 | the read-spelling control only |
| delegate read off the unparsed source, not the AST | 2 | non-vacuity + the AST control (the rule itself passes vacuously) |
| the action scan reaches nothing | 5 | 3 non-vacuity + both derivation controls |

Seven breaks, seven distinct firing sets, no dead guards. The three single-firing rows are what show
each rule is independently pinned; the unparsed-source row is the real bug this scan hit while it was
being written, and it is caught by the non-vacuity clause rather than by the rule, which is why that
clause is not decoration.

## Verification

Measured at `a95ad651`, on `lerobot 0.6.2` / `mujoco 3.5.0`.

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: 24 errors on this branch and 24 on a pristine
  `upstream/main` worktree, with the branch-only set empty.
- Blast radius: 410 test files (all of `tests/mesh`, every test naming `validate_command`,
  `validate_mesh_identifier`, `MAX_OVERRIDE_CODE_LEN`, `override_code`, `source_peer_id` or
  `device_name`, plus the repo-wide docstring and docs guards). The identical selection was run on
  this branch and on a pristine `upstream/main`, with the changed test file excluded from both:
  `23 failed, 13490 passed, 86 skipped, 24 errors` on each, in 404.07s and 400.58s. The summary
  lines are byte-identical and the 47 failing ids are the same set, with the branch-only and
  base-only sets both empty. All 47 are dependency-absent here and pass on CI: 45 under
  `tests/mesh/test_iot_*` on `ModuleNotFoundError: No module named 'awsiot'` (88 occurrences; the
  declared `[mesh-iot]` extra pins `awsiotsdk>=1.21.0,<2.0.0`), and the two
  `tests/test_doctor.py::TestDoctorVersionResolution` cases on
  `PackageNotFoundError: No package metadata was found for strands-robots`, which reproduce in
  isolation on a pristine `upstream/main` worktree because a worktree is not pip-installed.
- The updated guard on its own: 57 passed.

## Scope

The census's `Raises` and value-domain bullets are unchanged; only the per-action enumeration and the
`source_peer_id` / `device_name` descriptions move.

Two things measured and deliberately left alone. `execute` and `start` share one branch and one
18-field set, and the census already names both, so nothing there is per-action. And the census still
does not enumerate the field allowlist itself -- the set of keys `validate_command` will carry through
at all -- which is a much larger enumeration with its own drift question, and not this change.

## Artifact

The census is documentation, so there is no rendered behaviour to film. What the figure shows instead
is the completeness matrix above beside the verdicts the validator really returns for those fields,
captured by running both trees: the verdicts are identical in both columns, which is the control.

![per-action census completeness](https://raw.githubusercontent.com/cagataycali/robots/media-validate-command-census/census-per-action.png)

