### PR TITLE
test(drivers): pin the G1 driver's DDS readings reaching the mesh wire

### DIFF
--- a/changelog.d/2754-g1-driver-mesh-wire-test.md
+++ b/changelog.d/2754-g1-driver-mesh-wire-test.md
@@ -1,0 +1,22 @@
+### Tests: a native G1 driver's DDS readings are pinned reaching the mesh wire
+
+A native driver and the mesh sensor loops are joined by nothing but attribute
+names. `SensorLoopsMixin` reads sixteen underscore-prefixed attributes off
+whatever object the mesh was handed, and `G1Driver` fills four of them from its
+DDS callbacks; nothing declares that relationship, so a rename on either side is
+silent. The coverage that existed drove the readers through a host object whose
+`publish` records the payload, which cannot see either the composition or the
+encoding.
+
+This composes a real `Mesh` around a real `G1Driver` fed mocked DDS and asserts
+at the transport boundary that `strands/<peer>/lidar/summary`, `imu` and `health`
+arrive and decode. The readings are fed as the numpy the SDK reports - a Livox
+header is `int64`, an IMU orientation `float32`, and `json.dumps` refuses both -
+so the cells grade the payload the robot really sends rather than a
+pre-sanitised stand-in. A non-vacuity class shows the topics are the DDS samples
+and not the loop merely running: an unfed driver publishes no imu or lidar
+topic, while health still publishes because it aggregates host metrics too.
+
+The loops are driven one tick each without threads or sleeping, because
+`SensorLoopsMixin._paced` yields before it waits and so an already-set stop
+event produces exactly one iteration.

--- a/tests/drivers/test_g1_driver_reaches_the_mesh_wire.py
+++ b/tests/drivers/test_g1_driver_reaches_the_mesh_wire.py
@@ -1,0 +1,235 @@
+"""A native G1 driver's DDS readings reach the mesh wire, encoded.
+
+Issue #354's fourth acceptance criterion: a :class:`~strands_robots.mesh.Mesh`
+wrapping a :class:`~strands_robots.drivers.g1.G1Driver` fed mocked DDS publishes
+``strands/<peer>/lidar/summary``, ``imu`` and ``health``. Every other criterion
+was pinned when the driver landed; this one was verified by reading the two
+sides and checking that the key names agreed, which is exactly the check a test
+should be doing instead.
+
+What makes it worth a test rather than an inspection is that the two halves are
+joined by nothing but attribute names. ``SensorLoopsMixin`` reads sixteen
+underscore-prefixed attributes straight off whatever object the mesh was handed;
+the driver writes four of them from its DDS callbacks. Nothing declares that
+relationship, so a rename on either side is silent - and issue #2749 records the
+same seam failing in the other direction, where a contract-complete driver
+publishes no joint telemetry at all because joints are reached through an inner
+lerobot device this driver does not have. Pinning which topics *do* arrive is
+what makes that boundary legible.
+
+Three properties this file asserts that a reader-level test cannot:
+
+- the composition, with a real ``Mesh`` rather than a mixin host, so the
+  attribute names are checked against the object the mesh really reads;
+- the *encoding*, because ``session._put_zenoh_directly`` runs ``json.dumps``
+  before the bytes reach ``put`` and a payload it refuses is dropped for good -
+  the failure is deterministic, so no later tick recovers it. The capture here
+  encodes what it is handed, which is the same step moved to where a test can
+  see which side of it a record landed;
+- that the DDS side really is numpy. A Livox frame's header fields and an IMU's
+  orientation arrive as ``int64``/``float32``, and ``json.dumps`` refuses both,
+  so feeding plain Python floats would test a payload the robot never sends.
+
+The loops are driven one tick each, deterministically and without sleeping:
+``SensorLoopsMixin._paced`` yields *before* it waits, so a stop event that is
+already set produces exactly one iteration and then breaks.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from typing import Any
+
+import numpy as np
+import pytest
+
+import strands_robots.mesh.core as mesh_core
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.mesh.core import Mesh
+
+_PEER = "neon"
+
+#: The publish rates the loops resolve from the environment. Cleared so a rate
+#: configured on the host cannot turn a loop off (``_resolve_hz`` returning 0
+#: makes the loop return before its first tick) and change what this file grades.
+_RATE_ENV = (
+    "STRANDS_MESH_POSE_HZ",
+    "STRANDS_MESH_HEALTH_HZ",
+    "STRANDS_MESH_IMU_HZ",
+    "STRANDS_MESH_ODOM_HZ",
+    "STRANDS_MESH_LIDAR_SUMMARY_HZ",
+)
+
+#: The loops that publish the criterion's three topics, plus the state topic the
+#: lidar loop shares. Driven explicitly rather than through ``Mesh.start()`` so
+#: no thread, clock or network is involved.
+_LOOPS = ("_imu_loop", "_health_loop", "_lidar_loop")
+
+
+def _lowstate() -> Any:
+    """An ``rt/lowstate`` sample, with the IMU as the float32 the SDK reports."""
+    return types.SimpleNamespace(
+        imu_state=types.SimpleNamespace(
+            rpy=np.array([0.01, -0.02, 0.5], dtype=np.float32),
+            gyroscope=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            accelerometer=np.array([0.0, 0.0, 9.81], dtype=np.float32),
+            quaternion=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        ),
+        mode_machine=np.int64(501),
+    )
+
+
+def _bms() -> Any:
+    """An ``rt/lf/bmsstate`` sample, with the charge as a float32."""
+    return types.SimpleNamespace(soc=np.float32(87.5), charge=0, current=np.float32(-2.4), cycle=np.int64(42))
+
+
+def _lidar_state() -> Any:
+    """An ``rt/utlidar/lidar_state`` sample."""
+    return types.SimpleNamespace(code=0, freq=np.float32(10.0), sys_rotation_speed=np.float32(3600.0))
+
+
+def _lidar_cloud() -> Any:
+    """A Mid-360 ``PointCloud2_`` header at 10 Hz: 24000 points in one row."""
+    return types.SimpleNamespace(
+        width=np.int64(24000), height=np.int64(1), point_step=np.int64(16), row_step=np.int64(384000)
+    )
+
+
+class _Capture:
+    """Records what the transport would encode, and what it would refuse."""
+
+    def __init__(self) -> None:
+        self.wire: dict[str, Any] = {}
+        self.dropped: dict[str, str] = {}
+
+    def put(self, key: str, payload: dict[str, Any]) -> None:
+        try:
+            encoded = json.dumps(payload).encode()
+        except (TypeError, ValueError) as exc:
+            self.dropped[key] = f"{type(exc).__name__}: {exc}"
+            return
+        self.wire[key] = json.loads(encoded)
+
+
+@pytest.fixture
+def capture(monkeypatch: pytest.MonkeyPatch) -> _Capture:
+    """Replace the module-level ``put`` the mesh publishes through."""
+    recorder = _Capture()
+    monkeypatch.setattr(mesh_core, "put", recorder.put)
+    for name in _RATE_ENV:
+        monkeypatch.delenv(name, raising=False)
+    return recorder
+
+
+def _driver(*, fed: bool = True) -> G1Driver:
+    """A driver whose caches hold one DDS sample each, or nothing at all."""
+    driver = G1Driver(tool_name=_PEER, port="192.168.1.172")
+    if fed:
+        driver._on_lowstate(_lowstate())
+        driver._on_bms(_bms())
+        driver._on_lidar_state(_lidar_state())
+        driver._on_lidar_cloud(_lidar_cloud())
+    return driver
+
+
+def _tick(robot: Any, capture: _Capture) -> _Capture:
+    """Run one tick of each sensor loop of a real Mesh wrapping *robot*."""
+    mesh = Mesh(robot, _PEER)
+    mesh._running = True
+    # _paced yields before waiting, so an already-set stop event gives exactly
+    # one iteration per loop and the ticker returns without sleeping.
+    mesh._stop_event.set()
+    for loop in _LOOPS:
+        getattr(mesh, loop)()
+    return capture
+
+
+class TestTheCriterionTopicsArriveEncoded:
+    """Issue #354 criterion 4, asserted at the transport boundary."""
+
+    @pytest.mark.parametrize("topic", ["lidar/summary", "imu", "health"])
+    def test_the_topic_is_published(self, capture: _Capture, topic: str) -> None:
+        wire = _tick(_driver(), capture).wire
+        assert f"strands/{_PEER}/{topic}" in wire
+
+    def test_nothing_the_driver_reported_was_refused_by_the_encoder(self, capture: _Capture) -> None:
+        """A numpy reading must survive the encode, not be dropped before the wire."""
+        assert _tick(_driver(), capture).dropped == {}
+
+    def test_the_imu_record_carries_the_dds_orientation(self, capture: _Capture) -> None:
+        imu = _tick(_driver(), capture).wire[f"strands/{_PEER}/imu"]
+        assert imu["rpy"] == pytest.approx([0.01, -0.02, 0.5], rel=1e-6)
+        assert imu["accelerometer"] == pytest.approx([0.0, 0.0, 9.81], rel=1e-6)
+
+    def test_the_health_record_carries_the_battery_charge(self, capture: _Capture) -> None:
+        health = _tick(_driver(), capture).wire[f"strands/{_PEER}/health"]
+        assert health["battery_pct"] == pytest.approx(87.5, rel=1e-6)
+        assert health["charging"] is False
+
+    def test_the_lidar_summary_carries_the_cloud_size(self, capture: _Capture) -> None:
+        summary = _tick(_driver(), capture).wire[f"strands/{_PEER}/lidar/summary"]
+        assert summary["count"] == 24000
+        assert summary["width"] == 24000
+
+    def test_every_record_is_addressed_to_the_publishing_peer(self, capture: _Capture) -> None:
+        """The topic names the mesh's peer, and so does the record inside it."""
+        wire = _tick(_driver(), capture).wire
+        assert wire, "no topic was published, so this asserts nothing"
+        for topic, payload in wire.items():
+            assert topic.startswith(f"strands/{_PEER}/")
+            assert payload["peer_id"] == _PEER
+
+
+class TestTheLidarStateTopicComesWithTheSummary:
+    """The lidar loop publishes two topics; the criterion names one of them."""
+
+    def test_the_state_topic_is_published(self, capture: _Capture) -> None:
+        wire = _tick(_driver(), capture).wire
+        assert f"strands/{_PEER}/lidar/state" in wire
+
+    def test_the_state_record_carries_the_decoded_status_code(self, capture: _Capture) -> None:
+        state = _tick(_driver(), capture).wire[f"strands/{_PEER}/lidar/state"]
+        assert state["freq"] == pytest.approx(10.0)
+        assert "OK" in state["code_text"]
+
+
+class TestASilentDriverPublishesNoReading:
+    """Non-vacuity: the topics above are the DDS samples, not the loop running."""
+
+    @pytest.mark.parametrize("topic", ["lidar/summary", "lidar/state", "imu"])
+    def test_an_unfed_driver_publishes_no_sensor_topic(self, capture: _Capture, topic: str) -> None:
+        """Every sensor cache is optional, so a driver that never connected is quiet."""
+        wire = _tick(_driver(fed=False), capture).wire
+        assert f"strands/{_PEER}/{topic}" not in wire
+
+    def test_health_still_publishes_without_a_battery_reading(self, capture: _Capture) -> None:
+        """Health aggregates host metrics too, so it is the one topic that survives.
+
+        Asserted so the parametrized cell above is read for what it is: those
+        three topics are silent because their provider is absent, not because the
+        loop failed to run.
+        """
+        health = _tick(_driver(fed=False), capture).wire[f"strands/{_PEER}/health"]
+        assert "battery_pct" not in health
+
+
+class TestTheDriverIsWhatTheMeshReads:
+    """The seam itself: the mesh reads these attributes off the driver."""
+
+    @pytest.mark.parametrize("attribute", ["_imu", "_battery", "_lidar_state", "_lidar_summary"])
+    def test_the_driver_fills_the_attribute_the_mesh_reads(self, attribute: str) -> None:
+        """A rename on either side is otherwise silent - nothing declares this."""
+        assert getattr(_driver(), attribute) is not None
+
+    def test_the_mesh_holds_the_driver_itself(self) -> None:
+        """No inner lerobot device: the driver *is* the robot the mesh reads.
+
+        This is the property issue #2749 is about. It is asserted here as the
+        premise of the topics above, not as something desirable.
+        """
+        driver = _driver()
+        mesh = Mesh(driver, _PEER)
+        assert mesh.robot is driver
+        assert getattr(driver, "robot", None) is None


### PR DESCRIPTION
Closes the fourth acceptance criterion of the G1 native-driver work: a `Mesh` wrapping a `G1Driver` fed mocked DDS publishes `strands/<peer>/lidar/summary`, `imu` and `health`. Every other criterion was pinned when the driver landed; this one was verified by reading the two sides and checking that the key names agreed.

## Why an inspection is not enough here

A native driver and the mesh sensor loops are joined by **nothing but attribute names**. `SensorLoopsMixin` reads sixteen underscore-prefixed attributes straight off whatever object the mesh was handed, and `G1Driver` fills four of them from its DDS callbacks. Nothing declares that relationship, so a rename on either side is silent.

#2749 records the same seam failing in the other direction: a contract-complete native driver publishes no joint telemetry at all, because joints are reached through `getattr(robot, "robot", None)` - an inner lerobot device a native driver does not have. Pinning which topics *do* arrive is what makes that boundary legible rather than folklore.

## What this grades that a reader-level test cannot

`tests/mesh/test_sensor_readers.py` drives the readers through a host whose `publish` **records** the payload. That misses three things:

1. **The composition.** A real `Mesh` around the real driver, so the attribute names are checked against the object the mesh actually reads - not against a bag of attributes a fixture set.
2. **The encoding.** `session._put_zenoh_directly` runs `json.dumps` before the bytes reach `put`, and a payload it refuses is dropped for good: the failure is deterministic, so no later tick recovers it. The capture here encodes what it is handed, which is the same step moved to where a test can see which side of it a record landed.
3. **That the DDS side is numpy.** A Livox header field is `int64` and an IMU orientation is `float32`, and `json.dumps` refuses both. Feeding plain Python floats would grade a payload the robot never sends.

## Determinism

No threads, no sleeping, no network. `SensorLoopsMixin._paced` yields *before* it waits, so a stop event that is already set produces exactly one iteration per loop and then breaks. The loops are called directly rather than through `Mesh.start()`, and the publish-rate environment variables are cleared so a rate configured on the host cannot turn a loop off and change what the file grades.

## Cells

19 cases in four classes:

- **`TestTheCriterionTopicsArriveEncoded`** - the three topics arrive, nothing was refused by the encoder, and each record carries the reading its DDS sample supplied (IMU orientation, battery charge, cloud size).
- **`TestTheLidarStateTopicComesWithTheSummary`** - the lidar loop publishes two topics; the criterion names one.
- **`TestASilentDriverPublishesNoReading`** - non-vacuity. An unfed driver publishes no imu or lidar topic, so the cells above are the DDS samples rather than the loop merely running. Health is the one topic that survives, because it aggregates host metrics too, and that is asserted so the silent-topic cell is read for what it is.
- **`TestTheDriverIsWhatTheMeshReads`** - the seam itself, including that there is no inner lerobot device. Stated as the premise of the topics above, not as something desirable.

## Break table

Eight mutations across `drivers/g1.py` and `mesh/sensors.py`; both sources restored byte-identical after each.

| mutation | fires | cells |
|---|---|---|
| control (unmutated) | 0 | - |
| the driver renames its `_imu` cache | 3 | seam attribute, imu record, imu topic |
| the mesh reads a different lidar-summary attribute | 2 | summary topic + contents |
| the driver stops coercing the IMU | **0** | - |
| that, **and** the mesh's IMU coercion removed | 3 | encoder-refusal cell, imu record, imu topic |
| the summary topic loses its peer segment | 3 | peer-addressing cell, summary topic + contents |
| health stops reading the battery | 1 | battery charge |
| the lidar loop stops publishing the summary | 2 | summary topic + contents |
| the driver's decoders write nothing (vacuity probe) | 11 | all four seam cells plus every topic cell |

Eight mutations, seven detected, six distinct firing sets among those seven, control clean.

Two rows are worth reading rather than counting:

- **The driver-stops-coercing row fires 0, and that is correct.** `G1Driver`'s decoders already coerce with `float(...)`/`int(...)`, so a numpy value never reaches the mesh from *this* driver, and the mesh's `_coerce_record` is belt-and-braces for it. The next row removes both layers and fires 3 - so each layer alone suffices, and neither is dead. Reported rather than dropped, because "the encoder protection is exercised" would otherwise be an overclaim.
- The mesh-reads-a-different-attribute row and the loop-stops-publishing row share a firing set. Both make the summary topic never arrive - one because the reader finds no data, one because the publish is skipped - so they are the same observable at the wire, which is the level this file grades at.

## Gate

- `ruff check` and `ruff format --check` over `strands_robots tests tests_integ`: clean, 1567 files formatted.
- `mypy strands_robots tests tests_integ`: **24 == 24** against `main`, normalized message sets byte-identical in both directions, **0 in the new file**.
- The new file: 19 passed. `tests/drivers/` plus `tests/test_driver_seam.py`: 111 passed, on a mujoco 3.5.0 (declared floor) interpreter.
- Run together with all of `tests/mesh/` (the new file monkeypatches the module-level `put`, so leakage would show there): `4309 passed`, with 21 failures and 24 errors that are all `tests/mesh/test_iot_*` needing `awsiot` - absent here and declared in the `[mesh-iot]` extra. `tests/mesh/` alone produces the identical 21 and 24 with `4198 passed`, and 4309 - 4198 is exactly the 111 above, so nothing was lost or gained by combining them and the failures are pre-existing.

Test-only: no production file changes, so no behaviour to picture.
