### PR TITLE
fix(simulation): bound a rotated collision geom on the axes it occupies

### DIFF
--- a/changelog.d/2759-geom-rotation-collision-bound.md
+++ b/changelog.d/2759-geom-rotation-collision-bound.md
@@ -1,0 +1,26 @@
+### Fixed: a rotated collision geom is bounded on the axes it occupies
+
+`_geom_aabb` reports the axis-aligned box one `<geom>` occupies in its owning body's frame, and
+`load_mjcf_scene_objects` publishes the union of those as a `SceneObject`'s `size` and `position` -
+the physics footprint that stands in for the object. It read `pos` and `size` and never asked how
+the geom is turned. MJCF gives a geom five mutually exclusive ways to state a rotation (`quat`,
+`euler`, `axisangle`, `xyaxes`, `zaxis`), and dropping it does not make the bound approximate, it
+reports the extents on the wrong axes: a 0.60 m bar turned a quarter turn about z came back as
+`(0.6, 0.04, 0.04)` where MuJoCo places it along y at `(0.04, 0.6, 0.04)`.
+
+The same function already read a rotation on its other channel. A capsule or cylinder may spell its
+placement with `fromto`, whose endpoints carry the axis, and `_segment_aabb` bounds that exactly. So
+one geom got two different bounds depending on which of two spellings MuJoCo compiles to the same
+shape was used for it.
+
+Each primitive now gets its exact bound - the support function for a box and for an ellipsoid, and
+for a capsule or cylinder the endpoints rebuilt from the rotation and handed to `_segment_aabb`, so
+the two spellings share one answer rather than drifting. A sphere is unchanged, no rotation moving
+it, and the `fromto` branch stays rotation-free because MuJoCo derives that geom's orientation from
+the endpoints and discards any the element declares. `<compiler angle>` and `<compiler eulerseq>`
+are forwarded from the scene entry point, which already resolved them for the mesh reader.
+
+Over the 336 loadable MJCFs in the shipped asset cache, 421 bodies declare a rotated collidable
+analytic geom and 27 of the 72 registered robots own at least one. Against MuJoCo's own geometry the
+old rule under-bounded 279 of those bodies and over-bounded 247, the worst reporting 0.0085 m on an
+axis the geometry spans 0.1601 m; afterwards none of the 421 is off by more than 0.1%.

--- a/strands_robots/simulation/isaac/loaders.py
+++ b/strands_robots/simulation/isaac/loaders.py
@@ -1734,6 +1734,69 @@ def _segment_length(p1: tuple[float, float, float], p2: tuple[float, float, floa
     return math.sqrt(sum(d * d for d in delta))
 
 
+def _quat_matrix(
+    quat: tuple[float, float, float, float],
+) -> tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+]:
+    """Rotation matrix rows of a unit ``wxyz`` quaternion.
+
+    Column ``j`` is where the geom's own axis ``j`` points in the frame the
+    quaternion is expressed in, which is what a rotated primitive's extent is
+    built from. :func:`_parse_orientation` returns a unit quaternion whichever
+    spelling the element used, so no renormalization happens here.
+    """
+    w, x, y, z = quat
+    return (
+        (1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)),
+        (2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)),
+        (2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)),
+    )
+
+
+def _rotated_box_half(
+    half: tuple[float, float, float],
+    rot: tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+) -> tuple[float, float, float]:
+    """Half-extent of a rotated box - exact, not an approximation.
+
+    A box's farthest point along axis ``i`` is the corner whose every local
+    component pushes that way, so the extent is ``sum_j |R[i][j]| * half[j]``.
+    Read without the rotation the extent is reported on the geom's own axes
+    instead of the body's, which for a quarter turn is a permutation rather
+    than a small error: a 0.16 m finger pad rotated onto ``x`` keeps reporting
+    0.0085 m there.
+    """
+    return tuple(sum(abs(rot[i][j]) * half[j] for j in range(3)) for i in range(3))  # type: ignore[return-value]
+
+
+def _rotated_ellipsoid_half(
+    half: tuple[float, float, float],
+    rot: tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+) -> tuple[float, float, float]:
+    """Half-extent of a rotated ellipsoid - exact, and tighter than its box.
+
+    The support function of an ellipsoid with semi-axes ``half`` is
+    ``sqrt(sum_j (R[i][j] * half[j]) ** 2)``, which is why this cannot reuse
+    :func:`_rotated_box_half`: the box bound of the same rotated ellipsoid is
+    correct but loose, and a collision proxy standing in for the object should
+    not be inflated by the reader's choice of formula.
+    """
+    return tuple(  # type: ignore[return-value]
+        math.sqrt(sum((rot[i][j] * half[j]) ** 2 for j in range(3))) for i in range(3)
+    )
+
+
 def _segment_aabb(
     gtype: str,
     p1: tuple[float, float, float],
@@ -1772,6 +1835,9 @@ def _geom_aabb(
     geom: ET.Element,
     defaults: dict[str, dict[str, str]],
     childclass: str,
+    *,
+    angle_scale: float = math.pi / 180.0,
+    eulerseq: str = "xyz",
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
     """Return ``(center, half_extent)`` AABB for a collision ``<geom>``.
 
@@ -1780,6 +1846,17 @@ def _geom_aabb(
     the caller can fall back to other geoms. The geom-local ``pos`` is the
     AABB centre relative to the owning body's frame.
 
+    A geom's own rotation is part of its extent. MJCF lets a geom state one
+    with ``quat``, ``euler``, ``axisangle``, ``xyaxes`` or ``zaxis``, and read
+    without it the extent is reported on the geom's own axes rather than the
+    body's - for a quarter turn a permutation of the answer, not a small error.
+    :func:`_parse_orientation` resolves whichever spelling the geom (or the
+    ``<default>`` class it inherits from) used, and the bound is then the exact
+    one for that primitive: :func:`_rotated_box_half` for a box,
+    :func:`_rotated_ellipsoid_half` for an ellipsoid, the segment bound below
+    for a capsule or cylinder, and the radius itself for a sphere, which no
+    rotation changes.
+
     A capsule or cylinder may spell its placement and axis extent with
     ``fromto`` instead of ``pos`` + ``size``, in which case the endpoints
     carry both and ``size`` holds only the radius - the same fixed-component
@@ -1787,13 +1864,17 @@ def _geom_aabb(
     :func:`strands_robots.simulation.mujoco.scene_ops.fromto_fixed_size_components`
     states for the MuJoCo backend. Read as ``pos`` + ``size`` alone such a
     geom collapses to a ball of that radius at the body origin, losing the
-    length and the offset, so :func:`_parse_fromto` is consulted first.
-    ``fromto`` on a box or ellipsoid additionally squares the cross-section
-    by copying the first ``size`` component and needs the rotated-box bound;
-    those keep returning ``None`` (no analytic AABB) so the caller falls back
-    rather than asserting an approximation this does not compute.
+    length and the offset, so :func:`_parse_fromto` is consulted first. MuJoCo
+    derives a ``fromto`` geom's orientation from the endpoints and discards any
+    the element declares, so that branch is deliberately rotation-free; the
+    ``pos`` + ``size`` spelling builds the same endpoints from the rotation and
+    shares :func:`_segment_aabb`, so one geom cannot get two different bounds
+    for being spelled two ways. ``fromto`` on a box or ellipsoid additionally
+    squares the cross-section by copying the first ``size`` component, a
+    separate rule this reader does not derive, so those keep returning ``None``
+    (no analytic AABB) and the caller falls back.
 
-    ``type``, ``pos``, ``size`` and ``fromto`` are read through
+    ``type``, ``pos``, ``size``, ``fromto`` and the orientation are read through
     :func:`_class_attrs`: MJCF's ``<default>`` classes may supply any of them, so
     asking the element directly sees only the half the geom spells itself.
     """
@@ -1805,14 +1886,16 @@ def _geom_aabb(
         sizes = [float(p) for p in size_str.replace(",", " ").split()] if size_str else []
     except (ValueError, TypeError):
         sizes = []
+    rot = _quat_matrix(_parse_orientation(attrs, own=geom.attrib, angle_scale=angle_scale, eulerseq=eulerseq))
 
     if gtype == "box":
         if len(sizes) >= 3:
-            half = (sizes[0], sizes[1], sizes[2])
+            half = _rotated_box_half((sizes[0], sizes[1], sizes[2]), rot)
         else:
             return None
     elif gtype == "sphere":
         if sizes:
+            # A ball is its own rotation: the extent is the radius on every axis.
             r = sizes[0]
             half = (r, r, r)
         else:
@@ -1823,11 +1906,19 @@ def _geom_aabb(
         # the endpoints carrying the placement and the axis extent.
         segment = _parse_fromto(attrs.get("fromto"))
         if segment is not None:
+            # MuJoCo takes a ``fromto`` geom's axis from the endpoints and
+            # discards a declared orientation, so ``rot`` is not applied here.
             return _segment_aabb(gtype, segment[0], segment[1], sizes[0]) if sizes else None
         if len(sizes) >= 2:
             r, hl = sizes[0], sizes[1]
-            ext = hl + (r if gtype == "capsule" else 0.0)
-            half = (r, r, ext)
+            # The rotated local +z axis is the geom's own axis in the body
+            # frame, so the same endpoints a ``fromto`` would have carried are
+            # recoverable - and the exact segment bound is then shared with
+            # that branch rather than re-derived for this spelling.
+            axis = (rot[0][2], rot[1][2], rot[2][2])
+            p1 = tuple(pos[i] - axis[i] * hl for i in range(3))
+            p2 = tuple(pos[i] + axis[i] * hl for i in range(3))
+            return _segment_aabb(gtype, p1, p2, r)  # type: ignore[arg-type]
         else:
             # One size and no ``fromto`` is not a shape MuJoCo compiles
             # ("size 1 must be positive in geom"), so there is no geometry
@@ -1835,7 +1926,7 @@ def _geom_aabb(
             return None
     elif gtype == "ellipsoid":
         if len(sizes) >= 3:
-            half = (sizes[0], sizes[1], sizes[2])
+            half = _rotated_ellipsoid_half((sizes[0], sizes[1], sizes[2]), rot)
         else:
             return None
     else:
@@ -1848,6 +1939,9 @@ def _body_collision_aabb(
     body_el: ET.Element,
     defaults: dict[str, dict[str, str]],
     childclass: str,
+    *,
+    angle_scale: float = math.pi / 180.0,
+    eulerseq: str = "xyz",
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
     """Compute the AABB (center, full-size) over a body's own collidable geoms.
 
@@ -1865,8 +1959,14 @@ def _body_collision_aabb(
     geom that omits the attribute, which is MJCF's spelling of group 0.
 
     Geom positions are taken relative to the body frame, so the returned centre
-    is a body-frame offset. Returns ``None`` when no analytic geom is found
-    (e.g. a mesh-only visual body).
+    is a body-frame offset, and each geom's own rotation is folded into its
+    extent by :func:`_geom_aabb` - a body whose collision primitive is turned
+    onto another axis is bounded on the axes it really occupies. Returns
+    ``None`` when no analytic geom is found (e.g. a mesh-only visual body).
+
+    ``angle_scale`` and ``eulerseq`` come from the model's ``<compiler>`` and
+    are only forwarded; they default to MJCF's own defaults (degrees, ``xyz``)
+    so a caller reading a single body needs neither.
     """
     for collidable_only in (True, False):
         mins = [float("inf")] * 3
@@ -1876,7 +1976,7 @@ def _body_collision_aabb(
             attrs = _class_attrs(geom, defaults, childclass)
             if collidable_only and _geom_cannot_collide(attrs):
                 continue
-            aabb = _geom_aabb(geom, defaults, childclass)
+            aabb = _geom_aabb(geom, defaults, childclass, angle_scale=angle_scale, eulerseq=eulerseq)
             if aabb is None:
                 continue
             center, half = aabb
@@ -1897,6 +1997,9 @@ def _recursive_collision_aabb(
     bounds: list[list[float]],
     defaults: dict[str, dict[str, str]],
     childclass: str,
+    *,
+    angle_scale: float = math.pi / 180.0,
+    eulerseq: str = "xyz",
 ) -> bool:
     """Fold this body's (and nested bodies') collision AABBs into ``bounds``.
 
@@ -1906,7 +2009,7 @@ def _recursive_collision_aabb(
     """
     childclass = body_el.get("childclass") or childclass
     found = False
-    aabb = _body_collision_aabb(body_el, defaults, childclass)
+    aabb = _body_collision_aabb(body_el, defaults, childclass, angle_scale=angle_scale, eulerseq=eulerseq)
     if aabb is not None:
         center, size = aabb
         for i in range(3):
@@ -1918,7 +2021,12 @@ def _recursive_collision_aabb(
     for child in body_el.findall("body"):
         child_off = _parse_xyz(child.get("pos"))
         new_off = (offset[0] + child_off[0], offset[1] + child_off[1], offset[2] + child_off[2])
-        found = _recursive_collision_aabb(child, new_off, bounds, defaults, childclass) or found
+        found = (
+            _recursive_collision_aabb(
+                child, new_off, bounds, defaults, childclass, angle_scale=angle_scale, eulerseq=eulerseq
+            )
+            or found
+        )
     return found
 
 
@@ -2050,7 +2158,9 @@ def load_mjcf_scene_objects(path: str) -> list[SceneObject]:
         # (e.g. ``living_room_table`` -> ``living_room_table_col``), folding
         # nested-body offsets into the AABB.
         bounds = [[float("inf")] * 3, [float("-inf")] * 3]
-        found = _recursive_collision_aabb(body_el, (0.0, 0.0, 0.0), bounds, geom_defaults, cc)
+        found = _recursive_collision_aabb(
+            body_el, (0.0, 0.0, 0.0), bounds, geom_defaults, cc, angle_scale=angle_scale, eulerseq=eulerseq
+        )
         mins, maxs = bounds[0], bounds[1]
 
         if found:

--- a/tests/simulation/isaac/test_geom_rotation_widens_the_collision_bound.py
+++ b/tests/simulation/isaac/test_geom_rotation_widens_the_collision_bound.py
@@ -1,0 +1,524 @@
+"""A geom's own rotation is part of the collision bound it contributes.
+
+``_geom_aabb`` reports the axis-aligned box one ``<geom>`` occupies in its
+owning body's frame. ``_body_collision_aabb`` unions those, and
+``load_mjcf_scene_objects`` publishes the union as a
+:class:`~strands_robots.simulation.isaac.loaders.SceneObject`'s ``size`` and
+``position`` -- the physics footprint that stands in for the object. It read
+``pos`` and ``size`` and never asked how the geom is turned.
+
+MJCF gives a geom five mutually exclusive ways to state a rotation (``quat``,
+``euler``, ``axisangle``, ``xyaxes``, ``zaxis``), and dropping it does not make
+the bound approximate, it reports the extents on the wrong axes. A 0.60 m bar
+turned a quarter turn about z came back as ``(0.6, 0.04, 0.04)`` from
+``load_mjcf_scene_objects`` while MuJoCo places it along y at
+``(0.04, 0.6, 0.04)`` -- 15x too small on the axis the bar occupies and 15x too
+large on an axis it does not.
+
+The same function already read a rotation on its other channel. A capsule or
+cylinder may spell its placement with ``fromto``, whose endpoints carry the
+axis, and ``_segment_aabb`` bounds that exactly. So one geom got two different
+bounds depending on which spelling was used for it, though MuJoCo compiles both
+to the same shape -- measured below, because it is what makes this a defect
+rather than a missing feature.
+
+Over the 336 loadable MJCFs in the shipped asset cache, 421 bodies declare a
+rotated collidable analytic geom (574 with ``quat``, 53 with ``euler``), and 27
+of the 72 registered robots own at least one -- ``unitree_g1``, ``unitree_go2``,
+``unitree_h1``, ``ur5e``, ``ur10e``, ``stretch``, ``shadow_hand`` among them.
+Against MuJoCo's own geometry the old rule under-bounded 279 of those bodies and
+over-bounded 247; the worst was ``stretch``'s gripper finger, reported 0.0085 m
+on the axis it spans 0.1601 m. Afterwards none of the 421 is under- or
+over-bounded beyond 0.1%.
+
+MuJoCo is the oracle throughout. Expected extents are read off a compiled
+``MjModel`` -- for a box from its eight corners rotated by MuJoCo's own
+``mju_rotVecQuat``, which is exact, and for the curved primitives from a
+deterministic surface grid, which is why those carry a tolerance. Nothing here
+restates the formula under test.
+
+Deliberately unchanged, and pinned below: an unrotated geom of every analytic
+type, a sphere (which no rotation moves), the ``fromto`` channel -- MuJoCo
+derives that geom's orientation from the endpoints and discards any the element
+declares, so applying one there would be wrong -- and the preference for the
+geoms MuJoCo can actually collide.
+"""
+
+from __future__ import annotations
+
+import math
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+
+from strands_robots.simulation.isaac.loaders import (
+    _body_collision_aabb,
+    _geom_aabb,
+    _mjcf_angle_units,
+    _mjcf_class_defaults,
+    _mjcf_model_toplevel,
+    load_mjcf_scene_objects,
+)
+
+mujoco = pytest.importorskip("mujoco")
+
+#: A 0.60 x 0.04 x 0.04 m bar. Long enough that reporting its extent on the
+#: wrong axis is a 15x error rather than a rounding difference.
+BAR_HALF = (0.30, 0.02, 0.02)
+
+#: Every MJCF spelling of the same quarter turn about z, so the bound cannot
+#: depend on which one a model happens to use.
+QUARTER_TURN_ABOUT_Z = {
+    "quat": 'quat="0.7071067811865476 0 0 0.7071067811865476"',
+    "euler": 'euler="0 0 90"',
+    "axisangle": 'axisangle="0 0 1 90"',
+    "xyaxes": 'xyaxes="0 1 0 -1 0 0"',
+    # ``zaxis`` cannot express a turn about z, so it gets its own tilt below.
+}
+
+#: A tilt ``zaxis`` can express: local +z onto a direction with all three
+#: components non-zero, so no axis of the answer is zero or shared.
+SKEW_ZAXIS = 'zaxis="0.3 0.5 0.81"'
+
+#: A rotation with no special structure: ``zaxis`` builds the *minimal* rotation
+#: onto an axis, whose matrix is symmetric enough that a row and the matching
+#: column agree, so it cannot see an index slip. Three composed Euler angles can.
+GENERAL_ROTATION = 'euler="30 40 50"'
+
+#: Half-extents of MuJoCo's analytic primitives in ``geom_size`` terms, used to
+#: decide which compiled geoms the oracle has a surface for.
+_ANALYTIC = {
+    int(mujoco.mjtGeom.mjGEOM_BOX),
+    int(mujoco.mjtGeom.mjGEOM_SPHERE),
+    int(mujoco.mjtGeom.mjGEOM_CYLINDER),
+    int(mujoco.mjtGeom.mjGEOM_CAPSULE),
+    int(mujoco.mjtGeom.mjGEOM_ELLIPSOID),
+}
+
+#: Azimuth/elevation resolution of the surface grid for the curved primitives.
+#: 180 samples put the worst discretisation gap on a 0.3 m radius near 1e-4 m.
+_GRID = 180
+
+
+def _model(body: str, compiler: str = "", defaults: str = "") -> str:
+    return f"<mujoco>{compiler}{defaults}<worldbody>{body}</worldbody></mujoco>"
+
+
+def _bound(body: str, compiler: str = "", defaults: str = "", name: str = "link"):
+    """The loader's ``(centre, size)`` for one named body, units resolved as production does."""
+    xml = _model(body, compiler, defaults)
+    root = ET.fromstring(xml)
+    geom_defaults = _mjcf_class_defaults(root, ".", "geom")
+    angle_scale, eulerseq = _mjcf_angle_units(_mjcf_model_toplevel(root, "."))
+    body_el = root.find(f".//body[@name='{name}']")
+    assert body_el is not None
+    return _body_collision_aabb(
+        body_el,
+        geom_defaults,
+        body_el.get("childclass") or "",
+        angle_scale=angle_scale,
+        eulerseq=eulerseq,
+    )
+
+
+def _surface(gtype: int, size) -> list[tuple[float, float, float]]:
+    """Points on one geom's surface in its own local frame.
+
+    A box's eight corners are exact -- its farthest point along any direction is
+    always a corner. The curved primitives get a deterministic grid instead, so
+    the bounds derived from them are tight rather than exact.
+    """
+    if gtype == int(mujoco.mjtGeom.mjGEOM_BOX):
+        return [(sx * size[0], sy * size[1], sz * size[2]) for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)]
+    steps = [(-0.5 + (i + 0.5) / _GRID) * math.pi for i in range(_GRID)]
+    turns = [2.0 * math.pi * i / _GRID for i in range(_GRID)]
+    if gtype in (int(mujoco.mjtGeom.mjGEOM_SPHERE), int(mujoco.mjtGeom.mjGEOM_ELLIPSOID)):
+        semi = (size[0], size[0], size[0]) if gtype == int(mujoco.mjtGeom.mjGEOM_SPHERE) else tuple(size[:3])
+        return [
+            (semi[0] * math.cos(el) * math.cos(az), semi[1] * math.cos(el) * math.sin(az), semi[2] * math.sin(el))
+            for el in steps
+            for az in turns
+        ]
+    radius, half_length = size[0], size[1]
+    points = [(radius * math.cos(az), radius * math.sin(az), sz * half_length) for az in turns for sz in (-1, 1)]
+    if gtype == int(mujoco.mjtGeom.mjGEOM_CAPSULE):
+        points += [
+            (
+                radius * math.cos(el) * math.cos(az),
+                radius * math.cos(el) * math.sin(az),
+                radius * math.sin(el) + (half_length if el > 0 else -half_length),
+            )
+            for el in steps
+            for az in turns
+        ]
+    return points
+
+
+def _mujoco_bound(body: str, compiler: str = "", defaults: str = "", name: str = "link"):
+    """MuJoCo's own ``(centre, size)`` over a body's collidable analytic geoms.
+
+    Every geom's placement, rotation and ``<default>`` inheritance is read off
+    the compiled model, and each surface point is rotated with MuJoCo's
+    ``mju_rotVecQuat`` -- so no arithmetic from the module under test takes part.
+    """
+    model = mujoco.MjModel.from_xml_string(_model(body, compiler, defaults))
+    bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    assert bid != -1, name
+    mins = [float("inf")] * 3
+    maxs = [float("-inf")] * 3
+    for gid in range(model.ngeom):
+        if model.geom_bodyid[gid] != bid or int(model.geom_type[gid]) not in _ANALYTIC:
+            continue
+        if model.geom_contype[gid] == 0 and model.geom_conaffinity[gid] == 0:
+            continue
+        quat = model.geom_quat[gid]
+        pos = model.geom_pos[gid]
+        spun = np.zeros(3)
+        for point in _surface(int(model.geom_type[gid]), model.geom_size[gid]):
+            mujoco.mju_rotVecQuat(spun, np.asarray(point, dtype=float), quat)
+            for axis in range(3):
+                world = float(spun[axis]) + float(pos[axis])
+                mins[axis] = min(mins[axis], world)
+                maxs[axis] = max(maxs[axis], world)
+    assert maxs[0] > mins[0], "premise: the oracle found no collidable analytic geom"
+    return (
+        tuple((mins[i] + maxs[i]) / 2.0 for i in range(3)),
+        tuple(maxs[i] - mins[i] for i in range(3)),
+    )
+
+
+def _geom_of(body: str, defaults: str = "", index: int = 0):
+    """``(element, defaults map)`` for one geom, for the direct-``_geom_aabb`` cells."""
+    root = ET.fromstring(_model(body, "", defaults))
+    return root.findall(".//geom")[index], _mjcf_class_defaults(root, ".", "geom")
+
+
+class TestTheOracleAndTheRespellAreSound:
+    """Premises. Each of these must hold or the cells below prove nothing."""
+
+    def test_one_capsule_spelled_two_ways_is_one_shape_to_mujoco(self):
+        # The respell is what makes the two channels comparable: if MuJoCo saw
+        # two different shapes, two different bounds would be correct.
+        p1, p2, radius = (0.0, 0.0, -0.1), (0.1, 0.0, 0.1), 0.02
+        length = math.dist(p1, p2)
+        mid = tuple((p1[i] + p2[i]) / 2.0 for i in range(3))
+        unit = tuple((p2[i] - p1[i]) / length for i in range(3))
+        segment = mujoco.MjModel.from_xml_string(
+            _model(
+                f'<body name="link"><geom type="capsule" fromto="{p1[0]} {p1[1]} {p1[2]} '
+                f'{p2[0]} {p2[1]} {p2[2]}" size="{radius}"/></body>'
+            )
+        )
+        turned = mujoco.MjModel.from_xml_string(
+            _model(
+                f'<body name="link"><geom type="capsule" pos="{mid[0]} {mid[1]} {mid[2]}" '
+                f'zaxis="{unit[0]} {unit[1]} {unit[2]}" size="{radius} {length / 2}"/></body>'
+            )
+        )
+        assert int(segment.geom_type[0]) == int(turned.geom_type[0])
+        assert segment.geom_size[0][:2] == pytest.approx(turned.geom_size[0][:2], abs=1e-12)
+        assert list(segment.geom_pos[0]) == pytest.approx(list(turned.geom_pos[0]), abs=1e-12)
+        # A capsule is symmetric about its axis, so the two quaternions may
+        # differ by a half turn; what must agree is the axis, up to sign.
+        axes = []
+        for model in (segment, turned):
+            spun = np.zeros(3)
+            mujoco.mju_rotVecQuat(spun, np.array([0.0, 0.0, 1.0]), model.geom_quat[0])
+            axes.append(spun.tolist())
+        assert abs(sum(axes[0][i] * axes[1][i] for i in range(3))) == pytest.approx(1.0, abs=1e-12)
+
+    def test_mujoco_discards_an_orientation_declared_beside_fromto(self):
+        # This is why the ``fromto`` branch must stay rotation-free: honouring a
+        # declared rotation there would disagree with the compiler.
+        declared = 'quat="0.7071067811865476 0 0.7071067811865476 0"'
+        with_rotation = mujoco.MjModel.from_xml_string(
+            _model(f'<body name="link"><geom type="capsule" fromto="0 0 0 0 0 0.5" size="0.02" {declared}/></body>')
+        )
+        without = mujoco.MjModel.from_xml_string(
+            _model('<body name="link"><geom type="capsule" fromto="0 0 0 0 0 0.5" size="0.02"/></body>')
+        )
+        assert list(with_rotation.geom_quat[0]) == pytest.approx(list(without.geom_quat[0]), abs=1e-12)
+
+    def test_mujoco_refuses_pos_and_fromto_on_one_geom(self):
+        # So the two channels are genuinely exclusive and neither can be reached
+        # through the other's inputs.
+        with pytest.raises(ValueError, match="both pos and fromto"):
+            mujoco.MjModel.from_xml_string(
+                _model('<body name="link"><geom type="capsule" pos="1 0 0" fromto="0 0 0 0 0 0.5" size="0.02"/></body>')
+            )
+
+    def test_the_bar_is_long_enough_for_a_wrong_axis_to_be_obvious(self):
+        # A cube would hide every error this file is about.
+        assert BAR_HALF[0] > 10 * max(BAR_HALF[1], BAR_HALF[2])
+
+
+class TestARotatedGeomIsBoundedOnTheAxesItOccupies:
+    """The regression. Every expected value comes from MuJoCo, not from the reader."""
+
+    def test_a_quarter_turn_moves_the_long_axis(self):
+        body = (
+            f'<body name="link"><geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" '
+            f"{QUARTER_TURN_ABOUT_Z['euler']}/></body>"
+        )
+        centre, size = _bound(body)
+        assert size == pytest.approx(_mujoco_bound(body)[1], abs=1e-12)
+        assert size == pytest.approx((0.04, 0.60, 0.04), abs=1e-12)
+        assert centre == pytest.approx((0.0, 0.0, 0.0), abs=1e-12)
+
+    @pytest.mark.parametrize("spelling", sorted(QUARTER_TURN_ABOUT_Z))
+    def test_every_spelling_of_one_turn_gives_one_bound(self, spelling):
+        body = (
+            f'<body name="link"><geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" '
+            f"{QUARTER_TURN_ABOUT_Z[spelling]}/></body>"
+        )
+        assert _bound(body)[1] == pytest.approx(_mujoco_bound(body)[1], abs=1e-12)
+
+    def test_a_tilt_no_axis_of_which_is_zero(self):
+        # A turn about a single axis leaves one extent untouched, which a wrong
+        # formula can still get right. This tilt moves all three.
+        body = f'<body name="link"><geom type="box" size="0.3 0.2 0.1" {SKEW_ZAXIS}/></body>'
+        expected = _mujoco_bound(body)[1]
+        assert _bound(body)[1] == pytest.approx(expected, abs=1e-12)
+        assert min(expected) > 0.0 and len(set(round(v, 9) for v in expected)) == 3
+
+    def test_a_rotation_inherited_from_a_default_class_is_honoured(self):
+        # MJCF lets a ``<default>`` supply the orientation, so reading the
+        # element alone sees an unrotated geom where MuJoCo sees a turned one.
+        defaults = '<default><default class="turned"><geom euler="0 0 90"/></default></default>'
+        body = (
+            f'<body name="link"><geom class="turned" type="box" '
+            f'size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}"/></body>'
+        )
+        assert _bound(body, defaults=defaults)[1] == pytest.approx(_mujoco_bound(body, defaults=defaults)[1], abs=1e-12)
+
+    def test_an_element_spelling_beats_the_classs_quat(self):
+        # MJCF keeps the four alternative spellings in a slot separate from
+        # ``quat`` and prefers that slot, so the element's ``euler`` wins over a
+        # class ``quat``. Resolving that needs the element's own attributes, not
+        # only the merged view.
+        defaults = (
+            '<default><default class="turned">'
+            '<geom quat="0.7071067811865476 0 0 0.7071067811865476"/></default></default>'
+        )
+        body = (
+            f'<body name="link"><geom class="turned" type="box" '
+            f'size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" euler="0 90 0"/></body>'
+        )
+        assert _bound(body, defaults=defaults)[1] == pytest.approx(_mujoco_bound(body, defaults=defaults)[1], abs=1e-12)
+        # The class quat would have put the bar on y; the element's euler puts it on z.
+        assert _bound(body, defaults=defaults)[1] == pytest.approx((0.04, 0.04, 0.60), abs=1e-12)
+
+    def test_the_compiler_angle_unit_is_honoured(self):
+        # ``<compiler angle="radian">`` makes ``euler="0 0 1.5707963"`` the same
+        # quarter turn that reads as 1.57 degrees under the default.
+        compiler = '<compiler angle="radian"/>'
+        body = (
+            f'<body name="link"><geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" '
+            f'euler="0 0 {math.pi / 2}"/></body>'
+        )
+        assert _bound(body, compiler=compiler)[1] == pytest.approx(_mujoco_bound(body, compiler=compiler)[1], abs=1e-12)
+        assert _bound(body, compiler=compiler)[1] == pytest.approx((0.04, 0.60, 0.04), abs=1e-9)
+
+    def test_the_compiler_eulerseq_is_honoured(self):
+        # Under ``zyx`` the first angle turns about z; under the default ``xyz``
+        # it turns about x, and the two bounds differ.
+        compiler = '<compiler eulerseq="zyx"/>'
+        body = (
+            f'<body name="link"><geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" '
+            f'euler="90 0 0"/></body>'
+        )
+        assert _bound(body, compiler=compiler)[1] == pytest.approx(_mujoco_bound(body, compiler=compiler)[1], abs=1e-12)
+        assert _bound(body, compiler=compiler)[1] != pytest.approx(_bound(body)[1], abs=1e-9)
+
+    @pytest.mark.parametrize("rotation", [SKEW_ZAXIS, GENERAL_ROTATION], ids=["zaxis-tilt", "euler-general"])
+    @pytest.mark.parametrize(
+        ("gtype", "size"),
+        [
+            ("box", "0.3 0.2 0.1"),
+            ("capsule", "0.05 0.25"),
+            ("cylinder", "0.05 0.25"),
+            ("ellipsoid", "0.3 0.2 0.1"),
+        ],
+    )
+    def test_every_rotatable_primitive_matches_mujoco(self, gtype, size, rotation):
+        body = f'<body name="link"><geom type="{gtype}" size="{size}" {rotation}/></body>'
+        expected = _mujoco_bound(body)[1]
+        # The curved primitives are graded against a surface grid, which can only
+        # under-report an extent, so the reader may exceed it by the grid's gap.
+        assert _bound(body)[1] == pytest.approx(expected, rel=2e-3, abs=1e-12)
+        assert all(got >= want - 1e-12 for got, want in zip(_bound(body)[1], expected, strict=True))
+
+    def test_one_capsule_spelled_two_ways_gets_one_bound(self):
+        # The defect in one line: MuJoCo compiles these to the same shape (pinned
+        # in the premises above), so the reader owes them the same bound.
+        p1, p2, radius = (0.0, 0.0, -0.1), (0.1, 0.0, 0.1), 0.02
+        length = math.dist(p1, p2)
+        mid = tuple((p1[i] + p2[i]) / 2.0 for i in range(3))
+        unit = tuple((p2[i] - p1[i]) / length for i in range(3))
+        segment = (
+            f'<body name="link"><geom type="capsule" fromto="{p1[0]} {p1[1]} {p1[2]} '
+            f'{p2[0]} {p2[1]} {p2[2]}" size="{radius}"/></body>'
+        )
+        turned = (
+            f'<body name="link"><geom type="capsule" pos="{mid[0]} {mid[1]} {mid[2]}" '
+            f'zaxis="{unit[0]} {unit[1]} {unit[2]}" size="{radius} {length / 2}"/></body>'
+        )
+        by_endpoints, by_rotation = _bound(segment), _bound(turned)
+        assert by_rotation[0] == pytest.approx(by_endpoints[0], abs=1e-12)
+        assert by_rotation[1] == pytest.approx(by_endpoints[1], abs=1e-12)
+
+    def test_the_public_loader_reports_the_size_mujoco_places(self, tmp_path):
+        # Through ``load_mjcf_scene_objects``, which is what publishes the proxy.
+        scene = (
+            '<mujoco model="turned"><worldbody>'
+            '<geom name="floor" type="plane" size="2 2 0.1"/>'
+            '<body name="ruler" pos="0.4 0 0.1"><freejoint/>'
+            f'<geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" euler="0 0 90"/>'
+            "</body></worldbody></mujoco>"
+        )
+        path = tmp_path / "turned.xml"
+        path.write_text(scene)
+        objects = {obj.name: obj for obj in load_mjcf_scene_objects(str(path))}
+        assert set(objects) == {"ruler"}
+        assert tuple(objects["ruler"].size) == pytest.approx((0.04, 0.60, 0.04), abs=1e-12)
+
+    def test_the_public_loader_honours_a_radian_model(self, tmp_path):
+        # The units live on the model's ``<compiler>`` and the reader defaults to
+        # MJCF's own, so a chain that forgets to forward them reads a radian
+        # model in degrees and still returns a plausible box.
+        scene = (
+            '<mujoco model="radians"><compiler angle="radian"/><worldbody>'
+            '<geom name="floor" type="plane" size="2 2 0.1"/>'
+            '<body name="ruler" pos="0.4 0 0.1"><freejoint/>'
+            f'<geom type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" euler="0 0 {math.pi / 2}"/>'
+            "</body></worldbody></mujoco>"
+        )
+        path = tmp_path / "radians.xml"
+        path.write_text(scene)
+        objects = {obj.name: obj for obj in load_mjcf_scene_objects(str(path))}
+        assert tuple(objects["ruler"].size) == pytest.approx((0.04, 0.60, 0.04), abs=1e-9)
+
+    def test_no_rotation_reports_a_bound_smaller_than_the_geom(self):
+        # The unsafe direction, swept: a proxy narrower than the object it stands
+        # for lets a policy be evaluated against geometry that is not there.
+        size = f"{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}"
+        for degrees in range(0, 190, 10):
+            for axis in ("1 0 0", "0 1 0", "0 0 1", "1 1 0", "1 2 3"):
+                body = f'<body name="link"><geom type="box" size="{size}" axisangle="{axis} {degrees}"/></body>'
+                got = _bound(body)[1]
+                want = _mujoco_bound(body)[1]
+                assert all(g >= w - 1e-12 for g, w in zip(got, want, strict=True)), (degrees, axis, got, want)
+
+    def test_a_rotated_geom_widens_the_union_of_a_multi_geom_body(self):
+        # The bound is a union, so a turned geom has to reach the union too - not
+        # only be right when it is a body's only geom.
+        body = (
+            '<body name="link">'
+            '<geom name="hub" type="box" size="0.05 0.05 0.05"/>'
+            f'<geom name="arm" type="box" size="{BAR_HALF[0]} {BAR_HALF[1]} {BAR_HALF[2]}" euler="0 0 90"/>'
+            "</body>"
+        )
+        assert _bound(body)[1] == pytest.approx(_mujoco_bound(body)[1], abs=1e-12)
+        assert _bound(body)[1] == pytest.approx((0.10, 0.60, 0.10), abs=1e-12)
+
+
+class TestWhatARotationDoesNotChange:
+    """Controls. Every expectation here is one the reader already met."""
+
+    @pytest.mark.parametrize(
+        ("gtype", "size", "expected"),
+        [
+            ("box", "0.3 0.2 0.1", (0.6, 0.4, 0.2)),
+            ("sphere", "0.25", (0.5, 0.5, 0.5)),
+            ("capsule", "0.05 0.25", (0.1, 0.1, 0.6)),
+            ("cylinder", "0.05 0.25", (0.1, 0.1, 0.5)),
+            ("ellipsoid", "0.3 0.2 0.1", (0.6, 0.4, 0.2)),
+        ],
+    )
+    def test_an_unrotated_primitive_keeps_its_bound(self, gtype, size, expected):
+        body = f'<body name="link"><geom type="{gtype}" size="{size}"/></body>'
+        assert _bound(body)[1] == pytest.approx(expected, abs=1e-12)
+
+    def test_a_sphere_is_rotation_invariant(self):
+        plain = '<body name="link"><geom type="sphere" size="0.25"/></body>'
+        spun = f'<body name="link"><geom type="sphere" size="0.25" {SKEW_ZAXIS}/></body>'
+        assert _bound(spun)[0] == pytest.approx(_bound(plain)[0], abs=1e-12)
+        assert _bound(spun)[1] == pytest.approx(_bound(plain)[1], abs=1e-12)
+
+    def test_the_fromto_channel_ignores_a_declared_rotation(self):
+        # MuJoCo does too (pinned in the premises), so honouring one here would
+        # bound a shape the compiler does not build.
+        plain = '<body name="link"><geom type="capsule" fromto="0 0 -0.2 0 0 0.2" size="0.03"/></body>'
+        declared = (
+            '<body name="link"><geom type="capsule" fromto="0 0 -0.2 0 0 0.2" size="0.03" euler="0 90 0"/></body>'
+        )
+        assert _bound(declared)[0] == pytest.approx(_bound(plain)[0], abs=1e-12)
+        assert _bound(declared)[1] == pytest.approx(_bound(plain)[1], abs=1e-12)
+        assert _bound(plain)[1] == pytest.approx((0.06, 0.06, 0.46), abs=1e-12)
+
+    @pytest.mark.parametrize("gtype", ["mesh", "plane", "hfield", "sdf"])
+    def test_a_geom_with_no_analytic_bound_still_has_none(self, gtype):
+        extra = ' mesh="m"' if gtype == "mesh" else ""
+        geom, defaults = _geom_of(f'<body name="link"><geom type="{gtype}" size="1 1 1"{extra}/></body>')
+        assert _geom_aabb(geom, defaults, "") is None
+
+    def test_the_collidable_preference_still_decides(self):
+        # A turned decorative shell must not widen the proxy: the rotation is
+        # read after the contact declaration has already excluded the geom.
+        body = (
+            '<body name="link">'
+            '<geom type="box" size="0.5 0.1 0.1" contype="0" conaffinity="0" euler="0 0 90"/>'
+            '<geom type="box" size="0.1 0.1 0.1"/>'
+            "</body>"
+        )
+        assert _bound(body)[1] == pytest.approx((0.2, 0.2, 0.2), abs=1e-12)
+
+
+class TestTheCompilerUnitsReachTheReader:
+    """A default that is never overridden is a rule nothing applies."""
+
+    def test_the_scene_loader_forwards_the_compiler_units(self):
+        # ``_geom_aabb`` defaults to MJCF's own defaults, so a chain that forgets
+        # to forward them reads every ``<compiler angle="radian">`` model in
+        # degrees and still returns a plausible number.
+        import ast
+        import inspect
+
+        from strands_robots.simulation.isaac import loaders as mod
+
+        tree = ast.parse(inspect.getsource(mod))
+        forwarding = {
+            "load_mjcf_scene_objects": "_recursive_collision_aabb",
+            "_recursive_collision_aabb": "_body_collision_aabb",
+            "_body_collision_aabb": "_geom_aabb",
+        }
+        seen = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name not in forwarding:
+                continue
+            callee = forwarding[node.name]
+            calls = [
+                call
+                for call in ast.walk(node)
+                if isinstance(call, ast.Call) and getattr(call.func, "id", None) == callee
+            ]
+            assert calls, f"premise: {node.name} no longer calls {callee}"
+            for call in calls:
+                keywords = {kw.arg for kw in call.keywords}
+                assert {"angle_scale", "eulerseq"} <= keywords, (
+                    f"{node.name} calls {callee} without forwarding the compiler units"
+                )
+            seen[node.name] = len(calls)
+        assert set(seen) == set(forwarding), f"premise: only reached {sorted(seen)}"
+
+    def test_the_rotated_capsule_shares_the_exact_segment_bound(self):
+        # Both spellings of a capsule end at ``_segment_aabb``, so the cylinder
+        # cap term cannot drift between them.
+        import inspect
+
+        from strands_robots.simulation.isaac import loaders as mod
+
+        source = inspect.getsource(mod._geom_aabb)
+        assert source.count("_segment_aabb(") == 2, "the two capsule spellings no longer share one bound"
+        assert "math.sqrt" not in source, "_geom_aabb re-derives a segment extent instead of sharing it"


### PR DESCRIPTION
## Problem

`_geom_aabb` reports the axis-aligned box one `<geom>` occupies in its owning body's frame.
`_body_collision_aabb` unions those, and `load_mjcf_scene_objects` publishes the union as a
`SceneObject`'s `size` and `position` -- what that function's own docstring calls the "validated AABB
proxy", the physics footprint standing in for the object. It read `pos` and `size` and never asked
how the geom is turned.

MJCF gives a geom five mutually exclusive ways to state a rotation (`quat`, `euler`, `axisangle`,
`xyaxes`, `zaxis`). Dropping it does not make the bound approximate; for a quarter turn it reports
the extents on the wrong axes. Eight lines of MJCF through the public loader:

```xml
<body name="ruler" pos="0.4 0 0.1"><freejoint/>
  <geom type="box" size="0.30 0.02 0.02" euler="0 0 90"/>
</body>
```

| | `size` reported |
|---|---|
| MuJoCo (`geom_size` + `geom_quat`) | `(0.04, 0.60, 0.04)` |
| `load_mjcf_scene_objects` before | `(0.60, 0.04, 0.04)` |
| `load_mjcf_scene_objects` after | `(0.04, 0.60, 0.04)` |

15x too small on the axis the bar occupies and 15x too large on an axis it does not.

### The same function already read a rotation on its other channel

A capsule or cylinder may spell its placement with `fromto`, whose endpoints carry the axis, and
`_segment_aabb` bounds that exactly -- its docstring is explicit that it is "the exact bound rather
than the box of a rotated local box". So one geom got two different bounds depending on which
spelling was used for it, though MuJoCo compiles both to the same shape. Measured, one capsule from
`(0, 0, -0.1)` to `(0.1, 0, 0.1)` of radius 0.02:

| spelling | half-extent reported |
|---|---|
| `fromto` | `(0.07, 0.02, 0.12)` |
| `pos` + `zaxis` + `size` | `(0.02, 0.02, 0.132)` |
| sampled from the compiled geom's surface | `(0.07, 0.02, 0.12)` |

MuJoCo compiles the two to the same position, the same `geom_size` and parallel axes, which is
pinned as a premise -- if it saw two shapes, two bounds would be correct.

## Change

Each primitive now gets its exact bound:

- **box** -- the support function, `sum_j |R[i][j]| * half[j]`.
- **ellipsoid** -- `sqrt(sum_j (R[i][j] * half[j])**2)`, which is tighter than its box, so the proxy
  is not inflated by the reader's choice of formula.
- **capsule / cylinder** -- the endpoints a `fromto` would have carried are rebuilt from the rotated
  local +z axis and handed to `_segment_aabb`, so the two spellings share one answer instead of
  drifting. At identity this reproduces the previous result exactly.
- **sphere** -- unchanged; no rotation moves a ball.
- **`fromto`** -- deliberately still rotation-free. MuJoCo derives that geom's orientation from the
  endpoints and *discards* one declared beside them (measured, and pinned), so honouring it there
  would bound a shape the compiler does not build.

`<compiler angle>` and `<compiler eulerseq>` are forwarded from the scene entry point, which already
resolved them for the mesh reader three lines away.

## Measured over the shipped assets

336 loadable MJCFs in the asset cache; **421 bodies** declare a rotated collidable analytic geom
(`quat` 574 geoms, `euler` 53), and **27 of the 72 registered robots** own at least one --
`unitree_g1`, `unitree_go2`, `unitree_h1`, `unitree_a1`, `ur5e`, `ur10e`, `stretch`, `shadow_hand`,
`anymal_b`, `anymal_c` among them. Graded against MuJoCo's compiled geometry, each geom's surface
sampled and rotated by `mju_rotVecQuat`:

| | under-bounded on some axis | over-bounded | matching |
|---|---|---|---|
| before | 279 | 247 | 143 |
| after | 0 | 0 | 421 |

Worst under-bound before was `stretch`'s gripper finger, reported 0.0085 m on an axis its geometry
spans 0.1601 m (18.75x). After the change the worst deviation from the sampled surface is
4.9e-13 m too small and 1.4e-4 m too large, the latter being the sampling grid under-reporting a
curved surface rather than the formula being loose. 278 of the 421 reported sizes change; 129 grow
in volume and 53 shrink, the rest being permutations of the same extents.

## Visual

`unitree_go2`'s `FL_thigh` as MuJoCo compiles it, with the proxy each reader publishes drawn over
it. Coverage is measured from separate segmentation passes so the proxy's transparency cannot affect
the count.

![rotated collision bound](https://github.com/cagataycali/robots/releases/download/artifacts/rotated_collision_bound.png)

Of the 13864 pixels of collision geometry, the previously reported proxy leaves **11634 (84%)**
outside it; the new one leaves **0**, and covers exactly 13864 -- for a quarter turn the AABB is the
geom itself.

## Tests

`tests/simulation/isaac/test_geom_rotation_widens_the_collision_bound.py`, 41 cases. MuJoCo is the
oracle throughout: a box is graded against its eight corners rotated by MuJoCo's own
`mju_rotVecQuat` (exact), the curved primitives against a deterministic surface grid (hence a
tolerance). Nothing restates the formula under test.

Pre-fix, with every signature kept and only the rotation reading undone -- **24 failed, 17 passed**:

| class | failing | test functions |
|---|---|---|
| `TestTheOracleAndTheRespellAreSound` (premises) | 0 | 4 |
| `TestARotatedGeomIsBoundedOnTheAxesItOccupies` | 23 | 13 |
| `TestWhatARotationDoesNotChange` (controls) | 0 | 5 |
| `TestTheCompilerUnitsReachTheReader` | 1 | 2 |

A raw revert to `main` instead reports 27 failures, but nine of those are `TypeError` from the
pre-fix signatures rather than behaviour, which is why the behavioural revert is the number quoted.

### Mutations

11 applied, 10 detected, 10 distinct failing-id sets, control clean, source restored byte-identical.

| mutation | cells firing |
|---|---|
| rotation dropped (behavioural revert) | 24 |
| box extent loses `abs()` (signed sum) | 15 |
| box extent transposed, rows read for columns | 2 |
| ellipsoid given the looser box bound | 2 |
| capsule axis read off a row not a column | 2 |
| rotation applied to the `fromto` branch too | 1 |
| sphere given the box treatment | 1 |
| units not forwarded at the scene entry point | 2 |
| units dropped between the two AABB helpers | 2 |
| orientation read without the element's own attributes | 1 here, **12** in `test_mjcf_orientation_spellings.py` |
| signature's `angle_scale` default flipped to radians | **0** |

Two of these are worth spelling out. Reading a matrix row where a column belongs, and reading a
capsule's axis the same way, are both invisible under a `zaxis` tilt -- `zaxis` builds the *minimal*
rotation onto an axis, whose matrix is symmetric enough that the two agree -- so the primitive cases
are also run with three composed Euler angles, which is what catches an index slip. And the
signature default fires nothing because every production path forwards the units explicitly, which
the structural cell pins and which the two "units not forwarded" mutations show is load-bearing; the
default is unreachable from production and is MJCF's own (degrees, `xyz`).

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1572 files).
- mypy **24 == 24** against a pristine `upstream/main` worktree, normalized message sets
  byte-identical in both directions, 0 in either changed file.
- Paired run over an identical 600-file selection (all of `tests/simulation/`, `tests/benchmarks/libero/`
  and every guard that walks the tree or reads source), the new file excluded from both sides:
  **20094 collected and `5 failed, 19815 passed, 274 skipped` on both trees**, the same five failing
  ids, `comm` empty in both directions. All five pass in isolation (29 passed) -- they are
  large-selection artifacts, identical on base.
- `tests/simulation/isaac/` 1654 passed before the change and 1695 after, on the declared mujoco
  floor (3.5.0) with lerobot 0.6.2.

## Not changed

`fromto` on a box or ellipsoid still returns `None`. That exclusion was previously justified by
needing "the rotated-box bound, which this module deliberately does not compute" -- a reason this
change retires -- so the remaining one is stated accurately instead: MuJoCo squares such a geom's
cross-section by copying the first `size` component, a separate rule this reader does not derive.
No shipped asset spells it, and `_extract_mjcf_shape`, the other consumer of that exclusion, is
untouched here.
