### PR TITLE
fix(tools): refuse a servo velocity that would reverse the command

### DIFF
--- a/changelog.d/2747-feetech-velocity-direction-bit.md
+++ b/changelog.d/2747-feetech-velocity-direction-bit.md
@@ -1,0 +1,24 @@
+### Fixed: a servo velocity that would reverse the command is refused
+
+`Goal_Velocity` (register 0x2E) is sign-magnitude on the Feetech STS/SMS series:
+bit 15 carries the direction and bits 0-14 the magnitude. `serial_tool` bounded
+the field to the two-byte maximum instead, keyed to the byte width rather than to
+the register, so every magnitude from 32768 up was accepted and put its own two
+bytes on the wire - where the servo read them as a command in the opposite
+direction. `velocity=65535` ran the joint at full speed the wrong way,
+`velocity=40000` ran it in reverse at magnitude 7232, and `velocity=32768` read as
+magnitude zero and stopped a servo the caller had just asked to run. Each returned
+`status="success"` quoting the number supplied, so the report described a command
+the servo never received.
+
+This is the same silent reinterpretation the sibling fields are bounded to
+prevent, and it is not a truncation: the caller's value reached the wire intact
+and simply meant something else there. The field is now bounded to the largest
+magnitude that leaves the direction bit clear, derived from that bit rather than
+restating a number, and the refusal quotes the reason so a caller can see why
+32767 is the ceiling.
+
+`Goal_Position` (0x2A) shares the encoding and needed no change: its 12-bit
+ceiling of 4095 already sits far below the direction bit, which is what a bound
+keyed to the register rather than to the byte width buys. `docs/hardware/tools.md`
+documented the old `[0, 65535]` domain and is corrected with it.

--- a/docs/hardware/tools.md
+++ b/docs/hardware/tools.md
@@ -82,13 +82,21 @@ bytes of the outgoing packet, so an out-of-range value was never rejected on the
 wire - it was truncated into a different, reachable command while the success
 message quoted the value the caller supplied. `position=70000` put 4464 on the
 wire and `position=-1` put 65535, the largest the two-byte field holds. Each
-field is therefore bounded before the port is opened:
+field is therefore bounded before the port is opened.
+
+Two of those registers are bounded by more than their byte width. `Goal_Position`
+and `Goal_Velocity` are sign-magnitude on the STS/SMS series - bit 15 carries the
+direction - so a magnitude reaching that bit is not truncated but *reinterpreted*:
+`velocity=65535` put those exact two bytes on the wire and the servo ran full
+speed in the opposite direction, and `velocity=32768` read as magnitude zero,
+stopping a servo the caller had just asked to run. `position` was already inside
+that limit at 4095; `velocity` now is too.
 
 | Option | Accepted | Why the bound is where it is |
 |--------|----------|------------------------------|
 | `motor_id` | integer in `[1, 254]` | the frame carries the ID in one byte, and `255` is the header value |
 | `position` | integer in `[0, 4095]` | `Goal_Position` is a 12-bit register - the same full scale the reported angle divides by |
-| `velocity` | integer in `[0, 65535]` | `Goal_Velocity` is written as two bytes |
+| `velocity` | integer in `[0, 32767]` | `Goal_Velocity` is sign-magnitude with bit 15 the direction bit, so a larger magnitude commands the opposite direction |
 | `baudrate` | positive integer | pyserial coerces rather than checks, so `2.7` opens the port at 2 baud |
 | `read_bytes` | positive integer | pyserial's read loop is `while len(read) < size`, so a non-positive size returns no bytes and looks like a timeout |
 | `timeout` | finite number >= 0 | `0` is pyserial's non-blocking mode (return what is buffered); `nan` waits no time at all and `inf` overflows the deadline |

--- a/strands_robots/tools/serial_tool.py
+++ b/strands_robots/tools/serial_tool.py
@@ -12,6 +12,15 @@ into a different, reachable command: ``position=70000`` encodes as 4464 and
 success message still quotes the number the caller supplied. Bounding the field
 is what makes that message true.
 
+``Goal_Velocity`` takes more than the byte width to bound, because the STS/SMS
+series encodes it as sign-magnitude rather than plain unsigned: bit 15 carries
+the direction and bits 0-14 the magnitude. A magnitude that overflows into bit
+15 is therefore not truncated but *reinterpreted*. ``velocity=65535`` put those
+exact two bytes on the wire and the servo read them as full speed in the
+opposite direction, and ``velocity=32768`` read as magnitude zero -- stopping a
+servo the caller had just asked to run -- both reported as success quoting the
+number supplied.
+
 ``baudrate`` and ``read_bytes`` are coerced rather than checked by pyserial
 (``2.7`` becomes 2 baud, and a non-positive ``read_bytes`` reads nothing and
 reports success, which is indistinguishable from a timed-out read on a healthy
@@ -39,6 +48,16 @@ from strands_robots.utils import (
     positive_count_error,
 )
 
+# Bit index carrying the direction in the two STS/SMS registers this module
+# writes. ``Goal_Position`` (0x2A) and ``Goal_Velocity`` (0x2E) are both
+# sign-magnitude, so neither ceiling below is the two-byte maximum: a magnitude
+# reaching this bit is read by the servo as a command in the opposite
+# direction, which is a different command rather than a truncated one.
+_DIRECTION_BIT = 15
+
+# Largest magnitude either register carries with ``_DIRECTION_BIT`` still clear.
+_MAX_MAGNITUDE = (1 << _DIRECTION_BIT) - 1
+
 # Inclusive bounds and the reason for each ceiling, keyed by the parameter that
 # carries the field. The floor and the type are delegated to the shared count
 # domains so an off-type or negative value is reported in the words every other
@@ -51,7 +70,12 @@ _REGISTER_FIELDS: dict[str, tuple[int, int, str]] = {
         4095,
         "Goal_Position is a 12-bit register, the same full scale the reported angle divides by",
     ),
-    "velocity": (0, 65535, "Goal_Velocity is written as two bytes"),
+    "velocity": (
+        0,
+        _MAX_MAGNITUDE,
+        "Goal_Velocity is sign-magnitude with bit 15 the direction bit, so a larger "
+        "magnitude sets that bit and commands the opposite direction",
+    ),
 }
 
 # The options each action consumes. An action absent from this map reads none of

--- a/tests/tools/test_feetech_velocity_direction_bit.py
+++ b/tests/tools/test_feetech_velocity_direction_bit.py
@@ -1,0 +1,282 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A ``Goal_Velocity`` magnitude that would set the direction bit is refused.
+
+The STS/SMS series encodes ``Goal_Velocity`` (register 0x2E) as sign-magnitude,
+not as a plain unsigned 16-bit value: bit 15 carries the direction and bits 0-14
+the magnitude. :mod:`~strands_robots.tools.serial_tool` bounded the field to the
+two-byte maximum instead, so every magnitude from 32768 up was accepted and put
+its own two bytes on the wire - where the servo read them as a command in the
+opposite direction:
+
+===============  ==================  ==========================================
+``velocity=``    bytes on the wire   what the servo executes
+===============  ==================  ==========================================
+32767            ``2E FF 7F``        +32767, forward (the largest true magnitude)
+32768            ``2E 00 80``        magnitude 0 - it *stops*
+40000            ``2E 40 9C``        -7232, reverse
+65535            ``2E FF FF``        -32767, full speed reverse
+===============  ==================  ==========================================
+
+Each returned ``status="success"`` quoting the number supplied, so the report
+described a command the servo never received - and for 65535 the arm ran at full
+speed the wrong way. That is the same silent-reinterpretation the sibling fields
+are bounded to prevent, which is why the module's own docstring says bounding the
+field is what makes the success message true.
+
+``Goal_Position`` (0x2A) is sign-magnitude on bit 15 too, and needed no change:
+its 12-bit ceiling of 4095 sits far below the direction bit, so a position the
+tool accepts can never reach it. Its bound was already keyed to the register
+rather than to the byte width, which is exactly what ``velocity``'s was not.
+
+The vendor semantics is not this suite's invention. lerobot's Feetech tables
+declare ``"Goal_Velocity": 15`` in ``STS_SMS_SERIES_ENCODINGS_TABLE`` and encode
+through ``encode_sign_magnitude``, which raises for a magnitude above 32767;
+:class:`TestTheVendorAgreesWhereTheMagnitudeEnds` pins that agreement whenever
+lerobot is installed.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.serial_tool as serial_mod
+
+#: Bit index the vendor declares for ``Goal_Velocity`` on the STS/SMS series -
+#: lerobot spells it ``STS_SMS_SERIES_ENCODINGS_TABLE["Goal_Velocity"] = 15`` and
+#: :class:`TestTheVendorAgreesWhereTheMagnitudeEnds` checks that claim against
+#: lerobot itself. Stated here rather than read off the module under test so the
+#: premises and the over-reach controls grade the same register semantics whether
+#: or not the module has been fixed.
+DIRECTION_BIT = 15
+
+#: Largest magnitude leaving :data:`DIRECTION_BIT` clear.
+MAX_MAGNITUDE = (1 << DIRECTION_BIT) - 1
+
+#: Magnitudes that overflow into the direction bit, and what the servo reads
+#: each of them as once bit 15 is stripped off as the sign.
+REVERSING_MAGNITUDES = (
+    (32768, 0),
+    (40000, -7232),
+    (50000, -17232),
+    (65535, -32767),
+)
+
+#: Magnitudes the field carries with the direction bit still clear.
+TRUE_MAGNITUDES = (0, 1, 100, 4095, 32767)
+
+
+class _FakeSerial:
+    """Stand-in for ``serial.Serial`` recording the bytes that reach the wire."""
+
+    def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self.writes: list[bytes] = []
+        self.closed = False
+        self.in_waiting = 0
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def read(self, n: int = 1) -> bytes:
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSerial]:
+    """Record every port this tool opens; empty means the bus was never touched."""
+    created: list[_FakeSerial] = []
+
+    def _ctor(port: str, baudrate: int, timeout: float = 1.0) -> _FakeSerial:
+        instance = _FakeSerial(port, baudrate, timeout)
+        created.append(instance)
+        return instance
+
+    monkeypatch.setattr(serial, "Serial", _ctor)
+    return created
+
+
+def _call(**kwargs: Any) -> dict[str, Any]:
+    """Invoke the tool with a fake port, splatted so off-type values reach it."""
+    return serial_mod.serial_tool(port="/dev/fake0", **kwargs)
+
+
+def _text(result: dict[str, Any]) -> str:
+    return "\n".join(item.get("text", "") for item in result.get("content", []))
+
+
+def _register_value(packet: bytes) -> int:
+    """Decode the two-byte little-endian register value out of a written packet."""
+    return packet[6] | (packet[7] << 8)
+
+
+def _as_sign_magnitude(encoded: int, sign_bit: int) -> int:
+    """Read ``encoded`` the way the servo does: a sign bit and a magnitude.
+
+    Spelled out rather than imported so this file grades the register semantics
+    on an install with no lerobot at all.
+    """
+    magnitude = encoded & ((1 << sign_bit) - 1)
+    return -magnitude if (encoded >> sign_bit) & 1 else magnitude
+
+
+def _velocity_ceiling_expression() -> str:
+    """The source expression ``_REGISTER_FIELDS["velocity"]`` uses as its ceiling.
+
+    A literal 32767 there would behave identically today and drift the moment the
+    direction bit is reconsidered, so what is pinned is that the bound is *derived
+    from* :data:`~strands_robots.tools.serial_tool._MAX_MAGNITUDE` rather than
+    equal to it by coincidence.
+    """
+    source = Path(inspect.getfile(serial_mod)).read_text(encoding="utf-8")
+    (assignment,) = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "_REGISTER_FIELDS"
+    ]
+    fields = assignment.value
+    assert isinstance(fields, ast.Dict)
+    (entry,) = [
+        value
+        for key, value in zip(fields.keys, fields.values, strict=True)
+        if isinstance(key, ast.Constant) and key.value == "velocity"
+    ]
+    assert isinstance(entry, ast.Tuple)
+    return ast.unparse(entry.elts[1])
+
+
+class TestTheRegisterSemanticsThisBoundEncodes:
+    """Premises: what bit 15 does, and that it is reachable inside two bytes."""
+
+    def test_the_direction_bit_is_inside_the_two_byte_field(self) -> None:
+        # If the direction bit sat outside the field, the byte-width bound would
+        # have been correct and there would be nothing to refuse.
+        assert (1 << DIRECTION_BIT) <= 0xFFFF
+        assert MAX_MAGNITUDE < 0xFFFF
+
+    @pytest.mark.parametrize("magnitude,executed", REVERSING_MAGNITUDES)
+    def test_a_reversing_magnitude_really_does_change_the_command(self, magnitude: int, executed: int) -> None:
+        # The premise the refusal exists for: these are not truncations of the
+        # caller's number, they are different commands.
+        assert _as_sign_magnitude(magnitude, DIRECTION_BIT) == executed
+        assert executed != magnitude
+
+    @pytest.mark.parametrize("magnitude", TRUE_MAGNITUDES)
+    def test_an_accepted_magnitude_reads_back_as_itself(self, magnitude: int) -> None:
+        assert _as_sign_magnitude(magnitude, DIRECTION_BIT) == magnitude
+
+
+class TestAVelocityThatWouldReverseTheCommandIsRefused:
+    """The regression: the bus is never given a magnitude that means something else."""
+
+    @pytest.mark.parametrize("magnitude,_executed", REVERSING_MAGNITUDES)
+    def test_it_is_refused_before_the_port_opens(
+        self, magnitude: int, _executed: int, opened: list[_FakeSerial]
+    ) -> None:
+        result = _call(action="feetech_velocity", motor_id=1, velocity=magnitude)
+
+        assert result["status"] == "error"
+        assert "velocity" in _text(result)
+        assert "feetech_velocity" in _text(result)
+        assert opened == []
+
+    def test_the_refusal_explains_the_direction_bit_rather_than_the_byte_width(self) -> None:
+        result = _call(action="feetech_velocity", motor_id=1, velocity=65535)
+        text = _text(result)
+
+        # A caller told only "must be at most 32767" would reasonably read it as
+        # an arbitrary cap; the reason is what makes the number make sense.
+        assert "32767" in text
+        assert "sign-magnitude" in text
+        assert "direction" in text
+        assert "65535" in text
+
+    def test_the_ceiling_is_the_largest_magnitude_the_direction_bit_leaves_free(self) -> None:
+        _low, high, _why = serial_mod._REGISTER_FIELDS["velocity"]
+
+        assert high == MAX_MAGNITUDE == 32767
+        # One above the ceiling is exactly the direction bit, alone.
+        assert high + 1 == 1 << DIRECTION_BIT
+        # And the module derives that ceiling from the bit rather than restating
+        # a number, so the two cannot drift apart.
+        assert serial_mod._DIRECTION_BIT == DIRECTION_BIT
+        assert serial_mod._MAX_MAGNITUDE == MAX_MAGNITUDE
+        assert _velocity_ceiling_expression() == "_MAX_MAGNITUDE"
+
+
+class TestEveryMagnitudeTheToolAcceptsStillReachesTheWire:
+    """The over-reach guard: bounding the field must not narrow a true command."""
+
+    @pytest.mark.parametrize("magnitude", TRUE_MAGNITUDES)
+    def test_an_accepted_velocity_is_the_velocity_on_the_wire(self, magnitude: int, opened: list[_FakeSerial]) -> None:
+        result = _call(action="feetech_velocity", motor_id=1, velocity=magnitude)
+
+        assert result["status"] == "success"
+        assert _register_value(opened[0].writes[0]) == magnitude
+        # And it means what it says, which is the whole point of the bound.
+        assert _as_sign_magnitude(_register_value(opened[0].writes[0]), DIRECTION_BIT) == magnitude
+
+    def test_the_register_address_is_unchanged(self, opened: list[_FakeSerial]) -> None:
+        _call(action="feetech_velocity", motor_id=1, velocity=100)
+
+        # Goal_Velocity, address 46 - the bound must not move the write.
+        assert opened[0].writes[0][5] == 0x2E
+
+
+class TestTheSiblingPositionRegisterNeededNoChange:
+    """``Goal_Position`` shares the encoding and was already bounded below it."""
+
+    def test_its_ceiling_already_left_the_direction_bit_clear(self) -> None:
+        _low, high, _why = serial_mod._REGISTER_FIELDS["position"]
+
+        assert high == 4095
+        assert high <= MAX_MAGNITUDE
+        assert not (high >> DIRECTION_BIT) & 1
+
+    @pytest.mark.parametrize("position", (4096, 32768, 40000, 65535))
+    def test_a_position_that_could_reach_the_direction_bit_was_always_refused(
+        self, position: int, opened: list[_FakeSerial]
+    ) -> None:
+        result = _call(action="feetech_position", motor_id=1, position=position)
+
+        assert result["status"] == "error"
+        assert "position" in _text(result)
+        assert opened == []
+
+
+class TestTheVendorAgreesWhereTheMagnitudeEnds:
+    """lerobot encodes the same register, and refuses the same magnitudes."""
+
+    @pytest.mark.parametrize("magnitude,_executed", REVERSING_MAGNITUDES)
+    def test_lerobot_refuses_every_magnitude_this_tool_refuses(self, magnitude: int, _executed: int) -> None:
+        encoding = pytest.importorskip("lerobot.motors.encoding_utils")
+
+        with pytest.raises(ValueError):
+            encoding.encode_sign_magnitude(magnitude, DIRECTION_BIT)
+
+    @pytest.mark.parametrize("magnitude", TRUE_MAGNITUDES)
+    def test_lerobot_accepts_every_magnitude_this_tool_accepts(self, magnitude: int) -> None:
+        encoding = pytest.importorskip("lerobot.motors.encoding_utils")
+
+        assert encoding.encode_sign_magnitude(magnitude, DIRECTION_BIT) == magnitude
+
+    def test_the_sign_bit_index_is_the_one_the_vendor_table_declares(self) -> None:
+        tables = pytest.importorskip("lerobot.motors.feetech.tables")
+
+        assert tables.STS_SMS_SERIES_ENCODINGS_TABLE["Goal_Velocity"] == DIRECTION_BIT
+        assert tables.STS_SMS_SERIES_ENCODINGS_TABLE["Goal_Position"] == DIRECTION_BIT
+        # And that the address this tool writes is the one that table describes.
+        assert tables.STS_SMS_SERIES_CONTROL_TABLE["Goal_Velocity"] == (0x2E, 2)

--- a/tests/tools/test_serial_tool_numeric_domain.py
+++ b/tests/tools/test_serial_tool_numeric_domain.py
@@ -56,6 +56,13 @@ import serial
 # reached through this one alias.
 import strands_robots.tools.serial_tool as serial_mod
 
+# ``Goal_Position`` and ``Goal_Velocity`` are sign-magnitude on the STS/SMS
+# series (lerobot: ``STS_SMS_SERIES_ENCODINGS_TABLE`` declares bit 15 for both),
+# so the largest magnitude either carries is not the two-byte maximum. Stated
+# here rather than read off the module so this guard grades the bound itself.
+DIRECTION_BIT = 15
+MAX_MAGNITUDE = (1 << DIRECTION_BIT) - 1
+
 # One value per rejection reason.
 BAD_COUNTS = (0, -1, -100, 2.7, True, "8", None, [8])
 BAD_TIMEOUTS = (-1, -0.5, float("nan"), float("inf"), True, "1.0", None, [1.0])
@@ -152,7 +159,11 @@ class TestARegisterFieldIsNeverSilentlyTruncated:
         assert f"Position {position} " in _text(result)
         assert f"{position / 4095 * 360:.1f} deg" in _text(result)
 
-    @pytest.mark.parametrize("velocity", (0, 100, 65535))
+    # 32767 replaces the 65535 this case used to assert. Both put their own two
+    # bytes on the wire, but ``Goal_Velocity`` is sign-magnitude: 65535 sets bit
+    # 15, so the servo reads it as full speed in the *opposite* direction, which
+    # is precisely the masking-into-another-command this class refuses.
+    @pytest.mark.parametrize("velocity", (0, 100, 32767))
     def test_the_reported_velocity_is_the_velocity_on_the_wire(self, velocity: int, opened: list[_FakeSerial]) -> None:
         result = _call(action="feetech_velocity", motor_id=1, velocity=velocity)
 
@@ -304,11 +315,16 @@ class TestTheOptionTablesCannotDriftApart:
         consumed = {option for options in serial_mod._OPTIONS_BY_ACTION.values() for option in options}
         assert set(serial_mod._REGISTER_FIELDS) <= consumed
 
-    @pytest.mark.parametrize("field", ("motor_id", "position", "velocity"))
+    @pytest.mark.parametrize("field", tuple(serial_mod._REGISTER_FIELDS))
     def test_every_register_bound_is_a_value_the_field_can_hold(self, field: str) -> None:
         low, high, why = serial_mod._REGISTER_FIELDS[field]
         assert 0 <= low <= high
-        # ``position`` / ``velocity`` are written as two bytes and ``motor_id``
-        # as one, so no bound may exceed what its field encodes.
-        assert high <= (0xFF if field == "motor_id" else 0xFFFF)
+        # ``motor_id`` is the frame's single ID byte. The other two are
+        # sign-magnitude two-byte registers, so the ceiling that keeps a command
+        # meaning what it says is the largest magnitude leaving the direction bit
+        # clear - not the two-byte maximum, which the servo reads as the opposite
+        # direction. ``position`` sits well inside it at 4095, which is why its
+        # 12-bit bound was already safe.
+        limit = 0xFF if field == "motor_id" else MAX_MAGNITUDE
+        assert high <= limit
         assert why


### PR DESCRIPTION
## Problem

`Goal_Velocity` (register 0x2E) is **sign-magnitude** on the Feetech STS/SMS
series: bit 15 carries the direction and bits 0-14 the magnitude. `serial_tool`
bounded the field to the two-byte maximum instead - keyed to the byte width
rather than to the register - so every magnitude from 32768 up was accepted, put
its own two bytes on the wire, and was read by the servo as a command in the
opposite direction.

Measured by driving `serial_tool(action="feetech_velocity", ...)` against a
recording port and decoding the emitted bytes as sign-magnitude:

| `velocity=` | tool verdict | bytes emitted | what the servo executes |
|---|---|---|---|
| 32767 | accepted | `2E FF 7F` | +32767, forward (largest true magnitude) |
| 32768 | accepted | `2E 00 80` | magnitude 0 - it **stops** |
| 40000 | accepted | `2E 40 9C` | **-7232, reverse** |
| 50000 | accepted | `2E 50 C3` | **-17232, reverse** |
| 65535 | accepted | `2E FF FF` | **-32767, full speed reverse** |

Each returned `status="success"` quoting the number supplied, so the report
described a command the servo never received. This is not the truncation the
other register bounds exist for: the caller's value reached the wire intact and
simply meant something else there.

The vendor semantics is not this change's invention. lerobot declares
`STS_SMS_SERIES_ENCODINGS_TABLE["Goal_Velocity"] = 15` and encodes through
`encode_sign_magnitude`, which raises `ValueError` for every magnitude in the
table above and accepts every one below it - the same split this bound now draws.

`Goal_Position` (0x2A) shares the encoding and needed **no** change: its 12-bit
ceiling of 4095 sits far below the direction bit, so a position the tool accepts
can never reach it. Its bound was already keyed to the register, which is
precisely what `velocity`'s was not - measured in the same run, `position=4096`
and `position=40000` were both already refused.

## Why every gate was silent

`tests/tools/test_serial_tool_numeric_domain.py` asserted the defect, twice:

- `test_the_reported_velocity_is_the_velocity_on_the_wire[65535]` asserted 65535
  reaches the wire as 65535. True at the byte level and false in meaning - and
  the class it sits in is named `TestARegisterFieldIsNeverSilentlyTruncated`.
- `test_every_register_bound_is_a_value_the_field_can_hold` graded each ceiling
  against `0xFFFF`, the byte width. `position` at 4095 satisfies that rule with
  enormous slack, so the check passed for both fields while only one of them was
  keyed to its register.

Both are corrected here rather than worked around: the wire case now uses 32767,
and the structural rule grades against the largest magnitude the direction bit
leaves free. The bound is derived from the bit rather than restating 32767, so
the two cannot drift.

## Tests

New `tests/tools/test_feetech_velocity_direction_bit.py` (37 cases). The vendor
sign-bit index is stated in the test file and checked against lerobot, rather
than read off the module under test, so the premises and the over-reach controls
grade the same register semantics on either tree.

Pre-fix split, source reverted with the tests as shipped: **7 failed / 126
passed**, with **0** in the premise class, **0** in either control class and
**0** in the vendor-agreement class. The 6 failures are the regression class; the
7th is the existing structural guard, failing cleanly with `assert 65535 <=
32767`. No `AttributeError` on the new constants - they are reached from one cell
only, the one asserting the module agrees with the vendor.

Break table, 9 mutations, control clean, source restored byte-identical:

| mutation | fires | notes |
|---|---|---|
| control (no mutation) | 0 | |
| the fix reverted | 7 | the pre-fix set |
| `_MAX_MAGNITUDE` is the two-byte maximum | 7 | |
| `_DIRECTION_BIT` = 16 (outside the field) | 7 | |
| `_DIRECTION_BIT` = 14 (over-reach) | 4 | fires the accepted-magnitude controls in both files |
| `_MAX_MAGNITUDE` off by one (the bit itself allowed) | 4 | boundary |
| the reason no longer explains the direction bit | 1 | the message cell |
| the ceiling restates 32767 instead of keying it to the bit | 1 | behaviourally a no-op today; the drift is what is pinned |
| the sibling `position` ceiling widened to the byte width | 6 | fires the sibling control and the structural guard |
| the guard runs after the port is opened | 84 | 15 in the new file, 69 in the two existing files |

9 of 9 detected, 7 distinct firing sets. The three rows firing the identical 7
do so structurally - each makes the effective ceiling the two-byte maximum.

The over-reach row is the one worth reading: narrowing the direction bit by one
refuses 32767, a magnitude the register does carry, and 4 cells catch it - 3 in
the new file plus the accepted-magnitude case in the existing domain file. That
is the evidence this bound did not become stricter than the register.

## Gate

Identical 470-file selection (all of `tests/tools/`, plus every guard that walks
the tree, reads source or docstrings, or reads `docs/`), the new file excluded
from both trees: **22255 collected, `22 failed, 22125 passed, 108 skipped` on
both**, 22 identical failing ids, `comm` empty in both directions. All 22 are
pre-existing and dependency-shaped: 17 need `awsiot` (the `[mesh-iot]` extra), 2
are lerobot-from-source `encode()` drift, 1 is a leftover dataset in `/tmp`, 2
assert on emoji in rendered output.

`mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main`
worktree, normalized message sets byte-identical in both directions, 0 in the
changed files. `ruff check` and `ruff format --check` clean over 1562 files.

## Scope

One bound, its reason, the two assertions that encoded the old one, and the docs
row that documented it. Deliberately not included:

- **Signed velocity.** The tool has no way to express direction today, and
  accepting a negative `velocity` to mean reverse would be a new capability
  rather than a correction. Bounding the magnitude is what makes the existing
  success message true, which is the stated job of these bounds.
- **A tighter, model-specific speed ceiling.** The largest magnitude the field
  carries is a property of the packet; what an STS3215 will actually track is a
  property of the servo. This module's bounds are documented as the former, and
  `_REGISTER_FIELDS` says so.
- `pose_tool` writes only `Goal_Position` and clamps to each motor's declared
  range before encoding, so it never reaches this bit and is untouched.

No visual artifact: this is an input-domain fix on a serial write, not a policy,
simulation, rendering, recording or asset change. The byte-and-decode table above
is the evidence, and it is reproducible without hardware - which is also why the
regression runs on an install with no lerobot and no servo attached.
