### PR TITLE
fix(scripts): an answered review thread owes its resolve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,8 +291,8 @@ hatch run format            # ruff check --fix, ruff format
    - Thread's last non-bot comment is **yours** -> do not reply. You have
      already said it. If there is code to push, push it; the push is the
      message.
-   - Thread is **`isResolved`** -> do not reply. Resolution is a reviewer action
-     and terminal. Reopening it to restate a landed fix reads as noise, not
+   - Thread is **`isResolved`** -> do not reply. Resolution is terminal, whoever
+     performed it. Reopening it to restate a landed fix reads as noise, not
      diligence. `isOutdated` is **not** terminal, measured: it describes the diff
      rather than the conversation, and a thread keeps accepting comments after it
      flips - #2577's took two more after `d04a8969` moved its lines. It is also
@@ -302,6 +302,14 @@ hatch run format            # ruff check --fix, ruff format
      filed as settled.
    - Last comment is **someone else's** and your existing replies do not answer
      it -> reply once, then resolve.
+   - Thread you have **answered** and nobody has resolved -> resolve it, and still
+     do not reply. The three bullets above decide whether to *speak*, and none of
+     them reaches the thread's other terminal state.
+     `required_review_thread_resolution` is a branch ruleset rule, so a thread you
+     have answered goes on gating the merge until it is resolved, and no reviewer
+     can clear that for you. #2682 measured the cost: a cycle read #2680 as waiting
+     on a reviewer and stopped, when the fix had landed in `0fd0f4e3`, the reply was
+     posted, CI was green, and the only thing outstanding was the resolve.
 
    The authorship check is the cheap one, and it would have prevented ten of
    those twelve comments on its own: no semantic comparison, just the author of
@@ -320,13 +328,17 @@ hatch run format            # ruff check --fix, ruff format
    python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --all-open
    ```
 
-   `settled` and `answered` are not work. `awaiting-the-author` is, and it is the
-   only outcome that exits 1 - so the sweep answers "which of my open pull
-   requests actually need me" in one read. The report also names the commit each
-   thread was written against beside the pull request's head, which is what tells
-   "already fixed at `<oid>`" apart from "not yet fixed" without re-deriving the
-   fix (#2520). It reports and does not gate: what an author should do next is not
-   something a branch can turn green.
+   `settled` is not work. `awaiting-the-author` is a reply, `answered` is the
+   resolve that answer still owes, and **both** exit 1 - so the sweep answers
+   "which of my open pull requests actually need me" in one read. It did not
+   always, and the gap was in the reassuring direction: #2682 measured
+   `nothing-owed` and exit 0 over #2680, at the same head where
+   `check_merge_blockers.py` read `unresolved-threads` owed by the author.
+
+   The report also names the commit each thread was written against beside the
+   pull request's head, which is what tells "already fixed at `<oid>`" apart from
+   "not yet fixed" without re-deriving the fix (#2520). It reports and does not
+   gate: what an author should do next is not something a branch can turn green.
 
    What makes this worth writing down is that the previous rule was *satisfied*
    by all twelve. "Address all review comments", and "reply when a thread asks

--- a/changelog.d/2682-answered-thread-owes-the-resolve.md
+++ b/changelog.d/2682-answered-thread-owes-the-resolve.md
@@ -1,0 +1,22 @@
+### Fixed: an answered review thread is now reported as owing its resolve
+
+`check_thread_is_answered.py` classified a thread whose last non-bot comment is the
+author's as `answered` and called it "not work". That is true of the *reply* and
+false of the merge: `answered` is chosen only after `isResolved` has been ruled out,
+so every thread carrying it is answered **and** unresolved, and
+`required_review_thread_resolution` is a branch ruleset rule. Measured on #2680 at
+head `0fd0f4e3`, minutes apart with the same token: this sweep reported
+`nothing-owed` and exited 0, while `check_merge_blockers.py` reported
+`unresolved-threads` owed by the author. A sweep whose stated contract is "which of
+my open pull requests actually need me" cleared a pull request that could not merge
+until its author acted, and the cost was a whole scheduled cycle spent reaching the
+wrong conclusion.
+
+An answered-but-unresolved thread is now author-owed work: it exits 1, and the
+per-pull-request outcome is `author-owes-a-resolve` (or `author-owes-a-reply`, which
+outranks it, since a thread still owed an answer is not yet ready to be resolved).
+The remedy printed for it is the resolve **and an explicit refusal to reply** --
+restating a landed fix is the failure the check was written to prevent, and making
+the resolve owed must not license it again. `settled` is now the only outcome that
+is not work. AGENTS.md step 5 gains the matching fourth bullet, so an agent
+reasoning from the file reaches the same answer as one running the command.

--- a/scripts/check_thread_is_answered.py
+++ b/scripts/check_thread_is_answered.py
@@ -72,9 +72,12 @@ in order to tell "already fixed at ``d04a8969``" from "not yet fixed" (#2520).
 
 What decides the outcome, and what is only reported
 ---------------------------------------------------
-One rule decides it: **whoever spoke last owes the next move, unless a reviewer
-resolved the thread.** Resolution is terminal because it is a reviewer action.
-Everything else is the authorship test.
+One rule decides it: **whoever spoke last owes the next move, unless the thread is
+resolved.** Resolution is terminal. Everything else is the authorship test -- and
+what that test settles is *what* the author owes, not *whether* anything is owed: a
+thread whose last word is the author's owes the resolve, and one whose last word is
+a reviewer's owes a reply before it. Only ``isResolved`` clears a thread, because
+only ``isResolved`` is what the branch ruleset reads (#2682).
 
 Two fields that look like they belong in that decision are reported beside it
 instead, and both exclusions are deliberate.
@@ -109,17 +112,21 @@ What the steady state looks like, and why that is the point
 -----------------------------------------------------------
 Swept over the 150 most recently updated closed pull requests here, every one of
 the 26 review threads found is ``isResolved: true`` and therefore ``settled``, and
-all 150 report ``nothing-owed``. The same sweep over the 11 currently open pull
-requests also reports ``nothing-owed`` throughout.
+all 150 report ``nothing-owed``. Adding the resolve to what this reports leaves that
+measurement where it was, because ``settled`` is the one outcome that is not work
+under either reading. The same sweep over the 4 open pull requests at the time of
+that change also reports ``nothing-owed`` throughout -- 4 settled threads on #1722,
+none anywhere else.
 
 That is the expected result, not a broken check: threads in this repository do get
 resolved, so on a finished pull request ``settled`` is the only outcome left. The
 two discriminating outcomes exist only in the window between a reviewer's comment
 and its resolution -- which is exactly the window a scheduled run reads in, and
-exactly when the wrong answer costs a permanent duplicate reply. Their coverage
-therefore comes from ``tests/test_thread_is_answered.py``, which replays the
-measured payloads of the two incidents above with the flags as they stood in that
-window, rather than from a historical sweep that cannot contain them.
+exactly when the wrong answer costs a permanent duplicate reply, or a pull request
+that sits unmergeable with nothing in the sweep saying so. Their coverage therefore
+comes from ``tests/test_thread_is_answered.py``, which replays the measured payloads
+of the incidents above with the flags as they stood in that window, rather than from
+a historical sweep that cannot contain them.
 
 The incidents are attributable on timestamped fields alone, which is why
 authorship carries the rule. Thread resolution has no timestamp in the API, so
@@ -144,14 +151,21 @@ Per thread:
     ``isResolved``. Terminal; a reviewer has closed the business, and reopening it
     to restate a landed fix reads as noise.
 ``answered``
-    Open, and the last non-bot comment is the pull request author's. The author
-    has had the last word; the next move is the reviewer's.
+    Open, and the last non-bot comment is the pull request author's. The *reply* is
+    not owed; the resolve is. This outcome is chosen only after ``isResolved`` has
+    been ruled out, so every thread carrying it is answered **and** unresolved --
+    and ``required_review_thread_resolution`` is a branch ruleset rule, so the pull
+    request cannot merge until its author resolves it. Work, whose whole remedy is
+    the resolve (#2682).
 ``awaiting-the-author``
     Open, and the last non-bot comment belongs to someone other than the author
-    (or there is no non-bot comment). This is the only outcome that is work.
+    (or there is no non-bot comment). Work: a reply, then the resolve.
 
-Per pull request: ``nothing-owed``, or ``author-owes-a-reply`` when at least one
-thread is ``awaiting-the-author``.
+Per pull request: ``author-owes-a-reply`` when at least one thread is
+``awaiting-the-author``; ``author-owes-a-resolve`` when none is but at least one is
+``answered``; ``nothing-owed`` only when every thread is ``settled``. The reply
+outranks the resolve in that ordering because a thread still owed an answer is not
+yet ready to be resolved -- but both exit 1, because both are the author's.
 
 What this deliberately does not do
 ----------------------------------
@@ -173,7 +187,8 @@ Usage
     python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --pr 2577
     python3 scripts/check_thread_is_answered.py --repo strands-labs/robots --all-open
 
-Exit 1 when at least one evaluated pull request has a thread awaiting its author.
+Exit 1 when at least one evaluated pull request owes its author a move: a reply on
+a thread awaiting one, or the resolve on a thread it has already answered.
 
 Pinned by tests/test_thread_is_answered.py.
 """
@@ -213,6 +228,7 @@ AWAITING_THE_AUTHOR = "awaiting-the-author"
 
 NOTHING_OWED = "nothing-owed"
 AUTHOR_OWES_A_REPLY = "author-owes-a-reply"
+AUTHOR_OWES_A_RESOLVE = "author-owes-a-resolve"
 
 _API = "https://api.github.com/graphql"
 
@@ -226,11 +242,16 @@ WHAT_TO_DO: tuple[str, ...] = (
     "concern, one commit, one reply -- and the reply is owed only because the",
     "last word is not yours yet.",
     "",
-    "Threads reported `answered` or `settled` are not work. Do not reply to them",
-    "to restate a fix that has landed: the reviewer's question stays in the",
-    "thread verbatim after it is answered, so its presence is not evidence that",
-    "anything is outstanding. If code is owed, push it -- the push is the",
-    "message.",
+    "Resolve each `answered` thread, and do **not** reply to it. The reviewer's",
+    "question stays in the thread verbatim after it is answered, so its presence",
+    "is not evidence that anything is outstanding, and restating a landed fix is",
+    "the failure this check was written to prevent. The resolve is owed all the",
+    "same: `required_review_thread_resolution` is a branch ruleset rule, an",
+    "answered thread is not a resolved one, and no reviewer can clear it for you",
+    "-- so the merge sits until you do (#2682).",
+    "",
+    "Threads reported `settled` are not work. If code is owed, push it -- the",
+    "push is the message.",
     "",
     "`head moved` beside an `answered` thread says a commit followed the thread,",
     "not that the commit fixed it. It is there so a later run can tell",
@@ -260,7 +281,20 @@ class Thread:
 
     @property
     def is_owed(self) -> bool:
+        """A reply is owed: the last non-bot word is not the author's yet."""
         return self.outcome == AWAITING_THE_AUTHOR
+
+    @property
+    def owes_a_resolve(self) -> bool:
+        """A resolve is owed: the author has answered and nobody has resolved it.
+
+        No second look at ``isResolved`` is needed, because ``ANSWERED`` is only
+        chosen once that flag has been ruled out. Kept apart from ``is_owed`` so the
+        two remedies cannot collapse into one: the answer to a thread awaiting a
+        reply is words, and the answer to an answered thread is emphatically not
+        (#2682).
+        """
+        return self.outcome == ANSWERED
 
 
 @dataclass(frozen=True)
@@ -278,12 +312,21 @@ class Row:
         return tuple(t for t in self.threads if t.is_owed)
 
     @property
+    def unresolved(self) -> tuple[Thread, ...]:
+        """Threads this author has answered and not resolved -- merge blockers."""
+        return tuple(t for t in self.threads if t.owes_a_resolve)
+
+    @property
     def outcome(self) -> str:
-        return AUTHOR_OWES_A_REPLY if self.owed else NOTHING_OWED
+        if self.owed:
+            return AUTHOR_OWES_A_REPLY
+        if self.unresolved:
+            return AUTHOR_OWES_A_RESOLVE
+        return NOTHING_OWED
 
     @property
     def is_finding(self) -> bool:
-        return bool(self.owed)
+        return bool(self.owed) or bool(self.unresolved)
 
     @property
     def summary(self) -> str:
@@ -293,11 +336,17 @@ class Row:
                 f"{len(self.owed)} of {len(self.threads)} thread(s) are awaiting @{self.author}: "
                 f"{named}. Answer each once, then resolve it."
             )
+        if self.unresolved:
+            named = ", ".join(f"`{t.path}`" for t in self.unresolved)
+            return (
+                f"{len(self.unresolved)} of {len(self.threads)} thread(s) are answered by "
+                f"@{self.author} and not resolved: {named}. Resolve each; do not reply again. "
+                "The merge is blocked until they are resolved."
+            )
         if not self.threads:
             return "No review threads. Nothing is owed here."
         return (
-            f"All {len(self.threads)} thread(s) are settled or already answered by @{self.author}. "
-            "Nothing is owed here; the next move belongs to a reviewer."
+            f"All {len(self.threads)} thread(s) are settled. Nothing is owed here; the next move belongs to a reviewer."
         )
 
 
@@ -502,7 +551,7 @@ def _unread_note(row: Row) -> list[str]:
 
 def render_one(repo: str, row: Row) -> str:
     lines = [
-        "## Review threads owed a reply",
+        "## Review threads owed the author's next move",
         "",
         f"Outcome: **{row.outcome}**",
         "",
@@ -515,6 +564,7 @@ def render_one(repo: str, row: Row) -> str:
         f"| recorded head | {_short(row.head)} |",
         f"| threads | {len(row.threads)} |",
         f"| awaiting the author | {len(row.owed)} |",
+        f"| answered, not resolved | {len(row.unresolved)} |",
     ]
     if row.threads:
         lines += [""] + _thread_rows(row)
@@ -527,23 +577,23 @@ def render_one(repo: str, row: Row) -> str:
 def render_sweep(repo: str, rows: Sequence[Row], skipped: Sequence[int]) -> str:
     findings = [r for r in rows if r.is_finding]
     lines = [
-        "## Review threads owed a reply -- sweep",
+        "## Review threads owed the author's next move -- sweep",
         "",
         f"Evaluated {len(rows)} open non-draft pull request(s) in {repo}.",
         "",
     ]
     if findings:
         named = ", ".join(f"#{r.pr}" for r in findings)
-        lines += [f"**{len(findings)} pull request(s) have a thread awaiting their author:** {named}.", ""]
+        lines += [f"**{len(findings)} pull request(s) owe their author a move:** {named}.", ""]
     else:
-        lines += ["Every review thread is settled or already answered by its author.", ""]
+        lines += ["Every review thread is settled.", ""]
 
     lines += [
         "| pull request | author | outcome | threads | awaiting | answered | settled |",
         "|---|---|---|---|---|---|---|",
     ]
     for row in rows:
-        answered = sum(1 for t in row.threads if t.outcome == ANSWERED)
+        answered = len(row.unresolved)
         settled = sum(1 for t in row.threads if t.outcome == SETTLED)
         lines.append(
             f"| #{row.pr} | @{row.author} | {row.outcome} | {len(row.threads)} | "
@@ -571,7 +621,7 @@ def _publish(report: str) -> None:
 
 
 def _annotate(repo: str, row: Row) -> None:
-    print(f"::warning title=A review thread is awaiting its author::{repo}#{row.pr}: {row.summary}")
+    print(f"::warning title=A review thread needs its author::{repo}#{row.pr}: {row.summary}")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/test_thread_is_answered.py
+++ b/tests/test_thread_is_answered.py
@@ -18,6 +18,10 @@ Measured sources:
 - #2480, thread ``PRRT_kwDORUMiZs6aqPJ-``: a ``github-advanced-security`` comment
   answered by the author, ``isOutdated: false`` even after ``e83cf51`` fixed it.
 - #1722: four threads carrying a single bot comment each.
+- #2680, thread ``PRRT_kwDORUMiZs6bmZqs``: a ``[MUST FIX]`` answered by the author
+  at head ``0fd0f4e3`` with CI green, left unresolved -- and therefore an
+  unsatisfied ``required_review_thread_resolution`` while this check reported
+  ``nothing-owed`` (#2682).
 """
 
 from __future__ import annotations
@@ -110,6 +114,8 @@ def test_the_2577_thread_is_answered_when_its_third_comment_was_posted() -> None
     assert verdict.outcome == mod.ANSWERED
     assert verdict.is_owed is False
     assert verdict.last_author == AUTHOR
+    # No reply is owed, and the resolve still is: see #2682 and the pins below.
+    assert verdict.owes_a_resolve is True
 
 
 @pytest.mark.parametrize("replies", [1, 2, 3])
@@ -128,6 +134,82 @@ def test_the_2511_thread_is_answered_from_the_first_reply_onwards(replies: int) 
         HEAD_2511,
     )
     assert verdict.outcome == mod.ANSWERED
+
+
+# --------------------------------------------------------------------------
+# The resolve, which is owed by the author and is not a reply (#2682).
+# --------------------------------------------------------------------------
+
+
+def test_the_2680_answered_thread_is_a_finding_because_the_resolve_is_owed() -> None:
+    """The cycle that read #2680 as waiting on a reviewer and stopped.
+
+    One thread carrying a ``[MUST FIX]``, the fix landed in ``0fd0f4e3``, the reply
+    posted, CI green -- and ``required_review_thread_resolution`` unsatisfied, owed
+    by the author. The sweep whose contract is "which of my pull requests need me"
+    answered ``nothing-owed`` and exited 0 over a pull request that could not merge
+    until its author acted, which is the failure this pins.
+    """
+    row = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])], number=2680))
+    assert row.outcome == mod.AUTHOR_OWES_A_RESOLVE
+    assert row.is_finding is True
+    assert [t.path for t in row.unresolved] == ["tests/simulation/mujoco/test_randomize_persistence_boundary.py"]
+    assert "not resolved" in row.summary
+
+
+def test_the_resolve_is_owed_where_no_reply_is() -> None:
+    """Non-vacuity of the split: the two obligations move independently.
+
+    Same thread, same head. The reply is not owed because the last word is the
+    author's; that is precisely the condition under which the resolve is.
+    """
+    verdict = mod.classify(_thread([_comment(REVIEWER), _comment(AUTHOR)]), AUTHOR, HEAD_2577)
+    assert (verdict.is_owed, verdict.owes_a_resolve) == (False, True)
+
+
+def test_a_reply_outranks_a_resolve_when_one_pull_request_owes_both() -> None:
+    """A thread still owed an answer is not yet ready to be resolved.
+
+    So the per-pull-request outcome names the reply -- but the answered thread is
+    still counted, because it is a merge blocker whichever outcome is printed.
+    """
+    row = mod.evaluate(
+        _pr(
+            [
+                _thread([_comment(REVIEWER), _comment(AUTHOR)]),
+                _thread([_comment(REVIEWER)], path="strands_robots/utils.py"),
+            ]
+        )
+    )
+    assert row.outcome == mod.AUTHOR_OWES_A_REPLY
+    assert len(row.owed) == 1 and len(row.unresolved) == 1
+
+
+def test_an_answered_thread_on_another_authors_pull_request_is_owed_by_that_author() -> None:
+    """The obligation follows the pull request's author, as every outcome here does.
+
+    The sweep reads every open pull request, not only the viewer's, so the resolve
+    is attributed the same way the reply already was rather than to whoever ran it.
+    """
+    row = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment("Vivek0712")])], author="Vivek0712"))
+    assert row.outcome == mod.AUTHOR_OWES_A_RESOLVE
+    assert "@Vivek0712" in row.summary
+
+
+def test_the_remedy_for_an_answered_thread_is_the_resolve_and_forbids_a_reply() -> None:
+    """Making the resolve owed must not license the twelve-reply incident again.
+
+    The remedy has to say both things at once: resolve it, and do not reply to it.
+    A remedy that only said "work is owed here" would invite the duplicate reply
+    the check was written to prevent.
+    """
+    report = mod.render_one(
+        "strands-labs/robots",
+        mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])])),
+    )
+    assert "Resolve each `answered` thread, and do **not** reply to it." in report
+    assert "required_review_thread_resolution" in report
+    assert "| answered, not resolved | 1 |" in report
 
 
 # --------------------------------------------------------------------------
@@ -162,6 +244,8 @@ def test_a_resolved_thread_is_settled_whoever_spoke_last() -> None:
     verdict = mod.classify(_thread([_comment(AUTHOR), _comment(REVIEWER)], resolved=True), AUTHOR, HEAD_2577)
     assert verdict.outcome == mod.SETTLED
     assert verdict.is_owed is False
+    # The only outcome that owes neither move, and the only one the ruleset clears.
+    assert verdict.owes_a_resolve is False
 
 
 def test_a_reviewer_demand_on_an_outdated_thread_is_owed() -> None:
@@ -304,23 +388,26 @@ def test_an_absent_thread_total_is_not_read_as_a_shortfall() -> None:
 
 
 def test_the_remedy_appears_only_when_something_is_owed() -> None:
+    """``settled`` is now the only outcome that suppresses the remedy (#2682)."""
     owed = mod.evaluate(_pr([_thread([_comment(REVIEWER)])]))
     answered = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])]))
+    settled = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)], resolved=True)]))
     assert "### What clears this" in mod.render_one("strands-labs/robots", owed)
-    assert "### What clears this" not in mod.render_one("strands-labs/robots", answered)
+    assert "### What clears this" in mod.render_one("strands-labs/robots", answered)
+    assert "### What clears this" not in mod.render_one("strands-labs/robots", settled)
 
 
 def test_the_single_report_names_the_outcome_and_both_commits() -> None:
     row = mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])]))
     report = mod.render_one("strands-labs/robots", row)
-    assert f"Outcome: **{mod.NOTHING_OWED}**" in report
+    assert f"Outcome: **{mod.AUTHOR_OWES_A_RESOLVE}**" in report
     assert "`d04a8969`" in report
     assert "`b966ce64`" in report
 
 
 def test_the_sweep_names_every_pull_request_and_only_findings_in_detail() -> None:
     rows = [
-        mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)])], number=2577)),
+        mod.evaluate(_pr([_thread([_comment(REVIEWER), _comment(AUTHOR)], resolved=True)], number=2577)),
         mod.evaluate(_pr([_thread([_comment(REVIEWER)])], number=2511)),
     ]
     report = mod.render_sweep("strands-labs/robots", rows, [])
@@ -332,13 +419,14 @@ def test_the_sweep_names_every_pull_request_and_only_findings_in_detail() -> Non
 @pytest.mark.parametrize(
     ("threads", "expected"),
     [
-        ([_thread([_comment(REVIEWER), _comment(AUTHOR)])], 0),
+        # Answered and unresolved: no reply owed, the resolve owed, so exit 1 (#2682).
+        ([_thread([_comment(REVIEWER), _comment(AUTHOR)])], 1),
         ([_thread([_comment(REVIEWER), _comment(AUTHOR)], resolved=True)], 0),
         ([], 0),
         ([_thread([_comment(REVIEWER)])], 1),
     ],
 )
-def test_exit_status_is_one_only_when_a_thread_awaits_its_author(
+def test_exit_status_is_one_when_the_author_owes_a_reply_or_a_resolve(
     threads: list[dict], expected: int, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(mod, "fetch_one", lambda *_a, **_k: _pr(threads))


### PR DESCRIPTION
Fixes #2682.

## The defect

`check_thread_is_answered.py` classifies a thread whose last non-bot comment is the author's as `answered`, and reports it as not work. That is true of the *reply* and false of the *merge*.

`ANSWERED` is chosen only after `isResolved` has been ruled out, so **every thread carrying it is answered *and* unresolved** - and `required_review_thread_resolution` is a branch ruleset rule. So the one outcome the sweep called "nothing to do" is precisely the state that blocks the merge and that only the author can clear.

Measured on #2680 at head `0fd0f4e3`, both sweeps run minutes apart from `scripts/` with the same token:

| sweep | outcome for #2680 | exit |
|---|---|---|
| `check_thread_is_answered.py --all-open` | `nothing-owed`, 1 answered, 0 awaiting | **0** |
| `check_merge_blockers.py --all-open` | `unresolved-threads`, owed by the author | **1** |

A sweep whose stated contract is "which of my open pull requests actually need me" cleared a pull request that could not merge until its author acted. The cost was a whole scheduled cycle spent reaching the wrong conclusion, and the next one had to reach the right one.

## The fix

Replaying the #2680 payload through both versions of `evaluate()`:

| | thread outcome | pull request outcome | `is_finding` |
|---|---|---|---|
| before | `answered` | `nothing-owed` | `False` |
| after | `answered` | `author-owes-a-resolve` | `True` |

The thread taxonomy already isolated the right state, so nothing about *classification* changes. What changes is whether that state is work:

- `Thread.owes_a_resolve` sits beside `Thread.is_owed`. Kept separate on purpose: the remedy for a thread awaiting a reply is words, and the remedy for an answered thread is emphatically not.
- Per-pull-request outcome gains `author-owes-a-resolve`. `author-owes-a-reply` outranks it, because a thread still owed an answer is not yet ready to be resolved - but **both exit 1**, because both are the author's.
- `settled` is now the only outcome that is not work.

This is issue option 1 **and** option 2 ("Both. They are cheap and they fail differently"): AGENTS.md step 5 gains the matching fourth bullet and drops the sentence that was false in the reassuring direction, so an agent reasoning from the file reaches the same answer as one running the command.

## The risk this change carries, and what holds it down

Making an answered thread "work" is one step from re-licensing the twelve-reply incident the check was written to prevent. So the remedy text says both things at once - resolve it, **and do not reply to it** - and that wording is pinned rather than left to prose:

```
test_the_remedy_for_an_answered_thread_is_the_resolve_and_forbids_a_reply
```

## Verification

- `tests/test_thread_is_answered.py`: **46 passed**. Four existing tests encoded the old contract and flip deliberately (the remedy gate, the single-report outcome, the sweep's finding set, and the exit-status matrix); the `answered` incident pins for #2577/#2511 keep asserting `is_owed is False` and now also assert `owes_a_resolve is True`, so the reply is still refused at exactly the sites that measured it.
- New pins: the #2680 regression, non-vacuity of the reply/resolve split, reply-outranks-resolve, attribution to another author's pull request, and the remedy wording above.
- `ruff check` / `ruff format --check` / `mypy` clean on both changed files.
- Live `--all-open` against this repository, before and after: `nothing-owed` on all 4 open pull requests, exit 0. **This fix adds no finding to today's state** - 4 settled threads on #1722, none elsewhere - which is why coverage comes from replayed payloads, as the module docstring already argues it must.

## Scope

Four files: the script, its pins, the AGENTS.md step it contradicted, and a changelog fragment. No behaviour outside this sweep changes, and neither script gates CI.