### PR TITLE
test(isaac): grade the .msh reader against MuJoCo instead of its own layout assumption

### DIFF
--- a/changelog.d/2676-msh-reader-graded-against-mujoco.md
+++ b/changelog.d/2676-msh-reader-graded-against-mujoco.md
@@ -1,0 +1,30 @@
+### Quality: the .msh reader is graded against MuJoCo, not against its own layout assumption
+
+The legacy binary mesh (`.msh`) tests built every input with a helper that
+writes the four header fields in the order `load_mesh_geometry` reads them and
+lays the vertex, normal, texcoord and face blocks out in the order it walks
+them. A round trip through that helper cannot tell a correct layout from a
+mirrored one: a reader that swapped two header fields would be graded by a
+fixture that swapped them too, and both halves would move together. The format
+has no published specification beyond MuJoCo's own `LoadMSH`, so there was
+nothing on the other side of the comparison.
+
+The reader is now handed the same bytes as MuJoCo and required to agree with it,
+over three block layouts chosen so that a swap is visible: normals and
+texcoords both present, both absent, and texcoords present with normals absent -
+the asymmetric case, where a reader that transposed those two header fields
+computes a different total length for the same file. MuJoCo does not store the
+authored frame, so the comparison recovers it as
+`mesh_pos + R(mesh_quat) @ mesh_vert` and matches vertices on distance rather
+than on sort order.
+
+Two fixtures also declared three vertices, which `LoadMSH` refuses
+(`nvertex < 4`), so they graded the reader against a file the format's owner
+calls invalid; both now use a four-vertex tetrahedron. The refusal is pinned, as
+is MuJoCo's refusal of a coplanar mesh - that second refusal is why the
+comparisons need no separate extent premise.
+
+Every `.msh` asset LIBERO ships already agrees with MuJoCo to 6.54e-06 in the
+authored frame across all 88 files, so this pins correct behaviour rather than
+fixing a defect; what it removes is the possibility of that agreement drifting
+silently. No library behaviour changes.

--- a/tests/simulation/isaac/test_mesh_assets.py
+++ b/tests/simulation/isaac/test_mesh_assets.py
@@ -36,6 +36,14 @@ def _binary_stl(tri_vertices: list[tuple[tuple[float, float, float], ...]]) -> b
     return blob
 
 
+# MuJoCo's ``LoadMSH`` refuses ``nvertex < 4``, so every fixture below carries
+# at least four - a three-vertex .msh is a file the format's owner calls
+# invalid, and a reader graded only against such a file is graded against
+# nothing MuJoCo would ever hand it.
+_MSH_TETRA_VERTS = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)]
+_MSH_TETRA_FACES = [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]
+
+
 def _binary_msh(
     vertices: list[tuple[float, float, float]],
     faces: list[tuple[int, int, int]],
@@ -121,8 +129,8 @@ class TestLoadMeshGeometry:
         # bowl/plate VISUAL meshes - the exact objects #2459 names - so it
         # must parse, or those objects stay box proxies.
         asset = tmp_path / "bowl_vis.msh"
-        verts = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.0, 0.0, 3.0)]
-        faces = [(0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3)]
+        verts = _MSH_TETRA_VERTS
+        faces = _MSH_TETRA_FACES
         asset.write_bytes(_binary_msh(verts, faces, nnormal=4, ntexcoord=4))
         points, counts, indices = load_mesh_geometry(str(asset))
         assert points == verts
@@ -133,14 +141,14 @@ class TestLoadMeshGeometry:
         # Declared counts must reconcile with the byte length; a truncated
         # file must not parse as garbage geometry.
         asset = tmp_path / "torn.msh"
-        blob = _binary_msh([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)], [(0, 1, 2)])
+        blob = _binary_msh(_MSH_TETRA_VERTS, [(0, 1, 2)])
         asset.write_bytes(blob[:-4])
         with pytest.raises(ValueError, match="truncated"):
             load_mesh_geometry(str(asset))
 
     def test_msh_out_of_range_face_index_is_an_error(self, tmp_path):
         asset = tmp_path / "bad.msh"
-        asset.write_bytes(_binary_msh([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)], [(0, 1, 3)]))
+        asset.write_bytes(_binary_msh(_MSH_TETRA_VERTS, [(0, 1, 4)]))
         with pytest.raises(ValueError, match="out of range"):
             load_mesh_geometry(str(asset))
 
@@ -460,3 +468,139 @@ class TestConvertMeshToUsd:
 
 def test_extension_vocabularies_are_disjoint():
     assert not set(MESH_EXTENSIONS) & set(USD_EXTENSIONS)
+
+
+class TestTheMshLayoutIsGradedAgainstMujoco:
+    """Grade the ``.msh`` reader against MuJoCo, the format's only owner.
+
+    :func:`_binary_msh` writes the header fields in the order
+    :func:`load_mesh_geometry` reads them and lays the blocks out in the order
+    it walks them, so a round trip through it cannot tell a correct layout
+    from a mirrored one: a reader that swapped two header fields would be
+    graded by a fixture that swapped them too, and both halves would move
+    together. The legacy binary mesh has no published specification beyond
+    MuJoCo's own ``LoadMSH``, so these hand the same bytes to both and require
+    the geometry to agree.
+
+    MuJoCo does not store the authored frame: it recentres a mesh's vertices
+    on the mesh frame and rotates them onto its principal inertia axes, so
+    ``mesh_vert``'s extent is a permutation of the file's.
+    ``mesh_pos + R(mesh_quat) @ mesh_vert`` recovers the authored frame, and
+    that recovery is what makes the comparison exact rather than
+    up-to-a-rigid-motion.
+    """
+
+    @staticmethod
+    def _mujoco_file_frame(asset, tmp_path):
+        """Read ``asset`` with MuJoCo; return its vertices in the file frame."""
+        mujoco = pytest.importorskip("mujoco")
+        import numpy as np
+
+        xml = tmp_path / "one_mesh.xml"
+        xml.write_text(
+            f'<mujoco><asset><mesh name="m" file="{asset.name}"/></asset>'
+            '<worldbody><body><geom type="mesh" mesh="m"/></body></worldbody></mujoco>',
+            encoding="utf-8",
+        )
+        model = mujoco.MjModel.from_xml_path(str(xml))
+        adr, num = int(model.mesh_vertadr[0]), int(model.mesh_vertnum[0])
+        stored = np.asarray(model.mesh_vert[adr : adr + num], dtype=float)
+        rot = np.zeros(9)
+        mujoco.mju_quat2Mat(rot, np.asarray(model.mesh_quat[0], dtype=float))
+        authored = (rot.reshape(3, 3) @ stored.T).T + np.asarray(model.mesh_pos[0], dtype=float)
+        return authored, int(model.mesh_facenum[0])
+
+    @staticmethod
+    def _vertex_set_delta(one, other):
+        """Worst nearest-neighbour distance between two vertex sets.
+
+        A lexicographic sort is not a canonical form here: MuJoCo stores
+        vertices as ``float32``, so recovering the authored frame leaves about
+        1e-6 of error, and that is enough to flip the order of two vertices
+        whose leading coordinate ties - which reads as a large disagreement
+        between sets that are in fact identical. Match on distance instead.
+        """
+        import numpy as np
+
+        one = np.asarray(one, dtype=float)
+        other = np.asarray(other, dtype=float)
+        assert one.shape == other.shape, f"vertex counts differ: {one.shape} vs {other.shape}"
+        worst = 0.0
+        for point in one:
+            worst = max(worst, float(np.linalg.norm(other - point, axis=1).min()))
+        for point in other:
+            worst = max(worst, float(np.linalg.norm(one - point, axis=1).min()))
+        return worst
+
+    def _assert_agrees_with_mujoco(self, tmp_path, *, nnormal, ntexcoord):
+        asset = tmp_path / "graded.msh"
+        asset.write_bytes(_binary_msh(_MSH_TETRA_VERTS, _MSH_TETRA_FACES, nnormal=nnormal, ntexcoord=ntexcoord))
+        authored, facenum = self._mujoco_file_frame(asset, tmp_path)
+        points, counts, _indices = load_mesh_geometry(str(asset))
+        # No extent premise is needed here: MuJoCo runs qhull over the
+        # vertices and refuses a coplanar mesh outright, so any fixture that
+        # reaches this comparison already has real extent on every axis -
+        # pinned by test_mujoco_refuses_a_coplanar_msh below.
+        delta = self._vertex_set_delta(points, authored)
+        assert delta < 1e-4, (
+            f"the reader and MuJoCo disagree about the same bytes by {delta:.3g}: "
+            f"reader {points}, MuJoCo (authored frame) {authored.tolist()}"
+        )
+        assert len(counts) == facenum, f"faces: reader {len(counts)}, MuJoCo {facenum}"
+
+    def test_a_file_declaring_normals_and_texcoords_reads_as_mujoco_reads_it(self, tmp_path):
+        self._assert_agrees_with_mujoco(tmp_path, nnormal=4, ntexcoord=4)
+
+    def test_a_file_declaring_neither_reads_as_mujoco_reads_it(self, tmp_path):
+        # Block order: with both optional blocks absent the face records sit
+        # immediately after the vertices, so a reader that walked the blocks
+        # in a different order lands on the faces here and not above.
+        self._assert_agrees_with_mujoco(tmp_path, nnormal=0, ntexcoord=0)
+
+    def test_a_file_declaring_texcoords_but_no_normals_reads_as_mujoco_reads_it(self, tmp_path):
+        # Header field order: normals are three floats per vertex and
+        # texcoords two, so a reader that swapped those two header fields
+        # computes a different total length for these same bytes, and one of
+        # the two readings lands the face block somewhere the other does not.
+        self._assert_agrees_with_mujoco(tmp_path, nnormal=0, ntexcoord=4)
+
+    def test_mujoco_refuses_a_three_vertex_msh(self, tmp_path):
+        # The constraint the fixture repair above rests on: MuJoCo's LoadMSH
+        # refuses ``nvertex < 4``, so a three-vertex .msh is not a file the
+        # format's owner would ever hand this reader.
+        pytest.importorskip("mujoco")
+        asset = tmp_path / "too_few.msh"
+        asset.write_bytes(_binary_msh([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)], [(0, 1, 2)]))
+        with pytest.raises(Exception) as refused:  # noqa: B017 - the binding's own error type
+            self._mujoco_file_frame(asset, tmp_path)
+        assert "size" in str(refused.value).lower(), str(refused.value)
+
+    def test_mujoco_refuses_a_coplanar_msh(self, tmp_path):
+        # Why the comparisons above carry no extent premise: a degenerate
+        # fixture could not distinguish one block reading from another, and
+        # MuJoCo rules it out for us - it runs qhull over the vertices, which
+        # a coplanar set has no hull for.
+        pytest.importorskip("mujoco")
+        asset = tmp_path / "flat.msh"
+        flat = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 2.0, 0.0), (0.5, 1.0, 0.0)]
+        asset.write_bytes(_binary_msh(flat, _MSH_TETRA_FACES))
+        with pytest.raises(Exception) as refused:  # noqa: B017 - the binding's own error type
+            self._mujoco_file_frame(asset, tmp_path)
+        # Both spellings across the declared mujoco range: 3.5 reports a bare
+        # "qhull error", 3.12 "coplanar vertices, cannot compute convex hull".
+        message = str(refused.value).lower()
+        assert "qhull" in message or "coplanar" in message, message
+
+    def test_the_shared_fixture_is_one_mujoco_accepts(self, tmp_path):
+        # Non-vacuity: if MuJoCo refused the shared fixture, every comparison
+        # above would report a skip or an error rather than an agreement.
+        assert len(_MSH_TETRA_VERTS) >= 4
+        authored, facenum = self._mujoco_file_frame(self._written(tmp_path, nnormal=4, ntexcoord=4), tmp_path)
+        assert len(authored) == len(_MSH_TETRA_VERTS)
+        assert facenum == len(_MSH_TETRA_FACES)
+
+    @staticmethod
+    def _written(tmp_path, *, nnormal, ntexcoord):
+        asset = tmp_path / "shared.msh"
+        asset.write_bytes(_binary_msh(_MSH_TETRA_VERTS, _MSH_TETRA_FACES, nnormal=nnormal, ntexcoord=ntexcoord))
+        return asset


### PR DESCRIPTION
## Change

Grade the legacy binary mesh (`.msh`) reader in
`strands_robots/simulation/isaac/mesh_assets.py` against MuJoCo, the format's
only owner, instead of against a fixture that shares the reader's own layout
assumption. Test-only: no library file changes.

## Why this pin, now

`_binary_msh` - the helper every existing `.msh` test builds its input with -
writes the four header fields in the order `load_mesh_geometry` reads them and
lays the vertex / normal / texcoord / face blocks out in the order it walks
them. So a round trip through it cannot tell a correct layout from a mirrored
one: a reader that swapped two header fields would be graded by a fixture that
swapped them too, and both halves would move together. The legacy binary mesh
has no published specification beyond MuJoCo's own `LoadMSH`, so there was
nothing on the other side of the comparison.

Two of the three `.msh` fixtures also declared **three** vertices. MuJoCo
refuses `nvertex < 4` (`Error: invalid sizes in MSH file`), so those two graded
the reader against a file the format's owner calls invalid - measured, not
inferred.

This matters for LIBERO specifically: it ships 88 `.msh` assets, and
`mesh_aabb` turns what this reader returns into a mesh-only body's collision
proxy.

## What MuJoCo requires, measured

| fixture | MuJoCo | why it matters here |
| --- | --- | --- |
| 4-vertex tetra, `nnormal=ntexcoord=4` | accepted | the shared happy-path fixture |
| 4-vertex tetra, `nnormal=ntexcoord=0` | accepted | block order: faces sit directly after the vertices |
| 4-vertex tetra, `nnormal=0, ntexcoord=4` | accepted | header field order: normals are 3 floats/vertex, texcoords 2 |
| 3-vertex | refused, `invalid sizes in MSH file` | why every fixture now carries four |
| 4 coplanar vertices | refused, no convex hull | why the comparisons need no extent premise |

MuJoCo does not store the authored frame - it recentres a mesh on the mesh
frame and rotates it onto its principal inertia axes - so the comparison
recovers the file frame as `mesh_pos + R(mesh_quat) @ mesh_vert`, and matches
vertices on distance rather than on sort order (float32 storage leaves ~1e-6,
enough to flip two vertices whose leading coordinate ties).

## The reader is already correct on the real corpus

Every `.msh` asset LIBERO ships, reader vs MuJoCo in the authored frame:

| real `.msh` assets | compared | count mismatches | worst AABB disagreement |
| --- | --- | --- | --- |
| 88 | 88 | 0 | 6.54e-06 |

So this pins correct behaviour rather than fixing a defect. What it removes is
the possibility of that agreement drifting silently.

## Break table

Each row applied to a scratch tree; the parser breaks touch
`mesh_assets.py`, the fixture breaks touch the test file.

| break | fires |
| --- | --- |
| control (no break) | 0 of 33 |
| header fields `nnormal` / `ntexcoord` swapped in the parser | **1** - the asymmetric fixture alone |
| faces read immediately after the vertices | 3, incl. the **pre-existing** `test_binary_msh` |
| texcoords sized as 3 floats instead of 2 | 3, incl. the **pre-existing** `test_binary_msh` |
| shared fixture dropped below MuJoCo's 4-vertex floor | 5, incl. the non-vacuity test (`assert 3 >= 4`) |
| the coplanar fixture made non-coplanar | **1** - the coplanar test alone (`DID NOT RAISE`) |

Two rows fire exactly one test, and two fire a pre-existing test, so the new
pins compose with the contract that was already there rather than replacing it.

A sixth break - asserting the fixture has extent on every axis - showed that
assertion was **unreachable**: MuJoCo runs qhull over the vertices and refuses
a coplanar mesh before any comparison is made. The dead premise was removed and
replaced by `test_mujoco_refuses_a_coplanar_msh`, which states the guarantee the
oracle already provides.

## Verification

Measured at `bd55980`. The head has since moved to `1907aca`, which adds
only the changelog fragment (`git diff bd55980..1907aca -- '*.py'` is empty).

| check | result |
| --- | --- |
| changed file, mujoco 3.12.0 (what CI resolves) | 33 passed, 5 skipped |
| changed file, mujoco 3.5.0 (the declared floor) | 33 passed, 5 skipped |
| new class alone | 6 passed (none skipped) |
| `ruff check` / `ruff format --check`, CI scope | clean |
| `mypy strands_robots tests tests_integ` | 24 errors, byte-identical to `upstream/main` |

Gate: the isaac package plus every guard that walks the test tree or grades
sources, docstrings, strings or changelog fragments - 128 files, the identical
selection on both trees with the changed file excluded from each:

| tree | result |
| --- | --- |
| this branch | 4600 passed, 54 skipped, 0 failed (280.86s) |
| `upstream/main` | 4600 passed, 54 skipped, 0 failed (296.46s) |

Byte-identical, and the branch-only and base-only failing-id sets are both
empty.

## Scope

Only `tests/simulation/isaac/test_mesh_assets.py` changes (`git diff --numstat`
names one path), so there is no library behaviour to film. The 5 skips are the
pre-existing `usd-core`-absent conversion tests.

Deliberately out of scope: the OBJ and STL siblings in the same module can be
graded against the same oracle, but each is a separate contract.
