### PR TITLE
fix(docs): name the repository in the two documented check invocations that inferred it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,8 +284,8 @@ hatch run format            # ruff check --fix, ruff format
    that were open at the same instant selected 2 - and both were duplicates. Two
    branches *editing* one file is a different question with a different remedy
    (a merge order, possibly one composition run), and
-   `scripts/check_merge_base_overlap.py --all-open` owns it; that relation selects
-   117 of the same 1802. The two keys are complementary rather than nested: neither
+   `scripts/check_merge_base_overlap.py --github-repo <owner/name> --all-open`
+   owns it; that relation selects 117 of the same 1802. The two keys are complementary rather than nested: neither
    issue-keyed pair shares an added path, and neither claim-free pair claims an
    issue.
 
@@ -816,8 +816,8 @@ hatch run format            # ruff check --fix, ruff format
      resolving supplies one. That leaves `REVIEW_REQUIRED` itself carrying two
      remedies - a first approval, or a second account when the only approval
      came from the pusher - which is the split
-     `scripts/check_last_push_approval.py --all-open` reports and which no
-     single field distinguishes either.
+     `scripts/check_last_push_approval.py --repo <owner/name> --all-open`
+     reports and which no single field distinguishes either.
 
      `isOutdated: true` on an unresolved thread is the common form, and it is a
      prompt rather than reassurance: the diff moved on, so the request has

--- a/changelog.d/2723-documented-invocation-repository-inferred.md
+++ b/changelog.d/2723-documented-invocation-repository-inferred.md
@@ -1,0 +1,16 @@
+### Docs: every documented check invocation names the repository it reads, not only the fenced ones
+
+`AGENTS.md` spelled two check invocations inline -- step 1's merge-base overlap
+sweep and the last-push-approval split -- in a form that leaves the repository to
+`$GITHUB_REPOSITORY`. Run from a scheduled agent, whose checkout need not be this
+repository, step 1's spelling reported a clean open set for a repository holding
+none of the pull requests in question and exited 0: `cagataycali/strands-gtc-nvidia`,
+0 open pull requests, where the named repository had 2.
+
+`TestNoDocumentedInvocationLeavesTheRepositoryInferred` exists to prevent exactly
+that, but selected only mentions carrying a `python3` prefix. The prefix is
+typography rather than a property of the command -- a reader copies what is inside
+the backticks -- and requiring it hid 2 of the 13 documented invocations, both of
+which were the defect. The selector now grades a mention that names any option
+regardless of prefix, and skips one that names none, since that is a
+cross-reference rather than a command.

--- a/tests/test_duplicate_claim_check.py
+++ b/tests/test_duplicate_claim_check.py
@@ -114,9 +114,45 @@ def _documented_intake_argv(issue: int) -> list[str]:
     return [part.replace("<N>", str(issue)) for part in intake[0].split()]
 
 
+def _check_invocations_in(text: str) -> list[tuple[str, str]]:
+    """Return ``(script, remaining argv)`` for every check invocation in *text*.
+
+    An invocation is a mention that names at least one option, with or without a
+    ``python3`` prefix. The prefix is typography rather than a property of the
+    command: a reader copies what is inside the backticks, so an inline mention
+    that names a mode is as runnable as a fenced one. Requiring it hid 2 of the
+    13 invocations this file grades, and both of the two were the defect the
+    grading exists to catch - step 1's overlap sweep among them, which run from a
+    scheduled agent reported a clean open set for a repository holding none of
+    the pull requests in question, and exited 0.
+
+    A mention naming *no* option is a cross-reference and not graded: there is no
+    command to copy, so requiring a flag of it would be the same false rejection
+    :data:`_NAMES_REPOSITORY`'s scope note exists to avoid.
+    """
+    mentions = re.findall(r"scripts/(check_[a-z_]+\.py)([^\n`]*)", text)
+    return [(script, rest) for script, rest in mentions if "--" in rest]
+
+
 def _documented_check_invocations() -> list[tuple[str, str]]:
     """Return ``(script, remaining argv)`` for every check AGENTS.md invokes."""
-    return re.findall(r"python3 scripts/(check_[a-z_]+\.py)([^\n`]*)", _AGENTS.read_text(encoding="utf-8"))
+    return _check_invocations_in(_AGENTS.read_text(encoding="utf-8"))
+
+
+def _leaving_the_repository_inferred(invocations: list[tuple[str, str]]) -> list[str]:
+    """Those of *invocations* that can infer a repository and do not name one.
+
+    The one rule, so the sweep over ``AGENTS.md`` and the constructed exemplars in
+    :class:`TestNoDocumentedInvocationLeavesTheRepositoryInferred` cannot disagree
+    about what counts as a finding.
+    """
+    return [
+        f"{script}{rest}"
+        for script, rest in invocations
+        if script in _NAMES_REPOSITORY
+        for flag, marker in (_NAMES_REPOSITORY[script],)
+        if (marker is None or marker in rest) and flag not in rest
+    ]
 
 
 def _pair_ids() -> list[str]:
@@ -689,10 +725,42 @@ class TestNoDocumentedInvocationLeavesTheRepositoryInferred:
         assert len(invocations) >= 3, invocations
         inferring = [(script, rest) for script, rest in invocations if script in _NAMES_REPOSITORY]
         assert inferring, invocations
-        missing = [
-            f"{script}{rest}"
-            for script, rest in inferring
-            for flag, marker in (_NAMES_REPOSITORY[script],)
-            if (marker is None or marker in rest) and flag not in rest
-        ]
+        missing = _leaving_the_repository_inferred(invocations)
         assert not missing, missing
+
+    @pytest.mark.parametrize("prefix", ["python3 ", ""])
+    def test_an_invocation_is_graded_whichever_way_it_is_spelled(self, prefix: str) -> None:
+        """The ``python3`` prefix is typography, so it cannot decide what is graded.
+
+        Both of the two invocations it hid on the real document left the repository
+        inferred, and one of them is step 1's overlap sweep.
+        """
+        spelled = f"`{prefix}scripts/check_merge_base_overlap.py --github-repo o/n --all-open`"
+        assert _check_invocations_in(spelled) == [("check_merge_base_overlap.py", " --github-repo o/n --all-open")]
+
+    def test_an_inline_invocation_that_infers_the_repository_is_a_finding(self) -> None:
+        """The spelling this widening caught, and the report it produced."""
+        inline = "`scripts/check_merge_base_overlap.py --all-open` owns it"
+        assert _leaving_the_repository_inferred(_check_invocations_in(inline)) == [
+            "check_merge_base_overlap.py --all-open"
+        ]
+
+    def test_a_mention_naming_no_option_is_a_cross_reference(self) -> None:
+        """Not a command, so requiring a flag of it would be a false rejection."""
+        assert _check_invocations_in("see `scripts/check_duplicate_claim.py` for the account") == []
+
+    def test_the_single_branch_mode_is_not_required_to_name_the_api_repository(self) -> None:
+        """The mode marker is load-bearing: that mode reads a checkout and infers nothing.
+
+        Requiring the flag of it would be the false rejection
+        :data:`_NAMES_REPOSITORY`'s scope note names, so the marker is what keeps
+        this widening from reaching a mode that owes no repository.
+        """
+        single = "`scripts/check_merge_base_overlap.py --repo . --base-ref main --head HEAD`"
+        assert _check_invocations_in(single), "the single-branch spelling is still an invocation"
+        assert _leaving_the_repository_inferred(_check_invocations_in(single)) == []
+
+    def test_the_selector_separates_a_command_from_a_cross_reference(self) -> None:
+        """Non-vacuity: a selector answering one way would pass one case above."""
+        both = "`scripts/check_duplicate_claim.py` and `scripts/check_duplicate_claim.py --repo o/n --pr 1`"
+        assert [rest.strip() for _, rest in _check_invocations_in(both)] == ["--repo o/n --pr 1"]


### PR DESCRIPTION
Two of `AGENTS.md`'s documented check invocations leave the repository to `$GITHUB_REPOSITORY`. I copied one of them this cycle and it reported a clean open set for a repository holding none of the pull requests in question, exit 0.

## The problem

Step 1 tells an author to ask the two questions no per-pull-request check can answer, because both are properties of the *set* of open pull requests. One of the two is spelled inline:

```
`scripts/check_merge_base_overlap.py --all-open` owns it
```

Run from a scheduled agent, whose checkout need not be this repository, that spelling reads `$GITHUB_REPOSITORY`:

| spelling | repository read | open PRs | pairs | exit |
|---|---|---|---|---|
| `--all-open` (as documented at step 1) | `cagataycali/strands-gtc-nvidia` | 0 | 0 | 0 |
| `--github-repo strands-labs/robots --all-open` | `strands-labs/robots` | 2 | 1 | 0 |

Both say "Nothing here needs a merge-order decision." One of them is answering about a repository nobody asked about. This is the failure mode step 1 already documents for the sibling intake check - *"a wrong answer shaped exactly like the right one"* - reached here by copying the guidance rather than by omitting a flag.

The same document already knows the correct spelling: step 12 prints `--github-repo <owner/name> --all-open`. Only the step-1 mention is short, and step 1 is the one an author reads before authoring.

**A guard exists for exactly this.** `TestNoDocumentedInvocationLeavesTheRepositoryInferred` was added when the defect was last hit, and its docstring states the principle: *"The defect was a documented command, so the durable pin is on the guidance."* It selected invocations with:

```python
re.findall(r"python3 scripts/(check_[a-z_]+\.py)([^\n`]*)", ...)
```

The `python3 ` prefix is typography, not a property of the command - a reader copies what is inside the backticks either way. Requiring it hid 2 of the 13 documented invocations, and **both of the two were the defect**:

| selector | invocations matched | leaving the repository inferred |
|---|---|---|
| `python3 `-prefixed only (on `main`) | 11 | 0 |
| any spelling | 13 | 2 |

The two it could not see:

| invocation | script's API-repository flag | where |
|---|---|---|
| `scripts/check_merge_base_overlap.py --all-open` | `--github-repo` (default `$GITHUB_REPOSITORY`) | step 1 |
| `scripts/check_last_push_approval.py --all-open` | `--repo` (default `$GITHUB_REPOSITORY`) | the review-state discussion |

So the guard reported a clean document over the invocations it could see, which is the same shape as the report it was protecting against.

## The change

`AGENTS.md` - both inline invocations name the repository, matching the spelling step 12 already uses. Eight lines, rewrapped.

`tests/test_duplicate_claim_check.py` - the selector grades a mention that names at least one option, with or without the prefix. A mention naming *no* option is a cross-reference with no command to copy, so it is not graded: requiring a flag of it would be the false rejection `_NAMES_REPOSITORY`'s existing scope note is there to avoid. The selector is split out as `_check_invocations_in(text)` so it can be graded on constructed exemplars rather than only on the live document, and the finding rule is lifted into `_leaving_the_repository_inferred` so the sweep over `AGENTS.md` and those exemplars cannot disagree about what counts as a finding.

**Scope.** This does not touch the `$GITHUB_REPOSITORY` default on either script. That is the separate decision #2570 deliberately deferred ("a separate decision with its own tradeoff"), and #2571 was closed as a duplicate of the claim it settled. Nothing here re-opens it: what changes is only which spelling the guidance hands a reader. The mode marker keeps the widening off `check_merge_base_overlap.py`'s single-branch mode, which reads a checkout and infers nothing.

## Tests

Six cases in the existing class, on constructed text: an invocation is graded under both spellings of the prefix; an inline invocation that infers the repository is a finding; a mention naming no option is not; the single-branch spelling is an invocation but owes no API repository; and a non-vacuity case asserting the selector separates a command from a cross-reference.

| tree | result |
|---|---|
| `main` (old selector, uncorrected document) | **66 passed** - the blind spot |
| widened selector, uncorrected document | **1 failed**, 70 passed |
| this branch | **72 passed** |

The failure names the incident rather than a count:

```
AssertionError: ['check_merge_base_overlap.py --all-open', 'check_last_push_approval.py --all-open']
```

Break table, 5 mutations, control 0:

| mutation | tests firing |
|---|---|
| control, unmutated | 0 |
| the `python3` prefix requirement restored | 4 |
| the names-an-option filter dropped | 2 |
| the `AGENTS.md` correction reverted | 1 |
| the mode marker ignored in the finding rule | 1 |
| pre-fix code (prefix restored **and** correction reverted) | 4 |

The last row is the interesting one: it is 4, not 5. Restoring the prefix *masks* the document defect, so the two halves are not additive - the guard's blind spot is what let the wrong spelling ship, and the table shows the masking directly.

The marker row was 0 until its exemplar was added. Every mention of that script in `AGENTS.md` carries `--all-open`, so dropping the marker was a no-op over today's document and the property was unpinned; the single-branch exemplar pins it.

## Verification

- `ruff check` + `ruff format --check` clean on the changed file; `mypy tests/test_duplicate_claim_check.py` - *Success: no issues found in 1 source file*.
- Changelog fragment guards (`test_changelog_fragments.py`, `test_changelog_format.py`, `test_changelog_fragment_gate.py`): **89 passed**; `assemble_changelog.py --check` reports fragments OK.
- Blast radius = the 35 guards that read `AGENTS.md`, identical selection on both trees: **21 failed, 1011 passed, 62 skipped, 5 errors** on this branch against **21 failed, 1005 passed, 62 skipped, 5 errors** on a pristine `main` worktree. Failing-ID sets **byte-identical** (26 ids); passed reconciles exactly, `+6` being the six new cases. All 26 are environment-only in this container (`No module named 'serial'` / `'strands'`, and `hardware_robot` needing the lerobot extra), none branch-only.

## Dogfood

The corrected step-1 spelling, run against this branch:

```
## Merge-base overlap check - open set

`strands-labs/robots`, base `main`: 2 open non-draft pull request(s), 1 pair(s) compared.

No pair in the open set shares a changed path, and no pull request shares one with
what has landed on its base. Nothing here needs a merge-order decision.
```

That is also this pull request's own step-1 sweep, and it reports no blocking pair. `check_duplicate_claim.py --repo strands-labs/robots --all-open` reports `unique-additions`.

No visual artifact: this changes no policy, simulation, rendering, recording or asset behaviour. The two report panels above are the evidence.