### PR TITLE
fix(isaac): read a mesh asset's scale through its MJCF default class

### DIFF
--- a/changelog.d/2691-mjcf-mesh-asset-scale-default-class.md
+++ b/changelog.d/2691-mjcf-mesh-asset-scale-default-class.md
@@ -1,0 +1,34 @@
+### Fixed: a mesh asset's `scale` is read from its MJCF `<default>` class, instead of falling back to unit scale
+
+`_parse_mjcf_mesh_assets` read each `<asset><mesh>`'s `scale` off the element alone, but
+MJCF lets a `<default>` class supply it -- `<default class="right_hand"><mesh
+scale="0.001 0.001 0.001"/>` plus `<mesh class="right_hand" file="palm.obj"/>` declares a
+millimetre asset with no `scale` on the element at all. Every such mesh was reported at
+unit scale. That is a plausible value, so nothing downstream could tell an asset authored
+at unit scale from one whose declared scale was never read: the load reported success and
+the asset was reported up to a thousand times too large.
+
+The reported scale is not cosmetic. It rides onto the visual prim's xform as
+`SceneObject.mesh_scale`, and `mesh_aabb` measures the object's collision proxy `size`
+through it, so a body whose only geometry is a mesh reported a proxy scaled by the same
+factor -- Menagerie's `flybody` head, declared at `scale="0.1 0.1 0.1"` by the model's
+root class, was reported 0.50 x 0.77 x 0.64 m instead of 0.050 x 0.077 x 0.064 m.
+
+The reader now resolves `scale` through `_mjcf_class_defaults(root, mjcf_dir, "mesh")` and
+the shared `_class_attrs` precedence, which is how the sibling `<geom>` and `<joint>`
+readers in the same module already resolve their attributes: the element's own value wins,
+then its named class, then the root class (reachable as `""`, as `class="main"`, or by
+naming no class), with nested classes flattened and `<default>` read from the spliced
+model so a class declared in an `<include>`d fragment resolves. The mesh class map is
+collected separately from the geom one because one class carries a separate attribute set
+per element kind. `file` and `name` stay element-only reads, which is the format's rule
+rather than a simplification -- MuJoCo's schema refuses either attribute inside a
+`<default><mesh>`.
+
+Graded against `mujoco.MjSpec`'s own resolved `scale` -- the very attribute this reader
+reports -- across the shipped asset corpus: agreement rises from 9864 of 10320 mesh assets
+to 10320 of 10320, with no asset moving away from the compiler. The 456 corrected values
+span 18 shipped Menagerie models (`flybody`, `robotis_op3`, `anybotics_anymal_b`,
+`shadow_hand`, `trossen_wx250s`, `robotiq_2f85`, `stanford_tidybot`, `skydio_x2` and their
+scenes), and every one of them was reported at unit scale where the model declares 0.001,
+0.1 or 0.01.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1347,6 +1347,11 @@ def _class_attrs(el: ET.Element, defaults: dict[str, dict[str, str]], childclass
     ``defaults`` must be the map :func:`_mjcf_class_defaults` collected for
     ``el``'s own tag: a joint resolved against geom defaults would inherit a
     geom's ``type``, which names a shape rather than a degree of freedom.
+
+    An ``<asset><mesh>`` reaches this with an empty ``childclass``, which is the
+    format's own rule rather than a simplification: ``<asset>`` is a top-level
+    element, so no body encloses it and its only class is the one it names -
+    else the root class.
     """
     cls = el.get("class") or childclass
     return _merge_mjcf_attrs(defaults.get(cls, {}), el.attrib)
@@ -1406,6 +1411,19 @@ def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[
 
     A ``<mesh>`` without a ``name`` defaults to the file's basename without
     extension, per the MJCF spec.
+
+    ``scale`` resolves through the mesh's ``<default>`` class, because MJCF lets
+    a class supply it: ``<default class="X"><mesh scale="0.001 0.001 0.001"/>``
+    plus ``<mesh class="X" file="palm.obj"/>`` declares a millimetre asset with
+    no ``scale`` on the element at all. Read as the element's own attribute
+    alone, such a mesh reports the unit fallback - a plausible value, so nothing
+    downstream can tell "authored at unit scale" from "the declared scale was
+    not read", and the asset is reported a thousand times too large.
+
+    ``file`` and ``name`` are read from the element only, which is what the
+    format allows: MuJoCo's schema refuses either attribute inside a
+    ``<default><mesh>`` ("unrecognized attribute"), so a class cannot name an
+    asset or its file.
     """
     elements = _mjcf_model_toplevel(root, mjcf_dir)
 
@@ -1417,6 +1435,7 @@ def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[
                 mesh_base = d if os.path.isabs(d) else os.path.join(mjcf_dir, d)
                 break
 
+    mesh_defaults = _mjcf_class_defaults(root, mjcf_dir, "mesh")
     registry: dict[str, tuple[str, tuple[float, float, float]]] = {}
     for asset_el in (el for el in elements if el.tag == "asset"):
         for mesh_el in asset_el.findall("mesh"):
@@ -1425,7 +1444,8 @@ def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[
                 continue
             name = mesh_el.get("name") or os.path.splitext(os.path.basename(file_attr))[0]
             resolved = file_attr if os.path.isabs(file_attr) else os.path.join(mesh_base, file_attr)
-            scale = _parse_axis(mesh_el.get("scale"), default=(1.0, 1.0, 1.0))
+            attrs = _class_attrs(mesh_el, mesh_defaults, "")
+            scale = _parse_axis(attrs.get("scale"), default=(1.0, 1.0, 1.0))
             registry[name] = (os.path.normpath(resolved), scale)
     return registry
 

--- a/tests/simulation/isaac/test_mjcf_mesh_asset_scale_defaults.py
+++ b/tests/simulation/isaac/test_mjcf_mesh_asset_scale_defaults.py
@@ -1,0 +1,296 @@
+"""An MJCF mesh asset's ``scale`` resolves through its ``<default>`` class.
+
+MJCF lets a ``<default>`` class supply a mesh's ``scale``, exactly as it supplies
+a ``<geom>``'s ``type`` and a ``<joint>``'s ``axis``::
+
+    <default class="right_hand"><mesh scale="0.001 0.001 0.001"/></default>
+    <asset><mesh class="right_hand" file="palm.obj"/></asset>
+
+Read as the element's own attribute alone, such an asset reports the unit
+fallback. That is a plausible value, so nothing downstream can tell "authored at
+unit scale" from "the declared scale was not read": the asset is reported a
+thousand times too large under a successful load. The reported scale is not
+cosmetic - it rides onto the visual prim's xform as
+:attr:`~strands_robots.simulation.isaac.loaders.SceneObject.mesh_scale`, and
+:func:`~strands_robots.simulation.isaac.mesh_assets.mesh_aabb` measures the
+object's collision proxy ``size`` through it, so a body whose only geometry is a
+mesh reports a proxy scaled by the same factor.
+
+Every expectation here is derived from MuJoCo rather than restated:
+``mujoco.MjSpec`` exposes each mesh's own resolved ``scale``, which is the very
+attribute this reader reports, so ``TestTheResolvedScaleIsTheOneMujocoResolves``
+grades the loader against the compiler over each spelling. Note that a mesh
+declaring no ``name`` is unnamed in the spec until ``compile()`` runs - the
+compiler is what derives the name from the file - so the oracle compiles before
+reading names.
+
+``TestTheElementAndClassPrecedenceIsUnchanged`` pins the rules the fix must not
+disturb: an element's own ``scale`` still wins over its class's, a model with no
+``<default>`` at all is unaffected, and ``file``/``name`` stay element-only
+reads, which is the format's rule rather than a simplification - MuJoCo's schema
+refuses either attribute inside a ``<default><mesh>``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    _parse_mjcf_mesh_assets,
+    load_mjcf_scene_objects,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+#: Tetrahedron, full extent (0.4, 0.3, 0.2) at unit scale, 4 vertices.
+#: The three extents differ so a per-axis scale mix-up is visible in the size.
+_TETRA_OBJ = "v 0 0 0\nv 0.4 0 0\nv 0 0.3 0\nv 0 0 0.2\nf 1 2 3\nf 1 2 4\nf 1 3 4\nf 2 3 4\n"
+
+#: That extent, so no expectation below restates it.
+_TETRA_EXTENT = (0.4, 0.3, 0.2)
+
+#: The scale a reader that ignores the class reports. Every expectation below
+#: differs from it, which is what makes a passing test evidence of a real read.
+_UNIT = (1.0, 1.0, 1.0)
+
+#: Deliberately anisotropic: a reader that resolved the class but transposed or
+#: broadcast an axis would still disagree with the compiler.
+_CLASS_SCALE = "0.2 0.3 0.5"
+_CLASS_SCALE_T = (0.2, 0.3, 0.5)
+
+
+def _write_model(root: pathlib.Path, body: str, **fragments: str) -> str:
+    """Write ``body`` as ``model.xml`` (plus any fragments) and return its path."""
+    (root / "widget.obj").write_text(_TETRA_OBJ, encoding="utf-8")
+    for name, text in fragments.items():
+        (root / f"{name}.xml").write_text(text, encoding="utf-8")
+    top = root / "model.xml"
+    top.write_text(body, encoding="utf-8")
+    return str(top)
+
+
+def _reported_scale(path: str, mesh_name: str = "widget_mesh") -> tuple[float, float, float]:
+    """The loader's reported scale for one mesh asset."""
+    root = ET.parse(path).getroot()
+    registry = _parse_mjcf_mesh_assets(root, str(pathlib.Path(path).parent))
+    assert mesh_name in registry, f"{mesh_name!r} not in {sorted(registry)}"
+    return registry[mesh_name][1]
+
+
+def _mujoco_scale(path: str, mesh_name: str = "widget_mesh") -> tuple[float, float, float]:
+    """MuJoCo's own resolved ``scale`` for one mesh asset.
+
+    ``compile()`` runs first because a mesh declaring no ``name`` carries an
+    empty one in the parsed spec - the compiler derives it from the file - and
+    an oracle keyed on empty names would collapse every such mesh into one entry
+    and silently compare nothing.
+    """
+    spec = mujoco.MjSpec.from_file(path)
+    spec.compile()
+    by_name = {m.name: tuple(round(float(v), 12) for v in m.scale) for m in spec.meshes}
+    assert "" not in by_name, "a mesh is still unnamed after compile()"
+    assert mesh_name in by_name, f"{mesh_name!r} not in {sorted(by_name)}"
+    return by_name[mesh_name]  # type: ignore[return-value]
+
+
+#: One movable body whose only geometry is the mesh, so the reported proxy
+#: ``size`` is measured through the reported scale.
+def _body(mesh_ref: str = "widget_mesh") -> str:
+    return (
+        "  <worldbody>\n"
+        '    <body name="widget" pos="0 0 0"><freejoint/>\n'
+        f'      <geom type="mesh" mesh="{mesh_ref}" group="1"/>\n'
+        "    </body>\n"
+        "  </worldbody>\n"
+    )
+
+
+_BODY = _body()
+
+
+def _model(defaults: str, asset: str, mesh_ref: str = "widget_mesh") -> str:
+    return f"<mujoco>\n{defaults}  <asset>{asset}</asset>\n{_body(mesh_ref)}</mujoco>\n"
+
+
+#: ``(label, <default> block, <mesh> element, expected scale)`` - each a model
+#: MuJoCo compiles, pinned in ``TestTheResolvedScaleIsTheOneMujocoResolves``.
+_CLASS_SPELLINGS = [
+    (
+        "a named class the element names",
+        f'  <default><default class="mm"><mesh scale="{_CLASS_SCALE}"/></default></default>\n',
+        '<mesh name="widget_mesh" class="mm" file="widget.obj"/>',
+        _CLASS_SCALE_T,
+    ),
+    (
+        "the root class, which the element reaches by naming nothing",
+        f'  <default><mesh scale="{_CLASS_SCALE}"/></default>\n',
+        '<mesh name="widget_mesh" file="widget.obj"/>',
+        _CLASS_SCALE_T,
+    ),
+    (
+        "the root class spelled main",
+        f'  <default><mesh scale="{_CLASS_SCALE}"/></default>\n',
+        '<mesh name="widget_mesh" class="main" file="widget.obj"/>',
+        _CLASS_SCALE_T,
+    ),
+    (
+        "the innermost class of a nested chain",
+        '  <default><default class="outer"><mesh scale="9 9 9"/>\n'
+        f'    <default class="inner"><mesh scale="{_CLASS_SCALE}"/></default></default></default>\n',
+        '<mesh name="widget_mesh" class="inner" file="widget.obj"/>',
+        _CLASS_SCALE_T,
+    ),
+    (
+        "an enclosing class, inherited by a nested one that declares no mesh",
+        f'  <default><default class="outer"><mesh scale="{_CLASS_SCALE}"/>\n'
+        '    <default class="inner"/></default></default>\n',
+        '<mesh name="widget_mesh" class="inner" file="widget.obj"/>',
+        _CLASS_SCALE_T,
+    ),
+]
+
+
+class TestAMeshAssetScaleComesFromItsDefaultClass:
+    """Each spelling by which a class supplies a mesh's scale is read."""
+
+    @pytest.mark.parametrize(
+        ("label", "defaults", "asset", "expected"),
+        [pytest.param(*c, id=c[0].replace(" ", "_")) for c in _CLASS_SPELLINGS],
+    )
+    def test_the_class_declared_scale_is_reported(
+        self, tmp_path: pathlib.Path, label: str, defaults: str, asset: str, expected: tuple[float, float, float]
+    ) -> None:
+        assert expected != _UNIT, "premise: the expectation differs from the unit fallback"
+        path = _write_model(tmp_path, _model(defaults, asset))
+        assert _reported_scale(path) == pytest.approx(expected), label
+
+    def test_a_class_declared_in_an_included_fragment_is_read(self, tmp_path: pathlib.Path) -> None:
+        """``<default>`` is model-global, so the class may live in a fragment."""
+        path = _write_model(
+            tmp_path,
+            "<mujoco>\n"
+            '  <include file="classes.xml"/>\n'
+            '  <asset><mesh name="widget_mesh" class="mm" file="widget.obj"/></asset>\n'
+            f"{_BODY}</mujoco>\n",
+            classes=f'<mujoco><default><default class="mm"><mesh scale="{_CLASS_SCALE}"/></default></default></mujoco>',
+        )
+        assert _reported_scale(path) == pytest.approx(_CLASS_SCALE_T)
+
+    def test_an_unnamed_mesh_is_keyed_by_its_basename_and_still_scaled(self, tmp_path: pathlib.Path) -> None:
+        """A ``<mesh>`` may declare a class and no name, which is the common shape.
+
+        Most of the affected shipped assets are written this way - the class
+        carries the unit conversion and each mesh names only its file - so the
+        two rules have to hold together: the entry is keyed by the file's
+        basename AND scaled by its class.
+        """
+        defaults = f'  <default><default class="mm"><mesh scale="{_CLASS_SCALE}"/></default></default>\n'
+        path = _write_model(tmp_path, _model(defaults, '<mesh class="mm" file="widget.obj"/>', mesh_ref="widget"))
+
+        assert _reported_scale(path, "widget") == pytest.approx(_CLASS_SCALE_T)
+        assert _reported_scale(path, "widget") == pytest.approx(_mujoco_scale(path, "widget"))
+
+    def test_the_scale_reaches_the_reported_object_and_its_proxy_size(self, tmp_path: pathlib.Path) -> None:
+        """Through the public loader: the object's scale AND its proxy extent.
+
+        The body carries no analytic collision geometry, so the reported
+        ``size`` is the mesh's own extent measured through the reported scale -
+        the tetrahedron's (0.4, 0.3, 0.2) times the class's scale.
+        """
+        defaults = f'  <default><default class="mm"><mesh scale="{_CLASS_SCALE}"/></default></default>\n'
+        asset = '<mesh name="widget_mesh" class="mm" file="widget.obj"/>'
+        path = _write_model(tmp_path, _model(defaults, asset))
+
+        (obj,) = load_mjcf_scene_objects(path)
+
+        assert obj.mesh_scale == pytest.approx(_CLASS_SCALE_T)
+        expected_size = tuple(e * s for e, s in zip(_TETRA_EXTENT, _CLASS_SCALE_T, strict=True))
+        assert obj.size == pytest.approx(expected_size)
+        assert obj.size != pytest.approx(_TETRA_EXTENT), "premise: the proxy differs from the unit-scale one"
+
+
+class TestTheResolvedScaleIsTheOneMujocoResolves:
+    """The loader's reported scale is graded against the compiler's own."""
+
+    @pytest.mark.parametrize(
+        ("label", "defaults", "asset", "expected"),
+        [pytest.param(*c, id=c[0].replace(" ", "_")) for c in _CLASS_SPELLINGS],
+    )
+    def test_every_class_spelling_matches_mujoco(
+        self, tmp_path: pathlib.Path, label: str, defaults: str, asset: str, expected: tuple[float, float, float]
+    ) -> None:
+        path = _write_model(tmp_path, _model(defaults, asset))
+        truth = _mujoco_scale(path)
+        assert truth == pytest.approx(expected), f"premise: the fixture means what it says ({label})"
+        assert _reported_scale(path) == pytest.approx(truth), label
+
+    def test_an_element_scale_matches_mujoco(self, tmp_path: pathlib.Path) -> None:
+        path = _write_model(
+            tmp_path, _model("", f'<mesh name="widget_mesh" file="widget.obj" scale="{_CLASS_SCALE}"/>')
+        )
+        assert _reported_scale(path) == pytest.approx(_mujoco_scale(path))
+
+
+class TestTheElementAndClassPrecedenceIsUnchanged:
+    """The rules the class resolution must not disturb."""
+
+    def test_the_elements_own_scale_wins_over_its_class(self, tmp_path: pathlib.Path) -> None:
+        defaults = f'  <default><default class="mm"><mesh scale="{_CLASS_SCALE}"/></default></default>\n'
+        asset = '<mesh name="widget_mesh" class="mm" file="widget.obj" scale="4 4 4"/>'
+        path = _write_model(tmp_path, _model(defaults, asset))
+        assert _reported_scale(path) == pytest.approx((4.0, 4.0, 4.0))
+        assert _reported_scale(path) == pytest.approx(_mujoco_scale(path))
+
+    def test_a_model_with_no_defaults_reports_the_element_scale(self, tmp_path: pathlib.Path) -> None:
+        path = _write_model(tmp_path, _model("", '<mesh name="widget_mesh" file="widget.obj" scale="0.5 0.5 0.5"/>'))
+        assert _reported_scale(path) == pytest.approx((0.5, 0.5, 0.5))
+
+    def test_a_mesh_declaring_no_scale_anywhere_reports_unit(self, tmp_path: pathlib.Path) -> None:
+        path = _write_model(tmp_path, _model("", '<mesh name="widget_mesh" file="widget.obj"/>'))
+        assert _reported_scale(path) == pytest.approx(_UNIT)
+        assert _mujoco_scale(path) == pytest.approx(_UNIT)
+
+    @pytest.mark.parametrize(("kind", "attribute"), [("geom", "scale"), ("mesh", "size")])
+    def test_mujoco_keeps_the_two_kinds_attribute_sets_disjoint(
+        self, tmp_path: pathlib.Path, kind: str, attribute: str
+    ) -> None:
+        """Why the mesh class map is collected separately from the geom one.
+
+        One ``<default>`` class carries a separate attribute set per element
+        kind, and MuJoCo enforces it: neither ``scale`` on a ``<geom>`` nor
+        ``size`` on a ``<mesh>`` is a legal declaration, so resolving a mesh
+        against the geom map could only ever lose the scale - never borrow a
+        geom's. That is the shape the regression classes above measure.
+        """
+        defaults = f'  <default><{kind} {attribute}="0.7 0.7 0.7"/></default>\n'
+        path = _write_model(tmp_path, _model(defaults, '<mesh name="widget_mesh" file="widget.obj"/>'))
+        with pytest.raises(ValueError, match=f"unrecognized attribute: '{attribute}'"):
+            mujoco.MjSpec.from_file(path)
+
+    def test_a_geom_class_sharing_the_name_does_not_change_the_scale(self, tmp_path: pathlib.Path) -> None:
+        """One class name, two element kinds, one scale."""
+        defaults = (
+            f'  <default><default class="mm"><geom type="mesh" group="1"/>'
+            f'<mesh scale="{_CLASS_SCALE}"/></default></default>\n'
+        )
+        asset = '<mesh name="widget_mesh" class="mm" file="widget.obj"/>'
+        path = _write_model(tmp_path, _model(defaults, asset))
+        assert _reported_scale(path) == pytest.approx(_CLASS_SCALE_T)
+        assert _reported_scale(path) == pytest.approx(_mujoco_scale(path))
+
+    def test_a_class_no_default_declares_contributes_nothing(self, tmp_path: pathlib.Path) -> None:
+        """Naming the offending class is MuJoCo's report to make, not this reader's."""
+        asset = '<mesh name="widget_mesh" class="absent" file="widget.obj"/>'
+        path = _write_model(tmp_path, _model("", asset))
+        assert _reported_scale(path) == pytest.approx(_UNIT)
+
+    @pytest.mark.parametrize("attribute", ["file", "name"])
+    def test_mujoco_refuses_an_asset_attribute_inside_a_default(self, tmp_path: pathlib.Path, attribute: str) -> None:
+        """Why ``file`` and ``name`` stay element-only reads: the format says so."""
+        defaults = f'  <default><mesh {attribute}="widget.obj"/></default>\n'
+        path = _write_model(tmp_path, _model(defaults, '<mesh name="widget_mesh" file="widget.obj"/>'))
+        with pytest.raises(ValueError, match=f"unrecognized attribute: '{attribute}'"):
+            mujoco.MjSpec.from_file(path)


### PR DESCRIPTION
## Problem

`_parse_mjcf_mesh_assets` in `strands_robots/simulation/isaac/loaders.py` read each
`<asset><mesh>`'s `scale` off the element alone:

```python
scale = _parse_axis(mesh_el.get("scale"), default=(1.0, 1.0, 1.0))
```

MJCF lets a `<default>` class supply that attribute, exactly as it supplies a `<geom>`'s
`type` and a `<joint>`'s `axis` -- both of which this module already resolves through a
class:

```xml
<default class="right_hand"><mesh scale="0.001 0.001 0.001"/></default>
<asset><mesh class="right_hand" file="palm.obj"/></asset>
```

Every mesh written that way was reported at unit scale. Unit scale is a plausible value,
so nothing downstream can tell an asset authored at unit scale from one whose declared
scale was never read -- the load reports success and the asset is reported up to a
thousand times too large.

The reported scale is not cosmetic. It rides onto the visual prim's xform as
`SceneObject.mesh_scale`, and `mesh_aabb` measures the object's collision proxy `size`
through it, so a body whose only geometry is a mesh reports a proxy scaled by the same
factor. Through the public `load_mjcf_scene_objects`, on Menagerie's `flybody` head mesh
(the model's root class declares `<mesh scale="0.1 0.1 0.1"/>`, and each `<asset><mesh>`
names no scale):

| reading | reported `mesh_scale` | reported `size` |
| --- | --- | --- |
| `upstream/main` | `(1.0, 1.0, 1.0)` | 0.5037 x 0.7748 x 0.6438 m |
| this change | `(0.1, 0.1, 0.1)` | 0.0504 x 0.0775 x 0.0644 m |
| `mujoco.MjSpec`, resolving the class itself | `(0.1, 0.1, 0.1)` | -- |

A fruit fly's head reported as 0.77 m across, under a successful scene load.

## Change

`scale` now resolves through `_mjcf_class_defaults(root, mjcf_dir, "mesh")` and the shared
`_class_attrs` precedence -- the same two helpers the `<geom>` and `<joint>` readers in
this module already use, so the rule is stated once rather than per reader. That gives, for
free and by construction: the element's own value wins over its class's; the root class is
reachable as `""`, as `class="main"`, and by naming no class at all; nested classes are
flattened, so an inner class overrides an enclosing one and a nested class declaring no
`<mesh>` inherits it; and `<default>` is read from the spliced model, so a class declared
in an `<include>`d fragment resolves.

Two boundaries are deliberate and tested:

- The mesh class map is collected separately from the geom one, because one `<default>`
  class carries a separate attribute set per element kind. MuJoCo enforces this: neither
  `scale` on a `<geom>` nor `size` on a `<mesh>` is a legal declaration, so resolving a
  mesh against the geom map could only ever lose the scale.
- `file` and `name` stay element-only reads. That is the format's rule rather than a
  simplification -- MuJoCo's schema refuses either attribute inside a `<default><mesh>`
  ("unrecognized attribute"), so a class cannot name an asset or its file.

## Corpus grading

`mujoco.MjSpec` exposes each mesh's own resolved `scale`, which is the very attribute this
reader reports, so it grades the reader directly. Swept over the shipped asset corpus (537
models parsed, 336 graded -- the rest are include-fragments MuJoCo refuses standalone,
identically on both trees):

| reading | mesh assets agreeing with the compiler | disagreeing |
| --- | --- | --- |
| `upstream/main` | 9864 | 456 |
| this change | 10320 | 0 |

No asset moved away from the compiler. The 456 corrected values span 18 shipped Menagerie
models -- `flybody` (85 each in `fruitfly.xml` and `scene.xml`), `robotis_op3` (48),
`anybotics_anymal_b` (46), `shadow_hand` (13 right / 10 left), `trossen_wx250s` (10),
`robotiq_2f85` (8), `stanford_tidybot` (7), `skydio_x2` (1), and each of their scenes.
Every one was reported at unit scale where the model declares 0.001 (284 meshes), 0.1 (170)
or 0.01 (2).

One measurement worth recording, because it silently under-reports this class of defect: a
mesh declaring no `name` carries an *empty* name in a parsed `MjSpec` until `compile()`
runs -- the compiler is what derives the name from the file. An oracle that reads names
before compiling collapses every such mesh into one entry and compares nothing. Most of the
affected assets are written exactly that way, so the oracle here compiles first, and
`test_an_unnamed_mesh_is_keyed_by_its_basename_and_still_scaled` pins that shape.

## Tests

New: `tests/simulation/isaac/test_mjcf_mesh_asset_scale_defaults.py`, 23 tests in three
classes. Every expectation is derived from MuJoCo rather than restated, and every fixture
is a model MuJoCo compiles.

Pre-fix split (reader reverted to `upstream/main`, tests kept): **14 failed / 9 passed**,
all 14 in the two regression classes and **0** in `TestTheElementAndClassPrecedenceIsUnchanged`.

Break table -- each row a single mutation, with the tests it fires:

| mutation | fails | fires |
| --- | --- | --- |
| (control) branch as shipped | 0 | -- |
| exact pre-fix revert of the reader | 14 | every regression + oracle test |
| resolve against the **geom** class defaults instead of the mesh ones | 14 | same set: the geom map can never carry a `scale` |
| let the class override the element instead of the reverse | 1 | `test_the_elements_own_scale_wins_over_its_class` |
| read only the class, ignoring the element | 3 | the three element-precedence tests |
| always resolve against the root class, ignoring the named one | 10 | every named-class case; the root-class cases still pass |
| resolve `name=` through the class too | 0 | deliberate: MuJoCo refuses `name` inside a `<default><mesh>`, so no valid model can distinguish the two readings -- pinned by `test_mujoco_refuses_an_asset_attribute_inside_a_default` |
| oracle reads mesh names without compiling first | 1 | `test_an_unnamed_mesh_is_keyed_by_its_basename_and_still_scaled` alone |
| fixture scale set **to** the unit fallback, premises present | 6 | the premises, naming the cause |
| the same vacuous fixture with the premises removed | 0 | 23 tests pass while measuring nothing -- which is what the premises exist to catch |

## Artifact

`head_body.obj` from Menagerie's `flybody`, rendered headless in MuJoCo (EGL) at the scale
each column reports, centred on its own reported AABB, with an identical camera. The grey
bar is a 0.10 m box declared in the MJCF rather than by the loader, so it is an in-image
control.

![reported vs compiled mesh asset scale](https://github.com/cagataycali/robots/releases/download/artifacts/mesh_scale_default_class.png)

Measured on the renders with a segmentation pass (exact geom-id pixel counts, not a colour
threshold): subject pixels **41553** (`upstream/main`) / **359** (this change) / **359**
(MuJoCo resolving the class itself); subject bbox 205x259 / 18x25 / 18x25 px; control bar
**427 px in all three**. This change reproduces MuJoCo's own render exactly --
`np.array_equal` is `True`, mean |delta| `0.000000` -- while `upstream/main` sits 26.69 mean
levels away.

## Local gate

- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 errors on the branch and 24 on a pristine
  `upstream/main` worktree, byte-identical message sets**, 0 in the changed files.
- Selection of every test touching the loaders / mesh assets / scene objects (197 files,
  identical selection on both trees, the new file excluded from each):
  **`7587 passed, 73 skipped`, zero failures either side** (213.70s branch / 214.05s base).
- The new file: **23 passed on mujoco 3.12.0 and on 3.5.0**, the floor the manifest declares.
