### PR TITLE
fix(mesh): let a RosbridgeRobot command carry an operator decision

### DIFF
--- a/changelog.d/2705-rosbridge-command-operator-context.md
+++ b/changelog.d/2705-rosbridge-command-operator-context.md
@@ -1,0 +1,55 @@
+### Fixed: a `RosbridgeRobot` command can carry an operator's decision
+
+`use_rosbridge` gates a publish aimed at a safety-critical command surface, and `cmd_vel` is one.
+`RosbridgeRobot.drive` and `.stop` took no `tool_context` parameter and their two agent tools were
+not declared `@tool(context=True)`, so there was nothing for the gate to ask an operator with:
+every command this bridge sent to a blocklisted topic hit the gate's fail-closed branch. Measured
+against the real transport on the same `/cmd_vel`, with an operator standing by to approve:
+
+    RtpsRobot.stop(tool_context=ctx)  ->  success, 1 message published
+    RosbridgeRobot.stop()            ->  error, "No tool_context available for operator
+                                         approval", 0 published
+
+It was the only drive-owning class in the package with that gap - `RosBridgedRobot` and
+`RtpsRobot` inherit the threading from the shared mobile base, and `AckermannRosRobot`, which
+also owns its own `drive`/`stop`, threads it itself. The halt was the worst case: the one control
+the `tools` contract guarantees for anything that can start motion ("a caller that can start
+motion must be able to end it") was the one an operator who was present and willing could not
+authorise. The only remedies the bridge could offer were the blanket `BYPASS_TOOL_CONSENT` or a
+standing pre-approval, both of which give up the per-command decision the gate exists for.
+`drive`, `stop` and the trailing zero of a timed drive now forward the context, the trailing zero
+carrying the same one as the command it undoes - a zero that could not reach the gate would be
+refused on its own and leave the robot latched at the speed of a hold the operator did approve.
+
+The documentation said the opposite. `docs/rosbridge-integration.md` described the halt as
+`**stop() never gated** (this bridge only)`, repeated it in two comments of a runnable example
+(`# always publishes zero Twist, never gated`, `# single-shot, ungated`) and in a method table
+row, and `RosbridgeRobot.stop`'s own docstring read "Never gated on anything." A reader who
+believes that leaves `cmd_vel` out of `STRANDS_ROS2_COMMAND_ALLOW` and discovers in the field
+that the halt is refused - the unreachable-halt hazard, arriving through documentation. All four
+surfaces now state what is actually true of this bridge and every other: the halt needs no prior
+state and no enable handshake, and it is not exempt from a gate that is keyed on the command
+surface rather than on the payload. The shared mobile base already wrote that argument down; zero
+means "stationary" on a `Twist` but commands motion to the zero pose on a joint-command topic, so
+a payload-shaped carve-out could not be written correctly.
+
+`tests/test_use_ros_command_blocklist.py` exists to catch exactly this - it scans operator-facing
+prose for a clause that names the halt and denies it is gated, then grades the claim against the
+running gate. Its document list was three hardcoded files keyed on naming the pre-approval
+variable, and a per-transport integration page shows an operator how to drive `cmd_vel` without
+ever mentioning that variable, so the page carrying all three false claims sat outside everything
+the scan read. With the scan pointed at its old list and the prose left as it was, the guard
+passes: the blindness is the silence. The scanned set is now derived - a page qualifies when it
+names a blocklisted surface by the same final-segment rule the gate matches on - which takes it
+from 3 pages to 9 and pulls in every transport integration page. The narrow list is kept for the
+separate question it answers correctly, which pages document the variable itself, since its own
+non-vacuity check requires each entry to name it. This is the second hardcoded universe in this
+area to be derived after #2700 did the same for the drive-contract scope survey; the shape is a
+guard whose discovery signature is narrower than the thing it guards.
+
+A new `tests/mesh/test_rosbridge_robot_command_gate.py` is the fourth of four per-bridge gate
+suites, doubling the roslibpy client beneath the real `use_rosbridge` so the gate and the
+transport wiring both run unmodified. `tests/mesh/test_rosbridge_robot.py` could not have seen
+the defect: it patches the `use_rosbridge` symbol at the mesh boundary, which is the boundary the
+gate lives behind. Its structural half is derived over every drive-owning class, so a fifth
+mobile base fails it on arrival rather than shipping unapprovable.

--- a/docs/rosbridge-integration.md
+++ b/docs/rosbridge-integration.md
@@ -135,8 +135,8 @@ unclamped.
 ```python
 # Direct, programmatic control:
 robot.drive(linear=1.0, angular=0.0, duration=2.0)  # hold for 2 seconds
-robot.drive(linear=1.0)  # latch until stop() - single-shot, ungated
-robot.stop()  # always publishes zero Twist, never gated
+robot.drive(linear=1.0)  # latch until stop() - single-shot
+robot.stop()  # publishes zero Twist; gated like any cmd_vel publish
 pose = robot.get_pose()  # read one odometry sample
 scan = robot.get_scan()  # read one laser scan (error if no scan_topic)
 ```
@@ -164,14 +164,18 @@ scan = robot.get_scan()  # read one laser scan (error if no scan_topic)
   cannot leave the robot with a live velocity. This was previously this bridge's
   alone; the ROS 2 and RTPS bridges inherit it from the shared mobile base now,
   so a timed drive self-stops on all three.
-- **stop() never gated** (this bridge only): the stop method always publishes a
-  zero Twist, regardless of prior state or publish failures. On the ROS 2 bridge
-  the halt goes through the same operator gate as `drive()`.
+- **stop() needs no prior state**: the stop method publishes a zero Twist
+  regardless of whether an earlier command succeeded, and there is no enable
+  handshake to satisfy first. It is *not* exempt from the operator gate: that
+  gate is keyed on the command surface rather than on the payload, so a halt to
+  a blocklisted `cmd_vel` is approved exactly like a full-speed drive on every
+  mobile base, this one included. Pre-approve the topic with
+  `STRANDS_ROS2_COMMAND_ALLOW` if the halt must go out unattended.
 
 | Method | ROS action | Notes |
 |--------|------------|-------|
 | `drive(linear, angular, duration=, count=)` | publish `Twist` to `cmd_vel_topic` | `duration` holds the command at `publish_rate` Hz; no `duration` latches until stop |
-| `stop()` | publish zero `Twist` | never gated on anything |
+| `stop()` | publish zero `Twist` | needs no prior state; gated on the surface like `drive()` |
 | `get_pose()` | echo `odom_topic` | returns up to 1 sample |
 | `get_scan()` | echo `scan_topic` | error when no `scan_topic` configured |
 | `.tools` | - | per-instance named agent tools |

--- a/strands_robots/mesh/rosbridge_robot.py
+++ b/strands_robots/mesh/rosbridge_robot.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Any
 
 from strands import tool
-from strands.types.tools import AgentTool
+from strands.types.tools import AgentTool, ToolContext
 
 from strands_robots.mesh.ros_bridge import _check_topic
 from strands_robots.tools.use_rosbridge import _HOST_RE, _transport_port_error, use_rosbridge
@@ -163,7 +163,29 @@ class RosbridgeRobot:
     def _error(text: str) -> dict[str, Any]:
         return {"status": "error", "content": [{"text": text}]}
 
-    def _publish_twist(self, linear: float, angular: float, count: int) -> dict[str, Any]:
+    def _publish_twist(
+        self,
+        linear: float,
+        angular: float,
+        count: int,
+        tool_context: ToolContext | None = None,
+    ) -> dict[str, Any]:
+        """Publish ``count`` Twist messages, carrying the operator context.
+
+        ``use_rosbridge`` gates a publish aimed at a safety-critical command
+        surface, and ``cmd_vel`` is one, so the context has to reach it: without
+        one the gate has nothing to ask an operator with and fails closed on
+        every command this robot sends.
+
+        Args:
+            linear: Linear velocity for ``linear.x``.
+            angular: Angular velocity for ``angular.z``.
+            count: Number of messages to publish.
+            tool_context: Operator context forwarded to the transport.
+
+        Returns:
+            The ``use_rosbridge`` publish result dict.
+        """
         return use_rosbridge(
             action="publish",
             host=self.host,
@@ -173,6 +195,7 @@ class RosbridgeRobot:
             fields={"linear": {"x": float(linear)}, "angular": {"z": float(angular)}},
             count=count,
             rate=self.publish_rate,
+            tool_context=tool_context,
         )
 
     def drive(
@@ -181,6 +204,7 @@ class RosbridgeRobot:
         angular: float = 0.0,
         duration: float | None = None,
         count: int = 1,
+        tool_context: ToolContext | None = None,
     ) -> dict[str, Any]:
         """Publish a velocity command over rosbridge.
 
@@ -224,6 +248,11 @@ class RosbridgeRobot:
                 Must be a positive whole number; ``0`` or a negative count
                 publishes nothing, so reporting a successful drive for it hides
                 a command that never left the process.
+            tool_context: Operator context forwarded to ``use_rosbridge``, whose
+                gate prompts before a publish to a safety-critical command
+                surface. Without it the gate fails closed, so a command this
+                bridge could otherwise have carried is refused with no operator
+                ever asked.
 
         Returns:
             The ``use_rosbridge`` publish result dict, or an
@@ -265,14 +294,33 @@ class RosbridgeRobot:
         # publish period still means "send the command once".
         n = max(1, round(duration * self.publish_rate)) if duration is not None else count
         try:
-            return self._publish_twist(v, w, count=n)
+            return self._publish_twist(v, w, count=n, tool_context=tool_context)
         finally:
+            # The trailing zero carries the same context as the command it
+            # undoes: one that could not reach the gate would be refused on its
+            # own and leave the robot latched at the speed of an approved hold.
             if (duration is not None or n > 1) and (v or w):
-                self._publish_twist(0.0, 0.0, count=1)
+                self._publish_twist(0.0, 0.0, count=1, tool_context=tool_context)
 
-    def stop(self) -> dict[str, Any]:
-        """Publish a single zero Twist. Never gated on anything."""
-        return self._publish_twist(0.0, 0.0, count=1)
+    def stop(self, tool_context: ToolContext | None = None) -> dict[str, Any]:
+        """Publish a single zero Twist.
+
+        Never gated on this bridge's own state: a halt does not depend on a
+        prior command having succeeded, and there is no enable handshake to
+        satisfy. It is not exempt from the transport tool's command gate, which
+        is keyed on the surface rather than the payload - zero means
+        "stationary" on a ``Twist`` but commands motion to the zero pose on a
+        joint-command topic, so a payload-shaped carve-out could not be written
+        correctly. The halt stays reachable through the same approval path as
+        any other command instead, which is why it forwards the context.
+
+        Args:
+            tool_context: Operator context forwarded to ``use_rosbridge``.
+
+        Returns:
+            The ``use_rosbridge`` publish result dict.
+        """
+        return self._publish_twist(0.0, 0.0, count=1, tool_context=tool_context)
 
     def get_pose(self, timeout: float = 5.0) -> dict[str, Any]:
         """Read one odometry/pose sample from ``odom_topic``."""
@@ -302,7 +350,14 @@ class RosbridgeRobot:
 
     @property
     def tools(self) -> list[AgentTool]:
-        """This robot's capabilities as named strands agent tools."""
+        """This robot's capabilities as named strands agent tools.
+
+        The two tools that carry a command are declared ``@tool(context=True)``
+        and forward the injected context to :meth:`drive` and :meth:`stop`, so a
+        publish to a gated ``cmd_vel`` prompts the operator instead of failing
+        closed on every call. The read-only tools take no context because a read
+        is never gated.
+        """
         suffix = self.node_name.strip("/").replace("/", "_")
 
         @tool(
@@ -313,13 +368,23 @@ class RosbridgeRobot:
                 "duration s). A command with duration stops automatically afterwards; "
                 "without duration the last command latches until stop."
             ),
+            context=True,
         )
-        def drive(linear: float = 0.0, angular: float = 0.0, duration: float | None = None) -> dict[str, Any]:
-            return self.drive(linear=linear, angular=angular, duration=duration)
+        def drive(
+            linear: float = 0.0,
+            angular: float = 0.0,
+            duration: float | None = None,
+            tool_context: ToolContext | None = None,
+        ) -> dict[str, Any]:
+            return self.drive(linear=linear, angular=angular, duration=duration, tool_context=tool_context)
 
-        @tool(name=f"stop_{suffix}", description=f"Immediately stop the {self.node_name} robot.")
-        def stop() -> dict[str, Any]:
-            return self.stop()
+        @tool(
+            name=f"stop_{suffix}",
+            description=f"Immediately stop the {self.node_name} robot.",
+            context=True,
+        )
+        def stop(tool_context: ToolContext | None = None) -> dict[str, Any]:
+            return self.stop(tool_context=tool_context)
 
         @tool(name=f"get_pose_{suffix}", description=f"Read the current odometry/pose of the {self.node_name} robot.")
         def get_pose() -> dict[str, Any]:

--- a/tests/mesh/test_rosbridge_robot_command_gate.py
+++ b/tests/mesh/test_rosbridge_robot_command_gate.py
@@ -1,0 +1,405 @@
+"""A :class:`RosbridgeRobot` command must reach the ``use_rosbridge`` operator gate.
+
+The fourth of four. ``tests/mesh/test_ros_bridge_command_gate.py``,
+``tests/mesh/test_rtps_robot_command_gate.py`` and
+``tests/mesh/test_ackermann_command_gate.py`` each pin that their bridge's
+commands reach the shared operator gate of
+:mod:`strands_robots.tools._command_gate`; the rosbridge bridge had no such
+suite, and it was the one class that could not carry an operator's decision at
+all. Measured against the real ``use_rosbridge`` with an operator standing by to
+approve, on the same blocklisted ``/cmd_vel`` surface::
+
+    RtpsRobot.stop(tool_context=ctx)       -> success, 1 message published
+    RosbridgeRobot.stop()                  -> error, "No tool_context available
+                                              for operator approval", 0 published
+
+``RosbridgeRobot.drive`` and ``.stop`` took no ``tool_context`` parameter and its
+two commanding agent tools were not declared ``@tool(context=True)``, so there
+was nothing for the gate to ask with: every command this bridge sent to a
+blocklisted surface failed closed, and the only remedy it could offer was the
+blanket ``BYPASS_TOOL_CONSENT`` or a standing pre-approval. The halt was the
+worst case - the one control the ``tools`` contract guarantees ("a caller that
+can start motion must be able to end it") was the one an operator present and
+willing could not authorise.
+
+``tests/mesh/test_rosbridge_robot.py`` cannot see any of that: it patches the
+``use_rosbridge`` symbol at the mesh boundary, which is the boundary the gate
+lives behind. These tests keep the real ``use_rosbridge`` and double the roslibpy
+WebSocket client beneath it instead - the same boundary
+``tests/tools/test_use_rosbridge.py`` doubles - so the gate and the transport
+wiring both run unmodified while nothing reaches a real rosbridge server.
+
+The structural half is derived over every drive-owning class rather than listed,
+because "a command can carry an operator's decision" is a fleet property: a
+fifth mobile base fails it on arrival instead of shipping unapprovable the way
+this one did. ``tests/mesh/test_mobile_base.py`` grades only the classes that
+inherit the shared base, which is exactly why it never covered this one.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import pathlib
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import strands_robots.mesh as mesh_pkg
+import strands_robots.tools.use_rosbridge as rb_mod
+from strands_robots.mesh import RosbridgeRobot
+
+# ``/turtle1/cmd_vel`` matches the ``/cmd_vel`` blocklist entry on the
+# final-segment rule, so every command a robot on it sends is gated - which is
+# what makes it the right topic to measure the gate with.
+_BLOCKED_CMD_VEL = "/turtle1/cmd_vel"
+# Not a blocklisted surface, so a command to it must never prompt. The control
+# that keeps every assertion below about the gate rather than about publishing.
+_UNBLOCKED_CMD_VEL = "/rover/waypoint_request"
+
+_ZERO_TWIST = {"linear": {"x": 0.0}, "angular": {"z": 0.0}}
+
+
+class _FakeTopic:
+    """Records advertise/publish/subscribe against a doubled rosbridge client."""
+
+    def __init__(self, ros: _FakeRos, name: str, message_type: str) -> None:
+        self.ros, self.name, self.message_type = ros, name, message_type
+        ros.topics.append(self)
+
+    def advertise(self) -> None:
+        pass
+
+    def unadvertise(self) -> None:
+        pass
+
+    def publish(self, message: dict[str, Any]) -> None:
+        self.ros.published.append((self.name, dict(message)))
+
+    def subscribe(self, callback: Any) -> None:
+        for sample in self.ros.samples.get(self.name, []):
+            callback(sample)
+
+    def unsubscribe(self) -> None:
+        pass
+
+
+class _FakeRos:
+    """A roslibpy client double that connects and records what was published."""
+
+    def __init__(self, host: str | None = None, port: int | None = None) -> None:
+        self.host, self.port = host, port
+        self.is_connected = False
+        self.topics: list[_FakeTopic] = []
+        self.published: list[tuple[str, dict[str, Any]]] = []
+        self.samples: dict[str, list[dict[str, Any]]] = {}
+        _FakeRos.instances.append(self)
+
+    instances: list[_FakeRos] = []
+
+    def run(self, timeout: float | None = None) -> None:
+        self.is_connected = True
+
+
+def _install_doubles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand the roslibpy client down for one test, with no ambient pre-approval.
+
+    Both gate env vars short-circuit the operator prompt, so an ambient
+    ``BYPASS_TOOL_CONSENT`` - common in agent and automation shells - would make
+    every assertion here pass without the gate ever running.
+    """
+    monkeypatch.delenv("BYPASS_TOOL_CONSENT", raising=False)
+    monkeypatch.delenv("STRANDS_ROS2_COMMAND_ALLOW", raising=False)
+    _FakeRos.instances = []
+    module = types.ModuleType("roslibpy")
+    module.Ros = _FakeRos  # type: ignore[attr-defined]
+    module.Topic = _FakeTopic  # type: ignore[attr-defined]
+    module.Message = dict  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "roslibpy", module)
+    monkeypatch.setattr(rb_mod._backend, "_available", None)
+    monkeypatch.setattr(rb_mod._backend, "_connections", {})
+    # publish sleeps for the advertise settle and for the inter-message period.
+    monkeypatch.setattr(rb_mod.time, "sleep", lambda *_: None)
+
+
+def _published() -> list[tuple[str, dict[str, Any]]]:
+    return [entry for ros in _FakeRos.instances for entry in ros.published]
+
+
+def _texts(result: dict[str, Any]) -> str:
+    return " ".join(block.get("text", "") for block in result["content"])
+
+
+def _turtle(topic: str = _BLOCKED_CMD_VEL, **kwargs: Any) -> RosbridgeRobot:
+    # ``odom_type`` is declared so a read needs no rosapi type lookup: the read
+    # cases here are about whether the gate is consulted, not about resolution.
+    kwargs.setdefault("odom_type", "nav_msgs/Odometry")
+    return RosbridgeRobot(node_name="turtlesim", cmd_vel_topic=topic, odom_topic="/odom", **kwargs)
+
+
+def _tool(robot: RosbridgeRobot, name: str) -> Any:
+    return next(agent_tool for agent_tool in robot.tools if agent_tool.tool_name == name)
+
+
+def _approving() -> MagicMock:
+    context = MagicMock()
+    context.interrupt.return_value = "y"
+    return context
+
+
+class TestRosbridgeCommandsReachTheGate:
+    """The robot's agent tools must prompt the operator, not refuse outright."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_doubles(monkeypatch)
+
+    def test_stop_tool_halts_the_robot_once_the_operator_approves(self) -> None:
+        """The headline: the halt is gated, so it has to be reachable.
+
+        A bridge that cannot forward an operator context turns ``stop`` into an
+        unconditional refusal, removing the one control the ``tools`` contract
+        guarantees for anything that can start motion.
+        """
+        context = _approving()
+        result = _tool(_turtle(), "stop_turtlesim")(tool_context=context)
+        assert context.interrupt.called, "the stop tool never reached the operator gate"
+        assert context.interrupt.call_args[1]["reason"]["target"] == _BLOCKED_CMD_VEL
+        assert context.interrupt.call_args[1]["reason"]["action"] == "publish"
+        assert result["status"] == "success"
+        assert _published() == [(_BLOCKED_CMD_VEL, _ZERO_TWIST)]
+
+    def test_stop_tool_declined_publishes_nothing(self) -> None:
+        context = MagicMock()
+        context.interrupt.return_value = "n"
+        result = _tool(_turtle(), "stop_turtlesim")(tool_context=context)
+        assert result["status"] == "error"
+        assert "declined by the operator" in _texts(result)
+        assert _published() == []
+
+    def test_drive_tool_prompts_the_operator_and_publishes_on_approval(self) -> None:
+        context = _approving()
+        result = _tool(_turtle(), "drive_turtlesim")(linear=1.0, tool_context=context)
+        assert context.interrupt.called, "the drive tool never reached the operator gate"
+        assert result["status"] == "success"
+        assert _published() == [(_BLOCKED_CMD_VEL, {"linear": {"x": 1.0}, "angular": {"z": 0.0}})]
+
+    def test_drive_tool_declined_publishes_nothing(self) -> None:
+        context = MagicMock()
+        context.interrupt.return_value = "n"
+        result = _tool(_turtle(), "drive_turtlesim")(linear=1.0, tool_context=context)
+        assert result["status"] == "error"
+        assert "declined by the operator" in _texts(result)
+        assert _published() == []
+
+    def test_the_trailing_zero_of_a_timed_drive_reaches_the_same_operator(self) -> None:
+        """A timed drive owns its own stop, and that stop is gated too.
+
+        The trailing zero is a second publish to the same blocklisted surface, so
+        it needs its own approval. One that could not reach the gate would leave
+        the robot latched at the speed of a hold the operator did approve.
+        """
+        context = _approving()
+        robot = _turtle(publish_rate=2.0)
+        result = _tool(robot, "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert result["status"] == "success"
+        # Two prompts: one for the hold, one for the trailing zero that ends it.
+        assert context.interrupt.call_count == 2
+        # round(1.0 * 2.0) held messages, then a single zero.
+        published = _published()
+        assert len(published) == 3
+        assert published[0][1]["linear"]["x"] == 1.0
+        assert published[-1] == (_BLOCKED_CMD_VEL, _ZERO_TWIST)
+
+    def test_a_declined_hold_never_latches_a_velocity(self) -> None:
+        """Refusing the hold refuses the motion, and its undo has nothing to undo."""
+        context = MagicMock()
+        context.interrupt.return_value = "n"
+        result = _tool(_turtle(publish_rate=2.0), "drive_turtlesim")(linear=1.0, duration=1.0, tool_context=context)
+        assert result["status"] == "error"
+        assert _published() == []
+
+    def test_without_an_operator_the_refusal_names_both_ways_through(self) -> None:
+        """Fail-closed is correct with no operator - and must stay actionable.
+
+        This is what every command on this bridge used to do even with an
+        operator present, so the refusal is pinned as the no-context outcome
+        rather than as the bridge's behaviour.
+        """
+        result = _turtle().stop()
+        assert result["status"] == "error"
+        text = _texts(result)
+        assert "No tool_context available for operator approval" in text
+        assert "STRANDS_ROS2_COMMAND_ALLOW" in text and "BYPASS_TOOL_CONSENT" in text
+        assert _published() == []
+
+    def test_carrying_a_context_does_not_start_gating_an_unblocked_surface(self) -> None:
+        """Over-reach guard: the new parameter must not widen what is gated.
+
+        Forwarding a context has to leave the gate's own rule alone - it is keyed
+        on the surface, so a command to a topic the blocklist does not name still
+        goes out with no operator asked.
+        """
+        context = _approving()
+        result = _tool(_turtle(topic=_UNBLOCKED_CMD_VEL), "stop_turtlesim")(tool_context=context)
+        assert not context.interrupt.called, "an unblocked surface reached the operator gate"
+        assert result["status"] == "success"
+        assert _published() == [(_UNBLOCKED_CMD_VEL, _ZERO_TWIST)]
+
+    def test_a_pre_approved_surface_publishes_without_asking(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STRANDS_ROS2_COMMAND_ALLOW", "/cmd_vel")
+        context = _approving()
+        result = _turtle().stop(tool_context=context)
+        assert result["status"] == "success"
+        assert not context.interrupt.called, "a pre-approved surface still prompted"
+        assert _published() == [(_BLOCKED_CMD_VEL, _ZERO_TWIST)]
+
+
+class TestOnlyCommandsToABlockedSurfaceAreGated:
+    """Controls, valid before and after the fix: reads and unblocked surfaces.
+
+    None of these needs an operator context, which is what makes them controls:
+    they hold identically on a bridge that cannot carry one, so a failure here
+    means the gate's own rule moved rather than this bridge's wiring.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _hermetic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_doubles(monkeypatch)
+
+    def test_a_command_to_an_unblocked_surface_needs_no_context_at_all(self) -> None:
+        """The gate, not the transport, is what a missing context costs."""
+        result = _turtle(topic=_UNBLOCKED_CMD_VEL).stop()
+        assert result["status"] == "success"
+        assert _published() == [(_UNBLOCKED_CMD_VEL, _ZERO_TWIST)]
+
+    def test_reading_a_pose_never_prompts(self) -> None:
+        robot = _turtle()
+        result = robot.get_pose(timeout=0.01)
+        assert result["status"] == "success"
+        assert _published() == [], "a read published to the command surface"
+
+    def test_the_read_tools_take_no_operator_context(self) -> None:
+        """A read is never gated, so its tool must not ask for a decision."""
+        read_tool = _tool(_turtle(), "get_pose_turtlesim")
+        assert "tool_context" not in read_tool.tool_spec["inputSchema"]["json"].get("properties", {})
+
+
+def _drive_owning_classes() -> list[type]:
+    """Every shipped mobile base, derived from the public mesh modules.
+
+    A class that owns ``drive`` and lives in a public module of
+    ``strands_robots.mesh`` is a shipped platform bridge. Derived rather than
+    listed so a fifth one is graded on arrival; the ``_``-prefixed modules are
+    skipped because a shared base declares a contract but is not a platform
+    anyone drives.
+    """
+    package_dir = pathlib.Path(mesh_pkg.__file__).parent
+    owners: list[type] = []
+    for path in sorted(package_dir.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"strands_robots.mesh.{path.stem}")
+        owners.extend(
+            candidate
+            for candidate in vars(module).values()
+            if isinstance(candidate, type)
+            and candidate.__module__ == module.__name__
+            and callable(getattr(candidate, "drive", None))
+        )
+    return owners
+
+
+_COMMANDING_METHODS = ("drive", "stop")
+
+
+class TestEveryMobileBaseCanCarryAnOperatorDecision:
+    """Fleet-wide: a command surface an operator cannot answer for is unusable.
+
+    Both halves of the path are graded, because either one alone lets the
+    reported defect back in: the method has to accept a context, and the agent
+    tool that calls it has to be declared with one to receive it.
+    """
+
+    def test_the_survey_finds_the_bridges_it_is_meant_to_cover(self) -> None:
+        """Non-vacuity: an empty or one-class survey would assert nothing."""
+        names = {owner.__name__ for owner in _drive_owning_classes()}
+        assert {"RosbridgeRobot", "RtpsRobot", "RosBridgedRobot", "AckermannRosRobot"} <= names, (
+            f"the drive-owner survey found only {sorted(names)}"
+        )
+
+    @pytest.mark.parametrize("method", _COMMANDING_METHODS)
+    def test_every_commanding_method_accepts_an_operator_context(self, method: str) -> None:
+        missing = [
+            owner.__name__
+            for owner in _drive_owning_classes()
+            if "tool_context" not in inspect.signature(getattr(owner, method)).parameters
+        ]
+        assert not missing, (
+            f"{missing} cannot carry an operator decision into {method}(), so every command they send "
+            "to a blocklisted surface fails closed even with an operator standing by"
+        )
+
+    def test_every_commanding_agent_tool_is_declared_with_the_context(self) -> None:
+        """The tool has to ask for the context, or the method never receives one.
+
+        ``tool_context`` is deliberately absent from a tool's input schema - the
+        runtime injects it rather than the model supplying it - so the wiring is
+        read from the source of the ``tools`` property, the same way the
+        per-bridge suites read their own. Those grade one bridge each; this
+        grades whichever set of bridges ships.
+        """
+        offenders: list[str] = []
+        for owner in _drive_owning_classes():
+            for func in _decorated_tools(_tools_property_ast(owner)):
+                if not _forwards_a_commanding_method(func):
+                    continue
+                decorator = next(dec for dec in func.decorator_list if isinstance(dec, ast.Call))
+                context_kwarg = next((kw for kw in decorator.keywords if kw.arg == "context"), None)
+                enabled = context_kwarg is not None and getattr(context_kwarg.value, "value", None) is True
+                params = [arg.arg for arg in func.args.args] + [arg.arg for arg in func.args.kwonlyargs]
+                forwards = any(
+                    kw.arg == "tool_context"
+                    for node in ast.walk(func)
+                    if isinstance(node, ast.Call)
+                    for kw in node.keywords
+                )
+                if not (enabled and "tool_context" in params and forwards):
+                    offenders.append(f"{owner.__name__}.{func.name}")
+        assert not offenders, (
+            f"{offenders} do not declare @tool(context=True), receive the injected context and forward it, "
+            "so an operator's decision can never reach the command they carry"
+        )
+
+
+def _tools_property_ast(owner: type) -> ast.Module:
+    """Parse the module that defines ``owner``'s ``tools`` property.
+
+    A bridge inherits ``tools`` from the shared mobile base or declares its own,
+    so the file to read is the one the property is defined in rather than the one
+    the class is named in.
+    """
+    source_file = inspect.getsourcefile(owner.tools.fget)  # type: ignore[attr-defined]
+    assert source_file is not None, f"cannot locate the source of {owner.__name__}.tools"
+    return ast.parse(pathlib.Path(source_file).read_text(encoding="utf-8"))
+
+
+def _decorated_tools(tree: ast.Module) -> list[ast.FunctionDef]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and any(isinstance(dec, ast.Call) and getattr(dec.func, "id", None) == "tool" for dec in node.decorator_list)
+    ]
+
+
+def _forwards_a_commanding_method(func: ast.FunctionDef) -> bool:
+    """Whether this tool closure calls one of the commanding methods."""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _COMMANDING_METHODS
+        for node in ast.walk(func)
+    )

--- a/tests/test_use_ros_command_blocklist.py
+++ b/tests/test_use_ros_command_blocklist.py
@@ -431,10 +431,13 @@ def test_the_blocklist_is_documented_where_operators_look() -> None:
     assert "STRANDS_ROS2_COMMAND_ALLOW" in text
 
 
-# Files an operator reads to decide what to pre-approve before a headless run.
-# The README Configuration table is the single source of truth for env vars, so a
-# wrong contract there is the one that gets scaffolded from.
-_OPERATOR_FACING_DOCS: tuple[str, ...] = (
+# Files that document the pre-approval variable itself, and so have to describe
+# its reach correctly. The README Configuration table is the single source of
+# truth for env vars, so a wrong contract there is the one that gets scaffolded
+# from. Every entry is required to name the variable by
+# ``test_the_sweep_reaches_every_operator_facing_surface``, which is what keeps
+# this list from going stale into a vacuous sweep.
+_ALLOWLIST_DOCS: tuple[str, ...] = (
     "README.md",
     "docs/ros2-integration.md",
     "docs/security.md",
@@ -499,7 +502,7 @@ def _surfaces_documenting_the_allowlist() -> list[tuple[str, str]]:
         ``(surface_label, text)`` pairs, text lowercased for phrase matching.
     """
     surfaces: list[tuple[str, str]] = []
-    for name in _OPERATOR_FACING_DOCS:
+    for name in _ALLOWLIST_DOCS:
         lines = [
             line
             for line in (_repo_root() / name).read_text(encoding="utf-8").splitlines()
@@ -542,10 +545,35 @@ def _measured_allowlist_reach() -> tuple[str, list[str]]:
     return ("base" if extra else "exact"), extra
 
 
+def _command_surface_docs() -> list[str]:
+    """Every prose page that makes claims about a surface the gate blocks.
+
+    Derived rather than listed, because the set an exemption can be written into
+    is not the set that documents the pre-approval variable. A per-transport
+    integration page shows an operator how to drive ``cmd_vel`` and describes
+    what that costs, without ever naming ``STRANDS_ROS2_COMMAND_ALLOW`` - so it
+    can claim the halt is ungated while sitting outside :data:`_ALLOWLIST_DOCS`,
+    and that is where the claim this scan exists to refuse was actually written.
+
+    A page qualifies when it names one of the blocklisted surfaces by its final
+    path segment, which is the same rule the gate matches on (see
+    :func:`~strands_robots.tools._command_gate.match_blocklist`): a page that
+    talks about a surface the gate blocks is a page whose gating claims an
+    operator will act on.
+
+    Returns:
+        Repository-relative paths, sorted, with ``README.md`` first.
+    """
+    root = _repo_root()
+    bare = {entry.rsplit("/", 1)[-1] for entry in gate_mod.COMMAND_BLOCKLIST}
+    pages = ["README.md"] + sorted(str(path.relative_to(root)) for path in (root / "docs").rglob("*.md"))
+    return [name for name in pages if any(surface in (root / name).read_text(encoding="utf-8") for surface in bare)]
+
+
 def _documented_halt_exemptions() -> list[tuple[str, int, str]]:
     """Every operator-facing clause asserting the halt is exempt from the gate."""
     found: list[tuple[str, int, str]] = []
-    for name in _OPERATOR_FACING_DOCS:
+    for name in _command_surface_docs():
         text = (_repo_root() / name).read_text(encoding="utf-8")
         for lineno, line in enumerate(text.splitlines(), 1):
             for clause in re.split(r"(?<=[.;])\s+|\s*\|\s*", line):
@@ -568,6 +596,13 @@ class TestTheDocumentedExemptionsAreTheRealOnes:
     The documented claims are graded against the running gate rather than banned
     outright, so a gate that one day does exempt a payload makes the claim
     permissible instead of failing here.
+
+    The pages scanned are derived (:func:`_command_surface_docs`) rather than
+    listed. A hardcoded list of three pages was what let the hazard through: the
+    per-transport integration page for the rosbridge bridge documented its halt
+    as "never gated" in three places - a bullet and two comments in a runnable
+    example - and was outside every page the scan looked at, because it never
+    names the pre-approval variable that list is keyed on.
     """
 
     calls: dict[str, list[tuple[Any, ...]]]
@@ -644,6 +679,34 @@ class TestTheDocumentedExemptionsAreTheRealOnes:
             f"the gate treats a zero-velocity halt to a blocklisted surface as {measured}, "
             f"but the operator-facing documentation describes it as {documented}.\n"
             f"clauses claiming an exemption:\n{detail}"
+        )
+
+    def test_the_scan_reaches_every_page_that_documents_a_blocked_surface(self) -> None:
+        """Non-vacuity: the derived set must be wider than the allowlist pages.
+
+        The scan is only worth running over the pages an exemption can be
+        written into. Two properties make that true and are asserted rather than
+        assumed: every page that documents the pre-approval variable is in the
+        set (it necessarily names a surface too), and the per-transport
+        integration pages - which document driving a blocked surface without
+        naming the variable - are in it as well. Those are exactly the pages a
+        variable-keyed list cannot reach.
+        """
+        scanned = set(_command_surface_docs())
+        assert set(_ALLOWLIST_DOCS) <= scanned, (
+            f"pages documenting {gate_mod.COMMAND_ALLOW_ENV} are missing from the scan: "
+            f"{sorted(set(_ALLOWLIST_DOCS) - scanned)}"
+        )
+        transport_pages = {
+            "docs/ros2-integration.md",
+            "docs/rosbridge-integration.md",
+            "docs/rtps-integration.md",
+        }
+        assert transport_pages <= scanned, (
+            f"transport integration pages outside the scan: {sorted(transport_pages - scanned)}"
+        )
+        assert scanned - set(_ALLOWLIST_DOCS), (
+            "the derived set is no wider than the allowlist pages, so deriving it buys nothing"
         )
 
     def test_the_documented_read_exemption_is_real(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -756,7 +819,7 @@ class TestTheDocumentedAllowlistReachIsTheRealReach:
     def test_the_sweep_reaches_every_operator_facing_surface(self) -> None:
         """Non-vacuity: a doc reflow that hides the variable must fail loudly."""
         labels = [label for label, _ in _surfaces_documenting_the_allowlist()]
-        assert set(_OPERATOR_FACING_DOCS) <= set(labels), (
+        assert set(_ALLOWLIST_DOCS) <= set(labels), (
             f"only {labels} document {gate_mod.COMMAND_ALLOW_ENV}; a clean sweep would prove nothing"
         )
         assert "gate_command docstring" in labels, "the gate helper stopped naming the variable it reads"


### PR DESCRIPTION
## Problem

`use_rosbridge` gates a publish aimed at a safety-critical command surface, and `cmd_vel` is one.
`RosbridgeRobot.drive` and `.stop` took no `tool_context` parameter, and their two agent tools were
not declared `@tool(context=True)` -- so there was nothing for the gate to ask an operator with, and
every command this bridge sent to a blocklisted topic hit the gate's fail-closed branch.

Measured against the real transport (roslibpy client doubled, backend reachable), same `/cmd_vel`,
operator standing by to approve:

| call | prompted | status | published |
| --- | --- | --- | --- |
| `RtpsRobot.stop(tool_context=ctx)` | yes | `success` | 1 |
| `RosbridgeRobot.stop()` | no | `error` -- `No tool_context available for operator approval` | 0 |

It was the only drive-owning class in the package with that gap:

| class | `drive`/`stop` accept a context | why |
| --- | --- | --- |
| `RosBridgedRobot` | yes | inherits `MobileBaseRobot` |
| `RtpsRobot` | yes | inherits `MobileBaseRobot` |
| `AckermannRosRobot` | yes | owns `drive`/`stop`, threads it itself |
| `RosbridgeRobot` | **no** | owns `drive`/`stop`, did not |

The halt was the worst case. The one control the `tools` contract guarantees for anything that can
start motion -- "a caller that can start motion must be able to end it" -- was the one an operator
who was present and willing could not authorise. The only remedies the bridge could offer were the
blanket `BYPASS_TOOL_CONSENT` or a standing pre-approval, both of which give up the per-command
decision the gate exists for.

### The documentation said the opposite

`docs/rosbridge-integration.md` described the halt as `**stop() never gated** (this bridge only)`,
repeated it in two comments of a runnable example (`# always publishes zero Twist, never gated`,
`# single-shot, ungated`) and in a method-table row, and `RosbridgeRobot.stop`'s own docstring read
"Never gated on anything." A reader who believes that leaves `cmd_vel` out of
`STRANDS_ROS2_COMMAND_ALLOW` and discovers in the field that the halt is refused -- the
unreachable-halt hazard, arriving through documentation rather than through code.

`tests/test_use_ros_command_blocklist.py` exists to catch precisely that: it scans operator-facing
prose for a clause naming the halt and denying it is gated, then grades the claim against the
running gate. Its document list was three hardcoded files, keyed on naming the pre-approval
variable. A per-transport integration page shows an operator how to drive `cmd_vel` without ever
mentioning that variable, so the page carrying all three false claims sat outside everything the
scan read.

## Change

- `RosbridgeRobot._publish_twist`, `drive` and `stop` take and forward `tool_context`; the two
  commanding tools are `@tool(context=True)`. The trailing zero of a timed drive carries the same
  context as the command it undoes -- a zero that could not reach the gate would be refused on its
  own and leave the robot latched at the speed of a hold the operator did approve.
- All four prose surfaces now state what is true of this bridge and every other: the halt needs no
  prior state and no enable handshake, and it is *not* exempt from a gate keyed on the command
  surface rather than on the payload. `MobileBaseRobot.stop` already wrote that argument down --
  zero means "stationary" on a `Twist` but commands motion to the zero pose on a joint-command
  topic, so a payload-shaped carve-out could not be written correctly.
- The exemption scan's document set is derived: a page qualifies when it names a blocklisted
  surface by the same final-segment rule the gate matches on. 3 pages -> 9, pulling in every
  transport integration page. The narrow list is kept under a name describing what it does answer
  correctly (which pages document the variable itself), because its own non-vacuity check requires
  each entry to name it.
- New `tests/mesh/test_rosbridge_robot_command_gate.py`: the fourth of four per-bridge gate suites,
  alongside those for the ROS 2, RTPS and Ackermann bridges.

`tests/mesh/test_rosbridge_robot.py` could not have caught this: it patches the `use_rosbridge`
symbol at the mesh boundary, which is the boundary the gate lives behind. The new suite doubles the
roslibpy client *beneath* the real tool, so the gate and the transport wiring both run unmodified
while nothing reaches a rosbridge server.

## Tests

Pre-fix split, both source files reverted and the tests kept: **12 failed / 113 passed**.
Post-fix: **125 passed**. By class:

| class | pre-fix failures |
| --- | --- |
| `TestRosbridgeCommandsReachTheGate` (regression) | 8 |
| `TestEveryMobileBaseCanCarryAnOperatorDecision` (regression) | 3 |
| `TestTheDocumentedExemptionsAreTheRealOnes` (the docs guard) | 1 |
| `TestOnlyCommandsToABlockedSurfaceAreGated` (controls) | 0 |

The derived survey's own non-vacuity test passes on both trees, so it is not counted as regression
evidence.

### Break table

Each mutation applied to the fixed tree; firing set over the two test files.

| mutation | fires | which |
| --- | --- | --- |
| `stop` drops the forward | 2 | both stop cases |
| `drive` main publish drops the forward | 3 | both drive cases + the timed drive |
| trailing zero drops the forward | 1 | the timed drive **alone** |
| `_publish_twist` drops it to the transport | 5 | every publish path |
| stop tool not `context=True` | 1 | the structural check |
| drive tool not `context=True` | 1 | the structural check |
| **scan reverted to the hardcoded list AND prose reverted** | **0** | -- |
| derived doc set narrowed to `README.md` | 1 | the scan's non-vacuity check |
| both source files reverted (the reported defect) | 12 | matches the pre-fix split exactly |

Eight distinct firing sets over nine rows. The two `context=True` rows coincide, and the reason is
structural: one test grades every commanding tool of every bridge, so it cannot distinguish which
tool lost the declaration.

The **0** row is the point. With the scan pointed at its old three-file list and the prose left as
it was, the guard passes -- the blindness is the silence, not a failure anyone could have read. The
trailing-zero row firing exactly one test is what shows that path is pinned independently of the
command it undoes.

### Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1529 files).
- mypy **24 == 24** against a pristine `upstream/main` worktree; normalised message sets
  byte-identical both ways, 0 in changed files.
- Paired run, identical 553-file selection (all of `tests/mesh`, all of `tests/tools`, and every
  test that walks the tree with `ast`/`rglob`/`inspect.getsource` or reads `docs/`), with the two
  changed test files excluded from **both** trees: `66 failed, 21909 passed, 100 skipped,
  150 errors` on the branch and `66 failed, 21907 passed, 100 skipped, 150 errors` on the base --
  **failing-ID and error-ID sets identical, all four `comm` directions empty**. Every error is a
  declared extra absent from this environment (`device_connect_edge` 326, `awsiot` 88).
- The +2 passed is fully localised to `tests/test_args_docstring_completeness.py` (432 vs 430),
  which parametrises over documented functions and picks up the two new `Args` entries.
- `tests/mesh/test_zenoh_transport_security.py` is excluded from the pair and run alone on each
  tree (`9 passed, 2 skipped` on both), because a parallel Zenoh session manufactures cross-talk
  failures.

No visual artifact: this changes transport gating and prose, not policy, simulation, rendering,
recording or an asset. The measured tables above are the artifact.
