### PR TITLE
fix(isaac): refuse an ASCII-STL facet that carries no endfacet

### DIFF
--- a/changelog.d/2662-ascii-stl-unterminated-facet.md
+++ b/changelog.d/2662-ascii-stl-unterminated-facet.md
@@ -1,0 +1,28 @@
+### Fixed: an ASCII-STL facet with no `endfacet` is refused instead of dropped
+
+`_parse_stl_ascii` flushed a facet when it read an `endfacet` line and kept no
+state about one still being open. A file whose last facet was unterminated
+therefore parsed successfully, one triangle short, with that triangle's three
+vertices still in the returned points - and so in the bounds `mesh_aabb`
+reports and the `extent` `convert_mesh_to_usd` authors. Nothing was raised.
+The MJCF scene loader turns those bounds into a mesh-only body's collision
+proxy, so such an asset got a proxy spanning geometry its own mesh does not
+carry: the eval-integrity failure mode the default box proxy was removed for,
+arriving under `status="success"`.
+
+Two other spellings of the same missing state were loud but misdiagnosed. A
+file whose only facet was unterminated was refused as `has no triangle
+geometry (empty vertices/faces)`, for a file that declares a facet with three
+vertices. A `facet` keyword arriving before the previous `endfacet`
+accumulated both facets' vertices into one, so the file was refused for
+`facet with 6 vertices (expected 3)` - an arity no facet in it declares -
+against the line whose `endfacet` was the only correct thing about it.
+
+The open facet is now tracked by the line its first vertex is on, and refused
+at both ends, the following `facet` keyword and the end of the file, through
+one shared wording. The binary STL and legacy MSH parsers in the same module
+already refuse a truncated file by reconciling their declared counts against
+the byte length; an ASCII STL declares no counts, so the open facet is the
+only thing there is to reconcile. `facet with N vertices (expected 3)` is
+unchanged for a facet that really does declare the wrong number between its
+own `facet` and `endfacet` lines, and no other parser is touched.

--- a/strands_robots/simulation/isaac/mesh_assets.py
+++ b/strands_robots/simulation/isaac/mesh_assets.py
@@ -209,7 +209,33 @@ def _parse_stl_binary(data: bytes, tri_count: int) -> tuple[list[tuple[float, fl
     return points, counts, indices
 
 
+def _unterminated_facet_error(mesh_path: str, lineno: int, vertex_count: int, before: str) -> ValueError:
+    """The refusal for an ASCII-STL facet still open when something else ends it.
+
+    One wording for both sites - a following ``facet`` keyword, and the end
+    of the file - so the two cannot drift, and each names the line the open
+    facet's first vertex is on, which is the only line that identifies it.
+    """
+    return ValueError(
+        f"STL {mesh_path}:{lineno}: facet left unterminated - {vertex_count} vertices read and no 'endfacet' "
+        f"before {before}, so the triangle they form would be dropped while their coordinates stay in the bounds"
+    )
+
+
 def _parse_stl_ascii(mesh_path: str, data: bytes) -> tuple[list[tuple[float, float, float]], list[int], list[int]]:
+    """Parse an ASCII STL, deduplicating shared vertices.
+
+    A facet is flushed on its ``endfacet``, so a facet still open when the
+    file ends - or when another ``facet`` keyword arrives - is refused rather
+    than left pending. Its vertices are already in ``points``, and therefore
+    in the bounds :func:`mesh_aabb` reports and the ``extent``
+    :func:`convert_mesh_to_usd` authors, while the triangle they form is in
+    no face: accepting one returns bounds for geometry the mesh does not
+    carry, under no error at all. The two binary parsers in this module
+    already refuse a truncated file by reconciling their declared counts
+    against the byte length; this is the same refusal for the format whose
+    triangle count is not declared anywhere but in its structure.
+    """
     text = data.decode("utf-8", errors="replace")
     if not text.lstrip().lower().startswith("solid"):
         raise ValueError(f"STL {mesh_path}: neither a well-formed binary STL nor an ASCII one (no 'solid' header)")
@@ -218,9 +244,11 @@ def _parse_stl_ascii(mesh_path: str, data: bytes) -> tuple[list[tuple[float, flo
     counts: list[int] = []
     indices: list[int] = []
     facet: list[int] = []
+    facet_lineno = 0
     for lineno, raw in enumerate(text.splitlines(), start=1):
         line = raw.strip()
-        if line.lower().startswith("vertex"):
+        lowered = line.lower()
+        if lowered.startswith("vertex"):
             parts = line.split()
             if len(parts) < 4:
                 raise ValueError(f"STL {mesh_path}:{lineno}: vertex with fewer than 3 components: {line!r}")
@@ -233,13 +261,19 @@ def _parse_stl_ascii(mesh_path: str, data: bytes) -> tuple[list[tuple[float, flo
                 idx = len(points)
                 index_of[vert] = idx
                 points.append(vert)
+            if not facet:
+                facet_lineno = lineno
             facet.append(idx)
-        elif line.lower().startswith("endfacet"):
+        elif lowered.startswith("endfacet"):
             if len(facet) != 3:
                 raise ValueError(f"STL {mesh_path}:{lineno}: facet with {len(facet)} vertices (expected 3)")
             indices.extend(facet)
             counts.append(3)
             facet = []
+        elif lowered.startswith("facet") and facet:
+            raise _unterminated_facet_error(mesh_path, facet_lineno, len(facet), f"the facet starting on line {lineno}")
+    if facet:
+        raise _unterminated_facet_error(mesh_path, facet_lineno, len(facet), "the end of the file")
     if not points or not counts:
         raise ValueError(f"mesh {mesh_path} has no triangle geometry (empty vertices/faces)")
     return points, counts, indices

--- a/tests/simulation/isaac/test_mesh_assets.py
+++ b/tests/simulation/isaac/test_mesh_assets.py
@@ -307,21 +307,27 @@ class TestAnUnterminatedAsciiStlFacetIsRefused:
         # The headline: the file ends mid-facet, so the spike triangle reaches
         # no face while its vertices stay in the bounds. Nothing raised, and
         # mesh_aabb reported the closed file's extent for a one-face mesh.
+        # Shaped like the OBJ tab test above: the diagnosis sits on the branch
+        # that means the parser got it wrong, which for this file is acceptance.
         asset = tmp_path / "truncated.stl"
         asset.write_text(
             "solid part\n" + self._CLOSED_FACET + self._SPIKE_BODY + "endsolid part\n",
             encoding="utf-8",
         )
-        with pytest.raises(ValueError, match="facet left unterminated") as refused:
+        try:
             points, counts, _indices = load_mesh_geometry(str(asset))
+        except ValueError as refused:
+            message = str(refused)
+        else:
             _center, size = mesh_aabb(str(asset))
             raise AssertionError(
                 f"an unterminated facet parsed: {len(counts)} of 2 faces from {len(points)} vertices, "
                 f"and the z extent is {size[2]} - the bounds of a triangle the mesh does not carry"
             )
+        assert "facet left unterminated" in message
         # Line 11 is the open facet's first vertex; the file's last line is 15.
-        assert ":11:" in str(refused.value)
-        assert "the end of the file" in str(refused.value)
+        assert ":11:" in message
+        assert "the end of the file" in message
 
     def test_the_only_facet_unterminated_is_not_reported_as_an_empty_asset(self, tmp_path):
         # Refused before this change too, but as "no triangle geometry

--- a/tests/simulation/isaac/test_mesh_assets.py
+++ b/tests/simulation/isaac/test_mesh_assets.py
@@ -265,6 +265,122 @@ class TestObjKeywordsAreWhitespaceDelimited:
         assert counts == [3]
 
 
+class TestAnUnterminatedAsciiStlFacetIsRefused:
+    """A facet an ASCII STL never closes must not parse as a smaller mesh.
+
+    The parser flushes a facet on its ``endfacet``, so vertices read before an
+    ``endfacet`` that never arrives stay in ``points`` - and therefore in the
+    bounds :func:`mesh_aabb` reports and the ``extent``
+    :func:`convert_mesh_to_usd` authors - while the triangle they form reaches
+    no face. Accepting that returns a mesh whose bounds describe geometry it
+    does not carry, with nothing raised at all: the silent-proxy failure mode
+    #2459 removed the default box proxy for.
+
+    The binary STL and legacy MSH parsers in this module both refuse a
+    truncated file by reconciling their declared counts against the byte
+    length. An ASCII STL declares no counts, so the open facet is the only
+    thing there is to reconcile - which is why this is the same refusal rather
+    than a new rule.
+    """
+
+    # Two triangles sharing an edge, the second one 9 units tall, written so
+    # each line number below is the one the refusals name.
+    _CLOSED_FACET = "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\n"
+    _SPIKE_BODY = "facet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 0 9\nendloop\n"
+
+    def test_a_well_formed_two_facet_file_is_unchanged(self, tmp_path):
+        # The control the three refusals below are measured against: with both
+        # ``endfacet`` lines present this geometry parses, and the 9-unit
+        # triangle is real - so there is something for the others to lose.
+        asset = tmp_path / "closed.stl"
+        asset.write_text(
+            "solid part\n" + self._CLOSED_FACET + self._SPIKE_BODY + "endfacet\nendsolid part\n",
+            encoding="utf-8",
+        )
+        points, counts, _indices = load_mesh_geometry(str(asset))
+        _center, size = mesh_aabb(str(asset))
+        assert len(points) == 4
+        assert counts == [3, 3]
+        assert size[2] == pytest.approx(9.0)
+
+    def test_the_last_facet_without_an_endfacet_is_refused(self, tmp_path):
+        # The headline: the file ends mid-facet, so the spike triangle reaches
+        # no face while its vertices stay in the bounds. Nothing raised, and
+        # mesh_aabb reported the closed file's extent for a one-face mesh.
+        asset = tmp_path / "truncated.stl"
+        asset.write_text(
+            "solid part\n" + self._CLOSED_FACET + self._SPIKE_BODY + "endsolid part\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="facet left unterminated") as refused:
+            points, counts, _indices = load_mesh_geometry(str(asset))
+            _center, size = mesh_aabb(str(asset))
+            raise AssertionError(
+                f"an unterminated facet parsed: {len(counts)} of 2 faces from {len(points)} vertices, "
+                f"and the z extent is {size[2]} - the bounds of a triangle the mesh does not carry"
+            )
+        # Line 11 is the open facet's first vertex; the file's last line is 15.
+        assert ":11:" in str(refused.value)
+        assert "the end of the file" in str(refused.value)
+
+    def test_the_only_facet_unterminated_is_not_reported_as_an_empty_asset(self, tmp_path):
+        # Refused before this change too, but as "no triangle geometry
+        # (empty vertices/faces)" - for a file declaring a facet with three
+        # vertices, which sends a reader looking for the wrong defect.
+        asset = tmp_path / "single.stl"
+        asset.write_text("solid part\n" + self._SPIKE_BODY + "endsolid part\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="facet left unterminated") as refused:
+            load_mesh_geometry(str(asset))
+        message = str(refused.value)
+        assert ":4:" in message
+        assert "no triangle geometry" not in message
+
+    def test_the_refusal_names_the_open_facet_not_the_line_that_closes_the_next_one(self, tmp_path):
+        # A facet keyword arriving before the previous ``endfacet`` used to
+        # accumulate both facets' vertices into one, so the file was refused
+        # for "6 vertices (expected 3)" at line 14 - an arity no facet in the
+        # file declares, blaming the one line that is correct.
+        asset = tmp_path / "mid.stl"
+        asset.write_text(
+            "solid part\nfacet normal 0 0 1\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\n"
+            + self._SPIKE_BODY
+            + "endfacet\nendsolid part\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="facet left unterminated") as refused:
+            load_mesh_geometry(str(asset))
+        message = str(refused.value)
+        assert ":4:" in message, f"the open facet's first vertex is on line 4: {message}"
+        assert "the facet starting on line 8" in message
+        assert "6 vertices" not in message
+
+    def test_a_facet_that_really_declares_four_vertices_still_reports_its_arity(self, tmp_path):
+        # The pre-existing refusal for a genuinely malformed facet - one that
+        # opens and closes around four vertices - must survive: the new guard
+        # covers an absent ``endfacet``, not a wrong vertex count.
+        asset = tmp_path / "quad_facet.stl"
+        asset.write_text(
+            "solid part\nfacet normal 0 0 1\nouter loop\n"
+            "vertex 0 0 0\nvertex 1 0 0\nvertex 1 1 0\nvertex 0 1 0\n"
+            "endloop\nendfacet\nendsolid part\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match=r"facet with 4 vertices \(expected 3\)"):
+            load_mesh_geometry(str(asset))
+
+    def test_the_binary_sibling_already_refuses_a_truncated_file(self, tmp_path):
+        # Passes either way, and is the reason this refusal is not a new rule:
+        # the binary parser reconciles its declared triangle count against the
+        # byte length, so a file cut mid-record is refused rather than read as
+        # the triangles that survived.
+        asset = tmp_path / "torn.stl"
+        tri1 = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+        tri2 = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 9.0))
+        asset.write_bytes(_binary_stl([tri1, tri2])[:-50])
+        with pytest.raises(ValueError, match="neither a well-formed binary STL nor an ASCII one"):
+            load_mesh_geometry(str(asset))
+
+
 class TestMeshAabb:
     def test_full_extents_and_center(self, tmp_path):
         asset = tmp_path / "tetra.obj"


### PR DESCRIPTION
Closes #2661.

## Problem

`_parse_stl_ascii` flushes a facet when it reads an `endfacet` line and tracks nothing about one still being open. A file whose **last** facet is unterminated therefore parses successfully, one triangle short, with that triangle's three vertices still in `points` - and so in the bounds `mesh_aabb` reports and the `extent` `convert_mesh_to_usd` authors.

Four ASCII STL files built from the same two triangles - a unit-square corner and a 9-unit-tall one - differing only in which `endfacet` lines are present:

| the file | outcome on `main` |
| --- | --- |
| both facets closed (control) | 4 vertices, 2 faces, extent `1.0 x 1.0 x 9.0` |
| the **last** `endfacet` missing | **accepted**: 4 vertices, **1** face, extent still `1.0 x 1.0 x 9.0` |
| the **only** facet unterminated | `mesh <path> has no triangle geometry (empty vertices/faces)` - for a file declaring a facet with three vertices |
| a **mid-file** facet unterminated | `:14: facet with 6 vertices (expected 3)` - blames line 14's `endfacet`; the unclosed facet is the one before it, and no facet in the file declares six vertices |

Row 2 is the one that costs something: it raises nothing. `mesh_aabb` is what the MJCF scene loader turns into a mesh-only body's collision proxy, so the asset gets a proxy spanning a triangle its own mesh does not carry, under `status="success"` - the eval-integrity failure mode `#2459` removed the default box proxy for, and `#2659` fixed one instance of for OBJ vertices. Rows 3 and 4 are loud but misdiagnosed: one reports an empty asset for a file that declares a facet, the other reports an arity no line in the file has and blames the one line that is correct.

The two binary parsers in this same module both refuse a truncated file, because each reconciles its declared counts against the byte length:

| the file | outcome on `main` |
| --- | --- |
| binary STL, cut by one 50-byte record | `neither a well-formed binary STL nor an ASCII one (no 'solid' header)` |
| legacy MSH, cut by 4 bytes | `declared counts need 64 bytes but the file holds 60 - truncated, or not a legacy MuJoCo binary mesh` |

So one module answered "is a truncated asset an error" two different ways, and the module docstring states which one is the contract: "Nothing here degrades to a silent default."

## Change

The open facet is tracked by the line its first vertex is on, and refused at both ends - a following `facet` keyword, and the end of the file - through one shared wording (`_unterminated_facet_error`) so the two sites cannot drift. An ASCII STL declares no triangle count anywhere, so the open facet is the only thing there is to reconcile; that is what makes this the binary siblings' refusal rather than a new rule.

The regression test reports the mesh that parsed from an `else` branch rather than from inside `pytest.raises`. `pytest.raises.__exit__` suppresses, so putting the "it parsed instead" diagnosis at the end of the `with` body works at runtime - but a static reader cannot know a context manager swallows, so a `with` body ending in an unconditional `raise` makes the assertions after it unreachable, and CodeQL read them that way. The OBJ tab test this class's docstring points at already shapes it the other way round: `try` the call, put the diagnosis on the branch that means the parser got it wrong, assert afterwards. There the failure is a refusal so the diagnosis sits in `except`; here it is acceptance, so it sits in `else`. The diagnosis text and the wording the `match=` regex pinned are both unchanged - the latter is now an explicit assertion, so a different `ValueError` shows its whole message instead of a regex mismatch.

## Scope

Only the ASCII-STL facet state moves. `facet with N vertices (expected 3)` is unchanged for a facet that really does declare the wrong number between its own `facet` and `endfacet` lines; the vertex-arity and non-numeric-component refusals keep their exact wording and line numbers; vertex deduplication is untouched; and the binary STL, legacy MSH and OBJ parsers are not touched at all.

## Verification

Measured at `f2b8ed6` against `upstream/main` `671aae5`. `mesh_assets.py` is byte-identical at this branch's merge base and at current `upstream/main`, so the pre-fix numbers below are measured against the tree as it stands.

The new class copied onto a pristine base: **3 failed / 24 passed**, all three behavioural - the silent row plus the two misdiagnosed ones. The three controls in the class pass on both trees: a well-formed two-facet file still parses with a 9-unit z extent, a facet genuinely declaring four vertices still reports its arity, and the binary sibling already refuses a file cut mid-record.

Break table - each break fires a distinct set, so no guard is decoration:

| break | fires |
| --- | --- |
| control (nothing broken) | 0 of 32 |
| `git checkout upstream/main -- mesh_assets.py` | 3 - the full regression set |
| drop the end-of-file check only | 2 - the silent row and the empty-asset misdiagnosis |
| drop the following-`facet`-keyword branch only | 1 - the mid-file misdiagnosis |
| refuse a `facet` keyword whether or not one is open | 7 - including **two shipped tests** (`test_ascii_stl`, `test_the_ascii_stl_parser_already_tolerated_a_tab`), so the existing suite refuses the over-reach |
| name the current line instead of the open facet's first vertex | 3 - every refusal that pins which line identifies the facet |

Gate: 126 files (all of `tests/simulation/isaac`, plus every guard that walks the test tree or grades sources, docstrings, strings or changelog fragments - the ones a change to a test file can reach), the changed test file excluded from both trees so the run measures collateral damage only. **`4524 passed, 54 skipped` byte-identical on both trees, zero failures on either side** (286.36s vs 293.25s). `tests/simulation/isaac/test_mesh_assets.py` itself: 27 passed / 5 skipped (the 5 need `usd-core`); 32 collected either way, so the refactor moved no case.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1502 files). `mypy strands_robots tests tests_integ`: **24 errors on this branch and 24 on a pristine `upstream/main` worktree, with the branch-only set empty** and none in either changed file.

An AST sweep for the shape the alert names - a statement following a `with` whose body ends in `raise` or `return` - reports **0 sites** across `strands_robots` and `tests`, where before this round it reported exactly this one, tree-wide.
