### PR TITLE
fix(isaac): read the root <default> class under both of its spellings

### DIFF
--- a/changelog.d/2672-isaac-mjcf-root-default-class-spellings.md
+++ b/changelog.d/2672-isaac-mjcf-root-default-class-spellings.md
@@ -1,0 +1,7 @@
+### Fixed: the root `<default>` class is read under both of its spellings
+
+MJCF's root default class has two spellings and one identity: MuJoCo names the root `main` and refuses to let a model rename it, so a file may leave its top-level `<default>` unnamed or write `class="main"` and mean the same class. A geom reaches that class by either name, or by naming no class at all.
+
+The Isaac loaders' default-class resolver keyed the root on whichever spelling the file used, so every geom arriving by the other one resolved to nothing and fell through to the `box (0.05, 0.05, 0.05)` fallback. In one direction that is an unnamed root plus `<geom class="main"/>`. In the other it is the whole model, and it is what shipped assets do: Menagerie's `pal_tiago_dual` writes `<default class="main">` declaring `type="mesh" group="1"` and gives none of its 46 geoms a class, so 34 of them - the ones carrying no `type` or `fromto` of their own - reported a 10 cm cube for a mesh under `load_mjcf` reporting success. `group` is read through the same resolver, so group filtering was wrong for all 46.
+
+The root is now registered under both keys, which cannot shadow a distinct class: MuJoCo refuses a nested `class="main"` ("repeated default class name") and a nested unnamed `<default>` ("empty class name"). Both refusals are asserted alongside the fix, so the justification for aliasing is pinned rather than remembered.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -949,15 +949,16 @@ _MJCF_ROOT_DEFAULT_CLASS = "main"
 def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, str]]:
     """Every ``<default>`` class's effective ``<geom>`` attributes, flattened.
 
-    MJCF's ``<default>`` elements form a tree: the unnamed top-level element is
-    the root class, a ``<default class="X">`` inherits its enclosing element's
-    attributes, and a ``<geom>`` takes its class's attributes for every
-    attribute it does not spell itself. So ``type``, ``size`` and ``fromto`` -
-    the three attributes that decide what shape a geom is - need not appear on
-    the geom at all. Read as the geom's own attributes alone, a link whose class
-    declares ``type="capsule" size="0.05"`` reports the default box however long
-    its ``fromto`` segment is, which also makes the endpoint reading
-    :func:`_extract_mjcf_shape` performs unreachable for it.
+    MJCF's ``<default>`` elements form a tree: the top-level element is the
+    root class whether or not it names itself, a nested ``<default class="X">``
+    inherits its enclosing element's attributes, and a ``<geom>`` takes its
+    class's attributes for every attribute it does not spell itself. So
+    ``type``, ``size`` and ``fromto`` - the three attributes that decide what
+    shape a geom is - need not appear on the geom at all. Read as the geom's
+    own attributes alone, a link whose class declares ``type="capsule"
+    size="0.05"`` reports the default box however long its ``fromto`` segment
+    is, which also makes the endpoint reading :func:`_extract_mjcf_shape`
+    performs unreachable for it.
 
     ``<default>`` is a top-level element, so it is model-global: the fragment
     declaring a class need not be the fragment declaring the geom, and neither

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -940,6 +940,12 @@ def _mjcf_model_toplevel(root: ET.Element, base_dir: str, _seen: frozenset[str] 
     return out
 
 
+# MJCF's implicit root default class. MuJoCo names it and will not let a model
+# rename it, so this is the one spelling a file can use for the root besides
+# leaving the top-level ``<default>`` unnamed.
+_MJCF_ROOT_DEFAULT_CLASS = "main"
+
+
 def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, str]]:
     """Every ``<default>`` class's effective ``<geom>`` attributes, flattened.
 
@@ -959,10 +965,10 @@ def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, 
     for ``<compiler>`` and ``<asset>``.
 
     Returns a mapping from class name to that class's merged ``<geom>``
-    attributes, with the root class under ``""``. A class a geom names but no
-    ``<default>`` declares contributes nothing rather than failing the load:
-    MuJoCo refuses such a model itself, and naming the offending class is its
-    report to make.
+    attributes, with the root class under both of the spellings that reach it -
+    ``""`` and ``"main"``. A class a geom names but no ``<default>`` declares
+    contributes nothing rather than failing the load: MuJoCo refuses such a
+    model itself, and naming the offending class is its report to make.
     """
 
     def _geom_attrs_of(default_el: ET.Element) -> dict[str, str]:
@@ -971,21 +977,36 @@ def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, 
             return {}
         return {k: v for k, v in geom_el.attrib.items() if k != "class"}
 
-    classes: dict[str, dict[str, str]] = {"": {}}
+    classes: dict[str, dict[str, str]] = {"": {}, _MJCF_ROOT_DEFAULT_CLASS: {}}
 
-    def _flatten(default_el: ET.Element, inherited: dict[str, str]) -> None:
+    def _flatten(default_el: ET.Element, inherited: dict[str, str]) -> dict[str, str]:
         merged = {**inherited, **_geom_attrs_of(default_el)}
         classes[default_el.get("class", "")] = merged
         for nested in default_el.findall("default"):
             _flatten(nested, merged)
+        return merged
 
-    # A compilable model has exactly one top-level ``<default>`` - MuJoCo
-    # refuses a second ("top-level default class 'main' cannot be renamed") - so
-    # every class reachable from a spliced fragment is a descendant of one root,
-    # and a plain recursion from each is the whole tree.
     for el in _mjcf_model_toplevel(root, base_dir):
         if el.tag == "default":
-            _flatten(el, {})
+            # A top-level ``<default>`` is the root class under either of two
+            # spellings: MuJoCo names it ``main`` and refuses to let it be
+            # renamed ("top-level default class 'main' cannot be renamed"), so a
+            # file may leave it unnamed or write ``class="main"`` and mean the
+            # same class. A geom reaches it by the same two names, plus by
+            # naming no class at all. Keying it on whichever spelling the file
+            # used loses every geom that arrives by the other one - which is the
+            # whole model when the two disagree, and they disagree in shipped
+            # assets: Menagerie's ``pal_tiago_dual`` writes ``class="main"`` and
+            # gives none of its 46 geoms a class, so 34 of them report the
+            # fallback box for the ``type="mesh"`` that class declares.
+            #
+            # Registering both spellings cannot shadow a different class,
+            # because neither name is available to one: MuJoCo refuses a nested
+            # ``class="main"`` ("repeated default class name") and a nested
+            # unnamed ``<default>`` ("empty class name").
+            root_attrs = _flatten(el, {})
+            classes[""] = root_attrs
+            classes[_MJCF_ROOT_DEFAULT_CLASS] = root_attrs
     return classes
 
 

--- a/tests/simulation/isaac/test_mjcf_root_default_class_spellings.py
+++ b/tests/simulation/isaac/test_mjcf_root_default_class_spellings.py
@@ -1,0 +1,313 @@
+"""MJCF's root default class is one class under two spellings, and both reach it.
+
+A model's top-level ``<default>`` may be written unnamed or as
+``<default class="main">``, and those are the same class: MuJoCo names the root
+``main`` and refuses to let a model rename it ("top-level default class 'main'
+cannot be renamed"), so those two spellings are the only ones a file has. A geom
+reaches that class by the same two names - its own ``class="main"``, an enclosing
+body's ``childclass="main"`` - or by naming no class at all.
+
+Keyed on whichever spelling the file happened to use, the resolver loses every
+geom that arrives by the other one. In one direction that is the gap noted when
+:func:`_mjcf_geom_defaults` landed: an unnamed root plus ``<geom class="main"/>``.
+In the other it is the whole model, and it is what shipped assets actually do -
+Menagerie's ``pal_tiago_dual`` writes ``<default class="main">`` declaring
+``type="mesh" group="1"`` and gives none of its 46 geoms a ``class``, so 34 of
+them (the ones carrying no ``type`` or ``fromto`` of their own) reported the
+0.05 m fallback box for a mesh, under ``load_mjcf`` reporting success.
+
+MuJoCo is the oracle throughout: every expected shape is read back off a compiled
+``MjModel`` rather than restated. The refusals that make aliasing safe - a nested
+class cannot be named ``main``, and cannot be unnamed - are asserted here too, so
+the justification is pinned rather than remembered.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac import loaders as mod
+from strands_robots.simulation.isaac.loaders import load_mjcf, load_mjcf_scene_objects
+
+mujoco = pytest.importorskip("mujoco")
+
+_GEOM_TYPE_NAMES = {
+    int(mujoco.mjtGeom.mjGEOM_SPHERE): "sphere",
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE): "capsule",
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER): "cylinder",
+    int(mujoco.mjtGeom.mjGEOM_BOX): "box",
+    int(mujoco.mjtGeom.mjGEOM_MESH): "mesh",
+}
+
+
+def _write(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _compiled_geom(path, geom_name):
+    """MuJoCo's own ``(type, size)`` for a named geom - the oracle."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"premise: MuJoCo compiled no geom named {geom_name!r}"
+    # int(): a pybind11 enum does not match a numpy integer as a dict key.
+    return _GEOM_TYPE_NAMES[int(model.geom_type[gid])], tuple(float(x) for x in model.geom_size[gid])
+
+
+def _body(path, name):
+    return next(b for b in load_mjcf(str(path)).bodies if b.name == name)
+
+
+# The root class carries the shape; the geom carries nothing but its name. The
+# two files differ only in whether the root ``<default>`` spells its own name,
+# which MJCF says is the same class either way.
+_ROOT_SHAPE = '<geom type="capsule" size="0.06 0.21"/>'
+_UNNAMED_ROOT = f"""<mujoco model="m">
+  <default>{_ROOT_SHAPE}</default>
+  <worldbody>
+    <body name="seg" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="seg_g" class="main"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+_NAMED_ROOT = f"""<mujoco model="m">
+  <default class="main">{_ROOT_SHAPE}</default>
+  <worldbody>
+    <body name="seg" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="seg_g"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class TestTheRootClassAnswersToBothOfItsSpellings:
+    """The regression: the root class is reached by either name, and by neither."""
+
+    def test_a_named_root_supplies_a_geom_that_names_no_class(self, tmp_path):
+        """The shipped-asset case: every geom in the model omits ``class``."""
+        path = _write(tmp_path, "named.xml", _NAMED_ROOT)
+        true_type, true_size = _compiled_geom(path, "seg_g")
+        assert true_type == "capsule", "premise: MuJoCo reads the named root class"
+
+        seg = _body(path, "seg")
+        assert seg.shape == true_type, (
+            f"the root class is spelled class='main' and the geom names no class, so the loader "
+            f"reported {seg.shape!r} with size {seg.shape_size} - the fallback box - for a capsule"
+        )
+        # MuJoCo's capsule size is (radius, half-length).
+        assert seg.shape_size == pytest.approx((true_size[0], true_size[1]), abs=1e-9)
+
+    def test_an_unnamed_root_supplies_a_geom_that_names_it_main(self, tmp_path):
+        """The other direction: the file omits the name, the geom spells it."""
+        path = _write(tmp_path, "unnamed.xml", _UNNAMED_ROOT)
+        true_type, true_size = _compiled_geom(path, "seg_g")
+        assert true_type == "capsule", "premise: MuJoCo resolves class='main' to the unnamed root"
+
+        seg = _body(path, "seg")
+        assert seg.shape == true_type, (
+            f"class='main' names the unnamed root <default>, and the loader reported "
+            f"{seg.shape!r} with size {seg.shape_size} instead"
+        )
+        assert seg.shape_size == pytest.approx((true_size[0], true_size[1]), abs=1e-9)
+
+    def test_both_spellings_are_read_as_the_same_model(self, tmp_path):
+        """Neither file is privileged: they describe one model, so they read alike.
+
+        Asserted against MuJoCo rather than only against each other - two
+        readings that are both the fallback box are also equal, so agreement
+        alone is satisfied by the bug this file pins.
+        """
+        a_path = _write(tmp_path, "a.xml", _UNNAMED_ROOT)
+        b_path = _write(tmp_path, "b.xml", _NAMED_ROOT)
+        oracle = _compiled_geom(a_path, "seg_g")
+        assert oracle == _compiled_geom(b_path, "seg_g"), "premise: MuJoCo reads one model from either spelling"
+
+        unnamed = _body(a_path, "seg")
+        named = _body(b_path, "seg")
+        assert (unnamed.shape, unnamed.shape_size) == (named.shape, named.shape_size)
+        assert unnamed.shape == oracle[0]
+        assert unnamed.shape_size == pytest.approx((oracle[1][0], oracle[1][1]), abs=1e-9)
+
+    def test_a_named_root_reaches_a_subtree_through_childclass(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "cc.xml",
+            """<mujoco model="m">
+  <default class="main"><geom type="cylinder" size="0.02 0.11"/></default>
+  <worldbody>
+    <body name="upper" childclass="main" pos="0 0 1">
+      <joint name="j0" type="hinge" axis="0 1 0"/>
+      <geom name="upper_g"/>
+      <body name="lower" pos="0 0 -0.3">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom name="lower_g"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "lower_g")[0] == "cylinder", "premise"
+        for name in ("upper", "lower"):
+            body = _body(path, name)
+            assert body.shape == "cylinder", f"{name} did not reach the root class by childclass ({body.shape})"
+            assert body.shape_size == pytest.approx((0.02, 0.11), abs=1e-9)
+
+    def test_a_nested_class_under_a_named_root_still_inherits_it(self, tmp_path):
+        """Aliasing the root must not detach the tree hanging off it."""
+        path = _write(
+            tmp_path,
+            "nested.xml",
+            """<mujoco model="m">
+  <default class="main"><geom type="capsule"/>
+    <default class="leg"><geom size="0.03 0.09"/></default>
+  </default>
+  <worldbody>
+    <body name="seg" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="seg_g" class="leg"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "seg_g")[0] == "capsule", "premise"
+        seg = _body(path, "seg")
+        assert seg.shape == "capsule", f"'leg' did not inherit type from the named root ({seg.shape})"
+        assert seg.shape_size == pytest.approx((0.03, 0.09), abs=1e-9)
+
+    def test_the_scene_object_reader_reads_a_named_root_too(self, tmp_path):
+        """The second caller of the resolver, on the same model shape."""
+        path = _write(
+            tmp_path,
+            "scene.xml",
+            """<mujoco model="m">
+  <default class="main"><geom type="box" size="0.30 0.20 0.02"/></default>
+  <worldbody>
+    <body name="shelf" pos="0 0 0.5"><geom name="shelf_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "shelf_g")[0] == "box", "premise"
+        shelf = next(o for o in load_mjcf_scene_objects(str(path)) if o.name == "shelf")
+        # 0.60 x 0.40 x 0.04 full extent, not the mesh-less fallback.
+        assert shelf.size == pytest.approx((0.60, 0.40, 0.04), abs=1e-6), (
+            f"the proxy for a named-root box came back {shelf.size}"
+        )
+
+
+class TestTheResolverPublishesBothSpellings:
+    """The mapping itself, so the alias is pinned where it is made."""
+
+    @pytest.mark.parametrize("root_open", ["<default>", '<default class="main">'])
+    def test_the_root_class_is_registered_under_both_names(self, root_open):
+        xml = f'<mujoco model="m">{root_open}<geom type="sphere" size="0.04"/></default></mujoco>'
+        defaults = mod._mjcf_geom_defaults(ET.fromstring(xml), ".")
+        assert defaults[""] == defaults["main"], (
+            f'the root class differs by spelling: "" -> {defaults[""]}, "main" -> {defaults["main"]}'
+        )
+        # Non-vacuity: both keys carry the root's attributes, not two empty dicts.
+        assert defaults[""] == {"type": "sphere", "size": "0.04"}
+
+    def test_a_model_with_no_default_reports_both_names_as_empty(self):
+        defaults = mod._mjcf_geom_defaults(ET.fromstring('<mujoco model="m"><worldbody/></mujoco>'), ".")
+        assert defaults[""] == {}
+        assert defaults["main"] == {}
+
+
+class TestWhyAliasingTheRootIsSafe:
+    """MuJoCo's own refusals, which are what make ``""`` and ``main`` one class.
+
+    If a future MuJoCo let a nested class be named ``main``, or let the root be
+    renamed, the alias would map two distinct classes onto one and these tests
+    are where that shows up.
+    """
+
+    def _refuses(self, xml):
+        with pytest.raises(ValueError) as excinfo:
+            mujoco.MjModel.from_xml_string(xml)
+        return str(excinfo.value)
+
+    def test_mujoco_refuses_to_rename_the_root_class(self):
+        message = self._refuses(
+            '<mujoco model="m"><default class="base"><geom type="capsule" size="0.1 0.2"/></default>'
+            '<worldbody><body><geom class="base"/></body></worldbody></mujoco>'
+        )
+        assert "cannot be renamed" in message, message
+
+    def test_mujoco_refuses_a_nested_class_named_main(self):
+        message = self._refuses(
+            '<mujoco model="m"><default><geom type="capsule" size="0.1 0.2"/>'
+            '<default class="main"><geom size="0.05 0.3"/></default></default>'
+            "<worldbody><body><geom/></body></worldbody></mujoco>"
+        )
+        assert "repeated default class name" in message, message
+
+    def test_mujoco_refuses_a_nested_default_with_no_class(self):
+        message = self._refuses(
+            '<mujoco model="m"><default><geom type="capsule" size="0.1 0.2"/>'
+            '<default><geom size="0.05 0.3"/></default></default>'
+            "<worldbody><body><geom/></body></worldbody></mujoco>"
+        )
+        assert "empty class name" in message, message
+
+
+class TestWhatTheAliasMustNotChange:
+    """Controls, pinned in both directions."""
+
+    @pytest.mark.parametrize("root_open", ["<default>", '<default class="main">'])
+    def test_the_geoms_own_attribute_still_beats_the_root_class(self, tmp_path, root_open):
+        path = _write(
+            tmp_path,
+            "own.xml",
+            f"""<mujoco model="m">
+  {root_open}<geom type="capsule" size="0.06 0.21"/></default>
+  <worldbody>
+    <body name="ball" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="ball_g" class="main" type="sphere" size="0.09"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        true_type, true_size = _compiled_geom(path, "ball_g")
+        assert true_type == "sphere", "premise: the geom's own type wins"
+        ball = _body(path, "ball")
+        assert ball.shape == "sphere", f"the root class overrode the geom's own type ({ball.shape})"
+        # The reader spells a sphere ``(radius,)``; MuJoCo pads its size triple.
+        assert ball.shape_size == pytest.approx((true_size[0],), abs=1e-9)
+
+    def test_an_unnamed_root_still_supplies_an_unclassed_geom(self, tmp_path):
+        """The path that already worked, so the alias is additive."""
+        path = _write(
+            tmp_path,
+            "plain.xml",
+            """<mujoco model="m">
+  <default><geom type="sphere" size="0.04"/></default>
+  <worldbody>
+    <body name="ball" pos="0 0 1">
+      <joint name="j" type="hinge" axis="0 1 0"/>
+      <geom name="ball_g"/>
+    </body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "ball_g")[0] == "sphere", "premise"
+        assert _body(path, "ball").shape == "sphere"
+
+    def test_a_class_a_model_never_declares_still_contributes_nothing(self, tmp_path):
+        """``main`` is now always a key, so ``.get`` must still miss other names."""
+        defaults = mod._mjcf_geom_defaults(
+            ET.fromstring('<mujoco model="m"><default><geom type="sphere" size="0.04"/></default></mujoco>'), "."
+        )
+        assert "wheel" not in defaults


### PR DESCRIPTION
## Problem

MJCF's root default class has two spellings and one identity. MuJoCo names the root `main` and refuses to let a model rename it, so those two are the only spellings a file has:

```xml
<default>                  <!-- unnamed -->
<default class="main">     <!-- named, the same class -->
```
```
<default class="base">  ->  XML Error: top-level default class 'main' cannot be renamed
```

A geom reaches that class three ways: its own `class="main"`, an enclosing body's `childclass="main"`, or by naming no class at all. `_mjcf_geom_defaults` (#2669) writes `classes[default_el.get("class", "")]`, so it registers the root under **whichever spelling the file happened to use** and every geom arriving by the other one resolves to `{}` and falls through to `_extract_mjcf_shape`'s `box (0.05, 0.05, 0.05)` fallback.

The two directions fail differently, and the second is the whole model.

**a. Unnamed root, geom spells the name.** `<default>` plus `<geom class="main"/>` misses. Byte-identical to pre-#2669 behaviour, so not a regression - this was noted as a possible follow-up when #2669 was reviewed.

**b. Named root, geom names no class.** `classes[""]` is never written, so *every* geom in the model misses. This is what shipped assets do. Menagerie's `pal_tiago_dual/tiago_dual.xml`:

```xml
<default class="main">
  <geom contype="0" conaffinity="1" group="1" type="mesh" mass="0"/>
```

| measured on `tiago_dual.xml` | before | after |
| --- | --- | --- |
| geoms in the model | 46 | 46 |
| geoms carrying a `class` attribute | 0 | 0 |
| resolver's entry for `""` | `{}` | `{contype, conaffinity, group, type: mesh, mass}` |
| resolver's entry for `"main"` | `{contype, ..., type: mesh, ...}` | same |
| geoms whose shape the loader cannot name | **34** | **0** |

So 34 links reported a 10 cm cube for the `type="mesh"` their own root class declares, under `load_mjcf` reporting success - the same failure mode #2669 closed, for a spelling it did not cover. `group` is read through the same resolver, so collision/visual group filtering was wrong for all 46.

## Change

Register the root class under both keys. `_flatten` returns the merged attributes it just stored, and the top-level loop writes them to `""` and to `"main"`.

That is an alias rather than a guess, because neither name is available to any other class - MuJoCo refuses both alternatives:

```
<default><default class="main">...   ->  XML Error: repeated default class name
<default><default>...               ->  XML Error: empty class name
```

So aliasing cannot shadow a distinct class. Both refusals are asserted in the tests (`TestWhyAliasingTheRootIsSafe`), so if a future MuJoCo permits either, the justification fails loudly instead of the alias silently merging two classes.

The fix is in the resolver, so all three arrival paths are covered at once: `_geom_attrs` looks up `geom.get("class") or childclass`, and both `""` and `"main"` now resolve.

### One correction folded in, one concern kept out

The code comment this replaces attributed the `cannot be renamed` error to MuJoCo refusing a *second* top-level `<default>`. Measured, two top-level `<default>` elements in one file are **accepted and merged**; that error only fires when a top-level `<default>` is given a name other than `main`. The comment is removed rather than restated.

What that merge implies for this resolver is a real second bug - the loop restarts from `{}` per element, so the last top-level `<default>` replaces the others and a `type` the first declared is dropped. It is a distinct concern with a distinct fix, so it is filed as #2673 with its own measurement rather than widened into this diff.

## Tests

`tests/simulation/isaac/test_mjcf_root_default_class_spellings.py`, 16 cases. MuJoCo is the oracle throughout: every expected shape is read back off a compiled `MjModel` rather than restated.

Pre-fix split against `main` (`39a6447`, i.e. with #2669 landed): **7 failed / 9 passed**.

| class | pre-fix | what it pins |
| --- | --- | --- |
| `TestTheRootClassAnswersToBothOfItsSpellings` | 4 fail of 6 | the regression, on both readers and all three arrival paths |
| `TestTheResolverPublishesBothSpellings` | 3 fail of 3 | the alias at the point it is made, with a non-vacuity clause |
| `TestWhyAliasingTheRootIsSafe` | 0 of 3 | MuJoCo's refusals - premises, expected to hold on both trees |
| `TestWhatTheAliasMustNotChange` | 0 of 4 | controls: the geom's own attribute still wins, an unnamed root still supplies an unclassed geom, an undeclared class still contributes nothing |

The failure messages name the symptom rather than the assertion, e.g.

```
the root class is spelled class='main' and the geom names no class, so the loader
reported 'box' with size (0.05, 0.05, 0.05) - the fallback box - for a capsule
```

Two notes on test design:

- `test_both_spellings_are_read_as_the_same_model` checks the two files agree **and** that they agree with MuJoCo. Agreement alone is satisfied by the bug - two readings that are both the fallback box are also equal - so it asserts against the oracle as well, and consequently fails pre-fix.
- `test_a_class_a_model_never_declares_still_contributes_nothing` exists because `"main"` is now always a key: it pins that making it unconditional did not turn the mapping into one that answers for every name.

## Verification

mujoco 3.12.0, re-measured at the head `e4d935a`.

| suite | result |
| --- | --- |
| the new file | 16 passed |
| the new file on `main` | 7 failed, 9 passed |
| `test_mjcf_default_class_geometry.py` + `test_mjcf_bodies_are_model_global.py` (#2669's and #2667's pins) | 44 passed |
| `tests/simulation/isaac/` | 1015 passed, 38 skipped, 0 failed |

The 30 collection errors in `tests/simulation/isaac/` are all one file (`test_add_camera_numeric_validation.py`) and all `ModuleNotFoundError: No module named 'strands'` - the Strands SDK is absent from the venv these were measured in, and they reproduce identically on `main`. `ruff check` and `ruff format --check` clean on both touched files; no non-ASCII in either or in the fragment; no host paths in the tests.

## Commits

| commit | concern |
| --- | --- |
| `e317950` | the fix and its pins |
| `da6fafa` | changelog fragment |
| `e4d935a` | the same docstring's opening still called the root class "unnamed"; prose only |

Fixes #2670