### PR TITLE
fix(mesh): coerce a sensor payload's readings so the topic reaches the wire

### DIFF
--- a/changelog.d/2730-mesh-sensor-payload-json-encodable.md
+++ b/changelog.d/2730-mesh-sensor-payload-json-encodable.md
@@ -1,0 +1,51 @@
+### Fixed: a sensor payload's numpy readings are coerced, so the topic reaches the wire instead of being dropped
+
+`SensorLoopsMixin`'s readers merged the robot's provider mapping into the outgoing
+payload verbatim -- `summary.update(data)`, `imu.update(imu_data)`, and six more --
+and every extended sensor topic is published as JSON: `_put_zenoh_directly`
+encodes the payload before it reaches the wire. A payload the encoder refuses is
+not a transient failure that the next tick retries; it fails identically forever,
+which is why #2638 reports it at ERROR rather than absorbing it. The topic never
+publishes at all.
+
+The values a sensor stack reports are numpy. A lidar summary's bounding box is
+whatever `ndarray.min(axis=0)` returned, an IMU's orientation a `float32`, a
+device state code an `int64` -- and `json.dumps` refuses all three. So a robot
+exposing `_lidar_summary`, `_imu`, `_odom`, `_lidar_state`, `_map_info`, `_hands`,
+`_temps`, `_battery` or a `_pose`/`_slam_pose`/`_odom_pose` mapping built from its
+own readings had those topics silently absent from the mesh, with one ERROR line
+per topic to say so.
+
+The defect turned on the numpy *width*, which is why it survived. `np.float64`
+subclasses Python's `float` and `np.str_` subclasses `str`, so a payload built
+from those always encoded; `np.float32`, `np.float16`, `np.int32`, `np.int64`,
+`np.bool_` and `ndarray` subclass nothing and were refused. A robot on a float64
+pipeline published fine, and the same code reading a `float32` point cloud
+dropped every tick.
+
+Two paths in the same class already coerced for exactly this reason -- `_read_imu`'s
+inner-observation branch calls `tolist()`, `_read_pose`'s SE(3) branch calls
+`float()` -- and so does `Mesh.publish_step`. The eight readers that merge a
+provider mapping did not, so the class held two conventions for one wire format.
+Each reader now hands its payload to one `_coerce_record` before returning it:
+anything exposing `tolist()` becomes the equivalent Python list or number, and
+containers are rebuilt with their contents coerced, mapping keys included, because
+a `float32` is no more encodable as a key than as a value.
+
+The boundary is that coercion repairs readings rather than laundering payloads. A
+value that is not a reading -- an opaque object, a `bytes` blob -- is returned
+untouched, so it still reaches the encoder and is still reported by name; and the
+recursion is bounded, because a sensor record is shallow and a structure deeper
+than the bound is a cycle or an object graph rather than a reading, which #2638's
+report is the right answer for. Coercion also never edits robot state: `_read_health`
+stores the provider's `_temps` mapping by reference, so the entry is replaced in the
+payload rather than rewritten underneath the robot.
+
+`tests/mesh/test_sensor_payloads_are_json_encodable.py` drives all eight readers
+and all three pose branches with the numpy a sensor stack reports, asserting on the
+decoded record a subscriber sees. Each row carries a premise that its raw provider
+value is what the encoder refuses, so the table cannot pass on a payload that never
+needed coercing. Thirteen plausible regressions were applied and the pin re-run:
+twelve fire a different set, none goes undetected, and the control is clean. The
+rule that every reader routes its payload through the coercion is derived from the
+module rather than listed, so a reader added later is held to it on arrival.

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -47,6 +47,91 @@ from strands_robots.mesh.session import (
 logger = logging.getLogger(__name__)
 
 
+# A sensor payload is a plain record on the wire, so the values in it have to be
+# ones ``json.dumps`` accepts. ``_JSONABLE_MAX_DEPTH`` bounds how far down this
+# module will go looking for them.
+#
+# Past the bound the value is handed to the encoder unchanged. That is
+# deliberate: a sensor record is shallow (a mapping of names to scalars and short
+# vectors), so a structure deeper than this is not a reading but a pathological
+# payload - a cycle, or a nested object graph. Those are exactly the payloads
+# :func:`strands_robots.mesh.session._report_unencodable_payload` exists to
+# report at ERROR, and recursing into them here would turn a reported failure
+# into one absorbed by the reader's own handler.
+_JSONABLE_MAX_DEPTH = 8
+
+
+def _jsonable(value: Any, _depth: int = 0) -> Any:
+    """Coerce *value* into something ``json.dumps`` accepts, or leave it alone.
+
+    Every sensor topic is published as JSON
+    (:func:`strands_robots.mesh.session._put_zenoh_directly` encodes the payload
+    before it reaches the wire), and a payload the encoder refuses is not a
+    transient failure: it fails identically on every tick, so the topic never
+    publishes at all. A sensor pipeline reports its readings as numpy - a lidar
+    summary's bounding box is whatever ``ndarray.min(axis=0)`` returned, an IMU's
+    orientation is a ``float32`` - and none of those are JSON values.
+
+    So this coerces the two things that are readings expressed in a foreign
+    numeric type, and nothing else:
+
+    - anything exposing ``tolist()`` (a numpy array or scalar, a torch tensor)
+      becomes the equivalent Python list or number;
+    - lists, tuples and sets are rebuilt with their contents coerced, and
+      mappings with their keys coerced too, because a ``float32`` is no more
+      encodable as a key than as a value.
+
+    Anything else is returned unchanged rather than coerced to a string or
+    dropped. A payload carrying an object that is genuinely not a reading cannot
+    be repaired by guessing, and silently substituting something for it would
+    publish a record that misreports what the sensor said. Handing it to the
+    encoder untouched is what lets the transport report it by name.
+
+    Args:
+        value: A payload, or any value inside one.
+        _depth: Recursion depth, bounded by :data:`_JSONABLE_MAX_DEPTH`.
+
+    Returns:
+        The coerced value; the original object when there is nothing to coerce.
+    """
+    if _depth >= _JSONABLE_MAX_DEPTH:
+        return value
+    if isinstance(value, dict):
+        return {_jsonable(k, _depth + 1): _jsonable(v, _depth + 1) for k, v in value.items()}
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return tolist()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        # Named as concrete types rather than as ``Sequence``, because a ``str``
+        # is a sequence and rebuilding one would take a name apart into
+        # characters. A tuple has no JSON spelling of its own - ``json.dumps``
+        # already renders one as an array - so rebuilding every sequence as a
+        # list keeps the encoded form identical while coercing the contents.
+        return [_jsonable(item, _depth + 1) for item in value]
+    return value
+
+
+def _coerce_record(payload: dict[str, Any]) -> None:
+    """Coerce every entry of *payload* in place, so its declared type is kept.
+
+    The readers build a payload and return it under a ``dict[str, Any] | None``
+    signature. Rebuilding it through :func:`_jsonable` would return that
+    function's ``Any``, so the coercion is applied entry by entry here instead
+    and each reader keeps returning the object it built.
+
+    Only the top level is rewritten: :func:`_jsonable` never mutates, it returns
+    a new container, so a nested value the robot still owns - ``_read_health``
+    stores the provider's ``_temps`` mapping by reference - is replaced in the
+    payload rather than edited underneath the robot.
+
+    Args:
+        payload: The outgoing record, modified in place.
+    """
+    for key in list(payload):
+        value = _jsonable(payload.pop(key))
+        payload[_jsonable(key)] = value
+
+
 def _quat_wxyz_from_rotmat(mat: Any) -> list[float]:
     """Rotation matrix -> unit quaternion, scalar-first ``[w, x, y, z]``.
 
@@ -225,6 +310,7 @@ class SensorLoopsMixin:
                     pose.update(pose_data)
                     pose.setdefault("source", "provider")
                     pose.setdefault("frame", "map")
+                    _coerce_record(pose)
                     return pose
                 elif hasattr(pose_data, "shape") and getattr(pose_data, "shape", None) == (4, 4):
                     import numpy as np
@@ -237,6 +323,7 @@ class SensorLoopsMixin:
                     pose["quat"] = _quat_wxyz_from_rotmat(mat)
                     pose["source"] = "provider"
                     pose["frame"] = "map"
+                    _coerce_record(pose)
                     return pose
         except Exception:  # noqa: BLE001
             pass
@@ -248,6 +335,7 @@ class SensorLoopsMixin:
                 pose.update(slam_pose)
                 pose.setdefault("source", "slam")
                 pose.setdefault("frame", "map")
+                _coerce_record(pose)
                 return pose
         except Exception:  # noqa: BLE001
             pass
@@ -259,6 +347,7 @@ class SensorLoopsMixin:
                 pose.update(odom_pose)
                 pose.setdefault("source", "odom")
                 pose.setdefault("frame", "odom")
+                _coerce_record(pose)
                 return pose
         except Exception:  # noqa: BLE001
             pass
@@ -347,6 +436,7 @@ class SensorLoopsMixin:
         except (OSError, ValueError):
             pass
 
+        _coerce_record(health)
         return health if has_data else None
 
     # IMU
@@ -376,6 +466,7 @@ class SensorLoopsMixin:
             imu_data = getattr(r, "_imu", None)
             if imu_data is not None and isinstance(imu_data, dict):
                 imu.update(imu_data)
+                _coerce_record(imu)
                 return imu
         except Exception:  # noqa: BLE001
             pass
@@ -396,6 +487,7 @@ class SensorLoopsMixin:
                         elif key == "accelerometer":
                             imu["accel"] = val[:3] if len(val) >= 3 else val
                 if "rpy" in imu or "gyro" in imu or "accel" in imu:
+                    _coerce_record(imu)
                     return imu
         except Exception:  # noqa: BLE001
             pass
@@ -429,6 +521,7 @@ class SensorLoopsMixin:
                 odom: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 odom.update(odom_data)
                 odom.setdefault("frame", "odom")
+                _coerce_record(odom)
                 return odom
         except Exception:  # noqa: BLE001
             pass
@@ -474,6 +567,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 summary: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 summary.update(data)
+                _coerce_record(summary)
                 return summary
         except Exception:  # noqa: BLE001
             pass
@@ -486,6 +580,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 state: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 state.update(data)
+                _coerce_record(state)
                 return state
         except Exception:  # noqa: BLE001
             pass
@@ -522,6 +617,7 @@ class SensorLoopsMixin:
                         state = {"peer_id": self.peer_id, "hand": name, "t": time.time()}
                         state.update(data)
                         result[name] = state
+                _coerce_record(result)
                 return result if result else None
         except Exception:  # noqa: BLE001
             pass
@@ -553,6 +649,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 info: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 info.update(data)
+                _coerce_record(info)
                 return info
         except Exception:  # noqa: BLE001
             pass

--- a/tests/mesh/test_sensor_payloads_are_json_encodable.py
+++ b/tests/mesh/test_sensor_payloads_are_json_encodable.py
@@ -1,0 +1,390 @@
+"""A sensor payload built from real readings has to survive the JSON encoder.
+
+Every extended sensor topic is published as JSON:
+:func:`strands_robots.mesh.session._put_zenoh_directly` encodes the payload
+before it reaches the wire. A payload the encoder refuses is not a transient
+failure that the next tick retries - it fails identically forever, so the topic
+never publishes at all, which is why
+:func:`strands_robots.mesh.session._report_unencodable_payload` reports it at
+ERROR rather than absorbing it.
+
+The values a sensor stack actually reports are numpy: a lidar summary's bounding
+box is whatever ``ndarray.min(axis=0)`` returned, an IMU's orientation a
+``float32``, a device state code an ``int64``. None of those are JSON values, and
+:class:`~strands_robots.mesh.sensors.SensorLoopsMixin` merges the robot's
+provider dictionaries into the outgoing payload verbatim - so a robot whose
+readings are numpy had every tick of those topics dropped.
+
+Two paths in the same class already coerced for exactly this reason
+(``_read_imu``'s inner-observation branch calls ``tolist()``, ``_read_pose``'s
+SE(3) branch calls ``float()``), and so does
+:meth:`~strands_robots.mesh.core.Mesh.publish_step`. These tests hold every
+reader to that rule, and pin the boundary: a value that is not a reading is left
+untouched so the transport still names it.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.mesh import sensors as mesh_sensors
+from strands_robots.mesh.sensors import _JSONABLE_MAX_DEPTH, SensorLoopsMixin, _jsonable
+
+
+class _Host(SensorLoopsMixin):
+    """Minimal SensorLoopsMixin host that records published payloads."""
+
+    def __init__(self, robot: Any, peer_id: str = "neon") -> None:
+        self.robot = robot
+        self.peer_id = peer_id
+        self._running = True
+        self._stop_event = threading.Event()
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        self.published.append((key, payload))
+
+
+class _Robot:
+    """Bare attribute bag standing in for a robot exposing sensor providers."""
+
+
+def _host(**robot_attrs: Any) -> _Host:
+    robot = _Robot()
+    for name, value in robot_attrs.items():
+        setattr(robot, name, value)
+    return _Host(robot)
+
+
+def _encode(payload: Any) -> Any:
+    """Round-trip *payload* through the encoder the wire uses."""
+    return json.loads(json.dumps(payload))
+
+
+# One row per provider attribute, so every reader and every branch that merges a
+# provider dictionary is driven with the numpy a real sensor stack reports.
+# ``expected`` is read out of the decoded payload, which is what a subscriber
+# sees - the assertion is on the published record, not on an internal.
+_ROWS: tuple[tuple[str, dict[str, Any], str, dict[str, Any]], ...] = (
+    (
+        "lidar-summary",
+        {"_lidar_summary": {"count": np.int64(200), "bbox": np.array([-1.5, -2.5, 0.0]), "range": np.float32(7.25)}},
+        "_read_lidar_summary",
+        {"count": 200, "bbox": [-1.5, -2.5, 0.0], "range": 7.25},
+    ),
+    (
+        "lidar-state",
+        {"_lidar_state": {"freq": np.float32(10.0), "code": np.int64(3)}},
+        "_read_lidar_state",
+        {"freq": 10.0, "code": 3},
+    ),
+    (
+        "imu",
+        {"_imu": {"rpy": np.array([0.25, -0.5, 0.75]), "gyro": np.float32(0.125)}},
+        "_read_imu",
+        {"rpy": [0.25, -0.5, 0.75], "gyro": 0.125},
+    ),
+    (
+        "odom",
+        {"_odom": {"x": np.int64(1), "y": np.float32(-2.0)}},
+        "_read_odom",
+        {"x": 1, "y": -2.0, "frame": "odom"},
+    ),
+    (
+        "pose-provider",
+        {"_pose": {"x": np.float32(3.5), "quat": np.array([1.0, 0.0, 0.0, 0.0])}},
+        "_read_pose",
+        {"x": 3.5, "quat": [1.0, 0.0, 0.0, 0.0], "source": "provider"},
+    ),
+    (
+        "pose-slam",
+        {"_slam_pose": {"x": np.float32(-4.0)}},
+        "_read_pose",
+        {"x": -4.0, "source": "slam"},
+    ),
+    (
+        "pose-odom",
+        {"_odom_pose": {"y": np.float32(6.5)}},
+        "_read_pose",
+        {"y": 6.5, "source": "odom"},
+    ),
+    (
+        "health-battery",
+        {"_battery": {"pct": np.float32(87.5)}},
+        "_read_health",
+        {"battery_pct": 87.5},
+    ),
+    (
+        "health-temps",
+        {"_temps": {"cpu": np.float32(41.5)}},
+        "_read_health",
+        {"temps": {"cpu": 41.5}},
+    ),
+    (
+        "map-info",
+        {"_map_info": {"resolution": np.float32(0.05), "size": np.array([512, 512])}},
+        "_read_map_info",
+        {"resolution": 0.05, "size": [512, 512]},
+    ),
+)
+
+_IDS = tuple(row[0] for row in _ROWS)
+
+
+class TestEveryReadingReachesTheWire:
+    """A provider dictionary of numpy readings must encode, with its values intact."""
+
+    @pytest.mark.parametrize(("label", "attrs", "reader", "expected"), _ROWS, ids=_IDS)
+    def test_payload_encodes(self, label: str, attrs: dict[str, Any], reader: str, expected: dict[str, Any]) -> None:
+        payload = getattr(_host(**attrs), reader)()
+        assert payload is not None, f"{reader} read nothing for {label}"
+        # The encoder is the gate: this is the call that drops the topic forever.
+        decoded = _encode(payload)
+        for key, want in expected.items():
+            assert decoded[key] == pytest.approx(want), f"{label}: {key} arrived as {decoded[key]!r}"
+
+    def test_a_mixed_width_payload_encodes_and_keeps_both_values(self) -> None:
+        """One payload, one width already accepted and one refused.
+
+        The coercion has to repair the refused value without disturbing the one
+        that already encoded.
+        """
+        payload = _host(_lidar_summary={"wide": np.float64(1.5), "narrow": np.float32(2.5)})._read_lidar_summary()
+        assert payload is not None
+        decoded = _encode(payload)
+        assert decoded["wide"] == pytest.approx(1.5)
+        assert decoded["narrow"] == pytest.approx(2.5)
+
+    def test_hands_payload_encodes(self) -> None:
+        """``_read_hands`` returns a mapping of per-hand records, so it nests."""
+        hands = _host(_hands={"left": {"q": np.array([0.1, 0.2]), "force": np.float32(3.5)}})._read_hands()
+        assert hands is not None
+        decoded = _encode(hands)
+        assert decoded["left"]["q"] == pytest.approx([0.1, 0.2])
+        assert decoded["left"]["force"] == pytest.approx(3.5)
+        assert decoded["left"]["hand"] == "left"
+
+    def test_a_container_of_readings_is_coerced_throughout(self) -> None:
+        """A reading can sit inside a list, or be a mapping key.
+
+        A per-beam list and a channel-indexed mapping are both ordinary shapes
+        for a lidar summary, and the encoder refuses a numpy value wherever it
+        sits: ``json.dumps`` rejects a ``float32`` key with "keys must be str,
+        int, float, bool or None" just as it rejects one as a value.
+        """
+        provider = {
+            "per_beam": [np.float32(1.0), np.int64(2)],
+            # A key inside a NESTED mapping: the top-level keys are coerced by
+            # _coerce_record, so this is what grades the recursive helper's own
+            # key handling.
+            "nested": {"inner": (np.float32(3.0),), np.int64(3): "beam-3"},
+            np.int64(7): "channel-7",
+        }
+        payload = _host(_lidar_summary=provider)._read_lidar_summary()
+        assert payload is not None
+        decoded = _encode(payload)
+        assert decoded["per_beam"] == pytest.approx([1.0, 2.0])
+        assert decoded["nested"]["inner"] == pytest.approx([3.0])
+        assert decoded["nested"]["3"] == "beam-3"
+        assert decoded["7"] == "channel-7"
+
+    def test_those_container_shapes_are_refused_raw(self) -> None:
+        """Premise for the case above: each shape is unencodable before coercion."""
+        shapes: tuple[dict[Any, Any], ...] = (
+            {"per_beam": [np.float32(1.0)]},
+            {"nested": {"inner": (np.float32(3.0),)}},
+            {"nested": {np.int64(3): "beam-3"}},
+            {np.int64(7): "x"},
+        )
+        for raw in shapes:
+            with pytest.raises(TypeError):
+                json.dumps(raw)
+
+    @pytest.mark.parametrize(("label", "attrs", "reader", "expected"), _ROWS, ids=_IDS)
+    def test_the_raw_reading_is_what_the_encoder_refuses(
+        self, label: str, attrs: dict[str, Any], reader: str, expected: dict[str, Any]
+    ) -> None:
+        """Premise: each row's provider value is unencodable before any coercion.
+
+        Without this the table above would pass on a payload that never needed
+        coercing, and the suite would grade nothing.
+        """
+        (provider_value,) = attrs.values()
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps(provider_value)
+
+
+class TestAPlainPayloadIsUnchanged:
+    """Control: a provider already reporting JSON values keeps today's payload."""
+
+    def test_plain_values_survive_verbatim(self) -> None:
+        provider = {"count": 200, "bbox": [-1.5, -2.5, 0.0], "label": "front"}
+        payload = _host(_lidar_summary=provider)._read_lidar_summary()
+        assert payload is not None
+        assert {k: v for k, v in payload.items() if k in provider} == provider
+
+    def test_the_encoder_accepts_one_numpy_width_and_refuses_another(self) -> None:
+        """Premise: the defect turned on the numpy WIDTH, which is why it hid.
+
+        ``np.float64`` subclasses Python's ``float`` and ``np.str_`` subclasses
+        ``str``, so a payload built from those always encoded; ``np.float32`` and
+        ``np.int64`` subclass nothing and were refused. A robot on a float64
+        pipeline therefore published fine, and the same code reading a float32
+        lidar - what a point cloud cast to ``float32`` yields - dropped every
+        tick.
+        """
+        assert json.dumps({"already-fine": np.float64(1.5)}) == '{"already-fine": 1.5}'
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps({"dropped": np.float32(1.5)})
+
+    def test_absent_providers_still_read_nothing(self) -> None:
+        host = _host()
+        assert host._read_lidar_summary() is None
+        assert host._read_lidar_state() is None
+        assert host._read_odom() is None
+        assert host._read_pose() is None
+        assert host._read_map_info() is None
+        assert host._read_hands() is None
+
+    def test_frame_and_source_defaults_are_still_applied(self) -> None:
+        odom = _host(_odom={"x": np.float32(1.0)})._read_odom()
+        pose = _host(_slam_pose={"x": np.float32(1.0)})._read_pose()
+        assert odom is not None and pose is not None
+        assert odom["frame"] == "odom"
+        assert pose["frame"] == "map"
+
+    def test_the_se3_pose_branch_is_untouched(self) -> None:
+        """The SE(3) branch already coerced with ``float()``; it must still decode."""
+        mat = np.eye(4)
+        mat[0, 3], mat[1, 3], mat[2, 3] = 1.0, 2.0, 3.0
+        decoded = _encode(_host(_pose=mat)._read_pose())
+        assert (decoded["x"], decoded["y"], decoded["z"]) == pytest.approx((1.0, 2.0, 3.0))
+        assert len(decoded["quat"]) == 4
+
+
+class TestTheCoercionDoesNotReachIntoRobotState:
+    """The payload is repaired; the robot's own readings are left as they are."""
+
+    def test_the_robot_s_own_provider_mapping_is_not_edited(self) -> None:
+        """Coercion rebuilds nested values; it must not reach into robot state.
+
+        ``_read_health`` stores the provider's ``_temps`` mapping in the payload
+        by reference, so coercing the payload in place must replace that entry
+        rather than rewrite the mapping the robot is still using.
+        """
+        temps = {"cpu": np.float32(41.5)}
+        host = _host(_temps=temps)
+        payload = host._read_health()
+        assert payload is not None
+        assert _encode(payload)["temps"]["cpu"] == pytest.approx(41.5)
+        assert type(temps["cpu"]) is np.float32, "the robot's own reading was rewritten"
+        assert temps is not payload["temps"]
+
+
+class TestAValueThatIsNotAReadingIsLeftForTheTransport:
+    """Over-reach boundary: coercion repairs readings, it does not launder payloads."""
+
+    def test_an_opaque_object_is_preserved_by_identity(self) -> None:
+        sentinel = object()
+        payload = _host(_map_info={"sensor": sentinel})._read_map_info()
+        assert payload is not None
+        assert payload["sensor"] is sentinel
+        # Still unencodable, so the transport reports it by name rather than a
+        # substituted value being published as though it were a reading.
+        with pytest.raises(TypeError):
+            json.dumps(payload)
+
+    def test_a_string_is_not_taken_apart_into_characters(self) -> None:
+        payload = _host(_lidar_state={"status": "ok", "code": np.int64(0)})._read_lidar_state()
+        assert payload is not None
+        assert payload["status"] == "ok"
+
+    def test_bytes_are_not_guessed_at(self) -> None:
+        blob = b"\x00\x01"
+        payload = _host(_map_info={"blob": blob})._read_map_info()
+        assert payload is not None
+        assert payload["blob"] is blob
+
+    def test_a_payload_deeper_than_the_bound_is_handed_over_unchanged(self) -> None:
+        """Past the depth bound the value goes to the encoder, which reports it.
+
+        A sensor record is shallow, so a deeper structure is a pathological
+        payload rather than a reading. Absorbing it here would replace the
+        transport's ERROR report with silence from the reader's own handler.
+        """
+        deep: dict[str, Any] = {"leaf": np.float32(1.0)}
+        for _ in range(_JSONABLE_MAX_DEPTH + 2):
+            deep = {"next": deep}
+        coerced = _jsonable(deep)
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps(coerced)
+
+
+class TestTheCoercionIsSingleSourced:
+    """Every reader routes its payload through the one helper, by construction.
+
+    Derived from the module rather than listed, so a reader added later is held
+    to the rule the moment it lands instead of inheriting an exemption.
+    """
+
+    @staticmethod
+    def _reader_defs() -> list[ast.FunctionDef]:
+        source = pathlib.Path(mesh_sensors.__file__).read_text(encoding="utf-8")
+        return [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("_read_")
+        ]
+
+    def test_every_payload_return_is_coerced(self) -> None:
+        """Each payload is handed to the coercion before the reader returns it."""
+        offenders: list[str] = []
+        for fn in self._reader_defs():
+            coerced: dict[str, int] = {}
+            for node in ast.walk(fn):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "_coerce_record"
+                    and node.args
+                    and isinstance(node.args[0], ast.Name)
+                ):
+                    name = node.args[0].id
+                    coerced[name] = min(coerced.get(name, node.lineno), node.lineno)
+            for node in ast.walk(fn):
+                if not isinstance(node, ast.Return) or node.value is None:
+                    continue
+                if isinstance(node.value, ast.Constant) and node.value.value is None:
+                    continue
+                returned = node.value.id if isinstance(node.value, ast.Name) else None
+                if returned is None and isinstance(node.value, ast.IfExp) and isinstance(node.value.body, ast.Name):
+                    returned = node.value.body.id
+                rendered = ast.unparse(node.value)
+                if returned is None:
+                    offenders.append(f"{fn.name} line {node.lineno}: unrecognised payload return {rendered}")
+                elif returned not in coerced:
+                    offenders.append(f"{fn.name} line {node.lineno}: return {rendered} is never coerced")
+                elif coerced[returned] > node.lineno:
+                    offenders.append(f"{fn.name} line {node.lineno}: return {rendered} precedes its coercion")
+        assert not offenders, "sensor payloads reach the wire uncoerced:\n" + "\n".join(offenders)
+
+    def test_the_scan_reaches_every_reader(self) -> None:
+        """Non-vacuity: the rule above is graded over the readers that exist."""
+        found = {fn.name for fn in self._reader_defs()}
+        assert {
+            "_read_pose",
+            "_read_health",
+            "_read_imu",
+            "_read_odom",
+            "_read_lidar_summary",
+            "_read_lidar_state",
+            "_read_hands",
+            "_read_map_info",
+        } <= found, f"reader discovery found only {sorted(found)}"


### PR DESCRIPTION
## Problem

`SensorLoopsMixin`'s readers merge the robot's provider mapping into the outgoing payload verbatim (`summary.update(data)`, `imu.update(imu_data)`, and six more), and every extended sensor topic is published as JSON -- `strands_robots.mesh.session._put_zenoh_directly` encodes the payload before it reaches the wire.

A payload the encoder refuses is not a transient failure the next tick retries. It fails identically forever, which is exactly why #2638 reports it at ERROR rather than absorbing it. The topic never publishes at all.

The values a sensor stack reports are numpy: a lidar summary's bounding box is whatever `ndarray.min(axis=0)` returned, an IMU's orientation a `float32`, a device state code an `int64`. Measured on `numpy 2.2.6`:

| provider value | `json.dumps` | subclasses a Python builtin |
|---|---|---|
| `np.float64` | encodes | `float` |
| `np.str_` | encodes | `str` |
| `np.float32` / `np.float16` | refused | no |
| `np.int32` / `np.int64` | refused | no |
| `np.bool_` | refused | no |
| `np.ndarray` | refused | no |

That asymmetry is why this survived: a robot on a float64 pipeline published fine, and the same code reading a `float32` point cloud dropped every tick.

### Reproduction

A robot exposing the documented provider attributes with its own readings, driven through the production readers and the encode `put` performs:

```
strands/neon/lidar/summary  DROPPED  Object of type ndarray is not JSON serializable
strands/neon/imu            DROPPED  Object of type ndarray is not JSON serializable
strands/neon/lidar/state    DROPPED  Object of type float32 is not JSON serializable
strands/neon/health         DROPPED  Object of type float32 is not JSON serializable
```

All four are gone from the mesh, with one ERROR line per topic to say so.

## Why the class already disagreed with itself

Three paths in this code coerce for exactly this reason:

- `_read_imu`'s inner-observation branch: `if hasattr(val, "tolist"): val = val.tolist()`
- `_read_pose`'s SE(3) branch: `pose["x"] = float(mat[0, 3])`
- `Mesh.publish_step`: `obs_numeric[key] = value.tolist()`

The eight readers that merge a provider mapping did not, so one class held two conventions for one wire format. The eight sites are `_read_pose` (x3, for `_pose`/`_slam_pose`/`_odom_pose`), `_read_imu`, `_read_odom`, `_read_lidar_summary`, `_read_lidar_state`, `_read_hands`, `_read_map_info`, plus `_read_health`'s two direct assignments of `_battery` and `_temps`.

## Change

Each reader hands its payload to one `_coerce_record` before returning it. Anything exposing `tolist()` becomes the equivalent Python list or number; lists, tuples and sets are rebuilt with their contents coerced, and mappings with their keys coerced too, because a `float32` is no more encodable as a key than as a value.

The coercion is applied entry by entry in place, so every reader keeps its declared `dict[str, Any] | None` return type and the diff adds no signature changes.

### The boundary

Coercion repairs readings; it does not launder payloads.

- A value that is **not** a reading -- an opaque object, a `bytes` blob -- is returned untouched, so it still reaches the encoder and #2638 still names it. Substituting something for it would publish a record that misreports what the sensor said.
- The recursion is **bounded**. A sensor record is shallow, so a structure deeper than the bound is a cycle or an object graph rather than a reading, and #2638's ERROR report is the right answer for those. Recursing into them here would replace a reported failure with one absorbed by the reader's own handler.
- Coercion never edits robot state. `_read_health` stores the provider's `_temps` mapping by reference, so the entry is replaced in the payload rather than rewritten underneath the robot. `_jsonable` never mutates; it returns a new container.

## Tests

`tests/mesh/test_sensor_payloads_are_json_encodable.py`, 36 cases, drives all eight readers and all three pose branches with the numpy a sensor stack reports and asserts on the **decoded** record a subscriber sees.

Every row carries a premise that its raw provider value is what the encoder refuses, so the table cannot pass on a payload that never needed coercing. The rule that each reader routes its payload through the coercion is derived from the module with `ast` rather than listed, so a reader added later is held to it on arrival, and a non-vacuity case asserts the discovery reaches all eight.

**Pre-fix split** (helpers present, all 12 call sites removed -- a raw revert is a collection error since the tests import the helpers):

| class | fail | role |
|---|---|---|
| `TestEveryReadingReachesTheWire` | 13 | regression |
| `TestTheCoercionDoesNotReachIntoRobotState` | 1 | regression |
| `TestTheCoercionIsSingleSourced` | 1 of 2 | the derived rule fires, its non-vacuity case passes |
| `TestAPlainPayloadIsUnchanged` | **0** of 5 | control |
| `TestAValueThatIsNotAReadingIsLeftForTheTransport` | **0** of 4 | over-reach boundary |

`15 failed, 21 passed`, and nothing in either control class.

**Break table** -- 13 mutations, 12 distinct firing sets, control clean, none undetected:

| row | mutation | fires |
|---|---|---|
| b0 | control (no mutation) | 0 |
| b1 | the coercion neutered | 14 |
| b2 | only `_read_lidar_summary` stops coercing | 4 |
| b3 | only `_read_health` stops coercing | 4 |
| b4 | only `_read_hands` stops coercing | 2 |
| b5 | a value that is not a reading is stringified instead of preserved | 2 |
| b6 | the container branch widened to `Sequence`, so a name is taken apart | 21 |
| b7 | nested mappings not recursed | 4 |
| b8 | mapping keys left uncoerced inside `_jsonable` | 1 |
| b9 | the list/tuple branch dropped | 1 |
| b10 | the depth bound removed | 1 |
| b11 | `tolist()` replaced by `float()`, which cannot render an array | 6 |
| b12 | the coercion recurses in place, editing the robot's own mapping | 2 |
| b13 | the payload's own keys left uncoerced | 1 |

b5 is worth naming: stringifying an unencodable value is the tempting alternative, and it is what the over-reach control refuses -- a record that reports `"<object at 0x...>"` where a reading belongs is a quieter wrong answer, not a fix. Source restored byte-identically after every row.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1546 files).
- `mypy` **24 == 24** against a pristine `main` worktree, normalised message sets byte-identical both directions, 0 in the changed files.
- Paired run over an identical 539-file selection (all of `tests/mesh/`, plus every test that walks the tree, reads source or docstrings, or touches the encode path), with the new file excluded from both trees: **21727 collected and `23 failed, 21608 passed, 72 skipped, 24 errors` on both**, 47 identical failing/error ids, `comm` empty in both directions. 45 of the 47 need `awsiot` (`awsiotsdk`, declared in the `[mesh-iot]` extra, confirmed absent via `find_spec`); 2 are a pre-existing lerobot-from-source `encode()` signature drift in `tests/training/test_lerobot.py`.

## Artifact

The same script, same seed, run on both trees: the four topics a robot with float32 readings publishes.

![sensor payload on the wire](https://github.com/cagataycali/robots/releases/download/artifacts/sensor_payload_wire.png)

The orange line in the left column is the report `_report_unencodable_payload` emits. It is correct and it is all that happened: the payload is still never published. This change is complementary to #2638 -- that one made the drop visible, this one stops the drop for the values that are readings.
