### PR TITLE
test(mesh): grade the pacing shutdown paths that promise never to raise

### DIFF
--- a/changelog.d/2728-pacing-shutdown-contract-tests.md
+++ b/changelog.d/2728-pacing-shutdown-contract-tests.md
@@ -1,0 +1,42 @@
+### Tests: the pacing shutdown paths that promise never to raise are graded
+
+`Ticker.wake` and `Ticker._drain` document that they never raise, and
+`Ticker.close` that it is additionally idempotent. Nothing graded any of those
+three promises (#2728): the bodies of the five exception handlers they are made
+of were the only uncovered lines left in `strands_robots/mesh/pacing.py`, so the
+happy paths were tested and the reason each handler exists was not.
+
+The promises are load-bearing rather than defensive decoration. Every mesh
+publish loop paces on a `Ticker`, and `Ticker.wait` sits *outside* the `try` in
+each of those loops - the same placement the module docstring explains for the
+Windows doorbell. A shutdown path that raises therefore does not surface as a
+handled error: it kills the publish thread while the mesh itself still looks up,
+which is the module's own description of the hardest shape of this failure to
+attribute, "a robot that joins the fleet and streams nothing".
+
+`TestShutdownKeepsItsPromisesWhenADescriptorDiesUnderIt` drives each handler
+through the condition it exists for - the descriptor dying *under* the ticker,
+which is what a concurrent close or a reaped fd looks like from in there - and
+asserts a post-condition rather than only that nothing was raised. A call that
+merely returns would also pass against a handler that swallowed the error and
+abandoned the rest of the shutdown, so `close` is checked to have completed (a
+subsequent `wait` reports the ticker as closed) and a failed `wake` is checked
+not to have cost the caller the stop itself.
+
+Three of the five conditions are reached with real descriptors: a reaped read
+end, a closed write end, and a send buffer filled until it would block, whose
+`BlockingIOError` lands in the same handler as a closed socket. The other two
+drive a stand-in, for the reason `TestTheDoorbellIsSomethingEverySelectorAccepts`
+already states about the Windows selector - a POSIX `epoll` releases its fd
+idempotently and `socket.close()` does not raise on a double close, so on this
+host those two handlers cannot be reached with the real objects. They guard a
+platform that does raise, so the stand-in pins the contract instead of the
+platform.
+
+The socket case asserts that *both* halves of the doorbell were released even
+though the first raised. That is the assertion the handler is really for: a
+shutdown that gave up at the first failing `close()` would still never raise,
+and would leak a descriptor per paced loop.
+
+This takes `strands_robots/mesh/pacing.py` from 89% to 100% statement coverage -
+10 uncovered statements to 0 - with no production change.

--- a/tests/test_mesh_pacing_ticker.py
+++ b/tests/test_mesh_pacing_ticker.py
@@ -22,7 +22,7 @@ import selectors
 import socket
 import threading
 import time
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -439,3 +439,144 @@ class TestTheDoorbellIsSomethingEverySelectorAccepts:
         ticker.close()
         ticker.wake()  # after close: a no-op on a shutdown path, never an exception
         ticker.close()  # idempotent
+
+
+class TestShutdownKeepsItsPromisesWhenADescriptorDiesUnderIt:
+    """``wake``, ``_drain`` and ``close`` promise never to raise. Nothing graded it.
+
+    Those three promises are load-bearing rather than decorative. Every mesh
+    publish loop paces on a ``Ticker``, and :meth:`Ticker.wait` sits *outside*
+    the ``try`` in each of those loops -- the same placement the module docstring
+    explains for the Windows doorbell. So a shutdown path that raises does not
+    surface as a handled error: it kills the publish thread while the mesh itself
+    still looks up, which is the module's own description of the hardest shape of
+    this failure to attribute -- "a robot that joins the fleet and streams
+    nothing".
+
+    The happy paths are covered elsewhere in this file. What was untested is the
+    reason each handler exists: the descriptor dying *under* the ticker, which is
+    what a concurrent close or a reaped fd looks like from in here. Each test
+    below therefore asserts a post-condition rather than only that nothing was
+    raised -- a bare ``pytest.raises``-free call would also pass against a
+    handler that swallowed the error and abandoned the rest of the shutdown.
+
+    Two of the five drive a stand-in rather than a real descriptor, and for the
+    reason :class:`TestTheDoorbellIsSomethingEverySelectorAccepts` already states
+    for the Windows selector: a POSIX ``epoll`` releases its fd idempotently and
+    ``socket.close()`` never raises on a double close, so those two handlers
+    cannot be reached with the real objects on this host. They guard a platform
+    that does raise, so the stand-in pins the contract instead of the platform.
+    """
+
+    def test_a_drain_whose_read_end_is_gone_stays_silent(self) -> None:
+        """A concurrent close reaps the doorbell mid-``wait``; the tick goes on."""
+        stop = threading.Event()
+        with Ticker(0.01, stop) as ticker:
+            ticker.wake()
+            ticker._wake_r.close()
+
+            ticker._drain()  # the OSError branch: the socket is simply gone
+
+            # The post-condition: the ticker still answers the stop event, so a
+            # dead doorbell degrades pacing rather than the loop's shutdown.
+            stop.set()
+            assert ticker.wait() is True
+
+    @pytest.mark.parametrize("cause", ["write-end-closed", "doorbell-already-full"])
+    def test_a_wake_the_doorbell_cannot_take_stays_silent(self, cause: str) -> None:
+        """Both causes mean "a wake is already as rung as the waiter can see"."""
+        stop = threading.Event()
+        with Ticker(0.01, stop) as ticker:
+            if cause == "write-end-closed":
+                ticker._wake_w.close()
+            else:
+                # Fill the send buffer so the next send() would block. A
+                # BlockingIOError is an OSError, so it lands in the same handler.
+                with pytest.raises(BlockingIOError):
+                    while True:
+                        ticker._wake_w.send(b"\x01" * 4096)
+
+            ticker.wake()  # never raises, however the doorbell is broken
+
+            # A failed wake must not cost the caller the stop itself: that is
+            # the whole reason wake() is documented as best-effort.
+            stop.set()
+            assert ticker.wait() is True
+
+    def test_a_close_whose_doorbell_is_no_longer_watched_still_completes(self) -> None:
+        """The selector already dropped the registration; close finishes anyway."""
+        ticker = Ticker(0.01, threading.Event())
+        ticker._selector.unregister(ticker._wake_r)  # KeyError on the way out
+
+        ticker.close()
+
+        # Completed, not abandoned at the first raise: the closed flag is set, so
+        # wait() reports the ticker as done and close() is still idempotent.
+        with pytest.raises(RuntimeError, match="after close"):
+            ticker.wait()
+        ticker.close()
+
+    def test_a_close_whose_selector_raises_still_completes(self) -> None:
+        """A platform whose selector raises on release must not break shutdown."""
+        ticker = Ticker(0.01, threading.Event())
+        real_selector = ticker._selector
+        selector = _SelectorRaisingOnClose()
+        ticker._selector = cast(selectors.DefaultSelector, selector)
+
+        ticker.close()
+
+        assert selector.close_attempts == 1, "close() never tried to release the selector"
+        with pytest.raises(RuntimeError, match="after close"):
+            ticker.wait()
+        real_selector.close()
+
+    def test_a_close_whose_sockets_raise_releases_both_of_them(self) -> None:
+        """The second descriptor must still be released after the first raises.
+
+        This is the assertion the handler is really for: a shutdown that gave up
+        on the first failing ``close()`` would leak the other half of the
+        doorbell on every ticker, which is a descriptor leak per paced loop.
+        """
+        ticker = Ticker(0.01, threading.Event())
+        ticker._wake_r.close()
+        ticker._wake_w.close()
+        read_end, write_end = _RaisesOnClose(), _RaisesOnClose()
+        ticker._wake_r = cast(socket.socket, read_end)
+        ticker._wake_w = cast(socket.socket, write_end)
+
+        ticker.close()
+
+        assert (read_end.close_calls, write_end.close_calls) == (1, 1), (
+            "close() stopped at the first descriptor that raised, leaking the other"
+        )
+        with pytest.raises(RuntimeError, match="after close"):
+            ticker.wait()
+
+
+class _RaisesOnClose:
+    """A descriptor whose ``close()`` raises, as a non-POSIX platform's may.
+
+    Counts the attempts so a test can tell "the handler caught it" from "the
+    call was never made".
+    """
+
+    def __init__(self) -> None:
+        self.close_calls = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+        raise OSError("this platform raises on a double close")
+
+
+class _SelectorRaisingOnClose:
+    """A selector that releases its registration but raises on ``close()``."""
+
+    def __init__(self) -> None:
+        self.close_attempts = 0
+
+    def unregister(self, _fileobj: object) -> None:
+        return None
+
+    def close(self) -> None:
+        self.close_attempts += 1
+        raise OSError("the epoll/kqueue fd was released under us")


### PR DESCRIPTION
## Problem

`Ticker.wake` and `Ticker._drain` document that they never raise, and
`Ticker.close` that it is additionally idempotent. Nothing graded any of those
three promises. The bodies of the five exception handlers they are made of were
the only uncovered lines left in `strands_robots/mesh/pacing.py`:

```
strands_robots/mesh/pacing.py   93   10   89%   188-191, 206-211, 220-223, 226-229, 233-237
```

So the happy paths were tested and the reason each handler exists was not.

The promises are load-bearing rather than defensive decoration. Every mesh
publish loop paces on a `Ticker`, and `Ticker.wait` sits *outside* the `try` in
each of those loops - the same placement the module docstring already explains
for the Windows doorbell. A shutdown path that raises therefore does not surface
as a handled error: it kills the publish thread while the mesh itself still looks
up, which is the module's own description of the hardest shape of this failure to
attribute, "a robot that joins the fleet and streams nothing".

## Why the existing tests were silent

`test_wake_and_close_are_safe_in_any_order_and_repeatedly` and
`test_a_wake_still_survives_a_drain_and_a_close` already cover `wake`, `_drain`
and `close` on a *healthy* ticker, where no handler is entered. What none of them
reach is the condition each handler is written for: the descriptor dying *under*
the ticker, which is what a concurrent close or a reaped fd looks like from in
there.

## Change

One class, `TestShutdownKeepsItsPromisesWhenADescriptorDiesUnderIt`, drives each
handler through that condition. No production change.

Each test asserts a **post-condition**, not merely that nothing was raised. A
call that simply returns would also pass against a handler that swallowed the
error and abandoned the rest of the shutdown, so `close` is checked to have
completed (a subsequent `wait` reports the ticker as closed, and `close` is still
idempotent), and a failed `wake` is checked not to have cost the caller the stop
itself.

Three of the five conditions are reached with **real** descriptors: a reaped read
end, a closed write end, and a send buffer filled until it would block - whose
`BlockingIOError` is an `OSError` and so lands in the same handler as a closed
socket. The other two drive a stand-in, for the reason
`TestTheDoorbellIsSomethingEverySelectorAccepts` already states about the Windows
selector: a POSIX `epoll` releases its fd idempotently and `socket.close()` does
not raise on a double close, so those two handlers cannot be reached with the
real objects here. They guard a platform that does raise, so the stand-in pins
the contract instead of the platform.

The socket case asserts that **both** halves of the doorbell were released even
though the first raised. That is the assertion the handler is really for: a
shutdown that gave up at the first failing `close()` would still never raise, and
would leak a descriptor per paced loop.

## Break table

Each handler neutralised in turn (`except OSError:` -> `except
ZeroDivisionError:`, which keeps the `try` valid while letting the real error
through). Run against `tests/test_mesh_pacing_ticker.py`; the source was restored
byte-identical afterwards.

| # | mutation | fires | which |
|---|---|---|---|
| b0 | control: no mutation | 0 | - |
| b1 | `_drain`: the `OSError` handler is gone | 1 | `..._a_drain_whose_read_end_is_gone_stays_silent` |
| b2 | `wake`: the send-failure handler is gone | 2 | `..._a_wake_the_doorbell_cannot_take_stays_silent[write-end-closed]`, `[doorbell-already-full]` |
| b3 | `close`: the unregister handler is gone | 2 | `..._doorbell_is_no_longer_watched_still_completes`, `..._sockets_raise_releases_both_of_them` |
| b4 | `close`: the selector-release handler is gone | 1 | `..._a_close_whose_selector_raises_still_completes` |
| b5 | `close`: the socket-release handler is gone | 1 | `..._a_close_whose_sockets_raise_releases_both_of_them` |
| b6 | `close`: one `try` around the whole socket loop | 1 | `..._a_close_whose_sockets_raise_releases_both_of_them` |

All six mutations are detected and the control is clean. b5 and b6 share a firing
set, and the pair is the point rather than a redundancy - the *failure modes*
differ, and one test catches both through two different assertions:

- b5 breaks the promise outright: `E OSError: this platform raises on a double close` escapes `close()`.
- b6 raises nothing at all and leaks: `E AssertionError: close() stopped at the first descriptor that raised, leaking the other` / `assert (1, 0) == (1, 1)`.

b6 is only visible because the test asserts a post-condition; a no-raise check
would pass it.

b3 firing twice is also expected: the socket test replaces `_wake_r` with its
stand-in, which the selector never registered, so an unguarded `unregister` finds
no such key there either.

## Coverage

Measured by two full runs of `tests/` with `--cov=strands_robots`, one per tree:

| | statements | missing | coverage |
|---|---|---|---|
| `strands_robots/mesh/pacing.py` before | 93 | 10 | 89% |
| `strands_robots/mesh/pacing.py` after | 93 | **0** | **100%** |

Package total uncovered statements: 1904 -> 1894, with statement count unchanged
at 45871 (no production line was added).

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1545 files).
- `mypy strands_robots tests tests_integ`: **24 errors on this branch and 24 on a pristine `main` worktree**, normalised message sets byte-identical in both directions, 0 in the changed file.
- Full `tests/` both trees: base `29 failed, 38304 passed, 309 skipped, 24 errors`; branch `29 failed, 38310 passed, 309 skipped, 24 errors`. The `+6` is exactly the six new cases, and the failing/error ID sets are **identical** (53 each, `comm` empty both ways). Those 53 are pre-existing and dependency-related here: 44 need `awsiot` (the `[mesh-iot]` extra) and 3 are lerobot-from-source drift.
- `tests/test_mesh_pacing_ticker.py` alone: 81 passed, 1 skipped.

No visual artifact: this is test-only and touches no policy, simulation
behaviour, rendering, recording or robot asset. The break table and the coverage
pair are the evidence.
