### PR TITLE
fix(mesh): coerce a safety event's payload so the event reaches the wire

### DIFF
--- a/changelog.d/2741-safety-event-payload-reaches-the-wire.md
+++ b/changelog.d/2741-safety-event-payload-reaches-the-wire.md
@@ -1,0 +1,59 @@
+### Fixed: a safety event carrying a reading reaches the wire instead of being dropped
+
+`SensorLoopsMixin` builds nine records addressed to a `strands/<peer>/...` topic. Eight of
+them -- every `_read_*` reader -- pass the record through `_coerce_record` before it is
+published, because a sensor pipeline reports its readings as numpy and `json.dumps` refuses
+a `float32` (#2730). `publish_safety_event` builds the ninth, and did not coerce it.
+
+The consequence is total rather than partial: `_put_zenoh_directly` encodes the payload
+before it reaches the wire, so the event was never published at all. It is not a transient
+failure the next call retries either -- every call built the same way fails identically.
+Meanwhile the audit half of the *same* call wrote a `sig="SERIALISE_FAILED"` poison record
+and logged at ERROR, so the two halves of one call reported two different things: a forensic
+trail asserting that a safety event was raised, and no peer having received it.
+
+That disagreement is the one `session._report_unencodable_payload` describes in its own
+docstring. #2638 raised the report from DEBUG to ERROR so an operator could at least see the
+drop; the wire half still published nothing, and `_coerce_record` did not exist yet.
+
+Which readings were lost depends on the numpy *width*, which is why the gap was easy to
+miss. Measured through the encoder for a payload of `{"v": <value>}`:
+
+| value | before | after |
+|---|---|---|
+| `np.float32(2.97)` | dropped (`TypeError`) | published |
+| `np.int64(3)` | dropped (`TypeError`) | published |
+| `np.bool_(True)` | dropped (`TypeError`) | published |
+| `np.array([1.5, -2.5])` | dropped (`TypeError`) | published |
+| `np.float64(2.97)` | published | published |
+| `2.97` | published | published |
+
+`np.float64` subclasses Python's `float`, so a payload built from one always encoded and the
+same code reading a `float32` dropped every event. A reading is exactly what a safety
+payload carries -- the joint value that tripped a limit, the distance that closed -- and the
+public method's own docstring named no payload contract, while its audit sibling
+`log_safety_event` documents "Must be JSON-serialisable".
+
+The payload is now coerced once and the same coerced mapping is handed to both halves, so
+they report one event rather than two. Coercion happens in a copy: the caller keeps the
+mapping they passed unedited, and a fire-and-forget publish no longer holds an object the
+caller can still mutate after the call returns. Nothing else about the event changes -- the
+wire severity is still uniformly `"info"` (#272), the real severity still reaches the audit
+record only, a stopped host still publishes nothing, and an audit-write failure is still
+survived.
+
+The boundary is that coercion repairs readings rather than laundering payloads. A value that
+is genuinely not a reading is still passed through untouched, so the transport still reports
+it by name -- substituting a repr would publish a record that misstates what the safety path
+saw, which is worse than a reported drop.
+
+`tests/mesh/test_safety_event_payload_reaches_the_wire.py` drives the method through a host
+that *encodes* what it is handed, which is what the pre-existing coverage did not: the
+`publish` double in `tests/mesh/test_sensor_readers.py` records the payload, and the encoder
+runs one layer down in the transport, so a recording double accepts a payload the wire never
+would. Each row carries a premise that its raw value is what the encoder refuses. The rule
+that every record bound for the wire is coerced is derived from the module -- a method
+building a dict literal with a `peer_id` key is building one -- so a publisher added later is
+held to it on arrival; planting a tenth uncoerced builder fails the derived pin and passes a
+hardcoded one. Eleven plausible regressions were applied: nine fire a different set and the
+control is clean.

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -663,9 +663,40 @@ class SensorLoopsMixin:
         severity: str = "warning",
         payload: dict[str, Any] | None = None,
     ) -> None:
-        """Publish a safety event to the mesh AND write to audit log."""
+        """Publish a safety event to the mesh AND write to the audit log.
+
+        The payload is coerced once through :func:`_coerce_record` and the same
+        coerced mapping is handed to both halves, which is what makes the two
+        halves report one event instead of two different ones.
+        :func:`strands_robots.mesh.session._report_unencodable_payload` records
+        why that matters: on a payload the JSON encoder refuses, the audit half
+        writes a ``sig="SERIALISE_FAILED"`` poison record and logs at ERROR,
+        while the wire half publishes nothing at all - and the failure is not
+        transient, so no later tick recovers it. A reading expressed in a
+        foreign numeric type is exactly what a safety payload carries (the joint
+        value that tripped a limit, the distance that closed), and every other
+        record this mixin sends to the wire is coerced before it goes.
+
+        Coerced into a copy rather than in place, so the caller keeps the mapping
+        they passed unedited - the same reason :func:`_coerce_record` replaces a
+        nested container instead of editing the provider's own.
+
+        A value that is genuinely not a reading is still passed through
+        untouched rather than stringified, so the transport still reports it by
+        name: repairing an unrepresentable object by guessing would publish a
+        record that misstates what happened.
+
+        Args:
+            event_type: Short, lowercase event identifier (e.g. ``"estop"``).
+            severity: The real severity. It reaches the audit record only - the
+                wire copy is uniformly ``"info"`` (issue #272).
+            payload: Event-specific fields, or ``None`` for an event with none.
+        """
         if not self._running:
             return
+
+        record: dict[str, Any] = dict(payload) if payload is not None else {}
+        _coerce_record(record)
 
         event: dict[str, Any] = {
             "peer_id": self.peer_id,
@@ -675,7 +706,7 @@ class SensorLoopsMixin:
             # content-channel oracle for the rejection reason. The real
             # severity is preserved only in the local audit record below.
             "severity": "info",
-            "payload": payload or {},
+            "payload": record,
             "t": time.time(),
         }
 
@@ -685,7 +716,7 @@ class SensorLoopsMixin:
             log_safety_event(
                 event_type=event_type,
                 peer_id=self.peer_id,
-                payload={"severity": severity, **(payload or {})},
+                payload={"severity": severity, **record},
             )
         except Exception as exc:  # noqa: BLE001
             logger.debug("[mesh] %s: audit log write failed: %s", self.peer_id, exc)

--- a/tests/mesh/test_safety_event_payload_reaches_the_wire.py
+++ b/tests/mesh/test_safety_event_payload_reaches_the_wire.py
@@ -1,0 +1,319 @@
+"""A safety event reaches the wire even when its payload carries a reading.
+
+:class:`~strands_robots.mesh.sensors.SensorLoopsMixin` builds nine records
+addressed to a ``strands/<peer>/...`` topic. Eight of them - every ``_read_*``
+reader - pass the record through ``_coerce_record`` before it is published,
+because a sensor pipeline reports its readings as numpy and ``json.dumps``
+refuses a ``float32``. ``publish_safety_event`` builds the ninth, and did not
+coerce it: a safety payload carrying a reading was dropped before the wire while
+the audit half of the same call wrote a ``sig="SERIALISE_FAILED"`` poison record
+naming the failure. That is the disagreement
+:func:`strands_robots.mesh.session._report_unencodable_payload` describes in its
+own docstring - it raised the report from DEBUG to ERROR, and the wire half still
+published nothing.
+
+Why the existing coverage was silent: ``tests/mesh/test_sensor_readers.py``
+drives ``publish_safety_event`` through a host whose ``publish`` *records* the
+payload. The encoder runs one layer down, in the transport - ``json.dumps`` in
+``session._put_zenoh_directly``, before ``put`` - so a recording double accepts
+a payload the wire never would. The host here encodes what it is handed, which is
+what lets these cells see the drop at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import threading
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.mesh import sensors as mesh_sensors
+from strands_robots.mesh import session as mesh_session
+from strands_robots.mesh.sensors import SensorLoopsMixin
+
+#: A reading, its spelling, and what it must decode to on the far side. These
+#: are the numeric types a sensor pipeline hands over: ``ndarray.min(axis=0)``
+#: returns a ``float32``/``float64`` scalar, a joint vector is an ``ndarray``,
+#: and a comparison between them is a ``np.bool_``.
+_READINGS: tuple[tuple[str, Any, Any], ...] = (
+    ("float32-scalar", np.float32(2.97), pytest.approx(2.97, rel=1e-6)),
+    ("int64-scalar", np.int64(3), 3),
+    ("bool_-scalar", np.bool_(True), True),
+    ("float32-vector", np.array([1.5, -2.5], dtype=np.float32), [1.5, -2.5]),
+    ("float64-vector", np.array([1.5, -2.5]), [1.5, -2.5]),
+    ("list-of-float32", [np.float32(1.0), np.float32(2.0)], [1.0, 2.0]),
+    ("nested-mapping", {"q": np.float32(0.5)}, {"q": pytest.approx(0.5, rel=1e-6)}),
+)
+
+_IDS = tuple(row[0] for row in _READINGS)
+
+
+class _EncodingHost(SensorLoopsMixin):
+    """A mixin host whose ``publish`` encodes the way the transport does.
+
+    ``session._put_zenoh_directly`` encodes with ``json.dumps`` before handing
+    the bytes to ``put``, and a payload it refuses is dropped for good - the
+    failure is deterministic, so no later tick recovers it. Encoding here is
+    therefore not a stricter test double than production: it is the same step,
+    moved to where a unit test can observe which side of it the record landed.
+    """
+
+    def __init__(self, peer_id: str = "peer-1") -> None:
+        self.robot: Any = object()
+        self.peer_id = peer_id
+        self._running = True
+        self._stop_event = threading.Event()
+        self.handed: list[tuple[str, dict[str, Any]]] = []
+        self.wire: list[tuple[str, dict[str, Any]]] = []
+        self.dropped: list[tuple[str, str]] = []
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        self.handed.append((key, payload))
+        try:
+            encoded = json.dumps(payload).encode()
+        except (TypeError, ValueError) as exc:
+            self.dropped.append((key, f"{type(exc).__name__}: {exc}"))
+            return
+        self.wire.append((key, json.loads(encoded)))
+
+
+class _ProviderHost(_EncodingHost):
+    """An encoding host that also fronts a robot exposing sensor providers."""
+
+    def __init__(self, **provider_attrs: Any) -> None:
+        super().__init__()
+        robot = type("_Robot", (), {})()
+        for name, value in provider_attrs.items():
+            setattr(robot, name, value)
+        self.robot = robot
+
+
+@pytest.fixture
+def audited(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture the audit half's keyword arguments instead of writing a record."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(mesh_sensors, "log_safety_event", lambda **kw: calls.append(kw))
+    return calls
+
+
+def _record_builders() -> set[str]:
+    """Methods of the mixin that build a record addressed to the wire.
+
+    Derived, not listed: a record bound for a ``strands/<peer>/...`` topic
+    carries the peer that produced it, so a method containing a dict literal with
+    a ``"peer_id"`` key is building one. Reading the set off the source means a
+    publisher added later is held to the same rule as the nine that exist.
+    """
+    return {name for name, fn in _mixin_methods().items() if "peer_id" in _literal_keys(fn)}
+
+
+def _coercing_methods() -> set[str]:
+    """Methods of the mixin that call ``_coerce_record``."""
+    return {name for name, fn in _mixin_methods().items() if _calls(fn, "_coerce_record")}
+
+
+def _mixin_methods() -> dict[str, ast.FunctionDef]:
+    source = inspect.getsource(mesh_sensors)
+    cls = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "SensorLoopsMixin"
+    )
+    return {node.name: node for node in cls.body if isinstance(node, ast.FunctionDef)}
+
+
+def _literal_keys(fn: ast.FunctionDef) -> set[str]:
+    return {
+        key.value
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Dict)
+        for key in node.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+
+
+def _calls(fn: ast.FunctionDef, name: str) -> bool:
+    return any(isinstance(node, ast.Call) and name in ast.unparse(node.func) for node in ast.walk(fn))
+
+
+class TestThePremiseHolds:
+    """The reading really is unencodable, and the wire really encodes."""
+
+    @pytest.mark.parametrize(("label", "value", "expected"), _READINGS, ids=_IDS)
+    def test_json_refuses_the_reading_uncoerced(self, label: str, value: Any, expected: Any) -> None:
+        with pytest.raises(TypeError, match="not JSON serializable"):
+            json.dumps({"v": value})
+
+    def test_the_transport_encodes_before_it_puts(self) -> None:
+        source = inspect.getsource(mesh_session._put_zenoh_directly)
+        assert "json.dumps" in source, (
+            "premise: the wire encodes with json.dumps, which is why an encoding host is the "
+            "faithful double and a recording one is not"
+        )
+
+    def test_a_sibling_reader_given_the_same_reading_reaches_the_wire(self) -> None:
+        host = _ProviderHost(_map_info={"resolution": np.float32(0.05), "origin": np.array([1.0, 2.0])})
+        info = host._read_map_info()
+        assert info is not None
+        host.publish(f"strands/{host.peer_id}/map/info", info)
+        assert host.dropped == []
+        assert host.wire[0][1]["resolution"] == pytest.approx(0.05, rel=1e-6)
+
+
+class TestASafetyEventCarryingAReadingReachesTheWire:
+    """The regression: the record is coerced, so the event is published."""
+
+    @pytest.mark.parametrize(("label", "value", "expected"), _READINGS, ids=_IDS)
+    def test_the_event_is_published(self, audited: list[dict[str, Any]], label: str, value: Any, expected: Any) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("joint_limit_tripped", severity="critical", payload={"v": value})
+
+        assert host.dropped == [], f"a {label} reading was dropped before the wire: {host.dropped}"
+        assert len(host.wire) == 1
+        key, event = host.wire[0]
+        assert key == "strands/peer-1/safety/event"
+        assert event["payload"]["v"] == expected
+        # The rest of the envelope is unchanged by the coercion.
+        assert event["severity"] == "info"
+        assert event["type"] == "joint_limit_tripped"
+        assert event["peer_id"] == "peer-1"
+
+    def test_a_reading_used_as_a_key_reaches_the_wire(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        # Annotated at the call site: the parameter is ``dict[str, Any]``, and a
+        # reading used as a key is exactly the case ``_jsonable`` coerces.
+        keyed: dict[Any, Any] = {np.int64(7): "joint-7"}
+        host.publish_safety_event("estop", payload=keyed)
+
+        assert host.dropped == []
+        assert host.wire[0][1]["payload"] == {"7": "joint-7"}
+
+
+class TestBothHalvesReportTheSameEvent:
+    """The wire half and the audit half carry one coerced reading, not two."""
+
+    def test_the_audit_record_carries_the_coerced_reading(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop", severity="critical", payload={"q": np.float32(2.97)})
+
+        wire_payload = host.wire[0][1]["payload"]
+        audit_payload = audited[0]["payload"]
+        assert audit_payload["q"] == wire_payload["q"]
+        # The audit half no longer needs its poison-record path for this payload either.
+        json.dumps(audit_payload)
+
+
+class TestTheCallersMappingIsNotEdited:
+    """Coercion happens in a copy, so the caller keeps what they passed.
+
+    The event no longer carries the caller's own mapping: it used to be inserted
+    by reference, so a caller who reused or mutated the dict after the call
+    changed what a fire-and-forget publish was still holding.
+    """
+
+    def test_the_supplied_mapping_is_unchanged(self, audited: list[dict[str, Any]]) -> None:
+        nested = {"q": np.float32(0.5)}
+        payload: dict[str, Any] = {"reading": np.float32(2.97), "nested": nested}
+        host = _EncodingHost()
+        host.publish_safety_event("estop", payload=payload)
+
+        assert isinstance(payload["reading"], np.float32)
+        assert payload["nested"] is nested
+        assert isinstance(nested["q"], np.float32)
+
+    def test_the_published_payload_is_not_the_callers_object(self, audited: list[dict[str, Any]]) -> None:
+        payload: dict[str, Any] = {"reason": "x"}
+        host = _EncodingHost()
+        host.publish_safety_event("estop", payload=payload)
+
+        assert host.handed[0][1]["payload"] is not payload
+        payload["reason"] = "mutated after the call"
+        assert host.handed[0][1]["payload"] == {"reason": "x"}
+
+
+class TestEveryRecordBoundForTheWireIsCoerced:
+    """The rule, derived from the module rather than listed here."""
+
+    def test_the_derivation_is_not_vacuous(self) -> None:
+        builders = _record_builders()
+        assert len(builders) >= 9, f"expected every peer-stamped record builder, found {sorted(builders)}"
+        assert "publish_safety_event" in builders
+        assert {"_read_pose", "_read_health", "_read_imu", "_read_map_info"} <= builders
+
+    def test_every_record_builder_coerces(self) -> None:
+        uncoerced = _record_builders() - _coercing_methods()
+        assert uncoerced == set(), (
+            f"these methods build a record addressed to the wire and do not coerce it: {sorted(uncoerced)}"
+        )
+
+    def test_no_method_coerces_without_building_a_record(self) -> None:
+        stray = _coercing_methods() - _record_builders()
+        assert stray == set(), f"_coerce_record called where no wire record is built: {sorted(stray)}"
+
+
+class TestWhatIsUnchanged:
+    """Every expectation here is one the uncoerced code also met."""
+
+    def test_a_plain_payload_is_published_verbatim(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop", severity="critical", payload={"reason": "x", "n": 3})
+        assert host.wire[0][1]["payload"] == {"reason": "x", "n": 3}
+
+    def test_the_wire_severity_is_still_uniform(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop", severity="critical", payload={"reason": "x"})
+        assert host.wire[0][1]["severity"] == "info"
+        assert host.wire[0][1]["type"] == "estop"
+
+    def test_the_audit_record_still_carries_the_real_severity(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop", severity="critical", payload={"reason": "x"})
+        assert audited[0]["payload"]["severity"] == "critical"
+        assert audited[0]["event_type"] == "estop"
+
+    def test_no_payload_still_publishes_an_empty_one(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop")
+        assert host.wire[0][1]["payload"] == {}
+
+    def test_a_stopped_host_still_publishes_nothing(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host._running = False
+        host.publish_safety_event("estop", payload={"q": np.float32(1.0)})
+        assert host.wire == [] and host.dropped == [] and audited == []
+
+    def test_an_audit_failure_is_still_survived(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(**_kw: Any) -> None:
+            raise RuntimeError("audit backend down")
+
+        monkeypatch.setattr(mesh_sensors, "log_safety_event", _boom)
+        host = _EncodingHost()
+        host.publish_safety_event("estop", payload={"reason": "x"})
+        assert len(host.wire) == 1
+
+
+class TestAValueThatIsNotAReadingIsStillReported:
+    """The over-reach guard: coercing must not become stringifying.
+
+    ``_jsonable`` returns an object it cannot recognise unchanged, so the
+    transport still names it. Substituting a repr would publish a record that
+    misstates what the safety path saw, which is worse than a reported drop.
+    """
+
+    def test_an_unrepresentable_object_is_passed_through(self, audited: list[dict[str, Any]]) -> None:
+        sentinel = object()
+        host = _EncodingHost()
+        host.publish_safety_event("estop", payload={"thing": sentinel})
+
+        assert host.wire == []
+        assert len(host.dropped) == 1
+        assert "not JSON serializable" in host.dropped[0][1]
+
+    def test_a_string_payload_value_is_not_taken_apart(self, audited: list[dict[str, Any]]) -> None:
+        host = _EncodingHost()
+        host.publish_safety_event("estop", payload={"joint": "shoulder_pan"})
+        assert host.wire[0][1]["payload"]["joint"] == "shoulder_pan"


### PR DESCRIPTION
## Problem

`SensorLoopsMixin` builds nine records addressed to a `strands/<peer>/...` topic. Eight of them -- every `_read_*` reader -- pass the record through `_coerce_record` before it is published, because a sensor pipeline reports its readings as numpy and `json.dumps` refuses a `float32` (#2730). `publish_safety_event` builds the ninth, and did not coerce it.

The consequence is total rather than partial. `session._put_zenoh_directly` encodes the payload before it reaches the wire, so the event was never published at all -- and the failure is not transient, so no later call recovers it. The audit half of the *same* call, meanwhile, wrote a `sig="SERIALISE_FAILED"` poison record and logged at ERROR. One call, two reports: a forensic trail asserting a safety event was raised, and no peer having received it.

That disagreement is the one `session._report_unencodable_payload` describes in its own docstring:

> `publish_safety_event` writes the event to the wire AND to the local audit log; on an unencodable payload the audit half records a `sig="SERIALISE_FAILED"` poison record and logs at ERROR (naming the peer and the reason), while the wire half dropped the event silently.

\#2638 raised that report from DEBUG to ERROR so an operator could at least see the drop. The wire half still published nothing, and `_coerce_record` did not exist yet.

## Measured

Driven through the production encoder and the production reporter, one capture script run against both trees. The call is `publish_safety_event("joint_limit_tripped", severity="critical", payload={"joint": "shoulder_pan", "q": np.float32(2.9712), "limit": np.float32(2.9670)})`:

| | `upstream/main` | this branch |
|---|---|---|
| messages published | **0** | 1 |
| transport report | `ERROR ... the payload cannot be JSON-encoded, so this message and every later one built the same way is dropped before it reaches the wire ... Object of type float32 is not JSON serializable` | nothing reported |
| audit records written | 1 | 1 |
| audit payload serialises | **no** (poison-record path) | yes |
| audit severity | `critical` | `critical` |

Which readings were lost depended on the numpy *width*, which is why the gap was easy to miss. For a payload of `{"v": <value>}`:

| value | before | after |
|---|---|---|
| `np.float32(2.97)` | dropped (`TypeError`) | published |
| `np.int64(3)` | dropped (`TypeError`) | published |
| `np.bool_(True)` | dropped (`TypeError`) | published |
| `np.array([1.5, -2.5])` | dropped (`TypeError`) | published |
| `np.float64(2.97)` | published | published |
| `2.97` | published | published |

`np.float64` subclasses Python's `float`, so a payload built from one always encoded and the same code reading a `float32` dropped every event.

The in-file control is decisive: the *same* `np.float32(0.05)` handed to a sibling reader, `_read_map_info`, reaches the wire on **both** trees (`resolution = 0.05000000074505806`). One class, one wire format, two conventions -- and the one without a coercion is the safety topic.

## Reachability

A reading is what a safety payload naturally carries: the joint value that tripped a limit, the distance that closed. `publish_safety_event` is public and documented in `examples/fleet/dashboard.py` as part of the mesh surface, and its docstring named no payload contract at all, while its audit sibling `log_safety_event` documents "Must be JSON-serialisable".

The in-tree callers in `Mesh` all pass strings, ints and lists of peer ids, so none of the built-in safety events was affected. This is a latent defect on the public surface, stated plainly rather than dressed up.

## Change

Coerce the payload once, and hand the same coerced mapping to both halves, so they report one event instead of two. `+34/-3` in `strands_robots/mesh/sensors.py`.

Coercion happens in a copy, so the caller keeps the mapping they passed unedited -- the same reason `_coerce_record` replaces a nested container rather than editing the provider's own -- and a fire-and-forget publish no longer holds an object the caller can still mutate after the call returns.

Nothing else about the event changes: the wire severity is still uniformly `"info"` (#272), the real severity still reaches the audit record only, a stopped host still publishes nothing, and an audit-write failure is still survived.

The boundary is that coercion repairs readings rather than laundering payloads. A value that is genuinely not a reading is still passed through untouched, so the transport still reports it by name -- substituting a repr would publish a record that misstates what the safety path saw, which is worse than a reported drop.

## Why every gate was silent

`tests/mesh/test_sensor_readers.py` drives `publish_safety_event` through a host whose `publish` **records** the payload. The encoder runs one layer down, in the transport, so a recording double accepts a payload the wire never would. `tests/mesh/test_safety_event_payload_reaches_the_wire.py` uses a host that encodes what it is handed, which is the only way a unit test can see which side of the encoder the record landed on.

## Tests

`tests/mesh/test_safety_event_payload_reaches_the_wire.py`, 31 cells. Pre-fix: **11 failed / 20 passed**, with 0 of the 6 cells in `TestWhatIsUnchanged`, 0 of the 3 premises, and 0 of the 2 over-reach cells failing. Each reading row carries a premise that its raw value is what the encoder refuses, so the table cannot pass on a value that never needed coercing.

The rule that every record bound for the wire is coerced is derived from the module rather than listed: a method containing a dict literal with a `"peer_id"` key is building one. That selects exactly the nine builders, with no false positive in either direction (`coercing - builders` is empty), so a publisher added later is held to it on arrival.

Eleven plausible regressions applied, **nine distinct firing sets**, control clean, source restored byte-identical:

| mutation | fires | notes |
|---|---|---|
| control (no mutation) | 0 | |
| the coercion is removed | 10 | the defect |
| wire half coerced, audit half keeps the raw payload | 1 | the halves disagree again, the other way round |
| audit half coerced, wire half keeps the raw payload | 10 | |
| coerced in place, aliasing the caller's mapping | 2 | |
| values stringified instead of coerced | 10 | |
| coerced after the event is published | 9 | placement is load-bearing |
| `_jsonable` inlined instead of the shared `_coerce_record` | 1 | behaviourally equivalent; the derived pin is what fires |
| wire severity leaks the real severity (#272) | 8 | over-reach guard |
| a tenth record builder is planted, uncoerced | 1 | the derived pin catches it |
| the same plant, builder set hardcoded to today's nine | **0** | why the set is derived |

The last two rows are a pair: hardcoding the builder set makes the planted publisher invisible, which is the argument for deriving it. The `_jsonable`-inlined row shares its firing set with the plant for a structural reason -- both are "a record builder does not call the shared helper" -- and it is a behavioural no-op, so the structural cell is what pins the single-sourcing rather than a behavioural one.

## Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1560 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical in both directions, 0 in the changed files.
- Paired run over an identical 565-file selection (all of `tests/mesh/` plus every guard that walks the tree, reads source or docstrings, or reads `changelog.d`), the new file excluded from both trees: **24 failed, 101 skipped, 24 errors on both** (23108 vs 23106 collected), **48 failing/erroring ids each, `comm` empty in both directions**. 45 of the 48 need `awsiot`/`awscrt` (declared in the `[mesh-iot]` extra, absent here -- confirmed with `tomllib` + `find_spec`); the remaining three are pre-existing on both trees.
- The `+2` collected localises entirely to `tests/test_args_docstring_completeness.py` (446 vs 444), which parametrises over documented functions -- `publish_safety_event` gained an `Args:` block.
- `tests/mesh/test_zenoh_transport_security.py` is excluded from the paired selection and verified alone: **9 passed, 2 skipped on both trees**.
- The changed file plus `tests/mesh/test_sensor_readers.py`: 129 passed.

## Artifact

Both halves of the one call, on both trees, driven through the production encoder and the production once-per-topic reporter. The audit half is stubbed to record its arguments instead of writing to disk; everything else is production code.

![the wire half and the audit half of one safety event, on both trees](https://github.com/cagataycali/robots/releases/download/artifacts/safety-event-payload.png)
