### PR TITLE
fix(mesh): name every class that carries a scoped drive limit

### DIFF
--- a/changelog.d/2700-drive-limit-scope-names-every-carrier.md
+++ b/changelog.d/2700-drive-limit-scope-names-every-carrier.md
@@ -1,0 +1,43 @@
+### Fixed: the drive-contract scope markers name every class that carries a limit
+
+`docs/rosbridge-integration.md` and `RosbridgeRobot.drive` both marked the velocity clamp and
+the `max_duration` ceiling as belonging to the rosbridge bridge alone, and said in prose that
+`RosBridgedRobot.drive` and `RtpsRobot.drive` "carry none of the three". `AckermannRosRobot`
+declares both, as `max_speed` and a `max_duration` of its own. The scope marker is the whole
+point of those bullets - an unmarked guarantee reads as the fleet's, and a marked one tells a
+reader which platform they have to supply the ceiling for themselves - so a reader who has just
+been told the duration ceiling is one bridge's own carries the 30 s hold the page documents over
+to a DeepRacer and is refused by that car's 10 s ceiling. The failure direction is the safe one,
+but it is an unexplained refusal in the field, and the same reader plans around a velocity clamp
+they have been told the car does not have. The fleet's own pages already stated both halves:
+`docs/ros2-integration.md` documents the car's clamp and ceiling while the rosbridge page denied
+they existed anywhere else.
+
+`tests/mesh/test_drive_contract_fleet_scope.py` exists to grade that prose against a
+measurement rather than against a hand-kept list, but its universe was a hardcoded list of the
+three `Twist` bridges, so the fourth drive-owning class sat outside everything it checked and the
+false claim passed green. The surveyed set is now derived from the package - a class that owns
+`drive` and lives in a public module of `strands_robots.mesh` is a shipped platform bridge - and
+the lookup is by attribute rather than by a `def drive` in the class body, so a bridge that
+inherits `drive` from a shared base is still found while a private base module, which declares a
+contract but is not a platform anyone drives, stays out. A fifth class fails the inventory until
+it is given a case.
+
+Three of the five guarantees are read without touching the message layout and are measured over
+every drive-owning class: a refused input and a hold past a ceiling each forward no call at all,
+and a velocity clamp makes two different over-ceiling requests forward the identical call, which
+is as true of a servo pair as of a `Twist`. The clamp probe previously read
+`calls[0]["fields"]["linear"]["x"]` and raises `KeyError: 'linear'` on a `ServoCtrlMsg`, so it
+could not have been evaluated on that class even if the class had been listed. The two probes
+that do read `Twist` content, the single-shot latch and the trailing zero, stay scoped to the
+three `Twist` bridges for the reason `tests/mesh/test_bridge_stop_tool_parity.py` already gives:
+an Ackermann car halts with a zero `ServoCtrlMsg`, not a zero `Twist`.
+
+The measured split is now three-way - fleet-wide, carried by some, carried by this bridge alone -
+because a limit two platforms declare is neither of the outer two and filing it under either
+misinforms a reader of the other platforms. Both surfaces say which is which: the two bullets are
+marked `(not on every mobile base)` and name `AckermannRosRobot`, and the docstring paragraph
+opens `Not carried by every mobile base:` and credits the car's own lower ceiling. Two derived
+rules hold them there - a bullet may claim `this bridge only` only when the survey finds no other
+carrier, and every other carrier of a scoped guarantee has to be named. No library behaviour
+changes; the only non-test edit is a docstring.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -125,9 +125,11 @@ All parameters are optional except `node_name`, `cmd_vel_topic`, and `odom_topic
 and two of its guarantees are fleet-standard too: every value is checked against
 the same numeric domains the [ROS 2](ros2-integration.md) and
 [RTPS](rtps-integration.md) bridges use, and a bare single-shot command latches.
-The velocity clamps, the `max_duration` ceiling and the trailing zero Twist are
-specific to this bridge - the other two accept no ceilings and publish no
-trailing zero, so a timed drive there leaves the last velocity latched.
+The velocity clamps and the `max_duration` ceiling are shared with the Ackermann
+car bridge (`AckermannRosRobot`, which declares a `max_speed` and a
+`max_duration` of its own) but not with those two, and the trailing zero Twist is
+this bridge's alone - the ROS 2 and RTPS bridges accept no ceilings and publish
+no trailing zero, so a timed drive there leaves the last velocity latched.
 
 ```python
 # Direct, programmatic control:
@@ -145,12 +147,16 @@ scan = robot.get_scan()  # read one laser scan (error if no scan_topic)
 - **Single-shot latch**: a bare single-message `drive()` (no `duration`, no
   `count > 1`) publishes once and latches in the robot's controller until
   `stop()` is called. This is standard cmd_vel behavior.
-- **Velocity clamps** (this bridge only): linear and angular are independently
-  clamped to `max_linear` and `max_angular`. The other two bridges accept no
-  velocity ceiling and put the requested value on the wire unchanged.
-- **Loud duration rejection** (this bridge only): `duration` must be positive,
-  finite, and at most `max_duration`; anything else returns a detailed error and
-  nothing is published. The other two bridges accept any positive finite hold.
+- **Velocity clamps** (not on every mobile base): linear and angular are
+  independently clamped to `max_linear` and `max_angular`. `AckermannRosRobot`
+  clamps to a `max_speed` of its own the same way. The ROS 2 and RTPS bridges
+  accept no velocity ceiling and put the requested value on the wire unchanged.
+- **Loud duration rejection** (not on every mobile base): `duration` must be
+  positive, finite, and at most `max_duration`; anything else returns a detailed
+  error and nothing is published. `AckermannRosRobot` refuses a longer hold
+  against a `max_duration` of its own, which is lower, so a hold this bridge
+  accepts can be refused on that car. The ROS 2 and RTPS bridges accept any
+  positive finite hold.
 - **Timed-command trailing zero** (this bridge only): every drive with a
   `duration` argument and a non-zero command (or multi-message publish)
   automatically publishes a single zero Twist afterwards - even if the main

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -189,15 +189,20 @@ class RosbridgeRobot:
         and a bare single-shot command latches until :meth:`stop`, like any
         raw cmd_vel publish.
 
-        Specific to this bridge: velocities are clamped to ``max_linear`` and
-        ``max_angular``, a hold beyond ``max_duration`` is refused, and every
-        timed or multi-message non-zero command is followed by a single zero
-        Twist - even if the main publish failed - so a timed drive cannot
-        leave the robot with a live velocity. :meth:`RosBridgedRobot.drive`
-        and :meth:`RtpsRobot.drive` carry none of the three: they accept no
-        velocity or duration ceiling, publish the requested burst unclamped,
-        and stop publishing without a trailing zero, so a timed drive there
-        leaves the last velocity latched in the robot's controller.
+        Not carried by every mobile base: velocities are clamped to
+        ``max_linear`` and ``max_angular``, a hold beyond ``max_duration`` is
+        refused, and every timed or multi-message non-zero command is followed
+        by a single zero Twist - even if the main publish failed - so a timed
+        drive cannot leave the robot with a live velocity.
+        :class:`~strands_robots.mesh.ackermann_robot.AckermannRosRobot`
+        declares the first two as well, as ``max_speed`` and a ``max_duration``
+        of its own, because it too wraps a platform whose limits are known - so
+        a hold this bridge accepts can be refused on that car, and the reverse.
+        :meth:`RosBridgedRobot.drive` and :meth:`RtpsRobot.drive` carry none of
+        the three: they accept no velocity or duration ceiling, publish the
+        requested burst unclamped, and stop publishing without a trailing zero,
+        so a timed drive there leaves the last velocity latched in the robot's
+        controller.
 
         Args:
             linear: Forward linear velocity (m/s), mapped to ``linear.x``. Must

--- a/tests/mesh/test_drive_contract_fleet_scope.py
+++ b/tests/mesh/test_drive_contract_fleet_scope.py
@@ -1,11 +1,13 @@
-"""Which drive guarantees are fleet-wide, and which belong to one bridge only.
+"""Which drive guarantees are fleet-wide, and which only some platforms keep.
 
-Three mobile-base bridges expose the same ``drive(linear, angular, duration,
-count)`` call over three transports, and an operator or agent that learns the
-contract from one drives the others with it. Two of the guarantees really are
-shared - the numeric domains every value is checked against, and the single-shot
-latch - while the velocity clamp, the ``max_duration`` ceiling and the trailing
-zero Twist are carried by ``RosbridgeRobot`` alone.
+Four mesh classes expose the same ``drive(linear, angular, duration, count)``
+call over three transports and two message layouts, and an operator or agent
+that learns the contract from one drives the others with it. Two of the
+guarantees really are kept by every class they are measured on - the numeric
+domains every value is checked against, and the single-shot latch - while the
+velocity clamp and the ``max_duration`` ceiling are kept by ``RosbridgeRobot``
+and ``AckermannRosRobot``, and the trailing zero Twist by ``RosbridgeRobot``
+alone.
 
 That split matters most for the trailing zero, because it is the guarantee that
 a *timed* drive cannot leave a live velocity behind. Presenting it as fleet-wide
@@ -18,10 +20,22 @@ grades the prose against the measurement, rather than pinning either half to a
 hardcoded expectation. A bridge that later gains the trailing stop makes the
 scope assertion fail, which is the intended signal: the guarantee has become
 fleet-wide and the two places that scope it have to say so.
+
+The classes each guarantee is measured over are *derived*, not listed, because a
+scope claim can only be graded against the whole fleet: a class that owns
+``drive`` and lives in a public module of ``strands_robots.mesh`` is a shipped
+platform bridge, and a fifth one fails the inventory below until it is given a
+case. Two guarantees are read off the content of a ``Twist`` and so are measured
+on the three ``Twist`` bridges only - an Ackermann car halts with a zero
+``ServoCtrlMsg``, the same exclusion ``test_bridge_stop_tool_parity.py`` states
+for the same reason. The other three are read only from whether a call was
+forwarded at all and whether two requests forward the same thing, which is true
+of any message layout, so they are measured on every drive-owning class.
 """
 
 from __future__ import annotations
 
+import importlib
 import inspect
 import re
 from collections.abc import Callable
@@ -30,6 +44,8 @@ from typing import Any
 
 import pytest
 
+import strands_robots.mesh as mesh_pkg
+import strands_robots.mesh.ackermann_robot as ackermann_mod
 import strands_robots.mesh.ros_bridge as ros_bridge_mod
 import strands_robots.mesh.rosbridge_robot as rosbridge_mod
 import strands_robots.mesh.rtps_robot as rtps_mod
@@ -64,7 +80,60 @@ _BRIDGES: list[tuple[str, Any, str, Callable[[], Any]]] = [
     ),
 ]
 
+#: Every drive-owning class, for the guarantees that do not depend on the
+#: message layout. An Ackermann car takes the same ``drive`` call over a servo
+#: pair instead of a ``Twist``, so it is inside those three surveys and outside
+#: the two that read a ``Twist`` field.
+_DRIVE_OWNERS: list[tuple[str, Any, str, Callable[[], Any]]] = [
+    *_BRIDGES,
+    (
+        "AckermannRosRobot",
+        ackermann_mod,
+        "use_ros",
+        lambda: ackermann_mod.AckermannRosRobot("car", "/servo", publish_rate=10.0),
+    ),
+]
+
+#: The guarantees whose probe reads only whether a call was forwarded and
+#: whether two requests forward the same thing. Those two questions can be put
+#: to any transport, so these are measured over ``_DRIVE_OWNERS``; the rest read
+#: a ``Twist`` field and are measured over ``_BRIDGES``.
+_LAYOUT_INDEPENDENT = frozenset({"validated inputs", "velocity clamp", "duration ceiling"})
+
+#: A velocity no surveyed platform's ceiling reaches, so a request for it is
+#: over every declared limit. Pinned against the real ceilings by
+#: ``test_no_surveyed_ceiling_reaches_the_probe_velocity``.
+_ABOVE_ANY_CEILING = 99.0
+
 _ZERO_TWIST = {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+
+def _drive_owning_mesh_classes() -> dict[str, type]:
+    """The shipped mesh classes whose public API includes ``drive``.
+
+    Read from the package rather than listed so a new platform bridge cannot
+    sit outside the scope survey: the prose graded below claims things about
+    *every* mobile base, and a class the survey never learned exists makes
+    every one of those claims pass unmeasured.
+
+    A shipped platform bridge lives in a public module - a leading underscore
+    marks a shared base or helper (``_mobile_base``, ``_numeric_options``),
+    which declares the contract but is not a platform anyone drives - and the
+    lookup is by attribute, so a bridge that inherits ``drive`` from such a
+    base is still found.
+    """
+    package = Path(inspect.getfile(mesh_pkg)).parent
+    owners: dict[str, type] = {}
+    for path in sorted(package.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{mesh_pkg.__name__}.{path.stem}")
+        for name, obj in vars(module).items():
+            if name.startswith("_") or not inspect.isclass(obj) or obj.__module__ != module.__name__:
+                continue
+            if callable(getattr(obj, "drive", None)):
+                owners[name] = obj
+    return owners
 
 
 def _drive(
@@ -93,8 +162,18 @@ def _latches_a_single_shot(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool
 
 
 def _clamps_velocity(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
-    _, calls = _drive(monkeypatch, bridge, linear=99.0, count=1)
-    return bool(calls) and calls[0]["fields"]["linear"]["x"] < 99.0
+    """A ceiling makes two different over-ceiling requests indistinguishable.
+
+    Read as the equality of the two forwarded calls rather than off
+    ``fields["linear"]["x"]``, so the same probe answers for a servo pair as
+    for a ``Twist``: whatever a platform puts on the wire, a clamped request
+    puts the *ceiling* there both times. That the equality reports saturation
+    and not a payload that ignores ``linear`` is pinned by
+    ``test_the_clamp_probe_can_tell_two_velocities_apart``.
+    """
+    _, at = _drive(monkeypatch, bridge, linear=_ABOVE_ANY_CEILING, count=1)
+    _, above = _drive(monkeypatch, bridge, linear=_ABOVE_ANY_CEILING * 2, count=1)
+    return bool(at) and bool(above) and at[0] == above[0]
 
 
 def _refuses_a_hold_past_a_ceiling(monkeypatch: pytest.MonkeyPatch, bridge: Any) -> bool:
@@ -117,12 +196,24 @@ _GUARANTEES: dict[str, tuple[Callable[..., bool], str, str]] = {
 }
 
 _FLEET_MARKER = "Fleet-standard across all three mobile-base bridges:"
-_BRIDGE_MARKER = "Specific to this bridge:"
+_SCOPED_MARKER = "Not carried by every mobile base:"
+
+
+def _surveyed(guarantee: str) -> list[tuple[str, Any, str, Callable[[], Any]]]:
+    """The classes ``guarantee`` is measured over - see ``_LAYOUT_INDEPENDENT``."""
+    return _DRIVE_OWNERS if guarantee in _LAYOUT_INDEPENDENT else _BRIDGES
 
 
 def _measure(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
-    """The bridges that exhibit each guarantee, measured through ``drive``."""
-    return {name: [b[0] for b in _BRIDGES if probe(monkeypatch, b)] for name, (probe, _, _) in _GUARANTEES.items()}
+    """The classes that exhibit each guarantee, measured through ``drive``."""
+    return {
+        name: [c[0] for c in _surveyed(name) if probe(monkeypatch, c)] for name, (probe, _, _) in _GUARANTEES.items()
+    }
+
+
+def _holds_everywhere(guarantee: str, holders: list[str]) -> bool:
+    """Whether ``guarantee`` is kept by every class it is measured over."""
+    return set(holders) == {c[0] for c in _surveyed(guarantee)}
 
 
 def _paragraphs(text: str) -> list[str]:
@@ -135,7 +226,7 @@ def _scoped_paragraph(marker: str) -> str:
     matches = [p for p in _paragraphs(doc) if p.startswith(marker)]
     assert len(matches) == 1, (
         f"RosbridgeRobot.drive should carry exactly one paragraph opening {marker!r}, found {len(matches)}. "
-        "Two of its guarantees hold on all three bridges and three on this one alone, so the docstring has to "
+        "Some of its guarantees hold on every mobile base and some on only a few, so the docstring has to "
         "label which is which - an unlabelled list reads as fleet-wide."
     )
     return matches[0]
@@ -146,29 +237,104 @@ def test_the_three_bridges_are_the_ones_under_comparison() -> None:
     assert [b[0] for b in _BRIDGES] == ["RosBridgedRobot", "RtpsRobot", "RosbridgeRobot"]
 
 
+def test_every_drive_owning_mesh_class_is_surveyed() -> None:
+    """No shipped platform may sit outside the survey the prose is graded on.
+
+    The failure this exists for is silence, not a wrong answer: a class the
+    survey never learned about cannot contradict a "this bridge only" claim, so
+    every scope check passes while the claim it grades is false. Give the new
+    class a case here and the claims are measured against it.
+    """
+    assert {c[0] for c in _DRIVE_OWNERS} == set(_drive_owning_mesh_classes())
+
+
+def test_a_layout_independent_guarantee_is_measured_on_more_than_the_twist_bridges() -> None:
+    """Premise: the wider survey has to be wider, or it grades nothing new."""
+    assert _LAYOUT_INDEPENDENT, "some guarantee must be measurable on any message layout"
+    assert {c[0] for c in _BRIDGES} < {c[0] for c in _DRIVE_OWNERS}
+    for guarantee in _LAYOUT_INDEPENDENT:
+        assert guarantee in _GUARANTEES, f"{guarantee!r} is not one of the graded guarantees"
+
+
+def test_no_surveyed_ceiling_reaches_the_probe_velocity() -> None:
+    """Premise: ``_ABOVE_ANY_CEILING`` has to be above the declared ceilings.
+
+    A probe velocity a platform's own limit exceeds is not an over-ceiling
+    request at all, and the clamp probe would report that platform as
+    unclamped.
+    """
+    for label, _, _, factory in _DRIVE_OWNERS:
+        limits = {n: v for n, v in vars(factory()).items() if n.startswith("max_") and isinstance(v, float)}
+        for name, value in sorted(limits.items()):
+            assert value < _ABOVE_ANY_CEILING, (
+                f"{label}.{name} is {value}, at or above the {_ABOVE_ANY_CEILING} probe velocity"
+            )
+
+
+def test_the_clamp_probe_can_tell_two_velocities_apart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Premise: the clamp probe's equality must report saturation.
+
+    It compares two forwarded calls, so a platform that ignored ``linear``
+    entirely would read as clamped. An in-range request has to reach the wire
+    as something different from an over-ceiling one on every surveyed class.
+    """
+    for case in _DRIVE_OWNERS:
+        _, low = _drive(monkeypatch, case, linear=0.25, count=1)
+        _, high = _drive(monkeypatch, case, linear=_ABOVE_ANY_CEILING, count=1)
+        assert low and high, f"{case[0]} forwarded nothing for an in-range velocity"
+        assert low[0] != high[0], (
+            f"{case[0]} forwards the same call for 0.25 and {_ABOVE_ANY_CEILING} m/s, so the clamp probe "
+            "cannot tell a ceiling from a payload that never carries the requested velocity"
+        )
+
+
 def test_each_guarantee_is_exhibited_by_at_least_one_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
     """Premise: a probe that measures nothing would let any prose pass."""
     for name, bridges in _measure(monkeypatch).items():
         assert bridges, f"the probe for {name!r} found no bridge that exhibits it - the probe is broken"
 
 
-def test_the_drive_guarantees_split_into_fleet_wide_and_bridge_specific(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_drive_guarantees_split_into_fleet_wide_shared_and_bridge_specific(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The measured split the two prose surfaces have to describe.
 
-    Fails if a bridge gains or loses one of these, which is the point: the
-    guarantee's scope changed and the prose that scopes it is now stale.
+    Fails if a class gains or loses one of these, which is the point: the
+    guarantee's scope changed and the prose that scopes it is now stale. The
+    middle bucket is the one a two-way split cannot express - a limit two
+    platforms declare is neither fleet-wide nor one bridge's own, and calling
+    it either misinforms a reader of the other three.
     """
     measured = _measure(monkeypatch)
-    every = {b[0] for b in _BRIDGES}
 
-    fleet_wide = sorted(name for name, bridges in measured.items() if set(bridges) == every)
-    bridge_only = sorted(name for name, bridges in measured.items() if bridges == ["RosbridgeRobot"])
+    fleet_wide = sorted(name for name, holders in measured.items() if _holds_everywhere(name, holders))
+    several = sorted(
+        name for name, holders in measured.items() if not _holds_everywhere(name, holders) and len(holders) > 1
+    )
+    bridge_only = sorted(name for name, holders in measured.items() if holders == ["RosbridgeRobot"])
 
     assert fleet_wide == ["single-shot latch", "validated inputs"], measured
-    assert bridge_only == ["duration ceiling", "trailing zero Twist", "velocity clamp"], measured
-    assert sorted(fleet_wide + bridge_only) == sorted(_GUARANTEES), (
-        f"every guarantee must be either fleet-wide or this bridge's alone, got {measured}"
+    assert several == ["duration ceiling", "velocity clamp"], measured
+    assert bridge_only == ["trailing zero Twist"], measured
+    assert sorted(fleet_wide + several + bridge_only) == sorted(_GUARANTEES), (
+        f"every guarantee must be fleet-wide, shared by some, or this bridge's alone, got {measured}"
     )
+
+
+def test_the_clamp_and_the_ceiling_are_carried_by_the_two_bridges_that_know_a_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The measurement the two prose surfaces got wrong.
+
+    ``RosbridgeRobot`` and ``AckermannRosRobot`` each wrap a platform whose
+    limits are known, so each declares them; the ROS 2 and RTPS bridges publish
+    to whatever ``cmd_vel`` topic they are pointed at and declare none. A reader
+    told the clamp and the ceiling are one bridge's own plans a hold on a
+    DeepRacer that its own ``max_duration`` refuses.
+    """
+    measured = _measure(monkeypatch)
+    for guarantee in ("velocity clamp", "duration ceiling"):
+        assert measured[guarantee] == ["RosbridgeRobot", "AckermannRosRobot"], measured
 
 
 def test_a_timed_drive_self_stops_on_one_bridge_and_latches_on_the_other_two(
@@ -200,18 +366,18 @@ def test_no_paragraph_claiming_a_shared_contract_states_a_bridge_specific_guaran
     cannot leave a live velocity behind, and only this bridge has it.
     """
     measured = _measure(monkeypatch)
-    bridge_only = {_GUARANTEES[name][1]: name for name, bridges in measured.items() if bridges == ["RosbridgeRobot"]}
-    assert bridge_only, f"premise: some guarantee must be this bridge's alone, got {measured}"
+    scoped = {_GUARANTEES[name][1]: name for name, holders in measured.items() if not _holds_everywhere(name, holders)}
+    assert scoped, f"premise: some guarantee must not be fleet-wide, got {measured}"
 
     doc = inspect.getdoc(rosbridge_mod.RosbridgeRobot.drive) or ""
     claiming = [p for p in _paragraphs(doc) if _SHARING_CLAIM.search(p)]
     assert claiming, "premise: the docstring should say which guarantees the three bridges share"
 
     for paragraph in claiming:
-        overreach = sorted(f"{name!r} ({phrase!r})" for phrase, name in bridge_only.items() if phrase in paragraph)
+        overreach = sorted(f"{name!r} ({phrase!r})" for phrase, name in scoped.items() if phrase in paragraph)
         assert not overreach, (
             f"this paragraph of RosbridgeRobot.drive claims a shared contract and then states "
-            f"{', '.join(overreach)}, which no other bridge carries: {paragraph}"
+            f"{', '.join(overreach)}, which not every mobile base carries: {paragraph}"
         )
 
 
@@ -221,24 +387,55 @@ def test_the_docstring_states_each_guarantee_in_the_scope_it_holds_in(
 ) -> None:
     """A guarantee three bridges keep and one they do not cannot share a scope."""
     measured = _measure(monkeypatch)[guarantee]
-    is_fleet_wide = set(measured) == {b[0] for b in _BRIDGES}
+    is_fleet_wide = _holds_everywhere(guarantee, measured)
     phrase = _GUARANTEES[guarantee][1]
-    fleet, specific = _scoped_paragraph(_FLEET_MARKER), _scoped_paragraph(_BRIDGE_MARKER)
-    holder, other = (fleet, specific) if is_fleet_wide else (specific, fleet)
+    fleet, scoped = _scoped_paragraph(_FLEET_MARKER), _scoped_paragraph(_SCOPED_MARKER)
+    holder, other = (fleet, scoped) if is_fleet_wide else (scoped, fleet)
     scope = "fleet-wide" if is_fleet_wide else f"carried only by {', '.join(measured)}"
 
     assert phrase in holder, (
         f"{guarantee!r} is {scope}, so {phrase!r} belongs in the "
-        f"{'fleet-standard' if is_fleet_wide else 'bridge-specific'} paragraph of RosbridgeRobot.drive"
+        f"{'fleet-standard' if is_fleet_wide else 'scoped'} paragraph of RosbridgeRobot.drive"
     )
     assert phrase not in other, f"{guarantee!r} is {scope}, so {phrase!r} must not appear in the other scope"
 
 
-def test_the_docstring_names_what_the_other_two_bridges_do_instead() -> None:
-    """A reader told a guarantee is local still needs to know the alternative."""
-    specific = _scoped_paragraph(_BRIDGE_MARKER)
-    for sibling in ("RosBridgedRobot.drive", "RtpsRobot.drive"):
-        assert sibling in specific, f"the bridge-specific paragraph should name {sibling}"
+@pytest.mark.parametrize("guarantee", sorted(_GUARANTEES))
+def test_the_docstring_names_every_other_class_that_carries_a_scoped_guarantee(
+    monkeypatch: pytest.MonkeyPatch, guarantee: str
+) -> None:
+    """A limit another platform also declares has to be credited to it.
+
+    Reading ``RosbridgeRobot.drive`` is how a caller learns where each limit
+    stands, and a guarantee listed as this bridge's while a sibling class keeps
+    it too sends that sibling's operator looking for a ceiling they already
+    have - or, worse, planning around one they will hit.
+    """
+    holders = _measure(monkeypatch)[guarantee]
+    if _holds_everywhere(guarantee, holders):
+        pytest.skip(f"{guarantee!r} is fleet-wide, so there is no co-holder to credit")
+    scoped = _scoped_paragraph(_SCOPED_MARKER)
+    for name in holders:
+        if name == "RosbridgeRobot":
+            continue
+        assert name in scoped, (
+            f"{guarantee!r} is carried by {', '.join(holders)}, so the scoped paragraph of "
+            f"RosbridgeRobot.drive has to name {name} - as written it reads as this bridge's own"
+        )
+
+
+def test_the_docstring_names_what_every_other_drive_owner_does_instead() -> None:
+    """A reader told a guarantee is local still needs to know the alternative.
+
+    Derived from the survey rather than listed, so a fifth platform bridge has
+    to be placed in this paragraph too instead of being quietly left out of a
+    comparison that claims to cover the fleet.
+    """
+    specific = _scoped_paragraph(_SCOPED_MARKER)
+    for label, _, _, _ in _DRIVE_OWNERS:
+        if label == "RosbridgeRobot":
+            continue
+        assert label in specific, f"the scoped paragraph should say where {label} stands"
     assert "latched" in specific, "it should say a timed drive on the other two leaves the velocity latched"
 
 
@@ -259,20 +456,58 @@ def _drive_contract_bullets() -> dict[str, str]:
     return {label: " ".join((label + tail).split()) for label, tail in bullets}
 
 
+#: A bullet whose guarantee is not fleet-wide carries a parenthetical scope
+#: note right after its bold label; the list's own heading says "fleet-wide
+#: unless marked", so an unmarked bullet claims every mobile base.
+_SOLE_OWNER_CLAIM = "this bridge only"
+
+
 @pytest.mark.parametrize("guarantee", sorted(_GUARANTEES))
-def test_the_docs_page_marks_each_bridge_specific_guarantee(monkeypatch: pytest.MonkeyPatch, guarantee: str) -> None:
+def test_the_docs_page_marks_each_guarantee_that_is_not_fleet_wide(
+    monkeypatch: pytest.MonkeyPatch, guarantee: str
+) -> None:
     """The page's safety list is read as the fleet's unless it says otherwise."""
     measured = _measure(monkeypatch)[guarantee]
-    is_fleet_wide = set(measured) == {b[0] for b in _BRIDGES}
     label = _GUARANTEES[guarantee][2]
     bullets = _drive_contract_bullets()
 
     assert label in bullets, f"the drive-contract list should still document {label!r}, got {sorted(bullets)}"
-    marked = "this bridge only" in bullets[label]
-    if is_fleet_wide:
-        assert not marked, f"{guarantee!r} holds on all three bridges, so {label!r} must not be scoped to one"
+    bullet = bullets[label]
+    marked = bullet.startswith(f"{label} (")
+    if _holds_everywhere(guarantee, measured):
+        assert not marked, f"{guarantee!r} holds on every mobile base surveyed, so {label!r} must not be scoped"
     else:
         assert marked, (
             f"{guarantee!r} is carried only by {', '.join(measured)}, so the {label!r} bullet has to say so - "
             "unmarked, it reads as a guarantee of every mobile-base bridge"
+        )
+
+
+@pytest.mark.parametrize("guarantee", sorted(_GUARANTEES))
+def test_the_docs_page_calls_a_guarantee_this_bridges_own_only_when_it_is(
+    monkeypatch: pytest.MonkeyPatch, guarantee: str
+) -> None:
+    """The defect: a limit two platforms declare, marked as one bridge's own.
+
+    ``(this bridge only)`` is a stronger claim than "not fleet-wide", and it is
+    the claim a reader acts on: told the duration ceiling is this bridge's,
+    nobody expects ``AckermannRosRobot(...).drive(linear=0.5, duration=30.0)``
+    to be refused by a ceiling of its own. The bullet has to name every other
+    class that carries it instead.
+    """
+    holders = _measure(monkeypatch)[guarantee]
+    if _holds_everywhere(guarantee, holders):
+        pytest.skip(f"{guarantee!r} is fleet-wide, so its bullet is unmarked and credits nobody")
+    others = [name for name in holders if name != "RosbridgeRobot"]
+    if not others:
+        return
+    bullet = _drive_contract_bullets()[_GUARANTEES[guarantee][2]]
+    assert _SOLE_OWNER_CLAIM not in bullet, (
+        f"{guarantee!r} is carried by {', '.join(holders)}, so the "
+        f"{_GUARANTEES[guarantee][2]!r} bullet must not say {_SOLE_OWNER_CLAIM!r}"
+    )
+    for name in others:
+        assert name in bullet, (
+            f"{guarantee!r} is carried by {', '.join(holders)}, so the "
+            f"{_GUARANTEES[guarantee][2]!r} bullet has to name {name}"
         )


### PR DESCRIPTION
## What is wrong

`docs/rosbridge-integration.md` and `RosbridgeRobot.drive` both mark two drive
limits as belonging to the rosbridge bridge alone:

```
- **Velocity clamps** (this bridge only): linear and angular are independently
  clamped to `max_linear` and `max_angular`. The other two bridges accept no
  velocity ceiling and put the requested value on the wire unchanged.
- **Loud duration rejection** (this bridge only): ... The other two bridges
  accept any positive finite hold.
```

> Specific to this bridge: velocities are clamped to ``max_linear`` and
> ``max_angular``, a hold beyond ``max_duration`` is refused, [...]
> :meth:`RosBridgedRobot.drive` and :meth:`RtpsRobot.drive` carry none of the three

`AckermannRosRobot` carries both. Measured on `704dd33d` by driving each
drive-owning mesh class with its transport replaced by a recorder:

| class | inputs validated | velocity clamp | duration ceiling |
|---|---|---|---|
| `RosBridgedRobot` | yes | no | no |
| `RtpsRobot` | yes | no | no |
| `RosbridgeRobot` | yes | yes, `max_linear` 2.0 | yes, `max_duration` 30.0 |
| `AckermannRosRobot` | yes | yes, `max_speed` 1.5 | yes, `max_duration` 10.0 |

The costly detail is that the car's ceiling is *lower*, and the page documents
30.0 s as an accepted hold. A reader who takes that number to a DeepRacer gets,
on `704dd33d`:

```
>>> car = AckermannRosRobot.from_deepracer(node_name="deepracer")
>>> car.drive(linear=0.5, duration=30.0)
status: error
drive: duration 30.0s exceeds max_duration 10.0s - issue shorter commands instead of one long hold
published 0 messages
```

The failure direction is the safe one, but it is still an unexplained refusal in
the field - and the same reader plans around a velocity clamp they have been told
the car does not have.

The fleet's own documentation already states both halves and never compares them:
`docs/ros2-integration.md` says of the car "Commands are clamped to `max_speed`;
holds longer than `max_duration` are rejected loudly rather than silently
truncated", while `docs/rosbridge-integration.md` says those limits exist on one
bridge only.

## Why no test caught it

`tests/mesh/test_drive_contract_fleet_scope.py` exists precisely to grade this
prose against a measurement rather than against a hand-kept list, and its
docstring commits to raising exactly this signal. Its universe was a hardcoded
list of three:

```python
_BRIDGES: list[tuple[str, Any, str, Callable[[], Any]]] = [
    ("RosBridgedRobot", ...), ("RtpsRobot", ...), ("RosbridgeRobot", ...),
]
```

so the fourth drive-owning class was outside everything it measured. On pristine
`704dd33d` the file is `16 passed` while the claim it grades is false. The guard
is not wrong about the three it compares; it is silent about a class it never
learned exists.

Its clamp probe could not have been evaluated on that class either, even if the
class had been listed: it read `calls[0]["fields"]["linear"]["x"]`, which raises
`KeyError: 'linear'` on a `ServoCtrlMsg`.

## The change

**The surveyed set is derived from the package.** A class that owns `drive` and
lives in a *public* module of `strands_robots.mesh` is a shipped platform bridge.
The lookup is by attribute rather than by a `def drive` in the class body, so a
bridge that inherits `drive` from a shared base is still found, while a private
`_`-prefixed base module - which declares a contract but is not a platform anyone
drives - stays out. A fifth class fails the inventory until it is given a case.

**Three of the five guarantees are read without touching the message layout**, so
they are measured over every drive-owning class:

- `validated inputs`: a refused value forwards no call at all.
- `duration ceiling`: a hold past the ceiling forwards no call at all.
- `velocity clamp`: two *different* over-ceiling requests forward the *identical*
  call. A ceiling makes them indistinguishable whatever the payload looks like,
  so the same probe answers for a servo pair as for a `Twist`.

The two that do read `Twist` content (`single-shot latch`, `trailing zero Twist`)
stay scoped to the three `Twist` bridges, with the exclusion stated for the
reason `tests/mesh/test_bridge_stop_tool_parity.py` already states: an Ackermann
car halts with a zero `ServoCtrlMsg`, not a zero `Twist`. Widening those two is a
separate change and is deliberately not made here.

**The split becomes three-way** - fleet-wide, shared by some, this bridge's alone.
A limit two platforms declare is neither of the outer two, and filing it under
either misinforms a reader of the other platforms.

**Both prose surfaces are corrected.** The two bullets are marked
`(not on every mobile base)` and name `AckermannRosRobot`; the docstring
paragraph opens `Not carried by every mobile base:` and credits the car's
`max_speed` and its own lower `max_duration`. Two derived rules now hold them
there: a bullet may say `this bridge only` only when the survey finds no other
carrier, and a scoped guarantee's every other carrier has to be named.

No library behaviour changes - the only non-test edit is a docstring.

## Pre-fix

With both prose surfaces restored to `704dd33d` and the survey as shipped here:

```
11 failed, 16 passed, 4 skipped
```

All 11 are the prose-grading tests; 0 are in the premise or inventory classes.

## Break table

Each row is a single mutation applied to the branch, then
`pytest tests/mesh/test_drive_contract_fleet_scope.py`.

| mutation | fails | what it shows |
|---|---|---|
| none (as shipped) | 0 of 27 | control, plus 4 skips where a guarantee is fleet-wide |
| a fifth drive-owning class added to the package, inventory **derived** | 1 | `test_every_drive_owning_mesh_class_is_surveyed`, naming `'ProbeFifthRobot'` |
| the same fifth class, inventory **hardcoded** to today's four names | **0** | the hole this fixes: 27 pass while a shipped bridge sits outside every scope claim |
| `AckermannRosRobot` dropped from the surveyed set | 4 | inventory, the wider-survey premise, the split, and the two-carrier measurement |
| clamp probe reads `fields["linear"]["x"]` again | 24 | `KeyError: 'linear'` - the old probe cannot be evaluated on a servo bridge at all |
| `(this bridge only)` restored on the clamp bullet alone | 1 | the regression, on that one guarantee |
| the docstring stops crediting the co-holder | 3 | both scoped guarantees plus the "where does each other class stand" rule |
| the scoped paragraph relabelled as fleet-standard (over-reach) | 10 | includes the pre-existing `test_no_paragraph_claiming_a_shared_contract_states_a_bridge_specific_guarantee` |
| probe velocity dropped below the declared ceilings, premise present | 4 | the premise fires and names the cause |
| the same mistake with that premise removed | 3 | fewer failures and no diagnosis - which is why the premise is there |

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests
tests_integ`. mypy **24 errors on the branch and 24 on a pristine `704dd33d`
worktree, with byte-identical message sets** and none in the changed files.

Paired run, `tests/` minus the GPU/simulation subtrees (472 files), identical
selection on both trees with the changed test file deselected from each:

| tree | result |
|---|---|
| branch | `101 failed, 18356 passed, 120 skipped, 256 errors in 551.69s` |
| pristine `704dd33d` | `101 failed, 18356 passed, 120 skipped, 256 errors in 573.30s` |

Failing-ID and error-ID sets **identical both ways** (both `comm` directions
empty). Every one is an absent optional dependency in this environment -
`device_connect_edge` (290, declared `device-connect-edge>=0.2.0` in
`[device-connect]`), `awsiot` (44, `awsiotsdk` in `[mesh-iot]`), and a locally
installed lerobot 0.5.1 below the declared `>=0.6.1,<0.7.0` floor.

The changed file itself: `27 passed, 4 skipped`.

## Sequencing

PR #2696 edits the same docstring paragraph and the same docs bullets for a
different reason - it moves the trailing zero into the fleet-wide half once the
`Twist` bridges share a base. The two changes are independent in content: this
one is about the clamp and the ceiling, reproduces on pristine `main`, and would
survive that refactor unchanged. Whichever lands second needs a textual merge in
those two paragraphs; the scope rules added here are derived, so they will grade
the merged prose without further edits.

Fixes #2697.
