### PR TITLE
fix(transforms): keep the dtype each source camera declared

### DIFF
--- a/changelog.d/2770-transform-camera-dtype-parity.md
+++ b/changelog.d/2770-transform-camera-dtype-parity.md
@@ -1,0 +1,35 @@
+### Fixed: a transformed dataset keeps the dtype each source camera declared
+
+A LeRobot dataset declares each camera's storage per feature: one
+`observation.images.<cam>` can be `dtype="video"`, encoded into an MP4 under `videos/`, while
+another is `dtype="image"`, with its frames in the data parquet. `LeRobotDataset.create` accepts
+that declaration and reads both streams back, so it is a legal source. The output side has one
+knob for the whole dataset -- `DatasetRecorder.create` takes a single `use_videos` flag that
+decides every camera's dtype -- and `_SourceDataset` derived that flag by assigning it once per
+camera inside the loop that reads the camera shapes. It therefore held whichever camera the
+source's feature dict ended on.
+
+A two-camera source declaring one video stream and one image stream transformed with
+`status="success"` while the output stored a camera a different way, and the direction depended
+only on the order the features were declared in. Declaring the video stream first flattened it
+into still frames, so a source with one MP4 produced an output with none; declaring it last
+promoted the image column to video, so the same source produced two.
+
+`create_output_recorder` documents itself as "the SOURCE schema (parity by construction)", schema
+parity is the first acceptance criterion of the transform round-trip suite, and
+`docs/data/transforms.md` contract item 1 promises a generated episode is the same trajectory
+rendered differently. A stream stored a different way is none of those.
+
+The flag is now derived from the whole camera set, and a source whose cameras disagree is refused
+by `_SourceDataset.open`, naming each camera and the dtype it declared so an operator knows which
+stream to convert. That is the disposition `open` already takes for a source declaring a feature
+the pass-through cannot preserve, and for the same reason: the output recorder declares one dtype
+for every camera, so a mixed source cannot be reproduced, and writing it anyway would alter a
+column the contract promises to carry through. Re-encoding to one dtype instead would be a quieter
+version of the same answer -- coercing to `image` also flattens the video streams of sources that
+work today.
+
+Nothing changes for a source whose cameras agree, whichever dtype that is: an all-video recording
+still transforms to video and an all-image one still transforms to images, because a homogeneous
+set already derived the right flag whichever camera the loop ended on. Every camera's dtype is now
+recorded rather than only the last one, so the refusal can report the disagreement it found.

--- a/docs/data/transforms.md
+++ b/docs/data/transforms.md
@@ -23,6 +23,15 @@ record (strands-robots)  ->  transform (this page)  ->  train (create_trainer)
    the action, state and task columns from the source episode unchanged. A
    generated episode is the *same trajectory* rendered differently, never a
    different trajectory.
+
+   Schema parity is part of that promise, down to how each camera is stored.
+   The output dataset declares one `dtype` for every camera, so a source whose
+   `observation.images.*` streams disagree - one `video`, one `image` - cannot
+   be reproduced: writing it anyway would re-encode a camera, flattening a
+   video stream into still frames or promoting an image column to video, and
+   which way it went would depend only on the order the features were declared
+   in. Such a source is refused, naming each camera and the dtype it declared;
+   re-record or convert it so every camera stream shares one dtype.
 2. **Provenance is mandatory.** Every generated episode is recorded in the
    output dataset's `meta/provenance.json` with `synthetic=true`, the source
    episode index, and the transform's name and version. Training filters and

--- a/strands_robots/transforms/base.py
+++ b/strands_robots/transforms/base.py
@@ -714,9 +714,13 @@ class _SourceDataset:
     """Read side of the orchestration: one opened source LeRobotDataset.
 
     Internal to :meth:`DatasetTransform.transform`; holds the schema facts
-    (camera keys / dims, state and action column names, fps, robot type) the
-    output recorder is created from, so output schema parity is derived from
-    the source rather than restated.
+    (camera keys / dims / dtypes, state and action column names, fps, robot
+    type) the output recorder is created from, so output schema parity is
+    derived from the source rather than restated.
+
+    ``use_videos`` is one flag for the whole camera set because the output
+    recorder declares one dtype for every camera, so a source whose cameras
+    disagree cannot be reproduced and :meth:`open` refuses it.
     """
 
     def __init__(self, ds: Any, spec: TransformSpec) -> None:
@@ -724,7 +728,7 @@ class _SourceDataset:
         features: dict[str, Any] = dict(ds.meta.features)
         self.camera_keys: list[str] = [k[len(_IMAGE_PREFIX) :] for k in features if k.startswith(_IMAGE_PREFIX)]
         self.camera_dims: dict[str, tuple[int, int]] = {}
-        self.use_videos = True
+        self.camera_dtypes: dict[str, str] = {}
         for cam in self.camera_keys:
             feat = features[f"{_IMAGE_PREFIX}{cam}"]
             shape = tuple(feat.get("shape", ()))
@@ -733,7 +737,12 @@ class _SourceDataset:
                 self.camera_dims[cam] = (int(shape[1]), int(shape[2]))
             elif len(shape) == 3:
                 self.camera_dims[cam] = (int(shape[0]), int(shape[1]))
-            self.use_videos = feat.get("dtype") == "video"
+            self.camera_dtypes[cam] = str(feat.get("dtype") or "")
+        # One flag for the whole camera set, because that is what the output
+        # recorder declares. Assigning it per camera inside the loop left it
+        # holding whichever camera the iteration ended on, so a source mixing
+        # dtypes re-encoded the others silently; open() refuses that source.
+        self.use_videos = all(dtype == "video" for dtype in self.camera_dtypes.values())
         state_feat = features.get("observation.state", {})
         action_feat = features.get("action", {})
         self.state_names: list[str] = list(state_feat.get("names") or [])
@@ -749,7 +758,10 @@ class _SourceDataset:
 
         A string return keeps :meth:`DatasetTransform.transform`'s error
         channel uniform (a ``TransformResult`` with ``status="error"``) for
-        every source-side refusal.
+        every source-side refusal. Three sources are refused, all for the same
+        reason - the output could not be the source rendered differently: one
+        declaring a feature the pass-through cannot preserve, one declaring no
+        camera stream at all, and one whose cameras disagree about their dtype.
         """
         from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
@@ -776,6 +788,23 @@ class _SourceDataset:
             return (
                 "source dataset declares no observation.images.* stream - an episode augmentation transforms "
                 "video observations, so a dataset without any has nothing to transform"
+            )
+        if len(set(reader.camera_dtypes.values())) > 1:
+            # Same reason as the unsupported-feature refusal above: the output
+            # recorder declares one dtype for every camera (use_videos is a
+            # single flag), so a mixed source cannot be reproduced. Writing it
+            # anyway re-encodes at least one camera - a video stream flattened
+            # into still images, or an image column promoted to video - and
+            # which way it goes depends on the order the features are declared
+            # in. Schema parity is part of the pass-through contract, so the
+            # source is refused rather than silently changed.
+            declared = ", ".join(f"{_IMAGE_PREFIX}{cam}={dtype!r}" for cam, dtype in reader.camera_dtypes.items())
+            return (
+                f"source dataset declares camera streams with more than one dtype: {declared}. "
+                "The output dataset declares one dtype for every camera, so at least one stream would be "
+                "re-encoded in the output - a video stream written as still images, or an image column "
+                "promoted to video - which the schema-parity half of the pass-through contract forbids. "
+                "Re-record or convert the source so every observation.images.* stream shares one dtype."
             )
         return reader
 
@@ -839,7 +868,11 @@ class _SourceDataset:
         return episode_dict
 
     def create_output_recorder(self, spec: TransformSpec) -> Any:
-        """Create the output dataset with the SOURCE schema (parity by construction)."""
+        """Create the output dataset with the SOURCE schema (parity by construction).
+
+        ``use_videos`` is the single dtype every source camera declares, which
+        :meth:`open` has already established is unambiguous.
+        """
         from strands_robots.dataset_recorder import DatasetRecorder
 
         return DatasetRecorder.create(

--- a/tests/transforms/test_camera_dtype_parity.py
+++ b/tests/transforms/test_camera_dtype_parity.py
@@ -1,0 +1,292 @@
+"""Every camera in a transformed dataset keeps the dtype its source declared.
+
+A LeRobot dataset declares each camera's storage independently: one
+``observation.images.<cam>`` feature can be ``dtype="video"`` (frames encoded
+into an MP4 under ``videos/``) while another is ``dtype="image"`` (frames stored
+in the data parquet). ``LeRobotDataset.create`` accepts such a mixed
+declaration and reads both streams back, so it is a legal source - the premise
+class below records one and asserts it.
+
+The output side has one knob for the whole dataset: ``DatasetRecorder.create``
+takes a single ``use_videos`` flag that decides every camera's dtype.
+``_SourceDataset`` derived that flag by assigning it once per camera inside the
+loop that reads the camera shapes, so it ended up holding whichever camera the
+feature dict happened to end on. A two-camera source declaring one video stream
+and one image stream therefore transformed with ``status="success"`` while the
+output silently re-encoded a camera, and the direction depended only on the
+order the features were declared in:
+
+=========================================  ==============================  =========
+source cameras (declaration order)         pre-fix output cameras          MP4 files
+=========================================  ==============================  =========
+``top=video``, ``wrist=image``             both ``image``                  1 -> 0
+``wrist=image``, ``top=video``             both ``video``                  1 -> 2
+=========================================  ==============================  =========
+
+Both directions lose the source's schema:
+:meth:`~strands_robots.transforms.base._SourceDataset.create_output_recorder`
+documents itself as "the SOURCE schema (parity by construction)", schema parity
+is the first acceptance criterion of ``tests/transforms/test_round_trip.py``,
+and ``docs/data/transforms.md`` contract item 1 promises a generated episode is
+"the *same trajectory* rendered differently". A video stream flattened into
+still frames is not that.
+
+The same ``open()`` already refuses a source declaring a feature the
+pass-through cannot preserve, precisely so nothing is silently altered - so the
+fix follows that convention rather than inventing a second one: the flag is
+derived from the whole camera set, and a source whose cameras disagree is
+refused with a message naming each camera and its dtype. Homogeneous sources
+(every shipped recording, whichever dtype) are unaffected, which the over-reach
+control class holds.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+lerobot = pytest.importorskip("lerobot")
+pytest.importorskip("lerobot.datasets.lerobot_dataset")
+
+from strands_robots.transforms import TransformSpec, create_transform  # noqa: E402
+from strands_robots.transforms.base import _SourceDataset  # noqa: E402
+
+#: One camera declaration: ``(camera key suffix, dtype, (channels, height, width))``.
+_TOP = ("top", "video", (3, 32, 48))
+_WRIST = ("wrist", "image", (3, 24, 40))
+
+#: The two orders a mixed source can declare its cameras in. Pre-fix these
+#: produced opposite output schemas, which is the signature of a flag written
+#: once per camera rather than derived from the set.
+_MIXED_ORDERS = [
+    pytest.param([_TOP, _WRIST], id="video-first"),
+    pytest.param([_WRIST, _TOP], id="image-first"),
+]
+
+
+def _record_source(root: Path, cameras: list[tuple[str, str, tuple[int, int, int]]], frames: int = 3) -> Path:
+    """Record a real source dataset declaring ``cameras`` in the order given.
+
+    Built through ``LeRobotDataset.create`` rather than ``DatasetRecorder``
+    because the recorder's own ``use_videos`` flag cannot express a mixed
+    declaration - the asymmetry this file is about.
+    """
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    features: dict[str, Any] = {
+        "observation.state": {"dtype": "float32", "shape": (2,), "names": ["j1", "j2"]},
+        "action": {"dtype": "float32", "shape": (2,), "names": ["j1", "j2"]},
+    }
+    for cam, dtype, shape in cameras:
+        features[f"observation.images.{cam}"] = {
+            "dtype": dtype,
+            "shape": shape,
+            "names": ["channels", "height", "width"],
+        }
+    dataset = LeRobotDataset.create(
+        repo_id="local/source", fps=10, root=root, robot_type="probe", features=features, use_videos=True
+    )
+    rng = np.random.default_rng(0)
+    for i in range(frames):
+        frame: dict[str, Any] = {
+            "observation.state": np.array([0.125 + i, -0.25 - i], dtype=np.float32),
+            "action": np.array([0.5 + i, 1.5 + i], dtype=np.float32),
+            "task": "probe task",
+        }
+        for cam, _dtype, shape in cameras:
+            frame[f"observation.images.{cam}"] = rng.integers(0, 255, (shape[1], shape[2], 3), dtype=np.uint8)
+        dataset.add_frame(frame)
+    dataset.save_episode()
+    dataset.finalize()
+    return root
+
+
+def _camera_dtypes(root: Path) -> dict[str, str]:
+    """The dtype each ``observation.images.*`` feature declares on disk."""
+    info = json.loads((root / "meta" / "info.json").read_text(encoding="utf-8"))
+    return {k: v.get("dtype") for k, v in info["features"].items() if k.startswith("observation.images.")}
+
+
+def _mp4_names(root: Path) -> list[str]:
+    """Camera feature names that have an encoded MP4 under ``videos/``.
+
+    Derived from the component that follows ``videos`` rather than a fixed
+    depth, so a chunking-layout change surfaces as an empty set rather than as
+    a set of directory names that happens to compare equal on both sides.
+    """
+    names: set[str] = set()
+    for mp4 in root.rglob("*.mp4"):
+        parts = mp4.relative_to(root).parts
+        if "videos" in parts:
+            index = parts.index("videos")
+            if index + 1 < len(parts):
+                names.add(parts[index + 1])
+    return sorted(names)
+
+
+def _transform(source_root: Path, output_root: Path) -> Any:
+    """Run the reference backend over one source, one variant per episode."""
+    return create_transform("mock").transform(
+        TransformSpec(source_root=str(source_root), output_root=str(output_root), variants_per_episode=1, seed=7)
+    )
+
+
+def _reader(cameras: list[tuple[str, str, tuple[int, int, int]]]) -> _SourceDataset:
+    """A ``_SourceDataset`` over a stand-in whose ``meta`` declares ``cameras``.
+
+    The flag derivation reads nothing but ``meta.features``, so a stand-in
+    exercises the whole camera grid without recording a dataset per row.
+    """
+    features: dict[str, Any] = {}
+    for cam, dtype, shape in cameras:
+        features[f"observation.images.{cam}"] = {"dtype": dtype, "shape": shape}
+    meta = SimpleNamespace(features=features, fps=10, robot_type="probe", total_episodes=1)
+    spec = TransformSpec(source_root="unused", output_root="unused")
+    return _SourceDataset(SimpleNamespace(meta=meta), spec)
+
+
+class TestAMixedDtypeSourceIsALegalLeRobotDataset:
+    """Premise: the refused source is a dataset LeRobot itself writes and reads.
+
+    Without this the refusal could be dismissed as covering an input nothing
+    can produce.
+    """
+
+    @pytest.fixture(scope="class")
+    def mixed_root(self, tmp_path_factory) -> Path:
+        return _record_source(tmp_path_factory.mktemp("legal") / "source", [_TOP, _WRIST])
+
+    def test_each_camera_keeps_its_own_declared_dtype(self, mixed_root: Path) -> None:
+        assert _camera_dtypes(mixed_root) == {
+            "observation.images.top": "video",
+            "observation.images.wrist": "image",
+        }
+
+    def test_only_the_video_camera_is_encoded_to_an_mp4(self, mixed_root: Path) -> None:
+        assert _mp4_names(mixed_root) == ["observation.images.top"]
+
+    def test_both_streams_read_back_as_frames(self, mixed_root: Path) -> None:
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        frame = LeRobotDataset(repo_id="local/source", root=mixed_root)[0]
+        assert tuple(frame["observation.images.top"].shape) == (3, 32, 48)
+        assert tuple(frame["observation.images.wrist"].shape) == (3, 24, 40)
+
+
+class TestASourceWhoseCamerasDisagreeIsRefused:
+    """Regression: neither declaration order may be transformed silently."""
+
+    @pytest.mark.parametrize("cameras", _MIXED_ORDERS)
+    def test_the_transform_reports_an_error_envelope(self, cameras, tmp_path: Path) -> None:
+        source = _record_source(tmp_path / "source", cameras)
+        result = _transform(source, tmp_path / "out")
+        assert result.status == "error", result.message
+
+    @pytest.mark.parametrize("cameras", _MIXED_ORDERS)
+    def test_the_refusal_names_every_camera_stream(self, cameras, tmp_path: Path) -> None:
+        source = _record_source(tmp_path / "source", cameras)
+        message = _transform(source, tmp_path / "out").message or ""
+        for cam, _dtype, _shape in cameras:
+            assert f"observation.images.{cam}" in message, message
+
+    @pytest.mark.parametrize("cameras", _MIXED_ORDERS)
+    def test_the_refusal_pairs_each_camera_with_the_dtype_it_declared(self, cameras, tmp_path: Path) -> None:
+        """Which camera holds which dtype is what an operator has to convert."""
+        source = _record_source(tmp_path / "source", cameras)
+        message = _transform(source, tmp_path / "out").message or ""
+        for cam, dtype, _shape in cameras:
+            assert f"observation.images.{cam}={dtype!r}" in message, message
+
+    @pytest.mark.parametrize("cameras", _MIXED_ORDERS)
+    def test_nothing_is_written_to_the_output_root(self, cameras, tmp_path: Path) -> None:
+        source = _record_source(tmp_path / "source", cameras)
+        output = tmp_path / "out"
+        assert _transform(source, output).status == "error"
+        assert not output.exists() or not any(output.rglob("*"))
+
+    def test_a_refused_source_is_read_before_any_episode_is(self, tmp_path: Path) -> None:
+        """The refusal is a source-side one, so no episode is reported read."""
+        source = _record_source(tmp_path / "source", [_TOP, _WRIST])
+        result = _transform(source, tmp_path / "out")
+        assert (result.episodes_read, result.episodes_written) == (0, 0)
+
+
+class TestAHomogeneousSourceStillTransforms:
+    """Over-reach control: every dtype the fix leaves alone.
+
+    Each expectation here is one the pre-fix code also met - a source whose
+    cameras agree already derived the right flag, whichever camera the loop
+    ended on.
+    """
+
+    @pytest.mark.parametrize("dtype", ["video", "image"])
+    def test_two_cameras_transform_and_keep_the_source_dtype(self, dtype: str, tmp_path: Path) -> None:
+        cameras = [("top", dtype, (3, 32, 48)), ("wrist", dtype, (3, 24, 40))]
+        source = _record_source(tmp_path / "source", cameras)
+        output = tmp_path / "out"
+        result = _transform(source, output)
+        assert result.status == "success", result.message
+        assert _camera_dtypes(output) == _camera_dtypes(source)
+
+    @pytest.mark.parametrize("dtype", ["video", "image"])
+    def test_the_output_encodes_exactly_the_streams_the_source_did(self, dtype: str, tmp_path: Path) -> None:
+        cameras = [("top", dtype, (3, 32, 48)), ("wrist", dtype, (3, 24, 40))]
+        source = _record_source(tmp_path / "source", cameras)
+        output = tmp_path / "out"
+        assert _transform(source, output).status == "success"
+        assert _mp4_names(output) == _mp4_names(source)
+
+    def test_a_recorded_single_camera_dataset_still_transforms(self, record_source_dataset, tmp_path: Path) -> None:
+        """The shipped ``DatasetRecorder`` path, which declares one camera."""
+        source = Path(record_source_dataset([40]))
+        output = tmp_path / "out"
+        result = _transform(source, output)
+        assert result.status == "success", result.message
+        assert _camera_dtypes(output) == _camera_dtypes(source)
+
+
+class TestTheDtypeFlagIsAPropertyOfTheWholeCameraSet:
+    """The derivation, graded over a camera grid rather than one example."""
+
+    @pytest.mark.parametrize(
+        ("dtypes", "expected"),
+        [
+            pytest.param(["video"], True, id="one-video"),
+            pytest.param(["image"], False, id="one-image"),
+            pytest.param(["video", "video"], True, id="all-video"),
+            pytest.param(["image", "image"], False, id="all-image"),
+            pytest.param(["video", "image"], False, id="video-then-image"),
+            pytest.param(["image", "video"], False, id="image-then-video"),
+            pytest.param(["video", "video", "image"], False, id="one-dissenter-last"),
+            pytest.param(["image", "video", "video"], False, id="one-dissenter-first"),
+        ],
+    )
+    def test_videos_are_used_only_when_every_camera_declares_one(self, dtypes: list[str], expected: bool) -> None:
+        cameras = [(f"cam{i}", dtype, (3, 8, 8)) for i, dtype in enumerate(dtypes)]
+        assert _reader(cameras).use_videos is expected
+
+    @pytest.mark.parametrize(
+        "dtypes",
+        [
+            pytest.param(["video", "video"], id="all-video"),
+            pytest.param(["image", "image"], id="all-image"),
+            pytest.param(["video", "image"], id="mixed"),
+        ],
+    )
+    def test_reversing_the_declaration_order_does_not_change_the_flag(self, dtypes: list[str]) -> None:
+        forward = [(f"cam{i}", dtype, (3, 8, 8)) for i, dtype in enumerate(dtypes)]
+        assert _reader(forward).use_videos is _reader(forward[::-1]).use_videos
+
+    def test_every_camera_s_dtype_is_recorded_not_just_the_last(self) -> None:
+        cameras = [("top", "video", (3, 8, 8)), ("wrist", "image", (3, 8, 8))]
+        assert _reader(cameras).camera_dtypes == {"top": "video", "wrist": "image"}
+
+    def test_a_dtype_the_recorder_does_not_write_is_reported_as_declared(self) -> None:
+        """An unknown dtype is not a video, and is reported rather than mapped."""
+        reader = _reader([("depth", "uint16", (1, 8, 8))])
+        assert (reader.camera_dtypes, reader.use_videos) == ({"depth": "uint16"}, False)


### PR DESCRIPTION
## Problem

A LeRobot dataset declares each camera's storage per feature. One `observation.images.<cam>` can be `dtype="video"` (frames encoded into an MP4 under `videos/`) while another is `dtype="image"` (frames in the data parquet). `LeRobotDataset.create` accepts that declaration and reads both streams back, so it is a legal source - measured, and pinned as the premise class of the new test file.

The output side has one knob for the whole dataset: `DatasetRecorder.create` takes a single `use_videos` flag that decides every camera's dtype. `_SourceDataset.__init__` derived that flag by assigning it once per camera, inside the loop that reads the camera shapes:

```python
for cam in self.camera_keys:
    feat = features[f"{_IMAGE_PREFIX}{cam}"]
    ...
    self.use_videos = feat.get("dtype") == "video"   # last camera wins
```

So it held whichever camera the source's feature dict ended on. A two-camera source declaring one video stream and one image stream transformed with `status="success"` while the output stored a camera a different way, and the direction depended only on the order the features were declared in.

Measured end to end through `create_transform("mock").transform(...)` on real files, both orders:

| source cameras (declaration order) | output cameras before | MP4 files | after |
|---|---|---|---|
| `top='video'`, `wrist='image'` | `top='image'`, `wrist='image'` | 1 -> 0 | refused |
| `wrist='image'`, `top='video'` | `wrist='video'`, `top='video'` | 1 -> 2 | refused |

Both directions lose the source's schema. `create_output_recorder` documents itself as "the SOURCE schema (parity by construction)"; schema parity is the first acceptance criterion of `tests/transforms/test_round_trip.py`; and `docs/data/transforms.md` contract item 1 promises a generated episode is "the *same trajectory* rendered differently". A stream stored a different way is none of those.

## Change

`+40/-7` in `strands_robots/transforms/base.py`:

- every camera's dtype is recorded (`camera_dtypes`), not just the last one;
- `use_videos` is derived from the whole set (`all(dtype == "video" ...)`), which is exactly what the old code produced for a homogeneous source;
- `_SourceDataset.open` refuses a source whose cameras disagree, naming each camera and the dtype it declared so an operator knows which stream to convert.

Refusing is the disposition `open` already takes one branch up, for a source declaring a feature the pass-through cannot preserve, and for the same reason: the output recorder declares one dtype for every camera, so a mixed source cannot be reproduced, and writing it anyway alters a column the contract promises to carry through. The refusal sits after the dataset-stack probe and the no-camera refusal, and before any episode is read, so a refused source leaves nothing on disk (`episodes_read == 0`).

Re-encoding to one dtype instead is a quieter version of the same answer, and the break table shows it is worse: coercing everything to `image` also flattens the video streams of sources that work today.

## Visual

Read back through `LeRobotDataset` on both trees, from one source recorded once:

![camera dtype parity](https://github.com/cagataycali/robots/releases/download/artifacts/2770-transform-camera-dtype-parity.png)

Both trees record byte-identical source pixels (asserted in the figure script). The output frames are the mock backend's brightness-shifted variant, so their pixels differ from the source by design - the subject is the dtype each camera is stored as. Every number in the caption is asserted from the two runs' own JSON before the figure is drawn, and each panel is verified to be embedded verbatim (`np.array_equal` at its paste offset).

## Tests

New `tests/transforms/test_camera_dtype_parity.py`, 30 cases in four classes. Pre-fix: **14 failed / 16 passed**, with **0 of 3** in the premise class (the mixed source is a legal LeRobot dataset) and **0 of 3** in the over-reach control class (a homogeneous source, either dtype, still transforms and keeps its schema). The 14 are 9 refusal cases and 5 flag-derivation cases.

Mutation table, run sequentially against the fix (12 mutations, 11 detected, 10 distinct firing sets, source restored byte-identical per row):

| # | mutation | cases fired |
|---|---|---|
| b0 | control: no mutation | 0 (30 passed) |
| b1 | the mixed-dtype refusal is removed | 9 |
| b2 | flag assigned once per camera again (recording + refusal kept) | 3 |
| b3 | flag derived with `any()` instead of `all()` | 4 |
| b4 | refusal only fires above two distinct dtypes | 9 |
| b5 | refusal moved ahead of the no-camera refusal | 0 |
| b6 | refusal names the cameras but not their dtypes | 2 |
| b7 | refusal names the dtypes but not the cameras | 4 |
| b8 | over-reach: every non-video source refused | 2 |
| b9 | only the last camera's dtype is recorded | 13 |
| b10 | the wrong fix: coerce to video instead of refusing | 13 |
| b11 | the wrong fix: coerce to image instead of refusing | 14 |

Notes on the table:

- **b1 and b4 share a firing set**, for a structural reason: a two-camera mixed source has exactly two distinct dtypes, so `> 2` is equivalent to having no guard at all.
- **b5 fires nothing, and cannot**: with no cameras the dtype set is empty, so the two refusals are mutually exclusive by construction. The order between them is not an observable.
- **b8 is the over-reach row** and fires exactly the two `image` control cases - the fix must not turn "the cameras disagree" into "the cameras are not video".
- **b11 fires the most** because coercing to `image` breaks the all-video controls as well as leaving the mixed source unrefused; it is not a milder fix.

## Gate

- `ruff check` and `ruff format --check` clean over `strands_robots tests tests_integ` (1585 files).
- `mypy strands_robots tests tests_integ`: **24 == 24** against a pristine worktree of the merge base, normalized message sets byte-identical in both directions, 0 in the changed files.
- Paired run over an identical 374-file selection (all of `tests/transforms/` plus every test that walks the tree, reads docstrings, or reads `docs/` / `README` / `changelog.d`), with the new file excluded from both trees: identical **17898 collected** and `17 failed, 17815 passed, 66 skipped` on both, 17 identical failing ids, `comm` empty in both directions. All 17 need `awsiot` (the `[mesh-iot]` extra, absent in this environment) and are present in the base full-suite baseline.
- New file: 30 passed; `tests/transforms/` whole: 366 passed. mujoco 3.5.0 (the declared floor) with lerobot 0.6.2 from source.
- Changelog fragment validates (`scripts/assemble_changelog.py --check`, plus the 30 fragment/format guards).
