### PR TITLE
fix(examples): ask the Hub where its token lives, and offer a login that runs

### DIFF
--- a/changelog.d/2652-libero-hf-token-resolution.md
+++ b/changelog.d/2652-libero-hf-token-resolution.md
@@ -1,0 +1,24 @@
+### Fixed: a LIBERO driver's HF-token preflight resolves what the Hub resolves
+
+The three `examples/libero` drivers refuse `--policy groot` up front when no
+HuggingFace token is available, rather than letting the gated Cosmos-Reason2-2B
+download fail later inside `gr00t_inference`. That refusal read
+`~/.cache/huggingface/token` directly, so on any host that relocated its HF cache
+it named a file the Hub will not open: a box that was logged in got refused, three
+drivers out of three. It now asks `huggingface_hub.get_token()` and quotes
+`HF_TOKEN_PATH` in the refusal, so a relocated `HF_HOME` / `XDG_CACHE_HOME` /
+`HF_TOKEN_PATH` is honoured and, when there really is no token, the message names
+the path it looked in.
+
+The remedy it offered could not be run either. `huggingface-cli` is not published
+as a console script at the declared `huggingface_hub>=1.5` floor at all - 1.5.0's
+`console_scripts` are `hf` and `tiny-agents` - and the later 1.x releases that do
+install it exit "deprecated and no longer works". The drivers now prescribe
+`hf auth login`, which is what `doctor`, `dataset_recorder`, the README,
+`docs/troubleshooting.md` and `huggingface_hub.get_token`'s own docstring already
+name.
+
+`run_mujoco_agent.py` carried the check inline in its lifecycle block rather than
+as a resolver, and never read `HF_TOKEN` at all, so an `HF_TOKEN`-only host - the
+environment the drivers' own prose calls preferred for CI - was refused outright.
+It now shares the same resolver as its two siblings.

--- a/examples/libero/README.md
+++ b/examples/libero/README.md
@@ -94,7 +94,10 @@ evaluates the `mujoco` and Isaac single-env (`isaac-1`) rows.
 - `STRANDS_GR00T_IMAGE` / `STRANDS_GR00T_IMAGE_ALLOW` - operator-configured
   GR00T docker image + allowlist (`--image` sets these).
 - `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) - HuggingFace token for the gated
-  GR00T checkpoint download (`--policy groot`).
+  GR00T checkpoint download (`--policy groot`). With neither set, the drivers
+  fall back to the Hub's cached login (`hf auth login`), asking
+  `huggingface_hub` where that lives - so a relocated `HF_HOME` /
+  `XDG_CACHE_HOME` / `HF_TOKEN_PATH` is honoured.
 - `STRANDS_GR00T_SERVER_SEED` / `STRANDS_GR00T_STRICT_DETERMINISTIC` - consumed
   by the packaged determinism wrapper
   (`strands_robots/policies/groot/server_wrapper.py`) inside the GR00T

--- a/examples/libero/run.py
+++ b/examples/libero/run.py
@@ -42,9 +42,9 @@ Usage
     #    starts the inference server before the eval, then tears down on
     #    exit. Each step is idempotent so re-runs are cheap.
     #
-    #    Pre-condition: an HF token (the HF_TOKEN env var, or
-    #    `~/.cache/huggingface/token` from `huggingface-cli login`) with
-    #    access to `nvidia/Cosmos-Reason2-2B` (the gated VLM backbone) +
+    #    Pre-condition: an HF token (the HF_TOKEN env var, or the Hub's
+    #    cached login from `hf auth login`) with access to
+    #    `nvidia/Cosmos-Reason2-2B` (the gated VLM backbone) +
     #    Docker + an NVIDIA GPU.
     python examples/libero/run.py mujoco --policy groot --port 8000 --n-episodes 50
 
@@ -265,23 +265,43 @@ def _resolve_hf_token() -> str:
     """Resolve a HuggingFace token for the gated GR00T checkpoint download.
 
     Prefers the ``HF_TOKEN`` (or ``HUGGING_FACE_HUB_TOKEN``) environment
-    variable - CI / container environments typically inject the token that
-    way and don't have the ``~/.cache/huggingface/token`` file that
-    ``huggingface-cli login`` writes. Falls back to that file for interactive
-    dev boxes. Raises if neither is present.
-    """
-    from pathlib import Path
+    variable - CI / container environments typically inject the token
+    that way and have no cached login. Otherwise takes the cached login,
+    asking ``huggingface_hub`` where that lives rather than assuming: it
+    resolves ``HF_TOKEN_PATH``, else ``<HF_HOME>/token``, else
+    ``<XDG_CACHE_HOME>/huggingface/token``, else ``~/.cache/huggingface/token``.
+    Reading the last of those directly names a file the Hub will not open on a
+    host that relocated its cache, so a logged-in box was refused here.
 
+    Raises:
+        RuntimeError: Neither source yields a token. The message names the
+            path the Hub resolves on this host, so a relocated cache is
+            actionable, and ``hf auth login`` - the login entry point the
+            declared ``huggingface_hub>=1.5`` floor ships. ``huggingface-cli``
+            is not published as a console script at that floor, and the later
+            1.x releases that do install it exit "deprecated and no longer
+            works", so it is a dead end across the whole declared range.
+    """
     env_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if env_token and env_token.strip():
         return env_token.strip()
-    hf_token_path = Path("~/.cache/huggingface/token").expanduser()
-    if hf_token_path.is_file():
-        return hf_token_path.read_text().strip()
+    token_path = "the Hub's cached login"
+    try:
+        from huggingface_hub import get_token
+        from huggingface_hub.constants import HF_TOKEN_PATH
+    except ImportError:
+        # No Hub installed to ask where its cached login lives; the
+        # checkpoint download reports that missing dependency itself.
+        pass
+    else:
+        token_path = HF_TOKEN_PATH
+        cached = get_token()
+        if cached and cached.strip():
+            return cached.strip()
     raise RuntimeError(
         "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
-        "Set the HF_TOKEN env var (preferred for CI), or run "
-        "`huggingface-cli login` to write ~/.cache/huggingface/token, then retry."
+        "Set the HF_TOKEN env var (preferred for CI), or run `hf auth login` "
+        f"to write {token_path}, then retry."
     )
 
 

--- a/examples/libero/run_isaac_agent.py
+++ b/examples/libero/run_isaac_agent.py
@@ -142,7 +142,7 @@ Usage
 
     # 2) Real run against `nvidia/GR00T-N1.7-LIBERO`. Script auto-
     #    orchestrates the GR00T inference container (idempotent). Pre-
-    #    condition: HF token at `~/.cache/huggingface/token` (gated
+    #    condition: an HF token, from HF_TOKEN or `hf auth login` (gated
     #    Cosmos-Reason2-2B backbone) + Docker + an NVIDIA GPU + Isaac
     #    Sim 6.0+ installed.
     python examples/libero/run_isaac_agent.py --policy groot --port 8000 --n-episodes 5
@@ -314,23 +314,43 @@ def _resolve_hf_token() -> str:
     """Resolve a HuggingFace token for the gated GR00T checkpoint download.
 
     Prefers the ``HF_TOKEN`` (or ``HUGGING_FACE_HUB_TOKEN``) environment
-    variable -- CI / container environments typically inject the token that
-    way and don't have the ``~/.cache/huggingface/token`` file that
-    ``huggingface-cli login`` writes. Falls back to that file for interactive
-    dev boxes. Raises if neither is present.
-    """
-    from pathlib import Path
+    variable -- CI / container environments typically inject the token
+    that way and have no cached login. Otherwise takes the cached login,
+    asking ``huggingface_hub`` where that lives rather than assuming: it
+    resolves ``HF_TOKEN_PATH``, else ``<HF_HOME>/token``, else
+    ``<XDG_CACHE_HOME>/huggingface/token``, else ``~/.cache/huggingface/token``.
+    Reading the last of those directly names a file the Hub will not open on a
+    host that relocated its cache, so a logged-in box was refused here.
 
+    Raises:
+        RuntimeError: Neither source yields a token. The message names the
+            path the Hub resolves on this host, so a relocated cache is
+            actionable, and ``hf auth login`` - the login entry point the
+            declared ``huggingface_hub>=1.5`` floor ships. ``huggingface-cli``
+            is not published as a console script at that floor, and the later
+            1.x releases that do install it exit "deprecated and no longer
+            works", so it is a dead end across the whole declared range.
+    """
     env_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if env_token and env_token.strip():
         return env_token.strip()
-    hf_token_path = Path("~/.cache/huggingface/token").expanduser()
-    if hf_token_path.is_file():
-        return hf_token_path.read_text().strip()
+    token_path = "the Hub's cached login"
+    try:
+        from huggingface_hub import get_token
+        from huggingface_hub.constants import HF_TOKEN_PATH
+    except ImportError:
+        # No Hub installed to ask where its cached login lives; the
+        # checkpoint download reports that missing dependency itself.
+        pass
+    else:
+        token_path = HF_TOKEN_PATH
+        cached = get_token()
+        if cached and cached.strip():
+            return cached.strip()
     raise RuntimeError(
         "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
-        "Set the HF_TOKEN env var (preferred for CI), or run "
-        "`huggingface-cli login` to write ~/.cache/huggingface/token, then retry."
+        "Set the HF_TOKEN env var (preferred for CI), or run `hf auth login` "
+        f"to write {token_path}, then retry."
     )
 
 

--- a/examples/libero/run_mujoco_agent.py
+++ b/examples/libero/run_mujoco_agent.py
@@ -72,7 +72,7 @@ Usage
 
     # 2) Real run against `nvidia/GR00T-N1.7-LIBERO`. Script auto-
     #    orchestrates the GR00T inference container (idempotent). Pre-
-    #    condition: HF token at `~/.cache/huggingface/token` (gated
+    #    condition: an HF token, from HF_TOKEN or `hf auth login` (gated
     #    Cosmos-Reason2-2B backbone) + Docker + an NVIDIA GPU.
     python examples/libero/run_mujoco_agent.py --policy groot --port 8000 --n-episodes 5
 
@@ -217,6 +217,50 @@ def _configure_gr00t_image(image: str) -> None:
         os.environ["STRANDS_GR00T_IMAGE_ALLOW"] = ",".join(patterns)
 
 
+def _resolve_hf_token() -> str:
+    """Resolve a HuggingFace token for the gated GR00T checkpoint download.
+
+    Prefers the ``HF_TOKEN`` (or ``HUGGING_FACE_HUB_TOKEN``) environment
+    variable -- CI / container environments typically inject the token
+    that way and have no cached login. Otherwise takes the cached login,
+    asking ``huggingface_hub`` where that lives rather than assuming: it
+    resolves ``HF_TOKEN_PATH``, else ``<HF_HOME>/token``, else
+    ``<XDG_CACHE_HOME>/huggingface/token``, else ``~/.cache/huggingface/token``.
+    Reading the last of those directly names a file the Hub will not open on a
+    host that relocated its cache, so a logged-in box was refused here.
+
+    Raises:
+        RuntimeError: Neither source yields a token. The message names the
+            path the Hub resolves on this host, so a relocated cache is
+            actionable, and ``hf auth login`` - the login entry point the
+            declared ``huggingface_hub>=1.5`` floor ships. ``huggingface-cli``
+            is not published as a console script at that floor, and the later
+            1.x releases that do install it exit "deprecated and no longer
+            works", so it is a dead end across the whole declared range.
+    """
+    env_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if env_token and env_token.strip():
+        return env_token.strip()
+    token_path = "the Hub's cached login"
+    try:
+        from huggingface_hub import get_token
+        from huggingface_hub.constants import HF_TOKEN_PATH
+    except ImportError:
+        # No Hub installed to ask where its cached login lives; the
+        # checkpoint download reports that missing dependency itself.
+        pass
+    else:
+        token_path = HF_TOKEN_PATH
+        cached = get_token()
+        if cached and cached.strip():
+            return cached.strip()
+    raise RuntimeError(
+        "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
+        "Set the HF_TOKEN env var (preferred for CI), or run `hf auth login` "
+        f"to write {token_path}, then retry."
+    )
+
+
 def _bring_up_gr00t_server(args: argparse.Namespace, suite: str) -> dict | None:
     """Start the GR00T inference container and block until model is loaded.
 
@@ -228,7 +272,6 @@ def _bring_up_gr00t_server(args: argparse.Namespace, suite: str) -> dict | None:
         return None
 
     import subprocess
-    from pathlib import Path
     from time import monotonic, sleep
 
     _configure_gr00t_image(args.image)
@@ -240,12 +283,7 @@ def _bring_up_gr00t_server(args: argparse.Namespace, suite: str) -> dict | None:
         args.checkpoint_dir = _default_checkpoint_dir()
     print(f"[setup] checkpoint dir: {args.checkpoint_dir}")
 
-    hf_token_path = Path("~/.cache/huggingface/token").expanduser()
-    if not hf_token_path.is_file():
-        raise RuntimeError(
-            "--policy groot needs an HF token (Cosmos-Reason2-2B is gated). "
-            "Run `huggingface-cli login` first, then retry."
-        )
+    hf_token = _resolve_hf_token()
     result = gr00t_inference(
         action="lifecycle",
         lifecycle="full",
@@ -253,7 +291,7 @@ def _bring_up_gr00t_server(args: argparse.Namespace, suite: str) -> dict | None:
         hf_subfolder=suite,
         hf_local_dir=args.checkpoint_dir,
         container_name=args.container,
-        hf_token=hf_token_path.read_text().strip(),
+        hf_token=hf_token,
         checkpoint_path=f"/data/checkpoints/{suite}",
         embodiment_tag="libero_sim",
         protocol="n1.7",

--- a/tests/test_examples_hf_token_preflight.py
+++ b/tests/test_examples_hf_token_preflight.py
@@ -1,0 +1,299 @@
+"""A LIBERO driver's HF-token preflight answers about the token the Hub will use.
+
+The three ``examples/libero`` drivers refuse ``--policy groot`` up front when no
+HuggingFace token is available, rather than letting the gated checkpoint
+download fail later inside ``gr00t_inference``. The refusal *is* the preflight,
+so it carries two obligations: resolve the token the Hub resolves, and offer a
+remedy that works.
+
+``huggingface_hub`` resolves its cached login from ``HF_TOKEN_PATH``, else
+``<HF_HOME>/token``, else ``<XDG_CACHE_HOME>/huggingface/token``, else
+``~/.cache/huggingface/token``. Reading the last of those directly names a file
+the Hub will not open on any host that relocated its cache, so a box that *is*
+logged in gets refused - the same defect ``doctor`` carried until its token path
+moved onto the Hub's own resolution, whose guard is scoped to ``doctor`` and
+never reached these drivers.
+
+The remedy has its own failure mode. ``huggingface-cli`` is not published as a
+console script at the declared ``huggingface_hub>=1.5`` floor at all, and the
+later 1.x releases that do install it exit "deprecated and no longer works", so
+prescribing it is a dead end across the whole declared range. The live entry
+point is ``hf auth login`` - what ``doctor``, ``dataset_recorder``, the README,
+``docs/troubleshooting.md`` and ``huggingface_hub.get_token``'s own docstring
+all name.
+
+These drivers are not part of the installed package, so nothing else in CI
+imports them: a regression confined to ``examples/`` stays invisible without a
+test that loads them by path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES_LIBERO = _REPO_ROOT / "examples" / "libero"
+
+# The drivers carrying the preflight, and the backend each needs importable.
+_DRIVERS = (
+    ("run.py", None),
+    ("run_isaac_agent.py", None),
+    ("run_mujoco_agent.py", "mujoco"),
+)
+
+# Assembled from parts so the contiguous prescription never appears in this
+# file: the rule below scans this tree, and a grader that names the phrase it
+# forbids would report itself rather than the offender.
+_DEAD_CLI = "huggingface-cli"
+_LOGIN_VERB = "login"
+_DEAD_PRESCRIPTION = f"{_DEAD_CLI} {_LOGIN_VERB}"
+_LIVE_LOGIN_COMMAND = "hf auth login"
+
+# Trees whose prose a reader is expected to act on.
+_SCANNED = ("README.md", "docs", "examples", "strands_robots", "tests", "tests_integ", "changelog.d", "scripts")
+_SUFFIXES = (".py", ".md", ".ipynb")
+
+
+def _load_driver(filename: str):
+    """Import an example driver by path under a test-unique module name."""
+    path = _EXAMPLES_LIBERO / filename
+    assert path.is_file(), f"expected example driver at {path}"
+    module_name = f"_hf_preflight_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def _preflight(filename: str, backend: str | None):
+    """The driver's token preflight, skipping when its backend is absent."""
+    if backend is not None:
+        pytest.importorskip(backend)
+    pytest.importorskip("huggingface_hub")
+    module = _load_driver(filename)
+    resolver = getattr(module, "_resolve_hf_token", None)
+    assert callable(resolver), f"{filename} has no _resolve_hf_token preflight"
+    return resolver
+
+
+@pytest.fixture
+def hub_sees_nothing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Isolate the Hub's token resolution onto an empty path under ``tmp_path``.
+
+    ``huggingface_hub.constants.HF_TOKEN_PATH`` is computed at import time, so
+    setting the relocation variables in-process cannot move it. Its reader
+    (``_get_token_from_file``) takes the module attribute on every call, so
+    steering that attribute is what redirects the Hub here.
+
+    Returns:
+        The (absent) path the Hub now resolves, for a test to populate.
+    """
+    constants = pytest.importorskip("huggingface_hub.constants")
+    for variable in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_TOKEN_PATH", "HF_HOME", "XDG_CACHE_HOME"):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    relocated = tmp_path / "relocated-cache" / "huggingface" / "token"
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(relocated))
+    return relocated
+
+
+class TestThePreflightResolvesWhatTheHubResolves:
+    """The preflight admits every token source the Hub itself would use."""
+
+    @pytest.mark.parametrize(("filename", "backend"), _DRIVERS)
+    def test_a_cached_login_the_hub_resolves_is_accepted(
+        self, filename: str, backend: str | None, hub_sees_nothing: Path
+    ) -> None:
+        """A host that relocated its HF cache and logged in must not be refused.
+
+        This is the regression: reading ``~/.cache/huggingface/token`` directly
+        names a file that does not exist here, while the Hub resolves a token.
+        """
+        resolver = _preflight(filename, backend)
+        hub_sees_nothing.parent.mkdir(parents=True, exist_ok=True)
+        hub_sees_nothing.write_text("hf_cached_login_token\n")
+
+        from huggingface_hub import get_token
+
+        assert get_token() == "hf_cached_login_token", "premise: the Hub must resolve this token"
+        assert resolver() == "hf_cached_login_token"
+
+    @pytest.mark.parametrize(("filename", "backend"), _DRIVERS)
+    @pytest.mark.parametrize("variable", ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"])
+    def test_an_environment_token_is_accepted(
+        self,
+        filename: str,
+        backend: str | None,
+        variable: str,
+        monkeypatch: pytest.MonkeyPatch,
+        hub_sees_nothing: Path,
+    ) -> None:
+        """Both documented environment spellings are honoured with no token file.
+
+        ``HF_TOKEN`` is the spelling the drivers' own prose calls preferred for
+        CI, so a preflight that reads only a cached file refuses exactly the
+        environment it recommends.
+        """
+        resolver = _preflight(filename, backend)
+        monkeypatch.setenv(variable, "hf_env_token")
+        assert not hub_sees_nothing.exists(), "premise: no cached login on this host"
+        assert resolver() == "hf_env_token"
+
+    @pytest.mark.parametrize(("filename", "backend"), _DRIVERS)
+    def test_no_token_anywhere_is_still_refused(
+        self, filename: str, backend: str | None, hub_sees_nothing: Path
+    ) -> None:
+        """The preflight still exists: a host with no token is refused early."""
+        resolver = _preflight(filename, backend)
+        assert not hub_sees_nothing.exists(), "premise: no cached login on this host"
+        with pytest.raises(RuntimeError):
+            resolver()
+
+
+class TestTheEnvironmentPathReachesTheDownload:
+    """``run_mujoco_agent.py``'s preflight sits inline in its lifecycle block.
+
+    The other two drivers expose the preflight as ``_resolve_hf_token``, so the
+    resolution tests above reach them directly. This one drives the lifecycle
+    function itself with the download stubbed out, which is the only way to see
+    whether an ``HF_TOKEN``-only host - the environment the drivers' own prose
+    calls preferred for CI - gets past the gate at all.
+    """
+
+    def test_an_environment_token_alone_reaches_the_download(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hub_sees_nothing: Path
+    ) -> None:
+        pytest.importorskip("mujoco")
+        pytest.importorskip("huggingface_hub")
+        module = _load_driver("run_mujoco_agent.py")
+
+        class _ReachedTheDownload(Exception):
+            """Not a RuntimeError, so the token refusal stays distinguishable."""
+
+        def _stub_lifecycle(**kwargs: object) -> dict[str, object]:
+            raise _ReachedTheDownload(str(kwargs.get("hf_token")))
+
+        # `_configure_gr00t_image` writes these; let monkeypatch own them.
+        monkeypatch.setenv("STRANDS_GR00T_IMAGE", "gr00t:placeholder")
+        monkeypatch.setenv("STRANDS_GR00T_IMAGE_ALLOW", "gr00t:*")
+        monkeypatch.setattr(module, "gr00t_inference", _stub_lifecycle)
+        monkeypatch.setenv("HF_TOKEN", "hf_env_token")
+        assert not hub_sees_nothing.exists(), "premise: no cached login on this host"
+
+        args = argparse.Namespace(
+            policy="groot",
+            auto_server=True,
+            image="gr00t:test",
+            checkpoint_dir=str(tmp_path / "ckpt"),
+            container="libero-test",
+            port=8000,
+        )
+        with pytest.raises(_ReachedTheDownload) as reached:
+            module._bring_up_gr00t_server(args, "libero_spatial")
+        assert str(reached.value) == "hf_env_token", "the environment token must be the one forwarded"
+
+
+class TestTheRefusalIsActionable:
+    """The refusal names a command that runs and the file it looked in."""
+
+    @pytest.mark.parametrize(("filename", "backend"), _DRIVERS)
+    def test_the_refusal_names_the_live_login_command(
+        self, filename: str, backend: str | None, hub_sees_nothing: Path
+    ) -> None:
+        resolver = _preflight(filename, backend)
+        with pytest.raises(RuntimeError) as refused:
+            resolver()
+        message = str(refused.value)
+        assert _LIVE_LOGIN_COMMAND in message, f"{filename} refusal offers no runnable login: {message}"
+        assert _DEAD_PRESCRIPTION not in message, f"{filename} refusal prescribes a dead command: {message}"
+
+    @pytest.mark.parametrize(("filename", "backend"), _DRIVERS)
+    def test_the_refusal_names_the_path_the_hub_reads(
+        self, filename: str, backend: str | None, hub_sees_nothing: Path
+    ) -> None:
+        """A relocated cache is only actionable if the message says where it looked."""
+        resolver = _preflight(filename, backend)
+        with pytest.raises(RuntimeError) as refused:
+            resolver()
+        assert str(hub_sees_nothing) in str(refused.value), (
+            f"{filename} refusal does not name {hub_sees_nothing}, so a relocated "
+            f"cache cannot be acted on: {refused.value}"
+        )
+
+
+def _prose_files() -> list[Path]:
+    """Every tracked prose or source file a reader is expected to act on."""
+    files: list[Path] = []
+    for base in _SCANNED:
+        target = _REPO_ROOT / base
+        if target.is_file():
+            files.append(target)
+            continue
+        for path in sorted(target.rglob("*")):
+            if path.is_file() and path.suffix in _SUFFIXES and "__pycache__" not in path.parts:
+                files.append(path)
+    return files
+
+
+def _prescriptions(path: Path) -> list[int]:
+    """1-based line numbers where ``path`` prescribes the dead login command.
+
+    Notebooks are graded on their markdown and source cells rather than the raw
+    JSON, so a single claim is reported once at the file rather than repeatedly
+    across the escaped document.
+    """
+    if path.suffix == ".ipynb":
+        try:
+            cells = json.loads(path.read_text(encoding="utf-8")).get("cells", [])
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return []
+        text = "".join("".join(cell.get("source", [])) for cell in cells)
+        return [1] if _DEAD_PRESCRIPTION in text else []
+    return [n for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1) if _DEAD_PRESCRIPTION in line]
+
+
+class TestNoSurfacePrescribesADeadLoginCommand:
+    """No prose in the tree tells a reader to run a command that cannot run."""
+
+    def test_the_dead_login_command_is_prescribed_nowhere(self) -> None:
+        offenders = {
+            str(path.relative_to(_REPO_ROOT)): lines for path in _prose_files() if (lines := _prescriptions(path))
+        }
+        assert not offenders, (
+            f"prose prescribes `{_DEAD_PRESCRIPTION}`, which is not published as a console "
+            f"script at the declared huggingface_hub>=1.5 floor and exits "
+            f'"deprecated and no longer works" on the later 1.x releases that install it. '
+            f"Use `{_LIVE_LOGIN_COMMAND}`: {offenders}"
+        )
+
+    def test_naming_the_dead_entry_point_without_prescribing_it_is_allowed(self) -> None:
+        """Explaining *why* it is dead is not prescribing it.
+
+        ``docs/troubleshooting.md`` and this file both name ``huggingface-cli``
+        to say it does not work. The rule keys on the two-token prescription, so
+        the explanation is not an offender - otherwise the only way to document
+        the hazard would be to stop mentioning it.
+        """
+        naming = [p for p in _prose_files() if _DEAD_CLI in p.read_text(encoding="utf-8")]
+        assert naming, f"premise: something in the tree still explains why {_DEAD_CLI} is dead"
+        assert not {str(p.relative_to(_REPO_ROOT)) for p in naming if _prescriptions(p)}
+
+    def test_the_scan_reaches_the_prose_it_grades(self) -> None:
+        """A rule that reaches nothing would pass while the tree drifts."""
+        files = _prose_files()
+        assert len(files) > 500, f"prose scan collapsed to {len(files)} files"
+        reached = {p.parts[len(_REPO_ROOT.parts)] for p in files}
+        assert {"docs", "examples", "strands_robots", "tests"} <= reached, f"scan missed a tree: {sorted(reached)}"
+        live = [p for p in files if _LIVE_LOGIN_COMMAND in p.read_text(encoding="utf-8")]
+        assert len(live) >= 4, f"only {len(live)} files name the live login command"


### PR DESCRIPTION
## The defect

The three `examples/libero` drivers refuse `--policy groot` up front when no
HuggingFace token is available, rather than letting the gated Cosmos-Reason2-2B
download fail later inside `gr00t_inference`. That refusal *is* the preflight, so
it carries two obligations: resolve the token the Hub resolves, and name a login
that runs. It did neither.

`huggingface_hub` resolves its cached login from `HF_TOKEN_PATH`, else
`<HF_HOME>/token`, else `<XDG_CACHE_HOME>/huggingface/token`, else
`~/.cache/huggingface/token`. The preflight read the last of those directly, so
on any host that relocated its cache it names a file the Hub will not open - and
a box that *is* logged in gets refused. Measured on a host with `HF_HOME`
relocated and a token cached where the Hub looks for it:

| tree | relocated cache, logged in | `HF_TOKEN` set, no cached login | login offered |
| --- | --- | --- | --- |
| `upstream/main` | **REFUSED**, 3 of 3 drivers | refused by `run_mujoco_agent.py` | `huggingface-cli login` |
| this branch | accepted, 3 of 3 | accepted, 3 of 3 | `hf auth login` |

The remedy has its own failure mode, and it is worse than deprecated:

| offered command | published at the declared `huggingface_hub>=1.5` floor | running it |
| --- | --- | --- |
| `huggingface-cli login` | **no** - 1.5.0's `console_scripts` are `hf`, `tiny-agents` | `Warning: huggingface-cli is deprecated and no longer works. Use hf instead.` (exit 1) |
| `hf auth login` | yes | the live entry point |

So on a conforming minimal install the command does not exist at all, and on a
later 1.x that does ship it, it refuses to do anything. The advice is a dead end
across the whole declared range.

`run_mujoco_agent.py` carried the check inline in its lifecycle block rather than
as a resolver, and never read `HF_TOKEN` at all - so an `HF_TOKEN`-only host, the
environment the drivers' own prose calls preferred for CI, was refused outright.

## What changes

Resolve through `huggingface_hub.get_token()` and quote `HF_TOKEN_PATH` in the
refusal, so a relocated cache is actionable rather than a mystery. Prescribe
`hf auth login` - what `doctor`, `dataset_recorder`, the README,
`docs/troubleshooting.md` and `huggingface_hub.get_token`'s own docstring already
name. `run_mujoco_agent.py` gets the same extracted resolver as its two siblings,
so the environment path reaches the download there too.

The env-var branch is unchanged and still preferred: a container that injects
`HF_TOKEN` never pays for a Hub import.

## Scope

Six prescription sites across the three drivers, plus the one line in
`examples/libero/README.md`'s env-var list that now names the cached-login
alternative. `docs/troubleshooting.md` and the existing changelog fragments
already name `huggingface-cli` only to explain that it does not work, which the
new rule permits - it keys on the two-token prescription, not the mention.

## Tests

`tests/test_examples_hf_token_preflight.py` (22 tests). Pre-fix, against
`upstream/main`: **15 failed / 7 passed**. Nine are behavioural or structural -
the logged-in host refused, the refusal naming no runnable login, the refusal not
naming the path it looked in, and the prose rule reporting all six sites:

```
{'examples/libero/run.py': [46, 270, 284],
 'examples/libero/run_isaac_agent.py': [319, 333],
 'examples/libero/run_mujoco_agent.py': [247]}
```

The other six report that `run_mujoco_agent.py` had no extracted preflight at
all; they pin the shape rather than the behaviour. Its behavioural defect is
covered separately by `TestTheEnvironmentPathReachesTheDownload`, which drives
the lifecycle function with the download stubbed and fails pre-fix with the token
`RuntimeError`.

Each guard fires for its own regression and nothing else:

| break | failed of 22 | fires |
| --- | --- | --- |
| control | 0 | - |
| exact pre-fix (`git checkout upstream/main -- examples/libero/`) | 15 | everything |
| Hub resolution reverted, live command kept | 6 | the 3 cached-login and 3 path tests only |
| live command reverted, Hub resolution kept | 5 | the 3 command tests, the prose rule, the naming control |
| `run_mujoco_agent.py` reverted only | 9 | its 7 cases, the prose rule, the naming control |
| prose scan reaches nothing | 2 | the non-vacuity test only - the rule itself passes *vacuously* |
| rule keys on bare `huggingface-cli` instead of the two-token phrase | 2 | the naming control, plus the rule over-reporting |
| refusal drops the resolved path | 3 | the 3 path tests only |

The middle two are complementary, which is what shows the resolution half and the
remedy half are independently pinned. The prose rule passing vacuously under an
empty scan is why its non-vacuity clause is not decoration.

## Verification

Gate: 182 test files - every test that touches `examples/`, reads a docs page,
names an HF token, or walks the source tree - run with the identical selection on
both trees, this branch's new file excluded from each. Byte-identical:

| tree | result |
| --- | --- |
| this branch | `12 failed, 8086 passed, 86 skipped` in 354.72s |
| `upstream/main` | `12 failed, 8086 passed, 86 skipped` in 354.61s |

Two of the twelve differ *by id* between the trees, and both are in
`tests/mesh/test_zenoh_transport_security.py` failing with `zenoh.ZError`
(`Address already in use`) - two suites in parallel on a fixed localhost port.
That file is `9 passed, 2 skipped` run alone on **both** trees. The other ten are
dependency-absent locally: eight in `tests/mesh/test_iot_connect_timeout_domain.py`
on `awsiot` (the `[mesh-iot]` extra declares `awsiotsdk>=1.21.0,<2.0.0`, which CI
installs) and two in `tests/test_doctor.py` on `PackageNotFoundError`, since a
git worktree is not pip-installed.

`ruff check` and `ruff format --check` clean. `mypy strands_robots tests
tests_integ`: 24 errors on this branch and 24 on a pristine `upstream/main`
worktree, none in the changed files. Removing the hardcoded path left
`run_mujoco_agent.py`'s function-scope `from pathlib import Path` unused, which
`ruff` flagged - the import existed only to build that path.

## Artifact

One capture script per tree, run against the same host and the same
`huggingface_hub`: it relocates the HF cache, writes a token where the Hub looks
for it, drives each driver's own preflight, and then asks each tree's refusal
which login it names.

![HF token preflight, before and after](https://raw.githubusercontent.com/cagataycali/robots/media-hf-token-preflight-32629288213/hf-token-preflight.png)

The lower table is measured once and is identical for both trees - the figure
script asserts that, along with the premise that the Hub really does resolve the
relocated token, so the picture cannot drift from the claim. What differs between
the columns is only which token the preflight finds and which login it names.
