### PR TITLE
fix(mesh): a sensor record's identity is the publisher's, not the provider's

### DIFF
--- a/changelog.d/2744-sensor-record-identity-is-the-publishers.md
+++ b/changelog.d/2744-sensor-record-identity-is-the-publishers.md
@@ -1,0 +1,37 @@
+### Fixed: a sensor record's identity is the publisher's, not the provider's
+
+Every `SensorLoopsMixin._read_*` reader seeds a record with the keys this process decided,
+merges the robot's provider mapping over it, and publishes the result to a topic it builds
+from those same keys. Merged last, a provider mapping carrying one of the seeded names
+replaced the local reading. Nine merge sites across seven readers were affected, so a
+reading published to `strands/{peer_id}/...` could name a different peer inside it, and a
+hand record published under one hand's name could name another:
+
+| published to | provider mapping said | record said |
+|---|---|---|
+| `strands/alice/imu` | `peer_id: bob` | `peer_id: bob` |
+| `strands/alice/pose` | `peer_id: bob` | `peer_id: bob` |
+| `strands/alice/lidar/summary` | `peer_id: bob` | `peer_id: bob` |
+| `strands/alice/hand/left/state` | `peer_id: bob`, `hand: RIGHT` | `peer_id: bob`, `hand: RIGHT` |
+| `strands/alice/health` | `peer_id: bob` | `peer_id: alice` |
+
+The precedence is not a new rule. `docs/mesh.md` already states it for the presence payload
+-- the locally decided keys win a name collision with what a peer reports, because "the
+`peer_id` a peer is filed under is the one its topic and certificate bind - not a field
+inside the payload" -- and `PeerInfo.to_dict` implements it by spreading the peer's own
+payload *first*, its docstring naming exactly what spreading it last costs: "a `peer_id`
+the sender chooses is the key `Mesh.peers_by_id` and `Mesh.get_peer` look the peer up by".
+The health reader was already immune for a different reason, visible as the last row above:
+it lifts named fields (`battery.get("pct")`) and namespaces the rest under its own key, so
+no provider name reaches the top level of its record.
+
+The locally decided keys are now re-asserted after each merge, through one helper so the
+nine sites cannot drift apart, and the readers that merge wholesale are derived from the
+shipped class rather than listed -- an eighth such reader added later is held to the same
+precedence instead of inheriting an exemption by omission.
+
+Two boundaries are deliberately unchanged. `t` is not re-asserted: it is a stamp rather
+than a locally computed duration, so a provider that stamps a reading when it decoded it
+reports something truer than the moment the loop got round to publishing it. The
+`source`/`frame` labels keep their `setdefault` seeding, which exists precisely so a
+provider may name its own frame.

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -127,6 +127,16 @@ a loop. Every attempt, granted or refused, is written to the safety audit log.
 
 Sensor topics only publish when the robot exposes the attribute. Zero cost when unused.
 
+**A sensor record's identity is the publisher's too.** A reader seeds each record
+with what this process decided, merges the robot's provider mapping over it, and
+publishes to a topic built from those same keys - so the same precedence applies:
+`peer_id`, and the `hand` a hand record is filed under, win a name collision with
+the provider mapping. A provider naming another peer does not move its readings
+onto that peer's topic, and one naming another hand does not relabel the hand it
+was published under. A `t` the provider supplies *is* honoured: it is a stamp
+rather than a locally computed duration, so a driver that stamps a reading when
+it decoded it reports something truer than the moment the loop published it.
+
 ### Degraded state probes
 
 Every section of a state snapshot is optional, because a robot may be hardware,

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -298,6 +298,40 @@ class SensorLoopsMixin:
             except Exception as exc:  # noqa: BLE001
                 logger.debug("[mesh] %s: pose tick error: %s", self.peer_id, exc)
 
+    def _stamp_local_keys(self, record: dict[str, Any], **local: Any) -> dict[str, Any]:
+        """Re-assert the keys this process decides, after a provider payload merged in.
+
+        A sensor reader seeds a record, merges the robot's provider mapping over
+        it and publishes the result to a topic it builds itself. Merged last, a
+        provider mapping carrying one of those seeded names replaces the local
+        reading -- so a record can be published to ``strands/{peer_id}/...``
+        while naming a different peer inside, and a hand record can be published
+        under one hand's name while naming another.
+
+        The presence path already resolves this collision the other way:
+        :meth:`strands_robots.mesh.session.PeerInfo.to_dict` spreads the peer's
+        own payload *first* so the four keys that process decided win. This is
+        the same precedence for the sensor records, applied after the merge
+        rather than by ordering a single literal, because a reader merges from
+        several provider attributes in turn.
+
+        ``t`` is deliberately not re-asserted. It is a stamp rather than a
+        locally computed duration, and a provider that stamps a reading when it
+        decoded it is reporting something truer than the moment the loop got
+        round to publishing it.
+
+        Args:
+            record: The outgoing record, modified in place.
+            **local: Further keys this reader decided, such as the ``hand`` a
+                hand record is published under.
+
+        Returns:
+            The same ``record``, for use as an expression.
+        """
+        record["peer_id"] = self.peer_id
+        record.update(local)
+        return record
+
     def _read_pose(self) -> dict[str, Any] | None:
         r = self.robot
         pose: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
@@ -308,6 +342,7 @@ class SensorLoopsMixin:
             if pose_data is not None:
                 if isinstance(pose_data, dict):
                     pose.update(pose_data)
+                    self._stamp_local_keys(pose)
                     pose.setdefault("source", "provider")
                     pose.setdefault("frame", "map")
                     _coerce_record(pose)
@@ -333,6 +368,7 @@ class SensorLoopsMixin:
             slam_pose = getattr(r, "_slam_pose", None)
             if slam_pose is not None and isinstance(slam_pose, dict):
                 pose.update(slam_pose)
+                self._stamp_local_keys(pose)
                 pose.setdefault("source", "slam")
                 pose.setdefault("frame", "map")
                 _coerce_record(pose)
@@ -345,6 +381,7 @@ class SensorLoopsMixin:
             odom_pose = getattr(r, "_odom_pose", None)
             if odom_pose is not None and isinstance(odom_pose, dict):
                 pose.update(odom_pose)
+                self._stamp_local_keys(pose)
                 pose.setdefault("source", "odom")
                 pose.setdefault("frame", "odom")
                 _coerce_record(pose)
@@ -466,6 +503,7 @@ class SensorLoopsMixin:
             imu_data = getattr(r, "_imu", None)
             if imu_data is not None and isinstance(imu_data, dict):
                 imu.update(imu_data)
+                self._stamp_local_keys(imu)
                 _coerce_record(imu)
                 return imu
         except Exception:  # noqa: BLE001
@@ -520,6 +558,7 @@ class SensorLoopsMixin:
             if odom_data is not None and isinstance(odom_data, dict):
                 odom: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 odom.update(odom_data)
+                self._stamp_local_keys(odom)
                 odom.setdefault("frame", "odom")
                 _coerce_record(odom)
                 return odom
@@ -567,6 +606,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 summary: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 summary.update(data)
+                self._stamp_local_keys(summary)
                 _coerce_record(summary)
                 return summary
         except Exception:  # noqa: BLE001
@@ -580,6 +620,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 state: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 state.update(data)
+                self._stamp_local_keys(state)
                 _coerce_record(state)
                 return state
         except Exception:  # noqa: BLE001
@@ -616,6 +657,7 @@ class SensorLoopsMixin:
                     if isinstance(data, dict):
                         state = {"peer_id": self.peer_id, "hand": name, "t": time.time()}
                         state.update(data)
+                        self._stamp_local_keys(state, hand=name)
                         result[name] = state
                 _coerce_record(result)
                 return result if result else None
@@ -649,6 +691,7 @@ class SensorLoopsMixin:
             if data is not None and isinstance(data, dict):
                 info: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
                 info.update(data)
+                self._stamp_local_keys(info)
                 _coerce_record(info)
                 return info
         except Exception:  # noqa: BLE001

--- a/tests/mesh/test_sensor_record_identity_is_not_the_providers.py
+++ b/tests/mesh/test_sensor_record_identity_is_not_the_providers.py
@@ -1,0 +1,298 @@
+"""A sensor record's identity keys are the publisher's, not the provider's.
+
+Every ``SensorLoopsMixin._read_*`` reader seeds a record with the keys this
+process decided, merges the robot's provider mapping over it, and publishes the
+result to a topic it builds from those same keys. Merged last, a provider
+mapping carrying one of the seeded names replaced the local reading, so a record
+published to ``strands/{peer_id}/...`` could name a different peer inside it and
+a hand record published under one hand's name could name another.
+
+The precedence is not a new rule. ``docs/mesh.md`` already states it for the
+presence payload -- the locally decided keys "win a name collision" with what a
+peer reports, because "the ``peer_id`` a peer is filed under is the one its topic
+and certificate bind - not a field inside the payload" -- and
+:meth:`strands_robots.mesh.session.PeerInfo.to_dict` implements it by spreading
+the peer's own payload first. These cells hold the sensor readers to the same
+precedence, and pin the two boundaries deliberately left alone: ``t`` is a stamp
+rather than a locally computed duration, and the ``source``/``frame`` labels are
+seeded with :meth:`dict.setdefault` precisely so a provider may name its own.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh.sensors import SensorLoopsMixin
+from strands_robots.mesh.session import PeerInfo
+
+LOCAL_PEER = "alice"
+OTHER_PEER = "bob"
+
+
+class _Host(SensorLoopsMixin):
+    """Minimal SensorLoopsMixin host that records what it published."""
+
+    def __init__(self, robot: Any, peer_id: str = LOCAL_PEER) -> None:
+        self.robot = robot
+        self.peer_id = peer_id
+        self._running = True
+        self._stop_event = threading.Event()
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        self.published.append((key, payload))
+
+
+class _Robot:
+    """Bare attribute bag standing in for a robot exposing sensor providers."""
+
+
+def _host(**robot_attrs: Any) -> _Host:
+    robot = _Robot()
+    for name, value in robot_attrs.items():
+        setattr(robot, name, value)
+    return _Host(robot)
+
+
+# Each row: (id, provider attribute, the reader, a reading the provider supplies).
+# The provider mapping additionally claims ``peer_id`` in every row.
+_PROVIDER_ROWS: tuple[tuple[str, str, str, dict[str, Any]], ...] = (
+    ("pose-provider", "_pose", "_read_pose", {"x": 1.5}),
+    ("pose-slam", "_slam_pose", "_read_pose", {"x": 2.5}),
+    ("pose-odom", "_odom_pose", "_read_pose", {"x": 3.5}),
+    ("imu", "_imu", "_read_imu", {"rpy": [0.1, 0.2, 0.3]}),
+    ("odom", "_odom", "_read_odom", {"vx": 0.25}),
+    ("lidar-summary", "_lidar_summary", "_read_lidar_summary", {"count": 1234}),
+    ("lidar-state", "_lidar_state", "_read_lidar_state", {"freq": 10.0}),
+    ("map-info", "_map_info", "_read_map_info", {"width": 64}),
+)
+_ROW_IDS = tuple(row[0] for row in _PROVIDER_ROWS)
+
+
+def _read_with_hostile_provider(attr: str, reader: str, reading: dict[str, Any]) -> dict[str, Any]:
+    """Drive one reader with a provider mapping that also claims ``peer_id``."""
+    host = _host(**{attr: {**reading, "peer_id": OTHER_PEER}})
+    record = getattr(host, reader)()
+    assert record is not None, f"{reader} declined to read {attr}"
+    return record
+
+
+def _merging_readers() -> dict[str, tuple[str, ...]]:
+    """Readers that merge a provider mapping wholesale -> the vars they merge into.
+
+    Derived from the shipped class rather than listed, so a reader added later is
+    held to the same precedence instead of inheriting an exemption by omission.
+    A wholesale merge is ``<record>.update(<name>)``: the whole provider mapping,
+    under whatever names it carries. ``_read_health`` is deliberately absent --
+    it lifts named fields (``battery.get("pct")``) and namespaces the rest under
+    its own key, so no provider name reaches the top level of its record.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(SensorLoopsMixin)))
+    cls = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef))
+    found: dict[str, tuple[str, ...]] = {}
+    for fn in cls.body:
+        if not isinstance(fn, ast.FunctionDef) or not fn.name.startswith("_read_"):
+            continue
+        merged = [
+            ast.unparse(node.func.value)
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Name)
+        ]
+        if merged:
+            found[fn.name] = tuple(sorted(set(merged)))
+    return found
+
+
+def _stamp_calls(method_name: str) -> int:
+    """How many times *method_name* re-asserts the locally decided keys."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(getattr(SensorLoopsMixin, method_name))))
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "_stamp_local_keys"
+    )
+
+
+# The precedence this file holds the readers to ------------------------------
+
+
+class TestThePresencePathAlreadyResolvesThisCollision:
+    """The rule is the presence path's, measured rather than quoted."""
+
+    def test_a_presence_payload_cannot_rename_the_peer_it_is_filed_under(self) -> None:
+        peer = PeerInfo(peer_id=LOCAL_PEER, caps={"peer_id": OTHER_PEER, "tool_name": "arm"})
+        record = peer.to_dict()
+        assert record["peer_id"] == LOCAL_PEER
+        # The peer's own capabilities still come through; only the collision moves.
+        assert record["tool_name"] == "arm"
+
+
+# Regression -----------------------------------------------------------------
+
+
+class TestAProviderCannotRenameThePeerAReadingCameFrom:
+    """Nine merge sites, each publishing to a topic built from ``self.peer_id``."""
+
+    @pytest.mark.parametrize(("_id", "attr", "reader", "reading"), _PROVIDER_ROWS, ids=_ROW_IDS)
+    def test_the_record_names_the_publishing_peer(
+        self, _id: str, attr: str, reader: str, reading: dict[str, Any]
+    ) -> None:
+        record = _read_with_hostile_provider(attr, reader, reading)
+        assert record["peer_id"] == LOCAL_PEER
+
+    def test_a_hand_record_names_the_hand_it_is_published_under(self) -> None:
+        host = _host(_hands={"left": {"pos": 1.0, "peer_id": OTHER_PEER, "hand": "RIGHT"}})
+        hands = host._read_hands()
+        assert hands is not None
+        record = hands["left"]
+        assert record["peer_id"] == LOCAL_PEER
+        assert record["hand"] == "left"
+        assert record["pos"] == 1.0
+
+    def test_the_published_topic_and_the_record_agree_on_the_hand(self) -> None:
+        # The loop publishes to strands/{peer}/hand/{name}/state, so a record
+        # naming another hand contradicts the key it arrived under.
+        host = _host(_hands={"left": {"peer_id": OTHER_PEER, "hand": "RIGHT"}})
+        hands = host._read_hands()
+        assert hands is not None
+        for name, record in hands.items():
+            topic = f"strands/{host.peer_id}/hand/{name}/state"
+            assert topic == f"strands/{record['peer_id']}/hand/{record['hand']}/state"
+
+
+class TestReAssertingTheIdentityDoesNotCostTheReading:
+    """Over-reach guard: the merge must still deliver what it was read for."""
+
+    @pytest.mark.parametrize(("_id", "attr", "reader", "reading"), _PROVIDER_ROWS, ids=_ROW_IDS)
+    def test_the_providers_own_reading_still_reaches_the_record(
+        self, _id: str, attr: str, reader: str, reading: dict[str, Any]
+    ) -> None:
+        record = _read_with_hostile_provider(attr, reader, reading)
+        for key, value in reading.items():
+            assert record[key] == value
+
+
+# Structure: the rule is derived, so a reader added later inherits it ---------
+
+
+class TestEveryWholesaleMergeReAssertsTheLocalKeys:
+    """A reader that merges a provider mapping must re-assert what it decided."""
+
+    def test_every_merging_reader_re_asserts_them_once_per_merge(self) -> None:
+        for name, merged_into in sorted(_merging_readers().items()):
+            assert _stamp_calls(name) == len(
+                [
+                    node
+                    for node in ast.walk(ast.parse(textwrap.dedent(inspect.getsource(getattr(SensorLoopsMixin, name)))))
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "update"
+                    and len(node.args) == 1
+                    and isinstance(node.args[0], ast.Name)
+                ]
+            ), f"{name} merges into {merged_into} more often than it re-asserts the local keys"
+
+    def test_the_derivation_finds_the_readers_that_merge(self) -> None:
+        # Non-vacuity: the rule above is empty unless the scan finds the mergers.
+        assert set(_merging_readers()) == {
+            "_read_pose",
+            "_read_imu",
+            "_read_odom",
+            "_read_lidar_summary",
+            "_read_lidar_state",
+            "_read_hands",
+            "_read_map_info",
+        }
+
+    def test_the_health_reader_is_not_a_wholesale_merge(self) -> None:
+        # Its exemption is structural, not a listed exception: it lifts named
+        # fields, so no provider key reaches the top level of its record.
+        assert "_read_health" not in _merging_readers()
+
+
+# Boundaries deliberately left alone (these hold before the change too) ------
+
+
+class TestAStampStaysTheReadingsOwn:
+    """``t`` is not re-asserted: a decode-time stamp is truer than publish time."""
+
+    @pytest.mark.parametrize(("_id", "attr", "reader", "reading"), _PROVIDER_ROWS, ids=_ROW_IDS)
+    def test_a_provider_may_stamp_its_own_reading(
+        self, _id: str, attr: str, reader: str, reading: dict[str, Any]
+    ) -> None:
+        stamped = time.time() - 30.0
+        host = _host(**{attr: {**reading, "t": stamped}})
+        record = getattr(host, reader)()
+        assert record is not None
+        assert record["t"] == stamped
+
+    def test_a_reader_stamps_the_record_when_the_provider_does_not(self) -> None:
+        before = time.time()
+        record = _host(_lidar_summary={"count": 7})._read_lidar_summary()
+        assert record is not None
+        assert before <= record["t"] <= time.time()
+
+
+class TestAProviderStillNamesItsOwnFrameAndSource:
+    """``source``/``frame`` are seeded with setdefault, so the provider wins."""
+
+    def test_a_pose_provider_names_its_own_frame_and_source(self) -> None:
+        record = _host(_pose={"x": 1.0, "frame": "base_link", "source": "vio"})._read_pose()
+        assert record is not None
+        assert (record["frame"], record["source"]) == ("base_link", "vio")
+
+    def test_an_odom_provider_names_its_own_frame(self) -> None:
+        record = _host(_odom={"vx": 1.0, "frame": "wheel_odom"})._read_odom()
+        assert record is not None
+        assert record["frame"] == "wheel_odom"
+
+    def test_the_seeded_labels_are_still_applied_when_absent(self) -> None:
+        record = _host(_slam_pose={"x": 1.0})._read_pose()
+        assert record is not None
+        assert (record["frame"], record["source"]) == ("map", "slam")
+
+
+class TestTheHealthReaderIsUnchanged:
+    """It never merged wholesale, so nothing about it moves."""
+
+    def test_a_battery_mapping_cannot_rename_the_peer_or_restamp_the_record(self) -> None:
+        before = time.time()
+        record = _host(_battery={"pct": 55.0, "peer_id": OTHER_PEER, "t": 0.0})._read_health()
+        assert record is not None
+        assert record["peer_id"] == LOCAL_PEER
+        assert before <= record["t"] <= time.time()
+        assert record["battery_pct"] == 55.0
+
+    def test_a_temps_mapping_stays_under_its_own_key(self) -> None:
+        record = _host(_temps={"cpu": 41.0, "peer_id": OTHER_PEER})._read_health()
+        assert record is not None
+        assert record["peer_id"] == LOCAL_PEER
+        assert record["temps"] == {"cpu": 41.0, "peer_id": OTHER_PEER}
+
+
+class TestTheInnerRobotObservationPathIsUnaffected:
+    """The IMU fallback builds its own fields rather than merging a mapping."""
+
+    def test_an_inner_robot_imu_reading_still_names_the_publishing_peer(self) -> None:
+        class _Inner:
+            is_connected = True
+
+            def get_observation(self) -> dict[str, Any]:
+                return {"imu_rpy": [0.1, 0.2, 0.3], "gyroscope": [1.0, 2.0, 3.0]}
+
+        record = _host(robot=_Inner())._read_imu()
+        assert record is not None
+        assert record["peer_id"] == LOCAL_PEER
+        assert record["rpy"] == [0.1, 0.2, 0.3]
+        assert record["gyro"] == [1.0, 2.0, 3.0]


### PR DESCRIPTION
## Problem

Every `SensorLoopsMixin._read_*` reader seeds a record with the keys this process decided, merges the robot's provider mapping over it, and publishes the result to a topic it builds from those same keys:

```python
summary: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
summary.update(data)          # <- the provider mapping, merged last
```

Merged last, a provider mapping carrying one of the seeded names replaces the local reading. Nine merge sites across seven readers were affected, so a reading published to `strands/{peer_id}/...` could name a different peer inside it, and a hand record published under one hand's name could name another.

Measured against the shipped readers, peer `alice`, provider mapping claiming `peer_id: "bob"`:

| reader | merge sites | `peer_id` reported |
|---|---|---|
| `_read_pose` (`_pose`, `_slam_pose`, `_odom_pose`) | 3 | `bob` |
| `_read_imu` | 1 | `bob` |
| `_read_odom` | 1 | `bob` |
| `_read_lidar_summary` | 1 | `bob` |
| `_read_lidar_state` | 1 | `bob` |
| `_read_map_info` | 1 | `bob` |
| `_read_hands` | 1 | `bob`, and `hand: "RIGHT"` under topic `.../hand/left/state` |
| `_read_health` | 0 | `alice` |

`peer_id` inside a payload is read as an identity elsewhere in the package -- `mesh/core.py` takes `issuer_id = data.get("peer_id")` and `sender = data.get("peer_id", "<remote>")`, and `mesh/audit.py` keys records by it.

## Why this is not a new rule

`docs/mesh.md` already states the precedence for the presence payload:

> `age` is *your* process's reading of when it last heard from a peer, and the `peer_id` a peer is filed under is the one its topic and certificate bind - not a field inside the payload. [...] those four locally decided keys - `peer_id`, `type`, `hostname`, `age` - win a name collision with it.

`PeerInfo.to_dict` implements it by spreading the peer's own payload **first**, and its docstring already names the cost of spreading it last:

> Spread last, a payload carrying any of those four names replaced the local reading. [...] a `peer_id` the sender chooses is the key `Mesh.peers_by_id` and `Mesh.get_peer` look the peer up by.

`_read_health` was already immune, for a different reason: it lifts named fields (`battery.get("pct")`) and namespaces the rest under its own key, so no provider name reaches the top level of its record. It is the in-file control for this change.

## Change

Re-assert the locally decided keys after each merge, through one helper (`_stamp_local_keys`) so the nine sites cannot drift apart. The readers that merge wholesale are **derived** from the shipped class rather than listed, so an eighth such reader is held to the same precedence instead of inheriting an exemption by omission.

Two boundaries are deliberately unchanged, and both are pinned:

- **`t` is not re-asserted.** It is a stamp rather than a locally computed duration -- the distinction `docs/mesh.md` already draws -- so a provider that stamps a reading when it decoded it reports something truer than the moment the loop got round to publishing it.
- **`source`/`frame` keep their `setdefault` seeding**, which exists precisely so a provider may name its own frame.

## Verification

Pre-fix split, source reverted to `upstream/main`: **11 failed / 26 passed**.

| class | failed | total | role |
|---|---|---|---|
| `TestAProviderCannotRenameThePeerAReadingCameFrom` | 10 | 10 | regression |
| `TestEveryWholesaleMergeReAssertsTheLocalKeys` | 1 | 3 | regression (structural, derived) |
| `TestReAssertingTheIdentityDoesNotCostTheReading` | 0 | 8 | over-reach guard |
| `TestAStampStaysTheReadingsOwn` | 0 | 9 | boundary control (`t`) |
| `TestAProviderStillNamesItsOwnFrameAndSource` | 0 | 3 | boundary control (`setdefault` labels) |
| `TestTheHealthReaderIsUnchanged` | 0 | 2 | control (immune sibling) |
| `TestTheInnerRobotObservationPathIsUnaffected` | 0 | 1 | control (non-merging branch) |
| `TestThePresencePathAlreadyResolvesThisCollision` | 0 | 1 | premise (the rule is the presence path's) |

Nothing in any control, boundary or premise class moves.

### Mutations

17 source mutations, all 17 detected, 14 distinct firing sets, two controls clean, source restored byte-identical after every row.

| mutation | fires | note |
|---|---|---|
| control (no mutation) | 0 | |
| helper body dropped | 10 | |
| `**local` dropped, `peer_id` kept | 2 | the two hand cells |
| `peer_id` dropped, `**local` kept | 10 | same set as above -- both destroy the identity re-assertion |
| `setdefault` instead of assignment | 10 | the plausible-looking wrong fix: the provider already set the key, so it is a no-op |
| hands call drops `hand=name` | 2 | |
| each of the 8 single-record per-site calls removed | 2 each | own behavioural cell + the derived structural cell, 8 distinct sets |
| the hands per-site call removed entirely | 3 | both hand cells + the derived structural cell |
| **`t` also re-asserted** | 8 | over-reach: fires exactly the boundary-control class |
| **refuse instead of correct** | 18 | an error envelope is not a reading -- also costs the over-reach guard |
| raw revert | 11 | |

The derived inventory is load-bearing, not decorative. Planting an eighth wholesale-merging reader that forgets the rule:

| scenario | fires |
|---|---|
| control (no eighth reader) | 0 |
| eighth reader planted, **derived** scan | 2 |
| same plant, scan **hardcoded** to today's seven names | **0 -- silent** |

### Gate

- `ruff check` + `ruff format --check` clean over `strands_robots tests tests_integ` (1562 files).
- `mypy` **24 == 24** against a pristine `upstream/main` worktree (re-measured after the rebase), normalized message sets byte-identical both directions, 0 in the changed files.
- Paired run against the rebased base `442d9ca4`, over an identical 493-file selection (all of `tests/mesh/`, plus every guard that walks the tree or reads source, docstrings, `docs/` or `changelog.d/`), the new file excluded from both trees: **`21 failed, 19451 passed, 66 skipped, 24 errors` on both**, 45 identical failing/erroring ids, both `comm` directions empty. All 45 need `awsiot` (declared in the `[mesh-iot]` extra, absent here -- confirmed with `find_spec` + `tomllib`).
- `tests/mesh/test_zenoh_transport_security.py` run separately: 9 passed / 2 skipped on both trees.
- New file: 37 cases. With both pre-existing sensor suites and #2741's: **202 passed**.

### Composition with #2741

The safety-event fix in #2741 landed in the same file while this was in flight, so the branch is rebased on it and the two are verified to compose rather than merely to auto-merge. Reverting each side on the composed tree costs only its own cells:

| scenario | this PR's cells | #2741's cells |
|---|---|---|
| composed tree, nothing reverted | 0 | 0 |
| this PR's fix reverted | 11 | 0 |
| #2741's fix reverted | 0 | 10 |

The hunks are disjoint by construction: #2741 changes `publish_safety_event`, this changes the readers above it. `tests/mesh/test_safety_event_payload_reaches_the_wire.py` passes unchanged on this branch (part of the 202 above).

### Artifact

One robot (`peer_id: "alice"`) whose driver caches four readings and stamps each with a `peer_id` from its own config, captured by driving the shipped readers on both trees. The `health` row already agreed before the change -- it is the reader that lifts named fields instead of merging.

![sensor record identity](https://github.com/cagataycali/robots/releases/download/artifacts/2744-sensor-record-identity.png)
