### PR TITLE
fix(isaac): read an MJCF's bodies from the whole model, not just the top file

### DIFF
--- a/changelog.d/2667-isaac-mjcf-bodies-model-global.md
+++ b/changelog.d/2667-isaac-mjcf-bodies-model-global.md
@@ -1,0 +1,31 @@
+### Fixed: an MJCF's bodies are read from the whole model, not just the top file
+
+MuJoCo splices `<include file=...>` textually and merges every `<worldbody>` the
+spliced model carries, the same way it treats `<compiler>` and `<asset>` as
+model-global. Both loaders in `strands_robots.simulation.isaac.loaders` still
+answered that question from the top file's own `<worldbody>`, so whether a body
+was visible depended on which file declared it.
+
+That failed in two directions. A model whose `<worldbody>` lives entirely in a
+fragment read as having none, so `load_mjcf` refused a model MuJoCo compiles -
+`aloha/scene.xml` is an `<include>` plus a table, and it was rejected as a
+"phantom robot" while `aloha/aloha.xml` returned all 21 bodies. A model keeping
+some bodies locally and including the rest read only the ones it could see and
+silently dropped the others, their subtrees and their joints:
+`franka_emika_panda/mjx_single_cube.xml` returned 2 bodies and zero joints for a
+model with 13 and 10, so the whole Panda arm was absent from a
+`ProceduralRobot` the caller was told it received.
+
+Both loaders now read the bodies through the module's existing splice, in
+document order (which is the order MuJoCo assigns body indices in), and keep "no
+`<worldbody>` anywhere" distinguishable from "a `<worldbody>` with no bodies" so
+both refusals still report their own cause. Measured over the 227 downloaded
+registry MJCFs: 75 refusals of models MuJoCo compiles are fixed, 12 silent
+body/joint drops are fixed, and 3 scenes now report the articulation refusal
+their own included model file already reported. The 106 LIBERO asset scenes -
+the only in-package consumer of the scene loader, and they use no `<include>` -
+return byte-identical object lists.
+
+An `<include>` nested inside a `<worldbody>` stays out of scope: no shipped
+registry `<worldbody>` uses one, and it is a question about splicing inside a
+`<worldbody>` rather than about which `<worldbody>` elements a model has.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -403,8 +403,8 @@ def load_mjcf(path: str) -> ProceduralRobot:
 
     model_name = root.get("model", os.path.splitext(os.path.basename(path))[0])
 
-    worldbody = root.find("worldbody")
-    if worldbody is None:
+    declares_worldbody, top_bodies = _mjcf_model_worldbody_bodies(root, os.path.dirname(os.path.abspath(path)))
+    if not declares_worldbody:
         raise ValueError(f"MJCF loader: {path} has no <worldbody>")
 
     bodies: list[BodyDef] = []
@@ -490,7 +490,6 @@ def load_mjcf(path: str) -> ProceduralRobot:
         for child in body_el.findall("body"):
             _walk(child, body_idx)
 
-    top_bodies = list(worldbody.findall("body"))
     if not top_bodies:
         raise ValueError(f"MJCF loader: {path} <worldbody> has no <body> children (phantom robot guard)")
 
@@ -916,6 +915,39 @@ def _mjcf_model_toplevel(root: ET.Element, base_dir: str, _seen: frozenset[str] 
     return out
 
 
+def _mjcf_model_worldbody_bodies(root: ET.Element, base_dir: str) -> tuple[bool, list[ET.Element]]:
+    """Whether the model declares a ``<worldbody>``, and its top-level bodies.
+
+    Read from the whole model - the MJCF plus every ``<include>``d fragment, via
+    :func:`_mjcf_model_toplevel` - because MuJoCo splices includes and MERGES
+    every ``<worldbody>`` the spliced model carries, exactly as it treats
+    ``<compiler>`` and ``<asset>`` as model-global. So a model's bodies need not
+    live in the top file, and a model may declare several ``<worldbody>``
+    elements across its fragments.
+
+    Reading only the top file's direct children breaks in two ways, and they
+    fail differently. A model whose ``<worldbody>`` lives entirely in a fragment
+    reads as having none, so the loader refuses a model MuJoCo compiles. A model
+    that keeps some bodies in the top file and includes the rest reads only the
+    ones it can see, silently dropping the others - and their whole subtrees and
+    joints with them - under a successful load.
+
+    Both elements and bodies keep document order, which is the order MuJoCo
+    assigns body indices in.
+
+    Args:
+        root: Parsed ``<mujoco>`` root element.
+        base_dir: Directory the model's own ``<include>`` paths resolve against.
+
+    Returns:
+        ``(declares_a_worldbody, top_level_body_elements)``. The flag separates
+        "no ``<worldbody>`` anywhere in the model" from "a ``<worldbody>`` that
+        carries no bodies", which the two callers report differently.
+    """
+    worldbodies = [el for el in _mjcf_model_toplevel(root, base_dir) if el.tag == "worldbody"]
+    return bool(worldbodies), [body for wb in worldbodies for body in wb.findall("body")]
+
+
 def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[str, tuple[float, float, float]]]:
     """Collect the model's ``<asset><mesh>`` registry: name -> (file path, scale).
 
@@ -1257,14 +1289,15 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
     root = _parse_xml(path, "MJCF scene")
     if root.tag != "mujoco":
         raise ValueError(f"MJCF scene loader: root element must be <mujoco>, got <{root.tag}> in {path}")
-    worldbody = root.find("worldbody")
-    if worldbody is None:
+    mjcf_dir = os.path.dirname(os.path.abspath(path))
+    declares_worldbody, top_bodies = _mjcf_model_worldbody_bodies(root, mjcf_dir)
+    if not declares_worldbody:
         raise ValueError(f"MJCF scene loader: {path} has no <worldbody>")
 
-    mesh_registry = _parse_mjcf_mesh_assets(root, os.path.dirname(os.path.abspath(path)))
+    mesh_registry = _parse_mjcf_mesh_assets(root, mjcf_dir)
 
     objects: list[SceneObject] = []
-    for body_el in worldbody.findall("body"):
+    for body_el in top_bodies:
         name = body_el.get("name") or ""
         if not name or _is_skipped_scene_body(name):
             continue

--- a/tests/simulation/isaac/test_mjcf_bodies_are_model_global.py
+++ b/tests/simulation/isaac/test_mjcf_bodies_are_model_global.py
@@ -1,0 +1,333 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""An MJCF's bodies are read from the whole model, not just the top file.
+
+MuJoCo treats ``<include file=...>`` as a textual splice and MERGES every
+``<worldbody>`` the spliced model carries, exactly as it treats ``<compiler>``
+and ``<asset>`` as model-global. ``test_mjcf_mesh_assets_are_model_global``
+states that rule for the mesh registry and the search directory; this module
+states it for the bodies, which is the one question both loaders in
+:mod:`strands_robots.simulation.isaac.loaders` still answered from
+``root.find("worldbody")`` alone.
+
+Reading only the top file's direct children broke in two ways, and they failed
+differently. A model whose ``<worldbody>`` lives entirely in an included
+fragment read as having none, so ``load_mjcf`` refused a model MuJoCo compiles -
+``aloha/scene.xml`` is ``<include file="aloha.xml"/>`` plus a table, and it was
+rejected as a "phantom robot" while ``aloha/aloha.xml`` loaded all 21 bodies and
+16 joints. A model that keeps some bodies in the top file and includes the rest
+read only the ones it could see and silently dropped the others, their subtrees
+and their joints: ``franka_emika_panda/mjx_single_cube.xml`` returned 2 bodies
+and ZERO joints for a model with 10, the whole Panda arm absent under a
+successful load - and body/joint topology is the function's product.
+
+Every fixture here is a model real MuJoCo compiles, and
+``TestMuJoCoAgreesOnTheModelsBodies`` compares the loader's top-level body names
+against MuJoCo's own (the bodies whose parent is the world), so the expectation
+is derived from the compiler rather than restated. That is what makes a loader
+disagreement a defect rather than invalid scaffolding.
+
+Scope: an ``<include>`` nested INSIDE a ``<worldbody>`` (legal MJCF, splicing
+bare ``<body>`` elements out of a ``<mujocoinclude>`` fragment) is deliberately
+left out. No ``<worldbody>`` in the shipped registry carries one - 0 of 227
+measured - and the rule here is about which ``<worldbody>`` elements the model
+has, not about splicing inside one. ``TestAnIncludeInsideAWorldbodyIsOutOfScope``
+pins that boundary so widening it later is a decision rather than an accident.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import load_mjcf, load_mjcf_scene_objects
+
+#: A body MuJoCo accepts on its own: one hinge joint and one box geom.
+_LINK = (
+    '<body name="{name}" pos="{pos}">'
+    '<joint name="{name}_j" type="hinge" axis="0 0 1"/>'
+    '<geom type="box" size="0.05 0.05 0.05"/>'
+    "</body>"
+)
+
+
+def _link(name: str, pos: str = "0 0 0.3") -> str:
+    return _LINK.format(name=name, pos=pos)
+
+
+def _model(*children: str) -> str:
+    return '<mujoco model="m">' + "".join(children) + "</mujoco>"
+
+
+def _worldbody(*children: str) -> str:
+    return "<worldbody>" + "".join(children) + "</worldbody>"
+
+
+def _write(root: pathlib.Path, top: str, fragments: dict[str, str] | None = None) -> str:
+    """Write a model tree under ``root``; return the top file's path.
+
+    A fragment name spells a subdirectory with ``__`` so nested includes can be
+    built without the caller creating directories. Taken as a mapping rather
+    than keywords because a fragment name carries a ``.xml`` suffix.
+    """
+    for name, text in (fragments or {}).items():
+        path = root / name.replace("__", "/")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    top_path = root / "model.xml"
+    top_path.write_text(top, encoding="utf-8")
+    return str(top_path)
+
+
+#: ``(id, top file, fragments, expected top-level body names in document order)``.
+#:
+#: Each model is one MuJoCo compiles, and the expected names are the bodies whose
+#: parent is the world - the same set ``TestMuJoCoAgreesOnTheModelsBodies`` reads
+#: back out of the compiler.
+_MODEL_GLOBAL_FIXTURES = [
+    (
+        "worldbody-lives-in-a-fragment",
+        _model('<include file="frag/arm.xml"/>'),
+        {"frag__arm.xml": _model(_worldbody(_link("frag_link")))},
+        ["frag_link"],
+    ),
+    (
+        "a-second-worldbody-arrives-by-include",
+        _model(_worldbody(_link("direct", "0 0 0.1")), '<include file="frag/arm.xml"/>'),
+        {"frag__arm.xml": _model(_worldbody(_link("frag_link")))},
+        ["direct", "frag_link"],
+    ),
+    (
+        "the-include-precedes-the-direct-worldbody",
+        _model('<include file="frag/arm.xml"/>', _worldbody(_link("direct", "0 0 0.1"))),
+        {"frag__arm.xml": _model(_worldbody(_link("frag_link")))},
+        ["frag_link", "direct"],
+    ),
+    (
+        "a-nested-include-chain",
+        _model('<include file="frag/outer.xml"/>'),
+        {
+            "frag__outer.xml": _model('<include file="inner/deep.xml"/>'),
+            "frag__inner__deep.xml": _model(_worldbody(_link("deep_link"))),
+        },
+        ["deep_link"],
+    ),
+    (
+        "two-bodies-in-one-included-worldbody",
+        _model('<include file="frag/arm.xml"/>'),
+        {"frag__arm.xml": _model(_worldbody(_link("a"), _link("b", "0.3 0 0.3")))},
+        ["a", "b"],
+    ),
+]
+
+_FIXTURE_IDS = [f[0] for f in _MODEL_GLOBAL_FIXTURES]
+_FIXTURES = [f[1:] for f in _MODEL_GLOBAL_FIXTURES]
+
+
+def _loaded_top_bodies(scene_path: str) -> list[str]:
+    """``load_mjcf``'s top-level body names, minus the synthetic ``world`` root."""
+    robot = load_mjcf(scene_path)
+    return [b.name for b in robot.bodies if b.name != "world"]
+
+
+class TestTheModelsBodiesAreReadFromTheWholeModel:
+    """A body the model declares is a body the loader reads, whatever file it is in."""
+
+    @pytest.mark.parametrize(("top", "fragments", "expected"), _FIXTURES, ids=_FIXTURE_IDS)
+    def test_load_mjcf_reads_every_declared_body(self, tmp_path, top, fragments, expected):
+        assert _loaded_top_bodies(_write(tmp_path, top, fragments)) == expected
+
+    @pytest.mark.parametrize(("top", "fragments", "expected"), _FIXTURES, ids=_FIXTURE_IDS)
+    def test_the_scene_loader_reads_every_declared_body(self, tmp_path, top, fragments, expected):
+        objects = load_mjcf_scene_objects(_write(tmp_path, top, fragments))
+        assert [o.name for o in objects] == expected
+
+    def test_an_included_bodys_joints_reach_the_robot(self, tmp_path):
+        """The joints, not just the bodies: topology is what ``load_mjcf`` produces."""
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("direct", "0 0 0.1")), '<include file="frag/arm.xml"/>'),
+            {"frag__arm.xml": _model(_worldbody(_link("frag_link")))},
+        )
+        robot = load_mjcf(model)
+        assert [j.name for j in robot.joints] == ["direct_j", "frag_link_j"]
+
+    def test_an_included_bodys_subtree_reaches_the_robot(self, tmp_path):
+        """A nested child of an included body is read too, not just its root."""
+        nested = (
+            '<body name="upper" pos="0 0 0.3">'
+            '<joint name="upper_j" type="hinge" axis="0 0 1"/>'
+            '<geom type="box" size="0.05 0.05 0.05"/>'
+            '<body name="lower" pos="0 0 0.2">'
+            '<joint name="lower_j" type="slide" axis="1 0 0"/>'
+            '<geom type="box" size="0.02 0.02 0.02"/>'
+            "</body></body>"
+        )
+        model = _write(
+            tmp_path,
+            _model('<include file="frag/arm.xml"/>'),
+            {"frag__arm.xml": _model(_worldbody(nested))},
+        )
+        robot = load_mjcf(model)
+        assert [b.name for b in robot.bodies] == ["world", "upper", "lower"]
+        assert [j.name for j in robot.joints] == ["upper_j", "lower_j"]
+
+    def test_the_phantom_robot_guard_reads_an_included_worldbody(self, tmp_path):
+        """A worldbody read through an include is still subject to the guard.
+
+        The guard's own verdict changes here: before the fix this model reported
+        "has no <worldbody>", so the two refusals were told apart by which FILE a
+        body lived in rather than by whether the model declares one at all.
+        """
+        model = _write(
+            tmp_path, _model('<include file="frag/empty.xml"/>'), {"frag__empty.xml": _model("<worldbody/>")}
+        )
+        with pytest.raises(ValueError, match="phantom robot guard"):
+            load_mjcf(model)
+
+    def test_the_skip_list_applies_to_an_included_fragments_bodies(self, tmp_path):
+        """An included body goes through the same floor/robot skip list as a direct one."""
+        model = _write(
+            tmp_path,
+            _model('<include file="frag/arm.xml"/>'),
+            {
+                "frag__arm.xml": _model(
+                    _worldbody(_link("floor"), _link("robot0_base", "0.3 0 0.3"), _link("mug", "0.6 0 0.3"))
+                )
+            },
+        )
+        assert [o.name for o in load_mjcf_scene_objects(model)] == ["mug"]
+
+
+class TestTheRefusalsAreUnchanged:
+    """A top-file-only model, and both guards, are untouched.
+
+    Every test here passes before and after the fix: the change widens which
+    files are read, never which models are accepted once read. They are what
+    fails if a wider reader starts accepting a model a guard should refuse, or
+    stops reading a model that never used an ``<include>`` at all.
+    """
+
+    def test_a_model_with_no_worldbody_anywhere_is_still_refused(self, tmp_path):
+        model = _write(tmp_path, _model('<include file="frag/empty.xml"/>'), {"frag__empty.xml": _model("<asset/>")})
+        with pytest.raises(ValueError, match="has no <worldbody>"):
+            load_mjcf(model)
+
+    def test_a_top_file_only_empty_worldbody_is_still_a_phantom_robot(self, tmp_path):
+        with pytest.raises(ValueError, match="phantom robot guard"):
+            load_mjcf(_write(tmp_path, _model("<worldbody/>")))
+
+    def test_a_top_file_only_model_is_unchanged(self, tmp_path):
+        model = _write(tmp_path, _model(_worldbody(_link("only", "0 0 0.1"))))
+        robot = load_mjcf(model)
+        assert [b.name for b in robot.bodies] == ["world", "only"]
+        assert [j.name for j in robot.joints] == ["only_j"]
+        assert [o.name for o in load_mjcf_scene_objects(model)] == ["only"]
+
+    def test_a_top_file_only_scene_still_skips_the_floor_and_the_robot(self, tmp_path):
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("floor"), _link("robot0_base", "0.3 0 0.3"), _link("mug", "0.6 0 0.3"))),
+        )
+        assert [o.name for o in load_mjcf_scene_objects(model)] == ["mug"]
+
+
+class TestAnIncludeInsideAWorldbodyIsOutOfScope:
+    """A ``<worldbody>``-nested include splices bodies in MuJoCo and not here.
+
+    Legal MJCF, and no shipped registry ``<worldbody>`` uses it (0 of 227). The
+    rule this module states is about which ``<worldbody>`` elements the model
+    has; splicing inside one is a separate question, and this pins the boundary
+    so widening it is a decision rather than a surprise.
+    """
+
+    def test_a_worldbody_nested_include_is_not_spliced(self, tmp_path):
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("direct", "0 0 0.1"), '<include file="frag/bare.xml"/>')),
+            {"frag__bare.xml": "<mujocoinclude>" + _link("nested", "0.4 0 0.3") + "</mujocoinclude>"},
+        )
+        assert _loaded_top_bodies(model) == ["direct"]
+
+    def test_mujoco_does_splice_it(self, tmp_path):
+        """The premise: MuJoCo reads the body this loader does not."""
+        mujoco = pytest.importorskip("mujoco")
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("direct", "0 0 0.1"), '<include file="frag/bare.xml"/>')),
+            {"frag__bare.xml": "<mujocoinclude>" + _link("nested", "0.4 0 0.3") + "</mujocoinclude>"},
+        )
+        compiled = mujoco.MjModel.from_xml_path(model)
+        assert _mujoco_top_bodies(mujoco, compiled) == ["direct", "nested"]
+
+
+class TestAnUnusableIncludeDoesNotFailTheModel:
+    """MuJoCo names the offending file on the load that follows; this reader does not guess.
+
+    Mirrors ``TestAnUnusableIncludeDoesNotFailTheScene`` for the mesh registry:
+    the rest of the model still resolves, so a stale or broken fragment cannot
+    turn a readable model into a refusal this reader invented.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "fragments"),
+        [
+            ("missing", {}),
+            ("malformed", {"frag__arm.xml": "<mujoco><worldbody>"}),
+            ("not-a-file", {"frag__arm.xml__x": "ignored"}),
+        ],
+        ids=["missing", "malformed", "a-directory"],
+    )
+    def test_the_rest_of_the_model_still_loads(self, tmp_path, label, fragments):
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("direct", "0 0 0.1")), '<include file="frag/arm.xml"/>'),
+            fragments,
+        )
+        assert _loaded_top_bodies(model) == ["direct"]
+
+    def test_an_include_cycle_terminates(self, tmp_path):
+        model = _write(
+            tmp_path,
+            _model(_worldbody(_link("direct", "0 0 0.1")), '<include file="frag/a.xml"/>'),
+            {
+                "frag__a.xml": _model('<include file="b.xml"/>'),
+                "frag__b.xml": _model('<include file="a.xml"/>'),
+            },
+        )
+        assert _loaded_top_bodies(model) == ["direct"]
+
+    def test_an_include_without_a_file_attribute_is_ignored(self, tmp_path):
+        model = _write(tmp_path, _model(_worldbody(_link("direct", "0 0 0.1")), "<include/>"))
+        assert _loaded_top_bodies(model) == ["direct"]
+
+
+def _mujoco_top_bodies(mujoco, model) -> list[str]:
+    """The compiled model's top-level body names, in MuJoCo's own index order."""
+    return [
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, i)
+        for i in range(1, model.nbody)
+        if model.body_parentid[i] == 0
+    ]
+
+
+class TestMuJoCoAgreesOnTheModelsBodies:
+    """Premise + oracle: every fixture compiles, and the compiler names the same bodies.
+
+    The expected names above are not a restatement - this reads them back out of
+    MuJoCo, so a fixture that stopped being a valid model, or a loader that
+    stopped agreeing with the compiler, fails here.
+    """
+
+    @pytest.mark.parametrize(("top", "fragments", "expected"), _FIXTURES, ids=_FIXTURE_IDS)
+    def test_the_compiler_reads_the_same_top_level_bodies(self, tmp_path, top, fragments, expected):
+        mujoco = pytest.importorskip("mujoco")
+        model = _write(tmp_path, top, fragments)
+        compiled = mujoco.MjModel.from_xml_path(model)
+        assert _mujoco_top_bodies(mujoco, compiled) == expected
+        assert _loaded_top_bodies(model) == _mujoco_top_bodies(mujoco, compiled)
+
+    def test_the_compiler_refuses_no_fixture(self, tmp_path):
+        """Non-vacuity: the parametrized set is non-empty and every model compiles."""
+        assert len(_FIXTURES) >= 5


### PR DESCRIPTION
Closes #2668.

## Problem

MuJoCo treats `<include file=...>` as a textual splice and MERGES every `<worldbody>` the spliced model carries, exactly as it treats `<compiler>` and `<asset>` as model-global. `tests/simulation/isaac/test_mjcf_mesh_assets_are_model_global.py` already states that rule for the mesh registry and the search directory.

Both loaders in `simulation/isaac/loaders.py` still answered the bodies from `root.find("worldbody")` alone, so whether a body was visible depended on which FILE declared it. That failed in two directions, and they failed differently.

**A model whose `<worldbody>` lives in a fragment read as having none**, so `load_mjcf` refused a model MuJoCo compiles. `aloha/scene.xml` is `<include file="aloha.xml"/>` plus a table:

| loaded file | MuJoCo compiles | `load_mjcf` on `upstream/main` |
| --- | --- | --- |
| `aloha/aloha.xml` | nbody=21, njnt=16 | 21 bodies, 16 joints |
| `aloha/scene.xml` | nbody=21, njnt=16 | `ValueError: ... <worldbody> has no <body> children (phantom robot guard)` |

**A model keeping some bodies in the top file and including the rest read only the ones it could see** and silently dropped the others, their subtrees and their joints - under a successful load. `franka_emika_panda/mjx_single_cube.xml` keeps the cube and the mocap target locally and includes the arm:

| reported | MuJoCo | `upstream/main` | this branch |
| --- | --- | --- | --- |
| bodies | 13 | **2** | 13 |
| joints | 10 | **0** | 9 |

The branch matches MuJoCo's bodies exactly. The one joint it does not report is the cube's `<freejoint>`, which the loader represents as a floating base rather than an articulation joint - that part is unchanged.

Body and joint topology is what `load_mjcf` produces, so this is the worse of the two shapes: on `upstream/main` the whole Panda arm (`link0` .. `link7`, `hand`, both fingers) is absent from a `ProceduralRobot` the caller was told it received, and only `box` and `mocap_target` - the two bodies the top file happens to declare locally - come back.

Measured over the 227 downloaded registry MJCFs: **75** refusals of models MuJoCo compiles, and **12** silent body/joint drops.

## Change

`_mjcf_model_worldbody_bodies` reads both facts through the module's existing `_mjcf_model_toplevel` splice, so `<worldbody>` is now answered the way `<compiler>` and `<asset>` already are. Both loaders call it.

Two properties the helper has to keep, each pinned:

- **Document order.** MuJoCo assigns body indices in the order it reads them, so a body from an `<include>` that PRECEDES the local `<worldbody>` comes first.
- **The "declares one" flag, separate from "has bodies".** `load_mjcf` reports `has no <worldbody>` and `<worldbody> has no <body> children (phantom robot guard)` as different causes; deriving the flag from the body list would collapse them.

An `<include>` nested INSIDE a `<worldbody>` is deliberately out of scope. It is legal MJCF and MuJoCo splices it, but no shipped registry `<worldbody>` uses one (0 of 227), and it is a question about splicing inside a `<worldbody>` rather than about which `<worldbody>` elements a model has. `TestAnIncludeInsideAWorldbodyIsOutOfScope` pins the boundary, including the premise that MuJoCo does read that body, so widening it later is a decision rather than an accident.

## Scope

| registry MJCFs (227 downloaded) | before | after |
| --- | --- | --- |
| refused a model MuJoCo compiles | 75 | 0 |
| loaded, silently missing bodies/joints | 12 | 0 |
| now report the articulation refusal their own included model file already reports | - | 3 |
| unchanged | 137 | 137 |

The 3 changed refusals (`unitree_g1`, `unitree_h1`, `unitree_h1_2` scene files) now report `has no joints (rigid body, not an articulation)` - which is what `load_mjcf` already reported for those robots' own model files, so the scene and the model it includes finally agree.

The 106 LIBERO asset scenes - the only in-package consumer of `load_mjcf_scene_objects`, and they use no `<include>` - return byte-identical object lists before and after.

## Tests

`tests/simulation/isaac/test_mjcf_bodies_are_model_global.py`, 31 cases. `TestMuJoCoAgreesOnTheModelsBodies` compares the loader's top-level body names against MuJoCo's own (the bodies whose parent is the world), so the expectations are derived from the compiler rather than restated, and every fixture is a model MuJoCo compiles.

Pre-fix split against `upstream/main`: **19 failed / 12 passed**. All 19 failures are in the two regression classes; the three control classes pass on both trees.

| break | fails | which |
| --- | --- | --- |
| control (no break) | 0 of 31 | - |
| `git checkout upstream/main -- loaders.py` | 19 | the full regression set |
| `load_mjcf` reads the top file only | 13 | the `load_mjcf` half + the guard-verdict test + the oracle |
| `load_mjcf_scene_objects` reads the top file only | **6** | the scene-loader half only |
| only the FIRST `<worldbody>` is read | 7 | the two-worldbody cases only |
| the flag derived from the bodies, not the `<worldbody>` elements | **2** | both phantom-guard tests, including the top-file-only control |
| document order not preserved | 3 | the order-sensitive cases only |
| the `<include>` cycle guard removed | **1** | the cycle test only (5.07s vs 0.29s: recursion) |

The two loader breaks are complementary (13 + 6 = 19), which is what shows each loader is independently pinned. The flag break firing a control that passes on both trees is what shows the flag keeps the two refusals distinguishable.

## Verification

Measured at `c3987ed6`, on `mujoco 3.12.0` (the version CI resolves under `mujoco>=3.5.0,<4.0.0`). The head has since moved to `235b6167`, which adds only the changelog fragment (`git diff c3987ed6..235b6167 -- '*.py'` is empty).

- Identical 187-file selection on both trees with the new test file excluded from each (`tests/simulation`, `tests/simulation/isaac`, everything naming the loaders, plus the repo-wide source/docstring guards): **`7630 passed, 66 skipped` byte-identical**, 330.70s vs 330.69s, zero failures on either side.
- New file: 31 passed on `mujoco 3.12.0` and on `3.5.0` (the declared floor).
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 == 24 against a pristine `upstream/main` worktree, none in the changed files.

## Artifact

Each panel is what `load_mjcf` RETURNED, realized: one proxy box per reported `BodyDef`, at its reported pose, nested per its reported parent -> child edges. Same three registry assets in both columns; only `strands_robots` differs.

![loader bodies before and after](https://raw.githubusercontent.com/cagataycali/robots/media-isaac-mjcf-bodies-32662150967/isaac-mjcf-bodies.png)

Controls, asserted from the captured data inside the figure script: `aloha/aloha.xml` is identical in both columns (21 bodies, 16 joints, renders agreeing to 0.000000 mean level), and on this branch `aloha/scene.xml` renders BYTE-IDENTICALLY to `aloha/aloha.xml` - one robot, two spellings, one answer.

---

### Round 2 - description only

No code change: the diff and the head commit are untouched, so the approval stands on exactly the tree it was given for. Added the closing link to #2668, the defect issue this fixes, which was missing - without it this PR would have merged carrying neither a closing link nor a board item, which is the coverage gap #1961 tracks.
