### PR TITLE
fix(isaac): read both MJCF spellings of a free joint

### DIFF
--- a/changelog.d/2712-mjcf-freejoint-spelling.md
+++ b/changelog.d/2712-mjcf-freejoint-spelling.md
@@ -1,0 +1,39 @@
+### Fixed: both MJCF spellings of a free joint are read, instead of only one
+
+MJCF states a floating base two ways and MuJoCo compiles both to the same `mjJNT_FREE`:
+`<joint type="free">` and the dedicated `<freejoint>` element. `load_mjcf` walked
+`body_el.findall("joint")`, so only the first spelling produced a `JointDef` and a `<freejoint>`
+produced none at all - the base's six degrees of freedom were absent from the returned
+`ProceduralRobot` rather than reported as a joint a caller can see and skip. The scene reader in
+the same module already consulted both spellings, and the module's own docstring already named
+them as equivalent, so the robot reader was the one surface that knew about only one.
+
+`<freejoint>` is the spelling the shipped asset corpus uses. Of the 46 loadable robot MJCFs under
+`robot_descriptions` that declare a free joint, every one spells it `<freejoint>` and none spells
+`type="free"`, so a floating base was reported for none of them: the quadrupeds (`unitree_go2`,
+`anymal_c`, `spot`), the humanoids (`unitree_h1`, `talos`, `berkeley_humanoid`), and most visibly
+the aircraft - `skydio_x2` and `bitcraze_crazyflie_2` have exactly one joint each, that base, so
+the loader reported a robot with no joints whatsoever.
+
+Both tags are now read, in document order. MuJoCo fixes the two rules that makes this
+unambiguous, and each is pinned as a premise. A free joint may not share a body with any other
+joint (`more than 6 dofs in body`), so a body carrying a `<freejoint>` carries nothing else and
+the order of the two tags can never differ - which also means the change cannot reach the
+`_validate_kinematic_tree` compound-joint guard. And `<freejoint>` resolves no default class:
+MJCF has no `<default><freejoint>` block, and MuJoCo gives such a joint the built-in damping and
+armature even where a `<default><joint>` class is in force, while the `type="free"` spelling does
+inherit that class. The loader now diverges in exactly that place and in exactly that direction.
+
+Graded across the corpus by rewriting every `<freejoint .../>` as `<joint ... type="free"/>` and
+asking MuJoCo whether that is the same model - it is, for 48 of 48 files, with no premise
+violated - the two spellings agreed on 0 of 43 gradable files before and 43 of 43 now, with 43
+joints under-reported before and 0 now. 20 of the 43 reports are byte-identical field for field;
+the other 23 differ only in fields a `<default><joint>` class supplies, and MuJoCo diverges the
+same way on all 23. Nothing else changes: the load and refuse verdicts are the same on both
+readings.
+
+What `free` MAPS to is deliberately unchanged and pinned. `_MJCF_JOINT_TYPE_MAP` reports it as
+`"fixed"` because `JointDef` has no 6-DOF spelling, so a floating base is now visible in `joints`
+without being counted as an actuated DOF by `num_joints`. Whether the dataclass should gain such
+a spelling is a contract question about every producer of a `ProceduralRobot`, so moving it later
+has to be an explicit decision rather than a side effect of this one.

--- a/docs/simulation/isaac.md
+++ b/docs/simulation/isaac.md
@@ -228,7 +228,16 @@ open a window.
   parser can read: a URDF joint that omits the optional `<axis>` acts about
   **+X**, an MJCF `<joint>` that omits `axis` about **+Z**. Both are valid
   axes, so a joint read under the other format's default would be reported
-  acting in the perpendicular plane with the load still reporting success.
+  acting in the perpendicular plane with the load still reporting success. Both
+  of MJCF's spellings of a free joint are read - the dedicated `<freejoint>`
+  element and `<joint type="free">`, which MuJoCo compiles to the same joint -
+  so a floating base is reported rather than absent. `<freejoint>` is how every
+  shipped quadruped and humanoid states its base, and it resolves no default
+  class, because MJCF has no `<default><freejoint>` block: a `<default><joint>`
+  class reaches the `type="free"` spelling only, exactly as MuJoCo applies it.
+  Either spelling is reported with `joint_type="fixed"`, since `JointDef` has no
+  6-DOF spelling, so a floating base is visible in `joints` without being
+  counted as an actuated DOF by `num_joints`.
 
 Because the joint-name and observation contract matches the MuJoCo backend,
 policies and observation mappings transfer unchanged between backends.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -446,6 +446,19 @@ _MJCF_JOINT_TYPE_MAP = {
     "free": "fixed",
 }
 
+# MJCF spells a free joint two ways, and MuJoCo compiles both to the same
+# ``mjJNT_FREE``: ``<joint type="free">`` and the dedicated ``<freejoint>``
+# element. A reader that consults only the first reports no joint at all for a
+# floating base, which is how every quadruped and humanoid in the shipped asset
+# corpus declares its root. Both tags are read here so the two spellings of one
+# model produce one report.
+_MJCF_JOINT_TAGS = ("joint", "freejoint")
+
+# The tag whose type MJCF fixes rather than declaring: ``<freejoint>`` accepts
+# only ``name``, ``group`` and ``align`` - MuJoCo refuses ``type`` on it - and
+# MJCF has no ``<default><freejoint>`` block, so it resolves no default class.
+_MJCF_FREEJOINT_TAG = "freejoint"
+
 
 def load_mjcf(path: str) -> ProceduralRobot:
     """Load an MJCF file and return a :class:`ProceduralRobot`.
@@ -453,9 +466,10 @@ def load_mjcf(path: str) -> ProceduralRobot:
     Parses MuJoCo's MJCF format with stdlib
     :mod:`xml.etree.ElementTree`. Walks ``<worldbody>`` / nested ``<body>``
     elements depth-first to assign body indices in tree order, then emits a
-    :class:`JointDef` for each ``<joint>`` connecting that body to its
-    parent. Useful for LIBERO scenes (the matrix's main consumer ships
-    MJCF).
+    :class:`JointDef` for each joint connecting that body to its parent -
+    ``<joint>`` and the dedicated ``<freejoint>``, MJCF's two spellings of a
+    free joint, which MuJoCo compiles to the same joint. Useful for LIBERO
+    scenes (the matrix's main consumer ships MJCF).
 
     Each body's pose is reported in its parent's frame, as MJCF declares it:
     ``position`` from ``pos``, and ``orientation`` from whichever of MJCF's five
@@ -557,16 +571,28 @@ def load_mjcf(path: str) -> ProceduralRobot:
         )
         body_idx = len(bodies) - 1
 
-        # Each <joint> child connects this body to its parent.
-        for joint_el in body_el.findall("joint"):
-            # A joint's own attributes, with its default class's underneath: a
-            # class may declare ``type``, ``axis``, ``range``, ``damping`` and
-            # ``armature``, so a joint that spells none of them still has all
-            # five. ``name`` stays an attribute of the element - a class names a
-            # kind of joint, never an instance of one.
-            jattrs = _class_attrs(joint_el, joint_defaults, childclass)
+        # Each joint-bearing child connects this body to its parent, in
+        # document order. MuJoCo refuses a free joint beside any other joint on
+        # one body ("more than 6 dofs in body"), so a body carrying a
+        # <freejoint> carries nothing else and the order is never ambiguous.
+        for joint_el in (child for child in body_el if child.tag in _MJCF_JOINT_TAGS):
+            if joint_el.tag == _MJCF_FREEJOINT_TAG:
+                # <freejoint> declares no type, axis, range, damping or
+                # armature, and MJCF has no <default><freejoint> block, so it
+                # resolves no class: MuJoCo gives such a joint the built-in
+                # values even where a <default><joint> class is in force. Its
+                # own attributes are therefore all it has.
+                jattrs: dict[str, str] = {}
+                mjcf_type = "free"
+            else:
+                # A joint's own attributes, with its default class's underneath:
+                # a class may declare ``type``, ``axis``, ``range``, ``damping``
+                # and ``armature``, so a joint that spells none of them still
+                # has all five. ``name`` stays an attribute of the element - a
+                # class names a kind of joint, never an instance of one.
+                jattrs = _class_attrs(joint_el, joint_defaults, childclass)
+                mjcf_type = jattrs.get("type", "hinge")
             jname = joint_el.get("name") or f"{body_name}_joint_{len(joints)}"
-            mjcf_type = jattrs.get("type", "hinge")
             jtype = _MJCF_JOINT_TYPE_MAP.get(mjcf_type)
             if jtype is None:
                 raise ValueError(

--- a/tests/simulation/isaac/test_mjcf_freejoint_spelling.py
+++ b/tests/simulation/isaac/test_mjcf_freejoint_spelling.py
@@ -1,0 +1,307 @@
+"""MJCF's two spellings of a free joint report one model.
+
+MJCF states a floating base two ways and MuJoCo compiles both to the same
+``mjJNT_FREE``: ``<joint type="free">`` and the dedicated ``<freejoint>``
+element. ``load_mjcf`` walked ``body_el.findall("joint")``, so only the first
+spelling was read and a ``<freejoint>`` produced no :class:`JointDef` at all --
+the base's six degrees of freedom were absent from the report rather than
+reported as a joint the caller could see and skip.
+
+That is the spelling the shipped asset corpus uses. Of the 46 loadable robot
+MJCFs under ``robot_descriptions`` that declare a free joint, every one spells
+it ``<freejoint>`` and none spells ``type="free"``: the quadrupeds
+(``unitree_go2``, ``anymal_c``, ``spot``), the humanoids (``unitree_h1``,
+``talos``, ``berkeley_humanoid``) and, most visibly, the aircraft --
+``skydio_x2`` and ``bitcraze_crazyflie_2`` have exactly one joint each, the free
+base, so the loader reported a robot with no joints whatsoever.
+
+Every expectation here is derived from ``mujoco.MjModel`` rather than restated
+by hand, and MuJoCo also fixes the two rules the implementation rests on:
+
+* a free joint may not share a body with any other joint (``more than 6 dofs in
+  body``), so a ``<freejoint>`` is the only joint on its body and the document
+  order of the two tags is never ambiguous; and
+* ``<freejoint>`` resolves no default class -- MJCF has no
+  ``<default><freejoint>`` block, and MuJoCo gives such a joint the built-in
+  damping and armature even where a ``<default><joint>`` class is in force,
+  while the ``type="free"`` spelling does inherit that class.
+
+Deliberately unchanged: what ``free`` MAPS to. ``_MJCF_JOINT_TYPE_MAP`` reports
+it as ``"fixed"`` because :class:`JointDef` has no 6-DOF spelling, so a floating
+base is still excluded from ``num_joints``. Whether the dataclass should gain
+one is a contract question about every producer of a ``ProceduralRobot``; this
+change is only that the two spellings of one model agree, and the mapping is
+pinned below so a later answer has to move it explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import _MJCF_JOINT_TYPE_MAP, load_mjcf
+
+mujoco = pytest.importorskip("mujoco")
+
+#: The two ways MJCF spells a free joint, with no attributes on either.
+SPELLINGS = ("<freejoint/>", '<joint type="free"/>')
+
+#: A ``<default><joint>`` class supplying the two scalars a joint declaration
+#: can inherit. MuJoCo applies it to the ``type="free"`` spelling only.
+CLASS_DEFAULTS = '<default><joint damping="5" armature="0.3"/></default>'
+
+#: Attributes ``<freejoint>`` accepts beside ``name``, neither of which changes
+#: the fact that a joint is declared.
+ACCEPTED_EXTRAS = ('group="2"', 'align="true"')
+
+#: Attributes ``<freejoint>`` does not accept, so no reader has to resolve them.
+REFUSED_EXTRAS = ('type="free"', 'axis="0 0 1"', 'class="c"')
+
+#: The fields of a reported joint, compared as a whole so no difference between
+#: two reports of one model can hide in a field this suite forgot to name.
+FIELDS = (
+    "name",
+    "joint_type",
+    "parent_body",
+    "child_body",
+    "axis",
+    "limit_lower",
+    "limit_upper",
+    "damping",
+    "armature",
+)
+
+
+def _xml(joints: str, *, defaults: str = "", body: str = "base") -> str:
+    """An MJCF whose single body carries ``joints``."""
+    return (
+        f"<mujoco>{defaults}<worldbody>"
+        f'<body name="{body}" pos="0 0 0.5">'
+        f'<geom name="g" type="box" size="0.1 0.1 0.05"/>'
+        f"{joints}"
+        f"</body></worldbody></mujoco>"
+    )
+
+
+def _write(tmp_path, joints: str, *, defaults: str = "", name: str = "robot") -> str:
+    path = tmp_path / f"{name}.xml"
+    path.write_text(_xml(joints, defaults=defaults), encoding="utf-8")
+    return str(path)
+
+
+def _rows(path: str) -> list[tuple]:
+    """Every joint ``load_mjcf`` reports for the file, field by field."""
+    return [tuple(getattr(j, f) for f in FIELDS) for j in load_mjcf(path).joints]
+
+
+def _compiled(path: str) -> tuple[int, int, int, tuple[int, ...]]:
+    """What MuJoCo's compiler makes of the same file."""
+    model = mujoco.MjModel.from_xml_path(path)
+    return model.njnt, model.nq, model.nv, tuple(int(t) for t in model.jnt_type)
+
+
+def _free_dof(path: str) -> list[tuple[float, float]]:
+    """MuJoCo's own damping/armature on the first dof of each free joint."""
+    model = mujoco.MjModel.from_xml_path(path)
+    out = []
+    for j in range(model.njnt):
+        if int(model.jnt_type[j]) == int(mujoco.mjtJoint.mjJNT_FREE):
+            dof = int(model.jnt_dofadr[j])
+            out.append((float(model.dof_damping[dof]), float(model.dof_armature[dof])))
+    return out
+
+
+class TestThePremisesMujocoFixes:
+    """The rules the implementation rests on, each read from MuJoCo itself."""
+
+    def test_the_two_spellings_compile_to_the_same_model(self, tmp_path):
+        compiled = {s: _compiled(_write(tmp_path, s, name=f"m{i}")) for i, s in enumerate(SPELLINGS)}
+        assert len(set(compiled.values())) == 1, (
+            f"premise: the spellings describe one model, but MuJoCo compiled {compiled}"
+        )
+        njnt, nq, nv, types = compiled[SPELLINGS[0]]
+        assert (njnt, nq, nv) == (1, 7, 6)
+        assert types == (int(mujoco.mjtJoint.mjJNT_FREE),)
+
+    @pytest.mark.parametrize("spelling", SPELLINGS)
+    def test_a_free_joint_may_not_share_a_body_with_another_joint(self, tmp_path, spelling):
+        """So a body carrying one carries nothing else, and order cannot differ."""
+        path = _write(tmp_path, f'{spelling}<joint type="hinge" axis="0 0 1"/>', name="both")
+        with pytest.raises(ValueError, match="more than 6 dofs"):
+            mujoco.MjModel.from_xml_path(path)
+
+    @pytest.mark.parametrize("extra", REFUSED_EXTRAS)
+    def test_freejoint_refuses_the_attributes_it_does_not_own(self, tmp_path, extra):
+        path = _write(tmp_path, f"<freejoint {extra}/>", name="extra")
+        with pytest.raises(ValueError):
+            mujoco.MjModel.from_xml_path(path)
+
+    @pytest.mark.parametrize("extra", ACCEPTED_EXTRAS)
+    def test_freejoint_accepts_its_own_extras(self, tmp_path, extra):
+        path = _write(tmp_path, f"<freejoint {extra}/>", name="ok")
+        assert _compiled(path)[0] == 1
+
+    def test_mjcf_has_no_default_freejoint_block(self, tmp_path):
+        path = _write(tmp_path, "<freejoint/>", defaults="<default><freejoint/></default>", name="dflt")
+        with pytest.raises(ValueError):
+            mujoco.MjModel.from_xml_path(path)
+
+    def test_a_joint_class_reaches_one_spelling_and_not_the_other(self, tmp_path):
+        """MuJoCo's own answer, which is the answer the loader has to mirror."""
+        free = _write(tmp_path, "<freejoint/>", defaults=CLASS_DEFAULTS, name="cf")
+        typed = _write(tmp_path, '<joint type="free"/>', defaults=CLASS_DEFAULTS, name="ct")
+        assert _free_dof(free) == [(0.0, 0.0)], "premise: a <freejoint> inherits no class"
+        assert _free_dof(typed) == [(5.0, 0.3)], "premise: the type='free' spelling does"
+
+
+class TestAFreejointIsReported:
+    """The regression: a ``<freejoint>`` produced no joint at all."""
+
+    def test_a_body_whose_only_joint_is_a_freejoint_reports_one(self, tmp_path):
+        path = _write(tmp_path, "<freejoint/>")
+        assert _compiled(path)[0] == 1, "premise: MuJoCo compiles exactly one joint"
+        rows = _rows(path)
+        assert len(rows) == 1, f"MuJoCo compiles 1 joint for this model; the loader reported {len(rows)}"
+
+    def test_a_named_freejoint_is_reported_under_its_own_name(self, tmp_path):
+        path = _write(tmp_path, '<freejoint name="floating_base"/>')
+        assert [r[0] for r in _rows(path)] == ["floating_base"]
+
+    def test_an_unnamed_freejoint_takes_the_bodys_fallback_name(self, tmp_path):
+        """The same fallback every unnamed ``<joint>`` gets, so nothing is special."""
+        path = _write(tmp_path, "<freejoint/>", name="fallback")
+        assert [r[0] for r in _rows(path)] == ["base_joint_0"]
+
+    @pytest.mark.parametrize("extra", ACCEPTED_EXTRAS)
+    def test_the_extras_freejoint_accepts_do_not_hide_it(self, tmp_path, extra):
+        path = _write(tmp_path, f"<freejoint {extra}/>", name="extras")
+        assert len(_rows(path)) == 1
+
+    def test_a_floating_base_beside_actuated_joints_is_reported_too(self, tmp_path):
+        """The shipped humanoid shape: a free root body over an articulated chain."""
+        path = tmp_path / "chain.xml"
+        path.write_text(
+            "<mujoco><worldbody>"
+            '<body name="pelvis" pos="0 0 1"><freejoint name="floating_base"/>'
+            '<geom type="box" size="0.1 0.1 0.1"/>'
+            '<body name="thigh" pos="0 0 -0.2">'
+            '<joint name="hip" type="hinge" axis="0 1 0"/>'
+            '<geom type="box" size="0.05 0.05 0.1"/>'
+            "</body></body></worldbody></mujoco>",
+            encoding="utf-8",
+        )
+        njnt = _compiled(str(path))[0]
+        names = [r[0] for r in _rows(str(path))]
+        assert names == ["floating_base", "hip"], f"MuJoCo compiles {njnt} joints; the loader reported {names}"
+
+
+class TestBothSpellingsReportOneModel:
+    """Two spellings of one model, one report."""
+
+    def test_the_reports_are_identical_field_for_field(self, tmp_path):
+        reports = {s: _rows(_write(tmp_path, s, name=f"s{i}")) for i, s in enumerate(SPELLINGS)}
+        free, typed = reports["<freejoint/>"], reports['<joint type="free"/>']
+        assert free == typed, f"<freejoint/> reported {free}; type='free' reported {typed}"
+
+    def test_the_reported_joint_count_matches_the_compiler(self, tmp_path):
+        for i, spelling in enumerate(SPELLINGS):
+            path = _write(tmp_path, spelling, name=f"c{i}")
+            assert len(_rows(path)) == _compiled(path)[0], f"{spelling} under-reports the compiled joints"
+
+
+class TestTheDefaultClassBoundaryFollowsMjcf:
+    """Where the spellings legitimately differ, they differ MuJoCo's way."""
+
+    def test_the_class_reaches_the_typed_spelling_only(self, tmp_path):
+        free = _write(tmp_path, "<freejoint/>", defaults=CLASS_DEFAULTS, name="lf")
+        typed = _write(tmp_path, '<joint type="free"/>', defaults=CLASS_DEFAULTS, name="lt")
+        assert _free_dof(free) != _free_dof(typed), "premise: MuJoCo itself diverges here"
+        free_row, typed_row = _rows(free)[0], _rows(typed)[0]
+        assert (typed_row[FIELDS.index("damping")], typed_row[FIELDS.index("armature")]) == (5.0, 0.3)
+        assert (free_row[FIELDS.index("damping")], free_row[FIELDS.index("armature")]) != (5.0, 0.3), (
+            "a <freejoint> inherits no default class in MJCF, so the loader must not apply one"
+        )
+
+    def test_a_class_declaring_a_type_does_not_retype_a_freejoint(self, tmp_path):
+        """A ``<default><joint type="slide">`` class names a kind of ``<joint>``."""
+        path = _write(
+            tmp_path,
+            "<freejoint/>",
+            defaults='<default><joint type="slide" axis="1 0 0"/></default>',
+            name="retype",
+        )
+        assert _compiled(path)[3] == (int(mujoco.mjtJoint.mjJNT_FREE),), "premise: still a free joint"
+        assert [r[FIELDS.index("joint_type")] for r in _rows(path)] == ["fixed"]
+
+
+class TestTheOtherJointsAreUnchanged:
+    """Controls: reading a second tag must not disturb the first."""
+
+    @pytest.mark.parametrize(
+        ("mjcf_type", "reported"),
+        [("hinge", "revolute"), ("slide", "prismatic"), ("ball", "fixed"), ("free", "fixed")],
+    )
+    def test_every_declared_type_still_maps_as_before(self, tmp_path, mjcf_type, reported):
+        path = _write(tmp_path, f'<joint name="j" type="{mjcf_type}" axis="0 1 0"/>', name=mjcf_type)
+        assert [r[FIELDS.index("joint_type")] for r in _rows(path)] == [reported]
+
+    def test_a_joints_own_class_is_still_resolved(self, tmp_path):
+        path = _write(
+            tmp_path,
+            '<joint name="j" class="soft"/>',
+            defaults='<default class="soft"><joint type="hinge" axis="0 1 0" damping="7"/></default>',
+            name="cls",
+        )
+        row = _rows(path)[0]
+        assert row[FIELDS.index("joint_type")] == "revolute"
+        assert row[FIELDS.index("damping")] == 7.0
+
+    def test_an_unknown_joint_type_is_still_refused(self, tmp_path):
+        path = _write(tmp_path, '<joint name="j" type="screw"/>', name="unknown")
+        with pytest.raises(ValueError, match="unknown joint type"):
+            load_mjcf(path)
+
+    def test_a_chains_joints_are_still_reported_in_tree_order(self, tmp_path):
+        """One joint per body: the loader's topology guard refuses two on one edge."""
+        path = tmp_path / "order.xml"
+        path.write_text(
+            '<mujoco><worldbody><body name="base">'
+            '<joint name="first" type="hinge" axis="1 0 0"/>'
+            '<geom type="box" size="0.1 0.1 0.1"/>'
+            '<body name="arm" pos="0 0 0.2">'
+            '<joint name="second" type="slide" axis="0 0 1"/>'
+            '<geom type="box" size="0.05 0.05 0.1"/>'
+            "</body></body></worldbody></mujoco>",
+            encoding="utf-8",
+        )
+        assert [r[0] for r in _rows(str(path))] == ["first", "second"]
+
+    def test_two_joints_on_one_body_are_still_refused(self, tmp_path):
+        """The compound-joint guard, which a free joint can never reach: MuJoCo
+        refuses a free joint beside another joint before the loader is asked."""
+        path = tmp_path / "compound.xml"
+        path.write_text(
+            '<mujoco><worldbody><body name="base">'
+            '<geom type="box" size="0.1 0.1 0.1"/>'
+            '<body name="arm" pos="0 0 0.2">'
+            '<joint name="first" type="hinge" axis="1 0 0"/>'
+            '<joint name="second" type="slide" axis="0 0 1"/>'
+            '<geom type="box" size="0.05 0.05 0.1"/>'
+            "</body></body></worldbody></mujoco>",
+            encoding="utf-8",
+        )
+        assert _compiled(str(path))[0] == 2, "premise: MuJoCo compiles the 2-DOF pair"
+        with pytest.raises(ValueError, match="duplicate parent->child body edges"):
+            load_mjcf(str(path))
+
+
+class TestTheJointTypeVocabularyIsUnchanged:
+    """The boundary: what ``free`` maps to is a separate contract question."""
+
+    def test_free_is_still_reported_as_fixed(self):
+        assert _MJCF_JOINT_TYPE_MAP["free"] == "fixed"
+
+    def test_a_floating_base_is_still_excluded_from_the_actuated_count(self, tmp_path):
+        path = _write(tmp_path, "<freejoint/>", name="count")
+        robot = load_mjcf(path)
+        assert len(robot.joints) == 1, "the joint is reported"
+        assert robot.num_joints == 0, "and is still not counted as an actuated DOF"


### PR DESCRIPTION
## Problem

MJCF states a floating base two ways, and MuJoCo compiles both to the same `mjJNT_FREE`:
`<joint type="free">` and the dedicated `<freejoint>` element. `load_mjcf` walked
`body_el.findall("joint")`, so only the first spelling produced a `JointDef`. A `<freejoint>`
produced none at all: the base's six degrees of freedom were absent from the returned
`ProceduralRobot` rather than reported as a joint a caller can see and skip.

`<freejoint>` is the spelling the shipped asset corpus uses. Of the 46 loadable robot MJCFs under
`robot_descriptions` that declare a free joint, **every one spells it `<freejoint>` and none
spells `type="free"`**, so a floating base was reported for none of them. Measured through the
public loader, with MuJoCo's own count beside it:

| asset | MuJoCo compiles | main reports | this branch |
| --- | --- | --- | --- |
| `skydio_x2` | 1 joint (nv=6) | **0 - no joints at all** | 1 |
| `unitree_go2` | 13 joints (nv=18) | 12 - the base is absent | 13 |
| `unitree_h1` | 20 joints (nv=25) | 19 - the base is absent | 20 |

The two aircraft are the clearest case: their only joint *is* the free base, so the loader
reported a robot with no joints whatsoever, under a successful load.

The scene reader in the same module already consulted both spellings
(`body_el.find("freejoint") is not None or any(j.get("type") == "free" ...)`), and the module's
own docstring already named them as equivalent, so the robot reader was the single surface that
knew about only one.

## Change

Both tags are read, in document order. MuJoCo fixes the two rules that make this unambiguous, and
each is measured and pinned as a premise rather than assumed:

- **A free joint may not share a body with any other joint.** Both spellings are refused with
  `more than 6 dofs in body 'b'`, so a body carrying a `<freejoint>` carries nothing else, the
  order of the two tags can never differ, and the change cannot reach the
  `_validate_kinematic_tree` compound-joint guard (which still refuses a real 2-DOF body).
- **`<freejoint>` resolves no default class.** MJCF has no `<default><freejoint>` block (MuJoCo
  refuses one), and with `<default><joint damping="5" armature="0.3"/>` in force MuJoCo gives a
  `<freejoint>` `dof_damping=0.0, dof_armature=0.0` while the `type="free"` spelling inherits
  `5.0 / 0.3`. The loader now diverges in exactly that place and in exactly that direction.

Both rules are identical on mujoco 3.5.0 (the declared floor) and 3.12.0. `<freejoint>` also
accepts only `name`, `group` and `align`; MuJoCo refuses `type`, `axis` and `class` on it, so no
reader has to resolve them.

## Scope, deliberately not widened

What `free` *maps to* is unchanged. `_MJCF_JOINT_TYPE_MAP` still reports it as `"fixed"` because
`JointDef` has no 6-DOF spelling, so a floating base is now visible in `joints` without being
counted as an actuated DOF by `num_joints`. Whether the dataclass should gain such a spelling is a
contract question about every producer of a `ProceduralRobot`; it is pinned both ways here
(`TestTheJointTypeVocabularyIsUnchanged`) so that moving it later is an explicit decision rather
than a side effect of this one.

## Corpus grading

Every `<freejoint .../>` in the corpus was rewritten as `<joint ... type="free"/>` and MuJoCo was
asked whether that is the same model (`nq`, `nv`, `njnt`, `jnt_type`). Only files where it says
yes are graded, so any difference in the loader's two reports is the loader's. All nine `JointDef`
fields are compared, so nothing can hide in a field the sweep forgot to name.

| reading | premise holds | graded | joint-count parity | reports byte-identical | joints under-reported |
| --- | --- | --- | --- | --- | --- |
| main | 48 of 48 | 43 | 0 of 43 | 0 | 43 |
| this branch | 48 of 48 | 43 | **43 of 43** | 20 | **0** |

The 23 branch reports that are not byte-identical differ **only** in fields a `<default><joint>`
class supplies (`damping` 21, `armature` 15, `axis` 4, `limits` 2), and MuJoCo diverges the same
way on all 23 - that is the MJCF rule above, not a residual. Nothing is unexplained
(`residual_other: 0`), no premise is violated, and the 5 files the loader refuses are refused
identically on both readings.

## Tests

`tests/simulation/isaac/test_mjcf_freejoint_spelling.py`, 30 cases, every expectation derived
from `mujoco.MjModel` rather than restated by hand.

Pre-fix split on pristine `upstream/main`: **11 failed, 19 passed** - 6 in
`TestAFreejointIsReported`, 2 in `TestBothSpellingsReportOneModel`, 2 in
`TestTheDefaultClassBoundaryFollowsMjcf`, 1 in `TestTheJointTypeVocabularyIsUnchanged`, and
**0 in the 8 premise cases and 0 in the 7 control cases**. The one boundary-class failure is
there because the boundary (a floating base is reported but not counted) is only observable once
the joint exists at all; its first assertion is the premise for its second. Headline failure:
`MuJoCo compiles 1 joint for this model; the loader reported 0`.

### Mutation table

| mutation | tests fired | where |
| --- | --- | --- |
| control, no mutation | 0 | - |
| b1 the whole fix reverted: only `<joint>` is read | 11 | the four non-control classes; exactly the pre-fix set |
| b2 only `<freejoint>` is read (over-reach the other way) | 12 | incl. `TestTheOtherJointsAreUnchanged` |
| b3 a `<freejoint>` resolves a default class after all | 1 | the class boundary |
| b4 a `<freejoint>` takes its type from the class too | 2 | the class boundary |
| b5 a `<freejoint>` is mapped to revolute rather than free | 3 | parity + boundary + vocabulary |
| b6 a `<freejoint>` is always named `freejoint` | 4 | naming + parity |
| b7 a `<freejoint>` carrying `group`/`align` is skipped | 2 | the accepted-extras cases |
| b8 the free joint reports MuJoCo's dof values, not the loader's own defaults | 1 | field-for-field parity |
| b9 both tags read via two concatenated `findall()` passes | **0** | see below |

b9 fires nothing, and that is the finding rather than a hole: because MuJoCo refuses a free joint
beside any other joint on one body, a `<freejoint>` is the only joint on its body, so a
concatenated two-pass read can never produce a different order from a document-order read. The
mutation is semantically identical to the shipped code, and the premise that makes it so is
itself a test (`test_a_free_joint_may_not_share_a_body_with_another_joint`).

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1532 files).
- mypy: **5 == 5** against a pristine `upstream/main` worktree, message sets byte-identical, 0 in
  the changed files.
- Paired run over an identical 495-file selection (all of `tests/simulation/isaac/` plus every
  test naming the loaders, `ProceduralRobot`/`JointDef`/`BodyDef`, or walking the tree with
  `ast`/`rglob`/`inspect.getsource`), the new file excluded from both trees: **20287 collected and
  `18 failed, 20088 passed, 181 skipped` on both**, 18 failing ids each, both `comm` directions
  empty. All 18 are environmental and identical on both trees: 17 need `awsiot` (declared in the
  `[mesh-iot]` extra) and 1 is a leftover dataset directory in the shared temp dir.
- The new file passes on **mujoco 3.5.0** (the declared floor) and **3.12.0**; the whole
  `tests/simulation/isaac/` suite is 1431 passed / 5 skipped on 3.12.0.
- Docs guards (`test_docs_python_examples_are_callable`, `test_docs_no_stale_future_symbol_claims`,
  `test_docstrings_no_dangling_doc_refs`, and the source-string sweeps): 482 passed.
- Changelog fragment gates: 89 passed.

## Artifact

Rendered headless in MuJoCo (`MUJOCO_GL=egl`, mujoco 3.5.0) from the shipped assets themselves.
The renders are byte-identical on both trees - the asset does not change, the report does - which
is asserted in the render script, as is every number the figure prints. Panels are composited onto
a flat tone using MuJoCo's own segmentation render and framed from the measured subject bounding
box; the four lower panels share one camera and one crop, since they are a comparison.

The lower half is the stake. `skydio_x2` is stepped 0.30 s under gravity twice: once as MuJoCo
compiles it, and once with no joint for that body - the topology a report carrying no joint
describes. With the free base the body falls `+0.100 m -> -0.320 m` (a displacement of
`-0.420 m`, 1941 changed pixels between the two frames); with no joint, `njnt=0`, `nv=0`,
displacement `0.000 m`, and the two frames are byte-identical. The asset's own `<keyframe>` states
a 7-wide `qpos` that exists only because of that joint, and MuJoCo refuses the keyframe once it is
removed.

![MJCF free-joint spellings: reported joint counts against MuJoCo, and a drone stepped under gravity with and without its base joint](https://github.com/cagataycali/robots/releases/download/artifacts/mjcf-freejoint.png)
