### PR TITLE
test(lerobot_local): reset every step a processor module owns, not a subset

### DIFF
--- a/changelog.d/2704-processor-step-reset-covers-every-owned-step.md
+++ b/changelog.d/2704-processor-step-reset-covers-every-owned-step.md
@@ -1,0 +1,52 @@
+### Fixed: a forced processor-module re-import resets every step it owns, not a subset
+
+`tests/policies/lerobot_local/test_vla_jepa.py` is the regression guard for "the generic
+`lerobot_local` path already carries a brand-new VLA": it forces a fresh import of
+`lerobot.policies.vla_jepa.processor_vla_jepa` so the `@ProcessorStepRegistry.register`
+decorators run again, then asserts `_register_policy_processor_steps` put VLA-JEPA's bespoke
+postprocessor steps back. To force that import it evicted the module from `sys.modules` and
+cleared the step names -- but it cleared three names where the module registers four, leaving
+`vla_jepa_image_prep` behind.
+
+LeRobot refuses a duplicate: `ProcessorStepRegistry.register` raises `ValueError: Processor step
+'<name>' is already registered`. `vla_jepa_image_prep` is the module's FIRST decorator, so the
+re-import died on its way in, the three later steps never registered, and the test failed with
+`KeyError: Processor step 'vla_jepa_clip_actions' not found in registry` -- reporting the
+registration path for a state the reset had created. Measured on lerobot 0.6.2: given a reset that
+covers all four names, `_register_policy_processor_steps("vla_jepa")` registers all four, so the
+path being graded was working the whole time.
+
+The guard therefore had teeth in neither direction. Its own skip guard calls `list_policy_types()`,
+which imports every policy config module and so imports the `vla_jepa` package, whose `__init__`
+imports the processor module -- meaning the survivor is always registered by the time the body
+runs. So the test fails wherever `vla_jepa` is registered, which is exactly where it is meant to
+have teeth, and skips wherever it is not.
+
+It also left the process worse than it found it. With the module absent from `sys.modules` and one
+of its names still registered, every later import of that module trips the same surviving name, so
+the module is un-importable for the remainder of the run: a probe that imports it after this file
+executes raises `ValueError: Processor step 'vla_jepa_image_prep' is already registered`, and it
+passes when run without this file. Any future test touching VLA-JEPA in the same session would
+have failed for a reason belonging here.
+
+The reset is now read off the module rather than listed -- every registry entry whose step class
+has that `__module__` -- so a step lerobot adds, renames or moves is covered with no edit here,
+which matters because a name the reset misses is a name the re-import cannot re-register. Registry
+entries and the `sys.modules` entry are both restored on exit, and the original step classes are
+put back rather than the new objects the fresh import built, so a reference another test already
+holds and the registry entry stay the same class.
+
+The assertions still concern the three postprocessor steps a checkpoint's
+`policy_postprocessor.json` names; a non-vacuity check now requires those three to be among the
+names the module owns, so an upstream rename fails here naming both sides instead of passing on an
+empty intersection. Two tests are added: one pinning that the registry and `sys.modules` are left
+as they were found, one pinning the surviving-name hazard as behaviour, so the reason the reset has
+to be total is carried by a test rather than by a comment.
+
+`test_sys_modules_removal_leaves_no_orphan` grades unrestored `sys.modules` removals, and it is
+right not to have flagged this one: its rule covers a removal that orphans a reference some test
+*patches*, and nothing patches this module. The harm here comes from the same unrestored removal by
+a different route -- the module's import has a side effect that is not idempotent -- so the
+restoration is carried in the file that does the removing.
+
+No runtime code changes: `git diff --name-only -- strands_robots/` against the merge base is empty.

--- a/tests/policies/lerobot_local/test_vla_jepa.py
+++ b/tests/policies/lerobot_local/test_vla_jepa.py
@@ -25,6 +25,11 @@ lerobot versions and skip cleanly on a lerobot too old to ship ``vla_jepa``.
 
 from __future__ import annotations
 
+import contextlib
+import importlib
+import sys
+from collections.abc import Iterator
+
 import pytest
 
 pytest.importorskip("lerobot")
@@ -37,16 +42,93 @@ from strands_robots.policies.lerobot_local.resolution import (  # noqa: E402
     resolve_policy_class_by_name,
 )
 
+# The module whose import is the only thing that registers VLA-JEPA's steps.
+_VLA_JEPA_PROCESSOR_MODULE = "lerobot.policies.vla_jepa.processor_vla_jepa"
+
 # The three bespoke postprocessor steps VLA-JEPA registers (see lerobot
 # ``policies/vla_jepa/processor_vla_jepa.py``). A checkpoint's
 # ``policy_postprocessor.json`` references these by registry name, so they must
 # be present after the type's processor module is imported or pipeline load
 # fails with ``KeyError: Processor step '...' not found in registry``.
+#
+# This is the set the assertions are ABOUT. It is deliberately not the set used
+# to reset the registry: that one is read off the module (see
+# ``_steps_owned_by``), because resetting a subset of what a module registers
+# leaves the module un-importable rather than merely unregistered.
 _VLA_JEPA_PROCESSOR_STEPS = (
     "vla_jepa_clip_actions",
     "vla_jepa_pre_snap_gripper",
     "vla_jepa_binarize_gripper",
 )
+
+
+def _steps_owned_by(module_name: str) -> dict[str, type]:
+    """Every registry entry whose step class was defined in ``module_name``.
+
+    Read off the live registry rather than listed, so a step lerobot adds,
+    renames or moves is picked up with no edit here. That matters because the
+    reset below has to cover ALL of them: a name it misses is a name the
+    re-import cannot re-register.
+    """
+    from lerobot.processor import ProcessorStepRegistry
+
+    importlib.import_module(module_name)
+    return {
+        name: cls
+        for name, cls in ProcessorStepRegistry._registry.items()
+        if getattr(cls, "__module__", None) == module_name
+    }
+
+
+@contextlib.contextmanager
+def _forced_reimport(module_name: str) -> Iterator[dict[str, type]]:
+    """Make ``module_name``'s registration side effect happen again, then undo it.
+
+    ``@ProcessorStepRegistry.register`` runs at class-definition time, so the
+    only way to observe a module registering its steps is to import it fresh:
+    evict it from ``sys.modules`` AND clear the names it owns.
+
+    Clearing the names is not optional and it is not partial. LeRobot's
+    ``ProcessorStepRegistry.register`` raises ``ValueError: Processor step
+    '<name>' is already registered`` for a duplicate, so an import that meets
+    one surviving name dies at that decorator -- leaving every step declared
+    after it unregistered, and leaving the module itself permanently
+    un-importable for the rest of the process (each later attempt trips the
+    same surviving name). That is a strictly worse state than the one the reset
+    was trying to create, and it is invisible to the caller because the module
+    is gone from ``sys.modules`` and the registry still looks populated.
+
+    Both halves are restored on the way out, so a session that runs these tests
+    is left exactly as it was found. ``test_sys_modules_removal_leaves_no_orphan``
+    grades an unrestored removal that orphans a *patched* reference; nothing
+    patches this module, so that rule reads a removal here as legal and the
+    restoration has to be carried here.
+
+    Yields:
+        The ``{registry name: step class}`` mapping the module owned on entry,
+        which is also the set the re-import is expected to restore.
+    """
+    from lerobot.processor import ProcessorStepRegistry
+
+    owned = _steps_owned_by(module_name)
+    saved_module = sys.modules.get(module_name)
+    try:
+        sys.modules.pop(module_name, None)
+        for name in owned:
+            ProcessorStepRegistry.unregister(name)
+        yield owned
+    finally:
+        # Restore the ORIGINAL step classes, not whatever the re-import left.
+        # A fresh import builds new class objects for the same names, so
+        # "leave it as found" means putting the entries that were there back --
+        # otherwise a reference another test already holds and the registry
+        # entry would be two different classes with the same name.
+        for name, cls in owned.items():
+            if name in ProcessorStepRegistry._registry:
+                ProcessorStepRegistry.unregister(name)
+            ProcessorStepRegistry.register(name=name)(cls)
+        if saved_module is not None:
+            sys.modules[module_name] = saved_module
 
 
 def _require_vla_jepa_registered() -> None:
@@ -117,34 +199,84 @@ def test_vla_jepa_processor_steps_register_via_strands_path() -> None:
 
     Regression teeth for the generic import: ``_register_policy_processor_steps``
     is the only thing that imports ``processor_vla_jepa`` before a checkpoint's
-    postprocessor pipeline resolves its steps by name. Unregister the steps
-    first, then prove our call re-registers all three -- so a checkpoint whose
+    postprocessor pipeline resolves its steps by name. Clear the steps first,
+    then prove our call re-registers all three -- so a checkpoint whose
     ``policy_postprocessor.json`` lists ``vla_jepa_binarize_gripper`` loads
     instead of dying with ``KeyError`` from the registry.
     """
     _require_vla_jepa_registered()
-    import sys
-
     from lerobot.processor import ProcessorStepRegistry
 
-    # Start from a clean slate so the assertion proves OUR call did the
-    # registration, not a leftover import from an earlier test. The
-    # ``@ProcessorStepRegistry.register`` decorators only re-run on a fresh
-    # module import, so evict the cached module too -- otherwise
-    # ``_register_policy_processor_steps`` re-imports a cached module (a no-op)
-    # and the unregistered steps never come back.
-    sys.modules.pop("lerobot.policies.vla_jepa.processor_vla_jepa", None)
-    for name in _VLA_JEPA_PROCESSOR_STEPS:
-        try:
-            ProcessorStepRegistry.unregister(name)
-        except (KeyError, ValueError):
-            pass  # not registered yet -- fine
+    with _forced_reimport(_VLA_JEPA_PROCESSOR_MODULE) as owned:
+        # Non-vacuity: the named steps must be among the ones this module owns,
+        # or the assertions below grade nothing. A rename upstream fails here,
+        # naming both sides, instead of passing on an empty intersection.
+        missing = sorted(set(_VLA_JEPA_PROCESSOR_STEPS) - set(owned))
+        assert not missing, (
+            f"{_VLA_JEPA_PROCESSOR_MODULE} no longer registers {missing}; "
+            f"it registers {sorted(owned)}. Update _VLA_JEPA_PROCESSOR_STEPS."
+        )
 
-    _register_policy_processor_steps("vla_jepa")
+        _register_policy_processor_steps("vla_jepa")
 
-    for name in _VLA_JEPA_PROCESSOR_STEPS:
-        step_cls = ProcessorStepRegistry.get(name)
-        assert isinstance(step_cls, type), f"{name} did not register to a class"
+        for name in _VLA_JEPA_PROCESSOR_STEPS:
+            step_cls = ProcessorStepRegistry.get(name)
+            assert isinstance(step_cls, type), f"{name} did not register to a class"
+
+
+def test_forced_reimport_leaves_the_registry_and_sys_modules_as_found() -> None:
+    """The reset used above puts the world back, so a sibling test is unaffected.
+
+    The registration test is the only place in the suite that evicts a lerobot
+    module to re-run its side effect. If it leaked, every later test in the same
+    process that touches VLA-JEPA would fail for a reason belonging to this
+    file, so the restoration is pinned rather than assumed.
+    """
+    _require_vla_jepa_registered()
+    from lerobot.processor import ProcessorStepRegistry
+
+    before = dict(ProcessorStepRegistry._registry)
+    before_module = sys.modules.get(_VLA_JEPA_PROCESSOR_MODULE)
+
+    with _forced_reimport(_VLA_JEPA_PROCESSOR_MODULE) as owned:
+        assert owned, "nothing owned -- the reset would be measuring nothing"
+        # Premise: inside the block the steps really are gone, so the exit
+        # restoration below is doing work rather than observing a no-op.
+        assert not set(owned) & set(ProcessorStepRegistry._registry)
+        _register_policy_processor_steps("vla_jepa")
+
+    assert dict(ProcessorStepRegistry._registry) == before
+    assert sys.modules.get(_VLA_JEPA_PROCESSOR_MODULE) is before_module
+    # And the module is still importable: the surviving-name hazard below would
+    # make this raise.
+    importlib.import_module(_VLA_JEPA_PROCESSOR_MODULE)
+
+
+def test_clearing_only_some_of_a_modules_steps_makes_it_unimportable() -> None:
+    """Why the reset clears every step the module owns, not just the named ones.
+
+    Pins the hazard as behaviour: evict the module but leave ONE of its steps
+    registered, and the re-import dies on that step's decorator. The module is
+    then absent from ``sys.modules`` and un-importable for the rest of the
+    process, and every step declared after the survivor stays unregistered --
+    which surfaces later as ``KeyError: Processor step '...' not found in
+    registry``, naming a step rather than this cause.
+    """
+    _require_vla_jepa_registered()
+    from lerobot.processor import ProcessorStepRegistry
+
+    with _forced_reimport(_VLA_JEPA_PROCESSOR_MODULE) as owned:
+        assert len(owned) > 1, "need at least two steps to leave one behind"
+        survivor, survivor_cls = next(iter(owned.items()))
+        ProcessorStepRegistry.register(name=survivor)(survivor_cls)
+
+        with pytest.raises(ValueError, match=f"'{survivor}' is already registered"):
+            importlib.import_module(_VLA_JEPA_PROCESSOR_MODULE)
+
+        # Best-effort registration swallows that ValueError, so the caller is
+        # handed a registry still missing every other step.
+        _register_policy_processor_steps("vla_jepa")
+        assert set(owned) - {survivor} - set(ProcessorStepRegistry._registry)
 
 
 def test_vla_jepa_registered_type_resolution_is_well_behaved() -> None:


### PR DESCRIPTION
## Problem

`tests/policies/lerobot_local/test_vla_jepa.py::test_vla_jepa_processor_steps_register_via_strands_path`
is the regression guard for "the generic `lerobot_local` path already carries a brand-new VLA". It
forces a fresh import of `lerobot.policies.vla_jepa.processor_vla_jepa` so its
`@ProcessorStepRegistry.register` decorators run again, then asserts
`_register_policy_processor_steps` put VLA-JEPA's bespoke postprocessor steps back.

To force that import it evicted the module from `sys.modules` and cleared the step names. It
cleared **three** names; the module registers **four**:

| line in `processor_vla_jepa.py` | registry name | cleared by the reset |
|---|---|---|
| 43 | `vla_jepa_image_prep` | no |
| 103 | `vla_jepa_clip_actions` | yes |
| 118 | `vla_jepa_pre_snap_gripper` | yes |
| 151 | `vla_jepa_binarize_gripper` | yes |

LeRobot refuses a duplicate: `ProcessorStepRegistry.register` raises `ValueError: Processor step
'<name>' is already registered`. `vla_jepa_image_prep` is the module's **first** decorator, so the
re-import died on its way in, the three later steps never registered, and the test failed with
`KeyError: Processor step 'vla_jepa_clip_actions' not found in registry` plus a list of 58
unrelated step names -- reporting the registration path for a state the reset had created.

The path being graded was working the whole time. Measured against lerobot 0.6.2, in a fresh
process, with a reset that covers all four names:

```
_register_policy_processor_steps("vla_jepa")
-> ['vla_jepa_binarize_gripper', 'vla_jepa_clip_actions',
    'vla_jepa_image_prep', 'vla_jepa_pre_snap_gripper']
```

## The guard had teeth in neither direction

Its own skip guard calls `list_policy_types()`, which imports every policy config module and so
imports the `vla_jepa` package, whose `__init__` imports the processor module. The survivor is
therefore always registered by the time the body runs -- so the test fails wherever `vla_jepa` is
registered, which is exactly where it is meant to have teeth, and skips wherever it is not. It
fails when run as the only selected node id (`1 failed`), so this is not an ordering effect.

`vla_jepa` ships in the released lerobot as well as on `main`: `git ls-tree` counts 8 files under
`src/lerobot/policies/vla_jepa` at both `v0.6.0` and `v0.6.1`, and `uv.lock` pins `lerobot 0.6.1`.

## It also left the process un-importable

With the module absent from `sys.modules` and one of its names still registered, every later
import of that module trips the same surviving name. A probe that simply imports it, run in the
same session:

| selection | probe result |
|---|---|
| probe alone | `1 passed` |
| `test_vla_jepa.py` then probe | `2 failed` -- probe raises `ValueError: Processor step 'vla_jepa_image_prep' is already registered` |
| `test_vla_jepa.py` (this branch) then probe | `8 passed` |

So any future test touching VLA-JEPA in the same session would have failed for a reason belonging
to this file. The probe is evidence, not shipped -- the equivalent guard ships as
`test_forced_reimport_leaves_the_registry_and_sys_modules_as_found`.

`test_sys_modules_removal_leaves_no_orphan` grades unrestored `sys.modules` removals, and it is
right not to have flagged this one: its rule covers a removal that orphans a reference some test
*patches*, and nothing patches this module. The harm here arrives by a different route from the
same unrestored removal -- the module's import side effect is not idempotent -- so the restoration
is carried in the file that does the removing.

## Change

`_forced_reimport(module_name)` is a context manager that resets and restores:

- The set of names to clear is **read off the module** (every registry entry whose step class has
  that `__module__`) rather than listed, so a step lerobot adds, renames or moves is covered with
  no edit here. A name the reset misses is a name the re-import cannot re-register, which is what
  makes a derived inventory load-bearing rather than tidy.
- Registry entries and the `sys.modules` entry are both restored on exit, and the **original** step
  classes are put back rather than the new objects a fresh import builds, so a reference another
  test already holds and the registry entry stay the same class.

The assertions still concern the three postprocessor steps a checkpoint's
`policy_postprocessor.json` names. A non-vacuity check requires those three to be among the names
the module owns, so an upstream rename fails naming both sides instead of passing on an empty
intersection.

Two tests are added: one pinning that the registry and `sys.modules` are left as found, one pinning
the surviving-name hazard as behaviour, so the reason the reset has to be total is carried by a test
rather than by a comment.

## Pre-fix / post-fix

| selection | before | after |
|---|---|---|
| `test_vla_jepa.py` | `1 failed, 4 passed` | `7 passed` |
| the single registration node id | `1 failed` | `1 passed` |

## Break table

Each row mutates this branch and reports which tests fire. 7 mutations, 5 distinct firing sets.

| mutation | fires |
|---|---|
| reset clears only the 3 named steps (the shipped bug) | 3 -- registration, as-found, hazard |
| no restoration at all | 1 -- as-found |
| restore whatever the re-import left, not the originals | 1 -- as-found |
| clear the names but do not evict the module | 2 -- registration, hazard |
| hazard test forgets to leave a survivor registered | 1 -- hazard |
| `_steps_owned_by` does not import before reading | 0 |
| drop the non-vacuity rename guard | 0 |

Both zeros are explained rather than left as gaps:

- `_steps_owned_by`'s explicit import is defensive. Measured: `import lerobot.processor` does not
  cache the processor module, but `import lerobot.policies` does, and the module under test reaches
  the latter transitively -- so the module is always already imported here. The call is kept so the
  helper does not depend on an import happening elsewhere.
- The rename guard cannot fire while the named steps really are a subset of the owned ones. It is
  there for the upstream rename that would otherwise make the assertions grade an empty
  intersection, which is the failure mode this PR is fixing one level down.

The first row is the load-bearing one: the exact defect being fixed is now caught three ways.

## Gate

- `ruff check strands_robots tests tests_integ`: `All checks passed!`;
  `ruff format --check`: `1525 files already formatted`.
- `mypy strands_robots tests tests_integ`, branch vs a pristine `main` worktree, fresh cache dirs
  on both: **0 errors each**, message sets identical (`comm` empty both ways).
- Paired blast radius, 479 files (all of `tests/policies/lerobot_local`, plus every test that walks
  the tree with `ast`/`rglob`/`inspect.getsource`/`iter_modules`, plus every test mentioning
  `sys.modules`, `ProcessorStepRegistry`, `list_policy_types` or `_register_policy`), identical
  selection on both trees with the changed file excluded from each:
  **`6 failed, 20989 passed, 94 skipped` on BOTH**, failing-id sets identical, `comm` empty both
  ways. The 6 are host artifacts present on both trees: 2 needing `docker` on PATH, 4 arising from
  `rclpy`/DDS being importable locally.
- `changelog.d` fragment added; `scripts/check_changelog_fragment.py` clean, and the 304 changelog
  and tree-walking guard tests pass.

`git diff --name-only -- strands_robots/` against the merge base is **empty**: no runtime code
changes, which is also the strongest statement available that nothing else can regress.

## Live check

Because the subject is whether a policy's bespoke processor steps reach the registry, the same path
was exercised on a real checkpoint rather than only in the guard. Loading `lerobot/smolvla_base`
through `create_policy("lerobot_local", ...)` builds `ProcessorBridge(pre=6steps, post=2steps)`
with `smolvla_new_line_processor` registered -- the generic registration path landing a real
policy's bespoke step, end to end.

No visual artifact: the change touches no policy, simulation, rendering, recording or asset
behaviour. The evidence here is the registry state and the pass/fail tables above.
