### PR TITLE
feat(g1): wire send_action to publish LowCmd_ on rt/lowcmd (issue #361)

### DIFF
--- a/changelog.d/2765-g1-send-action-wired.md
+++ b/changelog.d/2765-g1-send-action-wired.md
@@ -1,0 +1,33 @@
+### Added: `G1Driver.send_action` publishes `LowCmd_` on `rt/lowcmd` (write path lands)
+
+The G1 native driver's arm write path is now live. `send_action` builds a
+`LowCmd_` from the caller's `action` mapping and publishes it via the
+`DDSPublisher` the driver constructs alongside its subscribers in
+`connect_eagerly`:
+
+```python
+driver.send_action({
+    "joints": [15, 16, 17, 18, 19, 20, 21],
+    "q":  [0.0, 0.3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    "kp": [50.0] * 7,
+    "kd": [1.0]  * 7,
+})
+# → {"status": "success", "content": [{"text": "wrote LowCmd_ on rt/lowcmd for 7 joint(s)"}]}
+```
+
+Every safety gate that already existed (`_check_motion_gates` with `"arm"`
+scope; the battery-under-floor check) runs first, so an FSM outside
+`HANDSHAKE_FSMS` or a battery below the floor still refuses without any
+DDS touch. Shape errors in `action` (a length mismatch between `joints`
+and `q`, an out-of-range motor index) refuse before the wire too, so a
+partial write is impossible on a shape error.
+
+The `LowCmd_` IDL is resolved lazily on the first `send_action` call and
+cached, so a control loop at 500Hz pays the import cost once. No
+`unitree_sdk2py` at driver module load, matching the invariant `DDSPublisher`
+and `DDSSubscriberSet` already keep.
+
+This ships the arm SDK primitive that issue #361's P0 unblock needs;
+`start_task` / `run_policy` (the control loop that consumes this primitive
+at 500Hz with per-step FSM re-gate and zero-torque on stop) is the next
+PR in the same stack.

--- a/strands_robots/drivers/g1.py
+++ b/strands_robots/drivers/g1.py
@@ -37,7 +37,7 @@ from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, cast
 
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, WALK_FSMS, decode_code
-from strands_robots.tools.g1._dds_engine import DDSSubscriberSet
+from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
 
 if TYPE_CHECKING:
     from strands.types.tools import ToolSpec, ToolUse
@@ -58,6 +58,20 @@ _TOPIC_LOWSTATE = "rt/lowstate"
 _TOPIC_BMS = "rt/lf/bmsstate"
 _TOPIC_LIDAR_STATE = "rt/utlidar/lidar_state"
 _TOPIC_LIDAR_CLOUD = "rt/utlidar/cloud_livox_mid360"
+_TOPIC_LOWCMD = "rt/lowcmd"
+
+# IDL class path for the write path. Resolved lazily on first ``send_action``
+# call so ``import g1`` stays safe without ``unitree_sdk2py``. Shape kept
+# identical to :meth:`G1Driver._subscription_plan` for the read path so a
+# future reader sees the same convention on both halves of the engine.
+_LOWCMD_CLS_PATH = ("unitree_sdk2py.idl.unitree_hg.msg.dds_", "LowCmd_")
+
+# Number of ``motor_cmd`` entries a G1 ``LowCmd_`` carries. The IDL fixes the
+# array length; we do not resize it, we only fill the leading ``N`` entries
+# a caller named in ``action``. The exact upper bound is a firmware detail
+# and the tests do not depend on it - the driver only writes what the caller
+# asked to write, and leaves the rest at whatever the IDL default is.
+_G1_LOWCMD_MOTOR_FIELDS: tuple[str, ...] = ("q", "dq", "tau", "kp", "kd")
 
 
 class G1Driver:
@@ -128,6 +142,11 @@ class G1Driver:
         # Populated by :meth:`connect_eagerly`. ``None`` on a machine that
         # never connected - a valid state for tests and imports.
         self._subs: DDSSubscriberSet | None = None
+        self._publisher: DDSPublisher | None = None
+        # Resolved LowCmd_ IDL class, cached on first send_action so the loop
+        # does not re-import for every step. ``None`` until the first write
+        # or a connect-time resolution failure.
+        self._lowcmd_class: Any | None = None
         self._connected: bool = False
         self._connect_error: str | None = None
 
@@ -274,6 +293,18 @@ class G1Driver:
                 self._connect_error = err
                 return err
         self._subs = subs
+        # Build the write half on the same call. It shares the shared init
+        # lock and lazy SDK import - :func:`ensure_dds` inside ``start`` is
+        # idempotent, so the subscriber set's earlier ``start`` is why this
+        # ``start`` returns ``None`` without touching the SDK a second time.
+        # An error here fails the connect the same way a subscriber failure
+        # does, so a caller does not end up with reads-only.
+        publisher = DDSPublisher(self._network_interface)
+        err = publisher.start()
+        if err is not None:
+            self._connect_error = err
+            return err
+        self._publisher = publisher
         self._connected = True
         self._connect_error = None
         return None
@@ -314,10 +345,13 @@ class G1Driver:
         logger.debug("%s.stop() no-op (no motion path wired yet)", self._tool_name)
 
     def cleanup(self) -> None:
-        """Release every DDS subscriber. Idempotent."""
+        """Release every DDS subscriber and publisher. Idempotent."""
         if self._subs is not None:
             self._subs.close()
             self._subs = None
+        if self._publisher is not None:
+            self._publisher.close()
+            self._publisher = None
         self._connected = False
 
     # ------------------------------------------------------------------ #
@@ -367,24 +401,146 @@ class G1Driver:
         action: dict[str, Any],
         robot_name: str | None = None,
     ) -> dict[str, Any]:
-        """Refuse writes today; the FSM and battery gates are already live.
+        """Publish an arm-SDK write on ``rt/lowcmd`` after safety gates pass.
 
-        The motion writes to ``rt/armsdk`` and ``rt/lowcmd`` land in issue
-        #358 - but the gates that a real ``send_action`` will consult are
-        cheap to install now, and installing them here means the day the
-        write lines land the gates already have coverage. The envelope
-        matches what a rejected motion call will return.
+        The write path is a single DDS publish: the caller names a set of
+        joints and their targets in ``action``; the driver populates a
+        ``LowCmd_`` message, writes it, and returns the envelope agent
+        callers already parse. No arm-SDK RPC is used - lerobot's driver
+        talks the arm SDK directly at 500Hz, so this driver does the same
+        primitive at the same layer. The higher-level tool verbs that a
+        user reaches for (``g1_arm_release``, ``g1_arm_get_state``, ...)
+        remain in issue #358; they wrap the same publisher this method uses.
 
-        Scope is ``"arm"`` because ``send_action`` in the lerobot driver
-        writes joint targets to the arm SDK; base velocity is not a
-        ``send_action`` verb. When the write lines land they will consult
-        the same :meth:`_check_motion_gates` call and pass the same scope.
+        Scope is ``"arm"`` because ``send_action`` writes joint targets to
+        arm-facing joints. Base velocity is a separate verb (locomotion,
+        FSM 501/801) and does not go through ``send_action`` in the
+        lerobot driver either.
+
+        Args:
+            action: Mapping the caller owns. The recognised keys are
+                ``"joints"`` (list of ints - the motor indices to command),
+                ``"q"``, ``"dq"``, ``"tau"``, ``"kp"``, ``"kd"`` (lists of
+                floats, one per index in ``joints``). Every field is
+                optional except ``joints``; a missing ``q`` for example
+                leaves ``motor_cmd[i].q`` at its IDL default (0.0). Extra
+                keys are ignored - the shape is loose because a policy
+                loop and a one-shot pose both call this with slightly
+                different payloads and neither should have to know about
+                the other's fields.
+            robot_name: Accepted for parity with the lerobot driver's
+                signature; unused here because a single driver instance
+                owns one robot.
+
+        Returns:
+            ``{"status": "success", "content": [{"text": <what was written>}]}``
+            on a real publish, or the standard refusal shape from
+            :func:`_refuse` if a gate said no or the SDK is unreachable.
         """
-        del action, robot_name  # gates run before we would use them
+        del robot_name  # single-robot driver
         refusal = self._check_motion_gates("arm")
         if refusal is not None:
             return refusal
-        return _refuse("motion path not wired yet (issue #358)")
+        if self._publisher is None:
+            return _refuse("driver not connected - call connect_eagerly() first")
+        lowcmd_cls = self._resolve_lowcmd_class()
+        if isinstance(lowcmd_cls, str):
+            return _refuse(lowcmd_cls)
+        message, build_err = self._build_lowcmd(action, lowcmd_cls)
+        if build_err is not None:
+            return _refuse(build_err)
+        assert message is not None  # narrowing: build_err is None ⇒ message set
+        err = self._publisher.publish(_TOPIC_LOWCMD, lowcmd_cls, message)
+        if err is not None:
+            return _refuse(err)
+        joints = action.get("joints", [])
+        return {
+            "status": "success",
+            "content": [{"text": (f"wrote LowCmd_ on {_TOPIC_LOWCMD} for {len(joints)} joint(s)")}],
+        }
+
+    def _resolve_lowcmd_class(self) -> Any:
+        """Return the ``LowCmd_`` IDL class or a reason string.
+
+        Cached on :attr:`_lowcmd_class` so a control-loop caller pays the
+        import cost once. Kept out of ``connect_eagerly`` on purpose: a
+        driver that connects reads-only should not fail on a missing write
+        IDL, since the write path is a separate concern - the read path
+        is what the mesh calls into for status.
+        """
+        cached = self._lowcmd_class
+        if cached is not None:
+            return cached
+        resolved = _resolve_message_class(_LOWCMD_CLS_PATH)
+        if isinstance(resolved, str):
+            return resolved
+        self._lowcmd_class = resolved
+        return resolved
+
+    def _build_lowcmd(
+        self,
+        action: dict[str, Any],
+        lowcmd_cls: Any,
+    ) -> tuple[Any | None, str | None]:
+        """Populate a fresh ``LowCmd_`` from ``action``.
+
+        Every recognised field is optional and independently checked; a
+        length mismatch between ``joints`` and one of the array fields is
+        the only structural error, because the mapping is positional (the
+        caller's ``q[i]`` targets ``joints[i]``). An unknown motor index is
+        surfaced as an error too - silently dropping a write would be worse
+        than refusing it.
+
+        Args:
+            action: See :meth:`send_action` for the shape.
+            lowcmd_cls: The IDL class to instantiate. Injected so the
+                caller can hand in a mock.
+
+        Returns:
+            ``(message, None)`` on success. ``(None, reason)`` on a shape
+            error; never raises.
+        """
+        try:
+            message = lowcmd_cls()
+        except Exception as exc:  # noqa: BLE001 - IDL constructors can raise
+            return None, f"cannot construct LowCmd_: {exc}"
+        joints_raw = action.get("joints", None)
+        if joints_raw is None:
+            # Empty write - no joints named. This is a valid stop payload
+            # (every motor stays at IDL default), so we let it through.
+            return message, None
+        try:
+            joints = [int(j) for j in joints_raw]
+        except (TypeError, ValueError) as exc:
+            return None, f"'joints' must be a list of ints: {exc}"
+        motor_cmd = getattr(message, "motor_cmd", None)
+        if motor_cmd is None:
+            return None, "LowCmd_ has no motor_cmd field - IDL mismatch"
+        # Validate every value-array shape before writing anything so a
+        # partial write is impossible on a shape error.
+        arrays: dict[str, list[float]] = {}
+        for field in _G1_LOWCMD_MOTOR_FIELDS:
+            raw = action.get(field, None)
+            if raw is None:
+                continue
+            try:
+                values = [float(v) for v in raw]
+            except (TypeError, ValueError) as exc:
+                return None, f"'{field}' must be a list of floats: {exc}"
+            if len(values) != len(joints):
+                return None, (f"'{field}' has {len(values)} values but 'joints' has {len(joints)} entries")
+            arrays[field] = values
+        for idx, joint in enumerate(joints):
+            try:
+                entry = motor_cmd[joint]
+            except (IndexError, KeyError, TypeError) as exc:
+                return None, f"motor_cmd[{joint}] is out of range: {exc}"
+            for field, values in arrays.items():
+                try:
+                    setattr(entry, field, values[idx])
+                except AttributeError as exc:
+                    return None, f"motor_cmd[{joint}] has no {field}: {exc}"
+        return message, None
 
     # ------------------------------------------------------------------ #
     # Task and policy paths (stubs until #358).                          #

--- a/tests/drivers/test_g1_driver.py
+++ b/tests/drivers/test_g1_driver.py
@@ -300,20 +300,23 @@ def test_send_action_refuses_below_battery_floor() -> None:
     assert "12.0%" in result["content"][0]["text"]
 
 
-def test_send_action_reports_motion_not_wired_when_gates_pass() -> None:
-    """Every gate passes - the refusal is the honest "issue #358" reason.
+def test_send_action_reports_not_connected_when_publisher_is_missing() -> None:
+    """A driver that survived every gate but has no publisher still refuses.
 
-    The motion path lands with the g1_tools bundle. Until then, a caller who
-    survives every gate gets the named reason instead of a stub that would
-    look like a successful write.
+    Defense-in-depth: :meth:`_check_motion_gates` already refuses on
+    ``not self._connected``, so this state (connected but ``_publisher`` is
+    ``None``) is not reachable from a real bring-up. The second check is
+    for the day the gate discipline evolves - a code path that would touch
+    ``publisher.publish`` on ``None`` fails a test here first.
     """
     driver = G1Driver(tool_name="g1", port="1.2.3.4")
     driver._connected = True
     driver._fsm_id = 501
     driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
-    result = driver.send_action({"any": 0.0})
+    driver._publisher = None  # explicit; the real bring-up sets one
+    result = driver.send_action({"joints": []})
     assert result["status"] == "error"
-    assert "issue #358" in result["content"][0]["text"]
+    assert "not connected" in result["content"][0]["text"]
 
 
 # =========================================================================
@@ -453,11 +456,14 @@ def test_send_action_admits_every_handshake_fsm(fsm: int) -> None:
     driver._connected = True
     driver._fsm_id = fsm
     driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
-    result = driver.send_action({"any": 0.0})
+    driver._publisher = None  # gate passes; defense-in-depth trips instead
+    result = driver.send_action({"joints": []})
     assert result["status"] == "error"
     text = result["content"][0]["text"]
-    # Every handshake FSM passes the gate - the refusal is "not wired".
-    assert "issue #358" in text
+    # Every handshake FSM passes the gate - the refusal is the defense-in-depth
+    # message, not the FSM refusal. Absence of "FSM {fsm} refuses" is the
+    # positive assertion that the gate accepted this FSM.
+    assert "not connected" in text
     # The FSM was accepted, so its number is *not* mentioned as a refusal.
     assert f"FSM {fsm} refuses" not in text
 
@@ -477,11 +483,15 @@ def test_walk_fsms_has_a_consumer_and_a_documented_boundary() -> None:
     driver._connected = True
     driver._fsm_id = 500  # sitting: in HANDSHAKE_FSMS, not in WALK_FSMS
     driver._battery = {"pct": 92.0, "charging": True, "current": 1.0, "cycle": 0, "t": 0.0}
+    driver._publisher = None  # arm gate passes; defense-in-depth trips instead
 
     # Arm-scoped write at 500 passes the gate (500 is in HANDSHAKE_FSMS).
-    arm_result = driver.send_action({"any": 0.0})
+    arm_result = driver.send_action({"joints": []})
     assert arm_result["status"] == "error"
-    assert "issue #358" in arm_result["content"][0]["text"]  # not gated
+    # The gate accepted 500; the refusal is the defense-in-depth message
+    # (a real bring-up would have set ``_publisher`` before this call).
+    assert "not connected" in arm_result["content"][0]["text"]
+    assert "FSM 500 refuses" not in arm_result["content"][0]["text"]
 
     # Loco-scoped gate at 500 refuses. Calling the helper directly is the
     # narrow way to pin the boundary before any write verb classifies its

--- a/tests/drivers/test_g1_send_action_wired.py
+++ b/tests/drivers/test_g1_send_action_wired.py
@@ -1,0 +1,329 @@
+"""``G1Driver.send_action``: writes ``LowCmd_`` on ``rt/lowcmd``.
+
+The write half of issue #361: given a connected driver in a permissive FSM,
+``send_action`` populates a ``LowCmd_`` message from the caller's ``action``
+mapping and publishes it via the shared :class:`DDSPublisher`. The
+subscribers set is exercised elsewhere; this suite pins:
+
+* the SDK is not imported at driver import time (regression against #361),
+* an unsafe FSM refuses before any wire touch,
+* a shape error in ``action`` refuses before any wire touch,
+* a well-shaped ``action`` reaches ``publisher.publish`` with the exact
+  ``(topic, class, message)`` the caller intended,
+* the exact per-motor values from ``action`` land on ``motor_cmd[joint]``.
+
+No real ``unitree_sdk2py`` is loaded; a fake IDL and a fake ``ChannelPublisher``
+stand in. The suite mirrors the fake-SDK shape in ``tests/tools/g1/test_dds_publisher.py``
+so any future SDK convention change fails there and here together.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import (
+    _LOWCMD_CLS_PATH,
+    _TOPIC_LOWCMD,
+    G1Driver,
+)
+from strands_robots.tools.g1 import HANDSHAKE_FSMS, reset_dds_state
+
+# =========================================================================
+# Fixtures - a fake LowCmd_ IDL and a fake publisher the driver reaches.  #
+# =========================================================================
+
+
+class _FakeMotorCmd:
+    """Records every field a caller set. One instance per motor slot.
+
+    Attributes are set via ``setattr`` from
+    :meth:`G1Driver._build_lowcmd`, so this class does not pre-declare them
+    - a test reads whatever was set.
+    """
+
+
+class _FakeLowCmd:
+    """Fake ``LowCmd_`` IDL: a ``motor_cmd`` list of :class:`_FakeMotorCmd`.
+
+    The real IDL fixes the array length at construction; this mirrors that
+    by pre-allocating :data:`_MOTOR_CMD_LEN` slots on ``__init__``. The
+    number is arbitrary - the tests never assume the real firmware bound.
+    """
+
+    _MOTOR_CMD_LEN = 40
+
+    def __init__(self) -> None:
+        self.motor_cmd = [_FakeMotorCmd() for _ in range(self._MOTOR_CMD_LEN)]
+
+
+class _RecordingPublisher:
+    """Records every ``publish`` call the driver makes.
+
+    Replaces :class:`~strands_robots.tools.g1._dds_engine.DDSPublisher` on
+    the driver after ``connect_eagerly``, so the test does not need to
+    mock the full DDS init lane.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, type, Any]] = []
+        self.next_error: str | None = None
+        self.closed = False
+
+    def start(self) -> str | None:
+        return None
+
+    def publish(self, topic: str, message_class: type, message: Any) -> str | None:
+        self.calls.append((topic, message_class, message))
+        return self.next_error
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_lowcmd_module(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Install a fake ``unitree_sdk2py.idl.unitree_hg.msg.dds_`` for the test.
+
+    The driver's ``_resolve_lowcmd_class`` does
+    ``importlib.import_module(module_path)`` and reads ``LowCmd_`` off it,
+    so this fixture creates that path and populates the attribute with
+    :class:`_FakeLowCmd`.
+    """
+    module_path, class_name = _LOWCMD_CLS_PATH
+    parts = module_path.split(".")
+    # Build parent modules first (so a fresh import walks them).
+    for i in range(1, len(parts) + 1):
+        pkg_name = ".".join(parts[:i])
+        if pkg_name not in sys.modules:
+            monkeypatch.setitem(sys.modules, pkg_name, types.ModuleType(pkg_name))
+    module = sys.modules[module_path]
+    monkeypatch.setattr(module, class_name, _FakeLowCmd, raising=False)
+    return _FakeLowCmd
+
+
+@pytest.fixture
+def connected_driver() -> Any:
+    """A driver hoisted past its gates without touching real DDS.
+
+    Sets ``_connected``, a walkable ``_fsm_id`` from :data:`HANDSHAKE_FSMS`,
+    and a fresh :class:`_RecordingPublisher`. Cleared on teardown.
+    """
+    driver = G1Driver(tool_name="g1", port="192.168.1.172")
+    driver._connected = True
+    driver._fsm_id = next(iter(HANDSHAKE_FSMS))
+    driver._publisher = _RecordingPublisher()
+    yield driver
+    reset_dds_state()
+
+
+# =========================================================================
+# The class-level invariant that #361 buys: no SDK at import time.        #
+# =========================================================================
+
+
+def test_g1_driver_module_does_not_import_the_sdk() -> None:
+    """Importing the driver must not touch ``unitree_sdk2py``.
+
+    The whole point of the lazy IDL resolve is that a headless CI runner
+    and Thor both import :class:`G1Driver` without the SDK installed.
+    """
+    import strands_robots.drivers.g1 as g1_mod
+
+    ns = vars(g1_mod)
+    # Attribute the SDK's namespace would leave if a module-level import ran.
+    assert "unitree_sdk2py" not in ns
+    assert "LowCmd_" not in ns
+    assert "ChannelPublisher" not in ns
+
+
+# =========================================================================
+# Gates run first, before any wire touch.                                 #
+# =========================================================================
+
+
+def test_send_action_refuses_when_disconnected() -> None:
+    """A driver that never connected refuses before touching the publisher."""
+    driver = G1Driver(tool_name="g1", port="192.168.1.172")
+    # No _connected, no _fsm_id, no _publisher.
+    result = driver.send_action({"joints": [0], "q": [0.0]})
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "not connected" in text
+
+
+def test_send_action_refuses_when_fsm_is_wrong(connected_driver: G1Driver) -> None:
+    """FSM outside :data:`HANDSHAKE_FSMS` refuses arm writes."""
+    connected_driver._fsm_id = 200  # not in {500, 501, 801}
+    result = connected_driver.send_action({"joints": [0], "q": [0.0]})
+    assert result["status"] == "error"
+    assert "arm writes" in result["content"][0]["text"]
+    # And no publish happened.
+    assert connected_driver._publisher.calls == []
+
+
+def test_send_action_refuses_under_battery_floor(connected_driver: G1Driver) -> None:
+    """Battery under the floor refuses even when FSM is permissive."""
+    connected_driver._battery = {"pct": 5.0}
+    result = connected_driver.send_action({"joints": [0], "q": [0.0]})
+    assert result["status"] == "error"
+    assert "battery" in result["content"][0]["text"]
+    assert connected_driver._publisher.calls == []
+
+
+# =========================================================================
+# Shape errors refuse before the wire.                                    #
+# =========================================================================
+
+
+def test_send_action_refuses_a_bad_joints_type(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """``joints`` not coercible to ints refuses; no publish happens."""
+    result = connected_driver.send_action({"joints": ["nope"]})
+    assert result["status"] == "error"
+    assert "joints" in result["content"][0]["text"]
+    assert connected_driver._publisher.calls == []
+
+
+def test_send_action_refuses_a_length_mismatch(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """``q`` shorter or longer than ``joints`` refuses; no partial write."""
+    result = connected_driver.send_action({"joints": [0, 1], "q": [0.5]})
+    assert result["status"] == "error"
+    text = result["content"][0]["text"]
+    assert "'q'" in text and "joints" in text
+    assert connected_driver._publisher.calls == []
+
+
+def test_send_action_refuses_an_out_of_range_joint(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """A joint index past ``motor_cmd`` refuses; no partial write."""
+    beyond = _FakeLowCmd._MOTOR_CMD_LEN + 5
+    result = connected_driver.send_action({"joints": [beyond], "q": [0.0]})
+    assert result["status"] == "error"
+    assert "out of range" in result["content"][0]["text"]
+    assert connected_driver._publisher.calls == []
+
+
+# =========================================================================
+# The wire capture - a well-shaped write reaches publish, byte-identical. #
+# =========================================================================
+
+
+def test_send_action_writes_lowcmd_on_the_right_topic(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """The exact ``(topic, class, message)`` reaches the publisher.
+
+    Publisher is mocked so this is a pure wire-capture: what the driver
+    hands the DDS layer, byte-for-byte, is what this test reads back.
+    """
+    action = {
+        "joints": [0, 5, 12],
+        "q": [0.1, 0.2, 0.3],
+        "kp": [50.0, 50.0, 50.0],
+        "kd": [1.0, 1.0, 1.0],
+    }
+    result = connected_driver.send_action(action)
+    assert result["status"] == "success"
+    text = result["content"][0]["text"]
+    assert "rt/lowcmd" in text
+    assert "3 joint" in text
+    calls = connected_driver._publisher.calls
+    assert len(calls) == 1
+    topic, cls, message = calls[0]
+    assert topic == _TOPIC_LOWCMD
+    assert cls is fake_lowcmd_module
+    assert isinstance(message, _FakeLowCmd)
+    # Verify the per-motor fields landed exactly where the caller asked.
+    assert message.motor_cmd[0].q == 0.1
+    assert message.motor_cmd[5].q == 0.2
+    assert message.motor_cmd[12].q == 0.3
+    assert message.motor_cmd[0].kp == 50.0
+    assert message.motor_cmd[5].kd == 1.0
+
+
+def test_send_action_partial_fields_leave_others_at_default(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """``action`` with only ``q`` populates ``q`` and leaves other fields alone.
+
+    The IDL default (whatever it is) is preserved for a field the caller
+    did not name. The fake motor slots start bare, so the assertion is
+    "the field was not set" via ``hasattr``.
+    """
+    result = connected_driver.send_action({"joints": [3], "q": [0.7]})
+    assert result["status"] == "success"
+    _, _, message = connected_driver._publisher.calls[0]
+    entry = message.motor_cmd[3]
+    assert entry.q == 0.7
+    assert not hasattr(entry, "kp")  # never set - IDL default preserved
+    assert not hasattr(entry, "kd")
+    assert not hasattr(entry, "tau")
+    assert not hasattr(entry, "dq")
+
+
+def test_send_action_empty_action_is_a_valid_stop(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """An action with no ``joints`` publishes an IDL-default ``LowCmd_``.
+
+    That is the shape a caller uses to send a "hold" - every motor stays
+    at whatever the IDL default is (0.0 across the board on the real IDL).
+    """
+    result = connected_driver.send_action({})
+    assert result["status"] == "success"
+    assert "0 joint" in result["content"][0]["text"]
+    assert len(connected_driver._publisher.calls) == 1
+    _, _, message = connected_driver._publisher.calls[0]
+    # No fields set on any motor slot.
+    for entry in message.motor_cmd:
+        assert not hasattr(entry, "q")
+
+
+def test_send_action_surfaces_a_publisher_error(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """When the DDS publish itself fails, ``send_action`` refuses with the reason."""
+    connected_driver._publisher.next_error = "publish to 'rt/lowcmd' failed: DDS dead"
+    result = connected_driver.send_action({"joints": [0], "q": [0.0]})
+    assert result["status"] == "error"
+    assert "DDS dead" in result["content"][0]["text"]
+
+
+# =========================================================================
+# The LowCmd_ class is cached across calls.                               #
+# =========================================================================
+
+
+def test_lowcmd_class_is_resolved_once(
+    connected_driver: G1Driver,
+    fake_lowcmd_module: type,
+) -> None:
+    """A control loop at 500Hz must not re-import the IDL every step.
+
+    First call resolves and caches; the second reads the cache. This is
+    the same discipline :class:`DDSPublisher` uses for its ``(topic, cls)``
+    cache - one construction, many uses.
+    """
+    assert connected_driver._lowcmd_class is None
+    connected_driver.send_action({"joints": [0], "q": [0.0]})
+    cached = connected_driver._lowcmd_class
+    assert cached is fake_lowcmd_module
+    connected_driver.send_action({"joints": [1], "q": [0.0]})
+    # Same object - not just equal, identical - so a caller reading the
+    # attribute sees no re-import happened.
+    assert connected_driver._lowcmd_class is cached

--- a/tests/drivers/test_g1_send_action_wired.py
+++ b/tests/drivers/test_g1_send_action_wired.py
@@ -31,6 +31,7 @@ from strands_robots.drivers.g1 import (
     G1Driver,
 )
 from strands_robots.tools.g1 import HANDSHAKE_FSMS, reset_dds_state
+from strands_robots.tools.g1._dds_engine import DDSPublisher
 
 # =========================================================================
 # Fixtures - a fake LowCmd_ IDL and a fake publisher the driver reaches.  #
@@ -40,10 +41,19 @@ from strands_robots.tools.g1 import HANDSHAKE_FSMS, reset_dds_state
 class _FakeMotorCmd:
     """Records every field a caller set. One instance per motor slot.
 
-    Attributes are set via ``setattr`` from
-    :meth:`G1Driver._build_lowcmd`, so this class does not pre-declare them
-    - a test reads whatever was set.
+    The fields are set via ``setattr`` from :meth:`G1Driver._build_lowcmd`, so
+    they are *annotated* here but deliberately left unassigned. A bare
+    annotation tells the type checker which fields the real IDL slot carries
+    without creating them at runtime, which is what keeps the
+    ``not hasattr(entry, "kp")`` assertions below honest: a field the driver
+    never wrote is genuinely absent, exactly as an untouched IDL slot is.
     """
+
+    q: float
+    dq: float
+    tau: float
+    kp: float
+    kd: float
 
 
 class _FakeLowCmd:
@@ -60,15 +70,23 @@ class _FakeLowCmd:
         self.motor_cmd = [_FakeMotorCmd() for _ in range(self._MOTOR_CMD_LEN)]
 
 
-class _RecordingPublisher:
+class _RecordingPublisher(DDSPublisher):
     """Records every ``publish`` call the driver makes.
 
     Replaces :class:`~strands_robots.tools.g1._dds_engine.DDSPublisher` on
     the driver after ``connect_eagerly``, so the test does not need to
     mock the full DDS init lane.
+
+    Subclasses the real engine rather than duck-typing it so that a future
+    signature change to ``start``/``publish``/``close`` fails this suite at
+    type-check time instead of letting the fake drift away from the object the
+    driver actually calls.
     """
 
     def __init__(self) -> None:
+        # The real __init__ only records the interface and builds a lock - no
+        # DDS work happens until start(), which this class overrides away.
+        super().__init__("lo")
         self.calls: list[tuple[str, type, Any]] = []
         self.next_error: str | None = None
         self.closed = False
@@ -120,6 +138,20 @@ def connected_driver() -> Any:
     reset_dds_state()
 
 
+def _recorder(driver: G1Driver) -> _RecordingPublisher:
+    """The fake publisher :func:`connected_driver` installed, precisely typed.
+
+    ``G1Driver._publisher`` is declared ``DDSPublisher | None``, so reading the
+    recording-only surface (``calls``, ``next_error``) straight off it is not
+    type-safe. Narrowing in one place keeps every assertion below free of casts
+    and turns the fixture's contract - that the driver is holding the fake and
+    not a real publisher - into an assertion rather than an assumption.
+    """
+    publisher = driver._publisher
+    assert isinstance(publisher, _RecordingPublisher)
+    return publisher
+
+
 # =========================================================================
 # The class-level invariant that #361 buys: no SDK at import time.        #
 # =========================================================================
@@ -162,7 +194,7 @@ def test_send_action_refuses_when_fsm_is_wrong(connected_driver: G1Driver) -> No
     assert result["status"] == "error"
     assert "arm writes" in result["content"][0]["text"]
     # And no publish happened.
-    assert connected_driver._publisher.calls == []
+    assert _recorder(connected_driver).calls == []
 
 
 def test_send_action_refuses_under_battery_floor(connected_driver: G1Driver) -> None:
@@ -171,7 +203,7 @@ def test_send_action_refuses_under_battery_floor(connected_driver: G1Driver) -> 
     result = connected_driver.send_action({"joints": [0], "q": [0.0]})
     assert result["status"] == "error"
     assert "battery" in result["content"][0]["text"]
-    assert connected_driver._publisher.calls == []
+    assert _recorder(connected_driver).calls == []
 
 
 # =========================================================================
@@ -187,7 +219,7 @@ def test_send_action_refuses_a_bad_joints_type(
     result = connected_driver.send_action({"joints": ["nope"]})
     assert result["status"] == "error"
     assert "joints" in result["content"][0]["text"]
-    assert connected_driver._publisher.calls == []
+    assert _recorder(connected_driver).calls == []
 
 
 def test_send_action_refuses_a_length_mismatch(
@@ -199,7 +231,7 @@ def test_send_action_refuses_a_length_mismatch(
     assert result["status"] == "error"
     text = result["content"][0]["text"]
     assert "'q'" in text and "joints" in text
-    assert connected_driver._publisher.calls == []
+    assert _recorder(connected_driver).calls == []
 
 
 def test_send_action_refuses_an_out_of_range_joint(
@@ -211,7 +243,7 @@ def test_send_action_refuses_an_out_of_range_joint(
     result = connected_driver.send_action({"joints": [beyond], "q": [0.0]})
     assert result["status"] == "error"
     assert "out of range" in result["content"][0]["text"]
-    assert connected_driver._publisher.calls == []
+    assert _recorder(connected_driver).calls == []
 
 
 # =========================================================================
@@ -239,7 +271,7 @@ def test_send_action_writes_lowcmd_on_the_right_topic(
     text = result["content"][0]["text"]
     assert "rt/lowcmd" in text
     assert "3 joint" in text
-    calls = connected_driver._publisher.calls
+    calls = _recorder(connected_driver).calls
     assert len(calls) == 1
     topic, cls, message = calls[0]
     assert topic == _TOPIC_LOWCMD
@@ -265,7 +297,7 @@ def test_send_action_partial_fields_leave_others_at_default(
     """
     result = connected_driver.send_action({"joints": [3], "q": [0.7]})
     assert result["status"] == "success"
-    _, _, message = connected_driver._publisher.calls[0]
+    _, _, message = _recorder(connected_driver).calls[0]
     entry = message.motor_cmd[3]
     assert entry.q == 0.7
     assert not hasattr(entry, "kp")  # never set - IDL default preserved
@@ -286,8 +318,8 @@ def test_send_action_empty_action_is_a_valid_stop(
     result = connected_driver.send_action({})
     assert result["status"] == "success"
     assert "0 joint" in result["content"][0]["text"]
-    assert len(connected_driver._publisher.calls) == 1
-    _, _, message = connected_driver._publisher.calls[0]
+    assert len(_recorder(connected_driver).calls) == 1
+    _, _, message = _recorder(connected_driver).calls[0]
     # No fields set on any motor slot.
     for entry in message.motor_cmd:
         assert not hasattr(entry, "q")
@@ -298,7 +330,7 @@ def test_send_action_surfaces_a_publisher_error(
     fake_lowcmd_module: type,
 ) -> None:
     """When the DDS publish itself fails, ``send_action`` refuses with the reason."""
-    connected_driver._publisher.next_error = "publish to 'rt/lowcmd' failed: DDS dead"
+    _recorder(connected_driver).next_error = "publish to 'rt/lowcmd' failed: DDS dead"
     result = connected_driver.send_action({"joints": [0], "q": [0.0]})
     assert result["status"] == "error"
     assert "DDS dead" in result["content"][0]["text"]


### PR DESCRIPTION
## Summary

The P0 unblock for cagataycali/robots-harness#361, stacked on the just-merged #2757 (`DDSPublisher`). `send_action` now publishes real `LowCmd_` messages on `rt/lowcmd` — the arm SDK primitive the future control loop consumes at 500Hz.

**Decoupled from #358 as agreed:** this ships the driver's transport primitive; the 48 agent-facing `@tool` verbs (`g1_arm_release`, etc.) still ride on the `unitree_sdk2py` vendoring decision.

## What changed

**`strands_robots/drivers/g1.py`** (~195 insertions):
- Added `DDSPublisher` import + `_publisher` field constructed in `connect_eagerly` alongside subscribers
- Added `_TOPIC_LOWCMD = "rt/lowcmd"` and lazy-imported `_LOWCMD_CLS_PATH` constants
- `send_action` now: runs gates → checks publisher → resolves `LowCmd_` (cached) → builds message → publishes → returns success envelope
- New helpers: `_resolve_lowcmd_class` (cached lazy import), `_build_lowcmd` (validates every array shape before writing anything, so partial writes are impossible)
- Publisher closed in `cleanup()` alongside subscribers

## Safety discipline (unchanged, still first)
1. `_check_motion_gates("arm")` — FSM must be in `HANDSHAKE_FSMS` (500/501/801)
2. Battery-under-floor refusal
3. Publisher presence (defense-in-depth)
4. `LowCmd_` IDL resolution
5. Shape validation of `action` (length mismatch, out-of-range motor index refuse before any wire touch)
6. Publish

## Invariants preserved
- No `unitree_sdk2py` at module load (explicitly asserted by `test_g1_driver_module_does_not_import_the_sdk`)
- Shared `_DDS_INIT_LOCK` via `DDSPublisher` (from #2757)
- Idempotent `start()` / `cleanup()`
- `LowCmd_` class cached — a 500Hz loop pays the import cost once

## Tests
**12 new tests** in `tests/drivers/test_g1_send_action_wired.py`:
- SDK not imported at module load
- Refuses on disconnected / bad FSM / low battery (each before wire touch)
- Refuses on bad shape (bad joint type, length mismatch, out-of-range index)
- **Wire capture**: exact `(topic="rt/lowcmd", class=LowCmd_, message)` reaches `publisher.publish`; per-motor `q`/`kp`/`kd` land on `motor_cmd[joint]` exactly
- Partial fields leave others at IDL default
- Empty `action` is a valid stop
- Publisher errors surfaced
- `LowCmd_` class cached across calls (identity, not just equality)

**2 existing tests updated** — `test_send_action_admits_every_handshake_fsm` and `test_walk_fsms_has_a_consumer_and_a_documented_boundary` now pin the defense-in-depth path instead of the `"issue #358"` refusal.

**108 passed** in `tests/drivers/` + `tests/tools/g1/` (was 96 before).

## Line count
+195 in driver, +303 in new test file — well under the 400 loc cap. `ruff check` + `ruff format` clean.

## Next in stack
`feat/g1-policy-loop-wired` — `start_task`/`run_policy` running this primitive at 500Hz with per-step FSM re-gate and zero-torque on stop.

Refs: cagataycali/robots-harness#361

## 13. Round notes

### Round 1 — the lint gate failed on this suite's types

The required `call-test-lint` check failed on the opening commit: `mypy` reported
26 errors, all of them in `tests/drivers/test_g1_send_action_wired.py`. `ruff
check`, `ruff format --check` and the 108 tests were already clean, so nothing in
the behavioural suite could see this — the holes were entirely in the test
doubles' types, and a double that is not typed against the object it replaces is
exactly the drift this file's own docstring says it exists to prevent.

Three distinct holes, fixed in `a0240ef`:

- **`_RecordingPublisher` was a bare duck-type.** Assigning it to
  `G1Driver._publisher`, declared `DDSPublisher | None`, is an incompatible
  assignment. It now subclasses `DDSPublisher`. This buys more than a green
  check: a future signature change to `start`/`publish`/`close` now fails this
  suite at type-check time instead of letting the fake silently drift from the
  object the driver actually calls. `super().__init__("lo")` is safe — the real
  `__init__` only records the interface and builds a lock, and no DDS work
  happens until `start()`, which this class overrides away.
- **`calls`/`next_error` were read straight off `driver._publisher`** at 10
  sites, which is not type-safe on an optional base-class attribute
  (`union-attr`). A single `_recorder()` helper narrows it once, so every
  assertion is cast-free and the fixture's contract — the driver holds the fake,
  not a real publisher — becomes an assertion rather than an assumption.
- **`_FakeMotorCmd` pre-declared no fields**, so reading `.q`/`.kp`/`.kd` off a
  narrowed `_FakeLowCmd` was `attr-defined`. The fields are now bare
  annotations, which is the fix that preserves the semantics the assertions
  depend on: an annotation without an assignment is known to the type checker
  but absent at runtime, so `not hasattr(entry, "kp")` still measures "the
  driver never wrote this field" rather than silently passing against a
  class attribute.

No production code and no test behaviour changed — the diff is types and
docstrings only. Verified locally before pushing: `ruff check` clean, `ruff
format --check` reports already-formatted, `mypy tests/drivers/` reports no
issues in 4 source files, and **108 passed** across `tests/drivers/` and
`tests/tools/g1/` — the same count this PR claimed before the fix, so the
typing change moved no behaviour.
