### PR TITLE
fix(tools): verify a Feetech reply instead of reading it at fixed offsets

### DIFF
--- a/changelog.d/2755-feetech-status-packet-framing.md
+++ b/changelog.d/2755-feetech-status-packet-framing.md
@@ -1,0 +1,38 @@
+### Fixed: a Feetech servo's reply is located and verified, instead of being read at fixed offsets
+
+`pose_tool`'s `read_motor_position` read the two position bytes from indices 5 and 6 of whatever
+the bus returned. The servo bus is half-duplex and shared by every motor on the arm, so a reply
+can arrive behind a byte the host's own transmission echoed, or be the late answer to a read that
+already timed out, sent by a different motor. Both shift those indices, and the result is a joint
+angle that is wrong rather than absent: a joint at 1024 counts (-89.98 degrees) was reported as
+-180.0 when one byte preceded its reply, and the tool quoted that as a measurement. A reply from
+another motor, a corrupted checksum and a frame one byte short were all accepted as well.
+
+The reply is now found and verified the way `scservo_sdk` -- the vendor SDK that owns this wire
+format, and which the `[lerobot]` extra already installs -- does it: the `FF FF` header is
+searched for rather than assumed at offset 0, the frame length is re-derived from `LEN`, the
+checksum is recomputed over the same span the outgoing packet signs, and the responding ID must be
+the one that was asked. Leading bytes are recovered from rather than refused, because bytes in
+front of the header do not make a reply corrupt, they make it offset -- the SDK reads the true
+1024 from exactly those bytes, and so does this now. A frame that cannot be verified reports no
+position, which is the signal every caller already handles: the `read_position` action answers
+with an error envelope instead of a number, and the interpolating paths decline to build a
+trajectory. Graded cell for cell against the SDK across nine framings, the two now agree
+everywhere.
+
+This was a motion fault and not only a reporting one. `_smooth_move` reads the current position
+before dividing the travel into increments, so a shifted reply made the arm interpolate from a
+place it was not: commanding a joint at 1024 counts toward 4095 wrote `[0, 511, 1023, 1535]`,
+opening a *smooth* move with a ninety-degree lurch away from the target. It now writes
+`[1024, 1279, 1535, 1791]`, byte for byte the trajectory a clean bus produces. `incremental_move`
+applied its delta to the same fiction and now refuses instead.
+
+Acting on a servo's error byte -- declining to drive an overheating motor -- is deliberately not
+decided here. A value inside the byte's range is a valid frame, as the SDK also holds, so a
+reported fault still reports its position; bounding the *value* to the register's 12-bit range is
+likewise a separate question from framing, and the suite pins that this parse answers neither.
+
+Nothing could have caught this: three test fixtures across three files built the reply with `0`
+where the checksum belongs and a hardcoded ID of 1, a frame no servo would send and one the vendor
+SDK calls corrupt. Each now carries a real checksum and answers as the motor the outgoing read
+addressed, so a misattributed position is visible to a test for the first time.

--- a/strands_robots/tools/pose_tool.py
+++ b/strands_robots/tools/pose_tool.py
@@ -8,6 +8,7 @@ This tool provides comprehensive pose management for robotic arms, including:
 - Safety checks and validation
 - Integration with LeRobot and serial communication
 - Pose interpolation and smooth transitions
+- Framed decoding of servo status replies
 """
 
 import json
@@ -389,6 +390,83 @@ def _pose_target_error(
     return _joint_delta_error(action, motor_name, delta)
 
 
+# --------------------------------------------------------------------------- #
+# Feetech status-packet framing
+# --------------------------------------------------------------------------- #
+# A servo answers a read with ``FF FF ID LEN ERR <params> CHK``. ``LEN`` counts
+# the error byte, the parameters and the checksum, so a whole frame is
+# ``LEN + 4`` bytes and its checksum is ``~sum(frame[2:-1]) & 0xFF`` -- the same
+# sum :meth:`MotorController.build_feetech_packet` writes on the way out.
+#
+# The reply cannot be read at fixed offsets. The bus is half-duplex and shared by
+# every servo on the arm, so what comes back may carry a leading byte the host's
+# own transmission echoed, or the late answer to a read that already timed out,
+# sent by a different motor. Indexing straight into the buffer turns either of
+# those into a position that is wrong rather than missing: a single leading byte
+# shifts the two position bytes by one, which reports a joint ninety degrees from
+# where it is and offers nothing to say the number is not a measurement.
+#
+# So the frame is located and verified instead. This mirrors the vendor SDK,
+# which is the authority for the wire format: ``scservo_sdk``'s ``rxPacket``
+# searches for the header, re-derives the frame length from ``LEN`` and verifies
+# the checksum, and its ``txRxPacket`` keeps reading until the responding ID
+# matches the one that was asked. Recovering the frame rather than refusing the
+# read is the deliberate half: bytes in front of the header do not make a reply
+# corrupt, they make it offset, and the position it carries is the real one.
+
+#: Both header bytes of a status packet.
+_STATUS_HEADER = b"\xff\xff"
+
+#: Shortest frame the format allows: ``FF FF ID LEN ERR CHK``.
+_STATUS_MIN_FRAME = 6
+
+#: Highest ID a *responding* servo can carry. 0xFE addresses every motor at once
+#: and 0xFF is a header byte, so neither can name the motor that answered.
+_STATUS_MAX_ID = 0xFD
+
+#: The error byte's top bit is unused, so anything above this is not an error
+#: byte and the header it followed was a coincidence in someone's payload.
+_STATUS_MAX_ERROR = 0x7F
+
+
+def _parse_status_packet(raw: bytes, motor_id: int, param_count: int) -> tuple[int, ...] | None:
+    """Extract the parameters of ``motor_id``'s reply from ``raw``, or ``None``.
+
+    Every candidate header in ``raw`` is tried, so a frame arriving behind
+    echoed or stale bytes is still found, and a pair of payload bytes that
+    merely looks like a header does not end the search.
+
+    Args:
+        raw: The bytes read from the bus, which may carry leading noise.
+        motor_id: The ID that was asked; only its answer counts.
+        param_count: How many parameter bytes the reply must carry.
+
+    Returns:
+        The reply's parameter bytes, or ``None`` when ``raw`` holds no verified
+        answer from ``motor_id``.
+    """
+    start = 0
+    while (index := raw.find(_STATUS_HEADER, start)) != -1:
+        start = index + 1
+        frame = raw[index:]
+        if len(frame) < _STATUS_MIN_FRAME:
+            # Every later header starts further right, so none can be longer.
+            break
+        responder, length, error = frame[2], frame[3], frame[4]
+        total = length + 4
+        if responder > _STATUS_MAX_ID or error > _STATUS_MAX_ERROR:
+            continue
+        if length != param_count + 2 or len(frame) < total:
+            continue
+        frame = frame[:total]
+        if (~sum(frame[2:-1])) & 0xFF != frame[-1]:
+            continue
+        if responder != motor_id:
+            continue
+        return tuple(frame[5:-1])
+    return None
+
+
 class MotorController:
     """Low-level motor control for fine movements."""
 
@@ -514,7 +592,19 @@ class MotorController:
         return failed
 
     def read_motor_position(self, motor_name: str) -> float | None:
-        """Read current motor position in degrees."""
+        """Read current motor position in degrees.
+
+        Args:
+            motor_name: Which configured motor to read.
+
+        Returns:
+            The joint angle in degrees, or ``None`` when the bus is closed or no
+            verified reply from this motor arrived. ``None`` is the established
+            "could not read" signal every caller already handles:
+            :func:`pose_tool`'s ``read_position`` turns it into an error envelope
+            instead of quoting a number, and the interpolating paths refuse to
+            build a trajectory from it.
+        """
         if not self.serial_conn or not self.serial_conn.is_open:
             return None
 
@@ -527,11 +617,21 @@ class MotorController:
             self.serial_conn.write(packet)
 
             time.sleep(0.01)  # Small delay for response
+            # An 8-byte frame answers this read. The slack is what absorbs bytes
+            # the half-duplex bus puts in front of it, which the parse then skips.
             response = self.serial_conn.read(10)
 
-            if len(response) >= 7:
-                position = response[5] | (response[6] << 8)
-                return self.position_to_degrees(motor_name, position)
+            reply = _parse_status_packet(response, motor_id, 2)
+            if reply is None:
+                logger.warning(
+                    "No verified reply from motor %s (id %d); discarding %s",
+                    motor_name,
+                    motor_id,
+                    response.hex(" ") if response else "an empty read",
+                )
+                return None
+            position = reply[0] | (reply[1] << 8)
+            return self.position_to_degrees(motor_name, position)
         except Exception as e:
             logger.error(f"Failed to read motor {motor_name}: {e}")
 

--- a/tests/tools/test_feetech_status_packet_framing.py
+++ b/tests/tools/test_feetech_status_packet_framing.py
@@ -1,0 +1,483 @@
+"""A Feetech servo's reply is located and verified, not read at fixed offsets.
+
+The servo bus is half-duplex and every motor on the arm shares it, so the bytes
+that come back from a read may carry a leading byte the host's own transmission
+echoed, or the late answer to a read that already timed out, sent by a different
+motor. Indexing straight into that buffer produces a joint angle that is wrong
+rather than absent, and the tool quotes it as a measurement.
+
+The frames these tests feed are graded against ``scservo_sdk`` - the vendor SDK
+that owns this wire format - in :class:`TestTheFramesHereAreWhatAServoSends`, so
+the well-formed cases are known-good rather than assumed-good and the malformed
+ones are known-bad. Everything else needs no dependency at all: the framing is
+pure byte handling, so the regression cells run on an install with no servo SDK
+and no arm attached.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import serial
+
+import strands_robots.tools.pose_tool as pose_mod
+from strands_robots.tools.pose_tool import MotorController, _parse_status_packet, pose_tool
+
+#: The ID of ``shoulder_pan``, and the position its reply carries throughout.
+#: 1024 is a quarter turn from the 4095-count full scale, which puts the joint at
+#: -90 degrees on its -180..180 range - far enough from both the value a shifted
+#: read reports (0 counts, -180 degrees) and the mid-scale default that a wrong
+#: answer cannot be mistaken for the right one.
+MOTOR = "shoulder_pan"
+MOTOR_ID = 1
+TRUE_COUNTS = 1024
+TRUE_DEGREES = -89.97802197802199
+
+#: The other motor on the bus, whose stale reply must not answer for MOTOR.
+OTHER_ID = 2
+
+
+def _status(motor_id: int, params: list[int], error: int = 0, checksum: int | None = None) -> bytes:
+    """Build one status packet: ``FF FF ID LEN ERR <params> CHK``.
+
+    Args:
+        motor_id: The responding servo's ID.
+        params: The reply's parameter bytes.
+        error: The error byte the servo reports.
+        checksum: Override the checksum, to build a corrupt frame.
+
+    Returns:
+        The frame's bytes.
+    """
+    body = [motor_id, len(params) + 2, error, *params]
+    check = (~sum(body)) & 0xFF if checksum is None else checksum
+    return bytes([0xFF, 0xFF, *body, check])
+
+
+def _position_reply(motor_id: int = MOTOR_ID, counts: int = TRUE_COUNTS, **kwargs: Any) -> bytes:
+    """A well-formed ``Present_Position`` reply carrying ``counts``."""
+    return _status(motor_id, [counts & 0xFF, (counts >> 8) & 0xFF], **kwargs)
+
+
+@pytest.fixture
+def bus(monkeypatch):
+    """A connected MotorController over a recording fake bus.
+
+    Returns:
+        A ``(controller, fake)`` pair. ``fake.queue_read`` adds one reply,
+        ``fake.serve`` replaces the whole queue, and ``fake.writes`` records
+        every packet written.
+    """
+
+    class Fake:
+        def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+            self.port = port
+            self.writes: list[bytes] = []
+            self._queue: list[bytes] = []
+            self.is_open = True
+
+        def queue_read(self, data: bytes) -> None:
+            self._queue.append(data)
+
+        def serve(self, data: bytes, times: int) -> None:
+            """Answer the next ``times`` reads with ``data``, discarding any queue.
+
+            Replacing rather than appending is what keeps a two-phase test
+            honest: leftovers from an earlier phase would answer the later one
+            and the second phase would silently re-measure the first.
+            """
+            self._queue = [data] * times
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(bytes(data))
+
+        def read(self, n: int = 1) -> bytes:
+            return self._queue.pop(0) if self._queue else b""
+
+        def close(self) -> None:
+            self.is_open = False
+
+    made: list[Fake] = []
+
+    def ctor(port: str, baudrate: int, timeout: float = 1.0) -> Fake:
+        fake = Fake(port, baudrate, timeout)
+        made.append(fake)
+        return fake
+
+    monkeypatch.setattr(serial, "Serial", ctor)
+    controller = MotorController("/dev/ttyTEST")
+    assert controller.connect()[0] is True
+    return controller, made[0]
+
+
+def _goal_positions(writes: list[bytes]) -> list[int]:
+    """Every Goal_Position value written, in order.
+
+    Args:
+        writes: Raw packets recorded from the bus.
+
+    Returns:
+        The little-endian position each ``INST_WRITE`` to register 0x2A carried.
+    """
+    return [w[6] | (w[7] << 8) for w in writes if len(w) >= 8 and w[4] == 0x03 and w[5] == 0x2A]
+
+
+# --------------------------------------------------------------------------- #
+# Premise: the frames below are the frames a servo really sends
+# --------------------------------------------------------------------------- #
+class TestTheFramesHereAreWhatAServoSends:
+    """Grade this file's fixtures against the SDK that owns the wire format.
+
+    Without this the suite could pass by agreeing with itself: a builder and a
+    parser written together share any misunderstanding of the format. The SDK
+    arrives with ``lerobot[feetech]``, which the ``[lerobot]`` extra declares, so
+    it is present wherever the rest of the servo path is - but it is skipped
+    rather than required, because nothing else in this file needs it.
+    """
+
+    @staticmethod
+    def _verdict(payload: bytes) -> int:
+        """The SDK's communication result for ``payload``."""
+        handler = pytest.importorskip("scservo_sdk.protocol_packet_handler").protocol_packet_handler()
+
+        class Port:
+            def __init__(self, data: bytes) -> None:
+                self.buf = bytearray(data)
+                self.dry = False
+
+            def readPort(self, length: int) -> list[int]:  # noqa: N802 - SDK's spelling
+                out = self.buf[:length]
+                del self.buf[:length]
+                if not out:
+                    self.dry = True
+                return list(out)
+
+            def setPacketTimeout(self, n: int) -> None:  # noqa: N802 - SDK's spelling
+                pass
+
+            def isPacketTimeout(self) -> bool:  # noqa: N802 - SDK's spelling
+                return self.dry
+
+        _packet, result = handler.rxPacket(Port(payload))
+        return int(result)
+
+    @pytest.mark.parametrize(
+        "label,payload",
+        [
+            ("clean", _position_reply()),
+            ("one-leading-byte", b"\x00" + _position_reply()),
+            ("two-leading-bytes", b"\x00\x00" + _position_reply()),
+            ("another-motor", _position_reply(motor_id=OTHER_ID)),
+        ],
+    )
+    def test_the_well_formed_frames_are_accepted_by_the_sdk(self, label: str, payload: bytes) -> None:
+        # Reached through importorskip rather than an import statement: the SDK
+        # ships no py.typed, so a static import would need a mypy override for a
+        # module only this file reads.
+        codes = pytest.importorskip("scservo_sdk.scservo_def")
+        assert self._verdict(payload) == codes.COMM_SUCCESS, f"{label} should be a frame the SDK accepts"
+
+    @pytest.mark.parametrize(
+        "label,payload",
+        [
+            ("bad-checksum", _position_reply(checksum=0x00)),
+            ("truncated", _position_reply()[:-1]),
+        ],
+    )
+    def test_the_malformed_frames_are_refused_by_the_sdk(self, label: str, payload: bytes) -> None:
+        codes = pytest.importorskip("scservo_sdk.scservo_def")
+        assert self._verdict(payload) == codes.COMM_RX_CORRUPT, f"{label} should be a frame the SDK refuses"
+
+    def test_the_sdk_recovers_the_position_from_a_shifted_frame(self) -> None:
+        """The SDK reads 1024 from a frame behind a leading byte.
+
+        This is what makes recovery - rather than refusal - the right answer for
+        leading noise: the vendor implementation gets the true position from
+        exactly these bytes.
+        """
+        handler = pytest.importorskip("scservo_sdk.protocol_packet_handler").protocol_packet_handler()
+
+        class Port:
+            def __init__(self, data: bytes) -> None:
+                self.buf = bytearray(data)
+                self.dry = False
+
+            def readPort(self, length: int) -> list[int]:  # noqa: N802 - SDK's spelling
+                out = self.buf[:length]
+                del self.buf[:length]
+                if not out:
+                    self.dry = True
+                return list(out)
+
+            def setPacketTimeout(self, n: int) -> None:  # noqa: N802 - SDK's spelling
+                pass
+
+            def isPacketTimeout(self) -> bool:  # noqa: N802 - SDK's spelling
+                return self.dry
+
+        packet, _result = handler.rxPacket(Port(b"\x00" + _position_reply()))
+        assert packet[5] | (packet[6] << 8) == TRUE_COUNTS
+
+
+# --------------------------------------------------------------------------- #
+# Regression: a reply behind leading bytes is still the reading
+# --------------------------------------------------------------------------- #
+class TestAReplyBehindLeadingBytesIsStillTheReading:
+    """Leading bytes offset a reply; they do not make it a different position."""
+
+    @pytest.mark.parametrize("leading", [0, 1, 2, 3, 7])
+    def test_the_true_position_is_reported_however_far_the_frame_is_offset(self, bus, leading: int) -> None:
+        controller, fake = bus
+        fake.queue_read(bytes(leading) + _position_reply())
+        assert controller.read_motor_position(MOTOR) == pytest.approx(TRUE_DEGREES)
+
+    def test_the_parse_returns_the_parameter_bytes(self) -> None:
+        assert _parse_status_packet(b"\x00" + _position_reply(), MOTOR_ID, 2) == (0x00, 0x04)
+
+    def test_a_coincidental_header_does_not_end_the_search(self) -> None:
+        """A frame that fails verification is skipped, not treated as the answer.
+
+        The corrupt frame in front carries a real header, so a parse that stopped
+        at the first header it found would report no reading at all while the
+        motor's answer sat in the same buffer.
+        """
+        raw = _position_reply(checksum=0x00) + _position_reply()
+        assert _parse_status_packet(raw, MOTOR_ID, 2) == (0x00, 0x04)
+
+    def test_another_motors_reply_does_not_hide_this_motors(self, bus) -> None:
+        controller, fake = bus
+        fake.queue_read(_position_reply(motor_id=OTHER_ID) + _position_reply())
+        assert controller.read_motor_position(MOTOR) == pytest.approx(TRUE_DEGREES)
+
+
+# --------------------------------------------------------------------------- #
+# Regression: an unverified reply is not a reading
+# --------------------------------------------------------------------------- #
+class TestAnUnverifiedReplyIsNotAReading:
+    """A reply that cannot be verified reports nothing rather than a number."""
+
+    @pytest.mark.parametrize(
+        "label,payload",
+        [
+            ("another-motor", _position_reply(motor_id=OTHER_ID)),
+            ("broadcast-id", _position_reply(motor_id=0xFE)),
+            ("bad-checksum", _position_reply(checksum=0x00)),
+            ("truncated-by-one", _position_reply()[:-1]),
+            ("header-only", b"\xff\xff"),
+            ("error-byte-not-an-error-byte", _position_reply(error=0x80)),
+            ("wrong-parameter-count", _status(MOTOR_ID, [0x00])),
+            ("no-bytes", b""),
+        ],
+    )
+    def test_the_read_reports_no_position(self, bus, label: str, payload: bytes) -> None:
+        controller, fake = bus
+        fake.queue_read(payload)
+        assert controller.read_motor_position(MOTOR) is None, f"{label} must not read as a position"
+
+    @pytest.mark.parametrize(
+        "label,payload",
+        [
+            ("another-motor", _position_reply(motor_id=OTHER_ID)),
+            ("bad-checksum", _position_reply(checksum=0x00)),
+            ("truncated-by-one", _position_reply()[:-1]),
+        ],
+    )
+    def test_the_discarded_bytes_are_reported(self, bus, caplog, label: str, payload: bytes) -> None:
+        """The bytes that were thrown away are named, so a bus fault is diagnosable."""
+        controller, fake = bus
+        fake.queue_read(payload)
+        with caplog.at_level("WARNING", logger=pose_mod.__name__):
+            assert controller.read_motor_position(MOTOR) is None
+        assert any(MOTOR in record.getMessage() for record in caplog.records), label
+
+
+class TestTheParseRefusesAFrameThatIsNotTheAnswerToThisRead:
+    """Each verification carries a case the others cannot catch.
+
+    Every frame here is well formed enough to pass the checks around the one
+    under test, so a check that were removed would not simply be covered by a
+    neighbour. The read itself would answer ``None`` for some of these anyway --
+    by raising inside the broad handler rather than by refusing -- so they are
+    graded on the parse, where the difference is visible.
+    """
+
+    def test_a_truncated_reply_is_refused_even_when_its_checksum_happens_to_agree(self) -> None:
+        """Length is checked, not inferred from a checksum that might still add up.
+
+        A frame reporting 64000 counts is ``FF FF 01 04 00 00 FA 00``. Drop the
+        checksum byte and the byte now at the end, 0xFA, is exactly the checksum
+        of everything before it -- so verifying the sum alone accepts a frame one
+        byte short and reads a single parameter as though it were two.
+        """
+        frame = _position_reply(counts=64000)
+        truncated = frame[:-1]
+        assert (~sum(truncated[2:-1])) & 0xFF == truncated[-1], "the coincidence this case rests on"
+        assert _parse_status_packet(truncated, MOTOR_ID, 2) is None
+
+    def test_a_reply_carrying_the_wrong_number_of_parameters_is_not_this_read(self) -> None:
+        """A well-formed one-byte reply is a different read's answer, not ours."""
+        frame = _status(MOTOR_ID, [0x00])
+        assert (~sum(frame[2:-1])) & 0xFF == frame[-1], "well formed - just not two parameters"
+        assert _parse_status_packet(frame, MOTOR_ID, 2) is None
+
+    def test_the_broadcast_address_never_answers_even_when_asked(self) -> None:
+        """0xFE addresses every motor at once, so no reply can come from it.
+
+        The vendor SDK refuses the same thing one layer up: ``readTxRx`` returns
+        ``COMM_NOT_AVAILABLE`` without reading when asked for an ID at or above
+        the broadcast address.
+        """
+        assert _parse_status_packet(_position_reply(motor_id=0xFE), 0xFE, 2) is None
+
+
+# --------------------------------------------------------------------------- #
+# Controls: what a verified reply must keep doing
+# --------------------------------------------------------------------------- #
+class TestAVerifiedReplyStillReads:
+    """Every expectation here also held before the frame was verified."""
+
+    def test_a_clean_reply_decodes_to_its_angle(self, bus) -> None:
+        controller, fake = bus
+        fake.queue_read(_position_reply())
+        assert controller.read_motor_position(MOTOR) == pytest.approx(TRUE_DEGREES)
+
+    @pytest.mark.parametrize("counts,degrees", [(0, -180.0), (2048, 0.043956043956), (4095, 180.0)])
+    def test_the_whole_register_range_reads(self, bus, counts: int, degrees: float) -> None:
+        controller, fake = bus
+        fake.queue_read(_position_reply(counts=counts))
+        assert controller.read_motor_position(MOTOR) == pytest.approx(degrees)
+
+    def test_a_closed_bus_still_reports_nothing(self) -> None:
+        assert MotorController("/dev/ttyTEST").read_motor_position(MOTOR) is None
+
+    def test_the_read_still_asks_for_present_position(self, bus) -> None:
+        """The request is unchanged: INST_READ of register 0x38, two bytes."""
+        controller, fake = bus
+        fake.queue_read(_position_reply())
+        controller.read_motor_position(MOTOR)
+        request = fake.writes[-1]
+        # FF FF | id | LEN=4 | INST_READ=0x02 | Present_Position=0x38 | 2 bytes
+        assert request[:7] == bytes([0xFF, 0xFF, MOTOR_ID, 0x04, 0x02, 0x38, 0x02])
+        assert request[7] == (~sum(request[2:7])) & 0xFF
+
+    def test_reading_every_motor_reads_each_one(self, bus) -> None:
+        controller, fake = bus
+        for name, config in controller.motor_configs.items():
+            fake.queue_read(_position_reply(motor_id=config["id"]))
+            assert name  # every configured motor is answered by its own ID
+        assert len(controller.read_all_positions()) == len(controller.motor_configs)
+
+
+# --------------------------------------------------------------------------- #
+# Over-reach: verification must not refuse a frame the format allows
+# --------------------------------------------------------------------------- #
+class TestVerificationRefusesNothingTheFormatAllows:
+    """A stricter parse must not turn working reads into failures."""
+
+    def test_a_payload_that_looks_like_a_header_still_reads(self, bus) -> None:
+        """Position 0xFFFF puts the header bytes inside the parameters.
+
+        The frame is well formed, so it reads. Bounding the *value* to the
+        register's 12-bit range is a separate question from framing, and this
+        pins that the parse does not quietly answer it.
+        """
+        controller, fake = bus
+        fake.queue_read(_position_reply(counts=0xFFFF))
+        assert controller.read_motor_position(MOTOR) is not None
+
+    @pytest.mark.parametrize("error", [0x00, 0x01, 0x04, 0x20, 0x7F])
+    def test_a_servo_reporting_a_fault_still_reports_its_position(self, bus, error: int) -> None:
+        """An error byte within range is a valid frame, as the SDK also holds.
+
+        Acting on the fault bits - refusing to move an overheating servo - is a
+        capability this parse deliberately does not decide; it would change what
+        a caller is told about a healthy reading.
+        """
+        controller, fake = bus
+        fake.queue_read(_position_reply(error=error))
+        assert controller.read_motor_position(MOTOR) == pytest.approx(TRUE_DEGREES)
+
+
+# --------------------------------------------------------------------------- #
+# The consequences a caller sees
+# --------------------------------------------------------------------------- #
+class TestTheToolReportsAnErrorRatherThanAWrongNumber:
+    """``pose_tool`` must not quote an unverified reply as a measurement."""
+
+    @pytest.mark.parametrize("action", ["read_position", "read_all"])
+    def test_an_unverifiable_reply_is_an_error_envelope(self, monkeypatch, action: str) -> None:
+        made: list[Any] = []
+
+        class Fake:
+            def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+                self.is_open = True
+                made.append(self)
+
+            def write(self, data: bytes) -> None:
+                pass
+
+            def read(self, n: int = 1) -> bytes:
+                return _position_reply(checksum=0x00)
+
+            def close(self) -> None:
+                self.is_open = False
+
+        monkeypatch.setattr(serial, "Serial", Fake)
+        result = pose_tool(action=action, port="/dev/ttyTEST", motor_name=MOTOR)
+        assert result["status"] == "error"
+        assert made, "the tool opened the bus"
+
+    def test_a_shifted_reply_is_reported_as_the_true_angle(self, monkeypatch) -> None:
+        class Fake:
+            def __init__(self, port: str, baudrate: int, timeout: float = 1.0) -> None:
+                self.is_open = True
+
+            def write(self, data: bytes) -> None:
+                pass
+
+            def read(self, n: int = 1) -> bytes:
+                return b"\x00" + _position_reply()
+
+            def close(self) -> None:
+                self.is_open = False
+
+        monkeypatch.setattr(serial, "Serial", Fake)
+        result = pose_tool(action="read_position", port="/dev/ttyTEST", motor_name=MOTOR)
+        assert result["status"] == "success"
+        assert result["content"][1]["json"]["position"] == pytest.approx(TRUE_DEGREES)
+
+
+class TestAnInterpolatedMoveStartsFromTheVerifiedPosition:
+    """A trajectory is built from where the arm is, not from a shifted read.
+
+    ``_smooth_move`` reads the current position and divides the travel to the
+    target into increments. A reply read at the wrong offset reports 0 counts for
+    a joint at 1024, so the first packet of a *smooth* move commands the joint
+    ninety degrees away from its target instead of toward it.
+    """
+
+    def test_the_first_commanded_step_is_the_arms_own_position(self, bus) -> None:
+        controller, fake = bus
+        fake.serve(b"\x00" + _position_reply(), 64)
+        controller._smooth_move({MOTOR: 180.0}, steps=4, step_delay=0.0)
+        assert _goal_positions(fake.writes)[0] == TRUE_COUNTS
+
+    def test_the_trajectory_matches_the_one_a_clean_bus_produces(self, bus) -> None:
+        """Leading noise changes nothing about the path the arm is given."""
+        controller, fake = bus
+
+        fake.serve(_position_reply(), 64)
+        controller._smooth_move({MOTOR: 180.0}, steps=4, step_delay=0.0)
+        clean = _goal_positions(fake.writes)
+        assert clean, "the clean bus produced a trajectory to compare against"
+
+        fake.writes.clear()
+        fake.serve(b"\x00\x00" + _position_reply(), 64)
+        controller._smooth_move({MOTOR: 180.0}, steps=4, step_delay=0.0)
+        assert _goal_positions(fake.writes) == clean
+
+    def test_an_incremental_move_refuses_an_unverifiable_current_position(self, bus) -> None:
+        controller, fake = bus
+        fake.queue_read(_position_reply(checksum=0x00))
+        assert controller.incremental_move(MOTOR, 5.0) is False

--- a/tests/tools/test_pose_tool.py
+++ b/tests/tools/test_pose_tool.py
@@ -192,11 +192,17 @@ def test_move_motor_without_connection_returns_false() -> None:
     assert ctrl.read_motor_position("shoulder_pan") is None
 
 
-def test_read_motor_position_decodes_response(fake_serial) -> None:
+def test_read_motor_position_decodes_a_well_formed_reply(fake_serial) -> None:
+    """A verified status packet decodes to the angle its counts name.
+
+    The frame is ``FF FF ID LEN ERR <lo> <hi> CHK`` with the checksum a servo
+    would send. The bytes are not read at fixed offsets -- what happens to a
+    reply that arrives behind echoed bytes, from another motor, or with a broken
+    checksum is graded in ``test_feetech_status_packet_framing``.
+    """
     ctrl = MotorController("/dev/ttyTEST")
     ctrl.connect()
-    # 7-byte response with position low/high at indices 5 and 6.
-    fake_serial[0].queue_read(bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, 0x00, 0x08]))
+    fake_serial[0].queue_read(bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, 0x00, 0x08, 0xF2]))
     deg = ctrl.read_motor_position("shoulder_pan")
     assert deg is not None
     # position 0x0800 == 2048 -> roughly mid-range for a -180..180 joint.
@@ -318,21 +324,31 @@ def test_module_source_is_ascii() -> None:
 # --------------------------------------------------------------------------- #
 # pose_tool: live-motor read/write actions (serial mocked)                     #
 # --------------------------------------------------------------------------- #
-def _position_packet(raw: int = 0x0800) -> bytes:
-    """A Feetech read response encoding ``raw`` (low|high<<8) at bytes 5/6."""
-    return bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
+def _position_packet(raw: int = 0x0800, motor_id: int = 0x01) -> bytes:
+    """A Feetech status packet reporting ``raw`` counts for ``motor_id``.
+
+    ``FF FF ID LEN ERR <lo> <hi> CHK``, carrying the checksum a servo would send
+    so the frame passes the verification ``read_motor_position`` performs. What
+    happens to a frame that fails that verification is graded in
+    ``test_feetech_status_packet_framing``.
+    """
+    body = [motor_id, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF]
+    return bytes([0xFF, 0xFF, *body, (~sum(body)) & 0xFF])
 
 
 class AlwaysReadingSerial(FakeSerial):
-    """A FakeSerial that always answers reads with a valid position packet.
+    """A FakeSerial that answers each read as the motor that read addressed.
 
     The real controller is constructed *inside* the tool dispatch, so tests
-    cannot pre-seed its read queue. This stand-in always returns a decodable
-    position so the read/store success-formatting branches are exercised.
+    cannot pre-seed its read queue. This stand-in replies with the ID the
+    outgoing packet asked for, which is what a servo bus does: a fake that
+    always answered as motor 1 would let one motor's position be reported as
+    another's with no test able to see it.
     """
 
     def read(self, n: int = 1) -> bytes:
-        return _position_packet()
+        asked = self.writes[-1][2] if self.writes else 0x01
+        return _position_packet(motor_id=asked)
 
 
 @pytest.fixture

--- a/tests/tools/test_pose_tool_interpolation_options.py
+++ b/tests/tools/test_pose_tool_interpolation_options.py
@@ -82,9 +82,15 @@ def _texts(result: dict[str, Any]) -> str:
     return "\n".join(item.get("text", "") for item in result.get("content", []))
 
 
-def _position_packet(raw: int = 0x0800) -> bytes:
-    """A Feetech read response encoding ``raw`` at bytes 5/6."""
-    return bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
+def _position_packet(raw: int = 0x0800, motor_id: int = 0x01) -> bytes:
+    """A Feetech status packet reporting ``raw`` counts for ``motor_id``.
+
+    ``FF FF ID LEN ERR <lo> <hi> CHK``, with the checksum a servo would send so
+    the frame passes the verification ``read_motor_position`` performs. Framing
+    itself is graded in ``test_feetech_status_packet_framing``.
+    """
+    body = [motor_id, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF]
+    return bytes([0xFF, 0xFF, *body, (~sum(body)) & 0xFF])
 
 
 class _ReadingSerial(FakeSerial):
@@ -96,7 +102,11 @@ class _ReadingSerial(FakeSerial):
     """
 
     def read(self, n: int = 1) -> bytes:
-        return _position_packet()
+        # Answer as the motor the outgoing packet addressed; a servo bus does,
+        # and a fake that always answered as motor 1 would let a read attribute
+        # one motor's position to another with no test able to see it.
+        asked = self.writes[-1][2] if self.writes else 0x01
+        return _position_packet(motor_id=asked)
 
 
 @pytest.fixture

--- a/tests/tools/test_pose_tool_target_domain.py
+++ b/tests/tools/test_pose_tool_target_domain.py
@@ -370,9 +370,15 @@ class TestNeighbouringTargetProducersStayOutOfScope:
         )
 
 
-def _position_packet(raw: int) -> bytes:
-    """A Feetech read response encoding ``raw`` at bytes 5/6."""
-    return bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
+def _position_packet(raw: int, motor_id: int = 0x01) -> bytes:
+    """A Feetech status packet reporting ``raw`` counts for ``motor_id``.
+
+    ``FF FF ID LEN ERR <lo> <hi> CHK``, with the checksum a servo would send so
+    the frame passes the verification ``read_motor_position`` performs. Framing
+    itself is graded in ``test_feetech_status_packet_framing``.
+    """
+    body = [motor_id, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF]
+    return bytes([0xFF, 0xFF, *body, (~sum(body)) & 0xFF])
 
 
 # A joint parked near the upper end of its travel, and a displacement inside the
@@ -394,7 +400,11 @@ class _ReadingSerial(FakeSerial):
     """
 
     def read(self, n: int = 1) -> bytes:
-        return _position_packet(_NEAR_UPPER_RAW)
+        # Answer as the motor the outgoing packet addressed; a servo bus does,
+        # and a fake that always answered as motor 1 would let a read attribute
+        # one motor's position to another with no test able to see it.
+        asked = self.writes[-1][2] if self.writes else 0x01
+        return _position_packet(_NEAR_UPPER_RAW, motor_id=asked)
 
 
 @pytest.fixture


### PR DESCRIPTION
## The reply was read at fixed offsets

`pose_tool`'s `read_motor_position` wrote an `INST_READ` for `Present_Position`, then did this with whatever came back:

```python
response = self.serial_conn.read(10)
if len(response) >= 7:
    position = response[5] | (response[6] << 8)
```

A Feetech status packet is `FF FF ID LEN ERR <params> CHK`. Indices 5 and 6 are the position bytes only if the frame begins at offset 0, is intact, and came from the motor that was asked. The bus guarantees none of those: it is half-duplex and shared by all six servos, so a reply can arrive behind a byte the host's own transmission echoed, or be the late answer to a read that already timed out, sent by a different motor.

Measured through the public `read_motor_position("shoulder_pan")` with the joint really at 1024 counts (-89.98 deg), against `scservo_sdk` -- the vendor SDK that owns this wire format, which the `[lerobot]` extra already installs -- on the identical bytes:

| bytes returned by the bus | before | after | `scservo_sdk` |
|---|---|---|---|
| `ff ff 01 04 00 00 04 f6` (clean) | -89.98 | -89.98 | `COMM_SUCCESS`, param 1024 |
| `00` + clean (one echoed byte) | **-180.0** | -89.98 | `COMM_SUCCESS`, param **1024** |
| `00 00` + clean | **-179.65** | -89.98 | `COMM_SUCCESS`, param **1024** |
| `ff ff 02 04 00 00 04 f5` (motor 2 answered) | **-89.98** | `None` | reports `id=2`, not the id asked |
| clean with the checksum zeroed | **-89.98** | `None` | **`COMM_RX_CORRUPT`** |
| clean, one byte short | **-89.98** | `None` | **`COMM_RX_CORRUPT`** |
| clean with `ERR=0x04` (overheat) | -89.98 | -89.98 | `COMM_SUCCESS`, reports `err=0x04` |

Every row returned `status="success"` before. Note the second and third rows: the SDK recovers the **true** 1024 from exactly those bytes, so this is not a case where being stricter is the fix -- the offset reply carries the real position and it was simply read in the wrong place.

## It was a motion fault, not only a reporting one

`_smooth_move` reads the current position and divides the travel to the target into increments, so a misread start is a trajectory that begins somewhere the arm is not. Commanding `shoulder_pan` from 1024 counts to 4095, with one stray byte on the bus:

![commanded trajectory before and after](https://github.com/cagataycali/robots/releases/download/artifacts/feetech-status-packet-framing.png)

```
before   [   0,  511, 1023, 1535, 2047, 2559, 3071, 3583, 4095]
after    [1024, 1407, 1791, 2175, 2559, 2943, 3327, 3711, 4095]   == the clean-bus trajectory, exactly
```

The first packet of a *smooth* move commanded the joint 1024 counts (90.0 degrees) away from its target instead of toward it. `incremental_move` added its delta to the same fiction; `store_pose` would have persisted it.

## Why nothing caught it

Three test fixtures, in three files, built the reply like this:

```python
bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, raw & 0xFF, (raw >> 8) & 0xFF, 0, 0, 0])
```

`0` sits where the checksum belongs, the ID is hardcoded to 1 for every motor, and two trailing zeros pad it out -- a frame no servo sends and one `scservo_sdk` calls `COMM_RX_CORRUPT`. A double that cannot express a corrupt or misattributed reply makes those cases untestable by construction, and the shipped test's own comment recorded the shape it was pinning: *"7-byte response with position low/high at indices 5 and 6."*

All three now carry a real checksum and answer as the motor the outgoing packet addressed. The correct formula was already in the suite -- `test_pose_tool_emergency_stop.py` computes `~sum(body) & 0xFF` when it checks *write* packets -- only the read fixtures were wrong.

## The change

`_parse_status_packet(raw, motor_id, param_count)` locates and verifies the frame, mirroring the SDK: search for the `FF FF` header rather than assuming offset 0, re-derive the frame length from `LEN`, recompute the checksum over the same span the outgoing packet signs, and require the responding ID to be the one asked. Every candidate header is tried, so a frame behind noise is found and a payload byte pair that merely looks like a header does not end the search.

A frame that cannot be verified reports `None` -- the existing "could not read" signal, so no caller contract changes: `read_position` answers with an error envelope instead of a number, and the interpolating paths decline to build a trajectory. The discarded bytes are logged so a bus fault stays diagnosable.

`read(10)` is deliberately unchanged: the slack beyond the 8-byte frame is what absorbs the leading bytes the parse now skips.

## Deliberately not decided here

- **Acting on the error byte.** A value inside the byte's range is a valid frame, as the SDK also holds, so a servo reporting overheat still reports its position. Refusing to drive a faulted servo changes what a caller is told about a healthy reading and wants its own change; `TestVerificationRefusesNothingTheFormatAllows` pins that this parse does not quietly decide it.
- **Bounding the value.** `Present_Position` is 12-bit, but a well-formed frame carrying 0xFFFF is still a well-formed frame. Framing and value domain are separate questions and the suite pins that this answers only the first.

## Tests

`tests/tools/test_feetech_status_packet_framing.py`, 48 cases. Reverting only the source (keeping the helper, restoring the positional read) gives **19 failed / 48**, with **0** of the 4 oracle-premise cells, **0** of the 5 controls, **0** of the 2 over-reach cells and **0** of the 3 parse-contract cells -- those last are pinned by the mutation table instead, since the helper still exists under that revert. A raw revert is a collection error, the file importing `_parse_status_packet`.

The premise class grades this file's own fixtures against `scservo_sdk` before anything else asserts on them, so the well-formed frames are known-good and the malformed ones known-bad rather than agreeing with a parser written alongside them. It is `importorskip`-gated; every other cell needs no dependency and no hardware.

12 mutations, 12 distinct failing-ID sets, none undetected, control clean, source restored byte-identical:

| mutation | fires |
|---|---|
| the whole verification dropped (pre-fix read) | 18 |
| header search dropped, parse at offset 0 only | 9 |
| checksum verification dropped | 5 |
| responding-ID check dropped | 2 |
| truncation check dropped | 1 |
| parameter-count check dropped | 1 |
| error-byte sanity dropped | 1 |
| broadcast/header IDs accepted as responders | 1 |
| search stops at the first candidate header | 1 |
| checksum summed over the whole frame | 35 |
| frame length off by one | 36 |
| the error byte returned as a parameter | 20 |

Three of those first fired 0 and each was a gap in the tests, not a redundant check. The sharpest is the truncation one: a reply reporting 64000 counts is `ff ff 01 04 00 00 fa 00`, and dropping its checksum byte leaves `fa` at the end -- which is exactly the checksum of everything before it. So a parse that verified the sum alone would accept a frame one byte short and read one parameter as two. The length must be checked, not inferred.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1562 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine `main` worktree, normalized message sets byte-identical in both directions, 0 attributable to the changed files.
- Paired pytest, identical 364-file selection (all of `tests/tools/` plus every guard that walks the tree, reads docstrings or reads source), the 4 changed test files excluded from both sides: **17 failed, 18050 passed, 68 skipped** on the branch against **17 failed, 18048 passed, 68 skipped** on base -- 17 identical failing IDs, both `comm` directions empty. All 17 need `awsiot` (`awsiotsdk`, declared in the `[mesh-iot]` extra and absent here; confirmed with `tomllib` + `find_spec`). The `+2` localizes entirely to `tests/test_args_docstring_completeness.py` (452 -> 454), which parametrizes over documented functions and picks up `read_motor_position`'s new `Args:`/`Returns:` blocks.
- `tests/tools/` whole: 3024 passed, 9 skipped.
