### PR TITLE
fix(sim): record an undriven robot's declared state columns as measurements

### DIFF
--- a/changelog.d/2699-recorded-undriven-robot-state.md
+++ b/changelog.d/2699-recorded-undriven-robot-state.md
@@ -1,0 +1,35 @@
+### Fixed: an undriven robot's declared `observation.state` columns are recorded as measurements
+
+`start_recording` declares `observation.state` over EVERY robot in the scene, prefixing each
+column with its robot's name (`alice__shoulder_pan`). A single-policy rollout's recording hook
+supplies only the driven robot's observation, so every column belonging to another robot was
+absent from the frame and took `DatasetRecorder.add_frame`'s `0.0` fill - in the same column,
+with the same dtype, as a measurement, for every frame of the episode, under `status="success"`.
+
+Nothing downstream can tell that zero from a reading. A policy trained on the dataset learns the
+other robot is permanently at its zero pose, and anything replaying or analysing the episode
+reads the same. The disagreement is unbounded: an undriven robot keeps whatever pose it was
+placed in, and contact with the driven robot moves it further. In a two-`so101` scene where the
+undriven arm sat at `[0.4653, -0.3447, 0.3548, 0.2475, 0.3476, 0.2970]` rad and reached
+`1.5042` rad on its first joint during the episode, all six of its declared columns were `0.0`
+on disk with zero span.
+
+`run_multi_policy`'s synchronized loop already had this right - it builds one merged observation
+per step covering every robot it drives. The three single-policy hooks did not, so which rollout
+entry point recorded an episode decided whether its state columns were measurements. They now
+resolve the columns they do not drive through one shared owner, `undriven_robot_state`, which
+reads each robot's scalar state through the engine's own
+`get_observation(robot_name=..., skip_images=True)` - the same call the driven robot's columns
+come from, at the same step - and merges it under the hook's existing prefix, with the driven
+robot's own reading winning any collision. Camera arrays are not collected: a frame is keyed by
+its camera rather than by a robot, and cameras are scoped by `start_recording(cameras=...)`.
+
+A bystander read the engine cannot serve is reported and skipped rather than ending the episode.
+The driven robot's columns are the rollout's primary product, so losing a whole episode of them
+to a bystander's read failure is strictly worse than the fill this replaces.
+
+The matching *action* columns are deliberately unchanged. No command was issued to a robot this
+rollout does not drive, so no value there is truthful, and settling it needs a schema decision
+about whether two independently-driven robots may share one dataset at all. A state column has
+no such ambiguity - the robot is in the scene and its joint positions are readable - so the two
+are separable and only the answerable half is changed here.

--- a/strands_robots/simulation/isaac/recording.py
+++ b/strands_robots/simulation/isaac/recording.py
@@ -56,6 +56,7 @@ from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
     dataset_recording_posture_error,
+    undriven_robot_state,
 )
 from strands_robots.utils import name_list_error
 
@@ -130,7 +131,15 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
         every robot (namespaced ``robot__joint`` when more than one robot is
         present, matching the MuJoCo/Newton backends), action columns from
         :meth:`robot_action_keys`, and the RTX cameras registered via
-        ``add_camera``. Camera resolutions are probed from one
+        ``add_camera``. In a multi-robot scene every robot's state columns are
+        declared, and a single-policy rollout fills the ones it does not
+        drive from the engine at each step, so a declared
+        ``observation.state`` column is a measurement rather than a zero
+        the robot is not at
+        (:func:`~strands_robots.simulation.recording.undriven_robot_state`).
+        The matching *action* columns are a separate question - no command
+        was issued to a robot this rollout does not drive - and are
+        unchanged. Camera resolutions are probed from one
         ``get_observation`` call because RTX cameras render at a DLSS-safe
         native size that can exceed the requested output size; declaring the
         probed shape keeps ``add_frame`` from rejecting every image. Per-step
@@ -588,7 +597,14 @@ class IsaacRecordingMixin(DatasetRecordingMixin):
             )
 
             if multi_robot:
-                obs = {f"{robot_name}__{k}": v for k, v in scalars.items()}
+                # The schema declares a state column for every robot in the
+                # scene, and this frame carries only the driven robot's. An
+                # undriven robot's columns are a readable measurement, so they
+                # are filled from the engine at this step rather than left to
+                # add_frame's 0.0 fill, which records them as a zero pose the
+                # robot is not in. Driven keys win any collision.
+                obs = undriven_robot_state(self, robot_name, self._robots)
+                obs.update({f"{robot_name}__{k}": v for k, v in scalars.items()})
                 obs.update(images)
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}
                 rec.add_frame(

--- a/strands_robots/simulation/mujoco/recording.py
+++ b/strands_robots/simulation/mujoco/recording.py
@@ -81,6 +81,17 @@ class RecordingMixin(DatasetRecordingMixin):
         ``get_actions`` call - the recorded frames advance with the robot
         rather than freezing on the chunk-start observation.
 
+        Multi-robot schema: the dataset declares state and action columns for
+        EVERY robot in the scene, prefixed with the robot's name
+        (``alice__shoulder_pan``). A single-policy rollout drives one of them,
+        and the state columns of the others are filled from the engine at each
+        step - so a declared ``observation.state`` column is a measurement,
+        never a zero pose the robot is not in
+        (:func:`~strands_robots.simulation.recording.undriven_robot_state`).
+        Their *action* columns are a separate question: no command was issued
+        to a robot this rollout does not drive, so no value is truthful, and
+        they are unchanged.
+
         Args:
             repo_id: HuggingFace dataset id (``owner/name``) or a local path. The
                 directory it records into is resolved by

--- a/strands_robots/simulation/mujoco/simulation.py
+++ b/strands_robots/simulation/mujoco/simulation.py
@@ -109,6 +109,7 @@ from strands_robots.simulation.mujoco.spec_builder import (
     material_spec_error,
 )
 from strands_robots.simulation.policy_runner import CooperativeStop
+from strands_robots.simulation.recording import undriven_robot_state
 from strands_robots.simulation.terrain import SUPPORTED_TERRAINS, validate_difficulty, validate_terrain
 from strands_robots.teleop_mixin import TeleopMixin
 from strands_robots.utils import (
@@ -5275,10 +5276,19 @@ class MuJoCoSimEngine(
                         # the schema. Camera values (ndarray) keep their (already
                         # namespaced) names - dataset_recorder normalizes '/'->'__'.
                         if len(world.robots) > 1:
-                            obs_keyed = {
-                                (k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v
-                                for k, v in observation.items()
-                            }
+                            # The schema declares a state column for every robot in the
+                            # scene, and this frame carries only the driven robot's. An
+                            # undriven robot's columns are a readable measurement, so they
+                            # are filled from the engine at this step rather than left to
+                            # add_frame's 0.0 fill, which records them as a zero pose the
+                            # robot is not in. Driven keys win any collision.
+                            obs_keyed = undriven_robot_state(self, robot_name, world.robots)
+                            obs_keyed.update(
+                                {
+                                    (k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v
+                                    for k, v in observation.items()
+                                }
+                            )
                             act_keyed = {f"{robot_name}__{k}": v for k, v in action.items()}
                             rec.add_frame(
                                 observation=obs_keyed,

--- a/strands_robots/simulation/newton/recording.py
+++ b/strands_robots/simulation/newton/recording.py
@@ -31,6 +31,7 @@ from strands_robots.simulation.recording import (
     DatasetRecordingMixin,
     dataset_recording_option_error,
     dataset_recording_posture_error,
+    undriven_robot_state,
 )
 from strands_robots.utils import name_list_error
 
@@ -79,7 +80,15 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
         Declares the dataset schema from the live scene - joint names from every
         robot (namespaced ``robot__joint`` when more than one robot is present,
         matching the MuJoCo backend) and the named cameras registered on
-        ``world.cameras`` (with their real render resolutions). Per-step frames
+        ``world.cameras`` (with their real render resolutions). In a multi-robot scene every robot's state columns are
+        declared, and a single-policy rollout fills the ones it does not
+        drive from the engine at each step, so a declared
+        ``observation.state`` column is a measurement rather than a zero
+        the robot is not at
+        (:func:`~strands_robots.simulation.recording.undriven_robot_state`).
+        The matching *action* columns are a separate question - no command
+        was issued to a robot this rollout does not drive - and are
+        unchanged. Per-step frames
         are then captured by the ``on_frame`` hook
         (:meth:`_make_run_policy_hook`) during ``run_policy``.
 
@@ -504,7 +513,15 @@ class NewtonRecordingMixin(DatasetRecordingMixin):
             if multi_robot:
                 import numpy as np
 
-                obs = {(k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v for k, v in obs.items()}
+                # The schema declares a state column for every robot in the
+                # scene, and this frame carries only the driven robot's. An
+                # undriven robot's columns are a readable measurement, so they
+                # are filled from the engine at this step rather than left to
+                # add_frame's 0.0 fill, which records them as a zero pose the
+                # robot is not in. Driven keys win any collision.
+                driven = {(k if isinstance(v, np.ndarray) else f"{robot_name}__{k}"): v for k, v in obs.items()}
+                obs = undriven_robot_state(self, robot_name, world.robots)
+                obs.update(driven)
                 act = {f"{robot_name}__{k}": v for k, v in action.items()}
                 rec.add_frame(
                     observation=obs,

--- a/strands_robots/simulation/recording.py
+++ b/strands_robots/simulation/recording.py
@@ -28,7 +28,7 @@ enforceable protocol.
 
 import logging
 import shutil
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -384,6 +384,93 @@ def _resume_schema_error(diffs: list[str]) -> str:
         "Use overwrite=True for a fresh dataset, or restore the original scene. Differences:\n  - "
         + "\n  - ".join(diffs)
     )
+
+
+def undriven_robot_state(engine: Any, driven_robot: str, robot_names: Iterable[str]) -> dict[str, Any]:
+    """Read the scalar state of every robot a recorded frame does not drive.
+
+    ``start_recording`` declares ``observation.state`` over EVERY robot in the
+    scene, prefixing each column with its robot's name
+    (``alice__shoulder_pan``). A single-policy rollout's recording hook supplies
+    only the driven robot's observation, so every column belonging to another
+    robot is absent from the frame and
+    :meth:`~strands_robots.dataset_recorder.DatasetRecorder.add_frame` writes it
+    as ``0.0`` - under ``status="success"``, for every frame of the episode.
+
+    That zero is not a missing value the consumer can detect. It is recorded in
+    the same column, with the same dtype, as a measurement: a policy trained on
+    the dataset reads ``observation.state`` and learns the other robot is
+    permanently at its zero pose, and anything replaying or analysing the
+    episode reads the same. The disagreement is unbounded - the undriven robot
+    keeps whatever pose it was placed in, and contact with the driven robot can
+    move it further during the episode.
+
+    Unlike the *action* columns of the same frame, there is nothing to decide
+    here. An action column asks what command was issued, and no command was
+    issued to a robot this rollout does not drive (#1715 works through why no
+    substitute is truthful). A state column asks where the robot is, the robot
+    is in the scene, and its joint positions are readable at that instant from
+    the same engine, at the same step, through the same
+    :meth:`~strands_robots.simulation.base.SimEngine.get_observation` the driven
+    robot's own columns come from. So the undriven columns are filled with the
+    measurement rather than left to the ``0.0`` fill.
+
+    This is the behaviour ``run_multi_policy``'s synchronized loop already has -
+    it builds one merged observation per step covering every robot it drives and
+    hands that to ``add_frame``. This helper is that same guarantee for the
+    three single-policy hooks, so which rollout entry point recorded an episode
+    stops changing whether its state columns are measurements.
+
+    Images are deliberately not collected. A camera array is keyed by the
+    camera's own name rather than a robot's, and the recording hooks scope
+    cameras through ``start_recording(cameras=...)``, so an undriven robot
+    contributes no image column. Only scalars are returned, prefixed exactly as
+    the hooks prefix the driven robot's.
+
+    Args:
+        engine: The simulation engine, read through its public
+            ``get_observation(robot_name=..., skip_images=True)``.
+        driven_robot: The robot this frame drives; its columns are supplied by
+            the hook itself and are not re-read here.
+        robot_names: Every robot the dataset schema declares columns for.
+
+    Returns:
+        ``{"<robot>__<joint>": value}`` for each scalar observation of each
+        robot other than ``driven_robot``. Empty when the scene holds only the
+        driven robot, which is the single-robot case where the schema is not
+        prefixed at all.
+    """
+    merged: dict[str, Any] = {}
+    for name in robot_names:
+        if name == driven_robot:
+            continue
+        try:
+            observation = engine.get_observation(robot_name=name, skip_images=True)
+        except (AttributeError, KeyError, RuntimeError, ValueError):
+            # ``engine`` is duck-typed - every backend's own engine reaches here,
+            # and a state read it cannot serve must degrade to the recorder's
+            # fill rather than end the episode. The driven robot's columns are
+            # the rollout's primary product: losing a whole episode of them to a
+            # bystander's read failure is strictly worse than the fill this
+            # helper exists to avoid, so the failure is reported and the frame
+            # still lands. ``AttributeError`` is in the set deliberately - an
+            # engine that has not built (or has torn down) the state buffers a
+            # per-robot read needs surfaces exactly that way.
+            logger.warning(
+                "recording: could not read state for robot %r this step; its declared "
+                "observation.state columns fall back to the recorder's fill for this frame.",
+                name,
+            )
+            continue
+        if not isinstance(observation, Mapping):
+            continue
+        for key, value in observation.items():
+            # Mirror the hooks' own split: a non-scalar value is a camera array,
+            # which is not a per-robot column.
+            if hasattr(value, "shape"):
+                continue
+            merged[f"{name}__{key}"] = value
+    return merged
 
 
 class DatasetRecordingMixin:

--- a/tests/simulation/test_recorded_undriven_robot_state.py
+++ b/tests/simulation/test_recorded_undriven_robot_state.py
@@ -1,0 +1,283 @@
+"""An undriven robot's declared ``observation.state`` columns are measurements.
+
+``start_recording`` declares ``observation.state`` over every robot in the
+scene, prefixing each column with its robot's name. A single-policy rollout's
+recording hook supplies only the driven robot's observation, so before this was
+fixed every column belonging to another robot fell through to
+``DatasetRecorder.add_frame``'s ``0.0`` fill - recorded in the same column, with
+the same dtype, as a measurement, for every frame, under ``status="success"``.
+
+Nothing downstream can tell that zero from a real reading: a policy trained on
+the dataset learns the other robot is permanently at its zero pose. The
+disagreement is unbounded, because an undriven robot keeps whatever pose it was
+placed in.
+
+The *action* half of the same frame is a separate question and deliberately not
+touched here - no command was issued to a robot this rollout does not drive, so
+there is no truthful value to write (#1715). A state column has one: the robot
+is in the scene and its joint positions are readable at that instant.
+
+``run_multi_policy``'s synchronized loop already merged every robot's state into
+one frame per step, so this was the three single-policy hooks disagreeing with
+the one path that had it right.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import pathlib
+import textwrap
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mujoco")
+pytest.importorskip("lerobot")
+
+from strands_robots.simulation.recording import undriven_robot_state  # noqa: E402
+
+_ROBOT_XML = """
+<mujoco model="probe_arm">
+  <compiler angle="radian" autolimits="true"/>
+  <option timestep="0.002"/>
+  <worldbody>
+    <light name="main" pos="0 0 3" dir="0 0 -1"/>
+    <body name="base" pos="0 0 0.1">
+      <geom type="cylinder" size="0.04 0.04" rgba="0.3 0.3 0.8 1"/>
+      <joint name="shoulder_pan" type="hinge" axis="0 0 1" range="-3.14 3.14"/>
+      <body name="link" pos="0 0 0.08">
+        <geom type="capsule" fromto="0 0 0 0 0 0.12" size="0.02" rgba="0.8 0.3 0.3 1"/>
+        <joint name="elbow" type="hinge" axis="0 1 0" range="-3.14 3.14"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="shoulder_pan_act" joint="shoulder_pan" kp="80"/>
+    <position name="elbow_act" joint="elbow" kp="80"/>
+  </actuator>
+</mujoco>
+"""
+
+#: The pose the undriven robot is parked in. Every component is far from ``0.0``
+#: so a recorded zero cannot be mistaken for this pose - the whole point of the
+#: fixture. Asserted against the fill in ``test_the_parked_pose_is_not_the_fill``.
+_PARKED = {"shoulder_pan": 0.9, "elbow": -0.7}
+
+_SETTLE_SUBSTEPS = 600
+
+
+@pytest.fixture
+def two_robot_recording(tmp_path: pathlib.Path) -> Any:
+    """A two-robot scene with ``bob`` parked away from ``alice`` and settled."""
+    from strands_robots.simulation import Simulation
+
+    xml = tmp_path / "probe_arm.xml"
+    xml.write_text(_ROBOT_XML, encoding="utf-8")
+
+    sim = Simulation()
+    sim.create_world()
+    sim.add_robot("alice", urdf_path=str(xml), position=[0.0, 0.0, 0.0])
+    # Far enough that no contact couples the two, so the parked pose holds and
+    # the last recorded frame can be compared against a post-rollout reading.
+    sim.add_robot("bob", urdf_path=str(xml), position=[2.0, 0.0, 0.0])
+    assert sim.send_action(_PARKED, robot_name="bob", n_substeps=_SETTLE_SUBSTEPS)["status"] == "success"
+    return sim
+
+
+def _record_one_episode(sim: Any, root: pathlib.Path) -> dict[str, Any]:
+    """Drive ``alice`` for a few steps with a recording open, then read the parquet."""
+    assert (
+        sim.start_recording(
+            repo_id="local/undriven_state_probe",
+            task="probe",
+            fps=10,
+            root=str(root),
+            cameras=["default"],
+            overwrite=True,
+        )["status"]
+        == "success"
+    )
+    assert (
+        sim.run_policy(
+            robot_name="alice",
+            policy_provider="mock",
+            instruction="probe",
+            n_steps=5,
+            control_frequency=10.0,
+            fast_mode=True,
+        )["status"]
+        == "success"
+    )
+    assert sim.stop_recording()["status"] == "success"
+
+    # Read back through the public reader rather than the parquet, so this is
+    # the round trip a consumer of the dataset actually performs.
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
+    names = info["features"]["observation.state"]["names"]
+    dataset = LeRobotDataset("local/undriven_state_probe", root=str(root))
+    assert len(dataset) > 0, f"reopened dataset at {root} is empty"
+    state = np.stack([np.asarray(dataset[i]["observation.state"], dtype=np.float64) for i in range(len(dataset))])
+    return {"names": names, "state": state}
+
+
+class TestAnUndrivenRobotsStateIsRecordedAsMeasured:
+    """The regression: a declared state column holds a reading, not the fill."""
+
+    def test_the_parked_pose_is_not_the_fill(self) -> None:
+        """Premise: a recorded zero would be indistinguishable from this pose."""
+        assert all(abs(v) > 0.1 for v in _PARKED.values()), (
+            f"the parked pose {_PARKED} must differ from add_frame's 0.0 fill in every "
+            "component, or a recording that fabricates zeros passes these tests"
+        )
+
+    def test_the_schema_declares_the_undriven_robots_columns(self, two_robot_recording: Any, tmp_path: Any) -> None:
+        """Premise: without declared ``bob__*`` columns there is nothing to fill."""
+        recorded = _record_one_episode(two_robot_recording, tmp_path / "ds_schema")
+        assert [n for n in recorded["names"] if n.startswith("bob__")] == ["bob__shoulder_pan", "bob__elbow"]
+
+    def test_the_undriven_robots_columns_are_not_the_zero_fill(self, two_robot_recording: Any, tmp_path: Any) -> None:
+        """The defect: every ``bob__*`` value on disk used to be ``0.0``."""
+        recorded = _record_one_episode(two_robot_recording, tmp_path / "ds_zero")
+        idx = [i for i, n in enumerate(recorded["names"]) if n.startswith("bob__")]
+        column = recorded["state"][:, idx]
+        assert not np.allclose(column, 0.0), (
+            "every declared observation.state column of the undriven robot 'bob' was recorded "
+            f"as the 0.0 fill while bob is parked at {_PARKED}: {column.tolist()}"
+        )
+
+    def test_the_undriven_robots_columns_match_the_engines_own_reading(
+        self, two_robot_recording: Any, tmp_path: Any
+    ) -> None:
+        """The recorded value is the measurement, not merely non-zero."""
+        sim = two_robot_recording
+        recorded = _record_one_episode(sim, tmp_path / "ds_match")
+        truth = sim.get_observation(robot_name="bob", skip_images=True)
+        for i, name in enumerate(recorded["names"]):
+            if not name.startswith("bob__"):
+                continue
+            joint = name.removeprefix("bob__")
+            assert float(recorded["state"][-1][i]) == pytest.approx(float(truth[joint]), abs=1e-3), (
+                f"{name} on disk disagrees with the engine's own reading of bob's {joint}"
+            )
+
+    def test_the_driven_robots_columns_still_track_a_real_trajectory(
+        self, two_robot_recording: Any, tmp_path: Any
+    ) -> None:
+        """Control: filling the undriven columns must not flatten the driven ones."""
+        recorded = _record_one_episode(two_robot_recording, tmp_path / "ds_driven")
+        idx = [i for i, n in enumerate(recorded["names"]) if n.startswith("alice__")]
+        assert idx, "premise: the driven robot must have declared columns too"
+        column = recorded["state"][:, idx]
+        assert np.ptp(column, axis=0).max() > 1e-4, (
+            f"the driven robot's own columns no longer vary across the episode: {column.tolist()}"
+        )
+
+    def test_a_driven_column_is_never_overwritten_by_the_undriven_fill(
+        self, two_robot_recording: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The precedence the fill depends on: this frame's own reading wins.
+
+        The undriven fill and the driven observation are merged into one frame,
+        so a fill that claimed a driven robot's column would silently replace a
+        real per-step reading with a second read taken through a different path.
+        Forced here by making the fill claim every column it must not own.
+        """
+        import strands_robots.simulation.mujoco.simulation as mujoco_sim
+
+        sentinel = -12345.0
+        monkeypatch.setattr(
+            mujoco_sim,
+            "undriven_robot_state",
+            lambda engine, driven, names: {f"{driven}__shoulder_pan": sentinel, "bob__shoulder_pan": sentinel},
+        )
+        recorded = _record_one_episode(two_robot_recording, tmp_path / "ds_precedence")
+        driven = recorded["names"].index("alice__shoulder_pan")
+        assert not np.any(recorded["state"][:, driven] == sentinel), (
+            "the undriven fill overwrote the driven robot's own per-step reading"
+        )
+        # The premise: the fill really was consulted, so the assertion above is
+        # about precedence rather than about a patch that never ran.
+        bystander = recorded["names"].index("bob__shoulder_pan")
+        assert np.all(recorded["state"][:, bystander] == sentinel), "premise: the patched fill was not consulted"
+
+
+class TestTheHelperReadsOnlyWhatItShould:
+    """``undriven_robot_state`` is the single owner, so its rule is pinned here."""
+
+    class _Engine:
+        def __init__(self, states: dict[str, dict[str, Any]], raises: set[str] | None = None) -> None:
+            self.states = states
+            self.raises = raises or set()
+            self.asked: list[str] = []
+
+        def get_observation(self, robot_name: str | None = None, skip_images: bool = False) -> dict[str, Any]:
+            assert skip_images is True, "a per-robot state read must not pay for a render"
+            self.asked.append(str(robot_name))
+            if robot_name in self.raises:
+                raise RuntimeError("transient read failure")
+            return self.states[str(robot_name)]
+
+    def test_the_driven_robot_is_not_re_read(self) -> None:
+        """The hook already carries the driven robot's own observation."""
+        engine = self._Engine({"alice": {"j": 1.0}, "bob": {"j": 2.0}})
+        assert undriven_robot_state(engine, "alice", ["alice", "bob"]) == {"bob__j": 2.0}
+        assert engine.asked == ["bob"]
+
+    def test_a_single_robot_scene_yields_nothing(self) -> None:
+        """A one-robot schema is not prefixed, so there is nothing to fill."""
+        engine = self._Engine({"alice": {"j": 1.0}})
+        assert undriven_robot_state(engine, "alice", ["alice"]) == {}
+        assert engine.asked == []
+
+    def test_array_values_are_left_out(self) -> None:
+        """A camera frame is keyed by the camera, never by a robot."""
+        engine = self._Engine({"bob": {"j": 2.0, "wrist": np.zeros((2, 2, 3), dtype=np.uint8)}})
+        assert undriven_robot_state(engine, "alice", ["alice", "bob"]) == {"bob__j": 2.0}
+
+    def test_a_failed_read_does_not_lose_the_episode(self) -> None:
+        """The driven robot's columns are the rollout's primary product."""
+        engine = self._Engine({"bob": {"j": 2.0}, "carol": {"j": 3.0}}, raises={"bob"})
+        assert undriven_robot_state(engine, "alice", ["alice", "bob", "carol"]) == {"carol__j": 3.0}
+
+
+class TestEverySinglePolicyHookConsultsTheSharedOwner:
+    """A fourth backend cannot reintroduce the fill by forgetting the helper."""
+
+    #: Each backend's single-policy recording hook, as ``(module, attribute)``.
+    HOOKS = [
+        ("strands_robots.simulation.mujoco.simulation", "MuJoCoSimEngine"),
+        ("strands_robots.simulation.isaac.recording", "IsaacRecordingMixin"),
+        ("strands_robots.simulation.newton.recording", "NewtonRecordingMixin"),
+    ]
+
+    def _hook_source(self, module_name: str, attr: str) -> str:
+        import importlib
+
+        module = importlib.import_module(module_name)
+        owner = getattr(module, attr)
+        return inspect.getsource(owner._make_run_policy_hook)
+
+    def test_the_hooks_under_survey_all_exist(self) -> None:
+        """Premise: a renamed backend would make every check below vacuous."""
+        for module_name, attr in self.HOOKS:
+            assert self._hook_source(module_name, attr), f"{module_name}.{attr} has no readable hook source"
+
+    @pytest.mark.parametrize(("module_name", "attr"), HOOKS)
+    def test_the_hook_fills_undriven_columns_from_the_shared_owner(self, module_name: str, attr: str) -> None:
+        """Each hook resolves the undriven columns through the one helper."""
+        source = self._hook_source(module_name, attr)
+        called = {
+            node.func.id
+            for node in ast.walk(ast.parse(textwrap.dedent(source)))
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "undriven_robot_state" in called, (
+            f"{module_name}.{attr}._make_run_policy_hook does not call undriven_robot_state, so a "
+            "multi-robot recording made through it writes the other robots' declared "
+            "observation.state columns as add_frame's 0.0 fill"
+        )


### PR DESCRIPTION
A multi-robot recording writes the state columns of every robot the rollout does not drive as `0.0`, in a column the dataset declares as `observation.state`, for every frame, under `status="success"`.

## The defect

`start_recording` declares `observation.state` over EVERY robot in the scene, prefixing each column with its robot's name (`alice__shoulder_pan`). A single-policy rollout's recording hook supplies only the driven robot's observation, so every column belonging to another robot is absent from the frame and `DatasetRecorder.add_frame` takes its `v is None -> action_vals.append(0.0)` fill.

Nothing downstream can tell that zero from a reading. It lands in the same column with the same dtype, so a policy trained on the dataset learns the other robot is permanently at its zero pose, and anything replaying or analysing the episode reads the same.

Reproduced on `704dd33d` - two `so101` arms in one scene, `run_policy(robot_name="arm")`, `fps=10`, `start_recording` then `stop_recording`, dataset reopened through `LeRobotDataset`:

| source | `so101__1` | `so101__2` | `so101__3` | `so101__4` | `so101__5` | `so101__6` |
|---|---|---|---|---|---|---|
| engine's own reading, before the rollout | 0.4653 | -0.3447 | 0.3548 | 0.2475 | 0.3476 | 0.2970 |
| recorded, frame 0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
| recorded, per-column span over the episode | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |

The declared column set is `['so101__1'..'so101__6', 'arm__1'..'arm__6']`, so those six are columns the dataset advertises. The disagreement is unbounded: an undriven robot keeps whatever pose it was placed in, and contact with the driven robot moves it further - in this scene `so101__1` reached 1.5042 rad by the end of the episode while its recorded column stayed flat at zero.

## One path in the codebase already had this right

`run_multi_policy`'s synchronized loop builds one merged observation per step covering every robot it drives and hands that to `add_frame`. The three single-policy hooks - MuJoCo's `_make_run_policy_hook`, and Isaac's and Newton's - did not, so which entry point recorded an episode decided whether its state columns were measurements.

## The change

A single owner, `strands_robots.simulation.recording.undriven_robot_state`, reads the scalar state of every robot the frame does not drive through the engine's own `get_observation(robot_name=..., skip_images=True)` - the same call the driven robot's columns come from, at the same step. The three hooks merge it under their existing per-robot prefix, with the driven robot's own reading winning any collision.

Images are deliberately not collected: a camera array is keyed by the camera rather than a robot, and cameras are scoped by `start_recording(cameras=...)`.

A bystander read that the engine cannot serve is reported and skipped rather than ending the episode - the driven robot's columns are the rollout's primary product, and losing a whole episode of them to a bystander's read failure is strictly worse than the fill this replaces. `AttributeError` is in that set on purpose: `engine` is duck-typed here, and an engine that has not built (or has torn down) the state buffers a per-robot read needs surfaces exactly that way.

## What is deliberately NOT changed

The *action* columns of the same frame. No command was issued to a robot this rollout does not drive, so there is no truthful value to write there - #1715 works through why the observation, a `ctrl` read-back and a carry-forward are each wrong, and settling it needs a schema decision about whether two independently-driven robots may share one dataset at all. A state column has no such ambiguity: the robot is in the scene and its joint positions are readable. Splitting the two keeps this landable without pre-empting that decision.

## Tests

`tests/simulation/test_recorded_undriven_robot_state.py`, 14 tests. The regression is a record -> reopen round trip through `LeRobotDataset` on a two-robot MuJoCo scene with `bob` parked at `{shoulder_pan: 0.9, elbow: -0.7}`, asserting its declared columns are the engine's own reading rather than the fill.

Pre-fix split, two ways because the helper is a new symbol:

- Reverting all source: collection fails with `ImportError: cannot import name 'undriven_robot_state'`, which hides the behavioural evidence.
- Reverting only the three call sites and keeping the helper: **6 failed, 8 passed**. All six are in the regression classes; the premises and controls pass on both trees. The headline message is the recorded column itself - `every declared observation.state column of the undriven robot 'bob' was recorded as the 0.0 fill while bob is parked at {'shoulder_pan': 0.9, 'elbow': -0.7}: [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]`.

Two premise tests keep it from going vacuous: the parked pose must differ from `0.0` in every component, and the schema must actually declare `bob__*` columns. Two controls: the driven robot's own columns still vary across the episode, and a fill that claims a driven robot's column does not overwrite that robot's per-step reading (forced by patching the fill to claim it, with a premise asserting the patch really ran). A structural check derives each backend's hook from its own class and requires it to consult the shared owner, so a fourth backend cannot reintroduce the fill by forgetting it - it fails for all three on the pre-fix tree.

## Verification

- New file: **14 passed**.
- `tests/simulation/newton/test_dataset_recording.py`: **14 passed**. Newton's fixture builds its engine through `__new__` without the Warp stack, so a per-robot state read is not serviceable there and takes the reported-and-skipped path; the assertions in that file are about the declared schema and are unaffected.
- New file + `tests/simulation/isaac/test_dataset_recording.py` + `tests/simulation/mujoco/test_recording_camera_scoping.py`: **46 passed**.
- Blast radius, 343 files (every test naming `start_recording`, `dataset_recorder`, `add_frame`, `get_observation`, `run_policy`, `observation.state` or `_make_run_policy_hook`), identical selection against a pristine `main` worktree in the same environment with the new file excluded from each: **2 failed, 12000 passed, 90 skipped on both trees**, 897.64s vs 897.78s, **failing node-ID sets byte-identical - zero branch-only, zero base-only**. Both pre-existing and unrelated: `newton/test_multi_camera.py::test_bad_position_shape_rejected` (asserts `'3 elements'` against a message reading `'must be a 3-element vector'`) and `test_dds_domain_id_domain.py::test_a_usable_domain_is_still_pinned_into_the_environment` (`DID NOT RAISE ImportError`, an artifact of the DDS stack being installed locally).
- `mypy strands_robots tests tests_integ`: **Success: no issues found in 1520 source files**, and zero branch-only messages against the pristine base worktree.
- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1523 files).

## Artifact

The undriven robot's six declared `observation.state` columns, read back out of the recorded
dataset over a 20-frame episode, on both trees. Dotted lines are the engine's own reading of the
same joints. Two-robot MuJoCo scene, headless, `fps=10`, the undriven arm parked and then nudged
by contact with the driven one.

![recorded observation.state of the undriven robot](https://github.com/cagataycali/robots/releases/download/artifacts/pr2699-undriven-state.png)

| measure | main (`704dd33d`) | this change |
|---|---|---|
| largest per-column span across the episode | 0.0000 rad | 1.0536 rad |
| final-frame `abs(recorded - engine's own reading)`, worst column | 1.5486 rad | 1.18e-08 rad |

Main records a flat zero for all six while the joints move through a rad of travel; the branch
agrees with the engine to 1.18e-08 rad. Every number in the table is re-derived from the recorded
traces by the script that draws the figure, which asserts them before rendering.

## Docs

`start_recording`'s docstring on all three backends now states the multi-robot schema rule: every robot's columns are declared, the undriven ones are filled from the engine each step so a declared `observation.state` column is a measurement, and the action columns are a separate question that is unchanged.
