### PR TITLE
fix(isaac): read a geom's shape from the <default> class it inherits

### DIFF
--- a/changelog.d/2669-isaac-mjcf-default-class-geometry.md
+++ b/changelog.d/2669-isaac-mjcf-default-class-geometry.md
@@ -1,0 +1,9 @@
+### Fixed: a geom's shape is read from the `<default>` class it inherits
+
+MJCF lets a `<geom>` spell almost nothing itself. `<default class="X">` supplies every attribute the element omits, `<body childclass="X">` names that class for a whole subtree, and the classes form an inheritance tree rooted at the unnamed top-level `<default>`. So `type`, `size` and `fromto` - the three attributes that decide what shape a geom is - need not be on the geom at all.
+
+Both MJCF readers in the Isaac loaders asked the element directly, so they saw only the half a geom spells itself. `asimov_v0`'s six leg links reported the 0.05 m fallback box for capsules whose `<default class="body_capsule">` declares `type="capsule" size="0.05"` over a 0.25 m `fromto` segment: a 10 cm cube for a 25 cm shin, on a shipped registry robot, under `load_mjcf` reporting success. The `abh_*` hands are the extreme form, where every geom is `<geom class="X"/>` and the class carries the mesh name, so the reader saw a four-geom body declaring no mesh at all.
+
+One rule now answers what a geom declared, for every reader: the geom's own class, else the nearest enclosing `childclass`, else the root class, overridden by whatever the element spells itself. Classes are model-global through `<include>`, the same splice `<compiler>` and `<asset>` already get.
+
+Measured over 660 MJCFs with MuJoCo's own compiled geoms as the oracle: 12 files change on the robot reader, all box to capsule or cylinder corrections; 66 change on the scene-object reader, 58 of them collision-proxy corrections and 8 that now refuse. Those 8 are `ability_hand_api` models MuJoCo itself refuses, where resolving the class-declared mesh name lets the fail-loud contract see a missing asset instead of silently emitting a box proxy. LIBERO is unchanged on both readers.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -407,6 +407,8 @@ def load_mjcf(path: str) -> ProceduralRobot:
     if worldbody is None:
         raise ValueError(f"MJCF loader: {path} has no <worldbody>")
 
+    geom_defaults = _mjcf_geom_defaults(root, os.path.dirname(os.path.abspath(path)))
+
     bodies: list[BodyDef] = []
     joints: list[JointDef] = []
 
@@ -422,7 +424,11 @@ def load_mjcf(path: str) -> ProceduralRobot:
         )
     )
 
-    def _walk(body_el: ET.Element, parent_idx: int) -> None:
+    def _walk(body_el: ET.Element, parent_idx: int, childclass: str) -> None:
+        # ``childclass`` is MJCF's per-subtree default class: it applies to every
+        # descendant that does not name a class of its own, and a nested body
+        # overrides it for its own subtree.
+        childclass = body_el.get("childclass") or childclass
         body_name = body_el.get("name") or f"body_{len(bodies)}"
         position = _parse_xyz(body_el.get("pos"))
 
@@ -434,7 +440,7 @@ def load_mjcf(path: str) -> ProceduralRobot:
             mass = _safe_float(inertial.get("mass"), 1.0)
 
         # Geometry - first <geom> primitive type.
-        shape, shape_size = _extract_mjcf_shape(body_el)
+        shape, shape_size = _extract_mjcf_shape(body_el, geom_defaults, childclass)
 
         bodies.append(
             BodyDef(
@@ -488,21 +494,26 @@ def load_mjcf(path: str) -> ProceduralRobot:
             )
 
         for child in body_el.findall("body"):
-            _walk(child, body_idx)
+            _walk(child, body_idx, childclass)
 
     top_bodies = list(worldbody.findall("body"))
     if not top_bodies:
         raise ValueError(f"MJCF loader: {path} <worldbody> has no <body> children (phantom robot guard)")
 
+    world_childclass = worldbody.get("childclass") or ""
     for body_el in top_bodies:
-        _walk(body_el, parent_idx=0)
+        _walk(body_el, parent_idx=0, childclass=world_childclass)
 
     robot = ProceduralRobot(name=model_name, bodies=bodies, joints=joints)
     _validate_kinematic_tree(robot)
     return robot
 
 
-def _extract_mjcf_shape(body_el: ET.Element) -> tuple[str, tuple[float, ...]]:
+def _extract_mjcf_shape(
+    body_el: ET.Element,
+    defaults: dict[str, dict[str, str]],
+    childclass: str,
+) -> tuple[str, tuple[float, ...]]:
     """Best-effort MJCF body -> (shape, shape_size) extraction from first <geom>.
 
     A capsule or cylinder may spell its axis extent with ``fromto`` instead of
@@ -519,12 +530,18 @@ def _extract_mjcf_shape(body_el: ET.Element) -> tuple[str, tuple[float, ...]]:
     rotated-box bound; those keep their existing default-box reading, matching
     the exclusion :func:`_geom_aabb` documents rather than asserting an
     approximation this does not compute.
+
+    All three attributes are read through :func:`_geom_attrs`, because a geom
+    need not spell any of them itself - ``<default>`` inheritance may supply
+    them, and a link whose class declares ``type="capsule"`` reads as the
+    fallback box if the element is asked directly.
     """
     geom = body_el.find("geom")
     if geom is None:
         return "box", (0.05, 0.05, 0.05)
-    gtype = geom.get("type", "box")
-    size_str = geom.get("size", "")
+    attrs = _geom_attrs(geom, defaults, childclass)
+    gtype = attrs.get("type", "box")
+    size_str = attrs.get("size", "")
     sizes: list[float] = []
     if size_str:
         try:
@@ -543,7 +560,7 @@ def _extract_mjcf_shape(body_el: ET.Element) -> tuple[str, tuple[float, ...]]:
         # MJCF size for capsule/cylinder is (radius, half-length) - but only
         # for the ``pos`` spelling. With ``fromto`` the endpoints carry the
         # length and ``size`` holds only the radius, so read them first.
-        segment = _parse_fromto(geom.get("fromto"))
+        segment = _parse_fromto(attrs.get("fromto"))
         if segment is not None:
             length = _segment_length(segment[0], segment[1])
             if length > 0.0:
@@ -916,6 +933,68 @@ def _mjcf_model_toplevel(root: ET.Element, base_dir: str, _seen: frozenset[str] 
     return out
 
 
+def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, str]]:
+    """Every ``<default>`` class's effective ``<geom>`` attributes, flattened.
+
+    MJCF's ``<default>`` elements form a tree: the unnamed top-level element is
+    the root class, a ``<default class="X">`` inherits its enclosing element's
+    attributes, and a ``<geom>`` takes its class's attributes for every
+    attribute it does not spell itself. So ``type``, ``size`` and ``fromto`` -
+    the three attributes that decide what shape a geom is - need not appear on
+    the geom at all. Read as the geom's own attributes alone, a link whose class
+    declares ``type="capsule" size="0.05"`` reports the default box however long
+    its ``fromto`` segment is, which also makes the endpoint reading
+    :func:`_extract_mjcf_shape` performs unreachable for it.
+
+    ``<default>`` is a top-level element, so it is model-global: the fragment
+    declaring a class need not be the fragment declaring the geom, and neither
+    need be the top file - the same splice :func:`_mjcf_model_toplevel` resolves
+    for ``<compiler>`` and ``<asset>``.
+
+    Returns a mapping from class name to that class's merged ``<geom>``
+    attributes, with the root class under ``""``. A class a geom names but no
+    ``<default>`` declares contributes nothing rather than failing the load:
+    MuJoCo refuses such a model itself, and naming the offending class is its
+    report to make.
+    """
+
+    def _geom_attrs_of(default_el: ET.Element) -> dict[str, str]:
+        geom_el = default_el.find("geom")
+        if geom_el is None:
+            return {}
+        return {k: v for k, v in geom_el.attrib.items() if k != "class"}
+
+    classes: dict[str, dict[str, str]] = {"": {}}
+
+    def _flatten(default_el: ET.Element, inherited: dict[str, str]) -> None:
+        merged = {**inherited, **_geom_attrs_of(default_el)}
+        classes[default_el.get("class", "")] = merged
+        for nested in default_el.findall("default"):
+            _flatten(nested, merged)
+
+    # A compilable model has exactly one top-level ``<default>`` - MuJoCo
+    # refuses a second ("top-level default class 'main' cannot be renamed") - so
+    # every class reachable from a spliced fragment is a descendant of one root,
+    # and a plain recursion from each is the whole tree.
+    for el in _mjcf_model_toplevel(root, base_dir):
+        if el.tag == "default":
+            _flatten(el, {})
+    return classes
+
+
+def _geom_attrs(geom: ET.Element, defaults: dict[str, dict[str, str]], childclass: str) -> dict[str, str]:
+    """A geom's effective attributes: its default class's, overridden by its own.
+
+    The class is the geom's own ``class``, else the nearest enclosing body's
+    ``childclass``, else the root class - MJCF's own precedence. Every geom
+    attribute this module reads goes through here so one rule answers "what did
+    this geom declare", rather than each reader asking the element directly and
+    seeing only half of it.
+    """
+    cls = geom.get("class") or childclass
+    return {**defaults.get(cls, {}), **geom.attrib}
+
+
 def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[str, tuple[float, float, float]]]:
     """Collect the model's ``<asset><mesh>`` registry: name -> (file path, scale).
 
@@ -963,6 +1042,8 @@ def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[
 
 def _find_body_mesh(
     body_el: ET.Element,
+    defaults: dict[str, dict[str, str]],
+    childclass: str,
     offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> tuple[str, tuple[float, float, float], tuple[float, float, float, float], bool] | None:
     """First mesh geom in a body subtree: ``(mesh name, body-frame pos, quat, is_visual)``.
@@ -976,16 +1057,23 @@ def _find_body_mesh(
     rotations are not composed - LIBERO's compiled object bodies do not
     rotate their nested visual bodies). Returns ``None`` when the subtree
     declares no mesh geom.
+
+    ``mesh``, ``pos``, ``quat`` and the ``group`` that decides visual-vs-
+    collision are read through :func:`_geom_attrs`, so a geom that inherits its
+    group from a ``<default class="visual">`` is preferred as MuJoCo reads it
+    rather than being taken for a collision geom.
     """
     first_any: tuple[str, tuple[float, float, float], tuple[float, float, float, float], bool] | None = None
+    childclass = body_el.get("childclass") or childclass
     for geom in body_el.findall("geom"):
-        mesh_name = geom.get("mesh")
+        attrs = _geom_attrs(geom, defaults, childclass)
+        mesh_name = attrs.get("mesh")
         if not mesh_name:
             continue
-        gpos = _parse_xyz(geom.get("pos"))
+        gpos = _parse_xyz(attrs.get("pos"))
         pos = (offset[0] + gpos[0], offset[1] + gpos[1], offset[2] + gpos[2])
-        quat = _parse_quat(geom.get("quat"))
-        is_visual = (geom.get("group") or "0") != "0"
+        quat = _parse_quat(attrs.get("quat"))
+        is_visual = (attrs.get("group") or "0") != "0"
         if is_visual:
             return (mesh_name, pos, quat, True)
         if first_any is None:
@@ -993,7 +1081,7 @@ def _find_body_mesh(
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
-        found = _find_body_mesh(child, new_off)
+        found = _find_body_mesh(child, defaults, childclass, new_off)
         if found is not None:
             if found[3]:
                 return found
@@ -1072,7 +1160,11 @@ def _segment_aabb(
     return center, half  # type: ignore[return-value]
 
 
-def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+def _geom_aabb(
+    geom: ET.Element,
+    defaults: dict[str, dict[str, str]],
+    childclass: str,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
     """Return ``(center, half_extent)`` AABB for a collision ``<geom>``.
 
     Handles MuJoCo's analytic primitives (box / sphere / cylinder /
@@ -1092,10 +1184,15 @@ def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[floa
     by copying the first ``size`` component and needs the rotated-box bound;
     those keep returning ``None`` (no analytic AABB) so the caller falls back
     rather than asserting an approximation this does not compute.
+
+    ``type``, ``pos``, ``size`` and ``fromto`` are read through
+    :func:`_geom_attrs`: MJCF's ``<default>`` classes may supply any of them, so
+    asking the element directly sees only the half the geom spells itself.
     """
-    gtype = geom.get("type", "sphere")
-    pos = _parse_xyz(geom.get("pos"))
-    size_str = geom.get("size", "")
+    attrs = _geom_attrs(geom, defaults, childclass)
+    gtype = attrs.get("type", "sphere")
+    pos = _parse_xyz(attrs.get("pos"))
+    size_str = attrs.get("size", "")
     try:
         sizes = [float(p) for p in size_str.replace(",", " ").split()] if size_str else []
     except (ValueError, TypeError):
@@ -1116,7 +1213,7 @@ def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[floa
         # MJCF spells these either as ``pos`` + ``size="radius half-length"``
         # along the geom's local z, or as ``fromto`` + ``size="radius"`` with
         # the endpoints carrying the placement and the axis extent.
-        segment = _parse_fromto(geom.get("fromto"))
+        segment = _parse_fromto(attrs.get("fromto"))
         if segment is not None:
             return _segment_aabb(gtype, segment[0], segment[1], sizes[0]) if sizes else None
         if len(sizes) >= 2:
@@ -1141,6 +1238,8 @@ def _geom_aabb(geom: ET.Element) -> tuple[tuple[float, float, float], tuple[floa
 
 def _body_collision_aabb(
     body_el: ET.Element,
+    defaults: dict[str, dict[str, str]],
+    childclass: str,
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
     """Compute the AABB (center, full-size) over a body's own geoms.
 
@@ -1155,9 +1254,10 @@ def _body_collision_aabb(
         maxs = [float("-inf")] * 3
         found = False
         for geom in body_el.findall("geom"):
-            if group_filter is not None and geom.get("group") != group_filter:
+            attrs = _geom_attrs(geom, defaults, childclass)
+            if group_filter is not None and attrs.get("group") != group_filter:
                 continue
-            aabb = _geom_aabb(geom)
+            aabb = _geom_aabb(geom, defaults, childclass)
             if aabb is None:
                 continue
             center, half = aabb
@@ -1176,6 +1276,8 @@ def _recursive_collision_aabb(
     body_el: ET.Element,
     offset: tuple[float, float, float],
     bounds: list[list[float]],
+    defaults: dict[str, dict[str, str]],
+    childclass: str,
 ) -> bool:
     """Fold this body's (and nested bodies') collision AABBs into ``bounds``.
 
@@ -1183,8 +1285,9 @@ def _recursive_collision_aabb(
     running body-frame offset from the top-level object body. Returns
     ``True`` if any analytic geometry was found in this subtree.
     """
+    childclass = body_el.get("childclass") or childclass
     found = False
-    aabb = _body_collision_aabb(body_el)
+    aabb = _body_collision_aabb(body_el, defaults, childclass)
     if aabb is not None:
         center, size = aabb
         for i in range(3):
@@ -1196,7 +1299,7 @@ def _recursive_collision_aabb(
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
-        found = _recursive_collision_aabb(child, new_off, bounds) or found
+        found = _recursive_collision_aabb(child, new_off, bounds, defaults, childclass) or found
     return found
 
 
@@ -1261,7 +1364,10 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
     if worldbody is None:
         raise ValueError(f"MJCF scene loader: {path} has no <worldbody>")
 
-    mesh_registry = _parse_mjcf_mesh_assets(root, os.path.dirname(os.path.abspath(path)))
+    mjcf_dir = os.path.dirname(os.path.abspath(path))
+    mesh_registry = _parse_mjcf_mesh_assets(root, mjcf_dir)
+    geom_defaults = _mjcf_geom_defaults(root, mjcf_dir)
+    world_childclass = worldbody.get("childclass") or ""
 
     objects: list[SceneObject] = []
     for body_el in worldbody.findall("body"):
@@ -1284,7 +1390,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         mesh_scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
         mesh_pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
         mesh_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
-        mesh_ref = _find_body_mesh(body_el)
+        mesh_ref = _find_body_mesh(body_el, geom_defaults, world_childclass)
         if mesh_ref is not None:
             mesh_name, mesh_pos, mesh_quat, _is_visual = mesh_ref
             asset = mesh_registry.get(mesh_name)
@@ -1314,7 +1420,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         # (e.g. ``living_room_table`` -> ``living_room_table_col``), folding
         # nested-body offsets into the AABB.
         bounds = [[float("inf")] * 3, [float("-inf")] * 3]
-        found = _recursive_collision_aabb(body_el, (0.0, 0.0, 0.0), bounds)
+        found = _recursive_collision_aabb(body_el, (0.0, 0.0, 0.0), bounds, geom_defaults, world_childclass)
         mins, maxs = bounds[0], bounds[1]
 
         if found:

--- a/tests/simulation/isaac/test_mjcf_default_class_geometry.py
+++ b/tests/simulation/isaac/test_mjcf_default_class_geometry.py
@@ -1,0 +1,368 @@
+"""A geom's shape is read from the ``<default>`` class it inherits.
+
+MJCF lets a ``<geom>`` spell almost nothing itself: ``<default class="X">``
+supplies every attribute the element omits, ``<body childclass="X">`` names that
+class for a whole subtree, and the classes form an inheritance tree rooted at
+the unnamed top-level ``<default>``. So ``type``, ``size`` and ``fromto`` - the
+three attributes that decide what shape a geom is - need not be on the geom.
+
+Read as the geom's own attributes alone, ``asimov_v0``'s six leg links report the
+0.05 m fallback box for capsules whose ``<default class="body_capsule">``
+declares ``type="capsule" size="0.05"`` and whose ``fromto`` runs 0.25 m: a 10 cm
+cube for a 25 cm shin, on a shipped registry robot, under ``load_mjcf`` reporting
+success. It also makes the endpoint reading ``_extract_mjcf_shape`` performs
+unreachable for exactly those links, because that branch is only taken once the
+geom is known to be a capsule or a cylinder.
+
+MuJoCo is the oracle throughout: every expected shape here is read back off a
+compiled ``MjModel`` rather than restated, so a fixture that is not a model
+MuJoCo compiles cannot silently become the contract.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac import loaders as mod
+from strands_robots.simulation.isaac.loaders import load_mjcf, load_mjcf_scene_objects
+
+mujoco = pytest.importorskip("mujoco")
+
+_GEOM_TYPE_NAMES = {
+    int(mujoco.mjtGeom.mjGEOM_PLANE): "plane",
+    int(mujoco.mjtGeom.mjGEOM_SPHERE): "sphere",
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE): "capsule",
+    int(mujoco.mjtGeom.mjGEOM_ELLIPSOID): "ellipsoid",
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER): "cylinder",
+    int(mujoco.mjtGeom.mjGEOM_BOX): "box",
+    int(mujoco.mjtGeom.mjGEOM_MESH): "mesh",
+}
+
+
+def _compiled_geom(path, geom_name):
+    """MuJoCo's own ``(type, size)`` for a named geom - the oracle."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"premise: MuJoCo compiled no geom named {geom_name!r}"
+    # int(): a pybind11 enum does not match a numpy integer as a dict key.
+    return _GEOM_TYPE_NAMES[int(model.geom_type[gid])], tuple(float(x) for x in model.geom_size[gid])
+
+
+def _write(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# The asimov_v0 shape: the class carries the type and the radius, the geom
+# carries only the endpoints.
+_CLASS_CAPSULE = """<mujoco model="m">
+  <default>
+    <default class="collision"><geom group="3" type="capsule"/></default>
+    <default class="body_capsule"><geom type="capsule" size="0.05"/></default>
+  </default>
+  <worldbody>
+    <body name="shin" pos="0 0 1">
+      <joint name="knee" type="hinge" axis="0 1 0"/>
+      <geom name="shin_col" class="body_capsule" fromto="0 0 0 0 0 -0.25"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class TestAClassDeclaredShapeIsTheShape:
+    """The regression: an attribute the geom inherits decides its shape."""
+
+    def test_a_class_declared_capsule_is_read_as_a_capsule(self, tmp_path):
+        path = _write(tmp_path, "shin.xml", _CLASS_CAPSULE)
+        true_type, true_size = _compiled_geom(path, "shin_col")
+        assert true_type == "capsule", "premise: MuJoCo reads the class's type"
+
+        robot = load_mjcf(str(path))
+        shin = next(b for b in robot.bodies if b.name == "shin")
+        assert shin.shape == true_type, (
+            f"the geom inherits type='capsule' from <default class='body_capsule'> and the loader "
+            f"reported {shin.shape!r} with size {shin.shape_size}, the fallback box, for a 0.25 m segment"
+        )
+        # MuJoCo's capsule size is (radius, half-length).
+        assert shin.shape_size == pytest.approx((true_size[0], true_size[1]), abs=1e-9)
+
+    def test_childclass_supplies_the_class_for_a_whole_subtree(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "cc.xml",
+            """<mujoco model="m">
+  <default><default class="link"><geom type="cylinder" size="0.02 0.11"/></default></default>
+  <worldbody>
+    <body name="upper" childclass="link" pos="0 0 1">
+      <joint name="j0" type="hinge" axis="0 1 0"/>
+      <geom name="upper_g"/>
+      <body name="lower" pos="0 0 -0.3">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom name="lower_g"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "lower_g")[0] == "cylinder", "premise"
+        robot = load_mjcf(str(path))
+        for name in ("upper", "lower"):
+            body = next(b for b in robot.bodies if b.name == name)
+            assert body.shape == "cylinder", f"{name} did not inherit childclass='link' ({body.shape})"
+            assert body.shape_size == pytest.approx((0.02, 0.11 + 0.0), abs=1e-9)
+
+    def test_a_nested_class_inherits_its_enclosing_classs_attributes(self, tmp_path):
+        # ``inner`` declares only the size; the type comes from ``outer``.
+        path = _write(
+            tmp_path,
+            "nested.xml",
+            """<mujoco model="m">
+  <default>
+    <default class="outer"><geom type="capsule"/>
+      <default class="inner"><geom size="0.03 0.09"/></default>
+    </default>
+  </default>
+  <worldbody>
+    <body name="seg" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="seg_g" class="inner"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "seg_g")[0] == "capsule", "premise"
+        seg = next(b for b in load_mjcf(str(path)).bodies if b.name == "seg")
+        assert seg.shape == "capsule", f"the nested class did not inherit type from its parent ({seg.shape})"
+
+    def test_the_unnamed_root_default_supplies_an_unclassed_geom(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "root.xml",
+            """<mujoco model="m">
+  <default><geom type="sphere" size="0.04"/></default>
+  <worldbody>
+    <body name="ball" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="ball_g"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        true_type, true_size = _compiled_geom(path, "ball_g")
+        assert true_type == "sphere", "premise"
+        ball = next(b for b in load_mjcf(str(path)).bodies if b.name == "ball")
+        assert ball.shape == "sphere", f"the root <default> was not read ({ball.shape})"
+        # The reader spells a sphere ``(radius,)``; MuJoCo pads its size triple.
+        assert ball.shape_size == pytest.approx((true_size[0],), abs=1e-9)
+
+    def test_a_nested_body_childclass_overrides_the_outer_one(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "cc2.xml",
+            """<mujoco model="m">
+  <default>
+    <default class="outer"><geom type="capsule" size="0.05 0.10"/></default>
+    <default class="inner"><geom type="box" size="0.01 0.02 0.03"/></default>
+  </default>
+  <worldbody>
+    <body name="a" childclass="outer" pos="0 0 1">
+      <joint name="j0" type="hinge" axis="0 1 0"/>
+      <geom name="ag"/>
+      <body name="b" childclass="inner" pos="0 0 -0.2">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom name="bg"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "ag")[0] == "capsule", "premise"
+        assert _compiled_geom(path, "bg")[0] == "box", "premise"
+        bodies = {x.name: x for x in load_mjcf(str(path)).bodies}
+        assert bodies["a"].shape == "capsule"
+        assert bodies["b"].shape == "box", "the inner childclass did not override the outer one"
+
+    def test_a_class_declared_in_an_include_fragment_is_model_global(self, tmp_path):
+        # ``<default>`` is a top-level element, so a spliced fragment declares it
+        # for the whole model - the same splice <compiler> and <asset> get.
+        (tmp_path / "frag.xml").write_text(
+            """<mujoco>
+  <default><default class="rod"><geom type="capsule" size="0.01 0.07"/></default></default>
+</mujoco>
+""",
+            encoding="utf-8",
+        )
+        path = _write(
+            tmp_path,
+            "top.xml",
+            """<mujoco model="m">
+  <include file="frag.xml"/>
+  <worldbody>
+    <body name="rod" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="rod_g" class="rod"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "rod_g")[0] == "capsule", "premise: MuJoCo splices the fragment"
+        rod = next(b for b in load_mjcf(str(path)).bodies if b.name == "rod")
+        assert rod.shape == "capsule", f"a class from an <include> fragment was not read ({rod.shape})"
+
+
+class TestTheSceneObjectReaderReadsTheClassToo:
+    """The same rule in the collision-proxy reader, and in mesh selection."""
+
+    def test_a_scene_object_proxy_reads_a_class_declared_box(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "scene.xml",
+            """<mujoco model="s">
+  <default><default class="fixture"><geom type="box" size="0.30 0.20 0.02" group="0"/></default></default>
+  <worldbody>
+    <body name="shelf" pos="0.5 0 0.4"><geom name="shelf_g" class="fixture"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "shelf_g")[0] == "box", "premise"
+        shelf = next(o for o in load_mjcf_scene_objects(str(path)) if o.name == "shelf")
+        # 0.60 x 0.40 x 0.04 full extent, not the mesh-less fallback.
+        assert shelf.size == pytest.approx((0.60, 0.40, 0.04), abs=1e-6), (
+            f"the proxy for a class-declared box came back {shelf.size}"
+        )
+
+    def test_a_mesh_named_only_by_a_class_is_found(self, tmp_path):
+        # The abh_* hands' shape: every geom is ``<geom class="X"/>`` and the
+        # class carries the mesh name, so asking the element sees no mesh at all.
+        (tmp_path / "m.obj").write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nv 0 0 1\nf 1 2 3\n", encoding="utf-8")
+        path = _write(
+            tmp_path,
+            "meshscene.xml",
+            """<mujoco model="s">
+  <asset><mesh name="widget" file="m.obj"/></asset>
+  <default><default class="vis"><geom type="mesh" mesh="widget" group="2"/></default></default>
+  <worldbody>
+    <body name="widget" pos="0.4 0 0.1"><geom name="widget_g" class="vis"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        widget = next(o for o in load_mjcf_scene_objects(str(path)) if o.name == "widget")
+        assert widget.mesh_path is not None, "a mesh named only by its <default> class was not found"
+        assert widget.mesh_path.endswith("m.obj")
+
+
+class TestThePrecedenceMJCFDefines:
+    """Controls. Both hold on ``upstream/main`` too: they pin that resolving a
+    class does not displace what the geom spells itself, and that a model with
+    no ``<default>`` at all is read exactly as before. Each fails for one of the
+    tempting shortcuts - letting the class win over the element, or making the
+    resolver's answer mandatory where there is nothing to resolve.
+    """
+
+    def test_a_geoms_own_attribute_overrides_its_class(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "override.xml",
+            """<mujoco model="m">
+  <default><default class="c"><geom type="capsule" size="0.05 0.10"/></default></default>
+  <worldbody>
+    <body name="b" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="g" class="c" type="box" size="0.01 0.02 0.03"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "g")[0] == "box", "premise: the geom's own type wins"
+        b = next(x for x in load_mjcf(str(path)).bodies if x.name == "b")
+        assert b.shape == "box"
+        assert b.shape_size == pytest.approx((0.01, 0.02, 0.03), abs=1e-9)
+
+    def test_a_model_with_no_defaults_is_read_exactly_as_before(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "plain.xml",
+            """<mujoco model="m">
+  <worldbody>
+    <body name="b" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="g" type="capsule" size="0.02 0.08"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        b = next(x for x in load_mjcf(str(path)).bodies if x.name == "b")
+        assert (b.shape, b.shape_size) == ("capsule", pytest.approx((0.02, 0.08), abs=1e-9))
+
+
+class TestOneRuleAnswersWhatAGeomDeclared:
+    """One rule answers "what did this geom declare", for every reader.
+
+    A reader that asks the element directly sees only the half the geom spells
+    itself, which is how the two shape readers came to disagree with MuJoCo. The
+    scan is derived from the module rather than a list of names, so a fifth
+    reader is held to the rule on arrival.
+    """
+
+    def test_every_geom_attribute_read_goes_through_the_resolver(self):
+        tree = ast.parse(inspect.getsource(mod))
+        offenders = []
+        scanned = 0
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef) or fn.name == "_geom_attrs":
+                continue
+            scanned += 1
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Call):
+                    continue
+                f = node.func
+                if (
+                    isinstance(f, ast.Attribute)
+                    and f.attr == "get"
+                    and isinstance(f.value, ast.Name)
+                    and f.value.id.startswith("geom")
+                ):
+                    offenders.append(f"{fn.name}:{node.lineno} {ast.unparse(node)}")
+        # A scan that reached nothing would report clean forever.
+        assert scanned >= 20, f"the scan reached only {scanned} functions in the module"
+        assert not offenders, (
+            "these read a geom attribute off the element, so a value its <default> class supplies "
+            f"is invisible to them: {offenders}"
+        )
+
+    def test_an_undeclared_class_contributes_nothing(self, tmp_path):
+        # MuJoCo refuses such a model itself, so naming the offending class is
+        # its report to make; the reader must not fail the load over it.
+        from strands_robots.simulation.isaac.loaders import _geom_attrs, _mjcf_geom_defaults
+
+        root = ET.fromstring(
+            '<mujoco><worldbody><body name="b"><geom name="g" class="nope"/></body></worldbody></mujoco>'
+        )
+        defaults = _mjcf_geom_defaults(root, str(tmp_path))
+        geom = root.find(".//geom")
+        assert geom is not None
+        assert _geom_attrs(geom, defaults, "") == {"name": "g", "class": "nope"}
+
+    def test_the_scan_reaches_the_readers_it_grades(self):
+        # A scan that reaches nothing would report clean forever.
+        src = inspect.getsource(mod)
+        for name in ("_extract_mjcf_shape", "_geom_aabb", "_body_collision_aabb", "_find_body_mesh"):
+            assert f"def {name}(" in src, f"premise: {name} is no longer in the scanned module"
+            assert "_geom_attrs(" in inspect.getsource(getattr(mod, name)), (
+                f"{name} does not resolve its geom attributes through the shared rule"
+            )


### PR DESCRIPTION
## Problem

MJCF lets a `<geom>` spell almost nothing itself. `<default class="X">` supplies every attribute the element omits, `<body childclass="X">` names that class for a whole subtree, and the classes form an inheritance tree rooted at the unnamed top-level `<default>`. So `type`, `size` and `fromto` - the three attributes that decide what shape a geom is - need not be on the geom at all.

Both MJCF readers in `simulation/isaac/loaders.py` asked the element directly, so they saw only the half a geom spells itself. `asimov_v0`, a shipped registry robot, declares its leg links this way:

```xml
<default class="body_capsule"><geom type="capsule" size="0.05"/></default>
...
<geom class="body_capsule" fromto="0 0 0 0 0 -0.25"/>
```

Read as the geom's own attributes alone, that geom has no `type` and a one-component `size`, so `_extract_mjcf_shape` fell through to its `box (0.05, 0.05, 0.05)` fallback: a 10 cm cube for a 25 cm shin, on six links, under `load_mjcf` reporting success. It also made the endpoint reading that same function performs unreachable for exactly those links, because that branch is only taken once the geom is known to be a capsule or a cylinder.

The `abh_*` hands are the extreme form. Every geom there is `<geom class="X"/>` - attribute-free apart from the class - so `_find_body_mesh` saw a four-geom body declaring no mesh at all, and nine finger segments of 7 mm radius reported as 10 cm cubes.

| link | MuJoCo's compiled geom | reported before |
| --- | --- | --- |
| `left_knee_link` | capsule, half-length 0.125 m | box, 0.05 m half-extent |
| `left_hip_pitch_link` | capsule, half-length 0.035355 m | box, 0.05 m half-extent |
| `left_hip_yaw_link` | capsule, half-length 0.02 m | box, 0.05 m half-extent |

## Change

`_mjcf_geom_defaults` flattens the class tree, and `_geom_attrs` answers "what did this geom declare" once, for every reader: the geom's own `class`, else the nearest enclosing `childclass`, else the root class, overridden by whatever the element spells itself. All twelve geom attribute reads in the module now go through it, so no reader is left asking the element.

Three properties are inherited from MJCF rather than invented:

- **The geom wins.** An attribute the element spells itself overrides the class, so resolving a class never displaces what a geom says.
- **The classes are model-global.** `<default>` is a top-level element, so a spliced `<include>` fragment declares classes for the whole model - the same splice `<compiler>` and `<asset>` already get here.
- **One root.** MuJoCo refuses a second top-level `<default>` ("top-level default class 'main' cannot be renamed"), so the tree is one recursion from one root.

An undeclared class contributes nothing rather than failing the load: MuJoCo refuses such a model itself and names the offending class, so that report is its to make.

## Blast radius

Measured over 660 MJCFs (the downloaded registry assets plus every LIBERO scene), with MuJoCo's own compiled geoms as the oracle:

| reader | files changed | what changed |
| --- | --- | --- |
| `load_mjcf` | 12 | all box -> capsule/cylinder corrections; no verdict changes |
| `load_mjcf_scene_objects` | 66 | 58 collision-proxy corrections, 8 that now refuse |
| LIBERO subset (109 files) | 0 | unchanged on both readers |

The 8 that now refuse are all `ability_hand_api` models, and **MuJoCo itself refuses all 8** - their `assets/` directory is absent (`Error opening file 'assets/FB_palm_ref.STL'`). Resolving the class-declared mesh name is what lets the fail-loud contract from #2459 see a missing asset there instead of silently emitting a box proxy, so the loader now agrees with MuJoCo that those files are broken. That is a genuine verdict change and the only one in the sweep.

## Visual

![default-class geometry](https://raw.githubusercontent.com/cagataycali/robots/media-mjcf-default-class/default-class-geometry.png)

Each panel renders the proxy geometry `load_mjcf` **returned** for the same three `asimov_v0` links, at the reported positions, headless with `MUJOCO_GL=egl`. The right panel is built from `model.geom_size` on the compiled model.

This branch's render is **byte-identical** to MuJoCo's (`np.array_equal` is `True`, mean absolute level difference `0.000000`). `upstream/main` is 13.62 mean levels away, with 15190 proxy pixels against 6597 - 2.3x the area.

## Tests

`tests/simulation/isaac/test_mjcf_default_class_geometry.py`, 13 cases, every expected shape read back off a compiled `MjModel` rather than restated. Pre-fix split against `upstream/main`: **11 failed / 2 passed**, all 11 in the regression and rule classes and none in the controls.

| break | fires |
| --- | --- |
| `git checkout upstream/main -- loaders.py` | 11, the full regression set |
| `childclass` ignored | 2, both `childclass` cases |
| a nested class does not inherit its parent | 1 |
| `<default>` read from the top file only | 1, the `<include>` case |
| the class wins over the geom's own attributes | 1, the precedence control alone |
| only the shape readers resolve; mesh and group left raw | 3, the mesh case and both rule tests |
| the AST scan reaches nothing | 1, the rule's own non-vacuity clause |
| control | 0 of 13 |

The two controls hold on `upstream/main` too - they pin that resolving a class does not displace what the geom spells itself, and that a model with no `<default>` at all is read exactly as before.

While writing the break table, the break aimed at the root class did not fire, which showed the pre-seed it broke was dead code: with one top-level `<default>` guaranteed, the recursion already populates the root class. It is removed, and the corpus sweep is byte-identical without it.

## Verification

Measured at `6b634f6`, mujoco 3.12.0. The head has since moved to `1863b46`, which adds only the changelog fragment (`git diff 6b634f6..1863b46 -- '*.py'` is empty).

| tree | result |
| --- | --- |
| this branch | `1 failed, 3106 passed, 64 skipped` |
| `upstream/main` | `1 failed, 3106 passed, 64 skipped` |

90-file selection (everything naming the loaders, the scene-object and robot readers, the LIBERO adapter, plus the repo-wide guards), identical on both trees with the new test file excluded from each. Failing-ID sets identical, branch-only and base-only both empty. The one shared failure is `test_declared_qp_backends_are_real_qpsolvers_extras`: `qpsolvers` is absent from this venv and is declared in `[sim-mujoco]` and `[cosmos3-sim]`, so CI installs it.

The new file: 13 passed on mujoco 3.12.0 and on 3.5.0, the declared floor. `ruff check` and `ruff format --check` clean; `mypy strands_robots tests tests_integ` 24 errors on both trees, branch-only empty.

## Rebased onto a moved base

`main` gained #2667 in the same file, so the head is now `e79093d`. Both new functions land at the same insertion point and both are kept. #2667 replaced the single `<worldbody>` element with a flattened body list, so the `childclass` read becomes per-body - a spliced model may carry several `<worldbody>` elements and they need not name the same class, which the previous single-element read could not express.

Re-measured on the merged tree: the pre-fix split against the new base is unchanged at **11 failed / 2 passed**, all 11 in the regression and rule classes; `tests/simulation/isaac/` is **1059 passed, 35 skipped**, covering this change, #2667's and #2662's together; `ruff check` and `ruff format --check` clean.