### PR TITLE
fix(mesh): record every resource the IoT bootstrap ensures in its ledger

### DIFF
--- a/changelog.d/2684-iot-bootstrap-ledger-completeness.md
+++ b/changelog.d/2684-iot-bootstrap-ledger-completeness.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **mesh**: every resource the AWS IoT bootstrap ensures is now recorded in
+  `BootstrappedAccount.created` / `.skipped`. Those two lists are the whole record an
+  operator has of what a provisioning run touched, and the closing log line counts them, but
+  three of the thirteen helpers that mutate the account ensured a resource without recording
+  it. `_grant_iot_invoke_lambda` recorded neither the `lambda:InvokeFunction` grant it creates
+  for the E-stop fan-out rule nor the one it finds already present, while the other
+  `add_permission` helper forty lines away recorded both - so the one resource absent from the
+  audit trail was a permission grant. `_ensure_iot_action_role` and `_ensure_provisioning_role`
+  recorded the role they create but not the existing role they reuse, unlike the two sibling
+  role helpers. Measured with the real helpers driven against fake clients: a fresh account
+  creates thirteen resources and reported twelve, a fully provisioned one reused eleven and
+  reported ten, and a resumed run - roles and Lambdas left by an earlier attempt, rules and
+  template lost - reused ten and reported seven. Both permission statements now record under a
+  single-sourced ledger name, because a resource-policy statement has no ARN of its own to
+  return; the values are unchanged, so existing assertions on the provisioning-hook entry hold.
+  No resource, ARN, IAM policy or API call changes - only what the run reports about itself.
+  A new structural guard derives the helper set from the module, so a helper added later is
+  held to the same contract on arrival.

--- a/strands_robots/mesh/iot/bootstrap.py
+++ b/strands_robots/mesh/iot/bootstrap.py
@@ -73,6 +73,13 @@ PROVISIONING_HOOK_ROLE = "strands-mesh-provisioning-hook-role"
 _PROVISIONING_HOOK_VERSION = 1
 LOG_GROUP_NAME = "/aws/iot/strands-mesh"
 
+#: Ledger names for the two Lambda resource policy statements the bootstrap
+#: grants. A permission statement has no ARN of its own, so these are the
+#: only handle :class:`BootstrappedAccount` can record it under - and they are
+#: single-sourced here so the record and any reader agree on the spelling.
+ESTOP_INVOKE_PERMISSION = "lambda-permission:estop-invoke"
+PROVISIONING_HOOK_INVOKE_PERMISSION = "lambda-permission:provisioning-hook-invoke"
+
 
 # Lambda source for the E-stop fan-out
 
@@ -253,7 +260,19 @@ _PROVISIONING_HOOK_SOURCE = textwrap.dedent(
 
 @dataclass
 class BootstrappedAccount:
-    """Identifiers + ARNs of every resource :func:`bootstrap_account` ensured."""
+    """Identifiers + ARNs of every resource :func:`bootstrap_account` ensured.
+
+    :attr:`created` and :attr:`skipped` together are the account's audit trail:
+    every resource the bootstrap ensures appears in exactly one of them -
+    :attr:`created` when this run brought it up, :attr:`skipped` when it was
+    already there. That is the whole record an operator has of what a
+    provisioning run touched (the closing log line counts these two lists), so a
+    resource ensured without an entry is one they cannot review or reverse.
+
+    A Lambda resource-policy statement has no ARN to return, so it is recorded
+    under its ledger name (:data:`ESTOP_INVOKE_PERMISSION`,
+    :data:`PROVISIONING_HOOK_INVOKE_PERMISSION`) rather than an ``*_arn`` field.
+    """
 
     region: str
     account_id: str
@@ -583,8 +602,9 @@ def _grant_iot_invoke_lambda(lam: Any, lambda_arn: str, account: BootstrappedAcc
             Principal="iot.amazonaws.com",
             SourceArn=rule_arn,
         )
+        account.created.append(ESTOP_INVOKE_PERMISSION)
     except lam.exceptions.ResourceConflictException:
-        pass  # already granted
+        account.skipped.append(ESTOP_INVOKE_PERMISSION)
 
 
 def _ensure_iot_action_role(iam: Any, account: BootstrappedAccount) -> str:
@@ -597,7 +617,9 @@ def _ensure_iot_action_role(iam: Any, account: BootstrappedAccount) -> str:
     """
     role_name = IOT_ACTION_ROLE
     try:
-        return iam.get_role(RoleName=role_name)["Role"]["Arn"]
+        role = iam.get_role(RoleName=role_name)
+        account.skipped.append(f"iam:{role_name}")
+        return str(role["Role"]["Arn"])
     except iam.exceptions.NoSuchEntityException:
         pass
 
@@ -808,9 +830,9 @@ def _grant_iot_invoke_provisioning_hook(lam: Any, hook_arn: str, account: Bootst
             Principal="iot.amazonaws.com",
             SourceArn=f"arn:aws:iot:{account.region}:{account.account_id}:provisioningtemplate/{PROVISIONING_TEMPLATE}",
         )
-        account.created.append("lambda-permission:provisioning-hook-invoke")
+        account.created.append(PROVISIONING_HOOK_INVOKE_PERMISSION)
     except lam.exceptions.ResourceConflictException:
-        account.skipped.append("lambda-permission:provisioning-hook-invoke")
+        account.skipped.append(PROVISIONING_HOOK_INVOKE_PERMISSION)
 
 
 def _ensure_provisioning_template(
@@ -905,7 +927,9 @@ def _ensure_provisioning_role(iam: Any, account: BootstrappedAccount) -> str:
     """
     name = PROVISIONING_ROLE
     try:
-        return iam.get_role(RoleName=name)["Role"]["Arn"]
+        role = iam.get_role(RoleName=name)
+        account.skipped.append(f"iam:{name}")
+        return str(role["Role"]["Arn"])
     except iam.exceptions.NoSuchEntityException:
         pass
 

--- a/tests/mesh/test_iot_bootstrap_ledger.py
+++ b/tests/mesh/test_iot_bootstrap_ledger.py
@@ -1,0 +1,503 @@
+"""Every resource the IoT bootstrap ensures lands in its created/skipped ledger.
+
+``BootstrappedAccount.created`` + ``.skipped`` are the only record an operator
+has of what a provisioning run touched, and the closing log line counts them.
+Three helpers were ensuring a resource without recording it:
+
+* ``_grant_iot_invoke_lambda`` recorded neither the ``lambda:InvokeFunction``
+  grant it created for the E-stop fan-out nor the one it found already present,
+  while its sibling ``_grant_iot_invoke_provisioning_hook`` recorded both. A
+  fresh bootstrap created thirteen resources and reported twelve, and the one
+  missing from the audit trail was a permission grant.
+* ``_ensure_iot_action_role`` and ``_ensure_provisioning_role`` recorded the role
+  they create but not the existing role they reuse, so a resumed bootstrap
+  reported fewer reused resources than it had reused.
+
+The end-to-end classes drive the real helpers against fake AWS clients, which is
+what makes the ledger counts observable; ``TestTheLedgerContractHoldsForEveryHelper``
+pins the invariant structurally so a helper added later cannot drift out of it.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from collections.abc import Collection
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from strands_robots.mesh.iot import bootstrap as boot_mod
+from strands_robots.mesh.iot.bootstrap import (
+    ESTOP_INVOKE_PERMISSION,
+    ESTOP_LAMBDA_NAME,
+    ESTOP_LAMBDA_ROLE,
+    IOT_ACTION_ROLE,
+    LOG_GROUP_NAME,
+    PROVISIONING_HOOK_INVOKE_PERMISSION,
+    PROVISIONING_HOOK_LAMBDA_NAME,
+    PROVISIONING_HOOK_ROLE,
+    PROVISIONING_ROLE,
+    PROVISIONING_TEMPLATE,
+    RULE_ESTOP_FANOUT,
+    RULE_SAFETY_TO_DYNAMODB,
+    SAFETY_TABLE_NAME,
+    BootstrappedAccount,
+)
+
+ACCOUNT = "111122223333"
+REGION = "us-west-2"
+
+# The ledger entry each resource of the fake account is recorded under. Built
+# from the module's own name constants so a renamed resource updates both the
+# fixture and the expectation together.
+LEDGER_NAME = {
+    "log": f"logs:{LOG_GROUP_NAME}",
+    "table": f"dynamodb:{SAFETY_TABLE_NAME}",
+    "lam_role": f"iam:{ESTOP_LAMBDA_ROLE}",
+    "estop_lambda": f"lambda:{ESTOP_LAMBDA_NAME}",
+    "action_role": f"iam:{IOT_ACTION_ROLE}",
+    "safety_rule": f"iot-rule:{RULE_SAFETY_TO_DYNAMODB}",
+    "estop_rule": f"iot-rule:{RULE_ESTOP_FANOUT}",
+    "estop_permission": ESTOP_INVOKE_PERMISSION,
+    "hook_role": f"iam:{PROVISIONING_HOOK_ROLE}",
+    "hook_lambda": f"lambda:{PROVISIONING_HOOK_LAMBDA_NAME}",
+    "prov_role": f"iam:{PROVISIONING_ROLE}",
+    "prov_template": f"iot-prov-template:{PROVISIONING_TEMPLATE}",
+    "hook_permission": PROVISIONING_HOOK_INVOKE_PERMISSION,
+}
+
+ROLE_KEY = {
+    ESTOP_LAMBDA_ROLE: "lam_role",
+    IOT_ACTION_ROLE: "action_role",
+    PROVISIONING_HOOK_ROLE: "hook_role",
+    PROVISIONING_ROLE: "prov_role",
+}
+LAMBDA_KEY = {
+    ESTOP_LAMBDA_NAME: "estop_lambda",
+    PROVISIONING_HOOK_LAMBDA_NAME: "hook_lambda",
+}
+RULE_KEY = {
+    RULE_SAFETY_TO_DYNAMODB: "safety_rule",
+    RULE_ESTOP_FANOUT: "estop_rule",
+}
+PERMISSION_KEY = {
+    "strands-mesh-iot-invoke": "estop_permission",
+    "strands-mesh-iot-provisioning-invoke": "hook_permission",
+}
+
+
+def _exceptions(*names: str) -> SimpleNamespace:
+    """A boto3-style ``client.exceptions`` namespace of real exception classes.
+
+    ``MagicMock`` cannot stand in here: ``except <MagicMock>`` raises
+    ``TypeError: catching classes that do not inherit from BaseException``.
+    """
+    return SimpleNamespace(**{n: type(n, (Exception,), {}) for n in names})
+
+
+class _FakeAws:
+    """boto3 stand-in whose account already holds the resources in ``present``.
+
+    Keys are those of :data:`LEDGER_NAME`. Every client is a ``MagicMock`` with
+    the describe/get calls wired to answer for that account, so the real
+    ``_ensure_*`` / ``_grant_*`` helpers run unmodified and the ledger they build
+    is the value under test.
+    """
+
+    def __init__(self, present: Collection[str], stale: Collection[str] = ()) -> None:
+        self.present = set(present)
+        # Lambdas whose deployed description carries no current version tag.
+        # _ensure_estop_lambda only honours force_update for a stale
+        # deployment, so its update path is unreachable without this.
+        self.stale = set(stale)
+        self.requested: list[str] = []
+
+    # boto3 module surface
+    def client(self, svc: str, **_: Any) -> Any:
+        self.requested.append(svc)
+        return getattr(self, f"_{svc.replace('-', '_')}")()
+
+    def _sts(self) -> Any:
+        c = MagicMock(name="sts")
+        c.get_caller_identity.return_value = {"Account": ACCOUNT}
+        c.meta.region_name = REGION
+        return c
+
+    def _iam(self) -> Any:
+        c = MagicMock(name="iam")
+        c.exceptions = _exceptions("NoSuchEntityException")
+
+        def get_role(RoleName: str, **_kw: Any) -> Any:  # noqa: N803 - boto3 casing
+            if ROLE_KEY[RoleName] not in self.present:
+                raise c.exceptions.NoSuchEntityException(RoleName)
+            return {"Role": {"Arn": f"arn:aws:iam::{ACCOUNT}:role/{RoleName}"}}
+
+        c.get_role.side_effect = get_role
+        c.create_role.side_effect = lambda RoleName, **_kw: {  # noqa: N803
+            "Role": {"Arn": f"arn:aws:iam::{ACCOUNT}:role/{RoleName}"}
+        }
+        return c
+
+    def _lambda(self) -> Any:
+        c = MagicMock(name="lambda")
+        c.exceptions = _exceptions(
+            "ResourceNotFoundException",
+            "ResourceConflictException",
+            "InvalidParameterValueException",
+        )
+        descriptions = {
+            ESTOP_LAMBDA_NAME: f"strands-mesh: E-stop [v{boot_mod._LAMBDA_VERSION}]",
+            PROVISIONING_HOOK_LAMBDA_NAME: f"strands-mesh: hook [v{boot_mod._PROVISIONING_HOOK_VERSION}]",
+        }
+        stale_descriptions = {
+            ESTOP_LAMBDA_NAME: "strands-mesh: E-stop [v0]",
+            PROVISIONING_HOOK_LAMBDA_NAME: "strands-mesh: hook [v0]",
+        }
+
+        def get_function(FunctionName: str, **_kw: Any) -> Any:  # noqa: N803
+            if LAMBDA_KEY[FunctionName] not in self.present:
+                raise c.exceptions.ResourceNotFoundException(FunctionName)
+            table = stale_descriptions if LAMBDA_KEY[FunctionName] in self.stale else descriptions
+            return {
+                "Configuration": {
+                    "Description": table[FunctionName],
+                    "FunctionArn": f"arn:aws:lambda:{REGION}:{ACCOUNT}:function:{FunctionName}",
+                }
+            }
+
+        def add_permission(StatementId: str, **_kw: Any) -> Any:  # noqa: N803
+            if PERMISSION_KEY[StatementId] in self.present:
+                raise c.exceptions.ResourceConflictException(StatementId)
+            return {"Statement": StatementId}
+
+        c.get_function.side_effect = get_function
+        c.add_permission.side_effect = add_permission
+        c.create_function.side_effect = lambda FunctionName, **_kw: {  # noqa: N803
+            "FunctionArn": f"arn:aws:lambda:{REGION}:{ACCOUNT}:function:{FunctionName}"
+        }
+        return c
+
+    def _dynamodb(self) -> Any:
+        c = MagicMock(name="dynamodb")
+        c.exceptions = _exceptions("ResourceNotFoundException")
+        arn = f"arn:aws:dynamodb:{REGION}:{ACCOUNT}:table/{SAFETY_TABLE_NAME}"
+
+        def describe_table(**_kw: Any) -> Any:
+            if "table" not in self.present:
+                raise c.exceptions.ResourceNotFoundException(SAFETY_TABLE_NAME)
+            return {"Table": {"TableArn": arn}}
+
+        c.describe_table.side_effect = describe_table
+        c.create_table.return_value = {"TableDescription": {"TableArn": arn}}
+        return c
+
+    def _iot(self) -> Any:
+        c = MagicMock(name="iot")
+        c.exceptions = _exceptions(
+            "ResourceNotFoundException",
+            "UnauthorizedException",
+            "InvalidRequestException",
+        )
+
+        def get_topic_rule(ruleName: str, **_kw: Any) -> Any:  # noqa: N803
+            if RULE_KEY[ruleName] not in self.present:
+                raise c.exceptions.ResourceNotFoundException(ruleName)
+            return {"ruleArn": f"arn:aws:iot:{REGION}:{ACCOUNT}:rule/{ruleName}"}
+
+        def describe_provisioning_template(**_kw: Any) -> Any:
+            if "prov_template" not in self.present:
+                raise c.exceptions.ResourceNotFoundException(PROVISIONING_TEMPLATE)
+            return {"templateName": PROVISIONING_TEMPLATE}
+
+        c.get_topic_rule.side_effect = get_topic_rule
+        c.describe_provisioning_template.side_effect = describe_provisioning_template
+        return c
+
+    def _logs(self) -> Any:
+        c = MagicMock(name="logs")
+        group = {
+            "logGroupName": LOG_GROUP_NAME,
+            "arn": f"arn:aws:logs:{REGION}:{ACCOUNT}:log-group:{LOG_GROUP_NAME}",
+        }
+
+        def describe_log_groups(**_kw: Any) -> Any:
+            # After create_log_group the helper describes again for the ARN, so
+            # the group has to exist from that point on.
+            return {"logGroups": [group] if "log" in self.present else []}
+
+        def create_log_group(**_kw: Any) -> Any:
+            self.present.add("log")
+            return {}
+
+        c.describe_log_groups.side_effect = describe_log_groups
+        c.create_log_group.side_effect = create_log_group
+        return c
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """IAM propagation waits total 23s across the bootstrap; skip them."""
+    monkeypatch.setattr(boot_mod.time, "sleep", lambda *_a, **_k: None)
+
+
+def _bootstrap(monkeypatch, present: set[str]) -> BootstrappedAccount:
+    fake = _FakeAws(present)
+    monkeypatch.setattr(boot_mod, "_require_boto3", lambda: fake)
+    return boot_mod.bootstrap_account(region=REGION, confirm=True, dry_run=False)
+
+
+# Every resource a bootstrap of an empty account brings up, in the order
+# bootstrap_account ensures them.
+FRESH_ACCOUNT_RESOURCES = (
+    "log",
+    "table",
+    "lam_role",
+    "estop_lambda",
+    "action_role",
+    "safety_rule",
+    "estop_rule",
+    "estop_permission",
+    "hook_role",
+    "hook_lambda",
+    "prov_role",
+    "prov_template",
+    "hook_permission",
+)
+
+# A fully provisioned account. The two roles nested inside the safety rule and
+# the provisioning template are absent because those parents return before
+# reaching them, so this run does not ensure them at all.
+FULL_ACCOUNT_RESOURCES = tuple(k for k in FRESH_ACCOUNT_RESOURCES if k not in {"action_role", "prov_role"})
+
+
+class TestEveryResourceABootstrapEnsuresIsRecorded:
+    """The ledger accounts for every resource, on the create and the reuse path."""
+
+    def test_a_fresh_account_records_every_resource_it_creates(self, monkeypatch, no_sleep):
+        out = _bootstrap(monkeypatch, present=set())
+
+        expected = [LEDGER_NAME[k] for k in FRESH_ACCOUNT_RESOURCES]
+        assert out.created == expected
+        assert out.skipped == []
+
+    def test_a_fully_provisioned_account_records_every_resource_it_reuses(self, monkeypatch, no_sleep):
+        out = _bootstrap(monkeypatch, present=set(LEDGER_NAME))
+
+        assert sorted(out.skipped) == sorted(LEDGER_NAME[k] for k in FULL_ACCOUNT_RESOURCES)
+        assert out.created == []
+
+    def test_a_resumed_bootstrap_records_the_roles_it_reuses(self, monkeypatch, no_sleep):
+        # The realistic re-run: an earlier attempt left the roles and Lambdas
+        # behind but died before the rules and the provisioning template. The
+        # two nested roles are reached here, on their reuse path.
+        present = set(LEDGER_NAME) - {"safety_rule", "estop_rule", "prov_template"}
+        out = _bootstrap(monkeypatch, present=present)
+
+        assert LEDGER_NAME["action_role"] in out.skipped
+        assert LEDGER_NAME["prov_role"] in out.skipped
+        assert LEDGER_NAME["estop_permission"] in out.skipped
+        # The rules it did have to create are recorded as created, not reused.
+        assert sorted(out.created) == sorted(LEDGER_NAME[k] for k in ("safety_rule", "estop_rule", "prov_template"))
+
+    @pytest.mark.parametrize(
+        "present",
+        [
+            pytest.param(set(), id="fresh"),
+            pytest.param(set(LEDGER_NAME), id="fully-provisioned"),
+            pytest.param(set(LEDGER_NAME) - {"safety_rule", "prov_template"}, id="resumed"),
+        ],
+    )
+    def test_no_resource_is_recorded_as_both_created_and_reused(self, monkeypatch, no_sleep, present):
+        out = _bootstrap(monkeypatch, present=present)
+
+        assert set(out.created) & set(out.skipped) == set()
+        assert len(out.created) == len(set(out.created))
+        assert len(out.skipped) == len(set(out.skipped))
+
+
+class TestTheGrantHelpersRecordTheirPermission:
+    """Both ``add_permission`` helpers record the statement, either way."""
+
+    @pytest.mark.parametrize(
+        ("helper", "statement_id", "entry"),
+        [
+            ("_grant_iot_invoke_lambda", "strands-mesh-iot-invoke", ESTOP_INVOKE_PERMISSION),
+            (
+                "_grant_iot_invoke_provisioning_hook",
+                "strands-mesh-iot-provisioning-invoke",
+                PROVISIONING_HOOK_INVOKE_PERMISSION,
+            ),
+        ],
+    )
+    def test_a_granted_permission_is_recorded_as_created(self, helper, statement_id, entry):
+        lam = MagicMock()
+        lam.exceptions = _exceptions("ResourceConflictException")
+        account = BootstrappedAccount(region=REGION, account_id=ACCOUNT)
+
+        getattr(boot_mod, helper)(lam, "arn:aws:lambda:::function:f", account)
+
+        assert lam.add_permission.call_args.kwargs["StatementId"] == statement_id
+        assert account.created == [entry]
+        assert account.skipped == []
+
+    @pytest.mark.parametrize(
+        ("helper", "entry"),
+        [
+            ("_grant_iot_invoke_lambda", ESTOP_INVOKE_PERMISSION),
+            ("_grant_iot_invoke_provisioning_hook", PROVISIONING_HOOK_INVOKE_PERMISSION),
+        ],
+    )
+    def test_an_already_granted_permission_is_recorded_as_reused(self, helper, entry):
+        lam = MagicMock()
+        lam.exceptions = _exceptions("ResourceConflictException")
+        lam.add_permission.side_effect = lam.exceptions.ResourceConflictException("exists")
+        account = BootstrappedAccount(region=REGION, account_id=ACCOUNT)
+
+        getattr(boot_mod, helper)(lam, "arn:aws:lambda:::function:f", account)
+
+        assert account.skipped == [entry]
+        assert account.created == []
+
+
+class TestTheRoleHelpersRecordAReusedRole:
+    """Every ``_ensure_*_role`` helper records the role it finds already there."""
+
+    @pytest.mark.parametrize(
+        ("helper", "role_name"),
+        [
+            ("_ensure_lambda_role", ESTOP_LAMBDA_ROLE),
+            ("_ensure_iot_action_role", IOT_ACTION_ROLE),
+            ("_ensure_provisioning_hook_role", PROVISIONING_HOOK_ROLE),
+            ("_ensure_provisioning_role", PROVISIONING_ROLE),
+        ],
+    )
+    def test_an_existing_role_is_recorded_as_reused_and_its_arn_returned(self, helper, role_name):
+        arn = f"arn:aws:iam::{ACCOUNT}:role/{role_name}"
+        iam = MagicMock()
+        iam.exceptions = _exceptions("NoSuchEntityException")
+        iam.get_role.return_value = {"Role": {"Arn": arn}}
+        account = BootstrappedAccount(region=REGION, account_id=ACCOUNT)
+
+        result = getattr(boot_mod, helper)(iam, account)
+
+        assert result == arn
+        assert account.skipped == [f"iam:{role_name}"]
+        assert account.created == []
+        iam.create_role.assert_not_called()
+
+
+class TestTheLedgerContractHoldsForEveryHelper:
+    """Structural: no helper can mutate the account without recording it.
+
+    A behavioural test only covers the helpers a scenario reaches. This grades
+    the module itself, so a helper added later inherits the contract.
+    """
+
+    MUTATING_CALLS = (
+        "create_",
+        "put_",
+        "add_permission",
+        "attach_",
+        "update_",
+        "register_",
+        "tag_",
+    )
+
+    def _mutating_helpers(self) -> dict[str, str]:
+        """``{function name: unparsed body}`` for every helper that mutates AWS."""
+        tree = ast.parse(Path(inspect.getfile(boot_mod)).read_text(encoding="utf-8"))
+        out = {}
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if not (node.name.startswith("_ensure") or node.name.startswith("_grant")):
+                continue
+            body = ast.unparse(ast.Module(body=node.body, type_ignores=[]))
+            if any(call in body for call in self.MUTATING_CALLS):
+                out[node.name] = body
+        return out
+
+    def test_the_scan_reaches_every_helper(self):
+        helpers = self._mutating_helpers()
+        # Non-vacuity: an empty or near-empty scan would pass the rule below
+        # while measuring nothing.
+        assert len(helpers) >= 13, sorted(helpers)
+        assert "_grant_iot_invoke_lambda" in helpers
+        assert "_ensure_provisioning_role" in helpers
+
+    def test_every_mutating_helper_records_both_outcomes(self):
+        missing = {
+            name: {
+                "created": "created.append" in body,
+                "skipped": "skipped.append" in body,
+            }
+            for name, body in self._mutating_helpers().items()
+            if not ("created.append" in body and "skipped.append" in body)
+        }
+        assert missing == {}, (
+            "every helper that ensures a resource must record it in "
+            f"BootstrappedAccount on both its create and its reuse path: {missing}"
+        )
+
+    def test_the_permission_ledger_names_are_single_sourced(self):
+        # A permission statement has no ARN, so its ledger name is its only
+        # handle; a repeated literal would let the two append sites disagree.
+        source = Path(inspect.getfile(boot_mod)).read_text(encoding="utf-8")
+        for name, value in (
+            ("ESTOP_INVOKE_PERMISSION", ESTOP_INVOKE_PERMISSION),
+            ("PROVISIONING_HOOK_INVOKE_PERMISSION", PROVISIONING_HOOK_INVOKE_PERMISSION),
+        ):
+            assert f'{name} = "{value}"' in source
+            assert source.count(f'"{value}"') == 1, f"{value!r} is spelled out more than once"
+
+
+class TestTheLedgerIsNotWidened:
+    """Boundaries this change deliberately leaves alone."""
+
+    def test_a_dry_run_records_nothing(self, monkeypatch, capsys):
+        fake = _FakeAws(set())
+        monkeypatch.setattr(boot_mod, "_require_boto3", lambda: fake)
+
+        out = boot_mod.bootstrap_account(region=REGION)  # dry_run defaults True
+
+        # A preview ensures nothing, so it records nothing - the printed
+        # preview is its output, not the ledger.
+        assert out.created == []
+        assert out.skipped == []
+        assert "[dry_run]" in capsys.readouterr().err
+
+    def test_an_updated_lambda_is_recorded_as_created_not_reused(self, monkeypatch, no_sleep):
+        # force_update replaces the deployed code, so it is a change to the
+        # account and belongs in created under the existing "(updated)"
+        # spelling, not in skipped. Both Lambdas are stale here because
+        # _ensure_estop_lambda only honours force_update for a stale
+        # deployment (_ensure_provisioning_hook_lambda updates either way).
+        fake = _FakeAws(set(LEDGER_NAME), stale={"estop_lambda", "hook_lambda"})
+        monkeypatch.setattr(boot_mod, "_require_boto3", lambda: fake)
+
+        out = boot_mod.bootstrap_account(region=REGION, confirm=True, dry_run=False, force_update=True)
+
+        for name in (ESTOP_LAMBDA_NAME, PROVISIONING_HOOK_LAMBDA_NAME):
+            assert f"lambda:{name} (updated)" in out.created
+            assert f"lambda:{name}" not in out.skipped
+
+    def test_a_stale_lambda_left_alone_is_still_recorded_as_reused(self, monkeypatch, no_sleep):
+        # Without force_update a stale deployment is warned about but not
+        # touched, so it stays a reuse - the ledger reports what happened,
+        # not what the operator was advised to do.
+        fake = _FakeAws(set(LEDGER_NAME), stale={"estop_lambda", "hook_lambda"})
+        monkeypatch.setattr(boot_mod, "_require_boto3", lambda: fake)
+
+        out = boot_mod.bootstrap_account(region=REGION, confirm=True, dry_run=False)
+
+        for name in (ESTOP_LAMBDA_NAME, PROVISIONING_HOOK_LAMBDA_NAME):
+            assert f"lambda:{name}" in out.skipped
+            assert f"lambda:{name} (updated)" not in out.created
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

`BootstrappedAccount.created` + `.skipped` are the whole record an operator has of what a provisioning run touched - the closing log line counts them, and the dataclass docstring calls itself the record of "every resource `bootstrap_account` ensured". Thirteen module-level helpers mutate the account. Twelve recorded what they did; three did not.

`_grant_iot_invoke_lambda` recorded neither the `lambda:InvokeFunction` grant it creates for the E-stop fan-out rule nor the one it finds already present. Its sibling `_grant_iot_invoke_provisioning_hook` - the other `add_permission` helper, forty lines away, with the same `try` / `ResourceConflictException` shape - recorded both. So the one resource missing from the audit trail was a permission grant.

`_ensure_iot_action_role` and `_ensure_provisioning_role` recorded the role they create but not the existing role they reuse, unlike `_ensure_lambda_role` and `_ensure_provisioning_hook_role`, which record both.

## Measurement

The real helpers driven against fake AWS clients, in the three states an account can be in:

| account state | `created` / `skipped` before | after |
| --- | --- | --- |
| fresh (nothing exists) | 12 / 0 | **13** / 0 |
| fully provisioned | 0 / 10 | 0 / **11** |
| resumed (roles + Lambdas kept, rules + template lost) | 3 / 7 | 3 / **10** |

The entry absent from the fresh-account record is exactly `lambda-permission:estop-invoke`. The resumed row is the realistic re-run - an earlier attempt died after the roles and Lambdas - and it is the one that reaches both role helpers on their reuse path; it under-reported three of the ten resources it reused.

## Change

The three missing ledger writes, each in the vocabulary its own sibling already uses. Both permission statements now record under a single-sourced constant (`ESTOP_INVOKE_PERMISSION`, `PROVISIONING_HOOK_INVOKE_PERMISSION`) because a resource-policy statement has no ARN of its own to return, so its ledger name is its only handle. The values are byte-identical to the literal the provisioning-hook helper used, so the existing assertions in `tests/mesh/test_iot_provisioning_hook.py` still hold unchanged.

`BootstrappedAccount`'s docstring now states the invariant the helpers are held to: every ensured resource appears in exactly one of the two lists.

Scope left alone deliberately, each with a control test: a `dry_run` preview ensures nothing so it records nothing, and a `force_update` replacement stays in `created` under the existing `(updated)` spelling rather than becoming a reuse.

## Tests

`tests/mesh/test_iot_bootstrap_ledger.py` (new, 20 tests). Nothing previously ran the real `_ensure_*` / `_grant_*` helpers together - the existing full-bootstrap tests stub every one of them, so the ledger they build was unobservable, and `TestGrantIotInvokeLambda` asserted the `add_permission` call without looking at the record. The new file supplies fake clients so the helpers run unmodified, then grades the ledger.

Pre-fix split, with only the three ledger writes reverted: **8 failed / 12 passed**, all eight in the three regression classes and zero in `TestTheLedgerIsNotWidened`. (Reverting the source file wholesale instead fails at collection, since the two ledger-name constants do not exist there.)

| break | fails | notable |
| --- | --- | --- |
| control (branch) | 0 of 20 | |
| all three writes reverted | 8 | the pre-fix behaviour |
| grant helper only | 6 | |
| `_ensure_iot_action_role` only | 3 | complementary with the row below |
| `_ensure_provisioning_role` only | 3 | shares only the resumed + structural tests |
| an already-present grant recorded as `created` | 4 | over-reach: a reuse reported as a change |
| sibling stops using the constant | 1 | the single-sourcing test alone |
| reuse path records but returns the wrong ARN shape | 1 | the role test alone |

`TestTheLedgerContractHoldsForEveryHelper` grades the module by AST rather than by scenario, so a helper added later inherits the contract; it carries its own non-vacuity assertion (the scan must reach at least thirteen helpers), because an empty scan would satisfy the rule while measuring nothing.

## Gate

`ruff check` + `ruff format --check` on `strands_robots tests tests_integ` clean. mypy **24 = 24** against a pristine `upstream/main` worktree, identical message sets, none in the changed files.

A 329-file selection - all of `tests/mesh`, every test naming the bootstrap, and every test that scans package sources - run identically on both trees with the new file excluded from each: **`73 failed, 10642 passed, 65 skipped, 150 errors`** on both (427.45s vs 427.83s), 73 failing ids each, set difference empty in both directions. Every shared failure is a declared optional dependency absent from this environment - `device_connect_edge` (302 occurrences) and `device_connect_agent_tools` (40), declared in `[device-connect]`, and `awsiot` (88), declared as `awsiotsdk` in `[mesh-iot]`, all of which `[all]` installs. The new file plus the three existing bootstrap test files: 83 passed under random ordering.

No visual artifact: this changes no policy, simulation, rendering, recording or robot asset - it changes what a provisioning run reports about itself.
