### PR TITLE
fix(isaac): read a robot link's rotation from its MJCF orientation spelling

### DIFF
--- a/changelog.d/2686-mjcf-robot-link-orientation.md
+++ b/changelog.d/2686-mjcf-robot-link-orientation.md
@@ -1,0 +1,26 @@
+### Fixed: a robot link's rotation is read from whichever MJCF spelling declares it, instead of being reported as identity
+
+`load_mjcf` read each `<body>`'s `pos` into `BodyDef.position` but read no rotation at
+all, so `BodyDef.orientation` kept its identity default for every link it reported. A
+robot whose links the model rotates was reported upright with the load reporting
+success, and identity is a valid orientation, so no caller could tell a link the model
+never rotates from one whose rotation was dropped -- half of one pose was read and half
+was silently discarded.
+
+The sibling reader in the same module, `load_mjcf_scene_objects`, already resolves all
+five of MJCF's mutually exclusive spellings (`quat`, `euler`, `axisangle`, `xyaxes` and
+`zaxis`) through `_parse_orientation`, under the model-global `<compiler angle>` and
+`<compiler eulerseq>`. The robot-link walk now reads the rotation the same way, in the
+parent's frame -- the frame `position` is already reported in, and the frame MuJoCo's
+`body_quat` stores, so nested links resolve too. `<compiler>` is read from the spliced
+model, so a robot inheriting `angle="radian"` from an `<include>` is not read as
+degrees. A body declaring two spellings is refused, as MuJoCo refuses such a model
+outright.
+
+Graded against `mujoco.MjModel.body_quat` across the shipped asset corpus, agreement
+rises from 5474 of 8502 links to 7692, with no verdict changes, no link moving away
+from the compiler, and 3030 corrected values spanning 307 assets. The 810 links that
+still differ are all non-unit `quat` declarations, which MuJoCo normalizes and
+`_parse_orientation` reports as written; that choice is shared with the scene reader
+rather than local to this one, so it is left unchanged here and pinned by a test so it
+cannot move silently.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -211,7 +211,10 @@ open a window.
   camera prims are parented to the stage camera scope rather than to an
   articulation link.
 - **Loaders** - `load_urdf` / `load_mjcf` / `load_usd` resolve to a
-  `ProceduralRobot` dataclass.
+  `ProceduralRobot` dataclass. `load_mjcf` reports each link's pose in its
+  parent's frame, reading the rotation from whichever of MJCF's five spellings
+  the body uses - `quat`, `euler`, `axisangle`, `xyaxes` or `zaxis` - under the
+  model-global `<compiler angle>` and `<compiler eulerseq>`.
 
 Because the joint-name and observation contract matches the MuJoCo backend,
 policies and observation mappings transfer unchanged between backends.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -378,6 +378,14 @@ def load_mjcf(path: str) -> ProceduralRobot:
     parent. Useful for LIBERO scenes (the matrix's main consumer ships
     MJCF).
 
+    Each body's pose is reported in its parent's frame, as MJCF declares it:
+    ``position`` from ``pos``, and ``orientation`` from whichever of MJCF's five
+    mutually exclusive orientation spellings the element uses (``quat``,
+    ``euler``, ``axisangle``, ``xyaxes`` or ``zaxis``). ``<compiler angle>`` and
+    ``<compiler eulerseq>`` are model-global and read from the spliced model, so
+    a robot inheriting ``angle="radian"`` from an ``<include>`` is not read as
+    degrees.
+
     Parameters
     ----------
     path : str
@@ -394,7 +402,9 @@ def load_mjcf(path: str) -> ProceduralRobot:
         If ``path`` doesn't exist.
     ValueError
         If the XML is malformed, the root tag isn't ``<mujoco>``, or no
-        ``<worldbody>`` / no descendant ``<body>`` is present.
+        ``<worldbody>`` / no descendant ``<body>`` is present, or a body
+        declares more than one orientation spelling (MuJoCo refuses such a
+        model outright, so there is no rotation to pick).
     """
     _require_existing_file(path, "MJCF")
     root = _parse_xml(path, "MJCF")
@@ -411,6 +421,11 @@ def load_mjcf(path: str) -> ProceduralRobot:
 
     geom_defaults = _mjcf_class_defaults(root, mjcf_dir, "geom")
     joint_defaults = _mjcf_class_defaults(root, mjcf_dir, "joint")
+    # Model-global, so read from the spliced model: a robot whose own
+    # <compiler> sets only meshdir still inherits angle="radian" from an
+    # <include>d fragment, and an angle read in the wrong units is a
+    # rotation wrong by a factor of 57.
+    angle_scale, eulerseq = _mjcf_angle_units(_mjcf_model_toplevel(root, mjcf_dir))
     bodies: list[BodyDef] = []
     joints: list[JointDef] = []
 
@@ -444,10 +459,18 @@ def load_mjcf(path: str) -> ProceduralRobot:
         # Geometry - first <geom> primitive type.
         shape, shape_size = _extract_mjcf_shape(body_el, geom_defaults, childclass)
 
+        # MJCF spells a body's rotation five mutually exclusive ways. The
+        # position above is read from the element, so reporting identity for
+        # the rotation half places a rotated link unrotated -- and identity
+        # is a valid orientation, so no caller can tell a link the model
+        # never rotates from one whose rotation was dropped.
+        orientation = _parse_orientation(body_el.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
+
         bodies.append(
             BodyDef(
                 name=body_name,
                 position=position,
+                orientation=orientation,
                 mass=mass,
                 shape=shape,
                 shape_size=shape_size,

--- a/tests/simulation/isaac/test_mjcf_robot_body_orientation.py
+++ b/tests/simulation/isaac/test_mjcf_robot_body_orientation.py
@@ -1,0 +1,290 @@
+"""A robot link's rotation, graded against MuJoCo's own compiler.
+
+``load_mjcf`` reads each ``<body>``'s ``pos`` into ``BodyDef.position`` but read
+no rotation at all, so every link of a robot the model rotates was reported
+upright while ``BodyDef.orientation`` kept its identity default. Identity is a
+valid orientation, so no caller could tell a link the model never rotates from
+one whose rotation was dropped -- the load reports success either way.
+
+The sibling reader in the same module, ``load_mjcf_scene_objects``, resolves all
+five of MJCF's mutually exclusive spellings (``quat``, ``euler``, ``axisangle``,
+``xyaxes`` and ``zaxis``) through ``_parse_orientation``. This is the same
+format feature read by the same module two different ways, and the scene
+reader's answer is the one MuJoCo compiles.
+
+Every expectation here is derived from ``mujoco.MjModel``: the fixture is
+compiled and the loader is compared against the ``body_quat`` the compiler
+stored, so no expected quaternion is restated by hand. ``body_quat`` is the
+body's frame relative to its parent, which is the same frame
+``BodyDef.position`` reports, so it is a direct oracle for nested links too.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.loaders import load_mjcf, load_mjcf_scene_objects
+
+mujoco = pytest.importorskip("mujoco")
+
+#: MJCF's five mutually exclusive orientation spellings.
+SPELLINGS = ("quat", "euler", "axisangle", "xyaxes", "zaxis")
+
+#: One declaration per spelling, all naming a rotation far from identity so a
+#: reader that fell back to identity cannot pass by coincidence.
+DECLARATIONS = {
+    "quat": "0.707106781 0 0 0.707106781",
+    "euler": "30 -40 55",
+    "axisangle": "0 1 0 -70",
+    "xyaxes": "0 1 0 -1 0 0",
+    "zaxis": "1 0 1",
+}
+
+#: The orientation a reader that asks about no spelling reports.
+IDENTITY = (1.0, 0.0, 0.0, 0.0)
+
+
+def _write_robot(tmp_path, body_attrs: str = "", compiler: str = "", *, name: str = "robot") -> str:
+    """A one-link articulated robot, compiled by both MuJoCo and the loader.
+
+    The link carries a hinge joint because ``load_mjcf`` refuses a model with no
+    articulation, and a box geom because a mesh geom's compiled frame is not the
+    frame the file declared.
+    """
+    path = tmp_path / f"{name}.xml"
+    path.write_text(
+        f"<mujoco>{compiler}<worldbody>"
+        f'<body name="link" pos="0.1 0.2 0.3" {body_attrs}>'
+        f'<joint name="j" type="hinge" axis="0 0 1"/>'
+        f'<geom name="g" type="box" size="0.1 0.05 0.02"/>'
+        f"</body></worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _write_nested_robot(tmp_path, parent_attrs: str, child_attrs: str) -> str:
+    """A two-link chain, so the nested link's parent-relative frame is graded too."""
+    path = tmp_path / "chain.xml"
+    path.write_text(
+        f'<mujoco><compiler angle="degree"/><worldbody>'
+        f'<body name="link" pos="0.1 0.2 0.3" {parent_attrs}>'
+        f'<joint name="j" type="hinge" axis="0 0 1"/>'
+        f'<geom name="g" type="box" size="0.1 0.05 0.02"/>'
+        f'<body name="forearm" pos="0.3 0 0" {child_attrs}>'
+        f'<joint name="j2" type="hinge" axis="0 1 0"/>'
+        f'<geom name="g2" type="box" size="0.1 0.05 0.02"/>'
+        f"</body></body></worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _mujoco_body_quat(path: str, name: str = "link") -> np.ndarray:
+    """The parent-relative orientation MuJoCo's compiler stored for one body."""
+    model = mujoco.MjModel.from_xml_path(path)
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert body > 0, f"premise: the fixture declares a body named {name!r}"
+    return np.asarray(model.body_quat[body], dtype=float)
+
+
+def _same_rotation(got, expected) -> float:
+    """Agreement of two wxyz quaternions, treating ``q`` and ``-q`` as one rotation."""
+    a = np.asarray(got, dtype=float)
+    b = np.asarray(expected, dtype=float)
+    return float(min(np.abs(a - b).max(), np.abs(a + b).max()))
+
+
+def _link(path: str, name: str = "link"):
+    """The ``BodyDef`` ``load_mjcf`` reports for one link, via the public loader."""
+    robot = load_mjcf(path)
+    matches = [b for b in robot.bodies if b.name == name]
+    assert len(matches) == 1, f"premise: one body named {name!r}, got {[b.name for b in robot.bodies]}"
+    return matches[0]
+
+
+class TestEveryRotationSpellingIsReadForARobotLink:
+    """The regression: every spelling was reported as identity, ``quat`` included."""
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_links_orientation_matches_the_compiler(self, tmp_path, spelling):
+        path = _write_robot(tmp_path, body_attrs=f'{spelling}="{DECLARATIONS[spelling]}"')
+        expected = _mujoco_body_quat(path)
+        assert _same_rotation(expected, IDENTITY) > 0.1, (
+            "premise: the declaration is far from identity, so a reader that fell "
+            "back to identity cannot pass by coincidence"
+        )
+        got = _link(path).orientation
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"a link declaring {spelling}={DECLARATIONS[spelling]!r} was reported as "
+            f"{tuple(round(v, 6) for v in got)}; MuJoCo compiles "
+            f"{tuple(round(float(v), 6) for v in expected)}"
+        )
+
+    def test_the_position_and_the_rotation_are_read_from_the_same_element(self, tmp_path):
+        """``pos`` was always read, so reporting identity dropped half of one pose."""
+        path = _write_robot(tmp_path, body_attrs='euler="0 0 90"')
+        link = _link(path)
+        assert link.position == pytest.approx((0.1, 0.2, 0.3))
+        assert _same_rotation(link.orientation, _mujoco_body_quat(path)) < 1e-6
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_nested_links_parent_relative_frame_matches_the_compiler(self, tmp_path, spelling):
+        """A nested link's rotation is relative to its parent, as its position is."""
+        path = _write_nested_robot(tmp_path, 'euler="0 0 25"', f'{spelling}="{DECLARATIONS[spelling]}"')
+        expected = _mujoco_body_quat(path, "forearm")
+        assert _same_rotation(expected, IDENTITY) > 0.1, "premise: the child's rotation is far from identity"
+        got = _link(path, "forearm").orientation
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"the nested link declaring {spelling} was reported as {tuple(round(v, 6) for v in got)}; "
+            f"MuJoCo compiles {tuple(round(float(v), 6) for v in expected)} relative to its parent"
+        )
+
+    def test_a_rotated_parent_does_not_absorb_its_childs_rotation(self, tmp_path):
+        """Each link reports its own declaration, so the two must differ here."""
+        path = _write_nested_robot(tmp_path, 'euler="0 0 90"', 'euler="0 90 0"')
+        parent = _link(path, "link").orientation
+        child = _link(path, "forearm").orientation
+        assert _same_rotation(parent, child) > 0.1, "premise: the fixture rotates the two links differently"
+        assert _same_rotation(parent, _mujoco_body_quat(path, "link")) < 1e-6
+        assert _same_rotation(child, _mujoco_body_quat(path, "forearm")) < 1e-6
+
+
+class TestTheAngleUnitsComeFromTheSplicedModel:
+    """``<compiler angle>`` and ``eulerseq`` are model-global, so an ``<include>`` supplies them."""
+
+    def test_the_degree_default_reads_ninety_as_a_quarter_turn(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='euler="0 0 90"')
+        expected = _mujoco_body_quat(path)
+        assert _same_rotation(_link(path).orientation, expected) < 1e-6
+        assert _same_rotation(expected, (math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5))) < 1e-6
+
+    def test_radians_are_honoured(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='euler="0 0 -1.5708"', compiler='<compiler angle="radian"/>')
+        expected = _mujoco_body_quat(path)
+        got = _link(path).orientation
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"euler='0 0 -1.5708' under angle='radian' was reported as {tuple(round(v, 6) for v in got)}; "
+            f"MuJoCo compiles {tuple(round(float(v), 6) for v in expected)}. Read as degrees it would be "
+            "a rotation of about one degree instead of a quarter turn."
+        )
+
+    def test_radians_declared_in_an_include_are_honoured(self, tmp_path):
+        (tmp_path / "units.xml").write_text('<mujoco><compiler angle="radian"/></mujoco>', encoding="utf-8")
+        path = tmp_path / "robot.xml"
+        path.write_text(
+            '<mujoco><include file="units.xml"/><worldbody>'
+            '<body name="link" pos="0.1 0.2 0.3" euler="0 0 -1.5708">'
+            '<joint name="j" type="hinge" axis="0 0 1"/>'
+            '<geom name="g" type="box" size="0.1 0.05 0.02"/>'
+            "</body></worldbody></mujoco>",
+            encoding="utf-8",
+        )
+        expected = _mujoco_body_quat(str(path))
+        got = _link(str(path)).orientation
+        assert _same_rotation(got, expected) < 1e-6, (
+            "angle='radian' declared in an <include> was not honoured: reported "
+            f"{tuple(round(v, 6) for v in got)}, MuJoCo compiles {tuple(round(float(v), 6) for v in expected)}"
+        )
+
+    @pytest.mark.parametrize("sequence", ["xyz", "zyx", "yxz", "XYZ", "ZYX", "YXZ"])
+    def test_the_euler_sequence_and_its_case_are_honoured(self, tmp_path, sequence):
+        path = _write_robot(
+            tmp_path,
+            body_attrs='euler="0.3 -0.7 1.1"',
+            compiler=f'<compiler angle="radian" eulerseq="{sequence}"/>',
+        )
+        expected = _mujoco_body_quat(path)
+        got = _link(path).orientation
+        assert _same_rotation(got, expected) < 1e-6, (
+            f"eulerseq='{sequence}' composes the three rotations in an order this reader did not follow: "
+            f"reported {tuple(round(v, 6) for v in got)}, MuJoCo compiles "
+            f"{tuple(round(float(v), 6) for v in expected)}"
+        )
+
+
+class TestTheTwoReadersOfOneModelAgree:
+    """One ``<body>``, read by both loaders in this module, reports one rotation."""
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_the_robot_and_scene_readers_report_the_same_rotation(self, tmp_path, spelling):
+        path = _write_robot(tmp_path, body_attrs=f'{spelling}="{DECLARATIONS[spelling]}"')
+        as_link = _link(path).orientation
+        objects = [o for o in load_mjcf_scene_objects(path) if o.name == "link"]
+        assert len(objects) == 1, "premise: the scene reader reports the same top-level body"
+        assert _same_rotation(as_link, objects[0].quat) < 1e-6, (
+            f"the robot-link reader reported {tuple(round(v, 6) for v in as_link)} for {spelling} while the "
+            f"scene reader in the same module reported {tuple(round(v, 6) for v in objects[0].quat)}"
+        )
+
+
+class TestAnAmbiguousRotationIsRefused:
+    """Two spellings on one body is a model MuJoCo refuses, so there is no rotation to pick."""
+
+    def test_mujoco_refuses_two_orientation_specifiers(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='quat="1 0 0 0" euler="0 0 90"')
+        with pytest.raises(ValueError, match="orientation"):
+            mujoco.MjModel.from_xml_path(path)
+
+    def test_the_loader_refuses_them_too(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='quat="1 0 0 0" euler="0 0 90"')
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            load_mjcf(path)
+
+
+class TestTheReportedRotationIsNotWidened:
+    """Behaviour that must not move: these hold before and after the change."""
+
+    def test_a_link_declaring_no_rotation_is_identity(self, tmp_path):
+        path = _write_robot(tmp_path)
+        assert _link(path).orientation == pytest.approx(IDENTITY)
+
+    def test_the_synthetic_world_body_is_identity(self, tmp_path):
+        """MJCF's world is implicit, so the reader's stand-in for it declares nothing."""
+        path = _write_robot(tmp_path, body_attrs='euler="0 0 90"')
+        world = [b for b in load_mjcf(path).bodies if b.name == "world"]
+        assert len(world) == 1
+        assert world[0].orientation == pytest.approx(IDENTITY)
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_malformed_declaration_is_identity(self, tmp_path, spelling):
+        path = _write_robot(tmp_path, body_attrs=f'{spelling}="not numbers at all"')
+        assert _link(path).orientation == pytest.approx(IDENTITY), (
+            "a value that cannot be read stays identity, the historical reading for a malformed quat"
+        )
+
+    def test_the_other_reported_link_fields_are_unchanged(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='euler="0 0 90"')
+        link = _link(path)
+        assert link.position == pytest.approx((0.1, 0.2, 0.3))
+        assert link.shape == "box"
+        assert link.shape_size == pytest.approx((0.1, 0.05, 0.02))
+
+
+class TestTheNormalizationBoundaryIsUnchanged:
+    """A ``quat`` is still reported as written, which is where this change stops.
+
+    MuJoCo normalizes a ``quat`` its compiler reads; ``_parse_orientation``
+    reports it as written, and that choice is shared with the scene reader
+    rather than local to this one. Reading the spelling and normalizing the
+    result are separate questions with separate blast radii, so the boundary is
+    pinned here instead of being moved silently: a non-unit ``quat`` reaches the
+    caller exactly as the file spells it.
+    """
+
+    def test_a_non_unit_quat_is_reported_as_written(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
+        got = _link(path).orientation
+        assert got == pytest.approx((1.0, -1.0, 0.0, 0.0))
+
+    def test_mujoco_normalizes_the_same_declaration(self, tmp_path):
+        """The premise of the boundary: the two answers differ, and by how much."""
+        path = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
+        expected = _mujoco_body_quat(path)
+        assert expected == pytest.approx((math.sqrt(0.5), -math.sqrt(0.5), 0.0, 0.0))
+        assert _same_rotation(_link(path).orientation, expected) > 0.1, (
+            "premise: the reported value and MuJoCo's differ, so this boundary is load-bearing rather than decorative"
+        )


### PR DESCRIPTION
## Problem

`load_mjcf` reads each `<body>`'s `pos` into `BodyDef.position` but read **no rotation at all**, so `BodyDef.orientation` kept its identity default for every link it reported. A robot whose links the model rotates was reported upright, with the load reporting success.

Identity is a valid orientation, so nothing downstream can tell a link the model never rotates from one whose rotation was dropped. Half of one pose was read and half was silently discarded.

The sibling reader in the same module, `load_mjcf_scene_objects`, already resolves all five of MJCF's mutually exclusive spellings -- `quat`, `euler`, `axisangle`, `xyaxes`, `zaxis` -- through `_parse_orientation`, under the model-global `<compiler angle>` and `<compiler eulerseq>`. One module, one format feature, two readings; the scene reader's is the one MuJoCo compiles.

Measured on a five-spelling fixture against `mujoco.MjModel.body_quat`, `load_mjcf` disagreed on **6 of 6** bodies -- `quat` included, because the reader never asked about orientation at all:

| body declares | `load_mjcf` reported | MuJoCo compiles |
| --- | --- | --- |
| `quat="0.7071 0 0 0.7071"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0, 0.707107)` |
| `euler="0 0 90"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0, 0.707107)` |
| `axisangle="0 0 1 90"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0, 0.707107)` |
| `zaxis="1 0 0"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0.707107, 0)` |
| `xyaxes="0 1 0 -1 0 0"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0, 0.707107)` |
| nested `euler="0 90 0"` | `(1, 0, 0, 0)` | `(0.707107, 0, 0.707107, 0)` |

## Change

The robot-link walk resolves the rotation through `_parse_orientation`, in the parent's frame -- the frame `position` is already reported in, and the frame `body_quat` stores. `<compiler angle>` and `<compiler eulerseq>` are read from the spliced model, so a robot inheriting `angle="radian"` from an `<include>` is not read as degrees (that misreading is a rotation wrong by a factor of 57). 13 lines of source.

A body declaring two spellings is now refused, as MuJoCo refuses such a model outright: there is no rotation to pick.

## Blast radius, graded against the compiler

Every shipped MJCF asset, both readings compared to `mujoco.MjModel.body_quat`:

| reading | links graded | agrees with MuJoCo | disagrees |
| --- | --- | --- | --- |
| `upstream/main` | 8502 | 5474 | 3028 |
| this branch | 8502 | **7692** | 810 |

**0 verdict changes** (765 load / 302 refuse on both readings) and **0 links moved away from the compiler**. The 3030 changed values span 307 assets; `reachy_mini` alone had 16 of its 17 links misreported.

All **810 of 810** remaining disagreements are one separate cause: a non-unit `quat` such as `quat="1 -1 0 0"`, which MuJoCo normalizes and `_parse_orientation` reports as written. That choice is shared with the scene reader (already reporting 18 non-unit quats on `main`) rather than local to this reader, so reading the spelling and normalizing the result are separate questions with separate blast radii. This change stops at the first, and `TestTheNormalizationBoundaryIsUnchanged` pins the boundary so it cannot move silently.

## Artifact

Each panel renders **only what the loader returned**: one proxy geom per reported `BodyDef`, nested per the model's own hierarchy, at the reported pose. Geometry and camera are identical across panels, so every visible difference is the per-body rotation. The third panel is built from `model.body_quat` -- the oracle itself.

![load_mjcf reports a robot link's rotation](https://github.com/cagataycali/robots/releases/download/artifacts/mjcf-robot-link-orientation.png)

The branch's render is **pixel-identical to MuJoCo's own** (`np.array_equal` True, mean |delta| `0.000000`); `main` sits 16.45 mean levels away. In-figure control: subject pixels 28072 / 35107 / 35107 -- branch and oracle equal, `main` different.

## Tests

`tests/simulation/isaac/test_mjcf_robot_body_orientation.py`, 38 tests. Every expectation is derived from `mujoco.MjModel`, so no expected quaternion is restated by hand, and each fixture premise-asserts that its rotation is far from identity -- a reader that fell back to identity cannot pass by coincidence.

Pre-fix split with the source reverted: **28 failed / 10 passed**, class-clean -- all 28 in the regression and boundary classes, **0** in `TestTheReportedRotationIsNotWidened`.

Break table, 7 breaks and 7 distinct firing sets:

| break | tests firing |
| --- | --- |
| drop the `BodyDef` field (rotation computed, not reported) | 27 |
| read only `quat` | 24 |
| assume degrees, ignoring `<compiler angle>` | 8 |
| read `<compiler>` from the top file only, not the spliced model | **1** (the `<include>` case alone) |
| over-reach: normalize the reported quaternion | **2** (the boundary class alone) |
| over-reach: report the absolute frame, not the parent-relative one | 6 |
| skip the mutual-exclusivity check | **1** (the refusal case alone) |

The two over-reach rows are what make the scope defensible: normalizing, or composing the parent's rotation in, each breaks a test that states why this reader does neither.

## Gate

- `ruff check` / `ruff format --check` clean on `strands_robots tests tests_integ`.
- `mypy`: **24 errors before, 24 after**, message sets byte-identical, none in the changed files.
- Regression selection of 130 files touching these loaders, run on both readings with the new file excluded from each: **`5964 passed, 71 skipped`, zero failures either side**, no branch-only or base-only failure.
- The new file: **38 passed on mujoco 3.12.0 and on 3.5.0**, the declared floor.
