### PR TITLE
fix(hardware): hold the ROS 2 bridge QoS depth to a domain the transport can carry

### DIFF
--- a/changelog.d/2719-ros-qos-history-depth-domain.md
+++ b/changelog.d/2719-ros-qos-history-depth-domain.md
@@ -1,0 +1,48 @@
+### Fixed: the ROS 2 bridge QoS depth is checked where the caller gives it
+
+`RosTelemetryBridge` and `HardwareRosBridge` take a `qos_depth` and hand it to rclpy's
+`create_publisher` / `create_subscription` as the `qos_or_depth` argument, which becomes
+`QoSProfile(depth=value, history=KEEP_LAST)`. Every sibling constructor parameter of that pair is
+measured at the boundary - `domain_id` against the RTPS port map, `spin_period` against the positive
+finite domain, `enable_commands` against the boolean domain, `joint_limits` against a finite numeric
+pair, each with the reason written down - and this one was handed through unchecked. It is also the
+only one whose consumer is not reached from the constructor: publishers are built lazily, on the
+first `publish_joint_states` / `publish_image` for a robot.
+
+So a bad depth reported a successful construction. Measured against rclpy on ROS 2 Jazzy, `0` and
+`False` were *accepted*: rclpy warns "A zero depth with KEEP_LAST doesn't make sense; no data could
+be stored. This will be interpreted as SYSTEM_DEFAULT" and builds the endpoint with the middleware
+default, so the declared depth was silently not the depth in force - reported by a `UserWarning`
+that `warnings.warn` shows once per location, so a second bridge in the same process said nothing at
+all. `True` was accepted as a silent depth of 1: one frame of history on a stream the caller asked
+to buffer.
+
+Every other spelling raised from inside rclpy, naming neither the parameter nor the bridge. `-1`
+gave `ValueError: history depth must be greater than or equal to zero`; `2.5`, `10.0`, `"10"`,
+`None`, `nan`, `inf` and `np.int64(10)` gave `TypeError: Expected QoSProfile or int`; and `2**31`
+and above failed the pybind11 conversion into the QoS profile instead. On the telemetry-only path
+none of those surfaced until the first frame was published, mid-run. On the command path
+`create_subscription` runs in the constructor, so the same mistake raised there - after the
+process-wide `ROS_DOMAIN_ID` write and after the node had been created.
+
+The depth is now measured against `positive_count_error`, the shared domain for a discrete count a C
+API consumes directly rather than coerces, which is exactly why the strict-`int` requirement is the
+right one here: rclpy refuses `np.int64(10)` outright even though it names a perfectly good depth.
+The floor of 1 closes `0` and `False`, and the domain's boolean refusal closes `True`. Only the
+transport's own ceiling is added on top, beside the transport that has it, in the manner of
+`_transport_port_error` in `strands_robots.tools.use_rosbridge`: the depth is stored in
+`rmw_qos_profile_t` through a pybind11 binding taking a signed 32-bit integer, so
+`MAX_QOS_HISTORY_DEPTH` is `2**31 - 1` - measured, not chosen, and pinned by the arithmetic so this
+library cannot start refusing a depth the transport is happy to carry.
+
+The guard is placed beside the `domain_id` check, ahead of both the process-wide `ROS_DOMAIN_ID`
+write and the rclpy probe. That is what makes a refused depth leave the environment as it found it,
+and makes the same caller mistake report identically on an install with the `[ros2]` extra and one
+without it - so the refusal is checked on a minimal install too. An accepted depth still reaches
+every endpoint verbatim: nothing coerces it, because a converted value is a depth on the wire the
+caller never named.
+
+Nothing observed any of this before. `qos_depth` appeared in no test, no doc and no example, and the
+one rclpy double in the suite that reaches `create_publisher` takes the depth as `_depth` and
+discards it, so no existing test could see which depth an endpoint was built with. The new tests
+record it instead.

--- a/strands_robots/hardware_ros_bridge.py
+++ b/strands_robots/hardware_ros_bridge.py
@@ -73,7 +73,13 @@ class HardwareRosBridge(RosTelemetryBridge):
             Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
             discovery ports from it, and 233 lands past the end of the port space.
         node_name: Internal rclpy node name (defaults to ``strands_hardware``).
-        qos_depth: Depth of the publishers'/subscription's KEEP_LAST history.
+        qos_depth: Depth of the publishers'/subscription's KEEP_LAST
+            history. Only a positive ``int`` up to
+            :data:`~strands_robots.ros_telemetry.MAX_QOS_HISTORY_DEPTH`
+            names a depth the transport can build an endpoint with. A
+            publisher is built on the first publish rather than here, so an
+            unusable depth would otherwise be reported mid-run, from inside
+            rclpy and naming no parameter.
         enable_commands: When True (default) and a ``robot`` is bound, subscribe
             to ``/<robot>/joint_command`` and drive the arm. Set False for a
             read-only (telemetry-only) bridge. Only a boolean names a posture:
@@ -104,7 +110,8 @@ class HardwareRosBridge(RosTelemetryBridge):
 
     Raises:
         ValueError: If ``enable_commands`` is not a boolean, if ``domain_id`` is
-            outside ``[0, 232]``, if ``spin_period``
+            outside ``[0, 232]``, if ``qos_depth`` is not a positive ``int`` the
+            transport can carry, if ``spin_period``
             is not a positive finite number, or if ``joint_limits`` is not a
             ``{"<motor>.pos": (min, max)}`` mapping of finite numeric pairs with
             ``min <= max``.

--- a/strands_robots/ros_telemetry.py
+++ b/strands_robots/ros_telemetry.py
@@ -31,7 +31,12 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-from strands_robots.utils import dds_domain_id_error, finite_number_error, require_optional
+from strands_robots.utils import (
+    dds_domain_id_error,
+    finite_number_error,
+    positive_count_error,
+    require_optional,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -56,6 +61,72 @@ ROS2_SYSTEM_INSTALL_HINT = (
     "The [ros2] extra installs only the cyclonedds RMW binding; it does not "
     "provision ROS 2 by itself."
 )
+
+
+#: Largest KEEP_LAST history depth the rclpy transport can be built with. The
+#: depth reaches the middleware as the ``depth`` field of ``rmw_qos_profile_t``,
+#: whose pybind11 binding takes a signed 32-bit integer, so this is the last
+#: value that converts: one more raises ``TypeError: __init__(): incompatible
+#: constructor arguments`` out of ``create_publisher`` - a message naming
+#: neither the parameter nor the bridge. Measured against rclpy on ROS 2 Jazzy:
+#: ``2**31 - 1`` builds a publisher, ``2**31`` does not.
+MAX_QOS_HISTORY_DEPTH = 2**31 - 1
+
+
+def _qos_history_depth_error(value: Any, param: str, context: str) -> str | None:
+    """Error text when ``value`` is not a usable KEEP_LAST history depth.
+
+    The depth is handed to ``create_publisher`` / ``create_subscription`` as the
+    ``qos_or_depth`` argument, which rclpy turns into
+    ``QoSProfile(depth=value, history=KEEP_LAST)``. It is the one bridge
+    parameter whose consumer is not reached from the constructor: the publishers
+    are built lazily, on the first ``publish_joint_states`` / ``publish_image``
+    for a robot, so an unusable depth is a construction that reports success and
+    a telemetry stream that fails - or silently is not the one asked for - later,
+    on the first frame.
+
+    Two failure modes, both measured against rclpy on ROS 2 Jazzy:
+
+    * ``0`` is **accepted**. rclpy warns "A zero depth with KEEP_LAST doesn't
+      make sense; no data could be stored. This will be interpreted as
+      SYSTEM_DEFAULT" and builds the publisher with the middleware default, so
+      the caller's declared depth is silently not the depth in force - and
+      ``warnings.warn`` shows once per location, so a second bridge in the same
+      process says nothing at all. ``False`` is that same value arriving by
+      another route, and ``True`` is a silent depth of 1 - one frame of history
+      on a stream the caller asked to buffer.
+    * every other spelling raises from *inside* rclpy, naming no parameter:
+      ``-1`` gives ``ValueError: history depth must be greater than or equal to
+      zero``, a float / ``str`` / ``None`` / ``nan`` / ``inf`` gives
+      ``TypeError: Expected QoSProfile or int``, and so does ``np.int64(10)``,
+      which names a perfectly good depth. Above
+      :data:`MAX_QOS_HISTORY_DEPTH` the pybind11 conversion fails instead.
+
+    So the floor, the ``bool`` refusal and the strict-``int`` requirement all
+    come from :func:`~strands_robots.utils.positive_count_error`, the shared
+    domain for a discrete count consumed directly by a C API rather than
+    coerced, and only the transport's ceiling is added here - beside the
+    transport that has it, in the manner of ``_transport_port_error`` in
+    :mod:`strands_robots.tools.use_rosbridge`.
+
+    Args:
+        value: The caller-supplied depth.
+        param: The parameter name it came from, used in the message.
+        context: Message prefix identifying the surface that received it - the
+            class name, for a constructor parameter.
+
+    Returns:
+        An error message, or ``None`` when the transport can carry the depth.
+    """
+    if error := positive_count_error(value, param, context):
+        return error
+    if value > MAX_QOS_HISTORY_DEPTH:
+        return (
+            f"{context}: {param} {value!r} is a positive integer that the rclpy transport "
+            f"cannot build a publisher with (it carries 1-{MAX_QOS_HISTORY_DEPTH}; the "
+            "middleware QoS profile stores the depth as a signed 32-bit integer)"
+        )
+    return None
 
 
 #: Env var an operator sets to explicitly run an INBOUND ``joint_command``
@@ -380,12 +451,18 @@ class RosTelemetryBridge(RosTelemetryBase):
             Only an ``int`` in ``[0, 232]`` names a domain: RTPS derives its
             discovery ports from it, and 233 lands past the end of the port space.
         node_name: Name of the internal rclpy node.
-        qos_depth: Depth of the publishers' KEEP_LAST history.
+        qos_depth: Depth of the publishers' KEEP_LAST history. Only a
+            positive ``int`` up to ``MAX_QOS_HISTORY_DEPTH`` names a depth
+            the transport can build a publisher with; the publishers are
+            built on the first publish, so the value is checked here rather
+            than surfacing mid-run from inside rclpy.
 
     Raises:
-        ValueError: If ``domain_id`` is outside ``[0, 232]``. Checked before the
-            process-wide ``ROS_DOMAIN_ID`` write, so a refused domain leaves the
-            environment as it found it.
+        ValueError: If ``domain_id`` is outside ``[0, 232]``, or if
+            ``qos_depth`` is not a positive ``int`` no greater than
+            :data:`MAX_QOS_HISTORY_DEPTH`. Both are checked before the
+            process-wide ``ROS_DOMAIN_ID`` write, so a refused bridge leaves
+            the environment as it found it.
         ImportError: When ``rclpy`` / the ROS 2 message packages are not
             importable, with an install hint (system ROS 2 or the docker image).
     """
@@ -399,6 +476,18 @@ class RosTelemetryBridge(RosTelemetryBase):
         # unusable value would otherwise outlive this call and steer every later
         # participant - a value the transport is never given the chance to reject.
         if error := dds_domain_id_error(domain_id, "domain_id", type(self).__name__):
+            raise ValueError(error)
+
+        # Refuse a history depth no publisher can be built with, in the same
+        # place and for the same reasons as the domain above: it lands ahead of
+        # both the process-wide write and the rclpy probe, so the refusal leaves
+        # the environment as it found it and reports identically on an install
+        # with the [ros2] extra and one without it. Unlike every other parameter
+        # here, this one's consumer is not reached from the constructor - the
+        # publishers are built on the first publish - so leaving it to the
+        # transport means a bridge that reports success and then fails, or
+        # quietly buffers a depth the caller did not ask for, on the first frame.
+        if error := _qos_history_depth_error(qos_depth, "qos_depth", type(self).__name__):
             raise ValueError(error)
 
         # Pin the domain before rclpy reads it. Set it unconditionally so the

--- a/tests/test_ros_qos_history_depth_domain.py
+++ b/tests/test_ros_qos_history_depth_domain.py
@@ -1,0 +1,407 @@
+"""The QoS history depth a ROS 2 bridge publishes with is checked where it is given.
+
+``RosTelemetryBridge`` and its hardware subclass take a ``qos_depth`` and hand it
+to ``create_publisher`` / ``create_subscription`` as rclpy's ``qos_or_depth``
+argument, which becomes ``QoSProfile(depth=value, history=KEEP_LAST)``. It is the
+one constructor parameter of that pair whose consumer is not reached from the
+constructor: the publishers are built lazily, on the first
+``publish_joint_states`` / ``publish_image`` for a robot. Every sibling parameter
+is measured at the boundary - ``domain_id`` against the RTPS port map,
+``spin_period`` against the positive finite domain, ``enable_commands`` against
+the boolean domain, ``joint_limits`` against a finite numeric pair - and this one
+was handed through unchecked.
+
+Measured against rclpy on ROS 2 Jazzy, every unusable spelling constructed a
+bridge that reported success:
+
+* ``0`` and ``False`` were **accepted** by rclpy, which warns "A zero depth with
+  KEEP_LAST doesn't make sense; no data could be stored. This will be
+  interpreted as SYSTEM_DEFAULT" and builds the publisher with the middleware
+  default. So the declared depth was silently not the depth in force, reported
+  by a ``UserWarning`` that ``warnings.warn`` shows once per location - a second
+  bridge in the same process said nothing at all. ``True`` was accepted as a
+  silent depth of 1.
+* ``-1`` raised ``ValueError: history depth must be greater than or equal to
+  zero``, and ``2.5`` / ``"10"`` / ``None`` / ``nan`` / ``inf`` /
+  ``np.int64(10)`` raised ``TypeError: Expected QoSProfile or int`` - from inside
+  rclpy, naming neither the parameter nor the bridge, and on the telemetry-only
+  path not until the first frame was published. On the command path
+  ``create_subscription`` runs in the constructor, so the same mistake raised
+  there instead, after the process-wide ``ROS_DOMAIN_ID`` write and after the
+  node was created.
+
+Nothing observed any of it. ``qos_depth`` appeared in no test, no doc and no
+example, and the only rclpy double in the suite that reaches ``create_publisher``
+takes the depth as ``_depth`` and discards it, so no existing test could see
+which depth an endpoint was built with. The double below records it instead,
+which is what lets the accepted-value control assert that a depth reaches the
+transport verbatim.
+
+``rclpy`` is optional and not installable from PyPI, so every refusal test here
+runs with it absent: the guard is placed ahead of the transport probe, which is
+what makes that possible and is asserted directly.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import pathlib
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots
+import strands_robots.utils as utils_mod
+from strands_robots.hardware_ros_bridge import HardwareRosBridge
+from strands_robots.ros_telemetry import (
+    MAX_QOS_HISTORY_DEPTH,
+    RosTelemetryBridge,
+    _qos_history_depth_error,
+)
+
+#: Values that cannot name a KEEP_LAST history depth, one per way of missing it.
+UNUSABLE_DEPTHS: list[Any] = [
+    0,  # accepted by rclpy as SYSTEM_DEFAULT: not the depth that was asked for
+    -1,  # below the floor
+    -10,
+    True,  # int subclass: a silent depth of 1
+    False,  # int subclass: the zero-depth path by another route
+    2.5,  # fractional
+    10.0,  # integral, still not an int the C API accepts
+    np.int64(10),  # names a usable depth; rclpy refuses the type
+    float("nan"),
+    float("inf"),
+    "10",  # a numeric string is not an int
+    None,
+    [10],
+    MAX_QOS_HISTORY_DEPTH + 1,  # first depth the QoS profile cannot store
+    2**32 - 1,
+]
+
+#: Values that do name a depth, including both ends of the range.
+USABLE_DEPTHS: list[int] = [1, 2, 10, MAX_QOS_HISTORY_DEPTH]
+
+
+def _refuses(build: Any, value: Any) -> bool:
+    """Whether ``build(value)`` refuses ``value`` as a history depth.
+
+    An ``ImportError`` means the value cleared the guard and the bridge then
+    found ``rclpy`` missing - an install problem, not a verdict about the depth -
+    so it counts as accepted.
+    """
+    try:
+        build(value)
+    except ValueError as exc:
+        return "qos_depth" in str(exc)
+    except ImportError:
+        return False
+    return False
+
+
+#: Every surface that takes a history depth, with the parameter it names it by.
+SURFACES: list[tuple[str, Any]] = [
+    ("RosTelemetryBridge(qos_depth=)", lambda v: RosTelemetryBridge(qos_depth=v)),
+    ("HardwareRosBridge(qos_depth=)", lambda v: HardwareRosBridge(qos_depth=v)),
+]
+SURFACE_IDS = [name.split("(")[0] for name, _ in SURFACES]
+
+
+class _RecordingNode:
+    """An rclpy node double that keeps the depth each endpoint was built with.
+
+    The suite's existing double takes the depth as ``_depth`` and drops it, so a
+    test driving it cannot tell a publisher built with the caller's depth from
+    one built with any other. Recording it is what makes the accepted-value
+    control a measurement rather than a restatement of the call.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.publisher_depths: list[Any] = []
+        self.subscription_depths: list[Any] = []
+
+    def get_clock(self) -> Any:
+        return SimpleNamespace(now=lambda: SimpleNamespace(to_msg=lambda: "stamp"))
+
+    def create_publisher(self, _msg_type: Any, topic: str, depth: Any) -> Any:
+        self.publisher_depths.append(depth)
+        return SimpleNamespace(topic=topic, publish=lambda _msg: None)
+
+    def create_subscription(self, _msg_type: Any, topic: str, callback: Any, depth: Any) -> Any:
+        self.subscription_depths.append(depth)
+        return SimpleNamespace(topic=topic, callback=callback)
+
+    def destroy_node(self) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_rclpy(monkeypatch: pytest.MonkeyPatch) -> list[_RecordingNode]:
+    """Inject a depth-recording rclpy + sensor_msgs.msg; yield the nodes made."""
+    nodes: list[_RecordingNode] = []
+
+    def _create_node(name: str) -> _RecordingNode:
+        node = _RecordingNode(name)
+        nodes.append(node)
+        return node
+
+    rclpy = ModuleType("rclpy")
+    rclpy.ok = lambda: True  # type: ignore[attr-defined]
+    rclpy.init = lambda: None  # type: ignore[attr-defined]
+    rclpy.shutdown = lambda: None  # type: ignore[attr-defined]
+    rclpy.create_node = _create_node  # type: ignore[attr-defined]
+    rclpy.spin_once = lambda _node, timeout_sec=0.0: None  # type: ignore[attr-defined]
+
+    class _Msg:
+        def __init__(self) -> None:
+            self.header = SimpleNamespace(stamp=None, frame_id="")
+            self.name: list[str] = []
+            self.position: list[float] = []
+
+    sensor_pkg = ModuleType("sensor_msgs")
+    sensor_msg = ModuleType("sensor_msgs.msg")
+    sensor_msg.JointState = _Msg  # type: ignore[attr-defined]
+    sensor_msg.Image = _Msg  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_pkg)
+    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msg)
+    monkeypatch.setattr(utils_mod, "_lazy_modules", {}, raising=False)
+    return nodes
+
+
+class TestTheDepthDomain:
+    """``_qos_history_depth_error`` decides which values name a history depth."""
+
+    @pytest.mark.parametrize("value", UNUSABLE_DEPTHS, ids=repr)
+    def test_a_value_that_cannot_name_a_depth_is_refused(self, value: Any) -> None:
+        error = _qos_history_depth_error(value, "qos_depth", "Bridge")
+        assert error is not None
+        assert error.startswith("Bridge: qos_depth ")
+
+    @pytest.mark.parametrize("value", USABLE_DEPTHS, ids=repr)
+    def test_a_depth_the_transport_can_carry_is_accepted(self, value: int) -> None:
+        assert _qos_history_depth_error(value, "qos_depth", "Bridge") is None
+
+    def test_the_message_names_the_parameter_it_came_from(self) -> None:
+        assert "some_depth" in str(_qos_history_depth_error(0, "some_depth", "Bridge"))
+
+    def test_a_depth_over_the_ceiling_is_refused_for_the_ceiling_not_the_floor(self) -> None:
+        """The two clauses report distinguishable reasons.
+
+        A single "must be a positive integer" for an over-ceiling value would
+        tell a caller who passed one that their value is not positive, which it
+        is - the transport simply cannot store it.
+        """
+        error = str(_qos_history_depth_error(MAX_QOS_HISTORY_DEPTH + 1, "qos_depth", "Bridge"))
+        assert str(MAX_QOS_HISTORY_DEPTH) in error
+        assert "positive integer" in error
+        assert "must be a positive integer" not in error
+
+
+class TestTheCeilingIsTheTransportsNotAPolicyChoice:
+    """``MAX_QOS_HISTORY_DEPTH`` is the QoS profile's storage bound, not a limit.
+
+    The depth is stored in ``rmw_qos_profile_t`` through a pybind11 binding that
+    takes a signed 32-bit integer, so the ceiling is the largest value that
+    converts. Pinning the arithmetic means the constant cannot drift away from
+    the reason it holds - a smaller number here would be this library refusing a
+    depth the transport is happy to carry.
+    """
+
+    def test_the_ceiling_is_the_largest_signed_32_bit_value(self) -> None:
+        assert MAX_QOS_HISTORY_DEPTH == 2**31 - 1
+        assert MAX_QOS_HISTORY_DEPTH.bit_length() == 31
+
+    def test_one_more_needs_a_wider_field_than_the_profile_has(self) -> None:
+        assert (MAX_QOS_HISTORY_DEPTH + 1).bit_length() == 32
+
+
+class TestARefusedDepthLeavesTheProcessEnvironmentAlone:
+    """The refusal precedes the process-wide ``ROS_DOMAIN_ID`` write.
+
+    That write is global to the process and lands before ``rclpy`` is imported,
+    so a bridge refused for its depth must not have steered every later
+    participant - and every subprocess inheriting the environment - on its way
+    to the refusal.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DEPTHS, ids=repr)
+    def test_a_refused_depth_does_not_touch_ros_domain_id(self, value: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        with pytest.raises(ValueError, match="qos_depth"):
+            RosTelemetryBridge(domain_id=11, qos_depth=value)
+        assert os.environ["ROS_DOMAIN_ID"] == "7"
+
+    def test_a_usable_depth_still_pins_the_domain_into_the_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        # rclpy is optional; the pin lands before it is imported, which is
+        # exactly why the guard has to run first.
+        with pytest.raises(ImportError):
+            RosTelemetryBridge(domain_id=11, qos_depth=10)
+        assert os.environ["ROS_DOMAIN_ID"] == "11"
+
+    def test_the_domain_is_still_answered_first(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both wrong: the domain is reported, because its write is the earlier harm."""
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        with pytest.raises(ValueError, match="invalid domain_id"):
+            RosTelemetryBridge(domain_id=-1, qos_depth=0)
+        assert os.environ["ROS_DOMAIN_ID"] == "7"
+
+
+class TestARefusedDepthReachesNoTransport:
+    """The guard runs before the bridge probes for its optional transport.
+
+    Placing it there is what lets the same caller mistake report identically on
+    an install with the ``[ros2]`` extra and one without it, and it means no
+    rclpy context is initialised and no node created for a bridge whose
+    publishers could never have been built.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DEPTHS, ids=repr)
+    def test_the_bridge_refuses_before_probing_for_rclpy(self, value: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        import strands_robots.ros_telemetry as telemetry_mod
+
+        def _unreachable(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("the rclpy probe must not be reached")
+
+        monkeypatch.setattr(telemetry_mod, "require_optional", _unreachable)
+        with pytest.raises(ValueError, match="qos_depth"):
+            RosTelemetryBridge(qos_depth=value)
+
+    def test_a_usable_depth_still_reaches_the_rclpy_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import strands_robots.ros_telemetry as telemetry_mod
+
+        probed: list[str] = []
+
+        def _record(module: str, **_kwargs: Any) -> Any:
+            probed.append(module)
+            raise ImportError("rclpy absent")
+
+        monkeypatch.setattr(telemetry_mod, "require_optional", _record)
+        with pytest.raises(ImportError):
+            RosTelemetryBridge(qos_depth=10)
+        assert probed == ["rclpy"]
+
+
+class TestBothBridgesRefuseTheSameDepths:
+    """Neither bridge may accept a depth the other refuses.
+
+    The subclass forwards the value to the base constructor, so one guard covers
+    both - and both are checked here so that forwarding cannot be dropped
+    silently.
+    """
+
+    @pytest.mark.parametrize("value", UNUSABLE_DEPTHS, ids=repr)
+    def test_an_unusable_depth_is_refused_by_every_surface(self, value: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        refused = {name: _refuses(build, value) for name, build in SURFACES}
+        assert all(refused.values()), f"accepted by {[n for n, r in refused.items() if not r]}"
+
+    @pytest.mark.parametrize("value", USABLE_DEPTHS, ids=repr)
+    def test_a_usable_depth_is_refused_by_no_surface(self, value: int, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ROS_DOMAIN_ID", "7")
+        refused = {name: _refuses(build, value) for name, build in SURFACES}
+        assert not any(refused.values()), f"refused by {[n for n, r in refused.items() if r]}"
+
+
+class TestAnAcceptedDepthReachesTheTransportVerbatim:
+    """A depth the guard accepts must be the depth each endpoint is built with.
+
+    The guard must not become a coercion: the whole reason the strict-``int``
+    requirement is inherited from the shared count domain is that the C API
+    refuses every other spelling of the same number, so quietly converting one
+    would put a depth on the wire that the caller never named.
+    """
+
+    @pytest.mark.parametrize("value", USABLE_DEPTHS, ids=repr)
+    def test_every_publisher_is_built_with_the_depth_that_was_accepted(
+        self, value: int, fake_rclpy: list[_RecordingNode]
+    ) -> None:
+        bridge = RosTelemetryBridge(qos_depth=value)
+        bridge.publish_joint_states("arm", ["j0"], [0.5])
+        bridge.publish_image("arm", "wrist", np.zeros((2, 2, 3), dtype=np.uint8))
+        node = fake_rclpy[-1]
+        assert node.publisher_depths == [value, value]
+        assert all(type(depth) is int for depth in node.publisher_depths)
+
+    def test_the_command_subscription_is_built_with_it_too(self, fake_rclpy: list[_RecordingNode]) -> None:
+        # Typed ``Any``: the bridge only reads ``name`` off the robot on this
+        # path, so a stand-in avoids opening a bus for a depth measurement.
+        robot: Any = SimpleNamespace(name="arm", send_action=lambda _action: {"status": "success"})
+        bridge = HardwareRosBridge(robot=robot, qos_depth=7, enable_commands=True)
+        try:
+            assert fake_rclpy[-1].subscription_depths == [7]
+        finally:
+            bridge.shutdown()
+
+
+class TestEveryDepthSurfaceRoutesThroughTheDomain:
+    """Structural guard: a depth-taking surface guards it or forwards it.
+
+    A surface that stores a caller-supplied ``qos_depth`` without either calling
+    the guard or handing the value to one that does is accepting a depth its
+    endpoints may not be constructible with. Checked structurally so a third
+    surface cannot ship without joining the rule.
+    """
+
+    #: Parameter names that carry a QoS history depth.
+    DEPTH_PARAMS = frozenset({"qos_depth"})
+
+    @staticmethod
+    def _package_root() -> pathlib.Path:
+        """The installed package directory, derived from an imported symbol."""
+        return pathlib.Path(inspect.getfile(strands_robots)).parent
+
+    @classmethod
+    def _classify(cls, source: str) -> dict[str, tuple[bool, bool]]:
+        """Map ``function name -> (calls the guard, forwards the parameter)``."""
+        found: dict[str, tuple[bool, bool]] = {}
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            args = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            taken = [a for a in args if a in cls.DEPTH_PARAMS]
+            if not taken:
+                continue
+            guards = any(
+                isinstance(call.func, ast.Name) and call.func.id == "_qos_history_depth_error"
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+            )
+            forwards = any(
+                keyword.arg in cls.DEPTH_PARAMS and isinstance(keyword.value, ast.Name) and keyword.value.id in taken
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call)
+                for keyword in call.keywords
+            )
+            found[node.name] = (guards, forwards)
+        return found
+
+    def _surfaces(self) -> dict[str, tuple[bool, bool]]:
+        surfaces: dict[str, tuple[bool, bool]] = {}
+        for path in sorted(self._package_root().rglob("*.py")):
+            for name, verdict in self._classify(path.read_text()).items():
+                surfaces[f"{path.relative_to(self._package_root())}::{name}"] = verdict
+        return surfaces
+
+    def test_the_scan_finds_every_known_depth_surface(self) -> None:
+        """Non-vacuity: a scan rooted elsewhere would report a clean sweep."""
+        assert set(self._surfaces()) == {
+            "hardware_ros_bridge.py::__init__",
+            "ros_telemetry.py::__init__",
+        }
+
+    def test_every_depth_surface_guards_or_forwards_the_value(self) -> None:
+        adrift = {name for name, (guards, forwards) in self._surfaces().items() if not (guards or forwards)}
+        assert not adrift, f"these surfaces neither validate nor forward the depth: {sorted(adrift)}"
+
+    def test_the_scanner_detects_a_surface_that_does_neither(self) -> None:
+        """A scanner that matched nothing would pass the sweep vacuously."""
+        planted = "def brand_new_bridge(self, *, qos_depth: int = 10) -> None:\n    self._depth = qos_depth\n"
+        assert self._classify(planted) == {"brand_new_bridge": (False, False)}


### PR DESCRIPTION
## Problem

`RosTelemetryBridge` and `HardwareRosBridge` take a `qos_depth` and hand it straight to rclpy's `create_publisher` / `create_subscription` as the `qos_or_depth` argument, which becomes `QoSProfile(depth=value, history=KEEP_LAST)`. Every sibling constructor parameter of that pair is measured at the boundary, each with its reason written down in the docstring:

| parameter | domain | in `Raises:` |
|---|---|---|
| `domain_id` | `dds_domain_id_error` (RTPS port map) | yes |
| `spin_period` | `positive_finite_number_error` | yes |
| `enable_commands` | `boolean_flag_error` | yes |
| `joint_limits` | finite numeric pairs, `min <= max` | yes |
| `qos_depth` | none | no |

It is also the only one whose consumer is not reached from the constructor: publishers are built lazily, on the first `publish_joint_states` / `publish_image` for a robot.

## What that cost, measured

Driving the real `RosTelemetryBridge` against real rclpy (ROS 2 Jazzy, `ros:jazzy-ros-core`), every spelling below **constructed successfully**:

| `qos_depth` | construction | first publish |
|---|---|---|
| `10` | OK | OK, `depth=10` |
| `0` | OK | OK, `depth=0` -> `UserWarning: A zero depth with KEEP_LAST doesn't make sense; no data could be stored. This will be interpreted as SYSTEM_DEFAULT` |
| `False` | OK | OK, same zero-depth path by another route |
| `True` | OK | OK, `depth=True` - a silent depth of 1 |
| `-1` | OK | `ValueError: history depth must be greater than or equal to zero` |
| `2.5` | OK | `TypeError: Expected QoSProfile or int, but received <class 'float'>` |
| `"10"` | OK | `TypeError: Expected QoSProfile or int, but received <class 'str'>` |
| `None` | OK | `TypeError: Expected QoSProfile or int, but received <class 'NoneType'>` |
| `2**31` | OK | `TypeError: __init__(): incompatible constructor arguments` (pybind11, into the QoS profile) |

Two distinct harms. The first four are *accepted*: the declared depth is silently not the depth in force, announced by a `UserWarning` that `warnings.warn` shows once per location - so a second bridge in the same process says nothing at all. The rest raise from inside rclpy, naming neither the parameter nor the bridge, and on the telemetry-only path not until the first frame is published, mid-run.

On the command path `create_subscription` runs in the constructor, so the same mistake lands there instead - and after the damage: with `qos_depth=2.5`, `HardwareRosBridge(robot=..., enable_commands=True)` raised the rclpy `TypeError` with `rclpy.ok()` still `True` and `ROS_DOMAIN_ID` already written to `'0'`.

`np.int64(10)` is worth naming separately: it denotes a perfectly good depth and rclpy refuses it outright (`TypeError: Expected QoSProfile or int`), as it does `np.int32`, `np.float64` and `np.bool_`.

## Why every existing gate was silent

`qos_depth` appears in no test, no doc and no example. The one rclpy double in the suite that reaches `create_publisher` takes the depth as `_depth` and discards it, so no existing test could observe which depth an endpoint was built with. The double added here records it.

## Change

`_qos_history_depth_error` in `strands_robots.ros_telemetry`, called beside the `domain_id` check.

The floor, the `bool` refusal and the strict-`int` requirement are inherited from `positive_count_error`, the shared domain for a discrete count a C API consumes directly rather than coerces - which is precisely the situation here, given rclpy's refusal of `np.int64`. The floor of 1 closes `0` and `False`; the domain's boolean refusal closes `True`.

Only the transport's own ceiling is added on top, beside the transport that has it, in the manner of `_transport_port_error` in `strands_robots.tools.use_rosbridge`. The depth reaches the middleware through `rmw_qos_profile_t`, whose pybind11 binding takes a signed 32-bit integer, so the boundary is measured rather than chosen: `2**31 - 1` builds a publisher, `2**31` does not. `MAX_QOS_HISTORY_DEPTH` is pinned to that arithmetic so this library cannot start refusing a depth the transport is happy to carry.

Placement is the `domain_id` placement, for the `domain_id` reasons: ahead of the process-wide `ROS_DOMAIN_ID` write, so a refused bridge leaves the environment as it found it, and ahead of the rclpy probe, so the same caller mistake reports identically on an install with the `[ros2]` extra and one without it - which is what lets every refusal test here run on a minimal install. An accepted depth still reaches every endpoint verbatim; nothing coerces it, because a converted value is a depth on the wire the caller never named.

## Tests

New `tests/test_ros_qos_history_depth_domain.py`, 83 cases. Pre-fix, with only the call site removed and the guard left defined: **46 failed, 37 passed**, every failure inside the four regression classes and none in the domain, ceiling-premise or accepted-value control classes. A raw revert of the whole change is a collection error instead, so both splits are reported.

11 mutations, control clean:

| mutation | fires | where |
|---|---|---|
| b0 control (no mutation) | 0 | - |
| b1 the guard call site is removed (the defect) | 46 | 4 regression classes |
| b2 the guard runs after the `ROS_DOMAIN_ID` write | 15 | the environment class only |
| b3 the guard runs after the rclpy probe | 45 | 3 classes |
| b4 the transport ceiling clause is dropped | 9 | domain + 3 |
| b5 the floor admits zero (`non_negative` instead of `positive`) | 5 | domain + 3 |
| b6 the `bool` refusal is dropped (hand-rolled floor) | 4 | domain + 3 |
| b7 an integral float / numpy int is admitted | 8 | domain + 3 |
| b8 the accepted depth is coerced with `int()` | 0 | see below |
| b9 the ceiling becomes a policy number (1000) | 2 | the ceiling-premise class only |
| b10 the subclass stops forwarding the depth | 17 | 3 classes, incl. the verbatim control |

b8's zero is reported rather than removed, because the reason is the guard: measured, `int(v) is v` for every accepted probe value, and `bool` - the one `int` subclass whose type `int()` would change - is refused. So the coercion is provably the identity on the accepted domain, an unreachable degree of freedom; the verbatim control that would catch a real coercion is pinned by b10 instead.

A structural sweep asserts every `qos_depth`-taking function either calls the guard or forwards the value, with a non-vacuity test naming today's two surfaces and a planted-source test proving the scanner detects a surface that does neither.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1538 files).
- mypy **24 == 24** against pristine `main`, normalized message sets byte-identical, zero in the changed files.
- Paired run over an identical 365-file selection (every test naming these bridges, the shared domains, `ROS_DOMAIN_ID` or `require_optional`, plus every test that walks the package with `ast` / `rglob` / `inspect`), the new file excluded from both trees: **18 failed, 17917 passed, 99 skipped, 24 errors on both**, 18058 collected each, 42 identical failing/erroring ids, both `comm` directions empty. 41 of the 42 need `awsiot` (`awsiotsdk`, declared in the `[mesh-iot]` extra, confirmed absent); the remaining one is pre-existing on `main`.
- The new file plus the three closest sibling suites: **236 passed** on a second environment (mujoco 3.12.0) as well as the first (mujoco 3.5.0 floor, lerobot 0.6.2 from source).
- Behaviour against real rclpy re-checked post-fix inside `ros:jazzy-ros-core`.

No visual artifact: this touches no policy, simulation behaviour, rendering, recording or robot asset. The measured tables above are the evidence. The sibling ceiling constants (`MAX_DDS_DOMAIN_ID`, `MAX_ZMQ_TIMEOUT_MS`, `MAX_IK_SMOOTHING`) appear in no docs page either, so the docstrings updated here - both classes' `Args:` and `Raises:` - are the whole documentation surface for this parameter.
