### PR TITLE
fix(simulation): carry an unnamed actuator's command across a scene rebuild

### DIFF
--- a/changelog.d/2743-unnamed-actuator-command-survives-a-rebuild.md
+++ b/changelog.d/2743-unnamed-actuator-command-survives-a-rebuild.md
@@ -39,3 +39,11 @@ upstream fails there rather than falling silently into the reported-rather-than-
 Deliberately unchanged: an actuator whose transmission is one that mapping does not know. Nothing
 then identifies its target across the rebuild, so it is reported rather than guessed at - the same
 residual the joint key leaves for a joint whose body is also unnamed.
+
+On mujoco 3.12 exactly one member of the enum sits in that residual, and it is unreachable rather
+than unhandled: `mjTRN_SO3`, the orientation servo, whose target is a site under one spelling and a
+ball joint under the other, so its transmission type alone does not fix which table names it. Such an
+actuator takes three controls, so a model carrying one compiles with `nu > nactuator` and this
+backend already declines it - it addresses an actuator by its control index - before any rebuild
+could snapshot it. Both halves of that argument are pinned by tests, so the key learns to carry its
+target's object type on the day that refusal lifts and not before.

--- a/changelog.d/2743-unnamed-actuator-command-survives-a-rebuild.md
+++ b/changelog.d/2743-unnamed-actuator-command-survives-a-rebuild.md
@@ -1,0 +1,41 @@
+### Fixed: a scene rebuild keeps an unnamed actuator's command instead of resetting it
+
+`remove_robot` cannot delete a body that was attached through `spec.attach()` without tripping a
+MuJoCo shutdown segfault, so `eject_robot_from_scene` rebuilds the scene spec from scratch. That
+compiles a fresh model and allocates a fresh `MjData`, which renumbers every actuator id, so the
+dynamic state is snapshotted under a name-based key beforehand and written back afterwards.
+
+The joint half of that snapshot identifies an unnamed joint through its owning body plus its position
+among that body's joints. The actuator half keyed on the actuator's own name alone and skipped
+anything unnamed, on the grounds that "its transmission target may drive several actuators, so it
+cannot be matched across the rebuild". A skipped key is skipped silently, so such an actuator's
+`ctrl` and its `act` activation were dropped and it came back at its fresh-compile zero - the
+setpoints holding a *surviving* robot's pose reset because some *other* robot was removed, under
+`status success`.
+
+The premise was sound and the conclusion too strong, exactly as it was for joints: the target alone
+does not single the actuator out, yet the target plus its position among the actuators driving that
+target does. MuJoCo stores actuators in declaration order and an eject removes a robot's actuators
+wholesale, so the surviving order is preserved, and no scene op inserts an actuator into a compiled
+model (the patch vocabulary is `add_body` / `add_geom` / `add_site` / `set_body_pos` /
+`set_body_quat` / `delete_body`). The transmission type belongs in the key alongside the target
+because `mjTRN_JOINT` and `mjTRN_JOINTINPARENT` are different transmissions that can name the same
+joint id, and the ordinal counts every actuator sharing a target rather than only the unnamed ones,
+so the snapshot and the restore count the same population.
+
+An unnamed `<actuator>` child is the ordinary MJCF spelling, not a contrivance: of the 235
+actuator-bearing models in the downloaded MuJoCo Menagerie tree, 7 leave every one of theirs unnamed
+- `ufactory_lite6` (6 of 6), `google_robot` (9 of 9) and `iit_softfoot` (1 of 1), 43 unnamed
+actuators in total - so a scene holding one of those arms lost its whole command vector on every
+rebuild.
+
+Measured through the public API on a scene of two robots, where a door is held at `0.90 rad` by a
+single unnamed `<position>` servo: `remove_robot("arm")` used to leave that servo's `ctrl` at `0.0`,
+and 400 steps later the door had been driven back to `0.17 rad`. It now reports `0.9`, and the door
+is still at `0.9000 rad`. An actuator's target is resolved through the `mjtTrn` member it drives
+through, and the mapping's coverage is derived from the enum in the tests, so a transmission added
+upstream fails there rather than falling silently into the reported-rather-than-guessed branch.
+
+Deliberately unchanged: an actuator whose transmission is one that mapping does not know. Nothing
+then identifies its target across the rebuild, so it is reported rather than guessed at - the same
+residual the joint key leaves for a joint whose body is also unnamed.

--- a/strands_robots/simulation/mujoco/scene_ops.py
+++ b/strands_robots/simulation/mujoco/scene_ops.py
@@ -1621,6 +1621,17 @@ def reposition_body_in_scene(
 # See :func:`_joint_key`.
 _JointKey = tuple[str, str] | tuple[str, str, int]
 
+# An actuator is keyed the same way, for the same reason. A named actuator takes
+# the two-element form ``("actuator", name)``.
+#
+# An unnamed actuator takes the four-element form
+# ``("target", trntype, target_name, ordinal)``: its transmission target names
+# it, and the ordinal disambiguates the several actuators that may share one
+# target. The transmission type belongs in the key because ``mjTRN_JOINT`` and
+# ``mjTRN_JOINTINPARENT`` are different transmissions on the same joint id.
+# See :func:`_actuator_key`.
+_ActuatorKey = tuple[str, str] | tuple[str, int, str, int]
+
 
 @dataclass(frozen=True)
 class _SceneState:
@@ -1640,9 +1651,10 @@ class _SceneState:
     Attributes:
         joints: ``key -> (qpos, qvel, qfrc_applied)`` slices, each at the width
             its joint type uses (free 7/6/6, ball 4/3/3, hinge or slide 1/1/1).
-        actuators: ``actuator name -> (ctrl, act)``. ``ctrl`` is the servo
-            setpoint holding a robot's pose; ``act`` is the internal activation
-            of a stateful actuator, its effective command.
+        actuators: ``key -> (ctrl, act)``. ``ctrl`` is the servo setpoint
+            holding a robot's pose; ``act`` is the internal activation of a
+            stateful actuator, its effective command. Keyed by
+            :func:`_actuator_key`, so an unnamed actuator is carried too.
         body_wrenches: ``body name -> [fx, fy, fz, tx, ty, tz]``, the external
             wrench :meth:`~strands_robots.simulation.mujoco.MuJoCoSimEngine.apply_force`
             latches in a body's own ``xfrc_applied`` row. ``qfrc_applied``
@@ -1655,7 +1667,7 @@ class _SceneState:
     """
 
     joints: dict[_JointKey, tuple[list[float], list[float], list[float]]]
-    actuators: dict[str, tuple[float, list[float]]]
+    actuators: dict[_ActuatorKey, tuple[float, list[float]]]
     body_wrenches: dict[str, list[float]]
     time: float
 
@@ -1704,6 +1716,101 @@ def _joint_key(model: Any, jid: int, mj: Any) -> _JointKey | None:
     return ("body_joint", body_name, jid - int(model.body_jntadr[body_id]))
 
 
+def _actuator_target_kind(trntype: int, mj: Any) -> Any | None:
+    """The ``mjtObj`` an actuator's ``trnid[0]`` indexes, for ``trntype``.
+
+    Each transmission points at a different kind of element, and MJCF names
+    every one of them (an actuator references its target by name, so the target
+    is never anonymous). ``None`` for a transmission this mapping does not
+    know: a future ``mjtTrn`` member is reported rather than resolved against
+    the wrong table.
+    """
+    trn = mj.mjtTrn
+    obj = mj.mjtObj
+    return {
+        int(trn.mjTRN_JOINT): obj.mjOBJ_JOINT,
+        int(trn.mjTRN_JOINTINPARENT): obj.mjOBJ_JOINT,
+        int(trn.mjTRN_SLIDERCRANK): obj.mjOBJ_SITE,
+        int(trn.mjTRN_TENDON): obj.mjOBJ_TENDON,
+        int(trn.mjTRN_SITE): obj.mjOBJ_SITE,
+        int(trn.mjTRN_BODY): obj.mjOBJ_BODY,
+    }.get(trntype)
+
+
+def _actuator_key(model: Any, aid: int, mj: Any) -> _ActuatorKey | None:
+    """Identify actuator ``aid`` by name, or through its transmission target.
+
+    Two key forms, in order of preference:
+
+    ``("actuator", name)``
+        The actuator carries a name, which is the handle a rebuild preserves.
+    ``("target", trntype, target_name, ordinal)``
+        An unnamed actuator, identified by what it drives and by its position
+        among the actuators driving the same target through the same
+        transmission. Several actuators may share one target -- a position and
+        a velocity servo on one hinge is the ordinary spelling -- so the target
+        alone does not single one out, but the target plus that ordinal does.
+        MuJoCo stores actuators in declaration order and an eject removes a
+        robot's actuators wholesale, so the surviving order (and therefore the
+        ordinal) is preserved. The transmission type is part of the key because
+        ``mjTRN_JOINT`` and ``mjTRN_JOINTINPARENT`` are different transmissions
+        that can name the same joint id.
+
+    An unnamed ``<actuator>`` child is the ordinary MJCF spelling: of the 235
+    actuator-bearing models in the MuJoCo Menagerie tree, 7 leave every one of
+    theirs unnamed (``ufactory_lite6``, ``google_robot``, ``iit_softfoot``), so
+    dropping these would reset a whole arm's setpoints on every rebuild.
+
+    Returns:
+        The key, or ``None`` when the transmission is one this mapping does not
+        know. Nothing then identifies the actuator across a rebuild, so it is
+        reported rather than guessed at.
+    """
+    name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, aid)
+    if name:
+        return ("actuator", name)
+    trntype = int(model.actuator_trntype[aid])
+    kind = _actuator_target_kind(trntype, mj)
+    if kind is None:
+        return None
+    target_id = int(model.actuator_trnid[aid][0])
+    target_name = mj.mj_id2name(model, kind, target_id)
+    if not target_name:
+        return None
+    ordinal = sum(
+        1
+        for other in range(aid)
+        if int(model.actuator_trntype[other]) == trntype and int(model.actuator_trnid[other][0]) == target_id
+    )
+    return ("target", trntype, str(target_name), ordinal)
+
+
+def _resolve_actuator_key(model: Any, key: _ActuatorKey, mj: Any) -> int:
+    """Resolve an :data:`_ActuatorKey` to an actuator id in ``model``, or ``-1``."""
+    if len(key) == 4:
+        _, trntype, target_name, ordinal = key
+        kind = _actuator_target_kind(int(trntype), mj)
+        if kind is None:
+            return -1
+        target_id = mj_name_to_id(model, kind, str(target_name))
+        if target_id < 0:
+            # The target is gone, so what the actuator drove no longer exists.
+            return -1
+        seen = 0
+        for aid in range(int(model.nu)):
+            if int(model.actuator_trntype[aid]) != trntype or int(model.actuator_trnid[aid][0]) != target_id:
+                continue
+            if seen == ordinal:
+                # An actuator that gained a name is carried by its own
+                # ``("actuator", name)`` key, so this handle must not claim it.
+                return -1 if mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, aid) else aid
+            seen += 1
+        # The target survives but no longer drives an actuator at that position.
+        return -1
+    _, name = key
+    return mj_name_to_id(model, mj.mjtObj.mjOBJ_ACTUATOR, str(name))
+
+
 def _snapshot_scene_state(world: SimWorld) -> _SceneState:
     """Capture ``world``'s dynamic state keyed by name, for a scene rebuild.
 
@@ -1734,18 +1841,20 @@ def _snapshot_scene_state(world: SimWorld) -> _SceneState:
             [float(x) for x in data.qfrc_applied[dof_adr : dof_adr + dof_w]],
         )
 
-    actuators: dict[str, tuple[float, list[float]]] = {}
+    actuators: dict[_ActuatorKey, tuple[float, list[float]]] = {}
     for aid in range(int(model.nu)):
-        name = mj.mj_id2name(model, mj.mjtObj.mjOBJ_ACTUATOR, aid)
-        if not name:
-            # No namespace names it, and its transmission target may drive
-            # several actuators, so it cannot be matched across the rebuild.
-            logger.debug("snapshot_scene_state: actuator id %d has no name, ctrl/act not carried over", aid)
+        akey = _actuator_key(model, aid, mj)
+        if akey is None:
+            logger.debug(
+                "snapshot_scene_state: actuator id %d drives through a transmission this build "
+                "cannot key, ctrl/act not carried over",
+                aid,
+            )
             continue
         act_adr = int(model.actuator_actadr[aid])
         act_num = int(model.actuator_actnum[aid])
         act_vals = [float(x) for x in data.act[act_adr : act_adr + act_num]] if act_adr >= 0 else []
-        actuators[name] = (float(data.ctrl[aid]), act_vals)
+        actuators[akey] = (float(data.ctrl[aid]), act_vals)
 
     return _SceneState(
         joints=joints,
@@ -1800,8 +1909,8 @@ def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
             data.qfrc_applied[dof_adr + i] = v
         restored += 1
 
-    for name, (ctrl_val, act_vals) in snapshot.actuators.items():
-        aid = mj_name_to_id(model, mj.mjtObj.mjOBJ_ACTUATOR, name)
+    for akey, (ctrl_val, act_vals) in snapshot.actuators.items():
+        aid = _resolve_actuator_key(model, akey, mj)
         if aid < 0:
             continue  # actuator belonged to the ejected robot
         data.ctrl[aid] = ctrl_val
@@ -1813,7 +1922,7 @@ def _restore_scene_state(world: SimWorld, snapshot: _SceneState) -> int:
             if act_vals or act_num:
                 logger.warning(
                     "_restore_scene_state: act width mismatch for actuator %r (%d!=%d), skipping activation",
-                    name,
+                    akey,
                     len(act_vals),
                     act_num,
                 )

--- a/tests/simulation/mujoco/test_unnamed_actuator_command_survives_a_rebuild.py
+++ b/tests/simulation/mujoco/test_unnamed_actuator_command_survives_a_rebuild.py
@@ -1,0 +1,435 @@
+"""An unnamed actuator keeps its command when a scene rebuild renumbers the model.
+
+``eject_robot_from_scene`` compiles a fresh model and allocates a fresh
+``MjData``, which renumbers every actuator id, so the dynamic state is
+snapshotted under a name-based key and written back afterwards. The joint half
+of that snapshot learned to carry an unnamed element through its owning body
+plus an ordinal; the actuator half still keyed on the actuator's own name alone
+and skipped anything unnamed, on the grounds that "its transmission target may
+drive several actuators, so it cannot be matched across the rebuild".
+
+A skipped actuator's ``ctrl`` and ``act`` were dropped, so it came back at its
+fresh-compile zero while the operation reported success -- the setpoints holding
+a surviving robot's pose, and the activation of a stateful actuator, silently
+reset because some *other* robot was removed.
+
+The premise was sound and the conclusion too strong, the same way it was for
+joints: the target alone does not single the actuator out, yet the target *plus
+its position among the actuators driving that target* does. MuJoCo stores
+actuators in declaration order and an eject removes a robot's actuators
+wholesale, so the surviving order is preserved, and no scene op inserts an
+actuator (the patch vocabulary is ``add_body`` / ``add_geom`` / ``add_site`` /
+``set_body_pos`` / ``set_body_quat`` / ``delete_body``).
+
+An unnamed ``<actuator>`` child is the ordinary MJCF spelling: of the 235
+actuator-bearing models in the MuJoCo Menagerie tree, 7 leave every one of
+theirs unnamed -- ``ufactory_lite6`` (6 of 6), ``google_robot`` (9 of 9) and
+``iit_softfoot`` (1 of 1) -- so such a scene lost its whole command vector.
+
+Three properties make the key load-bearing rather than decorative, and each has
+its own cell below:
+
+* Four actuators drive one hinge here -- one named, three not -- so the target
+  alone cannot tell them apart and keying on it would collapse three commands
+  into one. The ordinal counts the named one too, because the snapshot and the
+  restore have to count the same population.
+* Two of them name the same joint id through *different* transmissions
+  (``mjTRN_JOINT`` and ``mjTRN_JOINTINPARENT``), so the transmission type has to
+  be part of the key.
+* An actuator that gains a name is carried by its own ``("actuator", name)``
+  key, so the target handle must not also claim it.
+
+Still unmatched, deliberately: an actuator driving through a transmission the
+``mjtTrn`` mapping does not know. Nothing then identifies its target, so it is
+reported rather than guessed at, and the mapping's coverage is derived from the
+enum here so a future MuJoCo transmission fails this file instead of silently
+falling into that branch.
+
+GL-free: ``mesh=False`` and no rendering, so this runs without a GPU.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mujoco")
+
+import mujoco  # noqa: E402
+
+from strands_robots.simulation.mujoco import scene_ops  # noqa: E402
+from strands_robots.simulation.mujoco.simulation import Simulation  # noqa: E402
+
+# An arm whose only actuator is named, so it is carried by the pre-existing
+# ``("actuator", name)`` key. It is the robot the tests eject.
+_ARM_XML = """
+<mujoco model="arm">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="base" pos="0 0 0.05">
+      <geom type="box" size="0.04 0.04 0.05"/>
+      <body name="link" pos="0 0 0.1">
+        <joint name="pan" type="hinge" axis="0 0 1" range="-2 2" damping="1"/>
+        <geom type="capsule" fromto="0 0 0 0.14 0 0" size="0.02"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="pan_act" joint="pan" kp="10"/>
+  </actuator>
+</mujoco>
+"""
+
+# The furniture that must survive the eject untouched. Its actuator block is the
+# whole point: a NAMED actuator on the hinge ahead of three unnamed ones, so the
+# ordinal has to count named siblings too; a fourth unnamed one reaching the same
+# hinge through a different transmission; a fifth on a body; and a second named
+# one as the control. The stateful ``dyntype="integrator"`` entry also exercises
+# the ``act`` activation slice.
+_FURNITURE_XML = """
+<mujoco model="furniture">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="door_frame" pos="0.5 0 0.2">
+      <geom type="box" size="0.02 0.02 0.2"/>
+      <body name="door_panel" pos="0 0 0">
+        <joint name="door_hinge" type="hinge" axis="0 0 1" range="-3 3" damping="0.5"/>
+        <geom type="box" size="0.01 0.15 0.18" pos="0 0.15 0"/>
+      </body>
+    </body>
+    <body name="drawer" pos="-0.5 0 0.2">
+      <joint name="drawer_slide" type="slide" axis="1 0 0" range="-1 1" damping="0.5"/>
+      <geom type="box" size="0.06 0.06 0.06"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="door_brake" joint="door_hinge" kp="1"/>
+    <position joint="door_hinge" kp="5"/>
+    <velocity joint="door_hinge" kv="1"/>
+    <general joint="door_hinge" dyntype="integrator" gainprm="1"/>
+    <general jointinparent="door_hinge" gear="1"/>
+    <adhesion body="drawer" ctrlrange="0 1" gain="1"/>
+    <position name="drawer_slide_act" joint="drawer_slide" kp="1"/>
+  </actuator>
+</mujoco>
+"""
+
+#: One distinctive ``ctrl`` per unnamed actuator, in id order. They differ from
+#: each other so a swap between two actuators sharing a target is visible, and
+#: none is zero so a value lost to a fresh compile is visible too. The adhesion
+#: actuator's ``ctrlrange`` is ``0 1``, so its value is positive.
+_UNNAMED_CTRL = (0.63, -0.42, 0.19, -0.77, 0.31)
+
+#: The activation the one stateful unnamed actuator is seeded with.
+_ACTIVATION = 1.37
+
+#: The named furniture actuator's setpoint, restored by the pre-existing key.
+_NAMED_CTRL = 0.55
+
+
+def _actuator_names(model: Any) -> list[str | None]:
+    """Every actuator name the model carries, in id order (``None`` if unnamed)."""
+    return [mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_ACTUATOR, aid) for aid in range(int(model.nu))]
+
+
+def _unnamed_actuator_ids(model: Any) -> list[int]:
+    """Every actuator id the model carries no name for, in id order."""
+    return [aid for aid, name in enumerate(_actuator_names(model)) if not name]
+
+
+def _commands(model: Any, data: Any) -> dict[Any, float]:
+    """``key -> ctrl`` for every actuator, keyed the way the snapshot keys them."""
+    return {scene_ops._actuator_key(model, aid, mujoco): float(data.ctrl[aid]) for aid in range(int(model.nu))}
+
+
+def _activations(model: Any, data: Any) -> dict[Any, list[float]]:
+    """``key -> act`` slice for every actuator that carries activation state."""
+    out: dict[Any, list[float]] = {}
+    for aid in range(int(model.nu)):
+        adr = int(model.actuator_actadr[aid])
+        num = int(model.actuator_actnum[aid])
+        if adr >= 0 and num:
+            out[scene_ops._actuator_key(model, aid, mujoco)] = [float(x) for x in data.act[adr : adr + num]]
+    return out
+
+
+def _stateful_id(model: Any) -> int:
+    """The id of the one actuator carrying an activation slice."""
+    return next(aid for aid in range(int(model.nu)) if int(model.actuator_actadr[aid]) >= 0)
+
+
+@pytest.fixture
+def scene(tmp_path: Path) -> Any:
+    """A world holding the arm plus the furniture, with every setpoint seeded.
+
+    Yields the ``Simulation``, the ``{key: ctrl}`` map and the ``{key: act}`` map
+    the scene was seeded with, read back through the compiled model so the
+    expectations are the model's own view rather than a hand-kept list.
+    """
+    (tmp_path / "arm.xml").write_text(_ARM_XML)
+    (tmp_path / "furniture.xml").write_text(_FURNITURE_XML)
+
+    sim = Simulation(tool_name="test_unnamed_actuator_command_survives_a_rebuild", mesh=False)
+    sim.create_world(gravity=[0, 0, -9.81])
+    assert sim.add_robot(name="arm", urdf_path=str(tmp_path / "arm.xml"))["status"] == "success"
+    assert sim.add_robot(name="fur", urdf_path=str(tmp_path / "furniture.xml"))["status"] == "success"
+
+    world = sim._world
+    assert world is not None
+    model, data = world._model, world._data
+    assert model is not None and data is not None
+
+    unnamed = _unnamed_actuator_ids(model)
+    # The premise: the furniture really did compile to five unnamed actuators, so
+    # a rename upstream cannot quietly turn these tests into no-ops.
+    assert len(unnamed) == len(_UNNAMED_CTRL), _actuator_names(model)
+
+    for aid, value in zip(unnamed, _UNNAMED_CTRL, strict=True):
+        data.ctrl[aid] = value
+    named = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fur/drawer_slide_act")
+    data.ctrl[named] = _NAMED_CTRL
+    data.act[int(model.actuator_actadr[_stateful_id(model)])] = _ACTIVATION
+    mujoco.mj_forward(model, data)
+
+    yield sim, _commands(model, data), _activations(model, data)
+    sim.cleanup()
+
+
+def _survivors(sim: Any) -> dict[Any, float]:
+    """The current ``ctrl`` of every actuator, keyed as seeded."""
+    world = sim._world
+    return _commands(world._model, world._data)
+
+
+class TestAnUnnamedActuatorSurvivesTheEject:
+    """The regression: removing one robot must not reset the rest of the scene."""
+
+    def test_every_surviving_actuator_keeps_the_command_it_was_seeded_with(self, scene: Any) -> None:
+        sim, seeded, _ = scene
+        ejected = ("actuator", "arm/pan_act")
+        assert sim.remove_robot("arm")["status"] == "success"
+        assert _survivors(sim) == {key: value for key, value in seeded.items() if key != ejected}
+
+    def test_the_three_actuators_on_one_hinge_keep_their_distinct_commands(self, scene: Any) -> None:
+        """The case that makes the ordinal load-bearing: the target cannot tell them apart."""
+        sim, seeded, _ = scene
+        joint = int(mujoco.mjtTrn.mjTRN_JOINT)
+        shared = {key: value for key, value in seeded.items() if key[:3] == ("target", joint, "fur/door_hinge")}
+        assert sorted(key[3] for key in shared) == [1, 2, 3]
+        assert len(set(shared.values())) == 3
+
+        sim.remove_robot("arm")
+        after = _survivors(sim)
+        assert {key: after[key] for key in shared} == shared
+
+    def test_the_actuator_reached_through_another_transmission_keeps_its_command(self, scene: Any) -> None:
+        """The case that makes the transmission type load-bearing: same joint id, different key."""
+        sim, seeded, _ = scene
+        parent = ("target", int(mujoco.mjtTrn.mjTRN_JOINTINPARENT), "fur/door_hinge", 0)
+        assert parent in seeded
+        sim.remove_robot("arm")
+        assert _survivors(sim)[parent] == seeded[parent]
+
+    def test_an_unnamed_body_transmission_keeps_its_command(self, scene: Any) -> None:
+        """A transmission whose target is a body, not a joint, is keyed the same way."""
+        sim, seeded, _ = scene
+        body = ("target", int(mujoco.mjtTrn.mjTRN_BODY), "fur/drawer", 0)
+        assert body in seeded
+        sim.remove_robot("arm")
+        assert _survivors(sim)[body] == seeded[body]
+
+    def test_the_activation_of_a_stateful_unnamed_actuator_survives(self, scene: Any) -> None:
+        """``act`` is the effective command of a stateful actuator, so it is carried too."""
+        sim, _, activations = scene
+        assert list(activations.values()) == [[_ACTIVATION]]
+        sim.remove_robot("arm")
+        world = sim._world
+        assert _activations(world._model, world._data) == activations
+
+
+class TestThePremisesTheKeyRestsOn:
+    """What has to be true of the scene for the cells above to mean anything."""
+
+    def test_the_eject_renumbers_the_surviving_actuators(self, scene: Any) -> None:
+        """Without a renumber a positional copy would work and the key would be moot."""
+        sim, _, _ = scene
+        before = _unnamed_actuator_ids(sim._world._model)
+        sim.remove_robot("arm")
+        assert _unnamed_actuator_ids(sim._world._model) != before
+
+    def test_adding_a_robot_namespaces_a_named_actuator_and_leaves_an_unnamed_one_unnamed(self, scene: Any) -> None:
+        """The namespace is what makes a named actuator resolvable; it cannot name a nameless one."""
+        sim, _, _ = scene
+        names = _actuator_names(sim._world._model)
+        assert "arm/pan_act" in names
+        assert "fur/drawer_slide_act" in names
+        assert "fur/door_brake" in names
+        assert names.count(None) == len(_UNNAMED_CTRL)
+
+    def test_the_three_shared_actuators_really_name_one_target(self, scene: Any) -> None:
+        """If they named three targets the ordinal would be decoration."""
+        sim, _, _ = scene
+        model = sim._world._model
+        joint = int(mujoco.mjtTrn.mjTRN_JOINT)
+        targets = {
+            int(model.actuator_trnid[aid][0])
+            for aid in _unnamed_actuator_ids(model)
+            if int(model.actuator_trntype[aid]) == joint
+        }
+        assert len(targets) == 1
+
+    def test_two_transmissions_name_the_same_joint_id(self, scene: Any) -> None:
+        """If they named different ids the transmission type would be decoration."""
+        sim, _, _ = scene
+        model = sim._world._model
+        by_type: dict[int, set[int]] = {}
+        for aid in _unnamed_actuator_ids(model):
+            by_type.setdefault(int(model.actuator_trntype[aid]), set()).add(int(model.actuator_trnid[aid][0]))
+        joint = int(mujoco.mjtTrn.mjTRN_JOINT)
+        parent = int(mujoco.mjtTrn.mjTRN_JOINTINPARENT)
+        assert by_type[joint] == by_type[parent]
+
+    def test_a_named_actuator_shares_a_target_with_the_unnamed_ones(self, scene: Any) -> None:
+        """So the ordinal has to count named siblings; skipping them would desynchronise.
+
+        The snapshot and the restore count the same population. If the key
+        counted only unnamed siblings the two sides would disagree the moment a
+        named actuator shared a target, which this scene arranges.
+        """
+        sim, _, _ = scene
+        model = sim._world._model
+        brake = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fur/door_brake")
+        assert brake >= 0
+        shared = [
+            aid
+            for aid in _unnamed_actuator_ids(model)
+            if int(model.actuator_trntype[aid]) == int(model.actuator_trntype[brake])
+            and int(model.actuator_trnid[aid][0]) == int(model.actuator_trnid[brake][0])
+        ]
+        assert shared
+        assert brake < min(shared)
+
+    def test_the_seeded_commands_are_all_distinct_and_none_is_zero(self, scene: Any) -> None:
+        """A repeated or zero setpoint could not show a swap or a loss."""
+        assert len(set(_UNNAMED_CTRL)) == len(_UNNAMED_CTRL)
+        assert 0.0 not in _UNNAMED_CTRL
+
+
+class TestTheKeyVocabulary:
+    """The two key forms, and the residual case that is reported rather than guessed."""
+
+    def test_a_named_actuator_is_keyed_by_its_name(self, scene: Any) -> None:
+        sim, _, _ = scene
+        model = sim._world._model
+        aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "arm/pan_act")
+        assert scene_ops._actuator_key(model, aid, mujoco) == ("actuator", "arm/pan_act")
+
+    def test_an_unnamed_actuator_is_keyed_by_target_transmission_and_ordinal(self, scene: Any) -> None:
+        sim, _, _ = scene
+        model = sim._world._model
+        keys = [scene_ops._actuator_key(model, aid, mujoco) for aid in _unnamed_actuator_ids(model)]
+        assert keys == [
+            # Ordinal 0 on this target is the named ``fur/door_brake``, which is
+            # carried by its own key: the ordinal counts every actuator sharing
+            # the target, named or not, so the two sides agree.
+            ("target", int(mujoco.mjtTrn.mjTRN_JOINT), "fur/door_hinge", 1),
+            ("target", int(mujoco.mjtTrn.mjTRN_JOINT), "fur/door_hinge", 2),
+            ("target", int(mujoco.mjtTrn.mjTRN_JOINT), "fur/door_hinge", 3),
+            ("target", int(mujoco.mjtTrn.mjTRN_JOINTINPARENT), "fur/door_hinge", 0),
+            ("target", int(mujoco.mjtTrn.mjTRN_BODY), "fur/drawer", 0),
+        ]
+
+    def test_every_key_resolves_back_to_the_actuator_it_was_built_from(self, scene: Any) -> None:
+        """A key that did not round-trip would restore one actuator's command onto another."""
+        sim, _, _ = scene
+        model = sim._world._model
+        for aid in range(int(model.nu)):
+            key = scene_ops._actuator_key(model, aid, mujoco)
+            assert key is not None
+            assert scene_ops._resolve_actuator_key(model, key, mujoco) == aid
+
+    def test_the_target_handle_does_not_claim_an_actuator_that_carries_a_name(self, scene: Any) -> None:
+        """A named actuator is carried by its own key, so both handles must not resolve to it."""
+        sim, _, _ = scene
+        model = sim._world._model
+        named = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fur/drawer_slide_act")
+        target_handle = (
+            "target",
+            int(model.actuator_trntype[named]),
+            "fur/drawer_slide",
+            0,
+        )
+        assert scene_ops._resolve_actuator_key(model, target_handle, mujoco) == -1
+
+    def test_the_transmission_mapping_covers_every_transmission_mujoco_defines(self) -> None:
+        """Derived from ``mjtTrn`` so a transmission added upstream fails here.
+
+        ``mjTRN_UNDEFINED`` is excluded: it is the sentinel for "no transmission
+        resolved", not a kind of target.
+        """
+        defined = {
+            int(getattr(mujoco.mjtTrn, name))
+            for name in dir(mujoco.mjtTrn)
+            if name.startswith("mjTRN_") and name != "mjTRN_UNDEFINED"
+        }
+        assert defined
+        unmapped = {trn for trn in defined if scene_ops._actuator_target_kind(trn, mujoco) is None}
+        assert unmapped == set()
+
+    def test_an_unknown_transmission_is_reported_rather_than_guessed(self, scene: Any) -> None:
+        """The residual case: nothing identifies the target, so no key is built."""
+        sim, _, _ = scene
+        model = sim._world._model
+        assert scene_ops._actuator_target_kind(int(mujoco.mjtTrn.mjTRN_UNDEFINED), mujoco) is None
+        key = ("target", int(mujoco.mjtTrn.mjTRN_UNDEFINED), "fur/door_hinge", 0)
+        assert scene_ops._resolve_actuator_key(model, key, mujoco) == -1
+
+
+class TestWhatMustNotChange:
+    """Carrying an unnamed actuator must not widen what the restore claims."""
+
+    def test_the_named_actuator_still_survives_the_eject(self, scene: Any) -> None:
+        """The pre-existing guarantee, unchanged."""
+        sim, _, _ = scene
+        sim.remove_robot("arm")
+        model = sim._world._model
+        aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "fur/drawer_slide_act")
+        assert float(sim._world._data.ctrl[aid]) == _NAMED_CTRL
+
+    def test_the_ejected_robot_s_actuator_is_gone_rather_than_restored(self, scene: Any) -> None:
+        """Its absence is the point of the rebuild."""
+        sim, _, _ = scene
+        sim.remove_robot("arm")
+        assert "arm/pan_act" not in _actuator_names(sim._world._model)
+        assert int(sim._world._model.nu) == len(_UNNAMED_CTRL) + 2
+
+    def test_a_key_whose_target_is_gone_resolves_to_nothing(self, scene: Any) -> None:
+        """The ejected robot's elements no longer resolve, which is how they are skipped."""
+        sim, _, _ = scene
+        sim.remove_robot("arm")
+        model = sim._world._model
+        key = ("target", int(mujoco.mjtTrn.mjTRN_JOINT), "arm/pan", 0)
+        assert scene_ops._resolve_actuator_key(model, key, mujoco) == -1
+
+    def test_a_target_that_survives_without_that_many_actuators_resolves_to_nothing(self, scene: Any) -> None:
+        """An ordinal past the end is skipped rather than wrapped onto a sibling."""
+        sim, _, _ = scene
+        model = sim._world._model
+        key = ("target", int(mujoco.mjtTrn.mjTRN_JOINT), "fur/door_hinge", 99)
+        assert scene_ops._resolve_actuator_key(model, key, mujoco) == -1
+
+    def test_the_joint_state_the_rebuild_already_carried_still_arrives(self, scene: Any) -> None:
+        """The actuator key change must not disturb the joint half of the snapshot."""
+        sim, _, _ = scene
+        world = sim._world
+        adr = int(
+            world._model.jnt_qposadr[mujoco.mj_name2id(world._model, mujoco.mjtObj.mjOBJ_JOINT, "fur/door_hinge")]
+        )
+        world._data.qpos[adr] = 0.70
+        mujoco.mj_forward(world._model, world._data)
+        sim.remove_robot("arm")
+        model = world._model
+        after = int(model.jnt_qposadr[mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "fur/door_hinge")])
+        assert float(world._data.qpos[after]) == 0.70

--- a/tests/simulation/mujoco/test_unnamed_actuator_command_survives_a_rebuild.py
+++ b/tests/simulation/mujoco/test_unnamed_actuator_command_survives_a_rebuild.py
@@ -45,6 +45,19 @@ reported rather than guessed at, and the mapping's coverage is derived from the
 enum here so a future MuJoCo transmission fails this file instead of silently
 falling into that branch.
 
+Exactly one member of the enum is in that state today, and it is unreachable
+rather than unhandled. ``mjTRN_SO3`` (MuJoCo 3.12) is the orientation servo,
+whose target is a site under the ``site``/``refsite`` spelling and a ball joint
+under the other -- so its ``trnid[0]`` indexes a table its transmission type
+alone does not fix. It never gets here to be disambiguated: an orientation
+actuator takes three controls (four on the quaternion chart), so a model
+carrying one compiles with ``nu > nactuator`` and
+``_unaddressable_actuator_reason`` declines it before it is ever installed --
+this backend addresses an actuator by its control index. ``TestTheKeyVocabulary``
+pins both halves: that SO3 is the only unmapped member, and that such a model is
+refused. Widening the key to carry the target's ``mjtObj`` would be dead code
+until that refusal lifts.
+
 GL-free: ``mesh=False`` and no rendering, so this runs without a GPU.
 """
 
@@ -127,6 +140,28 @@ _ACTIVATION = 1.37
 
 #: The named furniture actuator's setpoint, restored by the pre-existing key.
 _NAMED_CTRL = 0.55
+
+#: ``mjTRN_SO3`` arrived in MuJoCo 3.12; the manifest floor is 3.5.
+_SO3_TRN = getattr(mujoco.mjtTrn, "mjTRN_SO3", None)
+
+# An orientation servo on a ball joint: the one transmission the key vocabulary
+# leaves out. Its three controls are what make the model unaddressable, and so
+# what keeps it from ever reaching the snapshot.
+_ORIENTATION_XML = """
+<mujoco model="orientation">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="wrist" pos="0 0 0.2">
+      <joint name="ball" type="ball"/>
+      <geom type="box" size="0.05 0.05 0.05"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <general name="orient" joint="ball" gaintype="so3" biastype="so3"
+             gainprm="10" biasprm="0 -10 1" ctrlrange="-1 1" forcerange="0 100"/>
+  </actuator>
+</mujoco>
+"""
 
 
 def _actuator_names(model: Any) -> list[str | None]:
@@ -363,8 +398,19 @@ class TestTheKeyVocabulary:
         )
         assert scene_ops._resolve_actuator_key(model, target_handle, mujoco) == -1
 
-    def test_the_transmission_mapping_covers_every_transmission_mujoco_defines(self) -> None:
+    def test_the_only_transmission_the_mapping_leaves_out_is_the_orientation_servo(self) -> None:
         """Derived from ``mjtTrn`` so a transmission added upstream fails here.
+
+        ``mjTRN_SO3`` is the one member deliberately absent: its ``trnid[0]``
+        indexes a site or a ball joint depending on how the actuator was
+        spelled, so the transmission type does not fix the table to read the
+        target's name from. It is left unmapped rather than disambiguated
+        because it cannot arrive -- see the cell below -- and the mapping is what
+        reports it if that ever changes.
+
+        The equality is the tripwire: a transmission added upstream is in
+        neither set and fails here instead of silently reaching the branch that
+        drops an actuator's command.
 
         ``mjTRN_UNDEFINED`` is excluded: it is the sentinel for "no transmission
         resolved", not a kind of target.
@@ -376,7 +422,28 @@ class TestTheKeyVocabulary:
         }
         assert defined
         unmapped = {trn for trn in defined if scene_ops._actuator_target_kind(trn, mujoco) is None}
-        assert unmapped == set()
+        assert unmapped == ({int(_SO3_TRN)} if _SO3_TRN is not None else set())
+
+    @pytest.mark.skipif(_SO3_TRN is None, reason="mjTRN_SO3 arrived in mujoco 3.12; the manifest floor is 3.5")
+    def test_an_orientation_actuator_is_refused_before_it_could_need_a_key(self) -> None:
+        """Why the unmapped transmission is unreachable rather than unhandled.
+
+        An orientation actuator takes three controls, so the model compiles with
+        ``nu > nactuator``. This backend addresses an actuator by its control
+        index, so :func:`scene_ops._unaddressable_actuator_reason` declines such
+        a model -- and a rebuild declines it before installing it, which is the
+        only path that reaches :func:`scene_ops._actuator_key`.
+
+        Should that refusal ever lift, this cell fails and the key has to learn
+        which table the target name came from.
+        """
+        so3 = _SO3_TRN
+        assert so3 is not None, "the skipif above admits only a build that defines mjTRN_SO3"
+        model = mujoco.MjModel.from_xml_string(_ORIENTATION_XML)
+        trntypes = {int(model.actuator_trntype[aid]) for aid in range(int(getattr(model, "nactuator", model.nu)))}
+        assert int(so3) in trntypes
+        assert int(model.nu) > int(model.nactuator)
+        assert scene_ops._unaddressable_actuator_reason(model, mujoco) is not None
 
     def test_an_unknown_transmission_is_reported_rather_than_guessed(self, scene: Any) -> None:
         """The residual case: nothing identifies the target, so no key is built."""


### PR DESCRIPTION
## Problem

`remove_robot` cannot delete a body attached through `spec.attach()` without tripping a MuJoCo
shutdown segfault, so `eject_robot_from_scene` rebuilds the scene spec from scratch. That compiles a
fresh model and allocates a fresh `MjData`, which renumbers every actuator id, so the dynamic state
is snapshotted under a name-based key beforehand and written back afterwards.

The joint half of that snapshot identifies an unnamed joint through its owning body plus its position
among that body's joints. The actuator half keyed on the actuator's own name alone and skipped
anything unnamed, on the grounds that *"its transmission target may drive several actuators, so it
cannot be matched across the rebuild"*. A skipped key is skipped silently, so such an actuator's
`ctrl` and its `act` activation were dropped and it came back at its fresh-compile zero. The
setpoints holding a **surviving** robot's pose reset because some **other** robot was removed, under
`status success`.

Reproduced through the public API on `main` (two robots, the furniture's two actuators unnamed):

```
add arm : success
add fur : success
nu = 3   names = ['arm/pan_act', None, None]
trnid    = [(0, -1), (1, -1), (1, -1)]     # both furniture actuators drive joint id 1
ctrl BEFORE : [0.0, 0.63, -0.42]
remove  : success
ctrl AFTER  : [0.0, 0.0]                   # both commands gone
```

An unnamed `<actuator>` child is the ordinary MJCF spelling, not a contrivance. Of the 235
actuator-bearing models in the downloaded MuJoCo Menagerie tree, 7 leave **every** one of theirs
unnamed - 43 unnamed actuators in total:

| model | actuators | unnamed |
|---|---|---|
| `ufactory_lite6/lite6.xml` | 6 | 6 |
| `google_robot/robot.xml` | 9 | 9 |
| `ufactory_lite6/lite6_gripper_narrow.xml` | 7 | 6 |
| `ufactory_lite6/lite6_gripper_wide.xml` | 7 | 6 |
| `iit_softfoot/scene.xml` | 1 | 1 |

So a scene holding one of those arms lost its whole command vector on every rebuild.

## Change

The premise was sound and the conclusion too strong, exactly as it was for joints: the target alone
does not single the actuator out, yet the target **plus its position among the actuators driving that
target** does. `_actuator_key` now returns one of two forms, and `_resolve_actuator_key` inverts it:

* `("actuator", name)` - a named actuator, the pre-existing handle.
* `("target", trntype, target_name, ordinal)` - an unnamed one.

Three properties make that key load-bearing rather than decorative, each measured:

* MuJoCo stores actuators in declaration order and an eject removes a robot's actuators **wholesale**,
  so the surviving order (and therefore the ordinal) is preserved. No scene op inserts an actuator
  into a compiled model - the patch vocabulary is `add_body` / `add_geom` / `add_site` /
  `set_body_pos` / `set_body_quat` / `delete_body` - so nothing shifts it.
* The transmission type belongs in the key because `mjTRN_JOINT` and `mjTRN_JOINTINPARENT` are
  different transmissions that can name the **same joint id**; measured on a fixture where they do.
* The ordinal counts every actuator sharing a target, named or not, so the snapshot and the restore
  count the same population. An actuator that gains a name is carried by its own `("actuator", name)`
  key, so the target handle explicitly declines to claim it.

`_actuator_target_kind` maps the `mjtTrn` member to the `mjtObj` its `trnid[0]` indexes, because each
transmission points at a different kind of element. An actuator references its target by name in
MJCF, so the target is never anonymous; a transmission the mapping does not know yields no key and is
reported rather than resolved against the wrong table.

## Visual

The physical consequence, in sim headless (EGL). A door is held at `0.90 rad` by a single **unnamed**
`<position>` servo. `remove_robot("arm")` used to leave that servo's `ctrl` at `0.0`, and 400 steps
later the servo had driven the door back to `0.17 rad`.

![a scene rebuild keeps an unnamed actuator's command](https://github.com/cagataycali/robots/releases/download/artifacts/unnamed_actuator_command.png)

| | door angle after 400 steps | unnamed actuator `ctrl` |
|---|---|---|
| before the eject | `0.9000 rad` | `0.9` |
| after, `main` | `0.1710 rad` | `0.0` |
| after, this branch | `0.9000 rad` | `0.9` |

The isolating comparison is panel 2 vs panel 3, both post-eject: 18061 px differ. Panels 1 vs 3
differ by 615 px, which is the arm the call removed. Lighting was read back from the model and
asserted identical across all three panels, and each panel is asserted to be embedded in the figure
byte-for-byte at its measured paste offset.

## Tests

`tests/simulation/mujoco/test_unnamed_actuator_command_survives_a_rebuild.py`, 24 cells in four
classes, named after the sibling file that pins the joint half.

Pre-fix split, with the helpers kept and only the two call sites reverted (a raw revert is a
collection error, since the tests import the new helpers):

| class | failing / total pre-fix |
|---|---|
| `TestAnUnnamedActuatorSurvivesTheEject` | **5 / 5** |
| `TestThePremisesTheKeyRestsOn` | 0 / 6 |
| `TestTheKeyVocabulary` | 0 / 6 |
| `TestWhatMustNotChange` | 0 / 5 |

Break table - 11 mutations, 9 detected, **9 distinct failing-id sets**, control clean, source
restored byte-identical, and **0 failures in the sibling joint suite on every row**:

| mutation | fires |
|---|---|
| the ordinal is always 0 | 5 |
| resolve ignores the transmission type | 3 |
| the gained-a-name guard is dropped | 1 |
| the ordinal counts only unnamed siblings | 5 |
| the mapping forgets the body transmission | 6 |
| a body target is looked up in the joint table | 5 |
| an ordinal past the end falls back to the last match | 1 |
| the snapshot stops reading the activation slice | 1 |
| the restore no longer writes `ctrl` | 5 |
| resolve accepts a vanished target | 0 |
| an unnamed target is keyed anyway | 0 |

The two zeros are reported with their reasons rather than dressed up. No actuator carries
`trnid[0] == -1`, so dropping the vanished-target guard leaves the loop finding nothing and returning
`-1` anyway - it is a fast path, not a correctness check. And an actuator references its target by
name in MJCF, so an anonymous target is unreachable through the format; that branch is
belt-and-braces for a hand-built model.

Two of these rows started at 0 and exposed real gaps in the fixture, which is why the fixture carries
a *named* actuator ahead of the unnamed ones on the same hinge (so an ordinal that skipped named
siblings desynchronises the two sides, 0 -> 5), and why the ordinal-bound mutation falls back to the
last match rather than merely widening `==` to `>=` (which is equivalent for any non-negative
ordinal, so it detected nothing).

The `mjtTrn` coverage check is derived from the enum, so a transmission added upstream fails this
file instead of silently falling into the reported-rather-than-guessed branch. It fired for real on
mujoco 3.12 - see the round 1 entry below.

## Gate

* `ruff check` + `ruff format --check` clean on both changed files.
* `mypy strands_robots tests tests_integ`: 24 errors, all pre-existing, **0 in either changed file**
  (the four-element key narrows on `len(key) == 4`, no `cast`, no `type: ignore`).
* `tests/simulation/` plus the docstring / export / except-tuple guards, 13773 selected with the new
  file deselected so the selection matches: **0 failures**, and 0 in the same subset of a pristine
  `main` full-suite baseline taken this session (39507 collected, 53 pre-existing failures, none in
  this subset). Both `comm` directions empty.
* The new file plus the four sibling eject / scene-state suites: **118 passed** on the declared
  mujoco floor, 3.5.0.
* `scripts/assemble_changelog.py --check` OK, and `tests/test_changelog_{fragments,format}.py` 30
  passed.

`_SceneState.actuators` is internal to `scene_ops`; its only consumer is `_restore_scene_state`, and
the only test touching it asserts the empty-dict case, so the key widening reaches no other caller.

The unnamed-actuator skip at `scene_ops.py:1743-1744` was among that module's unrun lines in the
baseline coverage report, which is how a whole behaviour sat ungraded.

## 13. Review rounds

### Round 1 - the enum-derived coverage check fired on mujoco 3.12

`call-test-lint` failed on
`TestTheKeyVocabulary::test_the_transmission_mapping_covers_every_transmission_mujoco_defines`:

```
>       assert unmapped == set()
E       assert {6} == set()
```

`6` is `mjTRN_SO3`, the orientation servo mujoco 3.12 added. The tripwire did exactly its job, so the
question it raises had to be answered rather than silenced.

**It cannot be answered by extending the mapping.** `mjTRN_SO3` is the one transmission whose type
does not fix which table its `trnid[0]` indexes. Measured on 3.12.0:

| spelling | `trntype` | `trnid` | `trnid[0]` names |
|---|---|---|---|
| `<general site="s" refsite="ref" gaintype="so3" .../>` | 6 | `[1, 0]` | site `s` |
| `<general joint="ball" gaintype="so3" .../>` | 6 | `[0, -1]` | joint `ball` |

Site names and joint names are separate namespaces, so a name read from the wrong table often still
resolves - onto an unrelated element. MuJoCo's own compiler says as much: *"so3 requires site or ball
joint transmission"*.

**Resolving it per actuator would be dead code today.** An orientation actuator takes three controls
(four on the quaternion chart), so a model carrying one compiles with `nu > nactuator`:

```
nu = 4 | nactuator = 2 | actuator_ctrladr = [0, 3] | actuator_ctrlnum = [3, 1]
```

This backend addresses an actuator by its control index, so `_unaddressable_actuator_reason` already
declines such a model - and `_recompile_preserving_state` declines it **before installing it**, which
is the only path that reaches `_actuator_key`. Carrying the target's `mjtObj` in the key is what tells
the two spellings apart, and it is worth adding on the day that refusal lifts, not before.

I implemented that wider key first and then reverted it: it was scope creep resting on a foundation
this backend deliberately refuses.

**So the mapping is unchanged - no production code in this round** - and the cell now pins both halves
of the argument instead of asserting a coverage claim that is not true:

* `test_the_only_transmission_the_mapping_leaves_out_is_the_orientation_servo` - the equality is still
  the tripwire, now against `{mjTRN_SO3}`, so a *new* transmission still fails here.
* `test_an_orientation_actuator_is_refused_before_it_could_need_a_key` - compiles the orientation
  model and asserts `nu > nactuator` and that `_unaddressable_actuator_reason` declines it. **This is
  the cell that fails if the refusal ever lifts**, which is when the key has to grow.

Both are skipped below the `mjTRN_SO3` floor (the manifest allows `mujoco>=3.5.0`), so the file still
passes on 3.5. The changelog fragment records the same reasoning.

Verified: 37 passed across this file and `test_multi_control_actuator_is_refused.py` on 3.12.0; `ruff
check`, `ruff format --check` and `mypy` clean on the changed file.
