### PR TITLE
fix(drivers): close the G1 DDS endpoints instead of only forgetting them

### DIFF
--- a/changelog.d/2768-g1-dds-close-releases-endpoints.md
+++ b/changelog.d/2768-g1-dds-close-releases-endpoints.md
@@ -1,0 +1,35 @@
+### Fixed: closing the G1 DDS engine releases its endpoints
+
+`DDSSubscriberSet.close` and `DDSPublisher.close` dropped their references and
+relied on garbage collection, each justifying that with a docstring asserting
+that the `unitree_sdk2py` class "has no explicit close". Both classes do define
+`Close()`, and for a subscriber the collection half is not merely optimistic but
+impossible: `subscribe()` builds every subscriber with `queueLen=10`, and at any
+queue length above zero the SDK starts a `ch_reader` daemon thread whose target
+is a bound method of the channel's reader. The running thread keeps the channel
+reachable, so the CycloneDDS `__del__` that would release the `DataReader` never
+runs.
+
+Measured against `unitree_sdk2py` 1.0.1, one `ch_reader` thread per
+subscription:
+
+```
+after subscribe:              1
+after del + 3x gc.collect():  1     <- what close() used to do
+after an explicit Close():    0
+```
+
+So `G1Driver.cleanup()` released nothing. The decoder callbacks kept filling
+caches for a driver reporting itself disconnected, and because `cleanup()` then
+sets `_connected = False`, the documented re-attach route - `cleanup()` followed
+by `connect_eagerly()` - subscribed all four topics a second time. That is the
+duplicate subscription the engine's shared construction lock exists to prevent,
+and it is the hazard `connect_eagerly()`'s own docstring already names when it
+declines to rebuild a live subscriber set.
+
+Both `close()` methods now call `Close()` on each endpoint, each under its own
+`try` so one SDK failure cannot strand the endpoints behind it, and swap the
+collection out under the lock first so a second call closes nothing twice. A
+writer starts no reader thread, so a dropped publisher did reach `__del__`; the
+change makes the release happen at the call rather than whenever the last
+reference happens to go.

--- a/strands_robots/tools/g1/_dds_engine.py
+++ b/strands_robots/tools/g1/_dds_engine.py
@@ -109,15 +109,35 @@ class DDSSubscriberSet:
             return None
 
     def close(self) -> None:
-        """Release every subscriber. Idempotent.
+        """Close every subscriber and forget it. Idempotent, and never raises.
 
-        ``ChannelSubscriber`` in ``unitree_sdk2py`` has no explicit close - it
-        relies on garbage collection - so this drops the references and lets
-        the collector claim them. Called from
-        :meth:`~strands_robots.drivers.g1.G1Driver.cleanup`.
+        ``ChannelSubscriber.Close()`` is what releases a subscription, and
+        dropping the reference is not a substitute. :meth:`subscribe` builds
+        each subscriber with ``queueLen=10``, and at any queue length above
+        zero ``unitree_sdk2py`` starts a ``ch_reader`` daemon thread whose
+        target is a bound method of the channel's reader. That running thread
+        keeps the whole channel reachable, so the CycloneDDS ``__del__`` that
+        would release the ``DataReader`` never runs: the thread keeps looping,
+        the reader stays matched, and the decoder callback keeps filling caches
+        for a driver that believes it is disconnected. ``Close()`` sets the
+        thread's stop event, joins it and drops the reader; nothing else does.
+
+        The list is swapped out under :attr:`_lock` before any ``Close()``
+        runs, so a second call finds nothing to close and a concurrent
+        :meth:`subscribe` - which appends without that lock - cannot mutate
+        the list being walked. Each subscriber is then closed under its own
+        ``try``, because a teardown that abandons the subscribers behind a
+        failing one leaks exactly what it was called to release.
+
+        Called from :meth:`~strands_robots.drivers.g1.G1Driver.cleanup`.
         """
         with self._lock:
-            self._subs.clear()
+            subs, self._subs = self._subs, []
+        for sub in subs:
+            try:
+                sub.Close()
+            except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+                logger.warning("failed to close a DDS subscriber: %s", exc)
 
 
 class DDSPublisher:
@@ -251,12 +271,27 @@ class DDSPublisher:
         return None
 
     def close(self) -> None:
-        """Release every publisher. Idempotent.
+        """Close every publisher and forget it. Idempotent, and never raises.
 
-        ``ChannelPublisher`` in ``unitree_sdk2py`` has no explicit close - it
-        relies on garbage collection - so this drops the references and lets
-        the collector claim them. Called from
-        :meth:`~strands_robots.drivers.g1.G1Driver.cleanup`.
+        ``ChannelPublisher.Close()`` releases the writer through
+        ``Channel.CloseWriter``. A writer starts no reader thread, so unlike
+        :meth:`DDSSubscriberSet.close` a dropped reference here does reach
+        CycloneDDS' ``__del__`` and the ``DataWriter`` is collected - but only
+        whenever the last reference happens to go, which a live traceback or a
+        reference cycle can defer indefinitely. Closing says when.
+
+        Mirrors :meth:`DDSSubscriberSet.close`: the cache is swapped out under
+        :attr:`_lock` so a second call closes nothing twice, and each publisher
+        is closed under its own ``try`` so one failure cannot strand the rest.
+
+        The driver holds no :class:`DDSPublisher` yet - the control loop that
+        owns one lands with issue #361 - so today this is reached only by a
+        caller that built its own.
         """
         with self._lock:
-            self._pubs.clear()
+            pubs, self._pubs = list(self._pubs.values()), {}
+        for pub in pubs:
+            try:
+                pub.Close()
+            except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
+                logger.warning("failed to close a DDS publisher: %s", exc)

--- a/tests/drivers/test_g1_dds_engine_release.py
+++ b/tests/drivers/test_g1_dds_engine_release.py
@@ -1,0 +1,313 @@
+"""G1 DDS teardown: closing an engine releases readers and writers, not just references.
+
+``DDSSubscriberSet.close`` is the driver's only release path -
+:meth:`~strands_robots.drivers.g1.G1Driver.cleanup` calls it and then drops the
+set - and ``DDSPublisher.close`` is its sibling on the write path. Both used to
+drop their references and rely on garbage collection, which is measurably wrong
+for a subscriber: :meth:`DDSSubscriberSet.subscribe` builds every subscriber
+with a non-zero queue length, and at any queue length above zero
+``unitree_sdk2py`` starts a ``ch_reader`` daemon thread whose target is a bound
+method of the channel's reader. The running thread keeps the channel reachable,
+so CycloneDDS' ``__del__`` never runs, and ``ChannelSubscriber.Close()`` - which
+both docstrings claimed did not exist - is the only thing that stops the thread
+and drops the ``DataReader``.
+
+A subscription that outlives ``cleanup()`` matters twice over: the decoder
+callback keeps writing caches for a driver that reports itself disconnected,
+and the next ``connect_eagerly()`` subscribes the same topics again - the
+duplicate that the engine's shared construction lock exists to prevent.
+
+The SDK is absent on a headless runner, so the behavioural cells drive
+recording stand-ins that model ``Init``/``Close``. The facts a stand-in cannot
+establish - that the real classes *have* ``Close`` - are pinned separately, and
+skip where the SDK is missing.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from strands_robots.drivers.g1 import G1Driver
+from strands_robots.tools.g1._dds_engine import DDSPublisher, DDSSubscriberSet
+
+_ENGINE_LOGGER = "strands_robots.tools.g1._dds_engine"
+
+
+class _RecordingEndpoint:
+    """Stands in for a ``ChannelSubscriber``/``ChannelPublisher``, counting closes."""
+
+    def __init__(self, topic: str, message_class: type) -> None:
+        self.topic = topic
+        self.message_class = message_class
+        self.queue_len: int | None = None
+        self.closes = 0
+
+    def Init(self, handler: Any = None, queue_len: int | None = None) -> None:  # noqa: N802 - SDK spelling
+        self.queue_len = queue_len
+
+    def Close(self) -> None:  # noqa: N802 - SDK spelling
+        self.closes += 1
+
+
+class _RaisingEndpoint(_RecordingEndpoint):
+    """An endpoint whose ``Close()`` fails the way the SDK's can."""
+
+    def Close(self) -> None:  # noqa: N802 - SDK spelling
+        self.closes += 1
+        raise RuntimeError("dds entity already gone")
+
+
+def _install_channel(
+    monkeypatch: pytest.MonkeyPatch,
+    attribute: str,
+    endpoint_class: type[_RecordingEndpoint],
+) -> list[_RecordingEndpoint]:
+    """Point ``unitree_sdk2py.core.channel.<attribute>`` at a recording factory.
+
+    ``monkeypatch.setitem`` restores whatever was in ``sys.modules`` before,
+    so a machine that really has the SDK gets it back.
+    """
+    built: list[_RecordingEndpoint] = []
+
+    def _factory(topic: str, message_class: type) -> _RecordingEndpoint:
+        endpoint = endpoint_class(topic, message_class)
+        built.append(endpoint)
+        return endpoint
+
+    channel = types.ModuleType("unitree_sdk2py.core.channel")
+    setattr(channel, attribute, _factory)
+    monkeypatch.setitem(sys.modules, "unitree_sdk2py.core.channel", channel)
+    return built
+
+
+def _subscribed(
+    monkeypatch: pytest.MonkeyPatch,
+    topics: tuple[str, ...],
+    endpoint_class: type[_RecordingEndpoint] = _RecordingEndpoint,
+) -> tuple[DDSSubscriberSet, list[_RecordingEndpoint]]:
+    """Return a set that really ran :meth:`DDSSubscriberSet.subscribe`.
+
+    The endpoints graded below are the ones ``subscribe`` built, so these cells
+    measure the objects the production path creates rather than a list a test
+    handed over. ``start()`` is skipped because it would call
+    ``ChannelFactoryInitialize`` against a real bus.
+    """
+    built = _install_channel(monkeypatch, "ChannelSubscriber", endpoint_class)
+    subs = DDSSubscriberSet("eth0")
+    subs._started = True
+    for topic in topics:
+        assert subs.subscribe(topic, dict, lambda _msg: None) is None
+    assert len(built) == len(topics)
+    return subs, built
+
+
+def _published(
+    monkeypatch: pytest.MonkeyPatch,
+    topics: tuple[str, ...],
+    endpoint_class: type[_RecordingEndpoint] = _RecordingEndpoint,
+) -> tuple[DDSPublisher, list[_RecordingEndpoint]]:
+    """Return a publisher cache that really ran :meth:`DDSPublisher.get_publisher`."""
+    built = _install_channel(monkeypatch, "ChannelPublisher", endpoint_class)
+    pubs = DDSPublisher("eth0")
+    pubs._started = True
+    for topic in topics:
+        endpoint, err = pubs.get_publisher(topic, dict)
+        assert err is None
+        assert endpoint is not None
+    assert len(built) == len(topics)
+    return pubs, built
+
+
+def _close_with_failing_endpoints(
+    caplog: pytest.LogCaptureFixture,
+    engine: DDSSubscriberSet | DDSPublisher,
+) -> list[logging.LogRecord]:
+    """Close ``engine`` while capturing what it reported."""
+    with caplog.at_level(logging.WARNING, logger=_ENGINE_LOGGER):
+        engine.close()
+    return list(caplog.records)
+
+
+# =========================================================================
+# Premise - the SDK really does expose an explicit close.                  #
+# =========================================================================
+
+
+class TestTheSdkHasAnExplicitClose:
+    """The facts a recording stand-in cannot establish.
+
+    Both ``close`` methods used to justify dropping references by asserting
+    that the SDK class "has no explicit close" and "relies on garbage
+    collection". A stand-in that defines ``Close`` would happily agree with a
+    fix built on the same wrong belief, so these cells ask the installed SDK
+    instead and skip where it is absent.
+    """
+
+    @staticmethod
+    def _channel() -> Any:
+        return pytest.importorskip(
+            "unitree_sdk2py.core.channel",
+            reason="needs unitree_sdk2py (office bring-up, not a headless runner)",
+        )
+
+    def test_channel_subscriber_exposes_close(self) -> None:
+        assert callable(getattr(self._channel().ChannelSubscriber, "Close", None))
+
+    def test_channel_publisher_exposes_close(self) -> None:
+        assert callable(getattr(self._channel().ChannelPublisher, "Close", None))
+
+    def test_the_channel_closes_a_reader_and_a_writer_separately(self) -> None:
+        """``Close`` routes to these, which is why closing releases anything."""
+        channel = self._channel().Channel
+        assert callable(getattr(channel, "CloseReader", None))
+        assert callable(getattr(channel, "CloseWriter", None))
+
+    def test_no_finaliser_releases_a_dropped_subscriber(self) -> None:
+        """No ``__del__``, so dropping the last reference runs no release code."""
+        assert getattr(self._channel().ChannelSubscriber, "__del__", None) is None
+
+
+class TestSubscribeAsksForAQueuedReader:
+    """The queue length is the whole reason a dropped subscriber leaks.
+
+    ``unitree_sdk2py`` only starts the ``ch_reader`` thread when the queue
+    length is above zero, and that thread is what keeps a dropped channel
+    reachable. This needs no SDK: the argument is one the engine chooses.
+    """
+
+    def test_every_subscriber_is_built_with_a_non_zero_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _subs, built = _subscribed(monkeypatch, ("rt/lowstate", "rt/lf/bmsstate"))
+        assert [endpoint.queue_len for endpoint in built] == [10, 10]
+
+
+# =========================================================================
+# Regression - the release actually happens.                               #
+# =========================================================================
+
+
+class TestClosingASubscriberSetReleasesEverySubscriber:
+    """Every subscriber the set built is closed, not merely forgotten."""
+
+    def test_close_closes_every_subscriber_it_built(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        subs, built = _subscribed(monkeypatch, ("rt/lowstate", "rt/lf/bmsstate"))
+        subs.close()
+        assert [endpoint.closes for endpoint in built] == [1, 1]
+
+    def test_the_driver_s_cleanup_closes_the_subscribers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``cleanup()`` is the route a caller takes; it must reach ``Close()``."""
+        subs, built = _subscribed(monkeypatch, ("rt/lowstate",))
+        driver = G1Driver(tool_name="g1", port="1.2.3.4")
+        driver._subs = subs
+        driver._connected = True
+
+        driver.cleanup()
+
+        assert [endpoint.closes for endpoint in built] == [1]
+        assert driver._subs is None
+        assert driver._connected is False
+
+    def test_a_failing_close_does_not_strand_the_subscribers_behind_it(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One SDK failure must not leak the rest - that is the whole job."""
+        subs, built = _subscribed(
+            monkeypatch, ("rt/lowstate", "rt/lf/bmsstate", "rt/utlidar/lidar_state"), _RaisingEndpoint
+        )
+        _close_with_failing_endpoints(caplog, subs)
+        assert [endpoint.closes for endpoint in built] == [1, 1, 1]
+
+    def test_every_close_failure_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A swallowed teardown failure is a leak nobody can see."""
+        subs, _built = _subscribed(
+            monkeypatch, ("rt/lowstate", "rt/lf/bmsstate", "rt/utlidar/lidar_state"), _RaisingEndpoint
+        )
+        assert len(_close_with_failing_endpoints(caplog, subs)) == 3
+
+    def test_the_report_names_the_reason_the_sdk_gave(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ "a subscriber failed to close" alone would not help anyone."""
+        subs, _built = _subscribed(monkeypatch, ("rt/lowstate",), _RaisingEndpoint)
+        _close_with_failing_endpoints(caplog, subs)
+        assert "dds entity already gone" in caplog.text
+
+    def test_a_second_close_does_not_close_anything_twice(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Idempotent means the SDK is asked exactly once per subscriber."""
+        subs, built = _subscribed(monkeypatch, ("rt/lowstate",))
+        subs.close()
+        subs.close()
+        assert [endpoint.closes for endpoint in built] == [1]
+
+
+class TestClosingAPublisherReleasesEveryPublisher:
+    """The write path's cache gets the same teardown as the read path's list.
+
+    A writer starts no reader thread, so a dropped publisher does eventually
+    reach CycloneDDS' ``__del__``. Closing it is about *when*: the release
+    happens at the call rather than whenever the last reference happens to go.
+    """
+
+    def test_close_closes_every_publisher_it_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pubs, built = _published(monkeypatch, ("rt/lowcmd", "rt/armsdk"))
+        pubs.close()
+        assert [endpoint.closes for endpoint in built] == [1, 1]
+
+    def test_a_failing_close_does_not_strand_the_publishers_behind_it(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pubs, built = _published(monkeypatch, ("rt/lowcmd", "rt/armsdk", "rt/api/sport"), _RaisingEndpoint)
+        _close_with_failing_endpoints(caplog, pubs)
+        assert [endpoint.closes for endpoint in built] == [1, 1, 1]
+
+    def test_every_close_failure_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        pubs, _built = _published(monkeypatch, ("rt/lowcmd", "rt/armsdk"), _RaisingEndpoint)
+        records = _close_with_failing_endpoints(caplog, pubs)
+        assert len(records) == 2
+        assert "publisher" in caplog.text
+
+    def test_a_second_close_does_not_close_anything_twice(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pubs, built = _published(monkeypatch, ("rt/lowcmd",))
+        pubs.close()
+        pubs.close()
+        assert [endpoint.closes for endpoint in built] == [1]
+
+
+# =========================================================================
+# Boundary - what the old contract promised is still true.                 #
+# =========================================================================
+
+
+class TestCloseStillForgetsWhatItClosed:
+    """Closing must not cost the properties the shipped ``close`` already had.
+
+    Every expectation here is one the pre-fix code also met, so a release
+    bolted on at the cost of the old contract fails here rather than passing
+    quietly. Idempotence sits with the regression cells instead: "the SDK is
+    asked exactly once" is not a claim the pre-fix code could satisfy, because
+    it never asked at all.
+    """
+
+    def test_a_closed_subscriber_set_holds_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        subs, _built = _subscribed(monkeypatch, ("rt/lowstate", "rt/lf/bmsstate"))
+        subs.close()
+        assert subs._subs == []
+
+    def test_a_closed_publisher_cache_holds_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pubs, _built = _published(monkeypatch, ("rt/lowcmd", "rt/armsdk"))
+        pubs.close()
+        assert pubs._pubs == {}
+
+    def test_closing_a_subscriber_set_that_never_subscribed_is_a_no_op(self) -> None:
+        DDSSubscriberSet("eth0").close()
+
+    def test_closing_a_publisher_that_never_published_is_a_no_op(self) -> None:
+        DDSPublisher("eth0").close()


### PR DESCRIPTION
## Problem

`DDSSubscriberSet.close` and `DDSPublisher.close` each dropped their references
and relied on garbage collection, and each justified that in its docstring:

> `ChannelSubscriber` in `unitree_sdk2py` has no explicit close - it relies on
> garbage collection - so this drops the references and lets the collector claim
> them.

Both halves are wrong. `ChannelSubscriber.Close()` and `ChannelPublisher.Close()`
both exist (they route to `Channel.CloseReader` / `Channel.CloseWriter`), and for
a subscriber the garbage-collection half is not merely optimistic - it cannot
happen. `subscribe()` builds every subscriber with `queueLen=10`, and at any
queue length above zero the SDK starts a `ch_reader` daemon thread whose target
is a bound method of the channel's reader. That running thread keeps the channel
reachable, so the CycloneDDS `__del__` that would release the `DataReader` never
runs.

Measured against `unitree_sdk2py` 1.0.1, counting `ch_reader` threads:

```
baseline                        0
after subscribe                 1     queueLen=10 starts the reader thread
ChannelSubscriber.Close exists  True
after del + 3x gc.collect()     1     <- exactly what close() did
after an explicit Close()       0
```

The mechanism isolates cleanly - the thread is the only variable:

| endpoint | `Close()` exists | drop refs + gc releases it |
| --- | --- | --- |
| `ChannelPublisher` (writer, no thread) | yes | yes |
| `ChannelSubscriber`, `queueLen=10` (what `subscribe()` uses) | yes | **no** |
| `ChannelSubscriber`, `queueLen=0` (no thread) | yes | yes |

## Why it matters

`G1Driver.cleanup()` is the only release path, and it released nothing. Four
subscriptions therefore outlived it: the decoder callbacks kept writing `_imu`,
`_fsm_id`, `_battery` and the LiDAR caches for a driver reporting itself
disconnected, and each leaked a live daemon thread.

The second consequence is worse. `cleanup()` sets `_connected = False`, so the
documented re-attach route - `cleanup()` then `connect_eagerly()` - built a fresh
`DDSSubscriberSet` and subscribed all four topics again while the previous four
were still attached. That is the duplicate subscription the shared
`_DDS_INIT_LOCK` exists to prevent, and it is the hazard `connect_eagerly()`
already names when it declines to rebuild a live set:

> Rebuilding the subscriber set instead would re-subscribe all four topics and
> drop the only reference to the previous one, leaking its subscribers on a bus
> whose bindings segfault under concurrent construction.

One route into that leak was guarded. The other performed it unconditionally.

## Change

Both `close()` methods now call `Close()` on each endpoint:

- Each endpoint is closed under its **own** `try`, so one SDK failure cannot
  strand the endpoints behind it - a teardown that gives up halfway leaks
  precisely what it was called to release. The failure is logged with the reason
  the SDK gave.
- The collection is swapped out under `_lock` **before** any `Close()` runs, so a
  second call closes nothing twice, and a concurrent `subscribe()` - which
  appends without that lock - cannot mutate the list being walked.
- The publisher gets the same treatment. Its writer starts no reader thread, so a
  dropped reference did reach `__del__`; the change makes the release happen at
  the call rather than whenever the last reference happens to go. The write path
  added in #2757 carried the same "has no explicit close" sentence, so both
  copies are corrected here rather than leaving the two siblings on different
  teardown conventions.
- `DDSPublisher.close`'s docstring claimed it is "called from
  `G1Driver.cleanup`". The driver holds no `DDSPublisher` yet, so that reference
  is corrected to say the control loop in issue #361 will own one.

No behaviour outside teardown changes: `start`, `subscribe`, `get_publisher` and
`publish` are untouched.

## Tests

`tests/drivers/test_g1_dds_engine_release.py`, 19 cells. Pre-fix, **10 fail and
9 pass**:

| class | failed/total | role |
| --- | --- | --- |
| `TestClosingASubscriberSetReleasesEverySubscriber` | 6/6 | regression |
| `TestClosingAPublisherReleasesEveryPublisher` | 4/4 | regression |
| `TestCloseStillForgetsWhatItClosed` | 0/4 | the old contract must survive |
| `TestSubscribeAsksForAQueuedReader` | 0/1 | the queue length is the mechanism |
| `TestTheSdkHasAnExplicitClose` | 0/4 | premise, against the installed SDK |

The behavioural cells drive recording stand-ins through the real `subscribe()`
and `get_publisher()`, so they grade the objects the production path builds. The
one fact a stand-in cannot establish - that the SDK classes *have* `Close` - is
pinned separately and skips where `unitree_sdk2py` is absent, which is every
headless runner. A stand-in that defines `Close` would otherwise agree happily
with a fix built on the same wrong belief.

### Mutation coverage

13 mutations, 12 detected, 12 distinct firing sets, control clean, source
restored byte-identical after every row:

| mutation | cells fired | pre-existing cells fired |
| --- | --- | --- |
| control (no mutation) | 0 | 0 |
| subscriber `Close()` dropped (the shipped defect) | 6 | 0 |
| publisher `Close()` dropped (the shipped defect) | 4 | 0 |
| both dropped (equivalent to a full revert) | 10 | 0 |
| subscriber: only the first is closed | 3 | 0 |
| subscriber: one `try` around the whole loop | 2 | 0 |
| subscriber: closed but never forgotten | 2 | 0 |
| subscriber: failure swallowed silently | 2 | 0 |
| subscriber: no guard, a failing `Close` propagates | 3 | 0 |
| publisher: one `try` around the whole loop | 2 | 0 |
| publisher: closed but never forgotten | 2 | **1** |
| `subscribe()` asks for an unqueued reader (`queueLen=0`) | 1 | 0 |
| tolerant `getattr(sub, "Close", None)` instead of the contract | **0** | 0 |

Two rows are worth reading:

- The two single-class rows are **disjoint and sum exactly** to the both-dropped
  row (6 + 4 = 10), so neither half rides on the other's tests.
- "publisher: closed but never forgotten" also trips
  `tests/tools/g1/test_dds_publisher.py::test_close_is_idempotent_and_drops_cache`,
  the write path's own guard - the new cells compose with it rather than
  duplicating it.

The one undetected row is honest and deliberate: replacing `sub.Close()` with a
tolerant `getattr(sub, "Close", None)` is behaviourally identical for anything
that defines `Close`, so no test can distinguish it. It is not adopted because
the SDK does define `Close` on both classes; a stand-in that lacks it is a
stand-in worth surfacing, not tolerating.

## Verification

- `ruff check` and `ruff format --check` clean over `strands_robots tests
  tests_integ` (1580 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a worktree pinned
  to this branch's merge-base, normalized message sets byte-identical in both
  directions, 0 in the changed files.
- Paired suite: an identical 332-file selection (all of `tests/drivers` and
  `tests/tools/g1`, plus every guard that walks the tree, reads source or
  docstrings, or reads `changelog.d`), with the new file excluded from both -
  identical **16782 collected** and `17 failed, 16705 passed, 60 skipped` on both
  trees. Failing-ID sets identical, both `comm` directions empty. All 17 are
  `ModuleNotFoundError: No module named 'awsiot'` (the `[mesh-iot]` extra, not
  installed here).
- New file: 19 passed, with the four SDK-gated premise cells running rather than
  skipping on a machine that has `unitree_sdk2py`.

The SDK used as the oracle is `unitree_sdk2py` 1.0.1; its `core/channel.py` is
byte-identical (md5 `a46a6312053b2c5b6943a3a4486335e9`) to the one in the
published `unitree-sdk2` 1.0.1 wheel, so the measurements above describe what a
declared dependency would install.

No visual artifact: this changes teardown and resource release, not a policy,
simulation, rendering, recording or asset. The measured thread-count table is the
evidence.
