### PR TITLE
fix(rendering): hold encode_clip's macro_block_size to the shared whole-number domain

### DIFF
--- a/changelog.d/2695-encode-clip-macro-block-size-domain.md
+++ b/changelog.d/2695-encode-clip-macro-block-size-domain.md
@@ -1,0 +1,33 @@
+### Fixed: `encode_clip`'s `macro_block_size` is held to the shared whole-number domain
+
+`encode_clip` has three encoder knobs and only two were checked: `fps` resolved through
+`positive_whole_number_error` and `quality` through `_clip_quality_error`, while
+`macro_block_size` was handed to the writer unchecked. The accepted set was wrong in both
+directions.
+
+`imageio`'s ffmpeg plugin normalizes a falsy value (`macro_block_size = macro_block_size or 1`)
+and only rounds when the value is `> 1`, so `0`, `-4`, `None`, `False` and `True` were all read
+as "no rounding" while the caller was told the clip had been written. On 60x40 frames a request
+for `macro_block_size=0` produced a clip byte-identical to `macro_block_size=1`, so nothing
+could tell a dropped request from an honored one. And `imageio-ffmpeg` enforces the knob's type
+with a bare `assert isinstance(macro_block_size, int)`, which `python -O` strips: on an
+optimized interpreter `nan` produced that same byte-identical clip and reported success, `2.5`
+and `inf` surfaced only as "the encoder wrote no clip", and `"8"` leaked a raw `TypeError` out
+of the writer's comparison. The verdict for one call depended on an interpreter flag - the same
+reason `quality` is not left to the writer's own assert either.
+
+In the other direction, `8.0`, `np.int64(8)` and `np.float64(8.0)` each name the same block size
+as the `8` that encodes, and the writer's `isinstance(..., int)` gate refused all three.
+
+The knob now resolves through the shared `positive_whole_number_error` beside the existing `fps`
+guard, so a value refused when it names a frame rate cannot be accepted when it names the
+rounding of that same clip, and it is passed to the writer as `int(macro_block_size)` exactly as
+`int(fps)` and `float(quality)` beside it already are. The guard runs before the optional-encoder
+probe, so the same mistake reports identically whether or not `imageio` is installed, and it
+applies to both containers: GIF has no macro blocks, but a call must not become valid by changing
+an extension.
+
+A block size that is a positive whole number and that the codec nonetheless refuses - `7` rounds
+a 48x32 frame to 49x35, which libx264 will not encode - stays the post-encode `RuntimeError` it
+already was. This function cannot know which rounded sizes a codec takes, so the domain applies
+no ceiling of its own and that boundary is pinned either way.

--- a/strands_robots/rendering/video.py
+++ b/strands_robots/rendering/video.py
@@ -104,9 +104,16 @@ def encode_clip(
             but the domain applies to both containers so that one call does not
             become valid by changing the output extension. A NumPy real is
             accepted and converted for the writer.
-        macro_block_size: libx264 macro-block rounding; ``1`` preserves the
-            exact frame size (the recorders' convention), ``8``/``16`` lets
-            ffmpeg pad to codec-friendly sizes. Ignored for GIF.
+        macro_block_size: libx264 macro-block rounding, a positive whole number
+            of pixels on the same shared media domain as ``fps`` (see
+            :func:`~strands_robots.utils.positive_whole_number_error`); ``1``
+            preserves the exact frame size (the recorders' convention),
+            ``8``/``16`` lets ffmpeg pad to codec-friendly sizes. Read only by
+            the MP4 writer, since GIF has no macro blocks, but the domain
+            applies to both containers for the same reason ``quality``'s does.
+            A NumPy integer or an integral float is accepted and converted for
+            the writer, whose own ``isinstance(..., int)`` gate would otherwise
+            refuse a block size this function has already accepted.
 
     Returns:
         The output path.
@@ -114,10 +121,11 @@ def encode_clip(
     Raises:
         ImportError: if ``imageio`` (and, for MP4, ``imageio-ffmpeg``) is not
             installed.
-        ValueError: if ``frames`` is empty, if ``fps`` is not a positive whole
-            number, or if ``quality`` is not a finite number in ``[1, 10]`` --
-            each would silently produce a corrupt, wrongly-timed or
-            wrongly-encoded artifact rather than the requested clip.
+        ValueError: if ``frames`` is empty, if ``fps`` or ``macro_block_size``
+            is not a positive whole number, or if ``quality`` is not a finite
+            number in ``[1, 10]`` -- each would silently produce a corrupt,
+            wrongly-timed or wrongly-encoded artifact rather than the requested
+            clip.
         RuntimeError: if the encoder wrote no clip despite accepting the
             frames (for example a ``macro_block_size`` that rounds the frame
             size to dimensions libx264 refuses), so the returned path always
@@ -128,6 +136,14 @@ def encode_clip(
     if text := positive_whole_number_error(fps, "fps", "encode_clip"):
         raise ValueError(text)
     if text := _clip_quality_error(quality):
+        raise ValueError(text)
+    # The rounding step is the third encoder knob and shares ``fps``'s domain:
+    # a block size of ``0`` or ``-4`` has no rounding to apply, and ``ffmpeg``
+    # is only asked to pad by a whole number of pixels. Guarded here rather
+    # than left to the writer, which enforces it with a bare
+    # ``assert isinstance(macro_block_size, int)`` that ``python -O`` strips -
+    # the same reason ``quality`` is not left to the writer's own assert.
+    if text := positive_whole_number_error(macro_block_size, "macro_block_size", "encode_clip"):
         raise ValueError(text)
     require_optional(
         "imageio",
@@ -151,7 +167,17 @@ def encode_clip(
         # writer gates the knob on ``isinstance(quality, (float, int))``, which
         # a NumPy scalar such as ``np.int64(8)`` or ``np.float32(8.0)`` fails
         # even though it names a quality this function has already accepted.
-        writer = imageio.get_writer(str(out), fps=int(fps), quality=float(quality), macro_block_size=macro_block_size)
+        # ``int(macro_block_size)`` is load-bearing for the same reason as the
+        # ``float(quality)`` beside it: the writer gates the knob on
+        # ``isinstance(macro_block_size, int)``, which a NumPy ``np.int64(8)``
+        # or an integral ``8.0`` fails even though each names a block size this
+        # function has already accepted.
+        writer = imageio.get_writer(
+            str(out),
+            fps=int(fps),
+            quality=float(quality),
+            macro_block_size=int(macro_block_size),
+        )
         try:
             for frame in frame_list:
                 writer.append_data(frame)

--- a/strands_robots/utils.py
+++ b/strands_robots/utils.py
@@ -794,7 +794,8 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     * The media knobs that count frames or pixels - the recorders' ``fps``,
       ``width``, ``height`` and in-memory frame cap, the
       ``run_policy(video=...)`` dict fields, and the
-      :func:`~strands_robots.rendering.encode_clip` playback rate.
+      :func:`~strands_robots.rendering.encode_clip` playback rate and
+      macro-block rounding.
     * The physics steps one applied action is held for - the ``n_substeps`` of
       every backend's
       :meth:`~strands_robots.simulation.base.SimEngine.send_action`.
@@ -823,7 +824,8 @@ def positive_whole_number_error(value: Any, param: str, context: str) -> str | N
     owns such a ceiling: :func:`coerce_zmq_timeout_ms` composes this guard and
     then applies :data:`MAX_ZMQ_TIMEOUT_MS`, because a ZMQ send/receive timeout
     is stored as a C ``int`` and this domain accepts ``2**31``.
-    Its callers are ``fps``, ``width``, ``height``, ``max_frames``, the mesh
+    Its callers are ``fps``, ``width``, ``height``, ``max_frames``,
+    ``encode_clip``'s ``macro_block_size``, the mesh
     robots' ``drive(count=...)``, ``send_action(n_substeps=)`` and the ZMQ
     clients' ``timeout_ms``. Two of those
     repeat work that nothing bounds: ``drive`` repeats an actuation command, so

--- a/tests/rendering/test_encode_clip_macro_block_size_domain.py
+++ b/tests/rendering/test_encode_clip_macro_block_size_domain.py
@@ -1,0 +1,275 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""``encode_clip`` only accepts a ``macro_block_size`` the clip encoder can honor.
+
+``macro_block_size`` is the third of ``encode_clip``'s three encoder knobs, and
+the only one left with no domain: ``fps`` resolves through
+:func:`~strands_robots.utils.positive_whole_number_error` and ``quality``
+through ``_clip_quality_error``, while the rounding step was handed to the
+writer unchecked. The accepted set was wrong in both directions.
+
+* **Nonsense in.** ``imageio``'s ffmpeg plugin normalizes a falsy value
+  (``macro_block_size = macro_block_size or 1``) and only rounds when the value
+  is ``> 1``, so ``0``, ``-4``, ``None``, ``False`` and ``True`` all encoded as
+  "no rounding" -- byte-identical to ``macro_block_size=1`` -- while the caller
+  was told the clip was written. ``True`` is the same ``bool`` substitution
+  ``_clip_quality_error`` already rejects for this module's other quality knob.
+* **The dependency's check is a bare assert.** ``imageio-ffmpeg`` guards the
+  knob with ``assert isinstance(macro_block_size, int)``, so the refusal was an
+  ``AssertionError`` -- absent from the documented ``Raises:`` set -- and
+  ``python -O`` strips it. On an optimized interpreter ``nan`` encoded that same
+  byte-identical clip and reported success, ``2.5`` and ``inf`` surfaced only as
+  "the encoder wrote no clip", and ``"8"`` leaked a raw ``TypeError`` out of the
+  writer's ``macro_block_size > 1`` comparison. The verdict for one call
+  depended on an interpreter flag.
+* **Usable out.** ``8.0``, ``np.int64(8)`` and ``np.float64(8.0)`` each name the
+  same block size as the ``8`` that encodes, and the writer's ``isinstance(...,
+  int)`` gate refused all three -- the mirror of the ``float(quality)``
+  conversion this module already documents as load-bearing.
+
+These tests pin the domain, its independence from ``-O``, that every usable
+spelling still reaches the writer, and that the codec's own refusal of a
+*legitimate* block size stays the post-encode ``RuntimeError`` it already was.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from strands_robots.rendering import encode_clip
+from strands_robots.utils import positive_whole_number_error
+
+# Values that name no macro-block size: zero and negative sizes, a missing
+# value, both bools (each acted as "no rounding"), a NumPy bool, a fractional
+# size, non-finite floats, a numeric string, a sequence, and an integer too
+# large to convert to a float.
+UNUSABLE_BLOCK_SIZE = [0, -4, None, False, True, np.True_, 2.5, math.nan, math.inf, -math.inf, "8", [8], 10**400]
+
+# Every spelling of a usable block size: the recorders' ``1``, the examples'
+# ``8``, the writer's own default ``16``, an integral float, and NumPy integers
+# and reals that the writer's type gate would refuse on its own.
+USABLE_BLOCK_SIZE = [1, 8, 16, 8.0, np.int64(8), np.float64(8.0)]
+
+# Values that were silently read as "no rounding" rather than refused. Kept
+# apart from the rest of ``UNUSABLE_BLOCK_SIZE`` because these are the ones the
+# caller was told had been honored.
+SILENTLY_IGNORED = [0, -4, None, False, True]
+
+
+def _frames(n: int = 6, w: int = 48, h: int = 32) -> list[np.ndarray]:
+    """``n`` distinct RGB frames of one shape (a gradient, so decode is visible).
+
+    ``48x32`` is divisible by 16, so every block size in
+    :data:`USABLE_BLOCK_SIZE` rounds it to itself and the codec accepts the
+    result -- the rounding's own effect is measured separately, on a frame size
+    chosen for it.
+    """
+    return [np.full((h, w, 3), (i * 20) % 256, dtype=np.uint8) for i in range(n)]
+
+
+def _odd_frames(n: int = 4) -> list[np.ndarray]:
+    """Frames at ``60x40``, divisible by neither 8 nor 16, so rounding is visible."""
+    return [np.full((40, 60, 3), 30 + i * 30, dtype=np.uint8) for i in range(n)]
+
+
+class TestAnUnusableMacroBlockSizeIsRefused:
+    """A value that names no block size is a ValueError, before any I/O."""
+
+    @pytest.mark.parametrize("suffix", [".gif", ".mp4"])
+    @pytest.mark.parametrize("macro_block_size", UNUSABLE_BLOCK_SIZE)
+    def test_it_is_refused_before_any_file_is_written(self, tmp_path, suffix, macro_block_size) -> None:
+        """The refusal names the parameter and leaves no artifact behind."""
+        out = tmp_path / f"clip{suffix}"
+        with pytest.raises(ValueError, match="macro_block_size must be"):
+            encode_clip(_frames(), out, fps=10, macro_block_size=macro_block_size)
+        assert not out.exists(), f"encode_clip(macro_block_size={macro_block_size!r}) left a file at {out}"
+
+    @pytest.mark.parametrize("macro_block_size", UNUSABLE_BLOCK_SIZE)
+    def test_the_refusal_is_the_shared_whole_number_domains_own_text(self, tmp_path, macro_block_size) -> None:
+        """One domain, one message: the rounding step shares ``fps``'s guard.
+
+        Compared against the helper rather than a restated string, so a block
+        size refused when it names a frame rate cannot be accepted when it names
+        the rounding of that same clip.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            encode_clip(_frames(), tmp_path / "clip.mp4", fps=10, macro_block_size=macro_block_size)
+        assert str(excinfo.value) == positive_whole_number_error(macro_block_size, "macro_block_size", "encode_clip")
+
+    @pytest.mark.parametrize("macro_block_size", [0, None, True, 2.5, "8"])
+    def test_it_is_refused_before_the_optional_encoder_is_probed(self, tmp_path, monkeypatch, macro_block_size) -> None:
+        """The same mistake reports identically whether or not imageio is installed."""
+        from strands_robots.rendering import video
+
+        def _no_imageio(*args, **kwargs):
+            raise AssertionError("require_optional must not be reached for a refused block size")
+
+        monkeypatch.setattr(video, "require_optional", _no_imageio)
+        with pytest.raises(ValueError, match="macro_block_size must be"):
+            encode_clip(_frames(), tmp_path / "clip.mp4", fps=10, macro_block_size=macro_block_size)
+
+    @pytest.mark.parametrize("macro_block_size", [0, None, True, 2.5])
+    def test_the_domain_does_not_depend_on_the_output_container(self, tmp_path, macro_block_size) -> None:
+        """GIF has no macro blocks, but changing the extension cannot make a call valid.
+
+        Otherwise the same call would be accepted or refused depending on a
+        string, and a caller would learn that a block size of ``0`` is fine.
+        """
+        messages = []
+        for suffix in (".gif", ".mp4"):
+            with pytest.raises(ValueError, match="macro_block_size must be") as excinfo:
+                encode_clip(_frames(), tmp_path / f"clip{suffix}", fps=10, macro_block_size=macro_block_size)
+            messages.append(str(excinfo.value))
+        assert messages[0] == messages[1], messages
+
+
+class TestTheIgnoredRequestWasInvisible:
+    """The values that were accepted encoded as if ``1`` had been asked for."""
+
+    @pytest.mark.parametrize("macro_block_size", SILENTLY_IGNORED)
+    def test_a_block_size_that_would_have_been_ignored_is_refused(self, tmp_path, macro_block_size) -> None:
+        """Nothing reported the knob had been dropped, so the refusal has to."""
+        out = tmp_path / "ignored.mp4"
+        with pytest.raises(ValueError, match="macro_block_size must be"):
+            encode_clip(_odd_frames(), out, fps=10, macro_block_size=macro_block_size)
+        assert not out.exists()
+
+    def test_the_substitution_it_would_have_made_is_not_a_no_op(self, tmp_path) -> None:
+        """Rounding changes the encoded clip, so being read as ``1`` mattered.
+
+        At ``60x40`` a block size of ``8`` pads the frame to ``64x40`` and ``16``
+        to ``64x48``, so a request that was silently read as "no rounding"
+        produced a clip at dimensions other than the ones asked for -- this is
+        the premise that makes the refusal above worth having.
+        """
+        pytest.importorskip("imageio.v2")
+        pytest.importorskip("imageio_ffmpeg")
+        imageio = pytest.importorskip("imageio.v2")
+        sizes = {}
+        for block in (1, 8, 16):
+            path = encode_clip(_odd_frames(), tmp_path / f"b{block}.mp4", fps=10, macro_block_size=block)
+            reader = imageio.get_reader(path)
+            try:
+                sizes[block] = tuple(reader.get_meta_data()["size"])
+            finally:
+                reader.close()
+        assert sizes[1] == (60, 40), sizes
+        assert len(set(sizes.values())) == 3, f"rounding must change the encoded size: {sizes}"
+
+
+class TestTheRefusalDoesNotDependOnAssertionsBeingEnabled:
+    """``python -O`` strips the writer's ``assert``, so the guard must not be one."""
+
+    def test_the_writers_own_check_is_gone_under_dash_o(self, tmp_path) -> None:
+        """Premise: with ``-O`` the dependency accepts a block size it otherwise asserts on.
+
+        Measured against the writer directly, bypassing ``encode_clip``, so this
+        states the dependency's behaviour rather than this module's.
+        """
+        pytest.importorskip("imageio.v2")
+        pytest.importorskip("imageio_ffmpeg")
+        code = (
+            "import math\n"
+            "import imageio.v2 as imageio\n"
+            f"writer = imageio.get_writer({str(tmp_path / 'raw.mp4')!r}, fps=10, macro_block_size=math.nan)\n"
+            "writer.close()\n"
+            "print('NO-ASSERTION')\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-O", "-c", code], capture_output=True, text=True, timeout=300, check=False
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr[-800:]!r}"
+        assert "NO-ASSERTION" in proc.stdout, proc.stdout
+
+    def test_every_unusable_block_size_is_still_refused_under_dash_o(self, tmp_path) -> None:
+        """Pre-fix, ``nan`` encoded a clip here and reported success."""
+        code = (
+            "import math\n"
+            "import numpy as np\n"
+            "from strands_robots.rendering import encode_clip\n"
+            "frames = [np.zeros((32, 48, 3), np.uint8) for _ in range(4)]\n"
+            "for bad in (0, -4, None, False, True, 2.5, math.nan, math.inf, '8'):\n"
+            "    try:\n"
+            f"        encode_clip(frames, {str(tmp_path / 'child.mp4')!r}, fps=10, macro_block_size=bad)\n"
+            "    except ValueError as exc:\n"
+            "        if 'macro_block_size must be' not in str(exc):\n"
+            "            print('WRONG-REASON', bad, exc)\n"
+            "            raise SystemExit(1)\n"
+            "    else:\n"
+            "        print('ACCEPTED', bad)\n"
+            "        raise SystemExit(1)\n"
+            "print('ALL-REFUSED')\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-O", "-c", code], capture_output=True, text=True, timeout=300, check=False
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr[-800:]!r}"
+        assert "ALL-REFUSED" in proc.stdout, proc.stdout
+
+
+class TestAUsableBlockSizeReachesTheWriter:
+    """Every spelling the domain accepts encodes, so the guard is not too narrow."""
+
+    @pytest.mark.parametrize("suffix", [".gif", ".mp4"])
+    @pytest.mark.parametrize("macro_block_size", USABLE_BLOCK_SIZE)
+    def test_every_accepted_spelling_encodes_a_clip(self, tmp_path, suffix, macro_block_size) -> None:
+        """A NumPy integer or an integral float is honored, not refused by the writer."""
+        pytest.importorskip("imageio.v2")
+        out = encode_clip(_frames(), tmp_path / f"clip{suffix}", fps=10, macro_block_size=macro_block_size)
+        assert out.exists() and out.stat().st_size > 0
+
+    @pytest.mark.parametrize("macro_block_size", [8.0, np.int64(8), np.float64(8.0)])
+    def test_a_numpy_or_float_spelling_encodes_identically_to_the_plain_int(self, tmp_path, macro_block_size) -> None:
+        """The ``int()`` at the writer is load-bearing, and does not change the request.
+
+        The writer gates the knob on ``isinstance(macro_block_size, int)``, which
+        ``np.int64(8)`` and ``8.0`` fail even though each names the same block
+        size as ``8``. Byte equality with the plain ``int`` pins both halves: the
+        value reaches the encoder, and the conversion is not a different request.
+        """
+        pytest.importorskip("imageio.v2")
+        pytest.importorskip("imageio_ffmpeg")
+        plain = encode_clip(_odd_frames(), tmp_path / "plain.mp4", fps=10, macro_block_size=8)
+        coerced = encode_clip(_odd_frames(), tmp_path / "coerced.mp4", fps=10, macro_block_size=macro_block_size)
+        assert hashlib.md5(coerced.read_bytes()).digest() == hashlib.md5(plain.read_bytes()).digest()
+
+
+class TestTheCodecRefusalBoundaryIsUnchanged:
+    """A legitimate block size the codec refuses stays the post-encode error."""
+
+    def test_a_whole_block_size_the_codec_refuses_is_still_reported_after_the_encode(self, tmp_path) -> None:
+        """``7`` is a positive whole number, so the domain accepts it and libx264 does not.
+
+        Deliberately not folded into the pre-flight guard: this function cannot
+        know which rounded sizes a codec accepts, so the verdict belongs to the
+        encoder and reaches the caller as the existing ``RuntimeError``.
+        """
+        pytest.importorskip("imageio.v2")
+        pytest.importorskip("imageio_ffmpeg")
+        assert positive_whole_number_error(7, "macro_block_size", "encode_clip") is None
+        out = tmp_path / "refused.mp4"
+        with pytest.raises(RuntimeError, match="wrote no clip"):
+            encode_clip(_frames(), out, fps=20, macro_block_size=7)
+        assert not out.exists() or out.stat().st_size == 0
+
+    def test_the_domain_applies_no_ceiling_of_its_own(self) -> None:
+        """An outsized block size is the codec's refusal to give, not the domain's.
+
+        ``10**6`` rounds a 48x32 frame to a megapixel-scale size libx264 will
+        not encode, and that is reported by the same ``RuntimeError`` as ``7``.
+        Pinned so a later ceiling is a decision rather than an accident.
+        """
+        assert positive_whole_number_error(10**6, "macro_block_size", "encode_clip") is None
+
+    def test_the_other_two_knobs_keep_their_own_domains(self, tmp_path) -> None:
+        """The rounding guard is added beside ``fps`` and ``quality``, not over them."""
+        with pytest.raises(ValueError, match="fps must be a positive whole number"):
+            encode_clip(_frames(), tmp_path / "a.mp4", fps=0, macro_block_size=1)
+        with pytest.raises(ValueError, match="quality must be"):
+            encode_clip(_frames(), tmp_path / "b.mp4", fps=10, quality=0, macro_block_size=1)

--- a/tests/rendering/test_encode_clip_quality_domain.py
+++ b/tests/rendering/test_encode_clip_quality_domain.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """``encode_clip`` only accepts a ``quality`` the clip encoder can honor.
 
-``quality`` was the one knob in ``encode_clip``'s signature with no domain, and
-the dependency's own enforcement is not a substitute for one:
+``quality`` was one of two knobs in ``encode_clip``'s signature with no domain
+(``macro_block_size`` is the other -- see
+``test_encode_clip_macro_block_size_domain``), and the dependency's own
+enforcement is not a substitute for one:
 
 * ``imageio-ffmpeg`` bounds the knob with a bare ``assert 1 <= quality <= 10``,
   so the refusal is an ``AssertionError`` -- absent from the documented


### PR DESCRIPTION
## Problem

`encode_clip` has three encoder knobs. Two are held to a domain: `fps` resolves through the shared `positive_whole_number_error`, and `quality` through `_clip_quality_error`. The third, `macro_block_size`, was handed to the writer unchecked - and the accepted set was wrong in both directions.

**Nonsense in.** `imageio`'s ffmpeg plugin normalizes a falsy value (`macro_block_size = macro_block_size or 1`) and only rounds when the value is `> 1`, so `0`, `-4`, `None`, `False` and `True` were all read as "no rounding" and the caller was told the clip had been written. Measured on 60x40 frames, a request for `macro_block_size=0` produced a clip **byte-identical** to `macro_block_size=1` (md5 `dffa78600e76`); nothing reported the knob had been dropped. `True` is the same `bool` substitution `_clip_quality_error` already rejects for this module's other quality knob.

**The dependency's check is a bare assert.** `imageio-ffmpeg` guards the knob with `assert isinstance(macro_block_size, int), "macro_block_size must be int"`, so the refusal was an `AssertionError` - absent from the documented `Raises:` set - and `python -O` strips it. On an optimized interpreter `nan` produced that same byte-identical clip and reported success, `2.5` and `inf` surfaced only as "the encoder wrote no clip", and `"8"` leaked a raw `TypeError` out of the writer's `macro_block_size > 1` comparison. **The verdict for one call depended on an interpreter flag.** This is exactly the reasoning already recorded above `_MIN_CLIP_QUALITY` for why `quality` is not left to the writer's own assert; it applies verbatim to the knob 25 lines below.

**Usable out.** `8.0`, `np.int64(8)` and `np.float64(8.0)` each name the same block size as the `8` that encodes, and the writer's `isinstance(..., int)` gate refused all three - the mirror of the `float(quality)` conversion this module already documents as load-bearing.

| request | upstream/main `f224db1c` | this branch |
| --- | --- | --- |
| `macro_block_size=1` | encoded 60x40, md5 `dffa78600e76` | encoded 60x40, md5 `dffa78600e76` |
| `macro_block_size=0` | encoded 60x40, md5 `dffa78600e76` (the `1` clip) | `ValueError: macro_block_size must be a positive whole number, got 0` |
| `nan`, assertions on | `AssertionError: macro_block_size must be int` | `ValueError` naming the parameter |
| `nan`, `python -O` | encoded 60x40, md5 `dffa78600e76` (the `1` clip) | the same `ValueError` |
| `np.int64(8)` | `AssertionError: macro_block_size must be int` | encoded 64x40, md5 `c06938be9bd9` (the `8` clip) |
| `macro_block_size=8` | encoded 64x40, md5 `c06938be9bd9` | encoded 64x40, md5 `c06938be9bd9` |

## Change

`encode_clip` resolves `macro_block_size` through `positive_whole_number_error` beside its existing `fps` guard - the same shared media domain, so a value refused when it names a frame rate cannot be accepted when it names the rounding of that same clip - and passes `int(macro_block_size)` to the writer, exactly as `int(fps)` and `float(quality)` beside it already do and for the same reason. The guard runs before `require_optional`, so the same mistake reports identically whether or not `imageio` is installed, and it applies to both containers: GIF has no macro blocks, but a call must not become valid by changing an extension.

`positive_whole_number_error`'s own docstring enumerates its callers, so `macro_block_size` is added there.

### Scope boundary

A **legitimate** block size the codec refuses stays the post-encode `RuntimeError` it already was: `7` rounds a 48x32 frame to 49x35, which libx264 will not encode, and `10**6` rounds it past what the encoder accepts. This function cannot know which rounded sizes a codec takes, so that verdict belongs to the encoder. The domain therefore applies no ceiling of its own, and `TestTheCodecRefusalBoundaryIsUnchanged` pins that either way, so a later ceiling is a decision rather than an accident.

## Tests

`tests/rendering/test_encode_clip_macro_block_size_domain.py`, 74 tests. Pre-fix (source reverted, test file kept): **60 failed / 14 passed**, all 60 in the four regression classes and **0 in the control class**.

| mutation | fires |
| --- | --- |
| control, no mutation | 0 of 74 |
| both source files reverted (exact pre-fix) | 60 |
| guard removed, `int()` coercion kept | 54 |
| `int(macro_block_size)` coercion removed, guard kept | 6 |
| guard moved after `require_optional` | 5 (the probe tests alone) |
| guard reports the wrong parameter name | 54 (coincides with the guard-removed row: both leave the parameter unnamed to the caller) |
| over-reach: `non_negative` domain, so `0` is accepted | 21 |
| over-reach: an upper bound of 8 added | 3, incl. the row needing `16` |
| over-reach: refuse a size the frame is not a multiple of | 5, incl. `TestTheCodecRefusalBoundaryIsUnchanged` |

The two halves are exactly complementary - 54 (guard) + 6 (coercion) = 60 (both reverted) - so each is independently pinned. The last row is the boundary control firing, which is what makes that boundary load-bearing rather than asserted.

`python -O` is exercised in a child interpreter, with a premise test that measures the dependency's own behaviour there directly (bypassing `encode_clip`), so the `-O` test cannot pass vacuously.

## Gate

- `ruff check` / `ruff format --check` on `strands_robots tests tests_integ`: clean.
- `mypy strands_robots tests tests_integ`: **24 errors on both** this branch and a pristine `upstream/main` worktree, identical message sets - the single diff is a pre-existing `utils.py` error line-shifted by the two docstring lines added.
- Broad selection of 359 test files (every test naming `encode_clip`, `positive_whole_number_error`, rendering, video, mjpeg or recording), identical on both trees with the new file excluded from each: `49 failed, 13734 passed, 132 skipped, 136 errors` on **both**, 49 failing ids each, set difference empty in both directions (589.43s vs 590.90s). Every failure is a declared optional dependency absent locally - `device_connect_edge` (`[device-connect]`) and `awsiot` (`[mesh-iot]`).
- `tests/rendering/`: 666 passed, 9 skipped, under both fixed and random ordering.

## Artifact

Decoded first frame of the clip `encode_clip` returned, per request, on each tree. Source frames are 60x40 (divisible by neither 8 nor 16) so the rounding is visible in the encoded size. Rows 1 and 5 are byte-identical on both trees, so only the disputed values move; every md5 and the two cross-tree equalities are asserted inside the script that draws the figure.

![encode_clip macro_block_size domain](https://github.com/cagataycali/robots/releases/download/artifacts/encode-clip-macro-block-size-domain.png)
