### PR TITLE
fix(examples): report a refused LIBERO setup step where it refuses

### DIFF
--- a/changelog.d/2677-libero-driver-reports-a-refused-setup-step.md
+++ b/changelog.d/2677-libero-driver-reports-a-refused-setup-step.md
@@ -1,0 +1,23 @@
+### Fixed: a refused LIBERO setup step is reported where it refuses
+
+The LIBERO driver's two setup shims read the same `{"status": ...}` envelope
+differently: the Isaac shim checked all five of its `Simulation` calls with
+inline guards, the MuJoCo shim checked none of its five. A refused
+`create_world`, `add_robot` or `load_scene` was therefore discarded, the run
+continued on a world that was never set up, and it printed a `success_rate=`
+line for a rollout whose setup had failed; a refused
+`start_cameras_recording` surfaced later as the zero-frame recording check,
+so the recorder never starting read as a camera that produced no frames.
+Measured on the real `Simulation`, a missing scene file and a camera the
+world does not have produced a byte-identical message, leaving the two
+causes indistinguishable.
+
+`_require_ok(envelope, step)` is now the single owner of the rule - it
+returns the envelope untouched on success and raises
+`RuntimeError("<step> failed: <envelope>")` otherwise - and both shims route
+every setup call through it. The Isaac shim's operator-visible wording is
+unchanged, and it still chains its `on_frame` handle off the returned
+envelope. `sim.destroy()` on the cleanup path and the per-episode
+`sim.step()` in the retry loop stay unchecked on purpose, pinned by controls:
+a cleanup that refuses must not mask the failure being cleaned up after, and
+the step's verdict belongs to the retry loop rather than to setup.

--- a/examples/libero/run.py
+++ b/examples/libero/run.py
@@ -513,6 +513,46 @@ class _EvalPlan:
     eval_kwargs: dict = field(default_factory=dict)
 
 
+def _require_ok(result: dict, what: str) -> dict:
+    """Refuse a setup step the backend declined, where it declined it.
+
+    Every ``Simulation`` / ``IsaacSimulation`` setup call answers a tool
+    envelope rather than raising, so a discarded return leaves a refusal
+    invisible. Both backend shims below assemble the same rollout out of the
+    same envelope-returning calls, and this is the single place either reads
+    the verdict - so they cannot drift back into two rules for it.
+
+    Measured on the ``mujoco`` shim before this existed, isolating one refused
+    step at a time: a refused ``create_world``, ``add_robot`` or ``load_scene``
+    printed a full ``success_rate=`` result line, which
+    ``libero_backend_matrix.py`` parses as a completed cell; and a refused
+    ``start_cameras_recording`` surfaced only after the whole rollout, as
+    ``rollout recorded 0 frames for camera 'image' (0 per-frame render
+    errors)`` - a render diagnosis for a recorder that never started, naming
+    neither the step nor the available-camera list the refusal carried.
+    ``stop_cameras_recording`` answers ``status="success"`` with
+    ``"Was not recording cameras."`` and no json block, so the ``finally``
+    arm gave no signal either.
+
+    Args:
+        result: The tool envelope the setup call answered.
+        what: The call's name, used verbatim in the refusal so the message
+            names the step that declined.
+
+    Returns:
+        ``result`` unchanged, so a caller needing the payload (the Isaac
+        recorder's ``on_frame`` handle) can chain off the check.
+
+    Raises:
+        RuntimeError: ``result`` does not report ``status="success"``. The
+            message carries the whole envelope, which is where the backend's
+            own remedy lives.
+    """
+    if result.get("status") != "success":
+        raise RuntimeError(f"{what} failed: {result}")
+    return result
+
+
 def _setup_mujoco(args: argparse.Namespace, suite: str):
     """MuJoCo setup shim: procedural Panda + LIBERO scene pre-warm.
 
@@ -523,7 +563,7 @@ def _setup_mujoco(args: argparse.Namespace, suite: str):
 
     sim = Simulation(tool_name="libero_sim", mesh=False)
     try:
-        sim.create_world()
+        _require_ok(sim.create_world(), "create_world")
         # Pre-add a Panda named ``robot`` so:
         #   1. evaluate_benchmark's pre-flight check (`No robots in sim`)
         #      passes BEFORE on_episode_start runs scene loading.
@@ -532,7 +572,7 @@ def _setup_mujoco(args: argparse.Namespace, suite: str):
         #      scenes ship a Franka Panda named `robot` (LIBERO/RoboSuite
         #      convention), so picking the same name client-side keeps
         #      the resolved robot stable across `on_episode_start`.
-        sim.add_robot("robot", data_config="panda")
+        _require_ok(sim.add_robot("robot", data_config="panda"), "add_robot")
 
         resolved_task = _resolve_task(suite, args.task)
 
@@ -560,7 +600,7 @@ def _setup_mujoco(args: argparse.Namespace, suite: str):
             if hasattr(spec, "ensure_scene"):
                 spec.ensure_scene()
             if spec.scene_path:
-                sim.load_scene(spec.scene_path)
+                _require_ok(sim.load_scene(spec.scene_path), "load_scene")
                 # Prewarm BEFORE the redundant-Panda check below, so
                 # prewarm's robot registration wraps the scene-supplied
                 # Panda first -> list_robots() returns ['robot'] -> the
@@ -573,12 +613,15 @@ def _setup_mujoco(args: argparse.Namespace, suite: str):
                 # don't expose `prewarm` and don't ship a Panda in
                 # the loaded scene MJCF.
                 if "robot" not in sim.list_robots():
-                    sim.add_robot("robot", data_config="panda")
+                    _require_ok(sim.add_robot("robot", data_config="panda"), "add_robot")
 
         def arm_recording(video_dir: str, rec_name: str) -> dict:
             # MuJoCo's recorder runs on a background thread; nothing to
             # thread into evaluate_benchmark.
-            sim.start_cameras_recording(cameras=recording_cameras, output_dir=video_dir, name=rec_name)
+            _require_ok(
+                sim.start_cameras_recording(cameras=recording_cameras, output_dir=video_dir, name=rec_name),
+                "start_cameras_recording",
+            )
             return {}
 
         plan = _EvalPlan(
@@ -773,9 +816,7 @@ def _setup_isaac(args: argparse.Namespace, suite: str):
     # STRANDS_ISAAC_RTX_PATHTRACING=1 upgrades to photoreal pathtracing.)
     sim = create_simulation("isaac", headless=True, num_envs=1, render_mode="rtx_realtime")
     try:
-        result = sim.create_world()
-        if result.get("status") != "success":
-            raise RuntimeError(f"create_world failed: {result}")
+        _require_ok(sim.create_world(), "create_world")
 
         # Load a *real* robot asset (default: Isaac's bundled Franka
         # Panda USD; override via --robot-usd / --robot-urdf). This
@@ -794,8 +835,7 @@ def _setup_isaac(args: argparse.Namespace, suite: str):
         else:
             print(f"[setup] loading robot from USD: {robot_usd}")
             result = sim.add_robot(name="robot", usd_path=robot_usd)
-        if result.get("status") != "success":
-            raise RuntimeError(f"add_robot failed: {result}")
+        _require_ok(result, "add_robot")
 
         # Isaac doesn't auto-attach viewport cameras the way MuJoCo's
         # mjData does. Add an explicit RTX camera at the same
@@ -810,8 +850,7 @@ def _setup_isaac(args: argparse.Namespace, suite: str):
             target=[0.0, 0.0, 0.5],
             fov=60.0,
         )
-        if result.get("status") != "success":
-            raise RuntimeError(f"add_camera failed: {result}")
+        _require_ok(result, "add_camera")
 
         # The libero_panda data-config ALSO requires a ``wrist_image`` video
         # key. Pre-add it here -- at the same static fallback vantage
@@ -832,8 +871,7 @@ def _setup_isaac(args: argparse.Namespace, suite: str):
             width=256,
             height=256,
         )
-        if result.get("status") != "success":
-            raise RuntimeError(f"add_camera failed: {result}")
+        _require_ok(result, "add_camera")
 
         # Warm up the RTX render product before recording. A camera added
         # after the last world step has an empty render product: its first
@@ -910,8 +948,7 @@ def _setup_isaac(args: argparse.Namespace, suite: str):
                 output_dir=video_dir,
                 name=rec_name,
             )
-            if rec.get("status") != "success":
-                raise RuntimeError(f"start_cameras_recording failed: {rec}")
+            _require_ok(rec, "start_cameras_recording")
             base_on_frame = next(c["json"]["on_frame"] for c in rec["content"] if "json" in c)
 
             def on_frame(step: int, observation: dict, action: dict) -> None:

--- a/tests/test_examples_libero_drivers.py
+++ b/tests/test_examples_libero_drivers.py
@@ -36,8 +36,10 @@ from __future__ import annotations
 import ast
 import importlib.util
 import inspect
+import re
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -468,3 +470,353 @@ def test_the_zero_frame_verdict_is_applied_unconditionally() -> None:
     assert len(calls) == 1, "the shared loop applies the verdict exactly once"
     conditional = {id(n) for branch in ast.walk(tree) if isinstance(branch, ast.If) for n in ast.walk(branch)}
     assert id(calls[0]) not in conditional, "the zero-frame verdict must not be conditional"
+
+
+# ---------------------------------------------------------------------------
+# A refused setup step is reported where it refuses, on either subcommand
+# ---------------------------------------------------------------------------
+#
+# Every `Simulation` / `IsaacSimulation` setup call answers a tool envelope
+# rather than raising. `_setup_isaac` read the verdict of all five of its
+# (`create_world`, `add_robot`, `add_camera` x2, `start_cameras_recording`);
+# `_setup_mujoco` discarded all five of its. Measured by driving the real
+# `_setup_mujoco` with one refused step at a time (the rest succeeding):
+#
+#   refused step             | before                          | after
+#   -------------------------|---------------------------------|--------------
+#   create_world             | printed a success_rate= line    | refused at setup
+#   add_robot                | printed a success_rate= line    | refused at setup
+#   load_scene               | printed a success_rate= line    | refused at setup
+#   start_cameras_recording  | RuntimeError after the rollout  | refused pre-rollout
+#
+# Three of the four shipped a full result line, which `libero_backend_matrix.py`
+# parses as a completed cell; the fourth surfaced only after the whole rollout
+# as `rollout recorded 0 frames for camera 'image' (0 per-frame render errors)`
+# - a render diagnosis for a recorder that never started. Before: 4 of 4 ran the
+# rollout and 0 of 4 named the step. After: 0 of 4 and 4 of 4.
+
+_SETUP_REFUSALS = {
+    "create_world": "create_world: a world already exists (robots: robot; objects: none).",
+    "add_robot": "Failed to load: asset for 'panda' is not on disk.",
+    "load_scene": "Scene file not found: /var/cache/libero/spatial_task_0.xml",
+    "start_cameras_recording": "Camera(s) not found: ['image', 'wrist_image']. Available: ['default']",
+}
+
+
+class _RefusingSetupSim:
+    """A ``Simulation`` stand-in that refuses exactly one setup step.
+
+    Refusing one at a time is what isolates *where* that step's refusal
+    surfaces; in practice several cascade.
+    """
+
+    def __init__(self, refuse: str | None, *, has_robot: bool = True) -> None:
+        self.refuse = refuse
+        self.calls: list[str] = []
+        self.recording = False
+        self._has_robot = has_robot
+
+    def _env(self, name: str) -> dict:
+        self.calls.append(name)
+        if name == self.refuse:
+            return {"status": "error", "content": [{"text": _SETUP_REFUSALS[name]}]}
+        return {"status": "success", "content": [{"text": f"{name} ok"}]}
+
+    def create_world(self, **_kw: object) -> dict:
+        return self._env("create_world")
+
+    def add_robot(self, *_a: object, **_kw: object) -> dict:
+        return self._env("add_robot")
+
+    def load_scene(self, *_a: object, **_kw: object) -> dict:
+        return self._env("load_scene")
+
+    def list_robots(self) -> list[str]:
+        return ["robot"] if self._has_robot else []
+
+    def start_cameras_recording(self, **_kw: object) -> dict:
+        result = self._env("start_cameras_recording")
+        self.recording = result["status"] == "success"
+        return result
+
+    def stop_cameras_recording(self) -> dict:
+        self.calls.append("stop_cameras_recording")
+        if not self.recording:
+            # Measured verbatim on a real MuJoCo sim: success, and no json block.
+            return {"status": "success", "content": [{"text": "Was not recording cameras."}]}
+        return {
+            "status": "success",
+            "content": [
+                {"text": "Stopped 'r' after 1.9s"},
+                {
+                    "json": {
+                        "artifacts": [
+                            {
+                                "camera": "image",
+                                "path": "/tmp/r__image.mp4",
+                                "frames": 120,
+                                "errors": 0,
+                                "size_kb": 16.2,
+                            }
+                        ]
+                    }
+                },
+            ],
+        }
+
+    def evaluate_benchmark(self, **_kw: object) -> dict:
+        self.calls.append("evaluate_benchmark")
+        return {"status": "success", "content": [{"json": {"success_rate": 0.4}}]}
+
+    def destroy(self) -> dict:
+        self.calls.append("destroy")
+        return {"status": "success", "content": [{"text": "ok"}]}
+
+
+class _PrewarmSpec:
+    """A benchmark spec whose scene the ``groot`` path pre-warms."""
+
+    scene_path = "/var/cache/libero/spatial_task_0.xml"
+
+    def ensure_scene(self) -> None:
+        return None
+
+    def prewarm(self, _sim: object) -> None:
+        return None
+
+
+def _drive_mujoco_setup(run, monkeypatch, tmp_path, refuse, *, has_robot=True):
+    """Run the real ``_setup_mujoco`` (and the recording arm) against a fake sim.
+
+    Returns ``(sim, raised)`` - ``raised`` is the exception the caller saw, or
+    ``None`` if the whole path reported success.
+    """
+    sim = _RefusingSetupSim(refuse, has_robot=has_robot)
+    sim_module = types.ModuleType("strands_robots.simulation")
+    sim_module.Simulation = lambda **_kw: sim  # type: ignore[attr-defined]
+    bench_module = types.ModuleType("strands_robots.simulation.benchmark")
+    bench_module.get_benchmark = lambda _name: _PrewarmSpec()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "strands_robots.simulation", sim_module)
+    monkeypatch.setitem(sys.modules, "strands_robots.simulation.benchmark", bench_module)
+    monkeypatch.setattr(run, "_resolve_task", lambda *_a, **_k: "libero_spatial_task_0")
+    monkeypatch.setattr(run, "_date_dir", lambda: str(tmp_path))
+
+    args = run.argparse.Namespace(
+        backend="mujoco", policy="groot", n_episodes=2, seed=7, task="libero_spatial_task_0", port=5555
+    )
+    try:
+        built_sim, plan = run._setup_mujoco(args, "libero_spatial")
+        run._evaluate_and_report(built_sim, args, plan)
+    except Exception as exc:  # noqa: BLE001 - the caller's own verdict is the subject
+        return sim, exc
+    return sim, None
+
+
+@pytest.mark.parametrize("refuse", sorted(_SETUP_REFUSALS))
+def test_a_refused_setup_step_is_reported_where_it_refuses(refuse, tmp_path, monkeypatch, capsys):
+    """A setup step the backend declined must not be discarded.
+
+    Fails pre-fix for all four: ``create_world`` / ``add_robot`` /
+    ``load_scene`` printed a full ``success_rate=`` line, and
+    ``start_cameras_recording`` raised only after the rollout with a render
+    diagnosis naming neither the step nor its camera list.
+    """
+    run = _load_example("run.py")
+    sim, raised = _drive_mujoco_setup(run, monkeypatch, tmp_path, refuse)
+
+    printed = capsys.readouterr().out
+    assert raised is not None, (
+        f"a refused {refuse} was discarded: the run reported success and printed {printed.strip()[:200]!r}"
+    )
+    assert "success_rate=" not in printed, f"a refused {refuse} still printed a result line: {printed[:200]!r}"
+    message = str(raised)
+    assert refuse in message, f"the refusal must name the step that declined; got: {message[:200]}"
+    assert _SETUP_REFUSALS[refuse] in message, f"the backend's own reason must survive; got: {message[:200]}"
+    assert "evaluate_benchmark" not in sim.calls, (
+        f"a refused {refuse} must not spend a whole rollout first (calls: {sim.calls})"
+    )
+
+
+def test_the_fallback_add_robot_is_checked_too(tmp_path, monkeypatch):
+    """The defensive ``add_robot`` behind the redundant-Panda check is a site too.
+
+    It only runs for a scene that ships no Panda, so a fake reporting an empty
+    ``list_robots()`` is what reaches it.
+    """
+    run = _load_example("run.py")
+    sim, raised = _drive_mujoco_setup(run, monkeypatch, tmp_path, "add_robot", has_robot=False)
+
+    assert raised is not None, "the fallback add_robot's refusal was discarded"
+    assert "add_robot" in str(raised)
+    assert sim.calls.count("add_robot") >= 1, f"premise: the fallback site ran (calls: {sim.calls})"
+
+
+# ---------------------------------------------------------------------------
+# Root cause: one owner for the rule, and no shim may drift off it
+# ---------------------------------------------------------------------------
+
+_SETUP_SHIMS = ("_setup_mujoco", "_setup_isaac")
+
+
+def _is_status_guard(test: ast.expr) -> bool:
+    """Is ``test`` the inline ``<envelope>.get("status") != "success"`` comparison?
+
+    Matched with the quotes stripped. ``ast.unparse`` normalises every string
+    literal to single quotes, so a double-quoted needle silently matches
+    nothing - and both rules below would then pass without grading anything.
+    """
+    rendered = ast.unparse(test).replace('"', "").replace("'", "")
+    return "get(status) !=" in rendered and "success" in rendered
+
+
+def _setup_shim_sim_calls(source: str) -> dict[str, dict[str, list[tuple[str, int]]]]:
+    """Per ``sim`` method, its call sites in either setup shim, split by check.
+
+    A site counts as checked when its envelope reaches a verdict: either it
+    flows into ``_require_ok`` (directly, or through a local that
+    ``_require_ok`` is later called on), or the local it was assigned to is
+    guarded by an explicit ``if <name>.get("status") != "success"``. Both forms
+    are recognised so the rule reads the same before and after the shared owner
+    exists.
+    """
+    tree = ast.parse(source)
+    shims = [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name in _SETUP_SHIMS]
+    assert len(shims) == len(_SETUP_SHIMS), f"expected both setup shims, found {[s.name for s in shims]}"
+
+    out: dict[str, dict[str, list[tuple[str, int]]]] = {}
+    for shim in shims:
+        checked_calls: set[int] = set()
+        checked_names: set[str] = set()
+        for node in ast.walk(shim):
+            # _require_ok(<call>, "what") / _require_ok(<name>, "what")
+            if isinstance(node, ast.Call) and ast.unparse(node.func) == "_require_ok" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Call):
+                    checked_calls.add(id(first))
+                elif isinstance(first, ast.Name):
+                    checked_names.add(first.id)
+            # if <name>.get("status") != "success"
+            if isinstance(node, ast.If) and _is_status_guard(node.test):
+                for sub in ast.walk(node.test):
+                    if isinstance(sub, ast.Attribute) and isinstance(sub.value, ast.Name):
+                        checked_names.add(sub.value.id)
+        # a call assigned to a checked local is itself checked
+        for node in ast.walk(shim):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                if any(isinstance(t, ast.Name) and t.id in checked_names for t in node.targets):
+                    checked_calls.add(id(node.value))
+
+        for node in ast.walk(shim):
+            if not isinstance(node, ast.Call):
+                continue
+            func = ast.unparse(node.func)
+            if not func.startswith("sim."):
+                continue
+            method = func.split(".", 1)[1]
+            bucket = out.setdefault(method, {"checked": [], "unchecked": []})
+            key = "checked" if id(node) in checked_calls else "unchecked"
+            bucket[key].append((shim.name, node.lineno))
+    return out
+
+
+def test_every_setup_step_checked_in_one_shim_is_checked_in_the_other() -> None:
+    """A setup step whose verdict one shim reads must be read wherever it is called.
+
+    Derived, so it needs no list of method names: ``destroy`` and ``step`` are
+    unchecked at every site (cleanup, and a retry loop whose observable is the
+    frame count) and are therefore consistent; ``create_world``, ``add_robot``
+    and ``start_cameras_recording`` were read in ``_setup_isaac`` and discarded
+    in ``_setup_mujoco``, which is exactly the drift this reports.
+    """
+    calls = _setup_shim_sim_calls((_EXAMPLES_LIBERO / "run.py").read_text(encoding="utf-8"))
+    assert len(calls) >= 6, f"the scan reached too few sim methods to mean anything: {sorted(calls)}"
+
+    offenders = {
+        method: sites["unchecked"] for method, sites in calls.items() if sites["checked"] and sites["unchecked"]
+    }
+    assert not offenders, (
+        "a setup step's verdict is read at one call site and discarded at another, "
+        f"so the two backend shims disagree about it: {offenders}"
+    )
+
+
+def test_the_setup_shims_route_every_check_through_one_owner() -> None:
+    """Single owner: neither shim re-derives the status comparison inline.
+
+    Two copies of the rule is how the shims drifted into one reading the
+    verdict and the other discarding it, so the check has one home.
+    """
+    source = (_EXAMPLES_LIBERO / "run.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    inline: list[tuple[str, int]] = []
+    for shim in [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name in _SETUP_SHIMS]:
+        for node in ast.walk(shim):
+            if isinstance(node, ast.If) and _is_status_guard(node.test):
+                inline.append((shim.name, node.lineno))
+    assert not inline, f"a setup shim re-derives the status check instead of calling _require_ok: {inline}"
+
+
+def test_the_shared_owner_reports_the_step_and_keeps_the_backend_reason() -> None:
+    """The refusal names the step and carries the envelope the backend answered."""
+    run = _load_example("run.py")
+    refusal = {"status": "error", "content": [{"text": "Camera(s) not found: ['image']"}]}
+
+    with pytest.raises(RuntimeError) as excinfo:
+        run._require_ok(refusal, "start_cameras_recording")
+
+    message = str(excinfo.value)
+    assert message.startswith("start_cameras_recording failed:"), message
+    assert "Camera(s) not found" in message, message
+
+
+def test_the_shared_owner_returns_the_envelope_untouched_on_success() -> None:
+    """Control: the Isaac recorder chains its ``on_frame`` handle off the check."""
+    run = _load_example("run.py")
+    envelope = {"status": "success", "content": [{"json": {"on_frame": "handle"}}]}
+
+    returned = run._require_ok(envelope, "start_cameras_recording")
+
+    assert returned is envelope
+
+
+def test_the_refusal_wording_is_unchanged() -> None:
+    """Control: the operator-visible template still reads ``<step> failed: <envelope>``.
+
+    Written to match either spelling of it - the per-site raises the shims used
+    before the shared owner existed, and the owner's own - so it pins the
+    wording rather than which function produces it.
+    """
+    source = (_EXAMPLES_LIBERO / "run.py").read_text(encoding="utf-8")
+
+    assert re.search(r"failed: \{(?:result|rec|what)\}", source), (
+        "the refusal template moved away from '<step> failed: <envelope>'"
+    )
+
+
+def test_the_cleanup_and_retry_loop_calls_are_deliberately_unchecked() -> None:
+    """Boundary: not every ``sim`` call in a shim answers a verdict worth reading.
+
+    ``destroy`` runs while already unwinding, and ``step`` sits in the RTX
+    warmup retry loop whose observable is the accumulated frame count - so both
+    stay unchecked, in both shims. This fails if the fix is widened to every
+    call rather than the setup steps.
+    """
+    calls = _setup_shim_sim_calls((_EXAMPLES_LIBERO / "run.py").read_text(encoding="utf-8"))
+
+    for method in ("destroy", "step"):
+        assert method in calls, f"premise: the shims still call sim.{method}"
+        assert not calls[method]["checked"], (
+            f"sim.{method} is not a setup step; checking it would refuse a rollout for a "
+            f"cleanup/retry call: {calls[method]['checked']}"
+        )
+
+
+def test_a_setup_that_succeeds_still_returns_a_plan_and_reports(tmp_path, monkeypatch, capsys):
+    """Control: the happy path is untouched - it still builds a plan and prints."""
+    run = _load_example("run.py")
+    sim, raised = _drive_mujoco_setup(run, monkeypatch, tmp_path, None)
+
+    assert raised is None, f"a fully successful setup must not raise: {raised}"
+    printed = capsys.readouterr().out
+    assert "success_rate=0.40" in printed and "backend=mujoco" in printed, printed[:300]
+    assert "evaluate_benchmark" in sim.calls, f"premise: the rollout ran (calls: {sim.calls})"


### PR DESCRIPTION
## The gap

Every `Simulation` / `IsaacSimulation` setup call returns a `{"status": ...}` envelope. The two LIBERO driver setup shims in `examples/libero/run.py` read those envelopes differently: `_setup_isaac` checked all five of its calls with inline `if r.get("status") == "error": raise` guards, and `_setup_mujoco` checked none of its five.

One driver, one merged eval loop, two rules for the same question.

## Measured

Driving `_setup_mujoco` with each step refused in turn, on the real `Simulation`:

| refused step | upstream/main | this branch |
| --- | --- | --- |
| `create_world` | proceeds, prints a `success_rate=` line | refuses, naming `create_world` |
| `add_robot` | proceeds, prints a `success_rate=` line | refuses, naming `add_robot` |
| `load_scene` | proceeds, prints a `success_rate=` line | refuses, naming `load_scene` |
| `start_cameras_recording` | reported as a *rendering* failure, later | refuses, naming `start_cameras_recording` |

The first three are silent: the run continues on a world that was never set up and prints a result line for a rollout whose setup failed. The fourth is louder but misdiagnosed - it surfaces as the zero-frame recording check, so a refused recorder start reads as a camera that produced no frames.

The refusal that is discarded is the one that says *what* went wrong, and it is discarded at the point where that is still knowable.

## Change

`_require_ok(envelope, step)` becomes the single owner of the rule: it returns the envelope untouched on success and raises `RuntimeError("<step> failed: <envelope>")` otherwise. Both shims route every setup call through it - `_setup_mujoco`'s five, and `_setup_isaac`'s five, which previously repeated the check inline.

`_setup_isaac`'s operator-visible wording is unchanged; the Isaac recorder still chains its `on_frame` handle off the returned envelope, which is why the owner returns it rather than swallowing it.

Deliberately left unchecked, and pinned as such: `sim.destroy()` on the cleanup path (a cleanup that refuses must not mask the failure being cleaned up after) and the per-episode `sim.step()` in the retry loop (its verdict is the loop's own, not a setup step's).

## Tests

`tests/test_examples_libero_drivers.py` gains a class that refuses one setup step at a time and asserts the driver names it, a structural rule that both shims route every setup call through the one owner, a consistency rule that a step checked in one shim is checked in the other, and controls for the owner's success behaviour and for the two deliberately-unchecked calls.

Pre-fix: **9 failed / 25 passed**. After: **34 passed**.

Break table - each break fires a distinct set, so no guard is decorative:

| break | fires |
| --- | --- |
| control (this branch) | 0 of 34 |
| exact pre-fix source | 9 - the full regression set |
| `_setup_mujoco` reverted only | 6 - the four behavioural cases, the fallback, and consistency |
| `_setup_isaac` reverted to inline guards | 2 - consistency and single-owner only |
| only the recording arm's check dropped | 2 - that case and consistency |
| the predicate loses its quote normalisation, on pre-fix source | 7 - **consistency and single-owner both go quiet** |
| over-reach: `sim.destroy()` checked too | 1 - the boundary control alone |
| the owner drops the envelope it returns | 1 - the returns-untouched control alone |
| the scan reaches no shim | 2 - non-vacuity and the boundary control |

The sixth row is why the structural rules read the source through `ast.unparse` rather than matching text: with a text predicate they silently stop finding the calls they grade, and a reader cannot tell that from a clean tree.

## Verification

Measured at `70b44215` on one host, mujoco 3.12.0 (what CI resolves) unless stated. The head has since moved to `d930dfdc`, which adds only the changelog fragment (`git diff 70b44215..d930dfdc` is that one file).

- Gate: 151 test files that read `examples/`, walk the test tree, or touch the LIBERO adapter, run identically on this branch and on a pristine `upstream/main` worktree with the changed test file excluded from both: **`2 failed, 4990 passed, 84 skipped`** on each, at 298.58s and 299.03s. The two failures are in `tests/mesh/test_zenoh_transport_security.py` and are a *different* subset on each tree - that file opens real localhost Zenoh sessions on fixed ports, so two parallel runs collide. Run alone it is `9 passed, 2 skipped` on **both** trees. Excluding that one contended file, **0 failing ids on either tree**.
- `mypy strands_robots tests tests_integ`: 24 pre-existing errors on both this branch and a pristine worktree, identical message sets, none in the changed files.
- `ruff check` / `ruff format --check` clean over the CI scope and over the changed example.
- The changed test file: **34 passed** on mujoco 3.12.0 and on 3.5.0, the declared floor.
- **387 passed, 51 skipped** across all 13 `tests/test_examples*.py` files with random ordering enabled.

## Artifact

The same real MuJoCo `Simulation` refusing for two different reasons, and the happy path unchanged. Only the task resolver, the benchmark lookup and `evaluate_benchmark` are stood in - they need the `benchmark-libero` extra and a live policy server. Every refusal shown is the `Simulation`'s own.

![the driver reporting a refused setup step](https://raw.githubusercontent.com/cagataycali/robots/media-libero-setup-refusal/libero-setup-refusal.png)

Row 2 is the point: on `upstream/main` a missing scene file and a camera the world does not have produce a **byte-identical** message about zero recorded frames, so the `load_scene` refusal is reported as a camera problem. On this branch each names its own step, and the scene-file case refuses during setup rather than after a rollout. The control row's printed result line and its render are identical on both trees - the render to a mean absolute difference of 0.000001 levels.

