### PR TITLE
fix(scripts): collide a claim-free duplicate pair on the file both branches create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,33 @@ hatch run format            # ruff check --fix, ruff format
    is why it belongs at step 1 and not at review. If a competing implementation is
    wanted on purpose, exactly one should claim the close and the other should
    cross-reference (`per #N`, `towards #N`) instead.
+
+   **The claim is not the only key.** 249 of the last 300 pull requests (#2345
+   through #2708) link no issue at all, so for most of the traffic the query above
+   has nothing to collide on - and two of the four duplicate pairs in that window
+   were claim-free: #2388/#2389 and #2707/#2708, each pair independently creating
+   one new test file. Once your branch is pushed and the pull request is open, ask
+   the second question:
+
+   ```
+   python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --all-open
+   ```
+
+   It reports only pairs that **create the same path**, which over the 1802 pairs
+   that were open at the same instant selected 2 - and both were duplicates. Two
+   branches *editing* one file is a different question with a different remedy
+   (a merge order, possibly one composition run), and
+   `scripts/check_merge_base_overlap.py --all-open` owns it; that relation selects
+   117 of the same 1802. The two keys are complementary rather than nested: neither
+   issue-keyed pair shares an added path, and neither claim-free pair claims an
+   issue.
+
+   This one cannot be asked before you start, and not for want of trying: a path
+   set is a property of a pushed branch, so there is nothing to read at intake. It
+   caps the review cost of a collision rather than preventing the work, which is
+   why it belongs here and `--issue` belongs above. It still arrives early enough
+   to matter - both claim-free pairs opened inside the same ~35-minute window every
+   other observed collision shares, 14m 41s and 29m 26s apart.
 2. Make changes, run `hatch run format && hatch run lint && hatch run test`
 3. Record the change as a news fragment: `changelog.d/<pr-number>-<slug>.md`
    (see [`changelog.d/README.md`](changelog.d/README.md)). **Never append to

--- a/changelog.d/2710-duplicate-work-added-path-key.md
+++ b/changelog.d/2710-duplicate-work-added-path-key.md
@@ -1,0 +1,45 @@
+### Fixed: a duplicate pair that claims no issue is now reported, keyed on the file both branches create
+
+`scripts/check_duplicate_claim.py` had one key, `closingIssuesReferences`, and both of its modes
+read it -- `--issue` at intake, `--pr` at review. Measured over the last 300 pull requests (#2345
+through #2708), **249 of them link no issue at all**, so for that 83% of the traffic there is no
+key to collide on: both modes report a unique claim while looking straight at a duplicate pair.
+Two of the four duplicate pairs in that window were exactly that shape, and each spent a full
+authoring plus review round on a change that could never ship:
+
+    shared added path                                       pair           closed
+    tests/test_recorder_counters_track_on_disk_frames.py    #2388, #2389   #2389
+    tests/training/test_checkpoint_cadence_domain.py        #2707, #2708   #2707
+
+The residual was recorded in the module as out of scope, justified by one measurement: 18 of the
+last 30 merges would fail a rule *requiring* a claim. That measurement stands and the conclusion
+drawn from it was wider than it supports -- it rules out demanding a claim, which neither
+claim-keyed mode does, and says nothing about colliding the pair on a different key. A changed-path
+set exists for every branch whether it claims anything or not.
+
+A third mode, `--all-open`, reports a pair whose **added** paths intersect. The narrowness is the
+whole claim: over the 1802 pairs that were open at the same instant, the added-path relation
+selects **2** and both are duplicates, where intersecting *any* changed path selects 117. Those 117
+are a composition question with a different remedy -- a merge order, possibly one test run -- and
+`scripts/check_merge_base_overlap.py --all-open` already owns it; two branches *creating* one file
+is not a composition to verify but two answers to one question. For contrast, the path relation
+this repository has already rejected (widening to a test's walked root) selected 11 of 36 pairs and
+named no defect.
+
+The two keys are complementary rather than nested, so neither replaces the other: neither
+issue-keyed pair in that window shares an added path, and neither claim-free pair claims an issue.
+Four duplicate pairs, two reachable from each key, none from both. The new mode also keeps this
+file's own policies rather than the sibling sweep's -- drafts are included, because a draft's new
+file is authored work whatever its merge state, and the open set is read through
+`repository.pullRequests(states: OPEN)` rather than `search`, which is eventually consistent and
+would miss a pull request opened seconds ago. That is the row this sweep exists to find: both
+claim-free pairs opened inside the same ~35-minute window every other observed collision shares,
+14m 41s and 29m 26s apart.
+
+It cannot be asked at intake, and the module now says so instead of leaving it implied: a path set
+is a property of a pushed branch, so there is nothing to read before the work starts. `--all-open`
+caps the review cost of a collision, which is what `--pr` does for a claim, while `--issue`
+remains the half that prevents the authoring. A truncated file list, an unreadable open set and an
+API error all reach `unknown-additions` rather than a pass, for the reason the claim-keyed modes
+refuse a truncated link set: a sweep that reports clean because it could not look far enough is
+worse than no sweep, because it looks like one.

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -69,17 +69,80 @@ through ``search``. Search is eventually consistent, so a pull request opened
 seconds ago may not be indexed -- and the missing row would be a false clean in
 exactly the ~35-minute window where every observed collision happened.
 
-Two questions, one comparison
------------------------------
+Three questions, two keys
+-------------------------
 ``--issue N``
-    Intake. *Before* authoring: does an open pull request already close #N?
-    Nothing is excluded from the comparison, because no pull request for it exists
-    yet.
+    Intake, keyed on the claim. *Before* authoring: does an open pull request
+    already close #N? Nothing is excluded from the comparison, because no pull
+    request for it exists yet.
 
 ``--pr N``
-    Review. Do this pull request's own claims collide with another open one's?
-    #N is excluded from its own comparison -- a pull request always shares its own
-    claim.
+    Review, keyed on the claim. Do this pull request's own claims collide with
+    another open one's? #N is excluded from its own comparison -- a pull request
+    always shares its own claim.
+
+``--all-open``
+    Review, keyed on the added path. Do two open pull requests create the same
+    file? Needs no issue number, which is the point: see below.
+
+The key a claim-free pair collides on
+-------------------------------------
+Both claim-keyed questions read ``closingIssuesReferences``, and **249 of the
+last 300 pull requests (#2345 through #2708) link no issue at all**. For that 83%
+of the traffic there is no key to collide on, so both modes report a unique claim
+while looking straight at a duplicate pair. Issue #2709 is the third recorded
+instance.
+
+That residual was listed here as out of scope on the strength of one
+measurement: 18 of the last 30 merges would fail a rule *requiring* a claim. The
+measurement stands and the conclusion drawn from it was wider than it supports.
+It rules out demanding a claim. It says nothing about colliding on a different
+key -- and a changed-path set exists for every branch whether it claims anything
+or not.
+
+The part of that set which answers this question is the paths a branch **adds**.
+Two branches editing one file is a composition to verify, which is the sibling
+sweep's question in ``scripts/check_merge_base_overlap.py``; its remedy is a
+merge order plus possibly one test run. Two branches *creating* one file is not a
+composition at all. It is two answers to one question, and one of them is going
+to be closed.
+
+Measured over those same 300 pull requests, on the 1802 pairs that were open at
+the same instant::
+
+    relation              pairs   duplicates among them
+    both edit a path        117   a composition question, not this one
+    both add a path           2   2
+
+Both of the two are duplicates, and neither was reachable from a claim::
+
+    shared added path                                       pair           closed
+    tests/test_recorder_counters_track_on_disk_frames.py    #2388, #2389   #2389
+    tests/training/test_checkpoint_cadence_domain.py        #2707, #2708   #2707
+
+The two keys are complementary rather than nested, which is why this is a second
+key and not a replacement for the first. The same window holds two *issue-keyed*
+pairs -- #2570/#2571 on #2569, and #2480/#2508 on #2466 -- and neither of them
+shares an added path, while neither claim-free pair claims an issue. Four
+duplicate pairs, two reachable from each key, none from both.
+
+The 2-of-1802 rate is the whole claim. The relation the sibling file rejected --
+widening a path intersection to a test's walked root -- selected 11 of 36 pairs
+and named no defect, and a finding attached to a third of the queue reads as
+boilerplate.
+
+Why this question cannot be asked at intake
+-------------------------------------------
+``--issue`` is asked before authoring, so it prevents the work. ``--all-open``
+cannot be, and not for want of trying: a path set is a property of a *pushed
+branch*, and at intake there is no branch to read one from. So this mode caps the
+review cost of a collision rather than preventing the authoring -- the same thing
+``--pr`` does for a claim, and the reason both live at review while ``--issue``
+lives at step 1.
+
+It still arrives early. Both measured pairs opened inside the ~35-minute window
+every other observed collision shares -- 14m 41s and 29m 26s apart -- so a sweep
+run when the second one opens sees it while the first is still in review.
 
 What this reports, and what it deliberately does not
 ----------------------------------------------------
@@ -97,13 +160,27 @@ What this reports, and what it deliberately does not
     A link set, or the open-pull-request list, could not be read completely. Not a
     finding -- an unreadable field is not evidence of a duplicate.
 
+``--all-open`` reports the same three shapes over the other key:
+
+``unique-additions``
+    No two open pull requests create the same file. The convention working.
+
+``duplicate-addition``
+    The finding.
+
+``unknown-additions``
+    A file list, or the open-pull-request list, could not be read completely.
+    Not a finding, for the same reason.
+
 Out of scope, deliberately:
 
-- **A pull request that claims nothing anywhere.** Two competing branches that
-  both omit the keyword collide invisibly here. That is the same residual the
-  sibling gate names and the one #1961 is about, and 18 of the last 30 merges
-  would fail a rule requiring a claim, so this needs no answer to that question
-  and cannot be dismissed by one.
+- **A pull request that claims nothing, in the claim-keyed modes.** Two competing
+  branches that both omit the keyword collide invisibly there, and still do:
+  requiring a claim is what 18 of the last 30 merges would fail, so neither
+  claim-keyed mode demands one. What changed is that the pair is no longer
+  unreachable -- ``--all-open`` collides it on an added path instead, and the
+  measurement above is the argument that this is narrow enough to be worth
+  reporting. See #2709 and #1961.
 - **Whether the issue exists, or is already closed.** A stale number is a
   different defect, and refusing it would report a finding against correct work
   whose issue someone else closed first.
@@ -120,20 +197,30 @@ work from being done twice, and it is complete as shipped.
 
 Usage
 -----
-``--repo``    ``owner/name``. Required in intake mode; in ``--pr`` mode it
+``--repo``    ``owner/name``. Required in intake mode; in the two review modes it
               defaults to ``$GITHUB_REPOSITORY``. See
-              :func:`inferred_repository_refusal` for why the two modes differ.
-``--issue``   an issue number, asked at intake. Mutually exclusive with ``--pr``.
+              :func:`inferred_repository_refusal` for why intake differs.
+``--issue``   an issue number, asked at intake. Exactly one of the three subject
+              flags is required.
 ``--pr``      a pull request number (default: ``$PR_NUMBER``).
+``--all-open``
+              sweep the open set for two pull requests creating one file. Takes no
+              number, and keeps the inferred repository default for the reason
+              ``--pr`` does: its caller is a workflow running where the pull
+              requests live. Unlike an issue number, a sweep of the wrong
+              repository is visible in its own report, which lists the pull
+              requests and paths it read.
 ``--token``   API token (default: ``$GITHUB_TOKEN``). Needs ``pull-requests: read``.
 
-Exit status is ``1`` for ``duplicate-claim``, else ``0``. A usage error, including an
-intake question whose repository was left to be inferred, exits ``2``.
+Exit status is ``1`` for ``duplicate-claim`` or ``duplicate-addition``, else ``0``. A
+usage error, including an intake question whose repository was left to be inferred,
+exits ``2``.
 """
 
 from __future__ import annotations
 
 import argparse
+import itertools
 import json
 import os
 import sys
@@ -157,10 +244,29 @@ OPEN_PAGE_SIZE = 100
 #: evidence of no collision.
 MAX_OPEN_PAGES = 20
 
+#: How many changed files to ask for per pull request. A longer list is refused
+#: rather than read short, for the reason :data:`LINK_PAGE_SIZE` gives: a file
+#: list cut off here could omit the very path that collides and report clean.
+FILE_PAGE_SIZE = 100
+
 NO_CLAIM = "no-claim"
 UNIQUE_CLAIM = "unique-claim"
 DUPLICATE_CLAIM = "duplicate-claim"
 UNKNOWN_CLAIMS = "unknown-claims"
+
+#: Outcomes of the added-path key. Named apart from the claim-keyed four rather
+#: than shared with them, because a report reader has to be able to tell which
+#: relation produced a finding: the two have different remedies.
+UNIQUE_ADDITIONS = "unique-additions"
+DUPLICATE_ADDITION = "duplicate-addition"
+UNKNOWN_ADDITIONS = "unknown-additions"
+
+#: The one ``changeType`` this key reads. GitHub's enum also carries
+#: ``MODIFIED``, ``REMOVED``, ``RENAMED``, ``COPIED`` and ``CHANGED``, and every
+#: one of those describes a file that already exists on the base -- which is the
+#: sibling sweep's composition question rather than this one. Reading them here
+#: is what turns a 2-of-1802 relation into a 117-of-1802 one.
+ADDED_CHANGE_TYPE = "ADDED"
 
 #: ``closingIssuesReferences`` is GraphQL-only -- no REST field carries it.
 _SELF_QUERY = """
@@ -187,6 +293,33 @@ query($owner: String!, $name: String!, $links: Int!, $open: Int!, $after: String
         closingIssuesReferences(first: $links) {
           totalCount
           nodes { number }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+#: Read through ``repository.pullRequests(states: OPEN)`` for the reason the
+#: claim query is: ``search`` is eventually consistent, and a pull request opened
+#: seconds ago is exactly the row this sweep exists to find. Drafts are included,
+#: matching this file's claim-keyed policy rather than the sibling sweep's -- a
+#: draft's new file is authored work whatever its merge state, so excluding one
+#: would hide a collision for as long as either side stayed a draft.
+#:
+#: ``changeType`` is GraphQL-only: the REST file list spells the same thing
+#: ``status``, in lower case.
+_ADDITIONS_QUERY = """
+query($owner: String!, $name: String!, $files: Int!, $open: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: $open, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        files(first: $files) {
+          totalCount
+          nodes { path changeType }
         }
       }
     }
@@ -254,6 +387,53 @@ class Verdict:
         )
 
 
+@dataclass(frozen=True)
+class AdditionVerdict:
+    """The outcome of the added-path sweep and the pairs it was computed from."""
+
+    outcome: str
+    #: ``(left, right, the paths both branches create)``. Ascending in all three
+    #: axes, so a diff of two reports shows changed verdicts rather than
+    #: reordered rows.
+    collisions: tuple[tuple[int, int, tuple[str, ...]], ...] = ()
+    #: How many open pull requests were read.
+    scanned: int = 0
+    detail: str = ""
+
+    @property
+    def is_finding(self) -> bool:
+        return self.outcome == DUPLICATE_ADDITION
+
+    @property
+    def compared(self) -> int:
+        """How many pairs the sweep computed, which is what it looked at."""
+        return self.scanned * (self.scanned - 1) // 2
+
+    @property
+    def implicated(self) -> tuple[int, ...]:
+        """Every pull request in a collision, sorted and deduplicated."""
+        return tuple(sorted({number for left, right, _ in self.collisions for number in (left, right)}))
+
+    @property
+    def summary(self) -> str:
+        if self.outcome == UNKNOWN_ADDITIONS:
+            return (
+                f"Could not read every file list: {self.detail} Not treated as a finding, because "
+                "an unreadable file list is not evidence that two branches create one file."
+            )
+        if self.outcome == UNIQUE_ADDITIONS:
+            return (
+                f"No two of the {self.scanned} open pull requests create the same file "
+                f"({self.compared} pair(s) compared)."
+            )
+        parts = "; ".join(f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions)
+        return (
+            f"{parts}. Two branches creating one file are two answers to one question rather "
+            "than a composition to verify, and whichever is closed spends a review approval on a "
+            "change that will not ship."
+        )
+
+
 def _join(parts: Sequence[str]) -> str:
     """Render a clause list as ``a`` / ``a and b`` / ``a, b and c``."""
     if not parts:
@@ -273,6 +453,11 @@ def _pulls(numbers: Sequence[int]) -> str:
     return _join([f"#{n}" for n in numbers]) or "no pull request"
 
 
+def _paths(paths: Sequence[str]) -> str:
+    """Render a path list the same way, backquoted so a report reads them as code."""
+    return _join([f"`{path}`" for path in paths]) or "no file"
+
+
 def find_collisions(
     claimed: Sequence[int], others: Mapping[int, Sequence[int]]
 ) -> tuple[tuple[int, tuple[int, ...]], ...]:
@@ -287,6 +472,44 @@ def find_collisions(
         if rivals:
             collisions.append((issue, rivals))
     return tuple(collisions)
+
+
+def find_addition_collisions(
+    additions: Mapping[int, Sequence[str]],
+) -> tuple[tuple[int, int, tuple[str, ...]], ...]:
+    """Return every pair of open pull requests that creates the same file.
+
+    Every pair is compared rather than only adjacent ones: two runs a few minutes
+    apart usually get consecutive numbers, but nothing guarantees it, and a
+    relation that holds for a pair is not a property of their distance.
+
+    Deterministic in all three axes -- the pairs by lower then higher number, and
+    each shared path list sorted -- for the reason :func:`find_collisions` gives.
+    """
+    ordered = sorted(additions)
+    found: list[tuple[int, int, tuple[str, ...]]] = []
+    for left, right in itertools.combinations(ordered, 2):
+        shared = tuple(sorted(set(additions[left]) & set(additions[right])))
+        if shared:
+            found.append((left, right, shared))
+    return tuple(found)
+
+
+def classify_additions(additions: Mapping[int, Sequence[str]] | None, detail: str = "") -> AdditionVerdict:
+    """Decide which of the three added-path states the open set is in.
+
+    ``None`` means the set could not be read, which is its own outcome for the
+    reason :func:`classify` gives: a silent API or permission change must not be
+    able to turn this sweep into a no-op that always agrees.
+    """
+    if additions is None:
+        return AdditionVerdict(UNKNOWN_ADDITIONS, (), 0, detail)
+    collisions = find_addition_collisions(additions)
+    return AdditionVerdict(
+        DUPLICATE_ADDITION if collisions else UNIQUE_ADDITIONS,
+        collisions,
+        len(additions),
+    )
 
 
 def classify(
@@ -358,6 +581,37 @@ def link_numbers(pull: Mapping[str, object]) -> tuple[int, ...]:
     return tuple(sorted({int(node["number"]) for node in nodes if isinstance(node, dict) and "number" in node}))
 
 
+def added_paths(pull: Mapping[str, object]) -> tuple[str, ...]:
+    """Return the paths one pull-request node creates, refusing a truncated list.
+
+    Only ``ADDED`` entries, which is the whole narrowness of this relation: a
+    ``MODIFIED`` path is a file that exists on the base, and two branches
+    touching one of those is the sibling sweep's question.
+
+    A list cut off at :data:`FILE_PAGE_SIZE` is refused rather than read short,
+    exactly as :func:`link_numbers` refuses a truncated link set -- the one thing
+    this sweep must never do is report clean because it did not look far enough.
+    """
+    files = pull.get("files") or {}
+    if not isinstance(files, dict):
+        raise ClaimSetUnreadable(f"#{pull.get('number')} carried no file list.")
+    nodes = files.get("nodes") or []
+    total = files.get("totalCount")
+    if isinstance(total, int) and total > len(nodes):
+        raise ClaimSetUnreadable(
+            f"#{pull.get('number')}'s file list is truncated ({total} files, {len(nodes)} read)."
+        )
+    return tuple(
+        sorted(
+            {
+                str(node["path"])
+                for node in nodes
+                if isinstance(node, dict) and node.get("changeType") == ADDED_CHANGE_TYPE and node.get("path")
+            }
+        )
+    )
+
+
 def resolve_claim(repo: str, pr: int, token: str) -> tuple[int, ...]:
     """Return the issues the pull request under test links.
 
@@ -422,6 +676,103 @@ def resolve_open_claims(repo: str, token: str, pr: int | None = None) -> dict[in
         if not isinstance(cursor, str):
             raise ClaimSetUnreadable("the open pull request list is paged but carried no cursor.")
     raise ClaimSetUnreadable(f"more than {MAX_OPEN_PAGES * OPEN_PAGE_SIZE} open pull requests; the list was truncated.")
+
+
+def resolve_open_additions(repo: str, token: str) -> dict[int, tuple[str, ...]]:
+    """Return ``{open pull request number: the paths it creates}``.
+
+    Nothing is excluded: unlike the claim-keyed review question there is no pull
+    request "under test" here, so there is no self-comparison to leave out. The
+    subject is the set.
+
+    Paginated for the reason :func:`resolve_open_claims` is -- a repository with
+    more open pull requests than :data:`OPEN_PAGE_SIZE` would otherwise get a
+    clean answer computed from a prefix of the set.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        raise ClaimSetUnreadable(f"repository {repo!r} is not in owner/name form.")
+    additions: dict[int, tuple[str, ...]] = {}
+    cursor: str | None = None
+    for _ in range(MAX_OPEN_PAGES):
+        repository = _repository(
+            _post(
+                _ADDITIONS_QUERY,
+                {
+                    "owner": owner,
+                    "name": name,
+                    "files": FILE_PAGE_SIZE,
+                    "open": OPEN_PAGE_SIZE,
+                    "after": cursor,
+                },
+                token,
+            )
+        )
+        page = repository.get("pullRequests")
+        if not isinstance(page, dict):
+            raise ClaimSetUnreadable("the response carried no open pull requests.")
+        for node in page.get("nodes") or []:
+            if not isinstance(node, dict) or "number" not in node:
+                continue
+            additions[int(node["number"])] = added_paths(node)
+        info = page.get("pageInfo") or {}
+        if not info.get("hasNextPage"):
+            return additions
+        cursor = info.get("endCursor")
+        if not isinstance(cursor, str):
+            raise ClaimSetUnreadable("the open pull request list is paged but carried no cursor.")
+    raise ClaimSetUnreadable(f"more than {MAX_OPEN_PAGES * OPEN_PAGE_SIZE} open pull requests; the list was truncated.")
+
+
+def render_additions(verdict: AdditionVerdict, repo: str) -> str:
+    """Render the added-path sweep's report.
+
+    Each multi-line paragraph is a named local joined with explicit ``+``, the
+    convention the sibling sweep's renderer states: implicit concatenation inside
+    a list of report lines is indistinguishable from a forgotten comma.
+    """
+    lines = [
+        "## Duplicate work - two branches creating one file",
+        "",
+        f"Outcome: **{verdict.outcome}**",
+        "",
+        verdict.summary,
+        "",
+        "| field | value |",
+        "|---|---|",
+        f"| repository | {repo} |",
+        f"| open pull requests read | {verdict.scanned} |",
+        f"| pairs compared | {verdict.compared} |",
+    ]
+    if not verdict.is_finding:
+        return "\n".join(lines)
+    lines += [
+        f"| pull requests implicated | {_pulls(verdict.implicated)} |",
+        "",
+        "| pull requests | file(s) both create |",
+        "|---|---|",
+    ]
+    for left, right, paths in verdict.collisions:
+        lines.append(f"| #{left} + #{right} | {_paths(paths)} |")
+    why = (
+        "Neither branch's file exists on the base, so this is not a merge order to decide: "
+        + "the two are answering the same question, and the second one to be read is work that "
+        + "was already done. Read the other pull request before continuing with either."
+    )
+    clears = (
+        "Close whichever of the two is redundant, or -- if both are wanted -- change one so it "
+        + "no longer creates the same path, which is the case where the shared name was the "
+        + "accident rather than the work. This is a report rather than a branch-clearable gate: "
+        + "the remedy is a decision between two authors, and no push by one of them settles it."
+    )
+    blind = (
+        "Neither pull request need have claimed an issue for this to be reported, which is the "
+        + "point of the second key: measured over the last 300 pull requests, two duplicate pairs "
+        + "were reachable from a claim and two only from an added path, with no pair reachable "
+        + "from both."
+    )
+    lines += ["", "### What this means", "", why, "", "### What clears this", "", clears, "", blind]
+    return "\n".join(lines)
 
 
 def render(verdict: Verdict, repo: str, pr: int | None = None, issue: int | None = None) -> str:
@@ -514,6 +865,33 @@ def inferred_repository_refusal(inferred: str) -> str:
     )
 
 
+def _emit(report: str) -> None:
+    """Print the report and append it to the CI job summary when there is one."""
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def _run_addition_sweep(repo: str, token: str) -> int:
+    """Sweep the open set for two pull requests creating one file."""
+    additions: dict[int, tuple[str, ...]] | None
+    detail = ""
+    try:
+        additions = resolve_open_additions(repo, token)
+    except (ClaimSetUnreadable, urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError) as exc:
+        additions, detail = None, str(exc)
+        print(f"check_duplicate_claim: {detail}", file=sys.stderr)
+
+    verdict = classify_additions(additions, detail)
+    _emit(render_additions(verdict, repo))
+    if verdict.is_finding:
+        print(f"::error title=Two open pull requests create the same file::{verdict.summary}")
+        return 1
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     # ``None`` rather than the environment value, so "was it supplied?" stays
@@ -522,6 +900,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--repo", default=None)
     parser.add_argument("--pr", default=os.environ.get("PR_NUMBER", ""))
     parser.add_argument("--issue", default="")
+    parser.add_argument("--all-open", action="store_true")
     parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN", ""))
     args = parser.parse_args(argv)
 
@@ -530,12 +909,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if not repo:
         parser.error("--repo is required (or set GITHUB_REPOSITORY)")
-    if bool(args.pr) == bool(args.issue):
-        parser.error("pass exactly one of --pr (review a pull request) and --issue (intake)")
+    if [bool(args.pr), bool(args.issue), args.all_open].count(True) != 1:
+        parser.error(
+            "pass exactly one of --pr (review a pull request's claims), --issue (intake) "
+            "and --all-open (sweep the open set for two branches creating one file)"
+        )
     if args.repo is None and args.issue:
         parser.error(inferred_repository_refusal(repo))
     if not args.token:
         parser.error("--token is required (or set GITHUB_TOKEN)")
+
+    if args.all_open:
+        return _run_addition_sweep(repo, args.token)
 
     pr = int(args.pr) if args.pr else None
     issue = int(args.issue) if args.issue else None
@@ -552,13 +937,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"check_duplicate_claim: {detail}", file=sys.stderr)
 
     verdict = classify(claimed, others, detail)
-    report = render(verdict, repo, pr, issue)
-    print(report)
-
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as handle:
-            handle.write(report + "\n")
+    _emit(render(verdict, repo, pr, issue))
 
     if verdict.is_finding:
         print(f"::error title=Two open pull requests claim one issue::{verdict.summary}")

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -426,7 +426,9 @@ class AdditionVerdict:
                 f"No two of the {self.scanned} open pull requests create the same file "
                 f"({self.compared} pair(s) compared)."
             )
-        parts = "; ".join(f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions)
+        parts = "; ".join(
+            f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions
+        )
         return (
             f"{parts}. Two branches creating one file are two answers to one question rather "
             "than a composition to verify, and whichever is closed spends a review approval on a "
@@ -598,9 +600,7 @@ def added_paths(pull: Mapping[str, object]) -> tuple[str, ...]:
     nodes = files.get("nodes") or []
     total = files.get("totalCount")
     if isinstance(total, int) and total > len(nodes):
-        raise ClaimSetUnreadable(
-            f"#{pull.get('number')}'s file list is truncated ({total} files, {len(nodes)} read)."
-        )
+        raise ClaimSetUnreadable(f"#{pull.get('number')}'s file list is truncated ({total} files, {len(nodes)} read).")
     return tuple(
         sorted(
             {

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -100,10 +100,18 @@ _NAMES_REPOSITORY: dict[str, tuple[str, str | None]] = {
 
 
 def _documented_intake_argv(issue: int) -> list[str]:
-    """Return the intake command step 1 prints, as an ``argv`` list."""
+    """Return the intake command step 1 prints, as an ``argv`` list.
+
+    Selected by ``--issue`` rather than by being the only invocation. Step 1
+    documents two commands since the added-path key landed, and the one this
+    helper's caller is about is the claim-keyed intake question; asserting
+    uniqueness would fail on the sibling command instead of on a shortened intake
+    one, which is the failure it exists to produce.
+    """
     found = re.findall(r"python3 scripts/check_duplicate_claim\.py([^\n`]*)", _AGENTS.read_text(encoding="utf-8"))
-    assert len(found) == 1, found
-    return [part.replace("<N>", str(issue)) for part in found[0].split()]
+    intake = [argv for argv in found if "--issue" in argv]
+    assert len(intake) == 1, found
+    return [part.replace("<N>", str(issue)) for part in intake[0].split()]
 
 
 def _documented_check_invocations() -> list[tuple[str, str]]:

--- a/tests/test_duplicate_work_added_path_key.py
+++ b/tests/test_duplicate_work_added_path_key.py
@@ -1,0 +1,562 @@
+"""Pins the added-path key against the claim-free duplicate pairs this repository shipped.
+
+``scripts/check_duplicate_claim.py`` was built around one key,
+``closingIssuesReferences``, and **249 of the last 300 pull requests (#2345
+through #2708) link no issue at all** -- so for most of the traffic both
+claim-keyed modes have nothing to collide on and report a unique claim while
+looking straight at a duplicate pair. Issue #2709 is the third recorded instance.
+
+:data:`_CLAIM_FREE_PAIRS` fixes the two measured ones in place, so the sweep is
+tested against real shapes rather than invented ones. Both were reconstructed
+from ``pulls/<n>/files``, which outlives the state change that closed one half of
+each.
+
+Three pins carry design decisions rather than behaviour:
+
+``TestTheTwoKeysAreComplementary``
+    The window holds four duplicate pairs: two reachable from a claim, two only
+    from an added path, and none from both. So this is a second key rather than a
+    replacement, and neither relation may be deleted in favour of the other.
+
+``TestOnlyACreatedPathCollides``
+    Widening the relation from ``ADDED`` to every ``changeType`` turns 2 selected
+    pairs of 1802 into 117, which is a composition question owned by
+    ``scripts/check_merge_base_overlap.py`` and not this one. The narrowness is
+    the whole claim, so it is asserted from both sides.
+
+``TestAnIncompleteAnswerIsNotAFinding``
+    A truncated file list, a truncated open-pull-request list and an API error
+    must all reach ``unknown-additions``. The failure mode guarded is not a false
+    accusation but a silent no-op: a sweep that reports clean because it could not
+    read the open set is worse than none, because it looks like one.
+
+See scripts/check_duplicate_claim.py, issue #2709, and the "PR Workflow" section
+of AGENTS.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "check_duplicate_claim.py"
+_AGENTS = _ROOT / "AGENTS.md"
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location("check_duplicate_claim", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+
+#: The two duplicate pairs in #2345..#2708 that claimed no issue, as
+#: ``(label, {number: added paths}, the path both create)``. Every path is the
+#: real one the pull request added; the changelog fragment is carried too,
+#: because it is the one added path that never collides -- its name embeds the
+#: pull request number -- and a fixture without it would not show that.
+_CLAIM_FREE_PAIRS = [
+    (
+        "#2388/#2389 - un-count frames a discarded episode never wrote",
+        {
+            2388: (
+                "changelog.d/2388-recorder-uncount-discarded-frames.md",
+                "tests/test_recorder_counters_track_on_disk_frames.py",
+            ),
+            2389: (
+                "changelog.d/2389-recorder-uncount-discarded-frames.md",
+                "tests/test_recorder_counters_track_on_disk_frames.py",
+            ),
+        },
+        "tests/test_recorder_counters_track_on_disk_frames.py",
+    ),
+    (
+        "#2707/#2708 - a value domain for TrainSpec.save_freq",
+        {
+            2707: (
+                "changelog.d/2707-trainspec-save-freq-domain.md",
+                "tests/training/test_checkpoint_cadence_domain.py",
+            ),
+            2708: ("tests/training/test_checkpoint_cadence_domain.py",),
+        },
+        "tests/training/test_checkpoint_cadence_domain.py",
+    ),
+]
+
+#: The two duplicate pairs in the same window that *were* reachable from a claim,
+#: as ``(left, right, the issue both claim, each side's added paths)``. Their
+#: added-path sets are disjoint, which is what makes the two keys complementary.
+_ISSUE_KEYED_PAIRS = [
+    (
+        2570,
+        2571,
+        2569,
+        {
+            2570: ("changelog.d/2570-all-open-refuses-a-local-checkout-flag.md",),
+            2571: ("changelog.d/2571-sweep-refuses-a-flag-it-cannot-honour.md",),
+        },
+    ),
+    (
+        2480,
+        2508,
+        2466,
+        {
+            2480: ("changelog.d/2466-dataset-transform-surface.md", "strands_robots/transforms/base.py"),
+            2508: ("changelog.d/2467-data-augmentation-notebook.md", "examples/notebooks/07_data_augmentation.ipynb"),
+        },
+    ),
+]
+
+
+def _node(number: int, files: list[dict[str, str]], total: int | None = None) -> dict[str, Any]:
+    """Build one pull-request node the way the GraphQL response shapes it."""
+    return {
+        "number": number,
+        "files": {"totalCount": len(files) if total is None else total, "nodes": files},
+    }
+
+
+def _added(*paths: str) -> list[dict[str, str]]:
+    return [{"path": path, "changeType": check.ADDED_CHANGE_TYPE} for path in paths]
+
+
+class TestTheMeasuredClaimFreePairsAreReported:
+    """Each measured pair is the finding, and names the file both branches create."""
+
+    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
+    def test_the_pair_is_the_finding(self, label: str, additions: dict[int, tuple[str, ...]], shared: str) -> None:
+        verdict = check.classify_additions(additions)
+        assert verdict.outcome == check.DUPLICATE_ADDITION, label
+        assert verdict.is_finding
+
+    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
+    def test_only_the_shared_path_is_reported(
+        self, label: str, additions: dict[int, tuple[str, ...]], shared: str
+    ) -> None:
+        left, right = sorted(additions)
+        assert check.classify_additions(additions).collisions == ((left, right, (shared,)),)
+
+    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
+    def test_both_pull_requests_are_named(
+        self, label: str, additions: dict[int, tuple[str, ...]], shared: str
+    ) -> None:
+        summary = check.classify_additions(additions).summary
+        for number in additions:
+            assert f"#{number}" in summary
+        assert shared in summary
+
+    def test_a_changelog_fragment_is_never_the_shared_path(self) -> None:
+        """Every branch adds one, and its name embeds the number, so it cannot collide.
+
+        The premise of the fixtures: without this, a relation over added paths
+        would fire on every pair in the queue.
+        """
+        for label, additions, _ in _CLAIM_FREE_PAIRS:
+            fragments = {path for paths in additions.values() for path in paths if path.startswith("changelog.d/")}
+            assert fragments, label
+            collisions = check.classify_additions(additions).collisions
+            reported = {path for _, _, paths in collisions for path in paths}
+            assert not (reported & fragments), label
+
+
+class TestTheTwoKeysAreComplementary:
+    """Four duplicate pairs, two reachable from each key, none from both."""
+
+    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
+    def test_a_claim_free_pair_is_invisible_to_the_claim_key(
+        self, label: str, additions: dict[int, tuple[str, ...]], shared: str
+    ) -> None:
+        """Neither half links an issue, so the claim-keyed verdict is ``no-claim``.
+
+        Not a defect being pinned in place -- requiring a claim is what 18 of the
+        last 30 merges would fail. It is why a second key had to exist.
+        """
+        left, right = sorted(additions)
+        verdict = check.classify(claimed=(), others={right: ()})
+        assert verdict.outcome == check.NO_CLAIM
+        assert not verdict.is_finding
+
+    @pytest.mark.parametrize(("left", "right", "issue", "additions"), _ISSUE_KEYED_PAIRS)
+    def test_an_issue_keyed_pair_is_invisible_to_the_added_path_key(
+        self, left: int, right: int, issue: int, additions: dict[int, tuple[str, ...]]
+    ) -> None:
+        assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
+
+    @pytest.mark.parametrize(("left", "right", "issue", "additions"), _ISSUE_KEYED_PAIRS)
+    def test_the_claim_key_still_reports_that_pair(
+        self, left: int, right: int, issue: int, additions: dict[int, tuple[str, ...]]
+    ) -> None:
+        """The non-vacuity half: each key must still catch what it was built for."""
+        verdict = check.classify(claimed=(issue,), others={right: (issue,)})
+        assert verdict.outcome == check.DUPLICATE_CLAIM
+        assert verdict.collisions == ((issue, (right,)),)
+
+    def test_neither_outcome_vocabulary_reuses_the_others_names(self) -> None:
+        """A reader has to be able to tell which relation produced a finding."""
+        claim = {check.NO_CLAIM, check.UNIQUE_CLAIM, check.DUPLICATE_CLAIM, check.UNKNOWN_CLAIMS}
+        addition = {check.UNIQUE_ADDITIONS, check.DUPLICATE_ADDITION, check.UNKNOWN_ADDITIONS}
+        assert not claim & addition
+        assert len(claim) == 4
+        assert len(addition) == 3
+
+
+class TestOnlyACreatedPathCollides:
+    """The narrowness is the claim: a path that already exists is the sibling's question."""
+
+    @pytest.mark.parametrize("change_type", ["MODIFIED", "REMOVED", "RENAMED", "COPIED", "CHANGED"])
+    def test_a_path_both_branches_merely_touch_is_not_a_finding(self, change_type: str) -> None:
+        shared = [{"path": "strands_robots/utils.py", "changeType": change_type}]
+        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
+
+    def test_the_same_path_created_by_both_is_the_finding(self) -> None:
+        """The control for the row above: only ``changeType`` differs."""
+        shared = _added("strands_robots/utils.py")
+        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        assert check.classify_additions(additions).outcome == check.DUPLICATE_ADDITION
+
+    def test_one_branch_creating_what_the_other_edits_is_not_a_finding(self) -> None:
+        """Impossible on one base, and if the API says it the sibling sweep owns it."""
+        creator = check.added_paths(_node(11, _added("docs/new.md")))
+        editor = check.added_paths(_node(12, [{"path": "docs/new.md", "changeType": "MODIFIED"}]))
+        assert check.classify_additions({11: creator, 12: editor}).outcome == check.UNIQUE_ADDITIONS
+
+    def test_prose_is_not_exempt(self) -> None:
+        """The sibling sweep's prose exemption does not transfer to this question.
+
+        There it holds because a shared ``.md`` edit cannot change what the suite
+        does and git reports the conflict anyway. Two branches each *writing* one
+        new page is duplicated authoring whatever the suffix.
+        """
+        additions = {n: check.added_paths(_node(n, _added("docs/guide.md"))) for n in (11, 12)}
+        verdict = check.classify_additions(additions)
+        assert verdict.outcome == check.DUPLICATE_ADDITION
+        assert verdict.collisions == ((11, 12, ("docs/guide.md",)),)
+
+
+class TestEveryPairIsComparedAndTheReportIsStable:
+    """Determinism in all three axes, and no reliance on adjacent numbers."""
+
+    def test_pull_requests_that_are_not_adjacent_are_still_compared(self) -> None:
+        additions = {
+            11: ("tests/test_a.py",),
+            12: ("tests/test_unrelated.py",),
+            99: ("tests/test_a.py",),
+        }
+        assert check.find_addition_collisions(additions) == ((11, 99, ("tests/test_a.py",)),)
+
+    def test_pairs_and_paths_are_sorted(self) -> None:
+        additions = {
+            99: ("tests/test_b.py", "tests/test_a.py"),
+            11: ("tests/test_b.py", "tests/test_a.py"),
+        }
+        assert check.find_addition_collisions(additions) == (
+            (11, 99, ("tests/test_a.py", "tests/test_b.py")),
+        )
+
+    def test_three_branches_creating_one_file_report_all_three_pairs(self) -> None:
+        additions = {n: ("tests/test_a.py",) for n in (11, 12, 13)}
+        assert check.find_addition_collisions(additions) == (
+            (11, 12, ("tests/test_a.py",)),
+            (11, 13, ("tests/test_a.py",)),
+            (12, 13, ("tests/test_a.py",)),
+        )
+        assert check.classify_additions(additions).implicated == (11, 12, 13)
+
+    def test_an_empty_open_set_is_clean_and_says_so(self) -> None:
+        verdict = check.classify_additions({})
+        assert verdict.outcome == check.UNIQUE_ADDITIONS
+        assert verdict.compared == 0
+
+    def test_the_pair_count_is_the_number_of_comparisons(self) -> None:
+        assert check.classify_additions({n: () for n in range(1, 5)}).compared == 6
+
+
+class TestAnIncompleteAnswerIsNotAFinding:
+    """An unread file list is neither a pass nor a finding."""
+
+    def test_an_unreadable_set_is_its_own_outcome(self) -> None:
+        verdict = check.classify_additions(None, "the API returned errors.")
+        assert verdict.outcome == check.UNKNOWN_ADDITIONS
+        assert not verdict.is_finding
+        assert "the API returned errors." in verdict.summary
+
+    def test_a_truncated_file_list_is_refused_rather_than_read_short(self) -> None:
+        node = _node(11, _added("tests/test_a.py"), total=check.FILE_PAGE_SIZE + 1)
+        with pytest.raises(check.ClaimSetUnreadable, match="file list is truncated"):
+            check.added_paths(node)
+
+    def test_a_complete_file_list_is_read(self) -> None:
+        assert check.added_paths(_node(11, _added("b", "a"))) == ("a", "b")
+
+    def test_a_node_without_a_file_list_is_unreadable(self) -> None:
+        with pytest.raises(check.ClaimSetUnreadable, match="carried no file list"):
+            check.added_paths({"number": 11, "files": "not a list"})
+
+    def test_a_repository_that_is_not_in_owner_name_form_is_refused(self) -> None:
+        with pytest.raises(check.ClaimSetUnreadable, match="owner/name form"):
+            check.resolve_open_additions("robots", "token")
+
+    def test_an_api_error_is_unreadable_rather_than_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(check, "_post", lambda *a, **k: {"errors": [{"message": "nope"}]})
+        with pytest.raises(check.ClaimSetUnreadable, match="the API returned errors"):
+            check.resolve_open_additions("owner/name", "token")
+
+    def test_a_page_without_a_cursor_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {
+            "data": {
+                "repository": {
+                    "pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": None}, "nodes": []}
+                }
+            }
+        }
+        monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
+        with pytest.raises(check.ClaimSetUnreadable, match="carried no cursor"):
+            check.resolve_open_additions("owner/name", "token")
+
+    def test_a_list_longer_than_the_page_bound_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = {
+            "data": {
+                "repository": {
+                    "pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": "next"}, "nodes": []}
+                }
+            }
+        }
+        monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
+        with pytest.raises(check.ClaimSetUnreadable, match="the list was truncated"):
+            check.resolve_open_additions("owner/name", "token")
+
+
+class TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts:
+    """Every page, every open pull request, from the repository rather than search."""
+
+    def test_every_page_is_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                            "nodes": [_node(11, _added("tests/test_a.py"))],
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [_node(12, _added("tests/test_a.py"))],
+                        }
+                    }
+                }
+            },
+        ]
+        seen: list[object] = []
+
+        def fake_post(query: str, variables: dict[str, object], token: str) -> object:
+            seen.append(variables.get("after"))
+            return pages[len(seen) - 1]
+
+        monkeypatch.setattr(check, "_post", fake_post)
+        additions = check.resolve_open_additions("owner/name", "token")
+        assert seen == [None, "c1"]
+        # The finding only exists across the page boundary, so a single-page read
+        # would report clean here.
+        assert check.classify_additions(additions).outcome == check.DUPLICATE_ADDITION
+
+    def test_the_open_set_is_read_from_the_repository_and_not_from_search(self) -> None:
+        """Search is eventually consistent, and a pull request opened seconds ago
+        is exactly the row this sweep exists to find."""
+        assert "pullRequests(states: OPEN" in check._ADDITIONS_QUERY
+        assert "search(" not in check._ADDITIONS_QUERY
+
+    def test_no_pull_request_is_excluded_for_being_a_draft(self) -> None:
+        """This file's claim-keyed policy, not the sibling sweep's.
+
+        A draft's new file is authored work whatever its merge state, so excluding
+        one would hide a collision for as long as either side stayed a draft.
+        """
+        source = _SCRIPT.read_text(encoding="utf-8")
+        sweep = source[source.index("def resolve_open_additions") : source.index("def render_additions")]
+        assert "draft" not in sweep.lower()
+        assert "draft" not in check._ADDITIONS_QUERY.lower()
+
+    def test_the_whole_set_is_compared_with_nothing_under_test(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No pull request is "the subject", so none is left out of the comparison."""
+        payload = {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [_node(11, _added("a.py")), _node(12, _added("b.py"))],
+                    }
+                }
+            }
+        }
+        monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
+        assert sorted(check.resolve_open_additions("owner/name", "token")) == [11, 12]
+
+
+class TestTheReportNamesBothPullRequestsAndTheRemedy:
+    """What a reader has to be able to act on."""
+
+    @staticmethod
+    def _finding() -> str:
+        _, additions, _ = _CLAIM_FREE_PAIRS[1]
+        return check.render_additions(check.classify_additions(additions), "strands-labs/robots")
+
+    def test_the_finding_names_both_pull_requests_and_the_shared_file(self) -> None:
+        report = self._finding()
+        assert "#2707 + #2708" in report
+        assert "tests/training/test_checkpoint_cadence_domain.py" in report
+
+    def test_the_finding_offers_the_remedy_and_says_no_push_settles_it(self) -> None:
+        report = self._finding()
+        assert "What clears this" in report
+        assert "Close whichever of the two is redundant" in report
+        assert "no push by one of them settles it" in report
+
+    def test_the_finding_separates_itself_from_the_composition_question(self) -> None:
+        assert "not a merge order to decide" in self._finding()
+
+    def test_a_clean_report_carries_no_remedy_section(self) -> None:
+        report = check.render_additions(check.classify_additions({11: ("a.py",)}), "owner/name")
+        assert check.UNIQUE_ADDITIONS in report
+        assert "What clears this" not in report
+
+    def test_a_clean_report_states_what_it_looked_at(self) -> None:
+        report = check.render_additions(check.classify_additions({n: () for n in (11, 12, 13)}), "owner/name")
+        assert "| open pull requests read | 3 |" in report
+        assert "| pairs compared | 3 |" in report
+
+    def test_one_row_per_colliding_pair(self) -> None:
+        additions = {n: ("tests/test_a.py",) for n in (11, 12, 13)}
+        report = check.render_additions(check.classify_additions(additions), "owner/name")
+        for pair in ("#11 + #12", "#11 + #13", "#12 + #13"):
+            assert pair in report
+
+
+class TestTheExitStatusIsOneOnlyForTheFinding:
+    """The contract the sibling gate scripts share: 1 is a finding, 2 is a usage error."""
+
+    @pytest.mark.parametrize(
+        ("additions", "expected"),
+        [
+            ({11: ("a.py",), 12: ("a.py",)}, 1),
+            ({11: ("a.py",), 12: ("b.py",)}, 0),
+        ],
+    )
+    def test_the_exit_status(
+        self, monkeypatch: pytest.MonkeyPatch, additions: dict[int, tuple[str, ...]], expected: int
+    ) -> None:
+        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: additions)
+        argv = ["--repo", "owner/name", "--all-open", "--token", "t"]
+        assert check.main(argv) == expected
+
+    def test_a_lookup_failure_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: object, **kwargs: object) -> dict[int, tuple[str, ...]]:
+            raise check.ClaimSetUnreadable("the response carried no repository.")
+
+        monkeypatch.setattr(check, "resolve_open_additions", boom)
+        assert check.main(["--repo", "owner/name", "--all-open", "--token", "t"]) == 0
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--repo", "owner/name", "--token", "t"],
+            ["--repo", "owner/name", "--all-open", "--pr", "5", "--token", "t"],
+            ["--repo", "owner/name", "--all-open", "--issue", "5", "--token", "t"],
+            ["--repo", "owner/name", "--all-open", "--pr", "5", "--issue", "6", "--token", "t"],
+        ],
+    )
+    def test_exactly_one_subject_is_required(self, argv: list[str]) -> None:
+        with pytest.raises(SystemExit) as raised:
+            check.main(argv)
+        assert raised.value.code == 2
+
+    def test_the_sweep_keeps_the_inferred_repository_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Its caller is a workflow running where the pull requests live, and a
+        sweep of the wrong repository is visible in its own report."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "owner/name")
+        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: {})
+        assert check.main(["--all-open", "--token", "t"]) == 0
+
+    def test_the_sweep_reads_no_claim_and_no_single_pull_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The two keys are independent: neither lookup of the other runs here."""
+
+        def forbidden(*args: object, **kwargs: object) -> object:
+            raise AssertionError("the added-path sweep must not read a claim")
+
+        monkeypatch.setattr(check, "resolve_claim", forbidden)
+        monkeypatch.setattr(check, "resolve_open_claims", forbidden)
+        monkeypatch.setattr(check, "resolve_open_additions", lambda *a, **k: {11: ("a.py",)})
+        assert check.main(["--repo", "owner/name", "--all-open", "--token", "t"]) == 0
+
+
+class TestTheGuidanceRecordsTheSecondKey:
+    """AGENTS.md step 1 owns the duplicate-work convention, both keys of it."""
+
+    @staticmethod
+    def _step_one() -> str:
+        text = _AGENTS.read_text(encoding="utf-8")
+        start = text.index("1. Create the feature branch")
+        end = text.index("2. Make changes", start)
+        return " ".join(text[start:end].split())
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "check_duplicate_claim.py --repo strands-labs/robots --all-open",
+            "link no issue at all",
+            "create the same path",
+            "a path set is a property of a pushed branch",
+            "check_merge_base_overlap.py",
+        ],
+    )
+    def test_step_one_carries_the_second_key(self, phrase: str) -> None:
+        assert phrase in self._step_one()
+
+    def test_the_guidance_keeps_the_intake_check_it_already_had(self) -> None:
+        """The second key is additive: the claim-keyed intake question stays."""
+        step_one = self._step_one()
+        assert "check_duplicate_claim.py --repo strands-labs/robots --issue" in step_one
+        assert "check that no open pull request already claims the issue" in step_one
+
+
+class TestTheModuleStatesTheMeasurementBehindTheRelation:
+    """A relation over paths is only worth wiring up if its precision is stated."""
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "1802 pairs",
+            "both add a path",
+            "two reachable from each key, none from both",
+            "a path set is a property of a *pushed",
+        ],
+    )
+    def test_the_docstring_carries_the_measurement(self, phrase: str) -> None:
+        assert check.__doc__ is not None
+        assert phrase in check.__doc__
+
+    def test_the_stale_scope_bullet_no_longer_calls_the_pair_unreachable(self) -> None:
+        """The 18-of-30 measurement stands; the conclusion drawn from it was wider.
+
+        It rules out *requiring* a claim, which neither claim-keyed mode does. It
+        never ruled out colliding the pair on a different key.
+        """
+        assert check.__doc__ is not None
+        assert "18 of the last 30 merges" in check.__doc__
+        assert "collides it on an added path instead" in check.__doc__

--- a/tests/test_duplicate_work_added_path_key.py
+++ b/tests/test_duplicate_work_added_path_key.py
@@ -60,12 +60,18 @@ def _load() -> Any:
 check = _load()
 
 
+#: One fixture row: ``(label, {number: added paths}, the path both create)``.
+_ClaimFreePair = tuple[str, dict[int, tuple[str, ...]], str]
+
+#: One row of the other key: ``(left, right, the issue both claim, added paths)``.
+_IssueKeyedPair = tuple[int, int, int, dict[int, tuple[str, ...]]]
+
 #: The two duplicate pairs in #2345..#2708 that claimed no issue, as
 #: ``(label, {number: added paths}, the path both create)``. Every path is the
 #: real one the pull request added; the changelog fragment is carried too,
 #: because it is the one added path that never collides -- its name embeds the
 #: pull request number -- and a fixture without it would not show that.
-_CLAIM_FREE_PAIRS = [
+_CLAIM_FREE_PAIRS: list[_ClaimFreePair] = [
     (
         "#2388/#2389 - un-count frames a discarded episode never wrote",
         {
@@ -96,7 +102,7 @@ _CLAIM_FREE_PAIRS = [
 #: The two duplicate pairs in the same window that *were* reachable from a claim,
 #: as ``(left, right, the issue both claim, each side's added paths)``. Their
 #: added-path sets are disjoint, which is what makes the two keys complementary.
-_ISSUE_KEYED_PAIRS = [
+_ISSUE_KEYED_PAIRS: list[_IssueKeyedPair] = [
     (
         2570,
         2571,
@@ -147,9 +153,7 @@ class TestTheMeasuredClaimFreePairsAreReported:
         assert check.classify_additions(additions).collisions == ((left, right, (shared,)),)
 
     @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
-    def test_both_pull_requests_are_named(
-        self, label: str, additions: dict[int, tuple[str, ...]], shared: str
-    ) -> None:
+    def test_both_pull_requests_are_named(self, label: str, additions: dict[int, tuple[str, ...]], shared: str) -> None:
         summary = check.classify_additions(additions).summary
         for number in additions:
             assert f"#{number}" in summary
@@ -260,9 +264,7 @@ class TestEveryPairIsComparedAndTheReportIsStable:
             99: ("tests/test_b.py", "tests/test_a.py"),
             11: ("tests/test_b.py", "tests/test_a.py"),
         }
-        assert check.find_addition_collisions(additions) == (
-            (11, 99, ("tests/test_a.py", "tests/test_b.py")),
-        )
+        assert check.find_addition_collisions(additions) == ((11, 99, ("tests/test_a.py", "tests/test_b.py")),)
 
     def test_three_branches_creating_one_file_report_all_three_pairs(self) -> None:
         additions = {n: ("tests/test_a.py",) for n in (11, 12, 13)}
@@ -315,9 +317,7 @@ class TestAnIncompleteAnswerIsNotAFinding:
     def test_a_page_without_a_cursor_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         payload = {
             "data": {
-                "repository": {
-                    "pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": None}, "nodes": []}
-                }
+                "repository": {"pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": None}, "nodes": []}}
             }
         }
         monkeypatch.setattr(check, "_post", lambda *a, **k: payload)
@@ -327,9 +327,7 @@ class TestAnIncompleteAnswerIsNotAFinding:
     def test_a_list_longer_than_the_page_bound_is_unreadable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         payload = {
             "data": {
-                "repository": {
-                    "pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": "next"}, "nodes": []}
-                }
+                "repository": {"pullRequests": {"pageInfo": {"hasNextPage": True, "endCursor": "next"}, "nodes": []}}
             }
         }
         monkeypatch.setattr(check, "_post", lambda *a, **k: payload)


### PR DESCRIPTION
Closes #2709

## Problem

`scripts/check_duplicate_claim.py` has one key, `closingIssuesReferences`, and both of its modes read it: `--issue` at intake, `--pr` at review. Measured over the last 300 pull requests (#2345 through #2708), **249 of them link no issue at all**. For that 83% of the traffic there is no key to collide on, so both modes report a unique claim while looking straight at a duplicate pair.

Two of the four duplicate pairs in that window were exactly that shape. Both halves of each were open at once, both claimed nothing, and both independently created one new test file:

| pair | opened apart | shared added path | outcome |
|---|---|---|---|
| #2388, #2389 | 14m 41s | `tests/test_recorder_counters_track_on_disk_frames.py` | #2389 closed as a duplicate of #2388 |
| #2707, #2708 | 29m 26s | `tests/training/test_checkpoint_cadence_domain.py` | #2707 closed after a MUST FIX review round |

Measured with the shipped check on the live half of the second pair:

```
$ python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --pr 2708
Outcome: **no-claim**
This pull request links no issue, so it cannot duplicate another's claim.
```

`closingIssuesReferences.totalCount` is `0` on all four of those pull requests. Exit `0`, and the report is shaped exactly like the answer a unique claim gets, which is the reassuring failure direction.

### Why the residual was recorded as out of scope, and why that was too wide

The module already listed this case as deliberately excluded, on the strength of one measurement: 18 of the last 30 merges would fail a rule *requiring* a claim. That measurement stands, and neither claim-keyed mode demands a claim. What it does not support is the conclusion drawn from it. It rules out demanding a claim; it says nothing about colliding the pair on a **different** key, and a changed-path set exists for every branch whether it claims anything or not.

## Change

A third mode, `--all-open`, keyed on the paths a branch **adds**. It takes no issue number, reads the open set in one query, and reports every pair whose added-path sets intersect.

Reconstructed from `pulls/2707/files` and `pulls/2708/files`, which outlive the state change that closed one half:

```
## Duplicate work - two branches creating one file

Outcome: **duplicate-addition**

#2707 and #2708 both create `tests/training/test_checkpoint_cadence_domain.py`. Two branches
creating one file are two answers to one question rather than a composition to verify, and
whichever is closed spends a review approval on a change that will not ship.

| pull requests | file(s) both create |
|---|---|
| #2707 + #2708 | `tests/training/test_checkpoint_cadence_domain.py` |
```

### The narrowness is the whole claim

A relation over paths is only worth reporting if it is precise, so it was measured before being wired to anything. Over the same 300 pull requests, on the **1802 pairs that were open at the same instant**:

| relation | pairs selected | duplicates among them |
|---|---|---|
| both **edit** some path | 117 (6.5%) | a composition question, not this one |
| both **add** some path | **2 (0.1%)** | **2** |

Those 117 are the sibling sweep's question, with a different remedy (a merge order, possibly one composition run), and `scripts/check_merge_base_overlap.py --all-open` already owns it. Two branches *editing* one file is a composition to verify; two branches *creating* one file is not a composition at all. For contrast, the path relation this repository has already rejected -- widening a path intersection to a test's walked root -- selected 11 of 36 pairs and named no defect. A finding attached to that much of the queue reads as boilerplate.

The changelog fragment is why the added-path relation stays quiet: every branch adds one, and its name embeds the pull request number, so it can never collide. That is asserted as a premise of the fixtures rather than left to luck.

### The two keys are complementary, so neither replaces the other

| pair | claims an issue | shares an added path |
|---|---|---|
| #2570, #2571 (both claim #2569) | yes | no |
| #2480, #2508 (both claim #2466) | yes | no |
| #2388, #2389 | no | yes |
| #2707, #2708 | no | yes |

Four duplicate pairs, two reachable from each key, none from both. `--issue` and `--pr` are untouched.

### Two policies kept from this file rather than borrowed from the sibling sweep

- **Drafts are included.** The sibling sweep excludes them because a draft cannot merge; this file includes them because a draft's link is a real claim. The same reasoning carries: a draft's new file is authored work whatever its merge state, so excluding one would hide a collision for as long as either side stayed a draft. One of the three currently open pull requests is a draft.
- **The open set is read through `repository.pullRequests(states: OPEN)`, not `search`.** Search is eventually consistent, and a pull request opened seconds ago is exactly the row this sweep exists to find.

This is also why the mode reads `changeType` from GraphQL in the same query as the open list, rather than reusing the sibling's REST file reader: that reader's open-set helper carries the opposite draft policy, and importing it would have imported the policy silently.

### Why this one cannot be asked at intake

`--issue` is asked before authoring, so it prevents the work. `--all-open` cannot be, and the module now says so instead of leaving it implied: a path set is a property of a pushed branch, so at intake there is nothing to read. It therefore caps the review cost of a collision rather than preventing the authoring, which is what `--pr` does for a claim. It still arrives early enough to matter -- both claim-free pairs opened inside the same ~35-minute window every other observed collision shares.

An unreadable answer is not a pass: a truncated file list, an unreadable open set and an API error all reach `unknown-additions`, for the reason the claim-keyed modes refuse a truncated link set.

## Tests

`tests/test_duplicate_work_added_path_key.py` (65 tests) pins both measured claim-free pairs as data, reconstructed from their real file lists.

Pre-fix split, with `scripts/check_duplicate_claim.py` and `AGENTS.md` reverted to `upstream/main`: **56 failed / 9 passed**. The 9 that pass are the controls, and they are the point -- 4 grade the claim key (2 assert the blindness, 2 assert it still catches what it was built for), 4 are usage-error rows, and 1 asserts the intake command survives unchanged.

| break | failing | notes |
|---|---|---|
| `added_paths` accepts every `changeType` (the edited relation) | 6 | every non-`ADDED` row, plus the create-vs-edit case |
| a `REMOVED` path collides too (over-reach) | 1 | the `REMOVED` row alone |
| prose exempt, borrowing the sibling sweep's `.md` rule | 1 | the prose boundary alone |
| only adjacent pull requests compared | 3 | includes the 3-way pair enumeration |
| a truncated file list read short | 1 | |
| an unreadable set reported as `unique-additions` | 1 | the silent no-op |
| drafts excluded (the sibling sweep's policy) | 1 | |
| the finding exits `0` | 1 | |
| only the first page of the open set read | 3 | the finding exists only across the page boundary |
| the docstring measurement dropped, code kept | 2 | |
| `AGENTS.md` not updated, code kept | 5 | |

11 mutations, **11 distinct firing sets**, control 0. Re-measured after `ruff format`, which collapsed one anchor.

## Verification

- Paired run of an identical 413-file selection (every test naming a gate script, the guidance, the changelog convention or a ruleset, plus every test that walks the tree with `ast`/`rglob`/`inspect.getsource` or reads `AGENTS.md` / `docs/`), on this branch and on a clean `upstream/main` worktree, with the new test file excluded from both: **17 failed, 18271 passed, 97 skipped on BOTH**. Failing-ID sets identical, `comm` empty in both directions. All 17 need `awsiot` (`awsiotsdk`, declared in the `[mesh-iot]` extra) and are absent locally.
- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean. The script is not in CI's lint scope but was held to the same rules.
- `mypy`: **24 == 24** against a pristine base worktree, normalized message sets byte-identical, none in the changed files.
- `python3 scripts/assemble_changelog.py --check`: OK, 742 pending.
- Dogfooded: run against the live open set with this pull request in it, the new mode reports `unique-additions` over 3 pull requests and 3 pairs, exit `0`.

No visual artifact: this changes a repository check, its guidance and its tests, and touches no policy, simulation, rendering, recording or robot asset. The measurements above are the evidence.

### One test helper widened

`tests/test_duplicate_claim_check.py`'s `_documented_intake_argv` asserted that `AGENTS.md` invokes this script exactly once, and step 1 now documents two commands. It selects the intake command by `--issue` instead. The failure it exists to produce -- a shortened intake command that no longer names the repository -- is unchanged; asserting uniqueness would have failed on the sibling command instead.
