### PR TITLE
fix(isaac): report an MJCF quat normalized, as the compiler reads it

### DIFF
--- a/changelog.d/2692-mjcf-quat-normalization.md
+++ b/changelog.d/2692-mjcf-quat-normalization.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **isaac**: an MJCF `quat` is reported normalized, the way MuJoCo's compiler reads it. A
+  quaternion describes a rotation only at unit norm, and MJCF authors routinely spell one
+  non-unit - `quat="1 -1 0 0"` is the idiomatic quarter turn. `_parse_quat` reported the four
+  components as written, so what the loaders handed back was not a rotation: MuJoCo's own
+  `mju_quat2Mat` builds the matrix from the components as given, and for that declaration it
+  yields the intended turn composed with a uniform scale of `|q|**2` - `det(R)` 8.0 instead of
+  1.0, a unit axis coming back twice as long. Graded against the `body_quat` MuJoCo's compiler
+  stored, 809 of 8398 robot links in the downloaded asset corpus disagreed with the compiler and
+  every one of the 809 is reconciled by normalizing; the reading now agrees on 8398 of 8398, with
+  no link moving away. 815 links across 140 files report a non-unit quaternion, including the
+  shipped registry robots `pal_tiago_dual` (15 links), `shadow_hand`, `wonik_allegro` and
+  `robotiq_2f85_v4`, plus 18 of 619 reported scene objects. `_parse_quat` is the one helper both
+  loaders resolve a `quat` through, so `load_mjcf`, `load_mjcf_scene_objects` and the mesh-geom
+  frame move together; the four alternative spellings (`euler`, `axisangle`, `xyaxes`, `zaxis`)
+  are constructed at unit norm already and are untouched. A zero quaternion has no direction to
+  normalize onto and joins the malformed readings (identity) rather than being reported as four
+  zeros - MuJoCo refuses such a model outright, and it is the one orientation
+  `coerce_orientation_quaternion` refuses on the write side, so reporting it was a reader handing
+  out a value this library's own writers reject. Magnitude remains outside the write contract: a
+  non-unit `orientation` passed into a setter is still accepted and normalized by the consumer.
+  This is what a read reports, where the consumer is unknown and the compiler is the oracle.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -214,7 +214,11 @@ open a window.
   `ProceduralRobot` dataclass. `load_mjcf` reports each link's pose in its
   parent's frame, reading the rotation from whichever of MJCF's five spellings
   the body uses - `quat`, `euler`, `axisangle`, `xyaxes` or `zaxis` - under the
-  model-global `<compiler angle>` and `<compiler eulerseq>`.
+  model-global `<compiler angle>` and `<compiler eulerseq>`. The reported
+  orientation is always a unit quaternion, the one MuJoCo's compiler stores: a
+  non-unit spelling such as `quat="1 -1 0 0"` (the idiomatic quarter turn) is
+  reported as the quarter turn it means, not as the components as written, which
+  applied as a rotation would scale the frame by `|q|^2` as well as turning it.
 
 Because the joint-name and observation contract matches the MuJoCo backend,
 policies and observation mappings transfer unchanged between backends.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -908,7 +908,21 @@ class SceneObject:
 
 
 def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
-    """Parse an MJCF ``quat="w x y z"`` string. Identity on failure."""
+    """Parse an MJCF ``quat="w x y z"`` string, normalized. Identity on failure.
+
+    A quaternion describes a rotation only at unit norm, and MuJoCo normalizes
+    every ``quat`` its compiler reads. Reporting the four components as written
+    hands the caller a value that is not a rotation: MuJoCo's own
+    ``mju_quat2Mat`` builds the matrix from the components as given, so
+    ``quat="1 -1 0 0"`` -- the idiomatic spelling of a quarter turn, which the
+    shipped asset corpus uses on hundreds of robot links -- yields that quarter
+    turn composed with a uniform scale of ``|q|**2``, twice size.
+
+    A zero quaternion has no direction to normalize onto, so it is read as
+    malformed: identity, this function's reading for every ``quat`` it cannot
+    use. MuJoCo refuses such a model outright ("zero quaternion is not
+    allowed"), so no model that compiles reaches here with one.
+    """
     if not quat_str:
         return (1.0, 0.0, 0.0, 0.0)
     try:
@@ -917,7 +931,10 @@ def _parse_quat(quat_str: str | None) -> tuple[float, float, float, float]:
         return (1.0, 0.0, 0.0, 0.0)
     if len(parts) != 4:
         return (1.0, 0.0, 0.0, 0.0)
-    return (parts[0], parts[1], parts[2], parts[3])
+    norm = math.sqrt(sum(p * p for p in parts))
+    if norm == 0.0:
+        return (1.0, 0.0, 0.0, 0.0)
+    return (parts[0] / norm, parts[1] / norm, parts[2] / norm, parts[3] / norm)
 
 
 #: MJCF's orientation spellings other than ``quat``. MuJoCo keeps these four in
@@ -1063,7 +1080,7 @@ def _parse_orientation(
     a model rotates is placed unrotated. Each is resolved the way MuJoCo's
     compiler does:
 
-    * ``quat="w x y z"`` -- taken as written (see the note below).
+    * ``quat="w x y z"`` -- normalized (see the note below).
     * ``euler="a b c"`` -- three rotations about the axes ``eulerseq`` names,
       composed about the *moving* axes (intrinsic), with the angles in the
       units ``<compiler angle>`` declares.
@@ -1082,10 +1099,10 @@ def _parse_orientation(
     ``quat``. :func:`_merge_mjcf_attrs` has already resolved which alternative
     spelling survives, so at most one reaches here.
 
-    A ``quat`` is reported as written rather than normalized. MuJoCo normalizes
-    it, but no ``quat`` in the shipped asset corpus is unnormalized, so
-    normalizing here would only move output for input no shipped model
-    contains; that is a separate contract from reading the spelling at all.
+    Every orientation this returns is a unit quaternion. The four alternative
+    spellings are constructed at unit norm, and a ``quat`` is normalized the way
+    MuJoCo's compiler normalizes it -- see :func:`_parse_quat` for why the
+    components as written are not a rotation.
 
     Args:
         attrs: The element's effective attributes -- ``el.attrib``, or

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -18,6 +18,8 @@ Focus areas (verified against the shipped loader behavior):
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from strands_robots.simulation.isaac.loaders import (
@@ -93,8 +95,10 @@ class TestSceneObjectExtraction:
         assert table.is_static is True
         assert table.size == pytest.approx((1.0, 0.6, 0.82))
         assert table.position == pytest.approx((1.0, 0.0, 0.01))
-        # The body-level quat is preserved as [w, x, y, z].
-        assert table.quat == pytest.approx((0.707, 0.0, 0.0, 0.707))
+        # The body-level quat is reported as [w, x, y, z], normalized the way
+        # MuJoCo's compiler normalizes it: the fixture's rounded 0.707 spelling
+        # of a quarter turn is reported as the quarter turn it means.
+        assert table.quat == pytest.approx((math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)))
         # The body-frame AABB-centre offset is recorded (#1820): pose
         # appliers recompose the prim pose from a NEW body pose as
         # ``body_pos + R(body_quat) @ offset``, which is unrecoverable

--- a/tests/simulation/isaac/test_mjcf_quat_normalization.py
+++ b/tests/simulation/isaac/test_mjcf_quat_normalization.py
@@ -1,0 +1,233 @@
+"""An MJCF ``quat`` is reported normalized, as MuJoCo's compiler reads it.
+
+A quaternion describes a rotation only at unit norm. MJCF authors routinely
+spell one non-unit -- ``quat="1 -1 0 0"`` is the idiomatic quarter turn, and the
+shipped asset corpus uses it on hundreds of robot links -- and MuJoCo's compiler
+normalizes what it reads. The loaders reported the four components as written,
+so what reached the caller was not a rotation: MuJoCo's own ``mju_quat2Mat``
+builds a matrix from the components as given, and that matrix scales by
+``|q|**2`` (twice size for the quarter turn above) on top of rotating.
+
+Every expectation here is derived from ``mujoco.MjModel``: the fixture is
+compiled and the loader compared against the ``body_quat`` the compiler stored,
+so no expected quaternion is restated by hand. The fixtures are shared with the
+orientation-spelling suite next door, because normalizing is a property of the
+one helper both readers resolve a ``quat`` through rather than of either reader.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from strands_robots.utils import coerce_orientation_quaternion
+
+from .test_mjcf_orientation_spellings import DECLARATIONS, _only, _write, _write_mesh_scene
+from .test_mjcf_robot_body_orientation import _link, _write_robot
+
+mujoco = pytest.importorskip("mujoco")
+
+#: ``quat`` declarations MuJoCo compiles, none of them a unit quaternion: the
+#: idiomatic quarter turn, a scaled identity, an unnormalized diagonal, a
+#: rounded quarter turn (the shape a hand-written asset produces) and a
+#: Pythagorean triple whose norm is exactly 5.
+NON_UNIT = ("1 -1 0 0", "2 0 0 0", "1 1 1 1", "0.707 0 0 0.707", "3 0 -4 0")
+
+#: Unit declarations, which must be reported unchanged rather than re-scaled.
+ALREADY_UNIT = ("1 0 0 0", "0.5 0.5 0.5 0.5", "0 1 0 0")
+
+#: ``quat`` values no reader can use, each already read as identity: the wrong
+#: number of components, or components that are not numbers at all.
+MALFORMED = ("1 0 0", "1 0 0 0 0", "not numbers", "")
+
+#: The one unusable value that has four numeric components. It has no direction
+#: to normalize onto, so it joins :data:`MALFORMED` rather than being scaled.
+ZERO = "0 0 0 0"
+
+IDENTITY = (1.0, 0.0, 0.0, 0.0)
+
+
+def _compiled_body_quat(path: str, name: str) -> np.ndarray:
+    """The orientation MuJoCo's compiler stored for the fixture's body."""
+    model = mujoco.MjModel.from_xml_path(path)
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert body >= 0, f"premise: the fixture declares a body named {name!r}"
+    return np.asarray(model.body_quat[body], dtype=float)
+
+
+def _rotation_matrix(quat) -> np.ndarray:
+    """The matrix MuJoCo builds from a quaternion, without normalizing it first.
+
+    ``mju_quat2Mat`` is what a consumer applying a reported orientation reaches
+    for, and it uses the components as given -- which is why the norm of the
+    reported value is load-bearing rather than cosmetic.
+    """
+    rot = np.zeros(9)
+    mujoco.mju_quat2Mat(rot, np.asarray(quat, dtype=float))
+    return rot.reshape(3, 3)
+
+
+def _norm(quat) -> float:
+    return math.sqrt(sum(float(c) * float(c) for c in quat))
+
+
+class TestTheFixturesAreWhatTheyClaim:
+    """Non-vacuity: the declarations really are non-unit, unit and unusable."""
+
+    @pytest.mark.parametrize("declaration", NON_UNIT)
+    def test_a_non_unit_declaration_is_not_already_normalized(self, declaration):
+        deviation = abs(_norm(declaration.split()) - 1.0)
+        assert deviation > 1e-6, (
+            f"premise: {declaration!r} differs from unit norm by {deviation}, far above the 1e-12 the "
+            "comparisons below allow, so normalizing it moves the reported value"
+        )
+
+    @pytest.mark.parametrize("declaration", ALREADY_UNIT)
+    def test_a_unit_declaration_is_already_normalized(self, declaration):
+        assert _norm(declaration.split()) == pytest.approx(1.0, abs=1e-12)
+
+    @pytest.mark.parametrize("declaration", NON_UNIT)
+    def test_mujoco_compiles_every_non_unit_declaration(self, tmp_path, declaration):
+        """The oracle exists: MuJoCo reads these models rather than refusing them."""
+        quat = _compiled_body_quat(_write_robot(tmp_path, body_attrs=f'quat="{declaration}"'), "link")
+        assert _norm(quat) == pytest.approx(1.0, abs=1e-12), "premise: MuJoCo's own answer is a unit quaternion"
+
+
+class TestARobotLinksQuatIsNormalized:
+    """The regression for ``load_mjcf``: a link's reported ``quat`` was the file's."""
+
+    @pytest.mark.parametrize("declaration", NON_UNIT)
+    def test_the_reported_orientation_is_the_one_mujoco_compiled(self, tmp_path, declaration):
+        path = _write_robot(tmp_path, body_attrs=f'quat="{declaration}"')
+        assert _link(path).orientation == pytest.approx(_compiled_body_quat(path, "link"), abs=1e-12)
+
+    @pytest.mark.parametrize("declaration", NON_UNIT)
+    def test_the_reported_orientation_is_a_unit_quaternion(self, tmp_path, declaration):
+        path = _write_robot(tmp_path, body_attrs=f'quat="{declaration}"')
+        assert _norm(_link(path).orientation) == pytest.approx(1.0, abs=1e-12)
+
+    def test_the_reported_orientation_rotates_without_scaling(self, tmp_path):
+        """What the norm costs a caller: the frame the reported value describes.
+
+        A quaternion applied as a rotation without being normalized first scales
+        the frame by ``|q|**2``. The quarter turn below is spelled at norm
+        ``sqrt(2)``, so the matrix built from the components as written doubles
+        every axis -- a link twice its size, from an orientation.
+        """
+        path = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
+        as_written = _rotation_matrix((1.0, -1.0, 0.0, 0.0))
+        assert np.linalg.norm(as_written @ np.array([1.0, 0.0, 0.0])) == pytest.approx(2.0), (
+            "premise: applying the declaration as written scales the frame, so the fix is not cosmetic"
+        )
+        reported = _rotation_matrix(_link(path).orientation)
+        assert np.linalg.det(reported) == pytest.approx(1.0, abs=1e-9)
+        for axis in np.eye(3):
+            assert np.linalg.norm(reported @ axis) == pytest.approx(1.0, abs=1e-9)
+
+    def test_a_nested_links_quat_is_normalized_too(self, tmp_path):
+        """The reported frame is parent-relative, and both levels are normalized."""
+        path = str(tmp_path / "nested.xml")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(
+                '<mujoco><worldbody><body name="link" pos="0.1 0 0" quat="1 -1 0 0">'
+                '<joint name="j" type="hinge" axis="0 0 1"/><geom type="box" size="0.1 0.05 0.02"/>'
+                '<body name="child" pos="0 0.2 0" quat="0 2 0 2">'
+                '<joint name="k" type="hinge" axis="0 1 0"/><geom type="box" size="0.05 0.05 0.05"/>'
+                "</body></body></worldbody></mujoco>"
+            )
+        for name in ("link", "child"):
+            got = _link(path, name).orientation
+            assert got == pytest.approx(_compiled_body_quat(path, name), abs=1e-12)
+            assert _norm(got) == pytest.approx(1.0, abs=1e-12)
+
+
+class TestASceneObjectsQuatIsNormalized:
+    """The same helper feeds ``load_mjcf_scene_objects``, so both readers move together."""
+
+    @pytest.mark.parametrize("declaration", NON_UNIT)
+    def test_the_reported_object_orientation_is_the_one_mujoco_compiled(self, tmp_path, declaration):
+        path = _write(tmp_path, body_attrs=f'quat="{declaration}"')
+        assert _only(path).quat == pytest.approx(_compiled_body_quat(path, "obj"), abs=1e-12)
+
+    def test_a_mesh_geoms_reported_frame_is_normalized(self, tmp_path):
+        """The third reader of the same helper: a mesh geom's frame within its body.
+
+        Graded transitively against the body reading of the same declaration --
+        MuJoCo folds a mesh's principal-inertia alignment into ``geom_quat``, so
+        the compiled value is not the frame the file declared and cannot serve
+        as the oracle here.
+        """
+        got = _only(_write_mesh_scene(tmp_path, 'quat="1 -1 0 0"')).mesh_quat
+        expected = _compiled_body_quat(_write(tmp_path, body_attrs='quat="1 -1 0 0"'), "obj")
+        assert got == pytest.approx(expected, abs=1e-12)
+        assert _norm(got) == pytest.approx(1.0, abs=1e-12)
+
+    def test_both_readers_report_one_declaration_the_same_way(self, tmp_path):
+        """One rotation, two public readers, one answer."""
+        robot = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
+        scene = _write(tmp_path, body_attrs='quat="1 -1 0 0"')
+        assert _link(robot).orientation == pytest.approx(_only(scene).quat, abs=1e-12)
+
+
+class TestAZeroQuatIsReadAsMalformed:
+    """The one non-unit ``quat`` that cannot be normalized was reported verbatim.
+
+    Four zeros are not a direction, so there is nothing to normalize onto and
+    the reading is identity -- this loader's answer for every ``quat`` it cannot
+    use. It is also the one orientation the library refuses on its write side, so
+    reporting it was a reader handing out a value its own writers reject.
+    """
+
+    def test_the_reported_orientation_is_identity(self, tmp_path):
+        path = _write_robot(tmp_path, body_attrs=f'quat="{ZERO}"')
+        assert _link(path).orientation == pytest.approx(IDENTITY)
+
+    def test_the_scene_reader_agrees(self, tmp_path):
+        path = _write(tmp_path, body_attrs=f'quat="{ZERO}"')
+        assert _only(path).quat == pytest.approx(IDENTITY)
+
+    def test_the_verbatim_reading_is_refused_on_the_write_side(self):
+        """The value the loaders used to report, offered to the library's own guard."""
+        accepted, error = coerce_orientation_quaternion("add_object", "orientation", [0.0, 0.0, 0.0, 0.0])
+        assert accepted is None
+        assert error is not None and "zero norm" in error
+
+    def test_mujoco_refuses_a_zero_quaternion(self, tmp_path):
+        """No compiled model is affected: MuJoCo refuses such a file outright."""
+        path = _write_robot(tmp_path, body_attrs=f'quat="{ZERO}"')
+        with pytest.raises(ValueError, match="zero quaternion is not allowed"):
+            mujoco.MjModel.from_xml_path(path)
+
+
+class TestTheReadingIsNotWidened:
+    """What normalizing must not disturb: unit input, the other four spellings, refusals."""
+
+    @pytest.mark.parametrize("declaration", ALREADY_UNIT)
+    def test_a_unit_quat_is_reported_unchanged(self, tmp_path, declaration):
+        expected = tuple(float(part) for part in declaration.split())
+        path = _write_robot(tmp_path, body_attrs=f'quat="{declaration}"')
+        assert _link(path).orientation == pytest.approx(expected, abs=1e-15)
+
+    @pytest.mark.parametrize("declaration", MALFORMED)
+    def test_a_quat_no_reader_can_use_is_identity(self, tmp_path, declaration):
+        path = _write_robot(tmp_path, body_attrs=f'quat="{declaration}"')
+        assert _link(path).orientation == pytest.approx(IDENTITY), (
+            "identity is this loader's historical reading for a malformed orientation"
+        )
+
+    @pytest.mark.parametrize("spelling", [s for s in DECLARATIONS if s != "quat"])
+    def test_the_alternative_spellings_still_match_mujoco(self, tmp_path, spelling):
+        """The four constructed spellings were already unit and are untouched."""
+        path = _write_robot(tmp_path, body_attrs=f'{spelling}="{DECLARATIONS[spelling]}"')
+        got = _link(path).orientation
+        expected = _compiled_body_quat(path, "link")
+        assert min(np.abs(np.array(got) - expected).max(), np.abs(np.array(got) + expected).max()) < 1e-9
+        assert _norm(got) == pytest.approx(1.0, abs=1e-12)
+
+    def test_the_other_reported_link_fields_are_unchanged(self, tmp_path):
+        link = _link(_write_robot(tmp_path, body_attrs='quat="1 -1 0 0"'))
+        assert link.position == pytest.approx((0.1, 0.2, 0.3))
+        assert link.shape == "box"
+        assert link.shape_size == pytest.approx((0.1, 0.05, 0.02))

--- a/tests/simulation/isaac/test_mjcf_robot_body_orientation.py
+++ b/tests/simulation/isaac/test_mjcf_robot_body_orientation.py
@@ -264,27 +264,20 @@ class TestTheReportedRotationIsNotWidened:
         assert link.shape_size == pytest.approx((0.1, 0.05, 0.02))
 
 
-class TestTheNormalizationBoundaryIsUnchanged:
-    """A ``quat`` is still reported as written, which is where this change stops.
+class TestANonUnitQuatIsNormalized:
+    """A ``quat`` is reported normalized, the way MuJoCo's compiler reads it.
 
-    MuJoCo normalizes a ``quat`` its compiler reads; ``_parse_orientation``
-    reports it as written, and that choice is shared with the scene reader
-    rather than local to this one. Reading the spelling and normalizing the
-    result are separate questions with separate blast radii, so the boundary is
-    pinned here instead of being moved silently: a non-unit ``quat`` reaches the
-    caller exactly as the file spells it.
+    A quaternion describes a rotation only at unit norm, and MJCF's idiomatic
+    quarter turn ``quat="1 -1 0 0"`` is not one -- reporting the four components
+    as written handed the caller a value that scales the frame it rotates. The
+    reading is graded across both loaders and both readers of the shared helper
+    in :mod:`tests.simulation.isaac.test_mjcf_quat_normalization`; what belongs
+    here is the link-level statement, beside the other four spellings.
     """
 
-    def test_a_non_unit_quat_is_reported_as_written(self, tmp_path):
-        path = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
-        got = _link(path).orientation
-        assert got == pytest.approx((1.0, -1.0, 0.0, 0.0))
-
-    def test_mujoco_normalizes_the_same_declaration(self, tmp_path):
-        """The premise of the boundary: the two answers differ, and by how much."""
+    def test_a_non_unit_quat_is_reported_as_mujoco_compiles_it(self, tmp_path):
         path = _write_robot(tmp_path, body_attrs='quat="1 -1 0 0"')
         expected = _mujoco_body_quat(path)
         assert expected == pytest.approx((math.sqrt(0.5), -math.sqrt(0.5), 0.0, 0.0))
-        assert _same_rotation(_link(path).orientation, expected) > 0.1, (
-            "premise: the reported value and MuJoCo's differ, so this boundary is load-bearing rather than decorative"
-        )
+        assert _link(path).orientation == pytest.approx(expected, abs=1e-12)
+        assert _same_rotation(_link(path).orientation, expected) < 1e-12


### PR DESCRIPTION
## Problem

A quaternion describes a rotation only at unit norm, and MJCF authors routinely spell one non-unit: `quat="1 -1 0 0"` is the idiomatic quarter turn. MuJoCo's compiler normalizes what it reads. `_parse_quat` reported the four components as written, so what the loaders handed back was not a rotation.

What that costs a caller, measured through MuJoCo's own converter:

| quaternion | norm | `mju_quat2Mat` det(R) | length of R applied to a unit axis |
| --- | --- | --- | --- |
| `1 -1 0 0` as written | 1.414214 | 8.0 | 2.0 |
| the same value normalized | 1.0 | 1.0 | 1.0 |

`mju_quat2Mat` builds the matrix from the components as given, so a frame reconstructed from the reported value is the intended quarter turn composed with a uniform scale of `|q|**2`.

The module docstring justified reporting the components as written with "no `quat` in the shipped asset corpus is unnormalized". The corpus refutes that.

## Change

`_parse_quat` normalizes. It is the one helper both loaders resolve a `quat` through, so `load_mjcf`, `load_mjcf_scene_objects` and the mesh-geom frame move together rather than one at a time.

Three things deliberately do not move:

- The four alternative spellings (`euler`, `axisangle`, `xyaxes`, `zaxis`) are constructed at unit norm already and are untouched.
- A malformed `quat` still reads as identity.
- A zero quaternion has no direction to normalize onto, so it joins the malformed readings instead of being scaled. Previously it was reported as four zeros. MuJoCo refuses such a model outright ("zero quaternion is not allowed"), and it is the one orientation `coerce_orientation_quaternion` refuses on the write side, so reporting it verbatim was a reader handing out a value this library's own writers reject.

Magnitude is still not part of the *write* contract: a non-unit `orientation` passed into a setter is accepted and normalized by the consumer, exactly as #2690 left it. This is about what a *read* reports, where the consumer is unknown and the oracle is the compiler.

## Measured against the compiler

Every robot link in the downloaded asset corpus, graded against the `body_quat` MuJoCo's compiler stored for the same body (compared up to sign, since `q` and `-q` are one rotation):

| reading | links graded | agree | disagree | reconciled by normalizing | unexplained |
| --- | --- | --- | --- | --- | --- |
| `upstream/main` | 8398 | 7589 | 809 | 809 | 0 |
| this branch | 8398 | 8398 | 0 | - | - |

Not one link moves away from the compiler, and the 809 that move toward it are explained in full: normalizing the reported value reconciles every one.

815 links across 140 files report a quaternion whose norm differs from 1 by more than `1e-6` (the six beyond the 809 round to the compiled value anyway). Affected shipped registry robots include `pal_tiago_dual` (15 links, in each of its 7 model and scene files), `shadow_hand`, `wonik_allegro` and `robotiq_2f85_v4`. On the scene-object side, 18 of 619 reported objects were non-unit, in `shadow_hand`, `wonik_allegro` and `robotiq_2f85_v4`.

## Artifact

`pal_tiago_dual`, `arm_left_2_link`, which declares `quat="1 1 0 0"`. Each panel draws the frame the reported orientation describes - three capsules from the origin along the columns of the matrix `mju_quat2Mat` builds from that value, 0.24 m per unit of length. The grey bar is declared in the MJCF rather than derived from the loader, which makes it an in-image control.

![reported orientation, upstream vs this branch vs the compiler](https://github.com/cagataycali/robots/releases/download/artifacts/quat_normalization.png)

| panel | reported wxyz | norm | det(R) | axis length | axis pixels (x, y, z) | reference bar |
| --- | --- | --- | --- | --- | --- | --- |
| `upstream/main` | `1, 1, 0, 0` | 1.414214 | 8.0 | 0.48 m | 2348, 2320, 2119 | 960 px |
| this branch | `0.707107, 0.707107, 0, 0` | 1.000000 | 1.0 | 0.24 m | 990, 1044, 847 | 960 px |
| MuJoCo's `body_quat` | `0.707107, 0.707107, 0, 0` | 1.000000 | 1.0 | 0.24 m | 990, 1044, 847 | 960 px |

The right two panels are byte-identical (`np.array_equal`), so the branch reports the frame the compiler stored; main is 2.70 mean levels away. Pixel counts are exact geom-id segmentation renders, not colour masks. Rendered headless (`MUJOCO_GL=egl`, mujoco 3.12.0).

## Tests

`tests/simulation/isaac/test_mjcf_quat_normalization.py`, 48 cases, every expectation derived from `mujoco.MjModel` rather than restated by hand. It covers both public loaders, the mesh-geom frame, a nested link (the reported frame is parent-relative and both levels are normalized), the frame the reported value builds, and the zero quaternion offered to this library's own write-side guard. A non-vacuity class asserts each fixture is what it claims: the non-unit declarations really differ from unit norm, and MuJoCo really compiles them.

Two existing expectations were superseded and are updated in the same change: the boundary class in `test_mjcf_robot_body_orientation.py` that pinned "reported as written", and a fixture in `test_description_loader_geometry.py` whose rounded `quat="0.707 0 0 0.707"` now reads as the quarter turn it means.

Pre-fix, with the source reverted and the tests kept: **22 failed, 106 passed** across the three files, all 22 in the four regression classes plus the superseded fixture, **0 in either control class**. Post-fix: **128 passed**, on mujoco 3.12.0 and on the declared 3.5.0 floor.

### What each break costs

Failures over the same three files (128 tests):

| mutation | failures | notes |
| --- | --- | --- |
| control, no mutation | 0 | |
| exact pre-fix source | 22 | the split above |
| infinity norm instead of Euclidean | 20 | also fires the pre-existing spelling suite and a control: a wrong norm breaks already-unit input too |
| no zero-norm guard | 2 | `ZeroDivisionError` on the zero case alone |
| raise on a zero quat instead of identity | 2 | the same two: the zero reading is pinned independently of how it fails |
| near-unit values left as written | 30 | the rounded `0.707` spelling is pinned separately from the plainly scaled ones |
| sign flipped (same rotation, other sign) | 17 | the comparisons grade sign against the compiler, not just the rotation |
| normalized in the robot reader only | 10 | scene-reader classes alone, which is why the fix belongs in the shared helper |

Eight mutations, seven distinct firing sets (the two zero-quaternion mutations coincide).

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean, 1514 files already formatted.
- `mypy strands_robots tests tests_integ`: 24 errors on this branch and 24 on a pristine `upstream/main` worktree, with byte-identical message sets and none in the changed files.
- A 242-file selection (every test naming the loaders, a reported pose, a scene object or the Isaac backend), with the three changed test files excluded from both sides so the collected set is identical: **9705 passed, 141 skipped, 45 errors on both trees** (201.70s vs 203.76s), 45 failing ids each, and both `comm` directions empty. The 45 errors are `device_connect_edge` missing from this local environment; it is declared as `device-connect-edge>=0.2.0` in the `[device-connect]` extra, which `[all]` pulls in.
- CodeQL AST preflight over the changed source file: identical hit sets on this branch and on the pristine base.

#### After merging main

`main` landed #2691 in this same file after this branch diverged, so the combination was verified rather than assumed:

- Both changes are present: the normalization in `_parse_quat` once, and #2691's mesh-asset class resolution at its call site.
- Both PRs' test files together: 151 passed. The whole `tests/simulation/isaac/` suite: 1334 passed, 5 skipped, under random ordering.
- A break that reverts #2691's mesh-asset class resolution on the merged tree fires 14 tests, all of them in its own three classes - so the resolution did not quietly drop it.
- The pre-fix split, re-measured against the new base: unchanged at 22 failed, 106 passed, with the same class distribution.
- The corpus grading, re-run on the merged tree: still 8398 of 8398 links agreeing with the compiler.
- The selection above (243 files at the new base): **9728 passed, 141 skipped, 45 errors on both trees** (194.33s vs 194.82s), both `comm` directions empty. `mypy` 24 == 24 with byte-identical message sets; `ruff` clean, 1515 files formatted.
