### PR TITLE
fix(simulation): name an empty model source instead of diagnosing the robot name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1738,6 +1738,32 @@ which side the enum is on.
   and by the render path's `cameras` resolution, which has read the same kind of selector
   `is None` all along - an empty camera selection there resolves to no camera rather than
   to every one.
+### A model source is read by absence when absence selects another resolution path
+- **The selector rule above allows a scalar path to be read by truthiness "because empty
+  and absent genuinely coincide there - the value is derived either way". That holds where
+  absence derives the SAME kind of value.** `examples/wbc/motionbricks_g1_mujoco.py`
+  declares `--scene-xml` with a `""` default and derives the scene from `--result-dir`, so
+  `""` IS its sentinel there and truthiness is correct. It does not hold where absence
+  selects a DIFFERENT RESOLUTION PATH: then the two spellings do not pick the same value
+  by another route, they pick a different thing to blame when the call fails.
+- **`add_robot`'s model source is that case.** Absent means "resolve from `data_config`, or
+  from the instance label via the deprecated registry short form"; supplied means "load
+  this file". Read by truthiness, `urdf_path=""` took the absent branch, so the refusal
+  diagnosed the NAME - close-match suggestions for a name the caller never asked to
+  resolve, and "Or pass data_config=<registered model> or urdf_path=<file>" to a caller who
+  had just passed exactly that. It was byte-identical to what supplying no source returns.
+- **The tell is the REPORT, not the value.** Both spellings error either way, so nothing
+  loads a wrong model; what diverges is which parameter the caller is sent to fix. One
+  whitespace character away (`urdf_path=" "`) the diagnosis was already correct ("File not
+  found"), which is the shape to match - refuse the empty value, not the unusable one.
+- **Check the whole family, and note that most of it was already right.** Newton reads
+  `urdf_path is not None`, Isaac reads `usd_path is None`, and `register_urdf` refuses an
+  empty `urdf_path` by name in both backends that expose it; MuJoCo's `add_robot` was the
+  one site reading the source by truthiness. Refuse behind any existing precedence (the
+  name-collision report still wins) so no settled message moves.
+- Pinned by `tests/simulation/mujoco/test_add_robot_unknown_model_message.py`, whose
+  controls pin the boundary (whitespace stays a path), the untouched short forms (`name=""`
+  still derives a label, an omitted source still diagnoses the name) and the precedence.
 ### A resolution knob is validated before the work it sizes
 - **Check the knob that sizes an expensive result before producing the result.** A
   resolution is caller input like any other, and the numeric domains

--- a/changelog.d/2657-add-robot-empty-model-source.md
+++ b/changelog.d/2657-add-robot-empty-model-source.md
@@ -1,0 +1,19 @@
+### Fixed: an empty `urdf_path`/`data_config` names that parameter instead of diagnosing the robot name
+
+`MuJoCoSimEngine.add_robot` read its model source by truthiness, so a source the caller
+supplied but left empty was indistinguishable from one they omitted. `urdf_path=""` took
+the absent branch, ran the deprecated name-as-registry-key fallback for a call that had
+asked for a file, and the refusal then diagnosed the name: it offered close-match
+suggestions for a name the caller never asked to resolve, and advised them to "pass
+data_config=<registered model> or urdf_path=<file>" - the kwarg they had just passed. The
+message was byte-identical to what supplying no source at all returns, so the report could
+not tell the two apart, while one whitespace character away (`urdf_path=" "`) the diagnosis
+was already correct ("File not found").
+
+A supplied-but-empty model source is now refused naming that parameter, the way
+`register_urdf` already refuses an empty `urdf_path` and the way the Newton
+(`urdf_path is not None`) and Isaac (`usd_path is None`) backends already read their own
+model source - MuJoCo's `add_robot` was the one site in the family reading it by
+truthiness. The guard sits after the existing name-taken check, so a caller who both
+reuses a label and empties the path is still told about the label, and whitespace stays a
+path rather than an empty value.

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -1677,6 +1677,17 @@ class MuJoCoSimEngine(
         model source". The bare model-source message is kept only when no
         ``name`` was supplied at all.
 
+        A model source that is SUPPLIED but empty (``urdf_path=""`` /
+        ``data_config=""``) is refused naming THAT parameter, rather than read
+        as omitted. Read by truthiness the two were indistinguishable, so an
+        empty path fell through to the name lookup and got the message above -
+        close-match suggestions for a name the caller never asked to resolve,
+        and advice to pass the very kwarg they had passed - byte-identical to
+        what supplying no source at all returns. One whitespace character away
+        (``urdf_path=" "``) the diagnosis was already correct ("File not
+        found"), which is the shape an empty value gets now too.
+        :meth:`register_urdf` refuses an empty ``urdf_path`` the same way.
+
         ``position`` (3 elements) and ``orientation`` (4-element wxyz quaternion)
         are validated up front: a wrong-length, non-numeric, or non-finite
         (nan/inf) vector returns an actionable ``{"status": "error"}`` and
@@ -1762,6 +1773,36 @@ class MuJoCoSimEngine(
                     }
                 ],
             }
+
+        # A model source the caller SUPPLIED but left empty is not one they
+        # omitted. The resolution below reads both by truthiness, so `""` was
+        # indistinguishable from `None`: the deprecated name-as-registry-key
+        # fallback ran for a call that had asked for a file, and the refusal
+        # then diagnosed the NAME - offering close-match suggestions for a
+        # name the caller never asked to resolve, and advising them to "pass
+        # data_config=<registered model> or urdf_path=<file>", the kwarg they
+        # had just passed. Name the empty parameter instead. This is the rule
+        # `name` states two paragraphs up ("another falsy value would take the
+        # same branch and report success under a label that was never asked
+        # for"), the rule `position`/`orientation` state below (`is None`
+        # means omitted, an `or` would read an empty vector as omitted), the
+        # rule :meth:`register_urdf` already applies to this same parameter,
+        # and the rule the Newton (`urdf_path is not None`) and Isaac
+        # (`usd_path is None`) backends already read their model source by.
+        for param, supplied in (("urdf_path", urdf_path), ("data_config", data_config)):
+            if supplied is not None and not supplied:
+                return {
+                    "status": "error",
+                    "content": [
+                        {
+                            "text": (
+                                f"add_robot: '{param}' must be a non-empty string. "
+                                f"Pass a model source, or omit {param}= to resolve the "
+                                f"model from the registry instead."
+                            )
+                        }
+                    ],
+                }
 
         # Resolution precedence:
         #   1. explicit `urdf_path` (anything on disk).

--- a/tests/simulation/mujoco/test_add_robot_unknown_model_message.py
+++ b/tests/simulation/mujoco/test_add_robot_unknown_model_message.py
@@ -10,6 +10,15 @@ data_config is required" that never names the robot nor points at discovery.
 The bare "supply a model source" message is preserved for the genuine no-name
 case (``add_robot()`` with nothing to resolve), and the deprecated positional
 name-as-registry-key short form still resolves a VALID name.
+
+A model source that is SUPPLIED but empty is a fourth condition, and it is not
+the "given without a model source" one above: read by truthiness the two were
+indistinguishable, so ``urdf_path=""`` fell through to the name lookup and got
+byte-identically what passing no source returns - a name diagnosis, close-match
+suggestions for a name the caller never asked to resolve, and advice to pass the
+kwarg they had just passed. It is refused naming that parameter instead, the way
+``register_urdf`` already refuses an empty ``urdf_path``. Whitespace stays a
+path ("File not found"), which is the boundary.
 """
 
 import os
@@ -68,3 +77,120 @@ class TestUnknownModelMessage:
         result = world.add_robot("so100")
         txt = result["content"][0]["text"] if result.get("content") else ""
         assert "No model found" not in txt, txt
+
+
+class TestASuppliedEmptyModelSourceIsNotAnOmittedOne:
+    """``urdf_path=""`` / ``data_config=""`` name the empty parameter."""
+
+    @pytest.mark.parametrize("param", ["urdf_path", "data_config"])
+    def test_a_supplied_empty_source_names_that_parameter(self, world, param):
+        """The refusal names the parameter the caller left empty."""
+        msg = _msg(world.add_robot(name="probe", **{param: ""}))
+        assert f"'{param}'" in msg, msg
+        assert "non-empty string" in msg, msg
+
+    @pytest.mark.parametrize("param", ["urdf_path", "data_config"])
+    def test_the_refusal_does_not_advise_passing_what_was_passed(self, world, param):
+        """A remedy the caller already applied is a dead end, not advice.
+
+        Pre-fix the message ended "Or pass data_config=<registered model> or
+        urdf_path=<file>" for a call that had passed exactly that.
+        """
+        msg = _msg(world.add_robot(name="probe", **{param: ""}))
+        assert "pass data_config=<registered model> or urdf_path=<file>" not in msg, msg
+
+    @pytest.mark.parametrize("param", ["urdf_path", "data_config"])
+    def test_a_supplied_empty_source_does_not_diagnose_the_name(self, world, param):
+        """The problem is the empty value, not the instance label.
+
+        Spelling suggestions for a name the caller never asked to resolve are
+        the wrong advice here for the same reason they are wrong for a
+        hardware-only entry and a missing asset: the name is not what failed.
+        """
+        msg = _msg(world.add_robot(name="probe", **{param: ""}))
+        assert "No model found for" not in msg, msg
+        assert "Did you mean" not in msg, msg
+
+    def test_a_supplied_empty_source_is_distinguishable_from_supplying_none(self, world):
+        """Supplying an empty source must not report as supplying no source.
+
+        This is the headline: pre-fix both calls returned the same bytes, so
+        the report could not tell "you passed an empty path" from "you passed
+        no path".
+        """
+        # The SAME label in both calls: the label is interpolated into the
+        # pre-fix message, so two different names would differ for an
+        # incidental reason rather than because the reports say different
+        # things. Neither call adds a robot, so the label stays free.
+        empty = _msg(world.add_robot(name="probe", urdf_path=""))
+        omitted = _msg(world.add_robot(name="probe"))
+        assert empty != omitted, f"indistinguishable: {empty!r}"
+
+    def test_an_empty_source_without_a_name_names_the_parameter(self, world):
+        """No name + an empty source still names the parameter.
+
+        Pre-fix this said the parameter "is required" to a caller who had
+        supplied it.
+        """
+        msg = _msg(world.add_robot(urdf_path=""))
+        assert "'urdf_path'" in msg, msg
+        assert "is required" not in msg, msg
+
+    def test_the_rule_covers_every_model_source_the_signature_declares(self, world):
+        """The graded set is the model-source parameters ``add_robot`` accepts.
+
+        Derived from the signature so a third model source added later is
+        refused-when-empty too, or this fails until it is graded.
+        """
+        import inspect
+
+        params = set(inspect.signature(type(world).add_robot).parameters)
+        declared = {p for p in params if p == "data_config" or p.endswith("_path")}
+        assert declared == {"urdf_path", "data_config"}, declared
+        for param in sorted(declared):
+            msg = _msg(world.add_robot(name=f"probe_{param}", **{param: ""}))
+            assert f"'{param}'" in msg, msg
+
+
+class TestTheBoundaryAndTheShortFormsAreUntouched:
+    """Controls: what an empty source must NOT change."""
+
+    def test_whitespace_is_a_path_not_an_empty_value(self, world):
+        """``urdf_path=" "`` stays a path, so it reports the missing file.
+
+        Mirrors ``register_urdf``'s ``if not urdf_path`` boundary exactly -
+        this rule refuses the empty value, not an unusable one.
+        """
+        msg = _msg(world.add_robot(name="probe", urdf_path=" "))
+        assert "File not found" in msg, msg
+
+    def test_an_omitted_source_still_diagnoses_the_name(self, world):
+        """An unresolvable label with NO source keeps the name diagnosis."""
+        msg = _msg(world.add_robot(name="panda_typo"))
+        assert "No model found for 'panda_typo'" in msg, msg
+        assert "list_urdfs" in msg, msg
+
+    def test_a_taken_label_still_reports_the_collision_first(self, world):
+        """The empty-source rule does not displace the name-collision report.
+
+        The guard sits after the existing name-taken check, so a caller who
+        made both mistakes is told about the label they cannot reuse - the
+        precedence this rule was added behind, not in front of.
+        """
+        # Hoisted out of the assert: this call IS the premise (it takes the
+        # label), so under `python -O` an asserted call would be stripped and
+        # the collision below would never be set up.
+        added = world.add_robot(name="arm", data_config="so101")
+        assert added["status"] == "success", added
+        msg = _msg(world.add_robot(name="arm", urdf_path=""))
+        assert "already exists" in msg, msg
+
+    def test_an_empty_name_still_derives_a_label(self, world):
+        """``name=""`` is the documented derive-a-label short form, not an error.
+
+        The falsy-value rule applies to the model SOURCE; ``name`` documents
+        ``None``/``""`` as the short form that auto-derives a label.
+        """
+        result = world.add_robot(name="", data_config="so101")
+        assert result["status"] == "success", result
+        assert "so101" in world.list_robots()


### PR DESCRIPTION
## Problem

`MuJoCoSimEngine.add_robot` read its model source by truthiness:

```python
resolved_path = urdf_path
if not resolved_path and data_config:
    ...
elif not resolved_path and name:
    # DEPRECATED name-as-registry-key fallback
```

So a model source the caller **supplied but left empty** was indistinguishable from one
they **omitted**. `urdf_path=""` took the absent branch, ran the deprecated
name-as-registry-key fallback for a call that had asked for a file, and the refusal then
diagnosed the *name*:

| call | message |
| --- | --- |
| `add_robot(name="probe", urdf_path="")` | `No model found for 'probe'. Did you mean: ur5e, spot, rby1? Use action='list_urdfs' ... Or pass data_config=<registered model> or urdf_path=<file> ...` |
| `add_robot(name="probe", data_config="")` | byte-identical to the above |
| `add_robot(name="probe")` (nothing supplied) | **byte-identical to the above** |
| `add_robot(urdf_path="")` | `Either urdf_path or data_config is required.` |
| `add_robot()` | **byte-identical to the above** |
| `add_robot(name="probe", urdf_path=" ")` | `File not found:  ` |

Three things are wrong at once, and the last row is the sharpest: **one whitespace
character away the diagnosis was already correct.**

1. It advises the caller to `pass data_config=<registered model> or urdf_path=<file>` -
   the kwarg they had just passed. `_unknown_model_msg`'s own docstring exists to avoid
   "a dead-end 'supply a model source'".
2. It offers close-match suggestions (`ur5e, spot, rby1`) for a name the caller never
   asked to resolve - they asked to load a file.
3. It is **byte-identical to supplying no source at all**, so the report cannot tell
   "you passed an empty path" from "you passed no path".

`add_robot` is in the published action enum and `urdf_path`/`data_config` are published
`string` properties, so a schema-constrained agent can emit either.

## Why this is the odd site out

Everything else in the family already reads the source by absence:

| surface | read | verdict |
| --- | --- | --- |
| Newton `add_robot` | `if urdf_path is not None:` | correct |
| Isaac `add_robot` | `usd_path is None` / `is not None` | correct |
| `register_urdf` (MuJoCo **and** Newton) | `if not urdf_path: "'urdf_path' must be a non-empty string."` | correct, refuses by name |
| MuJoCo `add_robot` | `if not resolved_path` | **this PR** |

And the rule is stated three times inside the same file:

- `add_robot`'s own `name` paragraph: *"another falsy value (`0`, `[]`) would take the
  same branch and report success under a label that was never asked for"*.
- 50 lines below the defect: *"`is None` means 'omitted' -> the documented default. `or`
  would additionally ... read an empty vector as omitted"* (for `position`/`orientation`).
- `register_urdf`, on this same parameter.

`_unknown_model_msg`'s docstring says **"Three conditions reach this message"** and
enumerates three; a supplied-empty source was a fourth. This PR restores that census to
three rather than needing a new claim.

## Change

Refuse a supplied-but-empty model source naming that parameter, mirroring
`register_urdf`'s wording:

```
add_robot: 'urdf_path' must be a non-empty string. Pass a model source, or omit
urdf_path= to resolve the model from the registry instead.
```

The guard sits **after** the existing name-taken check, so no settled precedence moves: a
caller who both reuses a label and empties the path is still told about the label. `" "`
stays a path (`File not found`), matching `register_urdf`'s `if not urdf_path` boundary
exactly - this refuses the empty value, not an unusable one.

`AGENTS.md` gets the rule, written as a **refinement** of the existing selector section.
That section says a scalar path may be read by truthiness *"because empty and absent
genuinely coincide there - the value is derived either way"*, which read literally
licenses this defect. It holds where absence derives the same kind of value
(`examples/wbc/motionbricks_g1_mujoco.py` declares `--scene-xml` with a `""` default and
derives it from `--result-dir`, so `""` IS its sentinel and truthiness is right there). It
does not hold where absence selects a different **resolution path**, because then the two
spellings pick a different thing to blame when the call fails.

## Tests

`tests/simulation/mujoco/test_add_robot_unknown_model_message.py` already owns this
contract (its docstring covers "an instance label given *without* a model source"). Nine
new items; **9 failed / 9 passed** against `upstream/main`, every failure behavioural with
the real message quoted, e.g.:

```
assert 'No model found for' not in 'No model found for 'probe'. Did you mean: ur5e, spot, rby1? ...'
assert "'urdf_path'" in 'Either urdf_path or data_config is required.'
```

Break table - 5 breaks, 5 distinct firing sets, zero dead guards:

| break | fires |
| --- | --- |
| control (this branch) | 0 of 18 |
| exact pre-fix (`git checkout upstream/main -- simulation.py`) | 9 - the whole regression set |
| guard covers only `urdf_path` | **4** - the three `data_config` cases + the signature-completeness pin |
| drop `is not None` (over-reach onto an *omitted* source) | **11, including 5 pre-existing tests** |
| guard moved *before* the name-taken check | **1** - the precedence control alone |
| guard strips whitespace | **1** - the whitespace boundary control alone |

The over-reach row is the one worth reading: the shipped suite itself refuses it
(`test_positional_typo_is_actionable`, `test_typo_offers_close_match_suggestion`,
`test_instance_label_without_model_points_at_both_options`,
`test_no_args_keeps_generic_model_source_message` all fire), which is what bounds the rule
to a *supplied* empty value. The two single-firing rows are what make the precedence and
whitespace controls load-bearing rather than decoration.

The completeness pin derives the graded set from `inspect.signature(add_robot)`, so a
third model source added later is refused-when-empty too or the test fails until it is
graded.

## Verification

Measured on `/tmp` worktrees, mujoco 3.12.0, `MUJOCO_GL=egl`.

| gate | result |
| --- | --- |
| 384-file selection, **identical on both trees** with the changed test file excluded from each | `5 failed, 10348 passed, 201 skipped` **byte-identical** (556.61s vs 557.29s, run in parallel) |
| failing-ID sets | identical - `comm` empty in **both** directions |
| the changed test file | 18 passed on this branch; **9 failed / 9 passed** on `upstream/main` |
| `mypy strands_robots tests tests_integ` | 24 == 24 against a pristine worktree, branch-only empty |
| `ruff check` + `ruff format --check` over the CI scope | clean |

The 5 shared failures are import-order artifacts of the wide selection, not regressions:
four in `test_recording_frame_loss_is_not_tolerated.py` and
`test_rendering_pacers_survive_a_clock_step.py[forward_30s]`, all
`KeyError: 'strands_robots.simulation.policy_runner'` or the clock-double binding assertion.
Those two files are **29 passed in isolation on the pristine base**.

A CodeQL AST pre-flight over both changed files reports the same hits on both trees for
`simulation.py` (two `py/empty-except` sites, line-shifted by exactly the +41 lines added)
and nothing for the test file.

## Artifact

One caller, one mistake (`urdf_path=""` from an unexpanded shell variable), on both trees.
After the refusal the capture script does exactly one blind thing: intersect the names the
refusal **quotes** with the parameters it passed empty, and retry the one it finds. Nothing
is hardcoded per column.

![add_robot empty model source](https://raw.githubusercontent.com/cagataycali/robots/media-add-robot-empty-model-source/add-robot-empty-model-source.png)

| measured | `upstream/main` | this branch |
| --- | --- | --- |
| names quoted in the refusal | `'arm'`, `'list_urdfs'` | `'urdf_path'` |
| a parameter the caller can fix | **none** | `'urdf_path'` |
| retry | not possible | `urdf_path=<the real scene.xml>` |
| outcome | **dead end**, `robots=[]`, nothing rendered | `success`, `robots=['arm']`, rendered |

Controls, asserted inside the figure script from the captured JSON:

- Passing the real path from the start returns a **byte-identical** success message on both
  trees, and the two renders agree to `0.000137` mean level.
- Following this branch's remedy lands the caller `0.000091` from having passed the real
  path first time, so the remedy is not merely actionable - it is equivalent to getting it
  right.

Neither spelling ever loaded a wrong model: both error either way. What changed is which
parameter the caller is sent to fix.
