### PR TITLE
fix(g1): record the DDS interface ensure_dds bound, not the one it was asked for

### DIFF
--- a/changelog.d/2773-dds-init-records-the-bound-interface.md
+++ b/changelog.d/2773-dds-init-records-the-bound-interface.md
@@ -1,0 +1,48 @@
+### Fixed: ensure_dds records the interface it bound, not the one it was asked for
+
+The G1 DDS helper's first stated requirement is that `ChannelFactoryInitialize`
+runs "exactly once per process, with a known network interface", and it keeps a
+module-level record of that interface so a later caller asking for a different
+one is refused rather than silently re-bound onto the wrong NIC. Its own comment
+on that record says a second call with a different interface "is a bug worth
+catching, not a silent no-op".
+
+The record was only sometimes true. `ChannelFactory.Init` short-circuits on
+`if __initialized: return True` and never reads its `networkInterface` argument,
+so a second `ChannelFactoryInitialize` returns normally without binding
+anything - a no-op indistinguishable, at the call site, from a successful bind.
+`ensure_dds` read that quiet return as a bind and recorded the interface it had
+asked for. Measured against `unitree_sdk2py` 1.0.1, with the bus brought up on
+`lo` by anything other than `ensure_dds`:
+
+```
+ensure_dds("eth-does-not-exist")  ->  None          # reported success
+recorded interface                ->  'eth-does-not-exist'
+factory actually bound to         ->  'lo'
+ensure_dds("another-nic")         ->  "...was called with interface
+                                       'eth-does-not-exist'; refusing to
+                                       re-initialise on 'another-nic'"
+```
+
+So every subscriber and publisher attached to whichever NIC the first caller
+chose while the helper reported the one this caller asked for - the silent
+re-bind, producing empty topics with no obvious cause, that the refusal exists
+to prevent - and the refusal that did eventually fire quoted an interface the
+bus was never on, sending a reader after the wrong fault.
+
+`ensure_dds` now asks the factory whether it is already bound before calling
+init. A bus this process did not bind is refused by name, giving the cause and
+the call to drop, and nothing is recorded - so the interface a later refusal
+compares against is only ever one `ensure_dds` actually bound. The SDK build
+that raises "already initialized" instead of short-circuiting reaches the same
+answer for the same reason, which also stops that branch's substring match
+turning a genuine init failure whose message contains "initialized" into a
+reported success. A build that does not publish its factory state keeps the
+behaviour it had before the probe existed.
+
+Nothing public distinguishes a bind from a no-op: `Init` returns `True` for
+both and `ChannelFactoryInitialize` discards that bool, so the probe reads the
+attribute the factory records its state on. That is a narrower coupling to the
+SDK than matching its exception text, which this function already does. The
+module docstring claimed a second init raises from `unitree_sdk2py`; it does
+not, and that claim is corrected to what the SDK does.

--- a/strands_robots/tools/g1/_g1_common.py
+++ b/strands_robots/tools/g1/_g1_common.py
@@ -4,10 +4,13 @@ Two things need to be true across the driver and (later, issue #358) the
 agent tools:
 
 * ``ChannelFactoryInitialize`` is called exactly once per process, with a
-  known network interface. Calling it twice from separate imports raises
-  from ``unitree_sdk2py``; calling it never leaves subscribers with no bus.
-  :func:`ensure_dds` runs it under a lock, records the interface, and is
-  idempotent for callers with the same choice.
+  known network interface. Calling it never leaves subscribers with no bus;
+  calling it a second time is *not* an error the SDK reports -
+  ``ChannelFactory.Init`` short-circuits on ``if __initialized: return True``
+  and ignores its ``networkInterface`` argument, so a re-init is a silent
+  no-op that is indistinguishable from a successful bind.
+  :func:`ensure_dds` runs it under a lock, records the interface it actually
+  bound, and is idempotent for callers with the same choice.
 * A ``ChannelSubscriber`` and a ``ChannelPublisher`` cannot be constructed
   concurrently: the CycloneDDS bindings segfault. :data:`_DDS_INIT_LOCK` is
   the *shared* lock the driver and the tools (issue #358) both hold while
@@ -21,6 +24,7 @@ mock the bus and skips the SDK entirely on Thor.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import threading
 
@@ -80,6 +84,47 @@ def decode_code(code: object) -> str:
 # ---------------------------------------------------------------------------
 _DDS_INIT_LOCK: threading.Lock = threading.Lock()
 
+#: The attribute ``ChannelFactory`` records "the bus is up" on. Nothing public
+#: reports it: ``Init`` returns ``True`` both when it binds an interface and
+#: when it short-circuits, and ``ChannelFactoryInitialize`` discards that bool.
+#: Reading the attribute is the only way to tell a bind from a no-op, and it is
+#: a narrower coupling to the SDK than matching its exception text, which
+#: :func:`ensure_dds` already does below.
+_SDK_FACTORY_BOUND_ATTR = "_ChannelFactory__initialized"
+
+
+def _sdk_factory_already_bound(channel_module: object) -> bool | None:
+    """Whether the SDK's channel factory is already bound to an interface.
+
+    Args:
+        channel_module: The imported ``unitree_sdk2py.core.channel`` module.
+
+    Returns:
+        ``True`` or ``False`` when this SDK build reports its factory state;
+        ``None`` when it does not expose it, so a caller keeps the behaviour
+        it had before rather than guessing which way to fail.
+    """
+    factory = getattr(channel_module, "ChannelFactory", None)
+    bound = getattr(factory, _SDK_FACTORY_BOUND_ATTR, None)
+    return bound if isinstance(bound, bool) else None
+
+
+def _bound_elsewhere_error(network_interface: str) -> str:
+    """The reason a bus this process did not bind cannot be confirmed.
+
+    Args:
+        network_interface: The interface the caller asked to bind.
+
+    Returns:
+        A named reason, in the voice the caller can act on.
+    """
+    return (
+        "the DDS channel factory was already initialised outside ensure_dds, so a "
+        f"bind to {network_interface!r} cannot be confirmed; let the driver initialise "
+        "the bus, or drop the ChannelFactoryInitialize call that runs before it"
+    )
+
+
 # Recorded once by :func:`ensure_dds` for a running process. A second call
 # with a different interface is a bug worth catching, not a silent no-op.
 _dds_state: dict[str, object] = {"initialized": False, "interface": None}
@@ -117,19 +162,33 @@ def ensure_dds(network_interface: str = "eth0") -> str | None:
             # does not have it (Thor, CI, every unit test) the ImportError is
             # returned as a named string rather than raised, and the caller
             # can decide whether to proceed with a mocked bus.
-            from unitree_sdk2py.core.channel import ChannelFactoryInitialize
+            sdk_channel = importlib.import_module("unitree_sdk2py.core.channel")
         except ImportError as exc:  # pragma: no cover - exercised on hardware
             return f"unitree_sdk2py is not installed: {exc}"
+        if _sdk_factory_already_bound(sdk_channel):
+            # Something bound the bus without coming through here, so the
+            # interface it is on is not this process's to know. Calling
+            # ChannelFactoryInitialize now would short-circuit and return
+            # normally, and recording ``network_interface`` off the back of
+            # that would attach every later subscriber to whichever NIC the
+            # first caller chose while reporting the one this caller asked
+            # for - the silent re-bind the refusal below exists to prevent.
+            return _bound_elsewhere_error(network_interface)
         try:
-            ChannelFactoryInitialize(0, network_interface)
+            sdk_channel.ChannelFactoryInitialize(0, network_interface)
         except Exception as exc:  # noqa: BLE001 - SDK raises bare Exception
             message = str(exc).lower()
             if "already" in message or "initialized" in message:
-                # Some SDK builds refuse a second init - treat that as success
-                # for the interface we recorded.
-                _dds_state["initialized"] = True
-                _dds_state["interface"] = network_interface
-                return None
+                # An SDK build that refuses a second init instead of
+                # short-circuiting: the same situation as the probe above, so
+                # the same answer. The bus is up, but on an interface this
+                # process did not choose, so reporting success here would
+                # record a NIC nobody bound.
+                return (
+                    "ChannelFactoryInitialize reports the factory was already "
+                    f"initialised, so a bind to {network_interface!r} cannot be "
+                    f"confirmed: {exc}"
+                )
             return f"ChannelFactoryInitialize failed: {exc}"
         _dds_state["initialized"] = True
         _dds_state["interface"] = network_interface

--- a/tests/tools/g1/test_dds_init_binds_a_known_interface.py
+++ b/tests/tools/g1/test_dds_init_binds_a_known_interface.py
@@ -1,0 +1,326 @@
+"""ensure_dds records the interface it bound, not the one it was asked for.
+
+The G1 DDS helper's first stated requirement is that
+``ChannelFactoryInitialize`` runs "exactly once per process, with a known
+network interface", and it keeps a module-level record of that interface so a
+later caller asking for a different one is refused rather than silently
+re-bound onto the wrong NIC.
+
+The record is only worth refusing on if it is true. ``ChannelFactory.Init``
+short-circuits on ``if __initialized: return True`` and never looks at its
+``networkInterface`` argument, so a second ``ChannelFactoryInitialize`` returns
+normally without binding anything - a no-op that is indistinguishable, at the
+call site, from a successful bind. A process where anything else brought the
+bus up first therefore had ``ensure_dds`` report success and record an
+interface the bus was never on, and a later refusal then quoted that
+fabricated interface back at the caller.
+
+Every cell here drives a fake ``unitree_sdk2py.core.channel``: binding the
+real factory is a process-wide side effect with no ``Shutdown``, so a suite
+that did it once would change what every later test observes.
+:class:`TestTheRealSdkBehavesTheWayTheDoubleDoes` pins the double against the
+installed SDK so it cannot drift into agreeing with a bug, and skips when the
+SDK is absent (Thor, CI) rather than passing vacuously.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from strands_robots.tools.g1 import _g1_common, reset_dds_state
+
+#: The attribute name the SDK mangles ``ChannelFactory.__initialized`` to.
+#: Stated here rather than read from the module so a cell that asserts the
+#: module agrees with the SDK is comparing two independent statements.
+SDK_BOUND_ATTR = "_ChannelFactory__initialized"
+
+
+class _FakeFactory:
+    """Stands in for ``ChannelFactory``: one class-level "bus is up" flag."""
+
+
+def _fake_channel_module(*, already_bound: bool, bound_attr: str = SDK_BOUND_ATTR) -> Any:
+    """A fake ``unitree_sdk2py.core.channel`` that records init calls.
+
+    Mirrors the one behaviour that matters: ``ChannelFactoryInitialize``
+    returns ``None`` whether or not it bound anything, so the caller cannot
+    tell a bind from a no-op by looking at the call.
+
+    Args:
+        already_bound: Whether the factory reports itself already bound.
+        bound_attr: The attribute the flag is published on. A build that
+            publishes it elsewhere is what ``None`` from the probe means.
+
+    Returns:
+        The fake module; its ``init_calls`` list records every call.
+    """
+    module = types.ModuleType("unitree_sdk2py.core.channel")
+    factory = type("ChannelFactory", (_FakeFactory,), {bound_attr: already_bound})
+    calls: list[tuple[int, str]] = []
+
+    def channel_factory_initialize(domain_id: int, network_interface: str) -> None:
+        calls.append((domain_id, network_interface))
+        setattr(factory, bound_attr, True)
+
+    module.ChannelFactory = factory  # type: ignore[attr-defined]
+    module.ChannelFactoryInitialize = channel_factory_initialize  # type: ignore[attr-defined]
+    module.init_calls = calls  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    """Install a fake SDK channel module and clear the recorded DDS state.
+
+    Yields a callable that installs a fake with a chosen initial flag and
+    returns it, so a cell picks "the bus was already up" or "the bus is down"
+    without reaching into ``sys.modules`` itself.
+    """
+    reset_dds_state()
+
+    def install(*, already_bound: bool, bound_attr: str = SDK_BOUND_ATTR) -> Any:
+        module = _fake_channel_module(already_bound=already_bound, bound_attr=bound_attr)
+        parent = types.ModuleType("unitree_sdk2py.core")
+        parent.channel = module  # type: ignore[attr-defined]
+        grandparent = types.ModuleType("unitree_sdk2py")
+        grandparent.core = parent  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "unitree_sdk2py", grandparent)
+        monkeypatch.setitem(sys.modules, "unitree_sdk2py.core", parent)
+        monkeypatch.setitem(sys.modules, "unitree_sdk2py.core.channel", module)
+        return module
+
+    yield install
+    reset_dds_state()
+
+
+# =========================================================================
+# The premise: a no-op and a bind look the same at the call site.          #
+# =========================================================================
+
+
+class TestTheDoubleIsFaithfulToTheCallSite:
+    """The fake reproduces the property that makes the defect possible."""
+
+    def test_a_second_initialize_returns_normally_without_binding(self, fake_sdk: Any) -> None:
+        """A fake already-bound factory still accepts an init call quietly."""
+        module = fake_sdk(already_bound=True)
+        assert module.ChannelFactoryInitialize(0, "wlan0") is None
+
+    def test_the_probe_reads_the_flag_the_factory_publishes(self, fake_sdk: Any) -> None:
+        """Both flag states are reported, so the probe is not a constant."""
+        assert _g1_common._sdk_factory_already_bound(fake_sdk(already_bound=True)) is True
+        assert _g1_common._sdk_factory_already_bound(fake_sdk(already_bound=False)) is False
+
+
+# =========================================================================
+# The regression: a bus this process did not bind is not recorded as ours. #
+# =========================================================================
+
+
+class TestABusBoundElsewhereIsNotRecordedAsOurs:
+    """``ensure_dds`` refuses rather than claiming an interface it cannot confirm."""
+
+    def test_a_factory_bound_elsewhere_is_refused(self, fake_sdk: Any) -> None:
+        """A bind that cannot be confirmed is a reason, not a success."""
+        fake_sdk(already_bound=True)
+
+        assert _g1_common.ensure_dds("eth-not-the-bound-one") is not None
+
+    def test_the_refusal_names_the_cause(self, fake_sdk: Any) -> None:
+        """ "the bus is down" and "someone else brought it up" need different fixes."""
+        fake_sdk(already_bound=True)
+
+        err = _g1_common.ensure_dds("eth-not-the-bound-one")
+
+        assert err is not None
+        assert "already initialised outside ensure_dds" in err
+
+    def test_the_refusal_names_the_interface_it_could_not_confirm(self, fake_sdk: Any) -> None:
+        """A caller with two interfaces needs to know which one was refused."""
+        fake_sdk(already_bound=True)
+
+        err = _g1_common.ensure_dds("eth-not-the-bound-one")
+
+        assert err is not None
+        assert "eth-not-the-bound-one" in err
+
+    def test_the_refusal_names_the_call_to_remove(self, fake_sdk: Any) -> None:
+        """The remedy is actionable: the caller is told what to drop."""
+        fake_sdk(already_bound=True)
+
+        err = _g1_common.ensure_dds("eth-not-the-bound-one")
+
+        assert err is not None
+        assert "ChannelFactoryInitialize" in err
+
+    def test_an_interface_that_was_not_bound_is_never_recorded(self, fake_sdk: Any) -> None:
+        """The record stays empty, so no later refusal can quote a false NIC."""
+        fake_sdk(already_bound=True)
+
+        _g1_common.ensure_dds("eth-not-the-bound-one")
+
+        assert _g1_common._dds_state["initialized"] is False
+        assert _g1_common._dds_state["interface"] is None
+
+    def test_no_second_initialize_is_issued_against_a_bound_factory(self, fake_sdk: Any) -> None:
+        """The probe runs before the call, so the no-op is never made."""
+        module = fake_sdk(already_bound=True)
+
+        _g1_common.ensure_dds("eth-not-the-bound-one")
+
+        assert module.init_calls == []
+
+    def test_a_build_that_refuses_a_second_init_is_refused_too(self, fake_sdk: Any) -> None:
+        """An SDK that raises "already initialized" is the same situation.
+
+        Such a build reports the bus is up on an interface this process did
+        not choose, so recording the requested one would fabricate the same
+        fact the probe above refuses to fabricate.
+        """
+        module = fake_sdk(already_bound=False)
+
+        def refuse(domain_id: int, network_interface: str) -> None:
+            raise Exception("factory already initialized")
+
+        module.ChannelFactoryInitialize = refuse
+
+        err = _g1_common.ensure_dds("wlan0")
+
+        assert err is not None
+        assert "already" in err
+        assert "wlan0" in err
+        assert _g1_common._dds_state["interface"] is None
+
+
+# =========================================================================
+# What is unchanged: a bind this process performed still reads as ours.    #
+# =========================================================================
+
+
+class TestAnAttestedBindIsUnchanged:
+    """Every cell here holds on the pre-fix code as well; that is the point."""
+
+    def test_a_first_bind_records_the_interface_it_bound(self, fake_sdk: Any) -> None:
+        """Success is reported and the interface is recorded."""
+        module = fake_sdk(already_bound=False)
+
+        assert _g1_common.ensure_dds("eth0") is None
+        assert module.init_calls == [(0, "eth0")]
+        assert _g1_common._dds_state["initialized"] is True
+        assert _g1_common._dds_state["interface"] == "eth0"
+
+    def test_a_repeat_call_with_the_same_interface_is_idempotent(self, fake_sdk: Any) -> None:
+        """The second call succeeds without a second init."""
+        module = fake_sdk(already_bound=False)
+        assert _g1_common.ensure_dds("eth0") is None
+
+        assert _g1_common.ensure_dds("eth0") is None
+        assert module.init_calls == [(0, "eth0")]
+
+    def test_a_repeat_call_with_another_interface_is_refused(self, fake_sdk: Any) -> None:
+        """The refusal names both the bound interface and the requested one."""
+        fake_sdk(already_bound=False)
+        assert _g1_common.ensure_dds("eth0") is None
+
+        err = _g1_common.ensure_dds("wlan0")
+
+        assert err is not None
+        assert "eth0" in err
+        assert "wlan0" in err
+        assert _g1_common._dds_state["interface"] == "eth0"
+
+    def test_a_failing_bind_is_reported_and_records_nothing(self, fake_sdk: Any) -> None:
+        """A genuine init failure keeps its own wording."""
+        module = fake_sdk(already_bound=False)
+
+        def fail(domain_id: int, network_interface: str) -> None:
+            raise Exception("channel factory init error.")
+
+        module.ChannelFactoryInitialize = fail
+
+        err = _g1_common.ensure_dds("eth-nonexistent")
+
+        assert err is not None
+        assert "ChannelFactoryInitialize failed" in err
+        assert _g1_common._dds_state["initialized"] is False
+
+
+class TestAnUnreadableSdkKeepsTheOlderBehaviour:
+    """A build that does not publish the flag must not be refused blindly."""
+
+    def test_the_probe_reports_unknown_rather_than_guessing(self, fake_sdk: Any) -> None:
+        """No flag where we look means "cannot tell", not "already bound"."""
+        module = fake_sdk(already_bound=True, bound_attr="_SomeOtherName__initialized")
+
+        assert _g1_common._sdk_factory_already_bound(module) is None
+
+    def test_a_bind_still_succeeds_when_the_flag_cannot_be_read(self, fake_sdk: Any) -> None:
+        """The caller keeps the behaviour it had before the probe existed."""
+        module = fake_sdk(already_bound=True, bound_attr="_SomeOtherName__initialized")
+
+        assert _g1_common.ensure_dds("eth0") is None
+        assert module.init_calls == [(0, "eth0")]
+        assert _g1_common._dds_state["interface"] == "eth0"
+
+    def test_a_module_without_a_factory_reports_unknown(self) -> None:
+        """A channel module with no ``ChannelFactory`` at all is not a crash."""
+        assert _g1_common._sdk_factory_already_bound(types.ModuleType("bare")) is None
+
+
+# =========================================================================
+# The double against the installed SDK - skips without it, never passes    #
+# vacuously.                                                              #
+# =========================================================================
+
+
+class TestTheRealSdkBehavesTheWayTheDoubleDoes:
+    """The three SDK facts the fix rests on, read off the installed package."""
+
+    @staticmethod
+    def _channel_module() -> Any:
+        return pytest.importorskip(
+            "unitree_sdk2py.core.channel",
+            reason="unitree_sdk2py is absent here; the double stands in for it",
+        )
+
+    def test_the_factory_publishes_its_bound_flag_where_the_probe_looks(self) -> None:
+        """A rename in the SDK fails here rather than silently disabling the probe."""
+        channel = self._channel_module()
+
+        flag = getattr(channel.ChannelFactory, SDK_BOUND_ATTR, None)
+
+        assert isinstance(flag, bool), f"{SDK_BOUND_ATTR} is not a bool on this SDK build"
+        assert _g1_common._SDK_FACTORY_BOUND_ATTR == SDK_BOUND_ATTR
+
+    def test_init_short_circuits_without_looking_at_the_interface(self) -> None:
+        """``Init`` returns early on the flag, so a re-init binds nothing."""
+        channel = self._channel_module()
+
+        source = inspect.getsource(channel.ChannelFactory.Init)
+        # Everything before the lock is the short-circuit; drop the signature
+        # line so the interface parameter's own declaration is not counted.
+        short_circuit = "\n".join(source.split("with ", 1)[0].splitlines()[1:])
+
+        assert "__initialized" in short_circuit
+        assert "return True" in short_circuit
+        assert "networkInterface" not in short_circuit
+
+    def test_initialize_discards_the_bool_init_returns(self) -> None:
+        """Nothing public distinguishes a bind from a no-op.
+
+        ``ChannelFactoryInitialize`` raises on a falsy ``Init`` and otherwise
+        returns ``None``, so the truthy branch carries no information - which
+        is why the flag has to be read directly.
+        """
+        channel = self._channel_module()
+
+        source = inspect.getsource(channel.ChannelFactoryInitialize)
+
+        assert "raise" in source
+        assert "return" not in source.split("raise", 1)[1]


### PR DESCRIPTION
## The defect

`strands_robots/tools/g1/_g1_common.py` opens by stating that
`ChannelFactoryInitialize` must run "exactly once per process, with a known
network interface", and it keeps a module-level record of that interface so a
later caller asking for a different one is refused instead of silently re-bound
onto the wrong NIC. The comment on that record is explicit about the policy:

> A second call with a different interface is a bug worth catching, not a silent no-op.

The record was only sometimes true. `ChannelFactory.Init` is:

```python
def Init(self, id: int, networkInterface: str = None, qos: Qos = None):
    if self.__class__.__initialized:
        return True
    ...
```

It short-circuits and never reads `networkInterface`, so a second
`ChannelFactoryInitialize` returns normally having bound nothing - a no-op that
is indistinguishable, at the call site, from a successful bind. `ensure_dds`
treated that quiet return as a bind and recorded the interface it had asked for.

Measured against `unitree_sdk2py` 1.0.1, with the bus brought up on `lo` by
anything other than `ensure_dds` (a caller following the SDK's own examples, or
another library in the same process - the exact case the module docstring names):

| | before | after |
|---|---|---|
| `ensure_dds("eth-does-not-exist")` | `None` (success) | named refusal |
| recorded interface | `'eth-does-not-exist'` | `None` |
| factory actually bound to | `lo` | `lo` |
| later `ensure_dds("another-nic")` | refused, quoting `'eth-does-not-exist'` | refused, naming the real cause |

Two consequences. Every subscriber and publisher attached to whichever NIC the
first caller chose while the helper reported the one this caller asked for -
the silent re-bind, producing empty topics with no obvious cause, that the
refusal exists to prevent. And the refusal that did eventually fire quoted an
interface the bus was never on, sending a reader after a fault that does not
exist.

## The change

Ask the factory whether it is already bound *before* calling init. A bus this
process did not bind is refused by name, giving the cause and the call to drop,
and nothing is recorded - so the interface a later refusal compares against is
only ever one `ensure_dds` actually bound.

```
the DDS channel factory was already initialised outside ensure_dds, so a bind to
'eth-does-not-exist' cannot be confirmed; let the driver initialise the bus, or
drop the ChannelFactoryInitialize call that runs before it
```

The SDK build that raises `already initialized` rather than short-circuiting is
the same situation and now reaches the same answer. That also closes a second,
latent hole in the same branch: its `"already" in message or "initialized" in
message` test admits a genuine failure whose text merely contains "initialized"
(`"could not be initialized"`), and that used to be recorded as success. Both
arms now refuse, so the over-broad match can no longer convert a failure into a
reported bind.

### Why the probe reads an SDK attribute

Nothing public distinguishes a bind from a no-op: `Init` returns `True` for both
and `ChannelFactoryInitialize` discards that bool, raising only when `Init` is
falsy. `ChannelFactory`'s public surface is
`Init, CreateChannel, CreateSendChannel, CreateRecvChannel` - none reports the
state. So the probe reads the attribute the factory records it on, guarded, and
reports "cannot tell" rather than guessing when a build does not publish it; in
that case the caller keeps exactly the behaviour it had before. This is a
*narrower* coupling to the SDK than the mechanism already shipping in this
function, which matches the vendor's exception text.

`TestTheRealSdkBehavesTheWayTheDoubleDoes` pins all three of those SDK facts
against the installed package, so a rename fails there rather than silently
disabling the probe, and skips when the SDK is absent rather than passing
vacuously.

### Behaviour change

A process that brought the bus up itself and then called `ensure_dds` used to
get success on a possibly-wrong NIC; it now gets a named, actionable refusal
that `_dds_engine` surfaces as a connect failure. That is the module's own
stated policy applied to the case it previously could not see, and it replaces
empty topics with a reason. No path where `ensure_dds` performed the bind
changes at all.

## Why every gate was silent

`ensure_dds` had never succeeded under test. The only path any suite reached was
"first call, init raises, message is not `already`" - so the idempotence
contract the module docstring leads with, the interface-mismatch refusal, and
the success bookkeeping were all unexecuted (lines 106-114 and 130-137, 11 of
39 statements). Every mutation in the table below fires **zero** of the 245
pre-existing tests in `tests/tools/g1/`, `tests/drivers/` and
`tests/test_driver_seam.py`.

## Tests

`tests/tools/g1/test_dds_init_binds_a_known_interface.py`, 19 cases. Every cell
drives a fake `unitree_sdk2py.core.channel`: binding the real factory is a
process-wide side effect with no `Shutdown`, so a suite that did it once would
change what every later test observes.

Behavioural pre-fix split (both halves reverted, new symbols kept) - **7 failed,
12 passed**:

| class | failed / total | role |
|---|---|---|
| `TestABusBoundElsewhereIsNotRecordedAsOurs` | 7 / 7 | the regression |
| `TestTheDoubleIsFaithfulToTheCallSite` | 0 / 2 | premise |
| `TestAnAttestedBindIsUnchanged` | 0 / 4 | control - holds pre-fix too |
| `TestAnUnreadableSdkKeepsTheOlderBehaviour` | 0 / 3 | over-reach control |
| `TestTheRealSdkBehavesTheWayTheDoubleDoes` | 0 / 3 | SDK parity |

### Mutations

11 mutations, 11 distinct failing-id sets, control clean, source restored
byte-identical. `sib` counts failures in the pre-existing G1 suites; `coll` is
19 on every row, so nothing is hidden by a deselection.

| row | mine | sib | mutation |
|---|---|---|---|
| b0 | 0 | 0 | control - no mutation |
| b1 | 6 | 0 | probe call removed from `ensure_dds` |
| b2 | 1 | 0 | SDK-refuses branch restored to record the requested NIC |
| b3 | 7 | 0 | both halves reverted (behavioural revert) |
| b4 | 2 | 0 | bound factory recorded as ours instead of refused |
| b5 | 4 | 0 | probe runs *after* `ChannelFactoryInitialize` |
| b6 | 7 | 0 | probe accepts any non-`None` flag (`isinstance` dropped) |
| b7 | 3 | 0 | probe treats an unreadable flag as already bound |
| b8 | 1 | 0 | refusal drops the interface it could not confirm |
| b9 | 1 | 0 | refusal drops the named cause |
| b10 | 1 | 0 | refusal drops the call to remove |

`b1 | b2 == b3` exactly and `b1` and `b2` share no failing test, so the two halves of the fix are
independently pinned. b4 is the tempting wrong fix - record it and return
success - and b5 shows the probe's position is load-bearing rather than
stylistic: run after init, and it reports the state our own call just created.

## Gate

- `ruff check strands_robots tests tests_integ`: clean. `ruff format --check`: 1585 files already formatted.
- `mypy strands_robots tests tests_integ`: **24 on this branch, 24 on the merge-base**, normalized message sets byte-identical in both directions, **0 in either changed file**.
- Paired run, identical 364-file selection (all `tests/tools/g1/` and `tests/drivers/`, plus every suite that walks the tree, reads source or docstrings, or names `ensure_dds`), the new file excluded from both trees: **17725 collected and `18 failed, 17647 passed, 60 skipped` on both**, failing-id sets identical, `comm` empty both directions. All 18 are pre-existing and environmental: 17 need `awsiot` (the `[mesh-iot]` extra, absent here) and one is a leftover dataset fixture.
- On the rebased base: `tests/tools/g1/ tests/drivers/ tests/test_driver_seam.py` **264 passed**, which includes #2768's and #2750's new suites.

### Coverage

`_g1_common.py` **72% -> 100%** (11 -> 0 missing; statements 39 -> 47). The
scoped selection is a faithful oracle for this module - it reports the same
`39 / 11 / 72%` and the same missing ranges as the full 40437-item run.

## Composition

#2768 landed mid-review and changes `_dds_engine.py`, which is `ensure_dds`'s
only in-tree caller. The two are disjoint: that PR changes how endpoints are
released, this one changes what `ensure_dds` records, and no path where
`ensure_dds` performed the bind is touched. Verified by re-running the whole
mutation table and both suites on the rebased tree - every row is unchanged.

No visual artifact: this changes a refusal and a bookkeeping record, not a
policy, simulation, rendering, recording or asset. The measured before/after
table and the mutation table are the evidence.
