### PR TITLE
fix(sim): name the joints whose rate drive is commanded elsewhere on a velocity write

### DIFF
--- a/changelog.d/2678-velocity-write-names-rate-drive.md
+++ b/changelog.d/2678-velocity-write-names-rate-drive.md
@@ -1,0 +1,41 @@
+### Fixed
+
+`set_joint_velocities` now names the joints whose actuator is commanding a
+different rate. The write lands and `qvel` reads back what was asked for, so
+`status` was `success` and the report was the plain `Set 1/1 joint velocities` --
+but on a joint driven by a `<velocity>` actuator that `ctrl` **is** the joint's
+own rate, so the drive was already commanding a velocity of its own and the next
+step resolved the disagreement in the drive's favour. Measured on a one-hinge bar
+with gravity off and `kv=2`: writing `+2.0` rad/s while the drive commanded
+`-3.0` left the joint at `-0.2532` rad after 72 steps, and writing the same
+`+2.0` while the drive commanded `+2.0` left it at `+0.2391`. Two opposite
+outcomes, and one byte-identical report.
+
+The sibling `set_joint_positions` had already settled the shape of that answer
+for a position servo, naming the joint and the setpoint that overrides it. Only
+the velocity half had no equivalent, and its remedy is not the same one:
+`hold=True` moves a servo's setpoint, while a rate drive's `ctrl` already is the
+rate, so the report points at `send_action`.
+
+`scene_ops.joint_rate_drive_map` is the velocity counterpart of the existing
+`joint_drive_map`, reading the same compiled fields: an affine bias with no
+position feedback but negative velocity feedback (`biasprm = [0, 0, -kv]`), a
+stateless `dyntype`, and a joint transmission resolved through
+`actuator_joint_id`. Measured against every MuJoCo actuator shortcut, `<velocity>`
+is the only one that clears all of them -- a torque motor, a position servo,
+`<intvelocity>` (whose `ctrl` is integrated into a pose), `<damper>` (whose `ctrl`
+scales damping rather than commanding a rate) and `<cylinder>` are all excluded,
+and a `<general>` spelling `<velocity>` longhand classifies identically, which is
+the point of reading the compiled fields rather than the element. Slot 2 has to
+be negative rather than merely non-zero: positive velocity feedback is
+anti-damping, and a written rate against it diverges rather than settling on any
+commanded value.
+
+A tendon rate drive is not reported. Its `ctrl` moves a tendon length rate, not
+the joint's, so there is no rate in the joint's units for the write to disagree
+with -- which is why the transmission is resolved through `actuator_joint_id`
+rather than read raw.
+
+Report only: no verdict, no accepted input and no written value moves, and a
+drive that happens to be commanding the written rate keeps the plain report
+byte-for-byte.

--- a/strands_robots/simulation/mujoco/physics.py
+++ b/strands_robots/simulation/mujoco/physics.py
@@ -33,6 +33,7 @@ from strands_robots.simulation.mujoco.backend import (
 from strands_robots.simulation.mujoco.scene_ops import (
     fromto_fixed_size_components,
     joint_drive_map,
+    joint_rate_drive_map,
     persist_body_mass,
     persist_geom_properties,
     refresh_body_inertial_from_geometry,
@@ -1744,6 +1745,20 @@ class PhysicsMixin:
         resolved inside ``robot_name``'s namespace before the cross-robot
         fallback, so a bare name reaches the robot the caller addressed, and a
         ``robot_name`` no robot carries is refused in both call forms.
+
+        The write is a state write, so on a joint driven by a *rate* actuator --
+        one whose ``ctrl`` is the joint's own velocity, per
+        :func:`~strands_robots.simulation.mujoco.scene_ops.joint_rate_drive_map`
+        -- it survives exactly as long as nothing steps: the drive is still
+        commanding whatever rate it held, and the next step resolves that
+        disagreement in the drive's favour. The success report therefore names
+        the written joints whose rate drive is commanded elsewhere, on the same
+        terms :meth:`set_joint_positions` reports a position servo holding a
+        different setpoint, and points at ``send_action`` -- which writes that
+        ``ctrl`` -- as the way to command the rate rather than only the state. A
+        joint driven by a torque motor, a stateful drive or a tendon is not
+        reported: its ``ctrl`` is not a velocity in the joint's units, so there
+        is no rate for it to disagree with.
         """
         if self._world is None or self._world._model is None or self._world._data is None:
             return {"status": "error", "content": [{"text": _NO_WORLD_MSG}]}
@@ -1825,12 +1840,30 @@ class PhysicsMixin:
             return err
 
         with self._lock:
+            rate_drives = joint_rate_drive_map(model, mj)
+            stale: list[str] = []
             for jnt_name, value in velocities.items():
-                dof_adr = model.jnt_dofadr[joint_ids[jnt_name]]
+                jnt_id = joint_ids[jnt_name]
+                dof_adr = model.jnt_dofadr[jnt_id]
                 data.qvel[dof_adr] = float(value)
+
+                act_id = rate_drives.get(jnt_id)
+                if act_id is None:
+                    continue
+                if float(data.ctrl[act_id]) != float(value):
+                    # Exact inequality is the claim being reported: the drive is
+                    # commanding a different rate in this joint's own units, so
+                    # the next step moves the velocity off the one just written.
+                    stale.append(jnt_name)
 
         count = len(velocities)
         msg = f"Set {count}/{count} joint velocities"
+        if stale:
+            msg += (
+                f". {len(stale)} of them are driven by an actuator still commanding a different rate "
+                f"({_joint_name_sample(stale)}), so the next step drives the velocity back toward that "
+                "command; command the drive itself through send_action with the rate you want held"
+            )
         return {
             "status": "success",
             "content": [{"text": msg}],

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -275,6 +275,71 @@ def joint_drive_map(model: Any, mj: Any) -> tuple[dict[int, int], dict[int, int]
     return servos, other
 
 
+def joint_rate_drive_map(model: Any, mj: Any) -> dict[int, int]:
+    """Map each joint whose actuator commands a *rate* in the joint's own units.
+
+    The velocity counterpart of :func:`joint_drive_map`, which answers the same
+    question for a pose. A *rate drive* is an actuator whose ``ctrl`` IS the
+    joint's velocity, so a velocity a caller writes into ``qvel`` is a value the
+    drive is simultaneously commanding somewhere else -- and the next step
+    resolves that disagreement in the drive's favour.
+
+    The three terms mirror :func:`joint_drive_map`'s, read off the same compiled
+    fields (measured against every MuJoCo actuator shortcut, only ``<velocity>``
+    clears all of them):
+
+    * ``biastype == mjBIAS_AFFINE`` - the bias is computed from the joint's own
+      state. Necessary and not sufficient: ``<position kp>`` and
+      ``<intvelocity kp>`` are affine-bias too.
+    * ``biasprm[1] == 0`` and ``biasprm[2] < 0`` - slot 1 is ``-kp`` (position
+      feedback) and slot 2 is ``-kv`` (velocity feedback), so a rate command is
+      the one with feedback on the rate and none on the pose. ``<velocity kv>``
+      compiles to ``biasprm = [0, 0, -kv]``; ``<position kp>`` to
+      ``[0, -kp, 0]``, which this excludes.
+    * ``dyntype == mjDYN_NONE`` - ``ctrl`` reaches the force law directly.
+      ``<intvelocity>`` also reads ``ctrl`` as a rate, but integrates it into a
+      *pose* target behind an ``act`` state, so the joint's velocity is not what
+      it commands and it is excluded here.
+    * the transmission is the joint itself, resolved through
+      :func:`actuator_joint_id`. A tendon velocity drive is disqualified for the
+      same two reasons a tendon servo is: ``ctrl`` is in the tendon's units
+      rather than the joint's, and one ``ctrl`` drives several joints at once.
+
+    Stock assets reach this path: Menagerie's ``pal_tiago`` ships a
+    ``tiago_velocity.xml`` whose arm is driven by 9 ``<velocity>`` actuators
+    (``pal_tiago_dual`` 18), and any caller MJCF loaded through
+    ``replace_scene_mjcf`` / ``patch_scene_mjcf`` may carry one.
+
+    Args:
+        model: The compiled ``MjModel``.
+        mj: The ``mujoco`` module.
+
+    Returns:
+        ``{joint id: actuator id}`` for every joint some actuator commands a
+        rate on. A joint driven by anything else -- a position servo, a torque
+        motor, a stateful drive, a tendon -- appears nowhere, because its
+        ``ctrl`` is not a velocity in the joint's units and so cannot disagree
+        with one. Where several rate drives target one joint the last in model
+        order is reported.
+    """
+    rate_drives: dict[int, int] = {}
+    affine = int(mj.mjtBias.mjBIAS_AFFINE)
+    stateless = int(mj.mjtDyn.mjDYN_NONE)
+    for act_id in range(int(model.nu)):
+        target = actuator_joint_id(model, act_id, mj)
+        if target < 0:
+            continue
+        commands_a_rate = (
+            int(model.actuator_biastype[act_id]) == affine
+            and float(model.actuator_biasprm[act_id, 1]) == 0.0
+            and float(model.actuator_biasprm[act_id, 2]) < 0.0
+            and int(model.actuator_dyntype[act_id]) == stateless
+        )
+        if commands_a_rate:
+            rate_drives[target] = act_id
+    return rate_drives
+
+
 def actuator_driven_joint_ids(model: Any, act_id: int, mj: Any) -> frozenset[int]:
     """Return every joint id actuator ``act_id`` drives.
 

--- a/tests/simulation/mujoco/test_joint_velocity_write_names_a_conflicting_rate_drive.py
+++ b/tests/simulation/mujoco/test_joint_velocity_write_names_a_conflicting_rate_drive.py
@@ -72,7 +72,13 @@ _DRIVES: list[tuple[str, str]] = [
 
 #: The tags whose ``ctrl`` is a velocity in the joint's own units.
 _RATE_TAGS = frozenset({"vel", "gen_vel"})
+
+#: The one of those the behavioural classes below write to. Read rather than
+#: spelled out at each call site so the joint they measure the physical outcome
+#: on cannot drift away from the tag the sweep expects the report to name.
 _RATE_TAG = "vel"
+_RATE_ACTUATOR = f"a_{_RATE_TAG}"
+_RATE_JOINT = f"arm/j_{_RATE_TAG}"
 
 
 def _scene_xml(tags: list[str]) -> str:
@@ -120,35 +126,60 @@ def _badqacc(engine: Any) -> int:
     return int(engine._world._data.warning[mj.mjtWarning.mjWARN_BADQACC].number)
 
 
+class TestTheBehaviouralFixtureIsARateDrive:
+    """The tag the behavioural classes write to is one the sweep expects to be named.
+
+    The classes below measure the physical outcome -- the sign reversal, the
+    hold -- on one joint, while :class:`TestOnlyARateDriveIsNamed` sweeps every
+    tag and grades it against ``_RATE_TAGS``. Nothing else ties the two halves
+    together: point the behavioural classes at a pose servo and they fail five
+    times over on a report that correctly says nothing, which reads as the
+    report having regressed rather than as the fixture no longer driving a rate.
+    """
+
+    def test_the_written_joint_is_a_declared_drive_the_sweep_expects_to_be_named(self) -> None:
+        declared = {tag for tag, _ in _DRIVES}
+
+        assert _RATE_TAG in declared, (
+            f"the behavioural classes write to j_{_RATE_TAG}, which the fixture does not "
+            f"declare; the drives it does are {sorted(declared)}"
+        )
+        assert _RATE_TAG in _RATE_TAGS, (
+            f"the behavioural classes write to j_{_RATE_TAG}, whose ctrl is not a rate in "
+            f"the joint's own units, so the report is right to stay silent and their "
+            f"failures would not be the report's; the rate drives are {sorted(_RATE_TAGS)}"
+        )
+
+
 class TestAConflictingRateDriveIsNamed:
     """The written joints whose rate drive commands something else are reported."""
 
     def test_the_report_names_the_joint_and_the_way_to_command_the_rate(self, sim: Any) -> None:
-        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
+        _ok(sim.send_action({_RATE_ACTUATOR: -3.0}), "send_action")
 
-        report = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+        report = _text(_ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities"))
 
-        assert "arm/j_vel" in report, report
+        assert _RATE_JOINT in report, report
         assert "commanding a different rate" in report, report
         assert "send_action" in report, report
 
     def test_the_written_rate_is_driven_back_toward_the_drives_command(self, sim: Any) -> None:
-        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
-        _ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities")
-        assert _qvel(sim, "arm/j_vel") == pytest.approx(2.0), "premise: the write landed in qvel"
+        _ok(sim.send_action({_RATE_ACTUATOR: -3.0}), "send_action")
+        _ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities")
+        assert _qvel(sim, _RATE_JOINT) == pytest.approx(2.0), "premise: the write landed in qvel"
 
         _ok(sim.step(50), "step")
 
-        settled = _qvel(sim, "arm/j_vel")
+        settled = _qvel(sim, _RATE_JOINT)
         assert _badqacc(sim) == 0, "premise: the fixture integrates without a bad-qacc warning"
         assert settled < 0.0, f"the written +2.0 should be driven toward the commanded -3.0, got {settled}"
 
     def test_a_conflicting_drive_reads_differently_from_one_commanding_the_written_rate(self, sim: Any) -> None:
-        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
-        agreeing = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+        _ok(sim.send_action({_RATE_ACTUATOR: 2.0}), "send_action")
+        agreeing = _text(_ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities"))
 
-        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
-        conflicting = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+        _ok(sim.send_action({_RATE_ACTUATOR: -3.0}), "send_action")
+        conflicting = _text(_ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities"))
 
         assert agreeing != conflicting, (
             "a drive commanding the written rate and one commanding another rate are opposite "
@@ -179,19 +210,19 @@ class TestTheReportIsNotWidened:
     """A drive commanding the written rate is not a disagreement."""
 
     def test_a_drive_commanding_the_written_rate_keeps_the_plain_report(self, sim: Any) -> None:
-        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
+        _ok(sim.send_action({_RATE_ACTUATOR: 2.0}), "send_action")
 
-        report = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+        report = _text(_ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities"))
 
         assert report == "Set 1/1 joint velocities", report
 
     def test_a_rate_drive_commanding_the_written_rate_holds_it(self, sim: Any) -> None:
-        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
-        _ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities")
+        _ok(sim.send_action({_RATE_ACTUATOR: 2.0}), "send_action")
+        _ok(sim.set_joint_velocities({_RATE_JOINT: 2.0}), "set_joint_velocities")
 
         _ok(sim.step(50), "step")
 
-        settled = _qvel(sim, "arm/j_vel")
+        settled = _qvel(sim, _RATE_JOINT)
         assert _badqacc(sim) == 0, "premise: the fixture integrates without a bad-qacc warning"
         assert settled > 1.0, f"the drive commands the written rate, so it should hold it, got {settled}"
 

--- a/tests/simulation/mujoco/test_joint_velocity_write_names_a_conflicting_rate_drive.py
+++ b/tests/simulation/mujoco/test_joint_velocity_write_names_a_conflicting_rate_drive.py
@@ -1,0 +1,267 @@
+"""A velocity write names the joints whose rate drive commands something else.
+
+``set_joint_velocities`` writes ``qvel`` directly. On a joint driven by a
+``<velocity>`` actuator that ``ctrl`` IS the joint's own rate, so the drive is
+already commanding a velocity of its own and the next step resolves the
+disagreement in the drive's favour: measured on the fixture below, a written
+``+2.0`` against a drive commanding ``-3.0`` reads ``-2.39877`` fifty steps
+later, sign reversed. The report said ``Set 1/1 joint velocities`` either way,
+byte-identical to the case where the drive commands the written rate and it is
+held -- one report for two opposite outcomes.
+
+Its sibling ``set_joint_positions`` names exactly this class for a position
+servo ("still commanded to a different setpoint ... the next step drives the
+pose back"), so the shape of the answer was already settled one method over;
+these tests pin the velocity half of it, and pin that the report stays silent
+for every drive whose ``ctrl`` is not a rate in the joint's own units.
+"""
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+from strands_robots.simulation import create_simulation
+
+#: A single-hinge body per drive, sized so a written rate settles without
+#: tripping the integrator (``badqacc`` stays 0 on every case below).
+_BODY = """
+    <body name="b_{tag}" pos="0 {y} 0.5">
+      <joint name="j_{tag}" type="hinge" axis="0 0 1" damping="0.5" armature="0.01"/>
+      <geom type="capsule" fromto="0 0 0 0.25 0 0" size="0.02" mass="1.0"/>
+    </body>"""
+
+_SCENE = """<mujoco model="drives">
+  <compiler angle="radian"/>
+  <worldbody>{bodies}
+  </worldbody>
+  <actuator>{actuators}
+  </actuator>
+</mujoco>"""
+
+#: ``(tag, actuator element)`` for every MuJoCo actuator shortcut that can drive
+#: a hinge, plus a joint no actuator drives. Only ``<velocity>`` commands a rate
+#: in the joint's own units.
+_DRIVES: list[tuple[str, str]] = [
+    ("vel", '<velocity name="a_vel" joint="j_vel" kv="2" ctrlrange="-10 10"/>'),
+    ("servo", '<position name="a_servo" joint="j_servo" kp="20" ctrlrange="-3 3"/>'),
+    ("motor", '<motor name="a_motor" joint="j_motor" ctrlrange="-5 5"/>'),
+    ("intvel", '<intvelocity name="a_intvel" joint="j_intvel" kp="20" actrange="-3 3" ctrlrange="-2 2"/>'),
+    ("damper", '<damper name="a_damper" joint="j_damper" kv="2" ctrlrange="0 1"/>'),
+    ("cylinder", '<cylinder name="a_cylinder" joint="j_cylinder" ctrlrange="-1 1"/>'),
+    ("general", '<general name="a_general" joint="j_general" ctrlrange="-1 1"/>'),
+    # <velocity> written longhand: the shortcut is sugar for exactly these
+    # compiled fields, so a model spelling it out must classify the same way.
+    (
+        "gen_vel",
+        '<general name="a_gen_vel" joint="j_gen_vel" biastype="affine" '
+        'biasprm="0 0 -2" gainprm="2" ctrlrange="-10 10"/>',
+    ),
+    # Positive velocity feedback is anti-damping rather than a rate command:
+    # measured, a written rate against it diverges (mj_step reports
+    # "Nan, Inf or huge value in QACC") instead of settling on any commanded
+    # value, so slot 2 has to be negative and not merely non-zero.
+    (
+        "gen_posbias",
+        '<general name="a_gen_posbias" joint="j_gen_posbias" biastype="affine" '
+        'biasprm="0 0 2" gainprm="2" ctrlrange="-10 10"/>',
+    ),
+    ("undriven", ""),
+]
+
+#: The tags whose ``ctrl`` is a velocity in the joint's own units.
+_RATE_TAGS = frozenset({"vel", "gen_vel"})
+_RATE_TAG = "vel"
+
+
+def _scene_xml(tags: list[str]) -> str:
+    bodies = "".join(_BODY.format(tag=t, y=round(0.4 * i, 2)) for i, t in enumerate(tags))
+    by_tag = dict(_DRIVES)
+    actuators = "".join(f"\n    {by_tag[t]}" for t in tags if by_tag[t])
+    return _SCENE.format(bodies=bodies, actuators=actuators)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str(result["content"][0]["text"])
+
+
+def _ok(result: dict[str, Any], what: str) -> dict[str, Any]:
+    if result.get("status") != "success":
+        raise AssertionError(f"{what} refused: {_text(result)}")
+    return result
+
+
+@pytest.fixture
+def sim(tmp_path: Any) -> Any:
+    """A world holding one robot with one hinge per drive kind."""
+    tags = [t for t, _ in _DRIVES]
+    path = tmp_path / "drives.xml"
+    path.write_text(_scene_xml(tags))
+    engine = create_simulation(backend="mujoco", tool_name="rate_drive_probe")
+    _ok(engine.create_world(gravity=[0, 0, 0]), "create_world")
+    _ok(engine.add_robot(name="arm", urdf_path=str(path)), "add_robot")
+    yield engine
+    engine.destroy()
+
+
+def _qvel(engine: Any, joint: str) -> float:
+    import mujoco as mj
+
+    model = engine.mj_model
+    jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, joint)
+    assert jid >= 0, f"premise: {joint!r} is a joint of the fixture"
+    return float(engine._world._data.qvel[model.jnt_dofadr[jid]])
+
+
+def _badqacc(engine: Any) -> int:
+    import mujoco as mj
+
+    return int(engine._world._data.warning[mj.mjtWarning.mjWARN_BADQACC].number)
+
+
+class TestAConflictingRateDriveIsNamed:
+    """The written joints whose rate drive commands something else are reported."""
+
+    def test_the_report_names_the_joint_and_the_way_to_command_the_rate(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
+
+        report = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+
+        assert "arm/j_vel" in report, report
+        assert "commanding a different rate" in report, report
+        assert "send_action" in report, report
+
+    def test_the_written_rate_is_driven_back_toward_the_drives_command(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
+        _ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities")
+        assert _qvel(sim, "arm/j_vel") == pytest.approx(2.0), "premise: the write landed in qvel"
+
+        _ok(sim.step(50), "step")
+
+        settled = _qvel(sim, "arm/j_vel")
+        assert _badqacc(sim) == 0, "premise: the fixture integrates without a bad-qacc warning"
+        assert settled < 0.0, f"the written +2.0 should be driven toward the commanded -3.0, got {settled}"
+
+    def test_a_conflicting_drive_reads_differently_from_one_commanding_the_written_rate(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
+        agreeing = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+
+        _ok(sim.send_action({"a_vel": -3.0}), "send_action")
+        conflicting = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+
+        assert agreeing != conflicting, (
+            "a drive commanding the written rate and one commanding another rate are opposite "
+            f"outcomes and must not share one report: {agreeing!r}"
+        )
+
+
+class TestOnlyARateDriveIsNamed:
+    """Every drive is commanded away from the written rate; only a rate drive reads."""
+
+    @pytest.mark.parametrize("tag", [t for t, _ in _DRIVES])
+    def test_a_drive_is_named_only_when_its_ctrl_is_a_rate_in_the_joints_units(self, sim: Any, tag: str) -> None:
+        if tag != "undriven":
+            # Command the drive to a value the write does not ask for. For a rate
+            # drive that is a conflicting velocity; for every other kind ctrl is a
+            # torque, a pose or a tendon length, so there is no rate to conflict.
+            _ok(sim.send_action({f"a_{tag}": 1.0}), "send_action")
+
+        report = _text(_ok(sim.set_joint_velocities({f"arm/j_{tag}": 2.0}), "set_joint_velocities"))
+
+        named = f"arm/j_{tag}" in report
+        assert named is (tag in _RATE_TAGS), (
+            f"j_{tag} named in the report: {tag in _RATE_TAGS} expected, {named} measured -- {report!r}"
+        )
+
+
+class TestTheReportIsNotWidened:
+    """A drive commanding the written rate is not a disagreement."""
+
+    def test_a_drive_commanding_the_written_rate_keeps_the_plain_report(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
+
+        report = _text(_ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities"))
+
+        assert report == "Set 1/1 joint velocities", report
+
+    def test_a_rate_drive_commanding_the_written_rate_holds_it(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_vel": 2.0}), "send_action")
+        _ok(sim.set_joint_velocities({"arm/j_vel": 2.0}), "set_joint_velocities")
+
+        _ok(sim.step(50), "step")
+
+        settled = _qvel(sim, "arm/j_vel")
+        assert _badqacc(sim) == 0, "premise: the fixture integrates without a bad-qacc warning"
+        assert settled > 1.0, f"the drive commands the written rate, so it should hold it, got {settled}"
+
+
+class TestTheSiblingPositionReportIsUnchanged:
+    """The pose half of this contract keeps its own wording and remedy."""
+
+    def test_a_stale_position_servo_still_names_hold(self, sim: Any) -> None:
+        _ok(sim.send_action({"a_servo": 0.0}), "send_action")
+
+        report = _text(_ok(sim.set_joint_positions({"arm/j_servo": 1.0}), "set_joint_positions"))
+
+        assert "arm/j_servo" in report, report
+        assert "different setpoint" in report, report
+        assert "hold=True" in report, report
+
+
+class TestTheRateDriveClassifier:
+    """Root-cause pins on the classifier the report is derived from.
+
+    These name ``joint_rate_drive_map`` directly, so on a tree without it they
+    can only report its absence; the behavioural evidence for the report itself
+    is in the classes above.
+    """
+
+    def test_the_scan_finds_the_fixtures_one_rate_drive(self, sim: Any) -> None:
+        import mujoco as mj
+
+        from strands_robots.simulation.mujoco.scene_ops import joint_rate_drive_map
+
+        rate_drives = joint_rate_drive_map(sim.mj_model, mj)
+
+        assert len(rate_drives) == len(_RATE_TAGS), (
+            f"the fixture declares {len(_RATE_TAGS)} rate drives (the <velocity> shortcut and its "
+            f"longhand <general> spelling); a scan reporting {len(rate_drives)} is not measuring the "
+            "discriminator"
+        )
+
+    def test_a_tendon_rate_drive_is_not_a_joint_rate_drive(self, tmp_path: Any) -> None:
+        import mujoco as mj
+
+        from strands_robots.simulation.mujoco.scene_ops import joint_rate_drive_map
+
+        xml = """<mujoco model="tendon">
+          <compiler angle="radian"/>
+          <worldbody>
+            <body name="b" pos="0 0 0.5">
+              <joint name="j1" type="hinge" axis="0 0 1" damping="0.5" armature="0.01"/>
+              <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="1"/>
+              <body name="c" pos="0.2 0 0">
+                <joint name="j2" type="hinge" axis="0 0 1" damping="0.5" armature="0.01"/>
+                <geom type="capsule" fromto="0 0 0 0.2 0 0" size="0.02" mass="1"/>
+              </body>
+            </body>
+          </worldbody>
+          <tendon>
+            <fixed name="t"><joint joint="j1" coef="1"/><joint joint="j2" coef="1"/></fixed>
+          </tendon>
+          <actuator>
+            <velocity name="a_t" tendon="t" kv="2" ctrlrange="-10 10"/>
+          </actuator>
+        </mujoco>"""
+        path = tmp_path / "tendon.xml"
+        path.write_text(xml)
+        model = mj.MjModel.from_xml_path(str(path))
+        assert int(model.nu) == 1, "premise: the fixture declares one tendon velocity actuator"
+
+        rate_drives = joint_rate_drive_map(model, mj)
+
+        assert rate_drives == {}, (
+            "a tendon drive's ctrl is in the tendon's units and drives several joints, so no single "
+            f"joint rate can be written into it: {rate_drives}"
+        )

--- a/tests/simulation/mujoco/test_public_member_docstrings.py
+++ b/tests/simulation/mujoco/test_public_member_docstrings.py
@@ -77,6 +77,7 @@ _EXPECTED_FUNCTIONS = {
     "scene_ops.py::inject_robot_into_scene",
     "scene_ops.py::install_compiled_model",
     "scene_ops.py::joint_drive_map",
+    "scene_ops.py::joint_rate_drive_map",
     "scene_ops.py::patch_scene_mjcf",
     "scene_ops.py::persist_body_mass",
     "scene_ops.py::persist_geom_properties",


### PR DESCRIPTION
## Problem

`set_joint_velocities` writes `qvel` directly. On a joint driven by a `<velocity>`
actuator that `ctrl` **is the joint's own rate**, so the drive is already commanding a
velocity of its own and the next step resolves the disagreement in the drive's favour.
Measured through the public surface on a one-hinge bar, gravity off, `kv=2`:

| drive `ctrl` | written | `qvel` right after the write | angle after 72 steps | report |
| --- | --- | --- | --- | --- |
| `-3.0` rad/s | `+2.0` | `+2.0000` (as asked) | **`-0.2532` rad** | `Set 1/1 joint velocities` |
| `+2.0` rad/s | `+2.0` | `+2.0000` | **`+0.2391` rad** | `Set 1/1 joint velocities` |

Two opposite outcomes -- the joint turns the other way -- and one byte-identical report.
The write lands, so `status` is `success` and `qvel` really does read back `+2.0`; what the
caller is not told is that something else is commanding that same quantity.

The sibling `set_joint_positions` already names exactly this class for a position servo:

> `1 of them are driven by a position servo still commanded to a different setpoint (arm/j),
> so the next step drives the pose back toward that setpoint; pass hold=True to move the
> setpoint too`

So the shape of the answer was settled one method over. Only the velocity half had no
equivalent, and `hold=True` is not the answer here -- a rate drive's own `ctrl` is the rate,
so the way to hold a velocity is to command the drive.

## Change

`scene_ops.joint_rate_drive_map` is the velocity counterpart of the existing
`joint_drive_map`. Its terms mirror that classifier and are read off the same compiled
fields: an affine bias, no position feedback but negative velocity feedback
(`biasprm = [0, 0, -kv]`), a stateless `dyntype`, and a joint transmission resolved through
`actuator_joint_id`. `set_joint_velocities` consults it and names the joints whose drive is
commanding a different rate, pointing at `send_action`, which writes that `ctrl`.

Measured against every MuJoCo actuator shortcut, `<velocity>` is the only one that clears
all of the terms:

| shortcut | `biastype` | `biasprm` | `dyntype` | `ctrl` is a joint rate |
| --- | --- | --- | --- | --- |
| `<velocity kv=2>` | affine | `[0, 0, -2]` | none | **yes** |
| `<position kp=10>` | affine | `[0, -10, 0]` | none | no (a pose) |
| `<motor>` | none | `[0, 0, 0]` | none | no (a torque) |
| `<intvelocity>` | affine | `[0, -1, 0]` | integrator | no (integrated to a pose) |
| `<damper kv=2>` | none | `[0, 0, 0]` | none | no (`ctrl` scales damping) |
| `<cylinder>` | none | `[0, 0, 0]` | filter | no |
| `<adhesion>` / `<general>` | none | `[0, 0, 0]` | none | no |

A `<general>` spelling `<velocity>` longhand (`biastype="affine" biasprm="0 0 -2"`)
classifies identically, which is the point of reading the compiled fields rather than the
element. Slot 2 has to be **negative** rather than merely non-zero: positive velocity
feedback is anti-damping, and measured, a written rate against it diverges (`mj_step`
reports `Nan, Inf or huge value in QACC`) instead of settling on any commanded value.

A joint driven by a torque motor, a position servo, a stateful drive or a tendon is not
reported: its `ctrl` is not a velocity in the joint's units, so there is no rate for the
write to disagree with.

## Scope

Report only -- no verdict, no accepted input and no written value moves, and a drive that
happens to be commanding the written rate keeps the plain report byte-for-byte. A `hold=`
parameter for `set_joint_velocities` (write the drive's `ctrl` as well as `qvel`, the way
`set_joint_positions(hold=True)` does) would be a new behaviour on a public surface and is
deliberately not part of this; `TestTheReportIsNotWidened` pins the current shape either way.

## Tests

`tests/simulation/mujoco/test_joint_velocity_write_names_a_conflicting_rate_drive.py`,
19 cases. Against `upstream/main`: **6 failed / 13 passed**, of which **4 are behavioural** --

- `AssertionError: Set 1/1 joint velocities` (the report does not name `arm/j_vel`)
- `AssertionError: a drive commanding the written rate and one commanding another rate are opposite outcomes and must not share one report: 'Set 1/1 joint velocities'`
- `j_vel named in the report: True expected, False measured -- 'Set 1/1 joint velocities'`
- `j_gen_vel named in the report: True expected, False measured -- 'Set 1/1 joint velocities'`

-- and 2 report only that `joint_rate_drive_map` does not exist yet. All four
`TestTheReportIsNotWidened` cases and every non-rate drive in the parametrized sweep pass on
both trees.

### Break table

| break | fires |
| --- | --- |
| control | 0 of 19 |
| exact pre-fix source | 6 (4 behavioural + 2 symbol) |
| the comparison dropped, or keyed on `0.0` rather than the written rate | 2 (the two-outcomes test + the plain-report control) |
| slot 2 merely non-zero rather than negative | 2 (the anti-damping fixture + the classifier count) |
| transmission target read raw rather than through `actuator_joint_id` | **1** (the tendon case alone) |
| the joint is named but the remedy omitted | **1** (the remedy assertion alone) |
| `_RATE_TAG` pointed at the pose servo | 3 (the premise names the cause + 2 behavioural) |
| the same, with the premise removed | 2, and **three of the five behavioural cases pass** while driving a drive whose `ctrl` is not a rate |
| `_RATE_TAG` pointed at a tag the fixture does not declare | 6 (the premise names the drives it does declare) |

The behavioural cases read the rate-drive tag rather than spelling it out, so the joint they
measure the physical outcome on and the tag the sweep expects the report to name cannot drift
apart; the last three rows are that premise. Its own value is that the drift is otherwise
*quiet*: with the premise removed and the tag pointed at the pose servo, three of the five
behavioural cases still pass, and the two that fail say only `Set 1/1 joint velocities` -- a
report that is correctly silent, which reads as the report having regressed.

Given the shortcut corpus above, `biasprm[2] < 0` is the term that discriminates on its own;
the affine-bias and stateless-`dyntype` terms are conjunctive and matter for a hand-written
`<general>`, which is why the longhand fixtures exist.

## Artifact

One program, run against both trees; only `strands_robots` differs. The two frame strips are
byte-identical across the trees (`np.array_equal` is `True` for the conflicting rollout) --
this changes what is reported, not what is simulated -- so the picture is the consequence the
report now names. Rendered headless on MuJoCo 3.12.0 (`MUJOCO_GL=egl`), gravity off so the
motion is the drive alone, `mj_step` reporting no bad-qacc warning in either rollout.

![velocity write on a rate-driven joint](https://raw.githubusercontent.com/cagataycali/robots/media-velocity-write-rate-drive/velocity_write_rate_drive.png)

## Verification

Measured at `4f47eba2`. The head has since moved to `0b070a05`, which adds the changelog
fragment and, in the test file alone, the rate-drive tag read plus its premise case:
`git diff 4f47eba2..0b070a05 -- 'strands_robots/'` is **empty**, so the source under test is
byte-identical to the tree the blast-radius and `mypy` runs below were measured on.

- Blast radius, the identical 374-file selection on both trees with the new test file excluded
  from each: **`44 failed, 10496 passed, 243 skipped, 126 errors` byte-identical** (649.82s vs
  649.86s), **170 failing ids on each tree with `comm` empty in both directions**. Every one is
  a locally absent optional dependency -- 326 `No module named 'device_connect_edge'`, declared
  as `device-connect-edge>=0.2.0` in the `device-connect` extra which `all` pulls in, plus
  `qpsolvers` from `sim-mujoco` and one numpy artifact.
- The new file: **19 passed** on MuJoCo **3.12.0** and on **3.5.0**, the declared floor.
- `ruff check` / `ruff format --check` clean; `mypy strands_robots tests tests_integ`
  **24 == 24** against a pristine worktree, none in the changed files.

## 13. Review rounds

**Round 1** -- `0b070a05`

- Static analysis flagged `_RATE_TAG` as an unused global. It was a leftover, and deleting it
  would have missed why it was there: the behavioural classes spelled `a_vel` / `arm/j_vel` out
  at each call site while the parametrized sweep graded against `_RATE_TAGS`, so nothing tied
  the joint whose physical outcome is measured to the tag the sweep expects the report to name.
  The behavioural cases now read the constant (`_RATE_ACTUATOR`, `_RATE_JOINT`) and
  `TestTheBehaviouralFixtureIsARateDrive` pins the tie. The drift it prevents is otherwise
  quiet: with the tag pointed at the pose servo, three of the five behavioural cases still pass
  and the two that fail report only a correctly-silent `Set 1/1 joint velocities`, which reads
  as the report having regressed rather than as the fixture no longer driving a rate.
  18 cases -> 19, and three rows added to the break table.
- `Verification` re-stated against the new head: `strands_robots/` is unchanged since the
  measured commit, so the blast radius still holds as reported; the case count is corrected to
  19, re-run on MuJoCo 3.12.0 and on the 3.5.0 floor; `ruff check`, `ruff format --check` and
  `mypy` are clean on the changed test file.
