### PR TITLE
test(training): grade every field-scoped domain guard, not the five one helper name reached

### DIFF
--- a/changelog.d/2722-field-scoped-guard-discovery.md
+++ b/changelog.d/2722-field-scoped-guard-discovery.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **training**: the guard that holds every field-scoped shared-domain guard to
+  the "a reader scan must see both forms of a read" rule now discovers all
+  thirteen of them rather than five. It keyed discovery on the *name* of the
+  helper a guard uses to list the backend modules, and the guards spell that
+  helper two ways (`_trainer_modules` and `_training_modules`), so the eight
+  guards using the other spelling sat outside the sweep - silently, because it
+  reported a clean tree over the five it could see and pinned that count as its
+  own non-vacuity assertion. All eight were the by-name-only scans the shared
+  rule exists to replace, so each certified a clean `readers == {...}` sweep
+  while a backend that forwards its gated field through a table and skips the
+  gate went unreported. Discovery is now keyed on the two properties that make a
+  guard gradeable (one reader helper, a scope rooted at the backend tree), the
+  eight reader scans route through the shared rule, and the forwarding-provider
+  assertions derive their own scope from what that provider actually forwards so
+  they no longer assume every gated field is one of them.

--- a/tests/training/test_clip_range_domain.py
+++ b/tests/training/test_clip_range_domain.py
@@ -71,6 +71,7 @@ from strands_robots.training._validate import (
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_finite_number_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend whose update clips a policy ratio.
 ON_POLICY = "ppo"
@@ -326,11 +327,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_width(source: str) -> bool:
-    """Does *source* read ``spec.clip_param``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "clip_param" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.clip_param``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("clip_param",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_discount_factor_domain.py
+++ b/tests/training/test_discount_factor_domain.py
@@ -35,6 +35,7 @@ from strands_robots.training._validate import (
 )
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
+from tests.training._spec_field_reads import reads_spec_field
 
 # Every backend that discounts a return with the field.
 RL_BACKENDS = ("ppo", "fast_sac")
@@ -227,11 +228,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_discount_factor(source: str) -> bool:
-    """Does *source* read ``spec.gamma``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "gamma" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.gamma``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("gamma",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_gae_lambda_domain.py
+++ b/tests/training/test_gae_lambda_domain.py
@@ -39,6 +39,7 @@ from strands_robots.training._validate import (
 )
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend that estimates an advantage trace.
 ON_POLICY = "ppo"
@@ -244,11 +245,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_trace_decay(source: str) -> bool:
-    """Does *source* read ``spec.lam``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "lam" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.lam``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("lam",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_gradient_clip_domain.py
+++ b/tests/training/test_gradient_clip_domain.py
@@ -60,6 +60,7 @@ from strands_robots.training._validate import _clip_bound_error, gradient_clip_p
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_finite_number_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend whose update clips a gradient.
 ON_POLICY = "ppo"
@@ -393,11 +394,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_clip(source: str) -> bool:
-    """Does *source* read ``spec.max_grad_norm``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "max_grad_norm" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.max_grad_norm``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("max_grad_norm",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_initial_temperature_domain.py
+++ b/tests/training/test_initial_temperature_domain.py
@@ -46,6 +46,7 @@ from strands_robots.training import create_trainer
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_finite_number_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend that holds an entropy temperature.
 OFF_POLICY = "fast_sac"
@@ -262,11 +263,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_temperature(source: str) -> bool:
-    """Does *source* read ``spec.init_alpha``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "init_alpha" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.init_alpha``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("init_alpha",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_loss_weight_domain.py
+++ b/tests/training/test_loss_weight_domain.py
@@ -39,6 +39,7 @@ from strands_robots.training._validate import loss_weight_problems
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import finite_number_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The backend that composes the weighted objective.
 ON_POLICY = "ppo"
@@ -257,13 +258,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_a_weight(source: str) -> bool:
-    """Does *source* read either ``spec.value_loss_coef`` or ``spec.entropy_coef``?"""
-    return any(
-        isinstance(node, ast.Attribute)
-        and node.attr in {"value_loss_coef", "entropy_coef"}
-        and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read either ``spec.value_loss_coef`` or ``spec.entropy_coef``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("value_loss_coef", "entropy_coef"))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_optimization_epochs_domain.py
+++ b/tests/training/test_optimization_epochs_domain.py
@@ -40,6 +40,7 @@ from strands_robots.training._validate import optimization_epochs_problems
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_count_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend whose update loops over a rollout batch.
 ON_POLICY = "ppo"
@@ -259,13 +260,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_epoch_count(source: str) -> bool:
-    """Does *source* read ``spec.num_learning_epochs``?"""
-    return any(
-        isinstance(node, ast.Attribute)
-        and node.attr == "num_learning_epochs"
-        and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.num_learning_epochs``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("num_learning_epochs",))
 
 
 def _calls_the_gate(source: str) -> bool:

--- a/tests/training/test_spec_field_read_discovery.py
+++ b/tests/training/test_spec_field_read_discovery.py
@@ -17,6 +17,17 @@ that backend - silently, because the guard reports a clean tree.
 This grades the guards from the outside rather than trusting each to grade
 itself: the set of field-scoped guards is discovered structurally, so a new
 domain guard is held to the same rule the moment it lands.
+
+That promise is only as wide as the discovery, and a discovery keyed on the
+*name* of a helper is not a structural one. The guards spell the helper that
+lists the backend modules two ways - ``_trainer_modules`` and
+``_training_modules`` - so a rule keyed on either spelling grades the guards
+that use it and reports a clean sweep over the rest.
+:func:`is_field_scoped_guard` keys on the two properties that make a guard
+gradeable instead (it has one reader helper, and its scope is rooted at the
+backend tree), and is the one rule both the sweep over the real tree and the
+constructed exemplars in :class:`TestTheDiscoveryDoesNotDependOnAHelperName`
+consult.
 """
 
 from __future__ import annotations
@@ -43,27 +54,99 @@ FIELD_SCOPED_GATES: dict[str, tuple[str, ...]] = {
     "_validation_episodes_problems": ("val_episodes",),
     "_lora_hyperparameter_problems": ("lora_r", "lora_alpha"),
     "_launch_topology_problems": ("num_gpus", "num_nodes"),
+    # The RL-hyperparameter gates. Their fields live on ``RLTrainSpec`` and no
+    # provider forwards them today, so they are graded on the reader scan only
+    # (see TestTheForwardingProviderIsInScopeForEveryGateItReads, which derives
+    # its own scope from what is actually forwarded).
+    "_discount_factor_problems": ("gamma",),
+    "_gae_lambda_problems": ("lam",),
+    "_optimization_epochs_problems": ("num_learning_epochs",),
+    "_temperature_learning_rate_problems": ("alpha_lr",),
+    "_initial_temperature_problems": ("init_alpha",),
+    "_gradient_clip_problems": ("max_grad_norm",),
+    "_loss_weight_problems": ("value_loss_coef", "entropy_coef"),
+    "_clip_range_problems": ("clip_param",),
 }
+
+
+def _scans_the_backend_tree(tree: ast.AST) -> bool:
+    """Does the module root a backend scan at the tree that defines ``Trainer``?
+
+    That rooting is what makes a guard's scope *derived from the tree* rather
+    than listed, which is the property this meta-guard needs to hold of the
+    guards it grades. Detected structurally - a ``inspect.getfile(Trainer)``
+    call - rather than through the name of the helper that wraps it, because
+    that name is incidental to the property: the guards spell it both
+    ``_trainer_modules`` and ``_training_modules``, so a discovery keyed on one
+    spelling silently drops every guard that uses the other.
+    """
+    return any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "getfile"
+        and any(isinstance(arg, ast.Name) and arg.id == "Trainer" for arg in node.args)
+        for node in ast.walk(tree)
+    )
+
+
+def is_field_scoped_guard(source: str) -> bool:
+    """Does *source* look like a field-scoped domain guard this must grade?
+
+    Two properties, both structural:
+
+    * it derives its scope from a reader scan - exactly one ``_reads...``
+      helper, which is the scan this meta-guard grades and the one
+      :func:`_reader_helper` resolves; and
+    * that scope is rooted at the backend tree
+      (:func:`_scans_the_backend_tree`), which is what makes it derived rather
+      than listed.
+
+    Neither property is the *name* of the helper that carries it. That
+    distinction is the point: a guard lists the backend modules through a helper
+    it spells either ``_trainer_modules`` or ``_training_modules``, so a rule
+    keyed on one spelling drops every guard using the other while reporting a
+    clean sweep of the rest.
+
+    The guards that pin a domain no backend may skip (learning rate, run size)
+    have no reader helper at all - they scan ``Trainer`` subclasses rather than
+    field reads - so they do not qualify, which is correct: there is no notion
+    of "reads the field" for this meta-guard to grade in them.
+    """
+    tree = ast.parse(source)
+    names = {node.name for node in tree.body if isinstance(node, ast.FunctionDef)}
+    readers = [n for n in names if n.startswith("_reads")]
+    return len(readers) == 1 and _scans_the_backend_tree(tree)
 
 
 def _guard_modules() -> dict[str, Any]:
     """The field-scoped domain guards, discovered by structure not by name.
 
-    A guard qualifies when it scans the backend tree (``_trainer_modules``),
-    tests membership of one gate (``_calls_the_gate``) and derives its scope
-    from a reader scan (a ``_reads...`` helper). Discovering them rather than
-    listing them means a new domain guard is held to this rule on arrival.
+    Membership is decided by :func:`is_field_scoped_guard`, so the sweep over
+    the real tree and the constructed exemplars in
+    :class:`TestTheDiscoveryDoesNotDependOnAHelperName` grade the same rule.
+    Discovering the guards rather than listing them means a new domain guard is
+    held to this one the moment it lands.
     """
     here = pathlib.Path(__file__).parent
     guards: dict[str, Any] = {}
     for path in sorted(here.glob("test_*_domain.py")):
-        source = path.read_text()
-        names = {node.name for node in ast.parse(source).body if isinstance(node, ast.FunctionDef)}
-        readers = sorted(n for n in names if n.startswith("_reads"))
-        if not readers or "_trainer_modules" not in names or "_calls_the_gate" not in names:
+        if not is_field_scoped_guard(path.read_text()):
             continue
         guards[path.name] = importlib.import_module(f"tests.training.{path.stem}")
     return guards
+
+
+#: The subset of :data:`FIELD_SCOPED_GATES` whose fields the forwarding provider
+#: actually passes on, derived from its table rather than assumed. The
+#: RL-hyperparameter gates own ``RLTrainSpec`` fields that no provider forwards,
+#: so asserting a forwarded read of them would assert a premise that is false;
+#: they are graded on the reader scan alone. ``TestTheForwardingProviderIsInScope``
+#: pins this set so a field leaving ``_FORWARDED_FIELDS`` still surfaces here.
+FORWARDED_GATES: dict[str, tuple[str, ...]] = {
+    gate: forwarded
+    for gate, fields in FIELD_SCOPED_GATES.items()
+    if (forwarded := tuple(f for f in fields if f in _FORWARDED_FIELDS))
+}
 
 
 def _reader_helper(module: Any) -> Any:
@@ -87,9 +170,17 @@ class TestEveryFieldScopedGuardSeesBothFormsOfARead:
         """Non-vacuity: a scan that matched nothing would grade nothing."""
         assert set(_guard_modules()) == {
             "test_checkpoint_cadence_domain.py",
+            "test_clip_range_domain.py",
+            "test_discount_factor_domain.py",
+            "test_gae_lambda_domain.py",
+            "test_gradient_clip_domain.py",
+            "test_initial_temperature_domain.py",
             "test_launch_topology_domain.py",
             "test_lora_hyperparameter_domain.py",
+            "test_loss_weight_domain.py",
+            "test_optimization_epochs_domain.py",
             "test_seed_domain.py",
+            "test_temperature_learning_rate_domain.py",
             "test_validation_episodes_domain.py",
         }
 
@@ -117,14 +208,27 @@ class TestEveryFieldScopedGuardSeesBothFormsOfARead:
 class TestTheForwardingProviderIsInScopeForEveryGateItReads:
     """The reader the literal-only scans could not see, on the real tree."""
 
-    @pytest.mark.parametrize(("gate", "fields"), sorted(FIELD_SCOPED_GATES.items()))
+    def test_the_forwarded_gates_are_the_expected_ones(self) -> None:
+        """Non-vacuity: a field leaving the table must surface here, not silently.
+
+        :data:`FORWARDED_GATES` is derived, so a field dropped from
+        ``_FORWARDED_FIELDS`` removes its gate from the parametrization below
+        rather than failing it. Pinning the set is what keeps that visible.
+        """
+        assert set(FORWARDED_GATES) == {
+            "_checkpoint_cadence_problems",
+            "_launch_topology_problems",
+            "_lora_hyperparameter_problems",
+            "_seed_problems",
+            "_validation_episodes_problems",
+        }
+
+    @pytest.mark.parametrize(("gate", "fields"), sorted(FORWARDED_GATES.items()))
     def test_it_is_discovered_as_a_reader(self, gate: str, fields: tuple[str, ...]) -> None:
         source = pathlib.Path(inspect.getfile(Trainer)).parent.joinpath("sagemaker.py").read_text()
-        forwarded = [f for f in fields if f in _FORWARDED_FIELDS]
-        assert forwarded, f"{gate}'s fields are no longer forwarded: {fields}"
-        assert reads_spec_field(source, forwarded)
+        assert reads_spec_field(source, fields)
 
-    @pytest.mark.parametrize(("gate", "fields"), sorted(FIELD_SCOPED_GATES.items()))
+    @pytest.mark.parametrize(("gate", "fields"), sorted(FORWARDED_GATES.items()))
     def test_it_routes_that_read_through_the_shared_gate(self, gate: str, fields: tuple[str, ...]) -> None:
         """Being in scope is only useful if the gate is then enforced on it."""
         source = pathlib.Path(inspect.getfile(Trainer)).parent.joinpath("sagemaker.py").read_text()
@@ -155,3 +259,81 @@ class TestTheSharedRuleIsPrecise:
 
     def test_an_unrelated_module_reads_nothing(self) -> None:
         assert not reads_spec_field("x = 1\n", ("seed",))
+
+
+#: A guard's reader helper: the scan this meta-guard grades.
+_A_READER = 'def _reads_the_thing(source: str) -> bool:\n    return "thing" in source\n'
+
+#: A scope helper rooted at the backend tree, which is what makes a guard's
+#: scope derived. The name is a parameter because the name is the thing that
+#: must not matter.
+_A_ROOTED_SCOPE = (
+    "def {helper}() -> list[pathlib.Path]:\n"
+    "    root = pathlib.Path(inspect.getfile(Trainer)).parent\n"
+    "    return sorted(root.rglob('*.py'))\n"
+)
+
+#: A scope that is *listed* rather than derived, under the name the previous
+#: rule keyed on - so accepting it would be over-reach, not compatibility.
+_A_LISTED_SCOPE = "def _trainer_modules() -> list[str]:\n    return ['ppo.py', 'fast_sac.py']\n"
+
+
+class TestTheDiscoveryDoesNotDependOnAHelperName:
+    """The hole this closed: eight guards were outside the sweep by one identifier.
+
+    Every guard here derives its scope by listing the backend modules, and spells
+    the helper that does it either ``_trainer_modules`` or ``_training_modules``.
+    Keying discovery on one spelling left the guards using the other ungraded -
+    silently, because the sweep reported a clean tree over the ones it could see.
+    """
+
+    @pytest.mark.parametrize("helper", ["_trainer_modules", "_training_modules", "_backend_modules"])
+    def test_a_guard_qualifies_whichever_way_it_names_its_scope_helper(self, helper: str) -> None:
+        assert is_field_scoped_guard(_A_READER + _A_ROOTED_SCOPE.format(helper=helper))
+
+    def test_a_listed_scope_does_not_qualify(self) -> None:
+        """Not derived from the tree, so this meta-guard's premise does not hold."""
+        assert not is_field_scoped_guard(_A_READER + _A_LISTED_SCOPE)
+
+    def test_a_scope_rooted_somewhere_else_does_not_qualify(self) -> None:
+        """ "Rooted at the backend tree" is the property, not "calls ``getfile``".
+
+        The guards resolve two locations that way: the backend tree, and the
+        module owning the gate (to exclude it from their own scan). A guard whose
+        scope came from the second is scanning a different population, so this
+        meta-guard's premise does not hold of it.
+        """
+        elsewhere = (
+            "def _trainer_modules() -> list[pathlib.Path]:\n"
+            "    root = pathlib.Path(inspect.getfile(seed_problems)).parent\n"
+            "    return sorted(root.rglob('*.py'))\n"
+        )
+        assert not is_field_scoped_guard(_A_READER + elsewhere)
+
+    def test_a_guard_with_no_reader_helper_does_not_qualify(self) -> None:
+        """The learning-rate and run-size shape: no notion of "reads the field"."""
+        assert not is_field_scoped_guard(_A_ROOTED_SCOPE.format(helper="_trainer_modules"))
+
+    def test_two_reader_helpers_do_not_qualify(self) -> None:
+        """:func:`_reader_helper` resolves exactly one, so two is not gradeable."""
+        second = "def _reads_another(source: str) -> bool:\n    return False\n"
+        source = _A_READER + second + _A_ROOTED_SCOPE.format(helper="_trainer_modules")
+        assert not is_field_scoped_guard(source)
+
+    def test_the_rule_separates_the_exemplars(self) -> None:
+        """Non-vacuity: a rule that answered one way would pass some case above."""
+        qualifying = _A_READER + _A_ROOTED_SCOPE.format(helper="_training_modules")
+        assert {is_field_scoped_guard(qualifying), is_field_scoped_guard(_A_READER + _A_LISTED_SCOPE)} == {True, False}
+
+    def test_every_discovered_guard_registers_its_gate(self) -> None:
+        """A discovered guard whose gate is unregistered fails opaquely.
+
+        The gate lookup in the tests above raises ``StopIteration`` rather than
+        naming the omission, so the mapping is checked here where it can.
+        """
+        unregistered = sorted(
+            name
+            for name, module in _guard_modules().items()
+            if not any(g in line for g in FIELD_SCOPED_GATES for line in inspect.getsource(module).splitlines())
+        )
+        assert unregistered == [], f"guards whose gate is absent from FIELD_SCOPED_GATES: {unregistered}"

--- a/tests/training/test_temperature_learning_rate_domain.py
+++ b/tests/training/test_temperature_learning_rate_domain.py
@@ -42,6 +42,7 @@ from strands_robots.training._validate import temperature_learning_rate_problems
 from strands_robots.training.base import Trainer
 from strands_robots.training.rl import RLTrainSpec
 from strands_robots.utils import positive_finite_number_error
+from tests.training._spec_field_reads import reads_spec_field
 
 # The one backend that tunes an entropy temperature.
 OFF_POLICY = "fast_sac"
@@ -282,11 +283,14 @@ def _training_modules() -> list[pathlib.Path]:
 
 
 def _reads_the_temperature_rate(source: str) -> bool:
-    """Does *source* read ``spec.alpha_lr``?"""
-    return any(
-        isinstance(node, ast.Attribute) and node.attr == "alpha_lr" and getattr(node.value, "id", None) == "spec"
-        for node in ast.walk(ast.parse(source))
-    )
+    """Does *source* read ``spec.alpha_lr``, by name or through a forwarding table?
+
+    Delegated to the shared rule so this guard and its siblings cannot disagree
+    about what counts as a read - a transport-only provider reads every field it
+    forwards through ``getattr(spec, field)`` and names none of them in an
+    attribute access.
+    """
+    return reads_spec_field(source, ("alpha_lr",))
 
 
 def _calls_the_gate(source: str) -> bool:


### PR DESCRIPTION
## Problem

`tests/training/test_spec_field_read_discovery.py` grades the field-scoped
shared-domain guards from the outside. Its own docstring states the promise:

> the set of field-scoped guards is discovered structurally, so a new domain
> guard is held to the same rule the moment it lands.

The discovery is keyed on the **name** of the helper a guard uses to list the
backend modules:

```python
if not readers or "_trainer_modules" not in names or "_calls_the_gate" not in names:
    continue
```

The guards spell that helper two ways. Five use `_trainer_modules`; eight use
`_training_modules`. So the sweep grades five of thirteen, and its own
non-vacuity assertion pins that count (`assert set(_guard_modules()) == {5 files}`),
which is what made the gap look deliberate.

The eight it could not see are exactly the eight that need it. Each carries its
own inline copy of the by-name-only read that the shared `reads_spec_field` rule
exists to replace, so each is blind to a **table-driven** read
(`getattr(spec, field)` over a tuple of names) - the form a provider that
forwards a spec on uses, and the form that names no field in any attribute
access:

| guard | field(s) | scope helper | sees a read by name | sees a table-driven read | graded by the sweep |
|---|---|---|---|---|---|
| `test_checkpoint_cadence_domain.py` | `save_freq` | `_trainer_modules` | yes | yes | yes |
| `test_launch_topology_domain.py` | `num_gpus`, `num_nodes` | `_trainer_modules` | yes | yes | yes |
| `test_lora_hyperparameter_domain.py` | `lora_r`, `lora_alpha` | `_trainer_modules` | yes | yes | yes |
| `test_seed_domain.py` | `seed` | `_trainer_modules` | yes | yes | yes |
| `test_validation_episodes_domain.py` | `val_episodes` | `_trainer_modules` | yes | yes | yes |
| `test_clip_range_domain.py` | `clip_param` | `_training_modules` | yes | **no** | **no** |
| `test_discount_factor_domain.py` | `gamma` | `_training_modules` | yes | **no** | **no** |
| `test_gae_lambda_domain.py` | `lam` | `_training_modules` | yes | **no** | **no** |
| `test_gradient_clip_domain.py` | `max_grad_norm` | `_training_modules` | yes | **no** | **no** |
| `test_initial_temperature_domain.py` | `init_alpha` | `_training_modules` | yes | **no** | **no** |
| `test_loss_weight_domain.py` | `value_loss_coef`, `entropy_coef` | `_training_modules` | yes | **no** | **no** |
| `test_optimization_epochs_domain.py` | `num_learning_epochs` | `_training_modules` | yes | **no** | **no** |
| `test_temperature_learning_rate_domain.py` | `alpha_lr` | `_training_modules` | yes | **no** | **no** |

The two sets coincide exactly: every guard outside the sweep is blind, and every
guard inside it is not. The eight predate the sweep (added 2026-08-07/08 against
2026-08-20), which is why they were never converted - and the entry that
introduced the shared rule records the scope it believed it had, "the **four**
field-scoped shared-domain guards".

The consequence is the thing each of those eight promises not to allow. From
`TestOneOwnerForTheDiscountDomain`:

> a third RL backend that starts discounting a return with the field fails this
> test until it does.

## Measured consequence

A real backend module gains a reader that forwards a gated field through a table
and never calls the gate - the shape a transport-only provider already uses:

```python
_PLANTED_FIELDS = ("gamma",)

def _planted_forward(spec: object) -> list[object]:
    return [getattr(spec, f) for f in _PLANTED_FIELDS]
```

Each guard's one-owner class, asked about its own field, on `main` and on this
branch:

| planted read of | before | after |
|---|---|---|
| `spec.clip_param` | 4 passed (clean sweep) | 2 failed |
| `spec.gamma` | 4 passed (clean sweep) | 2 failed |
| `spec.lam` | 4 passed (clean sweep) | 2 failed |
| `spec.max_grad_norm` | 4 passed (clean sweep) | 2 failed |
| `spec.init_alpha` | 4 passed (clean sweep) | 2 failed |
| `spec.value_loss_coef` | 4 passed (clean sweep) | 2 failed |
| `spec.num_learning_epochs` | 4 passed (clean sweep) | 2 failed |
| `spec.alpha_lr` | 4 passed (clean sweep) | 2 failed |

Eight for eight. After, the report names the module:

```
AssertionError: modules read spec.gamma without the shared gate: ['mock.py']
```

The silence is the failure mode: before, the guard reports a clean tree, so the
reader lands with the domain unenforced for it and nothing says so.

## Change

`tests/training/test_spec_field_read_discovery.py`

- Discovery is keyed on the two properties that make a guard gradeable rather
  than on the names of the helpers that carry them: it defines exactly one
  `_reads...` helper (the scan this file grades, and the one `_reader_helper`
  resolves), and its scope is rooted at the backend tree - detected as an
  `inspect.getfile(Trainer)` call, which is what makes the scope derived rather
  than listed. That rule is single-sourced in `is_field_scoped_guard`, so the
  sweep over the real tree and the constructed exemplars grade the same code.
- `FIELD_SCOPED_GATES` gains the eight gates, so a discovered guard's gate
  resolves instead of raising `StopIteration`.
- The forwarding-provider assertions derive their own scope from
  `_FORWARDED_FIELDS` (`FORWARDED_GATES`) instead of assuming every gated field
  is forwarded. The eight own `RLTrainSpec` fields that no provider forwards, so
  asserting a forwarded read of them would assert a false premise; they are
  graded on the reader scan alone. The derived set is pinned, so a field leaving
  the provider's table still surfaces rather than silently dropping its gate
  from the parametrization.

The eight guards' `_reads...` helpers now delegate to `reads_spec_field`, which
is the one place both forms of a read are defined.

`learning_rate` and `run_size` are deliberately still out of scope and now
excluded by a property rather than by a name: neither has a reader helper (they
scan `Trainer` subclasses, not field reads), so there is no notion of "reads the
field" here to grade. A test pins that.

## Tests

`TestTheDiscoveryDoesNotDependOnAHelperName` grades the rule on constructed
exemplars: a guard qualifies under `_trainer_modules`, `_training_modules` and a
third spelling; a *listed* scope under the previously-keyed name does not (so
this is not compatibility, it is a different property); a scope rooted at another
module does not; no reader helper does not; two reader helpers do not; and a
non-vacuity case asserts the rule separates them. One further test reports a
discovered guard whose gate is unregistered by name, because the gate lookup
elsewhere raises `StopIteration` without naming the omission.

Pre-fix, widening the discovery alone surfaces the eight directly:

```
FAILED ...::test_it_sees_a_table_driven_read[test_discount_factor_domain.py]
  AssertionError: test_discount_factor_domain.py does not see a table-driven read
  of spec.gamma, so a backend that forwards the field by name is outside its
  derived scope
```

`test_it_still_sees_a_read_by_name` passes for all thirteen throughout, so only
the table form was missing.

Mutation coverage of this change (failures over `tests/training/`):

| mutation | fires |
|---|---|
| control, unmutated | 0 |
| discovery requires the `_trainer_modules` spelling again | 4 |
| one reader helper reverted to the by-name form | 1 |
| forwarding assertions parametrized over every gate again | 16 |
| the tree-rooting requirement dropped | 2 |
| one-reader requirement weakened to at-least-one | 1 |
| a field leaves the provider's forwarding table | 3, two of them pre-existing |
| tree-rooting accepts any `getfile` call | 1 |

The last row was 0 until the exemplar for it was added: every guard that resolves
a non-`Trainer` module also resolves the backend tree, so the mutation was a
no-op over today's tree and the property was unpinned. The row above it fires two
tests that predate this change, which is what shows the premise guard removed
from the forwarding assertions is preserved rather than dropped.

## Verification

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1541 files).
- `mypy strands_robots tests tests_integ`: `Success: no issues found in 1538 source files`; zero errors introduced.
- `tests/training/` plus the changelog guards: 2952 passed, 4 skipped (2926 before; the 26 added are this change's).
- Blast radius, identical 336-file selection on both trees with the changed files
  excluded from each - all of `tests/training/` plus every test that walks the
  tree or reads sources - 15267 collected on each: failing-ID sets identical.
  Two failures are pre-existing and need `docker` on `PATH`; five more are
  pre-existing in the ROS suites and depend only on whether `rclpy` resolves,
  confirmed by re-running those four files on both trees under one matched
  interpreter path (5 failed, 294 passed on each, identical IDs).

No visual artifact: this changes no policy, simulation, rendering, recording or
asset behaviour. The before/after table above is the evidence.
