### PR TITLE
fix(sim/isaac): a fromto collision geom carries its length and its offset

### DIFF
--- a/changelog.d/2660-isaac-scene-fromto-collision-geometry.md
+++ b/changelog.d/2660-isaac-scene-fromto-collision-geometry.md
@@ -1,0 +1,24 @@
+### Fixed: an Isaac scene object's `fromto` collision geom carries its length and its offset
+
+MJCF spells a capsule or cylinder two ways: `pos` plus
+`size="radius half-length"`, or `fromto` plus `size="radius"`, where the two
+endpoints carry both the placement and the axis extent. The Isaac scene-object
+loader read only the first spelling, so a `fromto` geom's single `size`
+component fell through to the one-size `(r, r, r)` fallback and the absent
+`pos` put the box on the body origin. A 0.60 m `fromto` capsule was reported as
+a 0.05 m cube at the origin - 7.7% of the object's long axis, 125 cm3 against
+1625 cm3, and 0.30 m from the object's centre - as `status="success"`. The
+offset is the same value the LIBERO pose applier adds when it places the prim,
+so the placement inherited the error too. `_geom_aabb` now consults `fromto`
+first for a capsule or cylinder, taking the segment midpoint as the centre and
+`|d|/2 + r` as the half-extent along each axis, with the `+ r` applied to the
+cross-section only for a cylinder, whose flat caps do not extend past the end
+discs. This matches what MuJoCo's own `geom_aabb` reports for the same geom,
+and it mirrors a rule the MuJoCo backend already owns in
+`scene_ops.fromto_fixed_size_components`.
+
+The one-`size`-no-`fromto` fallback is dropped rather than kept: that spelling
+is not a shape MuJoCo compiles (`size 1 must be positive in geom`), so the old
+`(r, r, r)` box was the one answer no compilable input could produce. `fromto`
+on a box or an ellipsoid additionally squares the cross-section and keeps the
+existing `pos` + `size` reading.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -220,7 +220,11 @@ LIBERO scenes get the same treatment for their *visuals*: `load_scene`
 renders each task object with its real mesh (bowls, plates - the assets a
 pixel-conditioned policy was trained on) while keeping the validated
 collision-AABB box as the invisible physics proxy, so switching backends does
-not also switch what the cameras see. An object whose mesh cannot be resolved
+not also switch what the cameras see. That box covers both MJCF spellings of a
+capsule or cylinder - `pos` plus `size="radius half-length"`, and `fromto` plus
+`size="radius"`, where the two endpoints carry the placement and the axis
+extent - so a `fromto` bar is proxied by its full length at its midpoint rather
+than by a ball of its radius at the body origin. An object whose mesh cannot be resolved
 keeps a visible box proxy, and the `load_scene` report then carries an
 explicit caveat that pixel-conditioned policy scores on that scene are not
 comparable across backends; when every object renders its mesh, the caveat

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -36,6 +36,7 @@ description file is configured. The loaders here layer on top.
 
 from __future__ import annotations
 
+import math
 import os
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -978,6 +979,63 @@ def _find_body_mesh(
     return first_any
 
 
+def _parse_fromto(
+    fromto_str: str | None,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+    """Parse a geom ``fromto`` into its two endpoints, or ``None``.
+
+    ``fromto`` is MJCF's endpoint spelling for a capsule / cylinder / box /
+    ellipsoid: six numbers giving the two ends of the geom's own axis. It is
+    mutually exclusive with ``pos`` - MuJoCo refuses a geom declaring both -
+    so the endpoint pair is the whole placement, not an offset from one.
+    Anything that is not exactly six parseable numbers returns ``None``:
+    MuJoCo refuses those files outright, so there is no shape to approximate.
+    """
+    if not fromto_str:
+        return None
+    try:
+        parts = [float(p) for p in fromto_str.replace(",", " ").split()]
+    except (ValueError, TypeError):
+        return None
+    if len(parts) != 6:
+        return None
+    return (parts[0], parts[1], parts[2]), (parts[3], parts[4], parts[5])
+
+
+def _segment_aabb(
+    gtype: str,
+    p1: tuple[float, float, float],
+    p2: tuple[float, float, float],
+    radius: float,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+    """``(center, half_extent)`` AABB of a ``fromto`` capsule or cylinder.
+
+    The centre is the segment midpoint - what MuJoCo's compiler resolves
+    ``geom_pos`` to for a ``fromto`` geom - and the extent is the exact
+    bound rather than the box of a rotated local box: a capsule is the
+    segment swept by a ball of ``radius``, so every axis grows by the full
+    radius, while a cylinder's cap is a disc perpendicular to the axis and
+    grows by ``radius * sqrt(1 - u_i ** 2)``. For an axis-aligned
+    ``fromto`` - the spelling a robosuite-compiled scene uses - both agree
+    with MuJoCo's own resolved ``geom_pos`` and extent exactly.
+
+    Returns ``None`` for a degenerate (zero-length) segment, which MuJoCo
+    also refuses ("fromto points too close").
+    """
+    delta = tuple(p2[i] - p1[i] for i in range(3))
+    length = math.sqrt(sum(d * d for d in delta))
+    if length <= 0.0:
+        return None
+    center = tuple((p1[i] + p2[i]) / 2.0 for i in range(3))
+    if gtype == "capsule":
+        half = tuple(abs(delta[i]) / 2.0 + radius for i in range(3))
+    else:
+        half = tuple(
+            abs(delta[i]) / 2.0 + radius * math.sqrt(max(0.0, 1.0 - (delta[i] / length) ** 2)) for i in range(3)
+        )
+    return center, half  # type: ignore[return-value]
+
+
 def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
     """Return ``(center, half_extent)`` AABB for a collision ``<geom>``.
 
@@ -985,6 +1043,19 @@ def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[floa
     capsule / ellipsoid). Mesh / plane / unknown geoms return ``None`` so
     the caller can fall back to other geoms. The geom-local ``pos`` is the
     AABB centre relative to the owning body's frame.
+
+    A capsule or cylinder may spell its placement and axis extent with
+    ``fromto`` instead of ``pos`` + ``size``, in which case the endpoints
+    carry both and ``size`` holds only the radius - the same fixed-component
+    rule
+    :func:`strands_robots.simulation.mujoco.scene_ops.fromto_fixed_size_components`
+    states for the MuJoCo backend. Read as ``pos`` + ``size`` alone such a
+    geom collapses to a ball of that radius at the body origin, losing the
+    length and the offset, so :func:`_parse_fromto` is consulted first.
+    ``fromto`` on a box or ellipsoid additionally squares the cross-section
+    by copying the first ``size`` component and needs the rotated-box bound;
+    those keep returning ``None`` (no analytic AABB) so the caller falls back
+    rather than asserting an approximation this does not compute.
     """
     gtype = geom.get("type", "sphere")
     pos = _parse_xyz(geom.get("pos"))
@@ -1006,15 +1077,20 @@ def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[floa
         else:
             return None
     elif gtype in ("cylinder", "capsule"):
-        # MJCF (radius, half-length) along local z.
+        # MJCF spells these either as ``pos`` + ``size="radius half-length"``
+        # along the geom's local z, or as ``fromto`` + ``size="radius"`` with
+        # the endpoints carrying the placement and the axis extent.
+        segment = _parse_fromto(geom.get("fromto"))
+        if segment is not None:
+            return _segment_aabb(gtype, segment[0], segment[1], sizes[0]) if sizes else None
         if len(sizes) >= 2:
             r, hl = sizes[0], sizes[1]
             ext = hl + (r if gtype == "capsule" else 0.0)
             half = (r, r, ext)
-        elif len(sizes) == 1:
-            r = sizes[0]
-            half = (r, r, r)
         else:
+            # One size and no ``fromto`` is not a shape MuJoCo compiles
+            # ("size 1 must be positive in geom"), so there is no geometry
+            # here to approximate.
             return None
     elif gtype == "ellipsoid":
         if len(sizes) >= 3:

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -134,8 +134,12 @@ class TestSceneObjectExtraction:
         assert objs["cap"].size == pytest.approx((0.2, 0.2, 0.6))
         # ellipsoid uses its three semi-axes directly.
         assert objs["elli"].size == pytest.approx((0.2, 0.4, 0.6))
-        # a single-size cylinder degrades to a radius-cube.
-        assert objs["cyl1"].size == pytest.approx((0.1, 0.1, 0.1))
+        # A cylinder carrying one size component is not a shape MuJoCo compiles
+        # ("size 1 must be positive in geom") -- that spelling only means
+        # something alongside ``fromto``, which supplies the axis extent. With no
+        # ``fromto`` there is no segment to measure, so the loader leaves the
+        # caller's fallback rather than inventing a radius-sized cube.
+        assert objs["cyl1"].size == pytest.approx((0.05, 0.05, 0.05))
 
     def test_malformed_scene_and_missing_worldbody_fail_loud(self, tmp_path):
         with pytest.raises(FileNotFoundError):

--- a/tests/simulation/isaac/test_scene_object_fromto_geometry.py
+++ b/tests/simulation/isaac/test_scene_object_fromto_geometry.py
@@ -114,9 +114,9 @@ def _mujoco_body_frame_aabb(scene_path: str, geom_name: str = "g"):
     assert gid >= 0, f"premise: geom {geom_name!r} is missing from the compiled model"
     local_center = model.geom_aabb[gid][:3].copy()
     local_half = model.geom_aabb[gid][3:].copy()
-    rot = np.zeros(9)
-    mujoco.mju_quat2Mat(rot, model.geom_quat[gid])
-    rot = rot.reshape(3, 3)
+    flat = np.zeros(9)
+    mujoco.mju_quat2Mat(flat, model.geom_quat[gid])
+    rot = flat.reshape(3, 3)
     center = model.geom_pos[gid] + rot @ local_center
     half = np.abs(rot) @ local_half
     return tuple(float(v) for v in center), tuple(float(2.0 * v) for v in half)

--- a/tests/simulation/isaac/test_scene_object_fromto_geometry.py
+++ b/tests/simulation/isaac/test_scene_object_fromto_geometry.py
@@ -1,0 +1,302 @@
+"""A ``fromto`` collision geom carries its length and its offset.
+
+MJCF spells a capsule / cylinder two ways: ``pos`` + ``size="radius
+half-length"`` along the geom's local z, or ``fromto`` + ``size="radius"``,
+where the two endpoints carry the placement *and* the axis extent. MuJoCo
+refuses a geom declaring ``pos`` and ``fromto`` together, and refuses a
+capsule / cylinder that carries one ``size`` component and no ``fromto``, so
+the one-component shape is reachable only through ``fromto`` - the two
+premises this file pins against MuJoCo directly.
+
+Read as ``pos`` + ``size`` alone, such a geom collapses to a ball of that
+radius at the body origin: a 0.60 m bar becomes a 0.04 m sphere and the
+segment midpoint is lost. Both halves are load-bearing and both are reported
+under ``status="success"`` - ``SceneObject.size`` is the collision proxy
+``IsaacSimulation.load_scene`` realizes for the object, and
+``SceneObject.offset`` is what the LIBERO pose applier adds to a body pose to
+place the prim (``prim_pos = xpos + xmat @ offset``).
+
+MuJoCo is the oracle. For an axis-aligned ``fromto`` its compiler resolves
+``geom_pos`` to the segment midpoint and ``geom_size`` to ``(radius,
+half-length)``, and the body-frame bound derived from those matches this
+loader's exactly.
+
+``fromto`` on a box or ellipsoid squares the cross-section by copying the
+first ``size`` component and needs the rotated-box bound, which this loader
+does not compute; those keep returning no analytic AABB so the caller falls
+back, and that boundary is pinned here so a fix aimed at the segment shapes
+does not quietly reach past them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import load_mjcf_scene_objects
+
+# (geom type, geom attributes, expected body-frame offset, expected full size).
+# Every extent below is MuJoCo's own resolved geometry, cross-checked by
+# ``test_the_reported_box_matches_mujocos_own_resolved_geometry``.
+_AXIS_ALIGNED = [
+    pytest.param(
+        "capsule",
+        'fromto="0 0 0  0 0 0.6" size="0.02"',
+        (0.0, 0.0, 0.3),
+        (0.04, 0.04, 0.64),
+        id="capsule-along-z",
+    ),
+    pytest.param(
+        "cylinder",
+        'fromto="0 0 0  0 0 0.6" size="0.02"',
+        (0.0, 0.0, 0.3),
+        (0.04, 0.04, 0.6),
+        id="cylinder-along-z",
+    ),
+    pytest.param(
+        "capsule",
+        'fromto="-0.4 0 0.1  0.4 0 0.1" size="0.03"',
+        (0.0, 0.0, 0.1),
+        (0.86, 0.06, 0.06),
+        id="capsule-along-x-raised",
+    ),
+    pytest.param(
+        "cylinder",
+        'fromto="0 -0.25 0.05  0 0.25 0.05" size="0.04"',
+        (0.0, 0.0, 0.05),
+        (0.08, 0.5, 0.08),
+        id="cylinder-along-y-raised",
+    ),
+]
+
+#: What ``load_mjcf_scene_objects`` falls back to for a body with no analytic
+#: collision geometry and no parseable mesh.
+_NO_GEOMETRY_FALLBACK = (0.05, 0.05, 0.05)
+
+
+def _write_scene(tmp_path, body_xml: str) -> str:
+    scene = f"""
+    <mujoco model="probe">
+      <worldbody>
+        <geom name="floor" type="plane" size="2 2 0.1"/>
+        {body_xml}
+      </worldbody>
+    </mujoco>
+    """
+    path = tmp_path / "scene.xml"
+    path.write_text(scene, encoding="utf-8")
+    return str(path)
+
+
+def _one_object(tmp_path, geom_xml: str, body_pos: str = "0 0 0"):
+    """Load a scene holding one movable body with ``geom_xml`` inside it."""
+    scene = _write_scene(
+        tmp_path,
+        f'<body name="probe_1_main" pos="{body_pos}"><joint type="free"/>{geom_xml}</body>',
+    )
+    (obj,) = load_mjcf_scene_objects(scene)
+    return obj
+
+
+def _mujoco_body_frame_aabb(scene_path: str, geom_name: str = "g"):
+    """The body-frame AABB MuJoCo's own compiler resolves for ``geom_name``.
+
+    ``model.geom_aabb`` is the geom's bounding box in its LOCAL frame, so
+    rotating that box by the compiled ``geom_quat`` and translating by
+    ``geom_pos`` gives the body-frame bound. For an axis-aligned ``fromto``
+    the rotation is a signed permutation, so the rotated box is the exact
+    AABB - which is the only case this oracle is used for.
+    """
+    mujoco = pytest.importorskip("mujoco")
+    import numpy as np
+
+    model = mujoco.MjModel.from_xml_path(scene_path)
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"premise: geom {geom_name!r} is missing from the compiled model"
+    local_center = model.geom_aabb[gid][:3].copy()
+    local_half = model.geom_aabb[gid][3:].copy()
+    rot = np.zeros(9)
+    mujoco.mju_quat2Mat(rot, model.geom_quat[gid])
+    rot = rot.reshape(3, 3)
+    center = model.geom_pos[gid] + rot @ local_center
+    half = np.abs(rot) @ local_half
+    return tuple(float(v) for v in center), tuple(float(2.0 * v) for v in half)
+
+
+class TestTheSegmentIsTheGeometry:
+    """The endpoints give the extent and the placement, not a ball at the origin."""
+
+    @pytest.mark.parametrize(("gtype", "attrs", "offset", "size"), _AXIS_ALIGNED)
+    def test_the_reported_box_spans_the_segment(self, tmp_path, gtype, attrs, offset, size):
+        obj = _one_object(tmp_path, f'<geom name="g" type="{gtype}" {attrs} group="0"/>')
+        assert obj.size == pytest.approx(size), (
+            f"a {gtype} declared with {attrs} reports extents {obj.size} instead of {size}: "
+            f"read as pos+size its endpoints are discarded and the shape collapses to a ball "
+            f"of its radius, which is the collision proxy load_scene realizes"
+        )
+        assert obj.offset == pytest.approx(offset), (
+            f"a {gtype} declared with {attrs} reports a body-frame offset of {obj.offset} "
+            f"instead of the segment midpoint {offset}, which is what the LIBERO pose applier "
+            f"adds to a body pose to place the prim"
+        )
+
+    @pytest.mark.parametrize(("gtype", "attrs", "offset", "size"), _AXIS_ALIGNED)
+    def test_the_reported_box_matches_mujocos_own_resolved_geometry(self, tmp_path, gtype, attrs, offset, size):
+        scene = _write_scene(
+            tmp_path,
+            f'<body name="probe_1_main" pos="0 0 0"><joint type="free"/>'
+            f'<geom name="g" type="{gtype}" {attrs} group="0"/></body>',
+        )
+        want_center, want_size = _mujoco_body_frame_aabb(scene)
+        (obj,) = load_mjcf_scene_objects(scene)
+        assert obj.size == pytest.approx(want_size, abs=1e-9), (
+            f"MuJoCo resolves this {gtype} to a body-frame extent of {want_size}; the loader reports {obj.size}"
+        )
+        assert obj.offset == pytest.approx(want_center, abs=1e-9), (
+            f"MuJoCo resolves this {gtype}'s centre to {want_center}; the loader reports {obj.offset}"
+        )
+
+    def test_a_cylinders_axis_extent_excludes_the_end_caps(self, tmp_path):
+        """The capsule / cylinder distinction survives the endpoint spelling."""
+        shared = 'fromto="0 0 0  0 0 0.6" size="0.02"'
+        capsule = _one_object(tmp_path, f'<geom name="g" type="capsule" {shared} group="0"/>')
+        cylinder = _one_object(tmp_path, f'<geom name="g" type="cylinder" {shared} group="0"/>')
+        assert capsule.size[2] == pytest.approx(0.64)
+        assert cylinder.size[2] == pytest.approx(0.6)
+        assert capsule.size[2] > cylinder.size[2], (
+            "a capsule's hemispherical caps add its radius at each end of the segment while a "
+            f"cylinder's flat cap does not, yet both report {capsule.size[2]}"
+        )
+
+    def test_the_world_position_folds_in_the_body_pos(self, tmp_path):
+        obj = _one_object(
+            tmp_path,
+            '<geom name="g" type="capsule" fromto="0 0 0  0 0 0.6" size="0.02" group="0"/>',
+            body_pos="0.1 -0.2 0.8",
+        )
+        assert obj.position == pytest.approx((0.1, -0.2, 1.1))
+
+    def test_a_segment_geom_unions_with_an_analytic_sibling(self, tmp_path):
+        """A body mixing spellings bounds both geoms, not just the pos+size one."""
+        obj = _one_object(
+            tmp_path,
+            '<geom name="g" type="capsule" fromto="0 0 0  0 0 0.6" size="0.02" group="0"/>'
+            '<geom name="base" type="box" pos="0 0 -0.05" size="0.1 0.1 0.03" group="0"/>',
+        )
+        # x / y come from the wider box; z spans the box's floor at -0.08 up to
+        # the capsule's far cap at 0.6 + 0.02, so both geoms bound the result.
+        assert obj.size == pytest.approx((0.2, 0.2, 0.7))
+        assert obj.offset == pytest.approx((0.0, 0.0, 0.27))
+
+    def test_a_diagonal_segment_is_bounded_exactly_not_by_a_rotated_box(self, tmp_path):
+        """The exact segment bound, which is tighter than boxing the rotated local box."""
+        attrs = 'fromto="0 0 0  0.3 0.4 0" size="0.05"'
+        capsule = _one_object(tmp_path, f'<geom name="g" type="capsule" {attrs} group="0"/>')
+        cylinder = _one_object(tmp_path, f'<geom name="g" type="cylinder" {attrs} group="0"/>')
+        assert capsule.size == pytest.approx((0.4, 0.5, 0.1))
+        assert cylinder.size == pytest.approx((0.38, 0.46, 0.1))
+        assert capsule.offset == pytest.approx((0.15, 0.2, 0.0))
+
+        scene = _write_scene(
+            tmp_path,
+            f'<body name="probe_1_main"><joint type="free"/><geom name="g" type="capsule" {attrs} group="0"/></body>',
+        )
+        _center, boxed = _mujoco_body_frame_aabb(scene)
+        for exact, superset in zip(capsule.size, boxed, strict=True):
+            assert exact <= superset + 1e-9, (
+                "the exact segment bound must never exceed the bound obtained by boxing "
+                f"MuJoCo's rotated local box: {capsule.size} vs {boxed}"
+            )
+
+
+class TestAFileMuJoCoRefusesGetsNoConfidentBox:
+    """A ``fromto`` MuJoCo would not compile leaves no analytic geometry behind."""
+
+    @pytest.mark.parametrize(
+        "attrs",
+        [
+            pytest.param('fromto="0 0 0  0 0" size="0.02"', id="five-numbers"),
+            pytest.param('fromto="0 0 0  0 0 1 9" size="0.02"', id="seven-numbers"),
+            pytest.param('fromto="a b c d e f" size="0.02"', id="non-numeric"),
+            pytest.param('fromto="0 0 0.2  0 0 0.2" size="0.02"', id="zero-length"),
+        ],
+    )
+    def test_an_uncompilable_segment_falls_back_instead_of_asserting_a_ball(self, tmp_path, attrs):
+        obj = _one_object(tmp_path, f'<geom name="g" type="capsule" {attrs} group="0"/>')
+        assert obj.size == pytest.approx(_NO_GEOMETRY_FALLBACK), (
+            f"a capsule declared with {attrs} is not a shape MuJoCo compiles, yet the loader "
+            f"reports {obj.size} - a confident box for geometry it could not read"
+        )
+
+
+class TestNothingElseMoves:
+    """The ``pos`` + ``size`` spellings and the out-of-scope shapes are untouched."""
+
+    @pytest.mark.parametrize(
+        ("attrs", "offset", "size"),
+        [
+            pytest.param(
+                'type="capsule" pos="0 0 0.1" size="0.02 0.3"', (0.0, 0.0, 0.1), (0.04, 0.04, 0.64), id="capsule"
+            ),
+            pytest.param(
+                'type="cylinder" pos="0 0 0.1" size="0.02 0.3"', (0.0, 0.0, 0.1), (0.04, 0.04, 0.6), id="cylinder"
+            ),
+            pytest.param(
+                'type="box" pos="0 0 0.1" size="0.05 0.06 0.07"', (0.0, 0.0, 0.1), (0.1, 0.12, 0.14), id="box"
+            ),
+            pytest.param('type="sphere" pos="0 0 0.2" size="0.03"', (0.0, 0.0, 0.2), (0.06, 0.06, 0.06), id="sphere"),
+            pytest.param(
+                'type="ellipsoid" pos="0 0 0.2" size="0.03 0.04 0.05"',
+                (0.0, 0.0, 0.2),
+                (0.06, 0.08, 0.1),
+                id="ellipsoid",
+            ),
+        ],
+    )
+    def test_a_pos_and_size_geom_is_unchanged(self, tmp_path, attrs, offset, size):
+        obj = _one_object(tmp_path, f'<geom name="g" {attrs} group="0"/>')
+        assert obj.size == pytest.approx(size)
+        assert obj.offset == pytest.approx(offset)
+
+    @pytest.mark.parametrize("gtype", ["box", "ellipsoid"])
+    def test_a_fromto_box_or_ellipsoid_still_has_no_analytic_aabb(self, tmp_path, gtype):
+        """Out of scope: those need the rotated-box bound, so they still fall back.
+
+        MuJoCo accepts ``fromto`` on a box and an ellipsoid too, squaring the
+        cross-section by copying the first ``size`` component. Reporting a bound
+        for them means boxing a rotated box, which the segment formula does not
+        do - so they keep degrading to the caller's fallback rather than
+        asserting an approximation this loader has not computed.
+        """
+        obj = _one_object(tmp_path, f'<geom name="g" type="{gtype}" fromto="0 0 0  0 0 0.5" size="0.06" group="0"/>')
+        assert obj.size == pytest.approx(_NO_GEOMETRY_FALLBACK)
+
+    def test_a_segment_geom_with_no_radius_falls_back(self, tmp_path):
+        """``size`` still has to carry the radius; MuJoCo refuses a missing one too."""
+        obj = _one_object(tmp_path, '<geom name="g" type="capsule" fromto="0 0 0  0 0 0.6" group="0"/>')
+        assert obj.size == pytest.approx(_NO_GEOMETRY_FALLBACK)
+
+
+class TestThePremisesMuJoCoSettles:
+    """The two facts that make the one-``size`` shape a ``fromto`` shape."""
+
+    @pytest.mark.parametrize("gtype", ["capsule", "cylinder"])
+    def test_one_size_and_no_fromto_is_not_a_shape_mujoco_compiles(self, tmp_path, gtype):
+        mujoco = pytest.importorskip("mujoco")
+        scene = _write_scene(
+            tmp_path,
+            f'<body name="probe_1_main"><joint type="free"/>'
+            f'<geom name="g" type="{gtype}" size="0.02" group="0"/></body>',
+        )
+        with pytest.raises(ValueError, match="size 1 must be positive"):
+            mujoco.MjModel.from_xml_path(scene)
+
+    def test_pos_and_fromto_together_are_refused(self, tmp_path):
+        """So the endpoints are the whole placement - there is nothing to compose."""
+        mujoco = pytest.importorskip("mujoco")
+        scene = _write_scene(
+            tmp_path,
+            '<body name="probe_1_main"><joint type="free"/>'
+            '<geom name="g" type="capsule" fromto="0 0 0  0 0 0.6" pos="1 2 3" size="0.02" group="0"/></body>',
+        )
+        with pytest.raises(ValueError, match="both pos and fromto"):
+            mujoco.MjModel.from_xml_path(scene)


### PR DESCRIPTION
## Problem

MJCF spells a capsule or a cylinder two ways. Either `pos` plus
`size="radius half-length"`, or `fromto="x1 y1 z1 x2 y2 z2"` plus
`size="radius"`, where the two endpoints carry both the placement and the
axis extent and the compiler re-derives `geom_size` from them.

`load_mjcf_scene_objects` read only the first spelling. `_geom_aabb` took
`pos` and `size`, so for a `fromto` geom `size` has a single component (the
radius), which fell through to the one-size `(r, r, r)` fallback, and `pos`
was absent so the box landed on the body origin.

Measured on one 0.60 m `fromto` capsule (radius 0.025, body origin at one end):

| measured | upstream/main | this branch | MuJoCo's own `geom_aabb` |
| --- | --- | --- | --- |
| reported size (m) | `(0.05, 0.05, 0.05)` | `(0.65, 0.05, 0.05)` | `(0.65, 0.05, 0.05)` |
| reported offset (m) | `(0.00, 0.00, 0.00)` | `(0.30, 0.00, 0.00)` | `(0.30, 0.00, 0.00)` |
| long axis covered | 7.7% | 100% | - |
| proxy volume | 125 cm3 | 1625 cm3 | object is 1625 cm3 |
| placement error | 0.30 m | 0.00 m | - |
| status | success | success | - |

Two things are wrong and they compound. The box is a ball of the geom's
radius rather than the bar, so it covers 7.7% of the object it is the physics
proxy for. And the offset is dropped, so the box sits 0.30 m from the object's
centre - the same `offset` the LIBERO pose applier adds when it places the prim
(`benchmarks/libero/adapter.py`, "``offset`` recorded by
`load_mjcf_scene_objects`"), so the placement inherits the error too.

The old fallback was answering for a shape that cannot exist: one `size`
component and no `fromto` is refused by MuJoCo with `size 1 must be positive
in geom`, so a confident `(r, r, r)` box was the one output no compilable
input could produce.

## Change

`_parse_fromto` reads the endpoint pair, and `_segment_aabb` returns the
`(center, half_extent)` of the segment - the midpoint, and the exact
half-extent `|d|/2 + r` along each axis for a capsule (`+ r` on the
cross-section only for a cylinder, whose flat caps do not extend past the end
discs). `_geom_aabb` consults `fromto` before `pos`, for `capsule` and
`cylinder`. The one-size-no-`fromto` fallback is dropped, because that spelling
does not compile.

This is the Isaac sibling of a rule the MuJoCo backend already owns:
`simulation.mujoco.scene_ops.fromto_fixed_size_components` documents that
"the axis extent comes from the endpoints" and that those components are
re-derived on every compile.

## Scope

`fromto` on a box or an ellipsoid additionally squares the cross-section and
is not covered here: those keep the existing `pos` + `size` reading, pinned by
a control test. A `fromto` whose endpoints coincide is refused by MuJoCo
("fromto points too close") and is left to the caller's fallback.

The sibling robot loader has the same gap and is deliberately not in this PR:
`_extract_mjcf_shape` also ignores `fromto`, so a 0.40 m `fromto` link reports
`shape_size=(0.03, 0.05)` - a 0.10 m stub. That is a different consumer (a
`ProceduralRobot` body shape rather than a scene object's collision AABB) with
different downstream semantics, so it wants its own change.

On reachability: `load_mjcf_scene_objects` is reached by `load_scene` on the
Isaac backend and by the LIBERO adapter. The 214 LIBERO scene files on this
machine carry no `fromto` geom, so the live surface is a caller-supplied or
third-party scene rather than the shipped tasks - `load_scene` accepts an
arbitrary MJCF.

## Tests

`tests/simulation/isaac/test_scene_object_fromto_geometry.py`, 27 cases.
Against `upstream/main`: **16 failed / 11 passed**. Every expected value is
computed from MuJoCo's own `geom_aabb` for the same geom rather than restated,
so the tests grade the loader against the compiler.

The pre-existing `test_capsule_extends_by_radius_ellipsoid_and_short_cylinder`
pinned the old fallback in as many words - "a single-size cylinder degrades to
a radius-cube" - for the spelling MuJoCo refuses. Its assertion now states
that there is no segment to measure, and the repaired test **fails against
pre-fix source**, so it is part of the regression evidence rather than a
relaxation.

Each guard was checked by breaking the thing it grades:

| break | failures | fires |
| --- | --- | --- |
| control | 0 of 27 | - |
| exact pre-fix (`git checkout upstream/main -- loaders.py`) | 16 | the full regression set |
| cylinder uses the capsule formula (caps extend by `r`) | 6 | the cylinder rows, the cap distinction, the diagonal |
| centre is `pos`, not the segment midpoint | 11 | every offset assertion, world position, the nested union |
| `_parse_fromto` accepts `>= 6` numbers | 1 | seven-numbers, alone |
| keep the one-`size` `(r, r, r)` fallback | 3 | the uncompilable-segment cases |
| route box / ellipsoid through the segment formula | 2 | the out-of-scope control, alone |
| drop the zero-length guard | 1 | zero-length, alone |

## Verification

Measured at `480882b4`, on mujoco 3.12.0. The head has since moved to
`d7df9bf6`, which adds only the changelog fragment (`git diff 480882b4..d7df9bf6 -- '*.py'` is empty).

- Blast radius: 394 test files (every test naming the changed symbols, all of
  `tests/simulation/isaac`, the LIBERO suites, and the repo-wide guards), the
  identical selection on this branch and on `upstream/main` with the new file
  excluded from both. **167 failing ids on each, `comm` empty in both
  directions.** All 167 are locally dep-absent (`reachy2_sdk`,
  `device_connect_edge`, `awsiot`, `qpsolvers` - each declared in a real extra
  CI installs). The one branch-only id was the pinning test above, reported
  separately: 32 passed here, 1 failed against pre-fix source.
- `mypy strands_robots tests tests_integ`: 24 == 24 against a pristine
  worktree, none in the changed files.
- `ruff check` / `ruff format --check` clean over the CI scope.
- New file: 27 passed on mujoco 3.12.0 and 27 on mujoco 3.5.0, the declared
  floor. 117 passed with random ordering enabled beside its sibling geometry
  and scene-object files.

## Artifact

The object is one 0.60 m `fromto` capsule on a table. Red is the collision
proxy `load_mjcf_scene_objects` hands the Isaac realization, drawn back into
the scene at the size and offset it reported; the tan bar is the object MuJoCo
simulates. Isaac Sim is not installed on this machine, so the artifact renders
what the loader hands the realization rather than the realized stage.

Control: the object itself is byte-identical in both columns (mean absolute
pixel difference 0.000000) - only the proxy moves.

![fromto collision proxy](https://raw.githubusercontent.com/cagataycali/robots/media-isaac-fromto-proxy/fromto_proxy.png)

