### PR TITLE
fix(simulation): carry an unnamed joint's state across a scene rebuild

### DIFF
--- a/changelog.d/2725-unnamed-joint-state-across-a-rebuild.md
+++ b/changelog.d/2725-unnamed-joint-state-across-a-rebuild.md
@@ -1,0 +1,37 @@
+### Fixed: an unnamed joint keeps its state across a scene rebuild
+
+`eject_robot_from_scene` rebuilds the compiled model, which renumbers every joint id, so the
+dynamic state is snapshotted under a name-based key and written back once the new model exists.
+`_joint_key` built that key and returned `None` for any unnamed non-free joint, on the stated
+grounds that "its body may carry several, so the body does not single it out". A `None` key is
+skipped, so the joint's `qpos`, `qvel` and `qfrc_applied` were dropped and it came back at its
+fresh-compile value while the operation reported `success`.
+
+An unnamed `<joint>` is the ordinary MJCF spelling - a door hinge or a drawer slide is rarely
+named - so removing one robot silently reset the articulation of everything else in the scene.
+Measured on a scene holding an arm plus a door on an unnamed hinge and a drawer carrying two
+unnamed joints: with the door at `qpos 0.70` / `qvel -1.25`, the drawer hinge at `0.31` / `0.44`
+and the drawer slide at `-0.17` / `2.05`, `remove_robot("arm")` returned `success` and left all
+three at `0.0`, changing 16690 pixels of the rendered scene. The same call now leaves all three
+byte-identical to what they were seeded with.
+
+The premise was sound but the conclusion was too strong. The body does not single the joint out,
+but the body *plus the joint's position among that body's joints* does: MuJoCo stores a body's
+joints contiguously from `body_jntadr` in declaration order, so a third key form
+`("body_joint", body_name, ordinal)` identifies one joint of a body that carries several, and
+`_resolve_joint_key` resolves it back through the same two values. Nothing shifts an ordinal,
+because no scene op inserts a joint into an existing body - the patch vocabulary is `add_body`,
+`add_geom`, `add_site`, `set_body_pos`, `set_body_quat` and `delete_body`.
+
+Two joints of one body are what makes the ordinal load-bearing rather than decorative. A hinge and
+a slide both use width 1/1, so the width check `_restore_scene_state` already performs cannot tell
+them apart; keying both on the body alone would restore each from the other's values, and that
+swap is pinned.
+
+Everything else is unchanged and pinned as such. A named joint keeps its `("joint", name)` key. An
+unnamed free joint keeps its `("body", body_name)` key, which is unambiguous because the compiler
+refuses a free joint alongside any other joint on the same body. A joint whose body is *also*
+unnamed still gets no key: nothing identifies either end across the rebuild, so it is reported
+rather than guessed at. An ordinal past the body's joint count, a body that has vanished, and a
+joint that has since gained a name all resolve to nothing, so one joint is never restored from two
+entries.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -1614,7 +1614,12 @@ def reposition_body_in_scene(
 # The two namespaces are kept apart in the key because MuJoCo's joint and body
 # names are independent: a joint may be named exactly like some body, so a
 # single flat string key could collide.
-_JointKey = tuple[str, str]
+#
+# Any other unnamed joint takes the three-element form
+# ``("body_joint", body_name, ordinal)``: the body alone does not single it out
+# because a body may carry several joints, but the position among them does.
+# See :func:`_joint_key`.
+_JointKey = tuple[str, str] | tuple[str, str, int]
 
 
 @dataclass(frozen=True)
@@ -1665,20 +1670,38 @@ def _joint_state_widths(jtype: int, mj: Any) -> tuple[int, int]:
 
 
 def _joint_key(model: Any, jid: int, mj: Any) -> _JointKey | None:
-    """Identify joint ``jid`` by name, or by its owning body when it has none.
+    """Identify joint ``jid`` by name, or through its owning body when it has none.
 
-    Returns ``None`` for a joint no namespace can name -- an unnamed non-free
-    joint (its body may carry several, so the body does not single it out), or
-    an unnamed free joint on an unnamed body. Such a joint cannot be matched
-    across a rebuild, so it is reported rather than guessed at.
+    Three key forms, in order of preference:
+
+    ``("joint", name)``
+        The joint carries a name, which is the handle a rebuild preserves.
+    ``("body", body_name)``
+        An unnamed free joint. The compiler refuses a free joint alongside any
+        other joint on the same body, so the body names it unambiguously.
+    ``("body_joint", body_name, ordinal)``
+        Any other unnamed joint, identified by its position among the joints of
+        its body. MuJoCo stores a body's joints contiguously from
+        ``body_jntadr`` in declaration order, so ``ordinal`` singles out one
+        joint of a body that carries several. An unnamed ``<joint>`` is the
+        ordinary MJCF spelling -- a door hinge or a drawer slide is rarely
+        named -- so dropping these would reset them on every rebuild.
+
+    Returns:
+        The key, or ``None`` when neither the joint nor its body carries a
+        name. Nothing then identifies it across a rebuild, so it is reported
+        rather than guessed at.
     """
     name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid)
     if name:
         return ("joint", name)
-    if int(model.jnt_type[jid]) != mj.mjtJoint.mjJNT_FREE:
+    body_id = int(model.jnt_bodyid[jid])
+    body_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, body_id)
+    if not body_name:
         return None
-    body_name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_BODY, int(model.jnt_bodyid[jid]))
-    return ("body", body_name) if body_name else None
+    if int(model.jnt_type[jid]) == mj.mjtJoint.mjJNT_FREE:
+        return ("body", body_name)
+    return ("body_joint", body_name, jid - int(model.body_jntadr[body_id]))
 
 
 def _snapshot_scene_state(world: SimWorld) -> _SceneState:
@@ -1698,7 +1721,7 @@ def _snapshot_scene_state(world: SimWorld) -> _SceneState:
         key = _joint_key(model, jid, mj)
         if key is None:
             logger.debug(
-                "snapshot_scene_state: joint id %d has no name and no single owning body, state not carried over",
+                "snapshot_scene_state: neither joint id %d nor its body carries a name, state not carried over",
                 jid,
             )
             continue
@@ -1805,6 +1828,16 @@ def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
 
 def _resolve_joint_key(model: Any, key: _JointKey, mj: Any) -> int:
     """Resolve a :data:`_JointKey` to a joint id in ``model``, or ``-1``."""
+    if len(key) == 3:
+        _, body_name, ordinal = key
+        bid = mj_name_to_id(model, mj.mjtObj.mjOBJ_BODY, body_name)
+        if bid < 0 or ordinal >= int(model.body_jntnum[bid]):
+            # The body is gone, or no longer carries a joint at that position.
+            return -1
+        jid = int(model.body_jntadr[bid]) + ordinal
+        # A joint that gained a name is carried by its own ``("joint", name)``
+        # key, so this handle must not also claim it.
+        return -1 if mj.mj_id2name(model, mj.mjtObj.mjOBJ_JOINT, jid) else jid
     kind, name = key
     if kind == "joint":
         return mj_name_to_id(model, mj.mjtObj.mjOBJ_JOINT, name)

--- a/tests/simulation/mujoco/test_unnamed_joint_state_survives_a_rebuild.py
+++ b/tests/simulation/mujoco/test_unnamed_joint_state_survives_a_rebuild.py
@@ -1,0 +1,337 @@
+"""An unnamed joint keeps its state when a scene rebuild renumbers the model.
+
+``eject_robot_from_scene`` rebuilds the compiled model, which renumbers every
+joint id, so the dynamic state is snapshotted under a name-based key and written
+back afterwards. :func:`~strands_robots.simulation.mujoco.scene_ops._joint_key`
+builds that key, and it used to return ``None`` for any unnamed non-free joint,
+on the grounds that "its body may carry several, so the body does not single it
+out". A key of ``None`` is skipped, so the joint's ``qpos``, ``qvel`` and
+``qfrc_applied`` were dropped and it came back at its fresh-compile value while
+the operation reported success.
+
+An unnamed ``<joint>`` is the ordinary MJCF spelling -- a door hinge or a drawer
+slide is rarely named -- so removing one robot silently reset the rest of the
+scene's articulation. The premise was sound but the conclusion was too strong:
+the body does not single the joint out, yet the body *plus its position among
+that body's joints* does. MuJoCo stores a body's joints contiguously from
+``body_jntadr`` in declaration order, so the ordinal is a stable handle across a
+rebuild, and no scene op inserts a joint into an existing body (the patch
+vocabulary is ``add_body`` / ``add_geom`` / ``add_site`` / ``set_body_pos`` /
+``set_body_quat`` / ``delete_body``), so nothing shifts it.
+
+Two joints of one body are the case that makes the ordinal load-bearing rather
+than decorative: a hinge and a slide both use width 1/1, so the downstream width
+check in ``_restore_scene_state`` cannot tell them apart, and keying both on the
+body alone would swap their values.
+
+Still unmatched, deliberately: a joint whose body is *also* unnamed. Nothing
+identifies either end across the rebuild, so it is reported rather than guessed
+at, and that is pinned here too.
+
+GL-free: ``mesh=False`` and no rendering, so this runs without a GPU.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# An arm whose only joint is named, so it is carried by the pre-existing
+# ``("joint", name)`` key. It is the robot the tests eject.
+_ARM_XML = """
+<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.05">
+      <geom type="box" size="0.04 0.04 0.05"/>
+      <body name="link" pos="0 0 0.1">
+        <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" damping="1"/>
+        <geom type="capsule" fromto="0 0 0 0.14 0 0" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+# The furniture that must survive the eject untouched: a door on a single
+# unnamed hinge, and a drawer carrying two unnamed joints on one body.
+_FURNITURE_XML = """
+<mujoco model="furniture">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="door_frame" pos="0.5 0 0.2">
+      <geom type="box" size="0.02 0.02 0.2"/>
+      <body name="door_panel" pos="0 0 0">
+        <joint type="hinge" axis="0 0 1" range="-3 3" damping="0.5"/>
+        <geom type="box" size="0.01 0.15 0.18" pos="0 0.15 0"/>
+      </body>
+    </body>
+    <body name="drawer" pos="-0.5 0 0.2">
+      <joint type="hinge" axis="0 0 1" range="-3 3" damping="0.5"/>
+      <joint type="slide" axis="1 0 0" range="-1 1" damping="0.5"/>
+      <geom type="box" size="0.06 0.06 0.06"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+#: Distinctive values, one per unnamed degree of freedom. They differ from each
+#: other so a swap between two joints of one body is visible, and none is zero
+#: so a value lost to a fresh compile is visible too.
+_DOOR_STATE = (0.70, -1.25)
+_DRAWER_HINGE_STATE = (0.31, 0.44)
+_DRAWER_SLIDE_STATE = (-0.17, 2.05)
+
+
+def _model_from(xml: str) -> Any:
+    """Compile ``xml`` to a model, for the key helpers that need no world."""
+    return mujoco.MjModel.from_xml_string(xml)
+
+
+def _joint_id(model: Any, name: str) -> int:
+    """The id of the joint called ``name``."""
+    return mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+
+
+def _unnamed_joint_ids(model: Any) -> list[int]:
+    """Every joint id the model carries no name for, in id order."""
+    return [jid for jid in range(int(model.njnt)) if not mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, jid)]
+
+
+def _body_of(model: Any, jid: int) -> str:
+    """The name of the body owning joint ``jid``."""
+    return str(mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, int(model.jnt_bodyid[jid])))
+
+
+def _read(world: Any, jid: int) -> tuple[float, float]:
+    """The ``(qpos, qvel)`` of the single-dof joint ``jid``."""
+    qpos_adr = int(world._model.jnt_qposadr[jid])
+    dof_adr = int(world._model.jnt_dofadr[jid])
+    return float(world._data.qpos[qpos_adr]), float(world._data.qvel[dof_adr])
+
+
+def _write(world: Any, jid: int, state: tuple[float, float]) -> None:
+    """Seed the ``(qpos, qvel)`` of the single-dof joint ``jid``."""
+    qpos_adr = int(world._model.jnt_qposadr[jid])
+    dof_adr = int(world._model.jnt_dofadr[jid])
+    world._data.qpos[qpos_adr], world._data.qvel[dof_adr] = state
+
+
+@pytest.fixture
+def scene(tmp_path: Path) -> Any:
+    """A world holding the arm plus the furniture, with the furniture seeded.
+
+    Yields the ``Simulation`` and a ``{body name: {ordinal: state}}`` map of what
+    every unnamed joint was seeded with, read back through the compiled model so
+    the expectations are the model's own view rather than a hand-kept list.
+    """
+    (tmp_path / "arm.xml").write_text(_ARM_XML)
+    (tmp_path / "furniture.xml").write_text(_FURNITURE_XML)
+
+    sim = Simulation(tool_name="test_unnamed_joint_state_survives_a_rebuild", mesh=False)
+    sim.create_world(gravity=[0, 0, -9.81])
+    assert sim.add_robot(name="arm", urdf_path=str(tmp_path / "arm.xml"))["status"] == "success"
+    assert sim.add_robot(name="fur", urdf_path=str(tmp_path / "furniture.xml"))["status"] == "success"
+
+    world = sim._world
+    model = world._model
+    unnamed = _unnamed_joint_ids(model)
+    # The premise: the furniture really did compile to three unnamed joints, so a
+    # rename upstream cannot quietly turn these tests into no-ops.
+    assert len(unnamed) == 3, [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) for j in range(model.njnt)]
+
+    seeded: dict[str, dict[int, tuple[float, float]]] = {}
+    for jid in unnamed:
+        body = _body_of(model, jid)
+        ordinal = jid - int(model.body_jntadr[int(model.jnt_bodyid[jid])])
+        state = {
+            (0, True): _DOOR_STATE,
+            (0, False): _DRAWER_HINGE_STATE,
+            (1, False): _DRAWER_SLIDE_STATE,
+        }[(ordinal, body.endswith("door_panel"))]
+        _write(world, jid, state)
+        seeded.setdefault(body, {})[ordinal] = state
+    mujoco.mj_forward(model, world._data)
+
+    yield sim, seeded
+    sim.cleanup()
+
+
+def _survivors(sim: Any) -> dict[str, dict[int, tuple[float, float]]]:
+    """The current ``(qpos, qvel)`` of every unnamed joint, keyed as seeded."""
+    world = sim._world
+    model = world._model
+    out: dict[str, dict[int, tuple[float, float]]] = {}
+    for jid in _unnamed_joint_ids(model):
+        ordinal = jid - int(model.body_jntadr[int(model.jnt_bodyid[jid])])
+        out.setdefault(_body_of(model, jid), {})[ordinal] = _read(world, jid)
+    return out
+
+
+class TestAnUnnamedJointSurvivesTheEject:
+    """The regression: removing one robot must not reset the rest of the scene."""
+
+    def test_every_unnamed_joint_keeps_the_state_it_was_seeded_with(self, scene: Any) -> None:
+        sim, seeded = scene
+        assert sim.remove_robot("arm")["status"] == "success"
+        assert _survivors(sim) == seeded
+
+    def test_the_single_unnamed_hinge_keeps_its_position_and_velocity(self, scene: Any) -> None:
+        """The headline shape: a door on an unnamed hinge, spelled as MJCF spells it."""
+        sim, _ = scene
+        sim.remove_robot("arm")
+        door = next(body for body in _survivors(sim) if body.endswith("door_panel"))
+        assert _survivors(sim)[door][0] == _DOOR_STATE
+
+    def test_the_restore_counts_the_unnamed_joints(self, scene: Any) -> None:
+        """A skipped key is not merely invisible - it is absent from the count."""
+        sim, _ = scene
+        world = sim._world
+        snapshot = scene_ops._snapshot_scene_state(world)
+        assert scene_ops._restore_scene_state(world, snapshot) == int(world._model.njnt)
+
+
+class TestTheOrdinalTellsTwoJointsOfOneBodyApart:
+    """Two unnamed joints on one body: the case a body-only key would swap."""
+
+    def test_the_two_joints_of_one_body_keep_their_own_values(self, scene: Any) -> None:
+        sim, _ = scene
+        sim.remove_robot("arm")
+        drawer = next(body for body in _survivors(sim) if body.endswith("drawer"))
+        by_ordinal = _survivors(sim)[drawer]
+        assert by_ordinal[0] == _DRAWER_HINGE_STATE
+        assert by_ordinal[1] == _DRAWER_SLIDE_STATE
+
+    def test_the_two_joints_are_indistinguishable_by_width(self, scene: Any) -> None:
+        """The premise for the test above: the downstream width check cannot help.
+
+        ``_restore_scene_state`` skips an entry whose width no longer matches the
+        joint type. A hinge and a slide are both 1/1, so a swap between them
+        passes that check - only the key can keep them apart.
+        """
+        sim, _ = scene
+        model = sim._world._model
+        drawer_joints = [j for j in _unnamed_joint_ids(model) if _body_of(model, j).endswith("drawer")]
+        assert len(drawer_joints) == 2
+        widths = {scene_ops._joint_state_widths(int(model.jnt_type[j]), mujoco) for j in drawer_joints}
+        assert widths == {(1, 1)}, widths
+
+    def test_the_two_joints_get_distinct_keys(self, scene: Any) -> None:
+        sim, _ = scene
+        model = sim._world._model
+        drawer_joints = [j for j in _unnamed_joint_ids(model) if _body_of(model, j).endswith("drawer")]
+        keys = [scene_ops._joint_key(model, j, mujoco) for j in drawer_joints]
+        assert len(set(keys)) == len(keys), keys
+
+
+class TestWhichHandleEachJointGets:
+    """The key forms, on a model compiled straight from MJCF."""
+
+    def test_an_unnamed_joint_is_keyed_by_its_body_and_position(self) -> None:
+        model = _model_from(_FURNITURE_XML)
+        drawer = [j for j in _unnamed_joint_ids(model) if _body_of(model, j) == "drawer"]
+        assert [scene_ops._joint_key(model, j, mujoco) for j in drawer] == [
+            ("body_joint", "drawer", 0),
+            ("body_joint", "drawer", 1),
+        ]
+
+    def test_a_named_joint_is_still_keyed_by_its_name(self) -> None:
+        model = _model_from(_ARM_XML)
+        assert scene_ops._joint_key(model, _joint_id(model, "pan"), mujoco) == ("joint", "pan")
+
+    def test_an_unnamed_free_joint_is_still_keyed_by_its_body_alone(self) -> None:
+        """The free-joint form is unchanged: one free joint per body names it."""
+        model = _model_from(
+            """
+            <mujoco><worldbody>
+              <body name="crate" pos="0 0 1"><freejoint/><geom type="box" size="0.05 0.05 0.05"/></body>
+            </worldbody></mujoco>
+            """
+        )
+        assert scene_ops._joint_key(model, 0, mujoco) == ("body", "crate")
+
+    def test_a_joint_whose_body_is_also_unnamed_stays_unmatched(self) -> None:
+        """Nothing identifies either end, so it is reported rather than guessed at."""
+        model = _model_from(
+            """
+            <mujoco><worldbody>
+              <body pos="0 0 1"><joint type="hinge" axis="0 0 1"/><geom type="box" size="0.05 0.05 0.05"/></body>
+            </worldbody></mujoco>
+            """
+        )
+        assert scene_ops._joint_key(model, 0, mujoco) is None
+
+
+class TestTheOrdinalHandleResolvesOnlyWhatItNames:
+    """``_resolve_joint_key`` must not claim a joint the handle does not mean."""
+
+    def test_it_resolves_the_joint_at_that_position(self) -> None:
+        model = _model_from(_FURNITURE_XML)
+        expected = [j for j in _unnamed_joint_ids(model) if _body_of(model, j) == "drawer"]
+        assert [
+            scene_ops._resolve_joint_key(model, ("body_joint", "drawer", ordinal), mujoco) for ordinal in (0, 1)
+        ] == expected
+
+    def test_an_ordinal_past_the_body_s_joints_resolves_to_nothing(self) -> None:
+        model = _model_from(_FURNITURE_XML)
+        assert scene_ops._resolve_joint_key(model, ("body_joint", "drawer", 2), mujoco) == -1
+
+    def test_a_vanished_body_resolves_to_nothing(self) -> None:
+        model = _model_from(_FURNITURE_XML)
+        assert scene_ops._resolve_joint_key(model, ("body_joint", "gone", 0), mujoco) == -1
+
+    def test_a_joint_that_gained_a_name_is_left_to_its_own_key(self) -> None:
+        """A named joint is carried by ``("joint", name)``; the ordinal must not
+        also claim it, or one joint would be restored from two entries."""
+        model = _model_from(
+            """
+            <mujoco><worldbody>
+              <body name="drawer" pos="0 0 1">
+                <joint name="now_named" type="hinge" axis="0 0 1"/>
+                <geom type="box" size="0.05 0.05 0.05"/>
+              </body>
+            </worldbody></mujoco>
+            """
+        )
+        assert scene_ops._resolve_joint_key(model, ("body_joint", "drawer", 0), mujoco) == -1
+
+
+class TestTheEjectStillDoesWhatItDidBefore:
+    """Over-reach controls: carrying more state must not carry the wrong state."""
+
+    def test_the_named_joint_of_a_surviving_robot_still_survives(self, tmp_path: Path) -> None:
+        (tmp_path / "a.xml").write_text(_ARM_XML)
+        sim = Simulation(tool_name="test_unnamed_joint_named_control", mesh=False)
+        try:
+            sim.create_world(gravity=[0, 0, -9.81])
+            sim.add_robot(name="a", urdf_path=str(tmp_path / "a.xml"))
+            sim.add_robot(name="b", urdf_path=str(tmp_path / "a.xml"))
+            world = sim._world
+            keep = _joint_id(world._model, "b/pan")
+            _write(world, keep, (0.55, -0.9))
+            mujoco.mj_forward(world._model, world._data)
+            assert sim.remove_robot("a")["status"] == "success"
+            assert _read(sim._world, _joint_id(sim._world._model, "b/pan")) == (0.55, -0.9)
+        finally:
+            sim.cleanup()
+
+    def test_the_ejected_robot_leaves_no_joint_behind(self, scene: Any) -> None:
+        sim, _ = scene
+        sim.remove_robot("arm")
+        model = sim._world._model
+        names = [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) for j in range(int(model.njnt))]
+        assert "arm/pan" not in names, names
+
+    def test_the_furniture_is_reported_present_after_the_eject(self, scene: Any) -> None:
+        sim, _ = scene
+        sim.remove_robot("arm")
+        assert "fur" in sim.list_robots()

--- a/tests/simulation/mujoco/test_unnamed_joint_state_survives_a_rebuild.py
+++ b/tests/simulation/mujoco/test_unnamed_joint_state_survives_a_rebuild.py
@@ -143,6 +143,7 @@ def scene(tmp_path: Path) -> Any:
     assert sim.add_robot(name="fur", urdf_path=str(tmp_path / "furniture.xml"))["status"] == "success"
 
     world = sim._world
+    assert world is not None
     model = world._model
     unnamed = _unnamed_joint_ids(model)
     # The premise: the furniture really did compile to three unnamed joints, so a
@@ -316,11 +317,14 @@ class TestTheEjectStillDoesWhatItDidBefore:
             sim.add_robot(name="a", urdf_path=str(tmp_path / "a.xml"))
             sim.add_robot(name="b", urdf_path=str(tmp_path / "a.xml"))
             world = sim._world
+            assert world is not None
             keep = _joint_id(world._model, "b/pan")
             _write(world, keep, (0.55, -0.9))
             mujoco.mj_forward(world._model, world._data)
             assert sim.remove_robot("a")["status"] == "success"
-            assert _read(sim._world, _joint_id(sim._world._model, "b/pan")) == (0.55, -0.9)
+            rebuilt = sim._world
+            assert rebuilt is not None
+            assert _read(rebuilt, _joint_id(rebuilt._model, "b/pan")) == (0.55, -0.9)
         finally:
             sim.cleanup()
 


### PR DESCRIPTION
## Problem

`eject_robot_from_scene` rebuilds the compiled model, which renumbers every joint id. The dynamic
state is therefore snapshotted under a name-based key and written back once the new model exists.
`_joint_key` built that key and returned `None` for any unnamed non-free joint, on the stated
grounds that "its body may carry several, so the body does not single it out". A `None` key is
skipped, so the joint's `qpos`, `qvel` and `qfrc_applied` were dropped and it came back at its
fresh-compile value while the operation reported `success`.

An unnamed `<joint>` is the ordinary MJCF spelling: a door hinge or a drawer slide is rarely named.
So removing one robot silently reset the articulation of everything else in the scene.

Measured through the public API on a scene holding an arm plus a door on an unnamed hinge and a
drawer carrying two unnamed joints on one body:

| unnamed joint | seeded `(qpos, qvel)` | after `remove_robot("arm")`, before | after, with this change |
|---|---|---|---|
| `door_panel[0]` hinge | `(0.70, -1.25)` | `(0.0, 0.0)` | `(0.70, -1.25)` |
| `drawer[0]` hinge | `(0.31, 0.44)` | `(0.0, 0.0)` | `(0.31, 0.44)` |
| `drawer[1]` slide | `(-0.17, 2.05)` | `(0.0, 0.0)` | `(-0.17, 2.05)` |

Both calls returned `status: success`.

## Change

The premise was sound but the conclusion was too strong. The body does not single the joint out, but
the body *plus the joint's position among that body's joints* does. MuJoCo stores a body's joints
contiguously from `body_jntadr` in declaration order, so `_joint_key` gains a third form
`("body_joint", body_name, ordinal)` and `_resolve_joint_key` resolves it back through the same two
values.

Nothing shifts an ordinal, because no scene op inserts a joint into an existing body - the patch
vocabulary is `add_body`, `add_geom`, `add_site`, `set_body_pos`, `set_body_quat`, `delete_body`.

Unchanged, and pinned as unchanged: a named joint keeps `("joint", name)`; an unnamed free joint
keeps `("body", body_name)`, which is unambiguous because the compiler refuses a free joint
alongside any other joint on the same body; and a joint whose body is *also* unnamed still gets no
key, because nothing identifies either end across the rebuild.

Two joints of one body are what make the ordinal load-bearing rather than decorative: a hinge and a
slide both use width 1/1, so the width check `_restore_scene_state` already performs cannot tell
them apart, and keying both on the body alone would restore each from the other's values.

## Visual artifact

One MJCF scene, one `remove_robot("arm")` call, three renders from one fixed camera in MuJoCo
headless (EGL). Panel 2 drives the pre-change `_joint_key` through an otherwise identical call.

![unnamed joint state across a scene rebuild](https://github.com/cagataycali/robots/releases/download/artifacts/unnamed_joint_state.png)

Panels 2 and 3 are the same scene after the same call and differ in 16690 px, all of it the
furniture whose joints panel 2 reset. Panels 1 and 3 differ in 2456 px, which is the arm that was
removed. The figure script asserts each panel is embedded verbatim (`np.array_equal` at the measured
paste offset) and re-derives every quoted number from the state it read back.

## Tests

`tests/simulation/mujoco/test_unnamed_joint_state_survives_a_rebuild.py`, 17 tests, GL-free
(`mesh=False`, no rendering).

Pre-fix, reverting only the source: **6 failed, 11 passed**, with zero failures in the over-reach
control class or in either premise test.

Break table - 6 mutations, 5 distinct firing sets, control 0, source restored byte-identical:

| mutation | tests fired |
|---|---|
| control (no mutation) | 0 |
| raw revert: an unnamed non-free joint gets no key | 6 |
| `_resolve_joint_key` ignores the ordinal (always the body's first joint) | 3 |
| the ordinal is keyed off the model rather than the body (`jid` itself) | 5 |
| the "joint has since gained a name" guard dropped | 1 |
| the ordinal bound check dropped | 1 |

The ordinal-ignoring mutation is the one that would swap the drawer's hinge and slide; it fires the
round-trip test, the resolve test and the two-joints test, and no control.

## Gate

- `ruff check` clean; `ruff format --check` clean (1488 files already formatted).
- `mypy`: 0 errors in the changed module; the 4 reported on this tree are pre-existing and in other
  files.
- `tests/simulation/` plus the docstring and changelog guards, identical selection with the new file
  deselected: **13247 passed, 190 skipped, 0 failed**, and the FAILED/ERROR id sets are identical to
  a pristine-`main` measurement of the same selection (both empty, `comm` empty both directions).
- The new file plus `test_scene_ops_guardrails.py` and `test_remove_object_camera_cascade.py`, the
  two suites that exercise the same snapshot/restore path: **71 passed**.
- Run on MuJoCo 3.5.0 (the declared floor).


## Round 1 changelog

**`call-test-lint` was red on the pushed head; it is the only thing that moved.**

`hatch run lint` runs `mypy strands_robots tests tests_integ`, so the new test file is graded too.
`Simulation._world` is typed `SimWorld | None`, and the fixture plus the named-joint control read
`_model` / `_data` straight off it, which is six `union-attr` errors. The Gate section above measured
mypy on the changed *module* and missed them; the sentence "0 errors in the changed module" was true
and insufficient.

Fix, in the test file only: the fixture and the control assert the handle is present before reading
through it, the way the rest of the suite spells it (`assert sim._world is not None`), and the
control re-reads the handle after the eject into its own name rather than reading `sim._world` twice,
so the post-rebuild reads are narrowed on their own value. No assertion about the behaviour under
test changed, and no source file changed.

Re-measured on the new head:

- `hatch run lint`: `ruff check` clean, `ruff format --check` 1544 files already formatted, `mypy`
  **Success: no issues found in 1541 source files** (the 4 errors quoted in the Gate section above
  are gone from this tree as well).
- The new file plus `test_scene_ops_guardrails.py` and `test_remove_object_camera_cascade.py`:
  **71 passed**.
