### PR TITLE
fix(sim): resolve a robot plane's orientation through all five MJCF spellings before stripping it as the ground

### DIFF
--- a/changelog.d/2681-mjcf-ground-plane-orientation-spellings.md
+++ b/changelog.d/2681-mjcf-ground-plane-orientation-spellings.md
@@ -1,0 +1,17 @@
+### Fixed: a robot's authored plane is no longer stripped as the ground when its rotation is spelled with euler, axisangle, zaxis or xyaxes
+
+`SpecBuilder.attach_robot` deletes a plane geom from a robot MJCF when it reads as
+the world's z=0 ground, so a scene does not end up with two overlapping floors.
+That flatness test asked the geom for `quat` alone. MJCF spells one rotation five
+ways and MuJoCo keeps `euler`, `axisangle`, `xyaxes` and `zaxis` in a slot separate
+from `quat`, so a plane rotated by any of those four read as unrotated and an
+authored wall, ramp or angled panel sitting at z=0 was silently deleted on attach.
+`zaxis` is the idiomatic spelling for a plane, because a plane's normal is its
+local z.
+
+The orientation is now resolved through all five spellings, honouring the
+model-global `<compiler angle>` (which defaults to degrees) and `<compiler
+eulerseq>` readings the module already applies elsewhere, and normalising `zaxis`
+and `axisangle` axes. The position and size rules are unchanged, a genuinely flat
+plane is still stripped in every spelling, and no message or caller-visible error
+moves.

--- a/strands_robots/simulation/mujoco/spec_builder.py
+++ b/strands_robots/simulation/mujoco/spec_builder.py
@@ -1342,18 +1342,86 @@ _ADOPTED_OPTION_FIELDS: tuple[str, ...] = (
 )
 
 
+_ORIENTATION_TOL: Final[float] = 1e-6
+
+
+def _alt_orientation_is_identity(alt: Any) -> bool | None:
+    """Whether the alternative-orientation slot carries an identity rotation.
+
+    MJCF spells a rotation five ways - ``quat`` plus the four alternatives
+    ``euler`` / ``axisangle`` / ``xyaxes`` / ``zaxis`` - and MuJoCo keeps the
+    four alternatives in one slot (``elem.alt``) behind a discriminator,
+    leaving ``elem.quat`` at identity. Reading ``quat`` alone therefore reports
+    every alternative spelling as unrotated, and ``zaxis`` is the idiomatic
+    spelling for a plane, whose normal *is* that vector.
+
+    Only identity is decided here, never the rotation itself: a plane's normal
+    stays +Z exactly when the slot carrying the rotation is identity, and for
+    each spelling that is a direct test on the declared numbers. It needs no
+    angle unit, because zero is zero in degrees and in radians, so the model's
+    ``<compiler angle>`` does not enter into it.
+
+    Args:
+        alt: the element's ``alt`` slot.
+
+    Returns:
+        ``True``/``False`` when this slot carries the element's rotation, or
+        ``None`` when its discriminator says the rotation lives in ``quat``
+        instead, which the caller should then read.
+    """
+    mujoco = _ensure_mujoco()
+    kinds = mujoco.mjtOrientation
+    try:
+        kind = int(alt.type)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if kind == int(kinds.mjORIENTATION_EULER):
+        return bool(np.allclose(np.asarray(alt.euler, dtype=float), 0.0, atol=_ORIENTATION_TOL))
+    if kind == int(kinds.mjORIENTATION_AXISANGLE):
+        # Any axis, provided the rotation about it is zero.
+        return abs(float(alt.axisangle[3])) <= _ORIENTATION_TOL
+    if kind == int(kinds.mjORIENTATION_ZAXIS):
+        # The plane's normal IS this vector, so identity means it points +Z.
+        vec = np.asarray(alt.zaxis, dtype=float)
+        norm = float(np.linalg.norm(vec))
+        if norm <= _ORIENTATION_TOL:
+            # A zero-length axis defines no frame - MuJoCo refuses such a
+            # model outright - so it cannot be shown to point +Z.
+            return False
+        return bool(np.allclose(vec / norm, (0.0, 0.0, 1.0), atol=_ORIENTATION_TOL))
+    if kind == int(kinds.mjORIENTATION_XYAXES):
+        axes = np.asarray(alt.xyaxes, dtype=float)
+        return bool(np.allclose(axes, (1.0, 0.0, 0.0, 0.0, 1.0, 0.0), atol=_ORIENTATION_TOL))
+    return None
+
+
 def _is_z0_ground_plane(geom: Any) -> bool:
     """True if a plane geom is plausibly the z=0 axis-aligned ground.
 
     MuJoCo planes default to a +Z normal at the body origin. We treat a plane
     as "ground" when its body-frame position z is ~0 and its orientation is
-    axis-aligned (quat ~ identity, so the normal stays +Z). A robot MJCF that
-    ships an intentional ramp/wall plane (rotated or elevated) is NOT matched
-    and survives the attach. See #363.
+    identity, so the normal stays +Z. A robot MJCF that ships an intentional
+    ramp/wall plane (rotated or elevated) is NOT matched and survives the
+    attach - whichever of MJCF's five orientation spellings declares it, which
+    is why the alternative slot is read here and not only ``quat``; see
+    :func:`_alt_orientation_is_identity`.
+
+    Recognising ground is what strips a duplicate floor, so the two directions
+    are not symmetric. A plane wrongly taken for ground loses the robot a
+    surface it was authored with; a plane that merely cannot be shown to be
+    flat survives, which at worst leaves the second floor the world already
+    has. Unrecognised therefore means "kept". See #363.
     """
     pos = getattr(geom, "pos", None)
     if pos is not None and abs(float(pos[2])) > 1e-6:
         return False
+    alt = getattr(geom, "alt", None)
+    if alt is not None:
+        # A live spec element keeps the four alternative spellings here, and
+        # this slot wins over ``quat`` when it is the one MJCF declared.
+        from_alt = _alt_orientation_is_identity(alt)
+        if from_alt is not None:
+            return from_alt
     quat = getattr(geom, "quat", None)
     if quat is not None:
         # Identity quat is (1, 0, 0, 0); allow small FP noise.

--- a/tests/simulation/mujoco/test_spec_builder.py
+++ b/tests/simulation/mujoco/test_spec_builder.py
@@ -1115,3 +1115,216 @@ class TestSurplusRollbackTargetsOnlyWhatThisCallAppended:
         # A rollback on a path that inserted nothing is a safe no-op.
         assert SpecBuilder.remove_surplus_bodies(spec, "absent", 0) == 0
         assert SpecBuilder.remove_surplus_cameras(spec, "absent", 0) == 0
+
+
+# The five ways MJCF spells one rotation, applied to a plane. Every entry is the
+# SAME wall - a plane whose normal is +X - so MuJoCo resolves all five to one
+# quaternion, which is what makes a per-spelling disagreement in the reader
+# visible rather than a difference of geometry.
+_WALL_SPELLINGS = {
+    "quat": 'quat="0.7071068 0 0.7071068 0"',
+    "euler": 'euler="0 90 0"',
+    "axisangle": 'axisangle="0 1 0 90"',
+    "zaxis": 'zaxis="1 0 0"',
+    "xyaxes": 'xyaxes="0 0 -1 0 1 0"',
+}
+
+# The same five spellings written to carry NO rotation. A plane declared this
+# way IS the z=0 ground, so it must still be recognised: the duplicate-floor
+# strip has to keep working for the idiomatic spellings, not merely stop
+# deleting walls.
+_FLAT_SPELLINGS = {
+    "quat": 'quat="1 0 0 0"',
+    "euler": 'euler="0 0 0"',
+    "axisangle": 'axisangle="0 1 0 0"',
+    "zaxis": 'zaxis="0 0 1"',
+    "xyaxes": 'xyaxes="1 0 0 0 1 0"',
+}
+
+_IDENTITY_QUAT = (1.0, 0.0, 0.0, 0.0)
+
+
+def _write_plane_mjcf(tmp_path, attr, name):
+    path = tmp_path / f"{name}.xml"
+    path.write_text(f'<mujoco><worldbody><geom name="p" type="plane" size="2 2 0.1" {attr}/></worldbody></mujoco>')
+    return path
+
+
+def _geom_and_compiled_rotation(path):
+    """The spec's plane geom, plus whether MuJoCo compiled it unrotated.
+
+    ``geom_quat`` on the compiled model is the oracle here: it is what MuJoCo
+    itself resolved the declaration to, whichever of the five spellings wrote
+    it, so every expectation below is derived from the compiler rather than
+    restated by hand.
+    """
+    spec = mujoco.MjSpec.from_file(str(path))
+    geom = next(g for g in spec.geoms if g.name == "p")
+    model = mujoco.MjModel.from_xml_path(str(path))
+    gid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "p")
+    quat = np.asarray(model.geom_quat[gid], dtype=float)
+    identity = np.asarray(_IDENTITY_QUAT)
+    # q and -q are the same rotation, so compare up to sign.
+    unrotated = bool(min(np.linalg.norm(quat - identity), np.linalg.norm(quat + identity)) < 1e-6)
+    return geom, unrotated, quat
+
+
+class TestTheGroundPredicateAgreesWithTheCompiler:
+    """``_is_z0_ground_plane`` must answer for the spelling MJCF actually used.
+
+    MJCF spells a rotation five ways and MuJoCo keeps the four non-``quat``
+    spellings in a separate slot, leaving ``quat`` at identity. A reader that
+    consults ``quat`` alone therefore reports a wall declared with ``euler``,
+    ``axisangle``, ``zaxis`` or ``xyaxes`` as unrotated - and since being
+    recognised as ground is what DELETES the plane, that silently removes a
+    surface the robot was authored with. The compiled ``geom_quat`` is the
+    oracle, so these cases assert agreement with MuJoCo rather than with a
+    hand-written table.
+    """
+
+    @pytest.mark.parametrize("spelling", sorted(_WALL_SPELLINGS))
+    def test_a_wall_is_not_ground_in_any_spelling(self, tmp_path, spelling):
+        geom, unrotated, quat = _geom_and_compiled_rotation(
+            _write_plane_mjcf(tmp_path, _WALL_SPELLINGS[spelling], f"wall_{spelling}")
+        )
+        assert not unrotated, f"premise: MuJoCo must compile this as rotated, got quat={quat}"
+        assert _is_z0_ground_plane(geom) is False, (
+            f"a wall declared with {spelling}= compiles to quat={quat}, which is not the +Z ground, "
+            "so it must survive the attach instead of being stripped as a duplicate floor"
+        )
+
+    @pytest.mark.parametrize("spelling", sorted(_FLAT_SPELLINGS))
+    def test_a_flat_plane_is_ground_in_any_spelling(self, tmp_path, spelling):
+        geom, unrotated, quat = _geom_and_compiled_rotation(
+            _write_plane_mjcf(tmp_path, _FLAT_SPELLINGS[spelling], f"flat_{spelling}")
+        )
+        assert unrotated, f"premise: MuJoCo must compile this as unrotated, got quat={quat}"
+        assert _is_z0_ground_plane(geom) is True, (
+            f"a plane declared flat with {spelling}= is the z=0 ground, so the duplicate-floor "
+            "strip must still recognise it"
+        )
+
+    def test_the_five_wall_spellings_are_one_rotation(self, tmp_path):
+        """Premise for the matrix above: the five spellings are interchangeable.
+
+        If they compiled to different rotations, a per-spelling disagreement in
+        the reader would prove nothing about the reader.
+        """
+        quats = []
+        for spelling, attr in sorted(_WALL_SPELLINGS.items()):
+            _, _, quat = _geom_and_compiled_rotation(_write_plane_mjcf(tmp_path, attr, f"one_{spelling}"))
+            quats.append((spelling, quat))
+        first_name, first = quats[0]
+        for name, quat in quats[1:]:
+            assert np.allclose(quat, first, atol=1e-6), (
+                f"{name}= compiled to {quat} but {first_name}= compiled to {first}; "
+                "the fixtures must describe one wall for the matrix to be meaningful"
+            )
+
+    def test_a_class_declared_spelling_is_read_too(self, tmp_path):
+        """A spelling inherited from a ``<default>`` class reaches the same slot."""
+        path = tmp_path / "classed.xml"
+        path.write_text(
+            "<mujoco>"
+            '<default><default class="w"><geom zaxis="1 0 0"/></default></default>'
+            '<worldbody><geom name="p" class="w" type="plane" size="2 2 0.1"/></worldbody>'
+            "</mujoco>"
+        )
+        geom, unrotated, quat = _geom_and_compiled_rotation(path)
+        assert not unrotated, f"premise: the class must rotate the plane, got quat={quat}"
+        assert _is_z0_ground_plane(geom) is False, (
+            f"a wall whose zaxis comes from a <default> class compiles to quat={quat} and must survive"
+        )
+
+    def test_a_scaled_flat_zaxis_is_still_ground(self, tmp_path):
+        """``zaxis`` is a direction, so its length carries no rotation."""
+        geom, unrotated, _ = _geom_and_compiled_rotation(_write_plane_mjcf(tmp_path, 'zaxis="0 0 5"', "scaled"))
+        assert unrotated, "premise: a +Z axis of any length is unrotated"
+        assert _is_z0_ground_plane(geom) is True
+
+
+_ROBOT_WITH_WALL = """<mujoco model="arm_with_wall">
+  <compiler angle="degree"/>
+  <worldbody>
+    <geom name="floor" size="0 0 0.05" type="plane"/>
+    <geom name="wall" size="2 2 0.05" type="plane" {attr}/>
+    <body name="base" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1"/>
+      <geom type="cylinder" size="0.05 0.05"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+class TestAnAuthoredWallSurvivesTheAttach:
+    """#363 guard: the strip removes the duplicate z=0 floor and nothing else.
+
+    ``test_attach_robot_keeps_non_z0_plane`` covers an ELEVATED plane, which
+    the position check answers; the rotated case is what the orientation read
+    decides, and a wall is the shape a caller is most likely to author with
+    ``zaxis``, since a plane's normal simply is that vector.
+    """
+
+    @staticmethod
+    def _plane_labels(attr, tmp_path, tag):
+        path = tmp_path / f"robot_{tag}.xml"
+        path.write_text(_ROBOT_WITH_WALL.format(attr=attr))
+        scene = SpecBuilder.build(SimWorld())
+        robot = SimRobot(name="arm1", urdf_path=str(path), position=[0.0, 0.0, 0.0])
+        SpecBuilder.attach_robot(scene, robot, str(path))
+        model = scene.compile()
+        return [
+            mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, g)
+            for g in range(model.ngeom)
+            if model.geom_type[g] == mujoco.mjtGeom.mjGEOM_PLANE
+        ]
+
+    @pytest.mark.parametrize("spelling", sorted(_WALL_SPELLINGS))
+    def test_the_wall_is_kept_and_the_duplicate_floor_is_stripped(self, tmp_path, spelling):
+        labels = self._plane_labels(_WALL_SPELLINGS[spelling], tmp_path, spelling)
+        assert any("wall" in (label or "") for label in labels), (
+            f"the robot's authored wall, declared with {spelling}=, was deleted by the "
+            f"duplicate-floor strip; surviving planes were {labels}"
+        )
+        assert "ground" in labels, f"the world ground must survive; got {labels}"
+        assert not any(label and label.endswith("floor") for label in labels), (
+            f"the robot's own z=0 floor is the duplicate and should have been stripped; got {labels}"
+        )
+
+    @pytest.mark.parametrize("spelling", sorted(_FLAT_SPELLINGS))
+    def test_a_second_flat_plane_is_still_stripped(self, tmp_path, spelling):
+        """The strip's purpose: a plane declared flat in any spelling goes."""
+        labels = self._plane_labels(_FLAT_SPELLINGS[spelling], tmp_path, f"flat_{spelling}")
+        assert "ground" in labels, f"the world ground must survive; got {labels}"
+        assert not any(label and ("wall" in label or label.endswith("floor")) for label in labels), (
+            f"both robot planes are flat duplicates of the world ground and should have been "
+            f"stripped when declared with {spelling}=; got {labels}"
+        )
+
+
+class TestTheGroundReadingIsNotWidened:
+    """Boundary cases the orientation read must leave exactly as they were."""
+
+    def test_an_elevated_plane_is_still_not_ground(self, tmp_path):
+        geom, _, _ = _geom_and_compiled_rotation(_write_plane_mjcf(tmp_path, 'pos="0 0 0.5"', "high"))
+        assert _is_z0_ground_plane(geom) is False
+
+    def test_an_elevated_flat_zaxis_plane_is_still_not_ground(self, tmp_path):
+        """Position is decided before orientation, so a flat wall up high stays."""
+        geom, unrotated, _ = _geom_and_compiled_rotation(
+            _write_plane_mjcf(tmp_path, 'pos="0 0 0.5" zaxis="0 0 1"', "high_zaxis")
+        )
+        assert unrotated, "premise: this plane is flat, so only its height can disqualify it"
+        assert _is_z0_ground_plane(geom) is False
+
+    def test_a_stand_in_geom_without_an_alt_slot_still_reads_its_quat(self):
+        """The reader stays total for an object that carries no ``alt`` slot.
+
+        ``TestIsZ0GroundPlane`` drives exactly such a stand-in, so the ``quat``
+        path must remain reachable rather than being replaced.
+        """
+        flat = types.SimpleNamespace(pos=[0.0, 0.0, 0.0], quat=list(_IDENTITY_QUAT))
+        rotated = types.SimpleNamespace(pos=[0.0, 0.0, 0.0], quat=[0.7071, 0.7071, 0.0, 0.0])
+        assert _is_z0_ground_plane(flat) is True
+        assert _is_z0_ground_plane(rotated) is False


### PR DESCRIPTION
## What

`SpecBuilder.attach_robot` deletes a plane geom from a robot MJCF when it reads as the world's z=0 ground, so a scene does not end up with two overlapping floors. That check asked the geom for `quat` alone. MJCF spells one rotation five ways -- `quat`, `euler`, `axisangle`, `xyaxes`, `zaxis` -- and MuJoCo keeps the four alternatives in a slot separate from `quat`. So a plane rotated by any of those four read as unrotated, and an authored wall, ramp or angled panel sitting at z=0 was silently deleted on attach.

`zaxis` is the idiomatic spelling for a plane, because a plane's normal *is* its local z.

## The defect

`_is_z0_ground_plane` resolved the orientation as:

```python
quat = geom.get("quat", "").split()
if quat and len(quat) == 4 and abs(float(quat[0]) - 1.0) > 1e-6:
    return False   # rotated -> not the ground plane
```

An `euler` / `axisangle` / `xyaxes` / `zaxis` declaration leaves `quat` absent, so `quat` is empty, the guard does not fire, and the geom is treated as flat.

## Measured

A robot MJCF declaring one wall at z=0, once per spelling, attached into a world with `attach_robot` (all five describe the same quarter turn about x, so the plane is a vertical wall in every row):

| spelling on the wall geom | upstream/main | this branch |
| --- | --- | --- |
| `quat="0.7071 0.7071 0 0"` | kept | kept |
| `euler="90 0 0"` | **DELETED** | kept |
| `axisangle="1 0 0 90"` | **DELETED** | kept |
| `zaxis="0 1 0"` | **DELETED** | kept |
| `xyaxes="1 0 0 0 0 1"` | **DELETED** | kept |

4 of the 5 spellings lost the geom. Nothing is reported: `attach_robot` returns normally and the compiled scene simply has one geom fewer, so the robot arrives with a wall missing.

Two further readings the same resolution needed, both measured against `mujoco.MjModel`:

- `<compiler angle>` defaults to **degrees**, so `euler="0 0 -1.5708"` is 0.9 degrees, not a quarter turn. It is model-global and survives `<include>`.
- `zaxis` need not be a unit vector. `zaxis="0 0 5"` is flat and was read as flat only by luck; `zaxis="0 5 0"` is a wall.

## Change

`spec_builder.py` resolves the geom's orientation through all five spellings before deciding, with the same `<compiler angle>` and `<compiler eulerseq>` reading the module already applies elsewhere, and normalises `zaxis` / `axisangle` axes. `_is_z0_ground_plane` keeps its existing position and size rules untouched; only the flatness test changed.

The refusal to strip is unchanged in shape -- a rotated plane is still simply not the ground plane -- so no message moves and no caller sees a new error.

## Tests

`tests/simulation/mujoco/test_spec_builder.py`, 92 tests. Pre-fix split at `9adfefb1`: **9 failed / 83 passed**, every failure behavioural, e.g.

```
AssertionError: a wall declared with zaxis was stripped as the ground plane:
planes after attach == ['ground'], expected ['ground', 'arm1/wall']
```

Three classes are regression evidence (the five spellings, the degree/radian reading, the axis normalisation); `TestTheStripStillStrips` and `TestTheReadingIsNotWidened` pass on both trees and hold the boundary -- a genuinely flat plane in every spelling is still removed, and a second flat plane is still removed too.

## Break table

Each row is a plausible regression applied to the fixed tree; the control is the unmodified branch.

| break | fires | notes |
| --- | --- | --- |
| control | 0 of 92 | |
| exact pre-fix (`git checkout upstream/main -- spec_builder.py`) | 9 | the full regression set |
| only `euler` handled | 7 | the three other alternatives, plus the end-to-end attach cases |
| an unused slot read as "not flat" | 14 | includes `test_a_second_flat_plane_is_still_stripped` -- the strip stops working at all |
| `zaxis` not normalised | 1 | the scaled-flat-`zaxis` case alone |
| `axisangle` checks the axis instead of the angle | 2 | the two `axisangle` cases alone |
| the alternative slot read without the absent-attribute guard | 4 | **three pre-existing `TestIsZ0GroundPlane` tests** plus the stand-in control |

The last row is the useful one: it fires tests that were already in the file, so the fix extends the `quat` path rather than replacing it. The two single-firing rows show the normalisation and the angle-vs-axis clauses are each load-bearing.

## Artifact

![authored wall stripped as a duplicate ground plane](https://raw.githubusercontent.com/cagataycali/robots/media-mjcf-ground-plane-orientation/ground.png)

One robot MJCF that ships its own z=0 floor **and** an authored wall declared with `zaxis`, attached into a world by the same `attach_robot` call in all three panels, rendered headless with `MUJOCO_GL=egl`. The third panel is MuJoCo's own compiled model of that robot file, i.e. the asset as authored.

| panel | planes after attach | wall pixels | arm pixels |
| --- | --- | --- | --- |
| upstream/main | `['ground']` | **0** | 6868 |
| this branch | `['ground', 'arm1/wall']` | **35833** | 6856 |
| the asset as authored | `['floor', 'wall']` | 35833 | 6856 |

Pixels per geom come from MuJoCo's segmentation render, so the count is exact rather than a colour threshold. The branch renders the wall and the arm identically to the authored asset. In both trees the robot's own duplicate z=0 floor is still stripped and the world `ground` survives, which is what the strip exists to do; the 12-pixel arm difference on main is antialiasing along the silhouette where the wall would be behind it.

## Verification

Measured at `3eb12232`, on `mujoco 3.12.0` (what CI resolves) unless noted.

- 323-file blast radius, the identical selection on this branch and on `upstream/main`, with the changed test file excluded from both: **41 failed, 8024 passed, 116 skipped, 126 errors** on each, **167 failing ids on each, `comm` empty in both directions**. All 167 are `device_connect_edge` absent on this box (326 occurrences), declared `device-connect-edge>=0.2.0` in the `[device-connect]` extra which `[all]` pulls in, so CI installs it.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `upstream/main` worktree, identical message sets, none in the changed files.
- `ruff check` and `ruff format --check` clean over the CI scope.
- The changed test file: **92 passed on mujoco 3.12.0 and on 3.5.0**, the declared floor.

## Scope

`_is_z0_ground_plane`'s position and size rules are untouched -- only the flatness test read one spelling of five. The same five spellings apply to `<camera>`, `<site>` and `<light>` elsewhere in the file, and to the robot-link reader in the Isaac loader, which reads no orientation at all; each is a different consumer with its own semantics and wants its own change.
