### PR TITLE
feat(hardware): choose which driver builds a real robot

### DIFF
--- a/changelog.d/2734-hardware-driver-seam.md
+++ b/changelog.d/2734-hardware-driver-seam.md
@@ -1,0 +1,32 @@
+### Added: choose which driver builds a real robot
+
+`Robot(name, mode="real")` built exactly one thing - `strands_robots.hardware_robot.Robot`,
+which constructs a lerobot `RobotConfig` and wraps a lerobot driver. That is the right driver
+for every robot in the shipped registry and the wrong shape for a robot lerobot does not
+model: a humanoid with its own state machine, a rover reporting GPS, a base publishing a
+point cloud. There was no seam to reach anything else through, and nothing recorded which
+members of that 3000-line class the mesh, the teleop rail and the agent tool surface actually
+rely on - so a driver author had to read it to find out.
+
+`driver=` now selects the implementation: `"auto"` (the default) honours a robot's registry
+`hardware.driver` and otherwise builds the lerobot driver, `"lerobot"` pins that path, and
+`"strands"` builds the native driver registered for the robot via
+`strands_robots.drivers.register_native_driver`. Asking for a native driver that is not there
+is refused by name, listing the robots that do have one and both remedies, rather than being
+quietly served the lerobot driver - a caller who got the substitute would debug the wrong
+robot. The value is checked in every mode, so a typo is not accepted by whichever branch
+happens not to read it, and a driver name added to the vocabulary without a route in the
+factory is refused instead of taking a neighbour's branch.
+
+`strands_robots.drivers.HardwareDriver` writes the contract down, and it is the measured one
+rather than an aspirational one: `get_observation` is not a member (the mesh reads it from the
+driver's inner device), and neither are the sensor attributes a mesh publishes (`_pose`,
+`_imu` and their siblings are all read with a `getattr` default, so a driver with no lidar is
+complete). `register_native_driver` refuses a class that does not satisfy it and names the
+members it lacks, so a driver missing `stream` fails where it is registered rather than on
+the first agent call. Both drivers take the same post-build path onto the mesh, because a
+robot that is built but never published is one no peer can see.
+
+The default path is unchanged, and that is what the tests pin hardest: not mentioning
+`driver`, `driver="auto"` and `driver="lerobot"` build the same class with the same lerobot
+config.

--- a/docs/getting-started/robot-factory.md
+++ b/docs/getting-started/robot-factory.md
@@ -29,6 +29,7 @@ robot = Robot("so100", mode="auto")  # probes USB, falls back to sim
 | `peer_id` | str | `None` | Stable mesh peer id. Auto-generated if omitted. |
 | `orientation` | list | `None` | Robot base orientation `[w, x, y, z]` in sim world. Ignored when `mode="real"` (reported at debug level). |
 | `keyframe` | str \| int | `None` | Spawn in a model `<keyframe>` pose (name or index) instead of the zero configuration. Ignored when `mode="real"` (reported at debug level). |
+| `driver` | str | `"auto"` | Which implementation drives a real robot: `"auto"` / `"lerobot"` / `"strands"`. `"auto"` honours the robot's registry `hardware.driver` and otherwise builds the lerobot driver. Checked in every mode; only `mode="real"` acts on it (sim reports it as ignored at debug level). See [Choosing a driver](#choosing-a-driver). |
 | `**kwargs` | | | Forwarded to the backend or driver constructor as given. A name it does not recognize is ignored, not refused, so check the spelling against the forwardable list below. |
 
 ## Name resolution
@@ -75,6 +76,56 @@ opened - a non-finite limit would otherwise disable the clamp with no signal, an
 one inverts it into a fixed-magnitude step that ignores the policy. An `int` limit is
 normalized to `float` so it reaches the motors. Omit the parameter (or pass `None`) to leave
 the clamp disabled.
+
+## Choosing a driver
+
+`mode="real"` builds a driver. By default that is the lerobot one - it constructs a lerobot
+`RobotConfig` and wraps a lerobot driver, which is what every robot in the shipped registry
+uses.
+
+`driver=` selects a different one:
+
+| Value | Builds |
+|-------|--------|
+| `"auto"` (default) | The robot's registry `hardware.driver` if it declares one, else the lerobot driver. |
+| `"lerobot"` | The lerobot driver, explicitly. |
+| `"strands"` | The native driver registered for this robot. |
+
+A native driver is for a robot lerobot's arm/serial shape cannot model - a humanoid with its
+own state machine, a rover reporting GPS, a base publishing a point cloud. It is a separate
+class satisfying `strands_robots.drivers.HardwareDriver`, registered against a robot name:
+
+```python
+from strands_robots.drivers import register_native_driver
+
+register_native_driver("unitree_g1", G1Driver)
+
+robot = Robot("unitree_g1", mode="real", driver="strands", port="192.168.123.161")
+```
+
+`register_native_driver` refuses a class that does not satisfy the contract and names the
+members it is missing, so a half-built driver fails at the line that registers it rather
+than on the first agent call. `port=` stays polymorphic - a serial path, an IP address or a
+URL - because only the driver knows how to read it.
+
+Asking for a driver that is not there is refused, never quietly substituted:
+
+```python
+>>> Robot("so101", mode="real", driver="strands")
+ValueError: No native driver is registered for 'so101', so driver='strands' cannot build
+it. Robots with a native driver: none. Either use driver='lerobot' (today's default, which
+builds it through lerobot) or register one with
+strands_robots.drivers.register_native_driver().
+```
+
+A robot may also declare its driver in the registry, so a caller needs no `driver=` at all:
+
+```json
+"unitree_g1": {"hardware": {"lerobot_type": "unitree_g1", "driver": "strands"}}
+```
+
+`hardware.driver` is optional and validated when the registry loads: a value that is not a
+driver name is refused there, naming the robot, rather than being read as "no preference".
 
 ## Mesh
 

--- a/docs/hardware/robot-control.md
+++ b/docs/hardware/robot-control.md
@@ -137,6 +137,14 @@ robot.stop_teleop()   # stop all sessions
 | Policy execution | `run_policy()` / `start_policy()` | `start_task()` / `execute` action |
 | Rollout horizon | `duration` **or** `n_steps` (`n_steps` supersedes it) | `duration` **and** `n_steps` (ANDed, so `duration` always bounds it) |
 
+## Not only lerobot
+
+`HardwareRobot` is the driver `Robot(name, mode="real")` builds by default, and it is
+lerobot-shaped throughout. A robot lerobot does not model is built through the same factory
+with `driver="strands"`, against the contract
+`strands_robots.drivers.HardwareDriver` - which `HardwareRobot` itself satisfies. See
+[Choosing a driver](../getting-started/robot-factory.md#choosing-a-driver).
+
 ## See also
 
 - [Hardware tools](tools.md) - calibrate / camera / teleop helpers.

--- a/strands_robots/drivers/__init__.py
+++ b/strands_robots/drivers/__init__.py
@@ -1,0 +1,41 @@
+"""Driver seam for ``Robot(..., mode="real")``.
+
+:class:`~strands_robots.drivers.base.HardwareDriver` is the contract a real
+robot satisfies; :mod:`strands_robots.drivers.registry` decides which
+implementation a given robot gets. A driver package that is not lerobot-shaped
+registers itself here::
+
+    from strands_robots.drivers import register_native_driver
+
+    register_native_driver("unitree_g1", G1Driver)
+
+and ``Robot("unitree_g1", mode="real", driver="strands")`` then builds it.
+"""
+
+from strands_robots.drivers.base import (
+    DEFAULT_DRIVER,
+    DRIVER_CHOICES,
+    DRIVER_SURFACE,
+    HardwareDriver,
+    missing_driver_members,
+)
+from strands_robots.drivers.registry import (
+    driver_choice_error,
+    get_native_driver_class,
+    list_native_drivers,
+    register_native_driver,
+    resolve_driver,
+)
+
+__all__ = [
+    "DEFAULT_DRIVER",
+    "DRIVER_CHOICES",
+    "DRIVER_SURFACE",
+    "HardwareDriver",
+    "driver_choice_error",
+    "get_native_driver_class",
+    "list_native_drivers",
+    "missing_driver_members",
+    "register_native_driver",
+    "resolve_driver",
+]

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -1,0 +1,220 @@
+"""The contract a ``mode="real"`` driver satisfies.
+
+:func:`~strands_robots.robot.Robot` with ``mode="real"`` builds one object and
+hands it to everything downstream: a Strands agent invokes it as a tool, the
+Zenoh mesh publishes from it, and the teleop rail commands through it. Until a
+second implementation existed that object was always
+:class:`strands_robots.hardware_robot.Robot`, so the surface those consumers
+rely on was recorded nowhere - a driver author had to read a 3000-line class to
+learn which members are load-bearing.
+
+:class:`HardwareDriver` writes that surface down. It is deliberately the
+*measured* contract rather than an aspirational one, which makes it smaller than
+a reader might expect:
+
+* ``get_observation`` is **not** a member. The mesh reads observations from the
+  driver's *inner* device (``getattr(robot, "robot", None)`` in
+  :mod:`strands_robots.mesh.sensors`), and
+  :func:`strands_robots.bus_access.read_observation` takes that inner device -
+  so the top-level driver is not the thing asked for a frame.
+* The sensor attributes a mesh publishes (``_pose``, ``_imu``, ``_battery`` and
+  their siblings) are **not** members either. Every one is read with a
+  ``getattr(robot, name, None)`` default, so a driver with no IMU publishes no
+  IMU topic and is otherwise complete - making them optional by construction. A
+  Protocol cannot express "optional", and requiring them would refuse a
+  perfectly good arm for lacking a lidar.
+
+What remains is the surface a driver must have for an agent to call it and for
+the mesh's command and task paths to work. The four tool members
+(``tool_name``, ``tool_type``, ``tool_spec``, ``stream``) are also the abstract
+surface of :class:`strands.tools.tools.AgentTool`, which is what makes an object
+usable as a Strands tool at all.
+
+Structural, not nominal: a driver satisfies this by having the members, with no
+import of - or inheritance from - anything here. Inheriting ``AgentTool`` is
+still the easy way to get the tool quarter right.
+
+Constructor contract (a Protocol cannot express ``__init__``): the factory
+builds a native driver as
+``driver_cls(tool_name=<canonical name>, cameras=<cameras or None>,
+data_config=<data_config or None>, **kwargs)``, so a driver must accept those
+three keywords and tolerate the caller's extras. ``port=`` arrives in
+``**kwargs`` and stays polymorphic - a serial path, an IP address or a URL,
+interpreted by the driver that receives it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from strands.types.tools import ToolSpec, ToolUse
+
+    from strands_robots.policies import Policy
+
+
+@runtime_checkable
+class HardwareDriver(Protocol):
+    """The surface :func:`~strands_robots.robot.Robot` ``mode="real"`` returns.
+
+    See the module docstring for what is deliberately absent and why.
+    """
+
+    # --- Agent tool surface (also ``AgentTool``'s abstract members) --------- #
+
+    @property
+    def tool_name(self) -> str:
+        """Name the agent invokes this robot by."""
+
+    @property
+    def tool_type(self) -> str:
+        """Tool kind reported to the agent runtime."""
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        """Schema describing the actions the agent may request."""
+
+    def stream(self, tool_use: ToolUse, invocation_state: dict[str, Any], **kwargs: Any) -> AsyncGenerator[Any, None]:
+        """Run one agent tool call, yielding events and finally the result.
+
+        Args:
+            tool_use: The agent's request, carrying the tool id and parameters.
+            invocation_state: Caller-provided state passed to the agent.
+            **kwargs: Additional keyword arguments, for forward compatibility.
+
+        Yields:
+            Tool events, the last of which is the tool result. Spelled out
+            rather than borrowing ``strands.types.tools.ToolGenerator``, which
+            is an alias for exactly this type: the reference implementation
+            spells it out too, and naming the alias would add an SDK symbol this
+            package does not otherwise depend on.
+        """
+
+    # --- Command path ------------------------------------------------------ #
+
+    def send_action(self, action: dict[str, Any], robot_name: str | None = None) -> dict[str, Any]:
+        """Command one action.
+
+        Args:
+            action: Joint targets, keyed the way this driver names its joints.
+            robot_name: Which robot to command when the driver fronts several;
+                ``None`` means the driver's own robot.
+
+        Returns:
+            A status envelope describing what was commanded.
+        """
+
+    # --- Task and policy path ---------------------------------------------- #
+
+    def start_task(
+        self,
+        instruction: str,
+        policy_port: int | None = None,
+        policy_host: str = "localhost",
+        policy_provider: str = "groot",
+        duration: float = 30.0,
+        **policy_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Start a policy-driven task in the background.
+
+        Args:
+            instruction: Natural-language instruction for the policy.
+            policy_port: Port the policy server listens on; ``None`` uses the
+                provider's default.
+            policy_host: Host the policy server runs on.
+            policy_provider: Which policy provider to build.
+            duration: Wall-clock budget for the task, in seconds.
+            **policy_kwargs: Extra provider-specific policy options.
+
+        Returns:
+            A status envelope describing the task that started.
+        """
+
+    def run_policy(
+        self,
+        policy_object: Policy,
+        instruction: str = "",
+        duration: float = 30.0,
+        n_steps: int | None = None,
+    ) -> dict[str, Any]:
+        """Run an already-built policy against this robot.
+
+        Args:
+            policy_object: The policy to roll out.
+            instruction: Natural-language instruction handed to the policy.
+            duration: Wall-clock budget for the rollout, in seconds.
+            n_steps: Step budget; when given it wins over ``duration``.
+
+        Returns:
+            A status envelope describing the rollout.
+        """
+
+    def get_task_status(self) -> dict[str, Any]:
+        """Report the running task's state.
+
+        Returns:
+            A status envelope; the shape a caller polls between steps.
+        """
+
+    def stop_task(self) -> dict[str, Any]:
+        """Stop the running task.
+
+        Returns:
+            A status envelope describing what was stopped.
+        """
+
+    # --- Lifecycle --------------------------------------------------------- #
+
+    async def get_status(self) -> dict[str, Any]:
+        """Report the driver's own health and connection state.
+
+        Returns:
+            A status envelope the mesh publishes as this peer's presence.
+        """
+
+    async def stop(self) -> None:
+        """Stop motion and any background loop, leaving the robot connected."""
+
+    def cleanup(self) -> None:
+        """Release the device and every background resource held for it."""
+
+
+#: The driver a robot gets when nothing says otherwise. Every robot in the
+#: package registry is a lerobot robot today, so the default keeps them working
+#: without a per-robot declaration.
+DEFAULT_DRIVER = "lerobot"
+
+#: Accepted ``driver=`` values. ``"auto"`` expresses no preference: it reads the
+#: registry and falls back to :data:`DEFAULT_DRIVER`. Mirrors the
+#: :data:`~strands_robots.registry.LIST_ROBOTS_MODES` pattern - a value outside
+#: this tuple is refused by name rather than silently treated as the default,
+#: because a typo that resolves to a working driver is a caller who never learns
+#: the driver they asked for does not exist.
+DRIVER_CHOICES = ("auto", DEFAULT_DRIVER, "strands")
+
+
+#: Every member :class:`HardwareDriver` requires, derived from the Protocol
+#: itself so the two can never disagree. A second hand-written list would be a
+#: second source of truth, and the one that drifts is always the copy.
+DRIVER_SURFACE: tuple[str, ...] = tuple(sorted(name for name in dir(HardwareDriver) if not name.startswith("_")))
+
+
+def missing_driver_members(candidate: object) -> tuple[str, ...]:
+    """Report which :data:`DRIVER_SURFACE` members ``candidate`` does not have.
+
+    Answers for a *class* as well as an instance, which is what a caller
+    holding a driver class before construction needs -
+    :func:`issubclass` cannot: a Protocol declaring a ``@property`` has
+    non-method members, and ``issubclass`` refuses those outright with
+    ``TypeError``.
+
+    Args:
+        candidate: A driver class or a built driver instance.
+
+    Returns:
+        The missing member names in sorted order; empty when ``candidate``
+        satisfies the whole surface.
+    """
+    return tuple(name for name in DRIVER_SURFACE if not hasattr(candidate, name))

--- a/strands_robots/drivers/registry.py
+++ b/strands_robots/drivers/registry.py
@@ -1,0 +1,156 @@
+"""Choose which driver builds a ``mode="real"`` robot, and find it.
+
+Two questions, kept apart because they have different answers:
+
+* *Which driver?* :func:`resolve_driver` - a name, from the caller's ``driver=``
+  or the robot's registry entry, defaulting to
+  :data:`~strands_robots.drivers.base.DEFAULT_DRIVER`.
+* *Which class?* :func:`get_native_driver_class` - the class a native driver
+  package registered for this robot, or ``None``.
+
+The native table starts empty: every robot in the package registry is driven
+through lerobot, so nothing is registered until a driver package calls
+:func:`register_native_driver`. That is the seam - the point where an
+implementation that is not lerobot-shaped can be reached by
+:func:`~strands_robots.robot.Robot` without the factory knowing anything about
+it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from strands_robots.drivers.base import DEFAULT_DRIVER, DRIVER_CHOICES, missing_driver_members
+from strands_robots.registry import get_driver, resolve_name
+
+logger = logging.getLogger(__name__)
+
+#: Canonical robot name -> the class that drives it natively. Written only by
+#: :func:`register_native_driver`, so every entry has passed the surface check.
+_NATIVE_DRIVERS: dict[str, type] = {}
+
+
+def driver_choice_error(value: object, param: str, context: str) -> str | None:
+    """Report why ``value`` is not a driver name, or ``None`` if it is one.
+
+    Args:
+        value: The candidate driver name.
+        param: Parameter name to quote in the reason.
+        context: Calling surface to quote in the reason.
+
+    Returns:
+        A reason naming the accepted values, or ``None`` when ``value`` is
+        one of :data:`~strands_robots.drivers.base.DRIVER_CHOICES`.
+    """
+    if isinstance(value, str) and value in DRIVER_CHOICES:
+        return None
+    return f"{context}: {param} must be one of {', '.join(DRIVER_CHOICES)}, got {value!r}"
+
+
+def resolve_driver(canonical: str, explicit: str | None = None) -> str:
+    """Decide which driver name builds ``canonical``.
+
+    Precedence, highest first: the caller's explicit choice, the robot's
+    registry ``hardware.driver``, then
+    :data:`~strands_robots.drivers.base.DEFAULT_DRIVER`. ``"auto"`` and ``None``
+    both mean "no explicit choice", so they defer to the registry.
+
+    Args:
+        canonical: Canonical robot name (or any alias -
+            :func:`~strands_robots.registry.resolve_name` is applied).
+        explicit: The caller's ``driver=``, or ``None`` when unset.
+
+    Returns:
+        A concrete driver name - never ``"auto"``.
+
+    Raises:
+        ValueError: If ``explicit`` is not one of
+            :data:`~strands_robots.drivers.base.DRIVER_CHOICES`.
+    """
+    reason = driver_choice_error(explicit, "driver", "resolve_driver") if explicit is not None else None
+    if reason is not None:
+        raise ValueError(reason)
+
+    if explicit is not None and explicit != "auto":
+        return explicit
+
+    # The registry reports what a robot declares and applies no default, so the
+    # two "no preference" spellings - an absent field and a declared "auto" -
+    # both land here, on the same answer.
+    declared = get_driver(canonical)
+    if declared is None or declared == "auto":
+        return DEFAULT_DRIVER
+    return declared
+
+
+def register_native_driver(canonical: str, driver_cls: type, overwrite: bool = False) -> None:
+    """Register ``driver_cls`` as the native driver for ``canonical``.
+
+    The surface is checked here rather than at build time, because here is where
+    the mistake is made: a driver missing ``stream`` registers fine and then
+    fails on the first agent call, one process and several minutes away from the
+    line that is wrong.
+
+    Args:
+        canonical: Robot name the driver drives; resolved through
+            :func:`~strands_robots.registry.resolve_name` so an alias and its
+            canonical name cannot register two different drivers. The robot need
+            not exist in the registry yet - a driver package may register before
+            the entry it serves is merged, and refusing that would make
+            registration order-dependent.
+        driver_cls: The class to build. Must satisfy
+            :class:`~strands_robots.drivers.base.HardwareDriver`.
+        overwrite: Replace an existing registration instead of refusing it.
+
+    Raises:
+        TypeError: If ``driver_cls`` does not satisfy the driver surface. The
+            missing members are named - a contract violation, so the same class
+            of error :mod:`abc` raises for an unimplemented abstract method.
+        ValueError: If ``canonical`` already has a driver and ``overwrite`` is
+            ``False``.
+    """
+    missing = missing_driver_members(driver_cls)
+    if missing:
+        raise TypeError(
+            f"register_native_driver: {driver_cls.__name__} cannot drive {canonical!r} - "
+            f"it is missing {', '.join(missing)}. See strands_robots.drivers.HardwareDriver "
+            "for what a driver must expose."
+        )
+
+    key = resolve_name(canonical)
+    existing = _NATIVE_DRIVERS.get(key)
+    if existing is not None and not overwrite:
+        raise ValueError(
+            f"register_native_driver: {key!r} is already driven by {existing.__name__}. "
+            f"Pass overwrite=True to replace it with {driver_cls.__name__}."
+        )
+
+    _NATIVE_DRIVERS[key] = driver_cls
+    logger.debug("Registered native driver %s for %r", driver_cls.__name__, key)
+
+
+def get_native_driver_class(canonical: str) -> type | None:
+    """Return the native driver class for ``canonical``, or ``None``.
+
+    Args:
+        canonical: Robot name or alias.
+
+    Returns:
+        The registered class, or ``None`` when no native driver serves this
+        robot - which is every robot until a driver package registers one.
+    """
+    return _NATIVE_DRIVERS.get(resolve_name(canonical))
+
+
+def list_native_drivers() -> dict[str, str]:
+    """Report which robots have a native driver.
+
+    The discovery surface behind the refusal
+    :func:`~strands_robots.robot.Robot` raises for ``driver="strands"`` on a
+    robot with no native driver: a caller who asked for one needs to see what
+    is available, not only that their choice was not.
+
+    Returns:
+        Canonical robot name -> driver class name, sorted by robot name.
+    """
+    return {name: cls.__name__ for name, cls in sorted(_NATIVE_DRIVERS.items())}

--- a/strands_robots/registry/__init__.py
+++ b/strands_robots/registry/__init__.py
@@ -51,6 +51,7 @@ from .policies import (
 from .robots import (
     LIST_ROBOTS_MODES,
     format_robot_table,
+    get_driver,
     get_hardware_type,
     get_robot,
     has_hardware,
@@ -73,6 +74,7 @@ __all__ = [
     "get_robot",
     "has_sim",
     "has_hardware",
+    "get_driver",
     "get_hardware_type",
     "list_robots",
     "LIST_ROBOTS_MODES",

--- a/strands_robots/registry/loader.py
+++ b/strands_robots/registry/loader.py
@@ -123,9 +123,29 @@ def _validate(name: str, data: dict) -> None:
 
 
 def _validate_robots(data: dict) -> None:
-    """Ensure no two robots share the same alias."""
+    """Ensure no two robots share the same alias, and that declared drivers exist.
+
+    Raises:
+        ValueError: On a duplicate alias, an alias colliding with a canonical
+            robot name, or a ``hardware.driver`` outside
+            :data:`~strands_robots.drivers.base.DRIVER_CHOICES`.
+    """
+    # Imported lazily for the same reason as :func:`_user_registry_mtime` above:
+    # the driver seam reads the registry, so importing it at module scope would
+    # close an import cycle. A driver name is validated here rather than where it
+    # is read, because every reader - the factory, a tool, a driver package -
+    # would otherwise have to re-check it, and the one that forgets accepts a
+    # typo as "no preference" and quietly builds the default driver.
+    from strands_robots.drivers.base import DRIVER_CHOICES
+
     seen_aliases: dict[str, str] = {}
     for robot_name, info in data.get("robots", {}).items():
+        declared_driver = info.get("hardware", {}).get("driver")
+        if declared_driver is not None and declared_driver not in DRIVER_CHOICES:
+            raise ValueError(
+                f"Robot '{robot_name}' declares hardware.driver={declared_driver!r}, "
+                f"which is not a driver. Valid drivers: {', '.join(DRIVER_CHOICES)}."
+            )
         for alias in info.get("aliases", []):
             if alias in seen_aliases:
                 raise ValueError(

--- a/strands_robots/registry/robots.py
+++ b/strands_robots/registry/robots.py
@@ -111,6 +111,30 @@ def get_hardware_type(name: str) -> str | None:
     return None
 
 
+def get_driver(name: str) -> str | None:
+    """Get the driver a robot declares, verbatim, or ``None`` if it declares none.
+
+    A pure reader, like its sibling :func:`get_hardware_type`: it reports what
+    the registry says and applies no default. ``hardware.driver`` is optional and
+    absent everywhere in the package registry, because every robot here is driven
+    through lerobot. Deciding what an absent - or ``"auto"`` - declaration means
+    is :func:`~strands_robots.drivers.resolve_driver`'s job, which is also where
+    a caller's explicit choice outranks the registry.
+
+    Args:
+        name: Robot name, alias, or data_config.
+
+    Returns:
+        The declared driver name, or ``None`` when the robot declares no driver
+        (or is not registered at all).
+    """
+    info = get_robot(name)
+    if info and "hardware" in info:
+        declared: str | None = info["hardware"].get("driver")
+        return declared
+    return None
+
+
 def list_robots(mode: str = "all") -> list[dict[str, Any]]:
     """List available robots, optionally filtered.
 

--- a/strands_robots/robot.py
+++ b/strands_robots/robot.py
@@ -47,6 +47,12 @@ from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from strands_robots._mesh_switch import mesh_env_request
 from strands_robots._serial_discovery import scan_serial_devices
+from strands_robots.drivers import (
+    driver_choice_error,
+    get_native_driver_class,
+    list_native_drivers,
+    resolve_driver,
+)
 from strands_robots.registry import (
     get_hardware_type,
     get_robot,
@@ -57,6 +63,7 @@ from strands_robots.registry import (
 )
 
 if TYPE_CHECKING:
+    from strands_robots.drivers import HardwareDriver
     from strands_robots.hardware_robot import Robot as HardwareRobot
     from strands_robots.simulation import Simulation
 
@@ -174,6 +181,50 @@ def _validate_known_robot(canonical: str, original: str, urdf_path: str | None) 
         )
 
 
+def _build_native_driver(
+    canonical: str,
+    cameras: dict[str, dict[str, Any]] | None,
+    data_config: str | None,
+    kwargs: dict[str, Any],
+) -> HardwareDriver:
+    """Build the native driver registered for ``canonical``.
+
+    Args:
+        canonical: Canonical robot name, already known to be registered.
+        cameras: Camera configuration, forwarded verbatim.
+        data_config: Data-config name, forwarded verbatim.
+        kwargs: The caller's remaining keyword arguments, forwarded verbatim -
+            ``port=`` among them, which stays polymorphic (a serial path, an IP
+            address or a URL) because only the driver knows how to read it.
+
+    Returns:
+        The constructed driver.
+
+    Raises:
+        ValueError: If no native driver is registered for this robot. Named
+            rather than silently falling back to lerobot: a caller who asked for
+            a native driver and got the lerobot one would debug the wrong robot.
+    """
+    driver_cls = get_native_driver_class(canonical)
+    if driver_cls is None:
+        available = ", ".join(list_native_drivers()) or "none"
+        raise ValueError(
+            f"No native driver is registered for {canonical!r}, so driver='strands' cannot "
+            f"build it. Robots with a native driver: {available}. Either use driver='lerobot' "
+            "(today's default, which builds it through lerobot) or register one with "
+            "strands_robots.drivers.register_native_driver()."
+        )
+
+    # The constructor contract documented on strands_robots.drivers.base: the
+    # three keywords every driver takes, plus the caller's extras. ``robot=`` is
+    # deliberately NOT forwarded - it carries the lerobot type name, which means
+    # nothing to a driver that does not go through lerobot.
+    return cast(
+        "HardwareDriver",
+        driver_cls(tool_name=canonical, cameras=cameras, data_config=data_config, **kwargs),
+    )
+
+
 @overload
 def Robot(
     name: str,
@@ -186,6 +237,7 @@ def Robot(
     *,
     orientation: list[float] | None = ...,
     keyframe: str | int | None = ...,
+    driver: str = ...,
     **kwargs: Any,
 ) -> Simulation: ...
 
@@ -202,6 +254,24 @@ def Robot(
     *,
     orientation: list[float] | None = ...,
     keyframe: str | int | None = ...,
+    driver: Literal["strands"],
+    **kwargs: Any,
+) -> HardwareDriver: ...
+
+
+@overload
+def Robot(
+    name: str,
+    mode: Literal["real"],
+    backend: str = ...,
+    urdf_path: str | None = ...,
+    cameras: dict[str, dict[str, Any]] | None = ...,
+    position: list[float] | None = ...,
+    data_config: str | None = ...,
+    *,
+    orientation: list[float] | None = ...,
+    keyframe: str | int | None = ...,
+    driver: str = ...,
     **kwargs: Any,
 ) -> HardwareRobot: ...
 
@@ -218,6 +288,7 @@ def Robot(
     *,
     orientation: list[float] | None = ...,
     keyframe: str | int | None = ...,
+    driver: str = ...,
     **kwargs: Any,
 ) -> Simulation | HardwareRobot: ...
 
@@ -237,8 +308,9 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     *,
     orientation: list[float] | None = None,
     keyframe: str | int | None = None,
+    driver: str = "auto",
     **kwargs: Any,
-) -> Simulation | HardwareRobot:
+) -> Simulation | HardwareRobot | HardwareDriver:
     """Create a robot - returns a Simulation or HardwareRobot instance.
 
     This is a convenience factory, NOT a wrapper class.  You get the real
@@ -316,6 +388,17 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
               ``False`` to force it off; an explicit value always wins over the
               env default. ``STRANDS_MESH=false`` is a hard kill switch.
         peer_id: Optional mesh peer identifier. Auto-generated when omitted.
+        driver: Which implementation drives the robot in ``mode="real"``, one of
+            :data:`~strands_robots.drivers.base.DRIVER_CHOICES`. ``"auto"``
+            (default) states no preference: it honours the robot's registry
+            ``hardware.driver`` and otherwise builds the lerobot driver, so a
+            call that does not mention ``driver`` behaves exactly as before.
+            ``"lerobot"`` pins that path explicitly. ``"strands"`` builds the
+            native driver registered for this robot via
+            :func:`~strands_robots.drivers.register_native_driver`, and is
+            refused by name when none is - never quietly served the lerobot one.
+            The value is checked in every mode, but only ``mode="real"`` acts on
+            it; ``mode="sim"`` reports it as ignored at debug level.
         **kwargs: Forwarded to the underlying backend constructor.
 
     Returns:
@@ -323,7 +406,10 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
         ``strands_robots.hardware_robot.Robot`` (real hardware).
 
     Raises:
-        ValueError: If ``mode`` is not 'sim'/'real'/'auto', if ``cameras=``
+        ValueError: If ``mode`` is not 'sim'/'real'/'auto', if ``driver`` is not
+                    one of :data:`~strands_robots.drivers.base.DRIVER_CHOICES`,
+                    if ``driver="strands"`` names a robot with no registered
+                    native driver, if ``cameras=``
                     is passed in sim mode, if the robot name is empty
                     or not in the registry (and no ``urdf_path=`` given), or if
                     ``backend`` is not a known backend (the message lists the
@@ -362,6 +448,14 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
     if mode == "auto":
         mode = _auto_detect_mode(canonical)
 
+    # Checked for EVERY mode, not only the one that reads it. A sim robot has no
+    # driver to choose, but ``Robot("so100", driver="lerbot")`` is a typo either
+    # way, and a value only checked on the branch that uses it is a value the
+    # other branch accepts silently.
+    driver_reason = driver_choice_error(driver, "driver", "Robot")
+    if driver_reason is not None:
+        raise ValueError(driver_reason)
+
     # Resolve the mesh opt-in. Mesh is OFF by default so a bare
     # ``Robot("so100")`` is quiet and never spins up Zenoh/ACL/e-stop
     # machinery. ``mesh=None`` (the default) means "consult the
@@ -379,6 +473,14 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
                 "cameras= is only supported in mode='real'. "
                 "For sim cameras, add them via the simulation tool's "
                 "'add_camera' action after creation."
+            )
+
+        if driver != "auto":
+            logger.debug(
+                "driver=%r ignored in mode='sim' (a simulated robot is stepped by a physics "
+                "backend, not driven through a device); backend=%r selects the engine",
+                driver,
+                backend,
             )
 
         from strands_robots.simulation import create_simulation
@@ -513,46 +615,83 @@ def Robot(  # noqa: N802 - uppercase by design (factory mimicking a class constr
                 ", ".join(ignored_spawn_args),
             )
 
-        from strands_robots.hardware_robot import Robot as HardwareRobotCls
-
-        real_type = get_hardware_type(canonical) or canonical
-        hw = HardwareRobotCls(
-            tool_name=canonical,
-            robot=real_type,
-            cameras=cameras,
-            # Forwarded, not reported: unlike the spawn parameters above, the
-            # hardware class declares ``data_config`` and reads it - it is what
-            # ends up in the ``policy_config`` a policy is built with, so a
-            # multi-camera schema selected here has to arrive. Passed verbatim
-            # (``None`` is the hardware class's own default) rather than defaulted
-            # to the canonical name the way the sim path does, so a caller who
-            # names no config keeps today's behaviour.
-            data_config=data_config,
-            **kwargs,
-        )
-
-        # Attach a Zenoh mesh so the hardware Robot auto-discovers peers.
-        # Best-effort: a mesh failure must not kill a working hardware robot.
-        try:
-            from strands_robots.mesh import init_mesh
-
-            hw_mesh = init_mesh(
-                hw,
-                peer_id=peer_id,
-                peer_type="robot",
-                mesh=mesh,
+        resolved_driver = resolve_driver(canonical, driver)
+        hw: HardwareRobot | HardwareDriver
+        if resolved_driver == "strands":
+            hw = _build_native_driver(canonical, cameras, data_config, kwargs)
+        elif resolved_driver != "lerobot":
+            # Every branch is named, so a driver added to DRIVER_CHOICES without
+            # a route here is refused instead of quietly taking a neighbour's
+            # branch - the difference between "not implemented yet" and "built
+            # the wrong robot".
+            raise ValueError(
+                f"driver={resolved_driver!r} is a known driver name with no route in Robot(). "
+                "This is a gap in the factory, not in your call."
             )
-            if hw_mesh is not None:
-                hw.mesh = hw_mesh
-                hw.peer_id = hw_mesh.peer_id
-        except Exception as exc:  # noqa: BLE001 - mesh enrichment is best-effort
-            logger.warning("Failed to initialise mesh for %r: %s", canonical, exc)
+        else:
+            from strands_robots.hardware_robot import Robot as HardwareRobotCls
 
+            real_type = get_hardware_type(canonical) or canonical
+            hw = HardwareRobotCls(
+                tool_name=canonical,
+                robot=real_type,
+                cameras=cameras,
+                # Forwarded, not reported: unlike the spawn parameters above,
+                # the hardware class declares ``data_config`` and reads it - it
+                # is what ends up in the ``policy_config`` a policy is built
+                # with, so a multi-camera schema selected here has to arrive.
+                # Passed verbatim (``None`` is the hardware class's own default)
+                # rather than defaulted to the canonical name the way the sim
+                # path does, so a caller who names no config keeps today's
+                # behaviour.
+                data_config=data_config,
+                **kwargs,
+            )
+
+        # Both drivers are robots on the fleet, so both get the same two
+        # attachments. Reached after the branch rather than inside it: a driver
+        # that is built but never put on the mesh is a robot no peer can see.
+        _attach_mesh(hw, canonical, peer_id, mesh)
         _attach_device_connect(hw, canonical, mode, peer_id)
         return hw
 
     else:
         raise ValueError(f"Invalid mode {mode!r}. Choose 'sim', 'real', or 'auto' (case-insensitive).")
+
+
+def _attach_mesh(instance: Any, canonical: str, peer_id: str | None, mesh: bool) -> None:
+    """Attach a Zenoh mesh so a real robot auto-discovers its peers.
+
+    Takes ``Any`` for the same reason :func:`_attach_device_connect` does: it
+    decorates an instance with attributes the instance's own class need not
+    declare. ``mesh`` and ``peer_id`` are deliberately not part of
+    :class:`~strands_robots.drivers.base.HardwareDriver` - a driver does not
+    implement them, it receives them here.
+
+    Best-effort by design: a mesh that will not start must not take a working
+    robot down with it, so the failure is reported and the robot is returned.
+
+    Args:
+        instance: The robot to put on the mesh.
+        canonical: Canonical robot name, for the failure report.
+        peer_id: Requested peer identifier, or ``None`` to let the mesh choose.
+        mesh: The mesh opt-in, already resolved - the caller has folded the
+            ``STRANDS_MESH`` default into it, so ``None`` cannot arrive here.
+    """
+    try:
+        from strands_robots.mesh import init_mesh
+
+        hw_mesh = init_mesh(
+            instance,
+            peer_id=peer_id,
+            peer_type="robot",
+            mesh=mesh,
+        )
+        if hw_mesh is not None:
+            instance.mesh = hw_mesh
+            instance.peer_id = hw_mesh.peer_id
+    except Exception as exc:  # noqa: BLE001 - mesh enrichment is best-effort
+        logger.warning("Failed to initialise mesh for %r: %s", canonical, exc)
 
 
 def _attach_device_connect(instance: Any, canonical: str, mode: str, peer_id: str | None) -> None:

--- a/tests/registry/test_public_member_docstrings.py
+++ b/tests/registry/test_public_member_docstrings.py
@@ -63,6 +63,7 @@ _EXPECTED_FUNCTIONS = {
     "policies.py::list_policy_providers",
     "policies.py::resolve_policy",
     "robots.py::format_robot_table",
+    "robots.py::get_driver",
     "robots.py::get_hardware_type",
     "robots.py::get_robot",
     "robots.py::has_hardware",

--- a/tests/test_driver_seam.py
+++ b/tests/test_driver_seam.py
@@ -1,0 +1,526 @@
+"""``Robot(mode="real")`` can be told which driver to build, and refuses clearly.
+
+The factory built exactly one thing for a real robot:
+``strands_robots.hardware_robot.Robot``, which constructs a lerobot
+``RobotConfig`` and wraps a lerobot driver. A robot lerobot does not model - a
+humanoid with its own state machine, a rover reporting GPS, a base publishing a
+point cloud - had no way in, and nothing recorded which members of that
+3000-line class the mesh, the teleop rail and the agent tool surface actually
+rely on.
+
+These tests grade the seam that answers both: a ``driver=`` choice with a
+precedence order, a contract
+(:class:`~strands_robots.drivers.base.HardwareDriver`) the reference
+implementation is measured against, and a registration point that refuses a
+half-built driver at the line that registers it.
+
+The load-bearing test here is :class:`TestTheLerobotPathIsUnchanged`: the seam is
+only worth having if adding it moved nothing. It builds the same robot three ways
+- not mentioning ``driver`` at all, ``driver="auto"``, ``driver="lerobot"`` - and
+compares the class and the lerobot config all three produce.
+
+Everything runs against a patched lerobot factory, so no serial port is opened
+and no arm moves.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import strands_robots.drivers.registry as drivers_registry_mod
+import strands_robots.registry.robots as registry_robots_mod
+from strands_robots import Robot
+from strands_robots.drivers import (
+    DEFAULT_DRIVER,
+    DRIVER_CHOICES,
+    DRIVER_SURFACE,
+    HardwareDriver,
+    get_native_driver_class,
+    list_native_drivers,
+    missing_driver_members,
+    register_native_driver,
+    resolve_driver,
+)
+from strands_robots.registry import get_driver
+from strands_robots.registry.loader import _validate
+
+# A robot every real-mode test builds. Registered, has a lerobot type, and its
+# driver comes from the default rather than a declaration.
+_ROBOT = "so101"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_native_driver_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test its own native-driver table.
+
+    The table is module state that :func:`register_native_driver` writes, so a
+    test that registers a driver would otherwise decide what a later test sees -
+    and the refusal tests assert on a table being *empty*.
+    """
+    monkeypatch.setattr(drivers_registry_mod, "_NATIVE_DRIVERS", dict(drivers_registry_mod._NATIVE_DRIVERS))
+
+
+class _CompleteDriver:
+    """A native driver satisfying the whole driver surface.
+
+    Records the keywords the factory forwarded, which is what the constructor
+    contract in :mod:`strands_robots.drivers.base` promises a driver receives.
+    """
+
+    def __init__(self, tool_name: str, cameras: Any = None, data_config: Any = None, **kwargs: Any) -> None:
+        self.forwarded = {"tool_name": tool_name, "cameras": cameras, "data_config": data_config, **kwargs}
+
+    @property
+    def tool_name(self) -> str:
+        return str(self.forwarded["tool_name"])
+
+    @property
+    def tool_type(self) -> str:
+        return "robot"
+
+    @property
+    def tool_spec(self) -> Any:
+        return {"name": self.tool_name, "description": "test driver", "inputSchema": {}}
+
+    def stream(self, tool_use: Any, invocation_state: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def send_action(self, action: Any, robot_name: str | None = None) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def start_task(self, instruction: str, **policy_kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def run_policy(self, policy_object: Any, instruction: str = "", **kwargs: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def get_task_status(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def stop_task(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    async def get_status(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    async def stop(self) -> None:
+        return None
+
+    def cleanup(self) -> None:
+        return None
+
+
+def _fake_lerobot_device() -> MagicMock:
+    """A stand-in for a built lerobot robot, so no serial port is touched."""
+    device = MagicMock(name="lerobot_device")
+    device.name = "so_follower"
+    device.config = MagicMock()
+    device.config.cameras = {}
+    return device
+
+
+def _build_real(**factory_kwargs: Any) -> tuple[Any, Any]:
+    """Build ``_ROBOT`` in real mode, returning ``(robot, lerobot_config)``.
+
+    The patch target is lerobot's own ``make_robot_from_config``, which leaves
+    the whole strands-side config build on the call chain - so the returned
+    config is the one the factory's forwarding actually produced.
+    """
+    with patch("lerobot.robots.utils.make_robot_from_config", return_value=_fake_lerobot_device()) as made:
+        robot = Robot(_ROBOT, mode="real", port="/dev/null", **factory_kwargs)
+    config = made.call_args.args[0] if made.called else None
+    return robot, config
+
+
+class TestTheLerobotPathIsUnchanged:
+    """Adding the seam must not change what a real robot is today."""
+
+    def test_the_three_spellings_of_the_default_build_the_same_robot(self) -> None:
+        """Omitting ``driver``, ``"auto"`` and ``"lerobot"`` agree in every detail."""
+        pytest.importorskip("lerobot.robots.so_follower")
+
+        readings = []
+        for spelling in ({}, {"driver": "auto"}, {"driver": DEFAULT_DRIVER}):
+            robot, config = _build_real(**spelling)
+            readings.append(
+                (
+                    type(robot),
+                    robot.tool_name,
+                    config.id,
+                    config.port,
+                    type(config).__name__,
+                )
+            )
+
+        assert readings[0] == readings[1] == readings[2], (
+            f"driver= changed what the default path builds: {readings}. The seam is only "
+            "safe if a caller who never mentions driver gets today's robot."
+        )
+
+    def test_the_default_still_builds_the_lerobot_hardware_class(self) -> None:
+        """The class, not merely something duck-shaped like it."""
+        pytest.importorskip("lerobot.robots.so_follower")
+
+        from strands_robots.hardware_robot import Robot as HardwareRobotCls
+
+        robot, config = _build_real()
+        assert isinstance(robot, HardwareRobotCls)
+        assert config is not None, "the lerobot config build must stay on the call chain"
+
+    def test_caller_kwargs_still_reach_the_lerobot_config(self) -> None:
+        """``id=`` and friends are forwarded, not swallowed by the new parameter."""
+        pytest.importorskip("lerobot.robots.so_follower")
+
+        _, config = _build_real(id="left_arm", use_degrees=True)
+        assert config.id == "left_arm"
+        assert config.use_degrees is True
+
+
+class TestDriverResolutionPrecedence:
+    """Explicit choice, then the registry, then the default."""
+
+    def _with_declared_driver(self, monkeypatch: pytest.MonkeyPatch, declared: str | None) -> None:
+        """Serve a registry in which ``_ROBOT`` declares ``declared``."""
+        hardware: dict[str, Any] = {"lerobot_type": "so101_follower"}
+        if declared is not None:
+            hardware["driver"] = declared
+        monkeypatch.setattr(
+            registry_robots_mod,
+            "_load",
+            lambda name: {"robots": {_ROBOT: {"description": "test", "hardware": hardware}}},
+        )
+
+    def test_no_declaration_and_no_choice_is_the_default(self) -> None:
+        assert get_driver(_ROBOT) is None, "no package robot declares a driver"
+        assert resolve_driver(_ROBOT) == DEFAULT_DRIVER
+
+    def test_a_registry_declaration_beats_the_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._with_declared_driver(monkeypatch, "strands")
+        assert get_driver(_ROBOT) == "strands"
+        assert resolve_driver(_ROBOT) == "strands"
+
+    def test_an_explicit_choice_beats_a_registry_declaration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._with_declared_driver(monkeypatch, "strands")
+        assert resolve_driver(_ROBOT, DEFAULT_DRIVER) == DEFAULT_DRIVER
+
+    def test_auto_defers_rather_than_deciding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``"auto"`` must behave as "unset", not as a choice of its own."""
+        self._with_declared_driver(monkeypatch, "strands")
+        assert resolve_driver(_ROBOT, "auto") == resolve_driver(_ROBOT) == "strands"
+
+    def test_a_declared_auto_states_no_preference(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A registry saying ``"auto"`` is the same as a registry saying nothing."""
+        self._with_declared_driver(monkeypatch, "auto")
+        assert resolve_driver(_ROBOT) == DEFAULT_DRIVER
+
+    def test_resolution_never_reports_auto(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whatever is declared, the answer is a driver a caller can build."""
+        for declared in (None, "auto", "lerobot", "strands"):
+            self._with_declared_driver(monkeypatch, declared)
+            assert resolve_driver(_ROBOT) != "auto"
+
+    @pytest.mark.parametrize("bad", ["lerbot", "strand", "LEROBOT", "", "none"])
+    def test_an_unknown_driver_name_is_refused_by_name(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            resolve_driver(_ROBOT, bad)
+
+
+class TestTheDriverValueIsCheckedInEveryMode:
+    """A typo must not be accepted by whichever branch happens not to read it."""
+
+    def test_sim_mode_refuses_a_driver_that_is_not_a_driver(self) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            Robot(_ROBOT, mode="sim", driver="lerbot")
+
+    def test_real_mode_refuses_a_driver_that_is_not_a_driver(self) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            Robot(_ROBOT, mode="real", driver="lerbot", port="/dev/null")
+
+    def test_the_refusal_precedes_any_construction(self) -> None:
+        """Nothing is built for a call that is going to be refused."""
+        with (
+            patch("lerobot.robots.utils.make_robot_from_config") as made,
+            pytest.raises(ValueError, match="must be one of"),
+        ):
+            Robot(_ROBOT, mode="real", driver="lerbot", port="/dev/null")
+        assert not made.called
+
+
+class TestAskingForANativeDriverThatIsNotThere:
+    """``driver="strands"`` with no driver registered is refused, not substituted."""
+
+    def test_the_refusal_names_the_robot_and_both_remedies(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            Robot(_ROBOT, mode="real", driver="strands", port="/dev/null")
+
+        message = str(excinfo.value)
+        assert _ROBOT in message
+        assert f"driver='{DEFAULT_DRIVER}'" in message, "a caller needs the working alternative"
+        assert "register_native_driver" in message, "and the way to supply what they asked for"
+
+    def test_no_lerobot_robot_is_built_instead(self) -> None:
+        """Silently serving the lerobot driver would hide the missing driver."""
+        with (
+            patch("lerobot.robots.utils.make_robot_from_config") as made,
+            pytest.raises(ValueError, match="No native driver"),
+        ):
+            Robot(_ROBOT, mode="real", driver="strands", port="/dev/null")
+        assert not made.called
+
+    def test_the_refusal_reports_which_robots_do_have_one(self) -> None:
+        """The discovery surface: what is available, not only what is not."""
+        register_native_driver("unitree_g1", _CompleteDriver)
+        with pytest.raises(ValueError, match="unitree_g1"):
+            Robot(_ROBOT, mode="real", driver="strands", port="/dev/null")
+
+
+class TestBuildingARegisteredNativeDriver:
+    """The seam's point: a registered driver is what the factory returns."""
+
+    def test_the_factory_returns_the_registered_class(self) -> None:
+        register_native_driver(_ROBOT, _CompleteDriver)
+        robot = Robot(_ROBOT, mode="real", driver="strands", port="192.168.1.10")
+        assert isinstance(robot, _CompleteDriver)
+
+    def test_the_documented_constructor_keywords_arrive(self) -> None:
+        register_native_driver(_ROBOT, _CompleteDriver)
+        robot = Robot(
+            _ROBOT,
+            mode="real",
+            driver="strands",
+            cameras={"wrist": {"type": "opencv", "index_or_path": 0}},
+            data_config="so100_dualcam",
+            port="192.168.1.10",
+        )
+        # ``driver="strands"`` is typed as the driver contract, so reading a
+        # member of this particular driver needs the narrowing - which is the
+        # overload doing its job.
+        assert isinstance(robot, _CompleteDriver)
+        assert robot.forwarded["tool_name"] == _ROBOT
+        assert robot.forwarded["data_config"] == "so100_dualcam"
+        assert robot.forwarded["cameras"] == {"wrist": {"type": "opencv", "index_or_path": 0}}
+        assert robot.forwarded["port"] == "192.168.1.10", "port stays polymorphic - here an IP"
+
+    def test_the_lerobot_type_is_not_forwarded(self) -> None:
+        """``robot=`` names a lerobot type, which means nothing to a native driver."""
+        register_native_driver(_ROBOT, _CompleteDriver)
+        robot = Robot(_ROBOT, mode="real", driver="strands", port="192.168.1.10")
+        assert isinstance(robot, _CompleteDriver)
+        assert "robot" not in robot.forwarded
+
+    def test_a_native_driver_joins_the_fleet_like_any_other_robot(self) -> None:
+        """The post-build tail is shared, not written once for lerobot.
+
+        A driver reached through the seam is a robot on the fleet: the mesh
+        attach and the Device Connect ``.run()`` hook are what put it on the
+        network, and a native driver that skipped them would be built, returned,
+        and invisible to every peer.
+        """
+        register_native_driver(_ROBOT, _CompleteDriver)
+        # Annotated ``Any`` on purpose: these three are attached to the instance
+        # by the factory, so they are on no class the checker can consult - the
+        # same reason the production helpers take ``Any``.
+        robot: Any = Robot(_ROBOT, mode="real", driver="strands", port="192.168.1.10")
+
+        assert robot._peer_type == "robot", "a real driver is a robot peer, not a sim peer"
+        assert robot._peer_id, "every peer needs an identity on the mesh"
+        assert callable(robot.run), "``.run()`` is what brings a device online"
+
+    def test_a_registry_declaration_alone_routes_to_the_driver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A robot may declare its own driver, with no ``driver=`` at the call."""
+        monkeypatch.setattr(
+            registry_robots_mod,
+            "_load",
+            lambda name: {"robots": {_ROBOT: {"description": "t", "hardware": {"driver": "strands"}}}},
+        )
+        register_native_driver(_ROBOT, _CompleteDriver)
+        assert isinstance(Robot(_ROBOT, mode="real", port="192.168.1.10"), _CompleteDriver)
+
+
+class TestRegisteringADriver:
+    """Registration is where a half-built driver is caught."""
+
+    def test_a_driver_missing_members_is_refused_and_they_are_named(self) -> None:
+        class Halfway:
+            def send_action(self, action: Any, robot_name: str | None = None) -> dict[str, Any]:
+                return {}
+
+        with pytest.raises(TypeError) as excinfo:
+            register_native_driver(_ROBOT, Halfway)
+
+        message = str(excinfo.value)
+        assert "Halfway" in message
+        for absent in missing_driver_members(Halfway):
+            assert absent in message, f"the refusal must name {absent!r}, which the driver lacks"
+        assert get_native_driver_class(_ROBOT) is None, "a refused driver must not be registered"
+
+    def test_a_complete_driver_is_accepted(self) -> None:
+        register_native_driver(_ROBOT, _CompleteDriver)
+        assert get_native_driver_class(_ROBOT) is _CompleteDriver
+
+    def test_an_alias_and_its_canonical_name_are_one_registration(self) -> None:
+        """Otherwise two spellings of one robot could hold two different drivers."""
+        register_native_driver("so-101", _CompleteDriver)
+        assert get_native_driver_class(_ROBOT) is _CompleteDriver
+        assert list(list_native_drivers()) == [_ROBOT]
+
+    def test_a_second_registration_is_refused_unless_asked_for(self) -> None:
+        class Other(_CompleteDriver):
+            pass
+
+        register_native_driver(_ROBOT, _CompleteDriver)
+        with pytest.raises(ValueError, match="already driven by"):
+            register_native_driver(_ROBOT, Other)
+        assert get_native_driver_class(_ROBOT) is _CompleteDriver
+
+        register_native_driver(_ROBOT, Other, overwrite=True)
+        assert get_native_driver_class(_ROBOT) is Other
+
+
+class TestTheContractIsTheMeasuredOne:
+    """:class:`HardwareDriver` describes what the reference implementation has."""
+
+    def test_the_reference_implementation_satisfies_the_whole_surface(self) -> None:
+        """Derived, so a member no real robot has cannot be added to the contract."""
+        pytest.importorskip("lerobot")
+        from strands_robots.hardware_robot import Robot as HardwareRobotCls
+
+        assert missing_driver_members(HardwareRobotCls) == ()
+
+    def test_a_built_hardware_robot_is_a_driver(self) -> None:
+        """The ``isinstance`` a caller can run, on a real instance."""
+        pytest.importorskip("lerobot.robots.so_follower")
+
+        robot, _ = _build_real()
+        assert isinstance(robot, HardwareDriver)
+
+    def test_a_half_built_driver_is_not_one(self) -> None:
+        """Non-vacuity: the check must be able to say no."""
+
+        class Halfway:
+            def send_action(self, action: Any, robot_name: str | None = None) -> dict[str, Any]:
+                return {}
+
+        assert not isinstance(Halfway(), HardwareDriver)
+
+    def test_the_agent_tool_surface_is_part_of_the_contract(self) -> None:
+        """Derived from the SDK: a driver an agent cannot invoke is not a driver."""
+        from strands.tools.tools import AgentTool
+
+        required = set(AgentTool.__abstractmethods__)
+        assert required, "the SDK declares abstract members; the derivation is not vacuous"
+        assert required <= set(DRIVER_SURFACE), (
+            f"the contract must cover what makes an object callable by an agent, missing "
+            f"{sorted(required - set(DRIVER_SURFACE))}"
+        )
+
+    def test_the_contract_requires_no_private_member(self) -> None:
+        """A public contract naming a private attribute institutionalises it.
+
+        The sensor attributes a mesh publishes (``_pose``, ``_imu`` and their
+        siblings) are read with a ``getattr(robot, name, None)`` default, so they
+        are optional by construction - a driver with no lidar is complete. A
+        Protocol cannot say "optional", so requiring them would refuse a working
+        arm.
+        """
+        assert [name for name in DRIVER_SURFACE if name.startswith("_")] == []
+
+    def test_the_surface_is_derived_from_the_protocol(self) -> None:
+        """A hand-written second copy is the one that drifts."""
+        declared = {
+            node.name
+            for node in ast.walk(ast.parse(inspect.getsource(HardwareDriver)))
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and not node.name.startswith("_")
+        }
+        assert declared == set(DRIVER_SURFACE)
+
+
+class TestARegistryDeclarationIsValidated:
+    """``hardware.driver`` is checked where it is loaded, once."""
+
+    @pytest.mark.parametrize("declared", DRIVER_CHOICES)
+    def test_every_advertised_driver_is_accepted(self, declared: str) -> None:
+        _validate("robots", {"robots": {"probe": {"hardware": {"lerobot_type": "x", "driver": declared}}}})
+
+    def test_no_declaration_is_accepted(self) -> None:
+        _validate("robots", {"robots": {"probe": {"hardware": {"lerobot_type": "x"}}}})
+
+    def test_a_driver_that_does_not_exist_is_refused_naming_the_robot(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            _validate("robots", {"robots": {"probe": {"hardware": {"driver": "lerbot"}}}})
+
+        message = str(excinfo.value)
+        assert "probe" in message
+        assert "lerbot" in message
+        for choice in DRIVER_CHOICES:
+            assert choice in message, "the refusal must name what is accepted"
+
+    def test_the_package_registry_passes_its_own_check(self) -> None:
+        """The shipped registry is loadable, which is what a load asserts."""
+        assert get_driver(_ROBOT) is None
+
+    def test_a_user_declared_driver_is_validated_too(self) -> None:
+        """The overlay is merged before validation, so a user entry is graded.
+
+        Read off the loader rather than by writing a file: the claim is about the
+        *order* of two calls, and an ordering is what an ordering test should
+        assert.
+        """
+        from strands_robots.registry import loader as loader_mod
+
+        source = inspect.getsource(loader_mod._load)
+        merge_at = source.index("_merge_user_robots(data)")
+        validate_at = source.index("_validate(name, data)")
+        assert merge_at < validate_at, (
+            "the user overlay must be merged before validation, or a driver typo in user_robots.json is never graded"
+        )
+
+
+class TestAKnownDriverWithNoRouteIsRefused:
+    """A driver name added to the vocabulary must be routed, not assumed."""
+
+    def test_an_unrouted_driver_name_is_refused_rather_than_built(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import strands_robots.robot as robot_mod
+
+        monkeypatch.setattr(robot_mod, "resolve_driver", lambda canonical, explicit=None: "ros2")
+        with pytest.raises(ValueError, match="no route in Robot"):
+            Robot(_ROBOT, mode="real", port="/dev/null")
+
+
+class TestTheSeamIsReachableAsDocumented:
+    """The import path the module docstring tells a driver author to use."""
+
+    def test_the_public_names_are_importable_from_the_package(self) -> None:
+        import strands_robots.drivers as drivers_pkg
+
+        for name in drivers_pkg.__all__:
+            assert hasattr(drivers_pkg, name), f"{name} is exported but absent"
+
+    def test_the_seam_costs_no_heavy_import(self) -> None:
+        """``robot.py`` imports the seam at module scope, so it must stay cheap.
+
+        The factory is the surface ``import strands_robots`` defers precisely
+        because lerobot, torch and mujoco are expensive. A driver contract that
+        dragged one of them in would move that cost back to import time for
+        every caller, including the sim-only ones.
+        """
+        heavy = ("lerobot", "torch", "mujoco", "numpy", "cv2")
+        for module_path in sorted(Path(__file__).parent.parent.glob("strands_robots/drivers/*.py")):
+            tree = ast.parse(module_path.read_text(encoding="utf-8"))
+            for node in tree.body:  # module level only; a lazy import is fine
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                for name in names:
+                    assert not name.startswith(heavy), (
+                        f"{module_path.name} imports {name!r} at module scope; the driver seam "
+                        "is imported eagerly by strands_robots.robot and must stay light"
+                    )


### PR DESCRIPTION
## Problem

`Robot(name, mode="real")` built exactly one thing: `strands_robots.hardware_robot.Robot`,
which constructs a lerobot `RobotConfig` and wraps a lerobot driver. That is the right driver
for every robot in the shipped registry, and the wrong shape for a robot lerobot does not
model - a humanoid with its own state machine, a rover reporting GPS, a base publishing a
point cloud. There was no seam to reach anything else through.

Nothing recorded the contract either. The mesh, the teleop rail and the agent tool surface all
consume from whatever `mode="real"` returns, so the members they rely on were a property of a
3000-line class and of nothing else - a driver author had to read it to find out which ones
are load-bearing.

## Change

`driver=` selects the implementation, keyword-only so no positional call shifts meaning:

| Value | Builds |
|-------|--------|
| `"auto"` (default) | The robot's registry `hardware.driver` if it declares one, else the lerobot driver. |
| `"lerobot"` | The lerobot driver, explicitly. |
| `"strands"` | The native driver registered for this robot. |

`strands_robots.drivers.HardwareDriver` is the contract, `register_native_driver` is where a
driver joins, and `hardware.driver` lets a robot declare its own. Four decisions are worth
calling out.

**The contract is the measured one, not the plausible one.** Two members that look like they
belong are absent because the reference implementation does not have them: `get_observation`
(`hasattr(HardwareRobot, "get_observation")` is `False` - the mesh reads observations from the
driver's *inner* device at `mesh/sensors.py:384`, and `bus_access.read_observation` takes that
inner device), and `connect_eagerly` (0 occurrences anywhere in the tree). The sensor
attributes a mesh publishes are absent for a different reason: every one is read as
`getattr(robot, "_pose", None)`, so they are optional by construction - a driver with no lidar
is complete, a Protocol cannot say "optional", and requiring them would refuse a working arm.
They are also private, and a public contract that names a private attribute institutionalises
it. What is left is 12 members, four of which are `AgentTool`'s abstract surface - derived from
the SDK in the test rather than listed, so dropping one fails.

**A half-built driver is refused where it is registered.** `register_native_driver` checks the
surface against the class and names what is missing, so a driver without `stream` fails on the
line that is wrong rather than on the first agent call, one process later. The member list is
derived from the Protocol (`dir(HardwareDriver)`), so a second hand-written copy cannot drift
from it. Checking a *class* is why the check is not `issubclass`: a Protocol declaring a
`@property` has non-method members and `issubclass` refuses those with `TypeError`.

**Asking for a driver that is not there is refused, never substituted.** A caller handed the
lerobot driver after asking for a native one would debug the wrong robot. The refusal names the
robot, lists the robots that do have a native driver, and gives both remedies. The value is
checked in *every* mode - a sim robot has no driver to choose, but `driver="lerbot"` is a typo
either way, and a value checked only on the branch that reads it is a value the other branch
accepts silently. A driver name added to the vocabulary with no route in the factory is refused
too, rather than falling into a neighbour's branch.

**Statically honest.** `driver="strands"` returns something that is *not* a `HardwareRobot`, so
a `Literal["strands"]` overload returns `HardwareDriver` - keyed on the literal exactly as
`mode` already is. Without it the factory would promise `HardwareRobot` and hand back a driver
with no `.attach_teleop`, and nothing would say so.

The `mode="real"` post-build tail (mesh attach, Device Connect `.run()` hook) is now reached
after the branch instead of inside it, so both drivers take it: a driver that is built but
never published is a robot no peer can see. Extracting `_attach_mesh` is what mypy asked for -
it writes `mesh`/`peer_id` onto the instance, which a driver does not implement but receives,
so the helper takes `Any` for the same reason its existing `_attach_device_connect` sibling
does.

## The default path is unchanged

The load-bearing test. The same robot is built three ways - not mentioning `driver`,
`driver="auto"`, `driver="lerobot"` - and the class, `tool_name` and the produced lerobot
config (`id`, `port`, config type) are compared across all three. The patch target is lerobot's
own `make_robot_from_config`, so the entire strands-side config build stays on the call chain.
The only deletions in `robot.py` are the re-indented lerobot construction block (contents
preserved verbatim) and two annotation lines.

That class is a control - no mutation below fires it - so its non-vacuity is proved separately:
b13 makes the default `"strands"` and all three of its tests fail.

## Tests

45 new cases in `tests/test_driver_seam.py`, no hardware touched. 14 mutations, 14 distinct
firing sets, control clean, every file restored byte-identical:

| # | Mutation | Fires |
|---|----------|-------|
| b0 | control (no change) | 0 |
| b1 | the driver value is checked only in the real branch | 1 |
| b2 | `driver="strands"` with no driver falls back to lerobot | 3 |
| b3 | registration skips the surface check | 1 |
| b4 | `DRIVER_SURFACE` hardcoded instead of derived | 2 |
| b5 | the registry declaration outranks the caller's explicit choice | 7 |
| b6 | loader validation of `hardware.driver` dropped | 1 |
| b7 | the lerobot type is forwarded to a native driver too | 1 |
| b8 | an unrouted driver name silently builds a native driver | 1 |
| b9 | registration does not resolve an alias to the canonical name | 1 |
| b10 | the shared post-build tail is skipped for a native driver | 1 |
| b11 | `get_driver` applies the default itself instead of reporting the declaration | 2 |
| b12 | a declared `"auto"` is taken as a driver name | 2 |
| b13 | the default driver becomes `"strands"` (non-vacuity for the control class) | 4 |

A raw revert is a collection error, since the seam's symbols are what the file imports; the
table above is the evidence that each test is load-bearing.

`tests/registry/test_public_member_docstrings.py` declares the registry's public surface, so
`get_driver` is added to it there - the guard doing its job.

## Gate

Run against mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 from source.

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean, 1550 files.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main` worktree,
  normalized message sets byte-identical in both directions, 0 in the changed files.
- Full `tests/` on both trees: **53 == 53** failing/error ids, `comm` empty in both directions.
  All 53 are pre-existing and dependency-caused (44 `ModuleNotFoundError: awsiot`, the
  `[mesh-iot]` extra; the rest lerobot-from-source `encode()` drift).
- Collected `+56`, fully accounted: `+45` the new file, `+8` in
  `test_args_docstring_completeness.py` (4 Protocol methods x 2 tests), `+3` in
  `test_finalizer_reports_only_real_cleanup_failures.py` (one per new module). All pass.

No visual artifact: this changes no policy, simulation behaviour, rendering, recording or
asset. The measured tables above are the evidence.

## Docs

`docs/getting-started/robot-factory.md` gains the parameter row and a "Choosing a driver"
section; `docs/hardware/robot-control.md` points at it. The refusal quoted in the docs is
compared byte-for-byte against the real message.
