### PR TITLE
fix(vera): skip a provenance record the offline ckpt index cannot read

### DIFF
--- a/changelog.d/2721-vera-offline-ckpt-index-unusable-provenance.md
+++ b/changelog.d/2721-vera-offline-ckpt-index-unusable-provenance.md
@@ -6,19 +6,20 @@
   omits `wandb_run`, but handed anything else to the two operations that assume a
   string - using the value as a dict key and splitting it on `/` - so a payload
   that parses into an array, string, number or null, or an object whose
-  `wandb_run` is a number, list or object, raised out of the scan. That is fatal
-  rather than local: the module self-installs on import and `launch_server.py`
-  imports it before the server module, so one malformed record among the mounted
-  checkpoints killed the container entrypoint before the server was reached, and
-  the whole root is scanned in one pass, so the healthy records went with it -
-  including `37oa162u`, the run the entrypoint defaults to for mimicgen. The
-  tolerance was backwards: a file that could not be read at all was skipped,
-  while one that parsed into the wrong shape was fatal. Such a record is now
-  skipped and named in a warning with the type that made it unusable, following
-  the rule `transforms.provenance.load_provenance` applies to a provenance
-  payload - check the type before using the value - and differing only in
-  disposition, because this resolver has a fallback (the network) where a caller
-  asking which episodes are synthetic has none. Every record indexed before is
-  indexed on identical terms, and a checkpoint directory carrying no wandb run is
-  still skipped silently, since that is the ordinary case for every artifact not
-  loaded by run id.
+  `wandb_run` is a non-zero number, non-empty list or non-empty object, raised
+  out of the scan. That is fatal rather than local: the module self-installs on
+  import and `launch_server.py` imports it before the server module, so one
+  malformed record among the mounted checkpoints killed the container entrypoint
+  before the server was reached, and the whole root is scanned in one pass, so
+  the healthy records went with it - including `37oa162u`, the run the entrypoint
+  defaults to for mimicgen. The tolerance was backwards: a file that could not be
+  read at all was skipped, while one that parsed into the wrong shape was fatal.
+  Such a record is now skipped and named in a warning with the type that made it
+  unusable, following the rule `transforms.provenance.load_provenance` applies to
+  a provenance payload - check the type before using the value - and differing
+  only in disposition, because this resolver has a fallback (the network) where a
+  caller asking which episodes are synthetic has none. Every record indexed
+  before is indexed on identical terms, and a checkpoint directory carrying no
+  run to index (`wandb_run` absent, null, empty or otherwise falsy, which reaches
+  neither string operation and so never raised) is still skipped silently, since
+  that is the ordinary case for every artifact not loaded by run id.

--- a/changelog.d/2721-vera-offline-ckpt-index-unusable-provenance.md
+++ b/changelog.d/2721-vera-offline-ckpt-index-unusable-provenance.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **policies/vera/docker**: the offline checkpoint resolver skips a
+  `provenance.json` it cannot read as a run record, instead of raising on it.
+  `_index_local_ckpts` already skipped a file that does not parse and one that
+  omits `wandb_run`, but handed anything else to the two operations that assume a
+  string - using the value as a dict key and splitting it on `/` - so a payload
+  that parses into an array, string, number or null, or an object whose
+  `wandb_run` is a number, list or object, raised out of the scan. That is fatal
+  rather than local: the module self-installs on import and `launch_server.py`
+  imports it before the server module, so one malformed record among the mounted
+  checkpoints killed the container entrypoint before the server was reached, and
+  the whole root is scanned in one pass, so the healthy records went with it -
+  including `37oa162u`, the run the entrypoint defaults to for mimicgen. The
+  tolerance was backwards: a file that could not be read at all was skipped,
+  while one that parsed into the wrong shape was fatal. Such a record is now
+  skipped and named in a warning with the type that made it unusable, following
+  the rule `transforms.provenance.load_provenance` applies to a provenance
+  payload - check the type before using the value - and differing only in
+  disposition, because this resolver has a fallback (the network) where a caller
+  asking which episodes are synthetic has none. Every record indexed before is
+  indexed on identical terms, and a checkpoint directory carrying no wandb run is
+  still skipped silently, since that is the ordinary case for every artifact not
+  loaded by run id.

--- a/strands_robots/policies/vera/docker/README.md
+++ b/strands_robots/policies/vera/docker/README.md
@@ -112,7 +112,11 @@ An explicit `-e VERA_…` always overrides the auto-wiring.
   checkpoint's `provenance.json` (`wandb_offline_resolve.py`) and sets
   `WANDB_MODE=offline`, so **no wandb network / API key is needed**. Both the
   proven mimicgen IDM (`37oa162u`) and the omni default (`x21o0cwe`) resolve
-  locally; an unknown run id transparently falls back to wandb.
+  locally; an unknown run id transparently falls back to wandb. A
+  `provenance.json` the scan cannot read as a run record - it does not parse,
+  does not hold a JSON object, or carries a non-string `wandb_run` - is skipped
+  and named in a warning, so one malformed record among the mounted checkpoints
+  never costs the healthy ones.
 - The container only **serves** actions; the host runs the sim. The heavy
   `eval` extra (robosuite/mimicgen) is therefore **not** installed by default
   (build with `--build-arg VERA_WITH_EVAL=1` to bundle it).

--- a/strands_robots/policies/vera/docker/README.md
+++ b/strands_robots/policies/vera/docker/README.md
@@ -114,9 +114,12 @@ An explicit `-e VERA_…` always overrides the auto-wiring.
   proven mimicgen IDM (`37oa162u`) and the omni default (`x21o0cwe`) resolve
   locally; an unknown run id transparently falls back to wandb. A
   `provenance.json` the scan cannot read as a run record - it does not parse,
-  does not hold a JSON object, or carries a non-string `wandb_run` - is skipped
-  and named in a warning, so one malformed record among the mounted checkpoints
-  never costs the healthy ones.
+  does not hold a JSON object, or carries a non-string `wandb_run` - is skipped,
+  so one malformed record among the mounted checkpoints never costs the healthy
+  ones. A record that carried something unusable is named in a warning with the
+  offending type; one that carries no run to index (`wandb_run` absent, null,
+  empty or otherwise falsy) is skipped silently, since that is the ordinary case
+  for every artifact not loaded by run id.
 - The container only **serves** actions; the host runs the sim. The heavy
   `eval` extra (robosuite/mimicgen) is therefore **not** installed by default
   (build with `--build-arg VERA_WITH_EVAL=1` to bundle it).

--- a/strands_robots/policies/vera/docker/wandb_offline_resolve.py
+++ b/strands_robots/policies/vera/docker/wandb_offline_resolve.py
@@ -22,7 +22,10 @@ already imported into ``vera.policy.motion_policy_loading``) with a version that
 1. Scans ``$VERA_CKPT_ROOT`` for ``*/provenance.json`` whose ``wandb_run`` matches
    the requested ``run_path`` (full ``entity/project/run_id`` OR just the trailing
    ``run_id`` - tolerant of the entity/project drift between code defaults and the
-   released artifacts).
+   released artifacts). A file that cannot be read as such a record - it does not
+   parse, does not hold a JSON object, or carries a non-string ``wandb_run`` - is
+   skipped, so one malformed record among the mounted checkpoints never decides
+   whether the healthy ones resolve.
 2. If found, returns that dir's ``model.ckpt`` (+ the ``config.yaml`` sidecar as
    the run config when ``return_config=True``), exactly like the real function.
 3. If NOT found, falls back to the original wandb-backed implementation (so online
@@ -49,15 +52,41 @@ log = logging.getLogger("vera.offline_resolve")
 
 
 def _index_local_ckpts(ckpt_root: str) -> dict[str, Path]:
-    """Map every known wandb_run string (full + trailing run_id) -> ckpt dir."""
+    """Map every usable wandb_run string (full + trailing run_id) -> ckpt dir.
+
+    A ``provenance.json`` this cannot read as a run record is skipped, exactly
+    like one that omits ``wandb_run`` entirely: it does not parse, it does not
+    hold a JSON object, or its ``wandb_run`` is not a string. The index is built
+    while the container is still starting, and the resolver's only fallback is
+    the network this container exists to do without, so one malformed record
+    among the mounted checkpoints must not decide whether the healthy ones
+    resolve. :func:`strands_robots.transforms.provenance.load_provenance` reads
+    a provenance payload by the same rule - check the type before using the
+    value - and refuses instead, because a caller asking which episodes are
+    synthetic has no fallback to be handed.
+
+    Args:
+        ckpt_root: Directory scanned recursively for ``*/provenance.json``.
+
+    Returns:
+        Every usable run string mapped to the checkpoint directory that holds
+        it, keyed both by the full ``entity/project/run_id`` and by the trailing
+        ``run_id`` alone.
+    """
     index: dict[str, Path] = {}
     for prov in glob.glob(os.path.join(ckpt_root, "**", "provenance.json"), recursive=True):
         try:
             data = json.loads(Path(prov).read_text())
         except Exception:
             continue
+        if not isinstance(data, dict):
+            log.warning("[offline-resolve] ignoring %s: expected a JSON object, got %s", prov, type(data).__name__)
+            continue
         run = data.get("wandb_run")
         if not run:
+            continue
+        if not isinstance(run, str):
+            log.warning("[offline-resolve] ignoring %s: wandb_run must be a string, got %s", prov, type(run).__name__)
             continue
         ckpt_dir = Path(prov).parent
         if not (ckpt_dir / "model.ckpt").exists():

--- a/tests/policies/vera/test_offline_ckpt_index_skips_an_unusable_provenance_record.py
+++ b/tests/policies/vera/test_offline_ckpt_index_skips_an_unusable_provenance_record.py
@@ -1,0 +1,405 @@
+"""One unusable ``provenance.json`` never costs the container its healthy checkpoints.
+
+:mod:`strands_robots.policies.vera.docker.wandb_offline_resolve` exists for one
+reason: VERA loads its Jacobian IDM by wandb run id, and the real
+``download_checkpoint`` calls the wandb API before it looks at disk, so an
+offline container never starts. The resolver indexes the mounted checkpoints by
+the ``wandb_run`` recorded in each ``provenance.json`` and answers from disk
+instead.
+
+That index is built while the container is still starting - the launcher imports
+the module (which self-installs) and then calls ``install()`` - and it is built
+by scanning *every* ``provenance.json`` under the mounted root. So the scan is
+handed whatever the operator mounted, and its disposition towards a file it
+cannot use decides whether the server comes up at all. The module already skips
+a file that does not parse and one that omits ``wandb_run``; the cases below are
+the remaining ones, where the file parses into something that is simply not a
+run record. Those used to be handed straight to the operations that assume a
+string - hashing the value as a dict key and splitting it on ``/`` - so the scan
+raised, the import raised, and the checkpoints that *were* healthy went with it.
+
+The rule is the one :func:`strands_robots.transforms.provenance.load_provenance`
+applies to a provenance payload: check the type before using the value. The two
+differ only in disposition, and for the documented reason - a caller asking
+which episodes are synthetic has no fallback and is refused, while this resolver
+has one (the network) and the checkpoint it could not read is simply not in the
+index.
+
+The case set is not a hand-picked list of things that once crashed: each entry
+is graded against the property that makes it interesting - it parses as JSON but
+is not a usable record - so a case that stops being either is caught here rather
+than quietly becoming a duplicate of the parse-failure path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# The container helpers are excluded from type checking (``tool.mypy.exclude``):
+# they are written against the dependency set of the image, where ``vera`` and
+# ``omegaconf`` are installed and unstubbed here. mypy's ``exclude`` does not
+# apply to a module reached through a followed import, so a static import here
+# would quietly pull the module back into the type-checked graph. Importing it by
+# name keeps the declared exclusion effective.
+resolver: Any = importlib.import_module("strands_robots.policies.vera.docker.wandb_offline_resolve")
+
+# Two released-style records, laid out the way the hosted artifacts are: the run
+# the entrypoint defaults to for mimicgen, and the pusht IDM beside it.
+MIMICGEN_RUN = "your-wandb-entity/jacobian-learning/37oa162u"
+PUSHT_RUN = "your-wandb-entity/jacobian-learning/pusht01"
+
+# Payloads that parse as JSON but cannot be read as a run record. Either the
+# payload is not an object, or its ``wandb_run`` is not a string.
+UNUSABLE_PAYLOADS: dict[str, str] = {
+    "run-id-is-a-number": json.dumps({"wandb_run": 12345}),
+    "run-id-is-a-list": json.dumps({"wandb_run": ["your-wandb-entity", "jacobian-learning", "37oa162u"]}),
+    "run-id-is-an-object": json.dumps({"wandb_run": {"entity": "your-wandb-entity", "id": "37oa162u"}}),
+    "payload-is-an-array": json.dumps([{"wandb_run": MIMICGEN_RUN}]),
+    "payload-is-a-string": json.dumps(MIMICGEN_RUN),
+    "payload-is-a-number": json.dumps(7),
+    "payload-is-null": json.dumps(None),
+}
+
+# Payloads the scan already skipped before, kept here so widening the skip does
+# not widen the logging with it: none of these is a mistake worth a warning. A
+# checkpoint directory that carries no wandb run is the ordinary case for every
+# artifact that is not loaded by run id.
+QUIETLY_SKIPPED_PAYLOADS: dict[str, str] = {
+    "not-json-at-all": "{not json",
+    "an-empty-file": "",
+    "no-wandb_run-key": json.dumps({"artifact": "pusht-dfot"}),
+    "wandb_run-is-null": json.dumps({"wandb_run": None}),
+    "wandb_run-is-empty": json.dumps({"wandb_run": ""}),
+}
+
+
+def _module(name: str, **attrs: Any) -> Any:
+    """A stand-in module carrying the attributes an importer will read off it."""
+    module: Any = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+def _write_ckpt(root: Path, name: str, payload: str | None, *, model_ckpt: bool = True) -> Path:
+    """Create one checkpoint directory the way the released artifacts lay them out."""
+    ckpt_dir = root / name
+    ckpt_dir.mkdir(parents=True)
+    if payload is not None:
+        (ckpt_dir / "provenance.json").write_text(payload)
+    if model_ckpt:
+        (ckpt_dir / "model.ckpt").write_text("weights")
+    return ckpt_dir
+
+
+class _RecordingWandbDownload:
+    """The wandb-backed ``download_checkpoint`` the resolver falls back to.
+
+    The real one reaches the network. This one records the arguments it was
+    handed, so a test can say whether the fallback was taken and with what.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        run_path: str,
+        download_dir: str,
+        option: str = "latest",
+        return_config: bool = False,
+        force_redownload: bool = False,
+    ) -> Path:
+        self.calls.append(
+            {
+                "run_path": run_path,
+                "download_dir": download_dir,
+                "option": option,
+                "return_config": return_config,
+                "force_redownload": force_redownload,
+            }
+        )
+        return Path("/downloaded/from/wandb/model.ckpt")
+
+
+def _install_fake_vera(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, Any, _RecordingWandbDownload]:
+    """Make ``vera`` importable, as it is inside the container.
+
+    Returns the two modules the resolver patches and the recording fallback both
+    of them start out holding.
+    """
+    wandb_download = _RecordingWandbDownload()
+    ckpt_utils = _module("vera.utils.ckpt_utils", download_checkpoint=wandb_download)
+    loading = _module("vera.policy.motion_policy_loading", download_checkpoint=wandb_download)
+    utils = _module("vera.utils", __path__=[], ckpt_utils=ckpt_utils)
+    policy = _module("vera.policy", __path__=[], motion_policy_loading=loading)
+    vera = _module("vera", __path__=[], utils=utils, policy=policy)
+    for name, module in (
+        ("vera", vera),
+        ("vera.utils", utils),
+        ("vera.utils.ckpt_utils", ckpt_utils),
+        ("vera.policy", policy),
+        ("vera.policy.motion_policy_loading", loading),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+    return ckpt_utils, loading, wandb_download
+
+
+class TestTheCaseSetIsWhatItClaims:
+    """The unusable payloads are exactly the ones the parse check cannot catch."""
+
+    @pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
+    def test_each_case_parses_but_is_not_a_usable_record(self, label: str) -> None:
+        value = json.loads(UNUSABLE_PAYLOADS[label])
+        usable = isinstance(value, dict) and isinstance(value.get("wandb_run"), str)
+        assert not usable, f"{label!r} is a usable record and grades nothing"
+
+    def test_both_ways_of_being_unusable_are_represented(self) -> None:
+        payloads = [json.loads(p) for p in UNUSABLE_PAYLOADS.values()]
+        assert any(not isinstance(p, dict) for p in payloads), "no case exercises a non-object payload"
+        assert any(isinstance(p, dict) for p in payloads), "no case exercises a non-string wandb_run"
+
+    @pytest.mark.parametrize("label", sorted(QUIETLY_SKIPPED_PAYLOADS))
+    def test_the_quiet_cases_carry_no_run_to_index(self, label: str) -> None:
+        try:
+            value = json.loads(QUIETLY_SKIPPED_PAYLOADS[label])
+        except ValueError:
+            return  # does not parse: skipped by the parse check, which is the point
+        assert not (isinstance(value, dict) and value.get("wandb_run"))
+
+
+class TestOneUnusableRecordDoesNotCostTheHealthyOnes:
+    """The scan skips what it cannot read and keeps indexing the rest."""
+
+    @pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
+    def test_the_checkpoints_on_either_side_of_it_still_index(self, tmp_path: Path, label: str) -> None:
+        _write_ckpt(tmp_path, "pusht-idm", json.dumps({"wandb_run": PUSHT_RUN}))
+        _write_ckpt(tmp_path, "idm-omni-x21o0cwe", UNUSABLE_PAYLOADS[label])
+        _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+
+        index = resolver._index_local_ckpts(str(tmp_path))
+
+        assert set(index) == {MIMICGEN_RUN, "37oa162u", PUSHT_RUN, "pusht01"}
+        assert index["37oa162u"] == tmp_path / "idm-mimicgen-37oa162u"
+        assert index["pusht01"] == tmp_path / "pusht-idm"
+
+    def test_the_run_the_entrypoint_defaults_to_resolves_with_no_wandb(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The launcher's ``install()`` is the caller that used to die here."""
+        ckpt_utils, _, wandb_download = _install_fake_vera(monkeypatch)
+        _write_ckpt(tmp_path, "idm-omni-x21o0cwe", UNUSABLE_PAYLOADS["run-id-is-an-object"])
+        mimicgen = _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+
+        resolver.install(str(tmp_path))
+
+        assert ckpt_utils.download_checkpoint is not wandb_download
+        assert ckpt_utils.download_checkpoint("37oa162u", "/downloads") == mimicgen / "model.ckpt"
+        assert wandb_download.calls == []
+
+    @pytest.mark.parametrize("label", sorted(UNUSABLE_PAYLOADS))
+    def test_the_ignored_file_is_named_with_the_type_that_made_it_unusable(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, label: str
+    ) -> None:
+        payload = UNUSABLE_PAYLOADS[label]
+        _write_ckpt(tmp_path, "idm-omni-x21o0cwe", payload)
+
+        with caplog.at_level(logging.WARNING, logger="vera.offline_resolve"):
+            assert resolver._index_local_ckpts(str(tmp_path)) == {}
+
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert str(tmp_path / "idm-omni-x21o0cwe" / "provenance.json") in message
+        value = json.loads(payload)
+        offender = value.get("wandb_run") if isinstance(value, dict) else value
+        assert type(offender).__name__ in message
+
+
+class TestARecordTheScanCanUse:
+    """What the scan indexed before is indexed on exactly the same terms."""
+
+    def test_a_healthy_record_is_keyed_by_both_the_full_path_and_the_run_id(self, tmp_path: Path) -> None:
+        ckpt_dir = _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+
+        index = resolver._index_local_ckpts(str(tmp_path))
+
+        assert index == {MIMICGEN_RUN: ckpt_dir, "37oa162u": ckpt_dir}
+
+    @pytest.mark.parametrize("label", sorted(QUIETLY_SKIPPED_PAYLOADS))
+    def test_a_directory_with_no_run_to_index_is_skipped_without_a_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, label: str
+    ) -> None:
+        _write_ckpt(tmp_path, "pusht-dfot", QUIETLY_SKIPPED_PAYLOADS[label])
+
+        with caplog.at_level(logging.WARNING, logger="vera.offline_resolve"):
+            assert resolver._index_local_ckpts(str(tmp_path)) == {}
+
+        assert caplog.records == []
+
+    def test_a_record_whose_checkpoint_is_missing_is_skipped(self, tmp_path: Path) -> None:
+        _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}), model_ckpt=False)
+
+        assert resolver._index_local_ckpts(str(tmp_path)) == {}
+
+
+class TestThePatchedResolverPrefersTheLocalCheckpoint:
+    """What ``install()`` puts in front of the server, once the index is built."""
+
+    @pytest.fixture
+    def container(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        ckpt_utils, loading, wandb_download = _install_fake_vera(monkeypatch)
+        ckpt_dir = _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+        resolver.install(str(tmp_path))
+        return {
+            "ckpt_utils": ckpt_utils,
+            "loading": loading,
+            "wandb": wandb_download,
+            "ckpt_dir": ckpt_dir,
+            "root": tmp_path,
+        }
+
+    def test_the_full_run_path_resolves_to_the_mounted_checkpoint(self, container: dict[str, Any]) -> None:
+        resolved = container["ckpt_utils"].download_checkpoint(MIMICGEN_RUN, "/downloads")
+
+        assert resolved == container["ckpt_dir"] / "model.ckpt"
+        assert container["wandb"].calls == []
+
+    def test_a_different_entity_and_project_resolve_on_the_trailing_run_id(self, container: dict[str, Any]) -> None:
+        """The code defaults and the released artifacts disagree about the prefix."""
+        resolved = container["ckpt_utils"].download_checkpoint("someone-else/other-project/37oa162u", "/downloads")
+
+        assert resolved == container["ckpt_dir"] / "model.ckpt"
+        assert container["wandb"].calls == []
+
+    def test_an_unknown_run_id_falls_back_with_every_argument_intact(self, container: dict[str, Any]) -> None:
+        resolved = container["ckpt_utils"].download_checkpoint(
+            "your-wandb-entity/jacobian-learning/unknown", "/downloads", option="best"
+        )
+
+        assert resolved == Path("/downloaded/from/wandb/model.ckpt")
+        assert container["wandb"].calls == [
+            {
+                "run_path": "your-wandb-entity/jacobian-learning/unknown",
+                "download_dir": "/downloads",
+                "option": "best",
+                "return_config": False,
+                "force_redownload": False,
+            }
+        ]
+
+    def test_a_forced_redownload_goes_to_wandb_even_though_the_run_is_local(self, container: dict[str, Any]) -> None:
+        resolved = container["ckpt_utils"].download_checkpoint(MIMICGEN_RUN, "/downloads", force_redownload=True)
+
+        assert resolved == Path("/downloaded/from/wandb/model.ckpt")
+        assert [call["force_redownload"] for call in container["wandb"].calls] == [True]
+
+    def test_a_run_config_is_read_from_the_sidecar_beside_the_checkpoint(
+        self, container: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (container["ckpt_dir"] / "config.yaml").write_text("algo: jacobian\n")
+        sidecar_config = {"algo": "jacobian"}
+        omega = _module(
+            "omegaconf",
+            OmegaConf=_module(
+                "OmegaConf",
+                load=lambda path: {"path": str(path)},
+                to_container=lambda cfg, resolve=True: sidecar_config,
+            ),
+        )
+        monkeypatch.setitem(sys.modules, "omegaconf", omega)
+
+        resolved, config = container["ckpt_utils"].download_checkpoint(MIMICGEN_RUN, "/downloads", return_config=True)
+
+        assert resolved == container["ckpt_dir"] / "model.ckpt"
+        assert config == sidecar_config
+
+    def test_a_run_config_is_empty_when_the_checkpoint_carries_no_sidecar(self, container: dict[str, Any]) -> None:
+        resolved, config = container["ckpt_utils"].download_checkpoint(MIMICGEN_RUN, "/downloads", return_config=True)
+
+        assert resolved == container["ckpt_dir"] / "model.ckpt"
+        assert config == {}
+
+    def test_an_unreadable_sidecar_costs_the_config_not_the_checkpoint(
+        self, container: dict[str, Any], monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (container["ckpt_dir"] / "config.yaml").write_text("algo: [unterminated\n")
+
+        def _explode(path: Any) -> Any:
+            raise ValueError("could not parse the sidecar")
+
+        omega = _module("omegaconf", OmegaConf=_module("OmegaConf", load=_explode))
+        monkeypatch.setitem(sys.modules, "omegaconf", omega)
+
+        with caplog.at_level(logging.WARNING, logger="vera.offline_resolve"):
+            resolved, config = container["ckpt_utils"].download_checkpoint(
+                MIMICGEN_RUN, "/downloads", return_config=True
+            )
+
+        assert resolved == container["ckpt_dir"] / "model.ckpt"
+        assert config == {}
+        assert any("config.yaml" in record.getMessage() for record in caplog.records)
+
+    def test_the_symbol_already_imported_by_name_is_patched_too(self, container: dict[str, Any]) -> None:
+        """``motion_policy_loading`` bound the function at import, not by lookup."""
+        assert container["loading"].download_checkpoint is container["ckpt_utils"].download_checkpoint
+        assert container["loading"].download_checkpoint(MIMICGEN_RUN, "/downloads") == (
+            container["ckpt_dir"] / "model.ckpt"
+        )
+
+    def test_installing_twice_still_resolves_locally_and_falls_back_once(self, container: dict[str, Any]) -> None:
+        """The launcher imports the module and then calls ``install()`` again."""
+        resolver.install(str(container["root"]))
+
+        assert container["ckpt_utils"].download_checkpoint(MIMICGEN_RUN, "/downloads") == (
+            container["ckpt_dir"] / "model.ckpt"
+        )
+        container["ckpt_utils"].download_checkpoint("your-wandb-entity/jacobian-learning/unknown", "/downloads")
+        assert len(container["wandb"].calls) == 1
+
+
+class TestWhatInstallDoesWhenItCannotHelp:
+    """The resolver never becomes the reason the server fails to start."""
+
+    def test_an_empty_checkpoint_root_leaves_wandb_in_place_and_says_so(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        ckpt_utils, _, wandb_download = _install_fake_vera(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger="vera.offline_resolve"):
+            resolver.install(str(tmp_path))
+
+        assert any("no local provenance.json" in record.getMessage() for record in caplog.records)
+        assert ckpt_utils.download_checkpoint("any/run/id", "/downloads") == Path("/downloaded/from/wandb/model.ckpt")
+        assert len(wandb_download.calls) == 1
+
+    def test_nothing_is_patched_when_vera_is_not_importable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+        monkeypatch.setitem(sys.modules, "vera", None)
+
+        with caplog.at_level(logging.WARNING, logger="vera.offline_resolve"):
+            resolver.install(str(tmp_path))
+
+        assert any("could not import" in record.getMessage() for record in caplog.records)
+
+    def test_the_checkpoint_utils_patch_survives_an_unimportable_loading_module(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The by-name re-import is a bonus; the primary patch must still land."""
+        ckpt_utils, _, wandb_download = _install_fake_vera(monkeypatch)
+        ckpt_dir = _write_ckpt(tmp_path, "idm-mimicgen-37oa162u", json.dumps({"wandb_run": MIMICGEN_RUN}))
+        monkeypatch.setitem(sys.modules, "vera.policy.motion_policy_loading", None)
+
+        resolver.install(str(tmp_path))
+
+        assert ckpt_utils.download_checkpoint(MIMICGEN_RUN, "/downloads") == ckpt_dir / "model.ckpt"
+        assert wandb_download.calls == []


### PR DESCRIPTION
One malformed `provenance.json` under the mounted checkpoint root stopped the offline VERA container from starting, and took every healthy checkpoint beside it.

## The problem

`wandb_offline_resolve` exists because VERA loads its Jacobian IDM by wandb run id, and the real `download_checkpoint` calls the wandb API before it looks at disk, so an offline container never comes up. The module indexes the mounted checkpoints by the `wandb_run` recorded in each `provenance.json` and answers from disk instead.

`_index_local_ckpts` skipped a file that does not parse and one that omits `wandb_run`, then handed anything else straight to the two operations that assume a string - using the value as a dict key, and splitting it on `/`. So a payload that parses into something that is not a run record raised instead of being skipped. Measured over every way a `provenance.json` can be malformed:

| `provenance.json` payload | before | after |
|---|---|---|
| unparseable file | skipped, quietly | skipped, quietly |
| empty file | skipped, quietly | skipped, quietly |
| object, no `wandb_run` key | skipped, quietly | skipped, quietly |
| object, `wandb_run` is `null` | skipped, quietly | skipped, quietly |
| object, `wandb_run` is `""` | skipped, quietly | skipped, quietly |
| object, `wandb_run` is a falsy non-string (`0`, `false`, `[]`, `{}`) | skipped, quietly | skipped, quietly |
| object, `wandb_run` is a non-zero number | `AttributeError: 'int' object has no attribute 'split'` | skipped, named |
| object, `wandb_run` is a non-empty list | `TypeError: unhashable type: 'list'` | skipped, named |
| object, `wandb_run` is a non-empty object | `TypeError: unhashable type: 'dict'` | skipped, named |
| payload is a JSON array | `AttributeError: 'list' object has no attribute 'get'` | skipped, named |
| payload is a JSON string | `AttributeError: 'str' object has no attribute 'get'` | skipped, named |
| payload is a JSON number | `AttributeError: 'int' object has no attribute 'get'` | skipped, named |
| payload is JSON null | `AttributeError: 'NoneType' object has no attribute 'get'` | skipped, named |

Seven of the thirteen malformation modes raised, and the tolerance was exactly backwards: a file that could not be read at all was skipped, while one that parsed into the wrong shape was fatal.

The six quiet rows all route through the pre-existing `if not run` check, which sits *above* the new string guard and is deliberately silent: a checkpoint directory carrying no wandb run is the ordinary case for every artifact not loaded by run id. A falsy non-string is in that same class - `0`, `[]` and `{}` carry nothing to index, so their consequence is identical to a missing key, and neither before nor after does such a payload reach the two string operations. The warning is reserved for a record that carried *something* the index cannot use. Ordering is therefore load-bearing in both directions, and the break table below pins it.

It is fatal rather than local because the module self-installs at import and `launch_server.py` imports it before the server module, so the raise lands on the container entrypoint. The whole root is scanned in one pass, so the healthy records go with it. Driving the launcher's own `import` + `install()` sequence against a root holding two healthy released records and one malformed one:

```
# before
Traceback (most recent call last):
  File "/opt/launch_server.py", line 3, in <module>
    import wandb_offline_resolve
  File "/opt/wandb_offline_resolve.py", line 137, in <module>
    install()
  File "/opt/wandb_offline_resolve.py", line 79, in install
    index = _index_local_ckpts(ckpt_root)
  File "/opt/wandb_offline_resolve.py", line 65, in _index_local_ckpts
    index[run] = ckpt_dir  # full "entity/project/run_id"
TypeError: unhashable type: 'dict'
                                                     exit 1 - the server never starts

# after
WARNING [offline-resolve] ignoring /ckpts/idm-omni-x21o0cwe/provenance.json: wandb_run must be a string, got dict
INFO    [offline-resolve] indexed 4 local ckpt run ids under /ckpts: ['idm-mimicgen-37oa162u', 'pusht-idm']
INFO    [offline-resolve] your-wandb-entity/jacobian-learning/37oa162u -> /ckpts/idm-mimicgen-37oa162u/model.ckpt (local, no wandb)
                                                     exit 0
```

The run lost in that first case is `37oa162u` - the one `entrypoint.sh` defaults `VERA_DYNAMICS_RUN_ID` to for mimicgen.

## The change

`_index_local_ckpts` skips a record it cannot read as a run record, exactly as it already skips one that does not parse and one that omits the key, and names the file and the offending type in a warning so the operator can see which mounted checkpoint did not index.

The rule is the one `transforms.provenance.load_provenance` already applies to a provenance payload - check the type before using the value. The two differ only in disposition, for the reason that module documents: a caller asking which episodes are synthetic has no fallback and is refused, while this resolver has one (the network) and a checkpoint it could not read is simply absent from the index. Refusing here is what the code already did, and it is the behaviour that takes down the server this module exists to bring up.

Every previously-indexed record is indexed on identical terms, and the records that were skipped quietly stay quiet - a checkpoint directory carrying no wandb run is the ordinary case for every artifact not loaded by run id, so warning about it would be noise.

## Tests

`tests/policies/vera/test_offline_ckpt_index_skips_an_unusable_provenance_record.py`, 47 cases. On pre-fix code: **15 failed, 32 passed**, all 15 inside the regression class and none in the premise, control, resolver-behaviour or install classes.

The case set is graded rather than listed: each entry is checked against the property that makes it interesting - it parses as JSON but is not a usable record - so a case that stops being either is caught here instead of quietly duplicating the parse-failure path.

Break table, 11 mutations, 10 distinct firing sets, control 0:

| mutation | tests firing |
|---|---|
| control - no mutation | 0 |
| the JSON-object guard dropped | 8 |
| the `wandb_run` string guard dropped | 7 |
| both guards dropped (pre-fix code) | 15 |
| a non-string run id coerced with `str()` instead of skipped | 6 |
| only a null payload guarded (a narrower shape check) | 7 |
| both skips silent - the ignored file is not named | 7 |
| the warning widened to the records already skipped quietly | 3 |
| the shape guard placed after the key is read | 8 |
| only numbers refused, not every non-string | 6 |
| the missing-checkpoint skip dropped | 1 |

The two halves are disjoint and complementary: 8 + 7 = 15, the pre-fix total. Moving the shape guard below the key read fires the same 8 as dropping it, because `data.get` raises first - placement is load-bearing, not stylistic. Widening the warning to the quiet records fires 3 control cases, which is what keeps this from becoming a noisy scan.

The module was previously at 24% coverage (47 of 62 statements unreached, in two contiguous blocks) because nothing imported it; it is now at **100%** (0 of 68), taking the repository's uncovered total from 2031 to 1984.

One note on the import form: the container helpers are excluded from type checking (`tool.mypy.exclude`) since they are written against the image's dependency set, where `vera` and `omegaconf` are installed and unstubbed here. mypy's `exclude` does not apply to a module reached through a *followed* import, so a static import from a test would silently pull the module back into the type-checked graph and report six `import-not-found` errors. The test imports it by name, which keeps the declared exclusion effective.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1542 files).
- mypy **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical in both directions, 0 in the changed files.
- Paired run over an identical 372-file selection (the whole `tests/policies/vera` suite plus every guard that walks the tree, reads docstrings or reads project config), the new file excluded from both trees: **17 failed, 17187 passed, 72 skipped** on both, 17276 collected each, failing-id sets identical both ways. All 17 need `awsiot` (the `[mesh-iot]` extra), absent here and equally absent on both trees.
- The new file passes on mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 from source, and on mujoco 3.12.0. Whole `tests/policies/vera` suite: 793 passed.

## Artifact

The launcher's own import + `install()` sequence run against the same three-checkpoint root on both trees, captured verbatim (log timestamps trimmed; paths shown at the container's `/ckpts` and `/opt`):

![offline resolver before and after a malformed provenance record](https://github.com/cagataycali/robots/releases/download/artifacts/offline-resolve-malformed-provenance.png)

## Round 2 - changelog

`de66b8f` **docs(vera): scope the offline-resolver naming claim to the records it names** - two markdown files. No code, no tests, and no measured number above changes.

Review feedback noted that a *falsy* non-string `wandb_run` (`0`, `false`, `[]`, `{}`) is caught by the pre-existing `if not run` check before the new string guard, so it is skipped quietly rather than named.

The observation is correct, and measuring it showed the imprecision was wider than the `after` column. I drove `_index_local_ckpts` over all thirteen malformation modes on this tree, and over a reconstruction of the pre-fix function on the same inputs:

```
case               pre-fix   post-fix  named?
wandb_run=0        quiet     skipped   no
wandb_run=false    quiet     skipped   no
wandb_run=[]       quiet     skipped   no
wandb_run={}       quiet     skipped   no
wandb_run=''       quiet     skipped   no
wandb_run=null     quiet     skipped   no
wandb_run=12345    RAISE     skipped   YES  wandb_run must be a string, got int
wandb_run=['a']    RAISE     skipped   YES  wandb_run must be a string, got list
wandb_run={a:1}    RAISE     skipped   YES  wandb_run must be a string, got dict
payload=[]         RAISE     skipped   YES  expected a JSON object, got list
payload=null       RAISE     skipped   YES  expected a JSON object, got NoneType
payload=7          RAISE     skipped   YES  expected a JSON object, got int
payload='str'      RAISE     skipped   YES  expected a JSON object, got str

raising modes pre-fix: 7 of 13
```

So the `before` column was wrong too: `[]`, `{}` and `0` never reached the string operations pre-fix and never raised. The problem table above now splits the three collapsed non-string rows into four - one quiet row for the falsy values, three named rows for the truthy ones - and reports what each payload actually did. Thirteen modes, seven raising, unchanged in total.

**What the commit changes.** Two shipped documents claimed more than the code does, and unlike this description they do not stay behind after merge:

- the changelog fragment listed "a number, list or object" among the payloads that raised - true only of the non-zero, non-empty ones. Left as written it would have shipped a reproduction that does not reproduce, permanently, in `CHANGELOG.md`.
- `docker/README.md` said a non-string `wandb_run` "is skipped and named in a warning" - true of a record that carried something unusable, not of one that carried nothing.

Both now name the warning only for the records that get one, and state the quiet path explicitly. The two module docstrings needed no change: they claim only that such a record "is skipped", which is accurate for all thirteen modes.

**No guard change, for a reason rather than for the round budget.** The quiet disposition is the correct one: a falsy `wandb_run` carries nothing to index, so its consequence is indistinguishable from the missing key the same branch already handles silently by design, and the warning exists to name a record that carried *something* unusable. Reordering the guards to name `[]` would move the empty string `""` - the ordinary no-run-recorded case - onto the noisy path, which is exactly what the `the warning widened to the records already skipped quietly` mutation is in the break table to prevent (it fires 3 control cases). The branch stays pinned either way: `QUIETLY_SKIPPED_PAYLOADS` covers `wandb_run-is-null` and `wandb_run-is-empty`, which route through the identical check, and `test_a_directory_with_no_run_to_index_is_skipped_without_a_warning` asserts the empty log for every one of them.

`tests/test_changelog_fragment_gate.py`, `test_changelog_fragments.py`, `test_changelog_format.py`: **89 passed**. The fragment was also reflowed so no continuation line begins with `- `, which markdown would otherwise render as a nested bullet.