### PR TITLE
docs(mesh): the command census names every bound it enforces

### DIFF
--- a/changelog.d/2647-mesh-census-names-every-bound.md
+++ b/changelog.d/2647-mesh-census-names-every-bound.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **mesh**: `validate_command`'s `Performed checks:` census now states every bound the
+  validator enforces. A guard graded one direction of the set equality between the bounds a
+  census cites and the bounds the body reads - that a cited constant is one the body loads -
+  and left the other direction open, so two of the nine public bounds were enforced and
+  stated nowhere. `MAX_PASSTHROUGH_LEN` bounds `turn_id` and `sender_id`, and the census named
+  neither field: both are checked on every action rather than per-action, so a 129-character
+  correlation id, a printable non-ASCII one and a non-string were all refused with no bound
+  for a publisher to size to, on the two fields `Mesh` correlates an RPC turn and keys its
+  command-replay cache with. `MAX_PEER_ID_LEN` bounds `robot_name`'s length and each
+  `target_joints` key's length, where the census gave the charset without the length and
+  bounded the key count without each key. No verdict, message or accepted input changes -
+  with the census stripped, the module is byte-identical. The guard gains the reverse
+  direction, derived from the body so a bound added later is graded on arrival; only public
+  constants are graded, because the charset gates are private regexes whose admitted charset
+  the census names in words.

--- a/strands_robots/mesh/security.py
+++ b/strands_robots/mesh/security.py
@@ -911,6 +911,15 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
     Performed checks:
 
     * ``action`` must be a string and a member of :data:`ALLOWED_ACTIONS`.
+    * ``turn_id`` and ``sender_id`` (both optional) are checked on *every*
+      action, not per-action: each must be a str of at most
+      :data:`MAX_PASSTHROUGH_LEN` characters, printable ASCII only (no C0/DEL
+      or non-printable byte). They are wire-routing fields rather than action
+      payload -- ``Mesh`` correlates an RPC turn on ``turn_id`` and keys its
+      command-replay cache on ``(sender_id, turn_id)`` -- so a publisher
+      minting them needs the bound, and a control byte must not reach the
+      audit trail through either. Any other unvalidated key is dropped from
+      the sanitised copy rather than refused.
     * ``execute`` and ``start`` actions require:
         - ``instruction``: non-empty str up to :data:`MAX_INSTRUCTION_LEN`,
           carrying no C0/DEL/C1 control character. Printable non-ASCII is
@@ -926,14 +935,16 @@ def validate_command(cmd: dict[str, Any]) -> dict[str, Any]:
           No silent default -- a peer that omits this is rejected so it is
           never ambiguous whether ``mock`` was an explicit choice or a bug.
         - ``server_address`` (optional): in :func:`is_safe_server_address`.
-        - ``robot_name`` (optional): peer-id charset, used by sim peers
+        - ``robot_name`` (optional): peer-id charset, at most
+          :data:`MAX_PEER_ID_LEN` characters, used by sim peers
           to disambiguate which robot in the world the policy targets.
         - ``target_pose`` (optional): list of 7 floats
           ``[x, y, z, qw, qx, qy, qz]`` for planner-style providers
           (issue #300 well-known kwarg).
         - ``target_joints`` (optional): dict of joint-name to float
-          (issue #300 well-known kwarg). Bounded by
-          :data:`MAX_TARGET_JOINTS`.
+          (issue #300 well-known kwarg). Key count bounded by
+          :data:`MAX_TARGET_JOINTS`, and each key by
+          :data:`MAX_PEER_ID_LEN` characters.
         - ``target_velocity`` (optional): list of floats
           ``[vx, vy, omega]`` (m/s, m/s, rad/s) for locomotion providers
           (issue #300 well-known kwarg). Component count bounded by

--- a/tests/mesh/test_performed_checks_census_matches_the_code.py
+++ b/tests/mesh/test_performed_checks_census_matches_the_code.py
@@ -6,7 +6,7 @@ for a reader the census *is* the contract: a publisher author decides what to
 put on the wire from it, and an operator tuning the teleop safety envelope
 reads it to learn what the bound is. Nothing graded it.
 
-Two properties are checked, both derived from the function's own body so that a
+Three properties are checked, all derived from the function's own body so that a
 census added later is held to them with no list to update:
 
 * **A census may only cite a domain the function reads.** Citing a module
@@ -22,13 +22,28 @@ census added later is held to them with no list to update:
   shape ``if isinstance(v, T): raise`` says "T is refused", so a census that
   does not name ``T`` describes a wider admission than the code performs.
 
-Both rules are permissive by construction -- they can only under-report. A
-constant named in prose *outside* the bullets is not graded (the bullets are the
-enumeration; the surrounding paragraphs are commentary), and no wording is
-required beyond the type name itself.
+* **Every public bound the function enforces is named.** The first rule grades
+  one direction of a set equality -- that every constant the census *cites* is
+  one the body reads -- and left the other direction open, so a bound the body
+  enforces and the census never states was graded by nothing. That is how
+  ``validate_command`` came to enforce ``MAX_PASSTHROUGH_LEN`` on ``turn_id`` and
+  ``sender_id`` without naming either field, and to bound ``robot_name`` and each
+  ``target_joints`` key by ``MAX_PEER_ID_LEN`` while citing only the key *count*:
+  seven of the nine public constants it loads were cited, and a publisher sizing
+  an RPC correlation id from the census had no bound to size it to.
 
-``validate_command``'s census satisfies both rules unchanged, so it is the
-control: the properties are this module's own convention rather than a new one.
+All three rules are permissive by construction -- they can only under-report. A
+constant named in prose *outside* the bullets is not graded (the bullets are the
+enumeration; the surrounding paragraphs are commentary), no wording is required
+beyond the type name itself, and only *public* constants are graded: the module's
+charset gates are private regexes, and the census describes the admitted charset
+in words (``[A-Za-z0-9_.-]+``) rather than naming a ``_``-prefixed object a caller
+cannot reach.
+
+Which census is the control differs per rule, which is what makes each one this
+module's own convention rather than a new one: ``validate_command`` satisfies the
+first two unchanged, and ``validate_input_frame`` cites both of the bounds it
+enforces, so it satisfies the third.
 """
 
 from __future__ import annotations
@@ -47,7 +62,9 @@ from strands_robots.mesh import security
 #: rules would hold vacuously over an empty population.
 _MINIMUM_CENSUSES = 2
 
-_CONSTANT_RE = re.compile(r"[`\s(]([A-Z][A-Z0-9_]{3,})[`\s,.)]")
+# ``]`` terminates a citation too: a range reads ``[0, MAX_DURATION_S]``, and
+# without it that bound looks uncited to the rule below.
+_CONSTANT_RE = re.compile(r"[`\s(]([A-Z][A-Z0-9_]{3,})[`\s,.)\]]")
 _DATA_ROLE_RE = re.compile(r":data:`([A-Z][A-Z0-9_]*)`")
 
 
@@ -137,6 +154,16 @@ def _cited_constants(bullets: str, constants: set[str]) -> set[str]:
     return cited & constants
 
 
+def _public_bounds_enforced(fn: ast.FunctionDef | ast.AsyncFunctionDef, constants: set[str]) -> set[str]:
+    """Public module constants *fn* loads: the bounds a reader must be given.
+
+    Private constants are out of scope. The module's charset gates are
+    ``_``-prefixed regexes, and a census names the charset they admit in words
+    rather than an object a caller cannot reach.
+    """
+    return {c for c in _loaded_names(fn) & constants if not c.startswith("_")}
+
+
 def _refused(value: Any) -> str | None:
     """Drive the real validator with *value*; return its refusal, or ``None``."""
     try:
@@ -191,6 +218,25 @@ class TestThePerformedChecksCensusNamesWhatTheCodeDoes:
                 "narrows the teleop envelope reads the snapshot and is told the wrong number."
             )
 
+    def test_every_bound_the_function_enforces_is_named_in_its_census(self) -> None:
+        """The other direction: a bound the body reads but the census omits.
+
+        A reader sizes a value from the census, so a bound stated nowhere is a
+        refusal they cannot anticipate.
+        """
+        offenders: dict[str, list[str]] = {}
+        for name, node, bullets, constants in _censuses():
+            cited = _cited_constants(bullets, constants)
+            missing = sorted(c for c in _public_bounds_enforced(node, constants) if c not in cited)
+            if missing:
+                offenders[name] = missing
+        assert not offenders, (
+            f"a Performed-checks census omits a bound its own body enforces: {offenders}. "
+            "A publisher sizes a field from the census, so a bound it does not state is a "
+            "refusal the caller cannot anticipate; name the constant in the bullet for the "
+            "field it bounds."
+        )
+
     def test_every_type_the_function_refuses_is_named_in_its_census(self) -> None:
         """``if isinstance(v, T): raise`` means T is refused, so T is named."""
         offenders: dict[str, list[str]] = {}
@@ -239,6 +285,14 @@ class TestTheCensusRulesHoldOnTheSiblingUnchanged:
         name, node, bullets, _constants = next(c for c in _censuses() if c[0] == "validate_command")
         refused = _positively_refused_types(node)
         assert not [t for t in refused if not re.search(rf"\b{re.escape(t)}\b", bullets)], name
+
+    def test_the_frame_census_names_every_bound_it_enforces(self) -> None:
+        """The control for the bound rule: it holds on the frame validator as shipped."""
+        name, node, bullets, constants = next(c for c in _censuses() if c[0] == "validate_input_frame")
+        enforced = _public_bounds_enforced(node, constants)
+        assert enforced, "premise: the frame validator must enforce at least one public bound"
+        cited = _cited_constants(bullets, constants)
+        assert not [c for c in enforced if c not in cited], f"{name} enforces {sorted(enforced)}"
 
 
 class TestTheScanIsNotVacuous:
@@ -305,6 +359,31 @@ class TestTheRulesDoNotOverReach:
         refused = _positively_refused_types(fn)
         assert refused == {"bool"}
         assert not [t for t in refused if not re.search(rf"\b{re.escape(t)}\b", "* never a ``bool``.")]
+
+    def test_a_private_domain_is_not_graded_as_a_bound(self) -> None:
+        """A charset gate is a private regex; the census names the charset instead."""
+        fn = ast.parse("def f(v):\n    return _KEY_RE.fullmatch(v) and len(v) < MAX_LEN\n").body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _public_bounds_enforced(fn, {"MAX_LEN", "_KEY_RE"}) == {"MAX_LEN"}
+
+    def test_a_bound_cited_inside_a_range_is_recognised(self) -> None:
+        """Non-vacuity for the ``]`` terminator: ``[0, X]`` cites X.
+
+        Without it the shipped ``[0, MAX_DURATION_S]`` bullet reads as uncited
+        and the bound rule reports a field the census does state.
+        """
+        bullets = "    * ``duration``: ``[0, MAX_DURATION_S]``, defaults to 30.\n"
+        assert _cited_constants(bullets, {"MAX_DURATION_S"}) == {"MAX_DURATION_S"}
+
+    def test_a_planted_uncited_bound_is_reported(self) -> None:
+        """Non-vacuity for the bound rule: the check must be able to fail."""
+        fn = ast.parse("def f(v):\n    return len(v) < MAX_CITED and v < MAX_SILENT\n").body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        constants = {"MAX_CITED", "MAX_SILENT"}
+        bullets = "    * at most ``MAX_CITED`` characters.\n"
+        enforced = _public_bounds_enforced(fn, constants)
+        missing = sorted(c for c in enforced if c not in _cited_constants(bullets, constants))
+        assert missing == ["MAX_SILENT"], missing
 
     def test_a_planted_unread_citation_is_reported(self) -> None:
         """Non-vacuity for rule A: the check must be able to fail."""


### PR DESCRIPTION
## Problem

`validate_command`'s `Performed checks:` census is where a publisher author learns the wire contract. A guard already grades **one direction** of the set equality between the bounds a census cites and the bounds the validator reads:

> **A census may only cite a domain the function reads.** Citing a module constant the body never loads names a value that is not the one enforced.

The other direction was graded by nothing, and two bounds sat in it. Of the **nine public constants** `validate_command` loads, **seven were stated**:

| bound | what it bounds | stated? |
| --- | --- | --- |
| `MAX_PASSTHROUGH_LEN` (128) | `turn_id`, `sender_id` | **no - neither field was named at all** |
| `MAX_PEER_ID_LEN` (128) | `robot_name` length, each `target_joints` key's length | **no** |
| `ALLOWED_ACTIONS`, `MAX_INSTRUCTION_LEN`, `MAX_DURATION_S`, `MAX_TARGET_JOINTS`, `MAX_TARGET_VELOCITY_COMPONENTS`, `MAX_WORLD_UPDATE_BYTES`, `MAX_OVERRIDE_CODE_LEN` | | yes |

`turn_id` and `sender_id` are checked on **every** action rather than per-action, so the per-action half of the census could not reach them. Each is type-checked, length-bounded and gated to printable ASCII, and the docstring closes with "Raises `ValidationError` on any rule violation" - so these are rules, stated nowhere:

```
turn_id at 128 chars       ACCEPTED
turn_id at 129 chars       turn_id exceeds 128 chars (got 129)
turn_id printable non-ASCII  turn_id contains control characters, NUL, or non-printable bytes
turn_id as an int          turn_id must be a string (got int)
robot_name at 129 chars    robot_name length 129 > MAX_PEER_ID_LEN (128).
target_joints key at 129   target_joints key length 129 > MAX_PEER_ID_LEN (128).
```

Both are load-bearing rather than incidental: `Mesh` correlates an RPC turn on `turn_id` and keys its **command-replay cache** on `(sender_id, turn_id)` (`mesh/core.py`, "an attacker who captured one valid command envelope on the wire could replay it indefinitely"), and the IoT e-stop fan-out mints both, with `turn_id` set from the Lambda request id precisely so a fleet-wide e-stop is not dropped as a replay. `robot_name` disambiguates which robot in a sim world a policy targets, and `target_joints` carries the issue-#300 joint goal - the census bounded its key *count* while leaving each key's own length unstated.

Nothing published the numbers either: `MAX_PASSTHROUGH_LEN` appears in **zero** documentation files.

## Change

The census now states all nine bounds. `turn_id`/`sender_id` get a bullet of their own next to `action` - the other check that runs before any action branch - naming the type check, the bound and the charset, and saying why the two fields exist. `robot_name` gains its length beside its charset, and `target_joints` distinguishes the key-count bound from each key's length bound.

No verdict, message or accepted input changes. With the census stripped from both versions, the two modules are **byte-identical**.

The guard gains the reverse direction, derived from the body so a bound added later is graded on arrival. Two scoping decisions, both pinned:

- **Only public constants are graded.** The module's charset gates are `_`-prefixed regexes and the census names the charset they admit in words (`` `[A-Za-z0-9_.-]+` ``) rather than an object a caller cannot reach.
- **`]` terminates a citation.** The shipped `` `[0, MAX_DURATION_S]` `` bullet *does* cite that bound; without the terminator the citation regex missed it, and the new rule would have reported a field the census already states. That fix also makes the pre-existing rule strictly stronger, since it now sees every citation.

`validate_input_frame` cites both bounds it enforces, so it is the control for the new rule - just as `validate_command` is for the other two. Which census is the control differs per rule, which is what makes each one this module's own convention rather than a new one.

## Measured

Each column below runs **one** capture script that reads *that tree's* census, sizes each field to the length bound it states (160 characters where it states none), and publishes it through the real validator.

![census bounds stated vs enforced](https://raw.githubusercontent.com/cagataycali/robots/media-census-bounds/census-bounds.png)

| sized from the census | `upstream/main` | this branch |
| --- | --- | --- |
| `turn_id` | no bound stated -> `exceeds 128 chars (got 160)` | 128 -> accepted |
| `sender_id` | no bound stated -> `exceeds 128 chars (got 160)` | 128 -> accepted |
| `robot_name` | no bound stated -> `length 160 > MAX_PEER_ID_LEN (128)` | 128 -> accepted |
| `target_joints` key | no bound stated -> `key length 160 > MAX_PEER_ID_LEN (128)` | 128 -> accepted |
| **refused** | **4 of 4** | **0 of 4** |

The control is the validator itself: all seven probes above (128/129/non-ASCII/int/robot_name/joint-key/clean) return **byte-identical** verdicts in both trees, asserted inside the figure script from the captured JSON.

## Tests

The shipped guard reports **57 passed** on the unfixed tree with both bounds unstated - that is the gap. With the new rule, against the unfixed census:

| tree | failed | passed |
| --- | --- | --- |
| `upstream/main` | 1 | 61 |
| this branch | 0 | 62 |

The single failure names both omissions:

```
AssertionError: a Performed-checks census omits a bound its own body enforces:
{'validate_command': ['MAX_PASSTHROUGH_LEN', 'MAX_PEER_ID_LEN']}
```

One assertion flips; the 61 both-tree passes are the evidence no behaviour moved.

Each break fires a distinct set, so no guard is decoration:

| break | fires |
| --- | --- |
| revert the census wholesale | the rule alone - `['MAX_PASSTHROUGH_LEN', 'MAX_PEER_ID_LEN']` |
| revert only the `turn_id`/`sender_id` bullet | the rule alone - `['MAX_PASSTHROUGH_LEN']` |
| grade private constants too | the rule + **both** controls - `['_NATURAL_TEXT_CONTROL_RE', '_PEER_ID_RE', '_SAFE_PASSTHROUGH_RE']`, `['_INPUT_KEY_RE']` |
| drop the `]` terminator | the rule + the range-citation control - `['MAX_DURATION_S']`, a bound the census does state |
| the bound scan reaches nothing | the frame control + the private control + the planted non-vacuity test, and **not** the rule, which then passes vacuously |

That last row is why the non-vacuity clause is not decoration: with an empty scan the rule cannot fail, and only the controls notice.

Wider gate, the identical 375-file selection run on both trees with the changed guard excluded from each:

| tree | failed | passed | skipped | errors |
| --- | --- | --- | --- | --- |
| `upstream/main` | 21 | 12865 | 58 | 24 |
| this branch | 21 | 12865 | 58 | 24 |

Byte-identical summaries, and the 45 failing ids are the same set both ways with an empty diff in both directions. All 45 are `tests/mesh/test_iot_*` on `No module named 'awsiot'` - the `[mesh-iot]` extra (`awsiotsdk>=1.21.0,<2.0.0`), which CI installs. `mypy strands_robots tests tests_integ` reports the same 24 pre-existing errors on both trees, none in the changed files.

No visual artifact of robot behaviour applies: nothing in the diff reaches a policy, a simulation, rendering, recording or a robot asset, and with the census stripped the module is byte-identical. The figure above is the census read back and driven instead.

## Scope

The `target_joints` **key count** and the `world_update` byte budget were already cited and are untouched. Whether the census should also enumerate the full per-action field allowlist as a table, rather than as prose bullets, is a presentation question this leaves alone.

