### PR TITLE
fix(drivers): stop reporting a LiDAR point cap the summary never applies

### DIFF
--- a/changelog.d/2752-g1-lidar-summary-no-unapplied-cap.md
+++ b/changelog.d/2752-g1-lidar-summary-no-unapplied-cap.md
@@ -1,0 +1,21 @@
+### Fixed: a G1 LiDAR summary no longer reports a point cap it never applies
+
+`G1Driver._on_lidar_cloud` builds the record the mesh publishes on
+`strands/<peer>/lidar/summary`. Every field in it is read from the
+`PointCloud2_` header - width, height, point_step, row_step - so no point is
+ever enumerated and nothing is downsampled. The record nonetheless carried a
+`capped_at` field copied from a `lidar_max_points` constructor parameter, and
+that parameter had exactly one reader: the line that copied it into the field.
+A Mid-360 frame therefore published `count: 24000` beside `capped_at: 4000`,
+telling a consumer that the number next to it had been capped at 4000 when it
+was the cloud's true uncapped size. Setting the knob changed only that claim.
+The comment defending the constant named `_summarise_cloud`, a method with no
+definition anywhere in the tree.
+
+The field and the parameter are gone; a caller still passing `lidar_max_points=`
+is accepted and logged at debug, because the driver already ignores extras so
+the factory can forward them. `count` is deliberately unchanged: it is the
+cloud's true size, and a Mid-360 that drops from 24000 points to 3000 is
+reporting a fault that clamping the number would hide. What bounds the record is
+its fixed, header-derived shape - the same for a 200-point frame and a
+30k-point one - which is now what the docstring says and what the tests assert.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -48,13 +48,8 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Constants surfaced for tests and for issue #358 to share. The
-# ``_LIDAR_MAX_POINTS`` cap is deliberate: :meth:`_summarise_cloud` runs on the
-# DDS thread and a full Livox frame is ~30k points at 10 Hz. The point-cloud
-# tile (issue #356) publishes its own downsampled ``lidar/cloud`` topic; here
-# we only compute a summary.
+# Constants surfaced for tests and for issue #358 to share.
 # ---------------------------------------------------------------------------
-_LIDAR_MAX_POINTS: int = 4000
 _BATTERY_FLOOR_PCT: float = 15.0
 
 # The topics the driver reads. Kept together so a reader sees the whole
@@ -84,7 +79,6 @@ class G1Driver:
         port: str | None = None,
         network_interface: str = "eth0",
         battery_floor_pct: float = _BATTERY_FLOOR_PCT,
-        lidar_max_points: int = _LIDAR_MAX_POINTS,
         **kwargs: Any,
     ) -> None:
         """Record configuration; :meth:`connect_eagerly` does the DDS work.
@@ -109,9 +103,6 @@ class G1Driver:
             battery_floor_pct: Percentage below which :meth:`send_action`
                 refuses to write. The floor is separate from the FSM gate so
                 a caller can see which check refused.
-            lidar_max_points: Cap for the downsampled point count reported in
-                ``_lidar_summary``. Full clouds go through the dashboard's
-                own topic (issue #356), not this one.
             **kwargs: Ignored; accepted so the factory can forward extras
                 without the driver knowing what they are.
         """
@@ -122,7 +113,6 @@ class G1Driver:
         self._port = port
         self._network_interface = network_interface
         self._battery_floor_pct = float(battery_floor_pct)
-        self._lidar_max_points = int(lidar_max_points)
 
         # Cached DDS decode results. Every one is optional per the mesh
         # contract, so a driver that has not connected yet is not broken.
@@ -549,6 +539,14 @@ class G1Driver:
         too much to publish unpaced. The summary is what the mesh's health
         chip reads; the 3D tile (issue #356) subscribes the raw cloud itself
         through a paced publisher and does its own downsampling.
+
+        What bounds this record is that every field is read from the message
+        *header* - ``width``, ``height``, ``point_step``, ``row_step`` - so its
+        size is the same for a 200-point frame and a 30k-point one. No point is
+        enumerated here, and nothing is downsampled, so there is no point count
+        for a cap to apply to. ``count`` is therefore the cloud's true size: a
+        MID-360 that drops from 24000 points to 3000 is reporting a fault, and
+        clamping the number would hide exactly that.
         """
         try:
             width = int(getattr(msg, "width", 0))
@@ -556,7 +554,6 @@ class G1Driver:
             count = width * height
             self._lidar_summary = {
                 "count": count,
-                "capped_at": self._lidar_max_points,
                 "width": width,
                 "height": height,
                 "point_step": int(getattr(msg, "point_step", 0)),

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -207,15 +207,16 @@ def test_lidar_cloud_summary_is_bounded() -> None:
 
     The mesh publishes ``_lidar_summary`` as a small dict every tick; if
     :meth:`_on_lidar_cloud` shipped 30k points into that field the topic
-    would drown Zenoh. The cap is asserted here so a regression is loud.
+    would drown Zenoh. What keeps the record small is that every field is read
+    from the message header, so the summary has the same shape whatever the
+    cloud's size - which is what the absence of a point list asserts here.
     """
-    driver = G1Driver(tool_name="g1", port="1.2.3.4", lidar_max_points=4000)
+    driver = G1Driver(tool_name="g1", port="1.2.3.4")
     # Livox at 10 Hz reports width ~ 24000, height 1
     msg = types.SimpleNamespace(width=24000, height=1, point_step=16, row_step=24000 * 16)
     driver._on_lidar_cloud(msg)
     assert driver._lidar_summary is not None
     assert driver._lidar_summary["count"] == 24000
-    assert driver._lidar_summary["capped_at"] == 4000
     # No raw point list: the summary dict is small and fixed-shape.
     assert "points" not in driver._lidar_summary
 

--- a/tests/drivers/test_g1_lidar_summary_describes_the_cloud.py
+++ b/tests/drivers/test_g1_lidar_summary_describes_the_cloud.py
@@ -1,0 +1,208 @@
+"""A LiDAR summary describes the cloud, not the driver that summarised it.
+
+:meth:`~strands_robots.drivers.g1.G1Driver._on_lidar_cloud` builds the record
+the mesh publishes on ``strands/<peer>/lidar/summary``. Every field in it is
+read from the ``PointCloud2_`` *header* - ``width``, ``height``, ``point_step``,
+``row_step`` - so no point is ever enumerated and nothing is downsampled.
+
+The record nonetheless carried a ``capped_at`` field, copied from a
+``lidar_max_points`` constructor parameter, and that parameter had exactly one
+reader: the line that copied it into this field. So the summary published
+``count: 24000`` next to ``capped_at: 4000``, telling a consumer that the number
+beside it had been capped at 4000 when it was the cloud's true uncapped size.
+Setting the knob changed only that claim.
+
+The same block's justification named a method that does not exist: a module
+comment defended the constant with ":meth:`_summarise_cloud` runs on the DDS
+thread", and ``_summarise_cloud`` has no definition anywhere in the tree.
+
+Why the existing coverage was silent: ``tests/drivers/test_g1_driver.py``'s
+``test_lidar_cloud_summary_is_bounded`` asserted ``count == 24000`` and
+``capped_at == 4000`` in the same body, so the contradiction was pinned rather
+than caught. What actually bounds the record is its fixed, header-derived shape,
+which that test also asserts via the absence of a point list.
+
+These cells are split so the disposition is graded rather than assumed. The
+regression classes fail on the shipped code; the control classes state what must
+*not* change - in particular that ``count`` stays the cloud's true size, because
+the tempting repair is to clamp it, and a MID-360 that drops from 24000 points
+to 3000 is reporting a fault that clamping would hide.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+import types
+from typing import Any
+
+import pytest
+
+import strands_robots.drivers.g1 as g1_module
+from strands_robots.drivers.g1 import G1Driver
+
+#: A Livox MID-360 frame at 10 Hz, and a sparse one. ``point_step`` is 16 bytes
+#: per XYZI point, so ``row_step`` is ``width * point_step``.
+_FULL_FRAME = types.SimpleNamespace(width=24000, height=1, point_step=16, row_step=24000 * 16)
+_SPARSE_FRAME = types.SimpleNamespace(width=200, height=1, point_step=16, row_step=200 * 16)
+#: An *organised* cloud, where the point count is width times height rather than
+#: width alone. A MID-360 reports ``height=1``, so every unorganised fixture above
+#: leaves ``count = width * height`` indistinguishable from ``count = width``.
+_ORGANISED_FRAME = types.SimpleNamespace(width=640, height=480, point_step=16, row_step=640 * 16)
+
+
+def _summary(msg: Any, **driver_kwargs: Any) -> dict[str, Any]:
+    """Summarise *msg* through a driver built with *driver_kwargs*."""
+    driver = G1Driver(tool_name="g1", port="1.2.3.4", **driver_kwargs)
+    driver._on_lidar_cloud(msg)
+    summary = driver._lidar_summary
+    assert summary is not None, "the decoder produced no summary"
+    return summary
+
+
+def _without_clock(summary: dict[str, Any]) -> dict[str, Any]:
+    """Drop the wall-clock stamp, which differs between any two calls."""
+    return {key: value for key, value in summary.items() if key != "t"}
+
+
+def _meth_references() -> list[str]:
+    """Every ``:meth:`` cross-reference written in the driver module.
+
+    Derived from the source rather than listed, so a reference added later is
+    held to the same rule. Restricted to ``:meth:`` on purpose: a method either
+    exists as a callable or it does not, whereas an ``:attr:`` reference may
+    legitimately name an instance attribute that is assigned in ``__init__`` and
+    so is absent from the class.
+    """
+    return sorted(set(re.findall(r":meth:`~?([A-Za-z0-9_.]+)`", inspect.getsource(g1_module))))
+
+
+def _resolves(dotted: str) -> bool:
+    """Report whether *dotted* names a callable reachable from the module."""
+    if "." not in dotted:
+        return any(callable(getattr(owner, dotted, None)) for owner in (g1_module.G1Driver, g1_module))
+    head, _, last = dotted.rpartition(".")
+    owner = getattr(g1_module, head, None)
+    if owner is not None and callable(getattr(owner, last, None)):
+        return True
+    for module_path, attr_owner in ((head, None), (head.rpartition(".")[0], head.rpartition(".")[2])):
+        if not module_path:
+            continue
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            continue
+        target = module if attr_owner is None else getattr(module, attr_owner, None)
+        if callable(getattr(target, last, None)):
+            return True
+    return False
+
+
+class TestTheSummaryAdvertisesNoCapItDoesNotApply:
+    """The record must not claim a bound the decoder never enforces."""
+
+    def test_the_summary_carries_no_cap_field(self) -> None:
+        assert "capped_at" not in _summary(_FULL_FRAME)
+
+    def test_the_summary_is_a_function_of_the_message_alone(self) -> None:
+        """Two differently configured drivers summarise one cloud identically.
+
+        A cloud summary is a description of the cloud. Any field that moves when
+        the driver's configuration moves is describing the driver instead, which
+        is what ``capped_at`` did: it reported whatever the caller passed.
+        """
+        default = _summary(_FULL_FRAME)
+        reconfigured = _summary(
+            _FULL_FRAME,
+            network_interface="enp0s31f6",
+            battery_floor_pct=25.0,
+            lidar_max_points=500,
+        )
+        assert _without_clock(default) == _without_clock(reconfigured)
+
+    def test_no_constructor_parameter_is_named_for_a_point_cap(self) -> None:
+        """A knob whose only reader copied it into the record is gone.
+
+        Asserted on the signature rather than on behaviour because a parameter
+        that is accepted and ignored is indistinguishable from one that is
+        absent, and the claim here is that the driver no longer offers it.
+        """
+        parameters = inspect.signature(G1Driver.__init__).parameters
+        assert "lidar_max_points" not in parameters
+
+
+class TestTheModuleDocumentsNoMethodItDoesNotDefine:
+    """A cross-reference to a method that does not exist is a dead end."""
+
+    def test_every_meth_cross_reference_resolves(self) -> None:
+        references = _meth_references()
+        assert references, "the scan found no :meth: references, so it grades nothing"
+        assert [ref for ref in references if not _resolves(ref)] == []
+
+
+class TestTheReportedCountStaysTheClouds:
+    """Controls: what the repair must not change."""
+
+    def test_count_is_the_full_uncapped_point_count(self) -> None:
+        """The tempting repair is to clamp ``count``; it would hide a fault."""
+        assert _summary(_FULL_FRAME)["count"] == 24000
+
+    def test_a_sparse_frame_reports_its_own_count(self) -> None:
+        assert _summary(_SPARSE_FRAME)["count"] == 200
+
+    def test_an_organised_cloud_counts_width_times_height(self) -> None:
+        """Both dimensions are read, not just the row width."""
+        assert _summary(_ORGANISED_FRAME)["count"] == 640 * 480
+
+    def test_the_summary_carries_no_point_list(self) -> None:
+        summary = _summary(_FULL_FRAME)
+        assert "points" not in summary
+        assert all(isinstance(value, (int, float)) for value in summary.values())
+
+    def test_the_shape_is_the_same_for_a_sparse_and_a_full_frame(self) -> None:
+        """This, not a point cap, is what bounds the published record."""
+        assert set(_summary(_SPARSE_FRAME)) == set(_summary(_FULL_FRAME))
+
+    @pytest.mark.parametrize("field", ["width", "height", "point_step", "row_step"])
+    def test_every_header_field_is_reported(self, field: str) -> None:
+        assert _summary(_FULL_FRAME)[field] == getattr(_FULL_FRAME, field)
+
+
+class TestTheRestOfTheDriverIsUnchanged:
+    """Over-reach controls: the other decoders and the forwarding contract."""
+
+    def test_an_unknown_keyword_is_still_accepted(self) -> None:
+        """The factory forwards extras, so dropping a parameter breaks no caller."""
+        driver = G1Driver(tool_name="g1", port="1.2.3.4", something_the_driver_never_heard_of=7)
+        assert driver.tool_name == "g1"
+
+    def test_the_imu_decoder_still_populates(self) -> None:
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_lowstate(
+            types.SimpleNamespace(
+                imu_state=types.SimpleNamespace(rpy=[0.01, -0.02, 0.5]),
+                mode_machine=501,
+            )
+        )
+        assert driver._imu is not None
+        assert driver._imu["rpy"] == pytest.approx([0.01, -0.02, 0.5])
+        assert driver._fsm_id == 501
+
+    def test_the_battery_decoder_still_populates(self) -> None:
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_bms(types.SimpleNamespace(soc=87.5, charge=0, current=-2.4, cycle=42))
+        assert driver._battery is not None
+        assert driver._battery["pct"] == pytest.approx(87.5)
+
+    def test_the_lidar_state_decoder_still_populates(self) -> None:
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_lidar_state(types.SimpleNamespace(code=0, freq=10.0, sys_rotation_speed=3600.0))
+        assert driver._lidar_state is not None
+        assert driver._lidar_state["freq"] == pytest.approx(10.0)
+
+    def test_a_malformed_cloud_message_is_still_swallowed(self) -> None:
+        """The DDS thread must survive a bad frame rather than tear down."""
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._on_lidar_cloud(types.SimpleNamespace(width="not a number", height=1))
+        assert driver._lidar_summary is None


### PR DESCRIPTION
## Problem

`G1Driver._on_lidar_cloud` builds the record the mesh publishes on `strands/<peer>/lidar/summary`. Every field in it is read from the `PointCloud2_` **header** - `width`, `height`, `point_step`, `row_step` - so no point is ever enumerated and nothing is downsampled.

The record nonetheless carried a `capped_at` field, copied from a `lidar_max_points` constructor parameter. That parameter had exactly one reader:

```
$ grep -rn "lidar_max_points\|_LIDAR_MAX_POINTS" --include=*.py strands_robots/
strands_robots/drivers/g1.py:52:# ``_LIDAR_MAX_POINTS`` cap is deliberate: :meth:`_summarise_cloud` runs on the
strands_robots/drivers/g1.py:57:_LIDAR_MAX_POINTS: int = 4000
strands_robots/drivers/g1.py:87:        lidar_max_points: int = _LIDAR_MAX_POINTS,
strands_robots/drivers/g1.py:112:            lidar_max_points: Cap for the downsampled point count reported in
strands_robots/drivers/g1.py:125:        self._lidar_max_points = int(lidar_max_points)
strands_robots/drivers/g1.py:559:                "capped_at": self._lidar_max_points,
```

Line 559 is the only place the value is consumed, and it copies it into the payload. So a Mid-360 frame reached the wire as:

```
strands/neon/lidar/summary
{"capped_at": 4000, "count": 24000, "height": 1, "peer_id": "neon",
 "point_step": 16, "row_step": 384000, "t": ..., "width": 24000}
```

`count: 24000` beside `capped_at: 4000` tells a consumer the number next to it was capped at 4000. It is the cloud's true, uncapped size. Setting the knob changed only that claim.

The parameter's own docstring described behaviour the method does not implement - "Cap for the downsampled point count reported in `_lidar_summary`" - and the comment defending the constant named a method that does not exist:

```
# ``_LIDAR_MAX_POINTS`` cap is deliberate: :meth:`_summarise_cloud` runs on the
```

`_summarise_cloud` has no definition anywhere in the tree (`grep -rn` over `--include=*.py` returns only that comment).

## Change

The field, the parameter and the constant are removed, and the comment is corrected. `_on_lidar_cloud`'s docstring now states what actually bounds the record: every field comes from the header, so the summary has the same shape for a 200-point frame and a 30k-point one, and there is no point count for a cap to apply to.

**`count` is deliberately unchanged.** The tempting repair is to clamp it, and that would be worse than the field: a Mid-360 dropping from 24000 points to 3000 is reporting a fault, and clamping would hide exactly that. A control cell pins this, and the mutation that clamps `count` is in the break table below.

**No caller breaks.** The driver already accepts and ignores extra keyword arguments so the factory can forward them, so a caller still passing `lidar_max_points=` is logged at debug rather than refused - pinned by `test_an_unknown_keyword_is_still_accepted`. `capped_at` and `lidar_max_points` have zero consumers anywhere: no other module, no docs page, and nothing on the dashboard branch (checked with `git grep` against it).

## Why the existing coverage was silent

`tests/drivers/test_g1_driver.py::test_lidar_cloud_summary_is_bounded` asserted both halves of the contradiction in one body:

```python
assert driver._lidar_summary["count"] == 24000
assert driver._lidar_summary["capped_at"] == 4000
```

so the mismatch was pinned rather than caught. Its docstring said "The cap is asserted here so a regression is loud". What actually bounds the record is the fixed shape, which the same test also asserts via `"points" not in`. That cell keeps the shape assertion, drops the cap assertion, and its docstring now names the real bound.

## Tests

New `tests/drivers/test_g1_lidar_summary_describes_the_cloud.py`, 18 cases in four classes. Pre-fix (source reverted to `main`, tests kept): **4 failed / 14 passed**, all four in the two regression classes and **0 of the 14 control cells**.

The load-bearing regression cell is derived rather than a change-detector: `test_the_summary_is_a_function_of_the_message_alone` summarises one cloud through two differently-configured drivers and requires identical records modulo the clock stamp. A cloud summary describes the cloud; any field that moves when the driver's configuration moves is describing the driver instead, which is what `capped_at` did.

`test_every_meth_cross_reference_resolves` derives every `:meth:` reference from the module source and requires each to resolve to a callable - 7 today, of which `_summarise_cloud` was the one dead reference. It is restricted to `:meth:` on purpose: a method either exists or it does not, whereas an `:attr:` reference may legitimately name an instance attribute assigned in `__init__` and so absent from the class (`_imu`, `_battery`, `_fsm_id`, `_lidar_state`, `_lidar_summary` are all of that kind, and an unrestricted scan reports all five as false positives).

### Break table

Nine mutations against the fixed tree; source restored byte-identical after each.

| mutation | fires | cells |
|---|---|---|
| control (unmutated) | 0 | - |
| the cap field returns as a literal | 1 | `test_the_summary_carries_no_cap_field` |
| full revert (parameter + field) | 4 | the pre-fix set |
| the dead parameter returns, field stays gone | 1 | `test_no_constructor_parameter_is_named_for_a_point_cap` |
| **the wrong fix: `count` clamped to a cap** | 2 | both count cells |
| the dead `:meth:` reference returns | 1 | `test_every_meth_cross_reference_resolves` |
| a header field dropped from the record | 1 | `test_every_header_field_is_reported[width]` |
| the record gains another config-derived field | 2 | function-of-message, no-point-list |
| `count` loses the height factor | 1 | `test_an_organised_cloud_counts_width_times_height` |
| the `:meth:` scan regex matches nothing (vacuity probe) | 1 | `test_every_meth_cross_reference_resolves` |

9 mutations, **9 detected**, 8 distinct firing sets, control clean. The last two rows share a firing set for a structural reason: one is the defect returning, the other is the vacuity probe on the same cell, and the non-vacuity assertion inside it is what makes the second row fire.

One mutation initially fired 0 and exposed a gap in my own fixture: `count = width` is indistinguishable from `count = width * height` when every fixture is an unorganised Mid-360 frame with `height=1`. An organised-cloud fixture (640x480) closes it, which is why that row now fires.

## Gate

- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean, 1567 files formatted.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical in both directions, **0 in the changed files**.
- Paired run, identical 100-file selection (all of `tests/drivers/` plus every guard that walks the tree, reads source or docstrings, or reads `changelog.d`), with both changed test files excluded from each tree: identical **4173 collected** and `1 failed, 4117 passed, 55 skipped` on both, one identical failing id, `comm` empty in both directions. That failure is `tests/test_dataset_recorder.py::test_create_passes_vcodec_directly_when_supported`, a pre-existing `FileExistsError` on a leftover `/tmp/ds` dataset directory on this machine, unrelated to this change and identical on both sides.
- `tests/drivers/` plus `tests/test_driver_seam.py`: 110 passed, on both a mujoco 3.5.0 (declared floor) and a 3.12.0 interpreter.

No visual artifact: this changes what a record reports, not a policy, a simulation, a render or a recording. The measured before/after payload above is the evidence.
