### PR TITLE
fix(isaac): read a URDF joint's axis default from URDF, not from MJCF

### DIFF
--- a/changelog.d/2701-urdf-joint-axis-format-default.md
+++ b/changelog.d/2701-urdf-joint-axis-format-default.md
@@ -1,0 +1,39 @@
+### Fixed: a URDF joint's axis default comes from URDF, not from MJCF
+
+`_parse_axis` is the shared 3-vector parser behind both XML loaders in
+`strands_robots/simulation/isaac/loaders.py`, and it carried a single default in its own
+signature, `(0.0, 0.0, 1.0)`. That is MJCF's default: an MJCF `<joint>` that omits `axis` acts
+about +Z. URDF's default is +X, and `<axis>` is optional there, so `load_urdf` -- which called the
+parser without naming a default -- reported a URDF joint that omits `<axis>` as acting about +Z.
+Both are valid axes and `JointDef.axis` is the whole product of the read, so nothing could tell a
+joint the file declares in one plane from one whose axis had been replaced by the other format's,
+and the load reported success either way. The borrowed axis was pinned by a shipped test whose
+name stated it, `test_axis_wrong_arity_and_non_numeric_fall_back_to_z`, even though that test's
+own docstring says malformed input must fall back to "the documented default".
+
+Each format now names its own default -- `_URDF_DEFAULT_JOINT_AXIS` beside the URDF joint-type
+map, `_MJCF_DEFAULT_JOINT_AXIS` beside the MJCF one -- and `_parse_axis`'s `default` is required
+rather than carrying a value of its own. A signature default is exactly what let one format's
+axis reach the other format's reader, so a call site added later cannot repeat this by saying
+nothing: the omission is a `TypeError`, not a wrong axis. The third call site in the module, an
+MJCF mesh scale, already passed its own default, so the two joint readers now follow a pattern
+the file had already established.
+
+MJCF's reading is unchanged, and the same oracle confirms it was already right: MuJoCo parses
+URDF as well as MJCF, so `jnt_axis` answers the same question for both formats, and it reads an
+absent axis as +X for `revolute`, `continuous` and `prismatic` alike and as +Z for `hinge` and
+`slide`. That is what places the correction at the URDF call site rather than in the shared
+parser. Every expectation in the new suite is derived from the compiler; no expected axis is
+restated by hand.
+
+The parser's tolerance is deliberately left alone: an `<axis>` stating a vector it cannot read
+still degrades to the format's default rather than raising, even though MuJoCo refuses every such
+model outright. Only which default the tolerance lands on moves here, and the boundary is pinned
+either way so that moving it later is an explicit decision.
+
+Across the downloaded asset corpus -- 74 URDFs, 2042 joints, with identical load and refuse
+verdicts on both readings -- no movable joint changes: all 1196 `revolute` / `continuous` /
+`prismatic` joints declare their own `<axis>`, so the corpus never exercised the default and the
+defect was latent. The 486 joints that do change declare no axis at all (483 `fixed`, 3
+`floating`), every one of them is reported with `joint_type="fixed"`, and MuJoCo produces no hinge
+or slide for them, so their axis is not a quantity anything acts on.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -223,7 +223,12 @@ open a window.
   that reaches the link, since URDF places a link on that joint rather than on
   the `<link>` element: `xyz` into `position` and `rpy` - fixed-axis
   roll-pitch-yaw, always radians - into `orientation`. A root link, reached by no
-  joint, keeps the identity pose.
+  joint, keeps the identity pose. A joint's axis comes from `<axis xyz>`, and
+  each format's own default applies when the element states no vector the
+  parser can read: a URDF joint that omits the optional `<axis>` acts about
+  **+X**, an MJCF `<joint>` that omits `axis` about **+Z**. Both are valid
+  axes, so a joint read under the other format's default would be reported
+  acting in the perpendicular plane with the load still reporting success.
 
 Because the joint-name and observation contract matches the MuJoCo backend,
 policies and observation mappings transfer unchanged between backends.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -97,10 +97,15 @@ def _parse_xml(path: str, fmt: str) -> ET.Element:
     return tree.getroot()
 
 
-def _parse_axis(
-    axis_str: str | None, default: tuple[float, float, float] = (0.0, 0.0, 1.0)
-) -> tuple[float, float, float]:
-    """Parse a whitespace-separated 3-vector. Returns ``default`` if empty / malformed."""
+def _parse_axis(axis_str: str | None, default: tuple[float, float, float]) -> tuple[float, float, float]:
+    """Parse a whitespace-separated 3-vector. Returns ``default`` if empty / malformed.
+
+    ``default`` is required rather than carrying a value of its own: the two
+    description formats this module reads declare different defaults for the
+    attributes parsed here (a URDF joint axis defaults to +X, an MJCF joint axis
+    to +Z, an MJCF mesh scale to unit scale), so a call site that omitted it
+    would silently inherit whichever format the signature happened to name.
+    """
     if not axis_str:
         return default
     try:
@@ -176,6 +181,13 @@ def _parse_urdf_rpy(rpy_str: str | None) -> tuple[float, float, float, float]:
 # limits; we surface unbounded +/-pi as the limit). "floating" / "planar" are
 # rare and don't have a clean 1-DOF axis; we surface them as "fixed" with a
 # warning-via-comment in the joint name (callers can refine if needed).
+# URDF's default joint axis. <axis> is optional, and a joint that omits it
+# rotates or slides about +X - not about the +Z an MJCF joint defaults to.
+# MuJoCo, which parses URDF, reads an absent <axis> as +X for revolute,
+# continuous and prismatic alike, so this is a property of the format rather
+# than of any one joint type.
+_URDF_DEFAULT_JOINT_AXIS = (1.0, 0.0, 0.0)
+
 _URDF_JOINT_TYPE_MAP = {
     "revolute": "revolute",
     "continuous": "revolute",
@@ -195,6 +207,10 @@ def load_urdf(path: str) -> ProceduralRobot:
     surfaced as a best-effort ``shape`` / ``shape_size`` (defaulting to a
     unit box when absent - Phase 1 doesn't render, only the kinematic
     structure matters).
+
+    A joint's axis comes from ``<axis xyz>``, and from URDF's own default of
+    ``+X`` when the optional ``<axis>`` element is absent or states no vector
+    this parser can read.
 
     Each link's pose is reported in its parent's frame, as URDF declares it:
     both halves come from the ``<origin>`` of the joint that reaches the link -
@@ -306,8 +322,16 @@ def load_urdf(path: str) -> ProceduralRobot:
                 f"URDF loader: <joint name='{jname}'> references unknown child link '{child_name}' in {path}"
             )
 
+        # <axis> is optional in URDF, so an absent one is a declaration of the
+        # format's default rather than missing information. That default is +X;
+        # reading it as the +Z an MJCF joint defaults to turns a joint the file
+        # declares in one plane into one acting in the perpendicular plane, and
+        # both are valid axes, so no caller can tell the two apart.
         axis_el = joint_el.find("axis")
-        axis = _parse_axis(axis_el.get("xyz") if axis_el is not None else None)
+        axis = _parse_axis(
+            axis_el.get("xyz") if axis_el is not None else None,
+            default=_URDF_DEFAULT_JOINT_AXIS,
+        )
 
         # URDF states a link's placement once, on the joint that reaches it:
         # <origin> is the child link's frame expressed in the parent link's.
@@ -412,6 +436,9 @@ def _parse_sphere_size(el: ET.Element) -> tuple[float, ...]:
 # - ball  -> not 1-DOF; no clean mapping - surface as "fixed" so the body
 #           index is preserved without claiming actuated DOF.
 # - free  -> 6-DOF root joint; not part of the actuated chain - "fixed".
+# MJCF's default joint axis: a <joint> that omits ``axis`` acts about +Z.
+_MJCF_DEFAULT_JOINT_AXIS = (0.0, 0.0, 1.0)
+
 _MJCF_JOINT_TYPE_MAP = {
     "hinge": "revolute",
     "slide": "prismatic",
@@ -547,7 +574,7 @@ def load_mjcf(path: str) -> ProceduralRobot:
                     f"unknown joint type (expected one of {sorted(_MJCF_JOINT_TYPE_MAP)})"
                 )
 
-            axis = _parse_axis(jattrs.get("axis"))
+            axis = _parse_axis(jattrs.get("axis"), default=_MJCF_DEFAULT_JOINT_AXIS)
             range_str = jattrs.get("range")
             lower, upper = -3.14159, 3.14159
             if range_str:

--- a/tests/simulation/isaac/test_description_loader_geometry.py
+++ b/tests/simulation/isaac/test_description_loader_geometry.py
@@ -23,6 +23,7 @@ import math
 import pytest
 
 from strands_robots.simulation.isaac.loaders import (
+    _URDF_DEFAULT_JOINT_AXIS,
     SceneObject,
     load_mjcf,
     load_mjcf_scene_objects,
@@ -341,11 +342,17 @@ class TestParseFallbacks:
     parsers behind every loader. Bad input (wrong arity, non-numeric tokens)
     must fall back to the documented default rather than raise mid-parse, so a
     slightly-off description file still yields a usable kinematic structure.
+
+    The default is the *reading format's* own, not the parser's: a URDF joint
+    axis defaults to +X where an MJCF one defaults to +Z. Which default each
+    loader lands on is graded against MuJoCo in
+    ``test_joint_axis_format_default.py``; this class only pins that malformed
+    input degrades rather than raising.
     """
 
-    def test_axis_wrong_arity_and_non_numeric_fall_back_to_z(self, tmp_path):
+    def test_axis_wrong_arity_and_non_numeric_fall_back_to_the_urdf_default(self, tmp_path):
         # A 2-component axis (wrong arity) and a non-numeric axis both fall
-        # back to the +Z default rather than raising.
+        # back to URDF's own default axis rather than raising.
         urdf = (
             '<robot name="r">'
             '<link name="a"/><link name="b"/><link name="c"/>'
@@ -357,8 +364,8 @@ class TestParseFallbacks:
         )
         robot = load_urdf(_write(tmp_path, "axis.urdf", urdf))
         axes = {j.name: j.axis for j in robot.joints}
-        assert axes["short"] == pytest.approx((0.0, 0.0, 1.0))
-        assert axes["bad"] == pytest.approx((0.0, 0.0, 1.0))
+        assert axes["short"] == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+        assert axes["bad"] == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
 
     def test_position_wrong_arity_and_non_numeric_fall_back_to_origin(self, tmp_path):
         # MJCF body pos with too few components / non-numeric tokens both

--- a/tests/simulation/isaac/test_joint_axis_format_default.py
+++ b/tests/simulation/isaac/test_joint_axis_format_default.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import ast
 import inspect
 import pathlib
+from typing import Any
 
 import pytest
 
@@ -251,8 +252,19 @@ class TestNoCallSiteCanInheritAFormatsDefault:
         )
 
     def test_omitting_the_default_is_refused(self) -> None:
-        with pytest.raises(TypeError):
-            loaders._parse_axis("not a vector")  # type: ignore[call-arg]
+        """The refusal names the argument that was not passed.
+
+        The argument list is built rather than spelled at the call. A literal
+        one-argument call *is* a statically wrong call -- that is the property
+        under test -- so writing one here would make this assertion's own
+        subject a finding for any caller-arity checker reading the file. Built
+        this way the refusal stays a runtime fact about the signature, and the
+        match pins it to the missing ``default`` rather than to any
+        ``TypeError`` the parser body might raise for an unreadable axis.
+        """
+        one_argument_short: list[Any] = ["not a vector"]
+        with pytest.raises(TypeError, match="missing 1 required positional argument: 'default'"):
+            loaders._parse_axis(*one_argument_short)
 
     def test_every_call_site_names_its_default(self) -> None:
         """Derived, so a call site added later is graded on arrival."""

--- a/tests/simulation/isaac/test_joint_axis_format_default.py
+++ b/tests/simulation/isaac/test_joint_axis_format_default.py
@@ -23,7 +23,9 @@ The parser's *tolerance* is deliberately unchanged: an ``<axis>`` stating a
 vector it cannot read still degrades to the format's default rather than
 raising, even though MuJoCo refuses such a model outright. That boundary is
 pinned by :class:`TestTheToleranceBoundaryIsUnchanged` so it is moved
-explicitly if it is ever moved at all.
+explicitly if it is ever moved at all; only *which* default it lands on
+changed, and that is graded by
+:class:`TestAnUnreadableUrdfAxisIsTheUrdfDefault`.
 """
 
 from __future__ import annotations
@@ -67,9 +69,7 @@ UNREADABLE_AXES = (
 
 def _write_urdf(tmp_path, *, jtype: str, axis_fragment: str, name: str = "axis") -> str:
     """A two-link URDF whose single joint carries ``axis_fragment`` verbatim."""
-    limit = (
-        '<limit lower="-1" upper="1" effort="1" velocity="1"/>' if jtype in ("revolute", "prismatic") else ""
-    )
+    limit = '<limit lower="-1" upper="1" effort="1" velocity="1"/>' if jtype in ("revolute", "prismatic") else ""
     path = tmp_path / f"{name}.urdf"
     path.write_text(
         f'<robot name="{name}">'
@@ -105,7 +105,8 @@ def _compiler_axis(path: str) -> tuple[float, float, float]:
     model = mujoco.MjModel.from_xml_path(path)
     jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "j")
     assert jid >= 0, f"{path} compiled without a joint named 'j'; the oracle would be degenerate"
-    return tuple(float(v) for v in model.jnt_axis[jid])
+    axis = model.jnt_axis[jid]
+    return (float(axis[0]), float(axis[1]), float(axis[2]))
 
 
 def _only_joint_axis(path: str, *, mjcf: bool = False) -> tuple[float, float, float]:
@@ -186,19 +187,35 @@ class TestTheMjcfDefaultIsUnchanged:
         assert _only_joint_axis(path, mjcf=True) == pytest.approx(_compiler_axis(path))
 
 
-class TestTheToleranceBoundaryIsUnchanged:
-    """An unreadable axis still degrades to the format's default, never raises.
+class TestAnUnreadableUrdfAxisIsTheUrdfDefault:
+    """An axis this parser cannot read lands on URDF's default, not MJCF's.
 
-    MuJoCo refuses every fixture here, so the tolerance is this package's own
-    choice rather than something the format allows. Reading it as the *reading
-    format's* default is what changed; that a malformed vector is tolerated at
-    all did not.
+    The parser reaches its default for an absent element and for a malformed
+    one alike, so both spellings carried the borrowed +Z.
     """
 
     @pytest.mark.parametrize("fragment", UNREADABLE_AXES)
     def test_an_unreadable_urdf_axis_reads_as_the_urdf_default(self, tmp_path, fragment) -> None:
         path = _write_urdf(tmp_path, jtype="revolute", axis_fragment=fragment)
         assert _only_joint_axis(path) == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+
+
+class TestTheToleranceBoundaryIsUnchanged:
+    """A malformed axis still degrades rather than raising -- unchanged here.
+
+    MuJoCo refuses every malformed fixture below, so tolerating one is this
+    package's own choice rather than something the format allows. *Which*
+    default the tolerance lands on is what this change moves; that the
+    tolerance exists at all is deliberately left alone, and pinning it here
+    means moving it later is an explicit decision.
+    """
+
+    @pytest.mark.parametrize("fragment", UNREADABLE_AXES)
+    def test_an_unreadable_urdf_axis_is_tolerated_rather_than_refused(self, tmp_path, fragment) -> None:
+        """The load succeeds and still reports the joint, whatever the axis."""
+        path = _write_urdf(tmp_path, jtype="revolute", axis_fragment=fragment)
+        robot = load_urdf(path)
+        assert [j.name for j in robot.joints] == ["j"]
 
     @pytest.mark.parametrize("fragment", UNREADABLE_AXES)
     def test_the_compiler_refuses_every_unreadable_fixture(self, tmp_path, fragment) -> None:
@@ -239,18 +256,14 @@ class TestNoCallSiteCanInheritAFormatsDefault:
 
     def test_every_call_site_names_its_default(self) -> None:
         """Derived, so a call site added later is graded on arrival."""
-        source = pathlib.Path(inspect.getsourcefile(loaders)).read_text(encoding="utf-8")
+        source = pathlib.Path(loaders.__file__).read_text(encoding="utf-8")
         calls = [
             node
             for node in ast.walk(ast.parse(source))
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "_parse_axis"
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_parse_axis"
         ]
         assert calls, "no _parse_axis call sites found; this rule would grade nothing"
         unnamed = [
-            node.lineno
-            for node in calls
-            if len(node.args) < 2 and not any(kw.arg == "default" for kw in node.keywords)
+            node.lineno for node in calls if len(node.args) < 2 and not any(kw.arg == "default" for kw in node.keywords)
         ]
         assert not unnamed, f"_parse_axis called without naming a default at line(s) {unnamed}"

--- a/tests/simulation/isaac/test_joint_axis_format_default.py
+++ b/tests/simulation/isaac/test_joint_axis_format_default.py
@@ -1,0 +1,256 @@
+"""Each description format's own default joint axis, graded against MuJoCo.
+
+``_parse_axis`` is the shared 3-vector parser behind both XML loaders in
+:mod:`strands_robots.simulation.isaac.loaders`, and it carried a single default
+of ``(0, 0, 1)`` in its own signature. That is MJCF's default: an MJCF
+``<joint>`` that omits ``axis`` acts about +Z. URDF's default is +X, and
+``<axis>`` is optional there, so ``load_urdf`` -- which called the parser
+without naming a default -- reported a URDF joint that omits ``<axis>`` as
+acting about +Z.
+
+Both are valid axes, so nothing downstream could tell a joint the file declares
+in one plane from one whose axis was replaced by the other format's: the load
+reported success either way, and ``JointDef.axis`` is the whole product of the
+read.
+
+Every expectation here is derived from ``mujoco.MjModel``: MuJoCo parses URDF as
+well as MJCF, so ``jnt_axis`` answers the same question for both formats and no
+expected axis is restated by hand. The MJCF cases are graded by the same oracle
+in the same file, which is what makes "MJCF's default was right and the URDF
+call site was borrowing it" a measurement rather than a claim.
+
+The parser's *tolerance* is deliberately unchanged: an ``<axis>`` stating a
+vector it cannot read still degrades to the format's default rather than
+raising, even though MuJoCo refuses such a model outright. That boundary is
+pinned by :class:`TestTheToleranceBoundaryIsUnchanged` so it is moved
+explicitly if it is ever moved at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+from strands_robots.simulation.isaac import loaders
+from strands_robots.simulation.isaac.loaders import (
+    _MJCF_DEFAULT_JOINT_AXIS,
+    _URDF_DEFAULT_JOINT_AXIS,
+    load_mjcf,
+    load_urdf,
+)
+
+from .test_urdf_link_pose import INERTIAL
+
+mujoco = pytest.importorskip("mujoco")
+
+#: The URDF joint types that carry a 1-DOF axis, so an axis default is
+#: observable on each. ``fixed`` has no axis to report.
+MOVABLE_URDF_TYPES = ("revolute", "continuous", "prismatic")
+
+#: The MJCF joint types that carry a 1-DOF axis.
+MOVABLE_MJCF_TYPES = ("hinge", "slide")
+
+#: ``<axis>`` spellings that state no vector this parser can read: absent
+#: entirely, present with no ``xyz``, empty, wrong arity, and non-numeric. Each
+#: must land on the reading format's default.
+UNREADABLE_AXES = (
+    "",
+    "<axis/>",
+    '<axis xyz=""/>',
+    '<axis xyz="1 0"/>',
+    '<axis xyz="p q r"/>',
+)
+
+
+def _write_urdf(tmp_path, *, jtype: str, axis_fragment: str, name: str = "axis") -> str:
+    """A two-link URDF whose single joint carries ``axis_fragment`` verbatim."""
+    limit = (
+        '<limit lower="-1" upper="1" effort="1" velocity="1"/>' if jtype in ("revolute", "prismatic") else ""
+    )
+    path = tmp_path / f"{name}.urdf"
+    path.write_text(
+        f'<robot name="{name}">'
+        f'<link name="base">{INERTIAL}</link><link name="arm">{INERTIAL}</link>'
+        f'<joint name="j" type="{jtype}">'
+        f'<parent link="base"/><child link="arm"/>'
+        f'<origin xyz="0 0 0.2" rpy="0 0 0"/>{axis_fragment}{limit}'
+        f"</joint></robot>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _write_mjcf(tmp_path, *, jtype: str, axis_attr: str = "", name: str = "axis") -> str:
+    """A one-body MJCF whose single joint carries ``axis_attr`` verbatim."""
+    path = tmp_path / f"{name}.xml"
+    path.write_text(
+        f'<mujoco model="{name}"><worldbody>'
+        f'<body name="arm" pos="0 0 0.2"><geom type="box" size="0.1 0.02 0.02"/>'
+        f'<joint name="j" type="{jtype}"{axis_attr}/></body>'
+        f"</worldbody></mujoco>",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _compiler_axis(path: str) -> tuple[float, float, float]:
+    """The joint's axis as MuJoCo compiled the file -- the oracle.
+
+    Looked up by name so a model that compiled the joint under a different name
+    fails loudly instead of silently grading joint 0 of something else.
+    """
+    model = mujoco.MjModel.from_xml_path(path)
+    jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "j")
+    assert jid >= 0, f"{path} compiled without a joint named 'j'; the oracle would be degenerate"
+    return tuple(float(v) for v in model.jnt_axis[jid])
+
+
+def _only_joint_axis(path: str, *, mjcf: bool = False) -> tuple[float, float, float]:
+    """The single joint's reported axis, asserting the read produced exactly one."""
+    robot = load_mjcf(path) if mjcf else load_urdf(path)
+    assert len(robot.joints) == 1, f"fixture {path} produced {len(robot.joints)} joints, expected 1"
+    return robot.joints[0].axis
+
+
+class TestTheTwoFormatsDefaultsDiffer:
+    """The premise: nothing below can distinguish anything if they agree."""
+
+    def test_the_declared_defaults_are_different_vectors(self) -> None:
+        assert _URDF_DEFAULT_JOINT_AXIS != _MJCF_DEFAULT_JOINT_AXIS, (
+            "premise: this file grades one format's default against the other's, "
+            "which measures nothing unless they differ"
+        )
+
+    @pytest.mark.parametrize("jtype", MOVABLE_URDF_TYPES)
+    def test_the_compiler_reads_a_urdf_default_as_the_other_formats_is_not(self, tmp_path, jtype) -> None:
+        """The oracle itself distinguishes them, so the fixtures are not vacuous."""
+        truth = _compiler_axis(_write_urdf(tmp_path, jtype=jtype, axis_fragment=""))
+        assert truth == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+        assert truth != pytest.approx(_MJCF_DEFAULT_JOINT_AXIS)
+
+
+class TestAnAbsentUrdfAxisIsTheUrdfDefault:
+    """``<axis>`` is optional in URDF; omitting it declares +X, not +Z."""
+
+    @pytest.mark.parametrize("jtype", MOVABLE_URDF_TYPES)
+    def test_the_reported_axis_matches_the_compiler(self, tmp_path, jtype) -> None:
+        path = _write_urdf(tmp_path, jtype=jtype, axis_fragment="")
+        assert _only_joint_axis(path) == pytest.approx(_compiler_axis(path))
+
+    @pytest.mark.parametrize("jtype", MOVABLE_URDF_TYPES)
+    def test_the_reported_axis_is_not_the_mjcf_default(self, tmp_path, jtype) -> None:
+        """Stated separately: the failure this pins is one specific wrong vector."""
+        path = _write_urdf(tmp_path, jtype=jtype, axis_fragment="")
+        assert _only_joint_axis(path) != pytest.approx(_MJCF_DEFAULT_JOINT_AXIS)
+
+
+class TestADeclaredUrdfAxisIsUnchanged:
+    """Control: a joint that states its axis is still read from the element."""
+
+    @pytest.mark.parametrize(
+        "xyz",
+        ("1 0 0", "0 1 0", "0 0 1", "0 0 -1", "0.36 -0.48 0.8"),
+    )
+    def test_a_declared_axis_matches_the_compiler(self, tmp_path, xyz) -> None:
+        path = _write_urdf(tmp_path, jtype="revolute", axis_fragment=f'<axis xyz="{xyz}"/>')
+        assert _only_joint_axis(path) == pytest.approx(_compiler_axis(path), abs=1e-9)
+
+    def test_a_declared_z_axis_is_not_read_as_the_urdf_default(self, tmp_path) -> None:
+        """A joint that does declare +Z keeps +Z: the default never overrides it."""
+        path = _write_urdf(tmp_path, jtype="revolute", axis_fragment='<axis xyz="0 0 1"/>')
+        assert _only_joint_axis(path) == pytest.approx(_MJCF_DEFAULT_JOINT_AXIS)
+
+
+class TestTheMjcfDefaultIsUnchanged:
+    """The scope boundary: MJCF's default was already the compiler's answer.
+
+    Graded by the same oracle as the URDF cases, which is what establishes that
+    the fix belongs at the URDF call site rather than in the shared parser.
+    """
+
+    @pytest.mark.parametrize("jtype", MOVABLE_MJCF_TYPES)
+    def test_an_absent_mjcf_axis_matches_the_compiler(self, tmp_path, jtype) -> None:
+        path = _write_mjcf(tmp_path, jtype=jtype)
+        assert _only_joint_axis(path, mjcf=True) == pytest.approx(_compiler_axis(path))
+
+    @pytest.mark.parametrize("jtype", MOVABLE_MJCF_TYPES)
+    def test_an_absent_mjcf_axis_is_not_read_as_the_urdf_default(self, tmp_path, jtype) -> None:
+        path = _write_mjcf(tmp_path, jtype=jtype)
+        assert _only_joint_axis(path, mjcf=True) != pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+
+    def test_a_declared_mjcf_axis_matches_the_compiler(self, tmp_path) -> None:
+        path = _write_mjcf(tmp_path, jtype="hinge", axis_attr=' axis="0 1 0"')
+        assert _only_joint_axis(path, mjcf=True) == pytest.approx(_compiler_axis(path))
+
+
+class TestTheToleranceBoundaryIsUnchanged:
+    """An unreadable axis still degrades to the format's default, never raises.
+
+    MuJoCo refuses every fixture here, so the tolerance is this package's own
+    choice rather than something the format allows. Reading it as the *reading
+    format's* default is what changed; that a malformed vector is tolerated at
+    all did not.
+    """
+
+    @pytest.mark.parametrize("fragment", UNREADABLE_AXES)
+    def test_an_unreadable_urdf_axis_reads_as_the_urdf_default(self, tmp_path, fragment) -> None:
+        path = _write_urdf(tmp_path, jtype="revolute", axis_fragment=fragment)
+        assert _only_joint_axis(path) == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+
+    @pytest.mark.parametrize("fragment", UNREADABLE_AXES)
+    def test_the_compiler_refuses_every_unreadable_fixture(self, tmp_path, fragment) -> None:
+        """Premise: except for the absent one, which is the format's default.
+
+        An absent ``<axis>`` is a declaration; the other four are malformed, and
+        the compiler's refusal of them is what makes tolerating them a decision.
+        """
+        path = _write_urdf(tmp_path, jtype="revolute", axis_fragment=fragment)
+        if not fragment:
+            assert _compiler_axis(path) == pytest.approx(_URDF_DEFAULT_JOINT_AXIS)
+            return
+        with pytest.raises(ValueError):
+            mujoco.MjModel.from_xml_path(path)
+
+    def test_an_unreadable_mjcf_axis_reads_as_the_mjcf_default(self, tmp_path) -> None:
+        path = _write_mjcf(tmp_path, jtype="hinge", axis_attr=' axis="0 1"')
+        assert _only_joint_axis(path, mjcf=True) == pytest.approx(_MJCF_DEFAULT_JOINT_AXIS)
+
+
+class TestNoCallSiteCanInheritAFormatsDefault:
+    """The parser names no default of its own, so omitting one is not possible.
+
+    A signature default is what let one format's axis reach the other's reader.
+    Requiring the argument means a call site added later cannot repeat that by
+    saying nothing -- the omission is a ``TypeError``, not a wrong axis.
+    """
+
+    def test_parse_axis_declares_no_default_of_its_own(self) -> None:
+        parameter = inspect.signature(loaders._parse_axis).parameters["default"]
+        assert parameter.default is inspect.Parameter.empty, (
+            "a signature default would let a call site inherit one format's axis"
+        )
+
+    def test_omitting_the_default_is_refused(self) -> None:
+        with pytest.raises(TypeError):
+            loaders._parse_axis("not a vector")  # type: ignore[call-arg]
+
+    def test_every_call_site_names_its_default(self) -> None:
+        """Derived, so a call site added later is graded on arrival."""
+        source = pathlib.Path(inspect.getsourcefile(loaders)).read_text(encoding="utf-8")
+        calls = [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_parse_axis"
+        ]
+        assert calls, "no _parse_axis call sites found; this rule would grade nothing"
+        unnamed = [
+            node.lineno
+            for node in calls
+            if len(node.args) < 2 and not any(kw.arg == "default" for kw in node.keywords)
+        ]
+        assert not unnamed, f"_parse_axis called without naming a default at line(s) {unnamed}"


### PR DESCRIPTION
## Problem

`_parse_axis` is the shared 3-vector parser behind both XML loaders in
`strands_robots/simulation/isaac/loaders.py`, and it carried a single default in its own
signature: `default: tuple[float, float, float] = (0.0, 0.0, 1.0)`. That is **MJCF's** default -
an MJCF `<joint>` that omits `axis` acts about +Z.

**URDF's default is +X, and `<axis>` is optional there.** `load_urdf` called the parser without
naming a default, so a URDF joint that omits `<axis>` was reported as acting about +Z. Both are
valid axes and `JointDef.axis` is the whole product of the read, so nothing could tell a joint
the file declares in one plane from one whose axis had been replaced by the other format's - the
load reported success either way.

MuJoCo parses URDF, so it answers the same question for both formats and is a direct oracle:

| absent `<axis>`, URDF joint type | `load_urdf` reported | `mujoco` `jnt_axis` |
|---|---|---|
| `revolute` | `(0, 0, 1)` | `(1, 0, 0)` |
| `continuous` | `(0, 0, 1)` | `(1, 0, 0)` |
| `prismatic` | `(0, 0, 1)` | `(1, 0, 0)` |

The compiler reads +X for all three, so this is a property of the format rather than of any one
joint type. A joint that *declares* its axis was always read correctly; only the default was
borrowed.

The wrong default was pinned by a shipped test, `TestParseFallbacks::
test_axis_wrong_arity_and_non_numeric_fall_back_to_z`, whose name states the borrowed axis. Its
own docstring says malformed input "must fall back to the documented default" - and the
documented default for a URDF joint axis is +X.

## Change

Each format now names its own default, and the parser names none:

- `_URDF_DEFAULT_JOINT_AXIS = (1.0, 0.0, 0.0)` beside the URDF joint-type map, and
  `_MJCF_DEFAULT_JOINT_AXIS = (0.0, 0.0, 1.0)` beside the MJCF one.
- `_parse_axis`'s `default` is now **required**. A signature default is exactly what let one
  format's axis reach the other's reader, so omitting it is a `TypeError` rather than a wrong
  axis - a call site added later cannot repeat this by saying nothing. The third call site (an
  MJCF mesh scale) already passed its own `default=(1.0, 1.0, 1.0)`, so the pattern was already
  established in this file; the two joint readers now follow it.
- The shipped fallback test is renamed to `..._fall_back_to_the_urdf_default` and reads the
  constant, and its class docstring now says the default is the reading format's own.

MJCF is untouched: its default was already the compiler's answer, which the same oracle
confirms in the same file (`hinge` and `slide` both agree). That is what places the fix at the
URDF call site rather than in the shared parser.

**Deliberately unchanged:** an `<axis>` stating a vector the parser cannot read still degrades to
the format's default rather than raising, even though MuJoCo refuses every such model outright.
Only *which* default it lands on moves here. `TestTheToleranceBoundaryIsUnchanged` pins the
tolerance so moving it later is an explicit decision.

## Artifact

One URDF file with one joint that omits `<axis>`, one scene, one camera, one 60 degree command.
The only variable is which default the axis is read under. The third panel is MuJoCo's own read
of the same file, so it is the oracle rather than a second opinion.

![URDF joint axis default](https://github.com/cagataycali/robots/releases/download/artifacts/urdf-joint-axis-default-2701.png)

Rendered headless (EGL); per-geom pixel counts come from a segmentation render, so they are exact
and lighting-independent.

| panel | axis reported | bar tip at 60 deg | vs the oracle's render |
|---|---|---|---|
| `upstream/main` | `(0, 0, 1)` - swings horizontally | `x=-0.364, z=+0.030` | mean abs delta **6.4488** levels |
| this branch | `(1, 0, 0)` - swings vertically | `x=+0.000, z=+0.394` | **`np.array_equal` True**, mean abs delta **0.000000** |
| `mujoco` (oracle) | `(1, 0, 0)` | `x=+0.000, z=+0.394` | - |

The static reference post measures **674 px in every panel** (673 at rest) - one camera, one
light, one scene - so the difference in the image is the difference in the axis. In the composed
figure the branch and oracle columns are byte-identical and main's differs, asserted in the
figure script rather than eyeballed.

## Tests

New `tests/simulation/isaac/test_joint_axis_format_default.py` (40 tests). Every expectation is
derived from `mujoco.MjModel`; no expected axis is restated by hand.

Pre-fix, with the constants present and only the URDF call site borrowing MJCF's default:
**12 failed / 66 passed**, all 12 in the regression classes and **0 in the control, boundary or
premise classes**. Reverting the source file outright is a collection error, since the constants
are new.

Break table (both files, 83 tests, control 0):

| mutation | fails | what it shows |
|---|---|---|
| the URDF site borrows MJCF's default (the exact defect) | 12 | incl. the **pre-existing** `TestParseFallbacks` test |
| the URDF default set to a third vector (+Y) | 7 | the oracle-agreement tests and both premises catch a wrong constant |
| MJCF's default changed to URDF's (over-reach onto the sibling) | 12 | the whole MJCF boundary class fires, plus the premise |
| `_parse_axis` regains a signature default | 2 | exactly the two signature tests, nothing else |
| signature default restored **and** the URDF site omits it (full pre-fix shape) | 15 | union of the above, plus the derived call-site rule |
| malformed axis refused instead of tolerated (over-reach) | 6 | the tolerance boundary, incl. the **pre-existing** fallback test |
| the default overrides a *declared* axis (over-reach) | 7 | the declared-axis controls, incl. the **pre-existing** `TestUrdfRobotLoader::test_joint_types_limits_and_shapes` |
| the two defaults made equal, premise **present** | 12 | one test names the cause |
| the same, premise **removed** | 11 | 11 failures and no test says the defaults collided - which is why the premise is there |

#### How the missing-default refusal is spelled

`test_omitting_the_default_is_refused` asserts the runtime consequence of requiring the argument,
and builds the argument list rather than spelling a literal one-argument call: such a call *is* a
statically wrong call - the property under test - so writing one puts the assertion's own subject
in front of every caller-arity checker that reads the file. The match pins the refusal to the
missing `default` rather than to any `TypeError` the parser body might raise, which is a
strengthening: with the signature default restored **and** `_parse_axis` raising from its own
`except (ValueError, TypeError)` instead of degrading, a bare `pytest.raises(TypeError)` **passes**
while the defect is present, where the match **fails** with `Regex pattern did not match.`

## Blast radius

74 URDFs in the downloaded asset corpus, 2042 joints, both trees, identical load/refuse verdicts
(74 loaded, 2 refused either way):

- **0 of 1196 movable joints change.** Every `revolute` / `continuous` / `prismatic` joint in the
  corpus declares its own `<axis>`, so the corpus never exercised the default - the defect was
  latent, and the new suite is what makes it stay fixed.
- 486 joints change, and every one of them declares no axis at all: 483 URDF `fixed` and 3
  `floating`. All 486 are reported with `joint_type="fixed"`, none actuated, and MuJoCo produces
  no hinge or slide for them - a fixed joint's axis is not a quantity anything acts on.

## Gate

- `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ`.
- mypy **24 == 24** against a pristine `upstream/main` worktree, message sets byte-identical, 0
  in the changed files.
- Paired run over a 130-file selection (everything naming these loaders or their dataclasses),
  identical on both trees with the two changed test files excluded from each:
  **`5971 passed, 71 skipped`, zero failures either side**; branch-only and base-only failing-id
  sets both empty.
- The changed files pass on **mujoco 3.12.0** and on **3.5.0**, the declared floor (83 each), and
  `tests/simulation/isaac/` is `1423 passed, 5 skipped`.
- Current `main` is merged into the branch; on that composition `tests/simulation/isaac/`
  plus the three suites `main` added since this branch's base is **1718 passed, 9 skipped**.

