### PR TITLE
fix(isaac): read an OBJ keyword off the split, not as a "v " prefix

### DIFF
--- a/changelog.d/2659-obj-keyword-whitespace.md
+++ b/changelog.d/2659-obj-keyword-whitespace.md
@@ -1,0 +1,29 @@
+### Fixed: a tab-separated OBJ asset parses as the space-separated one does
+
+`_parse_obj` recognised an OBJ keyword by matching a `"v "` / `"f "` prefix.
+OBJ is whitespace-delimited, so a keyword may be followed by a tab as
+legitimately as by a space, and MuJoCo - the reference reader for every
+asset this module is pointed at - reads both forms identically. Matching the
+prefix skipped a tab-separated vertex line, and the resulting failure never
+named the vertex: an all-tab tetrahedron was refused as `has no triangle
+geometry (empty vertices/faces)` despite declaring four vertices and four
+faces, tab vertices beside space faces were reported as `face index 1 out of
+range (0 vertices declared)` against the face on line 5, and one writer
+emitting both separators silently dropped half the vertices so that every
+later 1-based face reference landed on the wrong one.
+
+The quiet case is the one that reaches a scene. A tab-separated vertex that
+no face references was dropped with nothing raised, so `mesh_aabb` reported
+bounds the file never declared - a 9-unit-tall asset came back with a zero z
+extent - and `mesh_aabb` is what the MJCF scene loader turns into a
+mesh-only body's collision proxy. That is the eval-integrity failure mode
+the default box proxy was removed for, arriving under `status="success"`.
+
+The keyword is now read off `line.split()`. `vn` / `vt` fall out naturally,
+being different keywords rather than the vertex keyword followed by a
+separator, and the ASCII-STL parser in the same module had always read its
+keyword this way - so one module no longer answers "is a tab a separator"
+two different ways. Every refusal keeps its exact wording and line number,
+and all 277 `.obj` / `.stl` / `.msh` assets in the LIBERO tree parse
+byte-identically: same vertex and face counts, same geometry, same
+`mesh_aabb` centre and extent.

--- a/strands_robots/simulation/isaac/mesh_assets.py
+++ b/strands_robots/simulation/isaac/mesh_assets.py
@@ -118,23 +118,37 @@ def load_mesh_geometry(
 
 
 def _parse_obj(mesh_path: str) -> tuple[list[tuple[float, float, float]], list[int], list[int]]:
-    """Parse a Wavefront OBJ: ``v`` positions + ``f`` faces (n-gons kept)."""
+    """Parse a Wavefront OBJ: ``v`` positions + ``f`` faces (n-gons kept).
+
+    OBJ is whitespace-delimited, so a keyword may be followed by a tab as
+    legitimately as by a space (MuJoCo reads either form identically). The
+    keyword is therefore read off the split fields rather than matched as a
+    ``"v "`` prefix: matching the prefix skipped a tab-separated ``v`` line,
+    which either dropped the vertex silently - leaving a mesh whose bounds
+    are the ones the file did not declare - or made a later face reference
+    fall out of range and blamed the face for a vertex the parser never
+    recognised. ``vn`` / ``vt`` still fall out naturally: they are different
+    keywords, not the vertex keyword followed by a separator.
+    """
     points: list[tuple[float, float, float]] = []
     counts: list[int] = []
     indices: list[int] = []
     with open(mesh_path, encoding="utf-8", errors="replace") as fh:
         for lineno, raw in enumerate(fh, start=1):
             line = raw.strip()
-            if line.startswith("v "):
-                parts = line.split()
+            parts = line.split()
+            if not parts:
+                continue
+            keyword = parts[0]
+            if keyword == "v":
                 if len(parts) < 4:
                     raise ValueError(f"OBJ {mesh_path}:{lineno}: vertex with fewer than 3 components: {line!r}")
                 try:
                     points.append((float(parts[1]), float(parts[2]), float(parts[3])))
                 except ValueError as e:
                     raise ValueError(f"OBJ {mesh_path}:{lineno}: non-numeric vertex component: {line!r}") from e
-            elif line.startswith("f "):
-                refs = line.split()[1:]
+            elif keyword == "f":
+                refs = parts[1:]
                 if len(refs) < 3:
                     raise ValueError(f"OBJ {mesh_path}:{lineno}: face with fewer than 3 vertices: {line!r}")
                 face: list[int] = []

--- a/tests/simulation/isaac/test_mesh_assets.py
+++ b/tests/simulation/isaac/test_mesh_assets.py
@@ -163,6 +163,108 @@ class TestLoadMeshGeometry:
             load_mesh_geometry(str(asset))
 
 
+class TestObjKeywordsAreWhitespaceDelimited:
+    """An OBJ keyword may be followed by a tab as legitimately as by a space.
+
+    OBJ is a whitespace-delimited format, and MuJoCo - the reference reader
+    for every asset this module is pointed at - reads the tab form and the
+    space form identically. Recognising the keyword by a ``"v "`` prefix
+    skipped a tab-separated vertex line, which either dropped the vertex with
+    nothing raised (leaving :func:`mesh_aabb` reporting bounds the file never
+    declared, and so a collision proxy the MJCF scene loader derives from
+    those bounds) or pushed a later face reference out of range and blamed
+    the face for a vertex the parser had never recognised.
+
+    The ASCII-STL parser in this same module always read its keyword off the
+    split fields, so the two parsers answered the same question two ways;
+    ``test_the_ascii_stl_parser_already_tolerated_a_tab`` pins that half.
+    """
+
+    def test_a_tab_separated_obj_parses_as_the_space_separated_one(self, tmp_path):
+        spaces = tmp_path / "spaces.obj"
+        spaces.write_text(_TETRA_OBJ, encoding="utf-8")
+        tabs = tmp_path / "tabs.obj"
+        tabs.write_text(_TETRA_OBJ.replace("v ", "v\t").replace("f ", "f\t"), encoding="utf-8")
+
+        reference = load_mesh_geometry(str(spaces))
+        try:
+            measured = load_mesh_geometry(str(tabs))
+        except ValueError as refused:
+            raise AssertionError(
+                "the same tetrahedron written with a tab after each v/f keyword was refused "
+                f"({refused}), and the refusal names the face rather than the vertex lines the "
+                "parser did not recognise - MuJoCo reads both forms identically"
+            ) from refused
+        assert measured == reference
+        assert mesh_aabb(str(tabs)) == mesh_aabb(str(spaces))
+
+    def test_a_tab_vertex_line_is_not_dropped_from_the_bounds(self, tmp_path):
+        # The 9-unit spike is declared on a tab line and referenced by no
+        # face, so dropping it raises nothing at all: the asset simply
+        # reports the bounds of the three vertices that were recognised.
+        # mesh_aabb is what the MJCF scene loader turns into a mesh-only
+        # body's collision proxy, so a silently flat z is a silently flat box.
+        asset = tmp_path / "spike.obj"
+        asset.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nv\t0 0 9\nf 1 2 3\n", encoding="utf-8")
+
+        points, counts, _indices = load_mesh_geometry(str(asset))
+        _center, size = mesh_aabb(str(asset))
+        assert len(points) == 4, f"the tab-separated vertex was dropped: {points}"
+        assert counts == [3]
+        assert size[2] == pytest.approx(9.0), f"bounds the file never declared: z extent {size[2]}"
+
+    def test_a_mixed_separator_obj_keeps_every_vertex(self, tmp_path):
+        # One writer emitting both separators is the case that shifts every
+        # subsequent 1-based face reference onto the wrong vertex.
+        asset = tmp_path / "mixed.obj"
+        asset.write_text(
+            "v 0 0 0\nv\t1 0 0\nv 0 2 0\nv\t0 0 3\nf 1 2 3\nf 1 2 4\nf 1 3 4\nf 2 3 4\n",
+            encoding="utf-8",
+        )
+        points, counts, indices = load_mesh_geometry(str(asset))
+        assert len(points) == 4
+        assert counts == [3, 3, 3, 3]
+        assert indices == [0, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3]
+
+    def test_vertex_normals_and_texcoords_are_still_not_vertices(self, tmp_path):
+        # ``vn`` / ``vt`` are their own keywords, not ``v`` plus a separator:
+        # reading the keyword off the split must not widen the vertex rule
+        # into them, in either the space or the tab spelling.
+        asset = tmp_path / "attrs.obj"
+        asset.write_text(
+            "v 0 0 0\nv 1 0 0\nv 0 1 0\nvn 0 0 1\nvt 0 0\nvn\t0 1 0\nvt\t1 0\nf 1 2 3\n",
+            encoding="utf-8",
+        )
+        points, counts, indices = load_mesh_geometry(str(asset))
+        assert len(points) == 3
+        assert counts == [3]
+        assert indices == [0, 1, 2]
+
+    def test_blank_and_comment_lines_are_ignored(self, tmp_path):
+        asset = tmp_path / "commented.obj"
+        asset.write_text(
+            "# Blender v3.2.2 OBJ File\n\nmtllib x.mtl\no Cube\n\t\n" + _TETRA_OBJ,
+            encoding="utf-8",
+        )
+        _points, counts, _indices = load_mesh_geometry(str(asset))
+        assert counts == [3, 3, 3, 3]
+
+    def test_the_ascii_stl_parser_already_tolerated_a_tab(self, tmp_path):
+        # Passes either way: the sibling parser in this module has always
+        # read its keyword off the split, which is why one module answered
+        # "is a tab a separator" two different ways.
+        asset = tmp_path / "part.stl"
+        asset.write_text(
+            "solid part\nfacet normal 0 0 1\nouter loop\n"
+            "vertex\t0 0 0\nvertex\t1 0 0\nvertex\t0 1 0\n"
+            "endloop\nendfacet\nendsolid part\n",
+            encoding="utf-8",
+        )
+        points, counts, _indices = load_mesh_geometry(str(asset))
+        assert len(points) == 3
+        assert counts == [3]
+
+
 class TestMeshAabb:
     def test_full_extents_and_center(self, tmp_path):
         asset = tmp_path / "tetra.obj"


### PR DESCRIPTION
## Problem

`_parse_obj` recognised an OBJ keyword by matching a `"v "` / `"f "` prefix. OBJ is a
whitespace-delimited format, so a keyword may be followed by a tab as legitimately as by a
space, and MuJoCo - the reference reader for every asset this module is pointed at - reads
both forms identically:

| the same tetrahedron | MuJoCo | `load_mesh_geometry` on `main` |
| --- | --- | --- |
| `v 0 0 0` (spaces) | 4 vertices, 4 faces | 4 vertices, 4 faces |
| `v\t0 0 0` (tabs) | 4 vertices, 4 faces | `has no triangle geometry (empty vertices/faces)` |

A skipped vertex line surfaced three ways, and none of them named the vertex:

| the file | outcome on `main` |
| --- | --- |
| every `v`/`f` tab-separated | `mesh <path> has no triangle geometry (empty vertices/faces)` - for a file declaring 4 vertices and 4 faces |
| tab vertices, space faces | `:5: face index 1 out of range (0 vertices declared)` - blames line 5's face; the vertices are on lines 1-4 |
| one writer emitting both | `:5: face index 3 out of range (2 vertices declared)` - 2 of 4 vertices silently dropped, so every later 1-based reference lands on the wrong vertex |
| a tab vertex no face references | **accepted**: 3 of 4 vertices, and `mesh_aabb` reports a z extent of `0.0` for a 9-unit-tall asset |

The last row raises nothing at all. `mesh_aabb` is what the MJCF scene loader turns into a
mesh-only body's collision proxy, so a silently dropped vertex is a silently wrong proxy under
`status="success"` - the eval-integrity failure mode `#2459` removed the default box proxy for.

The ASCII-STL parser in this same module has always read its keyword off the split fields, so
one module answered "is a tab a separator" two different ways.

## Change

`_parse_obj` reads the keyword off `line.split()` instead of matching a prefix. `vn` / `vt`
fall out naturally - they are different keywords, not the vertex keyword followed by a
separator - and an empty line is skipped explicitly.

## Scope

Only the OBJ keyword recognition moves. Every refusal keeps its exact wording and line number
(vertex arity, non-numeric component, face arity, non-integer index, out-of-range index,
`no triangle geometry`), negative face indices and `i/t/n` slash refs are untouched, and the
binary STL / ASCII STL / legacy MSH parsers are not touched at all.

**All 277 `.obj` / `.stl` / `.msh` assets in the real LIBERO tree parse byte-identically** -
same vertex and face counts, same geometry hash, same `mesh_aabb` centre and extent on both
trees (0 differing rows of 277).

## Verification

Measured at `70c0d1cd` against `upstream/main` `b717e91c`; the head has since moved to `3b1b7fc8`, which adds only the changelog fragment (`git diff 70c0d1cd..3b1b7fc8 -- '*.py'` is empty), so every number below still describes the tree under review.

Pre-fix split, new test class copied onto a pristine base: **3 failed / 18 passed**, all three
behavioural:

- `the same tetrahedron written with a tab after each v/f keyword was refused (mesh ... has no triangle geometry (empty vertices/faces)), and the refusal names the face rather than the vertex lines the parser did not recognise`
- `the tab-separated vertex was dropped: [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]`
- `OBJ ...:5: face index 3 out of range (2 vertices declared)`

The three remaining tests in the class pass on both trees: `vn`/`vt` are still not vertices,
blank and comment lines are still ignored, and the ASCII-STL sibling already tolerated a tab.

Break table - each break fires a distinct set, so no guard is decoration:

| break | fires |
| --- | --- |
| control (nothing broken) | 0 of 21 |
| `git checkout upstream/main -- mesh_assets.py` | 3 - the full regression set |
| widen the vertex rule to `keyword.startswith("v")` | 2 - the `vn`/`vt` control **and the pre-existing `test_obj_slash_syntax_and_quads`**, so the shipped suite itself refuses the over-reach |
| fix `v` but leave the face rule as the `"f "` prefix | 1 - the headline alone |
| remove the empty-line guard | 1 - the blank-line control, `IndexError: list index out of range` |

Gate: 149 files (every test naming the mesh-asset surface, all of `tests/simulation/isaac`, and
the repo-wide docstring / string / changelog guards), the changed test file excluded from both
trees so the run measures collateral damage only. **`6641 passed, 62 skipped` byte-identical on
both trees** (313.90s vs 314.29s), zero failures on either side. `tests/simulation/isaac/test_mesh_assets.py`
itself: 21 passed / 5 skipped (the 5 need `usd-core`).

`ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ`; `mypy` 24 == 24
against a pristine `upstream/main` worktree with none in the changed files.

## Artifact

The real LIBERO `white_yellow_mug.obj` (4227 vertices), re-emitted with a tab after each `v`/`f`
keyword. Each thumbnail is a headless MuJoCo render (`MUJOCO_GL=egl`) of the geometry that tree
parsed, re-emitted verbatim as a canonical OBJ - so the picture is what `load_mesh_geometry`
returned, not what MuJoCo read off the file.

![OBJ keyword whitespace](https://raw.githubusercontent.com/cagataycali/robots/media-obj-whitespace/obj_whitespace.png)

`main` refuses the tab form, so there is nothing to realize on the stage; this branch reads the
same 4227 vertices / 8454 faces and the same `0.1382 x 0.1025 x 0.1048 m` extent MuJoCo reports.
The space-separated control is identical on both trees and its render is byte-identical across
them (mean |delta| 0.000000).
