### PR TITLE
fix(mesh): read joints from a driver that owns its bus

### DIFF
--- a/changelog.d/2763-mesh-native-driver-joint-source.md
+++ b/changelog.d/2763-mesh-native-driver-joint-source.md
@@ -1,0 +1,35 @@
+### Fixed: the mesh reads joints from a driver that owns its bus
+
+A robot reaches its motors one of two ways. A lerobot robot is a wrapper: `hardware_robot.Robot`
+holds the device that owns the bus under `robot`, and the wrapper answers no read itself. A native
+driver owns the bus directly, so it *is* the device.
+
+`Mesh._read_state` resolved only the first shape, so a driver satisfying every member of
+`DRIVER_SURFACE` published no joint telemetry at all. Every other section reaches the mesh through a
+`getattr(robot, name, None)` read straight off the driver -- `_imu`, `_battery`, `_temps` and
+thirteen siblings -- so such a driver could report how hot a joint was and not where it was, while
+`missing_driver_members` reported no problem and the presence heartbeat kept advertising the peer.
+That is the presentation `_read_state`'s own docstring exists to avoid: a peer that "went silent on
+the state topic while its presence heartbeat kept advertising it -- indistinguishable from a peer
+whose state thread had died".
+
+`read_joints` could already read such a driver unchanged, preferring `bus.sync_read` and falling
+back to `get_observation`; nothing handed the driver to it. So the repair is to resolve the
+telemetry device rather than assume it. `bus_access.joint_read_source` prefers `robot.robot` and
+falls back to the robot itself, admitting a device exactly when `read_joints` has a route to it --
+the admission rule derived from that function's own branch rather than restated, so a caller cannot
+admit a device the reader raises on, or refuse one it could have read.
+
+Deriving the rule also repairs a narrower disagreement at the same site. The old gate required
+`get_observation`, which is the capability `read_joints` treats as its *fallback*, and refused a
+device carrying only the `bus` it *prefers* -- the shape an SO-100/SO-101 driver has, where joint
+position, velocity and current are the whole telemetry.
+
+An inner device is preferred whenever one is present, so a wrapper is never read in place of the
+device it wraps and a robot that already published joints resolves to the same device as before.
+`is_connected` remains the liveness gate, and a driver with no motors to report still publishes no
+`joints` without appearing as a failed probe in `degraded`.
+
+Scoped to the state topic's `joints` section. Two further consequences of a driver having no inner
+device are left for their own change: presence drops `connected` and `hw`, and
+`_publish_cameras_once` routes a real peer into `_publish_sim_cameras()`.

--- a/strands_robots/bus_access.py
+++ b/strands_robots/bus_access.py
@@ -224,3 +224,63 @@ def read_joints(device: Any) -> Any:
     # ``.pos`` is lerobot's own suffix (see SOFollower.get_observation) and the
     # shape the rest of this codebase already parses.
     return {f"{motor}.pos": value for motor, value in raw.items()}
+
+
+def _answers_a_joint_read(device: Any) -> bool:
+    """Whether :func:`read_joints` has a route to ``device``'s joint positions.
+
+    Derived from :func:`read_joints`'s own branch rather than restated: it reads
+    ``bus.sync_read`` when the device exposes one and falls back to
+    ``get_observation``, so a device carrying either can be read and a device
+    carrying neither cannot. Keeping the admission rule and the reader in one
+    module is what stops a caller admitting a device the reader then raises on,
+    or refusing one it could have read.
+
+    Args:
+        device: The candidate to test. Neither attribute is called.
+
+    Returns:
+        ``True`` when ``device`` exposes a ``bus`` with ``sync_read``, or a
+        ``get_observation``.
+    """
+    bus = getattr(device, "bus", None)
+    if bus is not None and hasattr(bus, "sync_read"):
+        return True
+    return hasattr(device, "get_observation")
+
+
+def joint_read_source(robot: Any) -> Any | None:
+    """The device to read ``robot``'s joint positions from, or ``None``.
+
+    A robot reaches its motors one of two ways. A lerobot robot is a *wrapper*:
+    :class:`strands_robots.hardware_robot.Robot` holds the device that owns the
+    bus under ``robot``, and the wrapper itself answers no read at all. A native
+    driver owns its bus directly, so it *is* the device.
+
+    Resolving only the first shape is what left the second publishing no joint
+    telemetry: a driver satisfying every member of
+    :data:`~strands_robots.drivers.DRIVER_SURFACE` reported its IMU, its lidar
+    summary and its motor temperatures - each read straight off the driver with a
+    ``getattr`` default - while ``joints`` was absent from the state topic,
+    because joints were the one section reached only through the inner device.
+    :func:`read_joints` could already read such a driver unchanged; nothing
+    handed it to it.
+
+    An inner device is still preferred whenever one is present, so a wrapper is
+    never read in place of the device it wraps.
+
+    Args:
+        robot: The object a telemetry consumer was handed - a lerobot wrapper, a
+            native driver, or anything else shaped like a driver.
+
+    Returns:
+        The inner device when ``robot`` has one that can answer a joint read;
+        ``robot`` itself when it has no inner device and can answer one; ``None``
+        when no joint read is possible, which callers report as "no joints" and
+        not as a failure.
+    """
+    device = getattr(robot, "robot", None)
+    if device is None:
+        # No inner device: a native driver owns its telemetry directly.
+        device = robot
+    return device if _answers_a_joint_read(device) else None

--- a/strands_robots/drivers/base.py
+++ b/strands_robots/drivers/base.py
@@ -12,11 +12,19 @@ learn which members are load-bearing.
 *measured* contract rather than an aspirational one, which makes it smaller than
 a reader might expect:
 
-* ``get_observation`` is **not** a member. The mesh reads observations from the
-  driver's *inner* device (``getattr(robot, "robot", None)`` in
-  :mod:`strands_robots.mesh.sensors`), and
+* ``get_observation`` is **not** a member. A lerobot robot is a wrapper: it
+  holds the device that owns the bus under ``robot``, and
   :func:`strands_robots.bus_access.read_observation` takes that inner device -
   so the top-level driver is not the thing asked for a frame.
+
+  A native driver has no inner device, and for joint telemetry that is now
+  resolved rather than assumed:
+  :func:`strands_robots.bus_access.joint_read_source` prefers ``robot.robot``
+  and falls back to the driver itself, so a driver that owns its bus publishes
+  ``joints`` on the state topic by exposing either a ``bus`` with ``sync_read``
+  or a ``get_observation``, plus ``is_connected`` to say it is live. Neither is
+  required, which is why neither is a member: a driver with no motors to report
+  is otherwise complete.
 * The sensor attributes a mesh publishes (``_pose``, ``_imu``, ``_battery`` and
   their siblings) are **not** members either. Every one is read with a
   ``getattr(robot, name, None)`` default, so a driver with no IMU publishes no

--- a/strands_robots/mesh/core.py
+++ b/strands_robots/mesh/core.py
@@ -23,7 +23,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from strands_robots._mesh_switch import mesh_env_request
-from strands_robots.bus_access import read_joints, read_observation
+from strands_robots.bus_access import joint_read_source, read_joints, read_observation
 from strands_robots.mesh import security as _security
 from strands_robots.mesh.audit import log_safety_event
 from strands_robots.mesh.pacing import Ticker
@@ -1393,8 +1393,12 @@ class Mesh(SensorLoopsMixin):
         snapshot: dict[str, Any] = {"peer_id": self.peer_id, "t": time.time()}
 
         try:
-            inner = getattr(r, "robot", None)
-            if inner is not None and hasattr(inner, "get_observation") and getattr(inner, "is_connected", False):
+            # A lerobot robot wraps the device that owns the bus; a native
+            # driver owns it directly. Resolving only the wrapper shape left a
+            # contract-complete native driver publishing every sensor it had
+            # and not one joint (#2749).
+            inner = joint_read_source(r)
+            if inner is not None and getattr(inner, "is_connected", False):
                 # Through the device's bus lock: this probe shares one serial
                 # conversation with the camera publisher, the sensors probe and
                 # teleop, and two readers at once make the SDK refuse the whole

--- a/tests/mesh/test_read_state_joints_from_a_driver_that_owns_its_bus.py
+++ b/tests/mesh/test_read_state_joints_from_a_driver_that_owns_its_bus.py
@@ -1,0 +1,335 @@
+"""A driver that owns its motor bus publishes ``joints`` on the state topic.
+
+A robot reaches its motors one of two ways. A lerobot robot is a *wrapper*:
+:class:`strands_robots.hardware_robot.Robot` holds the device that owns the bus
+under ``robot``, and the wrapper answers no read itself. A native driver
+(:mod:`strands_robots.drivers`) owns the bus directly, so it *is* the device.
+
+:meth:`~strands_robots.mesh.core.Mesh._read_state` resolved only the first shape,
+which left the second publishing no joint telemetry at all (#2749). Every other
+section reaches the mesh through a ``getattr(robot, name, None)`` read straight
+off the driver -- ``_imu``, ``_battery``, ``_temps`` and thirteen siblings -- so a
+contract-complete native driver could report how hot a joint was and not where it
+was, and ``missing_driver_members`` reported no problem.
+
+The reader was never the missing piece: :func:`read_joints` reads such a driver
+unchanged, preferring ``bus.sync_read`` and falling back to ``get_observation``.
+Nothing handed the driver to it. ``TestTheReaderCouldAlreadyReadTheDriver``
+pins that premise, because it is what makes resolving the device the whole fix.
+
+Two shapes matter and they are not the same test. A driver whose telemetry is a
+motor bus and nothing else -- an SO-100/SO-101 arm, where joint position,
+velocity and current *are* the telemetry -- carries no ``get_observation`` at
+all, and the old gate demanded exactly the capability ``read_joints`` treats as
+its fallback while refusing the one it prefers. Its mirror image -- a driver whose
+only reader *is* ``get_observation`` -- is here for the same reason: it is what
+makes each half of the admission rule independently load-bearing.
+
+What this file does not assert: that a wrapper may be read in place of the device
+it wraps. An inner device is preferred whenever one is present
+(``TestTheWrapperPathIsUnchanged``), so this widens which robots publish joints
+and changes nothing about which device answers for a robot that already did.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import numpy as np
+import pytest
+
+from strands_robots.bus_access import joint_read_source, read_joints
+from strands_robots.drivers import missing_driver_members
+from strands_robots.mesh.core import Mesh
+
+_PEER = "probe"
+
+#: Positions the stand-in buses report, in lerobot's own ``<motor>`` keying.
+_MOTORS = {"shoulder_pan": 12.5, "elbow_flex": -4.0, "gripper": 3.0}
+
+#: The same reading as ``get_observation`` shapes it, with lerobot's ``.pos``.
+_OBS = {f"{motor}.pos": value for motor, value in _MOTORS.items()}
+
+
+class _Bus:
+    """A motor bus, answering ``sync_read`` the way a feetech/dynamixel one does."""
+
+    def __init__(self, values: dict[str, Any] | None = None) -> None:
+        self._values = dict(_MOTORS if values is None else values)
+
+    def sync_read(self, register: str, **kwargs: Any) -> dict[str, Any]:
+        return dict(self._values)
+
+
+class _ContractOnly:
+    """Exactly the twelve members of ``DRIVER_SURFACE`` and nothing else.
+
+    Deliberately not a subclass of anything in the package: the seam is
+    structural, so a driver satisfies it by having the members.
+    """
+
+    tool_name_str = "so101"
+
+    @property
+    def tool_name(self) -> str:
+        return self.tool_name_str
+
+    @property
+    def tool_type(self) -> str:
+        return "robot"
+
+    @property
+    def tool_spec(self) -> dict[str, Any]:
+        return {"name": "so101", "description": "arm", "inputSchema": {"json": {}}}
+
+    async def stream(self, tool_use: Any, invocation_state: Any, **kwargs: Any) -> Any:
+        yield {}
+
+    def send_action(self, action: Any) -> Any:
+        return action
+
+    def get_status(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def get_task_status(self) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def start_task(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def stop_task(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def run_policy(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def stop(self, *a: Any, **k: Any) -> dict[str, Any]:
+        return {"status": "success"}
+
+    def cleanup(self) -> None:
+        return None
+
+
+class _InnerLerobotDevice:
+    """The device a lerobot wrapper holds: it owns the bus, the wrapper does not."""
+
+    is_connected = True
+    name = "so101_follower"
+    config = type("Config", (), {"cameras": {}})()
+
+    def __init__(self) -> None:
+        self.bus = _Bus()
+
+    def get_observation(self) -> dict[str, Any]:
+        return dict(_OBS)
+
+
+class Wrapper(_ContractOnly):
+    """A lerobot robot: the telemetry device is held under ``robot``."""
+
+    def __init__(self) -> None:
+        self.robot = _InnerLerobotDevice()
+
+
+class NativeWithObservation(_ContractOnly):
+    """A native driver exposing both a bus and ``get_observation``."""
+
+    is_connected = True
+    config = type("Config", (), {"cameras": {}})()
+
+    def __init__(self) -> None:
+        self.bus = _Bus()
+
+    def get_observation(self) -> dict[str, Any]:
+        return dict(_OBS)
+
+
+class NativeBusOnly(_ContractOnly):
+    """A native driver whose entire telemetry *is* the motor bus.
+
+    The shape an SO-100/SO-101 driver has. It carries no ``get_observation``,
+    which is the capability the old gate demanded.
+    """
+
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.bus = _Bus()
+
+
+class NativeObservationOnly(_ContractOnly):
+    """A native driver whose only reader is ``get_observation``: no motor bus.
+
+    The shape a network-backed or SDK-backed driver has, and the one that makes
+    the fallback branch of the admission rule load-bearing rather than
+    decorative -- every other native shape here also carries a bus.
+    """
+
+    is_connected = True
+    config = type("Config", (), {"cameras": {}})()
+
+    def get_observation(self) -> dict[str, Any]:
+        return dict(_OBS)
+
+
+class NativeNumpyBus(_ContractOnly):
+    """A native bus answering with numpy scalars, as a real SDK does."""
+
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.bus = _Bus({motor: np.float32(value) for motor, value in _MOTORS.items()})
+
+
+class NativeNothingToRead(_ContractOnly):
+    """A native driver with no motors to report: no bus, no observation."""
+
+    is_connected = True
+
+
+class NativeNotConnected(_ContractOnly):
+    """A readable native driver that says it is not live."""
+
+    is_connected = False
+
+    def __init__(self) -> None:
+        self.bus = _Bus()
+
+
+#: Every shape whose joints must reach the state topic.
+_PUBLISHES = (NativeWithObservation, NativeBusOnly, NativeObservationOnly, NativeNumpyBus, Wrapper)
+
+#: Every shape in this file, for the rules that hold across all of them.
+_ALL = _PUBLISHES + (NativeNothingToRead, NativeNotConnected)
+
+
+def _snapshot(cls: type) -> dict[str, Any]:
+    """The state snapshot a mesh built on ``cls`` reports, never ``None``."""
+    return Mesh(cls(), _PEER)._read_state() or {}
+
+
+class TestADriverThatOwnsItsBusPublishesJoints:
+    """The regression: a native driver's joint positions reach the state topic."""
+
+    @pytest.mark.parametrize("cls", [NativeWithObservation, NativeBusOnly, NativeObservationOnly, NativeNumpyBus])
+    def test_the_joints_section_is_present(self, cls: type) -> None:
+        """Absent before: joints were reached only through an inner device."""
+        assert "joints" in _snapshot(cls), f"{cls.__name__} published no joints"
+
+    @pytest.mark.parametrize("cls", [NativeWithObservation, NativeBusOnly, NativeObservationOnly, NativeNumpyBus])
+    def test_the_joints_are_the_positions_the_bus_reported(self, cls: type) -> None:
+        """Not merely present: the values are the ones the device answered with."""
+        joints = _snapshot(cls)["joints"]
+        assert {key: pytest.approx(value) for key, value in joints.items()} == {
+            key: pytest.approx(value) for key, value in _OBS.items()
+        }
+
+    @pytest.mark.parametrize("cls", [NativeWithObservation, NativeBusOnly, NativeObservationOnly, NativeNumpyBus])
+    def test_the_snapshot_survives_the_encoder_that_stands_between_it_and_the_wire(self, cls: type) -> None:
+        """``session._put_zenoh_directly`` runs ``json.dumps`` before ``put``.
+
+        A payload it refuses is dropped for good, so a section that reaches the
+        snapshot and not the wire is no better than an absent one. The numpy
+        shape is the one that tests this: ``json.dumps`` refuses ``np.float32``.
+        """
+        decoded = json.loads(json.dumps(_snapshot(cls)))
+        assert decoded["joints"].keys() == _OBS.keys()
+
+
+class TestTheWrapperPathIsUnchanged:
+    """An inner device is preferred, so a wrapper is never read in its place."""
+
+    def test_a_lerobot_wrapper_still_publishes_its_joints(self) -> None:
+        assert _snapshot(Wrapper)["joints"] == pytest.approx(_OBS)
+
+    def test_the_inner_device_is_the_resolved_source(self) -> None:
+        """Not the wrapper, even though both are shaped like a robot here."""
+        robot = Wrapper()
+        assert joint_read_source(robot) is robot.robot
+
+    def test_a_wrapper_holding_an_unreadable_device_reports_no_joints(self) -> None:
+        """Resolution must not escape to the wrapper when an inner device exists.
+
+        Falling back here would read a different robot than the one the wrapper
+        wraps, which is a wrong reading rather than a missing one.
+        """
+
+        class _WrapsSomethingUnreadable(_ContractOnly):
+            is_connected = True
+
+            def __init__(self) -> None:
+                self.bus = _Bus()
+                self.robot = object()
+
+        assert joint_read_source(_WrapsSomethingUnreadable()) is None
+        assert "joints" not in _snapshot(_WrapsSomethingUnreadable)
+
+
+class TestNothingToReadIsStillNothingToRead:
+    """The widening reaches drivers that can be read, and stops there."""
+
+    def test_a_driver_with_no_motors_publishes_no_joints(self) -> None:
+        assert "joints" not in _snapshot(NativeNothingToRead)
+
+    def test_a_driver_that_says_it_is_not_live_publishes_no_joints(self) -> None:
+        """``is_connected`` is the liveness gate and it still decides."""
+        assert "joints" not in _snapshot(NativeNotConnected)
+
+    def test_having_no_joints_is_not_reported_as_a_failed_probe(self) -> None:
+        """ "Nothing to report" and "the probe raised" are different states.
+
+        The ``degraded`` block exists so a peer whose joint probe is failing says
+        so; a driver with no motors must not appear there.
+        """
+        snapshot = _snapshot(NativeNothingToRead)
+        assert "hw_joints" not in snapshot.get("degraded", {})
+
+
+class TestTheReaderCouldAlreadyReadTheDriver:
+    """The premise: resolving the device is the whole fix.
+
+    If ``read_joints`` needed changing too, this file would be testing a
+    different repair than the one that was made.
+    """
+
+    @pytest.mark.parametrize("cls", [NativeWithObservation, NativeBusOnly, NativeObservationOnly, NativeNumpyBus])
+    def test_read_joints_reads_a_native_driver_unchanged(self, cls: type) -> None:
+        assert read_joints(cls()).keys() == _OBS.keys()
+
+    def test_a_lerobot_wrapper_itself_answers_no_read(self) -> None:
+        """Which is why an inner device has to be preferred rather than ignored."""
+        with pytest.raises(AttributeError):
+            read_joints(Wrapper())
+
+    @pytest.mark.parametrize("cls", _ALL)
+    def test_every_shape_here_satisfies_the_driver_contract(self, cls: type) -> None:
+        """None of these is missing a documented member, before or after."""
+        assert missing_driver_members(cls) == ()
+
+
+class TestTheAdmissionRuleTracksTheReader:
+    """A device is admitted exactly when the reader has a route to it.
+
+    Derived rather than listed, so a future branch in ``read_joints`` that the
+    resolver does not mirror fails here instead of raising in a mesh probe.
+    """
+
+    @pytest.mark.parametrize("cls", _ALL)
+    def test_resolution_and_readability_agree(self, cls: type) -> None:
+        robot = cls()
+        resolved = joint_read_source(robot)
+        try:
+            read_joints(resolved if resolved is not None else robot)
+        except AttributeError:
+            readable = False
+        else:
+            readable = True
+        assert (resolved is not None) is readable, (
+            f"{cls.__name__}: resolved={resolved is not None} readable={readable}"
+        )
+
+    def test_the_two_outcomes_are_both_reached(self) -> None:
+        """Non-vacuity: the rule above would pass on an all-readable set."""
+        outcomes = {joint_read_source(cls()) is not None for cls in _ALL}
+        assert outcomes == {True, False}


### PR DESCRIPTION
## Problem

A robot reaches its motors one of two ways. A lerobot robot is a **wrapper**:
`hardware_robot.Robot` holds the device that owns the bus under `robot`, and the wrapper
answers no read itself. A **native driver** owns the bus directly, so it *is* the device.

`Mesh._read_state` resolved only the first shape:

```python
inner = getattr(r, "robot", None)
if inner is not None and hasattr(inner, "get_observation") and getattr(inner, "is_connected", False):
    obs = read_joints(inner)
```

So a driver satisfying every member of `DRIVER_SURFACE` published no joint telemetry at
all. Every other section reaches the mesh through a `getattr(robot, name, None)` read
straight off the driver -- `_imu`, `_battery`, `_temps` and thirteen siblings -- so such a
driver could report **how hot a joint was and not where it was**, and
`missing_driver_members` reported no problem. The presence heartbeat kept advertising the
peer either way, which is the presentation `_read_state`'s own docstring exists to avoid:
"it went silent on the state topic while its presence heartbeat kept advertising it --
indistinguishable from a peer whose state thread had died".

Measured on `main`, driving the real `Mesh._read_state` over three driver shapes, each
contract-complete (`missing_driver_members(cls) == ()`):

| driver shape | `_read_state()` | `joints` | `read_joints(driver)` called directly |
|---|---|---|---|
| lerobot wrapper (inner device) | dict | 3 motors | `AttributeError` -- the wrapper answers no read |
| native, `get_observation` + bus | **`None`** | **absent** | **OK, 3 motors** |
| native, bus only | **`None`** | **absent** | **OK, 3 motors** |

The last column is the point: **`read_joints` could already read both native drivers,
unchanged. Nothing handed them to it.** The reader was never the missing piece -- it
prefers `bus.sync_read` and falls back to `get_observation` -- so the defect is entirely
in how the *device* was resolved.

The first row is the control that shapes the fix: a wrapper genuinely cannot be read, so
an inner device must still be **preferred**, not merely tried.

## Change

`bus_access.joint_read_source(robot)` resolves the device once: prefer `robot.robot`, fall
back to the robot itself, and admit it only when `read_joints` has a route to it. It lives
beside `read_joints` because its admission rule is *derived from* that function's own
branch rather than restated -- keeping the two in one module is what stops a caller
admitting a device the reader then raises on, or refusing one it could have read.

Deriving the rule also repairs a narrower disagreement at the same site: the old gate
required `get_observation`, which is the capability `read_joints` treats as its
**fallback**, and refused a device carrying only the `bus` it **prefers** -- the shape an
SO-100/SO-101 driver has, where joint position, velocity and current are the whole
telemetry.

An inner device is preferred whenever one is present, so a wrapper is never read in place
of the device it wraps, and a robot that already published joints resolves to the same
device as before. `is_connected` remains the liveness gate.

`drivers/base.py` documented the arrangement this changes ("The mesh reads observations
from the driver's *inner* device") and is updated in the same change.

## Why not the alternatives

Two other repairs were considered and are worse on measurement, not on taste:

- **Name the requirement in the `HardwareDriver` Protocol.** Not available:
  `missing_driver_members` checks `hasattr` on the class, and
  `hasattr(hardware_robot.Robot, 'robot' | 'get_observation' | 'is_connected' | 'bus')` is
  `False` for all four -- adding any of them makes the incumbent driver fail its own
  surface check.
- **Give joints a driver-level `_joints` cache**, like the other sixteen attributes. That
  duplicates `read_joints`, which already reads both shapes correctly.

Route 1 is also the only one that is backward-compatible by construction: when `robot.robot`
is present the resolved device is identical, so nothing about an existing peer moves.

## Tests

`tests/mesh/test_read_state_joints_from_a_driver_that_owns_its_bus.py`, 38 cases over five
driver shapes, driving the real `Mesh`, the real `read_joints` and its bus lock. Pre-fix
split (helper kept, call site reverted): **9 failed / 23 passed, and all 9 failures are in
the regression class** -- zero in the control, premise or derived classes. A raw revert is a
collection error, since the tests import the new symbol.

The suite asserts more than presence: the joints carry the values the bus reported, and the
snapshot survives `json.dumps` -- the step `session._put_zenoh_directly` performs before
`put`, where a refused payload is dropped for good. The numpy-scalar shape is what makes
that cell load-bearing, since `json.dumps` refuses `np.float32`.

Mutation table, 8 mutations, all 8 detected, 7 distinct firing sets, control clean, 38
collected in every row:

| mutation | cases fired |
|---|---|
| the fix removed (mesh resolves only `robot.robot`) | 12 |
| admission drops the bus branch (`get_observation` only) | 9 |
| admission drops the `get_observation` branch (bus only) | 4 |
| resolver skips the readability test | 4 |
| resolver ignores the inner device, always reads the robot | 3 |
| liveness gate (`is_connected`) dropped | 1 |
| resolver escapes to the wrapper when the inner device is unreadable | 1 |

The two four-case rows are why both halves of the admission rule are separately pinned: one
shape carries a bus and no `get_observation`, another carries `get_observation` and no bus,
so neither branch can be dropped unnoticed. `TestTheAdmissionRuleTracksTheReader` derives
the agreement between resolution and readability rather than listing it, with a non-vacuity
cell asserting both outcomes are reached.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1572 files).
- `mypy strands_robots tests tests_integ`: **`Success: no issues found in 1569 source files`**.
- Paired run over an identical 478-file selection (all of `tests/mesh`, all of
  `tests/drivers`, and every test that walks the tree, reads docstrings or names
  `bus_access`), with the new file excluded from both trees: **19054 collected and
  `5 failed, 18980 passed, 69 skipped` on both**, the five failing ids identical and both
  `comm` directions empty. All five expect `rclpy` to be absent and resolve it from a
  system ROS 2 install; they fail identically on an unmodified tree.
- Rebased onto `13fda66a`, which merged #2754. Its `TestTheDriverIsWhatTheMeshReads` pins
  `getattr(driver, "robot", None) is None` as a premise; that stays true here, because this
  change resolves the device on the mesh side and asks nothing of the driver. `tests/drivers`
  plus `tests/mesh/test_mesh.py` plus the new file: 168 passed.

## Scope

The state topic's `joints` section only. `inner is None` has two further consequences the
issue records -- presence drops `connected` and `hw`, and `_publish_cameras_once` routes a
real peer into `_publish_sim_cameras()` -- which are different subsystems with their own
semantics and are left for their own change. `G1Driver` declares neither `is_connected` nor
a readable bus today, so this opens the route rather than lighting up that driver: a native
driver publishes `joints` by exposing either a bus with `sync_read` or a `get_observation`,
plus `is_connected`, which `drivers/base.py` now says.

Closes #2749
