### PR TITLE
fix(verify-dataset): grade a dead control column per robot, not per whole vector

### DIFF
--- a/changelog.d/2702-dead-control-column-per-robot-block.md
+++ b/changelog.d/2702-dead-control-column-per-robot-block.md
@@ -1,0 +1,41 @@
+### Fixed: `verify-dataset` grades a dead control column per robot, not per whole vector
+
+`verify_dataset`'s dead-control-column check exists to catch a recording whose `action` or
+`observation.state` column was written as zeros because the writer's keys never resolved to the
+declared columns - correct episode counts, correct pixels, no control signal. It fired only when
+the ENTIRE vector was identically zero, and a multi-robot recording cannot present that shape.
+`start_recording` declares one column per robot per joint and prefixes each with its robot's
+instance name (`alice__shoulder_pan`), so a resolution that succeeds for one robot and fails for
+another leaves that robot's whole block of columns zero while the other robot's columns carry
+real measurements. The vector as a whole varies, so the check saw nothing and the report read
+`[PASS]`.
+
+The recorder documents this mechanism itself, in the comment that remaps the prefixed keys in
+`strands_robots/simulation/mujoco/simulation.py`: without the remap, `add_frame` "looks up the
+prefixed schema keys, finds nothing, and writes all-zero state/action vectors silently". That is
+the per-robot failure, and the gate written to catch it could only see the all-robot case.
+
+The vector is now split into the blocks `meta/info.json` declares - column indices grouped by the
+per-robot prefix - and a block that is wholly zero is reported the same way a wholly-zero vector
+is, naming the robot: `feature 'action' is identically zero for every 'bob' column across episode
+0 (60 frame(s))`. A zero SUBSET of one robot's block is deliberately left alone, because a
+gripper parked at zero for a whole episode is a measurement rather than a writer fault. The
+separator is the doubled underscore `start_recording` writes, not a single one: a real arm's
+joints are `shoulder_pan` / `gripper`, and splitting on `_` would turn one arm into four blocks
+and flag its parked gripper.
+
+The change is a strict extension. A wholly-zero vector reports the message it reported before,
+once, rather than one per block; a dataset whose `names` are absent, non-string or of a different
+width than the stats it is being asked about keeps the whole-vector rule, which is every
+single-robot recording; and `stats_vectors_checked` is unchanged, so the same work yields a finer
+verdict. Over the LeRobot datasets on one machine - 1314 roots, graded on both sides - 58 moved
+from pass to fail, no dataset moved from fail to pass, every problem string reported before was
+still reported, and every added string was the new per-block finding.
+
+This complements rather than duplicates the recorder fix in #2699. That change makes an undriven
+robot's `observation.state` columns measurements from now on, and states that the matching action
+columns are deliberately unchanged pending a schema decision. Neither can repair a dataset already
+on disk, and a recording made after it still carries an undriven robot's `action` block as zeros -
+which is exactly what this check now reports, without deciding the schema question: on a two-arm
+recording made on current `main`, the `action` block is named and the `observation.state` block is
+not, because that one now varies.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -348,20 +348,45 @@ strands-robots verify-dataset /path/to/dataset --no-check-videos  # skip the per
 ```
 
 `verify-dataset` reuses the same pure-pyarrow `read_dataset_episode_indices`
-helper (no `lerobot` import) and flags four failure modes: the mega-episode
+helper (no `lerobot` import) and flags five failure modes: the mega-episode
 (fewer distinct episodes than `--expected`), `meta/info.json` `total_episodes` /
 `total_frames` drifting from the parquet ground truth (caught even without
-`--expected`), any episode below `--min-frames` (default 1), and - unless
+`--expected`), any episode below `--min-frames` (default 1), - unless
 `--no-check-videos` is passed - any per-episode video file that is missing or
-empty on disk. The last check is the video-modality sibling of the
+empty on disk, and - unless `--no-check-stats` is passed - a dead control
+column. The video check is the video-modality sibling of the
 mega-episode class: a dataset can carry the right episode count yet have no
 pixels because the recorder's video encoder failed or the MP4 streams were
 never written. It resolves each camera's MP4 from `meta/info.json`'s
 `video_path` template and the episode parquet's `videos/<key>/chunk_index` /
 `file_index` columns, and reports the count it checked in
 `video_files_checked`. The programmatic form is
-`strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1, check_videos=True)`,
+`strands_robots.verify_dataset.verify_dataset(root, expected=None, min_frames=1, check_videos=True, check_stats=True)`,
 which returns the same report dict.
+
+The dead-control-column check is the proprioceptive sibling: correct counts and
+pixels, but the `action` (or `observation.state`) column was written as all
+zeros because the writer's keys never resolved to the declared columns. It reads
+the per-episode `min`/`max` stats LeRobot v3 writes inline, so it needs no video
+decode and no `data/` scan.
+
+A multi-robot recording is graded one level finer, per robot. `start_recording`
+gives every robot its own state/action columns and namespaces each declared name
+with the robot's instance name (`alice__shoulder_pan`), so a resolution failure
+that affects one robot alone leaves that robot's whole block of columns zero
+while the other robot's columns carry real measurements. The vector as a whole
+therefore still varies, and a whole-vector test reports `[PASS]`. The check
+splits the vector into the per-robot blocks `meta/info.json` declares and flags
+any block that is wholly zero, naming the robot:
+
+```
+feature 'observation.state' is identically zero for every 'bob' column across
+episode 0 (20 frame(s)) - dead control column block
+```
+
+A zero *subset* of one robot's block is left alone - a gripper parked at zero for
+a whole episode is a measurement, not a writer fault - and a dataset that
+declares no column names is graded by the whole-vector rule exactly as before.
 
 `--expected` and `--min-frames` are both non-negative integers, and each has a
 meaningful `0`: `--expected 0` asks that a dataset be empty, and `--min-frames 0`

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -29,7 +29,10 @@ Checks performed against a dataset root (the dir containing ``meta/``):
      a multi-frame episode - the dead-control-column corruption (correct
      counts and pixels, but the proprioceptive/action signal was written as
      all zeros), read from the per-episode stats (disable with
-     ``--no-check-stats``).
+     ``--no-check-stats``). A multi-robot recording is graded per robot, using
+     the per-robot column names it declares: one robot's whole block of
+     columns written as zeros is flagged even while another robot's columns
+     carry real measurements.
 
 Usage:
     strands-robots verify-dataset /path/to/dataset
@@ -82,7 +85,11 @@ def verify_dataset(
             video file referenced by the dataset exists and is non-empty.
         check_stats: When True (default), flag any episode whose ``action``
             or ``observation.state`` column is identically zero across the
-            whole episode (a dead control column).
+            whole episode (a dead control column). A multi-robot vector is
+            split into the per-robot blocks ``meta/info.json`` declares, and a
+            block that is wholly zero is flagged even when its siblings vary; a
+            zero SUBSET of one robot's block (a gripper parked at zero for the
+            whole episode) is a measurement and is not flagged.
 
     Returns:
         A report dict with:
@@ -192,6 +199,11 @@ def verify_dataset(
             detail = ", ".join(f"episode {ep}={n} frame(s)" for ep, n in short)
             problems.append(f"{len(short)} episode(s) below min_frames={min_frames}: {detail}")
 
+    # ``meta/info.json``, read once. Check 3 compares its counts against the
+    # parquet truth; check 6 reads its per-feature ``names`` to split a control
+    # vector into the per-robot blocks the recorder declared.
+    declared: dict[str, Any] = {}
+
     # Check 3: meta/info.json vs parquet ground truth (drift detection).
     info_json_path = root_path / "meta" / "info.json"
     if info_json_path.is_file():
@@ -199,7 +211,6 @@ def verify_dataset(
             declared = json.loads(info_json_path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as e:
             problems.append(f"could not read meta/info.json: {e}")
-            declared = {}
         decl_eps = declared.get("total_episodes")
         decl_frames = declared.get("total_frames")
         report["info_total_episodes"] = decl_eps
@@ -242,8 +253,15 @@ def verify_dataset(
     # declared columns, so every frame's action is written as zeros while the
     # episode and frame counts stay correct. The per-episode feature stats
     # LeRobot v3 writes inline make this a cheap, decoder-independent check.
+    # In a multi-robot scene each robot owns its own columns, so the resolution
+    # can fail for one robot alone; ``declared_features`` carries the per-robot
+    # names that split the vector into the blocks graded individually.
     if check_stats:
-        stats_checked, stats_problems = _verify_feature_stats(root_path, known_unreadable=known_unreadable)
+        stats_checked, stats_problems = _verify_feature_stats(
+            root_path,
+            known_unreadable=known_unreadable,
+            declared_features=declared.get("features"),
+        )
         report["stats_vectors_checked"] = stats_checked
         problems.extend(stats_problems)
 
@@ -441,7 +459,48 @@ def _verify_video_files(root_path: Path, *, known_unreadable: frozenset[str] = f
     return len(referenced), problems
 
 
-def _verify_feature_stats(root_path: Path, *, known_unreadable: frozenset[str] = frozenset()) -> tuple[int, list[str]]:
+def _declared_column_blocks(feature_spec: Any, width: int) -> list[tuple[str, tuple[int, ...]]]:
+    """Split a control feature's columns into the per-robot blocks it declares.
+
+    A multi-robot recording gives every robot its own state/action columns and
+    namespaces each declared name with the robot's instance name
+    (``alice__shoulder_pan``), the prefix ``start_recording`` writes. Grouping the
+    column indices by that prefix recovers, for each robot, exactly the columns
+    its own writer is responsible for filling.
+
+    Args:
+        feature_spec: The feature's ``meta/info.json`` entry (the mapping that
+            carries ``names``), or anything else when the dataset declares none.
+        width: Number of columns the episode stats actually carry. A ``names``
+            list of a different length does not describe this vector.
+
+    Returns:
+        One ``(robot_name, column_indices)`` pair per declared block. Empty when
+        the declaration cannot split this vector - absent, non-string or
+        wrong-width ``names`` - or when it describes a single unprefixed block,
+        which is the ordinary single-robot recording. In both cases the caller
+        keeps the whole-vector rule, so a dataset that declares nothing is graded
+        exactly as before.
+    """
+    names = feature_spec.get("names") if isinstance(feature_spec, dict) else None
+    if not isinstance(names, list) or len(names) != width:
+        return []
+    if not all(isinstance(name, str) for name in names):
+        return []
+    blocks: dict[str, list[int]] = {}
+    for index, name in enumerate(names):
+        blocks.setdefault(name.split("__", 1)[0] if "__" in name else "", []).append(index)
+    if len(blocks) < 2:
+        return []
+    return [(label, tuple(indices)) for label, indices in blocks.items()]
+
+
+def _verify_feature_stats(
+    root_path: Path,
+    *,
+    known_unreadable: frozenset[str] = frozenset(),
+    declared_features: dict[str, Any] | None = None,
+) -> tuple[int, list[str]]:
     """Flag dead (identically-zero) control columns via per-episode stats.
 
     LeRobot v3 writes per-episode feature statistics inline in
@@ -462,6 +521,17 @@ def _verify_feature_stats(root_path: Path, *, known_unreadable: frozenset[str] =
     column. Reading only the lightweight stats columns keeps this
     decoder-independent (no video decode, no ``data/`` scan).
 
+    A multi-robot recording needs the same check one level finer. It declares one
+    state/action column per robot per joint, so when the writer's keys resolve for
+    one robot and not another only that robot's block is written as zeros - the
+    vector as a whole still varies, and a whole-vector test cannot see it.
+    ``_declared_column_blocks`` recovers each robot's own columns from the
+    per-robot names in ``declared_features``, and a block that is wholly zero is
+    reported the same way a wholly-zero vector is. A zero subset of a block is
+    left alone: a gripper parked at zero for a whole episode is a measurement,
+    not a writer fault. With no usable declaration this is exactly the
+    whole-vector rule, so a dataset that declares no names is graded as before.
+
     Args:
         root_path: Dataset root directory (the dir that contains ``meta/``).
         known_unreadable: Episode-parquet paths (relative to ``root_path``) the
@@ -479,6 +549,7 @@ def _verify_feature_stats(root_path: Path, *, known_unreadable: frozenset[str] =
     except ImportError:  # pragma: no cover - pyarrow ships with the lerobot extra
         return 0, []
 
+    features_decl = declared_features if isinstance(declared_features, dict) else {}
     parquet_files = sorted((root_path / "meta" / "episodes").glob("**/*.parquet"))
     if not parquet_files:
         return 0, []
@@ -537,12 +608,32 @@ def _verify_feature_stats(root_path: Path, *, known_unreadable: frozenset[str] =
                 if n is not None and n < 2:
                     continue  # single frame: identically-zero is not yet corruption evidence
                 ep = int(episodes[i]) if i < len(episodes) and episodes[i] is not None else -1
-                if all(v == 0 for v in row_min) and all(v == 0 for v in row_max):
-                    frames = f"{n} frame(s)" if n is not None else "all frames"
+                frames = f"{n} frame(s)" if n is not None else "all frames"
+                width = min(len(row_min), len(row_max))
+                dead = {j for j in range(width) if row_min[j] == 0 and row_max[j] == 0}
+                if not dead:
+                    continue
+                if len(dead) == width:
                     problems.append(
                         f"feature '{feat}' is identically zero across episode {ep} ({frames}) - "
                         "dead control column (the recorded values never change and are all zero)"
                     )
+                    continue
+                # Some columns died and others did not. That is only evidence when
+                # the dead ones are exactly one robot's declared block: a scene's
+                # per-robot writer either resolves for that robot or writes its
+                # whole block as zeros, so a fully-dead block is the same
+                # corruption as a fully-dead vector in a single-robot recording.
+                # A dead SUBSET of a block is left alone - a gripper parked at
+                # zero for a whole episode is a measurement, not a writer fault.
+                for label, indices in _declared_column_blocks(features_decl.get(feat), width):
+                    if indices and dead.issuperset(indices):
+                        problems.append(
+                            f"feature '{feat}' is identically zero for every '{label}' column across "
+                            f"episode {ep} ({frames}) - dead control column block (that robot's "
+                            "recorded values never change and are all zero, while its siblings in "
+                            "the same vector vary)"
+                        )
     return checked, problems
 
 

--- a/strands_robots/verify_dataset.py
+++ b/strands_robots/verify_dataset.py
@@ -537,6 +537,10 @@ def _verify_feature_stats(
         known_unreadable: Episode-parquet paths (relative to ``root_path``) the
             caller has already reported as unreadable. They are skipped without
             a second problem string, so one broken shard is reported once.
+        declared_features: The ``features`` mapping from ``meta/info.json``,
+            whose per-feature ``names`` carry the per-robot column prefixes.
+            Read only to split a partially-dead vector into blocks; ``None``
+            (or anything that is not a mapping) keeps the whole-vector rule.
 
     Returns:
         A ``(checked, problems)`` tuple where ``checked`` is the number of

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -897,6 +897,210 @@ def _write_stats_parquet(root: Path, columns: dict[str, list]) -> Path:
     return root
 
 
+_ALICE_BOB_NAMES = [f"alice__{j}" for j in range(1, 7)] + [f"bob__{j}" for j in range(1, 7)]
+_SOLO_NAMES = [str(j) for j in range(1, 7)]
+
+
+def _control_info(names: list[str]) -> dict:
+    """A ``meta/info.json`` declaring both control features over ``names``.
+
+    Mirrors what ``start_recording`` writes: one column per robot per joint,
+    each named, with the per-robot prefix in a multi-robot scene.
+    """
+    spec = {"dtype": "float32", "shape": [len(names)], "names": list(names)}
+    return {"features": {"action": dict(spec), "observation.state": dict(spec)}}
+
+
+def _block(dead: set[int], width: int) -> tuple[list[float], list[float]]:
+    """A ``(min, max)`` stat pair whose ``dead`` indices are identically zero.
+
+    Every other index gets a distinct non-zero span, so a column is zero in the
+    pair exactly when the test asked for it.
+    """
+    mn = [0.0 if j in dead else -(j + 1.0) for j in range(width)]
+    mx = [0.0 if j in dead else (j + 1.0) for j in range(width)]
+    return mn, mx
+
+
+class TestDeadControlColumnPerRobotBlock:
+    """One robot's columns dead while a sibling robot's vary is flagged.
+
+    ``start_recording`` declares a multi-robot dataset with one column per robot
+    per joint, namespacing each with the robot's instance name
+    (``alice__shoulder_pan``). When a writer's keys never resolve for ONE of those
+    robots, that robot's whole block of columns is written as zeros while the other
+    robot's columns carry real measurements. The vector as a whole therefore
+    varies, so a whole-vector test cannot see it; the declared names are what
+    recover each robot's own columns.
+    """
+
+    def test_the_fixture_declares_two_distinct_robot_blocks(self) -> None:
+        blocks = {n.split("__", 1)[0] for n in _ALICE_BOB_NAMES}
+        assert blocks == {"alice", "bob"}, "premise: the fixture must span two robots"
+        assert all("__" not in n for n in _SOLO_NAMES), "premise: the solo fixture is unprefixed"
+
+    def test_one_robots_block_dead_while_the_sibling_varies_is_flagged(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        assert any(v != 0.0 for v in mn), "premise: the vector as a whole is not dead"
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is False
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 1
+        assert "bob" in dead[0]
+        assert "action" in dead[0]
+
+    def test_the_message_names_the_dead_robot_and_not_the_live_one(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(0, 6)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            state_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 1
+        assert "alice" in dead[0]
+        assert "bob" not in dead[0]
+
+    def test_both_control_features_report_their_own_dead_block(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            state_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 2
+        assert any("action" in p for p in dead)
+        assert any("observation.state" in p for p in dead)
+
+    def test_a_single_dead_joint_inside_a_robot_is_not_flagged(self, tmp_path: Path) -> None:
+        """A gripper held at zero all episode is a measurement, not a dead block."""
+        mn, mx = _block({11}, 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[90],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_a_single_robot_dataset_with_one_dead_joint_still_passes(self, tmp_path: Path) -> None:
+        mn, mx = _block({5}, 6)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[90],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_SOLO_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_a_wholly_dead_multi_robot_vector_reports_one_problem(self, tmp_path: Path) -> None:
+        """Every block dead is still the single whole-vector finding, not one per robot."""
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[([0.0] * 12, [0.0] * 12)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is False
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 1
+        assert "alice" not in dead[0] and "bob" not in dead[0]
+
+    def test_absent_declared_names_fall_back_to_the_whole_vector_rule(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_declared_names_of_the_wrong_width_fall_back(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES[:8]),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_a_single_frame_episode_is_not_flagged(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[1],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_a_healthy_multi_robot_dataset_passes(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            state_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+        assert report["stats_vectors_checked"] == 2
+
+    def test_no_check_stats_skips_the_block_check(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False, check_stats=False)
+        assert report["ok"] is True, report["problems"]
+        assert report["stats_vectors_checked"] == 0
+
+    def test_dead_block_drives_the_cli_exit_code(self, tmp_path: Path) -> None:
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ALICE_BOB_NAMES),
+        )
+        assert verify_main([str(tmp_path), "--no-check-videos"]) == 1
+
+
 class TestFeatureStatsEdgeCases:
     """Defensive branches of ``_verify_feature_stats`` over irregular parquet.
 

--- a/tests/test_verify_dataset.py
+++ b/tests/test_verify_dataset.py
@@ -26,6 +26,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from strands_robots.verify_dataset import (
+    _declared_column_blocks,
     _verify_feature_stats,
     _verify_video_files,
     _video_frame_count,
@@ -899,6 +900,11 @@ def _write_stats_parquet(root: Path, columns: dict[str, list]) -> Path:
 
 _ALICE_BOB_NAMES = [f"alice__{j}" for j in range(1, 7)] + [f"bob__{j}" for j in range(1, 7)]
 _SOLO_NAMES = [str(j) for j in range(1, 7)]
+# The joint names a real SO-10x arm declares. They carry single underscores, which
+# are NOT the per-robot separator: one arm is one block however its joints are
+# spelled.
+_ARM_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+_TWO_ARM_NAMES = [f"alice__{j}" for j in _ARM_JOINTS] + [f"bob__{j}" for j in _ARM_JOINTS]
 
 
 def _control_info(names: list[str]) -> dict:
@@ -1099,6 +1105,47 @@ class TestDeadControlColumnPerRobotBlock:
             info=_control_info(_ALICE_BOB_NAMES),
         )
         assert verify_main([str(tmp_path), "--no-check-videos"]) == 1
+
+    def test_a_solo_robots_columns_are_not_a_split(self) -> None:
+        """One robot is one block, so there is nothing to grade block-wise."""
+        spec = {"names": list(_SOLO_NAMES)}
+        assert _declared_column_blocks(spec, len(_SOLO_NAMES)) == []
+
+    def test_underscored_joint_names_do_not_split_a_solo_robot(self, tmp_path: Path) -> None:
+        """A real arm's ``shoulder_pan`` / ``gripper`` names are one robot, not four.
+
+        The per-robot separator is the doubled underscore ``start_recording``
+        writes. Splitting on a single underscore would turn one arm into several
+        blocks and flag a parked gripper as a dead block.
+        """
+        assert _declared_column_blocks({"names": list(_ARM_JOINTS)}, len(_ARM_JOINTS)) == []
+        mn, mx = _block({_ARM_JOINTS.index("gripper")}, len(_ARM_JOINTS))
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[90],
+            action_minmax=[(mn, mx)],
+            info=_control_info(_ARM_JOINTS),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        assert report["ok"] is True, report["problems"]
+
+    def test_two_real_arms_split_on_the_robot_prefix_only(self, tmp_path: Path) -> None:
+        """Two SO-10x arms are two blocks even though every joint name has an underscore."""
+        blocks = _declared_column_blocks({"names": list(_TWO_ARM_NAMES)}, len(_TWO_ARM_NAMES))
+        assert [label for label, _ in blocks] == ["alice", "bob"]
+        mn, mx = _block(set(range(6, 12)), 12)
+        _write_dataset_with_stats(
+            tmp_path,
+            episode_indices=[0],
+            counts=[20],
+            state_minmax=[(mn, mx)],
+            info=_control_info(_TWO_ARM_NAMES),
+        )
+        report = verify_dataset(tmp_path, check_videos=False)
+        dead = [p for p in report["problems"] if "identically zero" in p]
+        assert len(dead) == 1
+        assert "bob" in dead[0]
 
 
 class TestFeatureStatsEdgeCases:


### PR DESCRIPTION
## What is wrong

`verify_dataset`'s dead-control-column check exists to catch a recording whose `action` /
`observation.state` column was written as zeros because the writer's keys never resolved to the
declared columns: correct episode counts, correct pixels, no control signal. It fired only when the
**entire** vector was identically zero:

```python
if all(v == 0 for v in row_min) and all(v == 0 for v in row_max):
```

A multi-robot recording cannot present that shape. `start_recording` declares one column per robot
per joint and prefixes each with the robot's instance name (`mujoco/recording.py`:
`joint_names.extend(f"{rname}__{jn}" ...)`), so a resolution that succeeds for one robot and fails
for another leaves that robot's whole block of columns zero while the other robot's columns carry
real measurements. The vector as a whole varies, the check sees nothing, and the report reads
`[PASS]`.

The recorder documents exactly this mechanism, in the comment that remaps the prefixed keys
(`strands_robots/simulation/mujoco/simulation.py`):

> Without remapping here, `add_frame()` looks up the prefixed schema keys, finds nothing, and
> writes all-zero state/action vectors silently.

That is the per-robot failure. The gate written to catch it could only see the all-robot case.

## Measured on a real recording made on current `main`

Two `so101` arms, `alice` driven for 60 frames and `bob` standing in the scene, recorded through
`start_recording` / `run_policy` / `stop_recording` at `e3ff18dd` and reopened through
`LeRobotDataset` (60 frames, 1 episode, `observation.images.overview` as declared):

| declared column | `action` span | `observation.state` span |
|---|---|---|
| `alice__1 .. alice__6` | live | live |
| `bob__1 .. bob__6` | **0.0, all six** | non-zero, all six |

Same dataset, same command:

```
[PASS]  main @ e3ff18dd
[FAIL]  this change
  - feature 'action' is identically zero for every 'bob' column across
    episode 0 (60 frame(s)) - dead control column block
```

`observation.state` is deliberately **not** reported: #2699 now records an undriven robot's state
as measurements, so that block varies and only the genuinely dead one is named. The two features of
one dataset are graded differently on their own content, which is the discrimination the rule is
for.

![dead control column block](https://raw.githubusercontent.com/cagataycali/robots/media-dead-column-block/dead-column-block.png)

Rollout the dataset was recorded from (MuJoCo, headless):
https://raw.githubusercontent.com/cagataycali/robots/media-dead-column-block/two-arm-rollout.mp4

## The rule

Split the vector into the blocks `meta/info.json` declares - column indices grouped by the
per-robot prefix - and report a block that is wholly zero the same way a wholly-zero vector is
reported, naming the robot.

A zero **subset** of a block is deliberately left alone: a gripper parked at zero for a whole
episode is a measurement, not a writer fault. Measured across the LeRobot datasets on one machine,
103 partially-dead stat vectors are subsets of a block, and none of them is flagged.

The separator is the doubled underscore `start_recording` writes, not a single one. A real arm's
joints are `shoulder_pan` / `elbow_flex` / `gripper`; splitting on `_` would turn one arm into four
blocks and flag its parked gripper. That is a test case, not a comment.

## Strict extension

| property | measured |
|---|---|
| a wholly-zero vector | reports the message it reported before, once, not one per block |
| absent / non-string / wrong-width `names` | keeps the whole-vector rule (every single-robot recording) |
| `stats_vectors_checked` | unchanged - same work, finer verdict |
| blocks found for a single-robot recording | none: of 2221 declared control vectors, exactly 200 split, always into 2, and 0 splits occurred where any name lacked the `__` prefix |

Blast radius, real `verify_dataset` over 1314 dataset roots on both trees:

| | base | this change |
|---|---|---|
| pass / fail | 747 / 567 | 689 / 625 |
| pass -> fail | | 58 |
| **fail -> pass** | | **0** |
| base problem strings no longer reported | | 0 |
| new problem strings | | 74, all the per-block finding |
| exceptions raised | 0 | 0 |

The 58 are 48 pytest temporary fixtures and 10 recorded datasets.

## Tests

`tests/test_verify_dataset.py` grows a `TestDeadControlColumnPerRobotBlock` class: 73 tests in the
file, up from 57.

Pre-fix split. Reverting `verify_dataset.py` outright is a collection error, because the suite names
the new block-splitting helper; the behavioural pre-fix - helper present, declaration not plumbed
into the check - is **5 failed / 68 passed**, with all 5 in the regression cases and 0 in the
controls.

Break table, each mutation on the merged tree:

| mutation | fires |
|---|---|
| control, unmodified | 0 |
| declaration not plumbed into the check (behavioural pre-fix) | 5, all regression cases |
| a block is dead if **any** of its columns is dead | 1 - the parked-gripper false-positive guard |
| drop the single-block guard | 2 - the solo-robot contract and the underscored-joint-name case |
| drop the whole-vector early return | 1 - the "one problem, not one per block" case |
| stop checking `names` describes this vector | 1 - the wrong-width fallback |
| stop skipping single-frame episodes | 2, including the pre-existing `test_single_frame_all_zero_not_flagged` |
| split on `_` instead of `__` | 1 - the real-arm joint-name case |

Every mutation fires a distinct set; two rows fire only after the break table itself exposed that my
first fixtures (`"1".."6"`) could not distinguish them, which is why the realistic
`shoulder_pan`/`gripper` fixture exists.

## Gate

- `ruff check` / `ruff format --check` over `strands_robots tests tests_integ`: clean.
- `mypy` over the same targets: `Success: no issues found in 1519 source files`; branch-only error
  set empty against a pristine `main` worktree.
- 478-file selection (every test touching `verify_dataset`, the dataset recorder, recording, or a
  repo-wide docstring/changelog guard), identical on both trees with the changed test file excluded
  from each: **4 failed, 19268 passed, 35 skipped on both**, the 4 failing ids identical and both
  `comm` directions empty. They fail on pristine `main` alone too: 2 need `docker` on `PATH`
  (absent here, present in CI) and 2 assert an `ImportError` that `rclpy` being installed locally
  prevents.
- Scoped re-run after merging `main` (the three PRs that landed during the work): the changed file
  plus each of their own new suites plus the recording surface, **+16 passed against the same tree
  without this change, which is exactly the 16 tests added**, and an identical 4-failure set that
  is a module-caching artifact of the large selection (that file passes 13/13 alone on both trees).
- Changelog fragment validates; `docs/recording.md` gains the per-robot semantics and its list of
  failure modes, which said "four" and omitted the dead-column check entirely, now says five.
