### PR TITLE
fix(vera): stop the LPIPS shim refusing a frame the real check accepts

### DIFF
--- a/changelog.d/2732-vera-lpips-shim-unnormalized-range.md
+++ b/changelog.d/2732-vera-lpips-shim-unnormalized-range.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **policies/vera/docker**: the LPIPS compat shim no longer refuses a frame the
+  check it stands in for accepts. VERA's DFoT metrics import `_valid_img` from
+  `torchmetrics.image.lpip`, where modern torchmetrics no longer keeps it, and
+  the image installs `sitecustomize_vera` as an auto-imported `sitecustomize` to
+  supply the name - so the shim's verdict, not the real one, is the verdict the
+  metric acts on. The two branches of the real check in
+  `torchmetrics.functional.image.lpips` are deliberately asymmetric: both ends of
+  `[0, 1]` are bounded when `normalize=True`, and only the LOWER end of
+  `[-1, 1]` when `normalize=False`, because a frame already in the network's own
+  range is allowed to overshoot `1.0` - which a decoder emitting a tanh-shaped
+  frame routinely does by a float step or two. The shim bounded the upper end on
+  both branches, and `_lpips_update` turns a `False` from that check into a
+  `ValueError`, so the added bound did not make the metric stricter, it made an
+  eval that the unshimmed torchmetrics runs raise inside the image. Measured
+  against torchmetrics 1.9.0, 3 of 14 `(frame, normalize)` cells disagreed with
+  the real check - all three `normalize=False` frames whose maximum exceeds
+  `1.0`, the smallest of them by one float32 step - and 14 of 14 agree now. The
+  `normalize=True` branch, the lower bound, and the rank and channel-count rules
+  are unchanged, and the comment claiming the reimplementation was faithful now
+  records the asymmetry and why it matters.

--- a/strands_robots/policies/vera/docker/sitecustomize_vera.py
+++ b/strands_robots/policies/vera/docker/sitecustomize_vera.py
@@ -29,13 +29,18 @@ def _apply() -> None:
         if priv is not None:
             _lpip.NoTrainLpips = priv
 
-    # _valid_img: removed from the public module in modern torchmetrics - provide
-    # a faithful reimplementation (range/shape check used by the LPIPS metric).
+    # _valid_img: removed from the public module in modern torchmetrics - mirror
+    # the surviving implementation in torchmetrics.functional.image.lpips, the one
+    # the metric itself calls. Its two branches are deliberately asymmetric:
+    # normalize=True bounds both ends of [0, 1], while normalize=False bounds only
+    # the LOWER end of [-1, 1]. Bounding the upper end here too would refuse a
+    # tensor the real check accepts, and _lpips_update turns a False into a
+    # ValueError - so a decoded frame that overshoots 1.0 by a float step would
+    # fail an eval that the unshimmed torchmetrics runs.
     if not hasattr(_lpip, "_valid_img"):
 
         def _valid_img(img, normalize: bool):  # noqa: ANN001
-
-            value_check = img.min() >= 0.0 and img.max() <= 1.0 if normalize else img.min() >= -1.0 and img.max() <= 1.0
+            value_check = img.min() >= 0.0 and img.max() <= 1.0 if normalize else img.min() >= -1.0
             return img.ndim == 4 and img.shape[1] == 3 and bool(value_check)
 
         _lpip._valid_img = _valid_img

--- a/tests/policies/vera/test_lpips_shim_accepts_what_the_metric_accepts.py
+++ b/tests/policies/vera/test_lpips_shim_accepts_what_the_metric_accepts.py
@@ -1,0 +1,283 @@
+"""The LPIPS compat shim accepts exactly what the check it stands in for accepts.
+
+:mod:`strands_robots.policies.vera.docker.sitecustomize_vera` exists because
+VERA's DFoT metrics import ``_valid_img`` and ``NoTrainLpips`` from
+``torchmetrics.image.lpip``, and modern torchmetrics keeps neither name there.
+The image installs the module as an auto-imported ``sitecustomize``, so it runs
+before anything else in the container and re-exposes both names on that module.
+VERA then calls the shim's ``_valid_img`` rather than the real one.
+
+That makes the shim's verdict the metric's verdict, and the two branches of the
+real check are deliberately asymmetric. ``torchmetrics.functional.image.lpips``
+bounds both ends of ``[0, 1]`` when ``normalize=True`` and only the LOWER end of
+``[-1, 1]`` when ``normalize=False``: a frame already in the network's own range
+is allowed to overshoot ``1.0``, which is what a decoder emitting a tanh-shaped
+frame routinely does. ``_lpips_update`` turns a ``False`` from that check into a
+``ValueError``, so an upper bound added on the ``normalize=False`` side does not
+make the metric stricter - it makes an otherwise healthy eval raise.
+
+The cases below are graded against the range each frame actually carries rather
+than against a hand-written expectation, and the table is checked for the
+asymmetry itself, so a shim that collapses the two branches into one rule is
+caught here instead of in a container.
+
+The frames are plain :class:`numpy.ndarray` objects. The real check is duck-typed
+over ``min``/``max``/``ndim``/``shape``, and torch is not a dependency of this
+package, so an array is both a faithful stand-in and one that runs everywhere.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+# The container helpers are excluded from type checking (``tool.mypy.exclude``):
+# they are written against the dependency set of the image, where ``torchmetrics``
+# is installed and is not stubbed here. Reaching the module by name is how
+# tests/policies/vera/test_offline_ckpt_index_skips_an_unusable_provenance_record.py
+# reaches its own subject on that same path: it keeps an excluded module out of
+# this file's static import graph and types it as ``Any``, which is all an
+# unchecked module is worth to a caller.
+shim: Any = importlib.import_module("strands_robots.policies.vera.docker.sitecustomize_vera")
+
+# The smallest float32 above 1.0. A frame that overshoots by exactly this much is
+# the sharpest form of the case the shim used to refuse.
+FLOAT32_STEP_ABOVE_ONE = float(np.nextafter(np.float32(1.0), np.float32(2.0)))
+
+
+def _module(name: str, **attrs: Any) -> Any:
+    """A stand-in module carrying the attributes an importer will read off it."""
+    module: Any = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+class _PrivateNoTrainLpips:
+    """Stands in for the class modern torchmetrics keeps under a leading underscore."""
+
+
+def _install_torchmetrics(monkeypatch: pytest.MonkeyPatch, **lpip_attrs: Any) -> Any:
+    """Make ``torchmetrics.image.lpip`` importable, as it is inside the image.
+
+    Args:
+        monkeypatch: Fixture used to restore every ``sys.modules`` entry.
+        lpip_attrs: Attributes to place on the ``lpip`` stand-in. Omitting
+            ``_valid_img`` / ``NoTrainLpips`` reproduces the modern layout the
+            shim exists for.
+
+    Returns:
+        The ``torchmetrics.image.lpip`` stand-in the shim will patch.
+    """
+    lpip = _module("torchmetrics.image.lpip", **lpip_attrs)
+    image = _module("torchmetrics.image", __path__=[], lpip=lpip)
+    torchmetrics = _module("torchmetrics", __path__=[], image=image)
+    for name, module in (
+        ("torchmetrics", torchmetrics),
+        ("torchmetrics.image", image),
+        ("torchmetrics.image.lpip", lpip),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+    return lpip
+
+
+def _applied(monkeypatch: pytest.MonkeyPatch, **lpip_attrs: Any) -> Any:
+    """Install the stand-in, run the shim over it, and hand back the module."""
+    lpip = _install_torchmetrics(monkeypatch, _NoTrainLpips=_PrivateNoTrainLpips, **lpip_attrs)
+    shim._apply()
+    return lpip
+
+
+def _frame(low: float, high: float, *, batch: int = 1, channels: int = 3, dims: int = 4) -> np.ndarray:
+    """A frame batch spanning exactly ``[low, high]``.
+
+    Args:
+        low: Value planted in the first element, so ``min()`` is exactly this.
+        high: Value planted in the last element, so ``max()`` is exactly this.
+        batch: Leading batch dimension.
+        channels: Channel count - the check demands 3.
+        dims: Rank of the result - the check demands 4.
+
+    Returns:
+        A ``float32`` array whose extremes are the two arguments.
+    """
+    shape = (batch, channels) + (2,) * (dims - 2) if dims >= 2 else (batch,) * dims
+    array = np.full(shape, (low + high) / 2.0, dtype=np.float32)
+    flat = array.reshape(-1)
+    flat[0] = low
+    flat[-1] = high
+    return array
+
+
+# Each entry is a frame plus the verdict the real check returns for it, on both
+# branches. The verdicts are not free choices: they follow from the frame's own
+# range under the rule ``normalize`` bounds ``[0, 1]`` at both ends and
+# ``not normalize`` bounds ``[-1, ...]`` from below only.
+CASES: tuple[tuple[str, np.ndarray, bool, bool], ...] = (
+    ("the-unit-range", _frame(0.0, 1.0), True, True),
+    ("a-narrow-band-inside-the-unit-range", _frame(0.2, 0.8), True, True),
+    ("the-network-range", _frame(-1.0, 1.0), False, True),
+    ("one-float-step-above-the-network-range", _frame(-1.0, FLOAT32_STEP_ABOVE_ONE), False, True),
+    ("a-visible-overshoot-above-one", _frame(-1.0, 1.05), False, True),
+    ("far-above-one", _frame(-1.0, 3.0), False, True),
+    ("below-minus-one", _frame(-1.05, 1.0), False, False),
+    ("far-below-minus-one", _frame(-4.0, 0.5), False, False),
+)
+
+_IDS = tuple(case[0] for case in CASES)
+
+
+class TestTheCaseTableIsWhatItClaims:
+    """Each expected verdict follows from the frame's range, and both branches differ."""
+
+    @pytest.mark.parametrize(("label", "frame", "normalized", "unnormalized"), CASES, ids=_IDS)
+    def test_each_verdict_follows_from_the_range_the_frame_carries(
+        self, label: str, frame: np.ndarray, normalized: bool, unnormalized: bool
+    ) -> None:
+        low, high = float(frame.min()), float(frame.max())
+        assert normalized == (low >= 0.0 and high <= 1.0), f"{label}: normalized verdict contradicts [{low}, {high}]"
+        assert unnormalized == (low >= -1.0), f"{label}: unnormalized verdict contradicts a low of {low}"
+
+    def test_both_verdicts_occur_on_both_branches(self) -> None:
+        assert {case[2] for case in CASES} == {True, False}, "the normalized column never refuses or never accepts"
+        assert {case[3] for case in CASES} == {True, False}, "the unnormalized column never refuses or never accepts"
+
+    def test_the_asymmetry_between_the_branches_is_represented(self) -> None:
+        disagreeing = [case[0] for case in CASES if case[2] != case[3]]
+        assert disagreeing, "no case distinguishes the two branches, so a single shared rule would pass"
+
+    def test_an_overshoot_above_one_is_represented(self) -> None:
+        overshooting = [case[0] for case in CASES if float(case[1].max()) > 1.0]
+        assert overshooting, "no case overshoots 1.0, so the upper bound under test is never reached"
+
+
+class TestTheShimReproducesTheCheckItStandsIn:
+    """The installed ``_valid_img`` answers what the real one answers."""
+
+    @pytest.mark.parametrize(("label", "frame", "normalized", "unnormalized"), CASES, ids=_IDS)
+    def test_the_verdict_matches_on_both_branches(
+        self, monkeypatch: pytest.MonkeyPatch, label: str, frame: np.ndarray, normalized: bool, unnormalized: bool
+    ) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(frame, True) is normalized, f"{label}: wrong verdict with normalize=True"
+        assert lpip._valid_img(frame, False) is unnormalized, f"{label}: wrong verdict with normalize=False"
+
+    def test_the_verdict_is_a_plain_bool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A caller reading the result with ``is True`` needs a bool, not an array scalar."""
+        lpip = _applied(monkeypatch)
+        assert type(lpip._valid_img(_frame(0.0, 1.0), True)) is bool
+
+
+class TestTheUnnormalizedBranchIsBoundedOnlyFromBelow:
+    """A frame already in the network's range may overshoot 1.0."""
+
+    def test_one_float_step_above_one_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lpip = _applied(monkeypatch)
+        frame = _frame(-1.0, FLOAT32_STEP_ABOVE_ONE)
+        assert float(frame.max()) > 1.0, "the frame does not overshoot, so it grades nothing"
+        assert lpip._valid_img(frame, False) is True
+
+    @pytest.mark.parametrize("high", [1.0, FLOAT32_STEP_ABOVE_ONE, 1.05, 2.0, 10.0, 1.0e6])
+    def test_raising_the_upper_extreme_never_turns_an_accept_into_a_refusal(
+        self, monkeypatch: pytest.MonkeyPatch, high: float
+    ) -> None:
+        """The derived form of "no upper bound": the branch is monotone in ``max``."""
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(-1.0, high), False) is True
+
+    @pytest.mark.parametrize("low", [-1.0 - 1.0e-3, -1.05, -2.0, -100.0])
+    def test_the_lower_bound_is_still_enforced(self, monkeypatch: pytest.MonkeyPatch, low: float) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(low, 0.5), False) is False
+
+    def test_minus_one_itself_is_inside_the_range(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(-1.0, 0.5), False) is True
+
+
+class TestTheNormalizedBranchIsBoundedAtBothEnds:
+    """Widening the other branch must not widen this one with it."""
+
+    @pytest.mark.parametrize("high", [FLOAT32_STEP_ABOVE_ONE, 1.05, 2.0])
+    def test_an_overshoot_above_one_is_refused(self, monkeypatch: pytest.MonkeyPatch, high: float) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(0.0, high), True) is False
+
+    @pytest.mark.parametrize("low", [-1.0e-3, -1.0, -2.0])
+    def test_anything_below_zero_is_refused(self, monkeypatch: pytest.MonkeyPatch, low: float) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(low, 1.0), True) is False
+
+    def test_the_closed_unit_range_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(0.0, 1.0), True) is True
+
+
+class TestTheShapeRulesAreUnchanged:
+    """A range check that accepts more must not accept a frame of the wrong shape."""
+
+    @pytest.mark.parametrize("normalize", [True, False])
+    @pytest.mark.parametrize("dims", [2, 3, 5])
+    def test_only_a_rank_four_batch_is_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, normalize: bool, dims: int
+    ) -> None:
+        lpip = _applied(monkeypatch)
+        frame = _frame(0.0, 1.0, dims=dims)
+        assert frame.ndim == dims
+        assert lpip._valid_img(frame, normalize) is False
+
+    @pytest.mark.parametrize("normalize", [True, False])
+    @pytest.mark.parametrize("channels", [1, 2, 4])
+    def test_only_three_channels_are_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, normalize: bool, channels: int
+    ) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip._valid_img(_frame(0.0, 1.0, channels=channels), normalize) is False
+
+
+class TestNoTrainLpipsIsReExposed:
+    """The other name VERA imports from that module."""
+
+    def test_the_public_name_becomes_the_private_class(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lpip = _applied(monkeypatch)
+        assert lpip.NoTrainLpips is _PrivateNoTrainLpips
+
+    def test_a_module_carrying_neither_spelling_is_left_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Nothing to alias means nothing is invented under the public name."""
+        lpip = _install_torchmetrics(monkeypatch)
+        shim._apply()
+        assert not hasattr(lpip, "NoTrainLpips")
+
+
+class TestTheShimOnlyFillsInWhatIsMissing:
+    """A name the installed torchmetrics still provides is the one that is used."""
+
+    def test_an_existing_valid_img_is_not_replaced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sentinel = object()
+        lpip = _applied(monkeypatch, _valid_img=sentinel)
+        assert lpip._valid_img is sentinel
+
+    def test_an_existing_public_no_train_lpips_is_not_replaced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _PublicNoTrainLpips:
+            pass
+
+        lpip = _applied(monkeypatch, NoTrainLpips=_PublicNoTrainLpips)
+        assert lpip.NoTrainLpips is _PublicNoTrainLpips
+
+    def test_torchmetrics_being_absent_is_not_an_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The shim rides on ``sitecustomize``, so a raise here would break the interpreter."""
+        monkeypatch.setitem(sys.modules, "torchmetrics", None)
+        monkeypatch.delitem(sys.modules, "torchmetrics.image", raising=False)
+        monkeypatch.delitem(sys.modules, "torchmetrics.image.lpip", raising=False)
+        shim._apply()
+
+    def test_applying_the_shim_twice_keeps_the_first_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lpip = _applied(monkeypatch)
+        first = lpip._valid_img
+        shim._apply()
+        assert lpip._valid_img is first


### PR DESCRIPTION
## Problem

VERA's DFoT metrics import `NoTrainLpips` and `_valid_img` from
`torchmetrics.image.lpip`. Modern torchmetrics keeps neither name there, so the
image installs `strands_robots/policies/vera/docker/sitecustomize_vera.py` as an
auto-imported `sitecustomize` (`Dockerfile:107`) and re-exposes both. VERA then
calls the shim's `_valid_img`, which makes the shim's verdict the metric's
verdict.

The real check, still present at `torchmetrics.functional.image.lpips`, is
deliberately asymmetric:

```python
def _valid_img(img: Tensor, normalize: bool) -> bool:
    """Check that input is a valid image to the network."""
    value_check = img.max() <= 1.0 and img.min() >= 0.0 if normalize else img.min() >= -1
    return img.ndim == 4 and img.shape[1] == 3 and value_check
```

`normalize=True` bounds both ends of `[0, 1]`; `normalize=False` bounds only the
**lower** end of `[-1, 1]`, because a frame already in the network's own range is
allowed to overshoot `1.0` - which a decoder emitting a tanh-shaped frame does
routinely, by a float step or two. The shim bounded the upper end on both
branches, and `_lpips_update` turns a `False` from this check into a
`ValueError`, so the extra bound did not make the metric stricter: it made an
eval that the unshimmed torchmetrics runs raise inside the image.

## Measured against real torchmetrics 1.9.0 (torch 2.11.0)

Same tensor, real `_valid_img` beside the shipped shim. 3 of 14
`(frame, normalize)` cells disagreed on `main`; 14 of 14 agree on this branch.

| frame range | `normalize` | torchmetrics | shim on `main` | this branch |
|---|---|---|---|---|
| `[0.0, 1.0]` | True | accept | accept | accept |
| `[0.0, 1.0]` | False | accept | accept | accept |
| `[0.2, 0.8]` | True | accept | accept | accept |
| `[0.2, 0.8]` | False | accept | accept | accept |
| `[-1.0, 1.0]` | True | refuse | refuse | refuse |
| `[-1.0, 1.0]` | False | accept | accept | accept |
| `[-1.0, 1.0000001192092896]` (one float32 step over) | True | refuse | refuse | refuse |
| `[-1.0, 1.0000001192092896]` | False | accept | **refuse** | accept |
| `[-1.0, 1.05]` | True | refuse | refuse | refuse |
| `[-1.0, 1.05]` | False | accept | **refuse** | accept |
| `[-1.0, 3.0]` | True | refuse | refuse | refuse |
| `[-1.0, 3.0]` | False | accept | **refuse** | accept |
| `[-1.05, 1.0]` | True | refuse | refuse | refuse |
| `[-1.05, 1.0]` | False | refuse | refuse | refuse |

What the metric then does with a `[-1.0, 1.05]` frame at `normalize=False`,
through the real `torchmetrics.functional.image.lpips._lpips_update`:

| | outcome |
|---|---|
| real `_valid_img` | check passed (reached the LPIPS network) |
| shim on `main` | `ValueError: Expected both input arguments to be normalized tensors with shape [N, 3, H, W]` |
| shim on this branch | check passed (reached the LPIPS network) |

## Change

One expression, plus the comment above it. The `normalize=False` branch drops the
upper bound so it mirrors the check it stands in for; the comment now records the
asymmetry and why it is load-bearing, in place of the claim that the
reimplementation was faithful.

```diff
-            value_check = img.min() >= 0.0 and img.max() <= 1.0 if normalize else img.min() >= -1.0 and img.max() <= 1.0
+            value_check = img.min() >= 0.0 and img.max() <= 1.0 if normalize else img.min() >= -1.0
```

The `normalize=True` branch, the lower bound, the rank and channel-count rules,
the `NoTrainLpips` alias and the "only fill in what is missing" guards are
unchanged.

## Tests

`tests/policies/vera/test_lpips_shim_accepts_what_the_metric_accepts.py`, 57
cases. torchmetrics is not a dependency of this package, so the suite installs a
`torchmetrics.image.lpip` stand-in shaped like the modern layout (private
`_NoTrainLpips`, no `_valid_img`) and drives the shim over plain
`numpy.ndarray` frames - the real check is duck-typed over
`min`/`max`/`ndim`/`shape`, so an array is a faithful stand-in that runs
everywhere.

The case table is graded against the range each frame actually carries rather
than against a hand-written expectation, and the table itself is checked for the
property that makes it interesting: that the two branches disagree somewhere, and
that some frame overshoots `1.0`. A shim collapsing both branches into one shared
rule fails there rather than passing quietly.

Pre-fix split on this file: **9 failed, 48 passed**, with zero failures in the
case-table, `normalize=True`, shape-rule, `NoTrainLpips` and
"only-fill-in-what-is-missing" classes. The headline failure is
`test_one_float_step_above_one_is_accepted`.

## Mutation coverage

Each row is one mutation of the fixed module, graded against the new file. The 11
mutations that produce failures have 11 distinct firing sets.

| mutation | failed | firing classes |
|---|---|---|
| control (no mutation) | 0 | - |
| the upper bound restored on the `normalize=False` branch (the defect) | 9 | ReproducesTheCheck, UnnormalizedBranch |
| one shared rule for both branches (`normalize` ignored) | 9 | NormalizedBranch, ReproducesTheCheck |
| the `normalize=True` branch loses its upper bound | 3 | NormalizedBranch |
| the `normalize=False` lower bound dropped | 6 | ReproducesTheCheck, UnnormalizedBranch |
| the `normalize=False` lower bound made strict (`> -1.0`) | 12 | ReproducesTheCheck, UnnormalizedBranch |
| the two branches swapped | 17 | all three range classes |
| the rank check dropped | 6 | ShapeRules |
| the channel-count check dropped | 6 | ShapeRules |
| the verdict left as an array scalar instead of a `bool` | 28 | all three range classes |
| an already-installed `_valid_img` overwritten anyway | 2 | OnlyFillsInWhatIsMissing |
| an already-installed `NoTrainLpips` overwritten anyway | 1 | OnlyFillsInWhatIsMissing |
| the absent-torchmetrics handler narrowed away | 1 error | whole file (collection error) |

The last row is reported honestly as an error rather than a failure: the module
calls `_apply()` at import, so a handler that no longer catches the absent
dependency stops the module importing at all - `ModuleNotFoundError: No module
named 'torchmetrics'` out of `sitecustomize`, which is the reason that handler is
broad. The module source was restored byte-identical after every row.

## Coverage

`strands_robots/policies/vera/docker/sitecustomize_vera.py` was the
lowest-covered module in the package. Both numbers are from full
`pytest tests/` runs with `--cov=strands_robots`, one per tree:

| | statements | missing | covered |
|---|---|---|---|
| `main` | 16 | 9 (lines 27-41) | 44% |
| this branch | 16 | 0 | 100% |

Package total missing 1888 to 1878, with the statement count unchanged at 45871.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1546 files).
- `mypy strands_robots tests tests_integ`: **5 == 5** against a pristine `main`
  worktree, normalized message sets byte-identical in both directions, none in
  the changed files. The container helpers are in `tool.mypy.exclude`, and the
  test reaches its subject by name for the same reason its sibling on that path
  does.
- Full `pytest tests/` on both trees: `main` **29 failed, 38403 passed, 309
  skipped, 24 errors** (38765 collected); this branch **29 failed, 38460 passed,
  309 skipped, 24 errors** (38822 collected). `+57` is exactly the new cases, and
  the 53 failing/erroring ids are identical with an empty set difference in both
  directions (44 need `awsiot` from the `mesh-iot` extra; the rest are
  pre-existing on `main`).
- New file: 57 passed.

## Artifact

The two columns are the same measurement run against each tree with real
torchmetrics 1.9.0 installed, since CI does not have that dependency and cannot
produce this comparison.

![shim vs torchmetrics agreement](https://github.com/cagataycali/robots/releases/download/artifacts/lpips_shim_agreement.png)
