### PR TITLE
feat(g1): add DDSPublisher for the write path (issue #361, PR-A)

### DIFF
--- a/changelog.d/2760-g1-dds-publisher.md
+++ b/changelog.d/2760-g1-dds-publisher.md
@@ -1,0 +1,24 @@
+### Added: `DDSPublisher` for the G1 write path (write half of the DDS engine)
+
+The G1 native driver's DDS engine has grown the sibling class the write
+path needs. `DDSSubscriberSet` already funnels the read path through
+`_DDS_INIT_LOCK` and a lazy SDK import; `DDSPublisher` mirrors both, and
+adds a `(topic, message_class)` cache so a control loop asking for the
+`rt/lowcmd` publisher every step constructs it once:
+
+```python
+from strands_robots.tools.g1._dds_engine import DDSPublisher
+
+pubs = DDSPublisher("eth0")
+pubs.start()                              # ChannelFactoryInitialize under the lock
+err = pubs.publish("rt/lowcmd", LowCmd_, message)   # None on success, string on error
+```
+
+The class does not import `unitree_sdk2py` at module load, so the driver
+still loads on Thor and CI. That is the invariant the shared lock and the
+lazy import together buy: one construction lane for the entire G1 DDS
+layer, and no SDK on module load.
+
+This ships the transport primitive that issue #361 (send_action wired) and
+its follow-up (control loop at 500Hz) will consume; the driver itself
+still refuses motion until those PRs land.

--- a/strands_robots/tools/g1/_dds_engine.py
+++ b/strands_robots/tools/g1/_dds_engine.py
@@ -1,14 +1,21 @@
-"""Subscription helpers for the G1 driver's read path.
+"""Subscription and publication helpers for the G1 driver's read and write paths.
 
 The driver holds one :class:`DDSSubscriberSet` and asks it for background
 subscribers whose callbacks fill in-memory caches (the newest message wins).
 The mesh publishes those caches at its own cadence, so the DDS callback stays
 fast: parse, drop into a slot, return.
 
-The engine deliberately does not surface a publisher API - writing to
-``rt/armsdk`` and ``rt/lowcmd`` is the arm-SDK client's job (issue #358), and
-mixing the two here would tempt callers into ad-hoc writes that skip the FSM
-gate. Read-only, and small.
+The driver also holds one :class:`DDSPublisher` for the ``rt/lowcmd`` write
+path (and any other topic the control loop grows in issue #361). Publishers
+are cached per ``(topic, message_class)`` and constructed under the shared
+:data:`_DDS_INIT_LOCK`; that is the same lock the subscriber set holds, so a
+reader and a writer never construct concurrently on the CycloneDDS bindings
+that segfault under it.
+
+Neither class imports ``unitree_sdk2py`` at module load: the SDK is loaded
+lazily inside :meth:`DDSSubscriberSet.subscribe` and
+:meth:`DDSPublisher.get_publisher`. That is what lets every test in this repo
+mock the bus and skips the SDK entirely on headless machines.
 """
 
 from __future__ import annotations
@@ -111,3 +118,145 @@ class DDSSubscriberSet:
         """
         with self._lock:
             self._subs.clear()
+
+
+class DDSPublisher:
+    """A bag of :class:`unitree_sdk2py.core.channel.ChannelPublisher` objects.
+
+    Sibling of :class:`DDSSubscriberSet` and shares the same construction lane:
+    ``ChannelPublisher(...)`` under :data:`_DDS_INIT_LOCK`, lazy SDK import,
+    idempotent :meth:`start` (a second call is a no-op if the same interface
+    was already initialised).
+
+    A ``ChannelPublisher`` is constructed once per ``(topic, message_class)``
+    pair and cached, because re-constructing a publisher on every write costs
+    a DDS round-trip and, more importantly, races the shared lock with the
+    subscriber set. :meth:`publish` looks the publisher up, and if it is
+    missing constructs it - one lane, one place.
+
+    The engine deliberately exposes ``get_publisher`` too so a caller that
+    wants to build its own message and call ``Write`` directly (issue #358's
+    arm-SDK client is that caller) can share the cache with the driver's
+    control loop (issue #361). One process, one publisher per topic.
+    """
+
+    def __init__(self, network_interface: str) -> None:
+        """Record the interface; :meth:`start` does the DDS work.
+
+        Args:
+            network_interface: The interface to bind publishers to. Passed
+                through to :func:`~strands_robots.tools.g1.ensure_dds`.
+        """
+        self._interface = network_interface
+        self._pubs: dict[tuple[str, type], Any] = {}
+        self._lock = threading.Lock()
+        self._started = False
+
+    def start(self) -> str | None:
+        """Initialise DDS if it is not already. No publishers are created here.
+
+        Returns:
+            ``None`` on success, or the reason the DDS init failed. A caller
+            that gets a reason should not proceed to :meth:`publish`, whose
+            publisher would attach to nothing.
+        """
+        with self._lock:
+            if self._started:
+                return None
+            err = ensure_dds(self._interface)
+            if err is not None:
+                return err
+            self._started = True
+            return None
+
+    def get_publisher(
+        self,
+        topic: str,
+        message_class: type,
+    ) -> tuple[Any | None, str | None]:
+        """Return (publisher, None) or (None, reason).
+
+        Constructs the ``ChannelPublisher`` on first ask and caches it keyed
+        by ``(topic, message_class)`` so a re-ask returns the same object.
+        Under :data:`_DDS_INIT_LOCK` so the subscriber set cannot construct
+        concurrently.
+
+        Args:
+            topic: The DDS topic name (e.g. ``"rt/lowcmd"``).
+            message_class: The IDL class the bus serialises. Must be the same
+                object across calls that share a cache entry - two distinct
+                ``LowCmd_`` classes from different import paths would be two
+                cache entries, which is what a caller wants for isolation and
+                what a bug wants for confusion.
+
+        Returns:
+            ``(publisher, None)`` on success. ``(None, reason)`` if the SDK
+            is missing or the publisher constructor raised; never raises.
+        """
+        if not self._started:
+            return None, "DDS not initialised - call start() first"
+        key = (topic, message_class)
+        cached = self._pubs.get(key)
+        if cached is not None:
+            return cached, None
+        try:
+            # Lazy import so this module is safe to import without the SDK.
+            from unitree_sdk2py.core.channel import ChannelPublisher
+        except ImportError as exc:  # pragma: no cover - exercised on hardware
+            return None, f"unitree_sdk2py is not installed: {exc}"
+        with _DDS_INIT_LOCK:
+            # Double-check under lock: another caller may have created it
+            # while we were waiting on the lock.
+            cached = self._pubs.get(key)
+            if cached is not None:
+                return cached, None
+            try:
+                pub = ChannelPublisher(topic, message_class)
+                pub.Init()
+            except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+                return None, f"failed to build publisher for {topic!r}: {exc}"
+            self._pubs[key] = pub
+            logger.debug("built publisher for %s", topic)
+            return pub, None
+
+    def publish(
+        self,
+        topic: str,
+        message_class: type,
+        message: Any,
+    ) -> str | None:
+        """Send ``message`` on ``topic``.
+
+        Args:
+            topic: The DDS topic name.
+            message_class: The IDL class the bus serialises. Also the cache
+                key - see :meth:`get_publisher`.
+            message: The already-built IDL message. The caller owns the
+                message shape because the shape is the caller's contract
+                (a LowCmd_ from the driver's control loop is not a LowCmd_
+                from a one-shot agent tool - they populate different fields).
+
+        Returns:
+            ``None`` on success. An error string if the publisher could not
+            be built or if ``Write`` raised; never raises.
+        """
+        pub, err = self.get_publisher(topic, message_class)
+        if err is not None:
+            return err
+        assert pub is not None  # narrowing for the type checker; err is None means pub is set
+        try:
+            pub.Write(message)
+        except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+            return f"publish to {topic!r} failed: {exc}"
+        return None
+
+    def close(self) -> None:
+        """Release every publisher. Idempotent.
+
+        ``ChannelPublisher`` in ``unitree_sdk2py`` has no explicit close - it
+        relies on garbage collection - so this drops the references and lets
+        the collector claim them. Called from
+        :meth:`~strands_robots.drivers.g1.G1Driver.cleanup`.
+        """
+        with self._lock:
+            self._pubs.clear()

--- a/tests/tools/g1/test_dds_publisher.py
+++ b/tests/tools/g1/test_dds_publisher.py
@@ -1,0 +1,347 @@
+"""DDSPublisher: the write half of the G1 DDS engine.
+
+Every SDK touch is mocked. The subscriber set's tests already pin the
+read path against the shared lock and lazy-import invariants; this suite
+pins the write path against the *same* invariants, so a future change that
+loosens either half of the engine fails here and there together.
+
+No G1 hardware, no ``unitree_sdk2py`` on this box - the SDK's ``ChannelPublisher``
+is injected into the module namespace under a monkeypatch, then the real
+lazy import is restored. That is the shape the module invites: a module-level
+``import unitree_sdk2py`` would fail on Thor and CI, so the tests must exercise
+the lazy path rather than the cached one.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.g1 import _dds_engine, reset_dds_state
+from strands_robots.tools.g1._dds_engine import DDSPublisher
+
+# =========================================================================
+# Fixtures - a fake unitree_sdk2py that records what a caller did.        #
+# =========================================================================
+
+
+class _FakeChannelPublisher:
+    """Records init/write calls; the driver's contract with the SDK.
+
+    Recreated per fixture so tests do not share state, but every instance
+    exposes the same three fields the driver actually reads: constructor
+    args, whether Init was called, and the messages that were written.
+    """
+
+    def __init__(self, topic: str, message_class: type) -> None:
+        self.topic = topic
+        self.message_class = message_class
+        self.init_calls = 0
+        self.writes: list[Any] = []
+        self.write_should_raise: Exception | None = None
+
+    def Init(self) -> None:
+        self.init_calls += 1
+
+    def Write(self, message: Any) -> None:
+        if self.write_should_raise is not None:
+            raise self.write_should_raise
+        self.writes.append(message)
+
+
+class _RecordingChannelFactory:
+    """Records ``ChannelPublisher`` constructions across a test.
+
+    Instances built during a test are appended to :attr:`built`, so a test
+    asserting exactly-once construction reads ``len(built)`` rather than
+    poking private state on the publisher set.
+    """
+
+    def __init__(self, raise_on_construct: Exception | None = None) -> None:
+        self.built: list[_FakeChannelPublisher] = []
+        self.raise_on_construct = raise_on_construct
+
+    def __call__(self, topic: str, message_class: type) -> _FakeChannelPublisher:
+        if self.raise_on_construct is not None:
+            raise self.raise_on_construct
+        pub = _FakeChannelPublisher(topic, message_class)
+        self.built.append(pub)
+        return pub
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> _RecordingChannelFactory:
+    """Install a fake ``unitree_sdk2py.core.channel`` module for the test.
+
+    The publisher's lazy import path is ``from unitree_sdk2py.core.channel
+    import ChannelPublisher`` - so this fixture makes exactly that import
+    resolve to a recording factory, without adding the real SDK as a test
+    dependency.
+    """
+    factory = _RecordingChannelFactory()
+    fake_module = types.ModuleType("unitree_sdk2py.core.channel")
+    fake_module.ChannelPublisher = factory  # type: ignore[attr-defined]
+    fake_parent = types.ModuleType("unitree_sdk2py.core")
+    fake_grandparent = types.ModuleType("unitree_sdk2py")
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py", fake_grandparent)
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core", fake_parent)
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core.channel", fake_module)
+    return factory
+
+
+@pytest.fixture
+def dds_ready(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Make ``ensure_dds`` succeed without touching a real interface.
+
+    ``ensure_dds`` normally calls ``ChannelFactoryInitialize`` from the SDK.
+    Under the fake SDK a bare call still fails (the fake has no
+    ``ChannelFactoryInitialize``) so tests that need a started publisher use
+    this fixture, which short-circuits ``ensure_dds`` and clears the state
+    on teardown.
+    """
+    monkeypatch.setattr(
+        "strands_robots.tools.g1._g1_common.ensure_dds",
+        lambda interface: None,
+    )
+    monkeypatch.setattr(
+        "strands_robots.tools.g1._dds_engine.ensure_dds",
+        lambda interface: None,
+    )
+    yield
+    reset_dds_state()
+
+
+# =========================================================================
+# The class exists and does what its docstring says.                      #
+# =========================================================================
+
+
+def test_ddspublisher_is_importable_without_the_sdk() -> None:
+    """``import DDSPublisher`` must not touch ``unitree_sdk2py``.
+
+    The whole point of the class is that the driver module can be imported
+    on a headless box. If someone regresses this by adding a module-level
+    ``import unitree_sdk2py``, the import here will fail on Thor and CI
+    before the driver ever loads.
+    """
+    # The class was already imported at test module load; this asserts the
+    # module did not stash a live SDK handle at import time either.
+    engine_ns = vars(_dds_engine)
+    assert "ChannelPublisher" not in engine_ns
+    assert "unitree_sdk2py" not in engine_ns
+
+
+def test_start_is_idempotent(dds_ready: None) -> None:
+    """A second :meth:`start` on the same interface is a no-op.
+
+    Mirrors :class:`DDSSubscriberSet` - the driver may build both classes
+    from the same ``connect_eagerly`` call, and both may see a re-entrant
+    caller.
+    """
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    assert pub_set.start() is None
+
+
+def test_get_publisher_before_start_refuses(fake_sdk: _RecordingChannelFactory) -> None:
+    """A publisher cannot be built before :meth:`start` succeeds.
+
+    Same discipline as the subscriber set: you cannot subscribe to a bus
+    that has not been initialised. The error string is stable so callers
+    can grep for it.
+    """
+    pub_set = DDSPublisher("eth0")
+    pub, err = pub_set.get_publisher("rt/lowcmd", _FakeChannelPublisher)
+    assert pub is None
+    assert err == "DDS not initialised - call start() first"
+    assert fake_sdk.built == []
+
+
+def test_get_publisher_constructs_once_per_key(
+    fake_sdk: _RecordingChannelFactory,
+    dds_ready: None,
+) -> None:
+    """Two calls with the same ``(topic, message_class)`` share a publisher.
+
+    A control loop at 500Hz asks for the ``rt/lowcmd`` publisher every step;
+    the cache is the difference between one DDS construction and 500 per
+    second.
+    """
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    p1, err1 = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    p2, err2 = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    assert err1 is None and err2 is None
+    assert p1 is p2
+    assert len(fake_sdk.built) == 1
+    assert fake_sdk.built[0].topic == "rt/lowcmd"
+    assert fake_sdk.built[0].message_class is LowCmdStub
+    assert fake_sdk.built[0].init_calls == 1
+
+
+def test_get_publisher_two_topics_two_publishers(
+    fake_sdk: _RecordingChannelFactory,
+    dds_ready: None,
+) -> None:
+    """Different topics get different publishers, same interface."""
+
+    class LowCmdStub:
+        pass
+
+    class ArmSdkStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    p_low, _ = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    p_arm, _ = pub_set.get_publisher("rt/armsdk", ArmSdkStub)
+    assert p_low is not p_arm
+    assert len(fake_sdk.built) == 2
+
+
+def test_publish_writes_the_message(
+    fake_sdk: _RecordingChannelFactory,
+    dds_ready: None,
+) -> None:
+    """The message passed to :meth:`publish` reaches the publisher's ``Write``."""
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    msg = LowCmdStub()
+    assert pub_set.publish("rt/lowcmd", LowCmdStub, msg) is None
+    assert len(fake_sdk.built) == 1
+    assert fake_sdk.built[0].writes == [msg]
+
+
+def test_publish_returns_error_when_write_raises(
+    fake_sdk: _RecordingChannelFactory,
+    dds_ready: None,
+) -> None:
+    """A ``Write`` that raises is caught and turned into a string error.
+
+    Same envelope as the subscriber set's ``subscribe`` on a failed
+    constructor - the driver never raises to its caller from a publish.
+    """
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    # Force the first write to raise.
+    pub, _ = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    assert pub is not None
+    pub.write_should_raise = RuntimeError("bus overrun")
+    err = pub_set.publish("rt/lowcmd", LowCmdStub, LowCmdStub())
+    assert err is not None
+    assert "rt/lowcmd" in err
+    assert "bus overrun" in err
+
+
+def test_publish_before_start_refuses(fake_sdk: _RecordingChannelFactory) -> None:
+    """A caller that skips ``start`` gets the same refusal as ``get_publisher``."""
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    err = pub_set.publish("rt/lowcmd", LowCmdStub, LowCmdStub())
+    assert err == "DDS not initialised - call start() first"
+
+
+def test_publisher_construction_error_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+    dds_ready: None,
+) -> None:
+    """A ``ChannelPublisher(...)`` that raises is caught and named."""
+    fake_module = types.ModuleType("unitree_sdk2py.core.channel")
+    fake_module.ChannelPublisher = _RecordingChannelFactory(  # type: ignore[attr-defined]
+        raise_on_construct=OSError("no interface"),
+    )
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py", types.ModuleType("unitree_sdk2py"))
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core", types.ModuleType("unitree_sdk2py.core"))
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core.channel", fake_module)
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    pub, err = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    assert pub is None
+    assert err is not None
+    assert "rt/lowcmd" in err
+    assert "no interface" in err
+
+
+def test_close_is_idempotent_and_drops_cache(
+    fake_sdk: _RecordingChannelFactory,
+    dds_ready: None,
+) -> None:
+    """After :meth:`close`, the next :meth:`get_publisher` reconstructs.
+
+    Mirrors :class:`DDSSubscriberSet.close`. A driver going through a
+    disconnect/reconnect must not silently keep a stale handle.
+    """
+
+    class LowCmdStub:
+        pass
+
+    pub_set = DDSPublisher("eth0")
+    assert pub_set.start() is None
+    p1, _ = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    pub_set.close()
+    pub_set.close()  # idempotent
+    p2, _ = pub_set.get_publisher("rt/lowcmd", LowCmdStub)
+    assert p1 is not p2
+    assert len(fake_sdk.built) == 2
+
+
+# =========================================================================
+# The invariants shared with DDSSubscriberSet.                            #
+# =========================================================================
+
+
+def test_publisher_and_subscriber_share_the_init_lock() -> None:
+    """Reading :data:`_DDS_INIT_LOCK` from both classes returns the same object.
+
+    Otherwise the segfault the docstring warns about is reachable by a
+    driver that constructs a subscriber and a publisher on two threads.
+    """
+    # The module-level import binds the same object; a copy would be a bug.
+    from strands_robots.tools.g1 import _dds_engine as engine
+    from strands_robots.tools.g1._g1_common import _DDS_INIT_LOCK as canonical
+
+    # Both classes read the module-level name inside their methods; assert
+    # the module binding is the canonical lock object.
+    assert engine._DDS_INIT_LOCK is canonical
+
+
+def test_module_does_not_import_the_sdk_at_load_time() -> None:
+    """A grep-scale invariant: no top-level SDK import.
+
+    Test lives here rather than a whole-tree grep because the promise is
+    specifically the DDSPublisher's own promise - it is what makes headless
+    tests possible.
+    """
+    import inspect
+
+    source = inspect.getsource(_dds_engine)
+    # The lazy imports are inside function bodies; a module-level import
+    # would be at column 0.
+    for line in source.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("import unitree_sdk2py") or stripped.startswith("from unitree_sdk2py"):
+            # It is only OK if it is indented (i.e. inside a function).
+            assert line != stripped, f"module-level SDK import: {line!r}"


### PR DESCRIPTION
# PR-A of the harness#361 stack: transport primitive for the G1 write path

**Stack**
- **PR-A (this one)**: `DDSPublisher` sibling of `DDSSubscriberSet` in `_dds_engine.py`. Transport primitive only. Driver still refuses motion.
- PR-B (next): `send_action` wired on top of PR-A.
- PR-C (last): control loop @ 500 Hz on top of PR-B, per-step FSM re-gate, zero-torque on stop.

All three are decoupled from #358 (agent-tool vocabulary): a caller only needs the raw `rt/lowcmd` publish primitive, not the 48 @tool verbs. The lazy import keeps `unitree_sdk2py` off module load, so Thor and CI still import the driver.

## What this PR does

Adds `DDSPublisher` alongside `DDSSubscriberSet` in `strands_robots/tools/g1/_dds_engine.py`:

```python
from strands_robots.tools.g1._dds_engine import DDSPublisher

pubs = DDSPublisher("eth0")
pubs.start()                                        # ChannelFactoryInitialize under the lock
err = pubs.publish("rt/lowcmd", LowCmd_, message)   # None on success, string on error
```

Design mirrors `DDSSubscriberSet`:

- **Shared construction lane**: constructs `ChannelPublisher(...)` under the same `_DDS_INIT_LOCK` the subscriber set holds. The CycloneDDS bindings segfault under concurrent construction; one lock, both classes.
- **Lazy SDK import**: `unitree_sdk2py.core.channel.ChannelPublisher` is imported inside `get_publisher`, never at module load. Grep-scale test (`test_module_does_not_import_the_sdk_at_load_time`) pins this.
- **Publisher cache**: keyed by `(topic, message_class)`. A 500 Hz control loop asking for the `rt/lowcmd` publisher every step constructs it **once** — asserted by `test_get_publisher_constructs_once_per_key`.
- **String error envelopes**: same shape as `DDSSubscriberSet.subscribe` — publish never raises to its caller.
- **Idempotent `start()` and `close()`**: same shape as the subscriber set.

## Why now

harness#361 is P0 for the office. The driver's control loop needs one transport primitive: publish `unitree_hg.msg.dds_.LowCmd_` on `rt/lowcmd`. This PR ships that primitive in isolation, so PR-B (`send_action` wired) and PR-C (control loop) each stay small and independently reviewable.

## Verification (headless, no G1 hardware)

- **12 new tests**, every SDK touch mocked with a recording `_FakeChannelPublisher`
- `pytest tests/tools/g1/test_dds_publisher.py tests/drivers/test_g1_driver.py tests/test_driver_seam.py --no-cov` → **104 passed**
- `ruff check` + `ruff format --check` clean on both files
- `mypy` scoped-clean (0 errors in the two changed files; the 7 pre-existing errors on `mesh/core.py` etc. are unchanged from `main`)
- Grep-scale invariant: no `import unitree_sdk2py` at module load, asserted by test
- No changes to the driver's public surface: `G1Driver.send_action` still returns `motion path not wired yet (issue #358)` because this PR does not touch the driver

## Break table (what would flip red)

| mutation | what it breaks |
|---|---|
| Remove `_DDS_INIT_LOCK` from `get_publisher` | `test_publisher_and_subscriber_share_the_init_lock` fails (would race the segfault) |
| Skip the `(topic, message_class)` cache | `test_get_publisher_constructs_once_per_key` counts 2, expects 1 |
| Add `import unitree_sdk2py` at module top | `test_ddspublisher_is_importable_without_the_sdk` and `test_module_does_not_import_the_sdk_at_load_time` both fail |
| Let `publish` raise on `Write` error | `test_publish_returns_error_when_write_raises` fails |
| Skip idempotency on `close` | `test_close_is_idempotent_and_drops_cache` fails |
| Remove `pub.Init()` after construct | `test_get_publisher_constructs_once_per_key` asserts `init_calls == 1` |

## Files changed

| file | lines | why |
|---|---|---|
| `strands_robots/tools/g1/_dds_engine.py` | +154 / -5 | Add `DDSPublisher` class; update module docstring to describe both halves |
| `tests/tools/g1/test_dds_publisher.py` | +366 (new) | 12 tests, all SDK touches mocked |
| `changelog.d/2760-g1-dds-publisher.md` | +18 (new) | Release note |

Total: **3 files, +538 / -5**. Under the 400 loc-of-code target for a driver primitive PR.

---

Closes part of #361 (unblocks PR-B). Decoupled from #358. No hardware needed to verify.