### PR TITLE
fix(mesh): report a refused rollout when a fleet stop aggregates

### DIFF
--- a/changelog.d/2735-fleet-stop-refused-rollout.md
+++ b/changelog.d/2735-fleet-stop-refused-rollout.md
@@ -1,0 +1,32 @@
+### Fixed: a fleet-wide sim stop reports a rollout whose `stop_policy` refused, instead of answering `ok=True` over it
+
+`Mesh.emergency_stop` broadcasts `{"action": "stop"}` and carries no `robot_name`, so on a
+simulation peer it lands in the fleet-wide branch of `_dispatch`: read every active rollout
+from `_active_policy_robots()` and call `stop_policy` once per robot. That branch is the
+only stop path that aggregates, and it aggregated by assuming the answer -- the per-robot
+results were collected into `results` and the envelope hardcoded `ok=True`.
+
+`_peers_that_did_not_stop` reads only the top-level `ok`/`status`, never `results`, so a
+`stop_policy` that refused was scored as a halt: the refusal sat in the payload unread and
+the robot was listed under `stopped`. `emergency_stop` then kept the peer out of
+`peers_not_stopped` and did not fire the CRITICAL "robots may still be executing" warning.
+That is the affirmative lie the two sibling stop branches are commented against, and the
+exact shape `_peers_that_did_not_stop`'s own docstring lists as one it must catch.
+
+The two paths therefore disagreed about one refusal. Asked to stop `bob` by name the peer
+answered `{"status": "error", ...}` and was flagged; asked to stop everything with `bob`
+among the rollouts it answered `{"ok": True, "stopped": ["alice", "bob"], ...}` and was not.
+The path the fanout uses is the one that swallowed it.
+
+`ok` is now derived from the per-robot answers rather than assumed, through a single shared
+predicate. `_reports_failure_to_stop` owns the rule `ok is False or status == "error"` --
+both spellings, because the stop verbs disagree about their envelope: `stop_task` and the
+dispatch's own branches answer `{"ok": ...}` while `Simulation.stop_policy` answers the
+agent-tool `{"status": ...}`. `_peers_that_did_not_stop` reads that predicate instead of its
+own copy of the comparison, since a second copy of the rule is how the branch came to
+contradict the aggregation. The fleet-wide branch grades each answer with it, reports
+`ok=False` with `not_stopped` naming the refusing robots, keeps `stopped` for the ones that
+really stopped, logs at ERROR, and leaves `results` in place so the detail is available.
+
+A fleet stop in which every rollout stopped is unchanged, with no `not_stopped` and no
+`error` key; a peer with no rollouts and a robot-less gateway peer are both untouched.

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -19,7 +19,7 @@ import socket
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from strands_robots._mesh_switch import mesh_env_request
@@ -356,16 +356,47 @@ def _extract_sample_source_zid(sample: Any) -> str | None:
         return None
 
 
+def _reports_failure_to_stop(result: Mapping[str, Any]) -> bool:
+    """Whether a stop result AFFIRMATIVELY reports that nothing was stopped.
+
+    The single owner of that rule. Two callers read it and they must not drift:
+    :func:`_peers_that_did_not_stop` grades the envelopes an
+    :meth:`Mesh.emergency_stop` broadcast collected, and the fleet-wide sim
+    branch of :meth:`Mesh._dispatch` grades each per-robot ``stop_policy``
+    answer before deciding its own ``ok``. A second copy of the rule is how the
+    branch came to report ``ok=True`` over a refusal it had in hand.
+
+    Two spellings mean the same thing here, because the stop verbs disagree
+    about their envelope: ``stop_task`` and the dispatch's own branches answer
+    ``{"ok": ...}``, while ``Simulation.stop_policy`` answers the agent-tool
+    ``{"status": "success"|"error"}``.
+
+    Args:
+        result: A stop result, either a ``_dispatch`` return value or the
+            ``result`` member of a response envelope.
+
+    Returns:
+        ``True`` only when the result explicitly says a stop did not happen.
+        A shape carrying neither key is not a failure report -- see
+        :func:`_peers_that_did_not_stop` on why that stays conservative.
+    """
+    return result.get("ok") is False or result.get("status") == "error"
+
+
 def _peers_that_did_not_stop(responses: list[dict[str, Any]]) -> set[str]:
     """Identify responders that explicitly reported they did NOT stop.
 
-    An emergency stop is only as trustworthy as its accounting. Three shapes
+    An emergency stop is only as trustworthy as its accounting. Four shapes
     from ``Mesh._dispatch`` report a stop that did not happen: a peer whose
     registered robot exposes no ``stop_task`` answers ``{"ok": False, ...}``, a
     hardware stop that failed answers ``{"ok": False, "error": "stop_task
-    failed: ..."}``, and a sim peer whose ``stop_policy`` refused answers
-    ``{"status": "error", ...}``. Counting any of them as an acknowledgement
-    tells the operator the fleet halted while a robot is still executing.
+    failed: ..."}``, a sim peer asked to stop one named robot whose
+    ``stop_policy`` refused answers ``{"status": "error", ...}``, and a sim peer
+    asked to stop every active rollout -- which is what the
+    :meth:`Mesh.emergency_stop` fanout asks, since it carries no ``robot_name``
+    -- answers ``{"ok": False, "not_stopped": [...], ...}`` when any one of them
+    refused. Counting any of them as an acknowledgement tells the operator the
+    fleet halted while a robot is still executing.
 
     Deliberately conservative: only responses that AFFIRMATIVELY report failure
     are flagged. A response shape this function does not recognise is left out
@@ -388,7 +419,7 @@ def _peers_that_did_not_stop(responses: list[dict[str, Any]]) -> set[str]:
         result = response.get("result", response)
         if not isinstance(result, dict):
             continue
-        did_not_stop = result.get("ok") is False or result.get("status") == "error"
+        did_not_stop = _reports_failure_to_stop(result)
         if did_not_stop:
             failed.add(str(response.get("responder_id") or f"<unidentified-responder-{index}>"))
     return failed
@@ -2074,7 +2105,34 @@ class Mesh(SensorLoopsMixin):
                     if not active:
                         return {"ok": True, "stopped": [], "note": "no policies running"}
                     results = {name: dict(r.stop_policy(name)) for name in active}
-                    return {"ok": True, "stopped": list(results), "results": results}
+                    # ``ok`` is derived from the per-robot answers, never
+                    # assumed. Reporting ok=True here counted a refused
+                    # stop as a halt: the refusal sat in ``results``, which
+                    # ``_peers_that_did_not_stop`` does not read, so the
+                    # peer was scored as stopped and the operator was told
+                    # the fleet had halted. This is the ONLY stop path that
+                    # aggregates -- both sibling branches return the stop
+                    # verb's own answer, so a refusal reaches the
+                    # accounting through them unchanged.
+                    refused = sorted(n for n, res in results.items() if _reports_failure_to_stop(res))
+                    stopped = [n for n in results if n not in set(refused)]
+                    if refused:
+                        logger.error(
+                            "[safety] %s: stop_policy refused for %d of %d active rollout(s): %s; "
+                            "those policies may still be executing",
+                            self.peer_id,
+                            len(refused),
+                            len(results),
+                            refused,
+                        )
+                        return {
+                            "ok": False,
+                            "stopped": stopped,
+                            "not_stopped": refused,
+                            "results": results,
+                            "error": f"stop_policy refused for: {', '.join(refused)}",
+                        }
+                    return {"ok": True, "stopped": stopped, "results": results}
                 except Exception as exc:  # noqa: BLE001 - stop must answer, not raise
                     return {"ok": False, "error": f"stop_policy failed: {exc}"}
             # Child SimRobot peer: delegate stop to the parent sim

--- a/tests/mesh/test_fleet_stop_reports_a_refused_rollout.py
+++ b/tests/mesh/test_fleet_stop_reports_a_refused_rollout.py
@@ -1,0 +1,228 @@
+"""A fleet-wide sim stop must not report a refused rollout as halted.
+
+:meth:`strands_robots.mesh.Mesh.emergency_stop` broadcasts ``{"action":
+"stop"}`` and carries no ``robot_name``, so on a simulation peer it lands in the
+fleet-wide branch of ``_dispatch``: read every active rollout from
+``_active_policy_robots()`` and call ``stop_policy`` once per robot. That branch
+is the only stop path that AGGREGATES -- the named-robot branch and the child
+``_sim_parent`` branch each return the stop verb's own answer, so a refusal
+reaches the accounting through them unchanged.
+
+It aggregated by assuming the answer: the per-robot results were collected into
+``results`` and the envelope hardcoded ``ok=True``.
+:func:`strands_robots.mesh.core._peers_that_did_not_stop` reads only the
+top-level ``ok``/``status``, never ``results``, so a ``stop_policy`` that refused
+was scored as a halt -- the refusal was in the payload, unread. The operator was
+told the fleet had stopped, which is the affirmative lie the surrounding branches
+are commented against and the exact shape that function's own docstring lists as
+something it must catch.
+
+The two paths therefore disagreed about one refusal: asked to stop ``bob`` by
+name the peer answered ``{"status": "error"}`` and was flagged; asked to stop
+everything with ``bob`` among the rollouts it answered ``ok=True`` with ``bob``
+listed under ``stopped``.
+
+Pinned here: the refusal is reported and flagged, both paths agree about it, the
+verdict is derived through one shared predicate rather than a second copy of the
+rule, and -- the half that keeps the fix from being over-broad -- a fleet stop in
+which every rollout really did stop still answers affirmatively.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import Mesh
+from strands_robots.mesh.core import _peers_that_did_not_stop, _reports_failure_to_stop
+
+#: Refusal envelope ``Simulation.stop_policy`` returns for a robot it cannot
+#: resolve. Grounded against the real method by
+#: :class:`TestTheStandInMatchesTheRealStopVerb`.
+_REFUSAL: dict[str, Any] = {"status": "error", "content": [{"text": "Unknown robot 'bob'."}]}
+
+
+class _SimPeer:
+    """A simulation peer with two rollouts, one of which may refuse to stop.
+
+    Deliberately not a ``Mock``: ``hasattr`` is the router's test, and a mock
+    answers every ``hasattr`` truthfully-by-fabrication, so a mock would route
+    into branches this fixture is not exercising.
+    """
+
+    def __init__(self, active: list[str], refuse: tuple[str, ...] = ()) -> None:
+        self._active = list(active)
+        self._refuse = set(refuse)
+        self.stopped_calls: list[str] = []
+
+    def _active_policy_robots(self) -> list[str]:
+        return list(self._active)
+
+    def stop_policy(self, robot_name: str = "") -> dict[str, Any]:
+        self.stopped_calls.append(robot_name)
+        if robot_name in self._refuse:
+            return dict(_REFUSAL)
+        return {"status": "success", "content": [{"text": f"Stopped on '{robot_name}'"}]}
+
+
+def _dispatch_stop(peer: _SimPeer, **cmd: Any) -> dict[str, Any]:
+    """Answer ``_dispatch`` gives a stop command aimed at *peer*."""
+    mesh = Mesh(peer, peer_id="sim-1", peer_type="simulation")
+    return mesh._dispatch({"action": "stop", **cmd})
+
+
+def _flagged(result: dict[str, Any]) -> bool:
+    """Whether ``emergency_stop``'s accounting counts *result* as not stopped."""
+    return bool(_peers_that_did_not_stop([{"responder_id": "sim-1", "result": result}]))
+
+
+class TestAFleetStopReportsARefusedRollout:
+    """The refusal reaches the envelope the safety accounting reads."""
+
+    def test_a_refused_rollout_makes_the_fleet_answer_negative(self) -> None:
+        peer = _SimPeer(["alice", "bob"], refuse=("bob",))
+
+        result = _dispatch_stop(peer)
+
+        assert peer.stopped_calls == ["alice", "bob"], peer.stopped_calls
+        assert result["ok"] is False, result
+
+    def test_the_refusing_robot_is_named_and_not_counted_as_stopped(self) -> None:
+        result = _dispatch_stop(_SimPeer(["alice", "bob"], refuse=("bob",)))
+
+        assert result["not_stopped"] == ["bob"], result
+        assert result["stopped"] == ["alice"], result
+        assert "bob" in result["error"], result
+
+    def test_the_accounting_counts_the_peer_as_not_stopped(self) -> None:
+        result = _dispatch_stop(_SimPeer(["alice", "bob"], refuse=("bob",)))
+
+        assert _flagged(result) is True, result
+
+    def test_every_rollout_refusing_is_reported_in_full(self) -> None:
+        result = _dispatch_stop(_SimPeer(["alice", "bob"], refuse=("alice", "bob")))
+
+        assert result["ok"] is False, result
+        assert result["not_stopped"] == ["alice", "bob"], result
+        assert result["stopped"] == [], result
+
+    def test_the_per_robot_answers_are_still_carried(self) -> None:
+        """The detail stays available; ``ok`` no longer contradicts it."""
+        result = _dispatch_stop(_SimPeer(["alice", "bob"], refuse=("bob",)))
+
+        assert result["results"]["bob"] == _REFUSAL, result
+        assert result["results"]["alice"]["status"] == "success", result
+
+
+class TestBothStopPathsAgreeAboutARefusal:
+    """One refusal, one verdict, whether or not the command named the robot."""
+
+    @pytest.mark.parametrize("cmd", [{"robot_name": "bob"}, {}], ids=["named-robot", "fleet-wide"])
+    def test_a_refusal_is_flagged_whichever_path_carried_it(self, cmd: dict[str, Any]) -> None:
+        result = _dispatch_stop(_SimPeer(["bob"], refuse=("bob",)), **cmd)
+
+        assert _flagged(result) is True, (cmd, result)
+
+    @pytest.mark.parametrize("cmd", [{"robot_name": "bob"}, {}], ids=["named-robot", "fleet-wide"])
+    def test_a_stop_that_succeeded_is_not_flagged_on_either_path(self, cmd: dict[str, Any]) -> None:
+        result = _dispatch_stop(_SimPeer(["bob"]), **cmd)
+
+        assert _flagged(result) is False, (cmd, result)
+
+
+class TestAFleetStopThatSucceededIsUnchanged:
+    """Over-reach controls: only a refusal may turn the answer negative."""
+
+    def test_every_rollout_stopping_answers_affirmatively(self) -> None:
+        peer = _SimPeer(["alice", "bob"])
+
+        result = _dispatch_stop(peer)
+
+        assert result["ok"] is True, result
+        assert result["stopped"] == ["alice", "bob"], result
+        assert _flagged(result) is False, result
+
+    def test_a_fully_successful_stop_names_nothing_as_unstopped(self) -> None:
+        result = _dispatch_stop(_SimPeer(["alice", "bob"]))
+
+        assert "not_stopped" not in result, result
+        assert "error" not in result, result
+
+    def test_a_peer_with_no_rollouts_still_answers_affirmatively(self) -> None:
+        result = _dispatch_stop(_SimPeer([]))
+
+        assert result == {"ok": True, "stopped": [], "note": "no policies running"}, result
+        assert _flagged(result) is False, result
+
+    def test_a_robot_less_peer_is_unaffected(self) -> None:
+        """The gateway answer this branch sits below is not disturbed."""
+        result = Mesh(None, peer_id="gateway-1", peer_type="gateway")._dispatch({"action": "stop"})
+
+        assert result["ok"] is True, result
+        assert result["stopped"] == [], result
+        assert _flagged(result) is False, result
+
+
+class TestTheFailureRuleHasASingleOwner:
+    """Two readers, one predicate: a second copy is how the branch drifted."""
+
+    def test_the_predicate_recognises_both_envelope_spellings(self) -> None:
+        assert _reports_failure_to_stop({"ok": False}) is True
+        assert _reports_failure_to_stop({"status": "error"}) is True
+
+    def test_the_predicate_stays_conservative_about_shapes_it_cannot_read(self) -> None:
+        """An unrecognised shape is not a failure report -- a false "did not
+        stop" on the safety path is what trains operators to ignore warnings."""
+        assert _reports_failure_to_stop({}) is False
+        assert _reports_failure_to_stop({"ok": True}) is False
+        assert _reports_failure_to_stop({"status": "success"}) is False
+        assert _reports_failure_to_stop({"stopped": []}) is False
+
+    def test_both_readers_call_the_shared_predicate(self) -> None:
+        from strands_robots.mesh import core as core_mod
+
+        aggregation = inspect.getsource(core_mod._peers_that_did_not_stop)
+        dispatch = inspect.getsource(core_mod.Mesh._dispatch)
+
+        assert "_reports_failure_to_stop(" in aggregation, aggregation
+        assert "_reports_failure_to_stop(" in dispatch, "the fleet branch must not re-derive the rule"
+
+    def test_the_rule_itself_is_written_down_exactly_once(self) -> None:
+        """Derived, so a third copy of the comparison fails rather than drifts."""
+        from strands_robots.mesh import core as core_mod
+
+        source = Path(str(core_mod.__file__)).read_text(encoding="utf-8")
+        owner = inspect.getsource(core_mod._reports_failure_to_stop)
+        rule = re.compile(r'\.get\(\s*["\']status["\']\s*\)\s*==\s*["\']error["\']')
+
+        assert len(rule.findall(owner)) == 1, owner
+        assert len(rule.findall(source)) == 1, "the status=='error' rule is spelled outside its owner"
+
+
+class TestTheStandInMatchesTheRealStopVerb:
+    """Premise: the fixture stands in for the surface production exposes."""
+
+    def test_the_simulation_exposes_the_two_attributes_the_branch_routes_on(self) -> None:
+        mujoco_sim = pytest.importorskip("strands_robots.simulation.mujoco.simulation")
+        engine = mujoco_sim.MuJoCoSimEngine
+
+        for attribute in ("stop_policy", "_active_policy_robots"):
+            assert callable(getattr(engine, attribute, None)), attribute
+
+    def test_the_real_stop_policy_refuses_an_unresolvable_robot_with_the_fixture_shape(self) -> None:
+        """A refusal really is ``status="error"`` -- the shape the branch grades."""
+        pytest.importorskip("mujoco")
+        from strands_robots.simulation import create_simulation
+
+        sim: Any = create_simulation("mujoco")
+        try:
+            refusal = sim.stop_policy("no-such-robot")
+        finally:
+            sim.cleanup()
+
+        assert refusal["status"] == "error", refusal
+        assert _reports_failure_to_stop(refusal) is True, refusal


### PR DESCRIPTION
## Problem

`Mesh.emergency_stop` broadcasts `{"action": "stop"}` and carries no `robot_name`, so on a
simulation peer it lands in the fleet-wide branch of `_dispatch`: read every active rollout from
`_active_policy_robots()`, call `stop_policy` once per robot, and answer.

That branch is the only stop path that *aggregates*, and it aggregated by assuming the answer:

```python
results = {name: dict(r.stop_policy(name)) for name in active}
return {"ok": True, "stopped": list(results), "results": results}
```

`_peers_that_did_not_stop` reads only the top-level `ok`/`status`, never `results`. So a
`stop_policy` that refused was scored as a halt: the refusal was in the payload, unread, and the
robot was listed under `stopped`. `emergency_stop` then reported the peer as having stopped, kept it
out of `peers_not_stopped`, and did not fire the CRITICAL "robots may still be executing" warning.

That is the affirmative lie the two sibling branches are explicitly commented against, and the exact
shape `_peers_that_did_not_stop`'s own docstring lists as something it must catch: "a sim peer whose
`stop_policy` refused answers `{"status": "error", ...}`".

The two stop paths therefore disagreed about one refusal. Measured through `_dispatch` with a peer
carrying two rollouts where `bob`'s stop refuses:

| command | dispatch answer | counted as did-not-stop |
|---|---|---|
| `{"action": "stop", "robot_name": "bob"}` | `{"status": "error", ...}` | **yes** |
| `{"action": "stop"}` (what `emergency_stop` sends) | `{"ok": True, "stopped": ["alice", "bob"], ...}` | **no** |

Same refusal, opposite accounting, and the wrong one is the path the fanout uses.

## Change

`ok` is derived from the per-robot answers instead of assumed, through one shared predicate:

- New `_reports_failure_to_stop(result)` owns the rule `ok is False or status == "error"`. Both
  spellings are needed because the stop verbs disagree about their envelope: `stop_task` and the
  dispatch's own branches answer `{"ok": ...}`, `Simulation.stop_policy` answers the agent-tool
  `{"status": ...}`.
- `_peers_that_did_not_stop` now reads that predicate rather than its own copy of the comparison. A
  second copy of the rule is how the branch came to contradict the aggregation in the first place.
- The fleet-wide branch grades each answer with it, reports `ok: False` with `not_stopped` naming the
  refusing robots, keeps `stopped` for the ones that really stopped, logs at ERROR, and leaves
  `results` in place so the detail is still available.
- The aggregation's docstring enumerated three recognised shapes; it now enumerates the fourth and
  says which one the fanout produces.

A fleet stop in which every rollout stopped is unchanged: `{"ok": True, "stopped": [...]}`, with no
`not_stopped` and no `error` key. A peer with no rollouts and a robot-less gateway peer are both
untouched.

## Tests

`tests/mesh/test_fleet_stop_reports_a_refused_rollout.py`, 19 cases in 5 classes: the refusal is
reported and flagged, both paths agree about it, the rule has a single owner (derived, so a third
copy fails rather than drifts), over-reach controls for the fully-successful and no-rollout cases,
and a premise class grounding the stand-in against the real verb -- `create_simulation("mujoco")`
then `stop_policy("no-such-robot")` really does answer `status="error"`.

Pre-fix, reverting only the branch and keeping the shared helper: **6 failed / 13 passed**, with
**0 failures in the over-reach control class** and 0 in the premise class. The headline failure is
`{'ok': True, ..., 'stopped': ['alice', 'bob']}` while `results['bob']` reads `status: 'error'`.
A raw revert is instead a collection error, since the helper is a new symbol.

Break table, 10 mutations against the new file: **8 distinct firing sets, no undetected mutation,
control clean, source restored byte-identical.**

| mutation | fires |
|---|---|
| control | 0 |
| branch reverted, `ok` hardcoded True (the defect) | 6 |
| `refused` computed but `ok` still True | 4 |
| `stopped` lists every attempted robot | 2 |
| branch re-derives the rule inline (second copy) | 2 |
| aggregation re-derives the rule inline (second copy) | 2 |
| predicate drops the `status == "error"` spelling | 9 |
| predicate drops the `ok is False` spelling | 3 |
| predicate over-broad: anything not `ok=True` is a failure | 7 |
| `not_stopped` key omitted | 2 |
| `error` key omitted | 1 |

The two "second copy of the rule" mutations share a firing set, which is the point: they are the
same mutation class, and the structural tests are what catch either one.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1547 files).
- `mypy strands_robots tests tests_integ`: **0 branch-only messages** against a pristine `main`
  worktree (normalised message-set diff empty). The two pre-existing `mesh/core.py` `arg-type`
  errors are present on `main` unchanged.
- Paired run, identical 323-file selection (all of `tests/mesh/` plus every test naming
  `emergency_stop`, `_peers_that_did_not_stop` or `mesh.core`, and every guard walking the tree or
  reading docstrings), the new file excluded from both trees: **10450 collected and
  `21 failed, 10341 passed, 64 skipped, 24 errors` on both**, 45 failing/error ids each, `comm`
  empty in both directions. All 45 need `awsiot` (the `[mesh-iot]` extra).
- New file 19 passed; together with the existing `test_gateway_peer_stop_accounting.py`, 25 passed.

No visual artifact: this changes a dispatch envelope and the safety accounting that reads it, not
policy, simulation, rendering, recording or an asset. The measured before/after table above is the
evidence.
