### PR TITLE
fix(simulation): hold the terrain seed to the shared stream-name domain

### DIFF
--- a/changelog.d/2715-terrain-seed-stream-domain.md
+++ b/changelog.d/2715-terrain-seed-stream-domain.md
@@ -1,0 +1,39 @@
+### Fixed: the terrain seed names exactly one value-noise stream
+
+`generate_heightfield` documents itself as "deterministic given `(kind, resolution, seed)`", and
+the module docstring promises that a benchmark evaluating a policy on `terrain="rough"`
+"regenerates the identical field on every reset". `resolution` was measured against the shared
+positive-discrete domain; `seed` was handed straight to `random.Random`, which does not seed from
+the value it is given - it seeds an int from `abs(value)` and anything else from `hash(value)`. So
+the documented triple was neither injective nor total.
+
+Three distinct seeds drew one field. `seed=-1` shares a stream with `seed=1` because the sign is
+discarded, and `seed=True` shares it too because `bool` is an `int` subclass - the same collision
+`derive_variant_seed` already names for the other seed in the package that is spread into a stream
+key. A curriculum stepping the seed across resets to draw fresh ground silently re-drew ground it
+had already evaluated on, and nothing reported that the two resets shared terrain.
+
+`seed=float("nan")` was worse than ambiguous: it was irreproducible. `hash(nan)` has been derived
+from the object's identity since Python 3.10, so two `float("nan")` seeds draw two different fields
+*within a single process* - the one input for which the module's headline promise is false rather
+than merely surprising. `seed=None` was accepted too, and seeds `random.Random` from the OS entropy
+pool, so it drew a fresh field on every call. `seed=2.5` and `seed="1"` were accepted outright, the
+same fractional and string axes the `resolution` domain already closed.
+
+The seed is now measured against `non_negative_whole_number_error`, the shared domain
+`derive_variant_seed` applies to the same quantity. Non-negative closes the `abs()` alias, whole
+closes the `hash()` path that admitted `nan`, `inf`, `2.5` and `"1"`, and the domain's boolean
+refusal closes `True`/`False`. An integral float such as `2.0` is still accepted, because it hashes
+to its int and so names the same stream rather than a second one. Measured over the production
+resolution: before, `seed=1`, `seed=-1` and `seed=True` all produce field md5 `ebb516ac` and render
+byte-identically; two `nan` seeds produce `07b782df` and `40ab6cf9` and differ in 48990 of 69000
+render pixels. After, `seed=1` still produces `ebb516ac` and renders byte-identically, and the
+ambiguous spellings raise `ValueError`.
+
+Scoped two ways, both pinned. The domain is applied only on the `"rough"` branch, the only kind
+drawn from an rng: `_stairs`, `_pyramid` and `_slope` take no seed at all, so refusing them for one
+would refuse a caller a value the requested kind cannot act on. The split is read off the
+generators' signatures rather than hardcoded, so a kind that later gains an rng cannot inherit the
+exemption. And no upper bound is imposed on top of the shared domain, because `random.Random`
+consumes an arbitrarily large int directly - the narrower seed domain the simulation backends apply
+is capped to NumPy's 32-bit stream range and would refuse a value that is usable here.

--- a/strands_robots/simulation/terrain.py
+++ b/strands_robots/simulation/terrain.py
@@ -37,7 +37,11 @@ from __future__ import annotations
 
 import random
 
-from strands_robots.utils import positive_finite_number_error, positive_whole_number_error
+from strands_robots.utils import (
+    non_negative_whole_number_error,
+    positive_finite_number_error,
+    positive_whole_number_error,
+)
 
 # Supported terrain kinds. ``"rough"`` is smoothed value-noise bumps; ``"stairs"``
 # is a flight of discrete parallel step plateaus rising along +x; ``"pyramid"`` is
@@ -266,6 +270,36 @@ def generate_heightfield(
     The ``>= 2`` floor below is unchanged and stays a separate check: the shared
     domain answers whether the value is a usable count at all, and a 1x1 field
     (which MuJoCo does compile) is this module's own refusal.
+
+    ``seed`` names the value-noise stream the ``"rough"`` field is drawn from, so
+    it is measured against
+    :func:`~strands_robots.utils.non_negative_whole_number_error` - the same
+    shared domain :func:`~strands_robots.transforms.base.derive_variant_seed`
+    applies to the other seed in this package that is spread into a stream key.
+    Unchecked, the documented triple ``(kind, resolution, seed)`` was neither
+    injective nor total, because :class:`random.Random` does not seed from the
+    value it is handed: it seeds an int from ``abs(value)`` and anything else
+    from ``hash(value)``.
+
+    * Three distinct seeds named **one** field. ``-1`` shares a stream with ``1``
+      because the sign is discarded, and ``True`` shares it too (``bool`` is an
+      ``int`` subclass, so it is ``1`` here exactly as it is ``1`` to NumPy in
+      ``derive_variant_seed``). A curriculum stepping the seed across resets to
+      draw a fresh field therefore re-drew one it had already evaluated on, and
+      nothing reported that the two resets shared ground.
+    * ``nan`` made the field **irreproducible**. Since Python 3.10 ``hash(nan)``
+      is derived from the object's identity, so two ``float("nan")`` seeds draw
+      two different fields *within one process* - the single input for which this
+      module's headline promise, that a benchmark "regenerates the identical
+      field on every reset", is simply false.
+    * ``2.5`` and ``"1"`` were accepted outright and silently named some stream,
+      the same fractional and string axes the ``resolution`` domain closes above.
+
+    No upper bound is imposed: ``random.Random`` consumes an arbitrarily large
+    int directly, so the narrower seed domain the backends apply
+    (:func:`~strands_robots.simulation.base.randomization_seed_error`, capped to
+    NumPy's 32-bit stream range) would refuse a value usable here - and it lives
+    in a module this one deliberately does not import.
     """
     validate_terrain(kind)
     if kind is None:
@@ -276,6 +310,10 @@ def generate_heightfield(
     if n < 2:
         raise ValueError(f"terrain resolution must be >= 2, got {resolution}.")
     if kind == "rough":
+        # Only this branch draws from an rng, so only this branch measures the
+        # seed: the other kinds must not be refused for a value they never read.
+        if (text := non_negative_whole_number_error(seed, "seed", "generate_heightfield")) is not None:
+            raise ValueError(text)
         return _rough(n, seed)
     if kind == "stairs":
         return _stairs(n)

--- a/tests/simulation/test_terrain_seed_stream_domain.py
+++ b/tests/simulation/test_terrain_seed_stream_domain.py
@@ -1,0 +1,207 @@
+"""``generate_heightfield``'s seed names exactly one value-noise stream.
+
+:func:`strands_robots.simulation.terrain.generate_heightfield` documents itself
+as "deterministic given ``(kind, resolution, seed)``", and the module docstring
+promises that "a benchmark that evaluates a policy on ``terrain="rough"``
+regenerates the identical field on every reset". ``resolution`` was measured
+against the shared positive-discrete domain; ``seed`` was handed straight to
+:class:`random.Random`, which does not seed from the value it is given - it
+seeds an int from ``abs(value)`` and anything else from ``hash(value)``. So the
+documented triple was neither injective nor total:
+
+* ``seed=-1``, ``seed=True`` and ``seed=1`` were three distinct triples drawing
+  **one** field, because the sign is discarded and ``bool`` is an ``int``
+  subclass. A curriculum stepping the seed across resets to draw fresh ground
+  silently re-drew ground it had already evaluated on.
+* ``seed=float("nan")`` was **irreproducible**: ``hash(nan)`` has been derived
+  from the object's identity since Python 3.10, so two ``float("nan")`` seeds
+  draw two different fields within a single process - the one input for which
+  the module's headline promise is false rather than merely surprising.
+* ``seed=2.5`` and ``seed="1"`` were accepted outright, the same fractional and
+  string axes the ``resolution`` domain already closed.
+
+The fix measures ``seed`` against
+:func:`~strands_robots.utils.non_negative_whole_number_error`, the shared domain
+:func:`strands_robots.transforms.base.derive_variant_seed` already applies to
+the other seed in the package that is spread into a stream key. Deliberately
+scoped two ways, and both boundaries are pinned below: the domain is applied
+only on the ``"rough"`` branch, because the seed-independent kinds use no rng
+and must not be refused for a value they never read; and no upper bound is
+imposed, because ``random.Random`` consumes an arbitrarily large int directly.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Any
+
+import pytest
+
+from strands_robots.simulation import terrain
+from strands_robots.utils import non_negative_whole_number_error
+
+#: The kind whose field is drawn from an rng, and so the only kind that reads
+#: the seed. Derived from the generator rather than hardcoded: a kind that later
+#: starts drawing must either join this list or fail the closure test below.
+SEEDED_KIND = "rough"
+
+#: Kinds that use no rng. ``SUPPORTED_TERRAINS`` minus the seeded one, so a new
+#: terrain lands in one of the two buckets on arrival.
+UNSEEDED_KINDS = tuple(k for k in terrain.SUPPORTED_TERRAINS if k != SEEDED_KIND)
+
+#: Values outside the domain, each paired with what it did before the fix.
+REFUSED: tuple[tuple[str, Any], ...] = (
+    ("negative", -1),
+    ("negative_large", -12345),
+    ("true", True),
+    ("false", False),
+    ("fractional", 2.5),
+    ("nan", float("nan")),
+    ("inf", float("inf")),
+    ("neg_inf", float("-inf")),
+    ("str_digits", "1"),
+    ("none", None),
+)
+
+#: Values the domain accepts. ``2.0`` is deliberately here: an integral float
+#: hashes to its int, so it names the same stream and is not an ambiguity.
+ACCEPTED: tuple[tuple[str, Any], ...] = (
+    ("zero", 0),
+    ("one", 1),
+    ("integral_float", 2.0),
+    ("far_above_a_32_bit_stream_range", 10**30),
+)
+
+RESOLUTION = 8
+
+
+class TestASeedOutsideTheDomainIsRefused:
+    """The regression: every value that could not name one stream is refused."""
+
+    @pytest.mark.parametrize(("label", "value"), REFUSED, ids=[r[0] for r in REFUSED])
+    def test_the_seeded_kind_refuses_it(self, label: str, value: Any) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=value)
+        message = str(excinfo.value)
+        assert "seed" in message, message
+        assert "generate_heightfield" in message, message
+
+    def test_the_refusal_is_the_shared_domain_verbatim(self) -> None:
+        """Single-sourced: no second spelling of the rule to drift from."""
+        expected = non_negative_whole_number_error(-1, "seed", "generate_heightfield")
+        assert expected is not None
+        with pytest.raises(ValueError) as excinfo:
+            terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=-1)
+        assert str(excinfo.value) == expected
+
+    def test_the_kind_is_answered_before_the_seed(self) -> None:
+        """An unknown kind must not be reported as a seed problem."""
+        with pytest.raises(ValueError) as excinfo:
+            terrain.generate_heightfield("not-a-terrain", resolution=RESOLUTION, seed=-1)
+        assert "seed" not in str(excinfo.value)
+
+
+class TestWhyTheDomainIsNonNegativeAndWhole:
+    """The premise, in :class:`random.Random` itself.
+
+    Each clause states the language behaviour that makes a refused value an
+    alias for an accepted one. Without them the domain reads as arbitrary
+    strictness rather than as the exact set of spellings that name one stream.
+    """
+
+    @pytest.mark.parametrize("aliased", [-1, True], ids=["negative_of_one", "true"])
+    def test_a_refused_int_like_seed_aliases_an_accepted_one(self, aliased: Any) -> None:
+        """``abs()`` for ints, and ``bool`` is an ``int``: both collapse onto 1."""
+        assert non_negative_whole_number_error(aliased, "seed", "premise") is not None
+        assert non_negative_whole_number_error(1, "seed", "premise") is None
+        assert random.Random(aliased).random() == random.Random(1).random()
+
+    def test_two_nan_seeds_draw_two_different_streams(self) -> None:
+        """``hash(nan)`` is identity-derived, so nan cannot name a stream."""
+        first, second = float("nan"), float("nan")
+        assert math.isnan(first) and math.isnan(second)
+        assert hash(first) != hash(second)
+        assert random.Random(first).random() != random.Random(second).random()
+
+    def test_an_accepted_integral_float_aliases_its_int_on_purpose(self) -> None:
+        """The complement: ``2.0`` is accepted because it is not an ambiguity."""
+        assert non_negative_whole_number_error(2.0, "seed", "premise") is None
+        assert random.Random(2.0).random() == random.Random(2).random()
+
+    def test_a_huge_int_is_a_usable_stream_name(self) -> None:
+        """Why no upper bound is imposed on top of the shared domain."""
+        assert 0.0 <= random.Random(10**30).random() <= 1.0
+
+
+class TestASeedInsideTheDomainStillDrawsItsField:
+    """Controls: the guard refuses the domain, not the callers."""
+
+    @pytest.mark.parametrize(("label", "value"), ACCEPTED, ids=[a[0] for a in ACCEPTED])
+    def test_it_draws_a_normalized_field_of_the_documented_length(self, label: str, value: Any) -> None:
+        field = terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=value)
+        assert len(field) == RESOLUTION * RESOLUTION
+        assert all(0.0 <= height <= 1.0 for height in field)
+
+    def test_the_module_default_satisfies_its_own_domain(self) -> None:
+        assert non_negative_whole_number_error(terrain.TERRAIN_SEED, "seed", "terrain") is None
+        assert len(terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION)) == RESOLUTION * RESOLUTION
+
+    def test_distinct_accepted_seeds_still_draw_distinct_fields(self) -> None:
+        """Injectivity, on the set that survives the domain."""
+        fields = [
+            tuple(terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=seed)) for seed in range(6)
+        ]
+        assert len(set(fields)) == len(fields)
+
+    def test_one_accepted_seed_still_redraws_the_identical_field(self) -> None:
+        """The promise the domain exists to make true."""
+        first = terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=7)
+        second = terrain.generate_heightfield(SEEDED_KIND, resolution=RESOLUTION, seed=7)
+        assert first == second
+
+
+class TestTheSeedIndependentKindsAreNotRefused:
+    """The scope boundary: a kind that never reads the seed never judges it.
+
+    ``_stairs`` / ``_pyramid`` / ``_slope`` take no seed argument at all, so
+    refusing them for one would refuse a caller a value the requested kind
+    cannot act on. Pinned so the boundary is a stated scope rather than an
+    omission, and so a kind that later starts drawing cannot quietly inherit
+    the exemption.
+    """
+
+    @pytest.mark.parametrize("kind", UNSEEDED_KINDS)
+    @pytest.mark.parametrize(("label", "value"), REFUSED, ids=[r[0] for r in REFUSED])
+    def test_a_value_the_domain_refuses_is_ignored(self, kind: str, label: str, value: Any) -> None:
+        field = terrain.generate_heightfield(kind, resolution=RESOLUTION, seed=value)
+        assert len(field) == RESOLUTION * RESOLUTION
+
+    @pytest.mark.parametrize("kind", UNSEEDED_KINDS)
+    def test_the_field_is_the_same_whatever_the_seed_says(self, kind: str) -> None:
+        """The reason it is ignored: the field does not depend on it."""
+        assert terrain.generate_heightfield(kind, resolution=RESOLUTION, seed=0) == terrain.generate_heightfield(
+            kind, resolution=RESOLUTION, seed=99
+        )
+
+    def test_the_two_buckets_are_exhaustive_and_neither_is_empty(self) -> None:
+        """Non-vacuity: a new terrain kind must land in one of them."""
+        assert SEEDED_KIND in terrain.SUPPORTED_TERRAINS
+        assert UNSEEDED_KINDS
+        assert {SEEDED_KIND, *UNSEEDED_KINDS} == set(terrain.SUPPORTED_TERRAINS)
+
+    def test_only_the_seeded_kind_reads_a_seed(self) -> None:
+        """Closure: the split is read off the generators, not asserted about.
+
+        A kind that gains an rng gains a ``seed`` parameter, which lands it here
+        rather than in the exempt bucket - so the exemption cannot outlive the
+        reason for it.
+        """
+        import inspect
+
+        drawing = {
+            kind
+            for kind in terrain.SUPPORTED_TERRAINS
+            if "seed" in inspect.signature(getattr(terrain, f"_{kind}")).parameters
+        }
+        assert drawing == {SEEDED_KIND}


### PR DESCRIPTION
## Problem

`strands_robots.simulation.terrain.generate_heightfield` documents itself as "deterministic given `(kind, resolution, seed)`", and the module docstring promises that a benchmark evaluating a policy on `terrain="rough"` "regenerates the identical field on every reset". `resolution` is measured against the shared positive-discrete domain before anything is generated. `seed` was handed straight to `random.Random`.

`random.Random` does not seed from the value it is given. CPython's `random_seed` uses `abs(value)` for an int and `hash(value)` for anything else. So the documented triple was neither injective nor total:

| `seed` | before | why |
| --- | --- | --- |
| `1` | field `ebb516ac` | the field the caller asked for |
| `-1` | field `ebb516ac` | the sign is discarded |
| `True` | field `ebb516ac` | `bool` is an `int` subclass |
| `float("nan")` | a **different** field on each call | `hash(nan)` is identity-derived since Python 3.10 |
| `None` | a **different** field on each call | seeds from the OS entropy pool |
| `2.5`, `"1"`, `inf` | some field | accepted outright, hashed |

Two consequences, not one. Three distinct seeds named **one** field, so a terrain curriculum stepping the seed across resets to draw fresh ground silently re-drew ground it had already evaluated on and nothing reported that the two resets shared terrain. And `nan`/`None` made the field **irreproducible** - the inputs for which the module's headline promise is false rather than merely surprising. Measured on `main`: `seed=None` on three consecutive calls gives `c3bf0fcd`, `54239b82`, `6d6ce503`.

This is the same collision class `derive_variant_seed` already spells out at length for the other seed in the package that is spread into a stream key ("`True` is the value worth naming, since unrefused it is `1` to NumPy"). `seed` was the one seed parameter in the library with no domain: the simulation backends apply `randomization_seed_error` at eight call sites, `transforms` applies `non_negative_whole_number_error`, the GR00T server wrapper and the trainers each apply their own.

## Change

Measure `seed` against `non_negative_whole_number_error`, the shared domain `derive_variant_seed` applies to the same quantity, on the branch that reads it. Each clause of that domain closes one axis:

- **non-negative** closes the `abs()` alias (`-1` -> `1`),
- **whole** closes the `hash()` path, which is what admitted `nan`, `inf`, `2.5` and `"1"`,
- the domain's **boolean** refusal closes `True`/`False`,
- and `None` is refused, so an opt-out has to be spelled deliberately rather than inherited.

An integral float such as `2.0` is still accepted, because it hashes to its int and so names the *same* stream rather than a second one - the complement is pinned, so the domain reads as "the set of spellings that name exactly one stream" rather than as blanket strictness.

## Visual artifact

The generated field laid down as the MuJoCo `<hfield>` the module's own constants describe. Identical geometry, camera, lighting and material in all ten panels - the generated field is the only variable. Rendered headless (`MUJOCO_GL=egl`).

![terrain seed stream domain](https://github.com/cagataycali/robots/releases/download/artifacts/2715-terrain-seed-stream.png)

Every panel in the composed PNG was verified byte-identical to the render it claims, by searching for its paste offset and comparing the arrays. `seed=1`, `seed=-1` and `seed=True` render byte-identically on `main`; the two `nan` draws differ in 48990 of 69000 pixels; and `seed=1` on this branch renders byte-identically to `seed=1` on `main`, so nothing legitimate moved.

## Scope, and why each boundary is where it is

**Only the `"rough"` branch is guarded.** `_stairs`, `_pyramid` and `_slope` take no seed argument at all, so refusing them for one would refuse a caller a value the requested kind cannot act on - the same rule `NewtonSimEngine.open_viewer` follows for `width`/`height` ("only the gl branch reads them"). The split is derived from the generators' signatures rather than hardcoded, so a kind that later gains an rng lands in the guarded bucket instead of inheriting the exemption. Mutating `_stairs` to take a seed fires exactly that test.

**No upper bound is added.** `random.Random` consumes an arbitrarily large int directly (`Random(10**30)` draws fine), so the narrower seed domain the backends use - `randomization_seed_error`, capped to NumPy's 32-bit stream range - would refuse a value that is usable here, and it lives in a module `terrain` deliberately does not import. Adding a `2**32` ceiling fires exactly one test.

**The kind is still answered first.** An unknown kind must not be reported as a seed problem; moving the guard ahead of `validate_terrain` fires that test plus all 30 exemption tests.

## Tests

New `tests/simulation/test_terrain_seed_stream_domain.py`, 59 cases in four classes: the regression, the premise (the `random.Random` behaviour that makes each refused value an alias for an accepted one), the controls, and the scope boundary.

Pre-fix, with the source change reverted and the test kept: **11 failed, 48 passed** - and all 11 are in the regression class, none in the premise, control or boundary classes. The headline failure is `test_the_seeded_kind_refuses_it[nan] - DID NOT RAISE ValueError`.

Break table, 10 mutations, control clean, 9 distinct firing sets:

| mutation | fires | reads |
| --- | --- | --- |
| control (no mutation) | 0 | |
| guard removed entirely | 11 | the pre-fix tree |
| domain swapped to the positive sibling | 4 | refuses `0`, which is `TERRAIN_SEED` |
| hand-rolled `isinstance(seed, int)` | 6 | accepts `True` and `-1`, refuses `2.0` |
| domain applied to every kind | 30 | over-reach; exactly the exemption class |
| guard moved ahead of the kind check | 31 | the 30 above plus the ordering test |
| rule re-spelled locally | 12 | single-sourcing is load-bearing |
| value coerced with `abs(int(...))` instead of refused | 11 | coercing is not reporting |
| an upper bound added | 1 | the huge-int control |
| `_stairs` gains a seed parameter | 1 | the closure test |

`11` (guard removed) and `30` (over-reach) are disjoint, so the fix and its scope are pinned independently; `31` is the union of the over-reach set with the ordering test.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1535 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical, 0 in the changed files.
- Paired run over an identical 670-file selection (all of `tests/simulation/`, every test that walks the tree or reads docstrings, the docstring-xref and `Args`-completeness guards), the new file excluded from both trees: **25069 collected and `20 failed, 24769 passed, 280 skipped` on both**, 20 identical failing IDs, both `comm` directions empty. All 20 are pre-existing: 17 need `awsiot`/`awscrt` (absent; declared in the `[mesh-iot]` extra), 2 are lerobot-0.6.2-from-source drift in `tests/training/test_lerobot.py`, 1 is a stale dataset directory.
- The new file plus `tests/simulation/test_terrain.py`: **129 passed** on mujoco 3.5.0 (the declared floor) and on 3.12.0.
- Changelog-fragment guards: 108 passed.
