### PR TITLE
fix(simulation): report a body's visual mesh, not its collision hull

### DIFF
--- a/changelog.d/2737-mjcf-visual-mesh-preference.md
+++ b/changelog.d/2737-mjcf-visual-mesh-preference.md
@@ -1,0 +1,40 @@
+### Fixed: a body's reported mesh is its visual asset, not its collision hull
+
+MJCF bodies routinely carry two mesh geoms: the visual asset a renderer should show, and a convex
+hull the solver should collide. `_find_body_mesh` picks the one a reported `SceneObject` carries,
+and it picked "the first geom whose `group` is not `"0"`" - reading a non-default MuJoCo group as
+the visual marking.
+
+That is backwards for the dominant convention. MuJoCo Menagerie marks a visual geom with
+`contype="0" conaffinity="0"` and a collision geom with `group="3"`, and the collision geom is
+routinely declared first, so the rule returned the hull. In the shipped `shadow_dexee` hand the
+visual class carries no `group` at all - `<default class="finger/visual"><geom contype="0"
+conaffinity="0"/>` - so each finger skipped its eight visual mesh geoms for the ninth,
+`r3_finger_base_col`. `load_mjcf_scene_objects` reported those fingers as `r3_finger_base_col.stl`
+under a successful load while `hand_base` in the same file reported its visual STL: one reader,
+one file, two answers. `group` also cannot be the signal because the conventions built on it
+disagree - robosuite emits visual geoms as `group="1"` where Menagerie spells collision as
+`group="3"` - and MuJoCo attaches no meaning to it at all, it being a visualiser toggle.
+
+The candidates are now ranked, strongest first, rather than the first non-default group winning.
+MuJoCo lets two geoms touch only when `contype1 & conaffinity2` or `contype2 & conaffinity1` is
+non-zero, so a geom declaring both as `0` cannot collide with anything and exists purely to be
+looked at; that is the format's own statement of intent and it ranks first. A non-default group
+stays as the weaker hint, taken when the contact declaration says nothing and never over a
+contact-free geom. Document order still breaks a tie, so a subtree carrying no visual marking at
+all reports the same mesh it always did. A stronger candidate in a nested body wins over a weaker
+one on the body itself, which is the shape `shadow_dexee` has.
+
+Graded across the downloaded asset corpus - 554 MJCF files, 2736 bodies declaring a mesh geom -
+165 bodies in 18 files change their reported mesh and every one of them changes to a geom MuJoCo
+cannot collide with: 162 from a group-marked hull, 2 from an unmarked geom, and one tie between
+two contact-free geoms. No body moves the other way, no reported position or orientation changes
+for a body whose mesh is unchanged, and neither reading raises. The files include the canonical
+Menagerie assets `shadow_dexee` (19 bodies), `franka_fr3`, `franka_fr3_v2`,
+`boston_dynamics_spot/spot_arm` and `pal_tiago_dual`.
+
+Deliberately unchanged: a subtree where no geom is contact-free. `google_barkour_v0` has one set
+of meshes serving both roles, so its `group="1"` marking is the only signal in the file and it
+still decides; dropping the group tier instead of demoting it would have cost those bodies their
+answer, and that is pinned as a control. The rank is internal to the pick - the one production
+caller discards it - so nothing downstream of the reader gains a field.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1572,6 +1572,70 @@ def _parse_mjcf_mesh_assets(root: ET.Element, mjcf_dir: str) -> dict[str, tuple[
     return registry
 
 
+# How strongly a mesh geom's own declaration reads as its body's visual asset,
+# best first. Used only to order candidates within one body subtree.
+_MESH_VISUAL_RANK_NON_COLLIDING = 0
+_MESH_VISUAL_RANK_NON_DEFAULT_GROUP = 1
+_MESH_VISUAL_RANK_UNMARKED = 2
+
+
+def _geom_cannot_collide(attrs: dict[str, str]) -> bool:
+    """Whether a geom's own declaration makes it unable to collide with anything.
+
+    MuJoCo lets two geoms touch only when ``contype1 & conaffinity2`` or
+    ``contype2 & conaffinity1`` is non-zero, so a geom declaring *both* as
+    ``0`` can never collide with any other geom whatever the other declares.
+    MuJoCo defaults both to ``1``, so an omitted attribute reads as colliding.
+
+    A value that is not an integer also reads as colliding: MuJoCo refuses such
+    a model outright, so there is no intent to infer from it.
+
+    Args:
+        attrs: The geom's effective attributes from :func:`_class_attrs`, so a
+            geom inheriting the pair from a ``<default class="visual">`` is
+            judged as MuJoCo reads it rather than by what it spells itself.
+
+    Returns:
+        ``True`` when the geom is contact-free, and therefore decorative.
+    """
+    for key in ("contype", "conaffinity"):
+        try:
+            if int(attrs.get(key, "1")) != 0:
+                return False
+        except ValueError:
+            return False
+    return True
+
+
+def _mesh_geom_visual_rank(attrs: dict[str, str]) -> int:
+    """How strongly a mesh geom reads as its body's visual asset (lower is stronger).
+
+    A geom MuJoCo cannot collide with (see :func:`_geom_cannot_collide`) exists
+    only to be looked at, which is the format's own statement of intent, so it
+    ranks first.
+
+    ``group`` carries no meaning in MuJoCo itself - it is a visualiser toggle -
+    and the conventions built on it disagree: robosuite emits visual geoms as
+    ``group="1"`` while MuJoCo Menagerie spells *collision* as ``group="3"``.
+    A non-default group is therefore only a weak hint. It is taken when the
+    contact declaration says nothing, and never over a contact-free geom.
+    Anything else ranks last.
+
+    Args:
+        attrs: The geom's effective attributes from :func:`_class_attrs`.
+
+    Returns:
+        One of :data:`_MESH_VISUAL_RANK_NON_COLLIDING`,
+        :data:`_MESH_VISUAL_RANK_NON_DEFAULT_GROUP` or
+        :data:`_MESH_VISUAL_RANK_UNMARKED`.
+    """
+    if _geom_cannot_collide(attrs):
+        return _MESH_VISUAL_RANK_NON_COLLIDING
+    if (attrs.get("group") or "0") != "0":
+        return _MESH_VISUAL_RANK_NON_DEFAULT_GROUP
+    return _MESH_VISUAL_RANK_UNMARKED
+
+
 def _find_body_mesh(
     body_el: ET.Element,
     defaults: dict[str, dict[str, str]],
@@ -1580,25 +1644,34 @@ def _find_body_mesh(
     *,
     angle_scale: float = math.pi / 180.0,
     eulerseq: str = "xyz",
-) -> tuple[str, tuple[float, float, float], tuple[float, float, float, float], bool] | None:
-    """First mesh geom in a body subtree: ``(mesh name, body-frame pos, quat, is_visual)``.
+) -> tuple[str, tuple[float, float, float], tuple[float, float, float, float], int] | None:
+    """Best visual mesh geom in a body subtree: ``(mesh name, body-frame pos, quat, rank)``.
 
-    Prefers a *visual* mesh geom (MuJoCo ``group`` other than the collision
-    group ``"0"``; robosuite emits visual geoms as ``group="1"``) over a
-    collision mesh, because the visual asset is the one a pixel-conditioned
-    policy was trained on. Recurses into nested bodies, folding their
-    ``pos`` offsets into the returned body-frame position the same way
-    :func:`_recursive_collision_aabb` accumulates AABBs (nested body
-    rotations are not composed - LIBERO's compiled object bodies do not
-    rotate their nested visual bodies). Returns ``None`` when the subtree
-    declares no mesh geom.
+    Prefers the geom whose declaration reads most strongly as the body's visual
+    asset - :func:`_mesh_geom_visual_rank`, strongest first - because the visual
+    asset is the one a pixel-conditioned policy was trained on. Document order
+    breaks a tie between geoms of equal rank, so a subtree whose geoms carry no
+    visual marking at all still yields its first mesh.
 
-    ``mesh``, ``pos``, ``quat`` and the ``group`` that decides visual-vs-
-    collision are read through :func:`_class_attrs`, so a geom that inherits its
-    group from a ``<default class="visual">`` is preferred as MuJoCo reads it
-    rather than being taken for a collision geom.
+    Ranking rather than returning the first non-default ``group`` matters for the
+    dominant convention: MuJoCo Menagerie marks visual geoms with
+    ``contype="0" conaffinity="0"`` and *collision* geoms with ``group="3"``, and
+    a collision geom is routinely declared first. Taking a non-default group as
+    the visual signal therefore handed back the convex collision hull.
+
+    Recurses into nested bodies, folding their ``pos`` offsets into the returned
+    body-frame position the same way :func:`_recursive_collision_aabb`
+    accumulates AABBs (nested body rotations are not composed - LIBERO's
+    compiled object bodies do not rotate their nested visual bodies). A stronger
+    candidate in a nested body wins over a weaker one on the body itself.
+    Returns ``None`` when the subtree declares no mesh geom.
+
+    ``mesh``, ``pos``, ``quat`` and the ``contype``/``conaffinity``/``group``
+    that decide the rank are read through :func:`_class_attrs`, so a geom that
+    inherits them from a ``<default class="visual">`` is ranked as MuJoCo reads
+    it rather than being taken for a collision geom.
     """
-    first_any: tuple[str, tuple[float, float, float], tuple[float, float, float, float], bool] | None = None
+    best: tuple[str, tuple[float, float, float], tuple[float, float, float, float], int] | None = None
     childclass = body_el.get("childclass") or childclass
     for geom in body_el.findall("geom"):
         attrs = _class_attrs(geom, defaults, childclass)
@@ -1608,21 +1681,21 @@ def _find_body_mesh(
         gpos = _parse_xyz(attrs.get("pos"))
         pos = (offset[0] + gpos[0], offset[1] + gpos[1], offset[2] + gpos[2])
         quat = _parse_orientation(attrs, own=geom.attrib, angle_scale=angle_scale, eulerseq=eulerseq)
-        is_visual = (attrs.get("group") or "0") != "0"
-        if is_visual:
-            return (mesh_name, pos, quat, True)
-        if first_any is None:
-            first_any = (mesh_name, pos, quat, False)
+        rank = _mesh_geom_visual_rank(attrs)
+        if rank == _MESH_VISUAL_RANK_NON_COLLIDING:
+            return (mesh_name, pos, quat, rank)
+        if best is None or rank < best[3]:
+            best = (mesh_name, pos, quat, rank)
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
         found = _find_body_mesh(child, defaults, childclass, new_off, angle_scale=angle_scale, eulerseq=eulerseq)
         if found is not None:
-            if found[3]:
+            if found[3] == _MESH_VISUAL_RANK_NON_COLLIDING:
                 return found
-            if first_any is None:
-                first_any = found
-    return first_any
+            if found[3] < (best[3] if best is not None else _MESH_VISUAL_RANK_UNMARKED + 1):
+                best = found
+    return best
 
 
 def _parse_fromto(
@@ -1938,7 +2011,7 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         cc = body_childclass.get(id(body_el), "")
         mesh_ref = _find_body_mesh(body_el, geom_defaults, cc, angle_scale=angle_scale, eulerseq=eulerseq)
         if mesh_ref is not None:
-            mesh_name, mesh_pos, mesh_quat, _is_visual = mesh_ref
+            mesh_name, mesh_pos, mesh_quat, _visual_rank = mesh_ref
             asset = mesh_registry.get(mesh_name)
             if asset is not None:
                 candidate_path, mesh_scale = asset

--- a/tests/simulation/isaac/test_mjcf_visual_mesh_preference.py
+++ b/tests/simulation/isaac/test_mjcf_visual_mesh_preference.py
@@ -1,0 +1,312 @@
+"""A body's reported mesh is its visual asset, not its collision hull.
+
+MJCF bodies routinely carry two mesh geoms: the visual asset a renderer should
+show, and a convex hull the solver should collide. ``_find_body_mesh`` picks the
+one :class:`~strands_robots.simulation.isaac.loaders.SceneObject` carries, and it
+picked "the first geom whose ``group`` is not ``"0"``" - reading a non-default
+group as the visual marking.
+
+That is backwards for the dominant convention. MuJoCo Menagerie marks a *visual*
+geom with ``contype="0" conaffinity="0"`` and a *collision* geom with
+``group="3"``, and the collision geom is routinely declared first, so the rule
+returned the hull. In the shipped ``shadow_dexee`` hand the visual class carries
+no ``group`` at all -- ``<default class="finger/visual"><geom contype="0"
+conaffinity="0"/>`` -- so each finger skipped its eight visual mesh geoms for the
+ninth, ``r3_finger_base_col``. ``load_mjcf_scene_objects`` reported those fingers
+as ``r3_finger_base_col.stl`` under a successful load, while ``hand_base`` in the
+same file reported its visual STL: one reader, one file, two answers.
+
+The signal it now ranks first is the format's own. MuJoCo lets two geoms touch
+only when ``contype1 & conaffinity2`` or ``contype2 & conaffinity1`` is
+non-zero, so a geom declaring both as ``0`` cannot collide with anything and
+exists purely to be looked at. ``group`` carries no meaning in MuJoCo itself --
+it is a visualiser toggle -- and the conventions built on it disagree, robosuite
+emitting visual geoms as ``group="1"`` where Menagerie spells collision as
+``group="3"``. So a non-default group is kept only as the weaker hint, taken
+when the contact declaration says nothing.
+
+Every premise below is derived from ``mujoco.MjModel`` rather than restated: it
+is MuJoCo that fixes which geoms can touch, and MuJoCo that resolves a nested
+``<default>`` class onto the geom before either signal is read.
+
+Deliberately unchanged: a subtree where no geom is contact-free. There the
+weaker ``group`` hint still decides, and where nothing carries either signal the
+first mesh in document order is still reported. Both are pinned below, so a body
+the new signal says nothing about keeps the answer it has always had.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    _MESH_VISUAL_RANK_NON_COLLIDING,
+    _MESH_VISUAL_RANK_NON_DEFAULT_GROUP,
+    _MESH_VISUAL_RANK_UNMARKED,
+    _class_attrs,
+    _find_body_mesh,
+    _geom_cannot_collide,
+    _mesh_geom_visual_rank,
+    _mjcf_class_defaults,
+    _parse_mjcf_mesh_assets,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+#: The Menagerie spelling, verbatim in shape: the visual class marks itself only
+#: by being unable to collide and names no ``group``, and the collision class
+#: names ``group="3"`` through a nested class the geom actually cites. A reader
+#: that took the group as the visual signal preferred ``hull``.
+MENAGERIE_DEFAULTS = (
+    "<default>"
+    '<default class="visual"><geom type="mesh" contype="0" conaffinity="0"/></default>'
+    '<default class="collision"><geom type="mesh" group="3"/>'
+    '<default class="collision_hard"><geom condim="4"/></default>'
+    "</default>"
+    "</default>"
+)
+
+#: The two geoms of such a body, by the class each cites.
+VISUAL_GEOM = '<geom class="visual" mesh="skin" pos="0.1 0 0"/>'
+COLLISION_GEOM = '<geom class="collision_hard" mesh="hull" pos="0.5 0 0"/>'
+
+#: Both document orders. Which asset a body describes cannot depend on the order
+#: its two geoms happen to be written in, and the collision-first order is the
+#: one the shipped assets use.
+DOCUMENT_ORDERS = (
+    pytest.param(COLLISION_GEOM + VISUAL_GEOM, id="collision-declared-first"),
+    pytest.param(VISUAL_GEOM + COLLISION_GEOM, id="visual-declared-first"),
+)
+
+
+def _model(body: str, defaults: str = MENAGERIE_DEFAULTS) -> str:
+    """An MJCF whose worldbody is ``body``, with mesh assets MuJoCo can compile."""
+    return (
+        "<mujoco>"
+        f"{defaults}"
+        "<asset>"
+        '<mesh name="skin" vertex="0 0 0  0.4 0 0  0 0.3 0  0 0 0.2"/>'
+        '<mesh name="hull" vertex="0 0 0  0.9 0 0  0 0.8 0  0 0 0.7"/>'
+        "</asset>"
+        f"<worldbody>{body}</worldbody>"
+        "</mujoco>"
+    )
+
+
+def _read(body: str, defaults: str = MENAGERIE_DEFAULTS) -> tuple[str, tuple[float, ...], tuple[float, ...], int]:
+    """What the reader reports for the first body of ``_model(body)``."""
+    root = ET.fromstring(_model(body, defaults))
+    found = _find_body_mesh(next(iter(root.iter("body"))), _mjcf_class_defaults(root, ".", "geom"), "")
+    assert found is not None, "premise: the fixture body declares a mesh geom"
+    return found
+
+
+def _mujoco_contact_pairs(body: str, defaults: str = MENAGERIE_DEFAULTS) -> dict[str, tuple[int, int]]:
+    """Each named geom's compiled ``(contype, conaffinity)``, as MuJoCo resolves them."""
+    model = mujoco.MjModel.from_xml_string(_model(body, defaults))
+    return {
+        mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, i): (
+            int(model.geom_contype[i]),
+            int(model.geom_conaffinity[i]),
+        )
+        for i in range(model.ngeom)
+    }
+
+
+class TestMuJoCoFixesWhichGeomsCanTouch:
+    """The premises the ranking rests on, taken from the compiler."""
+
+    def test_the_visual_class_compiles_to_a_geom_that_cannot_collide(self):
+        # Both halves matter: contact-free for the visual geom is the signal, and
+        # the collision geom being able to touch is what makes it a real hull
+        # rather than a second decoration.
+        pairs = _mujoco_contact_pairs(
+            f'<body name="b">{COLLISION_GEOM.replace("mesh=", "name='hull_g' mesh=")}'
+            f"{VISUAL_GEOM.replace('mesh=', "name='skin_g' mesh=")}</body>"
+        )
+        assert pairs["skin_g"] == (0, 0)
+        assert pairs["hull_g"] != (0, 0)
+
+    def test_a_non_default_group_says_nothing_about_whether_a_geom_collides(self):
+        # This is why the group cannot be the visual signal: MuJoCo gives a
+        # group="3" geom the ordinary contact defaults.
+        pairs = _mujoco_contact_pairs('<body name="b"><geom name="g" type="mesh" mesh="hull" group="3"/></body>')
+        assert pairs["g"] != (0, 0)
+
+    def test_the_group_is_resolved_through_the_nested_default_class(self):
+        # The collision geom cites "collision_hard" and inherits group="3" from
+        # its parent class, so the fixture exercises class resolution rather
+        # than a group spelled on the geom.
+        root = ET.fromstring(_model(f'<body name="b">{COLLISION_GEOM}</body>'))
+        # The body's own geom, not the one inside the <default> block.
+        geom = next(iter(root.iter("body"))).findall("geom")[0]
+        assert _class_attrs(geom, _mjcf_class_defaults(root, ".", "geom"), "").get("group") == "3"
+
+
+class TestABodyReportsItsVisualMesh:
+    """The regression: the reported asset is the one a renderer should show."""
+
+    @pytest.mark.parametrize("body_geoms", DOCUMENT_ORDERS)
+    def test_the_visual_mesh_is_reported_whichever_geom_is_declared_first(self, body_geoms):
+        name, pos, _quat, rank = _read(f'<body name="b">{body_geoms}</body>')
+        assert name == "skin"
+        assert rank == _MESH_VISUAL_RANK_NON_COLLIDING
+        # The pose travels with the pick, so reporting the right name at the
+        # wrong geom's offset would still be the wrong asset.
+        assert pos == pytest.approx((0.1, 0.0, 0.0))
+
+    def test_a_visual_mesh_in_a_nested_body_beats_a_collision_mesh_on_the_body(self):
+        # shadow_dexee's shape: the addressed body carries the hull and the
+        # visual asset sits one body down.
+        name, pos, _quat, rank = _read(
+            f'<body name="b">{COLLISION_GEOM}<body name="inner" pos="0 0.25 0">{VISUAL_GEOM}</body></body>'
+        )
+        assert name == "skin"
+        assert rank == _MESH_VISUAL_RANK_NON_COLLIDING
+        # The nested body's own offset is folded into the reported position.
+        assert pos == pytest.approx((0.1, 0.25, 0.0))
+
+    def test_a_deeper_visual_mesh_beats_a_nearer_collision_mesh(self):
+        # The ranking is over the whole subtree, not one level of it, and the
+        # offsets of every body on the way accumulate.
+        name, pos, _quat, _rank = _read(
+            '<body name="b">'
+            f'<body name="mid" pos="0 0 0.1">{COLLISION_GEOM}'
+            f'<body name="deep" pos="0 0 0.2">{VISUAL_GEOM}</body></body></body>'
+        )
+        assert name == "skin"
+        assert pos == pytest.approx((0.1, 0.0, 0.3))
+
+
+class TestTheWeakerHintStillDecidesWhereItIsTheOnlySignal:
+    """Over-reach controls: bodies the contact declaration says nothing about.
+
+    Every expectation here is a mesh *name*, and every one of them is the name
+    the old rule reported too. Preferring the contact-free geom must not change
+    a single body the contact declaration is silent about.
+    """
+
+    def test_the_collision_hull_is_reported_when_it_is_the_only_mesh(self):
+        # A body with no visual asset still describes itself: refusing to report
+        # the hull would lose the only geometry there is.
+        name, _pos, _quat, _rank = _read(f'<body name="b">{COLLISION_GEOM}</body>')
+        assert name == "hull"
+
+    def test_a_non_default_group_still_wins_when_no_geom_is_contact_free(self):
+        # google_barkour_v0's shape: one set of meshes serves both roles, so the
+        # group is the only marking in the file. Preferring the contact-free geom
+        # must not cost these bodies the answer they have.
+        name, _pos, _quat, rank = _read(
+            '<body name="b"><geom type="mesh" mesh="hull"/><geom type="mesh" mesh="skin" group="1"/></body>',
+            defaults="",
+        )
+        assert name == "skin"
+
+    def test_an_unmarked_subtree_still_reports_its_first_mesh_in_document_order(self):
+        name, _pos, _quat, _rank = _read(
+            '<body name="b"><geom type="mesh" mesh="hull"/><geom type="mesh" mesh="skin"/></body>',
+            defaults="",
+        )
+        assert name == "hull"
+
+    def test_a_nearer_group_marked_mesh_beats_an_unmarked_one_in_a_nested_body(self):
+        name, _pos, _quat, _rank = _read(
+            '<body name="b"><geom type="mesh" mesh="skin" group="1"/>'
+            '<body name="inner"><geom type="mesh" mesh="hull"/></body></body>',
+            defaults="",
+        )
+        assert name == "skin"
+
+    def test_an_unmarked_mesh_on_the_body_loses_to_a_group_marked_one_below_it(self):
+        # Rank, not depth: a stronger candidate anywhere in the subtree wins.
+        name, _pos, _quat, _rank = _read(
+            '<body name="b"><geom type="mesh" mesh="hull"/>'
+            '<body name="inner"><geom type="mesh" mesh="skin" group="1"/></body></body>',
+            defaults="",
+        )
+        assert name == "skin"
+
+    def test_a_subtree_with_no_mesh_geom_reports_nothing(self):
+        root = ET.fromstring(_model('<body name="b"><geom type="sphere" size="0.1"/></body>'))
+        assert _find_body_mesh(next(iter(root.iter("body"))), _mjcf_class_defaults(root, ".", "geom"), "") is None
+
+
+class TestWhenAGeomCannotCollide:
+    """``_geom_cannot_collide``'s domain: both halves of the pair, or neither."""
+
+    @pytest.mark.parametrize(
+        ("attrs", "expected"),
+        [
+            pytest.param({"contype": "0", "conaffinity": "0"}, True, id="both-zero"),
+            pytest.param({"contype": "0"}, False, id="contype-only-conaffinity-defaults-to-1"),
+            pytest.param({"conaffinity": "0"}, False, id="conaffinity-only"),
+            pytest.param({}, False, id="neither-declared"),
+            pytest.param({"contype": "1", "conaffinity": "0"}, False, id="one-nonzero"),
+            pytest.param({"contype": "0", "conaffinity": "nope"}, False, id="unparseable"),
+            pytest.param({"contype": "0", "conaffinity": "0.0"}, False, id="not-an-integer"),
+        ],
+    )
+    def test_the_pair_decides(self, attrs, expected):
+        assert _geom_cannot_collide(attrs) is expected
+
+    def test_mujoco_agrees_a_single_zero_still_leaves_a_geom_able_to_touch(self):
+        # The asymmetry above is MuJoCo's, not this reader's: contype=0 alone
+        # leaves conaffinity at its default, so the geom can still be collided
+        # with by a geom whose contype overlaps it.
+        pairs = _mujoco_contact_pairs('<body name="b"><geom name="g" type="mesh" mesh="hull" contype="0"/></body>')
+        assert pairs["g"] != (0, 0)
+
+    def test_the_three_ranks_are_all_reachable(self):
+        # Without this a ranking that collapsed to one value would still satisfy
+        # every ordering expectation above by accident.
+        assert {
+            _mesh_geom_visual_rank({"contype": "0", "conaffinity": "0"}),
+            _mesh_geom_visual_rank({"group": "3"}),
+            _mesh_geom_visual_rank({}),
+        } == {
+            _MESH_VISUAL_RANK_NON_COLLIDING,
+            _MESH_VISUAL_RANK_NON_DEFAULT_GROUP,
+            _MESH_VISUAL_RANK_UNMARKED,
+        }
+
+    @pytest.mark.parametrize(
+        ("attrs", "expected"),
+        [
+            pytest.param({"contype": "0", "conaffinity": "0"}, _MESH_VISUAL_RANK_NON_COLLIDING, id="contact-free"),
+            pytest.param({"group": "3"}, _MESH_VISUAL_RANK_NON_DEFAULT_GROUP, id="menagerie-collision-group"),
+            pytest.param({"group": "1"}, _MESH_VISUAL_RANK_NON_DEFAULT_GROUP, id="robosuite-visual-group"),
+            pytest.param({}, _MESH_VISUAL_RANK_UNMARKED, id="unmarked"),
+            pytest.param({"group": "0"}, _MESH_VISUAL_RANK_UNMARKED, id="default-group-spelled-out"),
+        ],
+    )
+    def test_a_declaration_ranks_where_it_says_it_does(self, attrs, expected):
+        assert _mesh_geom_visual_rank(attrs) == expected
+
+    def test_a_contact_free_geom_outranks_a_group_marked_one(self):
+        assert _mesh_geom_visual_rank({"contype": "0", "conaffinity": "0", "group": "3"}) < _mesh_geom_visual_rank(
+            {"group": "1"}
+        )
+
+
+class TestAMeshAssetThatNamesNoFile:
+    """A ``<mesh>`` with no ``file`` contributes no path to resolve."""
+
+    def test_it_is_skipped_rather_than_registered_under_an_empty_path(self):
+        # MJCF lets a mesh carry inline vertices instead of a file, which every
+        # fixture above relies on; such an asset has no path for the scene
+        # loader to hand a renderer.
+        root = ET.fromstring(_model('<body name="b"><geom type="mesh" mesh="skin"/></body>'))
+        assert _parse_mjcf_mesh_assets(root, ".") == {}
+
+    def test_a_file_backed_asset_alongside_it_is_still_registered(self):
+        # Non-vacuity: the empty map above is the skip, not a reader that
+        # registers nothing at all.
+        root = ET.fromstring(
+            "<mujoco><asset>"
+            '<mesh name="inline" vertex="0 0 0  1 0 0  0 1 0  0 0 1"/>'
+            '<mesh name="ondisk" file="widget.obj"/>'
+            "</asset><worldbody/></mujoco>"
+        )
+        assert set(_parse_mjcf_mesh_assets(root, "/assets")) == {"ondisk"}


### PR DESCRIPTION
## Problem

MJCF bodies routinely carry two mesh geoms: the visual asset a renderer should show, and a convex
hull the solver should collide. `_find_body_mesh` decides which one a reported `SceneObject`
carries, and it picked *the first geom whose `group` is not `"0"`* — reading a non-default MuJoCo
group as the visual marking.

That is backwards for the dominant convention. MuJoCo Menagerie marks a **visual** geom with
`contype="0" conaffinity="0"` and a **collision** geom with `group="3"`, and routinely declares the
collision geom first. On the shipped `shadow_dexee` hand the visual class carries no `group` at all:

```xml
<default class="finger/visual"><geom type="mesh" contype="0" conaffinity="0"/></default>
<default class="finger/collision"><geom type="mesh" group="3" material="collision" mass="0"/>
  <default class="finger/collision_hard"><geom condim="4" .../></default></default>
```

so `F0/finger_base` skipped its **eight** visual mesh geoms for the ninth. Measured through the
public reader on that shipped asset:

| body | `load_mjcf_scene_objects` before | after |
|---|---|---|
| `hand_base` | `Asm-MRH-HB1-Visual,00-Plastic.stl` | unchanged |
| `F0/` `F1/` `F2/` | `r3_finger_base_col.stl` | `MRH-FB-MainALU-Visual,00.stl` |

One reader, one file, two answers, under a successful load. `group` cannot be the signal in any
case: MuJoCo attaches no meaning to it — it is a visualiser toggle — and the conventions built on it
disagree, robosuite emitting visual geoms as `group="1"` where Menagerie spells *collision* as
`group="3"`.

## Change

Rank the candidates, strongest first, instead of returning the first non-default group.

1. A geom MuJoCo **cannot collide with**. MuJoCo lets two geoms touch only when
   `contype1 & conaffinity2` or `contype2 & conaffinity1` is non-zero, so a geom declaring both as
   `0` can never collide with anything and exists purely to be looked at. That is the format's own
   statement of intent, so it ranks first.
2. A **non-default `group`**, kept as the weaker hint — taken when the contact declaration says
   nothing, never over a contact-free geom.
3. Anything else.

Document order still breaks a tie, so a subtree carrying no visual marking reports the mesh it
always did. A stronger candidate in a nested body wins over a weaker one on the body itself, which
is the shape `shadow_dexee` has. Both signals resolve through `_class_attrs`, so a geom inheriting
them from a `<default class="visual">` is ranked as MuJoCo reads it.

## Graded across the downloaded asset corpus

554 MJCF files, 2736 bodies declaring a mesh geom, both readings compared body by body:

| | |
|---|---|
| bodies reporting a mesh, before and after | 2736 / 2736, identical key set |
| bodies whose reported mesh changes | **165**, in 18 files |
| changed to a geom MuJoCo cannot collide with | **165 of 165** (162 from a group-marked hull, 2 from an unmarked geom, 1 tie between two contact-free geoms) |
| bodies whose reported mesh ranks *worse* after | **0** |
| position/orientation changes where the mesh is unchanged | **0** |
| exceptions, either reading | **0** |

The files include the canonical Menagerie assets `shadow_dexee` (19 bodies), `franka_fr3`,
`franka_fr3_v2`, `boston_dynamics_spot/spot_arm` and `pal_tiago_dual`, plus `openarm_bimanual` (25)
and the `ability_hand_api` arms.

## Rollout in MuJoCo (headless)

`mujoco_menagerie/shadow_dexee`, body `F0/finger_base`, rendered from the shipped STLs. One camera
and one headlight for all three panels — `mjv_defaultFreeCamera` derives its distance from each
model's own extent, so the frame is fixed once from the ground-truth model and reused, which is what
makes the panels comparable.

![MJCF visual mesh vs collision hull](https://github.com/cagataycali/robots/releases/download/artifacts/mjcf-visual-mesh.png)

The reported visual geom is one of the assembly's own parts at its own pose, and its silhouette
lies inside the assembly's to within **0** pixels. The hull is not a part of it and covers **7989**
pixels the whole visual assembly does not; the two reported assets' silhouettes differ in **13461**
pixels.

## Tests

`tests/simulation/isaac/test_mjcf_visual_mesh_preference.py`, 30 cases. Every premise is derived
from `mujoco.MjModel` rather than restated: MuJoCo is asked which geoms its compiler lets touch, and
that the fixture's `group="3"` really is inherited through the nested default class the geom cites.

Pre-fix split, with only the discriminator reverted so the module still imports:

| class | failing cells | test functions |
|---|---|---|
| `TestABodyReportsItsVisualMesh` (regression) | **4** | 3 |
| `TestMuJoCoFixesWhichGeomsCanTouch` (premise) | 0 | 3 |
| `TestTheWeakerHintStillDecidesWhereItIsTheOnlySignal` (over-reach control) | 0 | 6 |
| `TestWhenAGeomCannotCollide` (domain) | 0 | 5 |
| `TestAMeshAssetThatNamesNoFile` | 0 | 2 |

A raw revert is a collection error instead — the tests import the new rank constants.

11 mutations, 10 detected in 10 distinct failing-id sets, unmutated control clean, source restored
byte-identical, and 0 failures in `test_mjcf_default_class_geometry.py` (which structurally requires
`_find_body_mesh` to resolve its attributes through `_class_attrs`) for every row:

| mutation | fires |
|---|---|
| discriminator reverted to `group != "0"` | 4 |
| contact-free checks `contype` only | 3 |
| contact-free accepts either half zero | 17 |
| an omitted `contype`/`conaffinity` reads as zero | 14 |
| an unparseable value reads as contact-free | 2 |
| the group hint outranks a contact-free geom | 1 |
| the group tier dropped rather than demoted | 5 |
| a later geom of equal rank wins the tie | 1 |
| a nested candidate taken only when nothing was found | 1 |
| the nested body's own offset not folded in | 2 |
| the contact-free early return dropped from the geom loop | **0** |

The last row is reported rather than hidden: without that early return `best` still selects the
contact-free candidate, because rank 0 is minimal and ties keep the first, so it is a short-circuit
whose removal is behaviourally invisible. It does still stop the walk from descending into the rest
of a subtree once the answer is settled.

The two branches this reaches were previously uncovered, so the file also closes them: a visual mesh
found in a **nested** body, and a `<mesh>` asset declaring no `file`. `isaac/loaders.py` goes from
**73 uncovered lines (90%) to 68 (91%)**, and every line still uncovered is either inside `load_usd`
and its `pxr` import guard or unreachable from its only caller.

## Gate

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1554 files).
mypy **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical in both
directions, 0 in the changed files. `tests/simulation/isaac/` 1540 passed, 5 skipped.

Paired run over an identical 660-file selection — all of `tests/simulation/` plus every guard that
walks the tree, reads a docstring or names this module — with the new file excluded from both trees:
**23595 collected and `17 failed, 23329 passed, 249 skipped` on both** (928s vs 945s), identical
failing-ID sets, both `comm` directions empty. All 17 are `tests/mesh/test_iot_*` needing `awsiot`
from the `[mesh-iot]` extra, confirmed absent.

## Deliberately unchanged

A subtree where no geom is contact-free. `google_barkour_v0` has one set of meshes serving both
roles, so its `group="1"` marking is the only signal in the file and it still decides — dropping the
group tier instead of demoting it would have cost those 5 bodies their answer, which is why that
mutation is in the table and the case is a control. The rank is internal to the pick: the one
production caller discards it, so nothing downstream of the reader gains a field.
