### PR TITLE
fix(mesh): report which robot is running a policy on the state topic

### DIFF
--- a/changelog.d/2729-state-topic-active-flag.md
+++ b/changelog.d/2729-state-topic-active-flag.md
@@ -1,0 +1,49 @@
+### Fixed: a sim peer's state topic reports which robot is running a policy
+
+`Mesh._read_state` publishes a `robots` section naming every robot in the sim world, and the flag
+beside each name was the literal `True`. So it was constant for the life of the peer: it did not
+change when a policy started, it did not change when one stopped, and a scene's idle arms were
+indistinguishable from the one arm executing a rollout. Measured on a two-arm MuJoCo world with a
+mock rollout on `so100` only, reading the topic in all three phases:
+
+    at rest            {"so100": {"active": true}, "arm_b": {"active": true}}
+    rollout on so100   {"so100": {"active": true}, "arm_b": {"active": true}}
+    after stop         {"so100": {"active": true}, "arm_b": {"active": true}}
+
+The `status` command answers the same question correctly over the same three phases -
+`robots_running` is `[]`, `["so100"]`, `[]` - because it reads the running-policy registry. Two
+surfaces of one peer therefore disagreed about one fact, and the 10 Hz telemetry topic was the one
+that was wrong. The flag is now read from that same registry, so the topic and an on-demand status
+answer always name the same set.
+
+That disagreement was already known when the `status` path was written. Its own comment says sims
+"answered `{"status": "unknown"}` and their state topic hardcoded active=True - a running sim
+policy was invisible on the wire", so the state topic was named as part of the defect and only the
+command half was repaired. Nothing graded the remaining half: no test in `tests/mesh/` asserted on
+the flag at all, and `test_mesh.py::test_publishes_sim_clock` asserts the section's key set
+(`sorted(s["robots"].keys()) == ["arm0", "arm1"]`) without reading a value, which is exactly the
+shape that lets a constant survive.
+
+A `SimRobot` child peer keeps no registry of its own, so it consults the parent `Simulation`
+through the `_sim_parent` backref - the same backref `_dispatch` already uses to delegate
+`execute`/`start`, installed by `Simulation._attach_robot_to_mesh` alongside the `_world`
+reference that makes the child publish a state topic in the first place. Both peer kinds now
+report the identical map.
+
+Two dispositions are deliberate. A peer that keeps no such registry reports every robot `false`:
+nothing runs a policy on those robots through the simulation API, so none of them is executing
+one, and its `robots` section is still published. A registry that raises is left to reach
+`_read_state`'s section handler, which names `sim_world` in `degraded` - the documented mechanism
+for a probe that cannot answer. That is the opposite of `status`, which swallows because a command
+must answer; substituting a flag on the telemetry path is what would make the fault unreportable,
+and it is how the unmeasured `True` survived in the first place.
+
+The flag distinguishes a rollout from motion rather than motion from stillness, which is why it
+is read from the registry and not from the world. In the measured scene `so100` moves 0.4585 rad
+under its policy while `arm_b` moves 0.0320 rad - it is sagging under gravity, not executing
+anything - and a motion heuristic would have called both active.
+
+`docs/mesh.md` documented neither the section nor the flag; the published-topics table listed the
+state topic's content as "joints, sim time, task status, degraded probes". It now documents what
+`active` means, that it shares its source with `robots_running`, that which robots *exist* is the
+presence topic's `sim_robots`, and both boundary dispositions above.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -116,7 +116,7 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 | Topic | Rate | Content |
 |-------|------|---------|
 | `strands/{peer_id}/presence` | 2 Hz | heartbeat / peer discovery |
-| `strands/{peer_id}/state` | 10 Hz | joints, sim time, task status, degraded probes |
+| `strands/{peer_id}/state` | 10 Hz | joints, sim time, task status, which robots are running a policy, degraded probes |
 | `strands/{peer_id}/cmd` | on demand | incoming RPC commands |
 | `strands/{peer_id}/response/{id}` | on demand | RPC replies (turn_id correlated) |
 | `strands/{peer_id}/stream` | on demand | VLA execution steps |
@@ -171,6 +171,28 @@ diagnosis is something to report, so the peer publishes it.
 
 The categories are `hw_joints` (the motor bus), `task_state` (the running
 rollout), `sim_world` and `sim_joints`.
+
+### Which robot is running
+
+A sim peer's snapshot carries a `robots` section naming every robot in its world,
+each with an `active` flag:
+
+```json
+{"robots": {"arm_a": {"active": true}, "arm_b": {"active": false}}}
+```
+
+`active` means *this robot is executing a policy right now*. It is read from the
+same running-policy registry the `status` command answers `robots_running` from,
+so polling the topic and asking a peer directly never disagree. The scene's idle
+arms read `false`, which is what makes the one arm running a rollout
+identifiable, and the flag clears when that policy is stopped or its duration
+expires. Which robots *exist* is a separate question, answered by `sim_robots` on
+the presence topic.
+
+A peer that keeps no such registry reports every robot `false` - nothing runs a
+policy on them through the simulation API. A registry that cannot be read is a
+failing probe, so it is named under `sim_world` in `degraded` rather than
+answered with a flag nobody measured.
 
 ### Pose orientation
 

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -1307,7 +1307,8 @@ class Mesh(SensorLoopsMixin):
         hardware, sim, both or neither. A section is present when its probe
         answered and has something to report: ``joints`` (per-joint positions,
         from the motor bus or from the sim world), ``task`` (the running
-        rollout's status), ``sim_time`` and ``robots``.
+        rollout's status), ``sim_time`` and ``robots`` (the sim world's robots,
+        each with the ``active`` flag :meth:`_running_policy_robots` measures).
 
         A section that is ABSENT is therefore ambiguous on its own -- a robot
         with no joints and a robot whose joint probe just raised look identical
@@ -1377,7 +1378,8 @@ class Mesh(SensorLoopsMixin):
                     snapshot["sim_time"] = float(world_data.time)
                 world_robots = getattr(world, "robots", None)
                 if isinstance(world_robots, dict):
-                    snapshot["robots"] = {name: {"active": True} for name in world_robots}
+                    running = self._running_policy_robots()
+                    snapshot["robots"] = {name: {"active": name in running} for name in world_robots}
                 # Per-robot joint extraction for SimRobot children on the mesh.
                 # SimRobot has joint_names + namespace; read qpos/qvel from world.
                 joint_names = getattr(r, "joint_names", None)
@@ -1415,6 +1417,32 @@ class Mesh(SensorLoopsMixin):
             snapshot["degraded"] = degraded
 
         return snapshot if len(snapshot) > 2 else None
+
+    def _running_policy_robots(self) -> frozenset[str]:
+        """Names of this world's robots currently executing a policy.
+
+        The running-policy registry is the same source the ``status`` command
+        reads in :meth:`_dispatch`, so the state topic and an on-demand status
+        answer agree about which rollout is live. A ``SimRobot`` child peer
+        keeps no registry of its own and consults the parent ``Simulation``
+        through the ``_sim_parent`` backref that peer wiring installs.
+
+        A registry that raises is left to reach :meth:`_read_state`'s section
+        handler, which names ``sim_world`` in ``degraded``. That is the
+        opposite disposition to ``status``, which swallows because a command
+        must answer; the state topic reports a failing probe instead, and
+        substituting a flag here is what would make the fault unreportable.
+
+        Returns:
+            The names, empty when no peer in this chain keeps such a registry.
+            Nothing then runs a policy on those robots through the simulation
+            API, so none of them is executing one.
+        """
+        for holder in (self.robot, getattr(self.robot, "_sim_parent", None)):
+            probe = getattr(holder, "_active_policy_robots", None)
+            if callable(probe):
+                return frozenset(probe())
+        return frozenset()
 
     # Cameras - outgoing (opt-in)
     def _resolve_camera_hz(self) -> float:

--- a/tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py
+++ b/tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py
@@ -1,0 +1,237 @@
+"""The state topic's per-robot ``active`` flag is measured, not asserted.
+
+``Mesh._read_state`` publishes a ``robots`` section naming every robot in the
+sim world. The flag beside each name used to be the literal ``True``, so it was
+constant for the life of the peer: a scene's idle arms and the one arm executing
+a rollout were indistinguishable at 10 Hz, and the flag could not change when a
+policy started or stopped.
+
+The ``status`` command already answers that question from the running-policy
+registry (``robots_running``), so the two surfaces disagreed about one fact.
+These cases hold them to the same source: whatever set the flag marks active is
+the set ``status`` reports running, in every phase of a real rollout, from a
+parent ``Simulation`` peer and from a ``SimRobot`` child peer alike.
+
+Also pinned, so the measurement cannot be traded for the old shortcut: a peer
+that keeps no policy registry still gets its ``robots`` section, and a registry
+that raises is named in ``degraded`` rather than answered with a fabricated
+flag.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import core as mesh_core
+
+_START_TIMEOUT_S = 10.0
+_RUNNER = "so100"
+_BYSTANDER = "arm_b"
+
+
+def _active_names(snapshot: dict[str, Any] | None) -> set[str]:
+    """The robots a state snapshot marks active, as a set of names."""
+    assert snapshot is not None, "the peer published nothing on the state topic"
+    robots = snapshot.get("robots")
+    assert isinstance(robots, dict), f"no robots section in the snapshot: {sorted(snapshot)}"
+    return {name for name, entry in robots.items() if entry["active"]}
+
+
+def _await(predicate: Any, what: str) -> None:
+    """Block until ``predicate()`` holds, so a phase is entered deterministically."""
+    deadline = time.time() + _START_TIMEOUT_S
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+def _start_rollout(sim: Any) -> None:
+    """Start a mock rollout on ``_RUNNER`` and wait for its first control step."""
+    sim.start_policy(robot_name=_RUNNER, policy_provider="mock", duration=30.0, control_frequency=20.0)
+    _await(
+        lambda: getattr(sim._world.robots[_RUNNER], "policy_steps", 0) > 0,
+        "the rollout to take its first control step",
+    )
+
+
+def _stop_rollout(sim: Any) -> None:
+    """Stop the rollout and wait for the registry to drop it."""
+    sim.stop_policy(_RUNNER)
+    _await(lambda: not sim._active_policy_robots(), "the rollout to leave the registry")
+
+
+@pytest.fixture
+def two_robot_sim() -> Iterator[Any]:
+    """A live MuJoCo scene holding two robots, one of which will run a policy."""
+    pytest.importorskip("mujoco", reason="the flag is read off a live MuJoCo world")
+    import strands_robots
+
+    sim = strands_robots.Robot(_RUNNER, mode="sim")
+    sim.add_robot(_BYSTANDER, data_config="so101", position=[0.6, 0.0, 0.0])
+    try:
+        yield sim
+    finally:
+        sim.cleanup()
+
+
+class TestTheFlagTracksTheRunningPolicy:
+    """The regression: the flag distinguishes a rollout from an idle scene."""
+
+    def test_the_scene_holds_two_robots_so_the_flag_has_something_to_tell_apart(self, two_robot_sim: Any) -> None:
+        """Premise. With one robot, "exactly one is active" is true by arity."""
+        assert set(two_robot_sim._world.robots) == {_RUNNER, _BYSTANDER}
+
+    def test_no_robot_is_active_while_the_scene_is_idle(self, two_robot_sim: Any) -> None:
+        mesh = mesh_core.Mesh(two_robot_sim, peer_id="sim-idle")
+        assert _active_names(mesh._read_state()) == set()
+
+    def test_only_the_robot_running_a_policy_is_active(self, two_robot_sim: Any) -> None:
+        mesh = mesh_core.Mesh(two_robot_sim, peer_id="sim-running")
+        _start_rollout(two_robot_sim)
+        try:
+            # Independent of the registry the flag is read from: the runner's
+            # rollout really advanced, so "active" describes a live policy.
+            assert two_robot_sim._world.robots[_RUNNER].policy_steps > 0
+            assert _active_names(mesh._read_state()) == {_RUNNER}
+        finally:
+            _stop_rollout(two_robot_sim)
+
+    def test_no_robot_is_active_once_the_policy_stops(self, two_robot_sim: Any) -> None:
+        mesh = mesh_core.Mesh(two_robot_sim, peer_id="sim-stopped")
+        _start_rollout(two_robot_sim)
+        assert _active_names(mesh._read_state()) == {_RUNNER}
+        _stop_rollout(two_robot_sim)
+        assert _active_names(mesh._read_state()) == set()
+
+
+class TestTheStateTopicAndTheStatusCommandAgree:
+    """One fact, one source: the flag and ``robots_running`` never disagree."""
+
+    def test_they_agree_in_every_phase_of_a_rollout(self, two_robot_sim: Any) -> None:
+        mesh = mesh_core.Mesh(two_robot_sim, peer_id="sim-agree")
+
+        def both() -> tuple[set[str], set[str]]:
+            return (
+                _active_names(mesh._read_state()),
+                set(mesh._dispatch({"action": "status"})["robots_running"]),
+            )
+
+        seen = []
+        flagged, running = both()
+        assert flagged == running
+        seen.append(running)
+
+        _start_rollout(two_robot_sim)
+        try:
+            flagged, running = both()
+            assert flagged == running
+            seen.append(running)
+        finally:
+            _stop_rollout(two_robot_sim)
+
+        flagged, running = both()
+        assert flagged == running
+        seen.append(running)
+
+        # Non-vacuity: agreeing on the empty set in all three phases would pass
+        # the equality above while measuring nothing.
+        assert seen == [set(), {_RUNNER}, set()]
+
+    def test_a_child_peer_reports_the_same_map_as_its_parent(self, two_robot_sim: Any) -> None:
+        """A ``SimRobot`` peer holds no registry and consults ``_sim_parent``.
+
+        This is the wiring ``Simulation._attach_robot_to_mesh`` installs when a
+        per-robot peer is published, so the child peer answers for the whole
+        world exactly as the parent does.
+        """
+        child = two_robot_sim._world.robots[_BYSTANDER]
+        child._world = two_robot_sim._world
+        child._sim_parent = two_robot_sim
+        parent_mesh = mesh_core.Mesh(two_robot_sim, peer_id="sim-parent")
+        child_mesh = mesh_core.Mesh(child, peer_id="sim-child")
+
+        _start_rollout(two_robot_sim)
+        try:
+            assert _active_names(parent_mesh._read_state()) == {_RUNNER}
+            assert _active_names(child_mesh._read_state()) == {_RUNNER}
+        finally:
+            _stop_rollout(two_robot_sim)
+
+
+class _WorldStub:
+    """The two attributes ``_read_state``'s sim-world probe reads."""
+
+    def __init__(self) -> None:
+        self._data = SimpleNamespace(time=12.5)
+        self._model = None
+        self.robots = {"arm0": object(), "arm1": object()}
+
+
+class _NoRegistryRobot:
+    """A peer holding a sim world but keeping no running-policy registry."""
+
+    tool_name_str = "worldbot"
+
+    def __init__(self) -> None:
+        self._world = _WorldStub()
+
+
+class _DataAttributeRobot(_NoRegistryRobot):
+    """A peer carrying the registry's name as data rather than as a method."""
+
+    _active_policy_robots: list[str] = ["arm0"]
+
+
+class _RaisingRegistryRobot(_NoRegistryRobot):
+    """A peer whose running-policy registry cannot be read."""
+
+    def _active_policy_robots(self) -> list[str]:
+        raise RuntimeError("policy registry unreadable")
+
+
+class TestAPeerThatKeepsNoPolicyRegistry:
+    """Deriving the flag must not cost the section, nor invent a rollout."""
+
+    def test_its_robots_section_is_still_published(self) -> None:
+        snapshot = mesh_core.Mesh(_NoRegistryRobot(), peer_id="no-registry")._read_state()
+        assert snapshot is not None
+        assert set(snapshot["robots"]) == {"arm0", "arm1"}
+        assert snapshot["sim_time"] == 12.5
+
+    def test_none_of_its_robots_is_reported_active(self) -> None:
+        """No policy runs through the simulation API on such a peer."""
+        assert _active_names(mesh_core.Mesh(_NoRegistryRobot(), peer_id="no-reg2")._read_state()) == set()
+
+    def test_the_registry_name_carried_as_data_is_not_a_registry(self) -> None:
+        """Only something callable is consulted, so a peer that happens to carry
+        the name as an attribute reads as keeping no registry rather than having
+        its names taken for a rollout.
+        """
+        snapshot = mesh_core.Mesh(_DataAttributeRobot(), peer_id="data-attr")._read_state()
+        assert _active_names(snapshot) == set()
+        assert snapshot is not None
+        assert set(snapshot["robots"]) == {"arm0", "arm1"}
+
+
+class TestARaisingRegistryIsReportedRatherThanSubstituted:
+    """The state topic names a failing probe; it does not publish a guess."""
+
+    def test_the_failure_is_named_in_degraded(self) -> None:
+        snapshot = mesh_core.Mesh(_RaisingRegistryRobot(), peer_id="raising")._read_state()
+        assert snapshot is not None
+        assert snapshot["degraded"]["sim_world"]["reason"] == "RuntimeError"
+        assert "policy registry unreadable" in snapshot["degraded"]["sim_world"]["detail"]
+
+    def test_no_flag_is_published_for_a_probe_that_could_not_answer(self) -> None:
+        snapshot = mesh_core.Mesh(_RaisingRegistryRobot(), peer_id="raising2")._read_state()
+        assert snapshot is not None
+        assert "robots" not in snapshot
+        # The section handler still keeps what the probe had already read.
+        assert snapshot["sim_time"] == 12.5


### PR DESCRIPTION
## Problem

`Mesh._read_state` publishes a `robots` section naming every robot in the sim world, and the flag beside each name was the literal `True`:

```python
snapshot["robots"] = {name: {"active": True} for name in world_robots}
```

So the flag was constant for the life of the peer. It did not change when a policy started, it did not change when one stopped, and a scene's idle arms were indistinguishable from the one arm executing a rollout. Measured on a two-arm MuJoCo world (headless) with a mock rollout on `so100` only, reading both surfaces of the same peer in all three phases:

| phase | `state` topic, `main` | `status` command, `main` |
|---|---|---|
| at rest | `so100 true`, `arm_b true` | `idle`, `robots_running []` |
| rollout on `so100` | `so100 true`, `arm_b true` | `running`, `robots_running ["so100"]` |
| after stop | `so100 true`, `arm_b true` | `idle`, `robots_running []` |

Two surfaces of one peer disagreed about one fact, and the 10 Hz telemetry topic was the wrong one. The `status` command is right because it reads the running-policy registry; the state topic asserted rather than measured.

The disagreement was already known when the `status` path was written. That code's own comment says sims "answered `{"status": "unknown"}` and their state topic hardcoded active=True - a running sim policy was invisible on the wire", so the state topic was named as part of the defect and only the command half was repaired.

## Why nothing caught it

No test in `tests/mesh/` asserted on the flag at all. The one test that reaches the section, `test_mesh.py::test_publishes_sim_clock`, asserts its key set and not a value:

```python
assert sorted(s["robots"].keys()) == ["arm0", "arm1"]
```

which is exactly the shape that lets a constant survive indefinitely.

## Change

Read the flag from the registry the `status` command already reads, through one helper:

```python
def _running_policy_robots(self) -> frozenset[str]:
    for holder in (self.robot, getattr(self.robot, "_sim_parent", None)):
        probe = getattr(holder, "_active_policy_robots", None)
        if callable(probe):
            return frozenset(probe())
    return frozenset()
```

A `SimRobot` child peer keeps no registry of its own, so it consults the parent `Simulation` through the `_sim_parent` backref - the same backref `_dispatch` already uses to delegate `execute`/`start`, installed by `Simulation._attach_robot_to_mesh` alongside the `_world` reference that makes a child publish a state topic at all. Both peer kinds now report the identical map. After the change, on the same scene:

| phase | `state` topic | `status` command |
|---|---|---|
| at rest | `so100 false`, `arm_b false` | `idle`, `robots_running []` |
| rollout on `so100` | `so100 true`, `arm_b false` | `running`, `robots_running ["so100"]` |
| after stop | `so100 false`, `arm_b false` | `idle`, `robots_running []` |

### Two deliberate dispositions

A peer that keeps **no** such registry reports every robot `false` - nothing runs a policy on those robots through the simulation API - and its `robots` section is still published. A registry that **raises** is left to reach `_read_state`'s section handler, which names `sim_world` in `degraded`: the documented mechanism for a probe that cannot answer. That is the opposite of `status`, which swallows because a command must answer. Substituting a flag on the telemetry path is what would make the fault unreportable, and it is how the unmeasured `True` survived.

## Rollout in MuJoCo sim (headless)

![state topic active flag](https://github.com/cagataycali/robots/releases/download/artifacts/state_active_flag.png)

The flag distinguishes a rollout from motion, not motion from stillness - which is precisely why it is read from the registry rather than from the world. In the rendered scene `so100` moves **0.4585 rad** under its policy (14717 px of its own body change) while `arm_b` moves **0.0320 rad** (5053 px): it is sagging under gravity, not executing anything. A motion heuristic would have called both active. Both trees ran the same rollout - identical per-robot changed pixels and the same `status` answer - so only the reported flag differs.

## Tests

`tests/mesh/test_state_topic_reports_which_robot_runs_a_policy.py`, 11 cases. Pre-fix, with the source reverted and the tests kept: **9 failed, 2 passed**, the headline being `assert {'arm_b', 'so100'} == {'so100'}` - the idle bystander reported active during another arm's rollout. The 2 that pass pre-fix are the premise (the scene really holds two robots, so "exactly one is active" is not true by arity) and the over-reach control (deriving the flag must not cost the `robots` section), so no premise or control case is a regression case.

Mutation coverage on the fixed tree, each row the count of cases in the new file that fail:

| mutation | fires |
|---|---|
| control, unchanged | 0 |
| the flag back to the literal `True` | 9 |
| registry never consulted | 6 |
| the `_sim_parent` fallback dropped | 1 |
| only `_sim_parent` consulted, `self` dropped | 6 |
| a raising registry swallowed instead of reported | 2 |
| a raising registry answered with the old `True` | 2 |
| the flag inverted | 7 |
| the holder order swapped | 0 |
| the `callable()` guard relaxed to a presence check | 1 |

Nine of ten mutations are detected, six distinct firing sets, control clean, source restored byte-identical. The holder order fires nothing for a structural reason worth stating: no holder in the chain carries both ends, since a `SimRobot` has no `_active_policy_robots` of its own and a `Simulation` has no `_sim_parent`, so the order is immaterial rather than untested.

## Verification

- Paired run over an identical 572-file selection (all of `tests/mesh/` plus every test that walks the tree, reads docstrings or reads `docs/`), the new file excluded from both trees: **22931 collected** and **24 failed, 22766 passed, 117 skipped, 24 errors on both**, 48 identical failing ids, `comm` empty in both directions. All 48 were already failing on pristine `main`; 44 need `awsiot`/`awscrt` (declared in the `mesh-iot` extra, both absent here) and the rest are pre-existing.
- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ`. `mypy` **5 == 5** against a pristine `main` worktree, normalized message sets byte-identical in both directions, none in the changed files.
- The new file: **11 passed** on mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 from source, and on mujoco 3.12.0.
- The pre-existing `tests/mesh/` suite: 3620 passed, 10 skipped. Docs, xref and changelog guards: 1015 passed.

## Docs

`docs/mesh.md` documented neither the section nor the flag - the published-topics table listed the state topic's content as "joints, sim time, task status, degraded probes". A new "Which robot is running" subsection documents what `active` means, that it shares its source with `robots_running`, that which robots *exist* is the presence topic's `sim_robots`, and both boundary dispositions above.
