### PR TITLE
fix(tools): name the parameter a rosbridge port refusal was given

### DIFF
--- a/changelog.d/2764-rosbridge-refusal-names-its-parameter.md
+++ b/changelog.d/2764-rosbridge-refusal-names-its-parameter.md
@@ -1,0 +1,20 @@
+### Fixed: a rosbridge port refusal names the parameter it was given
+
+`use_rosbridge._transport_port_error` refuses a port that is legal TCP but outside the range the
+rosbridge WebSocket transport can address. It takes a `param` argument documented as "the parameter
+name it came from, used in the message" -- the same sentence eleven sibling helpers in this package
+carry -- and hard-coded the word `port` into the message instead, so the argument was accepted and
+never read. Eleven of the twelve helpers making that promise keep it; this one did not.
+
+That matters because the helper is shared by design. Its own docstring says it is applied by both
+the `use_rosbridge` tool and `RosbridgeRobot` so the two "cannot disagree about which ports it can
+carry", and the shared 16-bit domain that runs one line earlier on the same value
+(`utils.tcp_port_error`) does interpolate the name. A caller whose parameter is spelled anything
+other than `port` would therefore be told the wide domain refused its `bridge_port` and the
+transport refused a `port` it never passed.
+
+The message now interpolates `param`. Both shipping call sites pass the literal `"port"`, so every
+refusal text a caller can currently reach is byte-identical; the change is what makes the
+documented contract true for the third caller the docstring anticipates. A derived test reads the
+promise sentence out of the package and holds every helper carrying it to interpolating its
+`param`, so a twelfth helper that copies the sentence is graded when it lands.

--- a/strands_robots/tools/use_rosbridge.py
+++ b/strands_robots/tools/use_rosbridge.py
@@ -107,7 +107,7 @@ def _transport_port_error(port: int, param: str, context: str) -> str | None:
     """
     if port > _TRANSPORT_MAX_PORT:
         return (
-            f"{context}: port {port!r} is a legal TCP port that the rosbridge WebSocket "
+            f"{context}: {param} {port!r} is a legal TCP port that the rosbridge WebSocket "
             f"transport cannot address (it addresses 1-{_TRANSPORT_MAX_PORT}; autobahn's "
             "URL builder excludes the top of the range)"
         )

--- a/tests/tools/test_transport_refusal_names_its_parameter.py
+++ b/tests/tools/test_transport_refusal_names_its_parameter.py
@@ -1,0 +1,228 @@
+"""A refusal that takes a parameter name spends it on the message.
+
+Eleven helpers in this package document a ``param`` argument with one
+sentence - "The parameter name it came from, used in the message" - and
+interpolate it, so the caller is told which of their own parameters was
+refused. ``use_rosbridge._transport_port_error`` made the same promise and
+hard-coded the word ``port`` instead, which is only correct while every
+caller happens to name its parameter ``port``.
+
+That is not a hypothetical constraint on a private helper. Its own docstring
+says it is *shared* with
+:class:`~strands_robots.mesh.rosbridge_robot.RosbridgeRobot` precisely so the
+tool and the bridge "cannot disagree about which ports it can carry" - so a
+third caller is anticipated by design, and a caller whose parameter is spelled
+anything else would be handed a refusal naming a parameter it does not have,
+one line after the shared 16-bit domain named the parameter correctly.
+
+The population is derived from the promise rather than listed, so a twelfth
+helper that copies the sentence is held to it the moment it lands.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import re
+from typing import Any
+
+import pytest
+
+import strands_robots.tools.use_rosbridge as ur
+from strands_robots.utils import tcp_port_error
+
+# The sentence that constitutes the promise. Any helper whose docstring carries
+# it has told its callers the message names their parameter.
+PROMISE = "The parameter name it came from, used in the message"
+
+PACKAGE_ROOT = pathlib.Path(ur.__file__).resolve().parent.parent
+
+# One below the shared 16-bit ceiling: the highest port this transport carries.
+ADDRESSABLE_PORT = 65534
+# A legal TCP port the transport cannot address - what drives the refusal.
+UNADDRESSABLE_PORT = 65535
+
+
+def _is_declaration_only(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when ``fn`` has no body beyond its docstring.
+
+    A ``TYPE_CHECKING`` protocol declaration states a signature for a checker
+    and never builds a message, so it cannot honor - or break - the promise.
+    """
+    body = [s for s in fn.body if not (isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant))]
+    return not body
+
+
+def _reads_param(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when ``fn``'s body reads its ``param`` argument at least once."""
+    for statement in fn.body:
+        if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Constant):
+            continue
+        for node in ast.walk(statement):
+            if isinstance(node, ast.Name) and node.id == "param":
+                return True
+    return False
+
+
+def _promising_helpers() -> list[tuple[str, str, bool]]:
+    """Every implemented helper whose docstring carries :data:`PROMISE`.
+
+    Returns:
+        ``(module_path, function_name, reads_param)`` triples.
+    """
+    found: list[tuple[str, str, bool]] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - a syntax error is another test's problem
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            doc = ast.get_docstring(node) or ""
+            if PROMISE not in doc or _is_declaration_only(node):
+                continue
+            names = [a.arg for a in node.args.posonlyargs + node.args.args + node.args.kwonlyargs]
+            if "param" not in names:
+                continue
+            found.append((str(path.relative_to(PACKAGE_ROOT)), node.name, _reads_param(node)))
+    return found
+
+
+PROMISING = _promising_helpers()
+
+
+class TestTheRefusalNamesTheParameterItWasGiven:
+    """The regression: a caller's own parameter name reaches the message."""
+
+    @pytest.mark.parametrize("param", ["bridge_port", "ws_port", "rosbridge_port"])
+    def test_a_differently_spelled_parameter_is_named(self, param: str) -> None:
+        message = ur._transport_port_error(UNADDRESSABLE_PORT, param, "publish")
+
+        assert message is not None
+        assert param in message
+
+    def test_the_message_does_not_name_a_parameter_the_caller_never_passed(self) -> None:
+        """Hard-coding one spelling misnames every other one.
+
+        The boundary matters: ``bridge_port 65535`` *contains* the substring
+        ``port 65535``, so only a standalone ``port`` token is the wrong name.
+        """
+        message = ur._transport_port_error(UNADDRESSABLE_PORT, "bridge_port", "publish")
+
+        assert message is not None
+        assert re.search(rf"\bport {UNADDRESSABLE_PORT}", message) is None
+
+    def test_both_guards_on_one_parameter_name_the_same_parameter(self) -> None:
+        """The shared 16-bit domain runs one line earlier on the same value.
+
+        A caller who trips the wide domain and a caller who trips the
+        transport's narrower ceiling are the same caller with the same
+        parameter, so the two refusals cannot name different things.
+        """
+        param = "bridge_port"
+
+        wide = tcp_port_error(70000, param, "publish")
+        narrow = ur._transport_port_error(UNADDRESSABLE_PORT, param, "publish")
+
+        assert wide is not None and narrow is not None
+        assert param in wide
+        assert param in narrow
+
+
+class TestEveryHelperThatPromisesThisKeepsIt:
+    """Derived contract: the promise is a property of the sentence, not a list."""
+
+    def test_the_scan_finds_the_family_rather_than_one_member(self) -> None:
+        """Non-vacuity: an empty or single-member scan would prove nothing."""
+        assert len(PROMISING) >= 10, PROMISING
+
+    @pytest.mark.parametrize("module_path,name", [(m, n) for m, n, _ in PROMISING])
+    def test_the_helper_interpolates_the_parameter_it_documents(self, module_path: str, name: str) -> None:
+        reads = next(r for m, n, r in PROMISING if (m, n) == (module_path, name))
+
+        assert reads, f"{module_path}:{name} documents param as used in the message and never reads it"
+
+    def test_the_predicate_can_report_both_outcomes(self) -> None:
+        """Grade constructed exemplars, so the rule is not true by absence.
+
+        After the fix the package carries no violator, so the scan alone can
+        never exercise its own failing branch.
+        """
+        keeps = ast.parse(
+            "def keeps(value, param, context):\n"
+            f'    """Doc.\n\n    Args:\n        param: {PROMISE}.\n    """\n'
+            '    return f"{context}: invalid {param}"\n'
+        ).body[0]
+        breaks = ast.parse(
+            "def breaks(value, param, context):\n"
+            f'    """Doc.\n\n    Args:\n        param: {PROMISE}.\n    """\n'
+            '    return f"{context}: invalid port"\n'
+        ).body[0]
+        assert isinstance(keeps, ast.FunctionDef) and isinstance(breaks, ast.FunctionDef)
+
+        outcomes = {_reads_param(keeps), _reads_param(breaks)}
+
+        assert outcomes == {True, False}
+
+    def test_a_declaration_only_stub_is_not_held_to_the_promise(self) -> None:
+        """A protocol signature builds no message, so it cannot break one."""
+        stub = ast.parse('def f(value, param, context):\n    """Doc."""\n').body[0]
+        live = ast.parse("def f(value, param, context):\n    return param\n").body[0]
+        assert isinstance(stub, ast.FunctionDef) and isinstance(live, ast.FunctionDef)
+
+        assert _is_declaration_only(stub)
+        assert not _is_declaration_only(live)
+
+
+class TestTheShippingCallersSeeNoChange:
+    """Both call sites pass ``"port"``, so their refusal text is untouched."""
+
+    @pytest.mark.parametrize("context", ["publish", "service_call", "RosbridgeRobot"])
+    def test_the_port_spelling_still_reads_exactly_as_before(self, context: str) -> None:
+        message = ur._transport_port_error(UNADDRESSABLE_PORT, "port", context)
+
+        assert message == (
+            f"{context}: port {UNADDRESSABLE_PORT!r} is a legal TCP port that the rosbridge "
+            f"WebSocket transport cannot address (it addresses 1-{ur._TRANSPORT_MAX_PORT}; "
+            "autobahn's URL builder excludes the top of the range)"
+        )
+
+    def test_every_shipping_call_site_passes_the_literal_port(self) -> None:
+        """Why the change is text-identical in production, read off the source."""
+        spellings = set()
+        for module in (ur, __import__("strands_robots.mesh.rosbridge_robot", fromlist=["x"])):
+            tree = ast.parse(inspect.getsource(module))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "_transport_port_error"
+                    and len(node.args) >= 2
+                    and isinstance(node.args[1], ast.Constant)
+                ):
+                    spellings.add(node.args[1].value)
+
+        assert spellings == {"port"}
+
+
+class TestTheDomainIsUnchanged:
+    """Over-reach guard: naming the parameter must not move the boundary."""
+
+    @pytest.mark.parametrize("port", [1, 8080, ADDRESSABLE_PORT])
+    def test_an_addressable_port_is_still_accepted(self, port: int) -> None:
+        assert ur._transport_port_error(port, "port", "ctx") is None
+
+    def test_the_unaddressable_port_is_still_refused(self) -> None:
+        assert ur._transport_port_error(UNADDRESSABLE_PORT, "port", "ctx") is not None
+
+    def test_the_shared_owner_still_carries_the_whole_port_space(self) -> None:
+        assert tcp_port_error(UNADDRESSABLE_PORT, "port", "ctx") is None
+
+
+def test_the_helper_still_returns_none_for_a_usable_port_under_any_spelling() -> None:
+    """The parameter name is diagnostic only - it cannot change the verdict."""
+    verdicts: set[Any] = {ur._transport_port_error(ADDRESSABLE_PORT, p, "ctx") for p in ("port", "bridge_port", "x")}
+
+    assert verdicts == {None}


### PR DESCRIPTION
## Problem

`use_rosbridge._transport_port_error` refuses a port that is legal TCP but outside the range the rosbridge WebSocket transport can address. It takes a `param` argument and documents it with one sentence:

```
param: The parameter name it came from, used in the message.
```

It never reads it. The message hard-codes the word `port`:

```python
return (
    f"{context}: port {port!r} is a legal TCP port that the rosbridge WebSocket "
    f"transport cannot address (it addresses 1-{_TRANSPORT_MAX_PORT}; autobahn's "
    "URL builder excludes the top of the range)"
)
```

That sentence is not local colour. Eleven other helpers in this package carry it verbatim and interpolate the argument. Derived by scanning the package for the sentence itself:

| helpers documenting `param` as "used in the message" | interpolate it |
|---|---|
| 12 | 11 |

The one that does not is this helper. (`simulation/mujoco/physics.py::_validate_mass` also never reads its `param`, but it is a `TYPE_CHECKING` protocol declaration with no body, so it builds no message and does not carry the sentence.)

### Why it matters, measured

The helper is shared *by design*. Its own docstring says it is applied by both the `use_rosbridge` tool and `RosbridgeRobot` so the two "cannot disagree about which ports it can carry", and the shared 16-bit domain that runs one line earlier **on the same value** does interpolate the name. So the two refusals a single caller can trip disagree about what they are talking about:

| `param` passed | `utils.tcp_port_error` (runs first) | `_transport_port_error` (runs next) |
|---|---|---|
| `port` | `publish: invalid port: 70000 (expected 1-65535)` | `publish: port 65535 is a legal TCP port that ...` |
| `bridge_port` | `publish: invalid bridge_port: 70000 (expected 1-65535)` | `publish: port 65535 is a legal TCP port that ...` |
| `ws_port` | `publish: invalid ws_port: 70000 (expected 1-65535)` | `publish: port 65535 is a legal TCP port that ...` |

The wide domain names the caller's parameter for every spelling; the transport names it only when the caller happens to spell it `port`.

### Reachability, stated plainly

This is **latent**. Both shipping call sites pass the literal `"port"`, read off the source rather than asserted:

```
use_rosbridge.py:352      _transport_port_error(port, "port", action)
rosbridge_robot.py:106    _transport_port_error(port, "port", type(self).__name__)
```

So no caller today sees a wrong parameter name. What is broken today is the documented contract: the argument exists, is advertised as reaching the message, and cannot. The docstring anticipates a third caller explicitly, and that caller is the one who would be handed a refusal naming a parameter it never passed.

## Change

Interpolate `param`, which is what the docstring already promises. One line:

```diff
-            f"{context}: port {port!r} is a legal TCP port that the rosbridge WebSocket "
+            f"{context}: {param} {port!r} is a legal TCP port that the rosbridge WebSocket "
```

Because both call sites pass `"port"`, **every refusal text reachable in production is byte-identical** before and after. Verified against the base implementation executed side by side in one process:

| context | base vs branch |
|---|---|
| `publish` | identical |
| `service_call` | identical |
| `RosbridgeRobot` | identical |

The domain is untouched: `1` / `8080` / `65534` still accepted, `65535` still refused, and `tcp_port_error` still carries the whole 16-bit space.

## Tests

`tests/tools/test_transport_refusal_names_its_parameter.py`, 30 cases. The contract is **derived from the promise sentence**, not from a list, so a twelfth helper that copies the sentence is graded the moment it lands. Because the package carries no violator after the fix, the scan cannot exercise its own failing branch, so the predicate is additionally graded against constructed exemplars (one keeping the promise, one breaking it) with a `{True, False}` non-vacuity assertion.

Pre-fix split: **6 failed / 24 passed** - 5 in `TestTheRefusalNamesTheParameterItWasGiven`, 1 in `TestEveryHelperThatPromisesThisKeepsIt`, and **0 in `TestTheShippingCallersSeeNoChange`, `TestTheDomainIsUnchanged`** or the module-level cell.

### Mutation table

11 mutations, control clean, 6 distinct firing sets.

| mutation | fires | notes |
|---|---|---|
| control (nothing mutated) | 0 | `30 passed` |
| fix reverted (word `port` hard-coded again) | 6 | the pre-fix split |
| `param` named but the port value dropped | 3 | exactly the byte-identical-text controls |
| `context` interpolated where `param` belongs | 8 | |
| transport ceiling widened to 65535 | 9 | over-reach: the domain moved |
| guard never refuses | 9 | same set as above, same observable |
| **a NEW helper copies the promise and breaks it** | **1** | names `planted_error` |
| **same plant, scan hard-coded to today's names** | **0** | silent - why the set is derived |
| declaration-only filter removed | 0 | no shipped stub carries the sentence, so the filter is a forward guard; it is graded directly by `test_a_declaration_only_stub_is_not_held_to_the_promise` |

The last two rows are the point of the derived scan: a hard-coded list equal to today's members fires nothing and still looks like a working test.

One of my own assertions was unsound and the suite caught it: `bridge_port 65535` *contains* the substring `port 65535`, so the "does not name a parameter the caller never passed" cell needs a word boundary (`\bport 65535`), not a substring test.

## Gate

- `ruff check` + `ruff format --check` over `strands_robots tests tests_integ`: clean, 1580 files formatted.
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine worktree of the merge-base, normalized message sets **byte-identical in both directions**, 0 attributable to either changed file.
- Paired pytest, identical 407-file selection (all of `tests/tools/`, every guard that walks the tree or reads source/docstrings, and everything naming rosbridge / `tcp_port_error` / the changelog convention), with the new file excluded from **both** trees:

| tree | result |
|---|---|
| merge-base `13fda66a` | `17 failed, 19647 passed, 107 skipped` in 690.54s |
| branch | `17 failed, 19647 passed, 107 skipped` in 665.61s |

17 identical failing ids, `comm` empty in both directions. All 17 are `tests/mesh/test_iot_*` needing `awsiot`, which `pyproject.toml` declares in the `[mesh-iot]` extra and which is absent on this machine (confirmed with `tomllib` + `find_spec`).

No visual artifact: this changes a refusal string, not a policy, render, recording or asset. The measured before/after message tables above are the evidence.
