### PR TITLE
fix(kimodo): refuse a config file that cannot supply fields, by name

### DIFF
--- a/changelog.d/2736-kimodo-config-file-loader-refusals.md
+++ b/changelog.d/2736-kimodo-config-file-loader-refusals.md
@@ -1,0 +1,35 @@
+### Fixed
+
+- **policies/kimodo**: `KimodoConfig.from_json` now reports a config file it
+  cannot read the way its two sibling policy-config loaders already do. It
+  parsed the file and handed the result straight to `from_dict`, whose first act
+  is `data.items()`, so a file holding any JSON value other than an object
+  surfaced as `AttributeError: 'list' object has no attribute 'items'` - a
+  message naming a method of the parsed value rather than the file that could
+  not supply fields. Measured across the five non-object JSON values, all five
+  failed that way; all five are now `ValueError` naming the class, the resolved
+  path and the type found (`KimodoConfig file /tmp/cfg.json must contain a
+  mapping, got list`). A file that was not JSON escaped as a bare
+  `json.JSONDecodeError` and is now wrapped with the file named, a path that is
+  not a file raises `FileNotFoundError` naming the class instead of an errno
+  alone, and `~` is expanded - a config at `~/kimodo.json` was previously
+  reported missing while it existed, with the literal `~` in the message.
+  `MotionBricksConfig.from_file` and `WBCConfig.from_file` shipped all four
+  already, so this is two of three loaders' behaviour applied to the third, and
+  the new tests grade the rule over all three by discovering them rather than
+  listing them. The extension is deliberately still unchecked, unlike those two:
+  a JSON object stored under another name loads today, and refusing one would
+  stop a payload that currently works, so no input that loads today stops
+  loading.
+
+- **policies/kimodo**: the unrecognised-key policy is now documented as the one
+  the code implements. `from_dict` described the drop as happening "with a
+  warning"; measured, none of the three policy configs warns, and the other two
+  document the drop as silent forward compatibility, so the docstring was the
+  outlier. `docs/policies/kimodo.md` presents three interchangeable ways to set
+  a field and claimed a misspelled knob "raises `TypeError` at construction
+  instead of being silently ignored" - true for the two keyword forms, and not
+  for the `config` dict, which is read by `from_dict`:
+  `KimodoPolicy(config={"diffusion_stpes": 25})` builds with the default 100 and
+  emits nothing. The page now says which form refuses and which drops, and how
+  to have a typo refused.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -156,8 +156,29 @@ KimodoPolicy(config={"diffusion_steps": 25})           # a plain dict
 
 Precedence is per-field override > `config` field > the default in the table. A
 merged value is re-validated by `KimodoConfig`, so `diffusion_steps=0` is
-refused whichever way it arrives. There is no `**kwargs`: a misspelled knob
-raises `TypeError` at construction instead of being silently ignored.
+refused whichever way it arrives.
+
+A misspelled knob is refused by the two keyword forms and dropped by the dict
+form. Neither `KimodoPolicy` nor `KimodoConfig` takes `**kwargs`, so
+`KimodoPolicy(diffusion_stpes=25)` raises `TypeError` at construction. A
+`config` dict is read by `KimodoConfig.from_dict`, which drops keys that are not
+fields for forward compatibility - the policy the MotionBricks and WBC configs
+state for their own `from_dict` - so `KimodoPolicy(config={"diffusion_stpes":
+25})` builds with the default 100 and emits no warning. Pass the knob as a
+keyword, or build a `KimodoConfig` first, if a typo should be refused.
+
+### Loading a config from a file
+
+```python
+KimodoPolicy(config=KimodoConfig.from_json("~/kimodo.json"))
+```
+
+`from_json` expands `~` and names the file in every refusal: a path that is not
+a file raises `FileNotFoundError`, and a file that is not valid JSON or that
+holds a JSON value other than an object raises `ValueError` naming the file and
+what it found instead. Keys inside the object follow the drop policy above, and
+values keep the domains in the table. The extension is not checked, so a JSON
+object stored under any name loads.
 
 ## When the sampler runs again
 

--- a/strands_robots/policies/kimodo/config.py
+++ b/strands_robots/policies/kimodo/config.py
@@ -25,6 +25,7 @@ pipeline, so a real-model run supplies its sampler through ``motion_agent=``.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -161,16 +162,61 @@ class KimodoConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> KimodoConfig:
-        """Build a config from a plain dict (drops unknown keys with a warning)."""
+        """Build a config from a plain dict.
+
+        Only recognised keys are consumed; unknown keys are ignored for forward
+        compatibility, and no warning is emitted for a dropped key - the policy
+        :mod:`strands_robots.policies.motionbricks.config` and
+        :mod:`strands_robots.policies.wbc.config` state for their own
+        ``from_dict``.
+
+        Args:
+            data: Mapping of field name to value. Keys that are not fields of
+                this class are dropped.
+
+        Returns:
+            The config, validated by :meth:`__post_init__`.
+        """
         known = {f.name for f in cls.__dataclass_fields__.values()}
         kwargs = {k: v for k, v in data.items() if k in known}
         return cls(**kwargs)
 
     @classmethod
     def from_json(cls, path: str | Path) -> KimodoConfig:
-        """Load a config from a JSON file on disk."""
-        import json
+        """Load a config from a JSON file on disk.
 
-        p = Path(path)
-        with p.open("r", encoding="utf-8") as f:
-            return cls.from_dict(json.load(f))
+        A file that cannot supply fields is reported by name rather than
+        reaching :meth:`from_dict`, which is the reporting the sibling
+        policy-config file loaders in
+        :mod:`strands_robots.policies.motionbricks.config` and
+        :mod:`strands_robots.policies.wbc.config` already give. ``~`` in
+        ``path`` is expanded.
+
+        The extension is deliberately not checked, unlike those two loaders: a
+        JSON object stored under any name loads here today, and refusing one
+        would stop a payload that currently works. Every refusal below names an
+        input that already fails.
+
+        Args:
+            path: Path to a file holding a JSON object of config fields.
+
+        Returns:
+            The config, validated by :meth:`__post_init__`.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not name a file.
+            ValueError: If the file is not valid JSON, or holds a JSON value
+                that is not an object. A value inside the object keeps the
+                domain :meth:`__post_init__` applies to it, so the loader adds
+                no second domain of its own.
+        """
+        p = Path(path).expanduser()
+        if not p.is_file():
+            raise FileNotFoundError(f"KimodoConfig file not found: {p}")
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            raise ValueError(f"KimodoConfig file {p} is not valid JSON: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError(f"KimodoConfig file {p} must contain a mapping, got {type(data).__name__}")
+        return cls.from_dict(data)

--- a/tests/policies/kimodo/test_config_file_loader_refusals.py
+++ b/tests/policies/kimodo/test_config_file_loader_refusals.py
@@ -1,0 +1,373 @@
+"""A policy config file loader reports a payload it cannot use, by name.
+
+``KimodoConfig.from_json`` read a JSON file and handed whatever it parsed
+straight to :meth:`KimodoConfig.from_dict`, which immediately calls
+``data.items()``. A file holding a JSON array, string, number, boolean or
+``null`` therefore surfaced as ``AttributeError: 'list' object has no attribute
+'items'`` - a message naming a method of the parsed value rather than the file
+that could not supply fields. A file that was not JSON at all escaped as a bare
+``json.JSONDecodeError``, and ``~`` in the path was never expanded, so a config
+at ``~/kimodo.json`` was reported missing while it existed.
+
+The two sibling policy-config file loaders
+(:mod:`strands_robots.policies.motionbricks.config` and
+:mod:`strands_robots.policies.wbc.config`) already refuse a non-object payload
+with a message naming the class, the resolved path and the JSON type they got,
+already expand ``~``, and already wrap a decode failure. So the rule graded here
+is not new: it is the reporting two of the three loaders shipped, applied to the
+third.
+
+The survey is derived rather than listed - every public class in a
+``strands_robots/policies/*/config.py`` module that exposes a ``from_*(path)``
+classmethod is held to it, so a fourth policy config's loader is graded the hour
+it lands rather than inheriting an exemption by being absent from a tuple.
+
+One deliberate divergence stays: the two siblings refuse a file whose extension
+is not ``.json``, and ``from_json`` does not. A JSON object stored under another
+name loads today, and refusing it would stop a payload that currently works,
+so it is pinned as a control below rather than closed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_POLICY_CONFIG_ROOT = Path(__file__).resolve().parents[3] / "strands_robots" / "policies"
+_DOCS_ROOT = Path(__file__).resolve().parents[3] / "docs"
+
+# A minimal payload each loader accepts. Two of the three configs require an
+# entry, so a shared "this builds" fixture cannot be derived from the class
+# alone; the non-vacuity test below fails if a newly discovered loader has no
+# entry here, rather than skipping it.
+_MINIMAL_PAYLOAD: dict[str, dict[str, Any]] = {
+    "KimodoConfig": {"diffusion_steps": 50},
+    "MotionBricksConfig": {"result_dir": "results"},
+    "WBCConfig": {"policy_path": "policy.onnx"},
+}
+
+# Every JSON value that is not an object. ``from_dict`` needs ``.items()``, so
+# each of these is a payload no config loader can consume.
+_NON_OBJECT_PAYLOADS = (
+    ("array", "[1, 2, 3]", "list"),
+    ("string", '"diffusion_steps"', "str"),
+    ("number", "42", "int"),
+    ("boolean", "true", "bool"),
+    ("null", "null", "NoneType"),
+)
+
+
+def _config_modules() -> list[Any]:
+    """Import every ``strands_robots/policies/*/config.py`` module."""
+    return [
+        importlib.import_module(f"strands_robots.policies.{path.parent.name}.config")
+        for path in sorted(_POLICY_CONFIG_ROOT.glob("*/config.py"))
+    ]
+
+
+def _own_public_classes(module: Any) -> list[type]:
+    return [
+        obj
+        for name in dir(module)
+        if not name.startswith("_")
+        for obj in [getattr(module, name)]
+        if isinstance(obj, type) and getattr(obj, "__module__", None) == module.__name__
+    ]
+
+
+def _classmethods_taking(param: str) -> list[tuple[type, str]]:
+    """Find ``from_*`` classmethods whose only parameter is named ``param``."""
+    found: list[tuple[type, str]] = []
+    for module in _config_modules():
+        for cls in _own_public_classes(module):
+            for name in dir(cls):
+                if not name.startswith("from_"):
+                    continue
+                candidate = getattr(cls, name, None)
+                if not callable(candidate):
+                    continue
+                try:
+                    parameters = list(inspect.signature(candidate).parameters)
+                except (TypeError, ValueError):
+                    continue
+                if parameters == [param]:
+                    found.append((cls, name))
+    return sorted(found, key=lambda entry: (entry[0].__name__, entry[1]))
+
+
+def _path_loaders() -> list[tuple[type, str]]:
+    return _classmethods_taking("path")
+
+
+def _dict_loaders() -> list[tuple[type, str]]:
+    return _classmethods_taking("data")
+
+
+def _ids(loaders: list[tuple[type, str]]) -> list[str]:
+    return [f"{cls.__name__}.{name}" for cls, name in loaders]
+
+
+def _write_non_object(directory: Path) -> Path:
+    """Write a JSON array - a payload no config loader can consume."""
+    path = directory / "config.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    return path
+
+
+class TestTheSurveyReachesEveryPolicyConfigLoader:
+    """Non-vacuity: the derived sets are populated and cover the known loaders."""
+
+    def test_the_three_shipped_file_loaders_are_discovered(self) -> None:
+        assert _ids(_path_loaders()) == [
+            "KimodoConfig.from_json",
+            "MotionBricksConfig.from_file",
+            "WBCConfig.from_file",
+        ]
+
+    def test_the_three_shipped_dict_loaders_are_discovered(self) -> None:
+        assert _ids(_dict_loaders()) == [
+            "KimodoConfig.from_dict",
+            "MotionBricksConfig.from_dict",
+            "WBCConfig.from_dict",
+        ]
+
+    def test_every_discovered_loader_has_a_payload_that_builds(self) -> None:
+        discovered = {cls.__name__ for cls, _ in _path_loaders() + _dict_loaders()}
+        missing = discovered - set(_MINIMAL_PAYLOAD)
+        assert not missing, f"add a minimal payload for {sorted(missing)} so it is graded rather than skipped"
+
+    @pytest.mark.parametrize(
+        ("label", "text", "type_name"), _NON_OBJECT_PAYLOADS, ids=[p[0] for p in _NON_OBJECT_PAYLOADS]
+    )
+    def test_each_probe_payload_is_valid_json_that_is_not_an_object(
+        self, label: str, text: str, type_name: str
+    ) -> None:
+        parsed = json.loads(text)
+        assert not isinstance(parsed, dict)
+        assert type(parsed).__name__ == type_name
+
+
+class TestANonObjectPayloadIsRefusedByName:
+    """The regression: a file that cannot supply fields names itself, not ``.items()``."""
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    @pytest.mark.parametrize(
+        ("label", "text", "type_name"), _NON_OBJECT_PAYLOADS, ids=[p[0] for p in _NON_OBJECT_PAYLOADS]
+    )
+    def test_every_json_value_that_is_not_an_object_is_refused(
+        self, tmp_path: Path, cls: type, loader: str, label: str, text: str, type_name: str
+    ) -> None:
+        path = tmp_path / "config.json"
+        path.write_text(text, encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            getattr(cls, loader)(path)
+
+    # The three message components are graded separately so a refusal that stops
+    # naming one of them is distinguishable from a refusal that stops happening.
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_the_refusal_names_the_config_class(self, tmp_path: Path, cls: type, loader: str) -> None:
+        path = _write_non_object(tmp_path)
+
+        with pytest.raises(ValueError) as caught:
+            getattr(cls, loader)(path)
+
+        assert cls.__name__ in str(caught.value)
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_the_refusal_names_the_file_it_read(self, tmp_path: Path, cls: type, loader: str) -> None:
+        path = _write_non_object(tmp_path)
+
+        with pytest.raises(ValueError) as caught:
+            getattr(cls, loader)(path)
+
+        assert str(path) in str(caught.value)
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_the_refusal_names_the_json_type_it_got(self, tmp_path: Path, cls: type, loader: str) -> None:
+        path = _write_non_object(tmp_path)
+
+        with pytest.raises(ValueError) as caught:
+            getattr(cls, loader)(path)
+
+        assert "list" in str(caught.value)
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_a_file_that_is_not_json_is_reported_as_a_value_error(self, tmp_path: Path, cls: type, loader: str) -> None:
+        path = tmp_path / "config.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        with pytest.raises(ValueError) as caught:
+            getattr(cls, loader)(path)
+
+        message = str(caught.value)
+        assert cls.__name__ in message
+        assert str(path) in message
+        assert "not valid JSON" in message
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_a_missing_file_is_reported_with_the_path_it_looked_for(
+        self, tmp_path: Path, cls: type, loader: str
+    ) -> None:
+        path = tmp_path / "absent.json"
+
+        with pytest.raises(FileNotFoundError) as caught:
+            getattr(cls, loader)(path)
+
+        message = str(caught.value)
+        assert cls.__name__ in message
+        assert str(path) in message
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_a_directory_is_reported_as_a_missing_file_not_a_read_error(
+        self, tmp_path: Path, cls: type, loader: str
+    ) -> None:
+        """Why the check is ``is_file()`` and not ``exists()``."""
+        directory = tmp_path / "config.json"
+        directory.mkdir()
+
+        with pytest.raises(FileNotFoundError) as caught:
+            getattr(cls, loader)(directory)
+
+        assert cls.__name__ in str(caught.value)
+
+    @pytest.mark.parametrize(("cls", "loader"), _path_loaders(), ids=_ids(_path_loaders()))
+    def test_a_home_relative_path_is_expanded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cls: type, loader: str
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        (tmp_path / "config.json").write_text(json.dumps(_MINIMAL_PAYLOAD[cls.__name__]), encoding="utf-8")
+
+        assert isinstance(getattr(cls, loader)("~/config.json"), cls)
+
+
+class TestNoPayloadThatLoadsTodayStopsLoading:
+    """Over-reach controls: the refusals only reach inputs that already failed."""
+
+    def test_an_object_still_loads_through_the_json_loader(self, tmp_path: Path) -> None:
+        from strands_robots.policies.kimodo.config import KimodoConfig
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"diffusion_steps": 50, "guidance_scale": 3.0}), encoding="utf-8")
+
+        config = KimodoConfig.from_json(path)
+
+        assert (config.diffusion_steps, config.guidance_scale) == (50, 3.0)
+
+    def test_a_json_object_under_a_non_json_extension_still_loads(self, tmp_path: Path) -> None:
+        """The one divergence from the sibling loaders, pinned so it is deliberate."""
+        from strands_robots.policies.kimodo.config import KimodoConfig
+
+        path = tmp_path / "config.yaml"
+        path.write_text(json.dumps({"diffusion_steps": 7}), encoding="utf-8")
+
+        assert KimodoConfig.from_json(path).diffusion_steps == 7
+
+    def test_an_unrecognised_key_in_the_file_is_still_dropped(self, tmp_path: Path) -> None:
+        from strands_robots.policies.kimodo.config import KimodoConfig
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"diffusion_stpes": 999, "diffusion_steps": 50}), encoding="utf-8")
+
+        assert KimodoConfig.from_json(path).diffusion_steps == 50
+
+    def test_a_value_inside_the_object_keeps_the_domain_the_constructor_applies(self, tmp_path: Path) -> None:
+        """The loader adds no second domain: the field's own refusal still fires."""
+        from strands_robots.policies.kimodo.config import KimodoConfig
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"model_id": "   "}), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="model_id must be a non-empty string"):
+            KimodoConfig.from_json(path)
+
+        path.write_text(json.dumps({"diffusion_steps": 0}), encoding="utf-8")
+        with pytest.raises(ValueError, match="diffusion_steps"):
+            KimodoConfig.from_json(path)
+
+
+class TestAnUnrecognisedKeyIsDroppedWithoutWarning:
+    """The documented forward-compatibility policy, graded across the three configs.
+
+    ``KimodoConfig.from_dict`` documented the drop as happening "with a warning"
+    while its two siblings documented it as silent. Measured, none of the three
+    warns, so the docstring was the outlier and now states what the code does.
+    """
+
+    @pytest.mark.parametrize(("cls", "loader"), _dict_loaders(), ids=_ids(_dict_loaders()))
+    def test_no_warning_is_emitted_for_a_dropped_key(self, cls: type, loader: str) -> None:
+        payload = dict(_MINIMAL_PAYLOAD[cls.__name__])
+        payload["definitely_not_a_field"] = "x"
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            built = getattr(cls, loader)(payload)
+
+        assert isinstance(built, cls)
+        assert [str(w.message) for w in caught] == []
+
+    @pytest.mark.parametrize(("cls", "loader"), _dict_loaders(), ids=_ids(_dict_loaders()))
+    def test_the_drop_is_not_documented_as_warning(self, cls: type, loader: str) -> None:
+        doc = inspect.getdoc(getattr(cls, loader)) or ""
+        assert "with a warning" not in doc, f"{cls.__name__}.{loader} documents a warning it does not emit"
+
+
+class TestEachConstructionFormHandlesAMisspelledKnobAsDocumented:
+    """The config reference presents three interchangeable ways to set a field.
+
+    It claimed a misspelled knob "raises ``TypeError`` at construction instead of
+    being silently ignored", which held for the two keyword forms and not for the
+    ``config`` dict - that one is read by :meth:`KimodoConfig.from_dict`, whose
+    documented drop policy is exactly to ignore it. The page now says which form
+    does which, and these grade the three claims it makes.
+    """
+
+    def test_a_misspelled_keyword_on_the_policy_is_refused(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        with pytest.raises(TypeError, match="diffusion_stpes"):
+            KimodoPolicy(diffusion_stpes=25)
+
+    def test_a_misspelled_keyword_on_the_config_is_refused(self) -> None:
+        from strands_robots.policies.kimodo import KimodoConfig
+
+        with pytest.raises(TypeError, match="diffusion_stpes"):
+            KimodoConfig(diffusion_stpes=25)
+
+    def test_a_misspelled_key_in_a_config_dict_is_dropped_for_the_default(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            policy = KimodoPolicy(config={"diffusion_stpes": 25})
+
+        assert policy.config.diffusion_steps == 100
+        assert [str(w.message) for w in caught] == []
+
+    def test_a_correctly_spelled_key_in_a_config_dict_still_arrives(self) -> None:
+        from strands_robots.policies.kimodo import KimodoPolicy
+
+        assert KimodoPolicy(config={"diffusion_steps": 25}).config.diffusion_steps == 25
+
+    def test_the_page_no_longer_claims_a_typo_is_never_ignored(self) -> None:
+        page = _DOCS_ROOT / "policies" / "kimodo.md"
+
+        assert "instead of being silently ignored" not in page.read_text(encoding="utf-8"), (
+            f"{page.name} claims a misspelled knob is never silently ignored, "
+            "which the config dict form does not honour"
+        )
+
+    def test_the_page_names_the_reader_that_drops_the_key(self) -> None:
+        page = _DOCS_ROOT / "policies" / "kimodo.md"
+
+        assert "KimodoConfig.from_dict" in page.read_text(encoding="utf-8"), (
+            f"{page.name} does not name the reader that drops an unrecognised key"
+        )

--- a/tests/policies/kimodo/test_config_file_loader_refusals.py
+++ b/tests/policies/kimodo/test_config_file_loader_refusals.py
@@ -62,6 +62,14 @@ _NON_OBJECT_PAYLOADS = (
     ("null", "null", "NoneType"),
 )
 
+# A misspelled knob, held as a mapping so the two cases below can unpack it.
+# Spelling it as a literal keyword argument is itself a static type error
+# ("Unexpected keyword argument ... did you mean"), so a type checker rejects
+# the call before it runs and the runtime refusal these two grade never gets
+# measured. Unpacking keeps the call a runtime construct, which is the layer
+# the documented ``TypeError`` belongs to.
+_MISSPELLED_KNOB: dict[str, Any] = {"diffusion_stpes": 25}
+
 
 def _config_modules() -> list[Any]:
     """Import every ``strands_robots/policies/*/config.py`` module."""
@@ -334,13 +342,13 @@ class TestEachConstructionFormHandlesAMisspelledKnobAsDocumented:
         from strands_robots.policies.kimodo import KimodoPolicy
 
         with pytest.raises(TypeError, match="diffusion_stpes"):
-            KimodoPolicy(diffusion_stpes=25)
+            KimodoPolicy(**_MISSPELLED_KNOB)
 
     def test_a_misspelled_keyword_on_the_config_is_refused(self) -> None:
         from strands_robots.policies.kimodo import KimodoConfig
 
         with pytest.raises(TypeError, match="diffusion_stpes"):
-            KimodoConfig(diffusion_stpes=25)
+            KimodoConfig(**_MISSPELLED_KNOB)
 
     def test_a_misspelled_key_in_a_config_dict_is_dropped_for_the_default(self) -> None:
         from strands_robots.policies.kimodo import KimodoPolicy


### PR DESCRIPTION
## Problem

`KimodoConfig.from_json` parsed a JSON file and handed the result straight to `from_dict`, whose first act is `data.items()`:

```python
p = Path(path)
with p.open("r", encoding="utf-8") as f:
    return cls.from_dict(json.load(f))
```

So a file holding any JSON value other than an object surfaced as a message naming a method of the parsed value rather than the file that could not supply fields. Measured against `main`, one file per row:

| file contents | before | after |
|---|---|---|
| `[1, 2, 3]` | `AttributeError: 'list' object has no attribute 'items'` | `ValueError: KimodoConfig file /tmp/cfg.json must contain a mapping, got list` |
| `"diffusion_steps"` | `AttributeError: 'str' object has no attribute 'items'` | `... must contain a mapping, got str` |
| `42` | `AttributeError: 'int' object has no attribute 'items'` | `... must contain a mapping, got int` |
| `true` | `AttributeError: 'bool' object has no attribute 'items'` | `... must contain a mapping, got bool` |
| `null` | `AttributeError: 'NoneType' object has no attribute 'items'` | `... must contain a mapping, got NoneType` |
| `{not json` | bare `json.JSONDecodeError` | `ValueError: KimodoConfig file /tmp/cfg.json is not valid JSON: ...` |
| path absent | `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/absent.json'` | `FileNotFoundError: KimodoConfig file not found: /tmp/absent.json` |
| path is a directory | `IsADirectoryError` from the read | `FileNotFoundError: KimodoConfig file not found: /tmp/cfg.json` |
| `~/kimodo.json`, file present | `FileNotFoundError: ... '~/kimodo.json'` | loads |

The last row is the one a user hits without doing anything unusual: `~` was never expanded, so a config that exists was reported missing, with the literal `~` in the message.

## Why the disposition is not a judgement call

Three policy configs ship a file loader. The other two already do all four of these things, and one of them states why in its own `Raises:` block:

| loader | expands `~` | `is_file` named | decode wrapped | non-object refused |
|---|---|---|---|---|
| `MotionBricksConfig.from_file` | yes | yes | yes | yes |
| `WBCConfig.from_file` | yes | yes | yes | yes |
| `KimodoConfig.from_json` (before) | no | no | no | no |

`WBCConfig.from_file` and `MotionBricksConfig.from_file` both end with the identical

```python
if not isinstance(data, dict):
    raise ValueError(f"{cls} file {p} must contain a mapping, got {type(data).__name__}")
```

so this is two of three loaders' shipped reporting applied to the third, not a new rule. The tests grade it over all three by discovering them (any public class in a `strands_robots/policies/*/config.py` module exposing a `from_*(path)` classmethod), so a fourth policy config's loader is held to it on arrival rather than inheriting an exemption by being absent from a tuple.

## Deliberate scope boundary

The two siblings also refuse a file whose extension is not `.json`. `from_json` still does not, and that is deliberate: a JSON object stored under another name loads today, so refusing one would stop a payload that currently works. **No input that loads today stops loading** - every change above reports an input that already failed, or (in the `~` case) accepts one that should not have. The boundary is pinned as a control (`test_a_json_object_under_a_non_json_extension_still_loads`), and a mutation that adds the extension check fires exactly that one case.

## The unrecognised-key half

While measuring the above, two statements about unrecognised keys turned out to be false.

`from_dict` documented the drop as happening "with a warning". Measured, none of the three policy configs warns, and the other two document the drop as *silent* forward compatibility. So the docstring was the outlier, and it now states what the code does. The behaviour is unchanged - a mutation that adds the warning, and one that raises instead, are both included as over-reach rows and both fire.

`docs/policies/kimodo.md` presents three interchangeable ways to set a field and then claimed a misspelled knob "raises `TypeError` at construction instead of being silently ignored". Measured:

| form | misspelled knob |
|---|---|
| `KimodoPolicy(diffusion_stpes=25)` | `TypeError`, as documented |
| `KimodoConfig(diffusion_stpes=25)` | `TypeError`, as documented |
| `KimodoPolicy(config={"diffusion_stpes": 25})` | builds with `diffusion_steps=100`, no warning |

The third form is read by `from_dict`, whose documented policy is exactly to drop it, so the page was asserting the opposite of the code one paragraph below the example that reaches it. The page now says which form refuses and which drops, and how to have a typo refused. The three cases that grade it pass on `main` too - they are the measurement that decided the wording, not regression cases; the two that fail pre-change are the two prose claims.

## Tests

`tests/policies/kimodo/test_config_file_loader_refusals.py`, 60 cases.

Pre-change (source and docs page reverted to `main`, tests kept): **15 failed, 45 passed**. Every failing case is a `KimodoConfig` cell - `0` of the `MotionBricks` and `WBC` parametrizations fail, which is the evidence the rule is the siblings' shipped behaviour rather than something new. By class:

- `TestANonObjectPayloadIsRefusedByName` 12
- `TestAnUnrecognisedKeyIsDroppedWithoutWarning` 1
- `TestEachConstructionFormHandlesAMisspelledKnobAsDocumented` 2
- `TestTheSurveyReachesEveryPolicyConfigLoader` 0 (premise and non-vacuity)
- `TestNoPayloadThatLoadsTodayStopsLoading` 0 (over-reach controls)

Mutation table, run against the finished change: **16 mutations, 15 detected, 15 distinct firing sets, control clean.**

| mutation | fires |
|---|---|
| mapping check dropped | 8 |
| mapping check weakened to `data is not None` | 7 |
| refusal stops naming the JSON type | 1 |
| refusal stops naming the file | 1 |
| refusal stops naming the class | 1 |
| decode failure no longer wrapped | 1 |
| `expanduser()` dropped | 1 |
| `is_file` check dropped | 2 |
| `is_file` weakened to `exists` | 1 |
| `from_dict` docstring warning claim restored | 1 |
| over-reach: `from_dict` warns on a dropped key | 2 |
| over-reach: `from_dict` raises on an unrecognised key | 3 |
| over-reach: extension refused like the two siblings | 1 |
| docs: the refuted claim restored | 1 |
| docs: stops naming the reader that drops the key | 1 |
| `json` import moved back inside the method | 0 |

The last row is a semantic no-op and is reported as one: moving `json` to the module top (where both sibling configs keep it) changes no behaviour, so nothing should fire. The `is_file` pair is why the check is `is_file()` and not `exists()`: `exists()` lets a directory through to the read, and only the directory case distinguishes them.

## Coverage

`from_json` and the `model_id` domain were both entirely unexercised, which is how the loader shipped with none of the four guards. `strands_robots/policies/kimodo/config.py`: **56 statements, 5 missing, 91% to 63 statements, 0 missing, 100%**. Package total `1867 to 1861` missing.

## Gate

Paired full suite, base `1dbb5695` versus the branch, same environment (mujoco 3.5.0, lerobot 0.6.2):

- base: 39222 collected, `29 failed, 38860 passed, 309 skipped, 24 errors`
- branch: 39286 collected, `29 failed, 38924 passed, 309 skipped, 24 errors`
- 53 failing ids on each side, identical sets, `comm` empty in both directions (44 of them need `awsiot` from the `mesh-iot` extra, absent here)
- `+64 collected = +64 passed`, localised: 60 in the new file, and `tests/test_args_docstring_completeness.py` 440 to 444 because `from_dict` and `from_json` gained `Args:`/`Returns:` blocks

`ruff check`, `ruff format --check` and `mypy` over `strands_robots tests tests_integ` all clean; mypy is `24 == 24` against a pristine base worktree with byte-identical message sets and 0 in the changed files. The branch has since merged `d33a779d` (mesh only, no overlap with these files); lint, mypy, the mutation table and the pre-change split were all re-measured on the merged tree and are unchanged. The new file passes on the declared mujoco floor (3.5.0) and on 3.12.0.

No visual artifact: this changes a config file loader's refusals and two documentation statements, not a policy, simulation behaviour, rendering, recording or a robot asset. The measured tables above are the evidence.
