### PR TITLE
fix(mesh): keep the severity a safety event was raised with

### DIFF
--- a/changelog.d/2761-safety-severity-is-not-the-payloads.md
+++ b/changelog.d/2761-safety-severity-is-not-the-payloads.md
@@ -1,0 +1,41 @@
+### Fixed: a safety event keeps the severity it was raised with
+
+`SensorLoopsMixin.publish_safety_event` sends one event two ways and built the audit copy
+by spreading the caller's payload over the parameter, so a payload carrying a `severity`
+field replaced it -- with no refusal, and nothing logged:
+
+| raised with | payload said | audit record said |
+|---|---|---|
+| `severity="critical"` | (no `severity` field) | `critical` |
+| `severity="critical"` | `severity: "info"` | `info` |
+| `severity="critical"` | `severity: 0` | `0` |
+| `severity="warning"` (default) | `severity: "info"` | `info` |
+
+What makes the replacement consequential rather than cosmetic is that there is no second
+copy to compare against. The wire copy carries a uniformly `"info"` severity on purpose:
+issue #272 removed per-branch severity from `strands/+/safety/event` so a subscriber could
+not read it as a content-channel oracle for a rejection reason, and the method's own
+comment records the consequence -- "the real severity is preserved only in the local audit
+record below". A critical stop could therefore be audited as informational with nothing
+anywhere disagreeing.
+
+The precedence is not a new rule; this mixin already applies it eight times. `_read_pose`,
+`_read_imu`, `_read_odom`, `_read_lidar_summary`, `_read_lidar_state`, `_read_hands`,
+`_read_map_info` and `_read_health` merge a provider mapping and then re-assert the keys
+this process decided, through `_stamp_local_keys`, whose docstring names the hazard --
+"merged last, a provider mapping carrying one of those seeded names replaces the local
+reading" -- and cites `PeerInfo.to_dict`, which spreads the peer's own payload *first* so
+the locally decided keys win. `publish_safety_event` built the ninth record and was the one
+that spread last. It now spreads first, the same precedence by the same reasoning.
+
+The helper itself is deliberately not reused here: it also stamps `peer_id`, and
+`log_safety_event` already carries the peer as a field of its own envelope, so routing this
+record through it would change the record's shape rather than only its precedence.
+
+A `payload` entry named `severity` is discarded from the audit copy rather than preserved
+under another name, matching how `PeerInfo.to_dict` resolves the same collision; the wire
+copy is untouched, so a caller who puts a severity in the payload still sees it there. The
+rule is now derived from the shipped class -- no method of the mixin may place an explicit
+key ahead of a `**` spread, and a method that merges with `update` must re-assert its own
+keys -- so a tenth record builder added later is held to it instead of inheriting an
+exemption by omission.

--- a/strands_robots/mesh/sensors.py
+++ b/strands_robots/mesh/sensors.py
@@ -732,7 +732,11 @@ class SensorLoopsMixin:
         Args:
             event_type: Short, lowercase event identifier (e.g. ``"estop"``).
             severity: The real severity. It reaches the audit record only - the
-                wire copy is uniformly ``"info"`` (issue #272).
+                wire copy is uniformly ``"info"`` (issue #272) - so the audit
+                record is the only surviving copy, and this parameter wins over
+                a ``payload`` field of the same name rather than being replaced
+                by it. A ``payload`` entry named ``severity`` is not a second
+                channel for this argument; it is discarded from the audit copy.
             payload: Event-specific fields, or ``None`` for an event with none.
         """
         if not self._running:
@@ -759,7 +763,12 @@ class SensorLoopsMixin:
             log_safety_event(
                 event_type=event_type,
                 peer_id=self.peer_id,
-                payload={"severity": severity, **record},
+                # ``severity`` last: the parameter is the documented channel for the
+                # real severity, so an event-specific field that happens to be named
+                # ``severity`` must not replace it. Same precedence as
+                # ``session.PeerInfo.to_dict``, which spreads the peer's own payload
+                # first so the keys that process decided win a name collision.
+                payload={**record, "severity": severity},
             )
         except Exception as exc:  # noqa: BLE001
             logger.debug("[mesh] %s: audit log write failed: %s", self.peer_id, exc)

--- a/tests/mesh/test_safety_severity_is_the_parameters.py
+++ b/tests/mesh/test_safety_severity_is_the_parameters.py
@@ -1,0 +1,334 @@
+"""The severity a safety event is raised with survives a payload field of that name.
+
+:meth:`~strands_robots.mesh.sensors.SensorLoopsMixin.publish_safety_event` sends
+one event two ways. The wire copy carries a uniformly ``"info"`` severity, on
+purpose: issue #272 removed per-branch severity from
+``strands/+/safety/event`` so a subscriber could not read it as a
+content-channel oracle for a rejection reason. The consequence the method's own
+comment records is that the audit record is *the only surviving copy of the real
+severity*.
+
+That copy was built by spreading the caller's payload over the parameter::
+
+    payload={"severity": severity, **record}
+
+so a payload carrying a ``severity`` field replaced it - silently, with no
+refusal and nothing logged. An event raised ``severity="critical"`` was audited
+as whatever the payload said, and because the wire copy is uniform there is no
+second record to compare against.
+
+Eight of the nine record builders in this mixin already resolve exactly this
+collision the other way. ``_stamp_local_keys`` re-asserts the keys this process
+decided after a provider mapping merges in, and its own docstring names the
+hazard: "Merged last, a provider mapping carrying one of those seeded names
+replaces the local reading". It cites
+:meth:`strands_robots.mesh.session.PeerInfo.to_dict`, which spreads the peer's
+own payload *first* so the locally decided keys win. ``publish_safety_event``
+built the ninth record and was the one that spread last.
+
+Why the existing coverage was silent:
+``tests/mesh/test_safety_event_payload_reaches_the_wire.py`` owns a cell named
+``test_the_audit_record_still_carries_the_real_severity`` - the exact property
+that failed - but it drives ``payload={"reason": "x"}``. A payload with no
+``severity`` key cannot collide, so the assertion held whichever way the merge
+was ordered. ``tests/mesh/test_sensor_readers.py`` asserts the same thing with
+the same non-colliding payload. The property was named and never exercised.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from strands_robots.mesh import sensors as mesh_sensors
+from strands_robots.mesh.sensors import SensorLoopsMixin
+
+#: Payload spellings of a ``severity`` field, and why each is worth its own cell.
+#: A caller may name a field ``severity`` because their event has one (the audit
+#: payloads ``mesh.core._emit_resume_denied`` writes carry exactly that key), and
+#: the value need not even be a severity word.
+_COLLIDING_PAYLOADS: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("another-severity-word", {"joint": "elbow", "severity": "info"}),
+    ("the-in-repo-audit-payload-shape", {"sender_id": "a", "reason": "denied", "severity": "info"}),
+    ("not-a-severity-word-at-all", {"severity": 0}),
+    ("severity-is-the-only-field", {"severity": None}),
+    ("an-empty-string", {"severity": ""}),
+)
+
+_IDS = tuple(row[0] for row in _COLLIDING_PAYLOADS)
+
+#: The severities the cells below raise events with. No payload above uses either
+#: value, so a cell that passes cannot be passing because the two happened to
+#: agree - the coincidence case has its own class.
+_RAISED = "critical"
+_DEFAULT_SEVERITY = "warning"
+
+
+class _Host(SensorLoopsMixin):
+    """A mixin host that records what each half of the call was handed."""
+
+    def __init__(self, peer_id: str = "peer-1") -> None:
+        self.robot: Any = object()
+        self.peer_id = peer_id
+        self._running = True
+        self._stop_event = threading.Event()
+        self.wire: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, key: str, payload: dict[str, Any]) -> None:
+        self.wire.append((key, payload))
+
+
+@pytest.fixture
+def audited(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture the audit half's keyword arguments instead of writing a record."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(mesh_sensors, "log_safety_event", lambda **kw: calls.append(kw))
+    return calls
+
+
+# --- the derived rule ------------------------------------------------------
+
+
+def _mixin_methods() -> dict[str, ast.FunctionDef]:
+    source = inspect.getsource(mesh_sensors)
+    cls = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef) and node.name == "SensorLoopsMixin"
+    )
+    return {node.name: node for node in cls.body if isinstance(node, ast.FunctionDef)}
+
+
+def _shadowed_literal_keys(fn: ast.FunctionDef) -> set[str]:
+    """Explicit keys a ``**`` spread later in the same dict literal can replace.
+
+    Read off the literal rather than listed, so the rule is about the ordering
+    the language gives the merge and not about any particular key name.
+    """
+    shadowed: set[str] = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Dict):
+            continue
+        spreads = [i for i, key in enumerate(node.keys) if key is None]
+        if not spreads:
+            continue
+        last_spread = max(spreads)
+        shadowed |= {
+            key.value
+            for index, key in enumerate(node.keys)
+            if index < last_spread and isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+    return shadowed
+
+
+def _merges_a_foreign_mapping(fn: ast.FunctionDef) -> bool:
+    """Whether the method merges a mapping it did not build itself."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "update":
+            return True
+        if isinstance(node, ast.Dict) and any(key is None for key in node.keys):
+            return True
+    return False
+
+
+def _merging_methods() -> dict[str, ast.FunctionDef]:
+    """Methods that merge a foreign mapping into a record they seeded.
+
+    ``_stamp_local_keys`` is excluded because it *is* the re-assertion: its
+    ``record.update(local)`` is the local keys being put back, not a foreign
+    mapping being merged in.
+    """
+    return {
+        name: fn
+        for name, fn in _mixin_methods().items()
+        if name != "_stamp_local_keys" and _merges_a_foreign_mapping(fn)
+    }
+
+
+def _calls(fn: ast.FunctionDef, name: str) -> bool:
+    return any(isinstance(node, ast.Call) and name in ast.unparse(node.func) for node in ast.walk(fn))
+
+
+class TestThePremisesTheFixRestsOn:
+    """Measured, not assumed: why the audit copy is the one that matters."""
+
+    def test_the_wire_copy_carries_a_uniform_severity(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"joint": "elbow"})
+        assert host.wire[0][1]["severity"] == "info"
+
+    def test_so_the_audit_record_is_the_only_copy_of_the_real_severity(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"joint": "elbow"})
+        wire_event = host.wire[0][1]
+        assert "critical" not in json.dumps(wire_event)
+        assert audited[0]["payload"]["severity"] == "critical"
+
+    def test_the_mixin_really_merges_foreign_mappings(self) -> None:
+        merging = _merging_methods()
+        assert len(merging) >= 8, f"expected every merging builder, found {sorted(merging)}"
+        assert "publish_safety_event" in merging
+        assert {"_read_pose", "_read_imu", "_read_lidar_summary", "_read_map_info"} <= set(merging)
+
+    def test_the_shared_re_assertion_helper_exists_and_names_the_hazard(self) -> None:
+        doc = " ".join((SensorLoopsMixin._stamp_local_keys.__doc__ or "").split())
+        assert "carrying one of those seeded names replaces the local reading" in doc
+
+
+class TestTheSeverityParameterSurvivesAPayloadOfTheSameName:
+    """The regression. Each payload below collides; the parameter must win."""
+
+    @pytest.mark.parametrize(("_label", "payload"), _COLLIDING_PAYLOADS, ids=_IDS)
+    def test_the_audit_record_carries_the_parameter(
+        self, _label: str, payload: dict[str, Any], audited: list[dict[str, Any]]
+    ) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity=_RAISED, payload=payload)
+        assert audited[0]["payload"]["severity"] == _RAISED
+
+    @pytest.mark.parametrize(("_label", "payload"), _COLLIDING_PAYLOADS, ids=_IDS)
+    def test_the_default_severity_also_survives(
+        self, _label: str, payload: dict[str, Any], audited: list[dict[str, Any]]
+    ) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", payload=payload)
+        assert audited[0]["payload"]["severity"] == _DEFAULT_SEVERITY
+
+    def test_no_payload_above_agrees_with_the_severity_it_is_graded_against(self) -> None:
+        """Otherwise a cell could pass with the shadow still in place."""
+        for label, payload in _COLLIDING_PAYLOADS:
+            assert payload["severity"] not in (_RAISED, _DEFAULT_SEVERITY), label
+
+
+class TestTheShadowWasSilentWhenTheTwoValuesAgreed:
+    """Why a caller could carry the collision for a long time without noticing.
+
+    These two cells pass with the shadow in place and with it removed, and that
+    is the point rather than a gap: the merge only changed the record when the
+    payload's field happened to disagree with the parameter. The audit payloads
+    ``mesh.core._emit_resume_denied`` writes carry a ``severity`` field whose
+    value is the severity it would also pass as the argument, so the in-repo
+    shape is exactly the shape that agrees.
+    """
+
+    def test_a_payload_repeating_the_raised_severity_reads_the_same_either_way(
+        self, audited: list[dict[str, Any]]
+    ) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity=_RAISED, payload={"severity": _RAISED})
+        assert audited[0]["payload"]["severity"] == _RAISED
+
+    def test_a_payload_repeating_the_default_severity_reads_the_same_either_way(
+        self, audited: list[dict[str, Any]]
+    ) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", payload={"severity": _DEFAULT_SEVERITY})
+        assert audited[0]["payload"]["severity"] == _DEFAULT_SEVERITY
+
+
+class TestWhatIsUnchanged:
+    """Every expectation here is one the shadowed code also met."""
+
+    def test_a_payload_without_the_name_is_unaffected(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"joint": "elbow", "limit": 1.57})
+        assert audited[0]["payload"] == {"joint": "elbow", "limit": 1.57, "severity": "critical"}
+
+    def test_an_event_with_no_payload_still_audits_its_severity(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical")
+        assert audited[0]["payload"] == {"severity": "critical"}
+
+    def test_the_audit_envelope_still_names_the_event_and_the_peer(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host(peer_id="alice")
+        host.publish_safety_event("estop", severity="critical", payload={"joint": "elbow"})
+        assert audited[0]["event_type"] == "estop"
+        assert audited[0]["peer_id"] == "alice"
+
+    def test_a_stopped_host_still_publishes_and_audits_nothing(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host._running = False
+        host.publish_safety_event("estop", severity="critical", payload={"severity": "info"})
+        assert host.wire == [] and audited == []
+
+    def test_an_audit_failure_is_still_survived(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(**_kw: Any) -> None:
+            raise OSError("audit log unavailable")
+
+        monkeypatch.setattr(mesh_sensors, "log_safety_event", _boom)
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"severity": "info"})
+        assert host.wire[0][1]["type"] == "estop"
+
+
+class TestTheFixDoesNotReachIntoTheOtherHalf:
+    """Refusing the shadow must not edit the wire copy or the caller's mapping."""
+
+    def test_the_wire_payload_still_carries_the_callers_own_field(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"joint": "elbow", "severity": "info"})
+        assert host.wire[0][1]["payload"] == {"joint": "elbow", "severity": "info"}
+
+    def test_the_other_payload_fields_still_reach_the_audit_record(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event(
+            "estop", severity=_RAISED, payload={"sender_id": "a", "reason": "denied", "severity": "info"}
+        )
+        recorded = audited[0]["payload"]
+        assert recorded["sender_id"] == "a" and recorded["reason"] == "denied"
+        assert set(recorded) == {"sender_id", "reason", "severity"}
+
+    def test_the_supplied_mapping_is_unchanged(self, audited: list[dict[str, Any]]) -> None:
+        payload: dict[str, Any] = {"joint": "elbow", "severity": "info"}
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload=payload)
+        assert payload == {"joint": "elbow", "severity": "info"}
+
+    def test_the_two_halves_are_not_the_same_object(self, audited: list[dict[str, Any]]) -> None:
+        host = _Host()
+        host.publish_safety_event("estop", severity="critical", payload={"severity": "info"})
+        assert audited[0]["payload"] is not host.wire[0][1]["payload"]
+
+
+class TestNoMergedMappingShadowsALocalKey:
+    """The rule, derived from the module rather than listed here."""
+
+    def test_no_merging_method_places_a_key_before_a_spread(self) -> None:
+        offenders = {
+            name: sorted(shadowed)
+            for name, fn in _merging_methods().items()
+            if (shadowed := _shadowed_literal_keys(fn))
+        }
+        assert offenders == {}, (
+            f"these methods build a dict literal whose explicit keys a later ``**`` spread can replace: {offenders}"
+        )
+
+    def test_every_update_merge_re_asserts_the_local_keys(self) -> None:
+        unstamped = sorted(
+            name
+            for name, fn in _merging_methods().items()
+            if _calls(fn, ".update(") and not _calls(fn, "_stamp_local_keys")
+        )
+        assert unstamped == [], f"these methods merge with ``update`` and never re-assert their own keys: {unstamped}"
+
+    def test_the_shadow_rule_is_not_vacuous(self) -> None:
+        literal = ast.parse('{"severity": severity, **record}', mode="eval").body
+        fn = ast.parse("def f():\n    return " + ast.unparse(literal)).body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _shadowed_literal_keys(fn) == {"severity"}, "the rule must flag a key placed before a spread"
+
+    def test_the_shadow_rule_accepts_a_spread_that_comes_first(self) -> None:
+        fn = ast.parse('def f():\n    return {**record, "severity": severity}').body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _shadowed_literal_keys(fn) == set(), "a spread ahead of the local key is the accepted shape"
+
+    def test_a_key_between_two_spreads_is_still_shadowed(self) -> None:
+        """Being after one spread does not help if another follows."""
+        fn = ast.parse('def f():\n    return {**a, "severity": severity, **b}').body[0]
+        assert isinstance(fn, ast.FunctionDef)
+        assert _shadowed_literal_keys(fn) == {"severity"}


### PR DESCRIPTION
## Problem

`SensorLoopsMixin.publish_safety_event` sends one event two ways. It built the audit copy by
spreading the caller's payload over the parameter:

```python
payload={"severity": severity, **record}
```

so a payload carrying a `severity` field replaced it. No refusal, nothing logged. Measured
through the public method, capturing what each half was handed:

| raised with | payload | wire `event["severity"]` | audit `payload["severity"]` |
|---|---|---|---|
| `"critical"` | `{"joint": "elbow", "limit": 1.57}` | `info` | `critical` |
| `"critical"` | `{"joint": "elbow", "severity": "info"}` | `info` | **`info`** |
| `"critical"` | `{"severity": 0}` | `info` | **`0`** |
| `"warning"` (default) | `{"severity": "info"}` | `info` | **`info`** |

What makes that consequential rather than cosmetic is that there is no second copy to
compare against. The wire copy is uniformly `"info"` on purpose - issue #272 removed
per-branch severity from `strands/+/safety/event` so a subscriber could not read it as a
content-channel oracle for a rejection reason - and the method's own comment records the
consequence:

> The real severity is preserved only in the local audit record below.

So a critical stop could be audited as informational, with nothing anywhere disagreeing. I
also checked the negative: `"critical"` appears nowhere in the published wire event
(`assert "critical" not in json.dumps(event)`), which is the premise the fix rests on and is
pinned as such.

## Why this is the existing rule, not a new one

Eight of the nine record builders in this mixin already resolve exactly this collision the
other way. Derived from the shipped class rather than listed - a method that merges a mapping
it did not build, via `update` or a `**` spread:

| builder | merges | re-asserts its own keys |
|---|---|---|
| `_read_pose` (3 merge sites), `_read_imu`, `_read_odom`, `_read_lidar_summary`, `_read_lidar_state`, `_read_hands`, `_read_map_info`, `_read_health` | yes | yes, via `_stamp_local_keys` |
| `publish_safety_event` | yes | **no** |

`_stamp_local_keys` names the hazard in its own docstring - "merged last, a provider mapping
carrying one of those seeded names replaces the local reading" - and cites
`session.PeerInfo.to_dict`, which spreads the peer's own payload *first* so the locally
decided keys win. This applies that precedence to the ninth builder: `payload={**record,
"severity": severity}`.

The helper itself is deliberately not reused. It also stamps `peer_id`, and
`log_safety_event` already carries the peer as a field of its own envelope, so routing this
record through it would change the record's shape rather than only its precedence - measured
as break row b3 below, which trips four cells including two controls.

## Why every existing gate was silent

`tests/mesh/test_safety_event_payload_reaches_the_wire.py` owns a cell named
`test_the_audit_record_still_carries_the_real_severity` - the exact property that failed -
and drives it with `payload={"reason": "x"}`. A payload with no `severity` key cannot
collide, so the assertion held whichever way the merge was ordered.
`tests/mesh/test_sensor_readers.py:518` asserts the same thing with the same non-colliding
payload. The property was named and never exercised.

There is a second reason it could go unnoticed for a long time: the merge only changed the
record when the two values *disagreed*. The audit payloads `mesh.core._emit_resume_denied`
writes carry a `severity` field whose value is the severity it would also pass as the
argument, so the idiomatic in-repo shape is exactly the shape that agrees. Two cells pin
that (`TestTheShadowWasSilentWhenTheTwoValuesAgreed`); they pass either way, which is the
point rather than a gap, and they are reported as passing pre-fix below.

## Reachability

Latent, and stated plainly: of the 12 `publish_safety_event` call sites in the tree, **0**
pass a payload containing a `severity` key, so no shipped call path was affected. The method
is public API on `Mesh`, its docstring names the parameter as "the real severity", and the
`severity`-in-the-payload shape is what both audit-writing paths in this repo already
produce - `_emit_resume_denied` puts it there explicitly, and `publish_safety_event` puts it
there itself - so a caller naming that field is following the local convention rather than
doing something exotic.

## Tests

New file `tests/mesh/test_safety_severity_is_the_parameters.py`, 31 cells. Pre-fix split,
per class and per role:

| class | role | fail | total |
|---|---|---|---|
| `TestThePremisesTheFixRestsOn` | premise | 0 | 4 |
| `TestTheSeverityParameterSurvivesAPayloadOfTheSameName` | regression | 10 | 11 |
| `TestTheShadowWasSilentWhenTheTwoValuesAgreed` | passes either way, by design | 0 | 2 |
| `TestWhatIsUnchanged` | control | 0 | 5 |
| `TestTheFixDoesNotReachIntoTheOtherHalf` | over-reach guard | 0 | 4 |
| `TestNoMergedMappingShadowsALocalKey` | regression (derived) | 1 | 5 |
| | | **11** | **31** |

The one regression cell that passes pre-fix is
`test_no_payload_above_agrees_with_the_severity_it_is_graded_against`, a meta-assertion that
no parametrized payload repeats the severity it is graded against - without it a cell could
pass with the shadow still in place. Every payload in the regression set therefore differs
from both `"critical"` and the `"warning"` default.

## Break table

10 mutations, 9 distinct non-empty firing sets, control clean, source restored
byte-identical (md5-checked per row). `collected` recorded alongside `fires`, so a mutation
that deselects rather than fails cannot read as green.

| # | mutation | fires | collected |
|---|---|---|---|
| b0 | control, no mutation | 0 | 31 |
| b1 | payload spread last again (the defect) | 11 | 31 |
| b2 | severity re-asserted as a hardcoded literal | 9 | 31 |
| b3 | `_stamp_local_keys` used instead (also stamps `peer_id`) | 4 | 31 |
| b4 | alternative disposition: refuse a payload carrying the name | 18 | 31 |
| b5 | fix applied to the wire copy instead of the audit copy | 13 | 31 |
| b6 | the wire severity carries the real severity too | 2 | 31 |
| b7a | plant a 10th shadowing builder, inventory derived (as shipped) | 1 | 31 |
| b7b | the same plant, inventory hardcoded to today's names | **0** | 31 |
| b8 | shadow rule keyed on the first spread rather than the last | 1 | 31 |
| b9 | a regression payload made to agree with the severity it grades | 1 | 31 |

b7a/b7b is the pair that shows the derived inventory is load-bearing: a hardcoded list equal
to today's derived set is completely silent when a 10th builder lands, so the plant is the
only way to demonstrate the difference.

b4 is the disposition a reviewer might reasonably propose instead - refuse a payload carrying
the name. It trips 18 cells, including `test_an_audit_failure_is_still_survived`: raising
from a safety-event publisher is worse than the shadow it removes. b6 shows the over-reach
guard on the other half works - making the wire severity real trips the two premise cells,
so the wire's uniformity cannot be quietly given up.

b8 was found by this table: it fired 0 initially because every dict literal in the mixin has
at most one spread, so `min` and `max` agreed. A constructed exemplar with a key *between*
two spreads closes it, and the row now fires.

## Gate

- **Paired pytest, byte-identical.** Identical 495-file selection (all 206 `tests/mesh/`
  files plus 291 guards that walk the tree, read source/docstrings, or read `changelog.d`),
  the new file excluded from both trees, every path asserted present on both. Identical
  **20070 collected** and `21 failed, 19958 passed, 67 skipped, 24 errors` on both
  (648.75s vs 661.02s). 45 failing/erroring ids each, `comm` empty in **both** directions.
  All 45 are `tests/mesh/test_iot_*` and need `awsiot`/`awscrt`, both absent here and both
  declared in the `[mesh-iot]` extra (verified with `tomllib` + `find_spec`, not assumed).
- `tests/mesh/test_zenoh_transport_security.py` opens a live session, so it was excluded
  from the pair and run alone: **9 passed, 2 skipped on both trees**.
- **mypy** `strands_robots tests tests_integ`: **24 == 24** against a worktree pinned to the
  merge-base, normalized message sets byte-identical in both directions, **0** in the changed
  files.
- **ruff** `check` and `format --check` clean over `strands_robots tests tests_integ`
  (1578 files).
- The four sibling suites that assert a severity, on the rebased branch:
  `test_safety_event_payload_reaches_the_wire`, `test_sensor_readers`, `test_deep_mesh`,
  `test_estop_replay` - **197 passed**. With the changelog guards and the test file #2758
  added: **293 passed**.
- Changelog fragment validated by `scripts/assemble_changelog.py --check` and confirmed
  present in `--print` output.

No visual artifact: the change is to an audit record's key precedence, not to a policy,
simulation, render, recording or asset. The measured before/after table above is the
artifact.
