### PR TITLE
fix(scripts): collide duplicate work on the identity a created path declares

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,23 +271,30 @@ hatch run format            # ruff check --fix, ruff format
 
    **The claim is not the only key.** 249 of the last 300 pull requests (#2345
    through #2708) link no issue at all, so for most of the traffic the query above
-   has nothing to collide on - and two of the four duplicate pairs in that window
-   were claim-free: #2388/#2389 and #2707/#2708, each pair independently creating
-   one new test file. Once your branch is pushed and the pull request is open, ask
-   the second question:
+   has nothing to collide on - and three of the five duplicate pairs in the window
+   #2345 through #2767 were claim-free: #2388/#2389, #2707/#2708 and #2766/#2767.
+   Once your branch is pushed and the pull request is open, ask the second
+   question:
 
    ```
    python3 scripts/check_duplicate_claim.py --repo strands-labs/robots --all-open
    ```
 
-   It reports only pairs that **create the same path**, which over the 1802 pairs
-   that were open at the same instant selected 2 - and both were duplicates. Two
-   branches *editing* one file is a different question with a different remedy
+   It reports only pairs that **create the same thing**, which over the 2002 pairs
+   that were open at the same instant selected 3 - and all three were duplicates.
+   For almost every path that means creating the same path. The exception is a
+   changelog fragment, which is named `<number>-<slug>.md`: two branches describing
+   one change write one slug under two numbers, so they are paired on the slug and
+   the number is dropped. That is not a loose key - across the 350 pull requests in
+   that window which add a fragment there are **350 distinct slugs**, and the only
+   two used twice are the two duplicate pairs above that reused one.
+
+   Two branches *editing* one file is a different question with a different remedy
    (a merge order, possibly one composition run), and
    `scripts/check_merge_base_overlap.py --github-repo <owner/name> --all-open`
-   owns it; that relation selects 117 of the same 1802. The two keys are complementary rather than nested: neither
-   issue-keyed pair shares an added path, and neither claim-free pair claims an
-   issue.
+   owns it; that relation selects 127 of the same 2002. The two keys are
+   complementary rather than nested: no issue-keyed pair shares an added path, and
+   no claim-free pair claims an issue.
 
    This one cannot be asked before you start, and not for want of trying: a path
    set is a property of a pushed branch, so there is nothing to read at intake. It

--- a/changelog.d/2769-duplicate-work-created-identity-key.md
+++ b/changelog.d/2769-duplicate-work-created-identity-key.md
@@ -1,0 +1,41 @@
+### Fixed: duplicate work is collided on the identity a created path declares, so two changelog fragments naming one change are reported
+
+`scripts/check_duplicate_claim.py --all-open` pairs two open pull requests on a path they both
+**create**. A changelog fragment is named `<number>-<slug>.md`, so two branches describing one
+change write one slug under two numbers and their paths differ -- and a pair whose only shared
+creation is that entry collides on nothing. #2766/#2767 are exactly that pair: both wire
+`G1Driver.send_action` to publish on `rt/lowcmd`, opened 8m 06s apart, one putting its tests in a
+new file and the other into an existing one, so they create no common path at all. Run against the
+open set while both sat in it, the sweep reported `unique-additions - no two of the 9 open pull
+requests create the same file`.
+
+The exclusion was not an oversight but an assertion. A test pinned that a changelog fragment can
+never be the shared path, with the reason "its name embeds the number, so it cannot collide", and
+the fixtures carried a fragment to demonstrate it. The reason is true of the raw path and is exactly
+why the number is the half that has to go.
+
+The key is now the identity a created path declares. For every path but a fragment that is the path
+itself, so this is a strict widening: over the 2002 pairs in #2345 through #2767 that were open at
+the same instant it selects the same 2 pairs the raw path selects, plus #2766/#2767, and loses none.
+
+    what both create                                        pair           closed
+    tests/test_recorder_counters_track_on_disk_frames.py     #2388, #2389   #2389
+    tests/training/test_checkpoint_cadence_domain.py         #2707, #2708   #2707
+    changelog.d/*-g1-send-action-wired.md                    #2766, #2767   open
+
+The stated fear behind the old boundary was that keying on a fragment "would fire on every pair in
+the queue". It does not. Of those 353 pull requests, 350 add a fragment and between them use **350
+distinct slugs**; exactly two slugs are used twice, and both times the two users are a duplicate
+pair. The number is the noisy half: it is meant to be the pull request's own number and in 40 of
+those 350 it is not, because it is chosen before the pull request exists and races with whatever
+merges first.
+
+The report names the two branches' shared subject as `changelog.d/*-<slug>.md` rather than a
+filename, because the file it would otherwise print exists on neither branch. What a fragment *is*
+comes from `scripts/assemble_changelog.py` rather than a second copy of the pattern, so this sweep
+and the assembler cannot disagree; a name the assembler would reject keys on itself, which can only
+fail to report a pair rather than invent one.
+
+The two keys remain complementary. #2707/#2708 is still reachable only from the path -- #2707 added
+no fragment at all -- and neither issue-keyed pair in the window shares a created subject, so no
+relation may be deleted in favour of another.

--- a/scripts/check_duplicate_claim.py
+++ b/scripts/check_duplicate_claim.py
@@ -82,8 +82,9 @@ Three questions, two keys
     always shares its own claim.
 
 ``--all-open``
-    Review, keyed on the added path. Do two open pull requests create the same
-    file? Needs no issue number, which is the point: see below.
+    Review, keyed on what a branch creates. Do two open pull requests create the
+    same file, or two fragments naming one changelog entry? Needs no issue
+    number, which is the point: see below.
 
 The key a claim-free pair collides on
 -------------------------------------
@@ -107,29 +108,54 @@ merge order plus possibly one test run. Two branches *creating* one file is not 
 composition at all. It is two answers to one question, and one of them is going
 to be closed.
 
-Measured over those same 300 pull requests, on the 1802 pairs that were open at
-the same instant::
+Measured over 353 pull requests (#2345 through #2767), on the 2002 pairs that
+were open at the same instant::
 
-    relation              pairs   duplicates among them
-    both edit a path        117   a composition question, not this one
-    both add a path           2   2
+    relation                        pairs   duplicates among them
+    both edit a path                  127   a composition question, not this one
+    both add a path                     2   2
+    both create the same thing          3   3   <- what this sweep pairs on
 
-Both of the two are duplicates, and neither was reachable from a claim::
+All three are duplicates, and none was reachable from a claim::
 
-    shared added path                                       pair           closed
-    tests/test_recorder_counters_track_on_disk_frames.py    #2388, #2389   #2389
-    tests/training/test_checkpoint_cadence_domain.py        #2707, #2708   #2707
+    what both create                                        pair           closed
+    tests/test_recorder_counters_track_on_disk_frames.py     #2388, #2389   #2389
+    tests/training/test_checkpoint_cadence_domain.py         #2707, #2708   #2707
+    changelog.d/*-g1-send-action-wired.md                    #2766, #2767   open
 
 The two keys are complementary rather than nested, which is why this is a second
 key and not a replacement for the first. The same window holds two *issue-keyed*
 pairs -- #2570/#2571 on #2569, and #2480/#2508 on #2466 -- and neither of them
-shares an added path, while neither claim-free pair claims an issue. Four
-duplicate pairs, two reachable from each key, none from both.
+shares an added path, while no claim-free pair claims an issue. Five duplicate
+pairs, two reachable from the claim and three from what they create, none from
+both.
 
-The 2-of-1802 rate is the whole claim. The relation the sibling file rejected --
+The 3-of-2002 rate is the whole claim. The relation the sibling file rejected --
 widening a path intersection to a test's walked root -- selected 11 of 36 pairs
 and named no defect, and a finding attached to a third of the queue reads as
 boilerplate.
+
+Why a raw path was not the key
+------------------------------
+The third row was not reachable when this sweep shipped, and the reason is worth
+stating because it was written down as a certainty. A test asserted that a
+changelog fragment can never be the shared path, "because its name embeds the
+number", and the fixtures carried one to demonstrate it. That is true of the raw
+path, and it is exactly why the number has to be dropped: a fragment is named
+``<number>-<slug>.md``, so two branches describing one change write one slug under
+two numbers and collide on nothing.
+
+The fear behind that exclusion was that keying on a fragment "would fire on every
+pair in the queue". Measured, it does not. Of the 353 pull requests, 350 add a
+fragment, and between them they use **350 distinct slugs**; exactly two slugs are
+used twice, and both times the two users are a duplicate pair. The number is the
+noisy half, not the slug: it is meant to be the pull request's own number and in
+40 of those 350 it is not, because it is chosen before the pull request exists and
+races with whatever merges first.
+
+So the key is the identity a created path declares -- see :func:`addition_key`.
+For everything except a fragment that is the path itself, which is why widening it
+selected the same two pairs plus one and lost none.
 
 Why this question cannot be asked at intake
 -------------------------------------------
@@ -163,7 +189,8 @@ What this reports, and what it deliberately does not
 ``--all-open`` reports the same three shapes over the other key:
 
 ``unique-additions``
-    No two open pull requests create the same file. The convention working.
+    No two open pull requests create the same file, and no two name one changelog
+    entry. The convention working.
 
 ``duplicate-addition``
     The finding.
@@ -178,9 +205,9 @@ Out of scope, deliberately:
   branches that both omit the keyword collide invisibly there, and still do:
   requiring a claim is what 18 of the last 30 merges would fail, so neither
   claim-keyed mode demands one. What changed is that the pair is no longer
-  unreachable -- ``--all-open`` collides it on an added path instead, and the
-  measurement above is the argument that this is narrow enough to be worth
-  reporting. See #2709 and #1961.
+  unreachable -- ``--all-open`` collides it on what the two branches create
+  instead, and the measurement above is the argument that this is narrow enough to
+  be worth reporting. See #2709 and #1961.
 - **Whether the issue exists, or is already closed.** A stale number is a
   different defect, and refusing it would report a finding against correct work
   whose issue someone else closed first.
@@ -220,6 +247,7 @@ exits ``2``.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import itertools
 import json
 import os
@@ -228,6 +256,8 @@ import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
 
 API_ROOT = "https://api.github.com"
 
@@ -260,6 +290,42 @@ UNKNOWN_CLAIMS = "unknown-claims"
 UNIQUE_ADDITIONS = "unique-additions"
 DUPLICATE_ADDITION = "duplicate-addition"
 UNKNOWN_ADDITIONS = "unknown-additions"
+
+#: The directory whose created files name a change rather than being one.
+FRAGMENT_DIR = "changelog.d/"
+
+
+def _load_assembler() -> ModuleType:
+    """Load ``assemble_changelog`` from beside this script, for the naming rule.
+
+    By path, registered in :data:`sys.modules` before execution and reusing an
+    already-loaded copy: the shape and every reason for it are
+    ``scripts/check_changelog_fragment.py``'s :func:`_load_assembler`, which
+    reuses this same module for this same rule.
+    """
+    loaded = sys.modules.get("assemble_changelog")
+    if loaded is not None:
+        return loaded
+    path = Path(__file__).resolve().parent / "assemble_changelog.py"
+    spec = importlib.util.spec_from_file_location("assemble_changelog", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load the fragment naming rule from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["assemble_changelog"] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        del sys.modules["assemble_changelog"]
+        raise
+    return module
+
+
+#: The single source of what a fragment name is. Reused rather than restated so
+#: this sweep and the assembler cannot disagree about whether a created file
+#: under :data:`FRAGMENT_DIR` is a fragment at all -- a name the assembler would
+#: reject keys on itself here, which is the conservative direction.
+_ASSEMBLER = _load_assembler()
+
 
 #: The one ``changeType`` this key reads. GitHub's enum also carries
 #: ``MODIFIED``, ``REMOVED``, ``RENAMED``, ``COPIED`` and ``CHANGED``, and every
@@ -419,20 +485,20 @@ class AdditionVerdict:
         if self.outcome == UNKNOWN_ADDITIONS:
             return (
                 f"Could not read every file list: {self.detail} Not treated as a finding, because "
-                "an unreadable file list is not evidence that two branches create one file."
+                "an unreadable file list is not evidence that two branches create one thing."
             )
         if self.outcome == UNIQUE_ADDITIONS:
             return (
-                f"No two of the {self.scanned} open pull requests create the same file "
-                f"({self.compared} pair(s) compared)."
+                f"No two of the {self.scanned} open pull requests create the same file or name the "
+                f"same changelog entry ({self.compared} pair(s) compared)."
             )
         parts = "; ".join(
             f"{_pulls((left, right))} both create {_paths(paths)}" for left, right, paths in self.collisions
         )
         return (
-            f"{parts}. Two branches creating one file are two answers to one question rather "
-            "than a composition to verify, and whichever is closed spends a review approval on a "
-            "change that will not ship."
+            f"{parts}. Two branches creating one file, or two fragments declaring one changelog "
+            "entry, are two answers to one question rather than a composition to verify, and "
+            "whichever is closed spends a review approval on a change that will not ship."
         )
 
 
@@ -476,22 +542,73 @@ def find_collisions(
     return tuple(collisions)
 
 
+def addition_key(path: str) -> str:
+    """Return the identity a created path declares, which is what collides.
+
+    Almost every created path *is* its own identity: two branches writing
+    ``tests/foo.py`` have written one file, and the path is what says so.
+
+    A changelog fragment is the exception, and it is the only one. Its name is
+    ``<number>-<slug>.md`` by convention, so two branches describing the same
+    change write the same slug under two numbers and their paths differ -- while
+    the entry they are each declaring is the same entry. Measured over
+    #2345..#2767: 350 of the 353 pull requests add a fragment, between them using
+    **350 distinct slugs**, and the only two slugs used twice are #2388/#2389 and
+    #2766/#2767 -- both duplicate pairs. So a slug is in practice a name for a
+    piece of work, and two of them colliding is the thing this sweep looks for.
+
+    The number is dropped rather than compared because it carries no signal: it is
+    meant to be the pull request's own number and in 40 of those 350 it is not,
+    since a number is chosen before the pull request is opened and races with
+    whatever merges first.
+
+    Returned as a glob (``changelog.d/*-<slug>.md``) so the report names what the
+    two branches share without naming a file that exists on neither. A name the
+    assembler would not accept as a fragment -- a reserved ``README.md``, a
+    nested path, a slug that is not lowercase-and-hyphens -- keys on itself, which
+    is the conservative direction: it can only fail to report a pair, never invent
+    one.
+    """
+    if not path.startswith(FRAGMENT_DIR):
+        return path
+    name = path[len(FRAGMENT_DIR) :]
+    # Checked before the pattern rather than left to it. The pattern happens to
+    # reject today's only reserved name, but only because ``README.md`` has no
+    # leading digits; a reserved name that did would match it, and the assembler's
+    # list is the authority on which names are not fragments. A nested path needs
+    # no such check -- ``/`` is outside every character class in the pattern.
+    if name in _ASSEMBLER.RESERVED_NAMES:
+        return path
+    match = _ASSEMBLER.FRAGMENT_NAME.match(name)
+    if match is None:
+        return path
+    return f"{FRAGMENT_DIR}*-{name[match.end('number') + 1 :]}"
+
+
 def find_addition_collisions(
     additions: Mapping[int, Sequence[str]],
 ) -> tuple[tuple[int, int, tuple[str, ...]], ...]:
-    """Return every pair of open pull requests that creates the same file.
+    """Return every pair of open pull requests that creates the same thing.
+
+    Paired on :func:`addition_key` rather than on the raw path, so a pair whose
+    only shared creation is a changelog entry under two fragment numbers is
+    reported. For every other path the key is the path, so this is a strict
+    widening: measured over the 2002 co-open pairs in #2345..#2767 it selects the
+    same 2 pairs the raw path selects, plus #2766/#2767, and loses none.
 
     Every pair is compared rather than only adjacent ones: two runs a few minutes
     apart usually get consecutive numbers, but nothing guarantees it, and a
     relation that holds for a pair is not a property of their distance.
 
     Deterministic in all three axes -- the pairs by lower then higher number, and
-    each shared path list sorted -- for the reason :func:`find_collisions` gives.
+    each shared list sorted -- for the reason :func:`find_collisions` gives.
     """
     ordered = sorted(additions)
     found: list[tuple[int, int, tuple[str, ...]]] = []
     for left, right in itertools.combinations(ordered, 2):
-        shared = tuple(sorted(set(additions[left]) & set(additions[right])))
+        shared = tuple(
+            sorted({addition_key(path) for path in additions[left]} & {addition_key(path) for path in additions[right]})
+        )
         if shared:
             found.append((left, right, shared))
     return tuple(found)
@@ -732,7 +849,7 @@ def render_additions(verdict: AdditionVerdict, repo: str) -> str:
     a list of report lines is indistinguishable from a forgotten comma.
     """
     lines = [
-        "## Duplicate work - two branches creating one file",
+        "## Duplicate work - two branches creating one file or one changelog entry",
         "",
         f"Outcome: **{verdict.outcome}**",
         "",
@@ -749,7 +866,7 @@ def render_additions(verdict: AdditionVerdict, repo: str) -> str:
     lines += [
         f"| pull requests implicated | {_pulls(verdict.implicated)} |",
         "",
-        "| pull requests | file(s) both create |",
+        "| pull requests | what both create |",
         "|---|---|",
     ]
     for left, right, paths in verdict.collisions:
@@ -761,14 +878,15 @@ def render_additions(verdict: AdditionVerdict, repo: str) -> str:
     )
     clears = (
         "Close whichever of the two is redundant, or -- if both are wanted -- change one so it "
-        + "no longer creates the same path, which is the case where the shared name was the "
-        + "accident rather than the work. This is a report rather than a branch-clearable gate: "
+        + "no longer creates the same path or names the same changelog entry, which is the case "
+        + "where the shared name was the accident rather than the work. "
+        + "This is a report rather than a branch-clearable gate: "
         + "the remedy is a decision between two authors, and no push by one of them settles it."
     )
     blind = (
         "Neither pull request need have claimed an issue for this to be reported, which is the "
-        + "point of the second key: measured over the last 300 pull requests, two duplicate pairs "
-        + "were reachable from a claim and two only from an added path, with no pair reachable "
+        + "point of the second key: measured over #2345..#2767, two duplicate pairs were reachable "
+        + "from a claim and three only from something they both create, with no pair reachable "
         + "from both."
     )
     lines += ["", "### What this means", "", why, "", "### What clears this", "", clears, "", blind]

--- a/tests/test_duplicate_work_added_path_key.py
+++ b/tests/test_duplicate_work_added_path_key.py
@@ -1,4 +1,4 @@
-"""Pins the added-path key against the claim-free duplicate pairs this repository shipped.
+"""Pins the created-thing key against the claim-free duplicate pairs this repository shipped.
 
 ``scripts/check_duplicate_claim.py`` was built around one key,
 ``closingIssuesReferences``, and **249 of the last 300 pull requests (#2345
@@ -6,17 +6,26 @@ through #2708) link no issue at all** -- so for most of the traffic both
 claim-keyed modes have nothing to collide on and report a unique claim while
 looking straight at a duplicate pair. Issue #2709 is the third recorded instance.
 
-:data:`_CLAIM_FREE_PAIRS` fixes the two measured ones in place, so the sweep is
-tested against real shapes rather than invented ones. Both were reconstructed
+:data:`_CLAIM_FREE_PAIRS` fixes the three measured ones in place, so the sweep is
+tested against real shapes rather than invented ones. All three were reconstructed
 from ``pulls/<n>/files``, which outlives the state change that closed one half of
-each.
+two of them.
 
 Three pins carry design decisions rather than behaviour:
 
 ``TestTheTwoKeysAreComplementary``
-    The window holds four duplicate pairs: two reachable from a claim, two only
-    from an added path, and none from both. So this is a second key rather than a
-    replacement, and neither relation may be deleted in favour of the other.
+    The window holds five duplicate pairs: two reachable from a claim, three only
+    from what both branches create, and none from both. So this is a second key
+    rather than a replacement, and neither relation may be deleted in favour of the
+    other.
+
+``TestAFragmentCollidesOnItsSlugAndNotItsNumber``
+    What a created path collides *on*. Almost always itself; a changelog fragment
+    is named ``<number>-<slug>.md``, so it collides on the slug and the number is
+    dropped. That replaced an assertion that a fragment can never collide at all,
+    whose reason -- the number in its name -- was the half that had to go. The
+    bound on the widening is asserted beside it, because the reason for the old
+    boundary was a fear of firing on everything.
 
 ``TestOnlyACreatedPathCollides``
     Widening the relation from ``ADDED`` to every ``changeType`` turns 2 selected
@@ -60,17 +69,27 @@ def _load() -> Any:
 check = _load()
 
 
-#: One fixture row: ``(label, {number: added paths}, the path both create)``.
-_ClaimFreePair = tuple[str, dict[int, tuple[str, ...]], str]
+#: One fixture row: ``(label, {number: added paths}, the subjects both create)``.
+#: The third element is a tuple rather than one path because a pair can share more
+#: than one -- #2388/#2389 share both a test file and a changelog entry.
+_ClaimFreePair = tuple[str, dict[int, tuple[str, ...]], tuple[str, ...]]
 
 #: One row of the other key: ``(left, right, the issue both claim, added paths)``.
 _IssueKeyedPair = tuple[int, int, int, dict[int, tuple[str, ...]]]
 
-#: The two duplicate pairs in #2345..#2708 that claimed no issue, as
-#: ``(label, {number: added paths}, the path both create)``. Every path is the
-#: real one the pull request added; the changelog fragment is carried too,
-#: because it is the one added path that never collides -- its name embeds the
-#: pull request number -- and a fixture without it would not show that.
+#: The three duplicate pairs in #2345..#2767 that claimed no issue, as
+#: ``(label, {number: added paths}, the subjects both create)``. Every path is the
+#: real one the pull request added, read back from ``pulls/<n>/files``, which
+#: outlives the state change that closed one half of two of them.
+#:
+#: The three rows are deliberately one of each reachable shape, so no single
+#: relation can satisfy the class:
+#:
+#: * #2388/#2389 collide on **both** a created test file and a changelog slug.
+#: * #2707/#2708 collide on the **path only** -- #2707 added no fragment at all,
+#:   so there is no slug on one side to compare.
+#: * #2766/#2767 collide on the **slug only** -- one put its tests in a new file
+#:   and the other into an existing one, so they create no common path.
 _CLAIM_FREE_PAIRS: list[_ClaimFreePair] = [
     (
         "#2388/#2389 - un-count frames a discarded episode never wrote",
@@ -84,18 +103,32 @@ _CLAIM_FREE_PAIRS: list[_ClaimFreePair] = [
                 "tests/test_recorder_counters_track_on_disk_frames.py",
             ),
         },
-        "tests/test_recorder_counters_track_on_disk_frames.py",
+        (
+            "changelog.d/*-recorder-uncount-discarded-frames.md",
+            "tests/test_recorder_counters_track_on_disk_frames.py",
+        ),
     ),
     (
         "#2707/#2708 - a value domain for TrainSpec.save_freq",
         {
-            2707: (
-                "changelog.d/2707-trainspec-save-freq-domain.md",
+            2707: ("tests/training/test_checkpoint_cadence_domain.py",),
+            2708: (
+                "changelog.d/2708-lerobot-trainer-checkpoint-cadence-domain.md",
                 "tests/training/test_checkpoint_cadence_domain.py",
             ),
-            2708: ("tests/training/test_checkpoint_cadence_domain.py",),
         },
-        "tests/training/test_checkpoint_cadence_domain.py",
+        ("tests/training/test_checkpoint_cadence_domain.py",),
+    ),
+    (
+        "#2766/#2767 - wire G1Driver.send_action to rt/lowcmd",
+        {
+            2766: (
+                "changelog.d/2765-g1-send-action-wired.md",
+                "tests/drivers/test_g1_send_action_wired.py",
+            ),
+            2767: ("changelog.d/2761-g1-send-action-wired.md",),
+        },
+        ("changelog.d/*-g1-send-action-wired.md",),
     ),
 ]
 
@@ -136,45 +169,137 @@ def _added(*paths: str) -> list[dict[str, str]]:
     return [{"path": path, "changeType": check.ADDED_CHANGE_TYPE} for path in paths]
 
 
-class TestTheMeasuredClaimFreePairsAreReported:
-    """Each measured pair is the finding, and names the file both branches create."""
+_IDS = [row[0] for row in _CLAIM_FREE_PAIRS]
 
-    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
-    def test_the_pair_is_the_finding(self, label: str, additions: dict[int, tuple[str, ...]], shared: str) -> None:
+
+class TestTheMeasuredClaimFreePairsAreReported:
+    """Each measured pair is the finding, and names what both branches create."""
+
+    @pytest.mark.parametrize(("label", "additions", "subjects"), _CLAIM_FREE_PAIRS, ids=_IDS)
+    def test_the_pair_is_the_finding(
+        self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
+    ) -> None:
         verdict = check.classify_additions(additions)
         assert verdict.outcome == check.DUPLICATE_ADDITION, label
         assert verdict.is_finding
 
-    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
-    def test_only_the_shared_path_is_reported(
-        self, label: str, additions: dict[int, tuple[str, ...]], shared: str
+    @pytest.mark.parametrize(("label", "additions", "subjects"), _CLAIM_FREE_PAIRS, ids=_IDS)
+    def test_only_the_shared_subjects_are_reported(
+        self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
     ) -> None:
         left, right = sorted(additions)
-        assert check.classify_additions(additions).collisions == ((left, right, (shared,)),)
+        assert check.classify_additions(additions).collisions == ((left, right, subjects),)
 
-    @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
-    def test_both_pull_requests_are_named(self, label: str, additions: dict[int, tuple[str, ...]], shared: str) -> None:
+    @pytest.mark.parametrize(("label", "additions", "subjects"), _CLAIM_FREE_PAIRS, ids=_IDS)
+    def test_both_pull_requests_are_named(
+        self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
+    ) -> None:
         summary = check.classify_additions(additions).summary
         for number in additions:
             assert f"#{number}" in summary
-        assert shared in summary
+        for subject in subjects:
+            assert subject in summary
 
-    def test_a_changelog_fragment_is_never_the_shared_path(self) -> None:
-        """Every branch adds one, and its name embeds the number, so it cannot collide.
+    @pytest.mark.parametrize(("label", "additions", "subjects"), _CLAIM_FREE_PAIRS, ids=_IDS)
+    def test_no_reported_subject_is_invented(
+        self, label: str, additions: dict[int, tuple[str, ...]], subjects: tuple[str, ...]
+    ) -> None:
+        """Every subject is a real created path, or the slug-glob of two of them.
 
-        The premise of the fixtures: without this, a relation over added paths
-        would fire on every pair in the queue.
+        The report must not name a file that exists on neither branch. A path
+        subject has to have been added by both; a glob subject has to be what
+        :func:`addition_key` makes of a path each side really added.
         """
-        for label, additions, _ in _CLAIM_FREE_PAIRS:
-            fragments = {path for paths in additions.values() for path in paths if path.startswith("changelog.d/")}
-            assert fragments, label
-            collisions = check.classify_additions(additions).collisions
-            reported = {path for _, _, paths in collisions for path in paths}
-            assert not (reported & fragments), label
+        for left, right, reported in check.classify_additions(additions).collisions:
+            for subject in reported:
+                for number in (left, right):
+                    matches = [path for path in additions[number] if check.addition_key(path) == subject]
+                    assert matches, f"{label}: #{number} creates nothing keyed {subject!r}"
+                if "*" not in subject:
+                    assert subject in additions[left] and subject in additions[right], label
+
+
+class TestAFragmentCollidesOnItsSlugAndNotItsNumber:
+    """The exclusion this relation shipped with, and why the number was the wrong half.
+
+    ``test_a_changelog_fragment_is_never_the_shared_path`` used to assert the
+    opposite of the first case here. Its reason -- "its name embeds the number, so
+    it cannot collide" -- is true of the raw path and is exactly why the number is
+    dropped: #2766/#2767 wrote one slug under two numbers and shared no path at all.
+
+    The second case is the bound that keeps the first from firing on the whole
+    queue, and the measurement behind it is in :func:`check.addition_key`: 350
+    distinct slugs across the 350 pull requests in #2345..#2767 that add a fragment.
+    """
+
+    def test_two_fragments_with_one_slug_collide_under_different_numbers(self) -> None:
+        additions = {
+            2766: check.added_paths(_node(2766, _added("changelog.d/2765-g1-send-action-wired.md"))),
+            2767: check.added_paths(_node(2767, _added("changelog.d/2761-g1-send-action-wired.md"))),
+        }
+        verdict = check.classify_additions(additions)
+        assert verdict.outcome == check.DUPLICATE_ADDITION
+        assert verdict.collisions == ((2766, 2767, ("changelog.d/*-g1-send-action-wired.md",)),)
+
+    def test_two_fragments_with_different_slugs_do_not_collide(self) -> None:
+        """The over-reach control: every branch adds a fragment, so this is the norm."""
+        additions = {
+            11: check.added_paths(_node(11, _added("changelog.d/11-one-change.md"))),
+            12: check.added_paths(_node(12, _added("changelog.d/12-another-change.md"))),
+        }
+        assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
+
+    def test_the_same_slug_under_the_same_number_still_collides(self) -> None:
+        """Dropping the number must not lose the identical-path case it contained."""
+        shared = _added("changelog.d/11-one-change.md")
+        additions = {n: check.added_paths(_node(n, shared)) for n in (11, 12)}
+        assert check.classify_additions(additions).outcome == check.DUPLICATE_ADDITION
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "changelog.d/README.md",
+            "changelog.d/no-leading-number.md",
+            "changelog.d/2765-Not_A_Slug.md",
+            "changelog.d/nested/2765-slug.md",
+            "tests/test_x.py",
+            "strands_robots/utils.py",
+        ],
+    )
+    def test_anything_that_is_not_a_fragment_keys_on_itself(self, path: str) -> None:
+        """Including a name the assembler would reject, which is the safe direction.
+
+        Keying such a name on itself can only fail to report a pair. Inventing a
+        slug for it could report one that is not there.
+        """
+        assert check.addition_key(path) == path
+
+    def test_a_reserved_name_keys_on_itself_even_if_it_looks_like_a_fragment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The assembler's list is the authority, not the pattern's happy accident.
+
+        ``README.md`` is excluded by the pattern anyway, having no leading digits,
+        so the check reads as redundant against today's list. It is not redundant
+        against the list: a reserved name that *did* carry a number would match
+        the pattern, and the fragment directory's documentation file is not an
+        entry two branches can duplicate.
+        """
+        monkeypatch.setattr(check._ASSEMBLER, "RESERVED_NAMES", frozenset({"0-release-notes.md"}))
+        assert check._ASSEMBLER.FRAGMENT_NAME.match("0-release-notes.md"), "premise: the pattern accepts it"
+        assert check.addition_key("changelog.d/0-release-notes.md") == "changelog.d/0-release-notes.md"
+
+    def test_the_naming_rule_is_the_assemblers_and_not_a_second_copy(self) -> None:
+        """A restated regex could drift from what a fragment actually is."""
+        assert check._ASSEMBLER.FRAGMENT_NAME.match("2765-g1-send-action-wired.md")
+        assert "README.md" in check._ASSEMBLER.RESERVED_NAMES
+        source = _SCRIPT.read_text(encoding="utf-8")
+        assert "_ASSEMBLER.FRAGMENT_NAME" in source
+        assert "_ASSEMBLER.RESERVED_NAMES" in source
 
 
 class TestTheTwoKeysAreComplementary:
-    """Four duplicate pairs, two reachable from each key, none from both."""
+    """Five duplicate pairs: two reachable from the claim, three from what is created."""
 
     @pytest.mark.parametrize(("label", "additions", "shared"), _CLAIM_FREE_PAIRS, ids=lambda value: str(value)[:40])
     def test_a_claim_free_pair_is_invisible_to_the_claim_key(
@@ -191,7 +316,7 @@ class TestTheTwoKeysAreComplementary:
         assert not verdict.is_finding
 
     @pytest.mark.parametrize(("left", "right", "issue", "additions"), _ISSUE_KEYED_PAIRS)
-    def test_an_issue_keyed_pair_is_invisible_to_the_added_path_key(
+    def test_an_issue_keyed_pair_is_invisible_to_the_created_thing_key(
         self, left: int, right: int, issue: int, additions: dict[int, tuple[str, ...]]
     ) -> None:
         assert check.classify_additions(additions).outcome == check.UNIQUE_ADDITIONS
@@ -518,7 +643,8 @@ class TestTheGuidanceRecordsTheSecondKey:
         [
             "check_duplicate_claim.py --repo strands-labs/robots --all-open",
             "link no issue at all",
-            "create the same path",
+            "create the same thing",
+            "350 distinct slugs",
             "a path set is a property of a pushed branch",
             "check_merge_base_overlap.py",
         ],
@@ -536,18 +662,48 @@ class TestTheGuidanceRecordsTheSecondKey:
 class TestTheModuleStatesTheMeasurementBehindTheRelation:
     """A relation over paths is only worth wiring up if its precision is stated."""
 
+    @staticmethod
+    def _doc() -> str:
+        """The docstring with runs of whitespace collapsed.
+
+        So a pin is on the sentence rather than on where the paragraph happens to
+        wrap: re-flowing prose must not be able to drop a measurement silently,
+        and must not be able to fail this class either.
+        """
+        assert check.__doc__ is not None
+        return " ".join(check.__doc__.split())
+
     @pytest.mark.parametrize(
         "phrase",
         [
-            "1802 pairs",
+            "2002 pairs",
             "both add a path",
-            "two reachable from each key, none from both",
+            "both create the same thing",
+            "350 distinct slugs",
+            "none from both",
             "a path set is a property of a *pushed",
         ],
     )
     def test_the_docstring_carries_the_measurement(self, phrase: str) -> None:
-        assert check.__doc__ is not None
-        assert phrase in check.__doc__
+        assert phrase in self._doc()
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "would fire on every pair in the queue",
+            "40 of those 350",
+            "selected the same two pairs plus one and lost none",
+        ],
+    )
+    def test_the_docstring_states_why_the_number_is_dropped(self, phrase: str) -> None:
+        """The widening replaced a stated certainty, so its own bound is stated too.
+
+        The exclusion it lifted was justified by a fear -- that keying on a
+        fragment fires on the whole queue -- and a widening that does not answer
+        the reason for the boundary it moved is indistinguishable from having
+        missed it.
+        """
+        assert phrase in self._doc()
 
     def test_the_stale_scope_bullet_no_longer_calls_the_pair_unreachable(self) -> None:
         """The 18-of-30 measurement stands; the conclusion drawn from it was wider.
@@ -555,6 +711,6 @@ class TestTheModuleStatesTheMeasurementBehindTheRelation:
         It rules out *requiring* a claim, which neither claim-keyed mode does. It
         never ruled out colliding the pair on a different key.
         """
-        assert check.__doc__ is not None
-        assert "18 of the last 30 merges" in check.__doc__
-        assert "collides it on an added path instead" in check.__doc__
+        doc = self._doc()
+        assert "18 of the last 30 merges" in doc
+        assert "collides it on what the two branches create" in doc


### PR DESCRIPTION
## The gap

`scripts/check_duplicate_claim.py --all-open` pairs two open pull requests on a path they both
**create**. It shipped in #2710 to reach the duplicate pairs the claim key cannot see, since most
branches here link no issue.

A changelog fragment is named `<number>-<slug>.md`. So two branches describing one change write one
slug under two numbers, their paths differ, and a pair whose only shared creation is that entry
collides on nothing.

#2766/#2767 are that pair. Both wire `G1Driver.send_action` to publish `LowCmd_` on `rt/lowcmd`,
opened 8m 06s apart, one putting its tests in a new file and the other into an existing one, so they
create no common path at all:

| | #2766 | #2767 |
|---|---|---|
| fragment | `changelog.d/2765-g1-send-action-wired.md` | `changelog.d/2761-g1-send-action-wired.md` |
| tests | `tests/drivers/test_g1_send_action_wired.py` (new) | `tests/drivers/test_g1_driver.py` (existing) |

Run against the open set while both sat in it, `--all-open` on `main` answered:

```
Outcome: **unique-additions**
No two of the 11 open pull requests create the same file (55 pair(s) compared).
```

## Why this was not an oversight

It was an assertion. `test_a_changelog_fragment_is_never_the_shared_path` pinned that a fragment can
never be the shared path, and its docstring gave the reason:

> Every branch adds one, and its name embeds the number, so it cannot collide.

That is true of the raw path, and it is exactly why the number is the half that has to go. The
fixtures carried a fragment specifically to demonstrate the exclusion, and both halves of
#2388/#2389 in that fixture already share a slug -- the counter-example was in the test data.

The fear behind the boundary was stated too: without the exclusion, "a relation over added paths
would fire on every pair in the queue". That is the claim this change had to answer, and it is
measurable.

## Measured

Over 353 pull requests (#2345 through #2767), on the 2002 pairs open at the same instant. Both
versions of `find_addition_collisions` were run over the identical reconstructed inputs, the base one
loaded from `git show upstream/main:` so it is the shipped code rather than a memory of it:

| relation | pairs selected | duplicates among them |
|---|---|---|
| both edit a path | 127 | a composition question, `check_merge_base_overlap.py` owns it |
| both add a path (`main`) | 2 | 2 |
| both create the same thing (here) | 3 | 3 |

Strict superset: base's 2 pairs are a subset of the branch's 3, **0 lost**. The added pair is
#2766/#2767.

| what both create | pair | closed |
|---|---|---|
| `tests/test_recorder_counters_track_on_disk_frames.py` | #2388, #2389 | #2389 |
| `tests/training/test_checkpoint_cadence_domain.py` | #2707, #2708 | #2707 |
| `changelog.d/*-g1-send-action-wired.md` | #2766, #2767 | #2766 |

All three are duplicates confirmed from their own closing comments, not inferred.

**Slug reuse is not noisy.** Of those 353 pull requests, 350 add a fragment and between them use
**350 distinct slugs**. Exactly two slugs are used twice, and both times the two users are a
duplicate pair. The number is the noisy half: it is meant to be the pull request's own number and in
**40 of those 350 it is not**, because it is chosen before the pull request exists and races with
whatever merges first.

## The change

The collision key becomes the identity a created path declares (`addition_key`). For every path but
a fragment that is the path itself, which is why the widening loses nothing.

The report names the shared subject as `changelog.d/*-<slug>.md` rather than a filename, because the
filename it would otherwise print exists on neither branch. For an identical path the subject is the
path, so those rows are unchanged.

What a fragment *is* comes from `scripts/assemble_changelog.py` rather than a second copy of the
pattern -- `check_changelog_fragment.py` already reuses that module for the same rule -- so this
sweep and the assembler cannot disagree. A name the assembler would reject keys on itself, which can
only fail to report a pair rather than invent one.

One guard was removed rather than kept unexplained: a `"/" in name` test is unconditionally implied
by the pattern, since `/` is outside every character class in it. The reserved-name check stays,
because it is redundant only against *today's* list -- a reserved name carrying a leading number
would match the pattern -- and that is now graded by monkeypatching the assembler's list.

## Verification

Pre-fix split, reported both ways because a raw revert also removes the new symbol:

| revert | result |
|---|---|
| raw (source + guidance reverted, tests kept) | **24 failed / 135 passed** -- 17 behavioural, 7 `AttributeError` on the new symbol |
| behavioural (`addition_key` kept, relation reverted) | **6 failed / 153 passed** |

The 6 are 5 in `TestTheMeasuredClaimFreePairsAreReported` and 1 in the new class. **0 failures** in
`TestTheTwoKeysAreComplementary`, `TestOnlyACreatedPathCollides`,
`TestEveryPairIsComparedAndTheReportIsStable`, `TestAnIncompleteAnswerIsNotAFinding`,
`TestTheOpenSetIsReadLiveAndWholeAndIncludesDrafts`, `TestTheReportNamesBothPullRequestsAndTheRemedy`,
`TestTheExitStatusIsOneOnlyForTheFinding`, or anywhere in `tests/test_duplicate_claim_check.py`.

Break table -- 11 mutations, 10 detected, control clean, 8 distinct firing sets, `collected` a stable
160 in every row, source restored byte-identical:

| row | fires | mutation |
|---|---|---|
| b0 | 0 | control |
| b1 | 6 | relation keyed on the raw path again (the shipped behaviour) |
| b2 | 6 | `addition_key` is the identity, relation untouched |
| b3 | 6 | keyed on the number instead of the slug |
| b4 | 2 | the assembler's reserved-name list not consulted |
| b5 | 7 | the glob marker dropped, so the key looks like a real path |
| b6 | 1 | the fragment-directory test dropped |
| b7 | 8 | over-collide: key on the directory alone |
| b8 | 1 | the naming rule restated locally instead of reused |
| b9 | 4 | the docstring's measurement paragraph removed |
| b10 | 2 | the guidance left un-updated |

b1/b2/b3 share a firing set, and the reason is structural rather than a thin table: all three are
"the slug is not the key", and no two fixtures share a fragment number, so keying on the number is
indistinguishable from not keying on a fragment at all.

b7 is the over-reach guard, and it is the row that matters most for scope: keying on the directory
alone fires 8, including both cells of `TestTheTwoKeysAreComplementary`. The widening must not
swallow the claim key's territory, and the two issue-keyed pairs (#2570/#2571, #2480/#2508) still do
not collide under it -- their slugs differ.

b5 fires `test_no_reported_subject_is_invented`, which is the truthfulness pin: every reported
subject has to be a real created path, or the glob of a path each side really added.

Gate, both trees, identical 126-file selection (every test reading `AGENTS.md`, `scripts/`,
`changelog.d/`, or walking the tree), the changed test file excluded from each:

```
branch  4731 collected   4676 passed, 55 skipped   291.94s
base    4731 collected   4676 passed, 55 skipped   309.74s
```

Zero failures either side. `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine
`upstream/main` worktree, normalized message sets byte-identical, **0 in the changed files**. `ruff
check` and `ruff format --check` clean. The changed test file alone: **88 passed** (160 with its
claim-keyed sibling). Changelog fragments validate, and `tests/test_changelog_*`: 89 passed.

Dogfooded: run from this branch while both halves were open, `--all-open` reported
`duplicate-addition`, exit `1`, naming #2766 and #2767. #2766 has since been closed as the duplicate,
and the sweep run again over the 10 open pull requests -- this one included -- reports
`unique-additions` across 45 pairs, with no false positive on itself. The relation is a property of
the open set, so that is the correct answer once the pair is resolved rather than a regression.

No visual artifact: this changes a reporting relation in a repository script, not a policy,
simulation, render, recording or asset. The measured tables above are the evidence.

## Scope

`AGENTS.md` step 1 carries the same measurement and moves in the same change; its numbers were pinned
by `TestTheGuidanceRecordsTheSecondKey`, which is why b10 fires. Neither claim-keyed mode is touched,
the outcome vocabulary is unchanged, and the composition question stays with
`scripts/check_merge_base_overlap.py`.
