### PR TITLE
fix(isaac): merge a model's several top-level <default> elements

### DIFF
--- a/changelog.d/2673-isaac-mjcf-merge-toplevel-defaults.md
+++ b/changelog.d/2673-isaac-mjcf-merge-toplevel-defaults.md
@@ -1,0 +1,9 @@
+### Fixed: a model's several top-level `<default>` elements merge into one root class
+
+`<default>` is a top-level MJCF element, and MuJoCo merges every one a model carries into the single root class - the same model-global treatment it gives `<compiler>`, `<asset>` and `<worldbody>`. The merge is per attribute and in document order, so a later element overriding `size` does not discard a `type` an earlier one declared.
+
+The Isaac loaders' default-class resolver read each top-level element independently, restarting from nothing, so the last one **replaced** the others. The dropped attribute then failed the familiar silent way: a geom resolving against the root class found no `type`, so `load_mjcf` reported the `box (0.05, 0.05, 0.05)` fallback for a capsule under a successful load. `group` is read through the same resolver, so collision/visual filtering was wrong for the same geoms.
+
+The shape does not require a file that writes two `<default>` elements itself, which is what makes it more than a curiosity: `<include>` is a textual splice, so a scene including a robot contributes one element each. Measured on Menagerie, 7 models carry two top-level `<default>` elements once spliced, and `pal_tiago` and `pal_tiago_dual` lost their whole root class to the replace - 15 of 35 and 11 of 43 geoms respectively had no resolvable `group`.
+
+The root class is now accumulated across the elements rather than restarted at each. A nested class is still flattened where it appears, which is what MuJoCo does: it inherits the root as accumulated up to its own position, so a `type` declared by a top-level element *after* the one enclosing it does not reach it. That boundary is pinned, so widening the merge later is a decision rather than an accident.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -965,6 +965,20 @@ def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, 
     need be the top file - the same splice :func:`_mjcf_model_toplevel` resolves
     for ``<compiler>`` and ``<asset>``.
 
+    A model may carry SEVERAL top-level ``<default>`` elements, and MuJoCo
+    merges them into the one root class in document order - the same treatment
+    it gives ``<compiler>``, ``<asset>`` and ``<worldbody>``. They are therefore
+    accumulated here, not read independently. The merge is per attribute, so a
+    later element overriding ``size`` does not discard a ``type`` an earlier one
+    declared.
+
+    A nested class is flattened where it appears, which is what MuJoCo does: it
+    inherits the root class as accumulated *up to its own position*, so a
+    ``type`` declared by a top-level element AFTER the one enclosing it does not
+    reach it. Measured on mujoco 3.12.0 - a nested class in the first of two
+    top-level elements compiles with MuJoCo's own sphere default, not the
+    ``type="capsule"`` the second element declares.
+
     Returns a mapping from class name to that class's merged ``<geom>``
     attributes, with the root class under both of the spellings that reach it -
     ``""`` and ``"main"``. A class a geom names but no ``<default>`` declares
@@ -987,6 +1001,12 @@ def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, 
             _flatten(nested, merged)
         return merged
 
+    # The root class accumulates across the model's top-level ``<default>``
+    # elements rather than restarting at each one, because MuJoCo merges them.
+    # Starting from ``{}`` per element lets the last one REPLACE the others, so a
+    # ``type`` only the first declares is dropped and every geom resolving
+    # against the root reports the fallback box under a successful load.
+    root_attrs: dict[str, str] = {}
     for el in _mjcf_model_toplevel(root, base_dir):
         if el.tag == "default":
             # A top-level ``<default>`` is the root class under either of two
@@ -1005,7 +1025,7 @@ def _mjcf_geom_defaults(root: ET.Element, base_dir: str) -> dict[str, dict[str, 
             # because neither name is available to one: MuJoCo refuses a nested
             # ``class="main"`` ("repeated default class name") and a nested
             # unnamed ``<default>`` ("empty class name").
-            root_attrs = _flatten(el, {})
+            root_attrs = _flatten(el, root_attrs)
             classes[""] = root_attrs
             classes[_MJCF_ROOT_DEFAULT_CLASS] = root_attrs
     return classes

--- a/tests/simulation/isaac/test_mjcf_merged_toplevel_defaults.py
+++ b/tests/simulation/isaac/test_mjcf_merged_toplevel_defaults.py
@@ -1,0 +1,399 @@
+"""A model's several top-level ``<default>`` elements are one root class, merged.
+
+``<default>`` is a top-level MJCF element, and MuJoCo merges every one a model
+carries into the single root class - the same model-global treatment it gives
+``<compiler>``, ``<asset>`` and ``<worldbody>``. The merge is per attribute and
+in document order, so a later element overriding ``size`` does not discard a
+``type`` an earlier one declared.
+
+Read independently, each element restarting from nothing, the last one REPLACES
+the others. The dropped attribute then fails the familiar silent way: a geom
+resolving against the root class finds no ``type``, so ``load_mjcf`` reports the
+0.05 m fallback box for a capsule and reports success doing it. ``group`` is read
+through the same resolver, so collision/visual filtering is wrong for the same
+geoms.
+
+The shape is reachable without a file that writes two ``<default>`` elements
+itself, which is what makes it more than a curiosity: ``<include>`` is a textual
+splice, so a scene including a robot contributes one element each. Measured on
+Menagerie, 7 models carry two top-level ``<default>`` elements once spliced, and
+``pal_tiago`` and ``pal_tiago_dual`` lose their whole root class to the replace -
+15 of 35 and 11 of 43 geoms respectively had no resolvable ``group``, and one
+fewer had no resolvable ``type``.
+
+MuJoCo is the oracle throughout: every expected shape is read back off a compiled
+``MjModel`` rather than restated. Its scoping rule for nested classes is pinned
+too, because it is not the obvious one - a nested class is snapshotted where it
+appears, so it does NOT see a top-level element that follows the one enclosing
+it, and threading the root through the loop has to reproduce that rather than
+merge everything into everything.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import _mjcf_geom_defaults, load_mjcf
+
+mujoco = pytest.importorskip("mujoco")
+
+_GEOM_TYPE_NAMES = {
+    int(mujoco.mjtGeom.mjGEOM_SPHERE): "sphere",
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE): "capsule",
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER): "cylinder",
+    int(mujoco.mjtGeom.mjGEOM_BOX): "box",
+    int(mujoco.mjtGeom.mjGEOM_MESH): "mesh",
+}
+
+
+def _write(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _compiled_geom(path, geom_name):
+    """MuJoCo's own ``(type, size)`` for a named geom - the oracle."""
+    model = mujoco.MjModel.from_xml_path(str(path))
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+    assert gid >= 0, f"premise: MuJoCo compiled no geom named {geom_name!r}"
+    # int(): a pybind11 enum does not match a numpy integer as a dict key.
+    return _GEOM_TYPE_NAMES[int(model.geom_type[gid])], tuple(float(x) for x in model.geom_size[gid])
+
+
+def _body(path, name):
+    return next(b for b in load_mjcf(str(path)).bodies if b.name == name)
+
+
+def _resolved_classes(path):
+    return _mjcf_geom_defaults(ET.parse(path).getroot(), str(path.parent))
+
+
+def _assert_matches_mujoco(path, body_name, geom_name, why):
+    """The loader's shape for a body equals MuJoCo's for that body's geom."""
+    true_type, true_size = _compiled_geom(path, geom_name)
+    body = _body(path, body_name)
+    assert body.shape == true_type, (
+        f"{why}: MuJoCo reads {true_type!r}, and the loader reported {body.shape!r} with size {body.shape_size}"
+    )
+    # A capsule's or cylinder's MJCF size is (radius, half-length); MuJoCo pads
+    # geom_size to three components, so compare the ones it populates.
+    assert body.shape_size == pytest.approx(true_size[: len(body.shape_size)], abs=1e-9)
+    return true_type, true_size
+
+
+# The issue's minimal reproduction: the first element declares the ``type``, the
+# second overrides only ``size``. MuJoCo reads capsule (0.05, 0.3) - type from
+# the first, size from the second.
+_TYPE_THEN_SIZE = """<mujoco model="m">
+  <default><geom type="capsule" size="0.25 0.4"/></default>
+  <default><geom size="0.05 0.3"/></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g"/></body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class TestSeveralTopLevelDefaultsMergeIntoOneRootClass:
+    """The regression: every top-level element contributes, and none replaces."""
+
+    def test_a_type_the_first_element_declares_survives_a_later_one(self, tmp_path):
+        """The issue's reproduction: ``type`` from the first, ``size`` from the second."""
+        path = _write(tmp_path, "two.xml", _TYPE_THEN_SIZE)
+        true_type, true_size = _compiled_geom(path, "seg_g")
+        assert (true_type, true_size[0], true_size[1]) == ("capsule", 0.05, 0.3), (
+            "premise: MuJoCo merges the two top-level <default> elements per attribute"
+        )
+        _assert_matches_mujoco(
+            path,
+            "seg",
+            "seg_g",
+            "a second top-level <default> overriding only size dropped the first one's type",
+        )
+
+    def test_three_elements_merge_in_document_order(self, tmp_path):
+        """Not a two-element special case, and the last declaration of an attribute wins."""
+        path = _write(
+            tmp_path,
+            "three.xml",
+            """<mujoco model="m">
+  <default><geom type="capsule"/></default>
+  <default><geom size="0.1 0.2"/></default>
+  <default><geom size="0.05 0.3"/></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        _, true_size = _assert_matches_mujoco(
+            path, "seg", "seg_g", "three top-level <default> elements did not merge in document order"
+        )
+        assert (true_size[0], true_size[1]) == (0.05, 0.3), "premise: the last size declaration wins"
+
+    @pytest.mark.parametrize(
+        "first_open,second_open",
+        [
+            ("<default>", '<default class="main">'),
+            ('<default class="main">', "<default>"),
+        ],
+        ids=["unnamed_then_named", "named_then_unnamed"],
+    )
+    def test_the_two_root_spellings_merge_with_each_other(self, tmp_path, first_open, second_open):
+        """A file may spell the root either way in either element - one class regardless."""
+        path = _write(
+            tmp_path,
+            "spellings.xml",
+            f"""<mujoco model="m">
+  {first_open}<geom type="capsule" size="0.25 0.4"/></default>
+  {second_open}<geom size="0.05 0.3"/></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        _assert_matches_mujoco(
+            path,
+            "seg",
+            "seg_g",
+            "the root's two spellings across two top-level elements did not merge into one class",
+        )
+
+    @pytest.mark.parametrize(
+        "worldbody",
+        [
+            '<body name="seg"><geom name="seg_g" class="main"/></body>',
+            '<body name="p" childclass="main"><body name="seg"><geom name="seg_g"/></body></body>',
+        ],
+        ids=["geom_names_main", "body_childclass_main"],
+    )
+    def test_every_arrival_path_sees_the_merge(self, tmp_path, worldbody):
+        """The fix is in the resolver, so all three ways to reach the root are covered."""
+        path = _write(
+            tmp_path,
+            "arrival.xml",
+            f"""<mujoco model="m">
+  <default><geom type="capsule" size="0.25 0.4"/></default>
+  <default><geom size="0.05 0.3"/></default>
+  <worldbody>
+    {worldbody}
+  </worldbody>
+</mujoco>
+""",
+        )
+        _assert_matches_mujoco(
+            path, "seg", "seg_g", "a geom reaching the merged root by an explicit name saw only one element"
+        )
+
+    def test_an_included_fragment_contributing_a_second_element_merges(self, tmp_path):
+        """The reachable shape: the two elements are in two files, spliced by <include>.
+
+        This is what makes the bug more than a curiosity - a scene including a
+        robot contributes one top-level ``<default>`` each, and no file has to
+        write two for the resolver to see two.
+        """
+        _write(
+            tmp_path,
+            "robot.xml",
+            '<mujoco model="r"><default><geom size="0.05 0.3"/></default></mujoco>\n',
+        )
+        path = _write(
+            tmp_path,
+            "scene.xml",
+            """<mujoco model="m">
+  <default><geom type="capsule" size="0.25 0.4"/></default>
+  <include file="robot.xml"/>
+  <worldbody>
+    <body name="seg"><geom name="seg_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert len(_resolved_classes(path)[""]) == 2, (
+            "premise: the splice really did contribute a second top-level <default>"
+        )
+        _assert_matches_mujoco(path, "seg", "seg_g", "an <include>d fragment's <default> replaced the including file's")
+
+
+class TestTheResolverMergesRatherThanReplaces:
+    """The merge at the point it is made, not only through the shape it produces."""
+
+    def test_the_root_class_carries_attributes_from_every_element(self, tmp_path):
+        path = _write(tmp_path, "two.xml", _TYPE_THEN_SIZE)
+        root_class = _resolved_classes(path)[""]
+        assert root_class == {"type": "capsule", "size": "0.05 0.3"}, (
+            f"the root class should carry the first element's type and the second's size, got {root_class}"
+        )
+
+    def test_both_spellings_report_the_merged_class(self, tmp_path):
+        """The root is published under ``""`` and ``"main"``, and the merge reaches both."""
+        path = _write(tmp_path, "two.xml", _TYPE_THEN_SIZE)
+        classes = _resolved_classes(path)
+        assert classes[""] == classes["main"]
+        assert "type" in classes["main"], "the alias must publish the merged class, not one element's"
+
+
+class TestNestedClassesFollowDocumentOrder:
+    """MuJoCo snapshots a nested class where it appears; the resolver must too.
+
+    This is the boundary of the fix. Threading the root through the loop must not
+    become "merge every element into every class": a nested class inherits the
+    root as accumulated *up to its own position*, so an element that follows the
+    one enclosing it does not reach it.
+    """
+
+    def test_a_nested_class_inherits_the_root_accumulated_before_it(self, tmp_path):
+        """The enclosing element's own attributes reach it, and its own still win."""
+        path = _write(
+            tmp_path,
+            "nested.xml",
+            """<mujoco model="m">
+  <default>
+    <geom type="capsule" size="0.07 0.31"/>
+    <default class="leg"><geom size="0.06 0.2"/></default>
+  </default>
+  <default><geom size="0.9 0.9"/></default>
+  <worldbody>
+    <body name="leg_b"><geom name="leg_g" class="leg"/></body>
+    <body name="root_b"><geom name="root_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        # The nested class keeps its own size and takes type from the element
+        # enclosing it; the root takes the later element's size.
+        _assert_matches_mujoco(path, "leg_b", "leg_g", "a nested class lost the type of the element enclosing it")
+        _assert_matches_mujoco(path, "root_b", "root_g", "the root class did not take the later element's size")
+
+        classes = _resolved_classes(path)
+        assert classes["leg"] == {"type": "capsule", "size": "0.06 0.2"}
+        assert classes[""] == {"type": "capsule", "size": "0.9 0.9"}
+
+    def test_a_nested_class_does_not_inherit_a_later_top_level_element(self, tmp_path):
+        """MuJoCo's scoping rule, asserted where the resolver decides it.
+
+        Asserted on the resolver rather than on the reported shape: the geom here
+        resolves to no ``type`` at all, and what the loader reports for a typeless
+        geom (its ``box`` fallback) diverges from MuJoCo's own ``sphere`` default
+        for reasons that predate this fix and are not its business. The scoping
+        claim is checked against MuJoCo directly instead - the compiled model must
+        not read the later element's ``type``.
+        """
+        path = _write(
+            tmp_path,
+            "later.xml",
+            """<mujoco model="m">
+  <default>
+    <default class="leg"><geom size="0.06 0.2"/></default>
+  </default>
+  <default><geom type="capsule" size="0.5 0.6"/></default>
+  <worldbody>
+    <body name="leg_b"><geom name="leg_g" class="leg"/></body>
+    <body name="root_b"><geom name="root_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        assert _compiled_geom(path, "leg_g")[0] != "capsule", (
+            "premise: MuJoCo does not give a nested class the type of a top-level "
+            "element that follows the one enclosing it"
+        )
+
+        classes = _resolved_classes(path)
+        assert "type" in classes[""], "premise: the later element's type reaches the root class"
+        assert classes["leg"] == {"size": "0.06 0.2"}, (
+            f"the nested class took an attribute from a top-level element declared after the one "
+            f"enclosing it, so threading the root over-merged: {classes['leg']}"
+        )
+        # The root itself still merges, so the two rules coexist.
+        _assert_matches_mujoco(path, "root_b", "root_g", "the root class did not see the second element")
+
+    def test_mujoco_refuses_one_nested_class_name_in_two_elements(self):
+        """Why threading cannot make a nested class ambiguous across elements.
+
+        A premise, expected to hold before and after the fix. If a future MuJoCo
+        permits this, the reasoning behind writing each nested class to a single
+        key fails loudly here rather than silently merging two distinct classes.
+        """
+        with pytest.raises(ValueError, match="repeated default class name"):
+            mujoco.MjModel.from_xml_string(
+                """<mujoco model="m">
+  <default><default class="leg"><geom type="capsule"/></default></default>
+  <default><default class="leg"><geom size="0.05 0.3"/></default></default>
+  <worldbody><body name="b"><geom name="g" class="leg"/></body></worldbody>
+</mujoco>
+"""
+            )
+
+
+class TestWhatTheMergeMustNotChange:
+    """Controls: the single-element case, precedence, and non-vacuity."""
+
+    def test_a_single_top_level_default_reads_as_before(self, tmp_path):
+        """The overwhelmingly common shape, and the one the fix must leave alone."""
+        path = _write(
+            tmp_path,
+            "one.xml",
+            """<mujoco model="m">
+  <default><geom type="capsule" size="0.06 0.21"/></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        _assert_matches_mujoco(path, "seg", "seg_g", "a model with one top-level <default> changed")
+        assert _resolved_classes(path)[""] == {"type": "capsule", "size": "0.06 0.21"}
+
+    def test_the_geoms_own_attribute_still_beats_the_merged_root(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "own.xml",
+            """<mujoco model="m">
+  <default><geom type="capsule" size="0.25 0.4"/></default>
+  <default><geom size="0.05 0.3"/></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g" type="box" size="0.11 0.12 0.13"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        true_type, _ = _assert_matches_mujoco(
+            path, "seg", "seg_g", "the merged root class overrode the geom's own attributes"
+        )
+        assert true_type == "box", "premise: MuJoCo lets the geom's own type win over its class"
+
+    def test_two_elements_declaring_no_geom_contribute_nothing(self, tmp_path):
+        """Non-vacuity: two top-level elements alone do not populate the root class.
+
+        Menagerie's ``aloha/scene.xml`` and ``pal_talos`` are this shape - two
+        spliced top-level ``<default>`` elements carrying only nested classes -
+        and their root class is empty on both trees. So the four Menagerie
+        verdicts this fix changes are changed by the merge, not by the count.
+        """
+        path = _write(
+            tmp_path,
+            "empty_roots.xml",
+            """<mujoco model="m">
+  <default><default class="leg"><geom type="capsule" size="0.06 0.2"/></default></default>
+  <default><default class="arm"><geom type="cylinder" size="0.04 0.1"/></default></default>
+  <worldbody>
+    <body name="seg"><geom name="seg_g" class="leg"/></body>
+  </worldbody>
+</mujoco>
+""",
+        )
+        classes = _resolved_classes(path)
+        assert classes[""] == {}, f"neither element declares a <geom>, so the root class is empty: {classes['']}"
+        assert classes["leg"] == {"type": "capsule", "size": "0.06 0.2"}
+        assert classes["arm"] == {"type": "cylinder", "size": "0.04 0.1"}
+        _assert_matches_mujoco(path, "seg", "seg_g", "a nested class under one of two bare elements broke")
+
+    def test_a_class_the_model_never_declares_still_contributes_nothing(self, tmp_path):
+        """The merge did not turn the mapping into one that answers for every name."""
+        path = _write(tmp_path, "two.xml", _TYPE_THEN_SIZE)
+        assert _resolved_classes(path).get("nosuchclass") is None


### PR DESCRIPTION
## Problem

`<default>` is a top-level MJCF element, and MuJoCo merges every one a model carries into the single root class - the same model-global treatment it gives `<compiler>`, `<asset>` and `<worldbody>`, which is the treatment `_mjcf_model_toplevel` exists to reproduce.

`_mjcf_geom_defaults` recursed from each one independently:

```python
for el in _mjcf_model_toplevel(root, base_dir):
    if el.tag == "default":
        root_attrs = _flatten(el, {})     # restarts from {} per element
```

So the last top-level `<default>` **replaced** the others instead of merging with them.

```xml
<default><geom type="capsule" size="0.25 0.4"/></default>
<default><geom size="0.05 0.3"/></default>
```

| reader | result |
| --- | --- |
| MuJoCo (compiled `MjModel`) | `capsule`, size `(0.05, 0.3)` - `type` from the first, `size` from the second |
| resolver's entry for `""` | `{'size': '0.05 0.3'}` |
| `load_mjcf` | no `type` resolved, so the `box (0.05, 0.05, 0.05)` fallback |

The first element's `type="capsule"` is dropped, and the failure is the familiar silent one: a capsule reported as a 10 cm cube under a load reporting success. `group` is read through the same resolver, so collision/visual filtering is wrong for the same geoms.

## This is reachable in shipped assets, through `<include>`

No Menagerie file writes two top-level `<default>` elements itself. `<include>` is a textual splice, so it does not have to: a scene including a robot contributes one element each, and the resolver kept only whichever the splice yielded last.

Measured over all 261 Menagerie MJCFs - **7** carry two top-level `<default>` elements once spliced, and **4 change verdict**:

| model | resolver's root class before | after |
| --- | --- | --- |
| `pal_tiago/tiago_position.xml` | `{}` | `{contype, conaffinity, group, mass, type: mesh}` |
| `pal_tiago/scene_position.xml` | `{}` | same |
| `pal_tiago_dual/tiago_dual_position.xml` | `{}` | same |
| `pal_tiago_dual/scene_position.xml` | `{}` | same |

The whole root class was lost, so every geom naming no class resolved to nothing:

| model | geoms with no resolvable `group` | with no resolvable `type` |
| --- | --- | --- |
| `pal_tiago/tiago_position.xml` | **15** of 35 -> 0 | 14 -> 0 |
| `pal_tiago_dual/tiago_dual_position.xml` | **11** of 43 -> 0 | 10 -> 0 |

Being precise about the harm on these four: the reported *shape* does not change, because their root class declares `type="mesh"` and `_extract_mjcf_shape` maps a mesh to the same fallback box either way. What was wrong is the `group` read - the visual/collision split `_find_body_mesh` and `_geom_aabb` both branch on. The shape harm is the one the minimal reproduction above shows, and it needs only a root class declaring an analytic `type`.

The remaining 3 of the 7 (`aloha/scene.xml`, `pal_talos/*`) do not change: neither of their spliced elements carries a direct `<geom>`, so the root class is empty on both trees. That is the non-vacuity control - two elements alone are not sufficient, the loss needs a `<geom>` in one of them.

Blast radius overall: **261** models loaded through `load_mjcf` on both trees, 201 load / 60 refuse **identically**, 4 changed verdicts, all 4 listed above, no model changed between loading and refusing.

## Change

Accumulate the root attributes across the loop rather than restarting at each element - one line, plus the reasoning.

```diff
+   root_attrs: dict[str, str] = {}
    for el in _mjcf_model_toplevel(root, base_dir):
        if el.tag == "default":
-           root_attrs = _flatten(el, {})
+           root_attrs = _flatten(el, root_attrs)
```

### The boundary, which is not the obvious one

Threading the root must **not** become "merge every element into every class". A nested class is snapshotted where it appears, and MuJoCo says so - measured on mujoco 3.12.0:

```xml
<default><default class="leg"><geom size="0.06 0.2"/></default></default>
<default><geom type="capsule" size="0.5 0.6"/></default>
```

MuJoCo compiles `class="leg"` as a **sphere** - its own default - not the `capsule` the *following* top-level element declares. `_flatten` recurses into nested classes at the moment it processes each element, so it reproduces that ordering for free; the fix is correct because of where the recursion happens, not in spite of it. That boundary is pinned, so widening the merge later is a decision rather than an accident.

## Tests

`tests/simulation/isaac/test_mjcf_merged_toplevel_defaults.py`, 16 cases. MuJoCo is the oracle throughout: every expected shape is read back off a compiled `MjModel` rather than restated.

Pre-fix split against `main` (`2f18d9f5`, i.e. with #2669 and #2672 landed): **10 failed / 6 passed**.

| class | pre-fix | what it pins |
| --- | --- | --- |
| `TestSeveralTopLevelDefaultsMergeIntoOneRootClass` | **7 fail of 7** | the regression: two and three elements, both root spellings in either order, all three arrival paths, and the `<include>` splice |
| `TestTheResolverMergesRatherThanReplaces` | **2 fail of 2** | the merge at the point it is made, and that the `"main"` alias publishes the merged class |
| `TestNestedClassesFollowDocumentOrder` | 1 fail of 3 | the boundary above, plus MuJoCo's `repeated default class name` refusal as a premise |
| `TestWhatTheMergeMustNotChange` | 0 of 4 | controls: one element unchanged, the geom's own attribute still wins, two bare elements contribute nothing, an undeclared class contributes nothing |

Failure messages name the symptom rather than the assertion, e.g.

```
a second top-level <default> overriding only size dropped the first one's type:
MuJoCo reads 'capsule', and the loader reported 'box' with size (0.05, 0.05, 0.05)
```

### Break table - each break fires a distinct set, and none is dead

| break | fires |
| --- | --- |
| control (unmodified) | **0** of 16 |
| exact pre-fix (`_flatten(el, {})`) | 10 (the full regression set) |
| over-merge: give every nested class the whole model's root merge, ignoring document order | **1** (the scoping boundary alone) |
| earlier declaration wins instead of later | 9 |
| the `"main"` alias publishes one element instead of the merge | 3 |
| nested classes not registered at all (over-reach) | 3, incl. the bare-elements control |

Rows 2 and 3 are disjoint and complementary: the plausible-but-wrong reading of "MuJoCo merges them" - merge everything into everything - passes all 10 regression cases and is caught by exactly one test, which is the reason that test exists.

## Verification

mujoco 3.12.0, measured at the head `3c49c6aa`.

| suite | result |
| --- | --- |
| the new file | 16 passed |
| the new file on `main` | 10 failed, 6 passed |
| #2667's, #2669's and #2672's pins + `test_description_loader_geometry.py` | 126 passed |
| `tests/simulation/isaac/` | **1045 passed, 38 skipped, 0 failed** |
| the new file with 3 sibling MJCF suites, one selection | 76 passed |

The 30 collection errors in `tests/simulation/isaac/` are all one file (`test_add_camera_numeric_validation.py`) and all `ModuleNotFoundError: No module named 'strands'` - the Strands SDK is absent from the venv these were measured in, and they reproduce identically on `main` (`10 failed, 1035 passed, 38 skipped, 30 errors`, the 10 being this branch's new pins).

`ruff check` and `ruff format --check` clean on both touched files. `mypy` **63 == 63** against `main` for the same file, branch-only empty. No non-ASCII in either file or in the fragment; no host paths in the tests - every model is written under `tmp_path`.

## Commits

| commit | concern |
| --- | --- |
| `4fefea90` | the fix and its pins |
| `3c49c6aa` | changelog fragment |

Fixes #2673