### PR TITLE
fix(training): hold TrainSpec.save_freq to a whole number of steps

### DIFF
--- a/strands_robots/training/_validate.py
+++ b/strands_robots/training/_validate.py
@@ -120,6 +120,15 @@ because the two bounds have one domain for one reason - a clip bound is a
 positive width, and positive infinity is each field's only spelling of "do not
 clip". It is scoped like :func:`gae_lambda_problems`: ``spec.clip_param`` is read
 in ``rl/ppo.py`` and nowhere else.
+
+:func:`checkpoint_cadence_problems` is the fifteenth, on the *checkpointing*
+axis: ``save_freq``, the interval in optimizer steps at which a run writes a
+checkpoint. It is scoped like :func:`run_size_problems` - the three supervised
+backends and the SageMaker transport read it, the RL trainers never do - and it
+is the step count in the same argv as ``steps``, so it holds to the same
+``int`` requirement that gate applies. What it deliberately does not decide is
+the floor: a non-positive cadence is lerobot's documented spelling of "disable
+periodic saving", so only the type is graded.
 """
 
 from __future__ import annotations
@@ -1162,3 +1171,75 @@ def clip_range_problems(spec: TrainSpec, *, context: str) -> list[str]:
     """
     error = _clip_bound_error(getattr(spec, "clip_param", 0.2), "clip_param", context)
     return [error] if error is not None else []
+
+
+def checkpoint_cadence_problems(spec: TrainSpec, *, context: str) -> list[str]:
+    """Return checkpoint-cadence problems for a :class:`TrainSpec`.
+
+    ``save_freq`` is the interval, in optimizer steps, at which a run writes a
+    checkpoint. The backends that read it consume it in the same three shapes
+    :func:`launch_topology_problems` documents for a process count, and each one
+    fails silently or late:
+
+    * **A comparison selector.** The LeRobot backend derives the validation
+      cadence from it in two places - the ``--eval_steps=`` token on the argv
+      path and ``cfg.eval_steps`` on the in-process one - as ``spec.save_freq if
+      spec.save_freq > 0 else spec.steps``, because a non-positive cadence
+      disables periodic saving. ``nan`` compares false against everything, so it
+      takes that *disabled* branch: a spec asking to checkpoint every ``nan``
+      steps evaluates once at the very end instead, under a successful result.
+      ``True`` and ``inf`` are both greater than zero, so they pass through as
+      the cadence itself and reach an ``int`` field as a ``bool`` and a float.
+    * **An argv or override token.** ``--save_freq=`` (LeRobot),
+      ``--save_steps=`` (GR00T) and ``checkpoint.save_iter=`` (Cosmos) each
+      interpolate the value verbatim, so every spelling renders and fails, if at
+      all, inside the launched run once the dataset and model are already
+      loaded. LeRobot declares the field as a plain ``int``, so its own draccus
+      decoder refuses ``2.7`` and ``5000.0`` alike and ``True`` / ``nan`` /
+      ``inf`` as written.
+    * **An assignment into a typed config.** ``cfg.save_freq`` on LeRobot's
+      in-process path, ``save_steps`` in GR00T's ``FinetuneConfig`` kwargs and a
+      forwarded SageMaker hyperparameter - none of which coerces.
+
+    A string or ``None`` is worse than any of those: it raises ``TypeError`` out
+    of the comparison itself, from inside a :meth:`Trainer.validate` that is
+    documented to *return* problems.
+
+    Only a true ``int`` can be honored by all three shapes, so what is graded
+    here is the type, with the same strictness :func:`run_size_problems` applies
+    to ``steps``: an integral float is refused rather than coerced, because
+    ``save_freq`` is interpolated into the *same argv* as ``steps`` and read by
+    the same ``int`` decoder, and the same number cannot be refused for one step
+    count and accepted for the next. ``bool`` is rejected explicitly - it is an
+    ``int`` subclass, so a bare type test would admit ``True``, which renders as
+    the token ``True`` and is not decodable either.
+
+    **The floor is deliberately not part of this domain.** LeRobot documents a
+    non-positive ``save_freq`` as disabling periodic saving - its
+    ``should_save_checkpoint`` implements exactly that (``save_freq > 0 and step
+    % save_freq == 0``), avoiding a ``ZeroDivisionError`` from ``step % 0`` - and
+    the ``eval_steps`` fallback above is written for that case. So ``0`` and a
+    negative are a capability rather than an unusable value, and a *ceiling*
+    (a cadence above ``steps``, which writes only the final checkpoint) is a
+    legitimate configuration too. Neither endpoint is decided here.
+
+    Args:
+        spec: The spec to check.
+        context: Caller identity for the message prefix - the backend's
+            :attr:`~strands_robots.training.base.Trainer.provider_name`, so a
+            problem names the backend that refused the value.
+
+    Returns:
+        A single-element list when ``save_freq`` cannot be honored; empty
+        otherwise.
+    """
+    value = spec.save_freq
+    if isinstance(value, bool) or not isinstance(value, int):
+        return [
+            f"{context}: save_freq must be a whole number of steps, got {value!r}. "
+            "The cadence is decoded into an int field and compared against zero, "
+            "so a fractional, non-finite, boolean or non-numeric value cannot be "
+            "honored; pass a whole number of steps, or a non-positive one to "
+            "disable periodic saving."
+        ]
+    return []

--- a/strands_robots/training/base.py
+++ b/strands_robots/training/base.py
@@ -105,7 +105,20 @@ class TrainSpec:
             without updating a weight and ``inf`` writes a checkpoint of
             ``NaN``, neither of which any backend can report, so both are
             refused by :meth:`Trainer.validate` before a run starts.
-        save_freq: Checkpoint cadence in steps.
+        save_freq: Checkpoint cadence in optimizer steps. A whole number; a
+            non-positive value is LeRobot's documented spelling of "disable
+            periodic saving" (only the final checkpoint is written) and is
+            first-class here, so the floor is deliberately not part of the
+            domain. A fractional, non-finite, boolean or non-numeric cadence
+            cannot be honored by any of the three ways it is consumed - a
+            ``> 0`` selector that derives the validation cadence from it, an
+            ``--save_freq=`` / ``--save_steps=`` / ``checkpoint.save_iter=``
+            token decoded into an ``int`` field, and a direct assignment into a
+            typed config - so a backend that reads it MUST check it through
+            :meth:`Trainer._checkpoint_cadence_problems` rather than pass it on.
+            ``nan`` is the sharpest case: it compares false against everything,
+            so the selector reads it as *disabled* and the run evaluates once at
+            the end instead of at the cadence asked for.
         num_gpus: GPUs on this node. ``>1`` runs the backend under torch's
             in-process ``elastic_launch`` (the engine behind ``torchrun``).
             A positive integer; a non-positive, fractional, non-finite or
@@ -758,6 +771,51 @@ class Trainer(ABC):
         from strands_robots.training._validate import clip_range_problems
 
         return clip_range_problems(spec, context=self.provider_name)
+
+    def _checkpoint_cadence_problems(self, spec: TrainSpec) -> list[str]:
+        """Checkpoint-cadence preflight shared by every backend that reads it.
+
+        Returns a problem when :attr:`TrainSpec.save_freq` is not a whole number
+        of steps. A :meth:`validate` implementation that reads the field MUST
+        call this rather than interpolate the value: the cadence is consumed
+        three ways and each one fails silently or late. LeRobot derives the
+        validation cadence from it as ``save_freq if save_freq > 0 else steps``,
+        and because ``nan`` compares false against everything that selector
+        reads a ``nan`` cadence as *disabled* and evaluates once at the end
+        under a successful result; every backend also interpolates the value
+        verbatim into an argv or Hydra token whose ``int`` decoder refuses
+        ``2.7``, ``5000.0``, ``True``, ``nan`` and ``inf`` alike, but only once
+        the launched run has loaded its dataset and model; and a string or
+        ``None`` raises ``TypeError`` out of the comparison itself - from inside
+        a :meth:`validate` documented to *return* problems.
+
+        The floor is deliberately outside the domain: a non-positive cadence is
+        LeRobot's documented "disable periodic saving", implemented by its
+        ``should_save_checkpoint``, and the ``eval_steps`` fallback exists for
+        exactly that case. Only the type is graded, and with the same strictness
+        :meth:`_run_size_problems` applies to ``steps`` - the step count in the
+        same argv - so the same number cannot be refused for one and accepted
+        for the other.
+
+        A backend that does not read the field MUST NOT call this: per
+        :class:`TrainSpec` a backend ignores the fields it does not support, so
+        reporting on one it never reads would be a false rejection. That is why
+        this is scoped like :meth:`_run_size_problems` rather than like
+        :meth:`_learning_rate_problems`, which every backend does call.
+
+        Imported lazily for the same reason as :meth:`_security_problems` - to
+        keep the ``base -> _validate`` import one-way at runtime.
+
+        Args:
+            spec: The spec to preflight.
+
+        Returns:
+            A single-element list when ``save_freq`` cannot be honored; empty
+            otherwise.
+        """
+        from strands_robots.training._validate import checkpoint_cadence_problems
+
+        return checkpoint_cadence_problems(spec, context=self.provider_name)
 
     def prepare(self, spec: TrainSpec) -> None:
         """Optional one-time setup before :meth:`train`. Default no-op.

--- a/strands_robots/training/cosmos3.py
+++ b/strands_robots/training/cosmos3.py
@@ -129,7 +129,7 @@ class Cosmos3Trainer(Trainer):
         Runs the shared input-safety gate, then checks a LeRobotDataset v3
         ``dataset_root``, a ``base_model`` to convert to DCP, an
         ``output_dir``, a supported ``method``, a usable run size (``steps`` /
-        ``global_batch_size``), an
+        ``global_batch_size``), a whole-number checkpoint cadence (``save_freq``), an
         ``extra['sft_toml']`` recipe that exists, and a resolvable
         ``cosmos_framework`` checkout (COSMOS_ROOT / ``cosmos_root`` /
         ``extra['cosmos_root']``). Returns the problem list; empty means
@@ -155,6 +155,7 @@ class Cosmos3Trainer(Trainer):
                 f"unsupported method '{spec.method}' for Cosmos3 (expected one of {sorted(_SUPPORTED_METHODS)})"
             )
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
         problems.extend(self._seed_problems(spec))
         problems.extend(self._launch_topology_problems(spec))

--- a/strands_robots/training/groot.py
+++ b/strands_robots/training/groot.py
@@ -124,7 +124,8 @@ class Gr00tTrainer(Trainer):
         Runs the shared input-safety gate, then checks a LeRobotDataset v3
         ``dataset_root``, a ``base_model``, an ``output_dir``, a required
         ``embodiment`` tag, a supported ``method``, a usable run size (``steps``
-        / ``global_batch_size``), single-node only (``num_nodes == 1``), a
+        / ``global_batch_size``), a whole-number checkpoint cadence (``save_freq``), single-node only
+        (``num_nodes == 1``), a
         resolvable Isaac-GR00T
         checkout (GR00T_ROOT / ``groot_root`` / ``extra['groot_root']``),
         and an optional ``extra['modality_config_path']`` that exists.
@@ -154,6 +155,7 @@ class Gr00tTrainer(Trainer):
                 f"use tune={{...}} for fine-grained control"
             )
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
         # Captured rather than extended blind: the multi-node refusal below
         # compares num_nodes, which is only a meaningful comparison once this

--- a/strands_robots/training/lerobot.py
+++ b/strands_robots/training/lerobot.py
@@ -784,7 +784,8 @@ class LerobotTrainer(Trainer):
         Runs the shared input-safety gate, then checks a data source -
         exactly one of a local LeRobotDataset v3 ``dataset_root`` or a Hub
         ``dataset_repo_id`` (for streaming) - an ``output_dir``, a usable run
-        size (``steps`` / ``global_batch_size``), a ``device`` torch can parse,
+        size (``steps`` / ``global_batch_size``), a whole-number checkpoint cadence (``save_freq``), a
+        ``device`` torch can parse,
         single-node only
         (``num_nodes == 1``), a ``val_episodes``
         split below the dataset total and not asked for alongside ``streaming``
@@ -836,6 +837,7 @@ class LerobotTrainer(Trainer):
             problems.extend(self._validate_policy(spec))
 
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
         problems.extend(self._seed_problems(spec))
         problems.extend(self._device_problems())

--- a/strands_robots/training/sagemaker.py
+++ b/strands_robots/training/sagemaker.py
@@ -334,6 +334,7 @@ class SagemakerTrainer(Trainer):
 
         # --- shared numeric domains of every field this provider serializes ---
         problems.extend(self._run_size_problems(spec))
+        problems.extend(self._checkpoint_cadence_problems(spec))
         problems.extend(self._learning_rate_problems(spec))
         problems.extend(self._launch_topology_problems(spec))
         problems.extend(self._seed_problems(spec))

--- a/tests/training/test_checkpoint_cadence_domain.py
+++ b/tests/training/test_checkpoint_cadence_domain.py
@@ -1,0 +1,418 @@
+"""The checkpoint cadence a TrainSpec asks for is one shared whole-number domain.
+
+:attr:`~strands_robots.training.base.TrainSpec.save_freq` is the interval, in
+optimizer steps, at which a run writes a checkpoint. Four providers read it - the
+three supervised backends and the SageMaker transport - and each consumes it in
+the same three shapes a process count is consumed in:
+
+* a ``spec.save_freq > 0`` selector, which LeRobot uses twice to derive the
+  validation cadence (``--eval_steps=`` on the argv path, ``cfg.eval_steps`` on
+  the in-process one) because a non-positive cadence disables periodic saving;
+* an argv or Hydra token - ``--save_freq=`` (LeRobot), ``--save_steps=``
+  (GR00T), ``checkpoint.save_iter=`` (Cosmos) - decoded into an ``int`` field;
+* a direct assignment into a typed config (``cfg.save_freq``, GR00T's
+  ``save_steps`` kwarg, a forwarded SageMaker hyperparameter), none of which
+  coerces.
+
+Before this contract the field had no domain while its run-size neighbours
+``steps`` and ``global_batch_size`` - the step count in the very same argv -
+shared one, and every way a bad cadence failed was silent or late:
+
+* ``nan`` and ``False`` compare as *not* greater than zero (``nan`` compares
+  false against everything), so the selector read them as "periodic saving
+  disabled" and a spec asking to checkpoint every ``nan`` steps evaluated once
+  at the very end instead, under a successful result.
+* ``2.7``, ``5000.0``, ``True`` and ``inf`` *are* greater than zero, so they
+  passed through as the cadence itself and reached an ``int`` field as a float
+  or a ``bool``. Their argv token then failed inside the launched run, after the
+  dataset and model were already loaded.
+* A string, ``None`` or a list raised ``TypeError`` out of the comparison itself
+  - from inside a :meth:`Trainer.validate` documented to *return* problems.
+
+What this domain deliberately does *not* decide is the floor. LeRobot documents
+a non-positive ``save_freq`` as disabling periodic saving and its
+``should_save_checkpoint`` implements exactly that, so ``0`` and a negative are
+a capability rather than an unusable value - the ``eval_steps`` fallback above
+exists for them. Only the type is graded, and the boundary is pinned below so it
+cannot move silently.
+
+The tests pin the contract in both directions: every provider that reads the
+field refuses the same unusable values through the one shared gate with a
+message naming itself, the disable capability and a usable cadence are
+untouched, a backend that ignores the field reports nothing about it, and the
+refused values are grounded in what the selector and LeRobot's own decoder do
+with them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import math
+import pathlib
+from typing import Any
+
+import pytest
+
+from strands_robots.training._validate import checkpoint_cadence_problems
+from strands_robots.training.base import Trainer, TrainSpec
+from strands_robots.training.cosmos3 import Cosmos3Trainer
+from strands_robots.training.groot import Gr00tTrainer
+from strands_robots.training.lerobot import LerobotTrainer
+from strands_robots.training.mock import MockTrainer
+from strands_robots.training.sagemaker import SagemakerTrainer
+from strands_robots.utils import positive_count_error
+from tests.training._spec_field_reads import reads_spec_field
+
+FIELD = "save_freq"
+
+# The providers that read the cadence. SageMaker forwards it as a
+# hyperparameter; the other three interpolate it into a native token.
+CHECKPOINTING_BACKENDS = (LerobotTrainer, Gr00tTrainer, Cosmos3Trainer, SagemakerTrainer)
+
+# Values no backend can honor, split by how each one failed before the gate.
+
+# Read as "not more than zero" by the selector -> the cadence silently disabled.
+SILENTLY_DISABLED = (float("nan"), False)
+
+# Read as "more than zero" -> passed through as the cadence into an int field.
+REACHED_THE_INT_FIELD = (2.7, 5000.0, True, float("inf"))
+
+# Raised TypeError out of the comparison, from inside validate().
+RAISED_OUT_OF_VALIDATE: tuple[Any, ...] = ("5000", None, [5000])
+
+UNUSABLE = SILENTLY_DISABLED + REACHED_THE_INT_FIELD + RAISED_OUT_OF_VALIDATE
+
+# The floor is NOT part of the domain: a non-positive cadence disables periodic
+# saving, and a cadence above ``steps`` writes only the final checkpoint.
+USABLE = (0, -1, 1, 500, 10**9)
+
+
+@pytest.fixture
+def spec(tmp_path: pathlib.Path) -> TrainSpec:
+    """A spec whose cadence is the only thing under test.
+
+    ``validate`` may well report unrelated problems (GR00T wants a checkout,
+    Cosmos a recipe TOML, SageMaker a role); every assertion below filters for
+    the field name, so an unrelated problem cannot mask - or fake - a cadence
+    verdict.
+    """
+    return TrainSpec(
+        dataset_root=str(tmp_path / "ds"),
+        output_dir=str(tmp_path / "out"),
+        base_model="lerobot/act",
+        embodiment="new_embodiment",
+    )
+
+
+def _problems_about(trainer: Trainer, spec: TrainSpec) -> list[str]:
+    """``validate`` problems that name the cadence field."""
+    return [p for p in trainer.validate(spec) if FIELD in p]
+
+
+def _token_decodes(value: Any) -> bool:
+    """Does ``f"{value}"`` decode into an ``int`` the way LeRobot decodes it?
+
+    LeRobot declares ``save_freq`` as a plain ``int`` and parses the argv token
+    with draccus, so this is the real destination of the interpolated value.
+    """
+    draccus = pytest.importorskip("draccus")
+    try:
+        draccus.decode(int, f"{value}")
+    except Exception:
+        return False
+    return True
+
+
+def _comparison_survives(value: Any) -> bool:
+    """Does the ``> 0`` selector run at all for *value*?"""
+    try:
+        _ = value > 0
+    except TypeError:
+        return False
+    return True
+
+
+class TestEveryReadingBackendRefusesAnUnusableCadence:
+    """Each provider that reads the field refuses every unusable value."""
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_it_is_reported_as_a_problem(self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any) -> None:
+        spec.save_freq = value
+        problems = _problems_about(trainer_cls(), spec)
+        assert problems, f"{trainer_cls.__name__} accepted {FIELD}={value!r}"
+        assert any("must be a whole number of steps" in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    def test_the_problem_names_the_backend_that_refused_it(self, spec: TrainSpec, trainer_cls: type[Trainer]) -> None:
+        trainer = trainer_cls()
+        spec.save_freq = 2.7  # type: ignore[assignment]
+        assert any(p.startswith(f"{trainer.provider_name}: {FIELD} ") for p in _problems_about(trainer, spec))
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    @pytest.mark.parametrize("value", RAISED_OUT_OF_VALIDATE)
+    def test_a_non_numeric_cadence_is_a_problem_not_an_exception(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: Any
+    ) -> None:
+        """``validate`` returns problems; it must not raise out of a comparison."""
+        spec.save_freq = value
+        problems = trainer_cls().validate(spec)  # must not raise
+        assert any(FIELD in p for p in problems), problems
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    def test_the_refusal_names_the_disable_capability_it_kept(
+        self, spec: TrainSpec, trainer_cls: type[Trainer]
+    ) -> None:
+        """A caller who meant "never checkpoint" must be told how to say it.
+
+        The floor is outside the domain, so the message has to point at the
+        spelling that *is* accepted rather than leave "whole number" to imply a
+        positive one.
+        """
+        spec.save_freq = float("nan")  # type: ignore[assignment]
+        assert any("disable periodic saving" in p for p in _problems_about(trainer_cls(), spec))
+
+
+class TestTheDisableCapabilityAndAUsableCadenceAreUntouched:
+    """The floor is not part of the domain, and a usable cadence is not a problem."""
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    @pytest.mark.parametrize("value", USABLE)
+    def test_a_whole_number_cadence_is_not_a_problem(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: int
+    ) -> None:
+        spec.save_freq = value
+        assert _problems_about(trainer_cls(), spec) == []
+
+    @pytest.mark.parametrize("trainer_cls", CHECKPOINTING_BACKENDS)
+    @pytest.mark.parametrize("value", (0, -1))
+    def test_a_non_positive_cadence_is_the_documented_way_to_disable_saving(
+        self, spec: TrainSpec, trainer_cls: type[Trainer], value: int
+    ) -> None:
+        """LeRobot's ``should_save_checkpoint`` reads it as "no periodic saves".
+
+        Pinned separately from the usable-cadence case above because it is the
+        boundary this domain deliberately declines to decide: were the floor
+        folded in, these two values would be refused and the capability lost.
+        """
+        spec.save_freq = value
+        assert _problems_about(trainer_cls(), spec) == []
+
+    def test_the_default_cadence_is_inside_the_domain(self, spec: TrainSpec) -> None:
+        """Non-vacuity for every assertion above: the default is not refused."""
+        assert checkpoint_cadence_problems(spec, context="acme") == []
+        assert isinstance(spec.save_freq, int) and not isinstance(spec.save_freq, bool)
+
+
+class TestABackendThatIgnoresTheFieldReportsNothing:
+    """A backend must not report on a field it never reads.
+
+    :class:`TrainSpec` documents that a backend "reads the fields it supports
+    and ignores the rest", so this gate is scoped to the checkpointing providers
+    rather than made universal like the learning-rate one.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE)
+    def test_the_mock_backend_checkpoints_from_no_cadence(self, spec: TrainSpec, value: Any) -> None:
+        spec.save_freq = value
+        assert _problems_about(MockTrainer(), spec) == []
+
+    def test_an_rl_backend_checkpoints_from_no_cadence(self, tmp_path: pathlib.Path) -> None:
+        pytest.importorskip("torch")
+        from strands_robots.training.rl.base_algo import RLTrainSpec
+        from strands_robots.training.rl.fast_sac import FastSacTrainer
+
+        rl_spec = RLTrainSpec(
+            output_dir=str(tmp_path),
+            env_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        )
+        rl_spec.save_freq = 2.7  # type: ignore[assignment]
+        assert [p for p in FastSacTrainer().validate(rl_spec) if FIELD in p] == []
+
+
+class TestTheRefusedValuesAreOnesNoBackendCanHonor:
+    """Ground the domain in what the selector and LeRobot's own decoder do."""
+
+    @pytest.mark.parametrize("value", SILENTLY_DISABLED)
+    def test_a_silent_value_reads_as_not_more_than_zero(self, value: Any) -> None:
+        """The ``> 0`` selector routes each of these to the *disabled* branch."""
+        assert not value > 0
+
+    def test_nan_compares_false_against_every_bound(self) -> None:
+        """Why ``nan`` slipped through a comparison-based reading in both directions."""
+        nan = float("nan")
+        assert not nan > 0
+        assert not nan <= 0
+        assert math.isnan(nan)
+
+    @pytest.mark.parametrize("value", REACHED_THE_INT_FIELD)
+    def test_a_passed_through_value_reads_as_more_than_zero(self, value: Any) -> None:
+        assert value > 0
+
+    @pytest.mark.parametrize("value", RAISED_OUT_OF_VALIDATE)
+    def test_a_non_numeric_cadence_cannot_be_compared_at_all(self, value: Any) -> None:
+        """Which is why the ungated comparison raised rather than reporting."""
+        assert not _comparison_survives(value)
+
+    @pytest.mark.parametrize("value", SILENTLY_DISABLED + REACHED_THE_INT_FIELD)
+    def test_lerobots_own_decoder_refuses_the_token_it_renders(self, value: Any) -> None:
+        """The argv token's real destination refuses every one of these.
+
+        So nothing downstream would have told the caller either - the refusal
+        lands inside the launched run once the dataset and model are loaded.
+        """
+        assert not _token_decodes(value)
+
+    def test_every_unusable_value_fails_at_least_one_consumer(self) -> None:
+        """The two failure modes together cover the refused set.
+
+        Non-vacuity for the two tests above: a value that both decoded and
+        compared cleanly would have no consumer to justify refusing it.
+        """
+        survivors = [v for v in UNUSABLE if _token_decodes(v) and _comparison_survives(v)]
+        assert survivors == [], f"refused values no consumer objects to: {survivors}"
+
+    def test_both_failure_modes_are_represented(self) -> None:
+        """And that neither test above is measuring the whole set on its own."""
+        assert [v for v in UNUSABLE if not _comparison_survives(v)]
+        assert [v for v in UNUSABLE if _comparison_survives(v) and not _token_decodes(v)]
+
+    def test_a_string_cadence_fails_only_the_comparison(self) -> None:
+        """The one refused value whose *token* is perfectly decodable.
+
+        ``"5000"`` renders to the same token as ``5000``, so a domain argued
+        from the decoder alone would have admitted it - and then the ``> 0``
+        selector raises. It takes both consumers to justify the type test.
+        """
+        assert _token_decodes("5000")
+        assert not _comparison_survives("5000")
+
+    @pytest.mark.parametrize("value", (5000.0, True, 2.7))
+    def test_the_two_step_counts_in_one_argv_agree(self, value: Any) -> None:
+        """``steps`` is refused for the same spellings, by its own shared domain.
+
+        ``save_freq`` and ``steps`` are interpolated into the same argv and read
+        by the same ``int`` decoder, so the same number must not be refused for
+        one and accepted for the other. That is why the type test is strict
+        rather than accepting an integral float.
+        """
+        assert positive_count_error(value, "steps", "acme") is not None
+        assert checkpoint_cadence_problems(TrainSpec(save_freq=value), context="acme")
+
+
+def _trainer_modules() -> list[pathlib.Path]:
+    """Every backend module, INCLUDING the ``rl`` subpackage.
+
+    Rooted at the module that defines :class:`Trainer` so the scan cannot
+    silently point at the wrong tree. The module that *defines* the shared gate
+    is excluded - derived from the gate itself rather than named, so the
+    exclusion cannot drift - because it reads the field as its owner rather than
+    as a consumer of it.
+    """
+    root = pathlib.Path(inspect.getfile(Trainer)).parent
+    owner = pathlib.Path(inspect.getfile(checkpoint_cadence_problems)).resolve()
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py" and p.resolve() != owner)
+
+
+def _reads_the_cadence(source: str) -> bool:
+    """Does *source* read the field, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, (FIELD,))
+
+
+def _calls_the_gate(source: str) -> bool:
+    """Does *source* route through the shared gate?"""
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_checkpoint_cadence_problems"
+        for node in ast.walk(ast.parse(source))
+    )
+
+
+class TestOneOwnerForTheCheckpointCadenceDomain:
+    """No backend may re-implement the domain, and none may skip it.
+
+    The set of providers in scope is derived from the tree rather than listed:
+    a module that *reads* the field must route it through the shared gate, so a
+    fifth backend that starts checkpointing from ``save_freq`` fails this test
+    until it does.
+    """
+
+    def test_the_scan_finds_the_checkpointing_backends(self) -> None:
+        """Non-vacuity: a mis-rooted scan cannot report a clean sweep of nothing."""
+        readers = {p.name for p in _trainer_modules() if _reads_the_cadence(p.read_text())}
+        assert readers == {"cosmos3.py", "groot.py", "lerobot.py", "sagemaker.py"}
+
+    def test_every_backend_that_checkpoints_routes_through_the_shared_gate(self) -> None:
+        adrift = sorted(
+            p.name
+            for p in _trainer_modules()
+            if _reads_the_cadence(source := p.read_text()) and not _calls_the_gate(source)
+        )
+        assert adrift == [], f"modules reading the cadence without the shared gate: {adrift}"
+
+    def test_no_backend_re_implements_the_domain(self) -> None:
+        """A local type or floor test on the field is the hole this closed.
+
+        A ``> 0`` comparison is a different question - "did the caller disable
+        periodic saving" - and stays where it is.
+        """
+        offenders: list[str] = []
+        for path in _trainer_modules():
+            for line in path.read_text().splitlines():
+                if f"spec.{FIELD}" in line and ("<= 0" in line or "< 1" in line or "!= int" in line):
+                    offenders.append(f"{path.name}: {line.strip()}")
+        assert offenders == [], f"local domain checks on the cadence: {offenders}"
+
+    def test_the_selector_the_backends_do_keep_is_still_there(self) -> None:
+        """The gate must not have been mistaken for the disable branch.
+
+        ``save_freq if save_freq > 0 else steps`` is the reading that makes a
+        non-positive cadence mean "evaluate once at the end"; gating the type
+        does not remove it, and removing it would silently change what a
+        disabled cadence does to the validation schedule.
+        """
+        source = pathlib.Path(inspect.getfile(LerobotTrainer)).read_text()
+        assert source.count(f"spec.{FIELD} if spec.{FIELD} > 0 else spec.steps") == 2
+
+    def test_the_scanners_detect_a_planted_defect(self) -> None:
+        """A scanner that silently matched nothing would look like a clean tree."""
+        planted = "def validate(self, spec):\n    return [] if spec.save_freq > 0 else []\n"
+        assert _reads_the_cadence(planted)
+        assert not _calls_the_gate(planted)
+
+    def test_the_scanners_detect_a_table_driven_defect(self) -> None:
+        """A backend that forwards the field by name is a reader too.
+
+        The form the SageMaker transport takes: no attribute access mentions the
+        field, so a scan keyed on ``spec.save_freq`` alone reports a clean sweep
+        while that provider skips the gate.
+        """
+        planted = 'F = ("save_freq",)\ndef validate(self, spec):\n    return [getattr(spec, f) for f in F]\n'
+        assert _reads_the_cadence(planted)
+        assert not _calls_the_gate(planted)
+
+
+class TestTheGateIsUsableOnItsOwn:
+    """The shared gate's own contract, independent of any backend."""
+
+    def test_it_reports_the_context_it_was_given(self, spec: TrainSpec) -> None:
+        spec.save_freq = 2.7  # type: ignore[assignment]
+        (problem,) = checkpoint_cadence_problems(spec, context="acme")
+        assert problem.startswith("acme: save_freq must be a whole number of steps, got 2.7.")
+
+    def test_a_usable_cadence_reports_nothing(self, spec: TrainSpec) -> None:
+        spec.save_freq = 500
+        assert checkpoint_cadence_problems(spec, context="acme") == []
+
+    def test_it_reports_at_most_one_problem(self, spec: TrainSpec) -> None:
+        """One field, one problem - the message has to name the value once."""
+        spec.save_freq = None  # type: ignore[assignment]
+        assert len(checkpoint_cadence_problems(spec, context="acme")) == 1


### PR DESCRIPTION
## Problem

`TrainSpec.save_freq` is the interval, in optimizer steps, at which a run writes a checkpoint. Four providers read it — the three supervised backends and the SageMaker transport — and it was the only numeric field among them with no domain, while `steps`, the step count interpolated into the *very same argv*, already shared one. Its `Attributes:` entry was a bare one-liner ("Checkpoint cadence in steps.") where every numeric neighbour spends three to six lines on its domain and names the `Trainer.validate` gate that enforces it.

Measured on `main`: `validate()` reported nothing about the field, on any backend, for any unusable value.

| `save_freq` | lerobot_local | groot | cosmos3 | sagemaker |
|---|---|---|---|---|
| `2.7` / `5000.0` / `True` / `False` / `nan` / `inf` / `"5000"` / `None` | no problem | no problem | no problem | no problem |

Each provider consumes the value in three shapes, and every way an unusable cadence failed was silent or late.

**A comparison selector.** LeRobot derives the validation cadence from it in two places — `--eval_steps=` on the argv path and `cfg.eval_steps` on the in-process one — as `spec.save_freq if spec.save_freq > 0 else spec.steps`, because a non-positive cadence disables periodic saving. Driving `LerobotTrainer.build_command` on `main` with `steps=100, val_episodes=2`:

| `save_freq` | `validate()` | tokens built |
|---|---|---|
| `nan` | 0 problems | `--save_freq=nan` `--eval_steps=100` |
| `2.7` | 0 problems | `--save_freq=2.7` `--eval_steps=2.7` |
| `True` | 0 problems | `--save_freq=True` `--eval_steps=True` |
| `inf` | 0 problems | `--save_freq=inf` `--eval_steps=inf` |
| `"5000"` | 0 problems | raises `TypeError: '>' not supported between instances of 'str' and 'int'` |
| `None` | 0 problems | raises `TypeError: '>' not supported between instances of 'NoneType' and 'int'` |

`nan` is the sharpest: it compares false against everything, so the selector takes the *disabled* branch. A spec asking to checkpoint every `nan` steps evaluates once at the very end instead, under a successful result. And a string or `None` raises out of the comparison itself — from inside a `Trainer.validate` that is documented to *return* problems.

**An argv or override token.** The other three interpolate the value verbatim, with no gate at all:

| `save_freq` | groot | cosmos3 |
|---|---|---|
| `nan` | `--save_steps=nan` | `checkpoint.save_iter=nan` |
| `2.7` | `--save_steps=2.7` | `checkpoint.save_iter=2.7` |
| `None` | `--save_steps=None` | `checkpoint.save_iter=None` |

LeRobot declares the field as a plain `int`, so its own draccus decoder is the token's real destination — and it refuses eight of the ten spellings: `draccus.decode(int, "2.7")` → `DecodingError: Couldn't parse '2.7' into an int`, likewise for `5000.0`, `True`, `False`, `nan`, `inf` and `None`. That refusal lands inside the launched run, once the dataset and model are loaded.

**An assignment into a typed config.** `cfg.save_freq` (declared `int`, default `20000`), GR00T's `save_steps` kwarg, and a forwarded SageMaker hyperparameter — none of which coerces.

## Change

`Trainer._checkpoint_cadence_problems` routes the field through `checkpoint_cadence_problems`, a fifteenth shared gate in `strands_robots.training._validate`, called by the four providers that read it. The message names the backend that refused the value:

```
lerobot_local: save_freq must be a whole number of steps, got nan. The cadence is
decoded into an int field and compared against zero, so a fractional, non-finite,
boolean or non-numeric value cannot be honored; pass a whole number of steps, or a
non-positive one to disable periodic saving.
```

The type test is strict for the same reason the run-size gate's is: `save_freq` and `steps` reach the same `int` decoder in the same argv, so the same number must not be refused for one step count and accepted for the next (measured: `positive_count_error` already refuses `5000.0` and `True` for `steps`).

### The floor is deliberately not part of the domain

LeRobot documents a non-positive `save_freq` as disabling periodic saving — `should_save_checkpoint` implements exactly that (`save_freq > 0 and step % save_freq == 0`), avoiding a `ZeroDivisionError` from `step % 0` — and the `eval_steps` fallback above is written for that case. So `0` and a negative stay first-class, and the refusal points at that spelling rather than letting "whole number" imply a positive one. A cadence above `steps` is a legitimate configuration too. Neither endpoint is decided here, and both are pinned so they cannot move silently. After the change:

| `save_freq` | `validate()` | tokens built |
|---|---|---|
| `0` | clean | `--save_freq=0` `--eval_steps=100` |
| `-1` | clean | `--save_freq=-1` `--eval_steps=100` |
| `500` | clean | `--save_freq=500` `--eval_steps=500` |

### Scoping

The gate is scoped like the run-size one rather than made universal: `TrainSpec` documents that a backend "reads the fields it supports and ignores the rest", and the RL trainers never read the field, so they must not report on it. That scoping is enforced structurally — the set of providers required to route through the gate is derived from which modules actually read `save_freq`, by attribute access *or* through a forwarding table (the shared `reads_spec_field` rule), so a fifth backend that starts checkpointing from it fails the parity test until it does. The derived scan measures exactly `{cosmos3.py, groot.py, lerobot.py, sagemaker.py}`.

`tests/training/test_spec_field_read_discovery.py` grades the field-scoped guards from the outside and discovers them structurally, so it picked the new guard up on arrival and required it to be registered in `FIELD_SCOPED_GATES` — which is the behaviour its own docstring promises ("a new domain guard is held to the same rule the moment it lands"). Registering it is part of this change, and the new guard now passes the table-driven-read rule too.

## Tests

`tests/training/test_checkpoint_cadence_domain.py`, 126 tests, structured after the launch-topology sibling.

Pre-fix split, on this tree with only the four gate call sites reverted (the gate and the docs kept, so the suite still imports): **57 failed / 69 passed**, 56 of them in `TestEveryReadingBackendRefusesAnUnusableCadence` and 1 in the derived owner check, with **zero** in the control, boundary, premise or gate-contract classes. A raw revert of every changed source file instead fails at collection (`ImportError: cannot import name 'checkpoint_cadence_problems'`), which is why the behavioural split is the one quoted.

Break table (each mutation applied alone; control = unmodified tree):

| mutation | tests firing |
|---|---|
| control | 0 of 126 |
| gate never reports | 61 |
| `bool` admitted (drop the explicit bool test) | 9 |
| integral float coerced instead of refused | 5 |
| **over-reach: the floor folded into the domain** | 16, all in the disable-capability class |
| message drops the disable-capability hint | 4 |
| message does not name the context | 5 |
| only lerobot routes through the gate | 43 |
| only sagemaker skips the gate (the table-driven reader) | 15 |
| **over-reach: the disable selector removed from lerobot** | 1 |

Ten mutations, ten distinct firing sets. The two partial-routing rows are complementary — 42 + 14 = 56, the behavioural pre-fix count — so each provider is independently pinned. The two over-reach rows are what make the scope decisions load-bearing rather than prose: folding the floor in trips only the class that pins the disable capability, and removing the `> 0` selector trips only the test that pins it.

The premise class grades the refused set against both consumers rather than a hand-listed rule, using two classifiers (`_token_decodes`, `_comparison_survives`) plus a non-vacuity test that both failure modes are represented. That matters because the two do not agree: `"5000"` renders to the same token as `5000` and decodes perfectly, and fails *only* the comparison — so a domain argued from the decoder alone would have admitted it.

## Gate

* `ruff check` / `ruff format --check` clean over `strands_robots tests tests_integ` (1532 files).
* mypy: **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical both ways, 0 errors in any changed file.
* Paired broad run, identical 402-file selection on both trees (all of `tests/training/`, all of `tests/tools/`, and every test that walks the tree with `ast`/`rglob`/`inspect.getsource` or reads `docs/`), the two changed test files excluded from each: **20 failed, 18068 passed, 74 skipped** on **both**, 20 failing ids each, `comm` empty in both directions. All 20 are dependency- or upstream-drift artifacts present on `main` alone: 17 need `awsiot` (`awsiotsdk`, declared in the `[mesh-iot]` extra) and 3 are the `TypeError: encode() takes 1 positional argument but 2 were given` drift in `tests/training/test_lerobot*`.
* The changed test files pass on lerobot 0.6.2 + mujoco 3.5.0 and on lerobot 0.5.1 + mujoco 3.12.0: **151 passed** on both.

No visual artifact: this changes a preflight verdict, not a policy, simulation behaviour, rendering, recording or asset. The measured token and verdict tables above are the evidence.

## Sequencing note

#2706 landed the same domain on the `lerobot_train` tool's `save_freq` argument while this was in review, and `main` is merged in here. The two are separate surfaces — a tool parameter validated before `build_train_command` interpolates it, versus a `TrainSpec` field read by four trainer backends — and the split mirrors how `steps` was done (#1936 for the tool, #1939 for the trainer). Verified by break on the merged tree rather than by inspection: reverting #2706's call site fires **40** tests, all in its own file; reverting this change's four call sites fires **58**, all in this change's files. Disjoint sets, so nothing was quietly dropped by the merge, and both halves are independently pinned. Both readings agree on the floor for the same documented reason.
