### PR TITLE
fix(device-connect): read the state RPC's joints through the shared motor bus

### DIFF
--- a/changelog.d/2666-state-rpc-shares-the-motor-bus.md
+++ b/changelog.d/2666-state-rpc-shares-the-motor-bus.md
@@ -1,0 +1,7 @@
+### Fixed: the Device Connect state RPC reads an arm's joints through the shared motor bus
+
+`RobotDeviceDriver.getState` reached the wrapped lerobot device directly -- `inner = getattr(self._robot, "robot", None)`, then `asyncio.to_thread(inner.get_observation)` -- so it took no bus lock and read the full observation. The handler around that read logs at debug and returns what it has, so two independent failures both surfaced as a successful RPC whose response simply has no `joints` key: barging in on a reader already holding the bus drew `[TxRxResult] Port is in use!`, and lerobot's `get_observation` sync-reads the motors first and only then loops the cameras, so one dead USB camera threw away the joint positions already in hand.
+
+It now routes through `bus_access.read_joints`, which owns both rules. Measured against a lerobot-shaped follower: a dead camera and a held bus each went from no joints at all to the arm's six positions, and the contended read waits for its turn instead of colliding. A healthy read is byte-identical.
+
+The structural guard from #2614 could not see the site: it matches a device held as `self.robot` or `self.robot.*`, and this one arrives as `getattr(self._robot, "robot", None)` bound to a local, so the shipped rule reported a clean tree. Its sibling half already follows exactly that binding form on `bus_access` itself, and the graded population now does too.

--- a/strands_robots/device_connect/robot_driver.py
+++ b/strands_robots/device_connect/robot_driver.py
@@ -18,6 +18,7 @@ from device_connect_edge.drivers import (
 )
 from device_connect_edge.types import DeviceIdentity, DeviceStatus
 
+from strands_robots.bus_access import read_joints
 from strands_robots.device_connect._authz import authz_error, is_authorized_caller
 from strands_robots.mesh.security import is_safe_policy_provider
 
@@ -140,6 +141,11 @@ class RobotDeviceDriver(DeviceDriver):
         """Get current robot state (joints, task info).
 
         Returns joint positions and task state if a task is running.
+
+        The joints are read through the shared motor-bus lock, so this RPC
+        waits its turn behind an in-flight rollout, teleop write or mesh probe
+        instead of colliding with it, and reports the joints even when a
+        camera on the same driver is failing.
         """
         result = {}
         task = getattr(self._robot, "_task_state", None)
@@ -148,11 +154,21 @@ class RobotDeviceDriver(DeviceDriver):
             result["instruction"] = task.instruction
             result["step_count"] = task.step_count
 
-        # Try to read observation from the underlying LeRobot robot
+        # Read the joint half through the shared motor-bus lock
+        # (:func:`strands_robots.bus_access.read_joints`) rather than calling the
+        # driver's ``get_observation`` directly. Both failures that replaces were
+        # reported as an absent ``joints`` key under a successful RPC, because the
+        # handler below logs at debug and returns what it has. A read that barged in
+        # on one of the five converted readers already holding the bus collided
+        # ("Port is in use!"), and lerobot's ``get_observation`` sync-reads the
+        # motors FIRST and only then loops the cameras, so one dead USB camera threw
+        # away the joint positions already in hand. The frame filter below still
+        # matters: a driver exposing no readable motor bus falls back to the full
+        # observation, frames included.
         inner = getattr(self._robot, "robot", None)
         if inner and hasattr(inner, "get_observation"):
             try:
-                obs = await asyncio.to_thread(inner.get_observation)
+                obs = await asyncio.to_thread(read_joints, inner)
                 # Filter out camera frames (numpy arrays) - only include scalars
                 result["joints"] = {k: float(v) for k, v in obs.items() if not hasattr(v, "shape")}
             except Exception as e:

--- a/tests/test_device_connect_state_rpc_shares_the_bus.py
+++ b/tests/test_device_connect_state_rpc_shares_the_bus.py
@@ -1,0 +1,194 @@
+"""The Device Connect state RPC reads joints through the shared motor bus.
+
+``RobotDeviceDriver.getState`` is the "what is this arm doing" RPC an operator or
+an agent calls at will. It reached the wrapped lerobot device directly --
+``inner = getattr(self._robot, "robot", None)`` and then
+``asyncio.to_thread(inner.get_observation)`` -- so it took no bus lock and read
+the FULL observation. Two independent failures followed, and the handler around
+the read logs at debug and returns what it has, so both surfaced as a successful
+RPC whose response simply has no ``joints`` key:
+
+* it barged in on a reader already holding the bus and the SDK answered
+  ``[TxRxResult] Port is in use!``;
+* lerobot's ``get_observation`` sync-reads the motors FIRST and only then loops
+  the cameras, so one dead USB camera threw away the joint positions already in
+  hand -- the eleven-hour incident ``bus_access.read_joints`` exists to prevent.
+
+The fakes for the second case are imported from the test module that pins that
+incident, so this file grades the RPC against the same arm state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("device_connect_edge")
+
+from strands_robots.bus_access import bus_lock  # noqa: E402
+from strands_robots.device_connect.robot_driver import RobotDeviceDriver  # noqa: E402
+
+from .test_bus_read_joints import POSITIONS, _Arm, _Bus  # noqa: E402
+
+PORT_IN_USE = (
+    "Failed to sync read 'Present_Position' on ids=[1, 2, 3, 4, 5, 6] after 3 tries. [TxRxResult] Port is in use!"
+)
+
+
+class _Wrapper:
+    """A ``Robot``-shaped host holding one device.
+
+    Deliberately not a ``MagicMock``: on a mock, ``inner.bus`` auto-creates a
+    child that HAS ``sync_read``, and ``bus_lock`` finds an auto-created
+    attribute where the real device has none -- so a mock cannot tell a lock
+    that serialises from one that does not.
+    """
+
+    def __init__(self, device: Any) -> None:
+        self.robot = device
+        self._task_state = None
+        self.tool_name_str = "so101"
+
+
+class _ContendedArm:
+    """An arm that refuses an overlapping transaction, exactly like the SDK."""
+
+    def __init__(self) -> None:
+        self.busy = False
+        self.reads = 0
+        self.refusals = 0
+        self.bus = self
+        self.config = type("_Cfg", (), {"num_read_retries": 3})()
+        self.is_connected = True
+
+    def _enter(self) -> None:
+        if self.busy:
+            self.refusals += 1
+            raise ConnectionError(PORT_IN_USE)
+
+    def sync_read(self, register: str, num_retry: int | None = None) -> dict[str, float]:  # noqa: ARG002
+        self._enter()
+        self.reads += 1
+        return dict(POSITIONS)
+
+    def get_observation(self) -> dict[str, float]:
+        self._enter()
+        self.reads += 1
+        return {f"{motor}.pos": value for motor, value in POSITIONS.items()}
+
+
+def _state(device: Any) -> dict[str, Any]:
+    return asyncio.run(RobotDeviceDriver(_Wrapper(device)).getState())
+
+
+class TestTheJointsSurviveADeadCamera:
+    """The incident state: motors answer, a camera on the same driver does not."""
+
+    def test_the_joints_are_reported_while_get_observation_raises(self) -> None:
+        arm = _Arm(_Bus(POSITIONS))
+
+        state = _state(arm)
+
+        assert "joints" in state, (
+            "the RPC reported no joints for an arm whose motors answered: "
+            f"keys={sorted(state)} (get_observation raised, and the joints were already in hand)"
+        )
+        assert state["joints"]["shoulder_pan.pos"] == pytest.approx(1.0)
+        assert len(state["joints"]) == len(POSITIONS)
+
+    def test_the_reported_joints_are_the_arms_own_positions(self) -> None:
+        arm = _Arm(_Bus(POSITIONS))
+
+        joints = _state(arm)["joints"]
+
+        assert joints == {f"{motor}.pos": pytest.approx(value) for motor, value in POSITIONS.items()}
+
+
+class TestItWaitsItsTurnOnTheBus:
+    """A reader that barges in produces a collision and no data for anyone."""
+
+    def test_it_does_not_collide_with_a_reader_holding_the_lock(self) -> None:
+        arm = _ContendedArm()
+        released = threading.Event()
+
+        def hold() -> None:
+            with bus_lock(arm):
+                arm.busy = True
+                time.sleep(0.35)
+                arm.busy = False
+            released.set()
+
+        holder = threading.Thread(target=hold, daemon=True)
+        holder.start()
+        time.sleep(0.10)  # the holder owns the lock and the wire is in use
+
+        state = _state(arm)
+        released.wait(3)
+        holder.join(3)
+
+        assert arm.refusals == 0, f"the device refused {arm.refusals} overlapping transaction(s)"
+        assert "joints" in state, f"the RPC reported no joints while another reader held the bus: keys={sorted(state)}"
+        assert arm.reads == 1
+
+    def test_the_read_happens_under_the_device_lock(self) -> None:
+        """Probed from another thread: the lock is an RLock, so asking inside proves nothing."""
+        bus = _Bus(POSITIONS)
+        arm = _Arm(bus)
+        bus.owner = arm
+
+        _state(arm)
+
+        assert bus.locked_during_read is True, (
+            "the wire was driven with the device lock free, so a concurrent reader can collide with this RPC"
+        )
+
+
+class TestNothingElseChanges:
+    """What the change does not claim, and what must keep working."""
+
+    def test_a_healthy_arm_reports_the_same_joints(self) -> None:
+        """With nothing contending and every camera alive, the answer is what it was."""
+        arm = _ContendedArm()
+
+        assert _state(arm)["joints"] == {f"{m}.pos": pytest.approx(v) for m, v in POSITIONS.items()}
+
+    def test_the_frame_filter_still_applies_on_the_no_bus_fallback(self) -> None:
+        """A driver exposing no readable bus falls back to the full observation."""
+
+        class _NoBus:
+            bus = None
+            config = type("_Cfg", (), {"num_read_retries": 3})()
+
+            def get_observation(self) -> dict[str, Any]:
+                return {"shoulder_pan.pos": 1.0, "front": np.zeros((2, 2, 3), np.uint8)}
+
+        state = _state(_NoBus())
+
+        assert state["joints"] == {"shoulder_pan.pos": pytest.approx(1.0)}, (
+            "a camera frame reached the joints map, so the frame filter is no longer doing its job"
+        )
+
+    def test_a_host_with_no_device_reports_no_joints_and_no_error(self) -> None:
+        state = asyncio.run(RobotDeviceDriver(_Wrapper(None)).getState())
+
+        assert "joints" not in state
+        assert state == {}
+
+    def test_the_task_state_keys_are_untouched(self) -> None:
+        wrapper = _Wrapper(_ContendedArm())
+        wrapper._task_state = type(
+            "_Task",
+            (),
+            {"status": type("_S", (), {"value": "running"})(), "instruction": "pick up the cube", "step_count": 42},
+        )()
+
+        state = asyncio.run(RobotDeviceDriver(wrapper).getState())
+
+        assert state["task_status"] == "running"
+        assert state["instruction"] == "pick up the cube"
+        assert state["step_count"] == 42

--- a/tests/test_hardware_bus_is_shared_with_the_mesh.py
+++ b/tests/test_hardware_bus_is_shared_with_the_mesh.py
@@ -387,13 +387,51 @@ def _device_holding_modules() -> list[pathlib.Path]:
     return holders
 
 
+def _device_names_in(function: ast.AST) -> set[str]:
+    """Locals inside ``function`` bound to a device the module holds.
+
+    Mirrors the binding step :func:`_owned_bus_operations` already performs on
+    ``bus_access`` itself, where ``bus = getattr(device, "bus", None)`` parks the
+    thing being driven in a local. A module that reaches its wrapped robot as
+    ``getattr(holder, "robot", None)`` or ``holder.robot`` and then drives that
+    local is on the same serial bus as every other reader, so matching only the
+    ``self.robot`` spelling grades the expression rather than the device.
+
+    Args:
+        function: The function whose local bindings to collect.
+
+    Returns:
+        The local names bound to a held device.
+    """
+    names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and ast.unparse(value.func) == "getattr":
+            bound = len(value.args) >= 2 and isinstance(value.args[1], ast.Constant) and value.args[1].value == "robot"
+        elif isinstance(value, ast.Attribute):
+            bound = value.attr == "robot"
+        else:
+            bound = False
+        if bound:
+            names.add(target.id)
+    return names
+
+
 def _direct_device_touches() -> list[tuple[str, int, str]]:
     """Owned bus operations reached through a device the module holds.
 
     Matched on the expression rather than on a file list: reaching
     ``get_observation`` through ``self.robot`` is driving the wrapped hardware
     bus, while a simulation backend's identically named method drives no serial
-    port at all and is never in scope.
+    port at all and is never in scope. A device parked in a local first
+    (:func:`_device_names_in`) is the same bus reached by another spelling, so it
+    is graded too -- matching the attribute expression alone let a device
+    obtained as ``getattr(self._robot, "robot", None)`` drive the wire ungraded.
     """
     operations = _owned_bus_operations()
     touches: list[tuple[str, int, str]] = []
@@ -404,10 +442,13 @@ def _direct_device_touches() -> list[tuple[str, int, str]]:
             tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover - a module that does not parse
             continue
+        held_locals: set[str] = set()
+        for function in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)]:
+            held_locals |= _device_names_in(function)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Attribute) or node.attr not in operations:
                 continue
             holder = ast.unparse(node.value)
-            if holder == "self.robot" or holder.startswith("self.robot."):
+            if holder == "self.robot" or holder.startswith("self.robot.") or holder in held_locals:
                 touches.append((str(path.relative_to(PACKAGE.parent)), node.lineno, ast.unparse(node)))
     return sorted(touches)


### PR DESCRIPTION
## Problem

`RobotDeviceDriver.getState` is the "what is this arm doing" RPC an operator or an agent calls at will. It reached the wrapped lerobot device directly:

```python
inner = getattr(self._robot, "robot", None)
obs = await asyncio.to_thread(inner.get_observation)
```

so it took no bus lock and read the **full** observation. The handler around that read logs at debug and returns what it has, so two independent failures both surfaced as a **successful RPC whose response simply has no `joints` key**:

- it barged in on a reader already holding the bus, and the feetech SDK answered `[TxRxResult] Port is in use!`;
- lerobot's `get_observation` sync-reads the motors **first** and only then loops the cameras, so one dead USB camera threw away the joint positions already in hand -- the eleven-hour incident `bus_access.read_joints` exists to prevent (its docstring: *"a single dead USB camera silently disarmed the whole arm"*).

Measured against a lerobot-shaped follower, same six positions on the wire in every row:

| scenario | upstream/main | this branch |
| --- | --- | --- |
| healthy arm (control) | 6 joints | 6 joints, byte-identical |
| one dead USB camera | **no `joints` key**, no error | 6 joints |
| another reader holds the bus | **no `joints` key**, device refused 1 transaction | 6 joints, waited 0.25 s for its turn |

## Change

Route the read through `bus_access.read_joints`, which owns both rules -- one lock per device, and joints read from the motor bus rather than from an observation a camera can spoil. `getState`'s frame filter is kept, because the function documents a `read_observation` fallback for a driver exposing no readable bus.

## The guard could not see the site

#2614 shipped `test_no_caller_drives_a_held_device_outside_bus_access`, a rule over the source rather than one call site. It grades an owned bus operation reached through a device the module holds, matched as `self.robot` or `self.robot.*` -- and this device arrives as `getattr(self._robot, "robot", None)` bound to a local, so **the shipped guard reports a clean tree**:

| tree | shipped guard | widened guard |
| --- | --- | --- |
| unfixed tree | **3 passed** (clean) | fails: `robot_driver.py:155 (inner.get_observation)` |
| fixed tree | 3 passed | 11 passed |

Its sibling half already follows exactly that binding form on `bus_access` itself (`bus = getattr(device, "bus", None)`); `_device_names_in` now follows it on the graded population too, so a device parked in a local is on the same bus whichever spelling reaches it. The `.robot` restriction stays load-bearing: relaxing it to any local binding reports `doctor.py:353 (sim.get_observation)`, a simulation engine that drives no serial port.

## Tests

`tests/test_device_connect_state_rpc_shares_the_bus.py`, reusing the fakes from the module that pins the camera incident so the RPC is graded against the same arm state. **4 failed / 4 passed** on `upstream/main`, every failure behavioural:

```
the RPC reported no joints for an arm whose motors answered: keys=[]
  (get_observation raised, and the joints were already in hand)
the device refused 1 overlapping transaction(s)
the wire was driven with the device lock free, so a concurrent reader can collide with this RPC
```

The four `TestNothingElseChanges` cases pass on both trees.

Breaks, each firing its own set:

| break | fires |
| --- | --- |
| control | 0 of 19 |
| exact pre-fix source, guard widened | 5 -- all four behavioural plus the guard naming the site |
| `read_observation` instead of `read_joints` (lock taken, full observation) | 3 -- the camera half only; the contention test passes |
| drop the frame filter | 1 -- the no-bus fallback control alone |
| guard stops following the `getattr` binding, source fixed | 0 -- invisible on a clean tree; pair with the row below |
| source reverted **and** guard narrow (what shipped) | 4 behavioural, and the guard reports **clean** |
| guard treats any local binding as a device | 1 -- it reports `doctor.py:353`, a sim engine |

## Verification

Measured at `1a2a15be`; the head has since moved to `c5618856`, which adds only the changelog fragment (`git diff 1a2a15be..c5618856 -- '*.py'` is empty). 129 files -- everything reaching a bus read, a device driver, or a tree-walking guard -- run with the identical selection on both trees, the two changed test files excluded from each:

| tree | result |
| --- | --- |
| this branch | `2 failed, 5930 passed, 60 skipped` in 317.11s |
| `upstream/main` | `2 failed, 5930 passed, 60 skipped` in 316.11s |

Failing-ID sets identical, `comm` empty in both directions. Both shared failures are `tests/test_device_connect_hardening.py` on absent `device-connect-agent-tools`, declared in `[device-connect]` and installed by `[all]`. `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` is 24 errors on both trees with none in the changed files. The two changed test files: 19 passed.

## Sim artifact

The pose a Device Connect consumer reconstructs from `getState`, rendered headless in MuJoCo (`MUJOCO_GL=egl`) from the reported joints. The arm never moved -- what differs is whether its positions reached the response. The ground-truth render is identical across trees (mean level difference 0.000451) and the healthy row's joints are byte-identical, so the only difference is the two rows that had nothing to reconstruct.

![state RPC reports joints through the shared bus](https://raw.githubusercontent.com/cagataycali/robots/media-state-rpc-shares-the-bus/state-rpc-shares-the-bus.png)

