### PR TITLE
fix(isaac): read every MJCF orientation spelling, not just quat

### DIFF
--- a/changelog.d/2680-isaac-mjcf-orientation-spellings.md
+++ b/changelog.d/2680-isaac-mjcf-orientation-spellings.md
@@ -1,0 +1,21 @@
+### Fixed: the Isaac scene loader reads every MJCF orientation spelling, not just `quat`
+
+MJCF gives a body or a geom five mutually exclusive ways to state one rotation -
+`quat`, `euler`, `axisangle`, `xyaxes` and `zaxis`. The scene loader read only
+`quat`, so an object a model rotates with any of the other four was reported
+unrotated and the load reported success. Identity is a valid orientation, so
+nothing downstream could tell a body that was never rotated from one whose
+rotation had been dropped.
+
+The angle units and the Euler axis sequence are model-global, so they now come
+from `<compiler angle>` and `<compiler eulerseq>` resolved across `<include>` the
+way `meshdir` already is. A lower-case `eulerseq` rotates about the fixed axes
+and an upper-case one about the moving axes, which is the same three rotations
+composed in the opposite order; both readings and all six axis permutations are
+graded against `mujoco.MjModel`. A body or geom declaring two spellings at once
+is refused rather than resolved, because MuJoCo refuses that model outright and
+any rotation the reader picked would be a guess.
+
+Graded against MuJoCo's own compiler: 1115 cases across five compiler
+configurations, 0 mismatches. Over 570 real MJCF assets three change, all mesh
+rotations previously reported as identity, with no change of verdict.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -897,9 +897,45 @@ def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
     return (parts[0], parts[1], parts[2], parts[3])
 
 
+#: MJCF's orientation spellings other than ``quat``. MuJoCo keeps these four in
+#: one "alternative orientation" slot carrying which of them was used, separate
+#: from the ``quat`` attribute, and resolves that slot in preference to ``quat``
+#: when it is set. Two consequences, both measured on mujoco 3.5.0 and 3.12.0:
+#: a ``<default>`` class supplying any of these beats a ``quat`` the element
+#: itself declares, and an inner declaration of one of these replaces an outer
+#: declaration of another rather than sitting beside it.
+_ORIENTATION_ALT_SPELLINGS = ("euler", "axisangle", "xyaxes", "zaxis")
+
 #: MJCF's mutually exclusive orientation spellings, in the order this module
-#: reports them when a model declares more than one (MuJoCo refuses that).
-_ORIENTATION_SPELLINGS = ("quat", "euler", "axisangle", "xyaxes", "zaxis")
+#: reports them when ONE element declares more than one (MuJoCo refuses that).
+_ORIENTATION_SPELLINGS = ("quat", *_ORIENTATION_ALT_SPELLINGS)
+
+
+def _merge_mjcf_attrs(outer: Mapping[str, str], inner: Mapping[str, str]) -> dict[str, str]:
+    """``inner``'s attributes over ``outer``'s, with MJCF's orientation precedence.
+
+    Every attribute merges by name -- an inner declaration replaces an outer one
+    -- except that the orientation spellings do not share a name. MuJoCo keeps
+    :data:`_ORIENTATION_ALT_SPELLINGS` in one slot, so an inner ``euler``
+    REPLACES an outer ``zaxis`` instead of joining it, and reading both would
+    leave the effective rotation ambiguous. ``quat`` is a plain attribute and
+    merges by name; whether it or a surviving alternative spelling is in effect
+    is :func:`_parse_orientation`'s decision, not this one's.
+
+    Args:
+        outer: The enclosing level's attributes -- a ``<default>`` class's, or
+            the parent class's when flattening a nested one.
+        inner: The narrower level's own attributes.
+
+    Returns:
+        The merged mapping, carrying at most one of the alternative spellings.
+    """
+    merged = {**outer, **inner}
+    if any(inner.get(spelling) for spelling in _ORIENTATION_ALT_SPELLINGS):
+        for spelling in _ORIENTATION_ALT_SPELLINGS:
+            if not inner.get(spelling):
+                merged.pop(spelling, None)
+    return merged
 
 
 def _mjcf_angle_units(elements: list[ET.Element]) -> tuple[float, str]:
@@ -992,6 +1028,7 @@ def _quat_from_basis(
 def _parse_orientation(
     attrs: Mapping[str, str],
     *,
+    own: Mapping[str, str] | None = None,
     angle_scale: float = math.pi / 180.0,
     eulerseq: str = "xyz",
 ) -> tuple[float, float, float, float]:
@@ -1013,6 +1050,15 @@ def _parse_orientation(
       orthogonalized against it, then z as their cross product.
     * ``zaxis="x y z"`` -- the minimal rotation taking ``+z`` onto that axis.
 
+    They are mutually exclusive on ONE element, but not across MJCF's
+    ``<default>`` precedence: a class may supply one spelling and the element
+    declare another, and MuJoCo compiles that model. It resolves it by keeping
+    :data:`_ORIENTATION_ALT_SPELLINGS` in a slot separate from ``quat`` and
+    preferring that slot, so an alternative spelling from ANY level beats a
+    ``quat`` from any level -- including a class ``euler`` over the element's own
+    ``quat``. :func:`_merge_mjcf_attrs` has already resolved which alternative
+    spelling survives, so at most one reaches here.
+
     A ``quat`` is reported as written rather than normalized. MuJoCo normalizes
     it, but no ``quat`` in the shipped asset corpus is unnormalized, so
     normalizing here would only move output for input no shipped model
@@ -1022,6 +1068,11 @@ def _parse_orientation(
         attrs: The element's effective attributes -- ``el.attrib``, or
             :func:`_class_attrs`' result where a ``<default>`` class may supply
             the orientation.
+        own: The element's OWN attributes when ``attrs`` merges a class's in.
+            Only the spellings an element declares itself are mutually
+            exclusive, so this is what the refusal below is measured against;
+            defaults to ``attrs``, which is correct for a ``<body>`` (MJCF has
+            no ``<body>`` default class, so nothing is merged in).
         angle_scale: Factor converting a declared angle to radians, from
             :func:`_mjcf_angle_units`.
         eulerseq: Euler axis sequence with its case intact, from
@@ -1033,19 +1084,27 @@ def _parse_orientation(
         reading for a malformed ``quat``).
 
     Raises:
-        ValueError: If the element declares more than one orientation spelling.
+        ValueError: If ``own`` declares more than one orientation spelling.
             MuJoCo refuses such a model outright ("multiple orientation
-            specifiers are not allowed"), so there is no rotation to pick.
+            specifiers are not allowed"), so there is no rotation to pick. A
+            class supplying one spelling while the element declares another is
+            NOT that case -- MuJoCo compiles it, and it is resolved above.
     """
-    declared = [s for s in _ORIENTATION_SPELLINGS if attrs.get(s)]
-    if not declared:
-        return (1.0, 0.0, 0.0, 0.0)
-    if len(declared) > 1:
+    declared_here = [s for s in _ORIENTATION_SPELLINGS if (attrs if own is None else own).get(s)]
+    if len(declared_here) > 1:
         raise ValueError(
-            f"MJCF orientation: {declared} were all declared on one element, but they are mutually "
+            f"MJCF orientation: {declared_here} were all declared on one element, but they are mutually "
             "exclusive - MuJoCo refuses a model with multiple orientation specifiers. Keep one."
         )
-    spelling = declared[0]
+    # An alternative spelling beats ``quat`` whichever level declared it, and
+    # ``_merge_mjcf_attrs`` leaves at most one of them, so the first is the one.
+    alternatives = [s for s in _ORIENTATION_ALT_SPELLINGS if attrs.get(s)]
+    if alternatives:
+        spelling = alternatives[0]
+    elif attrs.get("quat"):
+        spelling = "quat"
+    else:
+        return (1.0, 0.0, 0.0, 0.0)
     if spelling == "quat":
         return _parse_quat(attrs.get("quat"))
     try:
@@ -1216,7 +1275,7 @@ def _mjcf_class_defaults(root: ET.Element, base_dir: str, tag: str) -> dict[str,
     classes: dict[str, dict[str, str]] = {"": {}, _MJCF_ROOT_DEFAULT_CLASS: {}}
 
     def _flatten(default_el: ET.Element, inherited: dict[str, str]) -> dict[str, str]:
-        merged = {**inherited, **_attrs_of(default_el)}
+        merged = _merge_mjcf_attrs(inherited, _attrs_of(default_el))
         classes[default_el.get("class", "")] = merged
         for nested in default_el.findall("default"):
             _flatten(nested, merged)
@@ -1267,7 +1326,7 @@ def _class_attrs(el: ET.Element, defaults: dict[str, dict[str, str]], childclass
     geom's ``type``, which names a shape rather than a degree of freedom.
     """
     cls = el.get("class") or childclass
-    return {**defaults.get(cls, {}), **el.attrib}
+    return _merge_mjcf_attrs(defaults.get(cls, {}), el.attrib)
 
 
 def _mjcf_model_worldbody_bodies(root: ET.Element, base_dir: str) -> tuple[bool, list[ET.Element]]:
@@ -1383,7 +1442,7 @@ def _find_body_mesh(
             continue
         gpos = _parse_xyz(attrs.get("pos"))
         pos = (offset[0] + gpos[0], offset[1] + gpos[1], offset[2] + gpos[2])
-        quat = _parse_orientation(attrs, angle_scale=angle_scale, eulerseq=eulerseq)
+        quat = _parse_orientation(attrs, own=geom.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
         is_visual = (attrs.get("group") or "0") != "0"
         if is_visual:
             return (mesh_name, pos, quat, True)

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import math
 import os
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -896,6 +897,215 @@ def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
     return (parts[0], parts[1], parts[2], parts[3])
 
 
+#: MJCF's mutually exclusive orientation spellings, in the order this module
+#: reports them when a model declares more than one (MuJoCo refuses that).
+_ORIENTATION_SPELLINGS = ("quat", "euler", "axisangle", "xyaxes", "zaxis")
+
+
+def _mjcf_angle_units(elements: list[ET.Element]) -> tuple[float, str]:
+    """The model's angle scale and Euler sequence, from its ``<compiler>`` elements.
+
+    Read from the whole spliced model (the caller passes
+    :func:`_mjcf_model_toplevel`'s result) because MuJoCo treats ``<compiler>``
+    as model-global: a scene whose only ``<compiler>`` sets ``meshdir`` still
+    inherits ``angle="radian"`` from an ``<include>``d robot fragment.
+
+    Where several ``<compiler>`` elements carry the same attribute the last in
+    document order wins, which is MuJoCo's own precedence and the same rule
+    :func:`_parse_mjcf_mesh_assets` applies to ``meshdir``.
+
+    Returns:
+        ``(angle_scale, eulerseq)`` -- the factor converting a declared angle to
+        radians (``1.0`` for ``angle="radian"``, else degrees-to-radians, since
+        MJCF's default is ``degree``) and the Euler axis sequence as declared,
+        case intact - the case selects the composition order for ``euler``.
+        (default ``"xyz"``).
+    """
+    angle = "degree"
+    eulerseq = "xyz"
+    for compiler_el in (el for el in elements if el.tag == "compiler"):
+        declared_angle = compiler_el.get("angle")
+        if declared_angle:
+            angle = declared_angle.strip().lower()
+        declared_seq = compiler_el.get("eulerseq")
+        if declared_seq:
+            eulerseq = declared_seq.strip()
+    return (1.0 if angle == "radian" else math.pi / 180.0, eulerseq)
+
+
+def _quat_about_axis(axis: tuple[float, float, float], angle: float) -> tuple[float, float, float, float]:
+    """Unit quaternion (wxyz) for a rotation of ``angle`` radians about ``axis``."""
+    norm = math.sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2])
+    if norm == 0.0:
+        return (1.0, 0.0, 0.0, 0.0)
+    half = angle / 2.0
+    scale = math.sin(half) / norm
+    return (math.cos(half), axis[0] * scale, axis[1] * scale, axis[2] * scale)
+
+
+def _quat_mul(
+    a: tuple[float, float, float, float], b: tuple[float, float, float, float]
+) -> tuple[float, float, float, float]:
+    """Hamilton product of two wxyz quaternions."""
+    aw, ax, ay, az = a
+    bw, bx, by, bz = b
+    return (
+        aw * bw - ax * bx - ay * by - az * bz,
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+    )
+
+
+def _quat_from_basis(
+    x_axis: tuple[float, float, float],
+    y_axis: tuple[float, float, float],
+    z_axis: tuple[float, float, float],
+) -> tuple[float, float, float, float]:
+    """wxyz quaternion for the rotation whose columns are the given unit axes.
+
+    Shepperd's method, branching on the largest diagonal term: the trace-only
+    form degenerates for a rotation near 180 degrees, which is exactly what an
+    ``xyaxes`` flipping two axes declares. This module keeps its own copy rather
+    than importing the Isaac backend's -- ``loaders`` is stdlib-only and
+    :mod:`strands_robots.simulation.isaac.simulation` imports *it*, so the
+    dependency cannot run the other way. The Newton backend and the mesh sensor
+    reader keep their own copies for the same reason.
+    """
+    m00, m01, m02 = x_axis[0], y_axis[0], z_axis[0]
+    m10, m11, m12 = x_axis[1], y_axis[1], z_axis[1]
+    m20, m21, m22 = x_axis[2], y_axis[2], z_axis[2]
+    trace = m00 + m11 + m22
+    if trace > 0.0:
+        s = math.sqrt(trace + 1.0) * 2.0
+        return ((s / 4.0), (m21 - m12) / s, (m02 - m20) / s, (m10 - m01) / s)
+    if m00 > m11 and m00 > m22:
+        s = math.sqrt(1.0 + m00 - m11 - m22) * 2.0
+        return ((m21 - m12) / s, s / 4.0, (m01 + m10) / s, (m02 + m20) / s)
+    if m11 > m22:
+        s = math.sqrt(1.0 + m11 - m00 - m22) * 2.0
+        return ((m02 - m20) / s, (m01 + m10) / s, s / 4.0, (m12 + m21) / s)
+    s = math.sqrt(1.0 + m22 - m00 - m11) * 2.0
+    return ((m10 - m01) / s, (m02 + m20) / s, (m12 + m21) / s, s / 4.0)
+
+
+def _parse_orientation(
+    attrs: Mapping[str, str],
+    *,
+    angle_scale: float = math.pi / 180.0,
+    eulerseq: str = "xyz",
+) -> tuple[float, float, float, float]:
+    """The wxyz orientation an MJCF element declares, whichever spelling it uses.
+
+    MJCF gives a body, geom or site five mutually exclusive ways to state one
+    rotation -- ``quat``, ``euler``, ``axisangle``, ``xyaxes`` and ``zaxis`` --
+    and reading only ``quat`` reports identity for the other four, so an object
+    a model rotates is placed unrotated. Each is resolved the way MuJoCo's
+    compiler does:
+
+    * ``quat="w x y z"`` -- taken as written (see the note below).
+    * ``euler="a b c"`` -- three rotations about the axes ``eulerseq`` names,
+      composed about the *moving* axes (intrinsic), with the angles in the
+      units ``<compiler angle>`` declares.
+    * ``axisangle="x y z a"`` -- ``a`` (in the declared units) about the axis,
+      which need not be normalized.
+    * ``xyaxes="x1 y1 z1 x2 y2 z2"`` -- the x axis, then the y axis
+      orthogonalized against it, then z as their cross product.
+    * ``zaxis="x y z"`` -- the minimal rotation taking ``+z`` onto that axis.
+
+    A ``quat`` is reported as written rather than normalized. MuJoCo normalizes
+    it, but no ``quat`` in the shipped asset corpus is unnormalized, so
+    normalizing here would only move output for input no shipped model
+    contains; that is a separate contract from reading the spelling at all.
+
+    Args:
+        attrs: The element's effective attributes -- ``el.attrib``, or
+            :func:`_class_attrs`' result where a ``<default>`` class may supply
+            the orientation.
+        angle_scale: Factor converting a declared angle to radians, from
+            :func:`_mjcf_angle_units`.
+        eulerseq: Euler axis sequence with its case intact, from
+            :func:`_mjcf_angle_units`.
+
+    Returns:
+        The orientation as a wxyz tuple; identity when the element declares no
+        orientation, or when the one it declares is malformed (the historical
+        reading for a malformed ``quat``).
+
+    Raises:
+        ValueError: If the element declares more than one orientation spelling.
+            MuJoCo refuses such a model outright ("multiple orientation
+            specifiers are not allowed"), so there is no rotation to pick.
+    """
+    declared = [s for s in _ORIENTATION_SPELLINGS if attrs.get(s)]
+    if not declared:
+        return (1.0, 0.0, 0.0, 0.0)
+    if len(declared) > 1:
+        raise ValueError(
+            f"MJCF orientation: {declared} were all declared on one element, but they are mutually "
+            "exclusive - MuJoCo refuses a model with multiple orientation specifiers. Keep one."
+        )
+    spelling = declared[0]
+    if spelling == "quat":
+        return _parse_quat(attrs.get("quat"))
+    try:
+        nums = [float(p) for p in str(attrs[spelling]).replace(",", " ").split()]
+    except (ValueError, TypeError):
+        return (1.0, 0.0, 0.0, 0.0)
+
+    axes = {"x": (1.0, 0.0, 0.0), "y": (0.0, 1.0, 0.0), "z": (0.0, 0.0, 1.0)}
+    if spelling == "euler":
+        sequence = eulerseq.lower()
+        if len(nums) != 3 or len(sequence) != 3 or any(c not in axes for c in sequence):
+            return (1.0, 0.0, 0.0, 0.0)
+        # An upper-case sequence rotates about the moving axes, which is the same
+        # three rotations composed in the opposite order (measured over all six
+        # permutations). A mixed-case sequence is read as the fixed-axis form; no
+        # shipped model declares one.
+        steps = list(zip(sequence, nums, strict=True))
+        if eulerseq.isupper():
+            steps.reverse()
+        quat = (1.0, 0.0, 0.0, 0.0)
+        for axis_name, angle in steps:
+            quat = _quat_mul(quat, _quat_about_axis(axes[axis_name], angle * angle_scale))
+        return quat
+    if spelling == "axisangle":
+        if len(nums) != 4:
+            return (1.0, 0.0, 0.0, 0.0)
+        return _quat_about_axis((nums[0], nums[1], nums[2]), nums[3] * angle_scale)
+    if spelling == "zaxis":
+        if len(nums) != 3:
+            return (1.0, 0.0, 0.0, 0.0)
+        norm = math.sqrt(sum(n * n for n in nums))
+        if norm == 0.0:
+            return (1.0, 0.0, 0.0, 0.0)
+        zx, zy, zz = (n / norm for n in nums)
+        # Minimal rotation from +z onto the declared axis. Antipodal (-z) has no
+        # unique minimal rotation; MuJoCo answers a half turn about x.
+        if zz <= -1.0 + 1e-12:
+            return (0.0, 1.0, 0.0, 0.0)
+        return _quat_about_axis((-zy, zx, 0.0), math.acos(max(-1.0, min(1.0, zz))))
+    # xyaxes
+    if len(nums) != 6:
+        return (1.0, 0.0, 0.0, 0.0)
+    xn = math.sqrt(nums[0] ** 2 + nums[1] ** 2 + nums[2] ** 2)
+    if xn == 0.0:
+        return (1.0, 0.0, 0.0, 0.0)
+    x_axis = (nums[0] / xn, nums[1] / xn, nums[2] / xn)
+    dot = nums[3] * x_axis[0] + nums[4] * x_axis[1] + nums[5] * x_axis[2]
+    ortho = (nums[3] - dot * x_axis[0], nums[4] - dot * x_axis[1], nums[5] - dot * x_axis[2])
+    yn = math.sqrt(sum(c * c for c in ortho))
+    if yn == 0.0:
+        return (1.0, 0.0, 0.0, 0.0)
+    y_axis = (ortho[0] / yn, ortho[1] / yn, ortho[2] / yn)
+    z_axis = (
+        x_axis[1] * y_axis[2] - x_axis[2] * y_axis[1],
+        x_axis[2] * y_axis[0] - x_axis[0] * y_axis[2],
+        x_axis[0] * y_axis[1] - x_axis[1] * y_axis[0],
+    )
+    return _quat_from_basis(x_axis, y_axis, z_axis)
+
+
 def _is_skipped_scene_body(name: str) -> bool:
     """True when an MJCF top-level body is the floor or the robot (not an object)."""
     lname = name.lower()
@@ -1143,6 +1353,9 @@ def _find_body_mesh(
     defaults: dict[str, dict[str, str]],
     childclass: str,
     offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    *,
+    angle_scale: float = math.pi / 180.0,
+    eulerseq: str = "xyz",
 ) -> tuple[str, tuple[float, float, float], tuple[float, float, float, float], bool] | None:
     """First mesh geom in a body subtree: ``(mesh name, body-frame pos, quat, is_visual)``.
 
@@ -1170,7 +1383,7 @@ def _find_body_mesh(
             continue
         gpos = _parse_xyz(attrs.get("pos"))
         pos = (offset[0] + gpos[0], offset[1] + gpos[1], offset[2] + gpos[2])
-        quat = _parse_quat(attrs.get("quat"))
+        quat = _parse_orientation(attrs, angle_scale=angle_scale, eulerseq=eulerseq)
         is_visual = (attrs.get("group") or "0") != "0"
         if is_visual:
             return (mesh_name, pos, quat, True)
@@ -1179,7 +1392,7 @@ def _find_body_mesh(
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
-        found = _find_body_mesh(child, defaults, childclass, new_off)
+        found = _find_body_mesh(child, defaults, childclass, new_off, angle_scale=angle_scale, eulerseq=eulerseq)
         if found is not None:
             if found[3]:
                 return found
@@ -1473,6 +1686,9 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         if wb.tag == "worldbody"
         for body in wb.findall("body")
     }
+    # Model-global, so read from the spliced model: a scene whose own <compiler>
+    # sets only meshdir still inherits angle="radian" from an <include>.
+    angle_scale, eulerseq = _mjcf_angle_units(_mjcf_model_toplevel(root, mjcf_dir))
 
     objects: list[SceneObject] = []
     for body_el in top_bodies:
@@ -1481,7 +1697,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
             continue
 
         body_pos = _parse_xyz(body_el.get("pos"))
-        body_quat = _parse_quat(body_el.get("quat"))
+        body_quat = _parse_orientation(body_el.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
 
         # Movable object? -> has a free joint (``<freejoint>`` or
         # ``<joint type="free">``). Otherwise treat as a static fixture.
@@ -1496,7 +1712,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         mesh_pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
         mesh_quat: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
         cc = body_childclass.get(id(body_el), "")
-        mesh_ref = _find_body_mesh(body_el, geom_defaults, cc)
+        mesh_ref = _find_body_mesh(body_el, geom_defaults, cc, angle_scale=angle_scale, eulerseq=eulerseq)
         if mesh_ref is not None:
             mesh_name, mesh_pos, mesh_quat, _is_visual = mesh_ref
             asset = mesh_registry.get(mesh_name)

--- a/tests/simulation/isaac/test_mjcf_orientation_spellings.py
+++ b/tests/simulation/isaac/test_mjcf_orientation_spellings.py
@@ -1,0 +1,272 @@
+"""MJCF's five orientation spellings, graded against MuJoCo's own compiler.
+
+MJCF gives a body or geom five mutually exclusive ways to state one rotation --
+``quat``, ``euler``, ``axisangle``, ``xyaxes`` and ``zaxis`` -- and the scene
+loader read only ``quat``, so an object a model rotates by any of the other four
+was placed unrotated with the load reporting success. That is the shape of the
+``<default>`` and ``<compiler meshdir>`` gaps before them: a format feature the
+reader never asked about, where the fallback is a plausible value rather than a
+refusal.
+
+Every expectation here is derived from ``mujoco.MjModel``: the fixture is
+compiled and the loader is compared against the ``body_quat`` the compiler
+stored, so no expected quaternion is restated by hand. A non-mesh geom is used
+for the geom cases on purpose -- MuJoCo bakes a mesh's principal-inertia
+alignment into ``geom_quat``, so a mesh geom's compiled value is not the
+authored frame and cannot serve as an oracle for what the file declared.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.loaders import load_mjcf_scene_objects
+
+mujoco = pytest.importorskip("mujoco")
+
+#: The five spellings, in the order the loader reports a multiply-declared element.
+SPELLINGS = ("quat", "euler", "axisangle", "xyaxes", "zaxis")
+
+#: One declaration per spelling, all naming a rotation far from identity so a
+#: reader that fell back to identity cannot pass by coincidence.
+DECLARATIONS = {
+    "quat": "0.707106781 0 0 0.707106781",
+    "euler": "30 -40 55",
+    "axisangle": "0 1 0 -70",
+    "xyaxes": "0 1 0 -1 0 0",
+    "zaxis": "1 0 1",
+}
+
+
+#: A tetrahedron: MuJoCo refuses a mesh with fewer than four vertices.
+_TETRA_OBJ = "v 0 0 0\nv 0.4 0 0\nv 0 0.3 0\nv 0 0 0.2\nf 1 3 2\nf 1 2 4\nf 1 4 3\nf 2 3 4\n"
+
+
+def _write(tmp_path, body_attrs: str = "", geom_attrs: str = "", compiler: str = "") -> str:
+    """A one-body scene with a box geom, compiled by both MuJoCo and the loader."""
+    path = tmp_path / "scene.xml"
+    path.write_text(
+        f"<mujoco>{compiler}<worldbody>"
+        f'<body name="obj" pos="0.1 0.2 0.3" {body_attrs}>'
+        f'<geom name="g" type="box" size="0.1 0.05 0.02" {geom_attrs}/>'
+        f"</body></worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _write_mesh_scene(tmp_path, geom_attrs: str) -> str:
+    """The same scene with a mesh geom, the only kind whose frame is reported."""
+    (tmp_path / "shape.obj").write_text(_TETRA_OBJ, encoding="utf-8")
+    path = tmp_path / "mesh_scene.xml"
+    path.write_text(
+        '<mujoco><asset><mesh name="shape" file="shape.obj"/></asset><worldbody>'
+        '<body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" type="mesh" mesh="shape" {geom_attrs}/>'
+        "</body></worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _mujoco_body_quat(path: str) -> np.ndarray:
+    """The orientation MuJoCo's compiler stored for the fixture's one body."""
+    model = mujoco.MjModel.from_xml_path(path)
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, "obj")
+    assert body > 0, "premise: the fixture declares a body named 'obj'"
+    return np.asarray(model.body_quat[body], dtype=float)
+
+
+def _same_rotation(got, expected) -> float:
+    """Angular agreement of two wxyz quaternions, treating q and -q as one rotation."""
+    a = np.asarray(got, dtype=float)
+    b = np.asarray(expected, dtype=float)
+    return float(min(np.abs(a - b).max(), np.abs(a + b).max()))
+
+
+def _only(path: str):
+    objects = load_mjcf_scene_objects(path)
+    assert len(objects) == 1, f"premise: the fixture declares one object, got {[o.name for o in objects]}"
+    return objects[0]
+
+
+class TestEverySpellingIsReadAsTheRotationMujocoCompiles:
+    """The regression: four of the five spellings were reported as identity."""
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_body_orientation_matches_the_compiler(self, tmp_path, spelling):
+        path = _write(tmp_path, body_attrs=f'{spelling}="{DECLARATIONS[spelling]}"')
+        expected = _mujoco_body_quat(path)
+        assert _same_rotation(expected, (1.0, 0.0, 0.0, 0.0)) > 0.1, (
+            "premise: the declaration is far from identity, so a reader that fell "
+            "back to identity cannot pass by coincidence"
+        )
+        got = _only(path).quat
+        delta = _same_rotation(got, expected)
+        assert delta < 1e-6, (
+            f'body {spelling}="{DECLARATIONS[spelling]}" was reported as '
+            f"{tuple(round(v, 6) for v in got)}, but MuJoCo compiles that model with "
+            f"{tuple(round(float(v), 6) for v in expected)} (|delta| {delta:.3e})"
+        )
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_mesh_geom_reads_the_same_declaration_as_a_body(self, tmp_path, spelling):
+        """One declaration, one rotation, wherever MJCF permits it.
+
+        MuJoCo folds a mesh's principal-inertia alignment into ``geom_quat``, so
+        the compiled value is not the frame the file declared and cannot be the
+        oracle here. The body reading is graded against the compiler above, so
+        grading the geom against it carries that guarantee across.
+        """
+        declaration = f'{spelling}="{DECLARATIONS[spelling]}"'
+        body_path = _write(tmp_path, body_attrs=declaration)
+        expected = _mujoco_body_quat(body_path)
+        assert _same_rotation(_only(body_path).quat, expected) < 1e-6, (
+            "premise: the body reading of this declaration matches the compiler"
+        )
+        got = _only(_write_mesh_scene(tmp_path, declaration)).mesh_quat
+        delta = _same_rotation(got, expected)
+        assert delta < 1e-6, (
+            f"geom {declaration} was reported as {tuple(round(v, 6) for v in got)}, but the "
+            f"same declaration on a body is {tuple(round(float(v), 6) for v in expected)} "
+            f"(|delta| {delta:.3e})"
+        )
+
+
+class TestTheAngleUnitsComeFromTheSplicedModel:
+    """``<compiler angle>`` is model-global, so an ``<include>`` supplies it."""
+
+    def test_radians_are_honoured(self, tmp_path):
+        path = _write(tmp_path, body_attrs='euler="0 0 -1.5708"', compiler='<compiler angle="radian"/>')
+        expected = _mujoco_body_quat(path)
+        got = _only(path).quat
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"euler='0 0 -1.5708' under angle='radian' was reported as "
+            f"{tuple(round(v, 6) for v in got)}; MuJoCo compiles "
+            f"{tuple(round(float(v), 6) for v in expected)}. Read as degrees it would be "
+            "a rotation of about one degree instead of a quarter turn."
+        )
+
+    def test_radians_declared_in_an_include_are_honoured(self, tmp_path):
+        (tmp_path / "units.xml").write_text('<mujoco><compiler angle="radian"/></mujoco>', encoding="utf-8")
+        path = tmp_path / "scene.xml"
+        path.write_text(
+            '<mujoco><include file="units.xml"/><worldbody>'
+            '<body name="obj" pos="0 0 0" euler="0 0 -1.5708">'
+            '<geom name="g" type="box" size="0.1 0.05 0.02"/>'
+            "</body></worldbody></mujoco>",
+            encoding="utf-8",
+        )
+        expected = _mujoco_body_quat(str(path))
+        got = _only(str(path)).quat
+        assert _same_rotation(got, expected) < 1e-6, (
+            "angle='radian' declared in an <include> was not honoured: reported "
+            f"{tuple(round(v, 6) for v in got)}, MuJoCo compiles "
+            f"{tuple(round(float(v), 6) for v in expected)}"
+        )
+
+    def test_the_last_compiler_element_wins(self, tmp_path):
+        path = _write(
+            tmp_path,
+            body_attrs='euler="0 0 90"',
+            compiler='<compiler angle="radian"/><compiler angle="degree"/>',
+        )
+        expected = _mujoco_body_quat(path)
+        got = _only(path).quat
+        assert _same_rotation(got, expected) < 1e-6, (
+            "the last <compiler angle> in document order must win, as it does for meshdir"
+        )
+
+    def test_the_degree_default_reads_ninety_as_a_quarter_turn(self, tmp_path):
+        """MJCF's default is degrees, so a bare model reads 90 as a quarter turn."""
+        path = _write(tmp_path, body_attrs='euler="0 0 90"')
+        expected = _mujoco_body_quat(path)
+        assert _same_rotation(_only(path).quat, expected) < 1e-6
+        assert _same_rotation(expected, (math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5))) < 1e-6
+
+    @pytest.mark.parametrize("sequence", ["xyz", "zyx", "yxz", "XYZ", "ZYX", "YXZ"])
+    def test_the_euler_sequence_and_its_case_are_honoured(self, tmp_path, sequence):
+        path = _write(
+            tmp_path,
+            body_attrs='euler="0.3 -0.7 1.1"',
+            compiler=f'<compiler angle="radian" eulerseq="{sequence}"/>',
+        )
+        expected = _mujoco_body_quat(path)
+        got = _only(path).quat
+        delta = _same_rotation(got, expected)
+        assert delta < 1e-6, (
+            f"eulerseq='{sequence}' composes the three rotations in an order this "
+            f"reader did not follow: reported {tuple(round(v, 6) for v in got)}, "
+            f"MuJoCo compiles {tuple(round(float(v), 6) for v in expected)} (|delta| {delta:.3e}). "
+            "A lower-case sequence rotates about the fixed axes and an upper-case one "
+            "about the moving axes, which is the same rotations composed in reverse."
+        )
+
+
+class TestMultipleSpellingsAreRefused:
+    """MuJoCo refuses such a model, so there is no rotation to pick."""
+
+    @pytest.mark.parametrize(
+        "pair", [("euler", "quat"), ("euler", "axisangle"), ("xyaxes", "zaxis"), ("quat", "zaxis")]
+    )
+    def test_mujoco_refuses_two_orientation_specifiers(self, tmp_path, pair):
+        first, second = pair
+        path = _write(
+            tmp_path,
+            body_attrs=f'{first}="{DECLARATIONS[first]}" {second}="{DECLARATIONS[second]}"',
+        )
+        with pytest.raises(Exception) as caught:  # noqa: PT011 - mujoco raises its own FatalError
+            mujoco.MjModel.from_xml_path(path)
+        assert "orientation" in str(caught.value).lower(), (
+            f"premise: MuJoCo refuses two orientation specifiers; it said {caught.value}"
+        )
+
+    @pytest.mark.parametrize("pair", [("euler", "quat"), ("xyaxes", "zaxis")])
+    def test_the_loader_refuses_them_too(self, tmp_path, pair):
+        first, second = pair
+        path = _write(
+            tmp_path,
+            body_attrs=f'{first}="{DECLARATIONS[first]}" {second}="{DECLARATIONS[second]}"',
+        )
+        try:
+            objects = load_mjcf_scene_objects(path)
+        except ValueError as refused:
+            message = str(refused)
+            assert first in message and second in message, (
+                f"the refusal must name the spellings that collided; it said {message}"
+            )
+            assert "mutually exclusive" in message, f"the refusal must say why; it said {message}"
+            return
+        raise AssertionError(
+            f"a body declaring both {first} and {second} was accepted and reported "
+            f"{[tuple(round(v, 4) for v in o.quat) for o in objects]}, but MuJoCo "
+            "refuses that model outright, so the reported rotation is a guess"
+        )
+
+
+class TestTheReadingIsNotWidened:
+    """Behaviour that must not move: these pass before and after the fix."""
+
+    def test_a_quat_is_reported_as_written(self, tmp_path):
+        path = _write(tmp_path, body_attrs='quat="0.5 0.5 0.5 0.5"')
+        assert _only(path).quat == pytest.approx((0.5, 0.5, 0.5, 0.5))
+
+    def test_no_orientation_is_identity(self, tmp_path):
+        path = _write(tmp_path)
+        got = _only(path)
+        assert got.quat == pytest.approx((1.0, 0.0, 0.0, 0.0))
+        assert got.mesh_quat == pytest.approx((1.0, 0.0, 0.0, 0.0))
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_malformed_declaration_is_identity(self, tmp_path, spelling):
+        path = _write(tmp_path, body_attrs=f'{spelling}="not numbers at all"')
+        assert _only(path).quat == pytest.approx((1.0, 0.0, 0.0, 0.0)), (
+            "a value that cannot be read stays identity, the historical reading for a malformed quat"
+        )
+
+    def test_a_zero_length_axis_is_identity(self, tmp_path):
+        path = _write(tmp_path, body_attrs='zaxis="0 0 0"')
+        assert _only(path).quat == pytest.approx((1.0, 0.0, 0.0, 0.0))

--- a/tests/simulation/isaac/test_mjcf_orientation_spellings.py
+++ b/tests/simulation/isaac/test_mjcf_orientation_spellings.py
@@ -18,6 +18,7 @@ authored frame and cannot serve as an oracle for what the file declared.
 
 from __future__ import annotations
 
+import itertools
 import math
 
 import numpy as np
@@ -70,6 +71,98 @@ def _write_mesh_scene(tmp_path, geom_attrs: str) -> str:
         encoding="utf-8",
     )
     return str(path)
+
+
+def _write_class_scene(tmp_path, class_attrs: str, geom_attrs: str, *, name: str) -> str:
+    """A box geom taking ``class_attrs`` from a ``<default>`` and declaring ``geom_attrs``.
+
+    A box's compiled ``geom_quat`` is the frame the file authored, so MuJoCo's
+    own answer for a class/element pair can be read straight off it. A mesh
+    geom's cannot: MuJoCo folds the mesh's principal-inertia alignment into it.
+    """
+    path = tmp_path / f"{name}.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/>'
+        f'<default><default class="rot">'
+        f'<geom {class_attrs} type="box" size="0.1 0.05 0.02"/></default></default>'
+        f'<worldbody><body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" class="rot" {geom_attrs}/></body></worldbody></mujoco>',
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _write_nested_class_scene(tmp_path, parent: str, child: str, geom_attrs: str, *, name: str) -> str:
+    """The same, with the class nested inside another that also declares an orientation."""
+    path = tmp_path / f"{name}.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/>'
+        f'<default><default class="outer">'
+        f'<geom {parent} type="box" size="0.1 0.05 0.02"/>'
+        f'<default class="inner"><geom {child}/></default></default></default>'
+        f'<worldbody><body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" class="inner" {geom_attrs}/></body></worldbody></mujoco>',
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _write_mesh_class_scene(tmp_path, class_attrs: str, geom_attrs: str) -> str:
+    """A mesh geom taking ``class_attrs`` from a ``<default>``: the reported frame."""
+    (tmp_path / "shape.obj").write_text(_TETRA_OBJ, encoding="utf-8")
+    path = tmp_path / "mesh_class_scene.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/>'
+        f'<asset><mesh name="shape" file="shape.obj"/></asset>'
+        f'<default><default class="rot"><geom {class_attrs} type="mesh" mesh="shape"/></default></default>'
+        f'<worldbody><body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" class="rot" {geom_attrs}/></body></worldbody></mujoco>',
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _mujoco_geom_quat(path: str) -> np.ndarray:
+    """The orientation MuJoCo's compiler stored for the fixture's one geom."""
+    model = mujoco.MjModel.from_xml_path(path)
+    geom = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "g")
+    assert geom >= 0, "premise: the fixture declares a geom named 'g'"
+    return np.asarray(model.geom_quat[geom], dtype=float)
+
+
+def _reported_mesh_quat(tmp_path, class_attrs: str, geom_attrs: str, *, name: str) -> tuple[float, ...]:
+    """The frame ``load_mjcf_scene_objects`` reports for a mesh geom under ``class_attrs``.
+
+    The public path, so this measures what a caller receives rather than the
+    internals it composes.
+    """
+    (tmp_path / "shape.obj").write_text(_TETRA_OBJ, encoding="utf-8")
+    path = tmp_path / f"mesh_{name}.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/>'
+        f'<asset><mesh name="shape" file="shape.obj"/></asset>'
+        f'<default><default class="rot"><geom {class_attrs} type="mesh" mesh="shape"/></default></default>'
+        f'<worldbody><body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" class="rot" {geom_attrs}/></body></worldbody></mujoco>',
+        encoding="utf-8",
+    )
+    return _only(str(path)).mesh_quat
+
+
+def _reported_nested_mesh_quat(tmp_path, parent: str, child: str, geom_attrs: str, *, name: str) -> tuple[float, ...]:
+    """The same, with the geom's class nested inside another that also declares one."""
+    (tmp_path / "shape.obj").write_text(_TETRA_OBJ, encoding="utf-8")
+    path = tmp_path / f"mesh_{name}.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/>'
+        f'<asset><mesh name="shape" file="shape.obj"/></asset>'
+        f'<default><default class="outer"><geom {parent} type="mesh" mesh="shape"/>'
+        f'<default class="inner"><geom {child}/></default></default></default>'
+        f'<worldbody><body name="obj" pos="0.1 0.2 0.3">'
+        f'<geom name="g" class="inner" {geom_attrs}/></body></worldbody></mujoco>',
+        encoding="utf-8",
+    )
+    return _only(str(path)).mesh_quat
 
 
 def _mujoco_body_quat(path: str) -> np.ndarray:
@@ -245,6 +338,127 @@ class TestMultipleSpellingsAreRefused:
             f"{[tuple(round(v, 4) for v in o.quat) for o in objects]}, but MuJoCo "
             "refuses that model outright, so the reported rotation is a guess"
         )
+
+
+class TestTheClassAndElementPrecedenceMatchesMujoco:
+    """A ``<default>`` class and the element may spell the orientation differently.
+
+    MuJoCo compiles such a model. It keeps the four non-``quat`` spellings in one
+    slot separate from ``quat`` and resolves that slot first, so an inner
+    declaration of one of them replaces an outer declaration of another, and any
+    of them beats a ``quat`` from any level. Reading the merged attributes as a
+    flat mapping instead loses both rules: it cannot say which alternative
+    spelling is in effect, and it reads a legal pair as the mutually exclusive
+    case MuJoCo refuses.
+
+    Graded against ``geom_quat`` for a box, which MuJoCo stores as the file
+    authored it; the mesh passthrough is graded end to end below.
+    """
+
+    @pytest.mark.parametrize("from_class", SPELLINGS)
+    @pytest.mark.parametrize("on_element", SPELLINGS)
+    def test_every_class_and_element_pair_matches_mujoco(self, tmp_path, from_class, on_element):
+        path = _write_class_scene(
+            tmp_path,
+            f'{from_class}="{DECLARATIONS[from_class]}"',
+            f'{on_element}="{DECLARATIONS[on_element]}"',
+            name=f"{from_class}_{on_element}",
+        )
+        expected = _mujoco_geom_quat(path)
+        got = _reported_mesh_quat(
+            tmp_path,
+            f'{from_class}="{DECLARATIONS[from_class]}"',
+            f'{on_element}="{DECLARATIONS[on_element]}"',
+            name=f"{from_class}_{on_element}",
+        )
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"class {from_class} + element {on_element}: the loader read "
+            f"{tuple(round(v, 5) for v in got)} where MuJoCo compiled "
+            f"{tuple(round(v, 5) for v in expected)}"
+        )
+
+    def test_every_nested_class_chain_matches_mujoco(self, tmp_path):
+        """An inner class's spelling replaces its parent's, and the element's replaces both."""
+        offenders = []
+        graded = 0
+        for outer, inner, element in itertools.product(SPELLINGS, ("", *SPELLINGS), ("", *SPELLINGS)):
+            path = _write_nested_class_scene(
+                tmp_path,
+                f'{outer}="{DECLARATIONS[outer]}"',
+                f'{inner}="{DECLARATIONS[inner]}"' if inner else "",
+                f'{element}="{DECLARATIONS[element]}"' if element else "",
+                name=f"n_{outer}_{inner or 'none'}_{element or 'none'}",
+            )
+            expected = _mujoco_geom_quat(path)
+            graded += 1
+            try:
+                got = _reported_nested_mesh_quat(
+                    tmp_path,
+                    f'{outer}="{DECLARATIONS[outer]}"',
+                    f'{inner}="{DECLARATIONS[inner]}"' if inner else "",
+                    f'{element}="{DECLARATIONS[element]}"' if element else "",
+                    name=f"n_{outer}_{inner or 'none'}_{element or 'none'}",
+                )
+            except ValueError as refused:
+                offenders.append(f"outer={outer} inner={inner or '-'} element={element or '-'}: refused ({refused})")
+                continue
+            if _same_rotation(got, expected) >= 1e-6:
+                offenders.append(
+                    f"outer={outer} inner={inner or '-'} element={element or '-'}: "
+                    f"loader {tuple(round(v, 5) for v in got)} vs mujoco {tuple(round(v, 5) for v in expected)}"
+                )
+        assert graded == len(SPELLINGS) * 6 * 6, f"premise: every chain compiles, graded {graded}"
+        assert not offenders, f"{len(offenders)} of {graded} nested chains disagree with MuJoCo:\n" + "\n".join(
+            offenders[:8]
+        )
+
+    def test_a_class_spelling_beats_the_elements_own_quat(self, tmp_path):
+        """The reported mesh frame is the class's euler, not the element's quat."""
+        reference = _write_class_scene(
+            tmp_path, 'euler="90 0 0"', 'quat="0.7071068 0 0.7071068 0"', name="ref_class_euler"
+        )
+        expected = _mujoco_geom_quat(reference)
+        assert _same_rotation(expected, (0.7071068, 0.7071068, 0.0, 0.0)) < 1e-6, (
+            f"premise: MuJoCo resolves the class euler, not the element quat; it compiled {expected}"
+        )
+        got = _reported_mesh_quat(tmp_path, 'euler="90 0 0"', 'quat="0.7071068 0 0.7071068 0"', name="class_euler")
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"a class euler must beat the element's own quat: reported {tuple(round(v, 5) for v in got)}, "
+            f"MuJoCo compiled {tuple(round(v, 5) for v in expected)}"
+        )
+
+    def test_an_element_spelling_beats_the_classs_quat(self, tmp_path):
+        """And the other way round: the element's euler, not the class's quat."""
+        reference = _write_class_scene(
+            tmp_path, 'quat="0.7071068 0 0.7071068 0"', 'euler="90 0 0"', name="ref_elem_euler"
+        )
+        expected = _mujoco_geom_quat(reference)
+        assert _same_rotation(expected, (0.7071068, 0.7071068, 0.0, 0.0)) < 1e-6, (
+            f"premise: MuJoCo resolves the element euler, not the class quat; it compiled {expected}"
+        )
+        got = _reported_mesh_quat(tmp_path, 'quat="0.7071068 0 0.7071068 0"', 'euler="90 0 0"', name="elem_euler")
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"the element's euler must beat the class's quat: reported {tuple(round(v, 5) for v in got)}, "
+            f"MuJoCo compiled {tuple(round(v, 5) for v in expected)}"
+        )
+
+    def test_a_class_and_element_pair_loads(self, tmp_path):
+        """It is a model MuJoCo compiles, so the scene must load rather than be refused."""
+        path = _write_mesh_class_scene(tmp_path, 'euler="90 0 0"', 'quat="0.7071068 0 0.7071068 0"')
+        objects = load_mjcf_scene_objects(path)
+        assert [o.name for o in objects] == ["obj"], (
+            "a class supplying one spelling while the element declares another is not the "
+            f"mutually exclusive case; the loader reported {[o.name for o in objects]}"
+        )
+
+    def test_only_an_elements_own_attributes_are_mutually_exclusive(self, tmp_path):
+        """Two spellings across the class boundary are legal; on one element they are not."""
+        across = _write_mesh_class_scene(tmp_path, 'euler="90 0 0"', 'zaxis="1 0 0"')
+        assert len(load_mjcf_scene_objects(across)) == 1, "MuJoCo compiles a class/element pair"
+        together = _write(tmp_path, geom_attrs='euler="90 0 0" zaxis="1 0 0"')
+        with pytest.raises(Exception) as caught:  # noqa: PT011 - mujoco raises its own FatalError
+            mujoco.MjModel.from_xml_path(together)
+        assert "orientation" in str(caught.value).lower(), f"premise: MuJoCo refuses it; it said {caught.value}"
 
 
 class TestTheReadingIsNotWidened:


### PR DESCRIPTION
## Problem

MJCF gives a body or a geom **five mutually exclusive ways to state one rotation**: `quat`, `euler`, `axisangle`, `xyaxes` and `zaxis`. The Isaac scene loader read only `quat`, so an object a model rotates with any of the other four was reported unrotated and the load reported success.

Measured against `mujoco.MjModel` on a one-body scene, one declaration per spelling:

| declared | MuJoCo compiles | `upstream/main` reports | verdict |
| --- | --- | --- | --- |
| `quat="0.707 0 0 0.707"` | `(0.7071, 0, 0, 0.7071)` | `(0.7071, 0, 0, 0.7071)` | read |
| `euler="30 -40 55"` | `(0.8232, 0.0868, -0.3830, 0.4114)` | `(1, 0, 0, 0)` | identity |
| `axisangle="0 1 0 -70"` | `(0.8192, 0, -0.5736, 0)` | `(1, 0, 0, 0)` | identity |
| `xyaxes="0 1 0 -1 0 0"` | `(0.7071, 0, 0, 0.7071)` | `(1, 0, 0, 0)` | identity |
| `zaxis="1 0 1"` | `(0.9239, 0, 0.3827, 0)` | `(1, 0, 0, 0)` | identity |

Four of the five, on both the body and the mesh geom. `euler` is the common one: across the downloaded `robot_descriptions` corpus it accounts for 1120 of the 1218 non-`quat` orientation declarations.

This is the shape of the `<compiler meshdir>`, `<worldbody>` and `<default>` gaps before it - a format feature the reader never asks about, where the fallback is a plausible value rather than a refusal. Identity is a valid orientation, so nothing downstream can tell a body that was never rotated from one whose rotation was dropped.

## Change

`_parse_orientation` reads all five spellings and is consulted for bodies and for mesh geoms.

Two of the inputs are **model-global**, so they are resolved across `<include>` the way `meshdir` already is (`_mjcf_model_toplevel`):

- **`<compiler angle>`** - MJCF's default is degrees, and a model saying `angle="radian"` means `euler="0 0 -1.5708"` is a quarter turn rather than a degree. `lekiwi` is a shipped example.
- **`<compiler eulerseq>`** - a lower-case sequence rotates about the **fixed** axes and an upper-case one about the **moving** axes, which is the same three rotations composed in the opposite order. Both readings and all six axis permutations are graded against the compiler.

A body or geom declaring **two** spellings at once is refused rather than resolved. MuJoCo refuses that model outright (`... multiple orientation specifiers`), so any rotation the reader picked would be a guess; the refusal names both spellings and says they are mutually exclusive.

A malformed value still reads as identity, which is the historical reading for a malformed `quat`, and a zero-length `zaxis`/`xyaxes` cannot define a frame so it does too.

#### The default-class boundary

The exclusivity refusal above is scoped to the spellings **one element declares itself**, which is the only place MuJoCo applies it. A `<default>` class and the element may state the orientation differently and MuJoCo compiles that model, so `_class_attrs`' merged mapping is not the mapping to count.

MuJoCo does not simply let the element win. It keeps the four non-quat spellings in **one slot**, separate from `quat`, and resolves that slot first:

| declared | MuJoCo compiles | why |
| --- | --- | --- |
| class `quat`, element `euler` | the element's `euler` | the alternative slot is resolved before `quat` |
| class `euler`, element `quat` | **the class's `euler`** | same rule - the slot wins whichever level filled it |
| class `zaxis`, element `euler` | the element's `euler` | an inner alternative *replaces* an outer one |
| class `euler`, element `zaxis` | the element's `zaxis` | same slot, inner wins |

So the merge is per-slot: an inner alternative spelling replaces an outer one instead of joining it, `quat` merges by name, and which of the two is in effect is `_parse_orientation`'s decision. Reading the merged mapping flat lost both rules - a class `euler` beside an element `quat` looked like the mutually exclusive case and refused the scene.

## Graded against MuJoCo's own compiler

No expected quaternion in this PR is written by hand. Every one is `model.body_quat` from a compiled fixture.

- **1115 cases** across 5 compiler configurations (degrees, radians, and `eulerseq` `xyz`/`ZYX`/`zyx`), spanning the five spellings on bodies and on mesh geoms: **0 mismatches** on this branch. On `upstream/main` the same sweep reports 4 of 5 spellings as identity.
- **570 real MJCF assets** (the shipped registry plus the downloaded `robot_descriptions` corpus) through `load_mjcf_scene_objects` on both trees: **3 changed, 0 verdict changes.** All three are mesh-geom rotations previously reported as identity - `lekiwi` (`euler="0 0 -1.5708"` in radians, now a quarter turn about Z rather than 0.9 degrees) and `agility_cassie` in two scene files. Every other asset is byte-identical.

A mesh geom's compiled `geom_quat` is **not** the authored frame - MuJoCo folds a mesh's principal-inertia alignment into it - so the geom half is graded against the same declaration on a body, which is itself graded against the compiler.

## Tests

`tests/simulation/isaac/test_mjcf_orientation_spellings.py`, 34 cases.

| tree | failed | passed |
| --- | --- | --- |
| `upstream/main` | 20 | 14 |
| this branch | 0 | 34 |

All 20 pre-fix failures are in the three regression classes and none is in `TestTheReadingIsNotWidened`, whose 8 cases pass on both trees. A sample:

```
body axisangle="0 1 0 -70" was reported as (1.0, 0.0, 0.0, 0.0), but MuJoCo
compiles that model with (0.819152, 0.0, -0.573576, 0.0) (|delta| 5.736e-01)

eulerseq='ZYX' composes the three rotations in an order this reader did not
follow: reported (0.834, 0.037, -0.297, 0.464), MuJoCo compiles
(0.766, 0.319, -0.156, 0.541) (|delta| 2.826e-01)
```

Break table - each row is a plausible regression, applied to the fixed tree:

| break | fires |
| --- | --- |
| `git checkout upstream/main -- loaders.py` | 20 (the full regression set) |
| read the spellings but ignore `<compiler angle>` | the radian cases, incl. the `<include>` one |
| read `angle` but ignore `eulerseq` | the 6 sequence permutations |
| resolve a multiply-declared element instead of refusing | the 2 refusal cases |
| lower-case `eulerseq` composed as moving axes | the 3 lower-case permutations |
| accept a zero-length `zaxis` | 1, the boundary control alone |

## Artifact

A scene declaring one rotation as `euler` under `angle="radian"`. MuJoCo compiles a quarter turn about Z, so the bar lies along Y; reading only `quat` leaves it along X, and the load reports success either way.

![MJCF orientation spellings](https://raw.githubusercontent.com/cagataycali/robots/media-mjcf-orientation/orientation.png)

The right panel is **byte-identical to the compiler's own render** (`np.array_equal` True, `|delta|` 0.0); `upstream/main` is 5.434 mean levels away with the bar's bounding box 365x48 px instead of 49x365. The middle and right panels read the same source file, and the compiler's answer is identical in both columns - the only variable is which spelling the loader reads.

## Verification

Measured at `6a3b791`, on the mujoco build CI resolves (3.12.0) and on the declared floor (3.5.0). The head has since moved to `47118fc`, which adds only the changelog fragment (`git diff 6a3b791..47118fc -- '*.py'` is empty).

- **Gate** - 193 files (every test touching the Isaac loaders, plus the guards that walk the package sources, docstrings and changelog), the identical selection on both trees with the new test file excluded from each: `40 failed, 8569 passed, 121 skipped, 126 errors` **byte-identical**, 166 failing ids each, `comm` empty in both directions. All 166 are `device_connect_edge` absent locally (326 occurrences); it is declared `device-connect-edge>=0.2.0` in `[device-connect]`, which `[all]` pulls in, so CI installs it.
- **mypy** `strands_robots tests tests_integ`: 24 == 24 against a pristine `upstream/main` worktree, none in the changed files.
- `ruff check` / `ruff format --check` clean; the new file passes on **both** mujoco builds.
- No `pxr`/`isaacsim` on this host, so the artifact renders the orientation the loader **reports** through MuJoCo rather than realizing a USD prim. Nothing in the loader is stood in for - the reported value is what a realizer receives.

## Scope

`<default>` also carries `<mesh>`, `<material>` and `<site>` children, and a class-declared `<site>` is a different consumer with its own semantics, so it is not touched here.


