### PR TITLE
fix(kimodo): decay the segment seam's rotation offset instead of the orientation

### DIFF
--- a/changelog.d/2738-kimodo-transition-root-turn.md
+++ b/changelog.d/2738-kimodo-transition-root-turn.md
@@ -1,0 +1,25 @@
+### Fixed
+
+- **policies/kimodo**: the segment-transition ease now decays the seam's
+  *rotation* offset rather than dragging each frame's orientation toward the
+  pose last commanded, so a motion that turns keeps its own turn rate through
+  the transition. The linear channels (root position, joint angles) have always
+  added one offset scaled by the frame's weight, which makes the correction a
+  function of the weight alone; the root's orientation was interpolated toward
+  `previous_pose` instead, so its correction depended on the frame's own
+  orientation. Measured on a 180 deg/s turn in place at the default five-frame
+  transition, the eased yaw rate ramped 8.67 -> 16.67 deg/frame against the
+  motion's uniform 6.00, and a seam whose orientations already agreed - nothing
+  rotational to absorb - still moved the root by up to 6.000 deg. The offset is
+  now the world-frame rotation carrying the segment's own start orientation onto
+  the pose last commanded, applied by pre-multiplication of the decayed arc, so
+  the eased yaw rate holds a uniform 12.67 deg/frame (the motion's 6.00 plus one
+  constant share of the decaying offset, exactly the shape the position and
+  joint channels produce) and a seam with no orientation offset leaves the root
+  untouched. The first eased frame is unchanged, because right-multiplication
+  commutes with the interpolation there, and the emitted action dict is
+  unchanged: `get_actions` returns joint targets, so the root pose this touches
+  is the internal reference the next seam eases onto. The existing transition
+  suite could not see any of this - its stub sampler writes an identity
+  quaternion into every frame, where an absolute pull and a decaying offset are
+  indistinguishable.

--- a/docs/policies/kimodo.md
+++ b/docs/policies/kimodo.md
@@ -253,6 +253,15 @@ wider pose gaps (opposing poses eased over more frames), lower it toward 1 to
 keep segment boundaries crisp. It is bounded below at 1, matching the domain the
 sampler enforces on its own transition length.
 
+Every channel absorbs its share of the offset the same way, so easing changes
+where a segment starts and not how it moves. Root position and joint angles take
+one offset scaled by the frame's weight. The root's orientation takes the
+rotational form of exactly that: the offset is the rotation carrying the
+segment's own start orientation onto the pose last commanded, and each eased
+frame is its own orientation turned by the weighted share of it. A motion that
+turns therefore keeps its turn rate through the transition, and a seam whose
+orientations already agree leaves the root alone.
+
 Note the difference in kind from the sampler's native multi-prompt path: Kimodo
 conditions the *diffusion* of the next segment on the previous segment's last
 frames, so the generated motion itself leads into the transition. The agent

--- a/strands_robots/policies/kimodo/policy.py
+++ b/strands_robots/policies/kimodo/policy.py
@@ -106,6 +106,41 @@ class KimodoMotionAgent(Protocol):
         ...
 
 
+#: Identity rotation, wxyz. The start of the arc a decaying orientation offset
+#: walks: at weight 0 the offset contributes nothing and a frame is emitted as
+#: the sampler produced it.
+_IDENTITY_QUAT = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+
+def _quat_conjugate(q: NDArray[np.float32]) -> NDArray[np.float32]:
+    """Conjugate of a wxyz quaternion, which inverts a unit rotation."""
+    return np.array([q[0], -q[1], -q[2], -q[3]], dtype=np.float32)
+
+
+def _quat_mul(a: NDArray[np.float32], b: NDArray[np.float32]) -> NDArray[np.float32]:
+    """Hamilton product ``a * b`` of two wxyz quaternions.
+
+    Local for the same reason the MJCF loader and the Newton backend keep their
+    own copies: the two other wxyz products in the tree are private to
+    :mod:`strands_robots.simulation.isaac.loaders` and the LIBERO adapter, and
+    reaching across a package for a private symbol is worse than a four-line
+    product. The public one in
+    :mod:`strands_robots.policies.protomotions.state_utils` is xyzw, so using it
+    would mean reordering at both ends of every call.
+    """
+    aw, ax, ay, az = (float(a[0]), float(a[1]), float(a[2]), float(a[3]))
+    bw, bx, by, bz = (float(b[0]), float(b[1]), float(b[2]), float(b[3]))
+    return np.array(
+        [
+            aw * bw - ax * bx - ay * by - az * bz,
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+        ],
+        dtype=np.float32,
+    )
+
+
 def _slerp_quat(
     q0: NDArray[np.float32],
     q1: NDArray[np.float32],
@@ -166,6 +201,14 @@ def _ease_onto_previous_pose(
     ``previous_pose``: that would command zero motion for one frame, trading a
     position step for a velocity stall.
 
+    Every channel absorbs its offset the same way, which is what makes "the
+    motion keeps its own shape" true of the root's orientation as well as its
+    position: the correction a frame receives is decided by the weight alone.
+    Interpolating each frame's orientation toward ``previous_pose`` instead
+    would make the correction depend on the frame's own orientation, so a
+    motion that turns would have its turn rate reshaped by the ease -- and a
+    seam with no orientation offset to absorb would still be reshaped.
+
     Args:
         qpos: The freshly sampled ``(n, 7 + njoints)`` motion, native rate.
         previous_pose: The last commanded ``(7 + njoints,)`` qpos frame.
@@ -180,18 +223,26 @@ def _ease_onto_previous_pose(
     if count <= 0:
         return qpos
     out = qpos.copy()
-    # Root orientation interpolates on the quaternion arc; root position and
-    # joint angles are ordinary linear channels.
+    # Root position and joint angles are ordinary linear channels: a single
+    # offset, scaled by the weight, is added to each frame.
     linear = list(range(3)) + list(range(_NUM_ROOT_QPOS, qpos.shape[1]))
     offset = previous_pose[linear] - qpos[0, linear]
     q_prev = previous_pose[3:7]
     q_prev = q_prev / max(float(np.linalg.norm(q_prev)), 1e-8)
+    q_start = qpos[0, 3:7]
+    q_start = q_start / max(float(np.linalg.norm(q_start)), 1e-8)
+    # Root orientation is the rotational analogue: the offset is the world-frame
+    # rotation carrying the motion's own start orientation onto the pose last
+    # commanded, and it decays by pre-multiplication. Decaying THIS rather than
+    # dragging each frame toward ``q_prev`` is what keeps the correction a
+    # function of the weight alone, exactly as the additive offset above is.
+    q_offset = _quat_mul(q_prev, _quat_conjugate(q_start))
     for i in range(count):
         weight = 1.0 - (i + 1) / (count + 1)
         out[i, linear] = qpos[i, linear] + weight * offset
         q_i = qpos[i, 3:7]
         q_i = q_i / max(float(np.linalg.norm(q_i)), 1e-8)
-        out[i, 3:7] = _slerp_quat(q_i, q_prev, weight)
+        out[i, 3:7] = _quat_mul(_slerp_quat(_IDENTITY_QUAT, q_offset, weight), q_i)
     return out
 
 

--- a/tests/policies/kimodo/test_transition_absorbs_an_offset_without_reshaping_the_turn.py
+++ b/tests/policies/kimodo/test_transition_absorbs_an_offset_without_reshaping_the_turn.py
@@ -1,0 +1,536 @@
+"""The segment-transition ease absorbs a pose offset without reshaping the motion.
+
+``_ease_onto_previous_pose`` decays the offset between a freshly sampled
+segment's start pose and the pose last commanded. Its documented promise is that
+"the motion keeps its own shape and velocity and only its starting offset is
+absorbed", and for the linear channels (root position, joint angles) that is
+plainly what the arithmetic does: one offset, scaled by the frame's weight, is
+added to every eased frame. The correction a frame receives is therefore decided
+by the weight alone.
+
+The root's orientation is the rotational analogue of that, and these cells pin
+it: the offset is the rotation carrying the segment's own start orientation onto
+the pose last commanded, and it decays by pre-multiplication. Two consequences
+are measurable and neither holds if each frame is instead interpolated toward
+the previous orientation:
+
+* a seam with no orientation offset to absorb leaves the root untouched, and
+* a motion that turns keeps a uniform turn rate through the transition.
+
+Why the existing transition suite cannot see this: its stub agent writes an
+identity quaternion into every frame of every motion, so the root never rotates
+there and a decaying offset is indistinguishable from an absolute pull. The
+distinguishing input is a motion whose root actually turns.
+
+The root pose is internal to the policy today - ``get_actions`` emits joint
+targets only - so ``TestTheEmittedActionIsUntouched`` pins that this stays true.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from strands_robots.policies.kimodo import KIMODO_G1_JOINTS, KimodoConfig, KimodoPolicy
+from strands_robots.policies.kimodo.policy import _ease_onto_previous_pose
+
+_ROOT = 7
+_NUM_JOINTS = len(KIMODO_G1_JOINTS)
+#: Rate the fixture motions yaw at, in degrees per native frame. 6 deg at 30 Hz
+#: is a 180 deg/s turn - brisk for a humanoid, and large enough that a reshaped
+#: turn rate is unmistakable rather than a rounding artefact.
+_TURN_DEG_PER_FRAME = 6.0
+#: Rotation of a fixture motion's first frame. Non-zero so the start
+#: orientation the offset is measured against is not the identity.
+_START_DEG = 30.0
+
+
+def _quat_about_axis(axis: tuple[float, float, float], degrees: float) -> np.ndarray:
+    """Unit wxyz quaternion for a rotation of ``degrees`` about ``axis``."""
+    unit = np.asarray(axis, dtype=np.float64)
+    unit = unit / np.linalg.norm(unit)
+    half = np.deg2rad(degrees) / 2.0
+    return np.array([np.cos(half), *(np.sin(half) * unit)], dtype=np.float32)
+
+
+def _quat_about_z(degrees: float) -> np.ndarray:
+    """Unit wxyz quaternion for a yaw of ``degrees`` about +Z."""
+    return _quat_about_axis((0.0, 0.0, 1.0), degrees)
+
+
+def _matrix_from_quat(quat: np.ndarray) -> np.ndarray:
+    """Rotation matrix of a unit wxyz quaternion.
+
+    Matrix arithmetic is the independent oracle these cells need: the
+    orientation the ease should emit is stated as a composition of matrices, so
+    a slip in the quaternion product it is compared against has nowhere to hide.
+    """
+    w, x, y, z = (float(component) for component in quat)
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _axis_angle_from_matrix(matrix: np.ndarray) -> tuple[np.ndarray, float]:
+    """Rotation axis (unit) and angle (radians) of a rotation matrix."""
+    angle = float(np.arccos(np.clip((float(np.trace(matrix)) - 1.0) / 2.0, -1.0, 1.0)))
+    axis = np.array(
+        [
+            matrix[2, 1] - matrix[1, 2],
+            matrix[0, 2] - matrix[2, 0],
+            matrix[1, 0] - matrix[0, 1],
+        ],
+        dtype=np.float64,
+    )
+    return axis / np.linalg.norm(axis), angle
+
+
+def _rotation_matrix(axis: np.ndarray, radians: float) -> np.ndarray:
+    """Rotation matrix for ``radians`` about a unit ``axis`` (Rodrigues)."""
+    skew = np.array(
+        [
+            [0.0, -axis[2], axis[1]],
+            [axis[2], 0.0, -axis[0]],
+            [-axis[1], axis[0], 0.0],
+        ],
+        dtype=np.float64,
+    )
+    return np.eye(3) + np.sin(radians) * skew + (1.0 - np.cos(radians)) * (skew @ skew)
+
+
+def _yaw_degrees(quat: np.ndarray) -> float:
+    """Yaw of a wxyz quaternion known to be a pure rotation about +Z."""
+    return float(np.rad2deg(2.0 * np.arctan2(float(quat[3]), float(quat[0]))))
+
+
+def _angle_between(a: np.ndarray, b: np.ndarray) -> float:
+    """Shorter-arc angle between two unit wxyz quaternions, in degrees.
+
+    Measured as ``4 * arcsin(d / 2)`` on the closer of ``a - b`` and ``a + b``,
+    the two representations of one rotation. The textbook
+    ``2 * arccos(|dot|)`` agrees analytically but not numerically: ``arccos`` is
+    ill-conditioned at 1, so a float32 quaternion compared with itself reports
+    around 0.04 deg of rotation and a "nothing moved" assertion cannot be
+    written at all. The form below reports 0 for equal inputs.
+    """
+    first = np.asarray(a, dtype=np.float64)
+    second = np.asarray(b, dtype=np.float64)
+    first = first / np.linalg.norm(first)
+    second = second / np.linalg.norm(second)
+    distance = min(float(np.linalg.norm(first - second)), float(np.linalg.norm(first + second)))
+    return float(np.rad2deg(4.0 * np.arcsin(min(1.0, distance / 2.0))))
+
+
+def _turning_motion(
+    frames: int,
+    *,
+    deg_per_frame: float = _TURN_DEG_PER_FRAME,
+    njoints: int = 4,
+    axis: tuple[float, float, float] = (0.0, 0.0, 1.0),
+    start_deg: float = _START_DEG,
+) -> np.ndarray:
+    """A motion whose root turns at a constant rate and whose channels all advance.
+
+    Args:
+        frames: Number of native frames.
+        deg_per_frame: Constant rotation increment per frame.
+        njoints: Number of joint channels.
+        axis: Axis the root turns about.
+        start_deg: Rotation of the first frame. Non-zero by default so the start
+            orientation the offset is measured from is not the identity, where
+            inverting it or not would look the same.
+
+    Returns:
+        A ``(frames, 7 + njoints)`` float32 qpos block.
+    """
+    qpos = np.zeros((frames, _ROOT + njoints), dtype=np.float32)
+    for index in range(frames):
+        qpos[index, 0:3] = (0.10 * index, 0.0, 0.90)
+        qpos[index, 3:7] = _quat_about_axis(axis, start_deg + deg_per_frame * index)
+        qpos[index, _ROOT:] = 0.02 * index
+    return qpos
+
+
+def _previous_pose(
+    motion: np.ndarray,
+    *,
+    yaw_offset: float,
+    joint_offset: float = 0.30,
+    base_deg: float = _START_DEG,
+) -> np.ndarray:
+    """The pose a seam must ease onto: the motion's start pose, displaced.
+
+    The orientation is built from ``base_deg + yaw_offset`` rather than by
+    recovering the yaw out of ``motion`` and rebuilding it: a float32 round trip
+    through the recovered angle lands an ULP away, which would leave a 0.04 deg
+    offset in the case that is supposed to carry none at all.
+
+    Args:
+        motion: The motion being eased.
+        yaw_offset: Degrees of yaw between the motion's start orientation and
+            the returned pose. Zero means there is no rotation to absorb.
+        joint_offset: Radians added to every joint channel, so the seam still
+            has something to absorb when ``yaw_offset`` is zero.
+        base_deg: Yaw of the motion's own first frame.
+
+    Returns:
+        A ``(7 + njoints,)`` float32 pose.
+    """
+    pose = motion[0].copy()
+    pose[3:7] = _quat_about_z(base_deg + yaw_offset)
+    pose[_ROOT:] += joint_offset
+    return pose
+
+
+def _weights(count: int) -> list[float]:
+    """The decay weights the ease applies, frame by frame."""
+    return [1.0 - (index + 1) / (count + 1) for index in range(count)]
+
+
+# --------------------------------------------------------------------------
+# Premises: the fixtures really do exercise what the cases below claim.
+# --------------------------------------------------------------------------
+class TestThePremisesOfTheseCases:
+    """Without these the cases could pass on a motion that never turns."""
+
+    def test_the_fixture_motion_turns_at_a_constant_rate(self) -> None:
+        motion = _turning_motion(12)
+        yaws = [_yaw_degrees(motion[i, 3:7]) for i in range(12)]
+        increments = np.diff(yaws)
+        assert increments.min() > 0.0, "the fixture root must actually turn"
+        assert np.allclose(increments, _TURN_DEG_PER_FRAME, atol=1e-3), increments
+
+    def test_a_zero_yaw_offset_really_leaves_nothing_rotational_to_absorb(self) -> None:
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=0.0)
+        assert _angle_between(pose[3:7], motion[0, 3:7]) == pytest.approx(0.0, abs=1e-9)
+        assert float(np.abs(pose[_ROOT:] - motion[0, _ROOT:]).max()) > 0.1, (
+            "the seam must still have a joint offset to absorb, or the whole ease is a no-op"
+        )
+
+    def test_the_angle_helper_reports_the_shorter_arc(self) -> None:
+        assert _angle_between(_quat_about_z(0.0), _quat_about_z(90.0)) == pytest.approx(90.0, abs=1e-3)
+        assert _angle_between(_quat_about_z(0.0), _quat_about_z(350.0)) == pytest.approx(10.0, abs=1e-3)
+
+    def test_the_angle_helper_resolves_a_rotation_far_smaller_than_the_defect(self) -> None:
+        """Otherwise "the root did not move" could not be asserted at all."""
+        assert _angle_between(_quat_about_z(30.0), _quat_about_z(30.0)) == pytest.approx(0.0, abs=1e-9)
+        assert _angle_between(_quat_about_z(30.0), _quat_about_z(30.001)) == pytest.approx(0.001, abs=1e-4)
+
+
+# --------------------------------------------------------------------------
+# The regression: a seam with no orientation offset must not move the root.
+# --------------------------------------------------------------------------
+class TestASeamWithNoOrientationOffsetLeavesTheRootAlone:
+    """The clearest statement of the guarantee: no offset, no correction."""
+
+    def test_the_root_orientation_is_untouched_while_the_joints_are_eased(self) -> None:
+        """A joint-only offset must be absorbed by the joints and nothing else."""
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=0.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, 5)
+
+        worst = max(_angle_between(eased[i, 3:7], motion[i, 3:7]) for i in range(len(motion)))
+        assert worst < 1e-3, (
+            f"the ease rotated the root by up to {worst:.4f} deg although the seam carried no orientation offset at all"
+        )
+        assert not np.array_equal(eased[:, _ROOT:], motion[:, _ROOT:]), "the joint offset should have been eased"
+
+    def test_a_seam_that_carries_no_offset_at_all_emits_the_motion_verbatim(self) -> None:
+        """Continuing from exactly the start pose is the identity on every channel.
+
+        Byte-exact rather than approximate, and by construction: a motion whose
+        first frame is the identity rotation makes the offset exactly the
+        identity, which the interpolation and the product both carry through
+        unchanged. The rotated-start case above is the same statement up to
+        float32 rounding.
+        """
+        motion = _turning_motion(12, start_deg=0.0)
+
+        eased = _ease_onto_previous_pose(motion, motion[0].copy(), 5)
+
+        assert np.array_equal(eased, motion)
+
+
+class TestTheCorrectionIsDecidedByTheWeightAlone:
+    """The property that makes the ease shape-preserving on every channel."""
+
+    @pytest.mark.parametrize("yaw_offset", [-40.0, -5.0, 25.0, 120.0, 200.0])
+    @pytest.mark.parametrize("count", [1, 5, 8])
+    def test_each_frame_is_rotated_by_the_weighted_share_of_the_offset(self, yaw_offset: float, count: int) -> None:
+        """The angle between an eased frame and its own frame is ``weight * offset``."""
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=yaw_offset)
+        total = _angle_between(pose[3:7], motion[0, 3:7])
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+
+        for index, weight in enumerate(_weights(count)):
+            applied = _angle_between(eased[index, 3:7], motion[index, 3:7])
+            assert applied == pytest.approx(weight * total, abs=0.05), (
+                f"frame {index} was rotated {applied:.3f} deg where the weight "
+                f"{weight:.3f} of a {total:.3f} deg offset is {weight * total:.3f} deg: the "
+                "correction is being decided by the frame's own orientation"
+            )
+
+    def test_two_motions_that_start_alike_receive_the_same_correction(self) -> None:
+        """Only the start pose and the seam decide the correction, not the motion."""
+        slow = _turning_motion(12, deg_per_frame=1.0)
+        fast = _turning_motion(12, deg_per_frame=11.0)
+        assert np.array_equal(slow[0, 3:7], fast[0, 3:7]), "premise: the two motions start alike"
+        pose = _previous_pose(slow, yaw_offset=-40.0)
+
+        eased_slow = _ease_onto_previous_pose(slow, pose, 5)
+        eased_fast = _ease_onto_previous_pose(fast, pose, 5)
+
+        for index in range(5):
+            applied_slow = _angle_between(eased_slow[index, 3:7], slow[index, 3:7])
+            applied_fast = _angle_between(eased_fast[index, 3:7], fast[index, 3:7])
+            assert applied_slow == pytest.approx(applied_fast, abs=0.05), (
+                f"frame {index}: the slower motion was corrected by {applied_slow:.3f} deg and the "
+                f"faster one by {applied_fast:.3f} deg, so the correction tracks the motion"
+            )
+
+
+class TestTheCorrectionIsAWorldFrameRotationOfTheOffset:
+    """Which rotation, stated in matrices so the quaternion side has an oracle.
+
+    The cases above measure how far each frame is rotated. These measure where
+    it is rotated to, on a motion whose turn axis is not the offset's: two
+    rotations about one axis commute, so a yaw-only fixture cannot tell a
+    world-frame correction from a body-frame one, nor a product from its
+    reverse.
+    """
+
+    #: A tilted turn axis and an unrelated orientation for the pose last
+    #: commanded, so no two rotations in the fixture share an axis.
+    MOTION_AXIS = (0.2, 0.9, -0.3)
+    SEAM_AXIS = (0.6, -0.2, 0.75)
+    SEAM_DEGREES = 55.0
+
+    def _fixture(self) -> tuple[np.ndarray, np.ndarray]:
+        motion = _turning_motion(12, axis=self.MOTION_AXIS, start_deg=17.0)
+        pose = motion[0].copy()
+        pose[3:7] = _quat_about_axis(self.SEAM_AXIS, self.SEAM_DEGREES)
+        pose[_ROOT:] += 0.30
+        return motion, pose
+
+    def test_the_fixture_axes_are_not_parallel(self) -> None:
+        """Premise: without this the convention cases below are vacuous."""
+        motion, pose = self._fixture()
+        seam_axis, _ = _axis_angle_from_matrix(_matrix_from_quat(pose[3:7]) @ _matrix_from_quat(motion[0, 3:7]).T)
+        motion_axis = np.asarray(self.MOTION_AXIS, dtype=np.float64)
+        motion_axis = motion_axis / np.linalg.norm(motion_axis)
+        assert abs(float(np.dot(seam_axis, motion_axis))) < 0.9, "the two axes must differ"
+        assert not np.allclose(motion[0, 3:7], _quat_about_axis((0.0, 0.0, 1.0), 0.0), atol=1e-6), (
+            "the start orientation must not be the identity"
+        )
+
+    @pytest.mark.parametrize("count", [1, 5, 8])
+    def test_every_eased_frame_is_its_own_frame_turned_by_the_decayed_offset(self, count: int) -> None:
+        """``eased = R(weight * offset) * frame``, composed in the world frame."""
+        motion, pose = self._fixture()
+        offset = _matrix_from_quat(pose[3:7]) @ _matrix_from_quat(motion[0, 3:7]).T
+        axis, angle = _axis_angle_from_matrix(offset)
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+
+        for index, weight in enumerate(_weights(count)):
+            expected = _rotation_matrix(axis, weight * angle) @ _matrix_from_quat(motion[index, 3:7])
+            actual = _matrix_from_quat(eased[index, 3:7])
+            assert np.allclose(actual, expected, atol=1e-4), (
+                f"frame {index} was not its own orientation turned by {weight:.3f} of the "
+                f"seam offset; worst element differs by {float(np.abs(actual - expected).max()):.2e}"
+            )
+
+
+class TestAUniformTurnStaysUniformThroughTheTransition:
+    """The rotational reading of "the motion keeps its own velocity"."""
+
+    def test_the_yaw_rate_is_constant_across_the_eased_frames(self) -> None:
+        """A constant turn plus a constant offset decay is a constant turn."""
+        count = 5
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+        yaws = [_yaw_degrees(eased[i, 3:7]) for i in range(count + 1)]
+        increments = np.diff(yaws)[:count]
+
+        assert np.allclose(increments, increments[0], atol=0.05), (
+            f"the eased yaw rate ramps instead of holding: {np.round(increments, 3).tolist()} deg/frame"
+        )
+
+    def test_the_yaw_rate_matches_the_linear_channels_own_rate(self) -> None:
+        """Both channels advance by their own step plus one share of the offset."""
+        count = 5
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+        total = _angle_between(pose[3:7], motion[0, 3:7])
+        share = total / (count + 1)
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+        yaws = [_yaw_degrees(eased[i, 3:7]) for i in range(count + 1)]
+        rotational = float(np.diff(yaws)[0])
+        joint_steps = np.diff(eased[: count + 1, _ROOT], axis=0)
+
+        assert abs(rotational) == pytest.approx(_TURN_DEG_PER_FRAME + share, abs=0.05)
+        assert np.allclose(joint_steps, joint_steps[0], atol=1e-6), (
+            f"premise: the linear channels advance uniformly, got {joint_steps}"
+        )
+
+    def test_a_wide_offset_never_reverses_the_turn(self) -> None:
+        """Pulling each frame toward a distant orientation can invert the turn."""
+        count = 5
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=200.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+        yaws = [_yaw_degrees(eased[i, 3:7]) for i in range(count + 1)]
+        increments = np.diff(yaws)[:count]
+
+        assert (increments > 0.0).all(), (
+            f"the root reversed direction inside the transition: {np.round(increments, 3).tolist()} deg/frame"
+        )
+
+
+# --------------------------------------------------------------------------
+# Controls: behaviour that must NOT change.
+# --------------------------------------------------------------------------
+class TestTheSeamItselfIsUnchanged:
+    """The first eased frame still lands where the ease has always put it."""
+
+    @pytest.mark.parametrize("count", [1, 5, 8])
+    def test_the_first_frame_is_one_share_short_of_the_pose_last_commanded(self, count: int) -> None:
+        """Deliberately not pinned onto it: that would stall velocity for a frame."""
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+        total = _angle_between(pose[3:7], motion[0, 3:7])
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+
+        remaining = _angle_between(eased[0, 3:7], pose[3:7])
+        assert remaining == pytest.approx(total / (count + 1), abs=0.05)
+
+    def test_frames_after_the_window_are_the_sampler_s_own(self) -> None:
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, 5)
+
+        assert np.array_equal(eased[5:], motion[5:])
+
+
+class TestTheLinearChannelsAndTheGuardsAreUnchanged:
+    """The rest of the ease keeps working exactly as before."""
+
+    def test_the_linear_channels_still_add_the_weighted_offset(self) -> None:
+        count = 5
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+        offset = pose[_ROOT:] - motion[0, _ROOT:]
+
+        eased = _ease_onto_previous_pose(motion, pose, count)
+
+        for index, weight in enumerate(_weights(count)):
+            expected = motion[index, _ROOT:] + weight * offset
+            assert np.allclose(eased[index, _ROOT:], expected, atol=1e-6)
+
+    def test_a_motion_whose_root_never_rotates_is_untouched(self) -> None:
+        """The shape the existing transition suite drives: identity every frame."""
+        motion = _turning_motion(12, deg_per_frame=0.0)
+        pose = _previous_pose(motion, yaw_offset=0.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, 5)
+
+        assert np.allclose(eased[:, 3:7], motion[:, 3:7], atol=1e-7)
+
+    @pytest.mark.parametrize("frames", [0, -3])
+    def test_a_non_positive_window_returns_the_motion_itself(self, frames: int) -> None:
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+
+        assert _ease_onto_previous_pose(motion, pose, frames) is motion
+
+    def test_the_sampled_motion_is_not_modified_in_place(self) -> None:
+        motion = _turning_motion(12)
+        before = motion.copy()
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+
+        _ease_onto_previous_pose(motion, pose, 5)
+
+        assert np.array_equal(motion, before)
+
+    def test_a_start_orientation_that_is_not_unit_names_the_same_rotation(self) -> None:
+        """The ease normalises what it is handed, so a scale must not change it."""
+        motion = _turning_motion(12)
+        scaled = motion.copy()
+        scaled[0, 3:7] = motion[0, 3:7] * 1.7
+        pose = _previous_pose(motion, yaw_offset=-40.0)
+
+        reference = _ease_onto_previous_pose(motion, pose, 5)
+        scaled_result = _ease_onto_previous_pose(scaled, pose, 5)
+
+        for index in range(5):
+            deviation = _angle_between(scaled_result[index, 3:7], reference[index, 3:7])
+            assert deviation < 1e-3, f"frame {index} moved {deviation:.4f} deg when the start pose was rescaled"
+
+    def test_every_eased_frame_is_still_a_unit_quaternion(self) -> None:
+        motion = _turning_motion(12)
+        pose = _previous_pose(motion, yaw_offset=200.0)
+
+        eased = _ease_onto_previous_pose(motion, pose, 5)
+
+        assert np.allclose(np.linalg.norm(eased[:, 3:7], axis=1), 1.0, atol=1e-6)
+
+
+class TestTheEmittedActionIsUntouched:
+    """The policy emits joint targets only, and this change does not alter them."""
+
+    def test_a_prompt_change_commands_the_weighted_joint_ease(self) -> None:
+        """Every commanded value is the closed form of the linear ease."""
+        count = 5
+        centres = {"turn left": 0.10, "turn right": -1.40}
+
+        class _TurningAgent:
+            """Two motions with turning roots, so the root channel is live."""
+
+            def sample(self, prompt, num_frames, diffusion_steps, guidance_scale, seed):
+                out = np.zeros((num_frames, _ROOT + _NUM_JOINTS), dtype=np.float32)
+                for index in range(num_frames):
+                    out[index, 3:7] = _quat_about_z(_TURN_DEG_PER_FRAME * index)
+                out[:, _ROOT:] = centres[prompt] + 0.02 * np.arange(num_frames, dtype=np.float32)[:, None]
+                return out
+
+        policy = KimodoPolicy(
+            config=KimodoConfig(num_frames=40, native_fps=30, tracker_fps=30, transition_frames=count),
+            motion_agent=_TurningAgent(),
+        )
+        policy.set_robot_state_keys(list(KIMODO_G1_JOINTS))
+        segment = 8
+        prompts = ["turn left"] * segment + ["turn right"] * segment
+        # One tick per prompt: the frame cursor advances once per call, so each
+        # action dict has to be taken once and then read across the joints.
+        ticks = [asyncio.run(policy.get_actions({}, prompt))[0] for prompt in prompts]
+        commanded = np.asarray(
+            [[action[name] for name in KIMODO_G1_JOINTS] for action in ticks],
+            dtype=np.float64,
+        )
+
+        second = _TurningAgent().sample("turn right", 40, 100, 7.5, None)
+        last_commanded = commanded[segment - 1][0]
+        offset = last_commanded - float(second[0, _ROOT])
+        for index, weight in enumerate(_weights(count)):
+            expected = float(second[index, _ROOT]) + weight * offset
+            assert commanded[segment + index][0] == pytest.approx(expected, abs=1e-5), (
+                f"eased tick {index} commanded {commanded[segment + index][0]:.6f} rad where the "
+                f"linear ease gives {expected:.6f} rad"
+            )


### PR DESCRIPTION
## Problem

`_ease_onto_previous_pose` absorbs the offset between a freshly sampled segment's
start pose and the pose last commanded. Its docstring states the guarantee: "the
motion keeps its own shape and velocity and only its starting offset is
absorbed". For the linear channels the arithmetic plainly does that -- one offset
scaled by the frame's weight is added to every eased frame, so the correction a
frame receives is decided by the weight alone:

```python
out[i, linear] = qpos[i, linear] + weight * offset
```

The root's orientation was handled the other way round -- every eased frame was
interpolated toward the previous pose's orientation:

```python
out[i, 3:7] = _slerp_quat(q_i, q_prev, weight)   # before
```

so its correction depended on the frame's own orientation. Two consequences,
both measured through the shipped function at the default `transition_frames=5`
on a 180 deg/s turn in place (6.00 deg per native frame):

| seam | before | after | the motion |
| --- | --- | --- | --- |
| orientations already agree (0.0 deg offset) | root moved up to **6.000 deg** | 1.7e-06 deg (float32 rounding) | -- |
| 40 deg heading offset, eased yaw rate | **8.67 -> 10.67 -> 12.67 -> 14.67 -> 16.67** deg/frame | uniform **12.67** deg/frame | 6.00 deg/frame |

The first row is the sharper one: a seam with nothing rotational to absorb still
had its root turned, by as much as one whole frame of the motion's own rotation.
The second is the shape defect -- a uniform turn came out as a ramp, where the
linear channels produce the motion's own step plus one *constant* share of the
decaying offset. With a wide offset the ramp can invert: at 200 deg the eased
yaw increments measured 28.67, 30.67, 32.67, **94.67, -23.33** deg/frame, i.e.
the root reverses direction inside the transition.

## Change

The offset is now the world-frame rotation carrying the segment's own start
orientation onto the pose last commanded, and it is that rotation which decays:

```python
q_offset = _quat_mul(q_prev, _quat_conjugate(q_start))
...
out[i, 3:7] = _quat_mul(_slerp_quat(_IDENTITY_QUAT, q_offset, weight), q_i)
```

Pre-multiplication is the rotational analogue of adding a world-frame
translation, which is what the position channel does. Three properties follow
and each is pinned:

* **The first eased frame is unchanged.** Interpolation is equivariant under
  right-multiplication, so `slerp(I, q_prev * q_start^-1, w) * q_start` is
  exactly `slerp(q_start, q_prev, w)`. Measured: identical to the last bit.
  The seam therefore still lands one share short of `previous_pose`, which is
  the existing deliberate choice (pinning it exactly would stall velocity for a
  frame).
* **A seam with no orientation offset is the identity on the root.** Byte-exact
  when the start orientation is the identity, and to float32 rounding otherwise.
* **The emitted action dict is unchanged.** `get_actions` returns joint targets
  (`frame[7:]`); the root pose this touches is the internal reference the next
  seam eases onto. A cell drives the policy through a prompt change with a
  turning stub sampler and checks every commanded joint value against the closed
  form of the linear ease.

`_quat_mul` and `_quat_conjugate` are local to the module, for the reason
`simulation/isaac/loaders._quat_from_basis` already gives for its own copy: the
other two wxyz products in the tree are private to `simulation/isaac` and the
LIBERO adapter, and the public one in `policies/protomotions/state_utils` is
xyzw, so using it would mean reordering at both ends of every call.

## Why nothing caught this

`tests/policies/kimodo/test_chained_prompt_transition_is_continuous.py` already
covers the transition, including
`test_the_transition_preserves_the_motion_s_own_velocity`. Its stub sampler
writes an identity quaternion into every frame of every motion (`out[:, 3] =
1.0`), so the root never rotates there -- and with a constant orientation an
absolute pull and a decaying offset are indistinguishable. The distinguishing
input is a motion whose root actually turns. Every mutation in the table below
fires **0** tests in that pre-existing suite.

## Tests

New file, 41 cases. Reverting only `strands_robots/policies/kimodo/policy.py` to
`main` gives **18 failed, 23 passed, 0 errors**, and the split is by class:

| class | failed/total |
| --- | --- |
| `TestThePremisesOfTheseCases` | 0/4 |
| `TestASeamWithNoOrientationOffsetLeavesTheRootAlone` | 2/2 |
| `TestTheCorrectionIsDecidedByTheWeightAlone` | 11/2 (parametrized) |
| `TestTheCorrectionIsAWorldFrameRotationOfTheOffset` | 2/2 |
| `TestAUniformTurnStaysUniformThroughTheTransition` | 3/3 |
| `TestTheSeamItselfIsUnchanged` | 0/2 |
| `TestTheLinearChannelsAndTheGuardsAreUnchanged` | 0/6 |
| `TestTheEmittedActionIsUntouched` | 0/1 |

Every premise and control class passes pre-fix; all 18 failures are in the four
regression classes.

The convention cases state the expected orientation in **matrices** rather than
quaternions, so the quaternion side has an independent oracle: the offset is read
off `M(q_prev) @ M(q_start).T` as an axis and angle, and each eased frame is
compared against `R(axis, weight * angle) @ M(frame)`.

### Mutation table

Each row mutates the source, then runs the new file and, separately, the rest of
`tests/policies/kimodo`.

| # | mutation | new file | rest of the kimodo suite |
| --- | --- | --- | --- |
| b0 | control, no mutation | 0 | 0 |
| b1 | each frame pulled toward the previous orientation (the defect) | 18 | 0 |
| b2 | offset taken in the body frame and post-multiplied | 2 | 0 |
| b3 | conjugate applied to the wrong operand | 8 | 0 |
| b4 | offset applied in full every frame (never decays) | 24 | 0 |
| b5 | the weight runs the wrong way | 17 | 0 |
| b6 | the conjugate does not invert | 24 | 0 |
| b7 | sign slip in one component of the product | 3 | 0 |
| b8 | the arc starts somewhere other than the identity | 27 | 0 |
| b9 | the start orientation is not normalised | 1 | 0 |
| b10 | the product operands are swapped | 3 | 0 |

10 of 10 detected, 9 distinct firing sets, control clean, source restored
byte-identical. b7 and b10 share a set: both are errors in the product itself
and only the matrix oracle sees either. b2, b6, b7 and b10 all fired 0 against
an earlier fixture that rotated only about +Z from an identity start -- rotations
about one axis commute, and inverting the identity is a no-op -- which is why the
fixtures now use a tilted turn axis, an unrelated seam orientation and a
non-identity start.

`_angle_between` in the test file deliberately avoids `2 * arccos(|dot|)`:
`arccos` is ill-conditioned at 1, so that form reports about 0.04 deg for a
float32 quaternion compared against itself and the "nothing moved" assertion
cannot be written at all. `4 * arcsin(d / 2)` on the closer of `a - b` and
`a + b` reports 0 for equal inputs, pinned by its own case.

## Visual

Unitree G1 (`mujoco_menagerie/unitree_g1/g1.xml`, 29 joints on a free base),
rendered headless with `MUJOCO_GL=egl`. The reference turns in place; the seam
shown carries a joint offset only, its orientation offset measuring 0.0 deg, so
an ease that absorbs only the offset it was given must leave the root exactly
where the sampler put it. Row 3 is bitwise identical to row 1 in all five eased
frames; row 2 differs by 0, 12740, 15348, 17800 and 18374 pixels.

![kimodo transition root turn](https://github.com/cagataycali/robots/releases/download/artifacts/kimodo-transition-root-turn.png)

## Gate

* `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1558 files).
* `mypy strands_robots tests tests_integ`: branch-only message set **empty**
  against a pristine worktree of the base commit (the 19 base-only messages are
  all `examples/isaac_gs/`, a cold-cache artifact of the throwaway worktree). 0
  messages in either changed file.
* Full `pytest tests/`: **29 failed, 39053 passed, 309 skipped, 24 errors**
  against **29 failed, 38918 passed, 309 skipped, 24 errors** on the base.
  Failing and erroring id sets are identical, 53 each, `comm` empty in both
  directions. All 53 are pre-existing and dependency-driven: 44 need `awsiot`
  (declared in the `mesh-iot` extra), 3 are lerobot-from-source
  `encode() takes 1 positional argument`, the rest missing dist metadata.
* `+41` collected is attributable to this branch, measured:
  `tests/test_args_docstring_completeness.py` collects 444 on both trees, so the
  two new private helpers add nothing to it. The other `+94` belongs to the two
  PRs that merged into `main` during the same window.
* Coverage of `strands_robots/policies/kimodo/policy.py`: **93% (10 missing) ->
  99% (1 missing)**. The previously unexercised branches were the whole of
  `_slerp_quat` apart from its nearly-parallel shortcut -- the shorter-arc sign
  flip and the real-arc arithmetic -- which the new cases reach through wide and
  antipodal seam offsets. Package total missing 1861 -> 1843.
* `tests/policies/kimodo/`: 130 passed on mujoco 3.5.0 (the declared floor) with
  lerobot 0.6.2 from source.
