### PR TITLE
fix(sim): settle run_policy's own two rates before it opens a recording

### DIFF
--- a/changelog.d/2698-run-policy-tool-rate-agreement.md
+++ b/changelog.d/2698-run-policy-tool-rate-agreement.md
@@ -1,0 +1,41 @@
+### Fixed: the `run_policy` tool settles its own two rates before it opens a recording
+
+The `run_policy` tool owns both halves of one rule. `dataset_fps` becomes the LeRobotDataset's
+declared frame rate; `control_frequency` is the rate the recorder is really driven at, one frame
+per control step with no decimation. LeRobot derives every timestamp positionally from the
+declared rate, so the two must be EQUAL - a differing pair cannot be honored, only mislabelled.
+
+Each rate was already checked on its own domain: `control_frequency` by the tool's pre-flight,
+`dataset_fps` by `start_recording` before it touches the target directory. Their *equality* was
+left to the rollout entry point, which this tool reaches only inside the episode loop - after
+`start_recording(overwrite=True)` has replaced whatever was at `dataset_root`. Measured over a
+real MuJoCo rollout that had recorded one episode of five frames, `dataset_fps=30` with
+`control_frequency=50.0` took `meta/info.json` from `total_episodes=1, total_frames=5` to
+`0, 0`, removed the per-camera MP4, and reported `run_policy: 0/2 episodes ok`. Neither argument
+was wrong on its own, so nothing refused the pair; the caller lost the dataset and recorded
+nothing in its place. The tool states this principle for every other knob it forwards - `seed`
+("reached NumPy inside the loop after step 2 had already created a dataset"), `video`, the
+provider keyword bags and `stop_when` - and the per-knob sweep that pins them could not see this
+one, because it derives the knobs forwarded to `Simulation.run_policy(...)` and a rule between
+two parameters is not a property of either.
+
+This is the third ordering of a disagreement whose other two are already refused: a rollout
+started against an open recording (`dataset_rate_mismatch_reason`) and a recording opened against
+a rollout in flight (`rollout_rate_mismatch_reason`). Each of those reads one rate off live state,
+so neither can be asked before either exists. The new `requested_rate_mismatch_reason` covers the
+case where both rates arrive as arguments to one call, and it reuses `rate_mismatch_explanation`,
+so a caller who reorders two calls or supplies both at once gets one account of the distortion
+rather than three. All three orderings are now held to the same verdict by a parity test.
+
+Because the new guard runs *before* either rate has been through its own domain, its accepted set
+is derived from those two domains rather than guessed: both rates are classified on
+`numbers.Real`, exactly as `positive_whole_number_error` and `positive_finite_number_error` do, so
+the `numpy.int64` / `numpy.float32` spellings a value read out of a config carries are judged too -
+an `isinstance(int | float)` narrowing would have passed a colliding pair straight through. The
+boolean question goes to the shared `is_boolean` predicate, since `bool` is a `numbers.Real` and
+would otherwise be diagnosed as a genuine 1 Hz rollout. A value either domain refuses returns no
+reason here, so it is still reported as the parameter error it is rather than as a rate
+disagreement.
+
+The check is gated on a requested recording: `dataset_fps` is forwarded nowhere when
+`dataset_root` is `None`, so the documented recording-less smoke-test mode still runs at any rate.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -75,6 +75,28 @@ matches one of them: their frames interleave into one episode whose single
 declared rate cannot describe both, so there is no `fps` to pass instead. Stop
 all but one, or restart them at a common `control_frequency`.
 
+The `run_policy` tool owns both rates at once - it takes `dataset_fps` and
+`control_frequency` as its own arguments and drives the whole
+`start_recording` -> rollout -> `stop_recording` cycle - so it settles the pair
+up front, before it opens anything. That matters because it opens its recording
+with `overwrite=True`: left to the per-episode rollout, the disagreement was
+reported only after any dataset already at `dataset_root` had been replaced with
+an empty one, and after every episode had failed with the same message.
+
+```python
+run_policy(simulation=sim, robot_name="so100", n_episodes=2,
+           control_frequency=50.0, dataset_fps=30,      # cannot both hold
+           dataset_root="/tmp/my_dataset")
+# -> "run_policy: this call would open a recording declaring 30 fps for a
+#     rollout capturing at control_frequency=50 Hz. [...] Align the two rates:
+#     pass control_frequency=30, or record at the rollout's rate
+#     (dataset_fps=50)."
+# The dataset already at /tmp/my_dataset is untouched.
+```
+
+`dataset_fps` is ignored when `dataset_root` is omitted (the recording-less
+smoke-test mode), so a rollout with no recording runs at any rate.
+
 ## Selecting which cameras to record
 
 By default every camera in the scene is recorded into the dataset - including

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -27,12 +27,14 @@ enforceable protocol.
 """
 
 import logging
+import math
+import numbers
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.utils import boolean_flag_error, positive_whole_number_error
+from strands_robots.utils import boolean_flag_error, is_boolean, positive_whole_number_error
 
 logger = logging.getLogger(__name__)
 
@@ -368,6 +370,97 @@ def rollout_rate_mismatch_error(method: str, fps: Any, rates: Mapping[str, float
     if reason is None:
         return None
     return {"status": "error", "content": [{"text": reason}]}
+
+
+def requested_rate_mismatch_reason(method: str, fps: Any, control_frequency: Any, fps_param: str = "fps") -> str | None:
+    """Explain why one call's own two rates cannot describe the same episode.
+
+    The third ordering of the disagreement its two siblings cover, and the only
+    one in which neither rate can be read off live state:
+    :func:`dataset_rate_mismatch_reason` reads the frame rate from an open
+    recorder, and :func:`rollout_rate_mismatch_reason` reads the capture rate
+    from a rollout already in flight, so neither can be asked before either
+    exists. A caller that supplies *both* rates in one call and opens the
+    recording itself has them in hand while nothing is open yet - and must be
+    answered then, because that call is also the one that destroys the target.
+
+    Its caller is :func:`~strands_robots.tools.run_policy.run_policy`, which
+    starts its recording with ``overwrite=True`` before the episode loop. Each
+    rate there is already checked on its own domain - ``control_frequency`` by
+    the tool's own guard, ``dataset_fps`` by ``start_recording`` ahead of the
+    target - but their *equality* was left to the rollout entry point, which the
+    tool reaches only inside the loop. Measured against an existing dataset of
+    one episode / five frames, ``dataset_fps=30`` with
+    ``control_frequency=50.0`` wiped it to ``total_episodes=0, total_frames=0``
+    and then reported ``0/2 episodes ok`` - the caller lost the dataset and
+    recorded nothing, for a pair of arguments neither of which was wrong on its
+    own.
+
+    No envelope twin is shipped alongside this reason (unlike its two siblings):
+    the one caller reports through a structured-error helper of its own, so an
+    envelope form here would be dead code.
+
+    Args:
+        method: Public surface name, used to prefix the error message.
+        fps: Caller-supplied dataset frame rate. A value outside the writable
+            domain returns ``None`` here so it is reported as the parameter
+            error it is by :func:`dataset_recording_option_error`, exactly as in
+            :func:`rollout_rate_mismatch_reason`.
+        control_frequency: Rate the rollout will capture frames at. A value
+            outside the positive-finite domain likewise returns ``None``, left
+            to the caller's own ``control_frequency`` guard. Both rates are
+            classified on ``numbers.Real``, the same predicate those two domains
+            use, so every spelling they accept is judged here too.
+        fps_param: How the caller spells the frame-rate argument, so the advised
+            remedy is one the caller can type. Defaults to ``fps``, the name
+            every backend's ``start_recording`` uses.
+
+    Returns:
+        The reason text naming both rates, the distortion and the remedies, or
+        ``None`` when the rates agree or either is outside its own domain.
+    """
+    # Unlike its two siblings, this guard is asked BEFORE either rate has been
+    # through its own domain - that is the point of it - so it classifies raw
+    # caller input, and it must accept every spelling those domains accept or it
+    # silently declines to judge a pair they will both honor. Hence
+    # ``numbers.Real``, exactly as ``positive_whole_number_error`` and
+    # ``positive_finite_number_error`` use: ``numpy.int64`` and ``numpy.float32``
+    # are neither ``int`` nor ``float`` subclasses, so an ``isinstance(int |
+    # float)`` narrowing here would have passed a colliding pair read out of a
+    # config straight through. The boolean question goes to the shared predicate
+    # (``bool`` IS a ``numbers.Real``, so it would otherwise be compared as
+    # 1 Hz).
+    if is_boolean(fps) or not isinstance(fps, numbers.Real):
+        return None
+    if is_boolean(control_frequency) or not isinstance(control_frequency, numbers.Real):
+        return None
+    try:
+        declared = float(fps)
+        rate = float(control_frequency)
+    except (OverflowError, TypeError, ValueError):
+        # An ``int`` beyond the float64 range cannot be compared with anything;
+        # its own domain refuses it with a reason of its own.
+        return None
+
+    if declared <= 0 or not declared.is_integer():
+        return None
+    fps_int = int(declared)
+    if rate <= 0 or not math.isfinite(rate):
+        return None
+
+    if abs(rate - fps_int) < 1e-9:
+        return None
+
+    remedy = f"pass control_frequency={fps_int}"
+    if rate.is_integer():
+        # ``fps`` must be a positive whole number, so only an integral capture
+        # rate is one the recording could be opened at instead.
+        remedy += f", or record at the rollout's rate ({fps_param}={int(rate)})"
+    return (
+        f"{method}: this call would open a recording declaring {fps_int} fps for a rollout "
+        f"capturing at control_frequency={rate:g} Hz. {rate_mismatch_explanation(fps_int, rate)} "
+        f"Align the two rates: {remedy}."
+    )
 
 
 def _resume_schema_error(diffs: list[str]) -> str:

--- a/strands_robots/tools/run_policy.py
+++ b/strands_robots/tools/run_policy.py
@@ -155,7 +155,9 @@ def run_policy(
             ``run_policy`` as ``n_steps``.
         control_frequency: Target Hz for policy queries. Must be a finite
             number > 0; an unusable rate is reported before the rollout
-            starts instead of aborting every episode mid-flight.
+            starts instead of aborting every episode mid-flight. When a
+            recording is requested it must also EQUAL ``dataset_fps`` - see
+            that parameter.
         action_horizon: Lower bound on actions consumed per policy call
             before re-querying; the effective interval is
             ``max(action_horizon, policy.execution_horizon)``, so a
@@ -173,8 +175,19 @@ def run_policy(
         dataset_repo_id: Forwarded to ``start_recording``.
         dataset_task: Task label forwarded to ``start_recording``.
         dataset_fps: Dataset FPS forwarded to ``start_recording``. Must be a
-            positive whole number; an unusable rate is reported before the
-            rollout starts instead of aborting the episode mid-flight.
+            positive whole number - reported by ``start_recording`` itself,
+            which checks the rate before it touches the target directory, so
+            an unusable value costs nothing. It must also EQUAL
+            ``control_frequency`` whenever ``dataset_root`` is set: the
+            recorder captures one frame per control step and never decimates,
+            while LeRobot timestamps every frame from the declared rate, so a
+            differing pair cannot be honored, only mislabelled. The
+            disagreement is refused up front
+            (:func:`~strands_robots.simulation.recording.requested_rate_mismatch_reason`)
+            rather than by the per-episode rollout - which this tool reaches
+            only after ``start_recording(overwrite=True)`` has replaced any
+            dataset already at ``dataset_root`` with an empty one. Ignored
+            entirely when ``dataset_root`` is ``None``.
         dataset_cameras: Camera names to record into the dataset.
             When set, forwarded as ``start_recording(cameras=...)``
             (supported by both the MuJoCo and Newton backends) to
@@ -272,6 +285,27 @@ def run_policy(
 
     if horizon_error := positive_count_error(action_horizon, "action_horizon", "run_policy"):
         return _err(horizon_error)
+
+    # The one rule between two of this tool's own parameters, and the only one
+    # whose refusal no downstream guard can reach in time. Each rate is already
+    # checked on its own domain - ``control_frequency`` just above,
+    # ``dataset_fps`` by ``start_recording`` ahead of the target it resolves -
+    # but the recorder is driven once per control step with no decimation and
+    # LeRobot timestamps every frame from the declared rate, so the two must be
+    # EQUAL. That equality is enforced by the rollout entry point, which this
+    # tool reaches only inside the episode loop: measured against an existing
+    # dataset of one episode / five frames, ``dataset_fps=30`` with
+    # ``control_frequency=50.0`` wiped it to ``total_episodes=0,
+    # total_frames=0`` and then reported ``0/2 episodes ok``. Gated on a
+    # requested recording because ``dataset_fps`` is forwarded nowhere without
+    # one, so a recording-less rollout is unaffected at any rate.
+    if dataset_root is not None:
+        from strands_robots.simulation.recording import requested_rate_mismatch_reason
+
+        if rate_error := requested_rate_mismatch_reason(
+            "run_policy", dataset_fps, control_frequency, fps_param="dataset_fps"
+        ):
+            return _err(rate_error)
 
     # Same pre-flight reason as the schema checks below: the per-episode seed is
     # derived arithmetically (``seed + ep``) OUTSIDE the per-episode try, so a

--- a/tests/simulation/test_input_validators_refuse_a_boolean.py
+++ b/tests/simulation/test_input_validators_refuse_a_boolean.py
@@ -535,6 +535,10 @@ _NOT_AN_INPUT_DOMAIN = {
 
 _GUARDED_VALIDATORS = {
     "randomization_range_error",
+    # The one rate guard that is asked before either rate has been through its
+    # own domain, so unlike the two exempted above it really does coerce raw
+    # caller input.
+    "requested_rate_mismatch_reason",
     "finite_non_negative_error",
     "_validate_timestep",
     "_validate_mass",

--- a/tests/simulation/test_recording_rate_matches_control_frequency.py
+++ b/tests/simulation/test_recording_rate_matches_control_frequency.py
@@ -23,14 +23,19 @@ from the dataset rate on the invariant that "the recorded control frequency IS
 the dataset fps" - so the same episode also replays at the wrong speed
 (round-tripped to 0.0000 rad at matching rates, 0.0317 rad at the defaults).
 
-The disagreement has two orderings and both are refused. A rollout started
-against an open recording is refused at every rollout entry point; a recording
-opened against a rollout already in flight is refused by ``start_recording``.
-``start_policy`` makes the second ordering reachable by design - it submits the
-rollout to an executor and returns while it continues - and on the same colliding
-defaults it saved 81 frames captured 0.0200s apart and declared them 0.0333s
-apart: a 2.6667s episode for a 1.62s capture, with ``start_policy``,
-``start_recording`` and ``stop_recording`` all reporting success.
+The disagreement has three orderings and all three are refused. A rollout
+started against an open recording is refused at every rollout entry point; a
+recording opened against a rollout already in flight is refused by
+``start_recording``. ``start_policy`` makes the second ordering reachable by
+design - it submits the rollout to an executor and returns while it continues -
+and on the same colliding defaults it saved 81 frames captured 0.0200s apart and
+declared them 0.0333s apart: a 2.6667s episode for a 1.62s capture, with
+``start_policy``, ``start_recording`` and ``stop_recording`` all reporting
+success. The third ordering is a single call that supplies both rates and opens
+the recording itself - the ``run_policy`` tool - where neither rate can be read
+off live state because nothing is open yet; it is refused by
+``requested_rate_mismatch_reason`` and covered in
+``tests/tools/test_run_policy_rate_agreement_preflight.py``.
 
 Refused rather than warned, matching the sibling rate guard in the same module:
 ``_verify_resume_schema`` already refuses an ``fps`` that disagrees with the
@@ -58,6 +63,7 @@ from strands_robots.simulation.recording import (  # noqa: E402
     dataset_rate_mismatch_reason,
     rate_mismatch_explanation,
     recorder_dataset_fps,
+    requested_rate_mismatch_reason,
     rollout_rate_mismatch_error,
     rollout_rate_mismatch_reason,
 )
@@ -609,21 +615,28 @@ class TestTheRolloutRateGuardHelperIsRobust:
     ("fps", "rate"),
     [(30, 50.0), (50, 30.0), (30, 30.0), (50, 50.0), (25, 25.0), (30, 33.3), (60, 50.0)],
 )
-def test_both_orderings_reach_the_same_verdict_and_explanation(fps, rate):
-    """One disagreement, so the two orderings may not disagree about it.
+def test_every_ordering_reaches_the_same_verdict_and_explanation(fps, rate):
+    """One disagreement, so its orderings may not disagree about it.
 
-    Whichever call came first, the frames and the timestamps come from the same
-    two rates - so a caller who reverses the order of two calls must not be told
-    the pair is acceptable in one direction and not the other, nor be given two
-    different accounts of the distortion.
+    Whichever call came first - and whether either had happened yet - the frames
+    and the timestamps come from the same two rates. So a caller who reverses the
+    order of two calls, or supplies both rates at once, must not be told the pair
+    is acceptable in one direction and not the other, nor be given a different
+    account of the distortion in each.
     """
-    forward = dataset_rate_mismatch_reason("run_policy", _FakeRecorder(fps), rate)
-    inverse = rollout_rate_mismatch_reason("start_recording", fps, {"arm": rate})
-    assert (forward is None) == (inverse is None), f"the two orderings disagree for fps={fps!r} capture rate={rate!r}"
-    if forward is not None and inverse is not None:
-        shared = rate_mismatch_explanation(fps, rate)
-        assert shared in forward
-        assert shared in inverse
+    verdicts = {
+        "rollout against an open recording": dataset_rate_mismatch_reason("run_policy", _FakeRecorder(fps), rate),
+        "recording against a running rollout": rollout_rate_mismatch_reason("start_recording", fps, {"arm": rate}),
+        "both rates in one call": requested_rate_mismatch_reason("run_policy", fps, rate),
+    }
+    refused = {name for name, reason in verdicts.items() if reason is not None}
+    assert refused in (set(), set(verdicts)), (
+        f"the orderings disagree for fps={fps!r} capture rate={rate!r}: only {sorted(refused)} refused it"
+    )
+    shared = rate_mismatch_explanation(fps, rate)
+    for name, reason in verdicts.items():
+        if reason is not None:
+            assert shared in reason, f"{name} gives its own account of the distortion"
 
 
 _START_RECORDING_BACKENDS = (

--- a/tests/tools/test_run_policy_rate_agreement_preflight.py
+++ b/tests/tools/test_run_policy_rate_agreement_preflight.py
@@ -1,0 +1,526 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The ``run_policy`` tool's own two rates must agree before it opens a recording.
+
+The tool owns both halves of one rule. ``dataset_fps`` becomes the
+LeRobotDataset's declared frame rate and ``control_frequency`` is the rate the
+recorder is actually driven at - one frame per control step, never decimated -
+so LeRobot's positional timestamps (``timestamp = frame_index / fps``) describe
+the episode only when the two are EQUAL.
+
+Each rate was already checked on its own domain: ``control_frequency`` by the
+tool's pre-flight, ``dataset_fps`` by ``start_recording`` before it touches the
+target directory. Their *equality* was left to the rollout entry point - which
+this tool reaches only inside the episode loop, after
+``start_recording(overwrite=True)`` has replaced whatever was at
+``dataset_root``. Measured over a real MuJoCo rollout that had recorded one
+episode of five frames, ``dataset_fps=30`` with ``control_frequency=50.0``::
+
+    meta/info.json: total_episodes=1, total_frames=5   (before the call)
+    meta/info.json: total_episodes=0, total_frames=0   (after it)
+    run_policy: 0/2 episodes ok | parquet-truth: total_episodes=0, total_frames=0
+
+Neither argument was wrong on its own, so nothing refused the pair; the caller
+lost the dataset and recorded nothing in its place. The tool's own pre-flight
+block states the principle for every other knob it forwards - ``seed``
+("reached NumPy inside the loop after step 2 had already created a dataset"),
+``video``, the provider keyword bags ("otherwise the tool leaves an empty
+dataset behind and reports every episode as raised") and ``stop_when``. The
+per-knob structural sweep in
+``tests/tools/test_run_policy_rollout_knob_preflight.py`` could not see this
+one: it derives the knobs forwarded to ``simulation.run_policy(...)``, and a
+rule between two parameters is not a property of either.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.tools.run_policy as rp_mod
+from strands_robots.simulation.recording import (
+    dataset_recording_option_error,
+    rate_mismatch_explanation,
+    requested_rate_mismatch_reason,
+)
+from strands_robots.utils import positive_finite_number_error
+from tests.tools.test_run_policy import _FakeSim
+
+#: Rates that disagree in both directions, plus the pair the library defaults
+#: used to collide at (``fps=30`` against ``control_frequency=50.0``).
+DISAGREEING: list[tuple[int, float]] = [(30, 50.0), (50, 30.0), (60, 50.0), (30, 33.3), (25, 30.0)]
+
+#: Pairs a caller may legitimately pass: equal rates, including the integral
+#: and NumPy spellings a value read out of a config arrives as.
+AGREEING: list[tuple[Any, Any]] = [(30, 30.0), (50, 50.0), (30, 30), (25, 25.0), (30, 30.0000000001)]
+
+
+def _run_tool(sim: Any, **kwargs: Any) -> dict[str, Any]:
+    """Call the tool with kwargs mypy cannot narrow.
+
+    Several values are deliberately outside the declared parameter types - that
+    is the point of the test - so they go through one funnel rather than being
+    suppressed at every call site.
+    """
+    return dict(rp_mod.run_policy(sim, **kwargs))
+
+
+def _text(result: dict[str, Any]) -> str:
+    return str((result.get("content") or [{}])[0].get("text", ""))
+
+
+def _truth(root: Path) -> tuple[int | None, int | None]:
+    """Read ``(total_episodes, total_frames)`` from a dataset's ``meta/info.json``."""
+    info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
+    return info.get("total_episodes"), info.get("total_frames")
+
+
+# One actuated hinge plus a camera: enough for a rollout to drive something and
+# for the dataset schema to declare an image column, with no asset download.
+_ARM_XML = """
+<mujoco model="rate_agreement_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.9 0.9 0.9 1"/>
+    <camera name="front" pos="0 -1 0.4" xyaxes="1 0 0 0 0.3 1"/>
+    <body name="base" pos="0 0 0.1">
+      <joint name="pan" type="hinge" axis="0 0 1"/>
+      <geom name="link" type="capsule" fromto="0 0 0 0.2 0 0" size="0.03"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="30"/>
+  </actuator>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def recording_sim(tmp_path):
+    """A live MuJoCo world that can write a real LeRobotDataset."""
+    pytest.importorskip("mujoco")
+    pytest.importorskip("lerobot")
+    import os
+
+    os.environ.setdefault("MUJOCO_GL", "egl")
+    from strands_robots.simulation.mujoco.simulation import Simulation
+
+    arm = tmp_path / "arm.xml"
+    arm.write_text(_ARM_XML, encoding="utf-8")
+    sim = Simulation()
+    sim.create_world()
+    assert sim.add_robot(name="arm", urdf_path=str(arm))["status"] == "success"
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+class TestTheRefusalPrecedesTheDestruction:
+    """The reason this is a defect and not a tidiness question.
+
+    ``start_recording`` is forwarded ``overwrite=True``, so reaching it with a
+    pair the episode loop will refuse costs the caller the dataset already at
+    that root - and leaves an empty one in its place.
+    """
+
+    @staticmethod
+    def _record_one_episode(sim, root: Path, fps: int) -> tuple[int | None, int | None]:
+        """Record a real episode at ``fps`` and return its parquet truth."""
+        assert (
+            sim.start_recording(repo_id="local/rate_agreement", task="t", fps=fps, root=str(root), overwrite=True)[
+                "status"
+            ]
+            == "success"
+        )
+        assert (
+            sim.run_policy(
+                robot_name="arm", policy_provider="mock", n_steps=5, control_frequency=float(fps), fast_mode=True
+            )["status"]
+            == "success"
+        )
+        assert sim.stop_recording()["status"] == "success"
+        return _truth(root)
+
+    def test_a_disagreeing_pair_leaves_an_existing_dataset_untouched(self, recording_sim, tmp_path) -> None:
+        root = tmp_path / "dataset"
+        before = self._record_one_episode(recording_sim, root, 30)
+        assert before == (1, 5), f"premise: the fixture recorded an episode, got {before}"
+
+        result = _run_tool(
+            recording_sim,
+            robot_name="arm",
+            policy_provider="mock",
+            n_episodes=2,
+            n_steps=5,
+            control_frequency=50.0,
+            dataset_fps=30,
+            dataset_root=str(root),
+            dataset_repo_id="local/rate_agreement",
+        )
+        assert result["status"] == "error"
+        assert "30 fps" in _text(result) and "control_frequency=50 Hz" in _text(result)
+        assert _truth(root) == before, "the refused call replaced the dataset at dataset_root"
+
+    def test_the_preserved_dataset_still_reopens_with_its_frames(self, recording_sim, tmp_path) -> None:
+        """Round trip: the episode survives as a dataset, not just as metadata."""
+        root = tmp_path / "dataset"
+        self._record_one_episode(recording_sim, root, 30)
+        _run_tool(
+            recording_sim,
+            robot_name="arm",
+            policy_provider="mock",
+            n_episodes=2,
+            n_steps=5,
+            control_frequency=50.0,
+            dataset_fps=30,
+            dataset_root=str(root),
+            dataset_repo_id="local/rate_agreement",
+        )
+        # Asserted before reopening: a LeRobotDataset whose root has been
+        # emptied falls back to the Hub, so a regression must fail on the local
+        # metadata rather than on a network lookup for a repo that is local-only.
+        assert _truth(root) == (1, 5)
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        dataset = LeRobotDataset(repo_id="local/rate_agreement", root=str(root))
+        assert dataset.fps == 30
+        assert dataset.num_frames == 5
+        assert list(root.rglob("*.mp4"))
+
+    def test_an_agreeing_pair_records_the_episodes_it_was_asked_for(self, recording_sim, tmp_path) -> None:
+        """Over-reach control, end to end: the honorable pair still records."""
+        root = tmp_path / "dataset"
+        result = _run_tool(
+            recording_sim,
+            robot_name="arm",
+            policy_provider="mock",
+            n_episodes=2,
+            n_steps=5,
+            control_frequency=30.0,
+            dataset_fps=30,
+            dataset_root=str(root),
+            dataset_repo_id="local/rate_agreement",
+        )
+        assert result["status"] == "success", _text(result)
+        assert _truth(root) == (2, 10)
+
+
+class TestTheRequestedRatesMustAgree:
+    """A pair that cannot describe one episode is refused, naming both rates."""
+
+    @pytest.mark.parametrize(("fps", "rate"), DISAGREEING, ids=repr)
+    def test_a_disagreeing_pair_is_refused(self, fps: int, rate: float) -> None:
+        result = _run_tool(
+            _FakeSim(),
+            n_episodes=2,
+            n_steps=4,
+            control_frequency=rate,
+            dataset_fps=fps,
+            dataset_root="/tmp/run-policy-rate-agreement",
+        )
+        assert result["status"] == "error"
+        assert f"{fps} fps" in _text(result)
+        assert f"control_frequency={rate:g}" in _text(result)
+
+    def test_the_refusal_carries_the_shared_account_of_the_distortion(self) -> None:
+        """One disagreement, so one explanation - not a second account of it."""
+        result = _run_tool(
+            _FakeSim(),
+            n_episodes=1,
+            n_steps=4,
+            control_frequency=50.0,
+            dataset_fps=30,
+            dataset_root="/tmp/run-policy-rate-agreement",
+        )
+        assert rate_mismatch_explanation(30, 50.0) in _text(result)
+
+    def test_the_refusal_names_both_remedies_in_the_callers_own_spelling(self) -> None:
+        """The advised argument is one the caller of *this tool* can type."""
+        result = _run_tool(
+            _FakeSim(),
+            n_episodes=1,
+            n_steps=4,
+            control_frequency=50.0,
+            dataset_fps=30,
+            dataset_root="/tmp/run-policy-rate-agreement",
+        )
+        assert "pass control_frequency=30" in _text(result)
+        assert "dataset_fps=50" in _text(result)
+        assert "fps=50)" not in _text(result).replace("dataset_fps=50)", "")
+
+    def test_nothing_is_started_and_no_episode_is_recorded(self) -> None:
+        sim = _FakeSim()
+        result = _run_tool(
+            sim,
+            n_episodes=3,
+            n_steps=4,
+            control_frequency=50.0,
+            dataset_fps=30,
+            dataset_root="/tmp/run-policy-rate-agreement",
+        )
+        assert result["status"] == "error"
+        assert sim.start_recording_calls == [], "the refused call reached start_recording(overwrite=True)"
+        assert sim.run_policy_calls == []
+        assert sim.stop_recording_calls == []
+        payload = next((b["json"] for b in result.get("content") or [] if "json" in b), None)
+        assert payload is None, "a refused pre-flight reports no episode records"
+
+
+class TestUsablePairsStillRun:
+    """Over-reach control: nothing a caller could legitimately pass is refused."""
+
+    @pytest.mark.parametrize(("fps", "rate"), AGREEING, ids=repr)
+    def test_an_agreeing_pair_drives_the_loop_and_records(self, fps: Any, rate: Any) -> None:
+        sim = _FakeSim()
+        result = _run_tool(
+            sim,
+            n_episodes=2,
+            n_steps=4,
+            control_frequency=rate,
+            dataset_fps=fps,
+            dataset_root="/tmp/run-policy-rate-agreement",
+        )
+        assert len(sim.start_recording_calls) == 1
+        assert sim.start_recording_calls[0]["fps"] == fps
+        assert len(sim.run_policy_calls) == 2
+        # ``status`` is "error" only because the fake writes no parquet truth.
+        assert "2/2 episodes ok" in _text(result)
+
+    @pytest.mark.parametrize("rate", [50.0, 12.5, 1.0], ids=repr)
+    def test_a_recordingless_rollout_runs_at_any_rate(self, rate: float) -> None:
+        """``dataset_fps`` is forwarded nowhere without ``dataset_root``.
+
+        The default ``dataset_fps=30`` disagrees with most rates a caller picks,
+        so gating the new check on a requested recording is what keeps the
+        smoke-test path (documented as "the loop runs without recording") open.
+        """
+        sim = _FakeSim()
+        result = _run_tool(sim, n_episodes=2, n_steps=4, control_frequency=rate)
+        assert result["status"] == "success"
+        assert len(sim.run_policy_calls) == 2
+        assert sim.start_recording_calls == []
+
+    def test_the_documented_defaults_agree_with_each_other(self) -> None:
+        """A caller who supplies neither rate must not be refused.
+
+        Read off the shipped signature rather than restated, so a default moved
+        to a colliding value fails here instead of in the field.
+        """
+        fn = _tool_function(_tool_source())
+        defaults = {
+            arg.arg: ast.literal_eval(default)
+            for arg, default in zip(fn.args.kwonlyargs, fn.args.kw_defaults, strict=True)
+            if default is not None
+        }
+        assert defaults["control_frequency"] == 30.0
+        assert defaults["dataset_fps"] == 30
+        assert (
+            requested_rate_mismatch_reason("run_policy", defaults["dataset_fps"], defaults["control_frequency"]) is None
+        )
+
+
+class TestTheHelperIsRobust:
+    """The reason helper's own domain, driven directly."""
+
+    @pytest.mark.parametrize(("fps", "rate"), AGREEING, ids=repr)
+    def test_agreeing_rates_return_none(self, fps: Any, rate: Any) -> None:
+        assert requested_rate_mismatch_reason("run_policy", fps, rate) is None
+
+    @pytest.mark.parametrize("fps", [0, -30, 2.5, float("nan"), True, np.bool_(True), "30", None, [30]], ids=repr)
+    def test_an_fps_outside_the_writable_domain_is_left_to_its_own_guard(self, fps: Any) -> None:
+        """Premise: each of these IS refused by the fps guard, as that error."""
+        assert dataset_recording_option_error("start_recording", fps) is not None
+        assert requested_rate_mismatch_reason("run_policy", fps, 50.0) is None
+
+    @pytest.mark.parametrize(
+        "rate", [0.0, -5.0, float("nan"), float("inf"), True, np.bool_(True), "30", None, [30]], ids=repr
+    )
+    def test_a_rate_outside_its_domain_is_left_to_its_own_guard(self, rate: Any) -> None:
+        """Each of these is its own parameter's error, not a rate disagreement."""
+        assert requested_rate_mismatch_reason("run_policy", 30, rate) is None
+
+    @pytest.mark.parametrize("value", [True, np.bool_(True)], ids=repr)
+    def test_a_boolean_rate_is_not_read_as_one_hertz(self, value: Any) -> None:
+        """``bool`` IS a ``numbers.Real``, so the type check alone lets it through.
+
+        ``float(True)`` is ``1.0``, and 1 is a rate this helper does compare (the
+        premise below), so a boolean would have been diagnosed as a genuine 1 Hz
+        rollout rather than reported as the flag-shaped mistake it is. That is
+        what the shared ``is_boolean`` predicate answers; ``numpy.bool_`` is
+        covered twice over, since it is not a ``numbers.Real`` either.
+        """
+        assert requested_rate_mismatch_reason("run_policy", 30, 1.0) is not None
+        assert requested_rate_mismatch_reason("run_policy", 30, value) is None
+        assert requested_rate_mismatch_reason("run_policy", value, 30.0) is None
+
+    def test_a_fractional_capture_rate_offers_only_the_remedy_it_can(self) -> None:
+        """No whole ``fps`` describes 33.3 Hz, so only the rate remedy is advised."""
+        reason = requested_rate_mismatch_reason("run_policy", 30, 33.3)
+        assert reason is not None
+        assert "pass control_frequency=30" in reason
+        assert "record at the rollout's rate" not in reason
+
+    def test_the_message_is_prefixed_with_the_calling_surface(self) -> None:
+        reason = requested_rate_mismatch_reason("some_surface", 30, 50.0)
+        assert reason is not None
+        assert reason.startswith("some_surface: ")
+
+    def test_the_fps_argument_is_named_as_the_caller_spells_it(self) -> None:
+        default = requested_rate_mismatch_reason("start_recording", 30, 50.0)
+        renamed = requested_rate_mismatch_reason("run_policy", 30, 50.0, fps_param="dataset_fps")
+        assert default is not None and renamed is not None
+        assert "(fps=50)" in default
+        assert "(dataset_fps=50)" in renamed
+
+
+#: Spellings a rate arrives as - the usable ones, the NumPy scalars a value read
+#: out of a config or produced by a comparison carries, and the unusable ones.
+#: ``numpy.int64`` and ``numpy.float32`` are neither ``int`` nor ``float``
+#: subclasses, which is what makes the parity below load-bearing.
+RATE_SPELLINGS: list[Any] = [
+    30,
+    30.0,
+    50.0,
+    np.int64(50),
+    np.float32(30.0),
+    np.float64(50.0),
+    0,
+    -30,
+    2.5,
+    float("nan"),
+    float("inf"),
+    True,
+    np.bool_(True),
+    "30",
+    None,
+]
+
+
+class TestTheGuardJudgesExactlyThePairsBothDomainsAccept:
+    """Derived parity: it may neither duplicate a domain nor decline to judge.
+
+    This guard runs *before* either rate has been through its own domain, so its
+    accepted set has to be derived from those two domains rather than guessed.
+    Too narrow and it silently passes a colliding pair (an ``isinstance(int |
+    float)`` narrowing declines every NumPy scalar); too wide and it reports a
+    rate disagreement for what is really one parameter's own error.
+    """
+
+    @pytest.mark.parametrize("rate", RATE_SPELLINGS, ids=repr)
+    @pytest.mark.parametrize("fps", RATE_SPELLINGS, ids=repr)
+    def test_the_verdict_follows_the_two_domains(self, fps: Any, rate: Any) -> None:
+        judged = requested_rate_mismatch_reason("run_policy", fps, rate) is not None
+        both_usable = (
+            dataset_recording_option_error("start_recording", fps) is None
+            and positive_finite_number_error(rate, "control_frequency", "run_policy") is None
+        )
+        if not both_usable:
+            assert not judged, "a pair one of whose halves is its own parameter error was read as a rate disagreement"
+            return
+        if float(fps) == float(rate):
+            assert not judged
+        else:
+            assert judged, "a pair both domains accept was passed through unjudged"
+
+    def test_the_grid_reaches_all_three_outcomes(self) -> None:
+        """Non-vacuity: a grid that never lands in a bucket asserts nothing there."""
+        outcomes = set()
+        for fps in RATE_SPELLINGS:
+            for rate in RATE_SPELLINGS:
+                usable = (
+                    dataset_recording_option_error("start_recording", fps) is None
+                    and positive_finite_number_error(rate, "control_frequency", "run_policy") is None
+                )
+                if not usable:
+                    outcomes.add("one half unusable")
+                elif float(fps) == float(rate):
+                    outcomes.add("agreeing")
+                else:
+                    outcomes.add("disagreeing")
+        assert outcomes == {"one half unusable", "agreeing", "disagreeing"}
+
+
+# --------------------------------------------------------------------------
+# Structural: the pair is judged before the statement that opens the recording
+# --------------------------------------------------------------------------
+
+
+def _tool_source() -> str:
+    return Path(inspect.getfile(rp_mod)).read_text(encoding="utf-8")
+
+
+def _tool_function(source: str) -> ast.FunctionDef:
+    """Return the ``run_policy`` tool's own FunctionDef from ``source``."""
+    tree = ast.parse(source)
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "run_policy"
+        and any(arg.arg == "simulation" for arg in node.args.args)
+    )
+
+
+def _pairs_judged_before_the_recording(source: str) -> list[set[str]]:
+    """Parameter-name sets read together by a call before ``start_recording``.
+
+    One entry per call reached in the pre-flight region, holding the tool
+    parameters named among its arguments - so a rule *between* parameters shows
+    up as a set of more than one, which a per-knob scan cannot represent.
+    """
+    fn = _tool_function(source)
+    params = {arg.arg for arg in fn.args.args + fn.args.kwonlyargs}
+    # Enumerate from 1: ``fn.body[0]`` is the docstring, and it documents the
+    # ``start_recording(root=dataset_root, ...)`` call by name.
+    start_index = next(
+        index
+        for index, node in enumerate(fn.body)
+        if index > 0 and "start_recording(" in (ast.get_source_segment(source, node) or "")
+    )
+    judged: list[set[str]] = []
+    for statement in fn.body[1:start_index]:
+        for node in ast.walk(statement):
+            if not isinstance(node, ast.Call):
+                continue
+            named = {
+                child.id
+                for argument in list(node.args) + [keyword.value for keyword in node.keywords]
+                for child in ast.walk(argument)
+                if isinstance(child, ast.Name) and child.id in params
+            }
+            if named:
+                judged.append(named)
+    return judged
+
+
+class TestThePairIsJudgedBeforeTheRecordingOpens:
+    """ "The facade will refuse it" is not enough when the facade runs after the wipe."""
+
+    def test_the_two_rates_are_read_together_before_step_two(self) -> None:
+        judged = _pairs_judged_before_the_recording(_tool_source())
+        assert any({"dataset_fps", "control_frequency"} <= names for names in judged), (
+            f"no pre-flight call reads both rates; pairs judged: {[sorted(n) for n in judged]}"
+        )
+
+    def test_the_scan_catches_a_removed_guard(self) -> None:
+        """Planted defect: a clean result must mean a clean source, not a blind scan."""
+        source = _tool_source()
+        guard = (
+            "        if rate_error := requested_rate_mismatch_reason(\n"
+            '            "run_policy", dataset_fps, control_frequency, fps_param="dataset_fps"\n'
+            "        ):\n"
+            "            return _err(rate_error)\n"
+        )
+        assert source.count(guard) == 1
+        planted = source.replace(guard, "")
+        judged = _pairs_judged_before_the_recording(planted)
+        assert not any({"dataset_fps", "control_frequency"} <= names for names in judged)


### PR DESCRIPTION
`run_policy` (the tool) is the only surface in the package that takes both a dataset frame rate
and a rollout capture rate as its own arguments. `dataset_fps` becomes the LeRobotDataset's
declared rate; `control_frequency` is the rate the recorder is really driven at, one frame per
control step with no decimation. LeRobot derives every timestamp positionally from the declared
rate, so the two must be EQUAL - a differing pair cannot be honored, only mislabelled.

Each rate was already checked on its own domain. Their equality was not, and the tool is the one
caller that cannot afford to leave it to the rollout: it opens its recording with
`overwrite=True` before the episode loop, so the refusal arrived from inside the loop, after the
caller's dataset had already been replaced with an empty one.

## Measured

A real MuJoCo rollout records one episode of five frames at 30 fps, then the tool is called with
`control_frequency=50.0, dataset_fps=30, dataset_root=<that dataset>`:

| `meta/info.json` at `dataset_root` | before this change | with this change |
| --- | --- | --- |
| before the call | `total_episodes=1  total_frames=5  fps=30` | `total_episodes=1  total_frames=5  fps=30` |
| after the call | `total_episodes=0  total_frames=0` | `total_episodes=1  total_frames=5` |
| per-camera MP4 | removed | present, byte-identical |
| dataset digest | changed | unchanged |
| reported | `run_policy: 0/2 episodes ok \| parquet-truth: total_episodes=0, total_frames=0` | names both rates, the distortion and both remedies |

Neither argument was wrong on its own, so nothing refused the pair: the caller lost the dataset
and recorded nothing in its place. Both calls return `status="error"`, so the status alone did not
distinguish them.

## Why the existing guards could not see it

The disagreement already has two orderings and both are refused - a rollout started against an
open recording (`dataset_rate_mismatch_reason`) and a recording opened against a rollout in
flight (`rollout_rate_mismatch_reason`). Each reads one rate off live state, so neither can be
asked before either exists. This is the third ordering: both rates arrive as arguments to one
call, while nothing is open.

The per-knob pre-flight sweep in `tests/tools/test_run_policy_rollout_knob_preflight.py` is
structurally blind to it too. It derives the numeric knobs forwarded to
`Simulation.run_policy(...)` - `n_steps`, `control_frequency`, `action_horizon` - and a rule
*between* two parameters is not a property of either. `dataset_fps` is forwarded to
`start_recording`, not to the rollout.

## The change

`requested_rate_mismatch_reason` joins its two siblings in `strands_robots/simulation/recording.py`
and reuses `rate_mismatch_explanation`, so a caller who reorders two calls or supplies both rates
at once gets one account of the distortion rather than three. A parity test now holds all three
orderings to the same verdict on the same value grid. Only the reason form is shipped: the one
caller reports through a structured-error helper of its own, so an envelope twin would be dead
code.

Because this guard runs *before* either rate has been through its own domain, its accepted set is
derived from those domains rather than guessed. Both rates are classified on `numbers.Real`,
exactly as `positive_whole_number_error` and `positive_finite_number_error` do, so the
`numpy.int64` / `numpy.float32` spellings a value read out of a config carries are judged too - an
`isinstance(int | float)` narrowing accepts neither, and would have passed a colliding pair
straight through (12 failing cases in the derived-parity test). The boolean question goes to the
shared `is_boolean` predicate: `bool` *is* a `numbers.Real`, so a flag would otherwise have been
diagnosed as a genuine 1 Hz rollout. A value either domain refuses returns no reason here, so it
is still reported as the parameter error it is rather than as a rate disagreement.

The check is gated on a requested recording. `dataset_fps` is forwarded nowhere when
`dataset_root` is `None`, so the documented recording-less smoke-test mode still runs at any rate
against the default `dataset_fps=30`.

## Artifact

The dataset at `dataset_root` before and after the same call, on each tree. Both panels in each
row are the first frame decoded from the dataset's own per-camera MP4; the two trees' starting
recordings agree to 0 levels. On the left the file the right column still decodes does not exist.
MuJoCo headless (`egl`), mock policy, 5-step rollouts.

![dataset before and after run_policy(dataset_fps=30, control_frequency=50.0), on both trees](https://github.com/cagataycali/robots/releases/download/artifacts/pr2698-rate-agreement.png)

Round trip on the honorable pair (`control_frequency=30.0, dataset_fps=30`, `n_episodes=2`):
`status="success"` and `meta/info.json` reads `total_episodes=2, total_frames=10`, pinned by
`test_an_agreeing_pair_records_the_episodes_it_was_asked_for`.

## Tests

`tests/tools/test_run_policy_rate_agreement_preflight.py` (new, 276 cases). Pre-fix split, with
the new helper present and only the tool's guard reverted: **12 failed / 264 passed** - 8 in
`TestTheRequestedRatesMustAgree`, 2 in `TestTheRefusalPrecedesTheDestruction`, 2 in
`TestThePairIsJudgedBeforeTheRecordingOpens`, and none in either control class. Reverting both source files instead
fails at collection on the absent symbol.

Break table - every mutation and the tests that catch it:

| mutation | tests firing | where |
| --- | --- | --- |
| control, unmodified | 0 | - |
| both source files reverted | collection error | absent symbol |
| only the tool's guard reverted | 12 | the three regression classes |
| checked even when no recording is requested | 3 | `TestUsablePairsStillRun` (recording-less rollouts) |
| exact equality replaces the `1e-9` tolerance | 2 | the near-equal accepted pair |
| an unwritable `fps` diagnosed here, not left to its own guard | 47 | derived parity + helper domain |
| `isinstance(int \| float)` replaces `numbers.Real` | 12 | derived parity (every NumPy spelling) |
| hand-rolled `bool` check replaces `is_boolean` | 1 | the shipped `TestTheBooleanDomainIsStructurallyClosed` |
| the remedy hardcodes `fps` over the caller's spelling | 2 | remedy wording |
| the recording-side remedy is never offered | 2 | remedy wording |
| its own account of the distortion replaces the shared one | 5 | the 3-way parity test + the shared-account test |

The last row and the `is_boolean` row fire tests that are not new: the widened parity test and the
repo's own boolean-domain contract. The two remedy rows fire the same pair, because both remove
the same clause from the message and the tests cannot distinguish them.

`requested_rate_mismatch_reason` is added to `_GUARDED_VALIDATORS` in
`tests/simulation/test_input_validators_refuse_a_boolean.py` rather than exempted like its two
siblings: they compare rates their callers have already validated, and this one does not.

## Gate

`ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`. mypy **24 == 24**
against a pristine `upstream/main` worktree, message sets byte-identical, none in the changed
files.

A 376-file selection (every test that mentions recording, a rate, `run_policy` or `fps`), the same
selection on both trees with the two changed test files excluded from each:
**`53 failed, 14055 passed, 87 skipped, 126 errors` on both** (627.14s vs 627.33s), 180 failing ids
each, both `comm` sets empty. The failures are pre-existing in this environment: 302 occurrences of
`No module named 'device_connect_edge'` (declared as `device-connect-edge>=0.2.0` in
`[device-connect]`) and 18 of `awsiot` (`awsiotsdk>=1.21.0,<2.0.0` in `[mesh-iot]`), with the
remainder identical on the pristine base.

The three changed test files: **620 passed** on mujoco 3.12.0 with lerobot 0.5.1, and **620 passed**
again on mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 built from `main`.
