### PR TITLE
fix(simulation): bound a body's collision proxy by the geoms MuJoCo can collide

### DIFF
--- a/changelog.d/2742-body-collision-bound-prefers-collidable-geoms.md
+++ b/changelog.d/2742-body-collision-bound-prefers-collidable-geoms.md
@@ -1,0 +1,46 @@
+### Fixed: a body's collision proxy is bounded by the geoms MuJoCo can collide
+
+`_body_collision_aabb` computes the axis-aligned box that stands in for a body's physics
+footprint, and it is what `load_mjcf_scene_objects` reports as a `SceneObject`'s `size` and
+`position`. It selected geoms with `group == "0"`, falling back to every geom when that matched
+nothing, and that is wrong in two independent ways.
+
+`group` carries no contact meaning in MuJoCo - it is a visualiser toggle - and the conventions
+built on it disagree, MuJoCo Menagerie marking collision geoms with `group="3"` where robosuite
+marks visual ones with `group="1"`. So the attribute cannot answer which geoms the solver will
+touch, which is the only question this function asks. Separately, the comparison was against the
+literal string: a geom that omits `group` *is* group 0, and MuJoCo resolves it to `geom_group == 0`,
+but the attribute reads as absent so the `"0"` pass skipped it.
+
+Both directions are measurable. In a Menagerie-shaped body every geom falls through to the
+every-geom fallback, so the proxy becomes the union of the decorative shell and the collision
+primitive: the shipped `franka_emika_panda` `mjx_hand` fingers reported a
+`(0.022, 0.026, 0.0532)` proxy centred `(0, 0.013, 0.0269)` where the body's collision geometry is
+`(0.0175, 0.0152, 0.0165)` centred `(0, 0.0076, 0.04525)` - 6.9x the volume, 3.2x the length along
+the finger, and centred on the wrong part of it. Of that finger's seven geoms exactly one,
+`left_finger_pad`, is left able to take part in a contact (`conaffinity="3"`); not one of them
+carries `group="0"`. And where the `"0"` pass did match, it narrowed instead: a body whose two
+collidable geoms spell `group="0"` and `group="3"` dropped the second one entirely, reporting a
+bound that excludes geometry the solver collides.
+
+The signal read is now the format's own, through the existing `_geom_cannot_collide` - already the
+tie-break `_mesh_geom_visual_rank` ranks first for the mirror question of which mesh is a body's
+visual asset. MuJoCo lets two geoms touch only when `contype1 & conaffinity2` or
+`contype2 & conaffinity1` is non-zero, so a geom declaring both as `0` can never take part in a
+contact. Reading either half of that pair alone would be wrong: `contype="0" conaffinity="1"` still
+collides with anything declaring `contype` non-zero, and such a geom stays inside the bound.
+
+Graded against MuJoCo itself across the downloaded asset corpus - 336 compilable MJCF files, 427
+bodies whose collidable analytic geoms are axis-aligned and therefore comparable to an axis-aligned
+bound - the reported bound now matches MuJoCo's own on 427 of 427, against 356 of 427 before. No
+body is worse. Over the wider corpus of 554 files and 1209 bodies with an analytic answer, 72
+change, all 72 shrink, none grows, and 27 also move their centre onto the geometry they stand for.
+
+Deliberately unchanged: a body whose every analytic geom is contact-free. There is nothing
+collidable to prefer, so all of them are bounded exactly as before - an approximate proxy is still
+better than none - and that is pinned as a control, as is the single-geom case.
+
+The `group` tier is dropped here rather than demoted the way `_mesh_geom_visual_rank` keeps it.
+That is a measurement, not a preference: keeping it as a refinement inside the collidable tier
+changes the answer for 0 of those 1209 bodies, whereas for the visual-mesh question it is the only
+signal some files carry.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1849,21 +1849,32 @@ def _body_collision_aabb(
     defaults: dict[str, dict[str, str]],
     childclass: str,
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
-    """Compute the AABB (center, full-size) over a body's own geoms.
+    """Compute the AABB (center, full-size) over a body's own collidable geoms.
 
-    Prefers MuJoCo collision geoms (``group="0"``); if a body has only
-    analytic geoms in another group those are used as a fallback. Geom
-    positions are taken relative to the body frame, so the returned centre
+    Prefers the geoms MuJoCo can actually collide, read off the format's own
+    contact declaration by :func:`_geom_cannot_collide`, so a decorative shell
+    drawn around a small collision primitive does not widen the proxy that
+    stands in for the body. A body whose every analytic geom is contact-free
+    falls back to all of them: an approximate bound is still better than none.
+
+    ``group`` is deliberately not consulted. It is a MuJoCo visualiser toggle
+    carrying no contact meaning, and the conventions built on it disagree -
+    Menagerie spells *collision* as ``group="3"`` while robosuite spells
+    *visual* as ``group="1"`` - which is why :func:`_mesh_geom_visual_rank`
+    takes it only as a weak hint. Selecting on ``group="0"`` also missed every
+    geom that omits the attribute, which is MJCF's spelling of group 0.
+
+    Geom positions are taken relative to the body frame, so the returned centre
     is a body-frame offset. Returns ``None`` when no analytic geom is found
     (e.g. a mesh-only visual body).
     """
-    for group_filter in ("0", None):
+    for collidable_only in (True, False):
         mins = [float("inf")] * 3
         maxs = [float("-inf")] * 3
         found = False
         for geom in body_el.findall("geom"):
             attrs = _class_attrs(geom, defaults, childclass)
-            if group_filter is not None and attrs.get("group") != group_filter:
+            if collidable_only and _geom_cannot_collide(attrs):
                 continue
             aabb = _geom_aabb(geom, defaults, childclass)
             if aabb is None:

--- a/tests/simulation/isaac/test_body_collision_bound_prefers_collidable_geoms.py
+++ b/tests/simulation/isaac/test_body_collision_bound_prefers_collidable_geoms.py
@@ -1,0 +1,322 @@
+"""A body's collision bound spans the geoms MuJoCo can actually collide.
+
+``_body_collision_aabb`` computes the axis-aligned box that stands in for a
+body's physics footprint, and it is what ``load_mjcf_scene_objects`` reports as
+a :class:`~strands_robots.simulation.isaac.loaders.SceneObject`'s ``size`` and
+``position``. It selected geoms by ``group == "0"``, falling back to every geom
+when that matched nothing, which is wrong in two independent ways.
+
+First, ``group`` carries no contact meaning in MuJoCo -- it is a visualiser
+toggle -- and the conventions built on it disagree: MuJoCo Menagerie marks
+*collision* geoms with ``group="3"`` while robosuite marks *visual* ones with
+``group="1"``. So the attribute cannot say which geoms the solver will touch,
+which is the only question this function asks.
+
+Second, the comparison was against the literal string. A geom that omits
+``group`` *is* group 0 -- MuJoCo resolves it to ``geom_group == 0`` -- but the
+attribute reads ``None``, so the ``"0"`` pass skipped it. In a Menagerie-shaped
+body every geom falls through to the "every geom" fallback and the bound becomes
+the union of the decorative shell and the collision primitive.
+
+Both directions are measurable. A body carrying a 1.0 m visual shell around a
+0.2 m collision box reported a ``(1.0, 1.0, 1.2)`` proxy centred 0.5 m away from
+the primitive it stands for; the shipped ``franka_emika_panda`` ``mjx_hand``
+fingers reported ``(0.022, 0.026, 0.0532)`` where MuJoCo's collision geometry is
+``(0.0175, 0.0152, 0.0165)`` -- 3.2x too long along the finger. And where the
+``"0"`` pass *did* match, it narrowed instead: a body whose two collidable geoms
+spell ``group="0"`` and ``group="3"`` dropped the second one entirely, reporting
+a bound that excludes geometry the solver collides.
+
+The signal now read is the format's own, through :func:`_geom_cannot_collide` --
+already the tie-break :func:`_mesh_geom_visual_rank` ranks first for the mirror
+question of which mesh is a body's *visual* asset. MuJoCo lets two geoms touch
+only when ``contype1 & conaffinity2`` or ``contype2 & conaffinity1`` is
+non-zero, so a geom declaring both as ``0`` can never take part in a contact.
+
+MuJoCo is the oracle throughout: every expected bound below is read back off a
+compiled ``MjModel`` rather than restated, including the ``geom_group``
+resolution that establishes what the old comparison missed.
+
+Deliberately unchanged: a body whose every analytic geom is contact-free. There
+is nothing collidable to prefer, so all of them are bounded exactly as before --
+an approximate proxy is still better than none. That is pinned below, as is the
+single-geom case, so a body the new signal says nothing new about keeps the
+answer it has always had.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    _body_collision_aabb,
+    _class_attrs,
+    _geom_cannot_collide,
+    _mjcf_class_defaults,
+    load_mjcf_scene_objects,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+#: The Menagerie spelling in shape: the visual class marks itself only by being
+#: unable to collide and names no ``group`` at all, and the collision class names
+#: ``group="3"``. Under the old rule neither geom matched ``group == "0"``.
+MENAGERIE_DEFAULTS = """<default>
+    <default class="visual"><geom contype="0" conaffinity="0"/></default>
+    <default class="collision"><geom group="3"/></default>
+  </default>"""
+
+#: A 1.0 m decorative shell around a 0.2 m collision box held 0.6 m up the z
+#: axis, so an over-bound differs from the truth in both size and centre.
+SHELL_AROUND_PRIMITIVE = """<body name="link">
+    <geom class="visual" type="box" size="0.5 0.5 0.5"/>
+    <geom class="collision" type="box" size="0.1 0.1 0.1" pos="0 0 0.6"/>
+  </body>"""
+
+#: Two geoms MuJoCo can both collide, distinguished only by ``group``. The old
+#: ``"0"`` pass matched the first and dropped the second.
+TWO_COLLIDABLE_GROUPS = """<body name="link">
+    <geom name="near" type="box" size="0.1 0.1 0.1" group="0"/>
+    <geom name="far" type="box" size="0.1 0.1 0.1" group="3" pos="0 0 0.4"/>
+  </body>"""
+
+#: ``contype="0"`` alone does not make a geom decorative: MuJoCo still lets it
+#: touch anything declaring ``contype`` non-zero, because ``contype_other &
+#: conaffinity_self`` is then non-zero. So the wide geom here is collidable and
+#: the bound must span it -- a rule reading either half of the pair on its own
+#: would drop it.
+HALF_DECLARED_CONTACT = """<body name="link">
+    <geom name="wide" type="box" size="0.5 0.5 0.5" contype="0" conaffinity="1"/>
+    <geom name="small" type="box" size="0.1 0.1 0.1"/>
+  </body>"""
+
+#: Nothing here can collide, so there is no preference to express.
+ONLY_CONTACT_FREE = """<body name="link">
+    <geom class="visual" type="box" size="0.5 0.5 0.5"/>
+    <geom class="visual" type="sphere" size="0.2" pos="0 0 0.8"/>
+  </body>"""
+
+#: One collidable geom and nothing else: both rules bound the same thing.
+SINGLE_GEOM = """<body name="link">
+    <geom type="box" size="0.3 0.2 0.1" pos="0.05 0 0"/>
+  </body>"""
+
+#: A nested collision child, the ``living_room_table`` -> ``..._col`` shape the
+#: recursive walk exists for, so the preference is exercised through it too.
+NESTED_COLLISION_CHILD = """<body name="link">
+    <geom class="visual" type="box" size="0.5 0.5 0.5"/>
+    <body name="link_col" pos="0 0 0.6">
+      <geom class="visual" type="box" size="0.4 0.4 0.4"/>
+      <geom class="collision" type="box" size="0.1 0.1 0.1"/>
+    </body>
+  </body>"""
+
+#: Half-extent of each analytic geom type, in MuJoCo's ``geom_size`` terms.
+_HALF_EXTENT = {
+    int(mujoco.mjtGeom.mjGEOM_BOX): lambda s: (s[0], s[1], s[2]),
+    int(mujoco.mjtGeom.mjGEOM_SPHERE): lambda s: (s[0], s[0], s[0]),
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER): lambda s: (s[0], s[0], s[1]),
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE): lambda s: (s[0], s[0], s[1] + s[0]),
+    int(mujoco.mjtGeom.mjGEOM_ELLIPSOID): lambda s: (s[0], s[1], s[2]),
+}
+
+
+def _model(body: str, defaults: str = MENAGERIE_DEFAULTS) -> str:
+    return f"<mujoco>{defaults}<worldbody>{body}</worldbody></mujoco>"
+
+
+def _compile(body: str, defaults: str = MENAGERIE_DEFAULTS):
+    return mujoco.MjModel.from_xml_string(_model(body, defaults))
+
+
+def _bound(body: str, defaults: str = MENAGERIE_DEFAULTS):
+    """The loader's ``(centre, size)`` for the model's single named body."""
+    root = ET.fromstring(_model(body, defaults))
+    geom_defaults = _mjcf_class_defaults(root, ".", "geom")
+    body_el = root.find(".//body")
+    assert body_el is not None
+    return _body_collision_aabb(body_el, geom_defaults, body_el.get("childclass") or "")
+
+
+def _mujoco_bound(body: str, defaults: str = MENAGERIE_DEFAULTS, name: str = "link"):
+    """MuJoCo's own ``(centre, size)`` over a body's collidable analytic geoms.
+
+    Read off a compiled model, so ``<default>`` inheritance and the contact
+    declaration are resolved by MuJoCo rather than by the code under test.
+    """
+    model = _compile(body, defaults)
+    bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert bid != -1, name
+    mins = [float("inf")] * 3
+    maxs = [float("-inf")] * 3
+    for gid in range(model.ngeom):
+        if model.geom_bodyid[gid] != bid:
+            continue
+        half_of = _HALF_EXTENT.get(int(model.geom_type[gid]))
+        if half_of is None:
+            continue
+        if model.geom_contype[gid] == 0 and model.geom_conaffinity[gid] == 0:
+            continue
+        half = half_of(model.geom_size[gid])
+        pos = model.geom_pos[gid]
+        for axis in range(3):
+            mins[axis] = min(mins[axis], pos[axis] - half[axis])
+            maxs[axis] = max(maxs[axis], pos[axis] + half[axis])
+    assert mins[0] != float("inf"), "no collidable analytic geom to compare against"
+    return (
+        tuple((mins[a] + maxs[a]) / 2.0 for a in range(3)),
+        tuple(maxs[a] - mins[a] for a in range(3)),
+    )
+
+
+def _geom_signals(body: str, defaults: str = MENAGERIE_DEFAULTS) -> dict[str, dict[str, object]]:
+    """Per-geom ``group``/contact facts as MuJoCo and as the loader see them."""
+    model = _compile(body, defaults)
+    root = ET.fromstring(_model(body, defaults))
+    geom_defaults = _mjcf_class_defaults(root, ".", "geom")
+    body_el = root.find(".//body")
+    assert body_el is not None
+    childclass = body_el.get("childclass") or ""
+    out: dict[str, dict[str, object]] = {}
+    for index, geom_el in enumerate(body_el.findall("geom")):
+        attrs = _class_attrs(geom_el, geom_defaults, childclass)
+        out[geom_el.get("name") or geom_el.get("class") or str(index)] = {
+            "mujoco_group": int(model.geom_group[index]),
+            "loader_group_attr": attrs.get("group"),
+            "mujoco_contact_free": bool(model.geom_contype[index] == 0 and model.geom_conaffinity[index] == 0),
+            "loader_cannot_collide": _geom_cannot_collide(attrs),
+        }
+    return out
+
+
+class TestMuJoCoFixesWhichGeomsCollide:
+    """The premises: what the format says, read off a compiled model."""
+
+    def test_a_geom_that_omits_group_is_group_zero_but_reads_as_absent(self) -> None:
+        """The blind spot in the old comparison, stated as MuJoCo resolves it."""
+        signals = _geom_signals(SHELL_AROUND_PRIMITIVE)["visual"]
+        assert signals["mujoco_group"] == 0
+        assert signals["loader_group_attr"] is None
+
+    def test_the_visual_class_makes_its_geom_unable_to_collide(self) -> None:
+        signals = _geom_signals(SHELL_AROUND_PRIMITIVE)["visual"]
+        assert signals["mujoco_contact_free"] is True
+        assert signals["loader_cannot_collide"] is True
+
+    def test_the_collision_class_geom_can_collide(self) -> None:
+        signals = _geom_signals(SHELL_AROUND_PRIMITIVE)["collision"]
+        assert signals["mujoco_contact_free"] is False
+        assert signals["loader_cannot_collide"] is False
+
+    def test_two_geoms_differing_only_by_group_can_both_collide(self) -> None:
+        """So the bound must span both -- ``group`` does not exclude either."""
+        signals = _geom_signals(TWO_COLLIDABLE_GROUPS)
+        assert signals["near"]["mujoco_contact_free"] is False
+        assert signals["far"]["mujoco_contact_free"] is False
+        assert (signals["near"]["mujoco_group"], signals["far"]["mujoco_group"]) == (0, 3)
+
+
+class TestABodyBoundsTheGeomsThatCanCollide:
+    """The bound is over the collidable geoms, and it is MuJoCo's."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(SHELL_AROUND_PRIMITIVE, id="shell-around-primitive"),
+            pytest.param(TWO_COLLIDABLE_GROUPS, id="two-collidable-groups"),
+            pytest.param(HALF_DECLARED_CONTACT, id="half-declared-contact"),
+            pytest.param(SINGLE_GEOM, id="single-geom"),
+        ],
+    )
+    def test_the_bound_is_the_one_mujoco_computes(self, body: str) -> None:
+        bound = _bound(body)
+        assert bound is not None
+        centre, size = bound
+        expected_centre, expected_size = _mujoco_bound(body)
+        assert centre == pytest.approx(expected_centre)
+        assert size == pytest.approx(expected_size)
+
+    def test_a_decorative_shell_does_not_widen_the_bound(self) -> None:
+        """The over-bound direction: the shell is 5x the primitive per axis."""
+        bound = _bound(SHELL_AROUND_PRIMITIVE)
+        assert bound is not None
+        _, size = bound
+        assert size == pytest.approx((0.2, 0.2, 0.2))
+
+    def test_a_decorative_shell_does_not_move_the_bound(self) -> None:
+        """A proxy centred on the union sits 0.5 m off the geometry it stands for."""
+        bound = _bound(SHELL_AROUND_PRIMITIVE)
+        assert bound is not None
+        centre, _ = bound
+        assert centre == pytest.approx((0.0, 0.0, 0.6))
+
+    def test_group_does_not_narrow_the_bound(self) -> None:
+        """The under-bound direction: both collidable geoms are inside it."""
+        bound = _bound(TWO_COLLIDABLE_GROUPS)
+        assert bound is not None
+        centre, size = bound
+        assert (centre, size) == (pytest.approx((0.0, 0.0, 0.2)), pytest.approx((0.2, 0.2, 0.6)))
+
+    def test_a_nested_collision_child_is_preferred_too(self) -> None:
+        """The recursive walk asks the same question of each nested body."""
+        root = ET.fromstring(_model(NESTED_COLLISION_CHILD))
+        geom_defaults = _mjcf_class_defaults(root, ".", "geom")
+        child = root.find(".//body/body")
+        assert child is not None
+        bound = _body_collision_aabb(child, geom_defaults, "")
+        assert bound is not None
+        assert bound[1] == pytest.approx((0.2, 0.2, 0.2))
+
+
+class TestASceneObjectCarriesTheCollisionBound:
+    """The public reader reports the proxy, so the fix is observable there."""
+
+    def test_the_proxy_size_and_position_are_the_collision_geometry_s(self, tmp_path) -> None:
+        scene = tmp_path / "scene.xml"
+        scene.write_text(
+            _model(
+                """<body name="mug" pos="1 2 0">
+    <freejoint/>
+    <geom class="visual" type="box" size="0.5 0.5 0.5"/>
+    <geom class="collision" type="box" size="0.1 0.1 0.1" pos="0 0 0.6"/>
+  </body>"""
+            ),
+            encoding="utf-8",
+        )
+        objects = {obj.name: obj for obj in load_mjcf_scene_objects(str(scene))}
+        assert "mug" in objects
+        mug = objects["mug"]
+        assert mug.size == pytest.approx((0.2, 0.2, 0.2))
+        assert mug.position == pytest.approx((1.0, 2.0, 0.6))
+
+
+class TestOnlyAGeomThatCannotCollideIsExcluded:
+    """The exclusion must not widen: both halves of the pair have to be zero."""
+
+    def test_one_zero_half_of_the_contact_pair_is_not_decorative(self) -> None:
+        """MuJoCo still collides such a geom, so it stays inside the bound."""
+        bound = _bound(HALF_DECLARED_CONTACT)
+        assert bound is not None
+        assert bound[1] == pytest.approx((1.0, 1.0, 1.0))
+
+    def test_mujoco_agrees_the_half_declared_geom_can_collide(self) -> None:
+        signals = _geom_signals(HALF_DECLARED_CONTACT)["wide"]
+        assert signals["mujoco_contact_free"] is False
+        assert signals["loader_cannot_collide"] is False
+
+
+class TestABodyWithNothingCollidableKeepsItsBound:
+    """No collidable geom means no preference to express: bound them all."""
+
+    def test_every_contact_free_geom_still_contributes(self) -> None:
+        bound = _bound(ONLY_CONTACT_FREE)
+        assert bound is not None
+        centre, size = bound
+        assert centre == pytest.approx((0.0, 0.0, 0.25))
+        assert size == pytest.approx((1.0, 1.0, 1.5))
+
+    def test_a_mesh_only_body_still_reports_nothing(self) -> None:
+        """No analytic geom at all keeps the ``None`` the caller falls back on."""
+        assert _bound("""<body name="link"><geom type="mesh" mesh="m"/></body>""") is None


### PR DESCRIPTION
## Problem

`_body_collision_aabb` computes the axis-aligned box that stands in for a body's physics footprint, and it is what `load_mjcf_scene_objects` reports as a `SceneObject`'s `size` and `position`. It selected geoms with `group == "0"`, falling back to every geom when that matched nothing. That is wrong in two independent ways.

`group` carries no contact meaning in MuJoCo - it is a visualiser toggle - and the conventions built on it disagree: Menagerie marks *collision* geoms with `group="3"` where robosuite marks *visual* ones with `group="1"`. So the attribute cannot answer which geoms the solver will touch, which is the only question this function asks.

Separately, the comparison was against the literal string. A geom that omits `group` **is** group 0 - MuJoCo resolves it to `geom_group == 0` - but the attribute reads as absent, so the `"0"` pass skipped it.

### Both directions are live

**It over-bounds.** In a Menagerie-shaped body every geom falls through to the every-geom fallback, so the proxy becomes the union of the decorative shell and the collision primitive. On the shipped `franka_emika_panda` `mjx_hand`:

| `left_finger` | reported | MuJoCo's collision geometry |
|---|---|---|
| proxy full size (m) | `(0.022, 0.02602, 0.0532)` | `(0.0175, 0.0152, 0.0165)` |
| proxy centre (m) | `(0.0, 0.01299, 0.0269)` | `(0.0, 0.00758, 0.04525)` |

6.9x the volume, 3.2x the length along the finger, and centred on the wrong part of it. Of that body's seven geoms exactly one - `left_finger_pad` - is left able to take part in a contact (`conaffinity="3"`), and not one of them carries `group="0"`.

**It also under-bounds.** Where the `"0"` pass did match, it narrowed: a body whose two collidable geoms spell `group="0"` and `group="3"` dropped the second one entirely, reporting `(0.2, 0.2, 0.2)` for geometry spanning `(0.2, 0.2, 0.6)`.

## Change

The signal read is now the format's own contact declaration, through the existing `_geom_cannot_collide` - already the tie-break `_mesh_geom_visual_rank` ranks first for the mirror question of which mesh is a body's *visual* asset. MuJoCo lets two geoms touch only when `contype1 & conaffinity2` or `contype2 & conaffinity1` is non-zero, so a geom declaring both as `0` can never take part in a contact. A body whose every analytic geom is contact-free still bounds all of them.

Reading either half of the pair alone would be wrong, and that is pinned: `contype="0" conaffinity="1"` still collides with anything declaring `contype` non-zero, so such a geom stays inside the bound.

**The `group` tier is dropped here rather than demoted the way `_mesh_geom_visual_rank` keeps it**, and that is a measurement rather than a preference: keeping it as a refinement inside the collidable tier changes the answer for **0** of the 1209 corpus bodies below, whereas for the visual-mesh question it is the only signal some files carry.

## Graded against MuJoCo

MuJoCo is the oracle: for each body its collision AABB is computed from `geom_contype`/`geom_conaffinity`/`geom_size`/`geom_pos` off a compiled `MjModel`, so `<default>` inheritance and the contact declaration are resolved by MuJoCo rather than by the code under test.

Restricted to bodies whose collidable analytic geoms are axis-aligned, and therefore comparable to an axis-aligned bound - 336 compilable MJCF files, 427 such bodies:

| | matches MuJoCo | worse than before |
|---|---|---|
| before | 356 / 427 | - |
| after | **427 / 427** | **0** |

Over the wider corpus of 554 files and 1209 bodies with an analytic answer: **72 change, all 72 shrink, none grows**, and 27 also move their centre onto the geometry they stand for.

## Sim artifact

`mjx_hand.xml` rendered headless (`MUJOCO_GL=egl`), unmodified except for the two translucent proxy boxes drawn from the loader's own reported centre and size. All three panels share one camera and one headlight.

![collision proxy before and after](https://github.com/cagataycali/robots/releases/download/artifacts/collision_proxy.png)

Pixel counts are unoccluded silhouettes taken from per-category segmentation passes, so the enclosing box does not hide what it contains:

| | before | after |
|---|---|---|
| proxy px outside the collidable geom | 54106 | **0** |
| collidable-geom px outside the proxy | 0 | **0** |

The new proxy's silhouette is exactly the collidable geom's (28878 px each), which is what an AABB of a single axis-aligned box should be.

## Tests

`tests/simulation/isaac/test_body_collision_bound_prefers_collidable_geoms.py`, 17 cases. Pre-fix **7 fail / 7 pass**, and the 7 that pass are the four MuJoCo premises, the two `TestABodyWithNothingCollidableKeepsItsBound` controls and the single-geom oracle case - nothing in a premise or control class fires.

Break table, 9 mutations against the branch (`isaac` = the rest of `tests/simulation/isaac/`, 1637 tests):

| mutation | mine | isaac |
|---|---|---|
| control (unmutated) | 0 | 0 |
| preference reverted to the `group=="0"` filter | 7 | 0 |
| the contact filter applied in BOTH passes | 1 | 0 |
| predicate inverted (prefers the decorative geoms) | 5 | 0 |
| tier order reversed (every geom first) | 5 | 0 |
| only the `contype` half of the pair is read | 2 | 0 |
| the every-geom fallback tier dropped | 1 | 0 |
| attributes read off the element, not its default class | 5 | **1** |
| the `group=="0"` filter re-added on top of the new tier | 7 | 0 |
| the `group` paragraph deleted from the docstring, code kept | 0 | 0 |

8 of 9 detected, 5 distinct failing-id sets, source restored byte-identical. Three rows share a set for a structural reason - inverting the predicate, reversing the tiers and bypassing `_class_attrs` all reduce to "the decorative shell contributes" for a shell-shaped body, and none of them changes the group-only case. The over-reach row that bypasses `_class_attrs` additionally trips the pre-existing `test_mjcf_default_class_geometry.py::TestOneRuleAnswersWhatAGeomDeclared::test_the_scan_reaches_the_readers_it_grades`, which requires every geom reader to go through that one rule. The last row is an honest 0: nothing grades that prose.

## Gate

Full `pytest tests/` on both trees, `MUJOCO_GL=egl`, mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 from source:

- base `26078397`: 39507 collected, `29 failed, 39145 passed, 309 skipped, 24 errors`
- branch: 39524 collected, `29 failed, 39162 passed, 309 skipped, 24 errors`

`+17` collected and `+17` passed is exactly the new file, and the failing/erroring id sets are **identical (53 each, both set differences empty)**. Those 53 are pre-existing on this host: 44 need `awsiot` (the `[mesh-iot]` extra), the rest are lerobot-from-source drift and a missing dist metadata entry.

`ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1560 files). mypy `24 == 24` against a pristine `main` worktree with byte-identical normalized message sets and none in the changed files. The changed file also passes on mujoco 3.12.0.

One line of coverage moved in an untouched module (`simulation/mujoco/simulation.py`, 21 -> 22 missing, line 5186 - a branch inside a threaded policy path). It is run-to-run nondeterminism, not this change: `simulation/isaac/loaders.py` reports an identical `723 / 68 / 91%` on both trees, since the defect was in what a covered function computed rather than in an uncovered line.

## Not changed

`_extract_mjcf_shape` still reads a link's shape from its first `<geom>`. That is a different question - a kinematic link's display shape rather than a collision proxy - and its docstring documents the first-geom rule, so it is left alone here.
