### PR TITLE
fix(sim): hold every orientation parameter to one quaternion domain

### DIFF
--- a/changelog.d/2690-one-quaternion-domain.md
+++ b/changelog.d/2690-one-quaternion-domain.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **sim**: every entry point that takes a wxyz `orientation` now holds it to one quaternion
+  domain. Four finite components make a readable vector, not a rotation: a value whose norm
+  rounds to zero has no direction to recover, and nothing downstream reported that. MuJoCo
+  refuses `quat="0 0 0 0"` through its XML door outright ("zero quaternion is not allowed") but
+  accepts it through the spec-attribute and `qpos` doors this package writes through,
+  substituting identity. `move_to` had always refused such a value, with a hand-rolled norm
+  check sitting directly after the shared pose guard, while its scene-construction siblings held
+  the same quaternion to the position contract - so the verdict depended on which entry point
+  received it. Measured on a body already holding a quarter turn about z,
+  `move_object(orientation=[0, 0, 0, 0])` reported success, echoed that quaternion back in its
+  text and left the body at identity: the requested value, the reported value and the actual
+  value all different, and the rotation the body did have destroyed. `add_object`, `add_robot`,
+  `set_robot_pose` and the structured `set_body_quat` / `add_body` scene ops accepted it the same
+  way. The check moves into the shared guard as `coerce_orientation_quaternion` /
+  `orientation_quaternion_error` and all eleven orientation call sites route through it, across
+  the MuJoCo, Isaac and Newton engines; `move_to` loses its private copy, so `MIN_QUATERNION_NORM`
+  has one definition rather than two. Magnitude is still not part of the contract - a non-unit
+  quaternion is accepted and normalized by the consumer as before, and only a norm with no
+  direction is refused. A structural guard derives the orientation call sites from the package,
+  so one added later is held to the same domain on arrival.

--- a/strands_robots/simulation/isaac/simulation.py
+++ b/strands_robots/simulation/isaac/simulation.py
@@ -47,6 +47,7 @@ from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     camera_fov_error,
+    coerce_orientation_quaternion,
     coerce_pose_vector,
     coerce_rgba,
     coerce_size_vector,
@@ -1660,7 +1661,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         position, _perr = coerce_pose_vector("add_robot", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        orientation, _oerr = coerce_pose_vector("add_robot", "orientation", orientation, 4)
+        orientation, _oerr = coerce_orientation_quaternion("add_robot", "orientation", orientation)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
         # The default None means identity; only a non-identity quaternion is
@@ -2197,7 +2198,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             position, _perr = coerce_pose_vector("add_object", "position", position, 3)
             if _perr is not None:
                 return {"status": "error", "content": [{"text": _perr}]}
-            orientation, _oerr = coerce_pose_vector("add_object", "orientation", orientation, 4)
+            orientation, _oerr = coerce_orientation_quaternion("add_object", "orientation", orientation)
             if _oerr is not None:
                 return {"status": "error", "content": [{"text": _oerr}]}
             # Same shared domain for the colour, whose accepted counts the
@@ -6576,7 +6577,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
             position, _perr = coerce_pose_vector("set_robot_pose", "position", position, 3)
             if _perr is not None:
                 return {"status": "error", "content": [{"text": _perr}]}
-            orientation, _oerr = coerce_pose_vector("set_robot_pose", "orientation", orientation, 4)
+            orientation, _oerr = coerce_orientation_quaternion("set_robot_pose", "orientation", orientation)
             if _oerr is not None:
                 return {"status": "error", "content": [{"text": _oerr}]}
             moved_to = "same" if position is None else position
@@ -6630,7 +6631,7 @@ class IsaacSimulation(IsaacMotionPrimitivesMixin, IsaacRecordingMixin, SimEngine
         position, _perr = coerce_pose_vector("move_object", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        orientation, _oerr = coerce_pose_vector("move_object", "orientation", orientation, 4)
+        orientation, _oerr = coerce_orientation_quaternion("move_object", "orientation", orientation)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
         try:

--- a/strands_robots/simulation/motion_primitives_base.py
+++ b/strands_robots/simulation/motion_primitives_base.py
@@ -28,7 +28,7 @@ from typing import Any
 import numpy as np
 
 from strands_robots.registry.robots import get_robot
-from strands_robots.utils import coerce_pose_vector
+from strands_robots.utils import coerce_orientation_quaternion, coerce_pose_vector
 
 # Name hints (lowercased substring match on the gripper DOF's name) used to
 # resolve the gripper when the robot registry carries no gripper metadata for
@@ -178,19 +178,9 @@ class MotionPrimitivesCore:
         if pos_err is not None:
             return None, None, 0, None, _err(pos_err)
         assert position is not None  # non-None input yields a non-None result
-        orientation, quat_err = coerce_pose_vector("move_to", "orientation", orientation, 4)
+        orientation, quat_err = coerce_orientation_quaternion("move_to", "orientation", orientation)
         if quat_err is not None:
             return None, None, 0, None, _err(quat_err)
-        if orientation is not None:
-            quat_norm = float(np.linalg.norm(np.asarray(orientation, dtype=np.float64)))
-            if quat_norm < 1e-8:
-                return (
-                    None,
-                    None,
-                    0,
-                    None,
-                    _err("move_to: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z]."),
-                )
         if not _is_finite_real(tol) or float(tol) <= 0.0:
             return None, None, 0, None, _err(f"move_to: 'tol' must be a positive number of meters, got {tol!r}.")
         if orientation_tol is not None and orientation is None:

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -43,7 +43,13 @@ from typing import Any
 from strands_robots.simulation.models import SimCamera, SimObject, SimRobot, SimWorld
 from strands_robots.simulation.mujoco.backend import _ensure_mujoco, filter_mujoco_attach_noise, mj_name_to_id
 from strands_robots.simulation.mujoco.spec_builder import _SIZE_LAYOUT, SpecBuilder
-from strands_robots.utils import coerce_rgba, entity_name_error, finite_vector_error, pose_vector_error
+from strands_robots.utils import (
+    coerce_rgba,
+    entity_name_error,
+    finite_vector_error,
+    orientation_quaternion_error,
+    pose_vector_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2281,9 +2287,16 @@ def _rgba_field_domain(kind: str, field: str, value: Any) -> tuple[Any, str | No
 # :func:`~strands_robots.utils.coerce_rgba` defines for every backend. ``size``
 # is the one field whose count is shape-dependent, so only its components are
 # checked here and the count is left to ``_validate_size``, which knows the shape.
+#
+# A ``quat`` carries one rule beyond its width, and it arrives from the same
+# shared domain every ``orientation=`` parameter uses
+# (:func:`~strands_robots.utils.orientation_quaternion_error`): a norm that
+# rounds to zero describes no rotation, and the spec-attribute door these ops
+# write through accepts it where MuJoCo's XML door refuses it outright ("zero
+# quaternion is not allowed").
 _OP_FIELD_DOMAINS: dict[str, Callable[[str, str, Any], tuple[Any, str | None]]] = {
     "pos": lambda kind, field, value: (value, pose_vector_error(kind, field, value, 3)),
-    "quat": lambda kind, field, value: (value, pose_vector_error(kind, field, value, 4)),
+    "quat": lambda kind, field, value: (value, orientation_quaternion_error(kind, field, value)),
     "rgba": _rgba_field_domain,
     "size": lambda kind, field, value: (value, finite_vector_error(kind, field, value)),
 }
@@ -2547,7 +2560,8 @@ def patch_scene_mjcf(world: SimWorld, ops: list[dict[str, Any]]) -> int:
     anything else is rejected, because an unread key would leave the op running
     on its fallback default (see :func:`_unknown_op_keys_error`). Every numeric
     field an op writes is held to its domain in :data:`_OP_FIELD_DOMAINS` - a
-    ``pos`` of exactly 3 finite components, a ``quat`` of 4, a ``rgba`` of 3
+    ``pos`` of exactly 3 finite components, a ``quat`` of 4 whose norm does not
+    round to zero, a ``rgba`` of 3
     (RGB, completed with an opaque alpha) or 4 - because MuJoCo bakes a
     ``nan``/``inf`` component into the model without complaint, and reports a
     width mismatch on the attribute writes by dumping a C++ overload table that

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -113,6 +113,7 @@ from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_diffi
 from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
     camera_fov_error,
+    coerce_orientation_quaternion,
     coerce_pose_vector,
     entity_name_error,
     finite_vector_error,
@@ -1740,7 +1741,7 @@ class MuJoCoSimEngine(
         position, e = coerce_pose_vector("add_robot", "position", position, 3)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        orientation, e = coerce_pose_vector("add_robot", "orientation", orientation, 4)
+        orientation, e = coerce_orientation_quaternion("add_robot", "orientation", orientation)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
 
@@ -3458,7 +3459,7 @@ class MuJoCoSimEngine(
                 ``"ellipsoid"``, ``"plane"``, or ``"mesh"``.
             position: World position ``[x, y, z]`` of the body origin (default
                 origin).
-            orientation: wxyz quaternion (default identity).
+            orientation: wxyz quaternion (default identity). Any non-unit value is fine -- the magnitude is ignored -- but one whose norm rounds to zero describes no rotation and is refused rather than silently applied as identity (:func:`~strands_robots.utils.coerce_orientation_quaternion`).
             size: Full extents in meters per the per-shape table above. Defaults
                 to ``[0.05, 0.05, 0.05]`` (a 5 cm box) when omitted. Must carry
                 every component the shape consumes -- 3 for ``box`` /
@@ -3598,7 +3599,7 @@ class MuJoCoSimEngine(
         position, e = coerce_pose_vector("add_object", "position", position, 3)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
-        orientation, e = coerce_pose_vector("add_object", "orientation", orientation, 4)
+        orientation, e = coerce_orientation_quaternion("add_object", "orientation", orientation)
         if e is not None:
             return {"status": "error", "content": [{"text": e}]}
         if size is not None and (e := finite_vector_error("add_object", "size", size)) is not None:
@@ -3808,7 +3809,10 @@ class MuJoCoSimEngine(
           other joints' state), just like ``add_object`` / ``remove_object``.
 
         ``position`` must be a 3-element vector and ``orientation`` a 4-element
-        wxyz quaternion; each must contain only finite real numbers. The vector
+        wxyz quaternion whose norm does not round to zero; each must contain only
+        finite real numbers. A zero quaternion describes no rotation, and MuJoCo
+        substitutes identity for one without complaint, so the success text would
+        echo an orientation the body does not have. The vector
         itself may be a list, a tuple or a NumPy array (pose arithmetic produces
         arrays), and its elements may be NumPy scalars. A wrong-length,
         non-numeric, or nan/inf pose is rejected up front rather than raising a
@@ -3841,7 +3845,7 @@ class MuJoCoSimEngine(
         position, perr = coerce_pose_vector("move_object", "position", position, 3)
         if perr is not None:
             return {"status": "error", "content": [{"text": perr}]}
-        orientation, oerr = coerce_pose_vector("move_object", "orientation", orientation, 4)
+        orientation, oerr = coerce_orientation_quaternion("move_object", "orientation", orientation)
         if oerr is not None:
             return {"status": "error", "content": [{"text": oerr}]}
 

--- a/strands_robots/simulation/newton/simulation.py
+++ b/strands_robots/simulation/newton/simulation.py
@@ -68,6 +68,7 @@ from strands_robots.simulation.terrain import validate_difficulty
 from strands_robots.utils import (
     FREE_CAMERA_TOKENS,
     camera_fov_error,
+    coerce_orientation_quaternion,
     coerce_pose_vector,
     coerce_rgba,
     coerce_size_vector,
@@ -615,7 +616,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         position, _perr = coerce_pose_vector("add_robot", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        orientation, _oerr = coerce_pose_vector("add_robot", "orientation", orientation, 4)
+        orientation, _oerr = coerce_orientation_quaternion("add_robot", "orientation", orientation)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
         if name in self._world.robots:
@@ -779,7 +780,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
                 ``"cylinder"``, or ``"mesh"``. ``"mesh"`` requires
                 ``mesh_path``.
             position: World position ``[x, y, z]`` (default origin).
-            orientation: wxyz quaternion (default identity).
+            orientation: wxyz quaternion (default identity). Any non-unit value is fine -- the magnitude is ignored -- but one whose norm rounds to zero describes no rotation and is refused rather than silently applied as identity (:func:`~strands_robots.utils.coerce_orientation_quaternion`).
             size: Half-extents (box) or ``[radius, ...]`` (others). For
                 ``shape="mesh"`` this is the per-axis scale applied to the
                 loaded geometry (default ``[1, 1, 1]`` -- the mesh's own units).
@@ -846,7 +847,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         position, _perr = coerce_pose_vector("add_object", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        orientation, _oerr = coerce_pose_vector("add_object", "orientation", orientation, 4)
+        orientation, _oerr = coerce_orientation_quaternion("add_object", "orientation", orientation)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
         # Same shared domain for the colour, whose accepted counts the 4-component
@@ -1009,7 +1010,7 @@ class NewtonSimEngine(DomainRandomizationMixin, NewtonRecordingMixin, SimEngine)
         position, _perr = coerce_pose_vector("move_object", "position", position, 3)
         if _perr is not None:
             return {"status": "error", "content": [{"text": _perr}]}
-        orientation, _oerr = coerce_pose_vector("move_object", "orientation", orientation, 4)
+        orientation, _oerr = coerce_orientation_quaternion("move_object", "orientation", orientation)
         if _oerr is not None:
             return {"status": "error", "content": [{"text": _oerr}]}
         with self._lock:

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -1930,7 +1930,10 @@ def coerce_pose_vector(
         param_name: Parameter name, used in error text.
         vec: The caller's value, or ``None`` when the parameter was omitted.
         expected_len: Component count the target buffer defines (3 for a
-            position, 4 for a wxyz quaternion).
+            position). An orientation is not validated through here directly:
+            four components are necessary but not sufficient for a rotation,
+            so wxyz callers use
+            :func:`coerce_orientation_quaternion`, which adds the norm rule.
 
     Returns:
         ``(None, None)`` when ``vec`` is ``None`` (omitted - the caller applies
@@ -1948,6 +1951,117 @@ def coerce_pose_vector(
     if err is not None:
         return None, err
     return floats, None
+
+
+#: The smallest quaternion norm this library reads as a rotation.
+#:
+#: A wxyz value below it cannot be turned into one. MuJoCo refuses the all-zero
+#: quaternion through its XML door outright ("XML Error: zero quaternion is not
+#: allowed"), but the spec-attribute and ``qpos`` doors this package writes
+#: through accept it, and a norm it does consider too small to normalize it
+#: stores verbatim - measured on mujoco 3.12.0, ``quat="1e-9 0 0 0"`` compiles
+#: to ``body_quat = [1e-9, 0, 0, 0]`` while ``quat="2 0 0 0"`` is normalized to
+#: identity. Either way the rotation the caller asked for is not the rotation
+#: the model carries, so the value is refused at the door instead.
+#:
+#: The bound is the one ``move_to`` has always applied; it moved here unchanged
+#: so every orientation entry point shares it.
+MIN_QUATERNION_NORM = 1e-8
+
+
+def _quaternion_direction_error(method: str, param_name: str, floats: list[float]) -> str | None:
+    """The one rule a quaternion adds over a position, shared by both wrappers.
+
+    ``floats`` has already been read and validated by :func:`_read_pose_vector`,
+    so this examines four plain ``float`` values rather than anything of the
+    caller's.
+
+    Args:
+        method: Calling method or op name, used in error text.
+        param_name: Parameter or field name, used in error text.
+        floats: The four wxyz components.
+
+    Returns:
+        A message when the components have no direction to recover, else ``None``.
+    """
+    norm = math.sqrt(sum(component * component for component in floats))
+    if norm < MIN_QUATERNION_NORM:
+        return f"{method}: '{param_name}' quaternion has ~zero norm; pass a valid [w, x, y, z]."
+    return None
+
+
+def coerce_orientation_quaternion(method: str, param_name: str, quat: Any) -> tuple[list[float] | None, str | None]:
+    """Validate an optional wxyz orientation and normalize it to plain floats.
+
+    Single definition of the library's orientation contract, shared by every
+    entry point that writes a wxyz quaternion so their accepted domains cannot
+    diverge. It is :func:`coerce_pose_vector` with ``expected_len=4`` plus the
+    one rule a quaternion adds over a position: four finite components are not
+    enough, because they can still fail to describe a rotation.
+
+    A quaternion is a DIRECTION with a magnitude the target buffers ignore, so
+    any non-unit value is fine - ``[0, 2, 0, 0]`` and ``[0, 1, 0, 0]`` are the
+    same half turn, and every consumer either normalizes or is scale-invariant.
+    A norm below :data:`MIN_QUATERNION_NORM` has no direction to recover,
+    though, and nothing downstream reports that: MuJoCo substitutes identity for
+    an all-zero body quaternion and reports success, so the rotation the caller
+    requested is silently replaced by no rotation at all. ``move_object`` then
+    echoes the requested quaternion back in its success text while
+    ``get_body_state`` reports identity - one call, two answers, neither of them
+    flagged.
+
+    Args:
+        method: Calling method name, used in error text.
+        param_name: Parameter name, used in error text.
+        quat: The caller's wxyz value, or ``None`` when the parameter was
+            omitted.
+
+    Returns:
+        ``(None, None)`` when ``quat`` is ``None`` (omitted - the caller applies
+        its own default), ``(floats, None)`` for four finite components whose
+        norm is a usable direction, or ``(None, error_message)`` otherwise.
+    """
+    if quat is None:
+        return None, None
+    # One read, through the guard's own, for the reason :func:`pose_vector_error`
+    # defers to it: the floats the direction check examines are the ones the
+    # component checks read, and reading them here cannot run the caller's code.
+    floats, err = _read_pose_vector(method, param_name, quat, 4)
+    if err is not None:
+        return None, err
+    if (direction_err := _quaternion_direction_error(method, param_name, floats)) is not None:
+        return None, direction_err
+    return floats, None
+
+
+def orientation_quaternion_error(method: str, param_name: str, quat: Any) -> str | None:
+    """Return an error message if ``quat`` is not a usable wxyz orientation.
+
+    Error-only wrapper over :func:`coerce_orientation_quaternion`, for the
+    callers that hold a value to the orientation domain without taking the
+    normalized floats back - the structured scene ops, which pass the caller's
+    value straight to the spec write.
+
+    It pairs with :func:`coerce_orientation_quaternion` the way
+    :func:`pose_vector_error` pairs with :func:`coerce_pose_vector`, and differs
+    from it in the same one respect: ``None`` is REFUSED here rather than read as
+    an omission. An op dict is not a keyword argument - a key that is PRESENT
+    carries a supplied value - so reading ``{"op": ..., "quat": None}`` as "no
+    orientation asked for" would apply identity under a success result.
+
+    Args:
+        method: Calling method or op name, used in error text.
+        param_name: Parameter or field name, used in error text.
+        quat: The caller's wxyz value, or ``None`` when omitted.
+
+    Returns:
+        ``None`` when ``quat`` is acceptable (including omitted), else the
+        message naming the method, the parameter and what is wrong.
+    """
+    floats, err = _read_pose_vector(method, param_name, quat, 4)
+    if err is not None:
+        return err
+    return _quaternion_direction_error(method, param_name, floats)
 
 
 #: The component counts a 4-component RGBA row can be built from. Alpha is the

--- a/tests/simulation/mujoco/test_pose_vector_rule_parity.py
+++ b/tests/simulation/mujoco/test_pose_vector_rule_parity.py
@@ -15,6 +15,13 @@ in both directions:
   ``1.0``: ``add_object(position=[True, 0, 0.3])`` reported success and placed
   the body a metre out on x. ``move_to`` refused it, and so does the agent-tool
   router - so the direct API was the only surface that took it.
+* The quaternion domain drifted the other way. ``move_to`` refused an
+  orientation whose norm rounds to zero - a value that describes no rotation -
+  with a hand-rolled check sitting right after the shared pose guard, and the
+  scene calls accepted it: ``move_object(orientation=[0, 0, 0, 0])`` reported
+  success and echoed that quaternion back while ``get_body_state`` reported
+  identity, because MuJoCo substitutes identity for a zero body quaternion
+  without complaint. Its own XML door refuses the same value outright.
 
 These pin the unified contract: every entry point refuses a pose it cannot
 read, refuses a ``bool`` where a coordinate belongs, accepts a NumPy array, and
@@ -40,6 +47,11 @@ UNREADABLE_POSES = [
     pytest.param(np.float64(1.0), id="numpy-scalar"),
     pytest.param((component for component in (0.2, 0.1, 0.2)), id="generator"),
 ]
+
+
+#: A wxyz value with four finite components and no direction. Every entry
+#: point below is asked to apply it.
+ZERO_QUATERNION = [0.0, 0.0, 0.0, 0.0]
 
 
 def _text(result):
@@ -184,3 +196,73 @@ class TestOrientationEntersTheSolve:
         result = sim.move_to(robot_name="arm", position=REACHABLE, orientation=[0.0, 0.0, 0.0, 0.0], max_steps=2)
         assert result["status"] == "error"
         assert "zero norm" in _text(result)
+
+
+class TestEveryEntryPointRefusesAQuaternionWithNoDirection:
+    """A zero-norm wxyz value is no rotation, whichever surface receives it."""
+
+    def test_mujoco_refuses_it_through_its_xml_door(self):
+        """The oracle: the same value, offered to MuJoCo as MJCF, is refused."""
+        import mujoco
+
+        xml = '<mujoco><worldbody><body name="b" quat="0 0 0 0">'
+        xml += '<geom type="box" size=".1 .1 .1"/></body></worldbody></mujoco>'
+        with pytest.raises(ValueError, match="zero quaternion"):
+            mujoco.MjModel.from_xml_string(xml)
+
+    def test_move_object_refuses_it_and_leaves_the_orientation_alone(self, sim):
+        quarter_turn = [0.7071, 0.0, 0.7071, 0.0]
+        assert sim.move_object(name="crate", orientation=quarter_turn)["status"] == "success"
+        before = _json(sim.get_body_state("crate"))["quaternion"]
+
+        refused = sim.move_object(name="crate", orientation=ZERO_QUATERNION)
+        assert refused["status"] == "error"
+        assert "zero norm" in _text(refused)
+        # The old success text named the zero quaternion while the body carried
+        # identity; the pose the body does have is the pose it had before.
+        assert _json(sim.get_body_state("crate"))["quaternion"] == pytest.approx(before)
+
+    def test_add_object_refuses_it_and_adds_nothing(self, sim):
+        refused = sim.add_object(
+            name="spun", shape="box", size=[0.05] * 3, position=[0.3, 0.0, 0.3], orientation=ZERO_QUATERNION
+        )
+        assert refused["status"] == "error"
+        assert "zero norm" in _text(refused)
+        assert "spun" not in _text(sim.list_objects())
+
+    def test_add_robot_refuses_it(self, sim, arm_path):
+        refused = sim.add_robot("spun_arm", urdf_path=arm_path, orientation=ZERO_QUATERNION)
+        assert refused["status"] == "error"
+        assert "zero norm" in _text(refused)
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            pytest.param({"op": "set_body_quat", "name": "crate"}, id="set_body_quat"),
+            pytest.param({"op": "add_body", "name": "spun_body"}, id="add_body"),
+        ],
+    )
+    def test_a_structured_scene_op_refuses_it(self, sim, op):
+        refused = sim.patch_scene_mjcf(ops=[{**op, "quat": ZERO_QUATERNION}])
+        assert refused["status"] == "error"
+        assert "zero norm" in _text(refused)
+
+    def test_the_scene_verdict_matches_move_to(self, sim):
+        """The parity this module exists for, on the orientation parameter."""
+        primitive = sim.move_to(robot_name="arm", position=REACHABLE, orientation=ZERO_QUATERNION, max_steps=2)
+        scene = sim.move_object(name="crate", orientation=ZERO_QUATERNION)
+        assert primitive["status"] == scene["status"] == "error", (
+            f"verdicts differ: move_to={primitive['status']}, move_object={scene['status']}"
+        )
+
+
+class TestMagnitudeIsStillNotPartOfTheContract:
+    """Only a norm with no direction is refused; any other magnitude is fine."""
+
+    def test_a_non_unit_quaternion_is_applied_and_reported_normalized(self, sim):
+        assert sim.move_object(name="crate", orientation=[0.0, 2.0, 0.0, 0.0])["status"] == "success"
+        assert _json(sim.get_body_state("crate"))["quaternion"] == pytest.approx([0.0, 1.0, 0.0, 0.0])
+
+    def test_a_scene_op_accepts_a_non_unit_quaternion(self, sim):
+        result = sim.patch_scene_mjcf(ops=[{"op": "set_body_quat", "name": "crate", "quat": [0.0, 2.0, 0.0, 0.0]}])
+        assert result["status"] == "success"

--- a/tests/test_orientation_quaternion_domain.py
+++ b/tests/test_orientation_quaternion_domain.py
@@ -1,0 +1,173 @@
+"""One quaternion domain for every entry point that takes an orientation.
+
+Four finite components make a readable vector, not a rotation. A wxyz value
+whose norm rounds to zero has no direction to recover, and nothing downstream
+says so: MuJoCo refuses ``quat="0 0 0 0"`` through its XML door outright ("zero
+quaternion is not allowed") but accepts it through the spec-attribute and
+``qpos`` doors this package writes through, substituting identity and reporting
+success. ``move_object`` then echoed the requested quaternion back in its
+success text while ``get_body_state`` reported identity.
+
+``move_to`` had always refused such a value, with a hand-rolled check sitting
+directly after the shared pose guard - so the library held one wxyz quaternion
+to two different domains depending on which entry point received it, the drift
+:func:`~strands_robots.utils.coerce_pose_vector` exists to prevent. These tests
+pin the shared domain and the rule that every orientation parameter reaches it.
+"""
+
+import ast
+import math
+import pathlib
+
+import numpy as np
+import pytest
+
+from strands_robots.utils import (
+    MIN_QUATERNION_NORM,
+    coerce_orientation_quaternion,
+    orientation_quaternion_error,
+)
+
+#: The two shared helpers that hold a value to the orientation domain.
+QUATERNION_DOMAIN = frozenset({"coerce_orientation_quaternion", "orientation_quaternion_error"})
+
+#: The general pose-vector guards. They read a width and finite components, which
+#: is the whole contract for a position and only part of it for an orientation.
+POSE_DOMAIN = frozenset({"coerce_pose_vector", "pose_vector_error"})
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent / "strands_robots"
+
+
+def _domain_calls():
+    """Every call to a pose or orientation guard that names an ``"orientation"``.
+
+    Returns:
+        ``(sites, files_scanned)`` where each site is
+        ``(module_path, lineno, callee_name)``.
+    """
+    sites, scanned = [], 0
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - the package parses
+            continue
+        scanned += 1
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            name = node.func.id
+            if name not in POSE_DOMAIN | QUATERNION_DOMAIN:
+                continue
+            named = [a.value for a in node.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+            if "orientation" in named:
+                sites.append((str(path.relative_to(PACKAGE_ROOT.parent)), node.lineno, name))
+    return sites, scanned
+
+
+class TestTheDomainReadsARotationRatherThanFourNumbers:
+    """What the shared orientation guard accepts and what it refuses."""
+
+    def test_an_omitted_orientation_is_not_a_value(self):
+        assert coerce_orientation_quaternion("add_object", "orientation", None) == (None, None)
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            pytest.param([1.0, 0.0, 0.0, 0.0], id="identity"),
+            pytest.param([0.0, 2.0, 0.0, 0.0], id="non-unit"),
+            pytest.param([0.7071, 0.0, 0.7071, 0.0], id="quarter-turn"),
+            pytest.param(np.array([0.0, 1.0, 0.0, 0.0]), id="numpy-array"),
+        ],
+    )
+    def test_a_quaternion_with_a_direction_is_accepted_whatever_its_magnitude(self, quat):
+        floats, err = coerce_orientation_quaternion("add_object", "orientation", quat)
+        assert err is None
+        assert floats == [float(component) for component in quat]
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            pytest.param([0.0, 0.0, 0.0, 0.0], id="all-zero"),
+            pytest.param([0.0, 0.0, 0.0, -0.0], id="negative-zero"),
+            pytest.param([1e-12, 0.0, 0.0, 0.0], id="below-the-bound"),
+            pytest.param(np.zeros(4), id="numpy-zeros"),
+        ],
+    )
+    def test_a_quaternion_with_no_direction_is_refused(self, quat):
+        floats, err = coerce_orientation_quaternion("move_object", "orientation", quat)
+        assert floats is None
+        assert err == "move_object: 'orientation' quaternion has ~zero norm; pass a valid [w, x, y, z]."
+
+    def test_the_bound_is_a_norm_not_a_component(self):
+        # Four components each BELOW the bound still make a usable direction:
+        # their norm is above it. Reading the largest component instead of the
+        # norm would refuse this value, which is why the check is a norm.
+        component = 0.6 * MIN_QUATERNION_NORM
+        norm = math.sqrt(4 * component**2)
+        assert component < MIN_QUATERNION_NORM < norm, "premise: every component below the bound, the norm above it"
+        floats, err = coerce_orientation_quaternion("add_robot", "orientation", [component] * 4)
+        assert err is None and floats is not None
+
+    @pytest.mark.parametrize(
+        "quat",
+        [
+            pytest.param([0.0, 1.0, 0.0], id="too-short"),
+            pytest.param([float("nan"), 1.0, 0.0, 0.0], id="nan-component"),
+            pytest.param([True, 1.0, 0.0, 0.0], id="bool-component"),
+            pytest.param(0.5, id="scalar"),
+        ],
+    )
+    def test_the_pose_vector_rules_still_apply(self, quat):
+        floats, err = coerce_orientation_quaternion("add_object", "orientation", quat)
+        assert floats is None and err is not None
+        assert "add_object" in err and "orientation" in err
+
+    def test_the_error_only_wrapper_agrees_on_every_supplied_value(self):
+        for quat in ([0.0] * 4, [0.0, 1.0, 0.0, 0.0], [1.0, 2.0], 0.5, np.zeros(4)):
+            assert (
+                orientation_quaternion_error("op", "quat", quat)
+                == (coerce_orientation_quaternion("op", "quat", quat)[1])
+            )
+
+    def test_the_two_wrappers_read_a_none_differently_and_that_is_the_point(self):
+        # The same split as pose_vector_error / coerce_pose_vector. A keyword
+        # argument left at None was not supplied; a key PRESENT in an op dict
+        # carries a value, and reading it as an omission would apply identity
+        # under a success result.
+        assert coerce_orientation_quaternion("add_object", "orientation", None) == (None, None)
+        refusal = orientation_quaternion_error("set_body_quat", "quat", None)
+        assert refusal is not None and "None" in refusal
+
+
+class TestEveryOrientationParameterReachesThatDomain:
+    """The rule that keeps the two contracts from drifting apart again."""
+
+    def test_no_orientation_is_held_to_the_position_contract(self):
+        sites, scanned = _domain_calls()
+        assert scanned >= 50, f"the scan reached only {scanned} modules; it is not measuring the package"
+        assert len(sites) >= 11, f"only {len(sites)} orientation guard calls found; the scan is not finding them"
+        general = [site for site in sites if site[2] in POSE_DOMAIN]
+        assert general == [], (
+            "these orientation parameters are held to the position contract (four finite components) "
+            f"instead of the quaternion domain: {general}"
+        )
+
+    def test_the_general_guards_are_no_longer_asked_for_four_components(self):
+        # A width of 4 asked of a pose guard is an orientation by construction:
+        # the only 4-component pose vector this library has is a wxyz quaternion.
+        # The shared reader both domains sit on (``_read_pose_vector``) is not in
+        # POSE_DOMAIN, so the quaternion domain's own read is not an offender.
+        offenders, scanned = [], 0
+        for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            scanned += 1
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                    continue
+                if node.func.id not in POSE_DOMAIN or not node.args:
+                    continue
+                last = node.args[-1]
+                if isinstance(last, ast.Constant) and last.value == 4:
+                    offenders.append((str(path.relative_to(PACKAGE_ROOT.parent)), node.lineno))
+        assert scanned >= 50, f"the scan reached only {scanned} modules; it is not measuring the package"
+        assert offenders == [], f"a four-component pose guard outside the quaternion domain: {offenders}"


### PR DESCRIPTION
## Problem

Four finite components make a readable vector, not a rotation. A wxyz value whose norm rounds to zero has no direction to recover, and nothing downstream reports that. MuJoCo refuses it through its XML door outright:

```
quat="0 0 0 0"   -> XML Error: zero quaternion is not allowed
```

but the spec-attribute and `qpos` doors this package writes through accept it, substituting identity. Measured on mujoco 3.12.0: `body.quat = [0, 0, 0, 0]` compiles to `body_quat = [0, 0, 0, 0]` and `mj_forward` reads it as identity, while `quat="2 0 0 0"` is normalized to identity and `quat="1e-9 0 0 0"` is stored verbatim.

`move_to` had always refused such a value, with a hand-rolled norm check sitting directly after the shared pose guard. Its scene-construction siblings held the same quaternion to the position contract - four finite components - so the verdict depended on which entry point received it. That is the drift `tests/simulation/mujoco/test_pose_vector_rule_parity.py` exists to prevent; it pinned the position contract on both sides and the quaternion contract on one.

Measured through the public API on `upstream/main` at `fe5ced57`, on a body already holding a quarter turn about z:

| call | verdict on main | body afterwards |
| --- | --- | --- |
| `move_to(orientation=[0,0,0,0])` | error, "~zero norm" | unchanged |
| `move_object(orientation=[0,0,0,0])` | success, text names `[0.0, 0.0, 0.0, 0.0]` | `[1, 0, 0, 0]` |
| `add_object(orientation=[0,0,0,0])` | success | `[1, 0, 0, 0]` |
| `add_robot(orientation=[0,0,0,0])` | success | identity |
| `patch_scene_mjcf` `set_body_quat` / `add_body` | success | identity |

The `move_object` row is the sharp one: the requested quaternion, the quaternion the success text names and the quaternion `get_body_state` reports are three different values, and the quarter turn the body did have is destroyed.

## Change

The norm rule moves into the shared guard beside `coerce_pose_vector`:

- `coerce_orientation_quaternion(method, param, quat)` - `coerce_pose_vector`'s four-component read plus the direction rule, for the `orientation=` keyword parameters.
- `orientation_quaternion_error(method, param, quat)` - the error-only form, for the structured scene ops that pass the caller's value straight to the spec write.
- `MIN_QUATERNION_NORM = 1e-8` - `move_to`'s shipped bound, unchanged.

All eleven orientation call sites route through it (`add_object`, `move_object`, `add_robot` and `set_robot_pose` across the MuJoCo, Isaac and Newton engines; `move_to`; the `quat` entry in the MuJoCo scene ops' field-domain table). `move_to` loses its private copy, so there is one definition rather than two.

Magnitude is still not part of the contract: `[0, 2, 0, 0]` and `[0, 1, 0, 0]` are the same half turn and both are accepted, normalized by the consumer as before. Only a norm with no direction is refused.

The two wrappers differ on `None` in exactly the way `pose_vector_error` and `coerce_pose_vector` already do: a keyword argument left at `None` was not supplied, while a key PRESENT in an op dict carries a value, so `{"op": "set_body_quat", "quat": None}` stays a refusal rather than becoming an omission that applies identity.

## Artifact

The same call on both trees, MuJoCo headless (`MUJOCO_GL=egl`). Left: the starting pose, byte-identical across trees. Middle: `upstream/main` reports success and the quarter turn is gone (5633 px of the render changed). Right: this branch refuses and the pose the body has is the pose it had.

![one quaternion domain](https://github.com/cagataycali/robots/releases/download/artifacts/quaternion_domain.png)

The branch's before/after renders differ by at most one level on a handful of pixels (0 px above a 20-level threshold) - EGL noise, not a pose change. Both premises are asserted inside the figure script.

## Tests

`tests/test_orientation_quaternion_domain.py` (new) covers the shared domain and the rule that keeps the two contracts together: no `orientation` is held to the position guard, and no pose guard is asked for a width of 4 anywhere in the package. `tests/simulation/mujoco/test_pose_vector_rule_parity.py` gains the behavioural half - each entry point refusing the value, the verdict matching `move_to`, MuJoCo's own XML refusal as the oracle, and two controls that a non-unit quaternion is still applied.

Pre-fix (the domain present, no call site using it): **8 failed / 308 passed**, all 8 in the two regression classes, 0 in the control classes.

| break | fires |
| --- | --- |
| control (as shipped) | 0 of 316 |
| the norm bound never fires | 12, incl. the two pre-existing `move_to` zero-norm tests |
| refuse any non-unit quaternion (over-reach) | 8, incl. the pre-existing `test_a_non_unit_quaternion_is_normalized` and `test_a_different_quaternion_changes_the_solve` |
| an omitted orientation read as a value | 44 failed + 36 errors |
| largest component instead of the norm | 1 (`test_the_bound_is_a_norm_not_a_component`) |
| revert the scene-op `quat` domain alone | 3 |
| revert the MuJoCo engine call sites alone | 6 |
| error-only wrapper reads a present `None` as an omission | 2, incl. the pre-existing `test_a_none_pose_is_refused[quat]` |

The two single-surface reverts fire complementary sets sharing only the structural rule, so each surface is independently pinned; the over-reach row is refused by the shipped suite rather than only by the new controls.

## Gate

`ruff check` and `ruff format --check` clean on `strands_robots tests tests_integ`. mypy: **5 errors on this branch, 5 on a pristine `upstream/main` worktree**, identical message sets, none in the changed files.

A 379-file selection (every test naming a pose guard, an orientation, `move_to`, the scene-construction calls or `patch_scene_mjcf`), run on both trees with the two changed test files excluded from each: **`14 failed, 12043 passed, 240 skipped, 45 errors` on both**, 532s vs 541s, with the branch-only and base-only failure sets both empty. The 14 are pre-existing (9 `tests_integ` needing live infra or model weights, 4 recording/pacer tests, 1 mesh integration); the 45 errors are `device_connect_edge` absent locally, declared in the `[device-connect]` extra that `[all]` pulls in.

The changed test files pass on mujoco 3.12.0 and on 3.5.0, the floor `pyproject.toml` declares: **139 passed** on both.
