### PR TITLE
ci: refuse a fix derived on a checkout the branch has moved past

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -775,10 +775,12 @@ hatch run format            # ruff check --fix, ruff format
      `require_last_push_approval` then disqualifies the pushing account from
      re-supplying it, turning a one-approval merge into one that needs a second
      reviewer.
-   - *And that the head it names is the branch's tip.* A pull request has two
-     answers to "what is the head commit" and they can disagree for hours.
-     `headRefOid` is the value the pull request *records*; the tip of the branch
-     in the head repository is the value that exists. GitHub normally reconciles
+   - *And that the head it names is the branch's tip.* A pull request has three
+     answers to "what is the head commit" and they can disagree for hours. Two
+     of them are the API's, and are the pair this bullet compares: `headRefOid`
+     is the value the pull request *records*; the tip of the branch in the head
+     repository is the value that exists. The third is the commit your clone is
+     actually on, which is the next bullet. GitHub normally reconciles
      them within a second of a push, and when it does not, nothing on the pull
      request says so - because every gate this step tells you to poll resolves
      the head *through the pull request's own view of it*, so they all agree
@@ -862,6 +864,65 @@ hatch run format            # ruff check --fix, ruff format
 
      It agreed with `git ls-remote` on all 10 open pull requests, so it needs no
      clone. Pinned by tests/test_pr_head_is_current.py. See #2538.
+   - *And that the tree you are deriving from is that tip.* The third answer is
+     `refs/pull/N/head`, and it is the one every checkout reaches for and the
+     only one with no signal at all. It is a mirror ref GitHub refreshes on its
+     own schedule, so it trails a push to the fork branch. Measured on #2678:
+
+     ```
+     git fetch origin pull/2678/head   ->  33f8bcf4   one commit behind
+     pullRequest { headRefOid }        ->  0b070a05   the tip
+     git merge-base --is-ancestor 33f8bcf4 0b070a05   ->  true, a pure lag
+     ```
+
+     What that costs is not a wasted fetch. The run believed it *had* checked out
+     the branch, grepped the symbol its review thread named, found it genuinely
+     unused on that tree, and derived a correct fix for source that no longer
+     existed. Only `git push` refusing as non-fast-forward surfaced the drift -
+     after the work. A fix touching a different file would have pushed cleanly.
+
+     And the answer was worse than a duplicate, which is why re-reading the
+     thread against the tip is not optional. The thread was a CodeQL "unused
+     global `_RATE_TAG`". Against the stale tree the fix is deletion and the
+     suite agrees - 18 passed, `ruff` clean. Against the tip the same finding
+     means the opposite: the constant was unused because the behavioural tests
+     spelled its value out at each call site, so nothing tied the joint under
+     measurement to the tag the parametrized sweep graded, and the fix is to
+     wire it up. Deletion would have passed CI while removing the invariant the
+     symbol carried. **An unused symbol in a test file is often a missing call
+     site rather than dead code, and the two fixes are indistinguishable by test
+     outcome.**
+
+     So resolve the head from the API and fetch the branch *by name*. Never
+     `refs/pull/N/head`, and re-fetching that ref can return the same stale
+     commit again:
+
+     ```
+     git fetch https://github.com/$HEAD_REPO.git $HEAD_REF
+     git rev-parse FETCH_HEAD      # must equal headRefOid from the API
+     ```
+
+     That assertion is the cheap part and catches the whole class: if
+     `FETCH_HEAD != headRefOid`, no fix derived on the local tree is
+     trustworthy. Or run the check, which resolves the head repository's ref
+     itself and exits 1 on a stale tree, so it can sit in front of the work:
+
+     ```
+     python3 scripts/check_checkout_is_pr_head.py --repo <owner/name> --pr <N>
+     ```
+
+     It compares by **ancestry, not equality**: a clone sitting at its own
+     unpushed commit contains the tip and reads `ahead`, which is the ordinary
+     state between a commit and its push and is not a finding. A tip missing
+     from the local object database is `stale-checkout` rather than
+     indeterminate - a clone that never fetched a commit cannot contain it.
+     Pinned by tests/test_checkout_is_pr_head.py. See #2520, which records four
+     instances: #2511 (one thread, four author replies), #2566 and #2577 (two
+     runs deriving one fix, the duplicate discarded only because a plain push
+     was refused) and #2678 above. That refusal is load-bearing by accident -
+     `git pull --rebase` then push lands an empty-diff commit on top, and
+     `--amend --force-with-lease` deletes the commit that already answered the
+     thread.
    And before merging, `reviewDecision: APPROVED` alone is not the gate: poll
    the **required** contexts' own conclusions and `mergeStateStatus == CLEAN`
    together, since `reviewDecision` flips before the checks finish.

--- a/changelog.d/2520-checkout-is-pr-head.md
+++ b/changelog.d/2520-checkout-is-pr-head.md
@@ -1,0 +1,37 @@
+### Added: a check for a checkout the pull request's branch has moved past
+
+`scripts/check_checkout_is_pr_head.py` compares the commit a local clone is on
+against the tip of the branch in the head repository, and exits 1 when the branch
+has commits the clone does not, so it can sit in front of the work.
+
+A pull request has three answers to "what is the head commit", not the two
+`check_pr_head_is_current.py` compares. The third is `refs/pull/N/head`, which is
+what a checkout reaches for and the only one carrying no signal: it is a mirror
+ref GitHub refreshes on its own schedule, so it trails a push to the fork
+branch. Measured on #2678, where the mirror served `33f8bcf4` while the API
+already served the tip `0b070a05`, one commit further on and with the mirror as
+its ancestor - a pure lag.
+
+The cost is not a wasted fetch. The run believed it had checked out the branch,
+grepped the symbol its review thread named, found it genuinely unused on that
+tree, and derived a correct fix for source that no longer existed; only `git
+push` refusing as non-fast-forward surfaced the drift, after the work. The answer
+was also worse than a duplicate. The thread was a CodeQL "unused global", which
+against the stale tree means deletion - 18 passed, `ruff` clean - and against the
+tip means the opposite, that the constant was unused because the behavioural
+tests spelled its value out at each call site and the fix is to wire it up.
+Deletion would have passed CI while removing the invariant the symbol carried.
+
+The comparison is ancestry, not equality. A clone sitting at its own unpushed
+commit contains the tip and reads `ahead`, which is the ordinary state between a
+commit and its push and is not a finding - a check that reported it would fire
+exactly when it is being used correctly. A tip absent from the local object
+database reads `stale-checkout` rather than indeterminate, since a clone that
+never fetched a commit cannot contain it.
+
+The tip is resolved from the head repository's own ref, because both cheap
+answers are ones this check exists to catch out. Its remedy is to fetch the
+branch by name and re-read the pull request's threads against that commit, never
+to rebase or amend onto it: the commit the branch already carries may be the
+answer to the thread, and #2520 records a plain push being refused as the only
+thing that prevented its destruction.

--- a/scripts/check_checkout_is_pr_head.py
+++ b/scripts/check_checkout_is_pr_head.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Refuse work derived on a checkout the pull request's branch has moved past.
+
+Why this exists
+---------------
+A pull request has *three* answers to "what is the head commit", not the two
+``check_pr_head_is_current.py`` compares. That check reads the two the API
+serves -- ``pullRequest { headRefOid }``, the value the pull request records,
+against the tip of the branch in the head repository, the value that exists.
+This one reads the third, which is the only one that decides what a fix gets
+derived from: **the commit the local clone is actually on**.
+
+The three disagree independently, and the third is the one with no signal:
+
+===================================  ======================================
+answer                               what moves it out of date
+===================================  ======================================
+``refs/pull/N/head``                 a mirror ref GitHub refreshes on its
+                                     own schedule, so it trails a push to
+                                     the fork branch
+``pullRequest { headRefOid }``       normally reconciled within a second of
+                                     a push; #2508 sat five hours behind
+tip of the head repository's branch  nothing -- this is the value that
+                                     exists, and what the other two are
+                                     *for*
+===================================  ======================================
+
+Measured on #2678. A run checked the pull request out the obvious way and got
+the mirror, while the API already served the commit that existed::
+
+    git fetch origin pull/2678/head    ->  33f8bcf4     one commit behind
+    pullRequest { headRefOid }         ->  0b070a05     the tip
+    git merge-base --is-ancestor 33f8bcf4 0b070a05  ->  true, a pure lag
+
+The cost is not a wasted fetch. The run believed it had checked out the branch,
+grepped the symbol its review thread named, found it genuinely unused *on that
+tree*, and derived a correct fix for source that no longer existed. What
+surfaced the drift was ``git push`` being refused as non-fast-forward -- after
+the work. A fix that happened to touch a different file would have pushed
+cleanly.
+
+And the answer it derived was worse than a duplicate. The thread was a CodeQL
+"unused global ``_RATE_TAG``". Against the stale tree the fix is deletion, and
+the suite agrees -- 18 passed, ruff clean. Against the tip the same finding
+means the opposite: the constant was unused because the behavioural tests spelled
+its value out at each call site, so nothing tied the joint under measurement to
+the tag the parametrized sweep graded. Deletion would have passed CI while
+removing the invariant the symbol existed to carry. An unused symbol in a test
+file is often a *missing call site* rather than dead code, and the two fixes are
+indistinguishable by test outcome.
+
+#2520 records four instances of this class -- #2511 (one thread, four author
+replies), #2566 (two runs deriving one fix), #2577 (two byte-identical commits,
+one discarded), and #2678 above. In three of the four the only thing that
+prevented a duplicate landing was a non-fast-forward push rejection, which is
+load-bearing purely by accident: it fires because the mandated push shape is a
+plain ``git push``, and both nearby shapes defeat it -- ``pull --rebase`` lands
+an empty-diff commit on top, and ``--amend --force-with-lease`` deletes the
+commit that already answered the thread.
+
+Being ahead is not the finding
+------------------------------
+The comparison cannot be equality. A run that has committed its own work sits at
+a commit the branch tip does not have yet, which is the ordinary state between a
+commit and its push, and a check that reports it would cry wolf exactly when it
+is being used correctly. So the question is ancestry, not identity: if the tip is
+an ancestor of the checkout, the checkout contains everything the branch has and
+the difference is the run's own unpushed work.
+
+A tip that is *absent from the local object database* is not an ancestor and is
+not unknowable either -- a local repository that has never fetched the tip
+cannot contain it, so it is reported as stale rather than as indeterminate.
+
+Outcomes
+--------
+``current``
+    The checkout is the branch tip. The ordinary state at the start of a cycle,
+    and the only one from which a thread's concern can be assessed.
+
+``ahead``
+    The tip is an ancestor of the checkout: the run's own commits, not yet
+    pushed. Not a finding.
+
+``stale-checkout``
+    The finding. The branch has commits the checkout does not, so anything
+    derived here answers a question about a tree somebody has already moved.
+
+``unresolvable-head``
+    The head repository or its branch could not be read -- a deleted fork, a
+    deleted branch. Reported as its own outcome rather than folded into a pass,
+    so a permissions or API-shape change cannot quietly turn this into a check
+    that always agrees.
+
+``unknown-checkout``
+    The local ``HEAD`` could not be read; not a directory this can judge.
+
+Why it reads the branch and not the mirror
+------------------------------------------
+Same reason ``check_pr_head_is_current.py`` reads the head repository's ref: the
+value under suspicion cannot be its own witness. Here both of the cheap answers
+are suspect -- the mirror is what produced the #2678 lag, and ``headRefOid`` is
+what produced the #2508 one -- so the tip is resolved from the head repository's
+own ref, through ``pullRequest { headRepository { nameWithOwner } headRefName }``.
+
+Usage
+-----
+::
+
+    python3 scripts/check_checkout_is_pr_head.py --repo strands-labs/robots --pr 2678
+    python3 scripts/check_checkout_is_pr_head.py --repo strands-labs/robots --pr 2678 \\
+        --checkout 33f8bcf4749a9146111294b4274be81326b50672
+
+``--checkout`` defaults to ``git rev-parse HEAD`` in ``--git-dir`` (default: the
+working directory). Exit 1 when the checkout is stale, so it can sit in front of
+the work in a shell ``&&`` chain.
+
+Unlike its sibling this takes no ``--all-open``: a checkout is a property of one
+clone, so there is no population to sweep.
+
+Pinned by tests/test_checkout_is_pr_head.py. See #2520.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+CURRENT = "current"
+AHEAD = "ahead"
+STALE_CHECKOUT = "stale-checkout"
+UNRESOLVABLE_HEAD = "unresolvable-head"
+UNKNOWN_CHECKOUT = "unknown-checkout"
+
+_API = "https://api.github.com/graphql"
+
+# The remedy, named once so the report and the docstring cannot drift into
+# describing different orderings for one rule.
+WHAT_CLEARS_THIS: tuple[str, ...] = (
+    "",
+    "### What clears this",
+    "",
+    "Fetch the branch itself from the head repository, by name. Not",
+    "`refs/pull/N/head` -- that mirror is what produced this finding on #2678,",
+    "and re-fetching it can return the same stale commit again:",
+    "",
+    "```",
+    "git fetch https://github.com/$HEAD_REPO.git $HEAD_REF",
+    "git rev-parse FETCH_HEAD      # must equal headRefOid from the API",
+    "```",
+    "",
+    "Then re-read the pull request's review threads against that commit before",
+    "deriving anything. A thread is a statement about the commit it was written",
+    "on; whether it is still true is a question about the tip. An unresolved",
+    "thread whose concern the tip already answers is the normal steady state",
+    "between a push and the next review pass, not a work item.",
+    "",
+    "Do **not** rebase or `--amend --force-with-lease` onto it. The commit the",
+    "branch already carries may be the answer to the thread, and both of those",
+    "shapes destroy it -- which is the failure #2520 records, where a plain",
+    "`git push` being refused was the only thing that prevented it.",
+)
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The outcome and the two commits it was computed from."""
+
+    outcome: str
+    checkout: str | None
+    tip: str | None
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == STALE_CHECKOUT
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == CURRENT:
+            return f"The checkout {_short(self.checkout)} is the branch tip. Derive from here."
+        if self.outcome == AHEAD:
+            return (
+                f"The branch tip {_short(self.tip)} is an ancestor of the checkout "
+                f"{_short(self.checkout)}, so the difference is this clone's own unpushed "
+                "work. Not a finding."
+            )
+        if self.outcome == UNRESOLVABLE_HEAD:
+            return (
+                f"Could not read the head repository's branch, so the checkout "
+                f"{_short(self.checkout)} could not be compared against anything. Not treated "
+                "as a finding: a deleted fork or branch is a different problem."
+            )
+        if self.outcome == UNKNOWN_CHECKOUT:
+            return (
+                "Could not read the local HEAD, so there is no checkout to judge. Pass "
+                "--checkout, or run this inside the clone."
+            )
+        return (
+            f"The checkout is {_short(self.checkout)}, but the branch tip is "
+            f"{_short(self.tip)} and the checkout does not contain it. Anything derived "
+            "here answers a question about a tree that has already moved, and a review "
+            "thread read against it may mean the opposite of what it means at the tip. "
+            "Fetch the branch by name and re-read the threads before deriving a fix."
+        )
+
+
+def _short(oid: str | None) -> str:
+    """Render a commit for a human without pretending an absent one is a commit."""
+    if not oid:
+        return "(unknown)"
+    return f"`{oid[:8]}`"
+
+
+def classify(checkout: str | None, tip: str | None, tip_is_ancestor: bool | None) -> Verdict:
+    """Decide whether a checkout is a tree a fix may be derived on.
+
+    ``tip_is_ancestor`` is passed in rather than computed so the decision stays a
+    pure function of three readings; ``None`` means the local repository could
+    not place the tip in its own history, which is not the same question as
+    "could not read the tip" and is *not* indeterminate: a repository that does
+    not contain a commit cannot have it as an ancestor, so it is stale.
+    """
+    if not checkout:
+        return Verdict(UNKNOWN_CHECKOUT, checkout, tip)
+    if not tip:
+        return Verdict(UNRESOLVABLE_HEAD, checkout, tip)
+    if checkout == tip:
+        return Verdict(CURRENT, checkout, tip)
+    if tip_is_ancestor:
+        return Verdict(AHEAD, checkout, tip)
+    return Verdict(STALE_CHECKOUT, checkout, tip)
+
+
+def _graphql(query: str, variables: dict[str, object], token: str) -> dict:
+    request = urllib.request.Request(
+        _API,
+        data=json.dumps({"query": query, "variables": variables}).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "strands-robots-check-checkout-is-pr-head",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - fixed API host
+        payload = json.load(response)
+    if payload.get("errors"):
+        raise ValueError(f"GraphQL errors: {payload['errors']}")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("GraphQL response carried no data object")
+    return data
+
+
+_ONE_PR = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number headRefName headRefOid
+      headRepository { nameWithOwner }
+    }
+  }
+}
+"""
+
+_REF_TIP = """
+query($owner:String!,$name:String!,$ref:String!){
+  repository(owner:$owner,name:$name){
+    ref(qualifiedName:$ref){ target { oid } }
+  }
+}
+"""
+
+
+def _split_repo(repo: str) -> tuple[str, str]:
+    if repo.count("/") != 1 or not all(repo.split("/")):
+        raise ValueError(f"--repo must be owner/name, got {repo!r}")
+    owner, name = repo.split("/")
+    return owner, name
+
+
+def _git(args: Sequence[str], cwd: str) -> str | None:
+    """Run git and return stdout, or ``None`` if it failed for any reason."""
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def local_head(cwd: str) -> str | None:
+    """The commit the clone at ``cwd`` is on, or ``None`` if it is not a clone."""
+    return _git(["rev-parse", "HEAD"], cwd)
+
+
+def tip_is_ancestor_of_checkout(tip: str, checkout: str, cwd: str) -> bool | None:
+    """Whether ``tip`` is in the history of ``checkout``, per the local repository.
+
+    ``None`` when the local repository does not have the ``tip`` object at all,
+    which the caller reads as stale rather than as unknown: a clone that has
+    never fetched a commit cannot contain it. Distinguished from ``False`` --
+    both are stale, but only ``False`` means the two commits genuinely diverged
+    -- so the two causes stay legible in a report.
+    """
+    if _git(["cat-file", "-e", f"{tip}^{{commit}}"], cwd) is None:
+        return None
+    return _git(["merge-base", "--is-ancestor", tip, checkout], cwd) is not None
+
+
+def branch_tip(head_repo: str, head_ref: str, token: str) -> str | None:
+    """Return the tip of ``head_ref`` in ``head_repo``, or ``None`` if unreadable.
+
+    Reads the head *repository's* ref. Neither ``refs/pull/N/head`` nor
+    ``headRefOid`` will do: both are answers this check exists to catch out.
+    """
+    try:
+        owner, name = _split_repo(head_repo)
+    except ValueError:
+        return None
+    try:
+        data = _graphql(
+            _REF_TIP,
+            {"owner": owner, "name": name, "ref": f"refs/heads/{head_ref}"},
+            token,
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError):
+        return None
+    repository = data.get("repository") or {}
+    ref = repository.get("ref") or {}
+    target = ref.get("target") or {}
+    oid = target.get("oid")
+    return oid if isinstance(oid, str) else None
+
+
+def fetch_pull_request(repo: str, number: int, token: str) -> dict:
+    owner, name = _split_repo(repo)
+    data = _graphql(_ONE_PR, {"owner": owner, "name": name, "number": number}, token)
+    repository = data.get("repository") or {}
+    node = repository.get("pullRequest")
+    if not isinstance(node, dict):
+        raise ValueError(f"{repo}#{number} did not resolve to a pull request")
+    return node
+
+
+@dataclass(frozen=True)
+class Report:
+    """One evaluated checkout."""
+
+    pr: int
+    verdict: Verdict
+    head_repo: str
+    head_ref: str
+    recorded: str | None
+
+    def render(self, repo: str) -> str:
+        lines = [
+            "## Checkout against the pull request's branch tip",
+            "",
+            f"Outcome: **{self.verdict.outcome}**",
+            "",
+            self.verdict.summary,
+            "",
+            "| field | value |",
+            "|---|---|",
+            f"| pull request | {repo}#{self.pr} |",
+            f"| head repository | `{self.head_repo}` |",
+            f"| head branch | `{self.head_ref}` |",
+            f"| local checkout | {_short(self.verdict.checkout)} |",
+            f"| branch tip | {_short(self.verdict.tip)} |",
+            f"| recorded headRefOid | {_short(self.recorded)} |",
+        ]
+        if self.recorded and self.verdict.tip and self.recorded != self.verdict.tip:
+            lines += [
+                "",
+                f"Note: the pull request records {_short(self.recorded)} while its branch tip "
+                f"is {_short(self.verdict.tip)}. That is the separate defect "
+                "`check_pr_head_is_current.py` reports, whose remedy is a reopen and not a "
+                "push; this check's verdict is against the tip either way.",
+            ]
+        if self.verdict.is_finding:
+            lines += list(WHAT_CLEARS_THIS)
+        return "\n".join(lines)
+
+
+def evaluate(node: dict, token: str, checkout: str | None, cwd: str) -> Report:
+    """Evaluate one pull request node against a checkout."""
+    head_repository = node.get("headRepository") or {}
+    head_repo = head_repository.get("nameWithOwner") or ""
+    head_ref = node.get("headRefName") or ""
+    recorded = node.get("headRefOid")
+    tip = branch_tip(head_repo, head_ref, token) if head_repo and head_ref else None
+    ancestry = tip_is_ancestor_of_checkout(tip, checkout, cwd) if tip and checkout and tip != checkout else None
+    return Report(
+        pr=int(node["number"]),
+        verdict=classify(checkout, tip, ancestry),
+        head_repo=head_repo or "(unknown)",
+        head_ref=head_ref or "(unknown)",
+        recorded=recorded,
+    )
+
+
+def _publish(report: str) -> None:
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
+    parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
+    parser.add_argument(
+        "--checkout",
+        default="",
+        help="Commit to judge. Defaults to git rev-parse HEAD in --git-dir.",
+    )
+    parser.add_argument(
+        "--git-dir",
+        default=".",
+        help="Clone whose HEAD and object database are read (default: the working directory).",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        print("check_checkout_is_pr_head: --repo is required", file=sys.stderr)
+        return 0
+    if not args.pr:
+        print("check_checkout_is_pr_head: --pr is required", file=sys.stderr)
+        return 0
+    if not args.token:
+        print("check_checkout_is_pr_head: no token; set --token or GITHUB_TOKEN", file=sys.stderr)
+        return 0
+
+    checkout = args.checkout or local_head(args.git_dir)
+    try:
+        node = fetch_pull_request(args.repo, int(args.pr), args.token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError) as exc:
+        # Fails open: a check that cannot reach the API must not be the reason a
+        # cycle stops, and its finding is advisory rather than a merge gate.
+        print(f"check_checkout_is_pr_head: could not evaluate {args.repo}#{args.pr}: {exc}", file=sys.stderr)
+        return 0
+    report = evaluate(node, args.token, checkout, args.git_dir)
+    _publish(report.render(args.repo))
+    if report.verdict.is_finding:
+        print(f"::warning title=Checkout is not the branch tip::{args.repo}#{report.pr}: {report.verdict.summary}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_checkout_is_pr_head.py
+++ b/tests/test_checkout_is_pr_head.py
@@ -1,0 +1,337 @@
+"""Pins the checkout classifier against the pull request that produced it.
+
+The observation is #2678. A run fetched what it believed was the pull request's
+branch and got a mirror ref that was one commit behind the commit the API was
+already serving::
+
+    git fetch origin pull/2678/head    ->  33f8bcf4      the mirror
+    pullRequest { headRefOid }         ->  0b070a05      the tip
+    git merge-base --is-ancestor 33f8bcf4 0b070a05  ->  true, a pure lag
+
+On that tree the symbol its review thread named (an "unused global" finding) was
+genuinely unused, so deletion was the correct local fix and the suite agreed --
+18 passed, ruff clean. At the tip the same finding meant the opposite: the
+constant was unused because the behavioural tests spelled its value out at each
+call site, and the fix was to wire it up. Deletion would have passed CI while
+removing the invariant the symbol carried, which is why the fixtures below are a
+*worse answer* case and not a duplicated-work case.
+
+Two properties carry the check, and both are pinned here rather than assumed:
+
+- Ahead is not stale. A run that has committed its own work is at a commit the
+  tip does not have, which is the ordinary state between a commit and its push.
+  A check that reported it would fire exactly when it is being used correctly,
+  so the comparison is ancestry and not equality.
+- A tip absent from the local object database is stale, not indeterminate. A
+  clone that never fetched a commit cannot contain it, and folding that into a
+  pass is the one failure mode that would turn this into a check agreeing with
+  everything.
+
+See scripts/check_checkout_is_pr_head.py, issue #2520, and the "PR Workflow"
+section of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_checkout_is_pr_head.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_checkout_is_pr_head", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+# The two commits #2678 carried at the moment of the lag, verbatim.
+MIRROR = "33f8bcf4749a9146111294b4274be81326b50672"
+TIP = "0b070a05c5f0c3ca240f0ef092d3fe5fb0fa7a78"
+
+# A commit the tip does not contain, standing for this clone's own unpushed work.
+LOCAL_WORK = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+class TestTheMeasuredPullRequest:
+    """#2678, at the lag and after it."""
+
+    def test_a_checkout_the_branch_has_moved_past_is_the_finding(self) -> None:
+        verdict = mod.classify(MIRROR, TIP, tip_is_ancestor=False)
+        assert verdict.outcome == mod.STALE_CHECKOUT
+        assert verdict.is_finding
+
+    def test_the_same_clone_reads_current_once_it_fetches_the_branch(self) -> None:
+        """The control. Only the checkout moved; the tip did not."""
+        verdict = mod.classify(TIP, TIP, tip_is_ancestor=True)
+        assert verdict.outcome == mod.CURRENT
+        assert not verdict.is_finding
+
+    def test_the_finding_names_both_commits(self) -> None:
+        summary = mod.classify(MIRROR, TIP, tip_is_ancestor=False).summary
+        assert MIRROR[:8] in summary
+        assert TIP[:8] in summary
+
+    def test_the_finding_says_a_thread_may_mean_something_else_at_the_tip(self) -> None:
+        """The expensive part of #2678 was not lost time, it was a wrong answer.
+
+        A reader told only "your checkout is behind" re-fetches and keeps the fix
+        they derived. The summary has to say that the *meaning* of the thread can
+        differ at the tip, which is what makes re-reading it non-optional.
+        """
+        summary = mod.classify(MIRROR, TIP, tip_is_ancestor=False).summary
+        assert "may mean the opposite" in summary
+        assert "re-read the threads" in summary
+
+
+class TestAheadIsNotStale:
+    """The clone's own unpushed work must not read as a finding."""
+
+    def test_a_checkout_containing_the_tip_is_ahead_not_stale(self) -> None:
+        verdict = mod.classify(LOCAL_WORK, TIP, tip_is_ancestor=True)
+        assert verdict.outcome == mod.AHEAD
+        assert not verdict.is_finding
+
+    def test_the_ahead_summary_says_the_difference_is_unpushed_work(self) -> None:
+        summary = mod.classify(LOCAL_WORK, TIP, tip_is_ancestor=True).summary
+        assert "unpushed work" in summary
+        assert "Not a finding" in summary
+
+    def test_ahead_and_stale_are_told_apart_only_by_ancestry(self) -> None:
+        """Identical commits, opposite verdicts. Ancestry is the whole decision."""
+        ahead = mod.classify(LOCAL_WORK, TIP, tip_is_ancestor=True)
+        stale = mod.classify(LOCAL_WORK, TIP, tip_is_ancestor=False)
+        assert (ahead.outcome, stale.outcome) == (mod.AHEAD, mod.STALE_CHECKOUT)
+
+
+class TestAnAbsentTipIsStaleRatherThanUnknown:
+    """A clone that never fetched the tip cannot contain it."""
+
+    def test_unknown_ancestry_is_the_finding(self) -> None:
+        verdict = mod.classify(MIRROR, TIP, tip_is_ancestor=None)
+        assert verdict.outcome == mod.STALE_CHECKOUT
+        assert verdict.is_finding
+
+    def test_an_unreadable_tip_is_not_a_finding_and_not_current(self) -> None:
+        """A deleted fork is a different problem, but it is not a pass either."""
+        verdict = mod.classify(MIRROR, None, tip_is_ancestor=None)
+        assert verdict.outcome == mod.UNRESOLVABLE_HEAD
+        assert not verdict.is_finding
+
+    def test_an_unreadable_checkout_is_its_own_outcome(self) -> None:
+        verdict = mod.classify(None, TIP, tip_is_ancestor=None)
+        assert verdict.outcome == mod.UNKNOWN_CHECKOUT
+        assert not verdict.is_finding
+
+    def test_two_absent_commits_do_not_read_as_current(self) -> None:
+        assert mod.classify(None, None, tip_is_ancestor=None).outcome != mod.CURRENT
+
+
+class TestTheRemedyIsToFetchTheBranchByName:
+    """The remedy has to refuse the mirror, or it recreates the finding."""
+
+    def test_it_refuses_refs_pull_by_name(self) -> None:
+        text = "\n".join(mod.WHAT_CLEARS_THIS)
+        assert "refs/pull/N/head" in text
+
+    def test_it_names_the_fetch_and_the_assertion_against_the_api(self) -> None:
+        text = "\n".join(mod.WHAT_CLEARS_THIS)
+        assert "git fetch https://github.com/$HEAD_REPO.git $HEAD_REF" in text
+        assert "must equal headRefOid" in text
+
+    def test_it_refuses_rebase_and_amend(self) -> None:
+        """Both shapes destroy a commit that may already answer the thread."""
+        text = "\n".join(mod.WHAT_CLEARS_THIS)
+        assert "rebase" in text
+        assert "--amend --force-with-lease" in text
+
+    def test_the_remedy_only_appears_on_a_finding(self) -> None:
+        anchor = mod.WHAT_CLEARS_THIS[1]
+        stale = mod.Report(1, mod.classify(MIRROR, TIP, False), "o/r", "b", TIP).render("o/r")
+        clean = mod.Report(1, mod.classify(TIP, TIP, True), "o/r", "b", TIP).render("o/r")
+        assert anchor in stale
+        assert anchor not in clean
+
+
+class TestAncestryIsReadFromTheLocalRepository:
+    """The one part that touches git, pinned against a repository built here."""
+
+    def test_a_parent_is_an_ancestor_of_its_child(self, tmp_path: Path) -> None:
+        cwd, first, second = _two_commit_repo(tmp_path)
+        assert mod.tip_is_ancestor_of_checkout(first, second, cwd) is True
+
+    def test_a_child_is_not_an_ancestor_of_its_parent(self, tmp_path: Path) -> None:
+        """The stale direction: the tip has a commit the checkout does not."""
+        cwd, first, second = _two_commit_repo(tmp_path)
+        assert mod.tip_is_ancestor_of_checkout(second, first, cwd) is False
+
+    def test_a_tip_absent_from_the_object_database_is_none(self, tmp_path: Path) -> None:
+        cwd, _first, second = _two_commit_repo(tmp_path)
+        assert mod.tip_is_ancestor_of_checkout(LOCAL_WORK, second, cwd) is None
+
+    def test_local_head_reads_the_checkout(self, tmp_path: Path) -> None:
+        cwd, _first, second = _two_commit_repo(tmp_path)
+        assert mod.local_head(cwd) == second
+
+    def test_local_head_of_a_non_repository_is_none(self, tmp_path: Path) -> None:
+        plain = tmp_path / "not-a-clone"
+        plain.mkdir()
+        assert mod.local_head(str(plain)) is None
+
+
+class TestTheTipIsReadFromTheHeadRepository:
+    """Neither suspect answer may stand in for the tip."""
+
+    def test_branch_tip_queries_the_head_repository_ref(self, monkeypatch) -> None:
+        seen: dict[str, object] = {}
+
+        def fake(query: str, variables: dict, token: str) -> dict:
+            seen.update(variables)
+            seen["query"] = query
+            return {"repository": {"ref": {"target": {"oid": TIP}}}}
+
+        monkeypatch.setattr(mod, "_graphql", fake)
+        assert mod.branch_tip("someone/robots", "topic", "t") == TIP
+        assert seen["owner"] == "someone"
+        assert seen["name"] == "robots"
+        assert seen["ref"] == "refs/heads/topic"
+        assert "pullRequest" not in str(seen["query"])
+
+    def test_an_unreadable_ref_returns_none_rather_than_raising(self, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "_graphql", lambda *a, **k: {"repository": {"ref": None}})
+        assert mod.branch_tip("someone/robots", "gone", "t") is None
+
+    def test_a_malformed_head_repository_is_unresolvable(self, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "_graphql", lambda *a, **k: {})
+        assert mod.branch_tip("not-a-repo", "topic", "t") is None
+
+
+class TestEvaluate:
+    """The wiring, including the note about its sibling check."""
+
+    NODE = {
+        "number": 2678,
+        "headRefName": "fix/velocity-write-names-conflicting-rate-drive",
+        "headRefOid": TIP,
+        "headRepository": {"nameWithOwner": "cagataycali/robots"},
+    }
+
+    def test_the_mirror_checkout_is_a_finding(self, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", lambda *a: False)
+        report = mod.evaluate(dict(self.NODE), "t", MIRROR, ".")
+        assert report.verdict.outcome == mod.STALE_CHECKOUT
+        assert report.pr == 2678
+
+    def test_ancestry_is_not_consulted_when_the_checkout_is_the_tip(self, monkeypatch) -> None:
+        """No git call for the ordinary case, and no way for one to change it."""
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+
+        def explode(*_a: object) -> bool:
+            raise AssertionError("ancestry must not be consulted when the commits are equal")
+
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", explode)
+        assert mod.evaluate(dict(self.NODE), "t", TIP, ".").verdict.outcome == mod.CURRENT
+
+    def test_a_null_head_repository_is_unresolvable_not_a_finding(self, monkeypatch) -> None:
+        node = dict(self.NODE, headRepository=None)
+        report = mod.evaluate(node, "t", MIRROR, ".")
+        assert report.verdict.outcome == mod.UNRESOLVABLE_HEAD
+        assert not report.verdict.is_finding
+
+    def test_a_recorded_head_behind_the_tip_is_named_as_the_sibling_defect(self, monkeypatch) -> None:
+        """#2508's defect and #2678's are independent, and both can be live at once."""
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", lambda *a: False)
+        node = dict(self.NODE, headRefOid=MIRROR)
+        rendered = mod.evaluate(node, "t", MIRROR, ".").render("strands-labs/robots")
+        assert "check_pr_head_is_current.py" in rendered
+
+    def test_no_sibling_note_when_the_record_matches_the_tip(self, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", lambda *a: False)
+        rendered = mod.evaluate(dict(self.NODE), "t", MIRROR, ".").render("strands-labs/robots")
+        assert "check_pr_head_is_current.py" not in rendered
+
+
+class TestExitStatus:
+    """A missing input must not fail the caller; a finding must."""
+
+    def test_a_missing_repo_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "", "--pr", "1", "--token", "t"]) == 0
+
+    def test_a_missing_pr_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "o/r", "--pr", "", "--token", "t"]) == 0
+
+    def test_a_missing_token_does_not_fail_the_caller(self) -> None:
+        assert mod.main(["--repo", "o/r", "--pr", "1", "--token", ""]) == 0
+
+    def test_an_unreachable_api_fails_open(self, monkeypatch) -> None:
+        def boom(*_a: object, **_k: object) -> dict:
+            raise ValueError("GraphQL errors: nope")
+
+        monkeypatch.setattr(mod, "fetch_pull_request", boom)
+        assert mod.main(["--repo", "o/r", "--pr", "1", "--token", "t", "--checkout", MIRROR]) == 0
+
+    def test_a_stale_checkout_exits_one(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(mod, "fetch_pull_request", lambda *a: dict(TestEvaluate.NODE))
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", lambda *a: False)
+        assert mod.main(["--repo", "o/r", "--pr", "2678", "--token", "t", "--checkout", MIRROR]) == 1
+        assert "::warning" in capsys.readouterr().out
+
+    def test_a_current_checkout_exits_zero_and_warns_nothing(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(mod, "fetch_pull_request", lambda *a: dict(TestEvaluate.NODE))
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        assert mod.main(["--repo", "o/r", "--pr", "2678", "--token", "t", "--checkout", TIP]) == 0
+        assert "::warning" not in capsys.readouterr().out
+
+    def test_an_ahead_checkout_exits_zero(self, monkeypatch) -> None:
+        """The shape a mid-cycle run is in, and it must not stop the run."""
+        monkeypatch.setattr(mod, "fetch_pull_request", lambda *a: dict(TestEvaluate.NODE))
+        monkeypatch.setattr(mod, "branch_tip", lambda *a: TIP)
+        monkeypatch.setattr(mod, "tip_is_ancestor_of_checkout", lambda *a: True)
+        assert mod.main(["--repo", "o/r", "--pr", "2678", "--token", "t", "--checkout", LOCAL_WORK]) == 0
+
+
+def _two_commit_repo(tmp_path: Path) -> tuple[str, str, str]:
+    """Build a hermetic two-commit repository. Returns (path, first, second).
+
+    Built here rather than reusing this repository's own history: the #2678
+    commits live on a fork branch that has since been deleted, so a test reading
+    them from the object database would pass or fail on what the clone happened
+    to fetch.
+    """
+    path = tmp_path / "repo"
+    path.mkdir()
+    cwd = str(path)
+
+    def git(*args: str) -> str:
+        return subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    git("init", "--quiet", "--initial-branch", "main")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "test")
+    git("config", "commit.gpgsign", "false")
+    (path / "f").write_text("one\n", encoding="utf-8")
+    git("add", "f")
+    git("commit", "--quiet", "-m", "first")
+    first = git("rev-parse", "HEAD")
+    (path / "f").write_text("two\n", encoding="utf-8")
+    git("add", "f")
+    git("commit", "--quiet", "-m", "second")
+    second = git("rev-parse", "HEAD")
+    return cwd, first, second

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -86,6 +86,7 @@ _INFERS_REPOSITORY: tuple[str, ...] = tuple(
 #: infer. Requiring the flag of that mode would be the same false rejection this
 #: scope exists to avoid.
 _NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
+    "check_checkout_is_pr_head.py": ("--repo", None),
     "check_closing_reference.py": ("--repo", None),
     "check_duplicate_claim.py": ("--repo", None),
     "check_last_push_approval.py": ("--repo", None),


### PR DESCRIPTION
## Problem

`check_pr_head_is_current.py` opens by saying a pull request has **two** answers to
"what is the head commit". It has three, and the count is not pedantry -- the third is the
one every checkout reaches for and the only one carrying no signal at all.

| answer | what moves it out of date |
| --- | --- |
| `refs/pull/N/head` | a mirror ref GitHub refreshes on its own schedule, so it trails a push to the fork branch |
| `pullRequest { headRefOid }` | normally reconciled within a second of a push; #2508 sat five hours behind |
| tip of the head repository's branch | nothing -- this is the value that exists, and what the other two are *for* |

Measured on #2678. A run checked the pull request out the obvious way and got the mirror,
while the API was already serving the commit that existed:

```
git fetch origin pull/2678/head   ->  33f8bcf4   one commit behind
pullRequest { headRefOid }        ->  0b070a05   the tip
git merge-base --is-ancestor 33f8bcf4 0b070a05   ->  true, a pure lag
```

The cost is not a wasted fetch. The run believed it *had* checked out the branch, grepped
the symbol its review thread named, found it genuinely unused **on that tree**, and derived
a correct fix for source that no longer existed. What surfaced the drift was `git push`
being refused as non-fast-forward -- after the work. A fix touching a different file would
have pushed cleanly.

### And the answer was worse than a duplicate

This is the part that makes re-reading the thread non-optional rather than tidy. The thread
was a CodeQL *unused global `_RATE_TAG`*.

| derived against | what the finding means | fix | suite |
| --- | --- | --- | --- |
| the stale mirror | dead code | delete the constant | 18 passed, `ruff` clean |
| the actual tip | a **missing call site** | wire the constant up, pin the tie | 19 passed |

The constant was unused because the behavioural tests spelled its value out at each call
site, so nothing tied the joint under measurement to the tag the parametrized sweep graded.
Deletion would have **passed CI while removing the invariant the symbol existed to carry**.
An unused symbol in a test file is often a missing call site rather than dead code, and the
two fixes are indistinguishable by test outcome.

#2520 records four instances of this class -- #2511 (one thread, four author replies), #2566
and #2577 (two runs deriving one fix), and #2678 above. In three of the four the only thing
that prevented a duplicate landing was the non-fast-forward rejection, which is load-bearing
purely by accident: it fires because the mandated push shape is a plain `git push`, and both
nearby shapes defeat it -- `pull --rebase` lands an empty-diff commit on top, and
`--amend --force-with-lease` deletes the commit that already answered the thread.

## Change

`scripts/check_checkout_is_pr_head.py` compares the commit a local clone is on against the
tip of the branch in the head repository, and exits 1 when the branch has commits the clone
does not, so it can sit in front of the work in a `&&` chain.

The tip is resolved from the head repository's own ref, for the same reason its sibling does
it: the value under suspicion cannot be its own witness. Here **both** cheap answers are
suspect -- the mirror produced the #2678 lag, `headRefOid` produced the #2508 one.

### Ancestry, not equality

The comparison cannot be equality, and this is the design point rather than a detail. A run
that has committed its own work sits at a commit the tip does not have yet -- the ordinary
state between a commit and its push -- so an equality check would fire **exactly when the
tool is being used correctly**, and a check that cries wolf gets ignored.

| checkout vs tip | outcome | finding |
| --- | --- | --- |
| equal | `current` | no |
| tip is an ancestor of the checkout | `ahead` (own unpushed work) | no |
| otherwise | `stale-checkout` | **yes** |
| tip unreadable (deleted fork/branch) | `unresolvable-head` | no |
| local `HEAD` unreadable | `unknown-checkout` | no |

A tip **absent from the local object database** is `stale-checkout`, not indeterminate: a
clone that never fetched a commit cannot contain it. `tip_is_ancestor_of_checkout` still
distinguishes that (`None`) from a genuine divergence (`False`) so the two causes stay
legible, but both are stale. Folding an unreadable reading into a pass is the one failure
mode that would turn this into a check agreeing with everything, which is why
`unresolvable-head` is its own outcome too.

`AGENTS.md` is corrected in the same diff -- the "two answers" sentence, plus a sibling
bullet for the third answer, the `FETCH_HEAD == headRefOid` assertion, and the
missing-call-site lesson. The doc's own framing is part of why the mistake feels safe.

## Scope

Additive. No existing script, test or workflow changes behaviour; `classify()` in the
sibling check is untouched and its 23 pinned tests pass unmodified. No workflow wires this
in, matching both existing agent-invoked checks (`check_pr_head_is_current.py` and
`check_thread_is_answered.py` have none): a checkout is a property of one clone, so there is
no `--all-open` population to sweep and nothing for a `pull_request` event to fire on.

It reports and does not gate. The remedy is to re-fetch and re-derive, which is not
something a branch clears by pushing.

## Tests

`tests/test_checkout_is_pr_head.py`, **35 cases**, using the two #2678 commits verbatim as
fixtures -- the pattern `test_pr_head_is_current.py` uses for #2508. The git-touching helper
is pinned against a two-commit repository built in `tmp_path`, deliberately not this
repository's history: the #2678 commits live on a fork branch that has since been deleted,
so a test reading them from the object database would pass or fail on what the clone
happened to fetch.

### Break table

| break | fires |
| --- | --- |
| control | 0 of 35 |
| ancestry dropped, equality only (`ahead` branch removed) | **4** |
| absent tip object folded into a pass (`None` -> `ahead`) | 1 |
| unreadable tip folded into `current` | 2 |
| remedy re-fetches the mirror instead of the branch by name | 1 |
| `evaluate` consults ancestry even when checkout == tip | 1 |
| tip taken from the record (`headRefOid`) instead of the fork ref | 2 |
| finding summary drops the "means something else at the tip" clause | 1 |
| sibling `headRefOid` note dropped | 1 |

The first row is the one worth naming: it is the mutation a reviewer would most plausibly
suggest as a simplification, and it breaks the tool for every mid-cycle run.

## Verification

Measured at `9830553`.

- **Live, on an open pull request** (#2646, `yinsong1986/robots`), the two directions:

| `--checkout` | outcome | exit |
| --- | --- | --- |
| `b036c956` (the tip) | `current` | 0 |
| `e07967f1` (its parent) | `stale-checkout` | **1**, with the `::warning` annotation |

- **Dogfooded on this pull request.** From the clone this branch was written in, with no
  argument but `--pr 2679`, the check resolved `cagataycali/robots`
  `ci/refuse-a-fix-derived-on-a-stale-checkout` and reported `current` at `98305533`, exit 0.
- **Settled-state control:** all three other open pull requests' `refs/pull/N/head` mirrors
  agreed with their `headRefOid` (`b036c956`, `741f4057`, `8d6a4c42`), so agreement is the
  ordinary case and the lag is the anomaly -- the check is silent on the steady state.
- **The lag did not reproduce on demand, which is the argument for a check rather than a
  habit.** Sampling `refs/pull/2679/head` against `headRefOid` every 3s for 15s from this
  pull request's creation, the mirror was already correct at the first sample (`98305533`,
  5/5 agreeing). A window that is usually absent and occasionally seconds-to-hours wide is
  one you cannot time your way around, and #2508 is the same phenomenon on the other API
  answer lasting over five hours. So the finding is rare, silent, and cheap to test for --
  which is why this exits 1 in front of the work rather than asking anyone to remember.
- `tests/test_checkout_is_pr_head.py`: **35 passed**.
- `tests/test_pr_head_is_current.py`: **23 passed**, unmodified.
- Convention sweeps that grade the whole tree, including the new files:
  `test_log_strings_are_ascii`, `test_except_tuples_state_their_real_scope`,
  `test_graphql_node_id_targeting`, `test_composition_compare_ref_form`,
  `test_composition_run_precondition`, `test_codeql_query_filters`,
  `test_all_exports_are_statically_defined` -- **139 passed, 1 failed**, the failure being
  `ModuleNotFoundError: No module named 'strands'`, reproduced identically on a stashed
  worktree, so it is a locally absent dependency and not this branch.
- `scripts/assemble_changelog.py --check`: `changelog fragments OK`.
  `tests/test_changelog_fragments.py` + `test_changelog_format.py`: 30 passed.
- `ruff check` / `ruff format --check` clean; `mypy` clean on both new files. File mode 644,
  matching the sibling scripts.

One correction to the record while measuring: my own note on #2520 said the mirror was "two
commits" behind. `git rev-list --count 33f8bcf4..0b070a05` is **1**. The oids and the
ancestry hold; the distance did not, and the PR says 1.
